### PR TITLE
fix glitchtip template

### DIFF
--- a/templates/compose/glitchtip.yaml
+++ b/templates/compose/glitchtip.yaml
@@ -53,7 +53,6 @@ services:
       - postgres
       - redis
     environment:
-      - SERVICE_FQDN_GLITCHTIP
       - DATABASE_URL=postgres://$SERVICE_USER_POSTGRESQL:$SERVICE_PASSWORD_POSTGRESQL@postgres:5432/${POSTGRESQL_DATABASE:-glitchtip}
       - SECRET_KEY=$SERVICE_BASE64_64_ENCRYPTION
       - EMAIL_URL=${EMAIL_URL:-consolemail://}


### PR DESCRIPTION

## Changes
- 
removed duplicate generate FQDN from worker, this had 2 domains generated and proxy woudn't know which container to use

now only the main web has a url

## Issues
- fix #
https://discord.com/channels/459365938081431553/1293242762568925204/1293244859750023260