### PR TITLE
fix: pull latest image for deploying docker compose buildpack

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -493,6 +493,12 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         // Build new container to limit downtime.
         $this->application_deployment_queue->addLogEntry('Pulling & building required images.');
 
+        $command = "cd {$this->basedir} && {$this->coolify_variables} docker compose pull";
+
+        $this->execute_remote_command(
+            [executeInDocker($this->deployment_uuid, $command), 'hidden' => true],
+        );
+
         if ($this->docker_compose_custom_build_command) {
             $this->execute_remote_command(
                 [executeInDocker($this->deployment_uuid, "cd {$this->basedir} && {$this->docker_compose_custom_build_command}"), 'hidden' => true],


### PR DESCRIPTION
## Changes
- Pull latest images when using docker compose buildpacks to deploy application

## Issues
- fix #4618

I've been modifying the container manually to fix this for my own use of Coolify, but I figured I'd push it upstream and see what happens.

(not a docker expert)