### PR TITLE
Supabase endpoint setting in Kong for realtime websocket connections is incorrect

### DIFF
--- a/templates/compose/supabase.yaml
+++ b/templates/compose/supabase.yaml
@@ -171,7 +171,7 @@ services:
             ## Secure Realtime routes
             - name: realtime-v1
               _comment: 'Realtime: /realtime/v1/* -> ws://realtime:4000/socket/*'
-              url: http://realtime-dev.supabase-realtime:4000/socket/
+              url: http://realtime-dev:4000/socket/
               routes:
                 - name: realtime-v1-all
                   strip_path: true


### PR DESCRIPTION
Supabase Installation works at first glance but the realtime feature is not.  Using realtime in the browser results  in errors for the wss:// connection. The problem is an incorrect url in the Kong configuration under storages:

```
  ## Secure Realtime routes
  - name: realtime-v1
    _comment: 'Realtime: /realtime/v1/* -> ws://realtime:4000/socket/*'
    url: http://realtime-dev.supabase-realtime:4000/socket/
    routes:
```

The Realtime Route points to **http://realtime-dev.supabase-realtime:4000/socket** but the correct url is  **http://realtime-dev:4000/socket/** 

Greets
-act