### PR TITLE
Fixing the CSRF bug for labelstudio versions 1.14.0 and higher

### DIFF
--- a/templates/compose/labelstudio.yaml
+++ b/templates/compose/labelstudio.yaml
@@ -12,6 +12,8 @@ services:
         condition: service_healthy
     environment:
       - SERVICE_FQDN_LABELSTUDIO_8080
+      - CSRF_TRUSTED_ORIGINS=${SERVICE_FQDN_LABELSTUDIO}
+      - EXPERIMENTAL_FEATURES=${EXPERIMENTAL_FEATURES:-1}
       - DJANGO_DB=${DJANGO_DB:-default}
       - POSTGRE_NAME=${POSTGRES_DB:-labelstudio}
       - POSTGRE_USER=${SERVICE_USER_POSTGRES}


### PR DESCRIPTION
## Changes
- Added two environment variables to labelstudio.yml:
  - CSRF_TRUSTED_ORIGINS
  - EXPERIMENTAL_FEATURES

## Issues
- fixing the [CSRF bug](https://github.com/HumanSignal/label-studio/issues/6296) for Label Studio version 1.14.0 and higher
