### PR TITLE
Changed the package manager used in the .husky/pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn lint-staged
+pnpm lint-staged


### PR DESCRIPTION
The pre-commit hook used yarn instead of pnpm. So contributors needed to have yarn and pnpm installed in order to work with the project. I changed the hook to use pnpm.