### PR TITLE
Allow Docker Apache write permissions

### DIFF
--- a/src/lib/buildPacks/php.ts
+++ b/src/lib/buildPacks/php.ts
@@ -11,6 +11,7 @@ const createDockerfile = async (data, image): Promise<void> => {
 	Dockerfile.push(`COPY ./${baseDirectory || ''} /var/www/html`);
 	Dockerfile.push(`EXPOSE 80`);
 	Dockerfile.push('CMD ["apache2-foreground"]');
+	Dockerfile.push('RUN chown -R www-data /var/www/html');
 	await fs.writeFile(`${workdir}/Dockerfile`, Dockerfile.join('\n'));
 };
 


### PR DESCRIPTION
I had a permission problem using PHP scripts, 
Running `chown -R www-data /var/www/html` after SSHing into the docker container helped fixing the problem.