### PR TITLE
Fixing Email Provider bug in postiz.yaml service

### DIFF
--- a/templates/compose/postiz.yaml
+++ b/templates/compose/postiz.yaml
@@ -35,6 +35,7 @@ services:
       - RESEND_API_KEY=${RESEND_API_KEY}
       - EMAIL_FROM_ADDRESS=${EMAIL_FROM_ADDRESS}
       - EMAIL_FROM_NAME=${EMAIL_FROM_NAME}
+      - EMAIL_PROVIDER=${EMAIL_PROVIDER}
       
       # Social Media API Settings
       - X_API_KEY=${SERVICE_X_API}


### PR DESCRIPTION
Small Fix to the postiz.yaml file, missing the Email Provider Environment Variable.

## Changes
-  Added “EMAIL_PROVIDER” as env to the docker composer

## Issues
- Email Invitation link error

Thanks https://github.com/dougm1966 for the heads-up.

@peaklabs-dev 