### PR TITLE
Add structure to the output content that is persisted

### DIFF
--- a/app/Actions/RemoteProcess/TidyOutput.php
+++ b/app/Actions/RemoteProcess/TidyOutput.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Actions\RemoteProcess;
+
+use Illuminate\Support\Collection;
+use Spatie\Activitylog\Models\Activity;
+
+class TidyOutput
+{
+    protected $output;
+
+    public function __construct(
+        protected Activity $activity
+    )
+    {
+    }
+
+    public function __invoke()
+    {
+        $chunks = preg_split(
+            RunRemoteProcess::MARK_REGEX,
+            $this->activity->description,
+            flags: PREG_SPLIT_DELIM_CAPTURE
+        );
+
+        $tidyRows = $this
+            ->joinMarksWithFollowingItem($chunks)
+            ->reject(fn($i) => $i === '')
+            ->map(function ($i) {
+                if (!preg_match('/\|--(\d+)\|(\d+)\|(out|err)--\|(.*)/', $i, $matches)) {
+                    return $i;
+                }
+                [$wholeLine, $sequence, $elapsedTime, $type, $output] = $matches;
+                return [
+                    'sequence' => $sequence,
+                    'time' => $elapsedTime,
+                    'type' => $type,
+                    'output' => $output,
+                ];
+            });
+
+            return $tidyRows
+                ->sortBy(fn($i) => $i['sequence'])
+                ->map(fn($i) => $i['output'])
+                ->implode("\n");
+    }
+
+    /**
+     * Function to join the defined mark, with the output
+     * that is the following element in the array.
+     *
+     * Turns this:
+     *      [
+     *          "|--1|149|out--|",
+     *          "/root\n",
+     *          "|--2|251|out--|",
+     *          "Welcome 1 times 1\n",
+     *          "|--3|366|out--|",
+     *          "Welcome 2 times 2\n",
+     *          "|--4|466|out--|",
+     *          "Welcome 3 times 3\n",
+     *      ]
+     *
+     *  into this:
+     *
+     *      [
+     *          "|--1|149|out--|/root\n",
+     *          "|--2|251|out--|Welcome 1 times 1\n",
+     *          "|--3|366|out--|Welcome 2 times 2\n",
+     *          "|--4|466|out--|Welcome 3 times 3\n",
+     *      ]
+     */
+    public function joinMarksWithFollowingItem($chunks): Collection
+    {
+        return collect($chunks)->reduce(function ($carry, $item) {
+            $last = $carry->last();
+            if (preg_match(RunRemoteProcess::MARK_REGEX, $last) && !preg_match(RunRemoteProcess::MARK_REGEX, $item)) {
+                // If the last element is a delimiter and the current element is not,
+                // join them together and replace the last element with the joined string
+                $carry->pop();
+                $joined = $last . $item;
+                $carry->push($joined);
+            } else {
+                // Otherwise, just add the current element to the result array
+                $carry->push($item);
+            }
+            return $carry;
+        }, collect());
+    }
+}

--- a/resources/views/livewire/poll-activity.blade.php
+++ b/resources/views/livewire/poll-activity.blade.php
@@ -1,5 +1,7 @@
 <div>
     <pre style="width: 100%;overflow-y: scroll;" @if ($isKeepAliveOn) wire:poll.750ms="polling" @endif>
-        {{ data_get($activity, 'description') }}
+        @isset($activity)
+        {{ (new App\Actions\RemoteProcess\TidyOutput($activity))() }}
+        @endisset
     </pre>
 </div>

--- a/tests/Feature/RemoteProcessTest.php
+++ b/tests/Feature/RemoteProcessTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Actions\RemoteProcess\RunRemoteProcess;
+use App\Actions\RemoteProcess\TidyOutput;
+use App\Models\Server;
+use Database\Seeders\DatabaseSeeder;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+uses(DatabaseMigrations::class);
+
+beforeEach(function () {
+    $this->seed(DatabaseSeeder::class);
+});
+
+it('outputs correctly', function () {
+
+    $host = Server::where('name', 'testing-local-docker-container')->first();
+
+    $activity = remoteProcess([
+        'pwd',
+        'x=1; while  [ $x -le 3 ]; do sleep 0.1 && echo "Welcome $x times" $(( x++ )); done',
+    ], $host);
+
+
+    preg_match(RunRemoteProcess::MARK_REGEX, $activity->description, $matchesInRawContent);
+    $out = (new TidyOutput($activity))();
+    preg_match(RunRemoteProcess::MARK_REGEX, $out, $matchesInTidyOutput);
+
+    expect($matchesInRawContent)
+        ->not()->toBeEmpty()
+        ->and($matchesInTidyOutput)
+        ->toBeEmpty();
+
+});

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -1,5 +1,0 @@
-<?php
-
-test('that true is true', function () {
-    expect(true)->toBeTrue();
-});


### PR DESCRIPTION
As discussed, we lose any other context when we persist the whole output to a single text field.
To avoid having multiple attributes, we decided to implement a Marking system we could later parse/clean/tidy.

=> Now that I write this, I think: Why don't we persist each output line as JSON???

Well, the feature is done with the first method, and goes as follows:

Say we have such output:  (pwd and a method with echo and sleep)
```
/root
Welcome 1 times 1
Welcome 2 times 2
Welcome 3 times 3
```

We add a mark to each output. |--SEQUENCE|ELAPSED_TIME|TYPE--|

```
|--1|100|out--|/root
|--2|233|out--|Welcome 1 times 1
|--3|345|out--|Welcome 2 times 2
|--4|456|out--|Welcome 3 times 3
```

Type It can be out or err.

Also, there is a very "complex" reducer, I tried to make it simple to grasp with comments like below, let me know if it's any good

![image](https://user-images.githubusercontent.com/26031459/229312093-53a66999-791b-42d6-8030-4cdd26e345f4.png)







