### PR TITLE
fix(MinIO): error in healthcheck command

### DIFF
--- a/templates/compose/minio.yaml
+++ b/templates/compose/minio.yaml
@@ -15,7 +15,7 @@ services:
     volumes:
       - minio-data:/data
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:9000/minio/health/live"]
+      test: ["CMD", "mc", "ready", "local"]
       interval: 5s
       timeout: 20s
       retries: 10

--- a/templates/compose/reactive-resume.yaml
+++ b/templates/compose/reactive-resume.yaml
@@ -53,7 +53,7 @@ services:
     volumes:
       - minio-data:/data
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:9000/minio/health/live"]
+      test: ["CMD", "mc", "ready", "local"]
       interval: 5s
       timeout: 20s
       retries: 10


### PR DESCRIPTION
The MinIO container was not becoming available, always returning error 404 through the proxy, the container does not contain the CURL or WGET commands, MinIO has its own verification command:
[#18389](https://github.com/minio/minio/issues/18389#issuecomment-1792826843)