### PR TITLE
remove n8n timezone environment variables

### DIFF
--- a/templates/compose/n8n-with-postgresql.yaml
+++ b/templates/compose/n8n-with-postgresql.yaml
@@ -12,8 +12,6 @@ services:
       - N8N_EDITOR_BASE_URL=${SERVICE_FQDN_N8N}
       - WEBHOOK_URL=${SERVICE_FQDN_N8N}
       - N8N_HOST=${SERVICE_URL_N8N}
-      - GENERIC_TIMEZONE=Europe/Berlin
-      - TZ=Europe/Berlin
       - DB_TYPE=postgresdb
       - DB_POSTGRESDB_DATABASE=${POSTGRES_DB:-n8n}
       - DB_POSTGRESDB_HOST=postgresql

--- a/templates/compose/n8n.yaml
+++ b/templates/compose/n8n.yaml
@@ -12,8 +12,6 @@ services:
       - N8N_EDITOR_BASE_URL=${SERVICE_FQDN_N8N}
       - WEBHOOK_URL=${SERVICE_FQDN_N8N}
       - N8N_HOST=${SERVICE_URL_N8N}
-      - GENERIC_TIMEZONE=Europe/Berlin
-      - TZ=Europe/Berlin
     volumes:
       - n8n-data:/home/node/.n8n
     healthcheck:


### PR DESCRIPTION
## Changes
- Removed all the timezone variables (below) from the n8n templates. 
     GENERIC_TIMEZONE=Europe/Berlin
     TZ=Europe/Berlin

With these variables hardcoded in the docker template, you cannot override them using the Coolify dashboard. 

With these removed, the n8n defaults back to the defaults listed in their docs (America/New_York) which allows users to add their own timezone settings via the Coolify dashboard and resource environment variables page.

## Issues
- fix #4603 - https://github.com/coollabsio/coolify/issues/4603
