### PR TITLE
Add plausible/analytics:stable docker tag

### DIFF
--- a/src/lib/database/common.ts
+++ b/src/lib/database/common.ts
@@ -110,7 +110,7 @@ export const supportedServiceTypesAndVersions = [
 		fancyName: 'Plausible Analytics',
 		baseImage: 'plausible/analytics',
 		images: ['bitnami/postgresql:13.2.0', 'yandex/clickhouse-server:21.3.2.5'],
-		versions: ['latest'],
+		versions: ['latest', 'stable'],
 		ports: {
 			main: 8000
 		}


### PR DESCRIPTION
Hi

I would like to be able to use a different docker tag for plausible analytics, is this the correct way to change this?

Thanks