### PR TITLE
Fix Redis Not defined issue in Trigger.dev Ext db template.

### DIFF
--- a/templates/compose/trigger-with-external-database.yaml
+++ b/templates/compose/trigger-with-external-database.yaml
@@ -25,6 +25,9 @@ services:
       - REPLY_TO_EMAIL=${REPLY_TO_EMAIL}
       - REDIS_HOST=${REDIS_HOST}
       - REDIS_PORT=${REDIS_PORT}
+      - 'REDIS_USERNAME=${REDIS_USERNAME}'
+      - 'REDIS_PASSWORD=${REDIS_PASSWORD}'
+      - REDIS_TLS_DISABLED=true
       
     healthcheck:
       test: "timeout 10s bash -c ':> /dev/tcp/127.0.0.1/3000' || exit 1"

--- a/templates/compose/trigger-with-external-database.yaml
+++ b/templates/compose/trigger-with-external-database.yaml
@@ -23,6 +23,9 @@ services:
       - RESEND_API_KEY=${RESEND_API_KEY}
       - FROM_EMAIL=${FROM_EMAIL}
       - REPLY_TO_EMAIL=${REPLY_TO_EMAIL}
+      - REDIS_HOST=${REDIS_HOST}
+      - REDIS_PORT=${REDIS_PORT}
+      
     healthcheck:
       test: "timeout 10s bash -c ':> /dev/tcp/127.0.0.1/3000' || exit 1"
       interval: 10s


### PR DESCRIPTION
- [x] I have selected the `next` branch as the destination for my PR, not `main`.
- [x] I have listed all changes in the `Changes` section.
- [ ] I have tested my changes.
- [ ] I have considered backwards compatibility.
- [x] I have removed this checklist and any unused sections.

## Changes
- Add Redis Host env vars in Trigger.dev External db template

## Issues
- fix Redis not defined issue in Trigger.dev External db template
