### PR TITLE
feat(api): name label

### DIFF
--- a/apps/api/src/lib/buildPacks/common.ts
+++ b/apps/api/src/lib/buildPacks/common.ts
@@ -644,6 +644,7 @@ export function makeLabelForStandaloneApplication({
 		`coolify.version=${version}`,
 		`coolify.applicationId=${applicationId}`,
 		`coolify.type=standalone-application`,
+		`coolify.name=${name}`,
 		`coolify.configuration=${base64Encode(
 			JSON.stringify({
 				applicationId,

--- a/apps/api/src/lib/common.ts
+++ b/apps/api/src/lib/common.ts
@@ -1075,6 +1075,7 @@ export async function makeLabelForStandaloneDatabase({ id, image, volume }) {
 		'coolify.managed=true',
 		`coolify.version=${version}`,
 		`coolify.type=standalone-database`,
+		`coolify.name=${database.name}`,
 		`coolify.configuration=${base64Encode(
 			JSON.stringify({
 				version,


### PR DESCRIPTION
Implements a `coolify.name` label with the application's name.

## Why?

I was setting up metrics for my server and wanted to display the application's name instead of the application id from coolify.