### PR TITLE
fix(create): flex wrap on server & network selection

### DIFF
--- a/resources/views/livewire/project/new/select.blade.php
+++ b/resources/views/livewire/project/new/select.blade.php
@@ -130,7 +130,7 @@
                 <li class="step step-secondary">Select a Server</li>
                 <li class="step">Select a Destination</li>
             </ul>
-            <div class="flex flex-col justify-center gap-2 text-left xl:flex-row">
+            <div class="flex flex-col justify-center gap-2 text-left xl:flex-row xl:flex-wrap">
                 @forelse($servers as $server)
                     <div class="box group" wire:click="setServer({{ $server }})">
                         <div class="flex flex-col mx-6">
@@ -158,7 +158,7 @@
                 <li class="step step-secondary">Select a Server</li>
                 <li class="step step-secondary">Select a Destination</li>
             </ul>
-            <div class="flex flex-col justify-center gap-2 text-left xl:flex-row">
+            <div class="flex flex-col justify-center gap-2 text-left xl:flex-row xl:flex-wrap">
                 @foreach ($standaloneDockers as $standaloneDocker)
                     <div class="box group" wire:click="setDestination('{{ $standaloneDocker->uuid }}')">
                         <div class="flex flex-col mx-6">


### PR DESCRIPTION
Fix the flex overflow on the selection page when creating a new resource.

**Before**
<img width="1475" alt="image" src="https://github.com/coollabsio/coolify/assets/9266227/d91c430d-6c3e-4801-a2aa-8ef76af55f7a">

**After**
<img width="1475" alt="image" src="https://github.com/coollabsio/coolify/assets/9266227/583a8489-cb7e-459f-ad33-97d8f64c4402">
