### PR TITLE
Fix firefly mariadb healthcheck preventing app startup.

### DIFF
--- a/templates/compose/firefly.yaml
+++ b/templates/compose/firefly.yaml
@@ -39,7 +39,7 @@ services:
       test:
         [
           "CMD",
-          "mysqladmin",
+          "mariadb-admin",
           "ping",
           "-h",
           "127.0.0.1",


### PR DESCRIPTION
Firefly III fails to start as the MariaDB container health check seems to fail on the `mariadb:lts` image. Switching the healthcheck command to `mariadb-admin` fixes the issue.
