### PR TITLE
Fix: PR Build GitHub Action 

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -19,6 +19,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      attestations: write
+      id-token: write
       actions: write
     steps:
       - uses: actions/checkout@v4
@@ -41,6 +43,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      attestations: write
+      id-token: write
       actions: write
     steps:
       - uses: actions/checkout@v4
@@ -63,6 +67,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      attestations: write
+      id-token: write
       actions: write
     needs: [amd64, aarch64]
     steps:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -19,8 +19,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-      attestations: write
-      id-token: write
+      actions: write
     steps:
       - uses: actions/checkout@v4
       - name: Login to ghcr.io
@@ -42,8 +41,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-      attestations: write
-      id-token: write
+      actions: write
     steps:
       - uses: actions/checkout@v4
       - name: Login to ghcr.io
@@ -65,8 +63,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-      attestations: write
-      id-token: write
+      actions: write
     needs: [amd64, aarch64]
     steps:
       - name: Checkout


### PR DESCRIPTION
-> I have not tested this but it should fix the issue:
```
Error: buildx failed with: ERROR: denied: installation not allowed to Write organization package
```

Make sure the following settings are set:
1. organization's settings
2. Navigate to "Actions" under "Code, planning, and automation"
3. Select "General"
4. Under "Workflow permissions", ensure that "Read and write permissions" is selected and "Allow GitHub Actions to create and approve pull requests" is checked

Changes:
- Fix: Added the write action