### PR TITLE
fix: prevent instance fqdn persisting to other server's dynamic proxy configs

### DIFF
--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -238,7 +238,7 @@ respond 404
         $dynamic_config_path = $this->proxyPath().'/dynamic';
         if ($this->proxyType() === 'TRAEFIK_V2') {
             $file = "$dynamic_config_path/coolify.yaml";
-            if (empty($settings->fqdn) || (isCloud() && $this->id !== 0)) {
+            if (empty($settings->fqdn) || (isCloud() && $this->id !== 0) || !$this->isLocalhost()) {
                 instant_remote_process([
                     "rm -f $file",
                 ], $this);
@@ -344,7 +344,7 @@ respond 404
             }
         } elseif ($this->proxyType() === 'CADDY') {
             $file = "$dynamic_config_path/coolify.caddy";
-            if (empty($settings->fqdn) || (isCloud() && $this->id !== 0)) {
+            if (empty($settings->fqdn) || (isCloud() && $this->id !== 0) || $this->isLocalhost()) {
                 instant_remote_process([
                     "rm -f $file",
                 ], $this);


### PR DESCRIPTION
fixes #2650

Add `isLocalhost()` check to prevent `coolify.yaml` from being created in other servers' dynamic proxy configs. This resolves issues with those proxies attempting to run certresolver for Coolify's instance domain.



