### PR TITLE
Fix caddy quic udp port

### DIFF
--- a/bootstrap/helpers/proxy.php
+++ b/bootstrap/helpers/proxy.php
@@ -239,6 +239,7 @@ function generate_default_proxy_configuration(Server $server)
                     'ports' => [
                         '80:80',
                         '443:443',
+                        '443:443/udp',
                     ],
                     'labels' => [
                         'coolify.managed=true',


### PR DESCRIPTION
## Changes
- Expose port 443/udp for Caddy proxy (to enable QUIC/HTTP3)

