### PR TITLE
Supabase: Fixes for Realtime

### DIFF
--- a/templates/compose/supabase.yaml
+++ b/templates/compose/supabase.yaml
@@ -940,9 +940,10 @@ services:
 
       - GOTRUE_EXTERNAL_PHONE_ENABLED=${ENABLE_PHONE_SIGNUP:-true}
       - GOTRUE_SMS_AUTOCONFIRM=${ENABLE_PHONE_AUTOCONFIRM:-true}
-  supabase-realtime:
+  realtime-dev.supabase-realtime:
     # This container name looks inconsistent but is correct because realtime constructs tenant id by parsing the subdomain
-    container_name: realtime-dev.supabase-realtime
+    # Name of service has to be changed as coolify is generating container names automatically
+    # container_name: realtime-dev.supabase-realtime
     image: supabase/realtime:v2.25.50
     depends_on:
       supabase-db:

--- a/templates/compose/supabase.yaml
+++ b/templates/compose/supabase.yaml
@@ -942,6 +942,7 @@ services:
       - GOTRUE_SMS_AUTOCONFIRM=${ENABLE_PHONE_AUTOCONFIRM:-true}
   supabase-realtime:
     # This container name looks inconsistent but is correct because realtime constructs tenant id by parsing the subdomain
+    container_name: realtime-dev.supabase-realtime
     image: supabase/realtime:v2.25.50
     depends_on:
       supabase-db:
@@ -961,7 +962,7 @@ services:
       - DB_USER=supabase_admin
       - DB_PASSWORD=${SERVICE_PASSWORD_POSTGRES}
       - DB_NAME=${POSTGRES_DB:-supabase}
-      - DB_AFTER_CONNECT_QUERY='SET search_path TO _realtime'
+      - DB_AFTER_CONNECT_QUERY=SET search_path TO _realtime
       - DB_ENC_KEY=supabaserealtime
       - API_JWT_SECRET=${SERVICE_PASSWORD_JWT}
       - FLY_ALLOC_ID=fly123

--- a/templates/compose/supabase.yaml
+++ b/templates/compose/supabase.yaml
@@ -663,7 +663,7 @@ services:
                 kong: 'starts_with(string!(.appname), "supabase-kong")'
                 auth: 'starts_with(string!(.appname), "supabase-auth")'
                 rest: 'starts_with(string!(.appname), "supabase-rest")'
-                realtime: 'starts_with(string!(.appname), "supabase-realtime")'
+                realtime: 'starts_with(string!(.appname), "realtime-dev.supabase-realtime")'
                 storage: 'starts_with(string!(.appname), "supabase-storage")'
                 functions: 'starts_with(string!(.appname), "supabase-functions")'
                 db: 'starts_with(string!(.appname), "supabase-db")'


### PR DESCRIPTION
- Uses the correct realtime container name
- Search path was not set to _realtime to due the quotes in the env variable DB_AFTER_CONNECT_QUERY

For details see these discussions on Discord:
https://discord.com/channels/459365938081431553/1217542291225448611
https://discord.com/channels/459365938081431553/1215010290325000232