### PR TITLE
Fix: Pull helper image if not available otherwise s3 backup upload fails

### DIFF
--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -497,11 +497,6 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
 
             $this->ensureHelperImageAvailable();
 
-            $settings = InstanceSettings::get();
-            $helperImage = config('coolify.helper_image');
-            $helperImageTag = $settings->helper_version;
-            $fullImageName = "{$helperImage}:{$helperImageTag}";
-
             $commands[] = "docker run -d --network {$network} --name backup-of-{$this->backup->uuid} --rm -v $this->backup_location:$this->backup_location:ro {$fullImageName}";
             $commands[] = "docker exec backup-of-{$this->backup->uuid} mc config host add temporary {$endpoint} $key $secret";
             $commands[] = "docker exec backup-of-{$this->backup->uuid} mc cp $this->backup_location temporary/$bucket{$this->backup_dir}/";


### PR DESCRIPTION
Fixes: https://github.com/coollabsio/coolify/issues/3355

Changes:
- If a backup needs to be uploaded to s3, the Coolify helper image must be available -> This implements a check for the helper image and if it is not available/not the latest version, the helper will be pulled from the ghrc.io repo.