### PR TITLE
fix: make "Update" heading visible in light mode

### DIFF
--- a/resources/views/livewire/settings/index.blade.php
+++ b/resources/views/livewire/settings/index.blade.php
@@ -95,7 +95,7 @@
             <x-forms.checkbox instantSave id="is_registration_enabled" label="Registration Allowed" />
             <x-forms.checkbox instantSave id="do_not_track" label="Do Not Track" />
         </div>
-        <h5 class="pt-4 font-bold text-white">Update</h5>
+        <h5 class="pt-4 font-bold">Update</h5>
         <div class="text-right md:w-96">
             @if (!is_null(env('AUTOUPDATE', null)))
                 <div class="text-right md:w-96">


### PR DESCRIPTION
## Changes
- Removed the unnecessary `text-white` class from the "Update" heading, ensuring visibility in both light and dark modes.