### PR TITLE
fix: gitlab personal repo listing

### DIFF
--- a/apps/ui/src/routes/applications/[id]/configuration/_GitlabRepositories.svelte
+++ b/apps/ui/src/routes/applications/[id]/configuration/_GitlabRepositories.svelte
@@ -56,6 +56,10 @@
 				Authorization: `Bearer ${$appSession.tokens.gitlab}`
 			});
 			username = user.username;
+			groups.push({
+				full_name: username,
+				name: username
+			});
 			await loadGroups();
 		} catch (error) {
 			loading.base = false;


### PR DESCRIPTION
I've looked into #878 and the code already accounts for personal repositories.
The only thing that is missing is adding the username to the groups list.
Thats what I've done in this PR.

On this note: maybe groups should be renamed to namespaces.
That name would fit for both groups and the personal namespace.
