### PR TITLE
Include extraFields when load service by uuid

### DIFF
--- a/app/Http/Controllers/Api/ServicesController.php
+++ b/app/Http/Controllers/Api/ServicesController.php
@@ -29,6 +29,7 @@ class ServicesController extends Controller
         $service->makeHidden([
             'docker_compose_raw',
             'docker_compose',
+            'extra_fields',
         ]);
 
         return serializeApiResponse($service);
@@ -414,6 +415,7 @@ class ServicesController extends Controller
         }
 
         $service = $service->load(['applications', 'databases']);
+        $service->extra_fields = $service->extraFields();
 
         return response()->json($this->removeSensitiveData($service));
     }

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -33,6 +33,7 @@ use Symfony\Component\Yaml\Yaml;
         'created_at' => ['type' => 'string', 'description' => 'The date and time when the service was created.'],
         'updated_at' => ['type' => 'string', 'description' => 'The date and time when the service was last updated.'],
         'deleted_at' => ['type' => 'string', 'description' => 'The date and time when the service was deleted.'],
+        'extra_fields' => ['type' => 'string', 'description' => 'Content is very complex. Will be implemented later.'],
     ],
 )]
 class Service extends BaseModel

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4647,6 +4647,9 @@ components:
         deleted_at:
           type: string
           description: 'The date and time when the service was deleted.'
+        extra_fields:
+          type: string
+          description: 'Content is very complex. Will be implemented later.'
       type: object
     Team:
       description: 'Team model'


### PR DESCRIPTION
A small change was made to expose `extraFields` for the service when loaded by UUID, but only for tokens with the `view:sensitive` permission.

This is needed because there’s currently no way to create a service and then retrieve the additional variables from it. 😅 Maybe there are some security considerations that prevent this from being merged, but @andrasbacsai, if you can provide some direction, I can work on it further, as I need this feature for my project.


Example output for MinIO:

```
"extra_fields": {
    "MinIO": {
      "Console URL": {
        "key": "MINIO_BROWSER_REDIRECT_URL",
        "value": "http:\/\/console-vc4cko4ggks4s8kkg84w400g.127.0.0.1.sslip.io",
        "rules": "required|url"
      },
      "S3 API URL": {
        "key": "MINIO_SERVER_URL",
        "value": "http:\/\/minio-vc4cko4ggks4s8kkg84w400g.127.0.0.1.sslip.io",
        "rules": "required|url"
      },
      "Admin User": {
        "key": "SERVICE_USER_MINIO",
        "value": "6F0rHt4jSDlSZ8LD",
        "rules": "required"
      },
      "Admin Password": {
        "key": "SERVICE_PASSWORD_MINIO",
        "value": "mOEvt00Yo7rX2DZp5rdyZN3YJUljCF7u",
        "rules": "required",
        "isPassword": true
      }
    }
}
```