### PR TITLE
fix(server): revalidate server button not showing in server's page

### DIFF
--- a/resources/views/livewire/server/form.blade.php
+++ b/resources/views/livewire/server/form.blade.php
@@ -2,7 +2,7 @@
     <form wire:submit.prevent='submit' class="flex flex-col">
         <div class="flex gap-2">
             <h2>General</h2>
-            @if ($server->id !== 0)
+            @if ($server->id === 0)
                 <x-new-modal buttonTitle="Save" title="Change Localhost" action="submit">
                     You could lost a lot of functionalities if you change the server details of the server where Coolify
                     is


### PR DESCRIPTION
# Summary

The revalidate server button is not showing up in server's page only in coolify's instance server:

<img src="https://github.com/coollabsio/coolify/assets/78874691/3ce369f7-ec4b-4a2c-b82f-7f1a2f116de6" height="400">
