### PR TITLE
New service OpenPanel

### DIFF
--- a/templates/compose/openpanel.yml
+++ b/templates/compose/openpanel.yml
@@ -1,0 +1,145 @@
+version: '3'
+services:
+  op-db:
+    image: 'postgres:14-alpine'
+    restart: always
+    volumes:
+      - 'op-db-data:/var/lib/postgresql/data'
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - 'pg_isready -U postgres'
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    ports:
+      - '5432:5432'
+    labels:
+      - coolify.proxy=true
+  op-kv:
+    image: 'redis:7.2.5-alpine'
+    restart: always
+    volumes:
+      - 'op-kv-data:/data'
+    command:
+      - redis-server
+      - '--maxmemory-policy'
+      - noeviction
+    labels:
+      - coolify.proxy=true
+  op-geo:
+    image: 'observabilitystack/geoip-api:latest'
+    restart: always
+    labels:
+      - coolify.proxy=true
+  op-ch:
+    image: 'clickhouse/clickhouse-server:24.3.2-alpine'
+    restart: always
+    volumes:
+      - 'op-ch-data:/var/lib/clickhouse'
+      - 'op-ch-logs:/var/log/clickhouse-server'
+      - '/path/to/openpanel/self-hosting/clickhouse/clickhouse-config.xml:/etc/clickhouse-server/config.d/op-config.xml:ro'
+      - '/path/to/openpanel/self-hosting/clickhouse/clickhouse-user-config.xml:/etc/clickhouse-server/users.d/op-user-config.xml:ro'
+      - '/path/to/openpanel/self-hosting/clickhouse/init-db.sh:/docker-entrypoint-initdb.d/init-db.sh:ro'
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - 'clickhouse-client --query "SELECT 1"'
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    labels:
+      - coolify.proxy=true
+  op-zk:
+    image: 'clickhouse/clickhouse-server:24.3.2-alpine'
+    volumes:
+      - 'op-zk-data:/var/lib/clickhouse'
+      - '/path/to/openpanel/self-hosting/clickhouse/clickhouse-keeper-config.xml:/etc/clickhouse-server/config.xml'
+    command:
+      - clickhouse-keeper
+      - '--config-file'
+      - /etc/clickhouse-server/config.xml
+    restart: always
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    labels:
+      - coolify.proxy=true
+  op-api:
+    image: 'lindesvard/openpanel-api:latest'
+    restart: always
+    command: "sh -c \"\n  echo 'Waiting for PostgreSQL to be ready...'\n  while ! nc -z op-db 5432; do\n    sleep 1\n  done\n  echo 'PostgreSQL is ready'\n\n  echo 'Waiting for ClickHouse to be ready...'\n  while ! nc -z op-ch 8123; do\n    sleep 1\n  done\n  echo 'ClickHouse is ready'\n\n  echo 'Running migrations...'\n  CI=true pnpm -r run migrate:deploy\n\n  pnpm start\n\"\n"
+    depends_on:
+      - op-db
+      - op-ch
+      - op-kv
+      - op-geo
+    env_file:
+      - /path/to/openpanel/self-hosting/.env
+  op-dashboard:
+    image: 'lindesvard/openpanel-dashboard:latest'
+    restart: always
+    depends_on:
+      - op-api
+    env_file:
+      - /path/to/openpanel/self-hosting/.env
+    labels:
+      - coolify.proxy=true
+  op-worker:
+    image: 'lindesvard/openpanel-worker:latest'
+    restart: always
+    depends_on:
+      - op-api
+    env_file:
+      - /path/to/openpanel/self-hosting/.env
+  op-worker-2:
+    image: 'lindesvard/openpanel-worker:latest'
+    restart: always
+    depends_on:
+      - op-api
+    env_file:
+      - /path/to/openpanel/self-hosting/.env
+  op-worker-3:
+    image: 'lindesvard/openpanel-worker:latest'
+    restart: always
+    depends_on:
+      - op-api
+    env_file:
+      - /path/to/openpanel/self-hosting/.env
+  op-worker-4:
+    image: 'lindesvard/openpanel-worker:latest'
+    restart: always
+    depends_on:
+      - op-api
+    env_file:
+      - /path/to/openpanel/self-hosting/.env
+  op-worker-5:
+    image: 'lindesvard/openpanel-worker:latest'
+    restart: always
+    depends_on:
+      - op-api
+    env_file:
+      - /path/to/openpanel/self-hosting/.env
+volumes:
+  op-db-data:
+    driver: local
+  op-kv-data:
+    driver: local
+  op-ch-data:
+    driver: local
+  op-ch-logs:
+    driver: local
+  op-proxy-data:
+    driver: local
+  op-proxy-config:
+    driver: local
+  op-zk-data:
+    driver: local


### PR DESCRIPTION
## Changes
- Add OpenPanel Service docker-compose file

## Guide

Clone the repository to your VPS
```git clone https://github.com/Openpanel-dev/openpanel && cd openpanel/self-hosting```

[Run the setup script](https://openpanel.dev/docs/self-hosting/self-hosting#run-the-setup-script)
- install node if your VPS doesn't already have it.
- The script should detect docker assuming you already have Coolify installed.

```
cd openpanel/self-hosting
./setup
```

Unlike mentioned on the guide, I did not execute ./start

Edit /path/to/openpanel/self-hosting/.env file

```
NODE_ENV="production"
SELF_HOSTED="true"
GEO_IP_HOST="http://op-geo:8080"
BATCH_SIZE="5000"
BATCH_INTERVAL="10000"
REDIS_URL="redis://op-kv:6379"
CLICKHOUSE_URL="http://op-ch:8123/openpanel"
DATABASE_URL="postgresql://postgres:postgres@op-db:5432/postgres?schema=public"
DATABASE_URL_DIRECT="postgresql://postgres:postgres@op-db:5432/postgres?schema=public"
NEXT_PUBLIC_DASHBOARD_URL="https://example.com"
NEXT_PUBLIC_API_URL="https://example.com/api"
xxXXXxxxxXXXXxxxx="$COOKIE_SECRET"
```

Add a caddy file in Servers -> Proxy -> Dynamic Configurations
```
example.com {
    encode gzip
    
    handle_path /api* {
        reverse_proxy op-api:3000
    }
    reverse_proxy /* op-dashboard:3000
}
worker.example.com {
    encode gzip
    basic_auth {
        admin xxxxxxxxx
    }
    reverse_proxy op-worker:3000
}
```

---

## Running service 

- Create a new resource and select **Docker compose empty**.
- Paste in docker-compose file

### Configure OP-API & OP-DASHBOARD services

OP-API Domain: https://example.com:3000/api
OP-DASHBOARD Domain: https://example.com:3000


---

![Resource Screenshot](https://github.com/user-attachments/assets/ca2a4e75-f0b4-4d15-bb73-9e51cd0447d2)


