### PR TITLE
scp fallback to ipv6 when it fails on ipv4

### DIFF
--- a/scripts/sync_volume.sh
+++ b/scripts/sync_volume.sh
@@ -39,7 +39,8 @@ ssh -p $SOURCE_PORT $SOURCE_USER@$SOURCE_SERVER "docker  run -v $SOURCE_VOLUME_N
 echo ""
 if [ -f "./$SOURCE_VOLUME_NAME.tgz" ]; then
     echo "Uploading backup file to $DESTINATION_SERVER:~/$DESTINATION_VOLUME_NAME.tgz"
-    scp -P $DESTINATION_PORT ./$SOURCE_VOLUME_NAME.tgz $DESTINATION_USER@$DESTINATION_SERVER:~/$DESTINATION_VOLUME_NAME.tgz
+    SCP_CMD="scp -P $DESTINATION_PORT ./$SOURCE_VOLUME_NAME.tgz $DESTINATION_USER@$DESTINATION_SERVER:~/$DESTINATION_VOLUME_NAME.tgz"
+    $SCP_CMD || $SCP_CMD -6
     echo ""
     echo "Restoring backup file on remote ($DESTINATION_SERVER:/~/$DESTINATION_VOLUME_NAME.tgz)"
     ssh -p $DESTINATION_PORT $DESTINATION_USER@$DESTINATION_SERVER "docker run -i -v $DESTINATION_VOLUME_NAME:/volume --log-driver none --rm loomchild/volume-backup restore -c pigz -vf < ~/$DESTINATION_VOLUME_NAME.tgz"


### PR DESCRIPTION
## Not pretty sure for these : 
- [ ] I have tested my changes. ==  I don't know how to test it
- [ ] I have considered backwards compatibility. == I may have overlooked some context issues. ie I don't know in which environment it runs.

## Changes
- Add fallback to scp command retrying in ipv6 mode when it failed for ipv4

## Issues
- Following a ticket where you talked about the solution to deployment issues with ipv6