### PR TITLE
[Bug] Fixed issue with docker-compose not loading for Gitlab instances

### DIFF
--- a/apps/ui/src/routes/applications/[id]/index.svelte
+++ b/apps/ui/src/routes/applications/[id]/index.svelte
@@ -366,11 +366,12 @@
 	async function reloadCompose() {
 		if (loading.reloadCompose) return;
 		loading.reloadCompose = true;
-		const composeLocation = application.dockerComposeFileLocation.startsWith('/')
-			? application.dockerComposeFileLocation
-			: `/${application.dockerComposeFileLocation}`;
 		try {
 			if (application.gitSource.type === 'github') {
+				const composeLocation = application.dockerComposeFileLocation.startsWith('/')
+				? application.dockerComposeFileLocation
+				: `/${application.dockerComposeFileLocation}`;
+				
 				const headers = isPublicRepository
 					? {}
 					: {
@@ -397,6 +398,17 @@
 				if (!$appSession.tokens.gitlab) {
 					await getGitlabToken();
 				}
+				
+				const composeLocation = application.dockerComposeFileLocation.startsWith('/')
+				? application.dockerComposeFileLocation.substring(1) // Remove the '/' from the start
+				: application.dockerComposeFileLocation;
+				
+				// If the file is in a subdirectory, lastIndex will be > 0
+				// Otherwise it will be -1 and path will be an empty string
+				const lastIndex = composeLocation.lastIndexOf('/') + 1
+				const path = composeLocation.substring(0, lastIndex)
+				const fileName = composeLocation.substring(lastIndex)
+								
 				const headers = isPublicRepository
 					? {}
 					: {
@@ -404,13 +416,13 @@
 					  };
 				const url = isPublicRepository
 					? ``
-					: `/v4/projects/${application.projectId}/repository/tree`;
+					: `/v4/projects/${application.projectId}/repository/tree?path=${path}`;
 				const files = await get(`${apiUrl}${url}`, {
 					...headers
 				});
 				const dockerComposeFileYml = files.find(
 					(file: { name: string; type: string }) =>
-						file.name === composeLocation && file.type === 'blob'
+						file.name === fileName && file.type === 'blob'
 				);
 				const id = dockerComposeFileYml.id;
 


### PR DESCRIPTION
There is an issue with loading docker compose files for a GitLab instance:

Currently, a `/` is automatically added to the filename which returns `undefined` when it tries to look up the docker-compose file

![image](https://user-images.githubusercontent.com/32551958/209999308-080b74bd-a734-46ca-aecf-b3636626a806.png)

This causes the following error to be displayed when trying to load the docker-compose.yaml file

![image](https://user-images.githubusercontent.com/32551958/209999623-152c7546-b70c-4453-b1d6-cb650e7ac1cf.png)


I've changed the current behavior to only apply to GitHub instances instead of all instances.
For GitLab instances it now does the following:

- Removes any `/` at the beginning of the path
- Works if the file is in a subdirectory (e.g. `/folder/docker-compose.yaml`)



