### PR TITLE
Update stirling-pdf.yaml

### DIFF
--- a/templates/compose/stirling-pdf.yaml
+++ b/templates/compose/stirling-pdf.yaml
@@ -15,3 +15,8 @@ services:
     environment:
       - SERVICE_FQDN_SPDF_8080
       - DOCKER_ENABLE_SECURITY=false
+    healthcheck:
+      test: 'curl --fail -I http://localhost:8080 || exit 1'
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
The service works fine now but shows up as Running (unhealthy). Adding a check on its main page on port 8080 makes it healthy.