### PR TITLE
add storage:link to dev environment

### DIFF
--- a/app/Console/Commands/Dev.php
+++ b/app/Console/Commands/Dev.php
@@ -48,6 +48,13 @@ class Dev extends Command
             echo "Generating APP_KEY.\n";
             Artisan::call('key:generate');
         }
+
+        // Generate STORAGE link if not exists
+        if (! file_exists(public_path('storage'))) {
+            echo "Generating STORAGE link.\n";
+            Artisan::call('storage:link');
+        }
+
         // Seed database if it's empty
         $settings = InstanceSettings::find(0);
         if (! $settings) {


### PR DESCRIPTION
Ive seen some people asking help on Discord about setting up Dev Env and forgetting to run `storage:link`

The easy setup today would be:
- Clone repo
- Rename `.env.development.example` to `.env` and change it as you like
- runs `docker compose -f docker-compose.yml -f docker-compose.dev.yml up`

Without this PR. User needs to run `php artisan storage:link` manually