### PR TITLE
Avoid crash if the team is not set

### DIFF
--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -89,8 +89,6 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
     public function handle(): void
     {
         try {
-            BackupCreated::dispatch($this->team->id);
-
             // Check if team is exists
             if (is_null($this->team)) {
                 $this->backup->update(['status' => 'failed']);
@@ -99,6 +97,9 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
 
                 return;
             }
+
+            BackupCreated::dispatch($this->team->id);
+            
             $status = str(data_get($this->database, 'status'));
             if (! $status->startsWith('running') && $this->database->id !== 0) {
                 ray('database not running');


### PR DESCRIPTION
> Always use `next` branch as destination branch for PRs, not `main`

Currently the `is_null($this->team)` check happens after the `$this->team->id` is accessed. The PR fixes this, so that the guard check happens before access.