### PR TITLE
Fix: Error response from daemon: all predefined address pools have been fully subnetted

### DIFF
--- a/other/nightly/install.sh
+++ b/other/nightly/install.sh
@@ -287,7 +287,10 @@ test -s /etc/docker/daemon.json && cp /etc/docker/daemon.json /etc/docker/daemon
   "log-opts": {
     "max-size": "10m",
     "max-file": "3"
-  }
+  },
+  "default-address-pools": [
+    {"base":"10.0.0.0/8","size":24}
+  ]
 }
 EOL
 cat >/etc/docker/daemon.json.coolify <<EOL
@@ -296,7 +299,10 @@ cat >/etc/docker/daemon.json.coolify <<EOL
   "log-opts": {
     "max-size": "10m",
     "max-file": "3"
-  }
+  },
+  "default-address-pools": [
+    {"base":"10.0.0.0/8","size":24}
+  ]
 }
 EOL
 TEMP_FILE=$(mktemp)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -287,7 +287,10 @@ test -s /etc/docker/daemon.json && cp /etc/docker/daemon.json /etc/docker/daemon
   "log-opts": {
     "max-size": "10m",
     "max-file": "3"
-  }
+  },
+  "default-address-pools": [
+    {"base":"10.0.0.0/8","size":24}
+  ]
 }
 EOL
 cat >/etc/docker/daemon.json.coolify <<EOL
@@ -296,7 +299,10 @@ cat >/etc/docker/daemon.json.coolify <<EOL
   "log-opts": {
     "max-size": "10m",
     "max-file": "3"
-  }
+  },
+  "default-address-pools": [
+    {"base":"10.0.0.0/8","size":24}
+  ]
 }
 EOL
 TEMP_FILE=$(mktemp)


### PR DESCRIPTION
## Note
- **How do we make sure existing installs get this as well? This would require re-running the installation script and also restarting Docker - All containers would be offline shortly (not ideal) but there is no other way to fix this (at least I think so)**
- This change is fully backward compatible, as all new containers will start using this range and old containers will stay on the old range of IPs.

## Changes
- Introduced a much larger default docker network address pool - docker by default only allows `256 different /20` networks - well I ran out of networks today :).
- I used the IP address range `{"base":"10.0.0.0/8","size":24}` because this is what Docker Swarm uses, I use it for clear security network separation (in my setups) and it provides the most usable networks of any private IP range. It allows for up to `65,536 different /24` networks, each with 254 usable IP addresses.

## Issues
- fix #3529
