### PR TITLE
Supabase Fixes: Default database name

### DIFF
--- a/templates/compose/supabase.yaml
+++ b/templates/compose/supabase.yaml
@@ -315,8 +315,8 @@ services:
       - POSTGRES_PORT=${POSTGRES_PORT:-5432}
       - PGPASSWORD=${SERVICE_PASSWORD_POSTGRES}
       - POSTGRES_PASSWORD=${SERVICE_PASSWORD_POSTGRES}
-      - PGDATABASE=${POSTGRES_DB:-supabase}
-      - POSTGRES_DB=${POSTGRES_DB:-supabase}
+      - PGDATABASE=${POSTGRES_DB:-postgres}
+      - POSTGRES_DB=${POSTGRES_DB:-postgres}
       - JWT_SECRET=${SERVICE_PASSWORD_JWT}
       - JWT_EXP=${JWT_EXPIRY:-3600}
     volumes:
@@ -590,7 +590,7 @@ services:
     environment:
       - LOGFLARE_NODE_HOST=127.0.0.1
       - DB_USERNAME=supabase_admin
-      - DB_DATABASE=${POSTGRES_DB:-supabase}
+      - DB_DATABASE=${POSTGRES_DB:-postgres}
       - DB_HOSTNAME=${POSTGRES_HOST:-supabase-db}
       - DB_PORT=${POSTGRES_PORT:-5432}
       - DB_PASSWORD=${SERVICE_PASSWORD_POSTGRES}
@@ -601,7 +601,7 @@ services:
       - LOGFLARE_SUPABASE_MODE=true
 
       # Comment variables to use Big Query backend for analytics
-      - POSTGRES_BACKEND_URL=postgresql://supabase_admin:${SERVICE_PASSWORD_POSTGRES}@${POSTGRES_HOST:-supabase-db}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-supabase}
+      - POSTGRES_BACKEND_URL=postgresql://supabase_admin:${SERVICE_PASSWORD_POSTGRES}@${POSTGRES_HOST:-supabase-db}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-postgres}
       - POSTGRES_BACKEND_SCHEMA=_analytics
       - LOGFLARE_FEATURE_FLAG_OVERRIDE=multibackend=true
 
@@ -877,7 +877,7 @@ services:
         condition: service_healthy
     restart: unless-stopped
     environment:
-      - PGRST_DB_URI=postgres://authenticator:${SERVICE_PASSWORD_POSTGRES}@${POSTGRES_HOST:-supabase-db}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-supabase}
+      - PGRST_DB_URI=postgres://authenticator:${SERVICE_PASSWORD_POSTGRES}@${POSTGRES_HOST:-supabase-db}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-postgres}
       - PGRST_DB_SCHEMAS=${PGRST_DB_SCHEMAS:-public}
       - PGRST_DB_ANON_ROLE=anon
       - PGRST_JWT_SECRET=${SERVICE_PASSWORD_JWT}
