### PR TITLE
Fix: Backups

### DIFF
--- a/app/Livewire/Project/Database/CreateScheduledBackup.php
+++ b/app/Livewire/Project/Database/CreateScheduledBackup.php
@@ -75,10 +75,10 @@ class CreateScheduledBackup extends Component
                 $this->dispatch('refreshScheduledBackups');
             }
 
-            $this->frequency = '';
-
         } catch (\Throwable $e) {
             return handleError($e, $this);
+        } finally {
+            $this->frequency = '';
         }
     }
 }

--- a/app/Livewire/Project/Database/CreateScheduledBackup.php
+++ b/app/Livewire/Project/Database/CreateScheduledBackup.php
@@ -21,8 +21,8 @@ class CreateScheduledBackup extends Component
 
     public bool $enabled = true;
 
-    #[Validate(['required', 'integer'])]
-    public int $s3StorageId;
+    #[Validate(['nullable', 'integer'])]
+    public ?int $s3StorageId = null;
 
     public Collection $definedS3s;
 

--- a/app/Livewire/Project/Database/CreateScheduledBackup.php
+++ b/app/Livewire/Project/Database/CreateScheduledBackup.php
@@ -49,6 +49,7 @@ class CreateScheduledBackup extends Component
 
                 return;
             }
+
             $payload = [
                 'enabled' => true,
                 'frequency' => $this->frequency,
@@ -58,6 +59,7 @@ class CreateScheduledBackup extends Component
                 'database_type' => $this->database->getMorphClass(),
                 'team_id' => currentTeam()->id,
             ];
+
             if ($this->database->type() === 'standalone-postgresql') {
                 $payload['databases_to_backup'] = $this->database->postgres_db;
             } elseif ($this->database->type() === 'standalone-mysql') {
@@ -72,11 +74,11 @@ class CreateScheduledBackup extends Component
             } else {
                 $this->dispatch('refreshScheduledBackups');
             }
+
+            $this->frequency = '';
+
         } catch (\Throwable $e) {
             return handleError($e, $this);
-        } finally {
-            $this->frequency = '';
-            $this->saveToS3 = true;
         }
     }
 }


### PR DESCRIPTION
## Changes
- fix: backup job without any s3 storages on the server can not be added
- fix: s3 is always enabled if you make a mistake when you first try to add a backup even though it should not be enabled by default