### PR TITLE
fix: fluent bit parsers.conf indentation level

### DIFF
--- a/app/Actions/Server/InstallLogDrain.php
+++ b/app/Actions/Server/InstallLogDrain.php
@@ -128,9 +128,9 @@ class InstallLogDrain
             if ($type !== 'custom') {
                 $parsers = base64_encode("
 [PARSER]
-Name        empty_line_skipper
-Format      regex
-Regex       /^(?!\s*$).+/
+    Name        empty_line_skipper
+    Format      regex
+    Regex       /^(?!\s*$).+/
 ");
             }
             $compose = base64_encode("


### PR DESCRIPTION
# Summary

This PR fixes fluent bit `parsers.conf` indentation level error.

```
[2024/02/17 14:54:20] [error] [config] indentation level is too low
[2024/02/17 14:54:20] [error] [config] error in parsers.conf:4: invalid indentation level
[2024/02/17 14:54:20] [ info] Configuration:
[2024/02/17 14:54:20] [ info]  flush time     | 5.000000 seconds
[2024/02/17 14:54:20] [ info]  grace          | 5 seconds
[2024/02/17 14:54:20] [ info]  daemon         | 0
```