@@ -912,7 +912,7 @@ services:
       - API_EXTERNAL_URL=${API_EXTERNAL_URL:-http://supabase-kong:8000}
 
       - GOTRUE_DB_DRIVER=postgres
-      - GOTRUE_DB_DATABASE_URL=postgres://supabase_auth_admin:${SERVICE_PASSWORD_POSTGRES}@${POSTGRES_HOST:-supabase-db}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-supabase}
+      - GOTRUE_DB_DATABASE_URL=postgres://supabase_auth_admin:${SERVICE_PASSWORD_POSTGRES}@${POSTGRES_HOST:-supabase-db}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-postgres}
 
       - GOTRUE_SITE_URL=${SERVICE_FQDN_SUPABASE_8000}
       - GOTRUE_URI_ALLOW_LIST=${ADDITIONAL_REDIRECT_URLS}
@@ -972,7 +972,7 @@ services:
       - DB_PORT=${POSTGRES_PORT:-5432}
       - DB_USER=supabase_admin
       - DB_PASSWORD=${SERVICE_PASSWORD_POSTGRES}
-      - DB_NAME=${POSTGRES_DB:-supabase}
+      - DB_NAME=${POSTGRES_DB:-postgres}
       - DB_AFTER_CONNECT_QUERY=SET search_path TO _realtime
       - DB_ENC_KEY=supabaserealtime
       - API_JWT_SECRET=${SERVICE_PASSWORD_JWT}
@@ -1046,7 +1046,7 @@ services:
       - SERVER_REGION=local
       - MULTI_TENANT=false
       - AUTH_JWT_SECRET=${SERVICE_PASSWORD_JWT}
-      - DATABASE_URL=postgres://supabase_storage_admin:${SERVICE_PASSWORD_POSTGRES}@${POSTGRES_HOST:-supabase-db}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-supabase}
+      - DATABASE_URL=postgres://supabase_storage_admin:${SERVICE_PASSWORD_POSTGRES}@${POSTGRES_HOST:-supabase-db}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-postgres}
       - DB_INSTALL_ROLES=false
       - STORAGE_BACKEND=s3
       - STORAGE_S3_BUCKET=stub
@@ -1069,7 +1069,7 @@ services:
       # - SERVICE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJyb2xlIjogInNlcnZpY2Vfcm9sZSIsCiAgImlzcyI6ICJzdXBhYmFzZSIsCiAgImlhdCI6IDE3MDg5ODg0MDAsCiAgImV4cCI6IDE4NjY4NDEyMDAKfQ.GA7yF2BmqTzqGkP_oqDdJAQVt0djjIxGYuhE0zFDJV4
       # - POSTGREST_URL=http://supabase-rest:3000
       # - PGRST_JWT_SECRET=${SERVICE_PASSWORD_JWT}
-      # - DATABASE_URL=postgres://supabase_storage_admin:${SERVICE_PASSWORD_POSTGRES}@${POSTGRES_HOST:-supabase-db}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-supabase}
+      # - DATABASE_URL=postgres://supabase_storage_admin:${SERVICE_PASSWORD_POSTGRES}@${POSTGRES_HOST:-supabase-db}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-postgres}
       # - FILE_SIZE_LIMIT=52428800
       # - STORAGE_BACKEND=s3
       # - STORAGE_S3_BUCKET=stub
@@ -1114,7 +1114,7 @@ services:
       - PG_META_PORT=8080
       - PG_META_DB_HOST=${POSTGRES_HOST:-supabase-db}
       - PG_META_DB_PORT=${POSTGRES_PORT:-5432}
-      - PG_META_DB_NAME=${POSTGRES_DB:-supabase}
+      - PG_META_DB_NAME=${POSTGRES_DB:-postgres}
       - PG_META_DB_USER=supabase_admin
       - PG_META_DB_PASSWORD=${SERVICE_PASSWORD_POSTGRES}
 
@@ -1128,7 +1128,7 @@ services:
       - SUPABASE_URL=http://supabase-kong:8000
       - SUPABASE_ANON_KEY=${SERVICE_SUPABASEANON_KEY}
       - SUPABASE_SERVICE_ROLE_KEY=${SERVICE_SUPABASESERVICE_KEY}
-      - SUPABASE_DB_URL=postgresql://postgres:${SERVICE_PASSWORD_POSTGRES}@${POSTGRES_HOST:-supabase-db}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-supabase}
+      - SUPABASE_DB_URL=postgresql://postgres:${SERVICE_PASSWORD_POSTGRES}@${POSTGRES_HOST:-supabase-db}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-postgres}
       # TODO: Allow configuring VERIFY_JWT per function. This PR might help: https://github.com/supabase/cli/pull/786
       - VERIFY_JWT=${FUNCTIONS_VERIFY_JWT:-false}
     volumes:

--- a/templates/compose/supabase.yaml
+++ b/templates/compose/supabase.yaml
@@ -561,8 +561,8 @@ services:
           \set jwt_exp `echo "$JWT_EXP"`
           \set db_name `echo "${POSTGRES_DB:-postgres}"`
 
-          ALTER DATABASE :'db_name' SET "app.settings.jwt_secret" TO :'jwt_secret';
-          ALTER DATABASE :'db_name' SET "app.settings.jwt_exp" TO :'jwt_exp';
+          ALTER DATABASE :db_name SET "app.settings.jwt_secret" TO :'jwt_secret';
+          ALTER DATABASE :db_name SET "app.settings.jwt_exp" TO :'jwt_exp';
 
       - type: bind
         source: ./volumes/db/logs.sql

--- a/templates/compose/supabase.yaml
+++ b/templates/compose/supabase.yaml
@@ -559,9 +559,10 @@ services:
         content: |
           \set jwt_secret `echo "$JWT_SECRET"`
           \set jwt_exp `echo "$JWT_EXP"`
+          \set db_name `echo "${POSTGRES_DB:-postgres}"`
 
-          ALTER DATABASE postgres SET "app.settings.jwt_secret" TO :'jwt_secret';
-          ALTER DATABASE postgres SET "app.settings.jwt_exp" TO :'jwt_exp';
+          ALTER DATABASE :'db_name' SET "app.settings.jwt_secret" TO :'jwt_secret';
+          ALTER DATABASE :'db_name' SET "app.settings.jwt_exp" TO :'jwt_exp';
 
       - type: bind
         source: ./volumes/db/logs.sql


### PR DESCRIPTION
Set default database name to `postgres` instead of `supabase`.
For example pg_cron extension needs database named as `postgres` by default.
The database on the cloud version of Supabase is named `postgres` as well.

> By default, the pg_cron background worker expects its metadata tables to be created in the “postgres” database.

Maybe this should be hardcoded?

