### PR TITLE
Adds basic support for pre/post-deployment commands.

### DIFF
--- a/app/Livewire/Project/Application/General.php
+++ b/app/Livewire/Project/Application/General.php
@@ -66,6 +66,8 @@ class General extends Component
         'application.docker_compose_custom_build_command' => 'nullable',
         'application.custom_labels' => 'nullable',
         'application.custom_docker_run_options' => 'nullable',
+        'application.pre_deployment_command' => 'nullable',
+        'application.pre_deployment_command_container' => 'nullable',
         'application.post_deployment_command' => 'nullable',
         'application.post_deployment_command_container' => 'nullable',
         'application.settings.is_static' => 'boolean|required',

--- a/app/Livewire/Project/Application/General.php
+++ b/app/Livewire/Project/Application/General.php
@@ -66,6 +66,8 @@ class General extends Component
         'application.docker_compose_custom_build_command' => 'nullable',
         'application.custom_labels' => 'nullable',
         'application.custom_docker_run_options' => 'nullable',
+        'application.post_deployment_command' => 'nullable',
+        'application.post_deployment_command_container' => 'nullable',
         'application.settings.is_static' => 'boolean|required',
         'application.settings.is_raw_compose_deployment_enabled' => 'boolean|required',
         'application.settings.is_build_server_enabled' => 'boolean|required',

--- a/database/migrations/2024_02_08_075523_add_post_deployment_to_applications.php
+++ b/database/migrations/2024_02_08_075523_add_post_deployment_to_applications.php
@@ -14,6 +14,8 @@ return new class extends Migration
         Schema::table('applications', function (Blueprint $table) {
             $table->string('post_deployment_command')->nullable();
             $table->string('post_deployment_command_container')->nullable();
+            $table->string('pre_deployment_command')->nullable();
+            $table->string('pre_deployment_command_container')->nullable();
         });
     }
 
@@ -25,6 +27,8 @@ return new class extends Migration
         Schema::table('applications', function (Blueprint $table) {
             $table->dropColumn('post_deployment_command');
             $table->dropColumn('post_deployment_command_container');
+            $table->dropColumn('pre_deployment_command');
+            $table->dropColumn('pre_deployment_command_container');
         });
     }
 };

--- a/database/migrations/2024_02_08_075523_add_post_deployment_to_applications.php
+++ b/database/migrations/2024_02_08_075523_add_post_deployment_to_applications.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('applications', function (Blueprint $table) {
+            $table->string('post_deployment_command')->nullable();
+            $table->string('post_deployment_command_container')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('applications', function (Blueprint $table) {
+            $table->dropColumn('post_deployment_command');
+            $table->dropColumn('post_deployment_command_container');
+        });
+    }
+};

--- a/resources/views/livewire/project/application/general.blade.php
+++ b/resources/views/livewire/project/application/general.blade.php
@@ -239,8 +239,14 @@
 
             <h3 class="pt-8">Deployment scripts</h3>
             <div class="flex flex-col gap-2 xl:flex-row">
+                    <x-forms.input placeholder="" id="application.pre_deployment_command" label="Pre deployment command"
+                        helper="An optional script or command to execute in the existing container before the deployment begins." />
+                    <x-forms.input placeholder="" id="application.pre_deployment_command_container" label="Container name"
+                        helper="The name of the container to execute within. You can leave it blank if your application only has one container." />
+            </div>
+            <div class="flex flex-col gap-2 xl:flex-row">
                     <x-forms.input placeholder="php artisan migrate" id="application.post_deployment_command" label="Post deployment command"
-                        helper="An optional script or command to execute in a container after the deployment completes." />
+                        helper="An optional script or command to execute in the newly built container after the deployment completes." />
                     <x-forms.input placeholder="php" id="application.post_deployment_command_container" label="Container name"
                         helper="The name of the container to execute within. You can leave it blank if your application only has one container." />
             </div>

--- a/resources/views/livewire/project/application/general.blade.php
+++ b/resources/views/livewire/project/application/general.blade.php
@@ -236,6 +236,14 @@
                 <x-forms.textarea label="Container Labels" rows="15" id="customLabels"></x-forms.textarea>
                 <x-forms.button wire:click="resetDefaultLabels">Reset to Coolify Generated Labels</x-forms.button>
             @endif
+
+            <h3 class="pt-8">Deployment scripts</h3>
+            <div class="flex flex-col gap-2 xl:flex-row">
+                    <x-forms.input placeholder="php artisan migrate" id="application.post_deployment_command" label="Post deployment command"
+                        helper="An optional script or command to execute in a container after the deployment completes." />
+                    <x-forms.input placeholder="php" id="application.post_deployment_command_container" label="Container name"
+                        helper="The name of the container to execute within. You can leave it blank if your application only has one container." />
+            </div>
         </div>
     </form>
 </div>


### PR DESCRIPTION
Runs a given command (or script) in a named container on applications after a deployment has completed. Largely replaces the need for custom entrypoints.

Also adds support for running pre-deployment commands to run in the existing container prior to new ones spinning up.

Some notes:
* Applications only, no services support
* Applications that do not support rolling deployments with health checks (e.g docker compose) may not be healthy, script/command would need to account for that

<img width="1021" alt="Screenshot 2024-02-08 at 8 03 37 PM" src="https://github.com/coollabsio/coolify/assets/1256274/3a88a588-623d-4cdc-afe6-c208b77ab86f">

<img width="1230" alt="Screenshot 2024-02-08 at 7 25 32 PM" src="https://github.com/coollabsio/coolify/assets/1256274/e6e334cf-e6b9-4d69-a17f-f9634e0f4101">
