### PR TITLE
Fix: Set a default server timezone

### DIFF
--- a/database/migrations/2024_09_08_130756_update_server_settings_default_timezone.php
+++ b/database/migrations/2024_09_08_130756_update_server_settings_default_timezone.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+class UpdateServerSettingsDefaultTimezone extends Migration
+{
+    public function up()
+    {
+        Schema::table('server_settings', function (Blueprint $table) {
+            $table->string('server_timezone')->default('UTC')->change();
+        });
+
+        DB::table('server_settings')
+            ->whereNull('server_timezone')
+            ->orWhere('server_timezone', '')
+            ->update(['server_timezone' => 'UTC']);
+    }
+
+    public function down()
+    {
+        Schema::table('server_settings', function (Blueprint $table) {
+            $table->string('server_timezone')->default('')->change();
+        });
+    }
+}


### PR DESCRIPTION
Changes:
- Fix: This PR fixes some execution problem with scheduled tasks and backups not working because there is no default server timezone set, now there is, except if the user has set one, then that one will be used.
