### PR TITLE
Fix typo in fileflows.yaml

### DIFF
--- a/templates/compose/fileflows.yaml
+++ b/templates/compose/fileflows.yaml
@@ -5,7 +5,7 @@
 # port: 5000
 
 services:
-  radarr:
+  fileflows:
     image: revenz/fileflows
     environment:
       - SERVICE_FQDN_FILEFLOWS_5000


### PR DESCRIPTION
The service was called `radarr` instead of `fileflows`

