### PR TITLE
[Feature] (GH-1026) Admin: invite users

### DIFF
--- a/apps/ui/src/routes/iam/index.svelte
+++ b/apps/ui/src/routes/iam/index.svelte
@@ -89,7 +89,7 @@
 				});
 			}
 			await post(`/iam/user/password`, { id });
-			return addToast({
+			addToast({
 				message: 'User setup successfully. They will be prompted to set their password when they next login.',
 				type: 'success'
 			});

--- a/apps/ui/src/routes/iam/index.svelte
+++ b/apps/ui/src/routes/iam/index.svelte
@@ -38,10 +38,7 @@
 	function generateRandomPassword(){
 		const pwLength = 16;
 		let generatedPassword = "";
-    const validChars = "0123456789" +
-        "abcdefghijklmnopqrstuvwxyz" +
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
-        ",.-+!\"#$%/=?";
+    const validChars = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ,.-+!\"#$%/=?";
 
     for (let i = 0; i < pwLength; i++) {
         let randomNumber = crypto.getRandomValues(new Uint32Array(1))[0];

--- a/apps/ui/src/routes/iam/index.svelte
+++ b/apps/ui/src/routes/iam/index.svelte
@@ -35,18 +35,18 @@
 		});
 	}
 
-	function generateRandomPassword(){
+	function generateRandomPassword() {
 		const pwLength = 16;
-		let generatedPassword = "";
-    const validChars = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ,.-+!\"#$%/=?";
+		let generatedPassword = '';
+		const validChars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ,.-+!"#$%/=?';
 
-    for (let i = 0; i < pwLength; i++) {
-        let randomNumber = crypto.getRandomValues(new Uint32Array(1))[0];
-        randomNumber = randomNumber / 0x100000000;
-        randomNumber = Math.floor(randomNumber * validChars.length);
+		for (let i = 0; i < pwLength; i++) {
+			let randomNumber = crypto.getRandomValues(new Uint32Array(1))[0];
+			randomNumber = randomNumber / 0x100000000;
+			randomNumber = Math.floor(randomNumber * validChars.length);
 
-        generatedPassword += validChars[randomNumber];
-    }
+			generatedPassword += validChars[randomNumber];
+		}
 		return generatedPassword;
 	}
 
@@ -69,7 +69,7 @@
 		try {
 			// Enable registration
 			await post(`/settings`, {
-				isRegistrationEnabled: true,
+				isRegistrationEnabled: true
 			});
 
 			const { token, payload } = await post(`/login`, {
@@ -87,18 +87,19 @@
 			}
 			await post(`/iam/user/password`, { id });
 			addToast({
-				message: 'User setup successfully. They will be prompted to set their password when they next login.',
+				message:
+					'User setup successfully. They will be prompted to set their password when they next login.',
 				type: 'success'
 			});
 		} catch (error: any) {
 			return addToast({
-				message: "There was an error adding the user",
+				message: 'There was an error adding the user',
 				type: 'error'
 			});
 		} finally {
 			// Set the registration enabled stauts back to previous state
 			await post(`/settings`, {
-				isRegistrationEnabled,
+				isRegistrationEnabled
 			});
 		}
 	}


### PR DESCRIPTION
**Issue:** https://github.com/coollabsio/coolify/issues/1026

**Description**
As an admin user, I would like the ability to add user accounts without explicitly enabling registration (which could expose the ability for users to create accounts without permission).

**Notes**
The process that's been implemented is:

 - Admin searches for users on the 'users' page
 - If no matching users are found, a 'Create account for <search term>' button appears
 - Clicking this button will use the search term as the details for the new user account

During this process, the `isRegistrationEnabled` flag will be set to `true`, the account registration request will be done, and appropriate response will be presented via toast. The `isRegistrationEnabled` flag will be set back to its original state.

The password that is set in the account is randomly generated using browser crypto functions, but the 'reset password' functionality will be called afterwards to prompt the user to set their password after login.

Please feel free to adjust this functionality as you deem appropriate.