### PR TITLE
fix filebrowser

### DIFF
--- a/templates/compose/filebrowser.yaml
+++ b/templates/compose/filebrowser.yaml
@@ -13,12 +13,20 @@ services:
         source: ./srv
         target: /srv
         isDirectory: true
-      - ./database.db:/database.db
+      - filebrowserdb:/data
       - type: bind
         source: ./filebrowser.json
         target: /.filebrowser.json
         read_only: true
-        content: "{}"
+        content: |
+          {
+            "port": 80,
+            "baseURL": "",
+            "address": "0.0.0.0",
+            "log": "stdout",
+            "database": "/data/database.db",
+            "root": "/srv"
+          }   
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:80"]
       interval: 2s


### PR DESCRIPTION
add filebrowser.json contents
start server listening to 0.0.0.0 on port 80
change to a global volume directory mount, filebrowser will then create db in this directory on first run
