### PR TITLE
feat(dev): allow windows users to use pnpm dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"version": "2.2.7",
 	"license": "AGPL-3.0",
 	"scripts": {
-		"dev": "docker-compose -f docker-compose-dev.yaml up -d && NODE_ENV=development svelte-kit dev",
+		"dev": "docker-compose -f docker-compose-dev.yaml up -d && cross-env NODE_ENV=development & svelte-kit dev",
 		"dev:stop": "docker-compose -f docker-compose-dev.yaml down",
 		"dev:logs": "docker-compose -f docker-compose-dev.yaml logs -f --tail 10",
 		"studio": "npx prisma studio",
@@ -37,6 +37,7 @@
 		"@typescript-eslint/parser": "4.31.1",
 		"@zerodevx/svelte-toast": "0.7.1",
 		"autoprefixer": "10.4.4",
+		"cross-env": "^7.0.3",
 		"cross-var": "1.1.0",
 		"eslint": "7.32.0",
 		"eslint-config-prettier": "8.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,7 @@ specifiers:
   compare-versions: 4.1.3
   cookie: 0.4.2
   cooltipz-css: ^2.1.0
+  cross-env: ^7.0.3
   cross-var: 1.1.0
   cuid: 2.1.8
   dayjs: 1.11.0
@@ -92,6 +93,7 @@ devDependencies:
   '@typescript-eslint/parser': 4.31.1_eslint@7.32.0+typescript@4.6.3
   '@zerodevx/svelte-toast': 0.7.1
   autoprefixer: 10.4.4_postcss@8.4.12
+  cross-env: 7.0.3
   cross-var: 1.1.0
   eslint: 7.32.0
   eslint-config-prettier: 8.5.0_eslint@7.32.0
@@ -2080,6 +2082,17 @@ packages:
     dependencies:
       luxon: 1.28.0
     dev: false
+
+  /cross-env/7.0.3:
+    resolution:
+      {
+        integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+      }
+    engines: { node: '>=10.14', npm: '>=6', yarn: '>=1' }
+    hasBin: true
+    dependencies:
+      cross-spawn: 7.0.3
+    dev: true
 
   /cross-spawn/5.1.0:
     resolution: { integrity: sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk= }


### PR DESCRIPTION
Hey!

I'm actually working on Win11 and I wasn't able to use use the develop without the `cross-env` option! I've tested it only on Windows, can someone test a `pnpm run dev` quickly ?

This can helps beginners not to be afraid !