### PR TITLE
Implemented typing for dockerfile configuration

### DIFF
--- a/src/lib/types/composeFile.ts
+++ b/src/lib/types/composeFile.ts
@@ -1,0 +1,49 @@
+import { makeLabelForServices } from '../buildPacks/common';
+
+export type ComposeFile = {
+	version: ComposerFileVersion;
+	services: Record<string, ComposeFileService>;
+	networks: Record<string, ComposeFileNetwork>;
+	volumes?: Record<string, ComposeFileVolume>;
+};
+
+export type ComposeFileService = {
+	container_name: string;
+	image?: string;
+	networks: string[];
+	environment: Record<string, unknown>;
+	volumes?: string[];
+	ulimits?: unknown;
+	labels?: string[];
+	restart: ComposeFileRestartOption;
+	depends_on?: string[];
+	command?: string;
+	build?: string;
+};
+
+export type ComposerFileVersion =
+	| '3.8'
+	| '3.7'
+	| '3.6'
+	| '3.5'
+	| '3.4'
+	| '3.3'
+	| '3.2'
+	| '3.1'
+	| '3.0'
+	| '2.4'
+	| '2.3'
+	| '2.2'
+	| '2.1'
+	| '2.0';
+
+export type ComposeFileRestartOption = 'no' | 'always' | 'on-failure' | 'unless-stopped';
+
+export type ComposeFileNetwork = {
+	external: boolean;
+};
+
+export type ComposeFileVolume = {
+	external?: boolean;
+	name?: string;
+};

--- a/src/routes/databases/[id]/start.json.ts
+++ b/src/routes/databases/[id]/start.json.ts
@@ -6,6 +6,7 @@ import yaml from 'js-yaml';
 import type { RequestHandler } from '@sveltejs/kit';
 import { makeLabelForStandaloneDatabase } from '$lib/buildPacks/common';
 import { startTcpProxy } from '$lib/haproxy';
