### PR TITLE
feat: real preview URL example

### DIFF
--- a/app/Livewire/Project/Application/Previews.php
+++ b/app/Livewire/Project/Application/Previews.php
@@ -90,16 +90,8 @@ class Previews extends Component
         }
 
         $fqdn = generateFqdn($this->application->destination->server, $this->application->uuid);
-        $url = Url::fromString($fqdn);
         $template = $this->application->preview_url_template;
-        $host = $url->getHost();
-        $schema = $url->getScheme();
-        $random = new Cuid2;
-        $preview_fqdn = str_replace('{{random}}', $random, $template);
-        $preview_fqdn = str_replace('{{domain}}', $host, $preview_fqdn);
-        $preview_fqdn = str_replace('{{pr_id}}', $preview->pull_request_id, $preview_fqdn);
-        $preview_fqdn = "$schema://$preview_fqdn";
-        $preview->fqdn = $preview_fqdn;
+        $preview->fqdn = get_preview_fqdn($template, $preview->pull_request_id, $fqdn);
         $preview->save();
         $this->dispatch('success', 'Domain generated.');
     }

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -1365,24 +1365,8 @@ class Application extends BaseModel
     {
         $preview = ApplicationPreview::findPreviewByApplicationAndPullId($this->id, $pull_request_id);
         if (is_null(data_get($preview, 'fqdn')) && $this->fqdn) {
-            if (str($this->fqdn)->contains(',')) {
-                $url = Url::fromString(str($this->fqdn)->explode(',')[0]);
-                $preview_fqdn = getFqdnWithoutPort(str($this->fqdn)->explode(',')[0]);
-            } else {
-                $url = Url::fromString($this->fqdn);
-                if (data_get($preview, 'fqdn')) {
-                    $preview_fqdn = getFqdnWithoutPort(data_get($preview, 'fqdn'));
-                }
-            }
             $template = $this->preview_url_template;
-            $host = $url->getHost();
-            $schema = $url->getScheme();
-            $random = new Cuid2;
-            $preview_fqdn = str_replace('{{random}}', $random, $template);
-            $preview_fqdn = str_replace('{{domain}}', $host, $preview_fqdn);
-            $preview_fqdn = str_replace('{{pr_id}}', $pull_request_id, $preview_fqdn);
-            $preview_fqdn = "$schema://$preview_fqdn";
-            $preview->fqdn = $preview_fqdn;
+            $preview->fqdn = get_preview_fqdn($template, $pull_request_id, $this->fqdn);
             $preview->save();
         }
 

--- a/app/View/Components/Forms/Input.php
+++ b/app/View/Components/Forms/Input.php
@@ -23,6 +23,10 @@ class Input extends Component
         public bool $isMultiline = false,
         public string $defaultClass = 'input',
         public string $autocomplete = 'off',
+        public bool $live = false,
+        public bool $dirty = false,
+        public string $dirtyClass = 'dark:focus:ring-warning dark:ring-warning',
+        public string $cleanClass = 'dark:focus:ring-coolgray-300 dark:ring-coolgray-300',
     ) {}
 
     public function render(): View|Closure|string
@@ -35,6 +39,13 @@ class Input extends Component
         }
         if ($this->type === 'password') {
             $this->defaultClass = $this->defaultClass.'  pr-[2.8rem]';
+        }
+        if ($this->live) {
+            if ($this->dirty) {
+                $this->defaultClass = $this->defaultClass.' '.$this->dirtyClass;
+            } else {
+                $this->defaultClass = $this->defaultClass.' '.$this->cleanClass;
+            }
         }
 
         // $this->label = Str::title($this->label);

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -304,6 +304,33 @@ function getFqdnWithoutPort(string $fqdn)
         return $fqdn;
     }
 }
+function get_preview_fqdn(string $template, int $pull_request_id, string $fqdn, ?string $random = new Cuid2): string
+{
+    if (str($fqdn)->contains(',')) {
+        return get_preview_fqdns(
+            $template,
+            $pull_request_id,
+            str($fqdn)->explode(',')
+        )->implode(',');
+    }
+
+    $url = Url::fromString($fqdn);
+    $host = $url->getHost();
+    $schema = $url->getScheme();
+
+    $preview_fqdn = str_replace('{{random}}', $random, $template);
+    $preview_fqdn = str_replace('{{domain}}', $host, $preview_fqdn);
+    $preview_fqdn = str_replace('{{pr_id}}', $pull_request_id, $preview_fqdn);
+
+    return "$schema://$preview_fqdn";
+}
+function get_preview_fqdns(string $template, int $pull_request_id, Collection $fqdns): Collection
+{
+    $random = new Cuid2;
+    return $fqdns->map(function ($fqdn) use ($template, $pull_request_id, $random) {
+        return get_preview_fqdn($template, $pull_request_id, $fqdn, $random);
+    });
+}
 /**
  * If fqdn is set, return it, otherwise return public ip.
  */

