### PR TITLE
feat(git-source): Add support for custom SSH user for GitLab self-hosted

### DIFF
--- a/apps/api/prisma/migrations/20221221140911_git_source_custom_user/migration.sql
+++ b/apps/api/prisma/migrations/20221221140911_git_source_custom_user/migration.sql
@@ -1,0 +1,27 @@
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_GitSource" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "forPublic" BOOLEAN NOT NULL DEFAULT false,
+    "type" TEXT,
+    "apiUrl" TEXT,
+    "htmlUrl" TEXT,
+    "customPort" INTEGER NOT NULL DEFAULT 22,
+    "customUser" TEXT NOT NULL DEFAULT 'git',
+    "organization" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "githubAppId" TEXT,
+    "gitlabAppId" TEXT,
+    "isSystemWide" BOOLEAN NOT NULL DEFAULT false,
+    CONSTRAINT "GitSource_gitlabAppId_fkey" FOREIGN KEY ("gitlabAppId") REFERENCES "GitlabApp" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "GitSource_githubAppId_fkey" FOREIGN KEY ("githubAppId") REFERENCES "GithubApp" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_GitSource" ("apiUrl", "createdAt", "customPort", "forPublic", "githubAppId", "gitlabAppId", "htmlUrl", "id", "isSystemWide", "name", "organization", "type", "updatedAt") SELECT "apiUrl", "createdAt", "customPort", "forPublic", "githubAppId", "gitlabAppId", "htmlUrl", "id", "isSystemWide", "name", "organization", "type", "updatedAt" FROM "GitSource";
+DROP TABLE "GitSource";
+ALTER TABLE "new_GitSource" RENAME TO "GitSource";
+CREATE UNIQUE INDEX "GitSource_githubAppId_key" ON "GitSource"("githubAppId");
+CREATE UNIQUE INDEX "GitSource_gitlabAppId_key" ON "GitSource"("gitlabAppId");
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -325,6 +325,7 @@ model GitSource {
   apiUrl       String?
   htmlUrl      String?
   customPort   Int           @default(22)
+  customUser   String        @default("git")
   organization String?
   createdAt    DateTime      @default(now())
   updatedAt    DateTime      @updatedAt

--- a/apps/api/src/jobs/deployApplication.ts
+++ b/apps/api/src/jobs/deployApplication.ts
@@ -419,6 +419,7 @@ import * as buildpacks from '../lib/buildPacks';
 										githubAppId: gitSource.githubApp?.id,
 										gitlabAppId: gitSource.gitlabApp?.id,
 										customPort: gitSource.customPort,
+										customUser: gitSource.customUser,
 										gitCommitHash,
 										configuration,
 										repository,

--- a/apps/api/src/lib/importers/gitlab.ts
+++ b/apps/api/src/lib/importers/gitlab.ts
@@ -12,7 +12,8 @@ export default async function ({
 	buildId,
 	privateSshKey,
 	customPort,
-	forPublic
+	forPublic,
+	customUser,
 }: {
 	applicationId: string;
 	workdir: string;
@@ -25,6 +26,7 @@ export default async function ({
 	privateSshKey: string;
 	customPort: number;
 	forPublic: boolean;
+	customUser: string;
 }): Promise<string> {
 	const url = htmlUrl.replace('https://', '').replace('http://', '').replace(/\/$/, '');
 	if (!forPublic) {
@@ -53,7 +55,7 @@ export default async function ({
 	} else {
 		await executeCommand({
 			command:
-				`git clone -q -b ${branch} git@${url}:${repository}.git --config core.sshCommand="ssh -p ${customPort} -q -i ${repodir}id.rsa -o StrictHostKeyChecking=no" ${workdir}/ && cd ${workdir}/ && git checkout ${gitCommitHash || ""} && git submodule update --init --recursive && git lfs pull && cd .. `, shell: true
+				`git clone -q -b ${branch} ${customUser}@${url}:${repository}.git --config core.sshCommand="ssh -p ${customPort} -q -i ${repodir}id.rsa -o StrictHostKeyChecking=no" ${workdir}/ && cd ${workdir}/ && git checkout ${gitCommitHash || ""} && git submodule update --init --recursive && git lfs pull && cd .. `, shell: true
 		}
 		);
 	}

--- a/apps/api/src/routes/api/v1/sources/handlers.ts
+++ b/apps/api/src/routes/api/v1/sources/handlers.ts
@@ -22,11 +22,11 @@ export async function listSources(request: FastifyRequest) {
 export async function saveSource(request, reply) {
     try {
         const { id } = request.params
-        let { name, htmlUrl, apiUrl, customPort, isSystemWide } = request.body
+        let { name, htmlUrl, apiUrl, customPort, customUser, isSystemWide } = request.body
         if (customPort) customPort = Number(customPort)
         await prisma.gitSource.update({
             where: { id },
-            data: { name, htmlUrl, apiUrl, customPort, isSystemWide }
+            data: { name, htmlUrl, apiUrl, customPort, customUser, isSystemWide }
         });
         return reply.code(201).send()
     } catch ({ status, message }) {
@@ -48,6 +48,7 @@ export async function getSource(request: FastifyRequest<OnlyId>) {
                     apiUrl: null,
                     organization: null,
                     customPort: 22,
+                    customUser: 'git',
                 },
                 settings
             }
@@ -102,7 +103,7 @@ export async function saveGitHubSource(request: FastifyRequest<SaveGitHubSource>
         const { teamId } = request.user
 
         const { id } = request.params
-        let { name, htmlUrl, apiUrl, organization, customPort, isSystemWide } = request.body
+        let { name, htmlUrl, apiUrl, organization, customPort, customUser, isSystemWide } = request.body
 
         if (customPort) customPort = Number(customPort)
         if (id === 'new') {
@@ -115,6 +116,7 @@ export async function saveGitHubSource(request: FastifyRequest<SaveGitHubSource>
                     apiUrl,
                     organization,
                     customPort,
+                    customUser,
                     isSystemWide,
                     type: 'github',
                     teams: { connect: { id: teamId } }
@@ -133,7 +135,7 @@ export async function saveGitLabSource(request: FastifyRequest<SaveGitLabSource>
     try {
         const { id } = request.params
         const { teamId } = request.user
-        let { type, name, htmlUrl, apiUrl, oauthId, appId, appSecret, groupName, customPort } =
+        let { type, name, htmlUrl, apiUrl, oauthId, appId, appSecret, groupName, customPort, customUser } =
             request.body
 
         if (oauthId) oauthId = Number(oauthId);
@@ -142,7 +144,7 @@ export async function saveGitLabSource(request: FastifyRequest<SaveGitLabSource>
 
         if (id === 'new') {
             const newId = cuid()
-            await prisma.gitSource.create({ data: { id: newId, type, apiUrl, htmlUrl, name, customPort, teams: { connect: { id: teamId } } } });
+            await prisma.gitSource.create({ data: { id: newId, type, apiUrl, htmlUrl, name, customPort, customUser, teams: { connect: { id: teamId } } } });
             await prisma.gitlabApp.create({
                 data: {
                     teams: { connect: { id: teamId } },
@@ -158,7 +160,7 @@ export async function saveGitLabSource(request: FastifyRequest<SaveGitLabSource>
                 id: newId
             }
         } else {
-            await prisma.gitSource.update({ where: { id }, data: { type, apiUrl, htmlUrl, name, customPort } });
+            await prisma.gitSource.update({ where: { id }, data: { type, apiUrl, htmlUrl, name, customPort, customUser } });
             await prisma.gitlabApp.update({
                 where: { id },
                 data: {

--- a/apps/api/src/routes/api/v1/sources/types.ts
+++ b/apps/api/src/routes/api/v1/sources/types.ts
@@ -21,6 +21,7 @@ export interface SaveGitLabSource extends OnlyId {
         appSecret: string,
         groupName: string,
         customPort: number,
+        customUser: string,
     }
 }
 export interface CheckGitLabOAuthId extends OnlyId {

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -325,6 +325,7 @@ model GitSource {
   apiUrl       String?
   htmlUrl      String?
   customPort   Int           @default(22)
+  customUser   String        @default("git")
   organization String?
   createdAt    DateTime      @default(now())
   updatedAt    DateTime      @updatedAt

--- a/apps/ui/src/routes/sources/[id]/_Gitlab.svelte
+++ b/apps/ui/src/routes/sources/[id]/_Gitlab.svelte
@@ -51,7 +51,8 @@
 					appId: source.gitlabApp.appId,
 					appSecret: source.gitlabApp.appSecret,
 					groupName: source.gitlabApp.groupName,
-					customPort: source.customPort
+					customPort: source.customPort,
+					customUser: source.customUser,
 				});
 				const from = $page.url.searchParams.get('from');
 				if (from) {
@@ -70,7 +71,8 @@
 					name: source.name,
 					htmlUrl: source.htmlUrl.replace(/\/$/, ''),
 					apiUrl: source.apiUrl.replace(/\/$/, ''),
-					customPort: source.customPort
+					customPort: source.customPort,
+					customuser: source.customuser
 				});
 				return addToast({
 					message: 'Configuration saved.',
@@ -244,6 +246,22 @@
 				/>
 			</div>
 			{#if selfHosted}
+				<div class="grid grid-cols-2 items-center">
+					<label for="customPort" class="text-base font-bold text-stone-100"
+						>Custom SSH User <Explainer
+							explanation={'If you use a self-hosted version of Git, you can provide a custom SSH user for all the Git related actions.'}
+						/></label
+					>
+					<input
+						class="w-full"
+						name="customUser"
+						id="customUser"
+						disabled={!selfHosted}
+						readonly={!selfHosted}
+						required
+						bind:value={source.customUser}
+					/>
+				</div>
 				<div class="grid grid-cols-2 items-center">
 					<label for="customPort" class="text-base font-bold text-stone-100"
 						>Custom SSH Port <Explainer


### PR DESCRIPTION
This PR aims to fix #803 by adding a field to change the SSH user used to clone repositories from a self-hosted GitLab instance. 

I am not 100% confident on my implementation as I am not very familiar with Svelte and Prisma.