### PR TITLE
Upgrade Keycloak Template to v26.0

### DIFF
--- a/templates/compose/keycloak-with-postgres.yaml
+++ b/templates/compose/keycloak-with-postgres.yaml
@@ -6,7 +6,7 @@
 
 services:
   keycloak:
-    image: quay.io/keycloak/keycloak:25.0.2
+    image: quay.io/keycloak/keycloak:26.0
     command:
       - start
     environment:
@@ -32,7 +32,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "exec 3<>/dev/tcp/127.0.0.1/9000;echo -e 'GET /health/ready HTTP/1.1\r\nhost: http://localhost\r\nConnection: close\r\n\r\n' >&3;if [ $? -eq 0 ]; then echo 'Healthcheck Successful';exit 0;else echo 'Healthcheck Failed';exit 1;fi;",
+          "exec 3<>/dev/tcp/127.0.0.1/9000; echo -e 'GET /health/ready HTTP/1.1\r\nHost: localhost:9000\r\nConnection: close\r\n\r\n' >&3;cat <&3 | grep -q '\"status\": \"UP\"' && exit 0 || exit 1",
         ]
       interval: 5s
       timeout: 20s

--- a/templates/compose/keycloak.yaml
+++ b/templates/compose/keycloak.yaml
@@ -6,7 +6,7 @@
 
 services:
   keycloak:
-    image: quay.io/keycloak/keycloak:25.0.2
+    image: quay.io/keycloak/keycloak:26.0
     command:
       - start
     environment:
@@ -24,7 +24,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "exec 3<>/dev/tcp/127.0.0.1/9000;echo -e 'GET /health/ready HTTP/1.1\r\nhost: http://localhost\r\nConnection: close\r\n\r\n' >&3;if [ $? -eq 0 ]; then echo 'Healthcheck Successful';exit 0;else echo 'Healthcheck Failed';exit 1;fi;",
+          "exec 3<>/dev/tcp/127.0.0.1/9000; echo -e 'GET /health/ready HTTP/1.1\r\nHost: localhost:9000\r\nConnection: close\r\n\r\n' >&3;cat <&3 | grep -q '\"status\": \"UP\"' && exit 0 || exit 1",
         ]
       interval: 5s
       timeout: 20s


### PR DESCRIPTION
Upgrades the Keycloak template from 25.0.2 to 26.0. 
Slightly modifies the health check to work with v26. The previous health check would result in an error:
https://gist.github.com/sarath-soman/5d9aec06953bbd0990c648605d4dba07?permalink_comment_id=5225055#gistcomment-5225055

The new health check was taken from the same discussion: https://gist.github.com/sarath-soman/5d9aec06953bbd0990c648605d4dba07?permalink_comment_id=5225953#gistcomment-5225953

## Changes
- Upgrade Keycloak image version in Keycloak templates to 26.0
- Slightly modify health checks because the previous health checks would cause errors in v26


