### PR TITLE
fix: application custom labels reset after saving

### DIFF
--- a/app/Livewire/Project/Application/General.php
+++ b/app/Livewire/Project/Application/General.php
@@ -347,7 +347,9 @@ class General extends Component
     public function submit($showToaster = true)
     {
         try {
-            $this->set_redirect();
+            if ($this->application->isDirty('redirect')) {
+                $this->set_redirect();
+            }
             $this->application->fqdn = str($this->application->fqdn)->replaceEnd(',', '')->trim();
             $this->application->fqdn = str($this->application->fqdn)->replaceStart(',', '')->trim();
             $this->application->fqdn = str($this->application->fqdn)->trim()->explode(',')->map(function ($domain) {


### PR DESCRIPTION
This PR fix custom labels always reset while saving in version `v4.0.0-beta.297`
I recommend make it show warning before change edited labels.