### PR TITLE
fix: Improve navigation from breadcrumb

### DIFF
--- a/resources/views/components/resources/breadcrumbs.blade.php
+++ b/resources/views/components/resources/breadcrumbs.blade.php
@@ -10,35 +10,72 @@
                 <a class="text-xs truncate lg:text-sm"
                     href="{{ route('project.show', ['project_uuid' => $this->parameters['project_uuid']]) }}">
                     {{ data_get($resource, 'environment.project.name', 'Undefined Name') }}</a>
-                <svg aria-hidden="true" class="w-4 h-4 mx-1 font-bold dark:text-warning" fill="currentColor"
-                    viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                    <path fill-rule="evenodd"
-                        d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-                        clip-rule="evenodd"></path>
-                </svg>
+                <x-dropdown>
+                    <x-slot:trigger>
+                        <svg aria-hidden="true" class="w-4 h-4 mx-1 font-bold cursor-pointer dark:text-warning hover:scale-110" fill="currentColor"
+                            viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                            <path fill-rule="evenodd"
+                                d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                                clip-rule="evenodd"></path>
+                        </svg>
+                    </x-slot:trigger>
+                    <div class="flex flex-col gap-1">
+                        @foreach($resource->environment->project->resources as $projectResource)
+                            <a href="{{ $projectResource->link() }}" class="dropdown-item">
+                                {{ $projectResource->name }}
+                            </a>
+                        @endforeach
+                    </div>
+                </x-dropdown>
             </div>
         </li>
         <li>
             <div class="flex items-center">
                 <a class="text-xs truncate lg:text-sm"
-                    href="{{ route('project.resource.index', ['environment_name' => $this->parameters['environment_name'], 'project_uuid' => $this->parameters['project_uuid']]) }}">{{ $this->parameters['environment_name'] }}</a>
-                <svg aria-hidden="true" class="w-4 h-4 mx-1 font-bold dark:text-warning" fill="currentColor"
-                    viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                    <path fill-rule="evenodd"
-                        d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-                        clip-rule="evenodd"></path>
-                </svg>
+                    href="{{ route('project.resource.index', ['environment_name' => $this->parameters['environment_name'], 'project_uuid' => $this->parameters['project_uuid']]) }}">
+                    {{ $this->parameters['environment_name'] }}</a>
+                <x-dropdown>
+                    <x-slot:trigger>
+                        <svg aria-hidden="true" class="w-4 h-4 mx-1 font-bold cursor-pointer dark:text-warning hover:scale-110" fill="currentColor"
+                            viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                            <path fill-rule="evenodd"
+                                d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                                clip-rule="evenodd"></path>
+                        </svg>
+                    </x-slot:trigger>
+                    <div class="flex flex-col gap-1">
+                        @foreach($resource->environment->resources as $envResource)
+                            <a href="{{ $envResource->link() }}" class="dropdown-item">
+                                {{ $envResource->name }}
+                            </a>
+                        @endforeach
+                    </div>
+                </x-dropdown>
             </div>
         </li>
         <li>
             <div class="flex items-center">
                 <span class="text-xs truncate lg:text-sm">{{ data_get($resource, 'name') }}</span>
-                <svg aria-hidden="true" class="w-4 h-4 mx-1 font-bold dark:text-warning" fill="currentColor"
-                    viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                    <path fill-rule="evenodd"
-                        d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-                        clip-rule="evenodd"></path>
-                </svg>
+                @if($resource->getMorphClass() !== 'App\Models\Service')
+                    <x-dropdown>
+                        <x-slot:trigger>
+                            <svg aria-hidden="true" class="w-4 h-4 mx-1 font-bold cursor-pointer dark:text-warning hover:scale-110" fill="currentColor"
+                                viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                                <path fill-rule="evenodd"
+                                    d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                                    clip-rule="evenodd"></path>
+                            </svg>
+                        </x-slot:trigger>
+                        <div class="flex flex-col gap-1">
+                            <a href="{{ route('project.application.configuration', $parameters) }}" class="dropdown-item">Configuration</a>
+                            <a href="{{ route('project.application.deployment.index', $parameters) }}" class="dropdown-item">Deployments</a>
+                            <a href="{{ route('project.application.logs', $parameters) }}" class="dropdown-item">Logs</a>
+                            @if (!$resource->destination->server->isSwarm())
+                                <a href="{{ route('project.application.command', $parameters) }}" class="dropdown-item">Terminal</a>
+                            @endif
+                        </div>
+                    </x-dropdown>
+                @endif
             </div>
         </li>
         @if ($resource->getMorphClass() == 'App\Models\Service')


### PR DESCRIPTION
[x] Added dropdown menus to each breadcrumb segment using <x-dropdown> component
[x] Added clickable chevron icons with hover effect (hover:scale-110) as dropdown triggers
[x] Added project resources navigation in first dropdown
[x] Added environment resources navigation in second dropdown
[x] Added resource section navigation (Configuration, Deployments, Logs, Terminal) in third dropdown
[x] Preserved existing status components and routing
[x] Maintained responsive text sizing (text-xs lg:text-sm)
[x] Added dark mode support for icons (dark:text-warning)
[x] Added gap spacing between dropdown items (gap-1)
[x] Added conditional Terminal link based on server type (!$resource->destination->server->isSwarm())

/claim #4117 
