### PR TITLE
fix unique constraint error on dev env

### DIFF
--- a/database/seeders/StandaloneDockerSeeder.php
+++ b/database/seeders/StandaloneDockerSeeder.php
@@ -12,11 +12,13 @@ class StandaloneDockerSeeder extends Seeder
      */
     public function run(): void
     {
-        StandaloneDocker::create([
-            'id' => 0,
-            'name' => 'Standalone Docker 1',
-            'network' => 'coolify',
-            'server_id' => 0,
-        ]);
+        if (StandaloneDocker::find(0) == null) {
+            StandaloneDocker::create([
+                'id' => 0,
+                'name' => 'Standalone Docker 1',
+                'network' => 'coolify',
+                'server_id' => 0,
+            ]);
+        }
     }
 }


### PR DESCRIPTION
This happens on a fresh dev setup or running  `docker exec -it coolify php artisan migrate:fresh --seed`
The constraint problem below happens, this commit fix this

```php
   Illuminate\Database\UniqueConstraintViolationException 

  SQLSTATE[23505]: Unique violation: 7 ERROR:  duplicate key value violates unique constraint "standalone_dockers_pkey"
DETAIL:  Key (id)=(0) already exists. (Connection: pgsql, SQL: insert into "standalone_dockers" ("id", "name", "network", "server_id", "uuid", "updated_at", "created_at") values (0, Standalone Docker 1, coolify, 0, jwwocck0occo8g88g480kokk, 2024-08-16 00:03:15, 2024-08-16 00:03:15) returning "id")

  at vendor/laravel/framework/src/Illuminate/Database/Connection.php:808
    804▕         // message to include the bindings with SQL, which will make this exception a
    805▕         // lot more helpful to the developer instead of just the database's errors.
    806▕         catch (Exception $e) {
    807▕             if ($this->isUniqueConstraintError($e)) {
  ➜ 808▕                 throw new UniqueConstraintViolationException(
    809▕                     $this->getName(), $query, $this->prepareBindings($bindings), $e
    810▕                 );
    811▕             }
    812▕ 

      +18 vendor frames 

  19  database/seeders/StandaloneDockerSeeder.php:15
      Illuminate\Database\Eloquent\Model::__callStatic()
      +8 vendor frames 

  28  database/seeders/DatabaseSeeder.php:11
      Illuminate\Database\Seeder::call()
```