### PR TITLE
Improve modal closing logic for intentional user interaction

### DIFF
--- a/resources/views/components/modal-input.blade.php
+++ b/resources/views/components/modal-input.blade.php
@@ -32,9 +32,9 @@
             <div x-show="modalOpen" x-transition:enter="ease-out duration-100" x-transition:enter-start="opacity-0"
                 x-transition:enter-end="opacity-100" x-transition:leave="ease-in duration-100"
                 x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0"
+                @if ($closeOutside) @click="modalOpen=false" @endif
                 class="absolute inset-0 w-full h-full bg-black bg-opacity-20 backdrop-blur-sm"></div>
             <div x-show="modalOpen" x-trap.inert.noscroll="modalOpen"
-                @if ($closeOutside) @click.outside="modalOpen=false" @endif
                 x-transition:enter="ease-out duration-100"
                 x-transition:enter-start="opacity-0 -translate-y-2 sm:scale-95"
                 x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"


### PR DESCRIPTION
## Changes
- improved modal's `closeOutside` mechanism to ensure user's deliberate intent

## Issues
It's a small annoyance but currently the `@click.outside` directive treats single mouseup/mousedown event happening outside of modal body as a "full" click. This can lead to unintentional closing of modals e.g. in the security area when highlighting key for copying.

https://github.com/user-attachments/assets/ff463714-9d55-4227-91fa-417959a289ee

Moving the logic to more explicit `@click` listener of backdrop resolves this inconsistency.


