### PR TITLE
Support PopOS as server

### DIFF
--- a/bootstrap/helpers/constants.php
+++ b/bootstrap/helpers/constants.php
@@ -46,7 +46,7 @@ const SPECIFIC_SERVICES = [
 
 // Based on /etc/os-release
 const SUPPORTED_OS = [
-    'ubuntu debian raspbian',
+    'ubuntu debian raspbian pop',
     'centos fedora rhel ol rocky amzn almalinux',
     'sles opensuse-leap opensuse-tumbleweed',
     'arch',


### PR DESCRIPTION
PopOS is already added as supported for the main Coolify instance, but fails when adding a PopOS machine as an additional server.

## Changes
- Added pop to the list of SUPPORTED_OS under ubuntu/debian
