### PR TITLE
Fix: Coolify docker installer fail on Fedora 41 with DNF5

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -326,6 +326,22 @@ if ! [ -x "$(command -v docker)" ]; then
                 exit 1
             fi
             ;;
+        "fedora")
+            if [ -x "$(command -v dnf5)" ]; then
+                # dnf5 is available
+                dnf config-manager addrepo --from-repofile=https://download.docker.com/linux/fedora/docker-ce.repo --overwrite >/dev/null 2>&1
+            else
+                # dnf5 is not available, use dnf
+                dnf config-manager --add-repo=https://download.docker.com/linux/fedora/docker-ce.repo >/dev/null 2>&1
+            fi
+            dnf install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin >/dev/null 2>&1
+            if ! [ -x "$(command -v docker)" ]; then
+                echo " - Docker could not be installed automatically. Please visit https://docs.docker.com/engine/install/ and install Docker manually to continue."
+                exit 1
+            fi
+            systemctl start docker >/dev/null 2>&1
+            systemctl enable docker >/dev/null 2>&1
+            ;;
         *)
             if [ "$OS_TYPE" = "ubuntu" ] && [ "$OS_VERSION" = "24.10" ]; then
                 echo "Docker automated installation is not supported on Ubuntu 24.10 (non-LTS release)."


### PR DESCRIPTION
## Changes
- fix: Docker installation failure on Fedora 41 with dnf5
```
3. Check Docker Installation. 
 - Docker is not installed. Installing Docker. It may take a while.
 - Until then, here's a joke for you:

# Executing docker install script, commit: e5543d473431b782227f8908005543bb4389b8de
+ sh -c 'dnf install -y -q dnf-plugins-core'
Package "dnf-plugins-core-4.9.0-1.fc41.noarch" is already installed.

Nothing to do.
+ sh -c 'dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo'
Unknown argument "--add-repo" for command "config-manager". Add "--help" for more information about the arguments.
```
Based on my observation, it fails with the Rancher Docker installer. I added a new case for Fedora to handle Docker installation. The script checks for the presence of `dnf5` and uses the updated `addrepo` options if available; otherwise, it falls back to using `dnf`.

## Issues
- fix #