### PR TITLE
fix: install.js errors (dotenv and js module type)

### DIFF
--- a/install/install.js
+++ b/install/install.js
@@ -1,6 +1,9 @@
-require('dotenv').config();
-const { program } = require('commander');
-const shell = require('shelljs');
+import dotEnvExtended from 'dotenv-extended';
+import { program } from 'commander';
+import shell from'shelljs';
+
+dotEnvExtended.load();
+
 const user = shell.exec('whoami', { silent: true }).stdout.replace('\n', '');
 
 program.version('0.0.1');


### PR DESCRIPTION
Tested install.sh on a vps and detected errors during docker config check and any other process related to install/install.js

Here the errors :

- Dotenv not used anymore

```
Error: Cannot find module 'dotenv'
Require stack:
- /usr/src/app/install/install.cjs
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:902:15)
    at Function.Module._load (internal/modules/cjs/loader.js:746:27)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at require (internal/modules/cjs/helpers.js:92:18)
    at Object.<anonymous> (/usr/src/app/install/install.cjs:1:1)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:76:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/usr/src/app/install/install.cjs' ]
}
```

- module type isn't commonjs

```
CommonJS script, rename it to use the '.cjs' file extension.
    at file:///usr/src/app/install/install.js:1:1
    at ModuleJob.run (internal/modules/esm/module_job.js:169:25)
    at async Loader.import (internal/modules/esm/loader.js:177:24)
    at async Object.loadESM (internal/process/esm_loader.js:68:5)

```

Don't know everything about this project but svelte project from docker is starting now