### PR TITLE
Adds support for installing on ARM-based Manjaro distributions.

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,7 +13,7 @@ CDN="https://cdn.coollabs.io/coolify"
 OS_TYPE=$(grep -w "ID" /etc/os-release | cut -d "=" -f 2 | tr -d '"')
 
 # Check if the OS is manjaro, if so, change it to arch
-if [ "$OS_TYPE" = "manjaro" ]; then
+if [ "$OS_TYPE" = "manjaro" ] || [ "$OS_TYPE" = "manjaro-arm" ]; then
     OS_TYPE="arch"
 fi
 


### PR DESCRIPTION
Currently, `install.sh` will fail early without a message indicating any issues when ran on Manjaro ARM as that lists it's OS type as `manjaro-arm`.

> Always use `next` branch as destination branch for PRs, not `main`
