### PR TITLE
Fix Ghost Template domain generation

### DIFF
--- a/templates/compose/ghost.yaml
+++ b/templates/compose/ghost.yaml
@@ -10,6 +10,7 @@ services:
     volumes:
       - ghost-content-data:/var/lib/ghost/content
     environment:
+      - SERVICE_FQDN_GHOST_2368
       - url=$SERVICE_FQDN_GHOST_2368
       - database__client=mysql
       - database__connection__host=mysql


### PR DESCRIPTION
Ghost Template doesn't generate a domain. I believe it's because it's missing the addition of this PR.