### PR TITLE
[Bug] Added support for HTTP source URLs in Git source

### DIFF
--- a/apps/ui/src/lib/api.ts
+++ b/apps/ui/src/lib/api.ts
@@ -72,17 +72,19 @@ async function send({
 			...headers
 		};
 	}
-	if (token && !path.startsWith('https://')) {
+
+	if (token && !path.startsWith('https://') && !path.startsWith('http://')) {
 		opts.headers = {
 			...opts.headers,
 			Authorization: `Bearer ${token}`
 		};
 	}
-	if (!path.startsWith('https://')) {
+
+	if (!path.startsWith('https://') && !path.startsWith('http://')) {
 		path = `/api/v1${path}`;
 	}
 
-	if (dev && !path.startsWith('https://')) {
+	if (dev && !path.startsWith('https://') && !path.startsWith('http://')) {
 		path = `${getAPIUrl()}${path}`;
 	}
 	if (method === 'POST' && data && !opts.body) {


### PR DESCRIPTION
![スクリーンショット 2023-04-24 16 57 13](https://user-images.githubusercontent.com/61042046/233934562-b130634e-f1f7-4584-8161-ae8599a966d3.png)

Currently only support `HTTPS` Git source.

I tried `HTTP` Git source and getting below error.

![スクリーンショット 2023-04-24 16 46 27](https://user-images.githubusercontent.com/61042046/233933444-c91c1f69-f138-435a-9803-79191473476a.png)

I solved this issue.

Let me know if you need any other information.