### PR TITLE
fix: storage check for mounted disks

### DIFF
--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -623,7 +623,7 @@ $schema://$host {
 
     public function getDiskUsage(): ?string
     {
-        return instant_remote_process(['df / --output=pcent | tr -cd 0-9'], $this, false);
+        return instant_remote_process(['df /var/lib/docker --output=pcent | tr -cd 0-9'], $this, false);
         // return instant_remote_process(["df /| tail -1 | awk '{ print $5}' | sed 's/%//g'"], $this, false);
     }
 
@@ -1271,7 +1271,7 @@ $schema://$host {
     public function storageCheck(): ?string
     {
         $commands = [
-            'df / --output=pcent | tr -cd 0-9',
+            'df /var/lib/docker --output=pcent | tr -cd 0-9',
         ];
 
         return instant_remote_process($commands, $this, false);

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -623,7 +623,7 @@ $schema://$host {
 
     public function getDiskUsage(): ?string
     {
-        return instant_remote_process(['df /var/lib/docker --output=pcent | tr -cd 0-9'], $this, false);
+        return instant_remote_process(['df "$(docker info --format \'{{.DockerRootDir}}\')" --output=pcent | tr -cd 0-9'], $this, false);
         // return instant_remote_process(["df /| tail -1 | awk '{ print $5}' | sed 's/%//g'"], $this, false);
     }
 
@@ -1271,7 +1271,7 @@ $schema://$host {
     public function storageCheck(): ?string
     {
         $commands = [
-            'df /var/lib/docker --output=pcent | tr -cd 0-9',
+            'df "$(docker info --format \'{{.DockerRootDir}}\')" --output=pcent | tr -cd 0-9',
         ];
 
         return instant_remote_process($commands, $this, false);


### PR DESCRIPTION
This fixes the storage check and purge logic for servers where multiple mounted disks are used.
Currently, the df command is run on the root path. However, in some cases there might be a different disk attached to the path where docker stores it's data.

## Changes
- The remote commands were adapted for the getDiskUsage and storageCheck inside the Server Model (app/Models/Server.php)

## Issues
![image](https://github.com/user-attachments/assets/77cb035e-df1d-4d6d-92bc-60fe08ced865)
