### PR TITLE
Fix: Broken helper manifests (for a short period a few hours)

### DIFF
--- a/.github/workflows/coolify-helper.yml
+++ b/.github/workflows/coolify-helper.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: "peaklabs-dev/coolify-helper"
+  IMAGE_NAME: "coollabsio/coolify-helper"
 
 jobs:
   amd64:
@@ -94,7 +94,6 @@ jobs:
       - name: Create & publish manifest
         run: |
           docker buildx imagetools create --append ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.VERSION }}-aarch64 --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.VERSION }} --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-          docker buildx imagetools create --append ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.VERSION }} --platform linux/arm/v8 --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.VERSION }} --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
       - uses: sarisia/actions-status-discord@v1
         if: always()
         with:

--- a/.github/workflows/coolify-helper.yml
+++ b/.github/workflows/coolify-helper.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: "coollabsio/coolify-helper"
+  IMAGE_NAME: "peaklabs-dev/coolify-helper"
 
 jobs:
   amd64:
@@ -94,6 +94,7 @@ jobs:
       - name: Create & publish manifest
         run: |
           docker buildx imagetools create --append ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.VERSION }}-aarch64 --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.VERSION }} --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          docker buildx imagetools create --append ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.VERSION }} --platform linux/arm/v8 --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.VERSION }} --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
       - uses: sarisia/actions-status-discord@v1
         if: always()
         with:

--- a/other/nightly/versions.json
+++ b/other/nightly/versions.json
@@ -7,7 +7,7 @@
             "version": "4.0.0-beta.355"
         },
         "helper": {
-            "version": "1.0.1"
+            "version": "1.0.2"
         },
         "realtime": {
             "version": "1.0.3"

--- a/versions.json
+++ b/versions.json
@@ -7,7 +7,7 @@
             "version": "4.0.0-beta.356"
         },
         "helper": {
-            "version": "1.0.1"
+            "version": "1.0.2"
         },
         "realtime": {
             "version": "1.0.3"


### PR DESCRIPTION
## Changes
- I accidentally pushed to main and broke the helper image manifest, I fixed it a few hours later by re-running the helper image job (the helper image 1.0.1 now is working again) the problem is the few people that have downloaded between when it was broken will run into problems if they are on ARM64 and will have to solve the problem manually via these steps: https://github.com/coollabsio/coolify/issues/3745#issuecomment-2395474995.
- This only updates the helper, so all people will get the new version with the fixed manifest (nothing in the helper was actually changed). The 1.0.1 image was only broken for a few hours, but any people who downloaded it between then have a broken mainfest version of the 1.0.1 helper affect are probably under 100 people, as most people should already have the 1.0.1 helper (and a new one is not pulled if you already have the latest one).

## Issues
- fix #3745
