### PR TITLE
fix: Setup script doesnt link to the correct source code file

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -64,7 +64,7 @@ fi
 echo -e "-------------"
 echo -e "Welcome to Coolify v4 beta installer!"
 echo -e "This script will install everything for you."
-echo -e "(Source code: https://github.com/coollabsio/coolify/blob/main/scripts/install.sh)\n"
+echo -e "(Source code: https://github.com/coollabsio/coolify/blob/main/scripts/install.sh )\n"
 echo -e "-------------"
 
 echo "OS: $OS_TYPE $OS_VERSION"


### PR DESCRIPTION
When clicking on the link on a console it links to `https://github.com/coollabsio/coolify/blob/main/scripts/install.sh)` and not `https://github.com/coollabsio/coolify/blob/main/scripts/install.sh`

![image](https://github.com/coollabsio/coolify/assets/63854611/27c22132-48b4-469b-8fc5-3abffc559d96)
