### PR TITLE
fix: modal (+ add) on dynamic config was not opening, removed x-cloak

### DIFF
--- a/resources/views/components/modal-input.blade.php
+++ b/resources/views/components/modal-input.blade.php
@@ -27,7 +27,7 @@
     @endif
     <template x-teleport="body">
         <div x-show="modalOpen"
-            class="fixed top-0 left-0 lg:px-0 px-4 z-[99] flex items-center justify-center w-screen h-screen" x-cloak>
+            class="fixed top-0 left-0 lg:px-0 px-4 z-[99] flex items-center justify-center w-screen h-screen">
             <div x-show="modalOpen" x-transition:enter="ease-out duration-100" x-transition:enter-start="opacity-0"
                 x-transition:enter-end="opacity-100" x-transition:leave="ease-in duration-100"
                 x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0"


### PR DESCRIPTION
Just updated an old version to latest, and modal stop working at Proxy > Dynamic Configs (+ Add)

Its a strange UI problem. Solved removing `x-cloak` attribute. Other modals was all fine though.

Found no issues about it, so would appreciate a test/review of this before ready to PR

![chrome_YTCAjF1BNM](https://github.com/user-attachments/assets/93612515-e339-4439-8629-871e35b4eec3)
