### PR TITLE
update openapi spec for healthcheck

### DIFF
--- a/app/Http/Controllers/Api/OtherController.php
+++ b/app/Http/Controllers/Api/OtherController.php
@@ -160,7 +160,7 @@ class OtherController extends Controller
     #[OA\Get(
         summary: 'Healthcheck',
         description: 'Healthcheck endpoint.',
-        path: '/healthcheck',
+        path: '/health',
         operationId: 'healthcheck',
         responses: [
             new OA\Response(

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3093,7 +3093,7 @@ paths:
       security:
         -
           bearerAuth: []
-  /healthcheck:
+  /health:
     get:
       summary: Healthcheck
       description: 'Healthcheck endpoint.'


### PR DESCRIPTION
The healthcheck api did not match documentation, I will open a separate PR for the docs repository. 

*NOTE*: I could not get the generation of the openapi.yml working and therefore made this small change manually. `php artisan openapi` did not apply the change I've done.

## Changes
- updated the openapi.yml with the correct API path
- updated the openapi annotation on the healthcheck with the correct path

## Issues
- as posted on discord
