### PR TITLE
Fix WebSocket connection for Terminal page when using Caddy

### DIFF
--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -413,7 +413,7 @@ $schema://$host {
     handle /app/* {
         reverse_proxy coolify-realtime:6001
     }
-    handle /terminal/ws/* {
+    handle /terminal/ws {
         reverse_proxy coolify-realtime:6002
     }
     reverse_proxy coolify:80


### PR DESCRIPTION
## Description
When using Caddy as a reverse proxy for Coolify, the WebSocket connection to the new Terminal page isn't working. This is because the current Caddy configuration only forwards requests to `/terminal/ws/*` to `coolify-realtime:6002`, but the actual WebSocket connection is made to `/terminal/ws`.

## Proposed Changes
Update the default Caddy configuration to correctly handle the WebSocket connection for the Terminal page.

### Current Configuration:
```php
$caddy_file = "
$schema://$host {
    handle /app/* {
        reverse_proxy coolify-realtime:6001
    }
    handle /terminal/ws/* {
        reverse_proxy coolify-realtime:6002
    }
    reverse_proxy coolify:80
}";
```

### Updated Configuration:
```php
$caddy_file = "
$schema://$host {
    handle /app/* {
        reverse_proxy coolify-realtime:6001
    }
    handle /terminal/ws {
        reverse_proxy coolify-realtime:6002
    }
    reverse_proxy coolify:80
}";
```

## Testing Done
- Tested the new configuration with Caddy as a reverse proxy
- Verified that the WebSocket connection for the Terminal page now works correctly