### PR TITLE
Fixes link to feature requests in GitHub's issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://coollabs.io/discord
     about: Reach out to us on Discord.
   - name: 🙋‍♂️ Feature Requests
-    url: https://github.com/coollabsio/coolify/discussions/categories/feature-requests-ideas
+    url: https://github.com/coollabsio/coolify/discussions/categories/new-features
     about: All feature requests will be discussed here.


### PR DESCRIPTION
It seems that link to feature requests in GitHub's template points to wrong category in Discussions.

This PR fixes it to `https://github.com/coollabsio/coolify/discussions/categories/new-features`