### PR TITLE
Fix: Server IP/Domain validation

### DIFF
--- a/app/Livewire/Server/New/ByIp.php
+++ b/app/Livewire/Server/New/ByIp.php
@@ -21,7 +21,7 @@ class ByIp extends Component
     #[Validate('nullable|integer', as: 'Private Key')]
     public ?int $private_key_id = null;
 
-    #[Validate('nullable|string|max:255', as: 'Private Key Name')]
+    #[Validate('nullable|string', as: 'Private Key Name')]
     public $new_private_key_name;
 
     #[Validate('nullable|string', as: 'Private Key Description')]
@@ -30,16 +30,16 @@ class ByIp extends Component
     #[Validate('nullable|string', as: 'Private Key Value')]
     public $new_private_key_value;
 
-    #[Validate('required|string|max:255', as: 'Name')]
+    #[Validate('required|string', as: 'Name')]
     public string $name;
 
-    #[Validate('nullable|string|max:255', as: 'Description')]
+    #[Validate('nullable|string', as: 'Description')]
     public ?string $description = null;
 
     #[Validate('required|string', as: 'IP Address/Domain')]
     public string $ip;
 
-    #[Validate('required|string|max:255', as: 'User')]
+    #[Validate('required|string', as: 'User')]
     public string $user = 'root';
 
     #[Validate('required|integer|between:1,65535', as: 'Port')]

--- a/app/Livewire/Server/New/ByIp.php
+++ b/app/Livewire/Server/New/ByIp.php
@@ -6,63 +6,59 @@ use App\Enums\ProxyTypes;
 use App\Models\Server;
 use App\Models\Team;
 use Illuminate\Support\Collection;
+use Livewire\Attributes\Locked;
+use Livewire\Attributes\Validate;
 use Livewire\Component;
 
 class ByIp extends Component
 {
+    #[Locked]
     public $private_keys;
 
+    #[Locked]
     public $limit_reached;
 
+    #[Validate('nullable|integer', as: 'Private Key')]
     public ?int $private_key_id = null;
 
+    #[Validate('nullable|string|max:255', as: 'Private Key Name')]
     public $new_private_key_name;
 
+    #[Validate('nullable|string', as: 'Private Key Description')]
     public $new_private_key_description;
 
+    #[Validate('nullable|string', as: 'Private Key Value')]
     public $new_private_key_value;
 
+    #[Validate('required|string|max:255', as: 'Name')]
     public string $name;
 
+    #[Validate('nullable|string|max:255', as: 'Description')]
     public ?string $description = null;
 
+    #[Validate('required|string', as: 'IP Address/Domain')]
     public string $ip;
 
+    #[Validate('required|string|max:255', as: 'User')]
     public string $user = 'root';
 
+    #[Validate('required|integer|between:1,65535', as: 'Port')]
     public int $port = 22;
 
+    #[Validate('required|boolean', as: 'Swarm Manager')]
     public bool $is_swarm_manager = false;
 
+    #[Validate('required|boolean', as: 'Swarm Worker')]
     public bool $is_swarm_worker = false;
 
+    #[Validate('nullable|integer', as: 'Swarm Cluster')]
     public $selected_swarm_cluster = null;
 
+    #[Validate('required|boolean', as: 'Build Server')]
     public bool $is_build_server = false;
 
+    #[Locked]
     public Collection $swarm_managers;
-
-    protected $rules = [
-        'name' => 'required|string',
-        'description' => 'nullable|string',
-        'ip' => 'required',
-        'user' => 'required|string',
-        'port' => 'required|integer',
-        'is_swarm_manager' => 'required|boolean',
-        'is_swarm_worker' => 'required|boolean',
-        'is_build_server' => 'required|boolean',
-    ];
-
-    protected $validationAttributes = [
-        'name' => 'Name',
-        'description' => 'Description',
-        'ip' => 'IP Address/Domain',
-        'user' => 'User',
-        'port' => 'Port',
-        'is_swarm_manager' => 'Swarm Manager',
-        'is_swarm_worker' => 'Swarm Worker',
-        'is_build_server' => 'Build Server',
-    ];
 
     public function mount()
     {
@@ -88,6 +84,12 @@ class ByIp extends Component
     {
         $this->validate();
         try {
+            if (Server::where('team_id', currentTeam()->id)
+                ->where('ip', $this->ip)
+                ->exists()) {
+                return $this->dispatch('error', 'This IP/Domain is already in use by another server in your team.');
+            }
+
             if (is_null($this->private_key_id)) {
                 return $this->dispatch('error', 'You must select a private key');
             }

--- a/app/Livewire/Server/Show.php
+++ b/app/Livewire/Server/Show.php
@@ -113,7 +113,8 @@ class Show extends Component
                 ->where('id', '!=', $this->server->id)
                 ->exists()) {
                 $this->ip = $this->server->ip;
-                throw new \Exception('This IP/Domain is already in use by another server in your team.');
+
+                return $this->dispatch('error', 'This IP/Domain is already in use by another server in your team.');
             }
 
             $this->server->name = $this->name;

--- a/app/Livewire/Server/Show.php
+++ b/app/Livewire/Server/Show.php
@@ -113,8 +113,7 @@ class Show extends Component
                 ->where('id', '!=', $this->server->id)
                 ->exists()) {
                 $this->ip = $this->server->ip;
-
-                return $this->dispatch('error', 'This IP/Domain is already in use by another server in your team.');
+                throw new \Exception('This IP/Domain is already in use by another server in your team.');
             }
 
             $this->server->name = $this->name;

--- a/app/Livewire/Server/Show.php
+++ b/app/Livewire/Server/Show.php
@@ -107,6 +107,15 @@ class Show extends Component
     {
         if ($toModel) {
             $this->validate();
+
+            if (Server::where('team_id', currentTeam()->id)
+                ->where('ip', $this->ip)
+                ->where('id', '!=', $this->server->id)
+                ->exists()) {
+                $this->ip = $this->server->ip;
+                throw new \Exception('This IP/Domain is already in use by another server in your team.');
+            }
+
             $this->server->name = $this->name;
             $this->server->description = $this->description;
             $this->server->ip = $this->ip;


### PR DESCRIPTION
## Changes
- fix: Prevent adding a new server with the same IP 2 times in the same team. I cannot think of a scenario where you would want the same IP/domain on a server in the same team. On Coolify in different teams, I could imagine a scenario where a different team has the same build server (so the new rule is only on a team basis).
- fix: Do not allow changing IP/domain to an IP/domain used by another server.
- chore: refactored validation to the new Livewire syntax

## Issues
- fix #3768
