### PR TITLE
Fix invalid docker version check

### DIFF
--- a/app/Livewire/Boarding/Index.php
+++ b/app/Livewire/Boarding/Index.php
@@ -66,11 +66,15 @@ class Index extends Component
 
     public bool $serverReachable = true;
 
+    public ?string $minDockerVersion = null;
+
     public function mount()
     {
         if (auth()->user()?->isMember() && auth()->user()->currentTeam()->show_boarding === true) {
             return redirect()->route('dashboard');
         }
+
+        $this->minDockerVersion = str(config('constants.docker_install_version'))->before('.');
         $this->privateKeyName = generate_random_name();
         $this->remoteServerName = generate_random_name();
         if (isDev()) {

--- a/app/Livewire/Server/ValidateAndInstall.php
+++ b/app/Livewire/Server/ValidateAndInstall.php
@@ -159,7 +159,7 @@ class ValidateAndInstall extends Component
                 $this->dispatch('refreshBoardingIndex');
                 $this->dispatch('success', 'Server validated.');
             } else {
-                $this->error = 'Docker Engine version is not 22+. Please install Docker manually before continuing: <a target="_blank" class="underline" href="https://docs.docker.com/engine/install/#server">documentation</a>.';
+                $this->error = 'Docker Engine version is not 25+. Please install Docker manually before continuing: <a target="_blank" class="underline" href="https://docs.docker.com/engine/install/#server">documentation</a>.';
                 $this->server->update([
                     'validation_logs' => $this->error,
                 ]);

--- a/app/Livewire/Server/ValidateAndInstall.php
+++ b/app/Livewire/Server/ValidateAndInstall.php
@@ -159,7 +159,8 @@ class ValidateAndInstall extends Component
                 $this->dispatch('refreshBoardingIndex');
                 $this->dispatch('success', 'Server validated.');
             } else {
-                $this->error = 'Docker Engine version is not 25+. Please install Docker manually before continuing: <a target="_blank" class="underline" href="https://docs.docker.com/engine/install/#server">documentation</a>.';
+                $requiredDockerVersion = str(config('constants.docker_install_version'))->before('.');
+                $this->error = 'Minimum Docker Engine version '.$requiredDockerVersion.' is not instaled. Please install Docker manually before continuing: <a target="_blank" class="underline" href="https://docs.docker.com/engine/install/#server">documentation</a>.';
                 $this->server->update([
                     'validation_logs' => $this->error,
                 ]);

--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -110,7 +110,7 @@ function checkMinimumDockerEngineVersion($dockerVersion)
 {
     $majorDockerVersion = str($dockerVersion)->before('.')->value();
     $requiredDockerVersion = str(config('constants.docker_install_version'))->before('.')->value();
-    if ($majorDockerVersion <= $requiredDockerVersion) {
+    if ($majorDockerVersion < $requiredDockerVersion) {
         $dockerVersion = null;
     }
 

--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -109,7 +109,8 @@ function format_docker_envs_to_json($rawOutput)
 function checkMinimumDockerEngineVersion($dockerVersion)
 {
     $majorDockerVersion = str($dockerVersion)->before('.')->value();
-    if ($majorDockerVersion <= 22) {
+    $requiredDockerVersion = str(config('constants.docker_install_version'))->before('.')->value();
+    if ($majorDockerVersion <= $requiredDockerVersion) {
         $dockerVersion = null;
     }
 

--- a/resources/views/livewire/boarding/index.blade.php
+++ b/resources/views/livewire/boarding/index.blade.php
@@ -323,7 +323,7 @@
                 </x-slot:actions>
                 <x-slot:explanation>
                     <p>This will install the latest Docker Engine on your server, configure a few things to be able
-                        to run optimal.<br><br>Minimum Docker Engine version is: 26<br><br>To manually install
+                    to run optimal.<br><br>Minimum Docker Engine version is: {{ $minDockerVersion }}<br><br>To manually install
                         Docker
                         Engine, check <a target="_blank" class="underline dark:text-warning"
                             href="https://docs.docker.com/engine/install/#server">this

--- a/resources/views/livewire/boarding/index.blade.php
+++ b/resources/views/livewire/boarding/index.blade.php
@@ -323,7 +323,7 @@
                 </x-slot:actions>
                 <x-slot:explanation>
                     <p>This will install the latest Docker Engine on your server, configure a few things to be able
-                        to run optimal.<br><br>Minimum Docker Engine version is: 22<br><br>To manually install
+                        to run optimal.<br><br>Minimum Docker Engine version is: 26<br><br>To manually install
                         Docker
                         Engine, check <a target="_blank" class="underline dark:text-warning"
                             href="https://docs.docker.com/engine/install/#server">this

--- a/resources/views/livewire/server/validate-and-install.blade.php
+++ b/resources/views/livewire/server/validate-and-install.blade.php
@@ -86,16 +86,24 @@
                         </g>
                     </svg></div>
                 @isset($docker_version)
+                    @if($docker_version)
                     <div class="flex w-64 gap-2">Minimum Docker version: <svg class="w-5 h-5 text-success"
+                                viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+                                <g fill="currentColor">
+                                    <path
+                                        d="m237.66 85.26l-128.4 128.4a8 8 0 0 1-11.32 0l-71.6-72a8 8 0 0 1 0-11.31l24-24a8 8 0 0 1 11.32 0l36.68 35.32a8 8 0 0 0 11.32 0l92.68-91.32a8 8 0 0 1 11.32 0l24 23.6a8 8 0 0 1 0 11.31"
+                                        opacity=".2" />
+                                    <path
+                                        d="m243.28 68.24l-24-23.56a16 16 0 0 0-22.58 0L104 136l-.11-.11l-36.64-35.27a16 16 0 0 0-22.57.06l-24 24a16 16 0 0 0 0 22.61l71.62 72a16 16 0 0 0 22.63 0l128.4-128.38a16 16 0 0 0-.05-22.67M103.62 208L32 136l24-24l.11.11l36.64 35.27a16 16 0 0 0 22.52 0L208.06 56L232 79.6Z" />
+                                </g>
+                            </svg></div>
+                    @else
+                    <div class="flex w-64 gap-2">Minimum Docker version: <svg class="w-5 h-5 text-error"
                             viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
-                            <g fill="currentColor">
-                                <path
-                                    d="m237.66 85.26l-128.4 128.4a8 8 0 0 1-11.32 0l-71.6-72a8 8 0 0 1 0-11.31l24-24a8 8 0 0 1 11.32 0l36.68 35.32a8 8 0 0 0 11.32 0l92.68-91.32a8 8 0 0 1 11.32 0l24 23.6a8 8 0 0 1 0 11.31"
-                                    opacity=".2" />
-                                <path
-                                    d="m243.28 68.24l-24-23.56a16 16 0 0 0-22.58 0L104 136l-.11-.11l-36.64-35.27a16 16 0 0 0-22.57.06l-24 24a16 16 0 0 0 0 22.61l71.62 72a16 16 0 0 0 22.63 0l128.4-128.38a16 16 0 0 0-.05-22.67M103.62 208L32 136l24-24l.11.11l36.64 35.27a16 16 0 0 0 22.52 0L208.06 56L232 79.6Z" />
-                            </g>
+                            <path fill="currentColor"
+                                d="M208.49 191.51a12 12 0 0 1-17 17L128 145l-63.51 63.49a12 12 0 0 1-17-17L111 128L47.51 64.49a12 12 0 0 1 17-17L128 111l63.51-63.52a12 12 0 0 1 17 17L145 128Z" />
                         </svg></div>
+                    @endif
                 @else
                     <div class="w-64"><x-loading text="Minimum Docker version:" /></div>
                 @endisset


### PR DESCRIPTION
## Changes
- Add proper error information on server docker version validation;
- Update minimum docker version checks to match current installation version (26). 
- Opted to reuse current config value for the server docker version check, to improve re-usability;
- Injected minimum docker version ok frontend for onboarding page and server validation checks.

## Issues
- fix #4128
