### PR TITLE
fix: connections being stuck and not processed until proxy restarts

### DIFF
--- a/bootstrap/helpers/proxy.php
+++ b/bootstrap/helpers/proxy.php
@@ -141,6 +141,8 @@ function generate_default_proxy_configuration(Server $server)
                     "--entrypoints.https.address=:443",
                     "--entrypoints.http.http.encodequerysemicolons=true",
                     "--entrypoints.https.http.encodequerysemicolons=true",
+                    "--entryPoints.http.http2.maxConcurrentStreams=50",
+                    "--entryPoints.https.http2.maxConcurrentStreams=50",
                     "--providers.docker.exposedbydefault=false",
                     "--providers.file.directory=/traefik/dynamic/",
                     "--providers.file.watch=true",


### PR DESCRIPTION
Before this change, when there was a surge of requests very quickly, traefik will be unresponsive until it is restarted. 
<img width="832" alt="Screenshot 2024-02-20 at 5 31 01 PM" src="https://github.com/coollabsio/coolify/assets/47493765/ee19151a-e5f1-4520-89e3-fa0e7b3defff">
https://community.traefik.io/t/after-many-requests-chrome-connections-are-pending-and-traefik-raises-errors/18844/3