### PR TITLE
Update health check endpoint of Nocodb service

### DIFF
--- a/templates/compose/nocodb.yaml
+++ b/templates/compose/nocodb.yaml
@@ -12,7 +12,7 @@ services:
     volumes:
       - nocodb-data:/usr/app/data/
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:8080"]
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:8080/api/v1/health"]
       interval: 5s
       timeout: 20s
       retries: 10


### PR DESCRIPTION
## Changes

Update NocoDB config file with correct health check endpoint.

## Issues

During the migration from an Alpine Linux-based Docker image to a Debian-based one, the behavior of wget changed. The previous setup worked because Alpine used BusyBox wget, which handled the / endpoint differently. However, in Debian, the GNU wget follows redirects more strictly, and the / endpoint now redirects to /dashboard, causing health checks to fail.

This update ensures compatibility with the Debian-based Docker image by pointing the health check to an appropriate endpoint, resolving the redirect handling issue.

Related Discord discussion: -  [here](https://discord.com/channels/661905455894888490/1323730041871532082/1325043127136030743)

Community forum topic:  [Cannot access NocoDB after install](https://community.nocodb.com/t/cannot-access-nocodb-after-install/1577)
