### PR TITLE
fix: don't check logDrain installation if it's not enabled

### DIFF
--- a/app/Jobs/ServerCheckJob.php
+++ b/app/Jobs/ServerCheckJob.php
@@ -124,6 +124,9 @@ class ServerCheckJob implements ShouldBeEncrypted, ShouldQueue
 
     private function checkLogDrainContainer()
     {
+        if(! $this->server->isLogDrainEnabled()) {
+            return;
+        }
         $foundLogDrainContainer = $this->containers->filter(function ($value, $key) {
             return data_get($value, 'Name') === '/coolify-log-drain';
         })->first();


### PR DESCRIPTION
> Always use `next` branch as destination branch for PRs, not `main`

While investigating for https://github.com/coollabsio/coolify/issues/3226, I found that the  `checkLogDrainContainer` method was always called, even if the log drain was not required.

Resulting in a check that was always false -> "Not required, so container not present, so we need to install it" loop.

Edit: In that case the job was doing nothing, inside `InstallLogDrain` we have a check that return if the log drain type is not defined. Not the win expected but still nice, it won't use the queue for nothing.