### PR TITLE
Adding service for paperless

### DIFF
--- a/public/svgs/paperless.svg
+++ b/public/svgs/paperless.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 27.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 1000 1000" style="enable-background:new 0 0 1000 1000;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+</style>
+<path class="st0" d="M299,891.7c-4.2-19.8-12.5-59.6-13.6-59.6c-176.7-105.7-155.8-288.7-97.3-393.4
+	c12.5,131.8,245.8,222.8,109.8,383.9c-1.1,2,6.2,27.2,12.5,50.2c27.2-46,68-101.4,65.8-106.7C208.9,358.2,731.9,326.9,840.6,73.7
+	c49.1,244.8-25.1,623.5-445.5,719.7c-2,1.1-76.3,131.8-79.5,132.9c0-2-31.4-1.1-27.2-11.5C290.7,908.4,294.8,900.1,299,891.7
+	L299,891.7z M293.8,793.4c53.3-61.8-9.4-167.4-47.1-201.9C310.5,701.3,306.3,765.1,293.8,793.4L293.8,793.4z"/>
+</svg>

--- a/templates/compose/paperless.yaml
+++ b/templates/compose/paperless.yaml
@@ -1,0 +1,60 @@
+# documentation: https://docs.paperless-ngx.com/configuration/
+# slogan: Paperless-ngx is a community-supported open-source document management system that transforms your physical documents into a searchable online archive so you can keep, well, less paper.
+# logo: svgs/paperless.svg
+# port: 8000
+services:
+  redis:
+    image: docker.io/library/redis:${REDIS_TAG:-7.2.5}
+    restart: unless-stopped
+    volumes:
+      - redis:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      timeout: 10s
+      retries: 3
+
+  paperless:
+    image: paperlessngx/paperless-ngx:${PAPERLESS_TAG:-2.10.2}
+    restart: unless-stopped
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-fs", "-S", "--max-time", "2", "http://localhost:8000"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    volumes:
+      - data:/usr/src/paperless/data
+      - media:/usr/src/paperless/media
+      - type: bind
+        source: ./export
+        target: /usr/src/paperless/export
+        is_directory: true
+      - type: bind
+        source: ./consume
+        target: /usr/src/paperless/consume
+        is_directory: true
+      - type: bind
+        source: ./init-workaround.sh
+        target: /init-workaround.sh
+        content: |
+          #!/bin/bash
+          # Workaround for https://github.com/coollabsio/coolify/discussions/2572
+          # Paperless won't start if the PAPERLESS_URL ends with a path.
+          if [[ "$PAPERLESS_URL" == */ ]]; then
+            PAPERLESS_URL="${PAPERLESS_URL%/}"
+            export PAPERLESS_URL
+          fi
+          # Run the original entrypoint
+          # ENTRYPOINT                    CMD
+          exec /sbin/docker-entrypoint.sh /usr/local/bin/paperless_cmd.sh
+    entrypoint: ["/init-workaround.sh"]
+    environment:
+      - PAPERLESS_ADMIN_PASSWORD=$SERVICE_PASSWORD_PAPERLESS_ADMIN
+      - PAPERLESS_ADMIN_USER=${PAPERLESS_ADMIN_USER:-admin}
+      - PAPERLESS_REDIS=redis://redis:6379
+      - PAPERLESS_SECRET_KEY=$SERVICE_PASSWORD_64_PAPERLESSSECRETKEY
+      - PAPERLESS_URL=${PAPERLESS_URL:-$SERVICE_FQDN_PAPERLESS}
+      - SERVICE_FQDN_PAPERLESS
+ 


### PR DESCRIPTION
fulfills: https://github.com/coollabsio/coolify/discussions/2349

This service is using a workaround for the issue mentioned here: https://github.com/coollabsio/coolify/discussions/2572
Notice how the entrypoint is replaced with a script that removes the forward slash from the env variable `PAPERLESS_URL`.

The environment variable for `PAPERLESS_SECRET_KEY` is set using the awkwardly named `SERVICE_PASSWORD_64_PAPERLESSSECRETKEY`. But if I used the name `SERVICE_PASSWORD_64_PAPERLESS_SECRET_KEY` it would not show up in the web GUI.
Tested in branch next ~v4.0.0-beta.307 (in dev mode using spin up).
