### PR TITLE
Depency bug causing errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
 		"format": "prettier --write ."
 	},
 	"devDependencies": {
-		"@sveltejs/adapter-node": "1.0.0-next.33",
-		"@sveltejs/kit": "1.0.0-next.125",
+		"@sveltejs/adapter-node": "1.0.0-next.39",
+		"@sveltejs/kit": "1.0.0-next.142",
 		"@types/dockerode": "^3.2.3",
 		"@typescript-eslint/eslint-plugin": "^4.26.1",
 		"@typescript-eslint/parser": "^4.26.1",
@@ -53,7 +53,7 @@
 		"microtip": "^0.2.2",
 		"mongoose": "^5.12.13",
 		"shelljs": "^0.8.4",
-		"svelte-kit-cookie-session": "^1.0.6",
+		"svelte-kit-cookie-session": "^1.3.1",
 		"svelte-select": "^3.17.0",
 		"systeminformation": "^5.7.7",
 		"unique-names-generator": "^4.5.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "coolify",
 	"description": "An open-source, hassle-free, self-hostable Heroku & Netlify alternative.",
-	"version": "1.0.23",
+	"version": "1.0.24",
 	"license": "AGPL-3.0",
 	"scripts": {
 		"dev:docker:start": "docker-compose -f docker-compose-dev.yml up -d",


### PR DESCRIPTION
One of the dependencies causing errors like you cannot log in with Github.

If you face such a problem and cannot initiate the automatic upgrade, just reinstall coolify (Your apps will be untouched!)