### PR TITLE
fix: Resolves deployment of docker compose applications when using a deploy key

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -862,6 +862,10 @@ class Application extends BaseModel
             if (!$only_checkout) {
                 $git_clone_command = $this->setGitImportSettings($deployment_uuid, $git_clone_command_base);
             }
+            else {
+                $git_clone_command = "git clone {$fullRepoUrl} -b {$this->git_branch} {$baseDir}";
+            }
+
             if ($exec_in_docker) {
                 $commands = collect([
                     executeInDocker($deployment_uuid, "mkdir -p /root/.ssh"),
@@ -979,6 +983,7 @@ class Application extends BaseModel
         //     $fileList->push(".$prComposeFile");
         // }
         $commands = collect([
+            "rm -rf /tmp/{$uuid}",
             "mkdir -p /tmp/{$uuid} && cd /tmp/{$uuid}",
             $cloneCommand,
             "git sparse-checkout init --cone",


### PR DESCRIPTION
This fixes an issue with deploying docker compose builds with a deploy key.

At the moment the `$git_clone_command` used to pull down the repo to initially read the docker-compose.yaml file is using `$only_checkout`, which is missing the git repository and basedir.

I've also made it remove the `/tmp/{$uuid}` location before running the clone to prevent an issue with git failing when cloning into an existing dir (if a previous deployment ssh command failed unexpectedly)