### PR TITLE
fix: bitbucket repos url

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -275,11 +275,19 @@ class Application extends BaseModel
         return Attribute::make(
             get: function () {
                 if (! is_null($this->source?->html_url) && ! is_null($this->git_repository) && ! is_null($this->git_branch)) {
+                    if (str($this->git_repository)->contains('bitbucket')) {
+                        return "{$this->source->html_url}/{$this->git_repository}/src/{$this->git_branch}";
+                    }
+
                     return "{$this->source->html_url}/{$this->git_repository}/tree/{$this->git_branch}";
                 }
                 // Convert the SSH URL to HTTPS URL
                 if (strpos($this->git_repository, 'git@') === 0) {
                     $git_repository = str_replace(['git@', ':', '.git'], ['', '/', ''], $this->git_repository);
+
+                    if (str($this->git_repository)->contains('bitbucket')) {
+                        return "https://{$git_repository}/src/{$this->git_branch}";
+                    }
 
                     return "https://{$git_repository}/tree/{$this->git_branch}";
                 }


### PR DESCRIPTION
Changing `/tree` in `/src` in Bitbucket repos URLs
Docs: https://support.atlassian.com/bitbucket-cloud/docs/hyperlink-to-source-code-in-bitbucket/