### PR TITLE
Fix: Ability to use the same ssh key in a different team

### DIFF
--- a/app/Models/PrivateKey.php
+++ b/app/Models/PrivateKey.php
@@ -218,13 +218,11 @@ class PrivateKey extends BaseModel
 
     private static function fingerprintExists($fingerprint, $excludeId = null)
     {
-        $query = self::where('fingerprint', $fingerprint);
-
-        if (! is_null($excludeId)) {
-            $query->where('id', '!=', $excludeId);
-        }
-
-        return $query->exists();
+        return self::query()
+            ->where('fingerprint', $fingerprint)
+            ->where('team_id', currentTeam()->id)
+            ->when($excludeId, fn ($query) => $query->where('id', '!=', $excludeId))
+            ->exists();
     }
 
     public static function cleanupUnusedKeys()


### PR DESCRIPTION
## Changes
- fix: SSH key needs to be unique but only in the current team. This fixes an issue when adding the same SSH key for a build server to different teams.
