### PR TITLE
fix(install.sh): set ownership and perms only for /data/coolify instead of /data

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -94,8 +94,8 @@ mkdir -p /data/coolify/ssh/mux
 mkdir -p /data/coolify/source
 mkdir -p /data/coolify/proxy/dynamic
 
-chown -R 9999:root /data
-chmod -R 700 /data
+chown -R 9999:root /data/coolify
+chmod -R 700 /data/coolify
 
 echo "Downloading required files from CDN..."
 curl -fsSL $CDN/docker-compose.yml -o /data/coolify/source/docker-compose.yml


### PR DESCRIPTION
The ownership and permissions are now set only for the /data/coolify directory instead of the entire /data directory. This ensures that the ownership and permissions are applied only to the necessary directory and not to other directories within /data.