### PR TITLE
Feat: Add Bounty issue type

### DIFF
--- a/.github/ISSUE_TEMPLATE/ENHANCEMENT_BOUNTY.yml
+++ b/.github/ISSUE_TEMPLATE/ENHANCEMENT_BOUNTY.yml
@@ -10,8 +10,8 @@ body:
           - **This issue template is exclusively for proposing new features, services, or improvements with an attached bounty.**
           - [Click here to create a new bounty](https://console.algora.io/org/coollabsio/bounties/new).
 
-        ## No Bounty?
-        - **Enhancements without a bounty can be discussed in the appropriate category of [Github Discussions](https://github.com/coollabsio/coolify/discussions).**
+        > [!NOTE]
+        > Enhancements without a bounty can be discussed in the appropriate category of [Github Discussions](https://github.com/coollabsio/coolify/discussions).
 
   - type: dropdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/ENHANCEMENT_BOUNTY.yml
+++ b/.github/ISSUE_TEMPLATE/ENHANCEMENT_BOUNTY.yml
@@ -7,11 +7,10 @@ body:
     attributes:
       value: |
         # 💎 Add a Bounty (with [algora.io](https://console.algora.io/org/coollabsio/bounties/new))
-          - This issue template is exclusively for proposing new features, services, or improvements with an attached bounty.
+          - **This issue template is exclusively for proposing new features, services, or improvements with an attached bounty.**
           - [Click here to create a new bounty](https://console.algora.io/org/coollabsio/bounties/new).
 
-        # Important
-        - **Please do not use this template unless you are adding a bounty to your request.**
+        ## No Bounty?
         - **Enhancements without a bounty can be discussed in the appropriate category of [Github Discussions](https://github.com/coollabsio/coolify/discussions).**
 
   - type: dropdown
@@ -34,7 +33,7 @@ body:
 
   - type: checkboxes
     attributes:
-      label: Terms
+      label: Enhancement Bounty Condition
       description: "By submitting this issue, you agree to the following:"
       options:
         - label: I have added or will add a bounty to this request.

--- a/.github/ISSUE_TEMPLATE/ENHANCEMENT_BOUNTY.yml
+++ b/.github/ISSUE_TEMPLATE/ENHANCEMENT_BOUNTY.yml
@@ -1,17 +1,16 @@
 name: 💎 Enhancement Bounty
 description: "Propose a new feature, service, or improvement with an attached bounty."
-title: "[Bounty]: "
+title: "[Enhancement]: "
 labels: ["✨ Enhancement", "🔍 Triage"]
 body:
   - type: markdown
     attributes:
       value: |
-        # 💎 Add a Bounty (with [algora.io](https://console.algora.io/org/coollabsio/bounties/new))
-          - **This issue template is exclusively for proposing new features, services, or improvements with an attached bounty.**
-          - [Click here to create a new bounty](https://console.algora.io/org/coollabsio/bounties/new).
+        > [!IMPORTANT]
+        > **This issue template is exclusively for proposing new features, services, or improvements with an attached bounty.** Enhancements without a bounty can be discussed in the appropriate category of [Github Discussions](https://github.com/coollabsio/coolify/discussions).
 
-        > [!NOTE]
-        > Enhancements without a bounty can be discussed in the appropriate category of [Github Discussions](https://github.com/coollabsio/coolify/discussions).
+        # 💎 Add a Bounty (with [algora.io](https://console.algora.io/org/coollabsio/bounties/new))
+          - [Click here to add the required bounty](https://console.algora.io/org/coollabsio/bounties/new)
 
   - type: dropdown
     attributes:
@@ -30,11 +29,3 @@ body:
       description: Provide a detailed description of the feature, improvement, or service you are proposing.
     validations:
       required: true
-
-  - type: checkboxes
-    attributes:
-      label: Enhancement Bounty Condition
-      description: "By submitting this issue, you agree to the following:"
-      options:
-        - label: I have added or will add a bounty to this request.
-          required: true

--- a/.github/ISSUE_TEMPLATE/ENHANCEMENT_BOUNTY.yml
+++ b/.github/ISSUE_TEMPLATE/ENHANCEMENT_BOUNTY.yml
@@ -1,0 +1,41 @@
+name: 💎 Enhancement Bounty
+description: "Propose a new feature, service, or improvement with an attached bounty."
+title: "[Bounty]: "
+labels: ["✨ Enhancement", "🔍 Triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # 💎 Add a Bounty (with [algora.io](https://console.algora.io/org/coollabsio/bounties/new))
+          - This issue template is exclusively for proposing new features, services, or improvements with an attached bounty.
+          - [Click here to create a new bounty](https://console.algora.io/org/coollabsio/bounties/new).
+
+        # Important
+        - **Please do not use this template unless you are adding a bounty to your request.**
+        - **Enhancements without a bounty can be discussed in the appropriate category of [Github Discussions](https://github.com/coollabsio/coolify/discussions).**
+
+  - type: dropdown
+    attributes:
+      label: Request Type
+      description: Select the type of request you are making.
+      options:
+        - New Feature
+        - New Service
+        - Improvement
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: Provide a detailed description of the feature, improvement, or service you are proposing.
+    validations:
+      required: true
+
+  - type: checkboxes
+    attributes:
+      label: Terms
+      description: "By submitting this issue, you agree to the following:"
+      options:
+        - label: I have added or will add a bounty to this request.
+          required: true


### PR DESCRIPTION
Changes:
- Currently there is only one issue type for bug reports. This PR adds a type for enhancements with a bounty attached, because as far as I know, discussions can not have bounties. So if someone wants to prioritize a feature, this bounty template can be used instead of discussion, otherwise discussion is still the place for features and so on.