### PR TITLE
Add auto-detect=false to Traefik conten-type automatic handling 

### DIFF
--- a/apps/api/src/lib/common.ts
+++ b/apps/api/src/lib/common.ts
@@ -727,6 +727,7 @@ export async function startTraefikProxy(id: string): Promise<void> {
 			--certificatesresolvers.letsencrypt.acme.httpchallenge=true \
 			--certificatesresolvers.letsencrypt.acme.storage=/etc/traefik/acme/acme.json \
 			--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web \
+			--label=traefik.http.middlewares.autodetect.contenttype.autodetect=false
 			--log.level=error`
 		});
 		await prisma.destinationDocker.update({

--- a/apps/api/src/lib/common.ts
+++ b/apps/api/src/lib/common.ts
@@ -727,7 +727,7 @@ export async function startTraefikProxy(id: string): Promise<void> {
 			--certificatesresolvers.letsencrypt.acme.httpchallenge=true \
 			--certificatesresolvers.letsencrypt.acme.storage=/etc/traefik/acme/acme.json \
 			--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web \
-			--label=traefik.http.middlewares.autodetect.contenttype.autodetect=false
+			--traefik.http.middlewares.autodetect.contenttype.autodetect=false \
 			--log.level=error`
 		});
 		await prisma.destinationDocker.update({


### PR DESCRIPTION
Reason: If on the same port there is a multiplexer that supports many protocols and infers them from the content-type passed from the client, then mess up with traefik auto detection feature