### PR TITLE
feat: add deploy-only token permission

### DIFF
--- a/app/Livewire/Security/ApiTokens.php
+++ b/app/Livewire/Security/ApiTokens.php
@@ -12,10 +12,9 @@ class ApiTokens extends Component
     public $tokens = [];
 
     public bool $viewSensitiveData = false;
-
     public bool $readOnly = true;
-
     public bool $rootAccess = false;
+    public bool $triggerDeploy = false;
 
     public array $permissions = ['read-only'];
 
@@ -62,10 +61,23 @@ class ApiTokens extends Component
             $this->permissions = ['*'];
             $this->readOnly = false;
             $this->viewSensitiveData = false;
+            $this->triggerDeploy = false;
         } else {
             $this->readOnly = true;
             $this->permissions = ['read-only'];
         }
+    }
+
+    public function updatedTriggerDeploy()
+    {
+        if ($this->triggerDeploy) {
+            $this->permissions[] = 'trigger-deploy';
+            $this->permissions = array_diff($this->permissions, ['*']);
+            $this->rootAccess = false;
+        } else {
+            $this->permissions = array_diff($this->permissions, ['trigger-deploy']);
+        }
+        $this->makeSureOneIsSelected();
     }
 
     public function makeSureOneIsSelected()

--- a/resources/views/livewire/security/api-tokens.blade.php
+++ b/resources/views/livewire/security/api-tokens.blade.php
@@ -39,6 +39,7 @@
             <x-forms.checkbox label="Root Access" wire:model.live="rootAccess"></x-forms.checkbox>
             <x-forms.checkbox label="Read-only" wire:model.live="readOnly"></x-forms.checkbox>
             <x-forms.checkbox label="View Sensitive Data" wire:model.live="viewSensitiveData"></x-forms.checkbox>
+            <x-forms.checkbox label="Trigger Deploy Webhooks" wire:model.live="triggerDeploy"></x-forms.checkbox>
         </div>
     </form>
     @if (session()->has('token'))

--- a/routes/api.php
+++ b/routes/api.php
@@ -54,7 +54,8 @@ Route::group([
     Route::patch('/security/keys/{uuid}', [SecurityController::class, 'update_key'])->middleware([IgnoreReadOnlyApiToken::class]);
     Route::delete('/security/keys/{uuid}', [SecurityController::class, 'delete_key'])->middleware([IgnoreReadOnlyApiToken::class]);
 
-    Route::match(['get', 'post'], '/deploy', [DeployController::class, 'deploy'])->middleware([IgnoreReadOnlyApiToken::class]);
+    Route::match(['get', 'post'], '/deploy', [DeployController::class, 'deploy'])
+        ->middleware([IgnoreReadOnlyApiToken::class, 'auth:sanctum', 'ability:trigger-deploy']);
     Route::get('/deployments', [DeployController::class, 'deployments']);
     Route::get('/deployments/{uuid}', [DeployController::class, 'deployment_by_uuid']);
 


### PR DESCRIPTION
## Changes
- Added a "Trigger Deploy Webhooks" permission that can only call api/v1/deploy

## Issues
- fix #2971
