### PR TITLE
fix: Supabase realtime service health check gets 403

### DIFF
--- a/templates/compose/supabase.yaml
+++ b/templates/compose/supabase.yaml
@@ -1012,7 +1012,7 @@ services:
           "-o",
           "/dev/null",
           "-H",
-          "Authorization: Bearer ${ANON_KEY}",
+          "Authorization: Bearer ${SERVICE_SUPABASEANON_KEY}",
           "http://127.0.0.1:4000/api/tenants/realtime-dev/health"
         ]
       timeout: 5s


### PR DESCRIPTION
Not really the end of the world, but a slight improvement of Supabase default installation.  

Noticed 403 errors for health-check in logs for realtime-dev service. 
Changed `ANON_KEY` -> `SERVICE_SUPABASEANON_KEY` and it resolved the issue

<details>
  <summary>before</summary>

![Screenshot 2024-06-19 at 20 30 56](https://github.com/coollabsio/coolify/assets/15659757/5bbc0ada-4e56-4b69-a187-7e29a098639a)
</details>

<details>
  <summary>after</summary>
  
![Screenshot 2024-06-19 at 20 31 15](https://github.com/coollabsio/coolify/assets/15659757/f827cc1a-7285-46f2-90c6-0c8eff367e6e)
</details>
