### PR TITLE
Use computed property for timezones

### DIFF
--- a/app/Livewire/Server/Show.php
+++ b/app/Livewire/Server/Show.php
@@ -5,7 +5,7 @@ namespace App\Livewire\Server;
 use App\Actions\Server\StartSentinel;
 use App\Actions\Server\StopSentinel;
 use App\Models\Server;
-use Livewire\Attributes\Locked;
+use Livewire\Attributes\Computed;
 use Livewire\Attributes\Validate;
 use Livewire\Component;
 
@@ -79,9 +79,6 @@ class Show extends Component
     #[Validate(['required'])]
     public string $serverTimezone;
 
-    #[Locked]
-    public array $timezones;
-
     public function getListeners()
     {
         $teamId = auth()->user()->currentTeam()->id;
@@ -96,11 +93,19 @@ class Show extends Component
     {
         try {
             $this->server = Server::ownedByCurrentTeam()->whereUuid($server_uuid)->firstOrFail();
-            $this->timezones = collect(timezone_identifiers_list())->sort()->values()->toArray();
             $this->syncData();
         } catch (\Throwable $e) {
             return handleError($e, $this);
         }
+    }
+
+    #[Computed]
+    public function timezones(): array
+    {
+        return collect(timezone_identifiers_list())
+            ->sort()
+            ->values()
+            ->toArray();
     }
 
     public function syncData(bool $toModel = false)

--- a/app/Livewire/Settings/Index.php
+++ b/app/Livewire/Settings/Index.php
@@ -7,7 +7,7 @@ use App\Models\InstanceSettings;
 use App\Models\Server;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
-use Livewire\Attributes\Locked;
+use Livewire\Attributes\Computed;
 use Livewire\Attributes\Validate;
 use Livewire\Component;
 
@@ -16,9 +16,6 @@ class Index extends Component
     public InstanceSettings $settings;
 
     protected Server $server;
-
-    #[Locked]
-    public $timezones;
 
     #[Validate('boolean')]
     public bool $is_auto_update_enabled;
@@ -101,10 +98,18 @@ class Index extends Component
             $this->is_api_enabled = $this->settings->is_api_enabled;
             $this->auto_update_frequency = $this->settings->auto_update_frequency;
             $this->update_check_frequency = $this->settings->update_check_frequency;
-            $this->timezones = collect(timezone_identifiers_list())->sort()->values()->toArray();
             $this->instance_timezone = $this->settings->instance_timezone;
             $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
         }
+    }
+
+    #[Computed]
+    public function timezones(): array
+    {
+        return collect(timezone_identifiers_list())
+            ->sort()
+            ->values()
+            ->toArray();
     }
 
     public function instantSave($isSave = true)

--- a/resources/views/livewire/server/show.blade.php
+++ b/resources/views/livewire/server/show.blade.php
@@ -88,7 +88,7 @@
                     <div class="w-full" x-data="{
                         open: false,
                         search: '{{ $serverTimezone ?: '' }}',
-                        timezones: @js($timezones),
+                        timezones: @js($this->timezones),
                         placeholder: '{{ $serverTimezone ? 'Search timezone...' : 'Select Server Timezone' }}',
                         init() {
                             this.$watch('search', value => {

--- a/resources/views/livewire/settings/index.blade.php
+++ b/resources/views/livewire/settings/index.blade.php
@@ -23,7 +23,7 @@
                     <div class="w-full" x-data="{
                         open: false,
                         search: '{{ $settings->instance_timezone ?: '' }}',
-                        timezones: @js($timezones),
+                        timezones: @js($this->timezones),
                         placeholder: '{{ $settings->instance_timezone ? 'Search timezone...' : 'Select Server Timezone' }}',
                         init() {
                             this.$watch('search', value => {


### PR DESCRIPTION
## Changes
- Improve performance by using [computed properties](https://livewire.laravel.com/docs/computed-properties) for the `timezones`.