### PR TITLE
fix: generated redis URL string

### DIFF
--- a/app/Http/Livewire/Project/Database/Redis/General.php
+++ b/app/Http/Livewire/Project/Database/Redis/General.php
@@ -80,9 +80,9 @@ class General extends Component
     public function getDbUrl() {
 
         if ($this->database->is_public) {
-            $this->db_url = "redis://{$this->database->redis_password}@{$this->database->destination->server->getIp}:{$this->database->public_port}/0";
+            $this->db_url = "redis://:{$this->database->redis_password}@{$this->database->destination->server->getIp}:{$this->database->public_port}/0";
         } else {
-            $this->db_url = "redis://{$this->database->redis_password}@{$this->database->uuid}:5432/0";
+            $this->db_url = "redis://:{$this->database->redis_password}@{$this->database->uuid}:6379/0";
         }
     }
     public function render()


### PR DESCRIPTION
The standard URL syntax looks for redis is `redis://[username]:[password]@localhost:6379/0`, in case no username is present, we need `:` before the password. 

reference: [IANA](https://www.iana.org/assignments/uri-schemes/prov/redis)
reference: [redis-py url spec](https://redis-py.readthedocs.io/en/stable/connections.html#redis.connection.ConnectionPool.from_url)

Also, the default port was not set correctly, this fixes that too