### PR TITLE
fix autocompletes

### DIFF
--- a/resources/views/components/modal-confirmation.blade.php
+++ b/resources/views/components/modal-confirmation.blade.php
@@ -268,13 +268,17 @@
                             <p>Please enter your password to confirm this destructive action.</p>
                         </div>
                         <div class="flex flex-col gap-2 mb-4">
-                            <label for="password-confirm"
+                            @php
+                                $passwordConfirm = Str::uuid();
+                            @endphp
+                            <label for="password-confirm-{{ $passwordConfirm }}"
                                 class="block text-sm font-medium text-gray-700 dark:text-gray-300">
                                 Your Password
                             </label>
-                            <form @submit.prevent="return false" @keydown.enter.prevent>
-                                <input type="password" id="password-confirm" x-model="password" class="w-full input"
-                                    placeholder="Enter your password">
+                            <form @submit.prevent="false" @keydown.enter.prevent>
+                                <input type="text" name="username" autocomplete="username" value="{{ auth()->user()->email }}" style="display: none;">
+                                <input type="password" id="password-confirm-{{ $passwordConfirm }}" x-model="password"
+                                    class="w-full input" placeholder="Enter your password" autocomplete="current-password">
                             </form>
                             <p x-show="passwordError" x-text="passwordError" class="mt-1 text-sm text-red-500"></p>
                             @error('password')

--- a/resources/views/livewire/notifications/telegram.blade.php
+++ b/resources/views/livewire/notifications/telegram.blade.php
@@ -20,11 +20,12 @@
             <x-forms.checkbox instantSave id="team.telegram_enabled" label="Enabled" />
         </div>
         <div class="flex gap-2">
-            <x-forms.input type="password"
-                helper="Get it from the <a class='inline-block underline dark:text-white' href='https://t.me/botfather' target='_blank'>BotFather Bot</a> on Telegram."
+
+                <x-forms.input type="password" autocomplete="new-password"
+                    helper="Get it from the <a class='inline-block underline dark:text-white' href='https://t.me/botfather' target='_blank'>BotFather Bot</a> on Telegram."
                 required id="team.telegram_token" label="Token" />
             <x-forms.input helper="Recommended to add your bot to a group chat and add its Chat ID here." required
-                id="team.telegram_chat_id" label="Chat ID" />
+                    id="team.telegram_chat_id" label="Chat ID" />
         </div>
         @if (data_get($team, 'telegram_enabled'))
             <h2 class="mt-4">Subscribe to events</h2>

--- a/resources/views/livewire/settings-email.blade.php
+++ b/resources/views/livewire/settings-email.blade.php
@@ -36,7 +36,8 @@
                     </div>
                     <div class="flex flex-col w-full gap-2 xl:flex-row">
                         <x-forms.input id="settings.smtp_username" label="SMTP Username" />
-                        <x-forms.input id="settings.smtp_password" type="password" label="SMTP Password" />
+                        <x-forms.input id="settings.smtp_password" type="password" label="SMTP Password"
+                            autocomplete="new-password" />
                         <x-forms.input id="settings.smtp_timeout" helper="Timeout value for sending emails."
                             label="Timeout" />
                     </div>

--- a/resources/views/livewire/settings-oauth.blade.php
+++ b/resources/views/livewire/settings-oauth.blade.php
@@ -25,7 +25,7 @@
                         <x-forms.input id="oauth_settings_map.{{ $oauth_setting->provider }}.client_id"
                             label="Client ID" />
                         <x-forms.input id="oauth_settings_map.{{ $oauth_setting->provider }}.client_secret"
-                            type="password" label="Client Secret" />
+                            type="password" label="Client Secret" autocomplete="new-password" />
                         <x-forms.input id="oauth_settings_map.{{ $oauth_setting->provider }}.redirect_uri"
                             label="Redirect URI" />
                         @if ($oauth_setting->provider == 'azure')


### PR DESCRIPTION
## Changes
- sometimes `autocomplete="off"` wont work so added `autocomplete="new-password"` in cases where made sense
- wrap `form` and added username as hidden to try a better autofill
- uuid because modals are rendered multiple times in same page, to avoid id dups (future improvement would be a single re-usable modal component)

## Issues
Following #3640 then:
- fix #3732
- hoping to fix #3698