### PR TITLE
Fix: Projects can be deleted with resources

### DIFF
--- a/app/Http/Controllers/Api/ProjectController.php
+++ b/app/Http/Controllers/Api/ProjectController.php
@@ -423,7 +423,7 @@ class ProjectController extends Controller
         if (! $project) {
             return response()->json(['message' => 'Project not found.'], 404);
         }
-        if ($project->resource_count() > 0) {
+        if (! $project->isEmpty()) {
             return response()->json(['message' => 'Project has resources, so it cannot be deleted.'], 400);
         }
 

--- a/app/Livewire/Project/DeleteEnvironment.php
+++ b/app/Livewire/Project/DeleteEnvironment.php
@@ -33,6 +33,6 @@ class DeleteEnvironment extends Component
             return redirect()->route('project.show', ['project_uuid' => $this->parameters['project_uuid']]);
         }
 
-        return $this->dispatch('error', 'Environment has defined resources, please delete them first.');
+        return $this->dispatch('error', "<strong>Environment {$environment->name}</strong> has defined resources, please delete them first.");
     }
 }

--- a/app/Livewire/Project/DeleteProject.php
+++ b/app/Livewire/Project/DeleteProject.php
@@ -27,11 +27,12 @@ class DeleteProject extends Component
             'project_id' => 'required|int',
         ]);
         $project = Project::findOrFail($this->project_id);
-        if ($project->applications->count() > 0) {
-            return $this->dispatch('error', 'Project has resources defined, please delete them first.');
-        }
-        $project->delete();
+        if ($project->isEmpty()) {
+            $project->delete();
 
-        return redirect()->route('project.index');
+            return redirect()->route('project.index');
+        }
+
+        return $this->dispatch('error', "<strong>Project {$project->name}</strong> has resources defined, please delete them first.");
     }
 }

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -123,9 +123,18 @@ class Project extends BaseModel
         return $this->hasManyThrough(StandaloneMariadb::class, Environment::class);
     }
 
-    public function resource_count()
+    public function isEmpty()
     {
-        return $this->applications()->count() + $this->postgresqls()->count() + $this->redis()->count() + $this->mongodbs()->count() + $this->mysqls()->count() + $this->mariadbs()->count() + $this->keydbs()->count() + $this->dragonflies()->count() + $this->clickhouses()->count() + $this->services()->count();
+        return $this->applications()->count() == 0 &&
+            $this->redis()->count() == 0 &&
+            $this->postgresqls()->count() == 0 &&
+            $this->mysqls()->count() == 0 &&
+            $this->keydbs()->count() == 0 &&
+            $this->dragonflies()->count() == 0 &&
+            $this->clickhouses()->count() == 0 &&
+            $this->mariadbs()->count() == 0 &&
+            $this->mongodbs()->count() == 0 &&
+            $this->services()->count() == 0;
     }
 
     public function databases()

--- a/resources/views/livewire/project/edit.blade.php
+++ b/resources/views/livewire/project/edit.blade.php
@@ -7,7 +7,7 @@
             <h1>Project: {{ data_get($project, 'name') }}</h1>
             <div class="flex items-end gap-2">
                 <x-forms.button type="submit">Save</x-forms.button>
-                <livewire:project.delete-project :disabled="$project->resource_count() > 0" :project_id="$project->id" />
+                <livewire:project.delete-project :disabled="!$project->isEmpty()" :project_id="$project->id" />
             </div>
         </div>
         <div class="pt-2 pb-10">Edit project details here.</div>

--- a/resources/views/livewire/project/show.blade.php
+++ b/resources/views/livewire/project/show.blade.php
@@ -7,7 +7,7 @@
         <x-modal-input buttonTitle="+ Add" title="New Environment">
             <livewire:project.add-environment :project="$project" />
         </x-modal-input>
-        <livewire:project.delete-project :disabled="$project->resource_count() > 0" :project_id="$project->id" />
+        <livewire:project.delete-project :disabled="!$project->isEmpty()" :project_id="$project->id" />
     </div>
     <div class="text-xs truncate subtitle lg:text-sm">{{ $project->name }}.</div>
     <div class="grid gap-2 lg:grid-cols-2">


### PR DESCRIPTION
## Note
-> I could have fixed this with a one line change by checking `resource_count() > 0` before deleting the project, but I decided to refactor the code a bit to use `isEmpty()` as we use that in other places as well.

## Changes
- Fix: Project with resources (compose base, services...) can be deleted, but the resources would of course still be there after the project was deleted (before deleting a project, we only checked applications, which is not enough).
- Improvement: Show better error message when deleting projects and environments.

## Issues
- fix: #3747
- fix: #3753
