### PR TITLE
feat: add a helper to livewire.settings to clarify the HTTPS feature

### DIFF
--- a/resources/views/livewire/settings/index.blade.php
+++ b/resources/views/livewire/settings/index.blade.php
@@ -15,7 +15,7 @@
         <div class="flex flex-col gap-2">
             <div class="flex flex-wrap items-end gap-2">
                 <h4 class="pt-6">Instance Settings</h4>
-                <x-forms.input id="settings.fqdn" label="Instance's Domain" placeholder="https://coolify.io" />
+                <x-forms.input id="settings.fqdn" label="Instance's Domain" helper="Enter the full domain name (FQDN) of the instance, including 'https://' if you want to secure the dashboard with HTTPS. Setting this will make the dashboard accessible via this domain, secured by HTTPS, instead of just the IP address." placeholder="https://coolify.yourdomain.com" />
                 <x-forms.input id="settings.instance_name" label="Instance's Name" placeholder="Coolify" />
                 <h4 class="w-full pt-6">DNS Validation</h4>
                 <div class="md:w-96">


### PR DESCRIPTION
I have seen issues from multiple people who couldn't figure out how to set up a domain and enable HTTPS. The process is quite easy but not very easy to find.

This PR adds a helper text to the instance domain name to clarify the use of enabling it.