### PR TITLE
fix: MongoDB backups failing

### DIFF
--- a/app/Models/StandaloneMongodb.php
+++ b/app/Models/StandaloneMongodb.php
@@ -224,6 +224,6 @@ class StandaloneMongodb extends BaseModel
         return $this->morphMany(ScheduledDatabaseBackup::class, 'database');
     }
     public function database_name() {
-        return $this->mongo_db;
+        return "???";
     }
 }


### PR DESCRIPTION
Caused by [this commit](https://github.com/coollabsio/coolify/commit/2770755f9d7448a42f724ba1770c96c23e41176a#diff-77f9c2fd0e12c48c92a5c474d4a9ee4b7d17e2e0ea2edc3945c8505ee85df328).

I removed backup database names from MongoDB, as MongoDB can store multiple databases.

This PR should close [#2081](https://github.com/coollabsio/coolify/issues/2081).