### PR TITLE
fix: use correct env variable for invoice ninja password

### DIFF
--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -369,7 +369,7 @@ class Service extends BaseModel
                     $email = $this->environment_variables()->where('key', 'IN_USER_EMAIL')->first();
                     $data = $data->merge([
                         'Email' => [
-                            'key' => 'IN_USER_EMAIL',
+                            'key' => data_get($email, 'key'),
                             'value' => data_get($email, 'value'),
                             'rules' => 'required|email',
                         ],
@@ -377,7 +377,7 @@ class Service extends BaseModel
                     $password = $this->environment_variables()->where('key', 'SERVICE_PASSWORD_INVOICENINJAUSER')->first();
                     $data = $data->merge([
                         'Password' => [
-                            'key' => 'IN_PASSWORD',
+                            'key' => data_get($password, 'key'),
                             'value' => data_get($password, 'value'),
                             'rules' => 'required',
                             'isPassword' => true,


### PR DESCRIPTION
## Description

Invoice ninja is not currently using the correct field when updating the password through service-specific configuration, which leads to the password introduced not being valid when trying to log in.

<img width="1726" alt="Screenshot 2024-10-10 at 17 57 01" src="https://github.com/user-attachments/assets/6acae095-c14e-4e3f-b46d-7c4cd0ee26e9">

<img width="1265" alt="Screenshot 2024-10-10 at 18 00 15" src="https://github.com/user-attachments/assets/a8bc6436-f004-4723-ba63-3d040ba7ddcc">


This pull request addresses the issue.

## Changes
- Use `SERVICE_PASSWORD_INVOICENINJAUSER` as the env variable that is bound to the password field for invoice ninja.



