### PR TITLE
[TEMPLATE] feat: add security and storage access key env to twenty template

### DIFF
--- a/templates/compose/twenty.yaml
+++ b/templates/compose/twenty.yaml
@@ -12,13 +12,15 @@ services:
       - SERVER_URL=$SERVICE_FQDN_TWENTY
       - FRONT_BASE_URL=$SERVICE_FQDN_TWENTY
       - ENABLE_DB_MIGRATIONS=true
-      - SIGN_IN_PREFILLED=false
+      - CACHE_STORAGE_TYPE=${CACHE_STORAGE_TYPE:-redis}
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
 
-      - STORAGE_TYPE=${STORAGE_TYPE:-local}
-      - STORAGE_S3_REGION=$STORAGE_S3_REGION
-      - STORAGE_S3_NAME=$STORAGE_S3_NAME
-      - STORAGE_S3_ENDPOINT=$STORAGE_S3_ENDPOINT
+      # https://twenty.com/developers/section/self-hosting/self-hosting-var#security
+      - API_RATE_LIMITING_TTL=${API_RATE_LIMITING_TTL:-100}
+      - API_RATE_LIMITING_LIMIT=${API_RATE_LIMITING_LIMIT:-100}
 
+      # https://twenty.com/developers/section/self-hosting/self-hosting-var#tokens
       - ACCESS_TOKEN_SECRET=$SERVICE_BASE64_32_ACCESS
       - LOGIN_TOKEN_SECRET=$SERVICE_BASE64_32_LOGIN
       - REFRESH_TOKEN_SECRET=$SERVICE_BASE64_32_REFRESH
@@ -26,6 +28,26 @@ services:
       - POSTGRES_ADMIN_PASSWORD=$SERVICE_PASSWORD_POSTGRES
       - PG_DATABASE_URL=postgres://postgres:$SERVICE_PASSWORD_POSTGRES@postgres:5432/default
 
+      # https://twenty.com/developers/section/self-hosting/self-hosting-var#auth
+      - IS_SIGN_UP_DISABLED=${IS_SIGN_UP_DISABLED:-false}
+      - PASSWORD_RESET_TOKEN_EXPIRES_IN=${PASSWORD_RESET_TOKEN_EXPIRES_IN:-5m}
+
+      # https://twenty.com/developers/section/self-hosting/self-hosting-var#workspace-cleaning
+      - WORKSPACE_INACTIVE_DAYS_BEFORE_NOTIFICATION=$WORKSPACE_INACTIVE_DAYS_BEFORE_NOTIFICATION
+      - WORKSPACE_INACTIVE_DAYS_BEFORE_DELETION=$WORKSPACE_INACTIVE_DAYS_BEFORE_DELETION
+
+      # https://twenty.com/developers/section/self-hosting/self-hosting-var#captcha
+      - STORAGE_TYPE=${STORAGE_TYPE:-local}
+      - STORAGE_S3_REGION=$STORAGE_S3_REGION
+      - STORAGE_S3_NAME=$STORAGE_S3_NAME
+      - STORAGE_S3_ENDPOINT=$STORAGE_S3_ENDPOINT
+      - STORAGE_S3_ACCESS_KEY_ID=$STORAGE_S3_ACCESS_KEY_ID
+      - STORAGE_S3_SECRET_ACCESS_KEY=$STORAGE_S3_SECRET_ACCESS_KEY
+
+      # https://twenty.com/developers/section/self-hosting/self-hosting-var#message-queue
+      - MESSAGE_QUEUE_TYPE=$MESSAGE_QUEUE_TYPE
+
+      # https://twenty.com/developers/section/self-hosting/self-hosting-var#email
       - EMAIL_FROM_ADDRESS=$EMAIL_FROM_ADDRESS
       - EMAIL_FROM_NAME=$EMAIL_FROM_NAME
       - EMAIL_SYSTEM_ADDRESS=$EMAIL_SYSTEM_ADDRESS
@@ -35,10 +57,12 @@ services:
       - EMAIL_SMTP_USER=$EMAIL_SMTP_USER
       - EMAIL_SMTP_PASSWORD=$EMAIL_SMTP_PASSWORD
 
+      # https://twenty.com/developers/section/self-hosting/self-hosting-var#debug-/-development
+      - SIGN_IN_PREFILLED=false
+      - DEBUG_MODE=${DEBUG_MODE:-false}
+
+      # https://twenty.com/developers/section/self-hosting/self-hosting-var#telemetry
       - TELEMETRY_ENABLED=${TELEMETRY_ENABLED:-false}
-      - CACHE_STORAGE_TYPE=${CACHE_STORAGE_TYPE:-redis}
-      - REDIS_HOST=redis
-      - REDIS_PORT=6379
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
There were a few important environment variables missing for twenty:
- To integrate third-party S3 compatible storage solutions, we need to provide `STORAGE_S3_ACCESS_KEY_ID` and `STORAGE_S3_SECRET_ACCESS_KEY` (e.g. R2 in my case)
- Rate limiting should be configurable depending on the use case by providing `API_RATE_LIMITING_TTL` and `API_RATE_LIMITING_LIMIT` with a generous default of 100 requests per 0.1s
- Disabling sign-ups for new workspaces is crucial as one would potential only invite via E-Mail or Link, requires `IS_SIGN_UP_DISABLED` to be set to `true` (default must be `false` to create initial workspace)
- Workspace cleanup options for inactive workspaces
- Password reset token expiration must be configurable depending on the case via `PASSWORD_RESET_TOKEN_EXPIRES_IN`
- Message queue type to replace the internal sync driver, can be set via `MESSAGE_QUEUE_TYPE`

I also re-grouped the environment variables based on the documentation order and added corresponding links for future contributors of the twenty service template. This compose file was tested on my VPS with my current Twenty instance and everything works as expected.

_I'm not sure if I'm supposed to add all possible configuration options. For now I just added what I thought would be important to configure._

