### PR TITLE
bug: fix allowTab logic

### DIFF
--- a/resources/views/components/forms/textarea.blade.php
+++ b/resources/views/components/forms/textarea.blade.php
@@ -56,7 +56,7 @@
 
         </div>
     @else
-        <textarea @keydown.tab="{{ $allowTab }} && handleKeydown" placeholder="{{ $placeholder }}" {{ $attributes->merge(['class' => $defaultClass]) }}
+        <textarea {{ $allowTab ? '@keydown.tab=handleKeydown' : '' }} placeholder="{{ $placeholder }}" {{ $attributes->merge(['class' => $defaultClass]) }}
             @if ($realtimeValidation) wire:model.debounce.200ms="{{ $id }}"
         @else
     wire:model={{ $value ?? $id }}

--- a/resources/views/components/forms/textarea.blade.php
+++ b/resources/views/components/forms/textarea.blade.php
@@ -4,7 +4,7 @@
             e.preventDefault();
 
             e.target.setRangeText(
-                '\t',
+                '  ',
                 e.target.selectionStart,
                 e.target.selectionStart,
                 'end'


### PR DESCRIPTION
I'm new to livewire syntax. The previous fix would break if `allowTab` was not passed in.

Edit: Came across another error, `A YAML file cannot contain tabs` - replaced tab character with 2 space.