### PR TITLE
Fixed bookstack.yaml

### DIFF
--- a/templates/compose/bookstack.yaml
+++ b/templates/compose/bookstack.yaml
@@ -10,13 +10,14 @@ services:
     environment:
       - SERVICE_FQDN_BOOKSTACK_80
       - APP_URL=${SERVICE_FQDN_BOOKSTACK}
+      - APP_KEY=${SERVICE_PASSWORD_APPKEY}
       - PUID=1000
       - PGID=1000
       - TZ=${TZ:-Europe/Berlin}
       - DB_HOST=mariadb
       - DB_PORT=3306
-      - DB_USER=${SERVICE_USER_MYSQL}
-      - DB_PASS=${SERVICE_PASSWORD_MYSQL}
+      - DB_USERNAME=${SERVICE_USER_MYSQL}
+      - DB_PASSWORD=${SERVICE_PASSWORD_MYSQL}
       - DB_DATABASE=${MYSQL_DATABASE:-bookstackapp}
       - QUEUE_CONNECTION=${QUEUE_CONNECTION}
       # You will need to set up an authentication provider as described at https://www.bookstackapp.com/docs/admin/third-party-auth/.
@@ -27,7 +28,7 @@ services:
     healthcheck:
       test:
         - CMD-SHELL
-        - 'wget -qO- http://127.0.0.1:80/'
+        - 'curl -f http://127.0.0.1:80/'
       interval: 5s
       timeout: 20s
       retries: 10

--- a/templates/compose/bookstack.yaml
+++ b/templates/compose/bookstack.yaml
@@ -23,6 +23,15 @@ services:
       # You will need to set up an authentication provider as described at https://www.bookstackapp.com/docs/admin/third-party-auth/.
       - GITHUB_APP_ID=${GITHUB_APP_ID}
       - GITHUB_APP_SECRET=${GITHUB_APP_SECRET}
+      # SMTP Mail variables as per https://www.bookstackapp.com/docs/admin/email-webhooks/#email-configuration/.
+      - MAIL_DRIVER=${MAIL_DRIVER:-smtp}
+      - MAIL_HOST=${MAIL_HOST}
+      - MAIL_PORT=${MAIL_PORT:-587}
+      - MAIL_ENCRYPTION=${MAIL_ENCRYPTION:-tls}
+      - MAIL_USERNAME=${MAIL_USERNAME}
+      - MAIL_PASSWORD=${MAIL_PASSWORD}
+      - MAIL_FROM=${MAIL_FROM}
+      - MAIL_FROM_NAME=${MAIL_FROM_NAME:-BookStack}
     volumes:
       - 'bookstack-data:/config'
     healthcheck:


### PR DESCRIPTION
Fixes Bookstack template.

Major props to Darren from the discord server for ~~helping~~ doing all the work. Just changing it here so others don't have to mess with it.

## Changes
- Added APP_KEY as it was not defined and container was erroring out with `An application key is missing, halting init!`
- Changed DB_USER and DB_PASS to the correct var's (DB_USERNAME and DB_PASSWORD) as the BookStack container was erroring out with `Access denied for user 'database_username'@'bookstack`
- Changed healthcheck from `wget` to `curl`, as wget kept getting redirected to the external/local ip and failing instead of loading header from localhost 127.0.0.1. Which resulted in unhealthy status and a 404.
