### PR TITLE
Fix: `/servers` API invalid responses / OpenAPI schema

### DIFF
--- a/app/Http/Controllers/Api/ServersController.php
+++ b/app/Http/Controllers/Api/ServersController.php
@@ -567,6 +567,9 @@ class ServersController extends Controller
             ['bearerAuth' => []],
         ],
         tags: ['Servers'],
+        parameters: [
+            new OA\Parameter(name: 'uuid', in: 'path', required: true, description: 'Server UUID', schema: new OA\Schema(type: 'string')),
+        ],
         requestBody: new OA\RequestBody(
             required: true,
             description: 'Server updated.',

--- a/app/Http/Controllers/Api/ServersController.php
+++ b/app/Http/Controllers/Api/ServersController.php
@@ -596,8 +596,7 @@ class ServersController extends Controller
                     new OA\MediaType(
                         mediaType: 'application/json',
                         schema: new OA\Schema(
-                            type: 'array',
-                            items: new OA\Items(ref: '#/components/schemas/Server')
+                            ref: '#/components/schemas/Server'
                         )
                     ),
                 ]),

--- a/app/Http/Controllers/Api/ServersController.php
+++ b/app/Http/Controllers/Api/ServersController.php
@@ -678,9 +678,7 @@ class ServersController extends Controller
             ValidateServer::dispatch($server);
         }
 
-        return response()->json([
-
-        ])->setStatusCode(201);
+        return response()->json(serializeApiResponse($server))->setStatusCode(201);
     }
 
     #[OA\Delete(

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -42,8 +42,6 @@ use Symfony\Component\Yaml\Yaml;
         'validation_logs' => ['type' => 'string', 'description' => 'The validation logs.'],
         'log_drain_notification_sent' => ['type' => 'boolean', 'description' => 'The flag to indicate if the log drain notification has been sent.'],
         'swarm_cluster' => ['type' => 'string', 'description' => 'The swarm cluster configuration.'],
-        'delete_unused_volumes' => ['type' => 'boolean', 'description' => 'The flag to indicate if the unused volumes should be deleted.'],
-        'delete_unused_networks' => ['type' => 'boolean', 'description' => 'The flag to indicate if the unused networks should be deleted.'],
         'settings' => ['$ref' => '#/components/schemas/ServerSetting'],
     ]
 )]

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -44,6 +44,7 @@ use Symfony\Component\Yaml\Yaml;
         'swarm_cluster' => ['type' => 'string', 'description' => 'The swarm cluster configuration.'],
         'delete_unused_volumes' => ['type' => 'boolean', 'description' => 'The flag to indicate if the unused volumes should be deleted.'],
         'delete_unused_networks' => ['type' => 'boolean', 'description' => 'The flag to indicate if the unused networks should be deleted.'],
+        'settings' => ['$ref' => '#/components/schemas/ServerSetting'],
     ]
 )]
 

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -813,7 +813,7 @@ $schema://$host {
     {
         return Attribute::make(
             get: function ($value) {
-                return preg_replace('/[^0-9]/', '', $value);
+                return (int) preg_replace('/[^0-9]/', '', $value);
             }
         );
     }

--- a/app/Models/ServerSetting.php
+++ b/app/Models/ServerSetting.php
@@ -45,6 +45,8 @@ use OpenApi\Attributes as OA;
         'wildcard_domain' => ['type' => 'string'],
         'created_at' => ['type' => 'string'],
         'updated_at' => ['type' => 'string'],
+        'delete_unused_volumes' => ['type' => 'boolean', 'description' => 'The flag to indicate if the unused volumes should be deleted.'],
+        'delete_unused_networks' => ['type' => 'boolean', 'description' => 'The flag to indicate if the unused networks should be deleted.'],
     ]
 )]
 class ServerSetting extends Model

--- a/openapi.json
+++ b/openapi.json
@@ -7456,6 +7456,9 @@
                     "delete_unused_networks": {
                         "type": "boolean",
                         "description": "The flag to indicate if the unused networks should be deleted."
+                    },
+                    "settings": {
+                        "$ref": "#\/components\/schemas\/ServerSetting"
                     }
                 },
                 "type": "object"

