### PR TITLE
Fix: Coolify installer should install OpenSSH if it is not installed

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -186,11 +186,50 @@ elif [ -x "$(command -v service)" ]; then
         SSH_DETECTED=true
     fi
 fi
+
 if [ "$SSH_DETECTED" = "false" ]; then
-    echo "###############################################################################"
-    echo "WARNING: Could not detect if OpenSSH server is installed and running - this does not mean that it is not installed, just that we could not detect it."
-    echo -e "Please make sure it is set, otherwise Coolify cannot connect to the host system. \n"
-    echo "###############################################################################"
+    echo " - OpenSSH server not detected. Installing OpenSSH server."
+    case "$OS_TYPE" in
+    arch)
+        pacman -Sy --noconfirm openssh >/dev/null
+        systemctl enable sshd >/dev/null 2>&1
+        systemctl start sshd >/dev/null 2>&1
+        ;;
+    alpine)
+        apk add openssh >/dev/null
+        rc-update add sshd default >/dev/null 2>&1
+        service sshd start >/dev/null 2>&1
+        ;;
+    ubuntu | debian | raspbian)
+        apt-get update -y >/dev/null
+        apt-get install -y openssh-server >/dev/null
+        systemctl enable ssh >/dev/null 2>&1
+        systemctl start ssh >/dev/null 2>&1
+        ;;
+    centos | fedora | rhel | ol | rocky | almalinux | amzn)
+        if [ "$OS_TYPE" = "amzn" ]; then
+            dnf install -y openssh-server >/dev/null
+        else
+            dnf install -y openssh-server >/dev/null
+        fi
+        systemctl enable sshd >/dev/null 2>&1
+        systemctl start sshd >/dev/null 2>&1
+        ;;
+    sles | opensuse-leap | opensuse-tumbleweed)
+        zypper install -y openssh >/dev/null
+        systemctl enable sshd >/dev/null 2>&1
+        systemctl start sshd >/dev/null 2>&1
+        ;;
+    *)
+        echo "###############################################################################"
+        echo "WARNING: Could not detect and install OpenSSH server - this does not mean that it is not installed or not running, just that we could not detect it."
+        echo -e "Please make sure it is installed and running, otherwise Coolify cannot connect to the host system. \n"
+        echo "###############################################################################"
+        exit 1
+        ;;
+    esac
+    echo " - OpenSSH server installed successfully."
+    SSH_DETECTED=true
 fi
 
 # Detect SSH PermitRootLogin


### PR DESCRIPTION
## Changes
- Fix: The following issue on minimal distortions when nothing is pre-installed (I had this problem when using Lightweight OS test machines on MacOS - light ubuntu):
```bash
2. Check OpenSSH server configuration.
###############################################################################
WARNING: Could not detect if OpenSSH server is installed and running - this does not mean that it is not installed, just that we could not detect it.
Please make sure it is set, otherwise Coolify cannot connect to the host system.

###############################################################################
bash: line 197: sshd: command not found
```
- Fix: OpenSSH now is installed when it is not detected