### PR TITLE
Update reactive-resume.yaml to enable one click deployment

### DIFF
--- a/templates/compose/reactive-resume.yaml
+++ b/templates/compose/reactive-resume.yaml
@@ -48,7 +48,8 @@ services:
     image: minio/minio
     command: server /data --console-address ":9001"
     environment:
-      - SERVICE_FQDN_MINIO_9000
+      - MINIO_SERVER_URL=$MINIO_SERVER_URL
+      - MINIO_BROWSER_REDIRECT_URL=$MINIO_BROWSER_REDIRECT_URL
       - MINIO_ROOT_USER=$SERVICE_USER_MINIO
       - MINIO_ROOT_PASSWORD=$SERVICE_PASSWORD_MINIO
     volumes:

--- a/templates/compose/reactive-resume.yaml
+++ b/templates/compose/reactive-resume.yaml
@@ -45,7 +45,7 @@ services:
       retries: 10
 
   minio:
-    image: minio/minio
+    image: quay.io/minio/minio:latest
     command: server /data --console-address ":9001"
     environment:
       - MINIO_SERVER_URL=$MINIO_SERVER_URL


### PR DESCRIPTION
Add the required env variables for Minio for Coolify handling. The previous fix #3762 I don't believe actually fixes the issue, but had some of the first steps. I suggest moving back to quay.io's image of Minio since that seems to be the more common version in these Services. The key issues here is the lack of two environment variables that are required for Minio in some odd edge-case processing. Adding these two variables allows for the Reactive Resume one click deployment to deploy Minio with Traefik tags added, which allows the PDF download feature to work when appropriate domains are added.

## Changes
- Updated the reactive-resume.yaml to conform to the required Minio deployment env variables in order to get Traefik tags automatically

## Issues
- fix #3746
