### PR TITLE
fix: display actual values for disk space checks in installer script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -30,7 +30,7 @@ WARNING_SPACE=false
 
 if [ "$TOTAL_SPACE" -lt "$REQUIRED_TOTAL_SPACE" ]; then
     WARNING_SPACE=true
-    cat << 'EOF'
+    cat << EOF
 WARNING: Insufficient total disk space!
 
 Total disk space:     ${TOTAL_SPACE}GB
@@ -41,7 +41,7 @@ EOF
 fi
 
 if [ "$AVAILABLE_SPACE" -lt "$REQUIRED_AVAILABLE_SPACE" ]; then
-    cat << 'EOF'
+    cat << EOF
 WARNING: Insufficient available disk space!
 
 Available disk space:   ${AVAILABLE_SPACE}GB
@@ -49,7 +49,7 @@ Required available space: ${REQUIRED_AVAILABLE_SPACE}GB
 
 ==================
 EOF
-    WARNING_SPACE=true
+WARNING_SPACE=true
 fi
 
 if [ "$WARNING_SPACE" = true ]; then


### PR DESCRIPTION
## Submit Checklist (REMOVE THIS SECTION BEFORE SUBMITTING)
- [x] I have selected the `next` branch as the destination for my PR, not `main`.
- [x] I have listed all changes in the `Changes` section.
- [x] I have filled out the `Issues` section with the issue/discussion link(s) (if applicable).
- [x] I have tested my changes.
- [x] I have considered backwards compatibility.
- [x] I have removed this checklist and any unused sections.

## Changes
- Fixed an issue in the Coolify installer script where disk space warnings displayed variable names instead of their actual values.  
- Replaced `cat << 'EOF'` with `cat << EOF` to enable variable substitution and display actual disk space values.  
- Improved clarity of disk space warning messages, including:
  - Total disk space.
  - Available disk space.
  - Required disk space thresholds.   

## Issues
- None filed yet. This PR directly addresses a minor script bug noticed during testing.  


#### **Before Fix**  

```
WARNING: Insufficient total disk space!  

Total disk space:     ${TOTAL_SPACE}GB  
Required disk space:  ${REQUIRED_TOTAL_SPACE}GB  
```

#### **After Fix**  
```
WARNING: Insufficient total disk space!  

Total disk space:     25GB  
Required disk space:  30GB  
```  

#4485 