### PR TITLE
fix: Adjusted the existing Supabase service image to allow redirect links in emails to follow the SITE_URL…

### DIFF
--- a/templates/compose/supabase.yaml
+++ b/templates/compose/supabase.yaml
@@ -317,6 +317,8 @@ services:
       # NEXT_ANALYTICS_BACKEND_PROVIDER=bigquery
   supabase-db:
     image: supabase/postgres:15.1.1.78
+    ports:
+      - "5432:5432"
     healthcheck:
       test: pg_isready -U postgres -h 127.0.0.1
       interval: 5s
@@ -955,7 +957,7 @@ services:
       - GOTRUE_DB_DRIVER=postgres
       - GOTRUE_DB_DATABASE_URL=postgres://supabase_auth_admin:${SERVICE_PASSWORD_POSTGRES}@${POSTGRES_HOSTNAME:-supabase-db}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-postgres}
       # The base URL your site is located at. Currently used in combination with other settings to construct URLs used in emails.
-      - GOTRUE_SITE_URL=${SERVICE_FQDN_SUPABASEKONG}
+      - GOTRUE_SITE_URL=${SITE_URL}
       # A comma separated list of URIs (e.g. "https://foo.example.com,https://*.foo.example.com,https://bar.example.com") which are permitted as valid redirect_to destinations.
       - GOTRUE_URI_ALLOW_LIST=${ADDITIONAL_REDIRECT_URLS}
       - GOTRUE_DISABLE_SIGNUP=${DISABLE_SIGNUP:-false}


### PR DESCRIPTION
… custimisation via SITE_URL env. Fix provided by Fiend & Darren, solution fix reproduced and tested by hum+.

## Issues
Redirect links in Supabase e-mail is based on the `SERVICE_FQDN_SUPABASEKONG`, this can be wrong at times, this modification takes in the SITE_URL for the e-mail links.

## Changes & Fix
- supabase-db:
    ports:
      - "5432:5432" # Addition
- Changed `FQDN_SUPABASE_URL=${FQDN_SUPABASE_URL}` to `GOTRUE_SITE_URL=${SITE_URL}`


