### PR TITLE
fix: SERVICE_FQDN appending source port

### DIFF
--- a/bootstrap/helpers/services.php
+++ b/bootstrap/helpers/services.php
@@ -121,7 +121,7 @@ function updateCompose(ServiceApplication|ServiceDatabase $resource)
                     $generatedEnv = EnvironmentVariable::where('service_id', $resource->service_id)->where('key', $variableName)->first();
                     // ray($generatedEnv);
                     if ($generatedEnv) {
-                        $generatedEnv->value = $fqdn . ':' . $port . $path;
+                        $generatedEnv->value = $fqdn . $path;
                         $generatedEnv->save();
                     }
                 }


### PR DESCRIPTION
SERVICE_FQDN variables has the Container Source Port appended onto it, which it shouldn't.
This fixes that bug which is in #2326.