### PR TITLE
Feat:  Create many secrets

### DIFF
--- a/apps/api/src/routes/api/v1/applications/index.ts
+++ b/apps/api/src/routes/api/v1/applications/index.ts
@@ -1,8 +1,8 @@
 import { FastifyPluginAsync } from 'fastify';
 import { OnlyId } from '../../../../types';
-import { cancelDeployment, checkDNS, checkDomain, checkRepository, cleanupUnconfiguredApplications, deleteApplication, deleteSecret, deleteStorage, deployApplication, getApplication, getApplicationLogs, getApplicationStatus, getBuildIdLogs, getBuildPack, getBuilds, getDockerImages, getGitHubToken, getGitLabSSHKey, getImages, getPreviews, getPreviewStatus, getSecrets, getStorages, getUsage, getUsageByContainer, listApplications, loadPreviews, newApplication, restartApplication, restartPreview, saveApplication, saveApplicationSettings, saveApplicationSource, saveBuildPack, saveConnectedDatabase, saveDeployKey, saveDestination, saveGitLabSSHKey,  saveRegistry,  saveRepository, saveSecret, saveStorage, stopApplication, stopPreviewApplication, updatePreviewSecret, updateSecret } from './handlers';
+import { cancelDeployment, checkDNS, checkDomain, checkRepository, cleanupUnconfiguredApplications, deleteApplication, deleteSecret, deleteStorage, deployApplication, getApplication, getApplicationLogs, getApplicationStatus, getBuildIdLogs, getBuildPack, getBuilds, getDockerImages, getGitHubToken, getGitLabSSHKey, getImages, getPreviews, getPreviewStatus, getSecrets, getStorages, getUsage, getUsageByContainer, listApplications, loadPreviews, newApplication, restartApplication, restartPreview, saveApplication, saveApplicationSettings, saveApplicationSource, saveBuildPack, saveConnectedDatabase, saveDeployKey, saveDestination, saveGitLabSSHKey,  saveRegistry,  saveRepository, saveSecret, saveStorage, stopApplication, stopPreviewApplication, updatePreviewSecret, updateSecret, saveManySecrets } from './handlers';
 
-import type { CancelDeployment, CheckDNS, CheckDomain, CheckRepository, DeleteApplication, DeleteSecret, DeleteStorage, DeployApplication, GetApplicationLogs, GetBuildIdLogs, GetBuilds, GetImages, RestartApplication, RestartPreviewApplication, SaveApplication, SaveApplicationSettings, SaveApplicationSource, SaveDeployKey, SaveDestination, SaveSecret, SaveStorage, StopPreviewApplication } from './types';
+import type { CancelDeployment, CheckDNS, CheckDomain, CheckRepository, DeleteApplication, DeleteSecret, DeleteStorage, DeployApplication, GetApplicationLogs, GetBuildIdLogs, GetBuilds, GetImages, RestartApplication, RestartPreviewApplication, SaveApplication, SaveApplicationSettings, SaveApplicationSource, SaveDeployKey, SaveDestination, SaveSecret, SaveStorage, StopPreviewApplication, SaveManySecrets } from './types';
 
 const root: FastifyPluginAsync = async (fastify): Promise<void> => {
     fastify.addHook('onRequest', async (request) => {
@@ -32,6 +32,7 @@ const root: FastifyPluginAsync = async (fastify): Promise<void> => {
 
     fastify.get<OnlyId>('/:id/secrets', async (request) => await getSecrets(request));
     fastify.post<SaveSecret>('/:id/secrets', async (request, reply) => await saveSecret(request, reply));
+    fastify.post<SaveManySecrets>('/:id/secrets/many', async (request, reply) => await saveManySecrets(request, reply));
     fastify.put<SaveSecret>('/:id/secrets', async (request, reply) => await updateSecret(request, reply));
     fastify.put<SaveSecret>('/:id/secrets/preview', async (request, reply) => await updatePreviewSecret(request, reply));
     fastify.delete<DeleteSecret>('/:id/secrets', async (request) => await deleteSecret(request));

--- a/apps/api/src/routes/api/v1/applications/types.ts
+++ b/apps/api/src/routes/api/v1/applications/types.ts
@@ -75,6 +75,18 @@ export interface SaveSecret extends OnlyId {
         isNew: boolean
     }
 }
+export interface SaveManySecrets extends OnlyId {
+    Body: {
+        forceAlreadyExist: boolean,
+        secrets: {
+            name: string,
+            value: string,
+            isBuildSecret: boolean,
+            previewSecret: boolean,
+            isNew: boolean
+        }[]
+    }
+}
 export interface DeleteSecret extends OnlyId {
     Body: { name: string }
 }


### PR DESCRIPTION
- #769

On this route is possible create many secretes, in one request, you can set if need replace repeated secrets. When not define and has one with some name, this it will be skipped.

New route: `/api/v1/applications/:id/secrets/many`

Interface for the route:
```
export interface SaveManySecrets extends OnlyId {
    Body: {
        forceAlreadyExist: boolean,
        secrets: {
            name: string,
            value: string,
            isBuildSecret: boolean,
            previewSecret: boolean,
            isNew: boolean
        }[]
    }
}
```