### PR TITLE
fix typo for embystat slogan

### DIFF
--- a/templates/compose/embystat.yaml
+++ b/templates/compose/embystat.yaml
@@ -1,5 +1,5 @@
 # documentation: https://github.com/mregni/EmbyStat
-# slogan: EmnyStat is a web analytics tool, designed to provide insight into website traffic and user behavior.
+# slogan: EmbyStat is a web analytics tool, designed to provide insight into website traffic and user behavior.
 # tags: media, server, movies, tv, music
 # port: 6555
 


### PR DESCRIPTION
Embystat, not Emnystat

## Changes
- Embystat template now has correct name in the description
