### PR TITLE
Changing Deno buildpack to not run main before copying directory

### DIFF
--- a/apps/api/src/lib/buildPacks/deno.ts
+++ b/apps/api/src/lib/buildPacks/deno.ts
@@ -42,9 +42,8 @@ const createDockerfile = async (data, image): Promise<void> => {
 		Dockerfile.push(`COPY .${baseDirectory || ''}/deps.ts /app`);
 		Dockerfile.push(`RUN deno cache deps.ts`);
 	}
-	Dockerfile.push(`COPY ${denoMainFile} /app`);
-	Dockerfile.push(`RUN deno cache ${denoMainFile}`);
 	Dockerfile.push(`COPY .${baseDirectory || ''} ./`);
+	Dockerfile.push(`RUN deno cache ${denoMainFile}`);
 	Dockerfile.push(`ENV NO_COLOR true`);
 	Dockerfile.push(`EXPOSE ${port}`);
 	Dockerfile.push(`CMD deno run ${denoOptions ? denoOptions.split(' ') : ''} ${denoMainFile}`);


### PR DESCRIPTION
## Motivation

The Dockerfile on Deno buildpack was running the command `deno cache <main-file>`  before copying the whole project to the working directory. This results in an error if the main file imports any other local file, as the deno cache command will try to build the main file without these local dependencies being there. 

This is not necessary to do before running `deno cache` on the `deps.ts` file because the deps file only manages external dependencies, accordingly to the suggestions made in the [deno manual](https://deno.land/manual/examples/manage_dependencies).

## Proposed solution

Copying the whole project to the working directory before running `deno cache` on the main file.

## Related issue
#478