### PR TITLE
replace images to get arm64 support in plausible service

### DIFF
--- a/apps/api/devTemplates.yaml
+++ b/apps/api/devTemplates.yaml
@@ -2976,7 +2976,7 @@
       label: Webhook URL
       defaultValue: $$generate_fqdn
       description: ""
-- templateVersion: 1.0.0
+- templateVersion: 1.1.0
   defaultVersion: stable
   documentation: https://plausible.io/doc/
   type: plausibleanalytics
@@ -3013,9 +3013,9 @@
         - "8000"
     $$id-postgresql:
       name: PostgreSQL
-      image: "bitnami/postgresql:13.2.0"
+      image: "postgres:14-alpine"
       volumes:
-        - "$$id-postgresql-data:/bitnami/postgresql"
+        - "$$id-postgresql-data:/postgresql"
       environment:
         - POSTGRESQL_PASSWORD=$$secret_postgresql_password
         - POSTGRESQL_USERNAME=$$config_postgresql_username
@@ -3024,7 +3024,7 @@
       name: Clickhouse
       volumes:
         - "$$id-clickhouse-data:/var/lib/clickhouse"
-      image: "yandex/clickhouse-server:21.3.2.5"
+      image: "clickhouse/clickhouse-server:22.9-alpine"
       ulimits:
         nofile:
           soft: 262144


### PR DESCRIPTION
I tried to run the Plausible service on my arm64 server, but I got an error in the services **Clickhouse** and **Postgres**, while both has arm64 support. 

I see that Coolify Plausible services uses a non-official images for that service, there's a major reason for that?

Coolify Plausible service uses:
- bitnami/postgres
- yandex/clickhouse-server

The official Plausible example for docker-compose uses:
- postgres:14-alpine
- clickhouse/clickhouse-server:22.9-alpine

I made these changes, but IDK if there's more work to do to replace those images.

https://github.com/plausible/hosting/blob/master/docker-compose.yml
