### PR TITLE
Friendlier env vars page.

### DIFF
--- a/resources/views/livewire/project/shared/environment-variable/show.blade.php
+++ b/resources/views/livewire/project/shared/environment-variable/show.blade.php
@@ -5,7 +5,7 @@
                     class="font-bold text-warning">({{ $env->key }})</span>?</p>
         </x-slot:modalBody>
     </x-modal>
-    <form wire:submit.prevent='submit' class="flex flex-col items-center gap-2 xl:flex-row">
+    <form wire:submit.prevent='submit' class="flex flex-col items-center gap-2 m-2 p-4 border lg:m-0 lg:p-0 lg:border-0 lg:flex-row">
         @if ($isLocked)
             <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                 <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">


### PR DESCRIPTION
This is a style-based change to fix a thing that has bugged me - the column-based layout of the env var page doesn't provide a clear indication of which env var row the controls apply to.  They could just as easily apply to the row below as the row above. I have made that mistake several times, only to wonder why my env vars aren't updating.  Wrapping each env var in a border box (though only for the column-based layout) neatly solves this problem.

It also changes the breakpoint for the row-based layout of env vars to be one size smaller (lg instead of xl).  If you're on a laptop using a browser with tabs on the left (I use [Arc](https://arc.net/) - let me know if you want an invite code, it's excellent!), you are juuust too thin to fall under xl, even though there is plenty of room still for the text boxes to be side-by-each.

Screenshot of column-based layout with borders (and some padding to clean it up) applied:

<img width="713" alt="Screenshot 2023-11-17 at 1 21 22 AM" src="https://github.com/coollabsio/coolify/assets/382432/ca148f0f-f0df-463d-8c8a-04e2e1e53638">