### PR TITLE
Update plausible.yaml to add ports

### DIFF
--- a/templates/compose/plausible.yaml
+++ b/templates/compose/plausible.yaml
@@ -17,6 +17,8 @@ services:
       - plausible_db
       - plausible_events_db
       - mail
+    ports:
+     - 8000:000
   mail:
     image: bytemark/smtp
 

--- a/templates/compose/plausible.yaml
+++ b/templates/compose/plausible.yaml
@@ -18,7 +18,7 @@ services:
       - plausible_events_db
       - mail
     ports:
-     - 8000:000
+     - 8000:8000
   mail:
     image: bytemark/smtp
 


### PR DESCRIPTION
Needed to override the defaults `127.0.0.1:8000:8000` to simply `8000:8000`

This was needed for me to get plausible's websockets working