--- a/openapi.json
+++ b/openapi.json
@@ -7449,14 +7449,6 @@
                         "type": "string",
                         "description": "The swarm cluster configuration."
                     },
-                    "delete_unused_volumes": {
-                        "type": "boolean",
-                        "description": "The flag to indicate if the unused volumes should be deleted."
-                    },
-                    "delete_unused_networks": {
-                        "type": "boolean",
-                        "description": "The flag to indicate if the unused networks should be deleted."
-                    },
                     "settings": {
                         "$ref": "#\/components\/schemas\/ServerSetting"
                     }
@@ -7567,6 +7559,14 @@
                     },
                     "updated_at": {
                         "type": "string"
+                    },
+                    "delete_unused_volumes": {
+                        "type": "boolean",
+                        "description": "The flag to indicate if the unused volumes should be deleted."
+                    },
+                    "delete_unused_networks": {
+                        "type": "boolean",
+                        "description": "The flag to indicate if the unused networks should be deleted."
                     }
                 },
                 "type": "object"

--- a/openapi.json
+++ b/openapi.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": {
         "title": "Coolify",
         "version": "0.1"
@@ -5451,10 +5451,7 @@
                         "content": {
                             "application\/json": {
                                 "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#\/components\/schemas\/Server"
-                                    }
+                                    "$ref": "#\/components\/schemas\/Server"
                                 }
                             }
                         }

--- a/openapi.json
+++ b/openapi.json
@@ -5391,6 +5391,17 @@
                 "summary": "Update",
                 "description": "Update Server.",
                 "operationId": "update-server-by-uuid",
+                "parameters": [
+                    {
+                        "name": "uuid",
+                        "in": "path",
+                        "description": "Server UUID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
                 "requestBody": {
                     "description": "Server updated.",
                     "required": true,

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4973,12 +4973,6 @@ components:
         swarm_cluster:
           type: string
           description: 'The swarm cluster configuration.'
-        delete_unused_volumes:
-          type: boolean
-          description: 'The flag to indicate if the unused volumes should be deleted.'
-        delete_unused_networks:
-          type: boolean
-          description: 'The flag to indicate if the unused networks should be deleted.'
         settings:
           $ref: '#/components/schemas/ServerSetting'
       type: object
@@ -5053,6 +5047,12 @@ components:
           type: string
         updated_at:
           type: string
+        delete_unused_volumes:
+          type: boolean
+          description: 'The flag to indicate if the unused volumes should be deleted.'
+        delete_unused_networks:
+          type: boolean
+          description: 'The flag to indicate if the unused networks should be deleted.'
       type: object
     Service:
       description: 'Service model'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3671,6 +3671,14 @@ paths:
       summary: Update
       description: 'Update Server.'
       operationId: update-server-by-uuid
+      parameters:
+        -
+          name: uuid
+          in: path
+          description: 'Server UUID'
+          required: true
+          schema:
+            type: string
       requestBody:
         description: 'Server updated.'
         required: true

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3713,9 +3713,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Server'
+                $ref: '#/components/schemas/Server'
         '401':
           $ref: '#/components/responses/401'
         '400':

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4979,6 +4979,8 @@ components:
         delete_unused_networks:
           type: boolean
           description: 'The flag to indicate if the unused networks should be deleted.'
+        settings:
+          $ref: '#/components/schemas/ServerSetting'
       type: object
     ServerSetting:
       description: 'Server Settings model'


### PR DESCRIPTION
## Changes
- Fixed POST `/servers` returning an empty response since beta.370+ 4a45de564603021f237cf0b8f953afce945195c4
- Fixed GET `/servers` + `/servers/{uuid}` returning `port` as a string instead of integer 059639eb428eaaedf126858a4a51f01f32211ae0

OpenAPI Schema:
- Fixed PATCH `/servers` schema return type 379045c8356c455e70ecc58d90331e44694e0cdb
- Added missing `uuid` parameter to PATCH `/servers` fead884809cfceb95439a5c7e5c1e9ef4d304a6a
- Added missing `settings` property on `Servers` model d6441549e8efe0646fff49f6551ac8b4a371e195
- Moved `delete_unused_*` properties from `Servers` to correct location on `ServerSettings` bbd7d8b567905195c1070fd1c831cc990b1de9e0
