### PR TITLE
Fix: Required environment variable throws and errors when updating shared variables

### DIFF
--- a/app/Livewire/Project/Shared/EnvironmentVariable/Show.php
+++ b/app/Livewire/Project/Shared/EnvironmentVariable/Show.php
@@ -112,14 +112,20 @@ class Show extends Component
                 $this->validate();
             }
 
-            if ($this->env->is_required && str($this->env->real_value)->isEmpty()) {
+            if (! $this->isSharedVariable && $this->env->is_required && str($this->env->real_value)->isEmpty()) {
                 $oldValue = $this->env->getOriginal('value');
                 $this->env->value = $oldValue;
                 $this->dispatch('error', 'Required environment variable cannot be empty.');
 
                 return;
             }
+
             $this->serialize();
+
+            if ($this->isSharedVariable) {
+                unset($this->env->is_required);
+            }
+
             $this->env->save();
             $this->dispatch('success', 'Environment variable updated.');
             $this->dispatch('envsUpdated');


### PR DESCRIPTION
## Changes
- Fix: is_requried column is not there for shared environment variables:
```
SQLSTATE[42703]: Undefined column: 7 ERROR: column "is_required" of relation "shared_environment_variables" does not exist LINE 1: ... "shared_environment_variables" set "value" = $1, "is_requir... ^
```

