### PR TITLE
fix: remove lint errors in database services

### DIFF
--- a/src/lib/database/services.ts
+++ b/src/lib/database/services.ts
@@ -18,7 +18,7 @@ const include: Prisma.ServiceInclude = {
 	hasura: true,
 	fider: true
 };
-export async function listServicesWithIncludes() {
+export async function listServicesWithIncludes(): Promise<Service[]> {
 	return await prisma.service.findMany({
 		include,
 		orderBy: { createdAt: 'desc' }
@@ -418,7 +418,6 @@ export async function updateWordpress({
 	fqdn,
 	name,
 	exposePort,
-	ownMysql,
 	mysqlDatabase,
 	extraConfig,
 	mysqlHost,


### PR DESCRIPTION
There were some minor lint errors that I found in vscode that I thought I would remove 😄 

1. Line 21 was missing a return type
2. Line 421 was simply unused