### PR TITLE
add https3 support to traefik and fix 404 redirect for traefik3

### DIFF
--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -209,10 +209,13 @@ respond 404
                                 1 => 'https',
                             ],
                             'service' => 'noop',
-                            'rule' => 'HostRegexp(`{catchall:.*}`)',
+                            'rule' => 'HostRegexp(`.+`)',
+                            'tls' => [
+                                'certResolver' => 'letsencrypt',
+                            ],
                             'priority' => 1,
                             'middlewares' => [
-                                0 => 'redirect-regexp@file',
+                                0 => 'redirect-regexp',
                             ],
                         ],
                     ],

--- a/bootstrap/helpers/proxy.php
+++ b/bootstrap/helpers/proxy.php
@@ -164,6 +164,7 @@ function generate_default_proxy_configuration(Server $server)
                     'ports' => [
                         '80:80',
                         '443:443',
+                        '443:443/udp',
                         '8080:8080',
                     ],
                     'healthcheck' => [
@@ -187,6 +188,7 @@ function generate_default_proxy_configuration(Server $server)
                         '--entryPoints.http.http2.maxConcurrentStreams=50',
                         '--entrypoints.https.http.encodequerysemicolons=true',
                         '--entryPoints.https.http2.maxConcurrentStreams=50',
+                        '--entrypoints.https.http3',
                         '--providers.docker.exposedbydefault=false',
                         '--providers.file.directory=/traefik/dynamic/',
                         '--providers.file.watch=true',


### PR DESCRIPTION
## Changes
- Add http3 support to traefik
- fix 404 redirect for traefik v3

## Issues
- fix #
current 404 redirect catch all rule does not work in traefik v3, as well as needing tls to work when using https redirects.
now typing any random subdomain, will redirect to your chosen target.

Turned on http3 support in traefik

