### PR TITLE
Fix healthcheck for Postgres in Authentic service

### DIFF
--- a/templates/compose/authentik.yaml
+++ b/templates/compose/authentik.yaml
@@ -9,7 +9,7 @@ services:
     image: docker.io/library/postgres:12-alpine
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -d authentik -U $${SERVICE_USER_POSTGRESQL}"]
+      test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
       interval: 2s
       timeout: 10s
       retries: 15
@@ -55,8 +55,10 @@ services:
       - ./media:/media
       - ./custom-templates:/templates
     depends_on:
-      - postgresql
-      - redis
+      postgresql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
   authentik-worker:
     image: ghcr.io/goauthentik/server:${AUTHENTIK_TAG:-2024.2.2}
     restart: unless-stopped
@@ -90,5 +92,7 @@ services:
       - ./certs:/certs
       - ./custom-templates:/templates
     depends_on:
-      - postgresql
-      - redis
+      postgresql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy


### PR DESCRIPTION
Postgres would never get in healthy state because the environment variable SERVICE_USER_POSTGRESQL was never set inside the container. Using POSTGRES_USER container env instead which receives the value from SERVICE_USER_POSTGRESQL.

Also adding the condition "service_healthy" for the depends_on. This will make the Authentic containers to wait for Postgres and Redis to be healthy before starting.

Fixes [#2612](https://github.com/coollabsio/coolify/issues/2612)
