### PR TITLE
fix: don't add `networks` key if `network_mode` is used

### DIFF
--- a/app/Actions/Service/StartService.php
+++ b/app/Actions/Service/StartService.php
@@ -16,8 +16,10 @@ class StartService
         $service->saveComposeConfigs();
         $commands[] = 'cd '.$service->workdir();
         $commands[] = "echo 'Saved configuration files to {$service->workdir()}.'";
-        $commands[] = "echo 'Creating Docker network.'";
-        $commands[] = "docker network inspect $service->uuid >/dev/null 2>&1 || docker network create --attachable $service->uuid";
+        if($service->networks()->count() > 0){
+            $commands[] = "echo 'Creating Docker network.'";
+            $commands[] = "docker network inspect $service->uuid >/dev/null 2>&1 || docker network create --attachable $service->uuid";
+        }
         $commands[] = 'echo Starting service.';
         $commands[] = "echo 'Pulling images.'";
         $commands[] = 'docker compose pull';


### PR DESCRIPTION
> Always use `next` branch as destination branch for PRs, not `main`

https://github.com/coollabsio/coolify/issues/3336

You can try with the docker-compose file from the issue or with any docker compose file with `network_mode: host`.
I also added a check to skip the network create command if we're not using any network (possible if network mode host is used)

Before:
![image](https://github.com/user-attachments/assets/f547665e-5c2e-4352-ba0a-ca2c08f1c518)
![image](https://github.com/user-attachments/assets/289840e1-a942-4f12-a1d7-2172d35b976d)

After:
![image](https://github.com/user-attachments/assets/97385683-27d2-42e5-9739-d6e85a62b51f)
no error

Note: As I don't know the service, I simply checked that the service started.
Tested on something I know:
```yaml
version: '3.8'
services:
  redis:
    image: 'redis:7.4.0-alpine'
    container_name: redis
    command: 'redis-server --port 1234'
    network_mode: host
```
you'll see that `redis-cli -p 1234` works

---

I simply wrapped everything related to the `networks` field with an if, not that great as it increase the indent. But I suppose there will be a refactor to clean that method as it's like 800 lines of code. So I kept it that way.
