### PR TITLE
Add new role enum and apply authorization

### DIFF
--- a/app/Enums/Role.php
+++ b/app/Enums/Role.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Enums;
+
+enum Role: string
+{
+    case MEMBER = 'member';
+    case ADMIN = 'admin';
+    case OWNER = 'owner';
+
+    public function rank(): int
+    {
+        return match ($this) {
+            self::MEMBER => 1,
+            self::ADMIN => 2,
+            self::OWNER => 3,
+        };
+    }
+
+    public function lt(Role|string $role): bool
+    {
+        if (is_string($role)) {
+            $role = Role::from($role);
+        }
+
+        return $this->rank() < $role->rank();
+    }
+
+    public function gt(Role|string $role): bool
+    {
+        if (is_string($role)) {
+            $role = Role::from($role);
+        }
+
+        return $this->rank() > $role->rank();
+    }
+}


### PR DESCRIPTION
I've implemented a new `Role` enum, which can become useful at a later point when we decide to [cast the eloquent properties](https://laravel.com/docs/11.x/eloquent-mutators#enum-casting) or using it in [validation rules](https://laravel.com/docs/11.x/validation#rule-enum).
This more verbose authorization also prevents downgrading attacks.
E.g. an admin can no longer remove an owner or downgrade his role to an admin or member.


## Changes
- implement new role enum
- apply authorization on `App\Livewire\Team\Member` component