### PR TITLE
Fix: Preselect environment when coming form the project screen

### DIFF
--- a/resources/views/livewire/dashboard.blade.php
+++ b/resources/views/livewire/dashboard.blade.php
@@ -28,16 +28,16 @@
                         <div class="flex flex-col justify-center flex-1">
                             <div class="box-title">{{ $project->name }}</div>
                             <div class="box-description">
-                                {{ $project->description }}</div>
+                                {{ $project->description }}
+                            </div>
                         </div>
-                        <div class="flex items-center justify-center gap-2 text-xs font-bold ">
+                        <div class="flex items-center justify-center gap-2 text-xs font-bold">
                             <a class="hover:underline"
-                                href="{{ route('project.resource.create', ['project_uuid' => data_get($project, 'uuid'), 'environment_name' => data_get($project, 'environments.0.name', 'production')]) }}">
-                                <span class="p-2 font-bold">+
-                                    Add Resource</span>
+                                href="{{ route('project.resource.create', ['project_uuid' => $project->uuid, 'environment_name' => $project->default_environment()]) }}">
+                                <span class="p-2 font-bold">+ Add Resource</span>
                             </a>
                             <a class="hover:underline"
-                                href="{{ route('project.edit', ['project_uuid' => data_get($project, 'uuid')]) }}">
+                                href="{{ route('project.edit', ['project_uuid' => $project->uuid]) }}">
                                 Settings
                             </a>
                         </div>
@@ -161,9 +161,6 @@
 
     <script>
         function gotoProject(uuid, environment) {
-            if (!environment) {
-                window.location.href = '/project/' + uuid;
-            }
             window.location.href = '/project/' + uuid + '/' + environment;
         }
     </script>

--- a/resources/views/livewire/dashboard.blade.php
+++ b/resources/views/livewire/dashboard.blade.php
@@ -159,9 +159,14 @@
         </div>
     @endif
 
+
     <script>
         function gotoProject(uuid, environment) {
-            window.location.href = '/project/' + uuid + '/' + environment;
+            if (environment) {
+                window.location.href = '/project/' + uuid + '/' + environment;
+            } else {
+                window.location.href = '/project/' + uuid;
+            }
         }
     </script>
     {{-- <x-forms.button wire:click='getIptables'>Get IPTABLES</x-forms.button> --}}

--- a/resources/views/livewire/project/index.blade.php
+++ b/resources/views/livewire/project/index.blade.php
@@ -32,8 +32,12 @@
     </div>
 
     <script>
-    function gotoProject(uuid, defaultEnvironment) {
-        window.location.href = '/project/' + uuid + '/' + defaultEnvironment;
+    function gotoProject(uuid, environment) {
+        if (environment) {
+            window.location.href = '/project/' + uuid + '/' + environment;
+        } else {
+            window.location.href = '/project/' + uuid;
+        }
     }
 </script>
 </div>

--- a/resources/views/livewire/project/index.blade.php
+++ b/resources/views/livewire/project/index.blade.php
@@ -11,9 +11,8 @@
     <div class="subtitle">All your projects are here.</div>
     <div class="grid gap-2 lg:grid-cols-2">
         @forelse ($projects as $project)
-            <div class="box group" x-data x-on:click="goto('{{ $project->uuid }}')">
-                <div class="flex flex-col justify-center flex-1 mx-6"
-                    onclick="gotoProject('{{ $project->uuid }}','{{ $project->default_environment() }}')">
+            <div class="box group" onclick="gotoProject('{{ $project->uuid }}', '{{ $project->default_environment() }}')">
+                <div class="flex flex-col justify-center flex-1 mx-6">
                     <div class="box-title">{{ $project->name }}</div>
                     <div class="box-description ">
                         {{ $project->description }}</div>
@@ -33,15 +32,8 @@
     </div>
 
     <script>
-        function goto(uuid) {
-            window.location.href = '/project/' + uuid;
-        }
-
-        function gotoProject(uuid, environment) {
-            if (!environment) {
-                window.location.href = '/project/' + uuid;
-            }
-            window.location.href = '/project/' + uuid + '/' + environment;
-        }
-    </script>
+    function gotoProject(uuid, defaultEnvironment) {
+        window.location.href = '/project/' + uuid + '/' + defaultEnvironment;
+    }
+</script>
 </div>


### PR DESCRIPTION
Fixes: https://github.com/coollabsio/coolify/issues/2682
Changes:
- Fix: Select the default project when coming from the Projects screen (form the project menu), as currently the automatic environment selection only works from the Dashboard screen.
- Fix: Validation if environment is null, empty, or undefined
