### PR TITLE
fix: setup script doesn't work on rhel based images with some curl variant already installed

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -93,7 +93,10 @@ centos | fedora | rhel | ol | rocky | almalinux | amzn)
         if ! command -v dnf >/dev/null; then
             yum install -y dnf >/dev/null
         fi
-        dnf install -y curl wget git jq >/dev/null
+        if ! command -v curl >/dev/null; then
+            dnf install -y curl >/dev/null
+        fi
+        dnf install -y wget git jq >/dev/null
     fi
     ;;
 sles | opensuse-leap | opensuse-tumbleweed)


### PR DESCRIPTION
Fixes the following error when running the setup script inside rhel based init container images (like this one https://hub.docker.com/r/almalinux/9-init):
```
# dnf install curl
Last metadata expiration check: 1:32:35 ago on Wed Aug 28 14:48:41 2024.
Error:
 Problem: problem with installed package curl-minimal-7.76.1-29.el9_4.x86_64
  - package curl-minimal-7.76.1-29.el9_4.x86_64 from @System conflicts with curl provided by curl-7.76.1-29.el9_4.1.x86_64 from baseos
  - package curl-minimal-7.76.1-29.el9_4.1.x86_64 from baseos conflicts with curl provided by curl-7.76.1-29.el9_4.1.x86_64 from baseos
  - package curl-minimal-7.76.1-29.el9_4.x86_64 from baseos conflicts with curl provided by curl-7.76.1-29.el9_4.1.x86_64 from baseos
  - cannot install the best candidate for the job
(try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```