### PR TITLE
Use new Stirling organisation Docker image

### DIFF
--- a/templates/compose/stirling-pdf.yaml
+++ b/templates/compose/stirling-pdf.yaml
@@ -6,7 +6,7 @@
 
 services:
   stirling-pdf:
-    image: frooodle/s-pdf:latest
+    image: stirlingtools/stirling-pdf:latest
     volumes:
       - stirling-training-data:/usr/share/tesseract-ocr/5/tessdata
       - stirling-configs:/configs


### PR DESCRIPTION
Use new Stirling organisation Docker image as per https://github.com/Stirling-Tools/Stirling-PDF/releases/tag/v0.33.1