### PR TITLE
Fix one-shot commands for a specific container being executed using host environment variables

### DIFF
--- a/app/Livewire/Project/Shared/ExecuteContainerCommand.php
+++ b/app/Livewire/Project/Shared/ExecuteContainerCommand.php
@@ -122,7 +122,7 @@ class ExecuteContainerCommand extends Component
             if ($server->isForceDisabled()) {
                 throw new \RuntimeException('Server is disabled.');
             }
-            $cmd = 'sh -c "if [ -f ~/.profile ]; then . ~/.profile; fi; ' . str_replace('"', '\"', $this->command)  . '"';
+            $cmd = "sh -c 'if [ -f ~/.profile ]; then . ~/.profile; fi; " . str_replace("'", "'\''", $this->command)  . "'";
             if (!empty($this->workDir)) {
                 $exec = "docker exec -w {$this->workDir} {$container_name} {$cmd}";
             } else {


### PR DESCRIPTION
With this change the one-shot commands run from the UI use the environment variables from the container instead of the host.

Closes #2172.

Example:

Container env vars:

![Captura de pantalla 2024-05-08 a la(s) 19 28 29](https://github.com/coollabsio/coolify/assets/450467/c33b9e6f-8b71-4584-b5c5-5ec00d285ce8)

One-shot command using env vars from the container works as expected now:

![Captura de pantalla 2024-05-08 a la(s) 19 29 09](https://github.com/coollabsio/coolify/assets/450467/32a85118-d176-4c02-b981-380c949bc441)

String quoted is executed correctly:

![Captura de pantalla 2024-05-08 a la(s) 19 29 50](https://github.com/coollabsio/coolify/assets/450467/58a38f9f-290b-40e0-8641-7d16fb892178)

