### PR TITLE
Update .env.windows-docker-desktop.example

### DIFF
--- a/.env.windows-docker-desktop.example
+++ b/.env.windows-docker-desktop.example
@@ -4,6 +4,7 @@ APP_ID=coolify-windows-docker-desktop
 APP_NAME=Coolify
 APP_KEY=base64:ssTlCmrIE/q7whnKMvT6DwURikg69COzGsAwFVROm80=
 
+DB_USERNAME=coolify
 DB_PASSWORD=coolify
 REDIS_PASSWORD=coolify
 


### PR DESCRIPTION
## Changes
-  Added DB_USERNAME variable to .env.windows-docker-desktop.example

## Issues
- fix # DB_USERNAME variable required for successful installation on self hosted, docker desktop for windows, which was missing
