### PR TITLE
Fixes Plausible TOTP key by changing it from BASE64 to REALBASE64_32

### DIFF
--- a/templates/compose/plausible.yaml
+++ b/templates/compose/plausible.yaml
@@ -12,7 +12,7 @@ services:
       - "DATABASE_URL=postgres://postgres:$SERVICE_PASSWORD_POSTGRES@plausible_db/plausible"
       - BASE_URL=$SERVICE_FQDN_PLAUSIBLE
       - SECRET_KEY_BASE=$SERVICE_BASE64_64_PLAUSIBLE
-      - TOTP_VAULT_KEY=$SERVICE_BASE64_TOTP
+      - TOTP_VAULT_KEY=$SERVICE_REALBASE64_32_TOTP
     depends_on:
       - plausible_db
       - plausible_events_db


### PR DESCRIPTION
When using the Plausible template-compose file, I get this error that prevents the service from working:

`2024-07-26T16:02:53.766880980Z ERROR! Config provider Config.Reader failed with: 2024-07-26T16:02:53.769234610Z ** (RuntimeError) TOTP_VAULT_KEY must exactly 32 bytes long. See https://github.com/plausible/community-edition/tree/v2.1.0?tab=readme-ov-file#quick-start`

So I modified the template to generate a 32-byte key so that it works directly right after hitting deploy.