### PR TITLE
fix: install.sh do not reinstall packages on arch

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -75,10 +75,7 @@ echo "Installing required packages..."
 
 case "$OS_TYPE" in
 arch)
-    pacman -Sy >/dev/null || true
-    if ! pacman -Q curl wget git jq >/dev/null; then
-        pacman -S --noconfirm curl wget git jq >/dev/null || true
-    fi
+    pacman -Sy --noconfirm --needed curl wget git jq >/dev/null || true
     ;;
 ubuntu | debian | raspbian)
     apt update -y >/dev/null


### PR DESCRIPTION
In arch-based distros, `pacman -S` always re-installs a package even if it exists, unlike something like `apt`, which will just show "package already installed".

To prevent the install script from reinstalling the package in arch, I have added the `--needed` flag, `man pacman`:

```text
--needed
           Do not reinstall the targets that are already up-to-date.
```

With this flag, you no longer need to check if the packages are installed with `pacman -Q`, so the `if` check can go away.

Finally, since the previous command `pacman -Sy` always runs, and with the `--needed` flag enabled no extra installation will take place, I have joined the commands.

EDIT: Here's how the command output and time taken looks:


```bash
❯ time sudo pacman -Sy --noconfirm --needed curl wget git jq
:: Synchronizing package databases...
 core is up to date
 extra is up to date
warning: curl-8.8.0-1 is up to date -- skipping
warning: wget-1.24.5-2 is up to date -- skipping
warning: git-2.45.2-1 is up to date -- skipping
warning: jq-1.7.1-2 is up to date -- skipping
 there is nothing to do
sudo pacman -Sy --noconfirm --needed curl wget git jq  0.02s user 0.02s system 3% cpu 0.863 total
```