### PR TITLE
Update healthcheck command for Minio

### DIFF
--- a/templates/compose/minio.yaml
+++ b/templates/compose/minio.yaml
@@ -15,7 +15,7 @@ services:
     volumes:
       - minio-data:/data
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:9000/minio/health/live"]
+      test: ["CMD", "mc", "ready", "local"]
       interval: 5s
       timeout: 20s
       retries: 10


### PR DESCRIPTION
Current minio setup via default resources fails healthcheck because of which traefik rules are not applied during deployment and the console is not reachable

Failure observed:
![Screenshot 2024-07-15 at 1 25 00 PM](https://github.com/user-attachments/assets/1dac005b-9aea-4040-974b-75ec06ba806d)

Using minio mc cli helps and everything works as expected
![Screenshot 2024-07-15 at 1 24 25 PM](https://github.com/user-attachments/assets/9e51e6ea-5094-4dc2-a47f-578ae8ec862e)

Solves a part of this issue: https://github.com/coollabsio/coolify/issues/2124