### PR TITLE
Removed space from the version number

### DIFF
--- a/src/lib/components/common.ts
+++ b/src/lib/components/common.ts
@@ -62,7 +62,7 @@ export const supportedDatabaseTypesAndVersions = [
 		name: 'postgresql',
 		fancyName: 'PostgreSQL',
 		baseImage: 'bitnami/postgresql',
-		versions: ['14.2.0', '13.6.0', '12.10.0	', '11.15.0', '10.20.0']
+		versions: ['14.2.0', '13.6.0', '12.10.0', '11.15.0', '10.20.0']
 	},
 	{
 		name: 'redis',


### PR DESCRIPTION
There was a space in the postgresql 12.10.0 version which broke the database deployment.