### PR TITLE
fix: recent executions in wrong order in scheduled-task list ui

### DIFF
--- a/app/Models/ScheduledDatabaseBackup.php
+++ b/app/Models/ScheduledDatabaseBackup.php
@@ -22,7 +22,8 @@ class ScheduledDatabaseBackup extends BaseModel
 
     public function executions(): HasMany
     {
-        return $this->hasMany(ScheduledDatabaseBackupExecution::class);
+        // Last execution first
+        return $this->hasMany(ScheduledDatabaseBackupExecution::class)->orderBy('created_at', 'desc');
     }
 
     public function s3()

--- a/app/Models/ScheduledTask.php
+++ b/app/Models/ScheduledTask.php
@@ -28,6 +28,7 @@ class ScheduledTask extends BaseModel
 
     public function executions(): HasMany
     {
+        // Last execution first
         return $this->hasMany(ScheduledTaskExecution::class)->orderBy('created_at', 'desc');
     }
 

--- a/resources/views/livewire/project/database/backup-executions.blade.php
+++ b/resources/views/livewire/project/database/backup-executions.blade.php
@@ -4,7 +4,7 @@
             <h3 class="py-4">Executions</h3>
             <x-forms.button wire:click='cleanupFailed'>Cleanup Failed Backups</x-forms.button>
         </div>
-        <div class="flex flex-col-reverse gap-4">
+        <div class="flex flex-col gap-4">
             @forelse($executions as $execution)
                 <div wire:key="{{ data_get($execution, 'id') }}" @class([
                     'flex flex-col border-l-2 transition-colors p-4 ',

--- a/resources/views/livewire/project/shared/scheduled-task/executions.blade.php
+++ b/resources/views/livewire/project/shared/scheduled-task/executions.blade.php
@@ -1,4 +1,4 @@
-<div class="flex flex-col-reverse gap-4">
+<div class="flex flex-col gap-4">
     @forelse($executions as $execution)
     @if (data_get($execution, 'id') == $selectedKey)
     <div class="p-4 mb-2 bg-gray-100 dark:bg-coolgray-200 rounded">

--- a/resources/views/livewire/project/shared/scheduled-task/show.blade.php
+++ b/resources/views/livewire/project/shared/scheduled-task/show.blade.php
@@ -42,6 +42,6 @@
 
         <div class="pt-4">
             <h3 class="py-4">Recent executions <span class="text-xs text-neutral-500">(click to check output)</span></h3>
-            <livewire:project.shared.scheduled-task.executions :task="$task" key="{{ $task->id }}" selectedKey="" :executions="$task->executions->take(-20)" />
+            <livewire:project.shared.scheduled-task.executions :task="$task" key="{{ $task->id }}" selectedKey="" :executions="$task->executions->take(20)" />
         </div>
 </div>


### PR DESCRIPTION
> Always use `next` branch as destination branch for PRs, not `main`

https://github.com/coollabsio/coolify/issues/3245

In https://github.com/coollabsio/coolify/pull/3186 executions sort was added using a sort `desc`.

But there is an issue:
https://github.com/coollabsio/coolify/blob/37915234adda3e992c01dba4c54dfc56de90144b/resources/views/livewire/project/shared/scheduled-task/show.blade.php#L45
Here we only keep the last 20. So by ordering in desc, we're only keeping the first 20 executions.



Test:
- add a scheduled task and observe
- you can also update the show.blade.php file to keep only 2 elements, this will be easier to see.
- As this mr also update the scheduled backup you can test that too

![image](https://github.com/user-attachments/assets/6042620d-64fc-4263-9138-fc00aeba5eee)
![image](https://github.com/user-attachments/assets/7014487e-1530-43d3-9be4-08600451b341)


