### PR TITLE
Fix deno options string

### DIFF
--- a/apps/api/src/lib/buildPacks/deno.ts
+++ b/apps/api/src/lib/buildPacks/deno.ts
@@ -49,7 +49,7 @@ const createDockerfile = async (data, image): Promise<void> => {
 	Dockerfile.push(`RUN deno cache ${denoMainFile}`);
 	Dockerfile.push(`ENV NO_COLOR true`);
 	Dockerfile.push(`EXPOSE ${port}`);
-	Dockerfile.push(`CMD deno run ${denoOptions ? denoOptions.split(' ') : ''} ${denoMainFile}`);
+	Dockerfile.push(`CMD deno run ${denoOptions || ''} ${denoMainFile}`);
 	await fs.writeFile(`${workdir}/Dockerfile`, Dockerfile.join('\n'));
 };
 


### PR DESCRIPTION
When I specify options for the deno run script:

<img width="1170" alt="image" src="https://user-images.githubusercontent.com/412859/194550782-29097240-4acc-44a9-a94a-45358fc147b4.png">

I get these errors:

`2022-10-07T12:01:13.331407389Z error: Found argument '--allow-env,--allow-read' which wasn't expected, or isn't valid in this context`.

This PR fixes the issue.