### PR TITLE
Trigger pull helper image job when upgrading coolify

### DIFF
--- a/app/Actions/Server/UpdateCoolify.php
+++ b/app/Actions/Server/UpdateCoolify.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Server;
 
+use App\Jobs\PullHelperImageJob;
 use App\Models\InstanceSettings;
 use App\Models\Server;
 use Lorisleiva\Actions\Concerns\AsAction;
@@ -55,6 +56,13 @@ class UpdateCoolify
 
             return;
         }
+
+        $all_servers = Server::all();
+        $servers = $all_servers->where('settings.is_usable', true)->where('settings.is_reachable', true)->where('ip', '!=', '1.2.3.4');
+        foreach ($servers as $server) {
+            PullHelperImageJob::dispatch($server);
+        }
+
         instant_remote_process(["docker pull -q ghcr.io/coollabsio/coolify:{$this->latestVersion}"], $this->server, false);
 
         remote_process([


### PR DESCRIPTION
> Always use `next` branch as destination branch for PRs, not `main`

On my server I've disabled Auto Update and basically disabled the `Update Check Frequency` by setting it to something very low `0 0 1 1 1`.
So in my case, the `PullHelperImage` job is never called, that's because I want to manually update the app to prevent any unexpected breaking change.

But currently outside of `PullHelperImage` there's no way to update the helper image (and I suppose the future realtime image / sentinel when available). This mr fixes this by calling this job when upgrading the app.

I've basically copy-pasted the `all_servers` filter from `Kernel::pull_images` and put in the upgrade method
