### PR TITLE
Fix: Route to the correct path when creating destination from db config

### DIFF
--- a/apps/ui/src/routes/databases/[id]/configuration/destination.svelte
+++ b/apps/ui/src/routes/databases/[id]/configuration/destination.svelte
@@ -65,7 +65,7 @@
 				{$t('application.configuration.no_configurable_destination')}
 			</div>
 			<div class="flex justify-center">
-				<a href="/new/destination" sveltekit:prefetch class="add-icon bg-sky-600 hover:bg-sky-500">
+				<a href="/destinations/new" sveltekit:prefetch class="add-icon bg-sky-600 hover:bg-sky-500">
 					<svg
 						class="w-6"
 						xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Currently, trying to create a destination from the db config UI throws an error because the link is incorrect/outdated.
<img width="845" alt="Screenshot 2022-08-30 at 06 49 27" src="https://user-images.githubusercontent.com/7240688/187351682-031cbddd-a7ad-4e23-937d-56baab487974.png">
