### PR TITLE
Fix metrics error when data is less than selected date

### DIFF
--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -611,7 +611,8 @@ $schema://$host {
             }
             $memory = json_decode($memory, true);
             $parsedCollection = collect($memory)->map(function ($metric) {
-                return [(int) $metric['time'], (float) $metric['usedPercent']];
+                $usedPercent = $metric['usedPercent'] ?? 0.0;
+                return [(int) $metric['time'], (float) $usedPercent];
             });
 
             return $parsedCollection->toArray();


### PR DESCRIPTION
Related to #4309

Fix the 'sql: Scan error on column index 5, name "usedPercent": converting NULL to float64 is unsupported' error on the metrics page.

* Update the `getMemoryMetrics` method in `app/Models/Server.php` to handle NULL values for the "usedPercent" field by setting them to 0.0.
* Add a check for NULL values in the `getMemoryMetrics` method before converting to float64.

