### PR TITLE
fix: keydb. add `:` delimiter for connection string

### DIFF
--- a/app/Models/StandaloneKeydb.php
+++ b/app/Models/StandaloneKeydb.php
@@ -209,7 +209,7 @@ class StandaloneKeydb extends BaseModel
     protected function internalDbUrl(): Attribute
     {
         return new Attribute(
-            get: fn () => "redis://{$this->keydb_password}@{$this->uuid}:6379/0",
+            get: fn () => "redis://:{$this->keydb_password}@{$this->uuid}:6379/0",
         );
     }
 
@@ -218,7 +218,7 @@ class StandaloneKeydb extends BaseModel
         return new Attribute(
             get: function () {
                 if ($this->is_public && $this->public_port) {
-                    return "redis://{$this->keydb_password}@{$this->destination->server->getIp}:{$this->public_port}/0";
+                    return "redis://:{$this->keydb_password}@{$this->destination->server->getIp}:{$this->public_port}/0";
                 }
 
                 return null;


### PR DESCRIPTION
Сonnection string for `KeyDB` is formed incorrectly => it is not possible to connect to the database with copy-paste.

Compared with Redis and fixed.

1. UI:
<img width="191" alt="image" src="https://github.com/user-attachments/assets/8500e2e3-1dfb-40e3-8cc4-2f914a70ea49">

<img width="174" alt="image" src="https://github.com/user-attachments/assets/e8ee4df3-48ab-4314-a02a-dcc05472e321">

2. Internal URL getter:
https://github.com/coollabsio/coolify/blob/next/app/Models/StandaloneRedis.php#L208
https://github.com/coollabsio/coolify/blob/next/app/Models/StandaloneKeydb.php#L212

3. External URL getter:
https://github.com/coollabsio/coolify/blob/next/app/Models/StandaloneRedis.php#L217
https://github.com/coollabsio/coolify/blob/next/app/Models/StandaloneKeydb.php#L221