### PR TITLE
fix: changing umami image URL to get latest version

### DIFF
--- a/apps/api/src/lib/services/supportedVersions.ts
+++ b/apps/api/src/lib/services/supportedVersions.ts
@@ -116,7 +116,7 @@ export const supportedServiceTypesAndVersions = [
 	{
 		name: 'umami',
 		fancyName: 'Umami',
-		baseImage: 'ghcr.io/mikecao/umami',
+		baseImage: 'ghcr.io/umami-software/umami',
 		images: ['postgres:12-alpine'],
 		versions: ['postgresql-latest'],
 		recommendedVersion: 'postgresql-latest',


### PR DESCRIPTION
# Problem 

Noticed that the umami service is not up to date with the latest version. 

### Current
![image](https://user-images.githubusercontent.com/48529975/189510057-dd80cd3c-d7c2-4408-a906-735d3726183c.png)

### Newest
![image](https://user-images.githubusercontent.com/48529975/189510070-cdf007d4-809e-4cc8-98d8-e9980df52a56.png)

# Solution

Made a little bit of research and found that the URL to the image of the service that has the more recent versions is now https://github.com/umami-software/umami/pkgs/container/umami instead of https://github.com/mikecao/umami/pkgs/container/umami that we're using today.

Changed the URL and it seems okay!
