### PR TITLE
Improved error message

### DIFF
--- a/resources/views/livewire/boarding/index.blade.php
+++ b/resources/views/livewire/boarding/index.blade.php
@@ -58,7 +58,7 @@
                         <br /> <br />
                         Please make sure you have the correct public key in your ~/.ssh/authorized_keys file for
                         user
-                        'root' or skip the boarding process and add a new private key manually to Coolify and to the
+                        'root' and that ssh server is installed and running, or skip the boarding process and add a new private key manually to Coolify and to the
                         server.
                         <br />
                         Check this <a target="_blank" class="underline"


### PR DESCRIPTION
As i was setting coolify on my system for the first time, I didn't understand why it wasn't working on localhost
apparently, Ubuntu desktop doesn't come with openssh-server installed :)

Changed the error message to include a bit of info on that possible error.