### PR TITLE
Fix azure oauth not recognizing tenant ID

### DIFF
--- a/bootstrap/helpers/socialite.php
+++ b/bootstrap/helpers/socialite.php
@@ -6,19 +6,30 @@ use Laravel\Socialite\Facades\Socialite;
 function get_socialite_provider(string $provider)
 {
     $oauth_setting = OauthSetting::firstWhere('provider', $provider);
+
+    if ($provider == 'azure') {
+        $azure_config = new \SocialiteProviders\Manager\Config(
+            $oauth_setting->client_id,
+            $oauth_setting->client_secret,
+            $oauth_setting->redirect_uri,
+            ['tenant' => $oauth_setting->tenant],
+          );
+        return Socialite::driver('azure')->setConfig($azure_config);
+    }
+
     $config = [
         'client_id' => $oauth_setting->client_id,
         'client_secret' => $oauth_setting->client_secret,
         'redirect' => $oauth_setting->redirect_uri,
-        'tenant' => $oauth_setting->tenant,
     ];
+
     $provider_class_map = [
-        'azure' => \SocialiteProviders\Azure\Provider::class,
         'bitbucket' => \Laravel\Socialite\Two\BitbucketProvider::class,
         'github' => \Laravel\Socialite\Two\GithubProvider::class,
         'gitlab' => \Laravel\Socialite\Two\GitlabProvider::class,
         'google' => \Laravel\Socialite\Two\GoogleProvider::class,
     ];
+
     return Socialite::buildProvider(
         $provider_class_map[$provider],
         $config

--- a/config/services.php
+++ b/config/services.php
@@ -30,4 +30,12 @@ return [
         'secret' => env('AWS_SECRET_ACCESS_KEY'),
         'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
     ],
+
+    'azure' => [    
+        'client_id' => env('AZURE_CLIENT_ID'),
+        'client_secret' => env('AZURE_CLIENT_SECRET'),
+        'redirect' => env('AZURE_REDIRECT_URI'),
+        'tenant' => env('AZURE_TENANT_ID'),
+        'proxy' => env('AZURE_PROXY'),
+      ],
 ];


### PR DESCRIPTION
In the current implementation the azure tenant ID does not get passed to the provider properly. This changes how the config is setup for azure according to its documentation here:

https://github.com/SocialiteProviders/Microsoft-Azure?tab=readme-ov-file#advanced-usage