### PR TITLE
fix: Avoid breaking the tile layout with long fqdn output

### DIFF
--- a/resources/views/livewire/project/resource/index.blade.php
+++ b/resources/views/livewire/project/resource/index.blade.php
@@ -67,7 +67,7 @@
                                     </template>
                                 </div>
                                 <div class="description" x-text="item.description"></div>
-                                <div class="description" x-text="item.fqdn"></div>
+                                <div class="description break-all" x-text="item.fqdn"></div>
                             </div>
                         </a>
                         <div class="flex gap-1 pt-1 group-hover:text-white group min-h-6">


### PR DESCRIPTION
Force the browser to break long lines for the fqdn output instead of overflowing the tile. This should solve issue #1769. The fix should add the tailwind class break-all which adds `word-break: break-all;` this solved my issue with #1769 