### PR TITLE
Fix 2 step deletion

### DIFF
--- a/app/Livewire/NavbarDeleteTeam.php
+++ b/app/Livewire/NavbarDeleteTeam.php
@@ -19,7 +19,7 @@ class NavbarDeleteTeam extends Component
 
     public function delete($password)
     {
-        if (! InstanceSettings::get('disable_two_step_confirmation')) {
+        if (! data_get(InstanceSettings::get(), 'disable_two_step_confirmation')) {
             if (! Hash::check($password, Auth::user()->password)) {
                 $this->addError('password', 'The provided password is incorrect.');
 

--- a/app/Livewire/Project/Database/BackupEdit.php
+++ b/app/Livewire/Project/Database/BackupEdit.php
@@ -59,7 +59,7 @@ class BackupEdit extends Component
 
     public function delete($password)
     {
-        if (! InstanceSettings::get('disable_two_step_confirmation')) {
+        if (! data_get(InstanceSettings::get(), 'disable_two_step_confirmation')) {
             if (! Hash::check($password, Auth::user()->password)) {
                 $this->addError('password', 'The provided password is incorrect.');
 

--- a/app/Livewire/Project/Database/BackupExecutions.php
+++ b/app/Livewire/Project/Database/BackupExecutions.php
@@ -42,7 +42,7 @@ class BackupExecutions extends Component
 
     public function deleteBackup($executionId, $password)
     {
-        if (! InstanceSettings::get('disable_two_step_confirmation')) {
+        if (! data_get(InstanceSettings::get(), 'disable_two_step_confirmation')) {
             if (! Hash::check($password, Auth::user()->password)) {
                 $this->addError('password', 'The provided password is incorrect.');
 

--- a/app/Livewire/Project/Service/FileStorage.php
+++ b/app/Livewire/Project/Service/FileStorage.php
@@ -88,7 +88,7 @@ class FileStorage extends Component
 
     public function delete($password)
     {
-        if (! InstanceSettings::get('disable_two_step_confirmation')) {
+        if (! data_get(InstanceSettings::get(), 'disable_two_step_confirmation')) {
             if (! Hash::check($password, Auth::user()->password)) {
                 $this->addError('password', 'The provided password is incorrect.');
 

--- a/app/Livewire/Project/Service/ServiceApplicationView.php
+++ b/app/Livewire/Project/Service/ServiceApplicationView.php
@@ -50,7 +50,7 @@ class ServiceApplicationView extends Component
 
     public function delete($password)
     {
-        if (! InstanceSettings::get('disable_two_step_confirmation')) {
+        if (! data_get(InstanceSettings::get(), 'disable_two_step_confirmation')) {
             if (! Hash::check($password, Auth::user()->password)) {
                 $this->addError('password', 'The provided password is incorrect.');
 

--- a/app/Livewire/Project/Shared/Danger.php
+++ b/app/Livewire/Project/Shared/Danger.php
@@ -92,7 +92,7 @@ class Danger extends Component
 
     public function delete($password)
     {
-        if (! InstanceSettings::get('disable_two_step_confirmation')) {
+        if (! data_get(InstanceSettings::get(), 'disable_two_step_confirmation')) {
             if (! Hash::check($password, Auth::user()->password)) {
                 $this->addError('password', 'The provided password is incorrect.');
 

--- a/app/Livewire/Project/Shared/Destination.php
+++ b/app/Livewire/Project/Shared/Destination.php
@@ -119,7 +119,7 @@ class Destination extends Component
 
     public function removeServer(int $network_id, int $server_id, $password)
     {
-        if (! InstanceSettings::get('disable_two_step_confirmation')) {
+        if (! data_get(InstanceSettings::get(), 'disable_two_step_confirmation')) {
             if (! Hash::check($password, Auth::user()->password)) {
                 $this->addError('password', 'The provided password is incorrect.');
 

--- a/app/Livewire/Project/Shared/Storages/Show.php
+++ b/app/Livewire/Project/Shared/Storages/Show.php
@@ -41,7 +41,7 @@ class Show extends Component
 
     public function delete($password)
     {
-        if (! InstanceSettings::get('disable_two_step_confirmation')) {
+        if (! data_get(InstanceSettings::get(), 'disable_two_step_confirmation')) {
             if (! Hash::check($password, Auth::user()->password)) {
                 $this->addError('password', 'The provided password is incorrect.');
 

--- a/app/Livewire/Server/Delete.php
+++ b/app/Livewire/Server/Delete.php
@@ -17,7 +17,7 @@ class Delete extends Component
 
     public function delete($password)
     {
-        if (! InstanceSettings::get('disable_two_step_confirmation')) {
+        if (! data_get(InstanceSettings::get(), 'disable_two_step_confirmation')) {
             if (! Hash::check($password, Auth::user()->password)) {
                 $this->addError('password', 'The provided password is incorrect.');
 

--- a/app/Livewire/Settings/Index.php
+++ b/app/Livewire/Settings/Index.php
@@ -5,6 +5,8 @@ namespace App\Livewire\Settings;
 use App\Jobs\CheckForUpdatesJob;
 use App\Models\InstanceSettings;
 use App\Models\Server;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
 use Livewire\Component;
 
 class Index extends Component
@@ -185,8 +187,14 @@ class Index extends Component
         return view('livewire.settings.index');
     }
 
-    public function toggleTwoStepConfirmation()
+    public function toggleTwoStepConfirmation($password)
     {
+        if (! Hash::check($password, Auth::user()->password)) {
+            $this->addError('password', 'The provided password is incorrect.');
+
+            return;
+        }
+
         $this->settings->disable_two_step_confirmation = true;
         $this->settings->save();
         $this->disable_two_step_confirmation = true;

--- a/app/Livewire/Team/AdminView.php
+++ b/app/Livewire/Team/AdminView.php
@@ -78,7 +78,7 @@ class AdminView extends Component
 
     public function delete($id, $password)
     {
-        if (! InstanceSettings::get('disable_two_step_confirmation')) {
+        if (! data_get(InstanceSettings::get(), 'disable_two_step_confirmation')) {
             if (! Hash::check($password, Auth::user()->password)) {
                 $this->addError('password', 'The provided password is incorrect.');
 


### PR DESCRIPTION
## Changes
- Fix: Password is now checked if 2-step confirmation is enabled (bug introduced on next, so no effect on current version).
- Fix: 2-step confirmation now checks for password before disabling.