--- a/resources/views/components/forms/input.blade.php
+++ b/resources/views/components/forms/input.blade.php
@@ -26,25 +26,35 @@
                 </div>
             @endif
             <input autocomplete="{{ $autocomplete }}" value="{{ $value }}"
-                {{ $attributes->merge(['class' => $defaultClass]) }} @required($required)
-                @if ($id !== 'null') wire:model={{ $id }} @endif
-                wire:dirty.class.remove='dark:focus:ring-coolgray-300 dark:ring-coolgray-300'
-                wire:dirty.class="dark:focus:ring-warning dark:ring-warning" wire:loading.attr="disabled"
-                type="{{ $type }}" @readonly($readonly) @disabled($disabled) id="{{ $id }}"
-                name="{{ $name }}" placeholder="{{ $attributes->get('placeholder') }}"
+                {{ $attributes->merge(['class' => $defaultClass]) }}
+                @required($required) @readonly($readonly) @disabled($disabled)
+                @if ($id !== 'null')
+                    id={{ $id }}
+                    @if ($live) wire:model.live={{ $id }} @else wire:model={{ $id }} @endif
+                @endif
+                @if (!$live)
+                    wire:dirty.class.remove="{{ $cleanClass }}"
+                    wire:dirty.class="{{ $dirtyClass }}"
+                    wire:loading.attr="disabled"
+                @endif
+                type="{{ $type }}" name="{{ $name }}" placeholder="{{ $attributes->get('placeholder') }}"
                 aria-placeholder="{{ $attributes->get('placeholder') }}">
-
         </div>
     @else
         <input autocomplete="{{ $autocomplete }}" @if ($value) value="{{ $value }}" @endif
-            {{ $attributes->merge(['class' => $defaultClass]) }} @required($required) @readonly($readonly)
-            @if ($id !== 'null') wire:model={{ $id }} @endif
-            wire:dirty.class.remove='dark:focus:ring-coolgray-300 dark:ring-coolgray-300'
-            wire:dirty.class="dark:focus:ring-warning dark:ring-warning" wire:loading.attr="disabled"
-            type="{{ $type }}" @disabled($disabled)
-            min="{{ $attributes->get('min') }}" max="{{ $attributes->get('max') }}"
-            @if ($id !== 'null') id={{ $id }} @endif name="{{ $name }}"
-            placeholder="{{ $attributes->get('placeholder') }}">
+            {{ $attributes->merge(['class' => $defaultClass]) }}
+            @required($required) @readonly($readonly) @disabled($disabled)
+            @if ($id !== 'null')
+                id={{ $id }}
+                @if ($live) wire:model.live={{ $id }} @else wire:model={{ $id }} @endif
+            @endif
+            @if (!$live)
+                wire:dirty.class.remove="{{ $cleanClass }}"
+                wire:dirty.class="{{ $dirtyClass }}"
+                wire:loading.attr="disabled"
+            @endif
+            type="{{ $type }}" min="{{ $attributes->get('min') }}" max="{{ $attributes->get('max') }}"
+            name="{{ $name }}" placeholder="{{ $attributes->get('placeholder') }}">
     @endif
     @if (!$label && $helper)
         <x-helper :helper="$helper" />

--- a/resources/views/livewire/project/application/preview/form.blade.php
+++ b/resources/views/livewire/project/application/preview/form.blade.php
@@ -6,10 +6,11 @@
     </div>
     <div class="pb-4 ">Preview Deployments based on pull requests are here.</div>
     <div class="flex flex-col gap-2 pb-4">
-        <x-forms.input id="application.preview_url_template" label="Preview URL Template"
+        <x-forms.input id="preview_url_template" label="Preview URL Template"
+            live dirty="{{ $preview_url_template !== $application->preview_url_template }}"
             helper="Templates:<span class='text-helper'>@@{{ random }}</span> to generate random sub-domain each time a PR is deployed, <span class='text-helper'>@@{{ pr_id }}</span> to use pull request ID as sub-domain or <span class='text-helper'>@@{{ domain }}</span> to replace the domain name with the application's domain name." />
         @if ($preview_url_template)
-            <div class="">Domain Preview: {{ $preview_url_template }}</div>
+            <div class="">Domain Preview: {{ $preview_url_example }}</div>
         @endif
     </div>
 </form>


### PR DESCRIPTION
## Changes
- Domain preview replaces {{pr_id}} and {{random}} not just {{domain}}
- Live updates
- {{random}} is now the same value for all URLs
- Refactored 4 different implementations to all use the same `get_preview_fqdn` function.


![Screenshot_20241012_223341](https://github.com/user-attachments/assets/4025ebc9-c398-49b4-a886-f86303a55f99)

Remaining tasks:
- [ ] Make sure all the other generate_preview_fqdn methods still work correctly
