### PR TITLE
ui: visual feedback when container is unhealthy

### DIFF
--- a/resources/views/components/status/running.blade.php
+++ b/resources/views/components/status/running.blade.php
@@ -8,6 +8,6 @@
         {{ str($status)->before(':')->headline() }}
     </div>
     @if (!str($status)->startsWith('Proxy') && !str($status)->contains('('))
-        <div class="text-xs text-success">({{ str($status)->after(':') }})</div>
+        <div class="text-xs {{ str($status)->contains('unhealthy') ? 'text-warning' : 'text-success' }}">({{ str($status)->after(':') }})</div>
     @endif
 </div>


### PR DESCRIPTION
from this: 
![image](https://github.com/coollabsio/coolify/assets/56850299/e8ac3d74-1800-4bd5-b498-1ac29e54abad)
to this:
![image](https://github.com/coollabsio/coolify/assets/56850299/f42972aa-70d1-404d-9f12-6ee299174d66)

I kept the `running` as is, not familiar with the codebase yet and did want to make my first pr too complex, but I am guessing `exited` would be in red already.