### PR TITLE
Keeping the Twenty Template Up to date

### DIFF
--- a/templates/compose/twenty.yaml
+++ b/templates/compose/twenty.yaml
@@ -13,21 +13,14 @@ services:
       - FRONT_BASE_URL=$SERVICE_FQDN_TWENTY
       - ENABLE_DB_MIGRATIONS=true
       - CACHE_STORAGE_TYPE=${CACHE_STORAGE_TYPE:-redis}
-      - REDIS_HOST=redis
-      - REDIS_PORT=6379
-      
-      # https://twenty.com/developers/section/self-hosting/docker-compose
-      - APP_SECRET=$SERVICE_BASE64_32_SECRET
-
+      - REDIS_URL=redis://redis:6379
+  
       # https://twenty.com/developers/section/self-hosting/self-hosting-var#security
       - API_RATE_LIMITING_TTL=${API_RATE_LIMITING_TTL:-100}
       - API_RATE_LIMITING_LIMIT=${API_RATE_LIMITING_LIMIT:-100}
 
       # https://twenty.com/developers/section/self-hosting/self-hosting-var#tokens
-      - ACCESS_TOKEN_SECRET=$SERVICE_BASE64_32_ACCESS
-      - LOGIN_TOKEN_SECRET=$SERVICE_BASE64_32_LOGIN
-      - REFRESH_TOKEN_SECRET=$SERVICE_BASE64_32_REFRESH
-      - FILE_TOKEN_SECRET=$SERVICE_BASE64_32_FILE
+      - APP_SECRET=$SERVICE_BASE64_32_SECRET
       - POSTGRES_ADMIN_PASSWORD=$SERVICE_PASSWORD_POSTGRES
       - PG_DATABASE_URL=postgres://postgres:$SERVICE_PASSWORD_POSTGRES@postgres:5432/default
 

--- a/templates/compose/twenty.yaml
+++ b/templates/compose/twenty.yaml
@@ -15,6 +15,9 @@ services:
       - CACHE_STORAGE_TYPE=${CACHE_STORAGE_TYPE:-redis}
       - REDIS_HOST=redis
       - REDIS_PORT=6379
+      
+      # https://twenty.com/developers/section/self-hosting/docker-compose
+      - APP_SECRET=$SERVICE_BASE64_32_SECRET
 
       # https://twenty.com/developers/section/self-hosting/self-hosting-var#security
       - API_RATE_LIMITING_TTL=${API_RATE_LIMITING_TTL:-100}


### PR DESCRIPTION
## Changes
- Removed: REDIS_HOST, REDIS_PORT
- Added: REDIS_URL=redis://redis:6379
- Removed: ACCESS_TOKEN_SECRET, LOGIN_TOKEN_SECRET, REFRESH_TOKEN_SECRET, FILE_TOKEN_SECRET
- Added: APP_SECRET=$SERVICE_BASE64_32_SECRET

## Issues
- Keeping the twenty .yaml file up to date.
https://twenty.com/developers/section/self-hosting/upgrade-guide#v0.31.0-to-v0.32.0
- Fix When deploying Twenty on Coolify, the container never reaches a healthy state, it stays in "starting" and then "unhealthy" before restarting again. https://discord.com/channels/459365938081431553/1121768420883562526/threads/1269353897059811473

