### PR TITLE
feat: Custom traefik middlewares v2

### DIFF
--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -332,8 +332,12 @@ function fqdnLabelsForTraefik(string $uuid, Collection $domains, bool $is_force_
             if (preg_match('/traefik\.http\.middlewares\.(.*?)(\.|$)/', $item, $matches)) {
                 return $matches[1];
             }
+            if (preg_match('/coolify\.traefik\.middlewares=(.*)/', $item, $matches)) {
+                return explode(',', $matches[1]);
+            }
             return null;
-        })->filter()
+        })->flatten()
+        ->filter()
         ->unique();
     }
     foreach ($domains as $loop => $domain) {


### PR DESCRIPTION
This MR extends #3637 .

## Changes
- The coolify.traefik.middlewares label can now be used to specify additional traefik middlewares which will be used by the routers coolify generates

Using the same compose file as the old MR:
<pre>
services:
    http-echo:
        ...
        labels:
            - traefik.http.middlewares.customMiddleware.oneType.merge=true
            - 'traefik.http.middlewares.mybasicauth.basicauth.users=test:$2y$12$ci.4U63YX83CwkyUrjqxAucnmi2xXOIlEF6T/KdP9824f1Rf1iyNG'
            - traefik.http.middlewares.example-middleware.redirectregex.regex=^(http|https)://www\.(.+)
            - traefik.http.middlewares.example-middleware.redirectregex.replacement=${1}://${2}
            - traefik.http.middlewares.example-middleware.redirectregex.permanent=true
            - traefik.http.middlewares.anotherCustomMiddleware.anotherType
</pre>

we can now add the middleware from #3754 by adding the coolify.traefik.middlewares label:

<pre>
services:
    http-echo:
        ...
        labels:
            - 'coolify.traefik.middlewares=crowdsec@file'
            - traefik.http.middlewares.customMiddleware.oneType.merge=true
            - 'traefik.http.middlewares.mybasicauth.basicauth.users=test:$2y$12$ci.4U63YX83CwkyUrjqxAucnmi2xXOIlEF6T/KdP9824f1Rf1iyNG'
            - traefik.http.middlewares.example-middleware.redirectregex.regex=^(http|https)://www\.(.+)
            - traefik.http.middlewares.example-middleware.redirectregex.replacement=${1}://${2}
            - traefik.http.middlewares.example-middleware.redirectregex.permanent=true
            - traefik.http.middlewares.anotherCustomMiddleware.anotherType
</pre>

which will result in the following label for the autogenerated router:

`- 'traefik.http.routers.http-0-redacted-http-echo.middlewares=gzip,crowdsec@file,customMiddleware,mybasicauth,example-middleware,anotherCustomMiddleware'`

## Issues
- fix #3754 
