### PR TITLE
[TEMPLATE] fix vikunja, add postgres variant.

### DIFF
--- a/templates/compose/vikunja-with-postgres.yaml
+++ b/templates/compose/vikunja-with-postgres.yaml
@@ -1,0 +1,42 @@
+# documentation: https://vikunja.io
+# slogan: The open-source, self-hostable to-do app. Organize everything, on all platforms.
+# tags: productivity,todo
+# logo: svgs/vikunja.svg
+# port: 3456
+
+services:
+  postgresql:
+    image: postgres:16-alpine
+    volumes:
+      - vikunja-postgresql-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=${SERVICE_USER_POSTGRESQL}
+      - POSTGRES_PASSWORD=${SERVICE_PASSWORD_POSTGRESQL}
+      - POSTGRES_DB=${POSTGRESQL_DATABASE}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+  vikunja:
+    image: vikunja/vikunja
+    environment:
+      - SERVICE_FQDN_VIKUNJA
+      - VIKUNJA_SERVICE_PUBLICURL=$SERVICE_FQDN_VIKUNJA
+      - VIKUNJA_SERVICE_JWTSECRET=$SERVICE_PASSWORD_JWTSECRET
+      - VIKUNJA_SERVICE_ENABLEREGISTRATION=true
+      - VIKUNJA_DATABASE_TYPE=postgres
+      - VIKUNJA_DATABASE_HOST=postgresql
+      - VIKUNJA_DATABASE_PASSWORD=${SERVICE_PASSWORD_POSTGRESQL}
+      - VIKUNJA_DATABASE_USER=${SERVICE_USER_POSTGRESQL}
+      - VIKUNJA_DATABASE_DATABASE=${POSTGRESQL_DATABASE}     
+    volumes:
+      - vikunja-data:/app/vikunja/
+    depends_on:
+      postgresql:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "http://127.0.0.1:3456"]
+      interval: 5s
+      timeout: 20s
+      retries: 10

--- a/templates/compose/vikunja.yaml
+++ b/templates/compose/vikunja.yaml
@@ -12,8 +12,10 @@ services:
       - VIKUNJA_SERVICE_PUBLICURL=$SERVICE_FQDN_VIKUNJA
       - VIKUNJA_SERVICE_JWTSECRET=$SERVICE_PASSWORD_JWTSECRET
       - VIKUNJA_SERVICE_ENABLEREGISTRATION=true
+      - VIKUNJA_DATABASE_PATH=/db/vikunja.db
     volumes:
       - vikunja-data:/app/vikunja/
+      - vikunja-sqlite-data:/db
     healthcheck:
       test: ["CMD", "wget", "--spider", "http://127.0.0.1:3456"]
       interval: 5s


### PR DESCRIPTION
Updated the docker-compose to look like the examples (https://vikunja.io/docs/full-docker-example#sqlite).

I hope setting the env var for the sqlite file also fixes the error I currently get on bootup:

```
2024-07-12T11:49:50.919349723Z 2024-07-12T11:49:50.919238061Z: CRITICAL	▶ migration/initMigration 002 Could not connect to db: could not open database file [uid=1000, gid=0]: open /db/vikunja.db: permission denied
2024-07-12T11:50:51.391725454Z 2024-07-12T11:50:51.391407893Z: INFO	▶ config/InitConfig 001 No config file found, using default or config from environment variables.
```
According to the docs:
> The default path Vikunja uses for sqlite is relative to the binary, which in the docker container would be /app/vikunja/vikunja.db. The VIKUNJA_DATABASE_PATH environment variable moves changes it so that the database file is stored in a volume at /db, to persist state across restarts.

But the migration script searchs for `/db/vikunja.db` instead of `/app/vikunja/vikunja.db`, which is my guess why it's failing, as it could still be created in the default location. That's why I set it via env, to make sure that both creation and migration use the same file.

Additionally I've added a postgres variant, following https://vikunja.io/docs/full-docker-example#postgresql

Note: I had no way to test it, as I couldn't find a section about running from source anywhere.