### PR TITLE
Bug fix: Update chatwoot service name to fix issues with reverse proxy

### DIFF
--- a/templates/compose/chatwoot.yaml
+++ b/templates/compose/chatwoot.yaml
@@ -5,7 +5,7 @@
 # port: 3000
 
 services:
-  rails:
+  chatwoot:
     image: chatwoot/chatwoot:latest
     depends_on:
       - postgres


### PR DESCRIPTION
This is my first time in this repo, so the root cause here might be wrong.

I'm using the Caddy proxy and could not one-click deploy Chatwoot. The reverse_proxy config used port 80 instead of port 3000.

The root cause seemed to be in `shared.php#newParser`. It tries to get the predefinedPort:

```
            $serviceDefinition = data_get($allServices, $tempServiceName);
            $predefinedPort = data_get($serviceDefinition, 'port');
            if ($serviceName === 'plausible') {
                $predefinedPort = '8000';
            }
```

by using the service name.

The services are being extracted from the docker compose yaml file:

```
    $services = data_get($yaml, 'services', collect([]));
```

This caused a mismatch with chatwoot:

1. The service definition in `service-templates.json` had a key of 'chatwoot'
2. The service name extracted from the docker compose file was `sidekiq` (I'm not sure why it wasn't `rails`)

It seems like there's an implicit variant that the service that is exposed via the proxy needs to have the same name as the service itself.

I might be missing something here. This does seem to fix the issue though. When I updated this manually in the `coolify` docker container and ran `php artisan services:generate` and created a new chatwoot service, it was accessible.

If that is an invariant, I'm happy to update the docs to reflect that too. There also might be other services that have this same issue.