### PR TITLE
fix(templates): filebrowser FQDN env variable

### DIFF
--- a/templates/compose/filebrowser.yaml
+++ b/templates/compose/filebrowser.yaml
@@ -7,7 +7,7 @@ services:
   filebrowser:
     image: filebrowser/filebrowser:latest
     environment:
-      - SERVICE_FQDN_FILEBROWSER
+      - SERVICE_FQDN_FILEBROWSER_80
     volumes:
       - type: bind
         source: ./srv


### PR DESCRIPTION
## Changes
- The filebrowser template FQDN env variable was wrong. This caused the template to not work at all without modifications.

## Issues
- fix #2641
