### PR TITLE
Upgrade PSQL version to fix an issue with indices corruption

### DIFF
--- a/src/lib/components/common.ts
+++ b/src/lib/components/common.ts
@@ -62,7 +62,7 @@ export const supportedDatabaseTypesAndVersions = [
 		name: 'postgresql',
 		fancyName: 'PostgreSQL',
 		baseImage: 'bitnami/postgresql',
-		versions: ['14.2.0', '13.6.0', '12.10.0', '11.15.0', '10.20.0']
+		versions: ['14.4.0', '13.6.0', '12.10.0', '11.15.0', '10.20.0']
 	},
 	{
 		name: 'redis',


### PR DESCRIPTION
https://www.postgresql.org/about/news/postgresql-144-released-2470/

PostgreSQL 14.4 fixes an issue with [CREATE INDEX CONCURRENTLY](https://www.postgresql.org/docs/current/sql-createindex.html) and [REINDEX CONCURRENTLY](https://www.postgresql.org/docs/current/sql-reindex.html) that could cause silent data corruption of indexes. Prior to the fix, CREATE INDEX CONCURRENTLY and REINDEX CONCURRENTLY could build indexes that would have missing entries, causing SELECT queries that used the index to not find certain rows.

Bitnami docker image is already [available for 14.4.0](https://hub.docker.com/layers/postgresql/bitnami/postgresql/14.4.0/images/sha256-005d2a2ecc225967137d301d74fb065fbb2934eb505dda0c4c787b765bf84e10)