### PR TITLE
Settings > Change heading to match other headings

### DIFF
--- a/resources/views/livewire/settings/index.blade.php
+++ b/resources/views/livewire/settings/index.blade.php
@@ -95,7 +95,7 @@
             <x-forms.checkbox instantSave id="is_registration_enabled" label="Registration Allowed" />
             <x-forms.checkbox instantSave id="do_not_track" label="Do Not Track" />
         </div>
-        <h5 class="pt-4 font-bold text-white">Update</h5>
+        <h4 class="pt-6">Update</h4>
         <div class="text-right md:w-96">
             @if (!is_null(env('AUTOUPDATE', null)))
                 <div class="text-right md:w-96">


### PR DESCRIPTION
## Changes
- Update the Heading to match others (`<h4>` tags and class `pt-6`). This means it also has better support when on light mode

Light Mode Before:
<img width="521" alt="image" src="https://github.com/user-attachments/assets/bd076199-279d-41b4-9c5d-6eed56b6a38b">

Light Mode After:

<img width="502" alt="image" src="https://github.com/user-attachments/assets/42c61543-34ee-4f94-a0c3-2e2da7bf110d">
