### PR TITLE
Update supabase.yaml with variables that enable Supabase external OAu…

### DIFF
--- a/templates/compose/supabase.yaml
+++ b/templates/compose/supabase.yaml
@@ -940,7 +940,10 @@ services:
       - GOTRUE_DB_DRIVER=postgres
       - GOTRUE_DB_DATABASE_URL=postgres://supabase_auth_admin:${SERVICE_PASSWORD_POSTGRES}@${POSTGRES_HOST:-supabase-db}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-postgres}
 
-      - GOTRUE_SITE_URL=${SERVICE_FQDN_SUPABASEKONG}
+      # The base URL your site is located at, eg. https://example.netlify.com/
+      # Currently used in combination with other settings to construct URLs used in emails.
+      # Any URI that shares a host with SITE_URL is a permitted value for redirect_to params (see /authorize etc.).
+      - GOTRUE_SITE_URL=${GOTRUE_SITE_URL}
       - GOTRUE_URI_ALLOW_LIST=${ADDITIONAL_REDIRECT_URLS}
       - GOTRUE_DISABLE_SIGNUP=${DISABLE_SIGNUP:-false}
 
@@ -979,6 +982,24 @@ services:
 
       - GOTRUE_EXTERNAL_PHONE_ENABLED=${ENABLE_PHONE_SIGNUP:-true}
       - GOTRUE_SMS_AUTOCONFIRM=${ENABLE_PHONE_AUTOCONFIRM:-true}
+
+      # Enable external OAuth providers like GitHub or Google to be configured
+      # from Supabase environment variables. GoTrue also supports apple, azure,
+      # bitbucket, discord, facebook, figma, github, gitlab, google, keycloak, linkedin,
+      # notion, spotify, slack, twitch, twitter and workos for external authentication.
+      # Add the variables you need here with the same names... GOTRUE_EXTERNAL_XXX_ENABLED, etc...
+      # https://github.com/supabase/auth?tab=readme-ov-file#external-authentication-providers
+      # You can see what you enabled in Supabase Studio (but you can't edit it):
+      # https://{SERVICE_FQDN_SUPABASEKONG}/project/default/auth/providers
+      - "GOTRUE_EXTERNAL_GITHUB_ENABLED=${GOTRUE_EXTERNAL_GITHUB_ENABLED:-false}"
+      - "GOTRUE_EXTERNAL_GITHUB_CLIENT_ID=${GOTRUE_EXTERNAL_GITHUB_CLIENT_ID}"
+      - "GOTRUE_EXTERNAL_GITHUB_REDIRECT_URI=${GOTRUE_EXTERNAL_GITHUB_REDIRECT_URI}"
+      - "GOTRUE_EXTERNAL_GITHUB_SECRET=${GOTRUE_EXTERNAL_GITHUB_SECRET}"
+      - "GOTRUE_EXTERNAL_GOOGLE_ENABLED=${GOTRUE_EXTERNAL_GOOGLE_ENABLED:-false}"
+      - "GOTRUE_EXTERNAL_GOOGLE_CLIENT_ID=${GOTRUE_EXTERNAL_GOOGLE_CLIENT_ID}"
+      - "GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI=${GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI}"
+      - "GOTRUE_EXTERNAL_GOOGLE_SECRET=${GOTRUE_EXTERNAL_GOOGLE_SECRET}"
+
       # Uncomment to enable custom access token hook. You'll need to create a public.custom_access_token_hook function and grant necessary permissions.
       # See: https://supabase.com/docs/guides/auth/auth-hooks#hook-custom-access-token for details
       # GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_ENABLED="true"


### PR DESCRIPTION
It is a little bit complicated to enable Github or Google external logins w/o understanding the details of how Coolify and docker compose work. I added some variables that hopefully will help people understand how to enable these providers.

Also, normally the application or service you write sits on an url which is different from the one used by Supabase. In that case the authentication breaks because Supabase GoTrue (the auth provider) was pointing GOTRUE_SITE_URL to the Supabase service instead of the customer's application. So I fixed that and explained a bit.
