### PR TITLE
feat: add some new labels to every container

### DIFF
--- a/app/Actions/Database/StartClickhouse.php
+++ b/app/Actions/Database/StartClickhouse.php
@@ -49,11 +49,7 @@ class StartClickhouse
                             'hard' => 262144,
                         ],
                     ],
-                    'labels' => [
-                        'coolify.managed' => 'true',
-                        'coolify.type' => 'database',
-                        'coolify.databaseId' => $this->database->id,
-                    ],
+                    'labels' => defaultDatabaseLabels($this->database)->toArray(),
                     'healthcheck' => [
                         'test' => "clickhouse-client --password {$this->database->clickhouse_admin_password} --query 'SELECT 1'",
                         'interval' => '5s',

--- a/app/Actions/Database/StartDragonfly.php
+++ b/app/Actions/Database/StartDragonfly.php
@@ -46,11 +46,7 @@ class StartDragonfly
                     'networks' => [
                         $this->database->destination->network,
                     ],
-                    'labels' => [
-                        'coolify.managed' => 'true',
-                        'coolify.type' => 'database',
-                        'coolify.databaseId' => $this->database->id,
-                    ],
+                    'labels' => defaultDatabaseLabels($this->database)->toArray(),
                     'healthcheck' => [
                         'test' => "redis-cli -a {$this->database->dragonfly_password} ping",
                         'interval' => '5s',

--- a/app/Actions/Database/StartKeydb.php
+++ b/app/Actions/Database/StartKeydb.php
@@ -48,11 +48,7 @@ class StartKeydb
                     'networks' => [
                         $this->database->destination->network,
                     ],
-                    'labels' => [
-                        'coolify.managed' => 'true',
-                        'coolify.type' => 'database',
-                        'coolify.databaseId' => $this->database->id,
-                    ],
+                    'labels' => defaultDatabaseLabels($this->database)->toArray(),
                     'healthcheck' => [
                         'test' => "keydb-cli --pass {$this->database->keydb_password} ping",
                         'interval' => '5s',

--- a/app/Actions/Database/StartMariadb.php
+++ b/app/Actions/Database/StartMariadb.php
@@ -43,11 +43,7 @@ class StartMariadb
                     'networks' => [
                         $this->database->destination->network,
                     ],
-                    'labels' => [
-                        'coolify.managed' => 'true',
-                        'coolify.type' => 'database',
-                        'coolify.databaseId' => $this->database->id,
-                    ],
+                    'labels' => defaultDatabaseLabels($this->database)->toArray(),
                     'healthcheck' => [
                         'test' => ['CMD', 'healthcheck.sh', '--connect', '--innodb_initialized'],
                         'interval' => '5s',

--- a/app/Actions/Database/StartMongodb.php
+++ b/app/Actions/Database/StartMongodb.php
@@ -51,11 +51,7 @@ class StartMongodb
                     'networks' => [
                         $this->database->destination->network,
                     ],
-                    'labels' => [
-                        'coolify.managed' => 'true',
-                        'coolify.type' => 'database',
-                        'coolify.databaseId' => $this->database->id,
-                    ],
+                    'labels' => defaultDatabaseLabels($this->database)->toArray(),
                     'healthcheck' => [
                         'test' => [
                             'CMD',

--- a/app/Actions/Database/StartMysql.php
+++ b/app/Actions/Database/StartMysql.php
@@ -43,11 +43,7 @@ class StartMysql
                     'networks' => [
                         $this->database->destination->network,
                     ],
-                    'labels' => [
-                        'coolify.managed' => 'true',
-                        'coolify.type' => 'database',
-                        'coolify.databaseId' => $this->database->id,
-                    ],
+                    'labels' => defaultDatabaseLabels($this->database)->toArray(),
                     'healthcheck' => [
                         'test' => ['CMD', 'mysqladmin', 'ping', '-h', 'localhost', '-u', 'root', "-p{$this->database->mysql_root_password}"],
                         'interval' => '5s',

--- a/app/Actions/Database/StartPostgresql.php
+++ b/app/Actions/Database/StartPostgresql.php
@@ -47,11 +47,7 @@ class StartPostgresql
                     'networks' => [
                         $this->database->destination->network,
                     ],
-                    'labels' => [
-                        'coolify.managed' => 'true',
-                        'coolify.type' => 'database',
-                        'coolify.databaseId' => $this->database->id,
-                    ],
+                    'labels' => defaultDatabaseLabels($this->database)->toArray(),
                     'healthcheck' => [
                         'test' => [
                             'CMD-SHELL',

--- a/app/Actions/Database/StartRedis.php
+++ b/app/Actions/Database/StartRedis.php
@@ -48,11 +48,7 @@ class StartRedis
                     'networks' => [
                         $this->database->destination->network,
                     ],
-                    'labels' => [
-                        'coolify.managed' => 'true',
-                        'coolify.type' => 'database',
-                        'coolify.databaseId' => $this->database->id,
-                    ],
+                    'labels' => defaultDatabaseLabels($this->database)->toArray(),
                     'healthcheck' => [
                         'test' => [
                             'CMD-SHELL',

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -1683,7 +1683,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                 return escapeDollarSign($value);
             });
         }
-        $labels = $labels->merge(defaultLabels($this->application->id, $this->application->uuid, $this->application->project()->name, $this->application->name, $this->pull_request_id))->toArray();
+        $labels = $labels->merge(defaultLabels($this->application->id, $this->application->uuid, $this->application->project()->name, $this->application->name, $this->application->environment->name, $this->pull_request_id))->toArray();
 
         // Check for custom HEALTHCHECK
         if ($this->application->build_pack === 'dockerfile' || $this->application->dockerfile) {

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -1683,7 +1683,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                 return escapeDollarSign($value);
             });
         }
-        $labels = $labels->merge(defaultLabels($this->application->id, $this->application->uuid, $this->pull_request_id))->toArray();
+        $labels = $labels->merge(defaultLabels($this->application->id, $this->application->uuid, $this->application->project()->name, $this->application->name, $this->pull_request_id))->toArray();
 
         // Check for custom HEALTHCHECK
         if ($this->application->build_pack === 'dockerfile' || $this->application->dockerfile) {

--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -188,7 +188,19 @@ function get_port_from_dockerfile($dockerfile): ?int
     return null;
 }
 
-function defaultLabels($id, $name, $pull_request_id = 0, string $type = 'application', $subType = null, $subId = null)
+function defaultDatabaseLabels($database) {
+    $labels = collect([]);
+    $labels->push('coolify.managed=true');
+    $labels->push('coolify.type=database');
+    $labels->push('coolify.databaseId='.$database->id);
+    $labels->push('coolify.resourceName='.Str::slug($database->name));
+    $labels->push('coolify.serviceName='.Str::slug($database->name));
+    $labels->push('coolify.projectName='.Str::slug($database->project()->name));
+
+    return $labels;
+}
+
+function defaultLabels($id, $name, string $projectName, string $resourceName, $pull_request_id = 0, string $type = 'application', $subType = null, $subId = null, $subName = null)
 {
     $labels = collect([]);
     $labels->push('coolify.managed=true');
@@ -196,14 +208,19 @@ function defaultLabels($id, $name, $pull_request_id = 0, string $type = 'applica
     $labels->push('coolify.'.$type.'Id='.$id);
     $labels->push("coolify.type=$type");
     $labels->push('coolify.name='.$name);
+    $labels->push('coolify.resourceName='.Str::slug($resourceName));
+    $labels->push('coolify.projectName='.Str::slug($projectName));
+    $labels->push('coolify.serviceName='.Str::slug($subName ?? $resourceName));
     $labels->push('coolify.pullRequestId='.$pull_request_id);
     if ($type === 'service') {
         $subId && $labels->push('coolify.service.subId='.$subId);
         $subType && $labels->push('coolify.service.subType='.$subType);
+        $subName && $labels->push('coolify.service.subName='.Str::slug($subName));
     }
 
     return $labels;
 }
+
 function generateServiceSpecificFqdns(ServiceApplication|Application $resource)
 {
     if ($resource->getMorphClass() === \App\Models\ServiceApplication::class) {

--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -196,11 +196,12 @@ function defaultDatabaseLabels($database) {
     $labels->push('coolify.resourceName='.Str::slug($database->name));
     $labels->push('coolify.serviceName='.Str::slug($database->name));
     $labels->push('coolify.projectName='.Str::slug($database->project()->name));
+    $labels->push('coolify.environment='.Str::slug($database->environment->name));
 
     return $labels;
 }
 
-function defaultLabels($id, $name, string $projectName, string $resourceName, $pull_request_id = 0, string $type = 'application', $subType = null, $subId = null, $subName = null)
+function defaultLabels($id, $name, string $projectName, string $resourceName, string $environment, $pull_request_id = 0, string $type = 'application', $subType = null, $subId = null, $subName = null)
 {
     $labels = collect([]);
     $labels->push('coolify.managed=true');
@@ -211,6 +212,8 @@ function defaultLabels($id, $name, string $projectName, string $resourceName, $p
     $labels->push('coolify.resourceName='.Str::slug($resourceName));
     $labels->push('coolify.projectName='.Str::slug($projectName));
     $labels->push('coolify.serviceName='.Str::slug($subName ?? $resourceName));
+    $labels->push('coolify.environment='.Str::slug($environment));
+
     $labels->push('coolify.pullRequestId='.$pull_request_id);
     if ($type === 'service') {
         $subId && $labels->push('coolify.service.subId='.$subId);

--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -196,7 +196,7 @@ function defaultDatabaseLabels($database) {
     $labels->push('coolify.resourceName='.Str::slug($database->name));
     $labels->push('coolify.serviceName='.Str::slug($database->name));
     $labels->push('coolify.projectName='.Str::slug($database->project()->name));
-    $labels->push('coolify.environment='.Str::slug($database->environment->name));
+    $labels->push('coolify.environmentName='.Str::slug($database->environment->name));
 
     return $labels;
 }
@@ -212,7 +212,7 @@ function defaultLabels($id, $name, string $projectName, string $resourceName, st
     $labels->push('coolify.resourceName='.Str::slug($resourceName));
     $labels->push('coolify.projectName='.Str::slug($projectName));
     $labels->push('coolify.serviceName='.Str::slug($subName ?? $resourceName));
-    $labels->push('coolify.environment='.Str::slug($environment));
+    $labels->push('coolify.environmentName='.Str::slug($environment));
 
     $labels->push('coolify.pullRequestId='.$pull_request_id);
     if ($type === 'service') {

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -2059,7 +2059,16 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                 } else {
                     $fqdns = collect(data_get($savedService, 'fqdns'))->filter();
                 }
-                $defaultLabels = defaultLabels($resource->id, $containerName, type: 'service', subType: $isDatabase ? 'database' : 'application', subId: $savedService->id);
+                $defaultLabels = defaultLabels(
+                    id: $resource->id,
+                    name: $containerName,
+                    projectName: $resource->project()->name,
+                    resourceName: $resource->name,
+                    type: 'service',
+                    subType: $isDatabase ? 'database' : 'application', 
+                    subId: $savedService->id,
+                    subName: $savedService->name,
+                );
                 $serviceLabels = $serviceLabels->merge($defaultLabels);
                 if (! $isDatabase && $fqdns->count() > 0) {
                     if ($fqdns) {
@@ -2887,7 +2896,15 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                     }
                 }
             }
-            $defaultLabels = defaultLabels($resource->id, $containerName, $pull_request_id, type: 'application');
+
+            $defaultLabels = defaultLabels(
+                id: $resource->id,
+                name: $containerName,
+                projectName: $resource->project()->name,
+                resourceName: $resource->name,
+                pull_request_id: $pull_request_id,
+                type: 'application'
+            );
             $serviceLabels = $serviceLabels->merge($defaultLabels);
 
             if ($server->isLogDrainEnabled()) {
@@ -3673,6 +3690,8 @@ function newParser(Application|Service $resource, int $pull_request_id = 0, ?int
             $defaultLabels = defaultLabels(
                 id: $resource->id,
                 name: $containerName,
+                projectName: $resource->project()->name,
+                resourceName: $resource->name,
                 pull_request_id: $pullRequestId,
                 type: 'application'
             );
@@ -3682,7 +3701,17 @@ function newParser(Application|Service $resource, int $pull_request_id = 0, ?int
             } else {
                 $fqdns = collect(data_get($savedService, 'fqdns'))->filter();
             }
-            $defaultLabels = defaultLabels($resource->id, $containerName, type: 'service', subType: $isDatabase ? 'database' : 'application', subId: $savedService->id);
+
+            $defaultLabels = defaultLabels(
+                id: $resource->id,
+                name: $containerName,
+                projectName: $resource->project()->name,
+                resourceName: $resource->name,
+                type: 'service',
+                subType: $isDatabase ? 'database' : 'application',
+                subId: $savedService->id,
+                subName: $savedService->human_name ?? $savedService->name,
+            );
         }
         // Add COOLIFY_FQDN & COOLIFY_URL to environment
         if (! $isDatabase && $fqdns instanceof Collection && $fqdns->count() > 0) {

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -2068,6 +2068,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                     subType: $isDatabase ? 'database' : 'application', 
                     subId: $savedService->id,
                     subName: $savedService->name,
+                    environment: $resource->environment->name,
                 );
                 $serviceLabels = $serviceLabels->merge($defaultLabels);
                 if (! $isDatabase && $fqdns->count() > 0) {
@@ -2902,6 +2903,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                 name: $containerName,
                 projectName: $resource->project()->name,
                 resourceName: $resource->name,
+                environment: $resource->environment->name,
                 pull_request_id: $pull_request_id,
                 type: 'application'
             );
@@ -3687,13 +3689,15 @@ function newParser(Application|Service $resource, int $pull_request_id = 0, ?int
                     }
                 }
             }
+
             $defaultLabels = defaultLabels(
                 id: $resource->id,
                 name: $containerName,
                 projectName: $resource->project()->name,
                 resourceName: $resource->name,
                 pull_request_id: $pullRequestId,
-                type: 'application'
+                type: 'application',
+                environment: $resource->environment->name,
             );
         } elseif ($isService) {
             if ($savedService->serviceType()) {
@@ -3711,6 +3715,7 @@ function newParser(Application|Service $resource, int $pull_request_id = 0, ?int
                 subType: $isDatabase ? 'database' : 'application',
                 subId: $savedService->id,
                 subName: $savedService->human_name ?? $savedService->name,
+                environment: $resource->environment->name,
             );
         }
         // Add COOLIFY_FQDN & COOLIFY_URL to environment


### PR DESCRIPTION
## Changes

I strongly encourage to read the comment that initiated this PR: [https://github.com/coollabsio/coolify/discussions/3569#discussioncomment-11233242](https://github.com/coollabsio/coolify/discussions/3569#discussioncomment-11233242)

**TL;DR:** The main issue is the difficulty in monitoring due to automatically generated container names. Currently, when I look at my Grafana/cAdvisor dashboard tracking CPU usage for each container managed by Coolify, I only see cuid names , which makes it impossible to identify what each container corresponds to. 

So we need a way to have "human-readable" names for each container. This PR addresses the issue by adding three new labels to each container managed by Coolify :

- `coolify.resourceName`: The name of the `Application` or `Service`
- `coolify.projectName`: The name of the project where the resource lives
- `coolify.serviceName`: This one might be a bit confusing, and perhaps we can find a better name. If the resource is of type `Service`, it will be the sub-service name. If it's of type `Application`, it will be the application name. This label is necessary because, using my monitoring use case as an example, I need metrics/logs for **each** of my containers. To differentiate them, I need a unique name. If I'm using a `Service`, I can't rely on `coolify.resourceName` since all the services in my docker-compose file would have the same value. I hope this explanation makes sense.

This is my first contribution to Coolify, and I'm not familiar with PHP either, so feel free to point out any corrections or improvements I should made

( And thanks a lot for making Coolify 💙 )

## Issues
- https://github.com/coollabsio/coolify/discussions/3569
