### PR TITLE
fix: default build command for Node is null

### DIFF
--- a/apps/api/src/lib/buildPacks/common.ts
+++ b/apps/api/src/lib/buildPacks/common.ts
@@ -348,7 +348,7 @@ export const setDefaultConfiguration = async (data: any) => {
 	if (!startCommand && buildPack !== 'static' && buildPack !== 'laravel')
 		startCommand = template?.startCommand || 'yarn start';
 	if (!buildCommand && buildPack !== 'static' && buildPack !== 'laravel')
-		buildCommand = template?.buildCommand || null;
+		buildCommand = template?.buildCommand || 'yarn build';
 	if (!publishDirectory) publishDirectory = template?.publishDirectory || null;
 	if (baseDirectory) {
 		if (!baseDirectory.startsWith('/')) baseDirectory = `/${baseDirectory}`;


### PR DESCRIPTION
I added the `yarn build` as default because in the UI for Node buildpack it shows the default as that command but it is actually `null`.

Before:
![image](https://user-images.githubusercontent.com/76017384/188295439-bc5ac02a-e883-41df-bddc-8f5dccfd58c8.png)

Now:
![image](https://user-images.githubusercontent.com/76017384/188295443-eb222c26-6050-461f-b9cd-59556af0532f.png)
