### PR TITLE
fix deploy key selection in applications source menu

### DIFF
--- a/resources/views/livewire/project/application/source.blade.php
+++ b/resources/views/livewire/project/application/source.blade.php
@@ -43,7 +43,7 @@
             <h4 class="py-2 ">Select another Private Key</h4>
             <div class="flex flex-wrap gap-2">
                 @foreach ($privateKeys as $key)
-                    <x-forms.button wire:click.defer="setPrivateKey('{{ $key->id }}')">{{ $key->name }}
+                    <x-forms.button wire:click="setPrivateKey('{{ $key->id }}')">{{ $key->name }}
                     </x-forms.button>
                 @endforeach
             </div>


### PR DESCRIPTION
## Changes
- fix: Remove defer from private key selection

Removes the .defer modifier from wire:click event on private key selection buttons


## Issues
- fix https://discord.com/channels/459365938081431553/1311602674428411914
