### PR TITLE
Update nocodb.yaml test healthcheck

### DIFF
--- a/templates/compose/nocodb.yaml
+++ b/templates/compose/nocodb.yaml
@@ -12,7 +12,7 @@ services:
     volumes:
       - nocodb-data:/usr/app/data/
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:8080"]
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8080"]
       interval: 5s
       timeout: 20s
       retries: 10


### PR DESCRIPTION
## Changes
- Update nocodb.yaml according to last release (https://github.com/nocodb/nocodb/releases/tag/0.258.11)

From NocoDb support: "_We had migrated from alpine base image to debian, so I guess wget is not available
can you replace wget with curl and try_"