### PR TITLE
fix: MinIO invalid login

### DIFF
--- a/apps/api/src/lib/services/handlers.ts
+++ b/apps/api/src/lib/services/handlers.ts
@@ -314,7 +314,7 @@ async function startMinioService(request: FastifyRequest<ServiceStartStop>) {
             destinationDocker,
             persistentStorage,
             exposePort,
-            minio: { rootUser, rootUserPassword },
+            minio: { rootUser, rootUserPassword, apiFqdn },
             serviceSecret
         } = service;
 
@@ -333,7 +333,7 @@ async function startMinioService(request: FastifyRequest<ServiceStartStop>) {
                 image: `${image}:${version}`,
                 volumes: [`${id}-minio-data:/data`],
                 environmentVariables: {
-                    MINIO_SERVER_URL: fqdn,
+                    MINIO_SERVER_URL: apiFqdn,
                     MINIO_DOMAIN: getDomain(fqdn),
                     MINIO_ROOT_USER: rootUser,
                     MINIO_ROOT_PASSWORD: rootUserPassword,


### PR DESCRIPTION
Seems there was an issue with MinIO and it returning invalid login when utilizing the provided credentials. I have tracked down the issue to the handler.ts file where the environment variables for the service are set.

MINIO_SERVER_URL is set to the console fqdn changed it to the api fqdn allows it to login again. Also just removing MINIO_SERVER_URL fixes it. It would seem old version of coolify didn't set the MINIO_SERVER_URL.