### PR TITLE
feat: allow tab in textarea

### DIFF
--- a/app/View/Components/Forms/Textarea.php
+++ b/app/View/Components/Forms/Textarea.php
@@ -22,6 +22,7 @@ class Textarea extends Component
         public bool    $required = false,
         public bool    $disabled = false,
         public bool    $readonly = false,
+        public bool    $allowTab = false,
         public ?string $helper = null,
         public bool    $realtimeValidation = false,
         public bool    $allowToPeak = true,

--- a/resources/views/components/forms/textarea.blade.php
+++ b/resources/views/components/forms/textarea.blade.php
@@ -1,3 +1,18 @@
+<script>
+    function handleKeydown(e) {
+        if (e.keyCode === 9) {
+            e.preventDefault();
+
+            e.target.setRangeText(
+                '\t',
+                e.target.selectionStart,
+                e.target.selectionStart,
+                'end'
+            );
+        }
+    }
+</script>
+
 <div class="flex-1 form-control">
     @if ($label)
         <label class="flex items-center gap-1 mb-1 text-sm font-medium">{{ $label }}
@@ -41,7 +56,7 @@
 
         </div>
     @else
-        <textarea placeholder="{{ $placeholder }}" {{ $attributes->merge(['class' => $defaultClass]) }}
+        <textarea @keydown.tab="{{ $allowTab }} && handleKeydown" placeholder="{{ $placeholder }}" {{ $attributes->merge(['class' => $defaultClass]) }}
             @if ($realtimeValidation) wire:model.debounce.200ms="{{ $id }}"
         @else
     wire:model={{ $value ?? $id }}

--- a/resources/views/livewire/project/service/edit-compose.blade.php
+++ b/resources/views/livewire/project/service/edit-compose.blade.php
@@ -4,7 +4,7 @@
         name collision. <br>To see the actual volume names, check the Deployable Compose file, or go to Storage
         menu.</div>
     <div x-cloak x-show="raw" class="font-mono">
-        <x-forms.textarea rows="20" id="service.docker_compose_raw">
+        <x-forms.textarea allowTab rows="20" id="service.docker_compose_raw">
         </x-forms.textarea>
     </div>
     <div x-cloak x-show="raw === false" class="font-mono">

--- a/resources/views/livewire/server/proxy/new-dynamic-configuration.blade.php
+++ b/resources/views/livewire/server/proxy/new-dynamic-configuration.blade.php
@@ -1,5 +1,5 @@
 <form wire:submit.prevent="addDynamicConfiguration" class="flex flex-col w-full gap-4">
     <x-forms.input autofocus id="fileName" label="Filename" required />
-    <x-forms.textarea id="value" label="Configuration" required rows="20" />
+    <x-forms.textarea allowTab id="value" label="Configuration" required rows="20" />
     <x-forms.button type="submit" @click="slideOverOpen=false">Save</x-forms.button>
 </form>


### PR DESCRIPTION
This adds a property to the `Textarea` component that when set to `true` will allow the tab key to be pressed without losing focus of the `<textarea>`

This is useful when editing `docker-compose.yml` files and dynamic configuration files. I'm still learning the code base, so I'm not sure if there are other textarea instances that will benefit from it.