### PR TITLE
Fix: WordPress and ClassicPress with MySQL have no ARM images

### DIFF
--- a/templates/compose/classicpress-with-mysql.yaml
+++ b/templates/compose/classicpress-with-mysql.yaml
@@ -22,7 +22,7 @@ services:
       timeout: 10s
       retries: 10
   mariadb:
-    image: mysql:5.7
+    image: mysql:8
     volumes:
       - mysql-data:/var/lib/mysql
     environment:

--- a/templates/compose/wordpress-with-mysql.yaml
+++ b/templates/compose/wordpress-with-mysql.yaml
@@ -22,7 +22,7 @@ services:
       timeout: 10s
       retries: 10
   mysql:
-    image: mysql:5.7
+    image: mysql:8
     volumes:
       - mysql-data:/var/lib/mysql
     environment:


### PR DESCRIPTION
Fixes: https://github.com/coollabsio/coolify/issues/3189
Changes:
- Fix: Updated MySQL version to 8 as only then native ARM support was added