### PR TITLE
Fix: MongoDB's custom configuration missing file permissions

### DIFF
--- a/app/Actions/Database/StartMongodb.php
+++ b/app/Actions/Database/StartMongodb.php
@@ -196,6 +196,8 @@ class StartMongodb
         $content = $this->database->mongo_conf;
         $content_base64 = base64_encode($content);
         $this->commands[] = "echo '{$content_base64}' | base64 -d | tee $this->configuration_dir/{$filename} > /dev/null";
+        $this->commands[] = "chmod 644 $this->configuration_dir/{$filename}";
+        $this->commands[] = "chown `id -u`:mongod $this->configuration_dir/{$filename}";
     }
 
     private function add_default_database()


### PR DESCRIPTION
## Lore
- Once a custom configuration was placed in Coolify for a MongoDB Instance, it failed to start due to insuffcient permissions in the new .conf file.

```
Error: EACCES: permission denied, open '/etc/mongo/mongod.conf'
```

## Changes
- Updated MongoDB's Custom Configuration file permissions to 644 (MongoDB's default)

## Issues
- fix #3970
