### PR TITLE
Feat: Ability to rename GitHub App

### DIFF
--- a/app/Http/Controllers/Webhook/Github.php
+++ b/app/Http/Controllers/Webhook/Github.php
@@ -463,7 +463,7 @@ class Github extends Controller
             $private_key = data_get($data, 'pem');
             $webhook_secret = data_get($data, 'webhook_secret');
             $private_key = PrivateKey::create([
-                'name' => $slug,
+                'name' => "github-app-{$slug}",
                 'private_key' => $private_key,
                 'team_id' => $github_app->team_id,
                 'is_git_related' => true,

--- a/app/Livewire/Source/Github/Change.php
+++ b/app/Livewire/Source/Github/Change.php
@@ -158,6 +158,10 @@ class Change extends Component
 
     public function getGithubAppNameUpdatePath()
     {
+        if (str($this->github_app->organization)->isNotEmpty()) {
+            return "{$this->github_app->html_url}/organizations/{$this->github_app->organization}/settings/apps/{$this->github_app->name}";
+        }
+
         return "{$this->github_app->html_url}/settings/apps/{$this->github_app->name}";
     }
 
@@ -184,7 +188,7 @@ class Change extends Component
     public function updateGithubAppName()
     {
         try {
-            $privateKey = PrivateKey::find($this->github_app->private_key_id);
+            $privateKey = PrivateKey::ownedByCurrentTeam()->find($this->github_app->private_key_id);
 
             if (! $privateKey) {
                 $this->dispatch('error', 'No private key found for this GitHub App.');

--- a/app/Livewire/Source/Github/Change.php
+++ b/app/Livewire/Source/Github/Change.php
@@ -56,6 +56,13 @@ class Change extends Component
         'github_app.administration' => 'nullable|string',
     ];
 
+    public function boot()
+    {
+        if ($this->github_app) {
+            $this->github_app->makeVisible(['client_secret', 'webhook_secret']);
+        }
+    }
+
     public function checkPermissions()
     {
         GithubAppPermissionJob::dispatchSync($this->github_app);
@@ -102,10 +109,10 @@ class Change extends Component
         try {
             $github_app_uuid = request()->github_app_uuid;
             $this->github_app = GithubApp::ownedByCurrentTeam()->whereUuid($github_app_uuid)->firstOrFail();
+            $this->github_app->makeVisible(['client_secret', 'webhook_secret']);
 
             $this->applications = $this->github_app->applications;
             $settings = instanceSettings();
-            $this->github_app->makeVisible('client_secret')->makeVisible('webhook_secret');
 
             $this->name = str($this->github_app->name)->kebab();
             $this->fqdn = $settings->fqdn;

--- a/app/Livewire/Source/Github/Change.php
+++ b/app/Livewire/Source/Github/Change.php
@@ -142,6 +142,11 @@ class Change extends Component
         }
     }
 
+    public function getUpdatePath()
+    {
+        return "{$this->github_app->html_url}/settings/apps/{$this->github_app->app_id}";
+    }
+
     public function submit()
     {
         try {

--- a/app/Livewire/Source/Github/Change.php
+++ b/app/Livewire/Source/Github/Change.php
@@ -62,6 +62,7 @@ class Change extends Component
         $this->github_app->refresh()->makeVisible('client_secret')->makeVisible('webhook_secret');
         $this->dispatch('success', 'Github App permissions updated.');
     }
+
     // public function check()
     // {
 
@@ -95,6 +96,7 @@ class Change extends Component
 
     //     ray($runners_by_repository);
     // }
+
     public function mount()
     {
         try {
@@ -147,7 +149,7 @@ class Change extends Component
         }
     }
 
-    public function getUpdatePath()
+    public function getGithubAppNameUpdatePath()
     {
         return "{$this->github_app->html_url}/settings/apps/{$this->github_app->name}";
     }
@@ -172,13 +174,13 @@ class Change extends Component
             ->toString();
     }
 
-    public function syncGithubAppName()
+    public function updateGithubAppName()
     {
         try {
             $privateKey = PrivateKey::find($this->github_app->private_key_id);
 
             if (! $privateKey) {
-                $this->dispatch('error', 'Private key not found for this GitHub App.');
+                $this->dispatch('error', 'No private key found for this GitHub App.');
 
                 return;
             }
@@ -201,13 +203,13 @@ class Change extends Component
                     $privateKey->name = "github-app-{$app_slug}";
                     $privateKey->save();
                     $this->github_app->save();
-                    $this->dispatch('success', 'Github App name and SSH key name synchronized successfully.');
+                    $this->dispatch('success', 'GitHub App name and SSH key name synchronized successfully.');
                 } else {
-                    $this->dispatch('info', 'Could not find app slug in GitHub response.');
+                    $this->dispatch('info', 'Could not find App Name (slug) in GitHub response.');
                 }
             } else {
                 $error_message = $response->json()['message'] ?? 'Unknown error';
-                $this->dispatch('error', "Failed to fetch Github App information: {$error_message}");
+                $this->dispatch('error', "Failed to fetch GitHub App information: {$error_message}");
             }
         } catch (\Throwable $e) {
             return handleError($e, $this);

--- a/app/Livewire/Source/Github/Change.php
+++ b/app/Livewire/Source/Github/Change.php
@@ -151,14 +151,14 @@ class Change extends Component
     public function syncGithubAppName()
     {
         try {
-            $jwt = $this->github_app->generateJWT();
+            $github_access_token = generate_github_installation_token($this->github_app);
 
-            $response = Http::withToken($jwt)
+            $response = Http::withToken($github_access_token)
                 ->withHeaders([
                     'Accept' => 'application/vnd.github+json',
                     'X-GitHub-Api-Version' => '2022-11-28',
                 ])
-                ->get('https://api.github.com/app');
+                ->get("{$this->github_app->api_url}/app");
 
             if ($response->successful()) {
                 $app_data = $response->json();

--- a/app/Livewire/Source/Github/Change.php
+++ b/app/Livewire/Source/Github/Change.php
@@ -198,8 +198,10 @@ class Change extends Component
                 if ($app_slug) {
                     $this->github_app->name = $app_slug;
                     $this->name = str($app_slug)->kebab();
+                    $privateKey->name = "github-app-{$app_slug}";
+                    $privateKey->save();
                     $this->github_app->save();
-                    $this->dispatch('success', 'Github App name synchronized successfully.');
+                    $this->dispatch('success', 'Github App name and SSH key name synchronized successfully.');
                 } else {
                     $this->dispatch('info', 'Could not find app slug in GitHub response.');
                 }

--- a/database/seeders/GithubAppSeeder.php
+++ b/database/seeders/GithubAppSeeder.php
@@ -23,6 +23,7 @@ class GithubAppSeeder extends Seeder
         GithubApp::create([
             'name' => 'coolify-laravel-development-public',
             'uuid' => '69420',
+            'organization' => 'coollabsio',
             'api_url' => 'https://api.github.com',
             'html_url' => 'https://github.com',
             'is_public' => false,

--- a/resources/views/livewire/source/github/change.blade.php
+++ b/resources/views/livewire/source/github/change.blade.php
@@ -60,6 +60,7 @@
                     <div class="flex gap-2">
                         <div class="flex items-end gap-2 w-full">
                             <x-forms.input id="github_app.name" label="App Name" disabled />
+                            <x-forms.button wire:click.prevent="syncGithubAppName">Sync Name</x-forms.button>
                             <a href="{{ $this->getUpdatePath() }}">
                                 <x-forms.button>
                                     Update

--- a/resources/views/livewire/source/github/change.blade.php
+++ b/resources/views/livewire/source/github/change.blade.php
@@ -60,10 +60,12 @@
                     <div class="flex gap-2">
                         <div class="flex items-end gap-2 w-full">
                             <x-forms.input id="github_app.name" label="App Name" disabled />
-                            <x-forms.button wire:click.prevent="syncGithubAppName">Sync Name</x-forms.button>
-                            <a href="{{ $this->getUpdatePath() }}">
+                            <x-forms.button wire:click.prevent="updateGithubAppName" class="bg-coollabs">
+                                Sync Name
+                            </x-forms.button>
+                            <a href="{{ $this->getGithubAppNameUpdatePath() }}">
                                 <x-forms.button>
-                                    Update
+                                    Rename
                                     <x-external-link />
                                 </x-forms.button>
                             </a>

--- a/resources/views/livewire/source/github/change.blade.php
+++ b/resources/views/livewire/source/github/change.blade.php
@@ -58,7 +58,15 @@
             @else
                 <div class="flex flex-col gap-2">
                     <div class="flex gap-2">
-                        <x-forms.input id="github_app.name" label="App Name" disabled />
+                        <div class="flex items-end gap-2 w-full">
+                            <x-forms.input id="github_app.name" label="App Name" disabled />
+                            <a href="{{ $this->getUpdatePath() }}">
+                                <x-forms.button>
+                                    Update
+                                    <x-external-link />
+                                </x-forms.button>
+                            </a>
+                        </div>
                         <x-forms.input id="github_app.organization" label="Organization" disabled
                             placeholder="If empty, personal user will be used" />
                     </div>


### PR DESCRIPTION
## Changes
- Feat: Ability to change the name of a GitHub app from Coolify.
- Feat: Ability to sync the new name for GitHub to Coolify and the SSH Key (both the GitHub app and SSH key will get the new slug as the name).
- chore: add `github-app-` as a prefix in front of GitHub APP SSH Keys to make it more clear what they are for.

**Preview:**
![image](https://github.com/user-attachments/assets/18f7e8a6-6f52-40df-b807-945ee01cc93b)


- Implements: https://github.com/coollabsio/coolify/discussions/4016
