### PR TITLE
Update button label from "Developer view" to "Developer view (require…

### DIFF
--- a/resources/views/livewire/project/shared/environment-variable/all.blade.php
+++ b/resources/views/livewire/project/shared/environment-variable/all.blade.php
@@ -6,9 +6,9 @@
                 <livewire:project.shared.environment-variable.add />
             </x-modal-input>
             <x-forms.button
-                wire:click='switch'>{{ $view === 'normal' ? 'Developer view' : 'Normal view' }}</x-forms.button>
+                wire:click='switch'>{{ $view === 'normal' ? 'Developer view' : 'Normal view (required to set variables at build time)' }}</x-forms.button>
         </div>
-        <div>Environment variables (secrets) for this resource.</div>
+        <div>Environment variables (secrets) for this resource. </div>
         @if ($this->resourceClass === 'App\Models\Application' && data_get($this->resource, 'build_pack') !== 'dockercompose')
             <div class="w-64 pt-2">
                 <x-forms.checkbox id="resource.settings.is_env_sorting_enabled" label="Sort alphabetically"


### PR DESCRIPTION
…d to set variables at build time).

Without this, there is no way for the browser user to know that these environmental variables ARE NOT available at build time. For newby-ish dev's that a subtle difference that is only manifested because of the way docker builds happen.

> Always use `next` branch as destination branch for PRs, not `main`

This pull request addresses issue #3229.
