### PR TITLE
Expanded checkbox clickable area to include label

### DIFF
--- a/resources/views/components/forms/checkbox.blade.php
+++ b/resources/views/components/forms/checkbox.blade.php
@@ -14,8 +14,8 @@
     'w-full' => $fullWidth,
 ])>
     @if (!$hideLabel)
-        <label @class(['flex gap-4 px-0 min-w-fit label', 'opacity-40' => $disabled])>
-            <span class="flex gap-2">
+        <label @class(['flex gap-4 items-center px-0 min-w-fit label w-full cursor-pointer', 'opacity-40' => $disabled])>
+            <span class="flex flex-grow gap-2">
                 @if ($label)
                     {!! $label !!}
                 @else
@@ -25,11 +25,11 @@
                     <x-helper :helper="$helper" />
                 @endif
             </span>
+    @endif
+            <input @disabled($disabled) type="checkbox" {{ $attributes->merge(['class' => $defaultClass]) }}
+                @if ($instantSave) wire:loading.attr="disabled" wire:click='{{ $instantSave === 'instantSave' || $instantSave == '1' ? 'instantSave' : $instantSave }}'
+                wire:model={{ $id }} @else wire:model={{ $value ?? $id }} @endif />
+    @if (!$hideLabel)
         </label>
     @endif
-    <span class="flex-grow"></span>
-    <input @disabled($disabled) type="checkbox" {{ $attributes->merge(['class' => $defaultClass]) }}
-        @if ($instantSave) wire:loading.attr="disabled" wire:click='{{ $instantSave === 'instantSave' || $instantSave == '1' ? 'instantSave' : $instantSave }}'
-       wire:model={{ $id }} @else wire:model={{ $value ?? $id }} @endif />
-
 </div>


### PR DESCRIPTION
## Changes
- Expanded checkbox clickable area to include label.

| Before | After |
|-|-|
| Can only click on checkboxes<br><br>![firefox_f17hlybo7X](https://github.com/user-attachments/assets/bb106e43-0ae0-4d0d-a084-147e557633e6) | Can click anywhere<br><br>![firefox_ChupKejF8d](https://github.com/user-attachments/assets/f4324c6b-0ab9-4db3-9070-b66515cbd9a2) |


