### PR TITLE
feat: Expose project description in API response

### DIFF
--- a/app/Http/Controllers/Api/DeployController.php
+++ b/app/Http/Controllers/Api/DeployController.php
@@ -84,7 +84,7 @@ class DeployController extends Controller
         ],
         tags: ['Deployments'],
         parameters: [
-            new OA\Parameter(name: 'uuid', in: 'path', required: true, description: 'Deployment Uuid', schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'uuid', in: 'path', required: true, description: 'Deployment UUID', schema: new OA\Schema(type: 'string')),
         ],
         responses: [
             new OA\Response(
@@ -147,7 +147,7 @@ class DeployController extends Controller
         responses: [
             new OA\Response(
                 response: 200,
-                description: 'Get deployment(s) Uuid\'s',
+                description: 'Get deployment(s) UUID\'s',
                 content: [
                     new OA\MediaType(
                         mediaType: 'application/json',

--- a/app/Http/Controllers/Api/ProjectController.php
+++ b/app/Http/Controllers/Api/ProjectController.php
@@ -11,7 +11,7 @@ class ProjectController extends Controller
 {
     #[OA\Get(
         summary: 'List',
-        description: 'list projects.',
+        description: 'List projects.',
         path: '/projects',
         security: [
             ['bearerAuth' => []],
@@ -54,7 +54,7 @@ class ProjectController extends Controller
 
     #[OA\Get(
         summary: 'Get',
-        description: 'Get project by Uuid.',
+        description: 'Get project by UUID.',
         path: '/projects/{uuid}',
         security: [
             ['bearerAuth' => []],
@@ -136,7 +136,7 @@ class ProjectController extends Controller
             return invalidTokenResponse();
         }
         if (! $request->uuid) {
-            return response()->json(['message' => 'Uuid is required.'], 422);
+            return response()->json(['message' => 'UUID is required.'], 422);
         }
         if (! $request->environment_name) {
             return response()->json(['message' => 'Environment name is required.'], 422);
@@ -333,7 +333,7 @@ class ProjectController extends Controller
         }
         $uuid = $request->uuid;
         if (! $uuid) {
-            return response()->json(['message' => 'Uuid is required.'], 422);
+            return response()->json(['message' => 'UUID is required.'], 422);
         }
 
         $project = Project::whereTeamId($teamId)->whereUuid($uuid)->first();
@@ -408,7 +408,7 @@ class ProjectController extends Controller
         }
 
         if (! $request->uuid) {
-            return response()->json(['message' => 'Uuid is required.'], 422);
+            return response()->json(['message' => 'UUID is required.'], 422);
         }
         $project = Project::whereTeamId($teamId)->whereUuid($request->uuid)->first();
         if (! $project) {

--- a/app/Http/Controllers/Api/ProjectController.php
+++ b/app/Http/Controllers/Api/ProjectController.php
@@ -46,7 +46,7 @@ class ProjectController extends Controller
         if (is_null($teamId)) {
             return invalidTokenResponse();
         }
-        $projects = Project::whereTeamId($teamId)->select('id', 'name', 'uuid')->get();
+        $projects = Project::whereTeamId($teamId)->select('id', 'name', 'description', 'uuid')->get();
 
         return response()->json(serializeApiResponse($projects),
         );

--- a/app/Http/Controllers/Api/SecurityController.php
+++ b/app/Http/Controllers/Api/SecurityController.php
@@ -73,7 +73,7 @@ class SecurityController extends Controller
         ],
         tags: ['Private Keys'],
         parameters: [
-            new OA\Parameter(name: 'uuid', in: 'path', required: true, description: 'Private Key Uuid', schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'uuid', in: 'path', required: true, description: 'Private Key UUID', schema: new OA\Schema(type: 'string')),
         ],
         responses: [
             new OA\Response(
@@ -318,7 +318,7 @@ class SecurityController extends Controller
         ],
         tags: ['Private Keys'],
         parameters: [
-            new OA\Parameter(name: 'uuid', in: 'path', required: true, description: 'Private Key Uuid', schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'uuid', in: 'path', required: true, description: 'Private Key UUID', schema: new OA\Schema(type: 'string')),
         ],
         responses: [
             new OA\Response(

--- a/app/Http/Controllers/Api/ServersController.php
+++ b/app/Http/Controllers/Api/ServersController.php
@@ -105,7 +105,7 @@ class ServersController extends Controller
         ],
         tags: ['Servers'],
         parameters: [
-            new OA\Parameter(name: 'uuid', in: 'path', required: true, description: 'Server\'s Uuid', schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'uuid', in: 'path', required: true, description: 'Server\'s UUID', schema: new OA\Schema(type: 'string')),
         ],
         responses: [
             new OA\Response(
@@ -182,7 +182,7 @@ class ServersController extends Controller
         ],
         tags: ['Servers'],
         parameters: [
-            new OA\Parameter(name: 'uuid', in: 'path', required: true, description: 'Server\'s Uuid', schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'uuid', in: 'path', required: true, description: 'Server\'s UUID', schema: new OA\Schema(type: 'string')),
         ],
         responses: [
             new OA\Response(
@@ -259,7 +259,7 @@ class ServersController extends Controller
         ],
         tags: ['Servers'],
         parameters: [
-            new OA\Parameter(name: 'uuid', in: 'path', required: true, description: 'Server\'s Uuid', schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'uuid', in: 'path', required: true, description: 'Server\'s UUID', schema: new OA\Schema(type: 'string')),
         ],
         responses: [
             new OA\Response(

--- a/app/Http/Controllers/Api/ServicesController.php
+++ b/app/Http/Controllers/Api/ServicesController.php
@@ -375,7 +375,7 @@ class ServicesController extends Controller
         responses: [
             new OA\Response(
                 response: 200,
-                description: 'Get a service by Uuid.',
+                description: 'Get a service by UUID.',
                 content: [
                     new OA\MediaType(
                         mediaType: 'application/json',
@@ -432,7 +432,7 @@ class ServicesController extends Controller
         responses: [
             new OA\Response(
                 response: 200,
-                description: 'Delete a service by Uuid',
+                description: 'Delete a service by UUID',
                 content: [
                     new OA\MediaType(
                         mediaType: 'application/json',

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -11,6 +11,7 @@ use OpenApi\Attributes as OA;
         'id' => ['type' => 'integer'],
         'uuid' => ['type' => 'string'],
         'name' => ['type' => 'string'],
+        'description' => ['type' => 'string'],
         'environments' => new OA\Property(
             property: 'environments',
             type: 'array',


### PR DESCRIPTION
This PR includes a project’s description in the `/api/v1/projects` [API response](https://coolify.io/docs/api/operations/list-projects).

I made an Alfred Workflow to list projects and thought it would be nice to have these—I imagine there are plenty of other reasons to have them as well! It also makes project responses slightly more consistent with servers, which already include their descriptions.

Before:

```json
[
  {
    "id": 1,
    "uuid": "jooog48kokckw0g4sgwcgsow",
    "name": "My first project"
  },
  {
    "id": 2,
    "uuid": "fw0o8s4ocwcco8s44c8gkskw",
    "name": "A Second Project"
  }
]
```

After:

```json
[
  {
    "id": 1,
    "uuid": "jooog48kokckw0g4sgwcgsow",
    "description": "This is a test project in development",
    "name": "My first project"
  },
  {
    "id": 2,
    "uuid": "fw0o8s4ocwcco8s44c8gkskw",
    "description": "This is my second project\u2019s description. I want it to show up in the API.",
    "name": "A Second Project"
  }
]
```

I also capitalized a few user-facing strings while I was in there for consistency! One beginning of a sentence, and the rest `Uuid` → `UUID` since it’s [an acronym](https://en.wikipedia.org/wiki/Universally_unique_identifier). (I can submit that separately if it was annoying or problematic to add here.)