+import type { ComposeFile } from '$lib/types/composeFile';
 
 export const post: RequestHandler = async (event) => {
 	const { teamId, status, body } = await getUserDetails(event);
@@ -33,7 +34,7 @@ export const post: RequestHandler = async (event) => {
 
 		const { workdir } = await createDirectories({ repository: type, buildId: id });
 
-		const composeFile = {
+		const composeFile: ComposeFile = {
 			version: '3.8',
 			services: {
 				[id]: {

--- a/src/routes/services/[id]/ghost/start.json.ts
+++ b/src/routes/services/[id]/ghost/start.json.ts
@@ -11,6 +11,7 @@ import yaml from 'js-yaml';
 import type { RequestHandler } from '@sveltejs/kit';
 import { ErrorHandler, getServiceImage } from '$lib/database';
 import { makeLabelForServices } from '$lib/buildPacks/common';
+import type { ComposeFile } from '$lib/types/composeFile';
 
 export const post: RequestHandler = async (event) => {
 	const { teamId, status, body } = await getUserDetails(event);
@@ -75,7 +76,7 @@ export const post: RequestHandler = async (event) => {
 				config.ghost.environmentVariables[secret.name] = secret.value;
 			});
 		}
-		const composeFile = {
+		const composeFile: ComposeFile = {
 			version: '3.8',
 			services: {
 				[id]: {

--- a/src/routes/services/[id]/languagetool/start.json.ts
+++ b/src/routes/services/[id]/languagetool/start.json.ts
@@ -5,6 +5,7 @@ import yaml from 'js-yaml';
 import type { RequestHandler } from '@sveltejs/kit';
 import { ErrorHandler, getServiceImage } from '$lib/database';
 import { makeLabelForServices } from '$lib/buildPacks/common';
+import type { ComposeFile } from '$lib/types/composeFile';
 
 export const post: RequestHandler = async (event) => {
 	const { teamId, status, body } = await getUserDetails(event);
@@ -32,7 +33,7 @@ export const post: RequestHandler = async (event) => {
 				config.environmentVariables[secret.name] = secret.value;
 			});
 		}
-		const composeFile = {
+		const composeFile: ComposeFile = {
 			version: '3.8',
 			services: {
 				[id]: {

--- a/src/routes/services/[id]/meilisearch/start.json.ts
+++ b/src/routes/services/[id]/meilisearch/start.json.ts
@@ -5,6 +5,7 @@ import yaml from 'js-yaml';
 import type { RequestHandler } from '@sveltejs/kit';
 import { ErrorHandler, getServiceImage } from '$lib/database';
 import { makeLabelForServices } from '$lib/buildPacks/common';
+import type { ComposeFile } from '$lib/types/composeFile';
 
 export const post: RequestHandler = async (event) => {
 	const { teamId, status, body } = await getUserDetails(event);
@@ -37,7 +38,7 @@ export const post: RequestHandler = async (event) => {
 				config.environmentVariables[secret.name] = secret.value;
 			});
 		}
-		const composeFile = {
+		const composeFile: ComposeFile = {
 			version: '3.8',
 			services: {
 				[id]: {

--- a/src/routes/services/[id]/minio/start.json.ts
+++ b/src/routes/services/[id]/minio/start.json.ts
@@ -8,6 +8,7 @@ import getPort, { portNumbers } from 'get-port';
 import { getDomain } from '$lib/components/common';
 import { ErrorHandler, getServiceImage } from '$lib/database';
 import { makeLabelForServices } from '$lib/buildPacks/common';
+import type { ComposeFile } from '$lib/types/composeFile';
 
 export const post: RequestHandler = async (event) => {
 	const { teamId, status, body } = await getUserDetails(event);
@@ -55,7 +56,7 @@ export const post: RequestHandler = async (event) => {
 				config.environmentVariables[secret.name] = secret.value;
 			});
 		}
-		const composeFile = {
+		const composeFile: ComposeFile = {
 			version: '3.8',
 			services: {
 				[id]: {

--- a/src/routes/services/[id]/n8n/start.json.ts
+++ b/src/routes/services/[id]/n8n/start.json.ts
@@ -5,6 +5,7 @@ import yaml from 'js-yaml';
 import type { RequestHandler } from '@sveltejs/kit';
 import { ErrorHandler, getServiceImage } from '$lib/database';
 import { makeLabelForServices } from '$lib/buildPacks/common';
+import type { ComposeFile } from '$lib/types/composeFile';
 
 export const post: RequestHandler = async (event) => {
 	const { teamId, status, body } = await getUserDetails(event);
@@ -33,7 +34,7 @@ export const post: RequestHandler = async (event) => {
 				config.environmentVariables[secret.name] = secret.value;
 			});
 		}
-		const composeFile = {
+		const composeFile: ComposeFile = {
 			version: '3.8',
 			services: {
 				[id]: {

--- a/src/routes/services/[id]/nocodb/start.json.ts
+++ b/src/routes/services/[id]/nocodb/start.json.ts
@@ -5,6 +5,7 @@ import yaml from 'js-yaml';
 import type { RequestHandler } from '@sveltejs/kit';
 import { ErrorHandler, getServiceImage } from '$lib/database';
 import { makeLabelForServices } from '$lib/buildPacks/common';
+import type { ComposeFile } from '$lib/types/composeFile';
 
 export const post: RequestHandler = async (event) => {
 	const { teamId, status, body } = await getUserDetails(event);
@@ -30,7 +31,7 @@ export const post: RequestHandler = async (event) => {
 				config.environmentVariables[secret.name] = secret.value;
 			});
 		}
-		const composeFile = {
+		const composeFile: ComposeFile = {
 			version: '3.8',
 			services: {
 				[id]: {

--- a/src/routes/services/[id]/plausibleanalytics/start.json.ts
+++ b/src/routes/services/[id]/plausibleanalytics/start.json.ts
@@ -5,6 +5,7 @@ import yaml from 'js-yaml';
 import type { RequestHandler } from '@sveltejs/kit';
 import { ErrorHandler, getServiceImage } from '$lib/database';
 import { makeLabelForServices } from '$lib/buildPacks/common';
+import type { ComposeFile } from '$lib/types/composeFile';
 
 export const post: RequestHandler = async (event) => {
 	const { teamId, status, body } = await getUserDetails(event);
@@ -120,7 +121,7 @@ COPY ./init.query /docker-entrypoint-initdb.d/init.query
 COPY ./init-db.sh /docker-entrypoint-initdb.d/init-db.sh`;
 
 		await fs.writeFile(`${workdir}/Dockerfile`, Dockerfile);
-		const composeFile = {
+		const composeFile: ComposeFile = {
 			version: '3.8',
 			services: {
 				[id]: {

--- a/src/routes/services/[id]/uptimekuma/start.json.ts
+++ b/src/routes/services/[id]/uptimekuma/start.json.ts
@@ -5,6 +5,7 @@ import yaml from 'js-yaml';
 import type { RequestHandler } from '@sveltejs/kit';
 import { ErrorHandler, getServiceImage } from '$lib/database';
 import { makeLabelForServices } from '$lib/buildPacks/common';
+import type { ComposeFile } from '$lib/types/composeFile';
 
 export const post: RequestHandler = async (event) => {
 	const { teamId, status, body } = await getUserDetails(event);
@@ -31,7 +32,7 @@ export const post: RequestHandler = async (event) => {
 				config.environmentVariables[secret.name] = secret.value;
 			});
 		}
-		const composeFile = {
+		const composeFile: ComposeFile = {
 			version: '3.8',
 			services: {
 				[id]: {

--- a/src/routes/services/[id]/vaultwarden/start.json.ts
+++ b/src/routes/services/[id]/vaultwarden/start.json.ts
@@ -5,6 +5,7 @@ import yaml from 'js-yaml';
 import type { RequestHandler } from '@sveltejs/kit';
 import { getServiceImage, ErrorHandler } from '$lib/database';
 import { makeLabelForServices } from '$lib/buildPacks/common';
+import type { ComposeFile } from '$lib/types/composeFile';
 
 export const post: RequestHandler = async (event) => {
 	const { teamId, status, body } = await getUserDetails(event);
@@ -32,7 +33,7 @@ export const post: RequestHandler = async (event) => {
 				config.environmentVariables[secret.name] = secret.value;
 			});
 		}
-		const composeFile = {
+		const composeFile: ComposeFile = {
 			version: '3.8',
 			services: {
 				[id]: {

--- a/src/routes/services/[id]/vscodeserver/start.json.ts
+++ b/src/routes/services/[id]/vscodeserver/start.json.ts
@@ -5,6 +5,7 @@ import yaml from 'js-yaml';
 import type { RequestHandler } from '@sveltejs/kit';
 import { ErrorHandler, getServiceImage } from '$lib/database';
 import { makeLabelForServices } from '$lib/buildPacks/common';
+import type { ComposeFile } from '$lib/types/composeFile';
 
 export const post: RequestHandler = async (event) => {
 	const { teamId, status, body } = await getUserDetails(event);
@@ -41,7 +42,7 @@ export const post: RequestHandler = async (event) => {
 				config.environmentVariables[secret.name] = secret.value;
 			});
 		}
-		const composeFile = {
+		const composeFile: ComposeFile = {
 			version: '3.8',
 			services: {
 				[id]: {

--- a/src/routes/services/[id]/wordpress/start.json.ts
+++ b/src/routes/services/[id]/wordpress/start.json.ts
@@ -5,6 +5,7 @@ import yaml from 'js-yaml';
 import type { RequestHandler } from '@sveltejs/kit';
 import { ErrorHandler, getServiceImage } from '$lib/database';
 import { makeLabelForServices } from '$lib/buildPacks/common';
+import type { ComposeFile } from '$lib/types/composeFile';
 
 export const post: RequestHandler = async (event) => {
 	const { teamId, status, body } = await getUserDetails(event);
@@ -65,7 +66,7 @@ export const post: RequestHandler = async (event) => {
 				config.wordpress.environmentVariables[secret.name] = secret.value;
 			});
 		}
-		const composeFile = {
+		const composeFile: ComposeFile = {
 			version: '3.8',
 			services: {
 				[id]: {


### PR DESCRIPTION
I thought it made sense for us to insert types for the objects in the project. I started by defining types for the docker-compose.yaml files. The defined types can still be greatly extended, but they meet our current needs. What do you think about typing the project?