### PR TITLE
fix the console error on Documentation hover

### DIFF
--- a/apps/ui/src/routes/__layout.svelte
+++ b/apps/ui/src/routes/__layout.svelte
@@ -299,10 +299,9 @@
 						</a>
 						<a
 							id="documentation"
-							sveltekit:prefetch
 							href="https://docs.coollabs.io/coolify/"
 							target="_blank"
-							rel="noopener noreferrer"
+							rel="noreferrer external"
 							class="icons hover:text-info"
 						>
 							<svg


### PR DESCRIPTION
There is a console-error while hovering the newly implemented Documentation link. The main issue was the sveltekit:prefetch but after reading the [svelte-link-documentation](https://kit.svelte.dev/docs/link-options#data-sveltekit-reload) I added the "external" to rel

Thanks to @rickaard for pointing this out to me