### PR TITLE
disable discord link previews

### DIFF
--- a/app/Notifications/Application/DeploymentFailed.php
+++ b/app/Notifications/Application/DeploymentFailed.php
@@ -75,11 +75,11 @@ class DeploymentFailed extends Notification implements ShouldQueue
     public function toDiscord(): string
     {
         if ($this->preview) {
-            $message = 'Coolify:  Pull request #'.$this->preview->pull_request_id.' of '.$this->application_name.' ('.$this->preview->fqdn.') deployment failed: ';
-            $message .= '[View Deployment Logs]('.$this->deployment_url.')';
+            $message = 'Coolify:  Pull request #'.$this->preview->pull_request_id.' of '.$this->application_name.' (<'.$this->preview->fqdn.'>) deployment failed: ';
+            $message .= '[View Deployment Logs](<'.$this->deployment_url.'>)';
         } else {
-            $message = 'Coolify: Deployment failed of '.$this->application_name.' ('.$this->fqdn.'): ';
-            $message .= '[View Deployment Logs]('.$this->deployment_url.')';
+            $message = 'Coolify: Deployment failed of '.$this->application_name.' (<'.$this->fqdn.'>): ';
+            $message .= '[View Deployment Logs](<'.$this->deployment_url.'>)';
         }
 
         return $message;

--- a/app/Notifications/Application/DeploymentSuccess.php
+++ b/app/Notifications/Application/DeploymentSuccess.php
@@ -85,17 +85,17 @@ class DeploymentSuccess extends Notification implements ShouldQueue
 
 ';
             if ($this->preview->fqdn) {
-                $message .= '[Open Application]('.$this->preview->fqdn.') | ';
+                $message .= '[Open Application](<'.$this->preview->fqdn.'>) | ';
             }
-            $message .= '[Deployment logs]('.$this->deployment_url.')';
+            $message .= '[Deployment logs](<'.$this->deployment_url.'>)';
         } else {
             $message = 'Coolify: New version successfully deployed of '.$this->application_name.'
 
 ';
             if ($this->fqdn) {
-                $message .= '[Open Application]('.$this->fqdn.') | ';
+                $message .= '[Open Application](<'.$this->fqdn.'>) | ';
             }
-            $message .= '[Deployment logs]('.$this->deployment_url.')';
+            $message .= '[Deployment logs](<'.$this->deployment_url.'>)';
         }
 
         return $message;

--- a/app/Notifications/Application/StatusChanged.php
+++ b/app/Notifications/Application/StatusChanged.php
@@ -60,7 +60,7 @@ class StatusChanged extends Notification implements ShouldQueue
         $message = 'Coolify: '.$this->resource_name.' has been stopped.
 
 ';
-        $message .= '[Open Application in Coolify]('.$this->resource_url.')';
+        $message .= '[Open Application in Coolify](<'.$this->resource_url.'>)';
 
         return $message;
     }

--- a/app/Notifications/ScheduledTask/TaskFailed.php
+++ b/app/Notifications/ScheduledTask/TaskFailed.php
@@ -48,7 +48,7 @@ class TaskFailed extends Notification implements ShouldQueue
 
     public function toDiscord(): string
     {
-        return "Coolify: Scheduled task ({$this->task->name}, [link]({$this->url})) failed with output: {$this->output}";
+        return "Coolify: Scheduled task ({$this->task->name}, [link](<{$this->url}>)) failed with output: {$this->output}";
     }
 
     public function toTelegram(): array

--- a/app/Notifications/Server/ForceDisabled.php
+++ b/app/Notifications/Server/ForceDisabled.php
@@ -52,7 +52,7 @@ class ForceDisabled extends Notification implements ShouldQueue
 
     public function toDiscord(): string
     {
-        $message = "Coolify: Server ({$this->server->name}) disabled because it is not paid!\n All automations and integrations are stopped.\nPlease update your subscription to enable the server again [here](https://app.coolify.io/subscriptions).";
+        $message = "Coolify: Server ({$this->server->name}) disabled because it is not paid!\n All automations and integrations are stopped.\nPlease update your subscription to enable the server again [here](<https://app.coolify.io/subscriptions>).";
 
         return $message;
     }

--- a/app/Notifications/Server/HighDiskUsage.php
+++ b/app/Notifications/Server/HighDiskUsage.php
@@ -54,7 +54,7 @@ class HighDiskUsage extends Notification implements ShouldQueue
 
     public function toDiscord(): string
     {
-        $message = "Coolify: Server '{$this->server->name}' high disk usage detected!\nDisk usage: {$this->disk_usage}%. Threshold: {$this->docker_cleanup_threshold}%.\nPlease cleanup your disk to prevent data-loss.\nHere are some tips: https://coolify.io/docs/knowledge-base/server/automated-cleanup.";
+        $message = "Coolify: Server '{$this->server->name}' high disk usage detected!\nDisk usage: {$this->disk_usage}%. Threshold: {$this->docker_cleanup_threshold}%.\nPlease cleanup your disk to prevent data-loss.\nHere are some tips: <https://coolify.io/docs/knowledge-base/server/automated-cleanup>.";
 
         return $message;
     }

--- a/app/Notifications/Test.php
+++ b/app/Notifications/Test.php
@@ -33,7 +33,7 @@ class Test extends Notification implements ShouldQueue
     {
         $message = 'Coolify: This is a test Discord notification from Coolify.';
         $message .= "\n\n";
-        $message .= '[Go to your dashboard]('.base_url().')';
+        $message .= '[Go to your dashboard](<'.base_url().'>)';
 
         return $message;
     }


### PR DESCRIPTION
They're very annoying in a log because you can only fit two on the screen at once. Discord has no way to entirely disable previews in a channel or for webhooks, so all links have to be wrapped in `<>` instead.