### PR TITLE
Update directus-with-postgresql.yaml - Version bump

### DIFF
--- a/templates/compose/directus-with-postgresql.yaml
+++ b/templates/compose/directus-with-postgresql.yaml
@@ -4,7 +4,7 @@
 
 services:
   directus:
-    image: directus/directus:10.7
+    image: directus/directus:10.9
     volumes:
       - directus-uploads:/directus/uploads
       - directus-extensions:/directus/extensions


### PR DESCRIPTION
Bump Directus with PG one-click service image from version `10.7` to `10.9`.