### PR TITLE
fix: only add 'networks' key if 'network_mode' is absent

### DIFF
--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -527,28 +527,32 @@ function getTopLevelNetworks(Service|Application $resource)
             $definedNetwork = collect([$resource->uuid]);
             $services = collect($services)->map(function ($service, $_) use ($topLevelNetworks, $definedNetwork) {
                 $serviceNetworks = collect(data_get($service, 'networks', []));
+                $hasNetworkMode = data_get($service, 'network_mode');
 
-                // Collect/create/update networks
-                if ($serviceNetworks->count() > 0) {
-                    foreach ($serviceNetworks as $networkName => $networkDetails) {
-                        $networkExists = $topLevelNetworks->contains(function ($value, $key) use ($networkName) {
-                            return $value == $networkName || $key == $networkName;
-                        });
-                        if (!$networkExists) {
-                            $topLevelNetworks->put($networkDetails, null);
+                 // Only add 'networks' key if 'network_mode' is absent
+                if (!$hasNetworkMode) {
+                    // Collect/create/update networks
+                    if ($serviceNetworks->count() > 0) {
+                        foreach ($serviceNetworks as $networkName => $networkDetails) {
+                            $networkExists = $topLevelNetworks->contains(function ($value, $key) use ($networkName) {
+                                return $value == $networkName || $key == $networkName;
+                            });
+                            if (!$networkExists) {
+                                $topLevelNetworks->put($networkDetails, null);
+                            }
                         }
                     }
-                }
 
-                $definedNetworkExists = $topLevelNetworks->contains(function ($value, $_) use ($definedNetwork) {
-                    return $value == $definedNetwork;
-                });
-                if (!$definedNetworkExists) {
-                    foreach ($definedNetwork as $network) {
-                        $topLevelNetworks->put($network,  [
-                            'name' => $network,
-                            'external' => true
-                        ]);
+                    $definedNetworkExists = $topLevelNetworks->contains(function ($value, $_) use ($definedNetwork) {
+                        return $value == $definedNetwork;
+                    });
+                    if (!$definedNetworkExists) {
+                        foreach ($definedNetwork as $network) {
+                            $topLevelNetworks->put($network,  [
+                                'name' => $network,
+                                'external' => true
+                            ]);
+                        }
                     }
                 }
 


### PR DESCRIPTION
i didn't test it, but please test if you can

fixes this error:

```sh
Error: validating /data/coolify/services/x/docker-compose.yml: services.homebridge Additional property network is not allowed
```

when using a compose like:

```yml
services:
  homebridge:
    image: 'homebridge/homebridge:latest'
    restart: always
    network_mode: host
    ports:
      - '51752:51752'
    volumes:
      - './volumes/homebridge:/homebridge'
    logging:
      driver: json-file
      options:
        max-size: 10mb
        max-file: '1'
```