### PR TITLE
fix: hostname -I not supported on Arch Linux

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -160,8 +160,7 @@ echo -e "1. Installing required packages (curl, wget, git, jq, openssl). "
 
 case "$OS_TYPE" in
 arch)
-    # inetutils provides the 'hostname' command
-    pacman -Sy --noconfirm --needed curl wget git jq openssl inetutils >/dev/null || true
+    pacman -Sy --noconfirm --needed curl wget git jq openssl >/dev/null || true
     ;;
 alpine)
     sed -i '/^#.*\/community/s/^#//' /etc/apk/repositories
@@ -543,7 +542,7 @@ echo -e "You can access Coolify through your Public IP: http://$(curl -4s https:
 
 set +e
 DEFAULT_PRIVATE_IP=$(ip route get 1 | sed -n 's/^.*src \([0-9.]*\) .*$/\1/p')
-PRIVATE_IPS=$(hostname -I)
+PRIVATE_IPS=$(hostname -I 2>/dev/null || ip -o addr show scope global | awk '{print $4}' | cut -d/ -f1)
 set -e
 
 if [ -n "$PRIVATE_IPS" ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -160,7 +160,8 @@ echo -e "1. Installing required packages (curl, wget, git, jq, openssl). "
 
 case "$OS_TYPE" in
 arch)
-    pacman -Sy --noconfirm --needed curl wget git jq openssl >/dev/null || true
+    # inetutils provides the 'hostname' command
+    pacman -Sy --noconfirm --needed curl wget git jq openssl inetutils >/dev/null || true
     ;;
 alpine)
     sed -i '/^#.*\/community/s/^#//' /etc/apk/repositories


### PR DESCRIPTION
# Update 2024-12-24

Refactored to use
```
ip -o addr show scope global | awk '{print $4}' | cut -d/ -f1
```

if `hostname -I` is not supported, e.g. on Arch Linux.



# Original PR

This provides the `hostname` command used in the `install.sh` script, which is not available by default on Arch Linux.

The hostname command is used here:

https://github.com/coollabsio/coolify/blob/ef56797c7d592658a6f5fc1dde7568f23d8b82c4/scripts/install.sh#L545

Some relevant resources:
- https://bbs.archlinux.org/viewtopic.php?id=125308
- https://archlinux.org/news/deprecation-of-net-tools/
- https://man.archlinux.org/man/hostname.1.en

## Changes

From:

https://github.com/coollabsio/coolify/blob/ef56797c7d592658a6f5fc1dde7568f23d8b82c4/scripts/install.sh#L161-L164

The [inetutils](https://archlinux.org/packages/core/x86_64/inetutils) package was added to the pacman install command for Arch Linux

## Issues

Arch Linux does not ship with the `hostname` command by default (provided by inetutils). For example:

![Reproduction Steps](https://github.com/user-attachments/assets/d1c4cf55-79e3-4b44-8e90-acf93782c3c1)

<details>
<summary>Reproduction command logs</summary>

```
$ sudo docker run -it --rm archlinux:latest
Unable to find image 'archlinux:latest' locally
latest: Pulling from library/archlinux
7fa4bb7a964d: Pull complete 
f8d609407a8e: Pull complete 
Digest: sha256:901cf83a14f09d9ba70b219e22f67abd4d6346cb6d3f0c048cd08f22fb9a7425
Status: Downloaded newer image for archlinux:latest
[root@13a16f1a73a0 /]# hostname
bash: hostname: command not found
[root@13a16f1a73a0 /]# pacman -Sy --noconfirm --needed inetutils
:: Synchronizing package databases...
 core downloading...
 extra downloading...
error: restricting filesystem access failed because the landlock ruleset could not be applied!
resolving dependencies...
looking for conflicting packages...

Package (1)     New Version  Net Change  Download Size

core/inetutils  2.5-1          1.07 MiB       0.30 MiB

Total Download Size:   0.30 MiB
Total Installed Size:  1.07 MiB

:: Proceed with installation? [Y/n] 
:: Retrieving packages...
 inetutils-2.5-1-x86_64 downloading...
error: restricting filesystem access failed because the landlock ruleset could not be applied!
checking keyring...
checking package integrity...
loading package files...
checking for file conflicts...
:: Processing package changes...
installing inetutils...
:: Running post-transaction hooks...
(1/3) Creating system user accounts...
Creating group '_talkd' with GID 972.
Creating user '_talkd' (User for legacy talkd server) with UID 972 and GID 972.
(2/3) Reloading system manager configuration...
  Skipped: Current root is not booted.
(3/3) Arming ConditionNeedsUpdate...
[root@13a16f1a73a0 /]# hostname
13a16f1a73a0
```

</details>

---

As an aside, I also tested the other OS-es, and most come with the `hostname` command available by default, except Arch and Opensuse, at least based on their docker images.