### PR TITLE
Add missing font weights

### DIFF
--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -6,9 +6,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="preconnect" href="https://api.fonts.coollabs.io" crossorigin>
     <link rel="dns-prefetch" href="https://api.fonts.coollabs.io" />
-    <link rel="preload" href="https://api.fonts.coollabs.io/css2?family=Inter&display=swap" as="style" />
+    <link rel="preload" href="https://api.fonts.coollabs.io/css2?family=Inter:wght@400;500;600;700;800&display=swap" as="style" />
     <link rel="preload" href="https://cdn.fonts.coollabs.io/inter/normal/400.woff2" as="style" />
-    <link href="https://api.fonts.coollabs.io/css2?family=Inter&display=swap" rel="stylesheet">
+    <link rel="preload" href="https://cdn.fonts.coollabs.io/inter/normal/500.woff2" as="style" />
+    <link rel="preload" href="https://cdn.fonts.coollabs.io/inter/normal/600.woff2" as="style" />
+    <link rel="preload" href="https://cdn.fonts.coollabs.io/inter/normal/700.woff2" as="style" />
+    <link rel="preload" href="https://cdn.fonts.coollabs.io/inter/normal/800.woff2" as="style" />
+    <link href="https://api.fonts.coollabs.io/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
     <meta name="robots" content="noindex">
     <title>Coolify</title>
     @env('local')


### PR DESCRIPTION
Weights 400-800 are used in CSS, but only 400 is downloaded currently. This adds the rest of the weights. Maybe the Inter variable font could be downloaded instead? I'm guessing it'll be a smaller size than downloading five different weights of Inter, but I'm not sure if the coollabs font CDN supports variable fonts.