### PR TITLE
Feat: Improve backup retention (for database backups)

### DIFF
--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -459,14 +459,9 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
 
     private function remove_old_backups(): void
     {
-        if ($this->backup->number_of_backups_locally === 0) {
-            $deletable = $this->backup->executions()->where('status', 'success');
-        } else {
-            $deletable = $this->backup->executions()->where('status', 'success')->skip($this->backup->number_of_backups_locally - 1);
-        }
-        foreach ($deletable->get() as $execution) {
-            delete_backup_locally($execution->filename, $this->server);
-            $execution->delete();
+        deleteOldBackupsLocally($this->backup);
+        if ($this->backup->save_s3) {
+            deleteOldBackupsFromS3($this->backup);
         }
     }
 

--- a/app/Livewire/Project/Database/BackupEdit.php
+++ b/app/Livewire/Project/Database/BackupEdit.php
@@ -43,16 +43,28 @@ class BackupEdit extends Component
     #[Validate(['string'])]
     public string $timezone = '';
 
-    #[Validate(['required', 'integer', 'min:1'])]
-    public int $numberOfBackupsLocally = 1;
+    #[Validate(['required', 'integer'])]
+    public int $databaseBackupRetentionAmountLocally = 0;
+
+    #[Validate(['required', 'integer'])]
+    public ?int $databaseBackupRetentionDaysLocally = 0;
+
+    #[Validate(['required', 'integer'])]
+    public ?int $databaseBackupRetentionAmountS3 = 0;
+
+    #[Validate(['required', 'integer'])]
+    public ?int $databaseBackupRetentionDaysS3 = 0;
+
+    #[Validate(['required', 'integer'])]
+    public ?int $databaseBackupRetentionMaxStorageS3 = 0;
 
     #[Validate(['required', 'boolean'])]
     public bool $saveS3 = false;
 
-    #[Validate(['nullable', 'integer'])]
+    #[Validate(['required', 'integer'])]
     public ?int $s3StorageId = 1;
 
-    #[Validate(['nullable', 'string'])]
+    #[Validate(['required', 'string'])]
     public ?string $databasesToBackup = null;
 
     #[Validate(['required', 'boolean'])]
@@ -73,7 +85,11 @@ class BackupEdit extends Component
         if ($toModel) {
             $this->backup->enabled = $this->backupEnabled;
             $this->backup->frequency = $this->frequency;
-            $this->backup->number_of_backups_locally = $this->numberOfBackupsLocally;
+            $this->backup->database_backup_retention_amount_locally = $this->databaseBackupRetentionAmountLocally;
+            $this->backup->database_backup_retention_days_locally = $this->databaseBackupRetentionDaysLocally;
+            $this->backup->database_backup_retention_amount_s3 = $this->databaseBackupRetentionAmountS3;
+            $this->backup->database_backup_retention_days_s3 = $this->databaseBackupRetentionDaysS3;
+            $this->backup->database_backup_retention_max_storage_s3 = $this->databaseBackupRetentionMaxStorageS3;
             $this->backup->save_s3 = $this->saveS3;
             $this->backup->s3_storage_id = $this->s3StorageId;
             $this->backup->databases_to_backup = $this->databasesToBackup;
@@ -84,7 +100,11 @@ class BackupEdit extends Component
             $this->backupEnabled = $this->backup->enabled;
             $this->frequency = $this->backup->frequency;
             $this->timezone = data_get($this->backup->server(), 'settings.server_timezone', 'Instance timezone');
-            $this->numberOfBackupsLocally = $this->backup->number_of_backups_locally;
+            $this->databaseBackupRetentionAmountLocally = $this->backup->database_backup_retention_amount_locally;
+            $this->databaseBackupRetentionDaysLocally = $this->backup->database_backup_retention_days_locally;
+            $this->databaseBackupRetentionAmountS3 = $this->backup->database_backup_retention_amount_s3;
+            $this->databaseBackupRetentionDaysS3 = $this->backup->database_backup_retention_days_s3;
+            $this->databaseBackupRetentionMaxStorageS3 = $this->backup->database_backup_retention_max_storage_s3;
             $this->saveS3 = $this->backup->save_s3;
             $this->s3StorageId = $this->backup->s3_storage_id;
             $this->databasesToBackup = $this->backup->databases_to_backup;
@@ -104,10 +124,10 @@ class BackupEdit extends Component
 
         try {
             if ($this->delete_associated_backups_locally) {
-                $this->deleteAssociatedBackupsLocally();
+                deleteOldBackupsLocally($this->backup);
             }
-            if ($this->delete_associated_backups_s3) {
-                $this->deleteAssociatedBackupsS3();
+            if ($this->delete_associated_backups_s3 && $this->backup->s3) {
+                deleteOldBackupsFromS3($this->backup);
             }
 
             $this->backup->delete();
@@ -160,63 +180,12 @@ class BackupEdit extends Component
         }
     }
 
-    private function deleteAssociatedBackupsLocally()
-    {
-        $executions = $this->backup->executions;
-        $backupFolder = null;
-
-        foreach ($executions as $execution) {
-            if ($this->backup->database->getMorphClass() === \App\Models\ServiceDatabase::class) {
-                $server = $this->backup->database->service->destination->server;
-            } else {
-                $server = $this->backup->database->destination->server;
-            }
-
-            if (! $backupFolder) {
-                $backupFolder = dirname($execution->filename);
-            }
-
-            delete_backup_locally($execution->filename, $server);
-            $execution->delete();
-        }
-
-        if (str($backupFolder)->isNotEmpty()) {
-            $this->deleteEmptyBackupFolder($backupFolder, $server);
-        }
-    }
-
-    private function deleteAssociatedBackupsS3()
-    {
-        // Add function to delete backups from S3
-    }
-
-    private function deleteAssociatedBackupsSftp()
-    {
-        // Add function to delete backups from SFTP
-    }
-
-    private function deleteEmptyBackupFolder($folderPath, $server)
-    {
-        $checkEmpty = instant_remote_process(["[ -z \"$(ls -A '$folderPath')\" ] && echo 'empty' || echo 'not empty'"], $server);
-
-        if (trim($checkEmpty) === 'empty') {
-            instant_remote_process(["rmdir '$folderPath'"], $server);
-
-            $parentFolder = dirname($folderPath);
-            $checkParentEmpty = instant_remote_process(["[ -z \"$(ls -A '$parentFolder')\" ] && echo 'empty' || echo 'not empty'"], $server);
-
-            if (trim($checkParentEmpty) === 'empty') {
-                instant_remote_process(["rmdir '$parentFolder'"], $server);
-            }
-        }
-    }
-
     public function render()
     {
         return view('livewire.project.database.backup-edit', [
             'checkboxes' => [
                 ['id' => 'delete_associated_backups_locally', 'label' => __('database.delete_backups_locally')],
-                // ['id' => 'delete_associated_backups_s3', 'label' => 'All backups associated with this backup job from this database will be permanently deleted from the selected S3 Storage.']
+                ['id' => 'delete_associated_backups_s3', 'label' => 'All backups associated with this backup job for this database will be permanently deleted from the selected S3 Storage.'],
                 // ['id' => 'delete_associated_backups_sftp', 'label' => 'All backups associated with this backup job from this database will be permanently deleted from the selected SFTP Storage.']
             ],
         ]);

--- a/app/Livewire/Project/Database/BackupEdit.php
+++ b/app/Livewire/Project/Database/BackupEdit.php
@@ -124,10 +124,12 @@ class BackupEdit extends Component
 
         try {
             if ($this->delete_associated_backups_locally) {
-                deleteOldBackupsLocally($this->backup);
+                $filenames = $this->backup->executions->pluck('filename')->filter()->all();
+                deleteBackupsLocally($filenames, $this->backup->server);
             }
             if ($this->delete_associated_backups_s3 && $this->backup->s3) {
-                deleteOldBackupsFromS3($this->backup);
+                $filenames = $this->backup->executions->pluck('filename')->filter()->all();
+                deleteBackupsS3($filenames, $this->backup->s3);
             }
 
             $this->backup->delete();

--- a/app/Livewire/Project/Database/BackupEdit.php
+++ b/app/Livewire/Project/Database/BackupEdit.php
@@ -64,10 +64,10 @@ class BackupEdit extends Component
     #[Validate(['required', 'boolean'])]
     public bool $saveS3 = false;
 
-    #[Validate(['required', 'integer'])]
+    #[Validate(['nullable', 'integer'])]
     public ?int $s3StorageId = 1;
 
-    #[Validate(['required', 'string'])]
+    #[Validate(['nullable', 'string'])]
     public ?string $databasesToBackup = null;
 
     #[Validate(['required', 'boolean'])]

--- a/app/Livewire/Project/Database/BackupEdit.php
+++ b/app/Livewire/Project/Database/BackupEdit.php
@@ -49,14 +49,17 @@ class BackupEdit extends Component
     #[Validate(['required', 'integer'])]
     public ?int $databaseBackupRetentionDaysLocally = 0;
 
+    #[Validate(['required', 'numeric', 'min:0'])]
+    public ?float $databaseBackupRetentionMaxStorageLocally = 0;
+
     #[Validate(['required', 'integer'])]
     public ?int $databaseBackupRetentionAmountS3 = 0;
 
     #[Validate(['required', 'integer'])]
     public ?int $databaseBackupRetentionDaysS3 = 0;
 
-    #[Validate(['required', 'integer'])]
-    public ?int $databaseBackupRetentionMaxStorageS3 = 0;
+    #[Validate(['required', 'numeric', 'min:0'])]
+    public ?float $databaseBackupRetentionMaxStorageS3 = 0;
 
     #[Validate(['required', 'boolean'])]
     public bool $saveS3 = false;
@@ -87,6 +90,7 @@ class BackupEdit extends Component
             $this->backup->frequency = $this->frequency;
             $this->backup->database_backup_retention_amount_locally = $this->databaseBackupRetentionAmountLocally;
             $this->backup->database_backup_retention_days_locally = $this->databaseBackupRetentionDaysLocally;
+            $this->backup->database_backup_retention_max_storage_locally = $this->databaseBackupRetentionMaxStorageLocally;
             $this->backup->database_backup_retention_amount_s3 = $this->databaseBackupRetentionAmountS3;
             $this->backup->database_backup_retention_days_s3 = $this->databaseBackupRetentionDaysS3;
             $this->backup->database_backup_retention_max_storage_s3 = $this->databaseBackupRetentionMaxStorageS3;
@@ -102,6 +106,7 @@ class BackupEdit extends Component
             $this->timezone = data_get($this->backup->server(), 'settings.server_timezone', 'Instance timezone');
             $this->databaseBackupRetentionAmountLocally = $this->backup->database_backup_retention_amount_locally;
             $this->databaseBackupRetentionDaysLocally = $this->backup->database_backup_retention_days_locally;
+            $this->databaseBackupRetentionMaxStorageLocally = $this->backup->database_backup_retention_max_storage_locally;
             $this->databaseBackupRetentionAmountS3 = $this->backup->database_backup_retention_amount_s3;
             $this->databaseBackupRetentionDaysS3 = $this->backup->database_backup_retention_days_s3;
             $this->databaseBackupRetentionMaxStorageS3 = $this->backup->database_backup_retention_max_storage_s3;

--- a/app/Livewire/Project/Database/BackupExecutions.php
+++ b/app/Livewire/Project/Database/BackupExecutions.php
@@ -62,10 +62,12 @@ class BackupExecutions extends Component
             : $execution->scheduledDatabaseBackup->database->destination->server;
 
         try {
-            deleteBackupsLocally($execution->filename, $server);
+            if ($execution->filename) {
+                deleteBackupsLocally($execution->filename, $server);
 
-            if ($this->delete_backup_s3 && $execution->scheduledDatabaseBackup->s3) {
-                deleteBackupsS3($execution->filename, $execution->scheduledDatabaseBackup->s3);
+                if ($this->delete_backup_s3 && $execution->scheduledDatabaseBackup->s3) {
+                    deleteBackupsS3($execution->filename, $execution->scheduledDatabaseBackup->s3);
+                }
             }
 
             $execution->delete();

--- a/app/Livewire/Project/Database/BackupExecutions.php
+++ b/app/Livewire/Project/Database/BackupExecutions.php
@@ -18,9 +18,9 @@ class BackupExecutions extends Component
 
     public $setDeletableBackup;
 
-    public $delete_backup_s3 = true;
+    public $delete_backup_s3 = false;
 
-    public $delete_backup_sftp = true;
+    public $delete_backup_sftp = false;
 
     public function getListeners()
     {
@@ -57,18 +57,14 @@ class BackupExecutions extends Component
             return;
         }
 
-        if ($execution->scheduledDatabaseBackup->database->getMorphClass() === \App\Models\ServiceDatabase::class) {
-            delete_backup_locally($execution->filename, $execution->scheduledDatabaseBackup->database->service->destination->server);
-        } else {
-            delete_backup_locally($execution->filename, $execution->scheduledDatabaseBackup->database->destination->server);
-        }
+        $server = $execution->scheduledDatabaseBackup->database->getMorphClass() === \App\Models\ServiceDatabase::class
+            ? $execution->scheduledDatabaseBackup->database->service->destination->server
+            : $execution->scheduledDatabaseBackup->database->destination->server;
 
-        if ($this->delete_backup_s3) {
-            // Add logic to delete from S3
-        }
+        deleteBackupsLocally($execution->filename, $server);
 
-        if ($this->delete_backup_sftp) {
-            // Add logic to delete from SFTP
+        if ($this->delete_backup_s3 && $execution->scheduledDatabaseBackup->s3) {
+            deleteBackupsS3($execution->filename, $server, $execution->scheduledDatabaseBackup->s3);
         }
 
         $execution->delete();
@@ -143,7 +139,7 @@ class BackupExecutions extends Component
         return view('livewire.project.database.backup-executions', [
             'checkboxes' => [
                 ['id' => 'delete_backup_s3', 'label' => 'Delete the selected backup permanently form S3 Storage'],
-                ['id' => 'delete_backup_sftp', 'label' => 'Delete the selected backup permanently form SFTP Storage'],
+                // ['id' => 'delete_backup_sftp', 'label' => 'Delete the selected backup permanently form SFTP Storage'],
             ],
         ]);
     }

--- a/bootstrap/helpers/databases.php
+++ b/bootstrap/helpers/databases.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\EnvironmentVariable;
+use App\Models\S3Storage;
 use App\Models\Server;
 use App\Models\StandaloneClickhouse;
 use App\Models\StandaloneDocker;
@@ -11,6 +12,7 @@ use App\Models\StandaloneMongodb;
 use App\Models\StandaloneMysql;
 use App\Models\StandalonePostgresql;
 use App\Models\StandaloneRedis;
+use Illuminate\Support\Facades\Storage;
 use Visus\Cuid2\Cuid2;
 
 function generate_database_name(string $type): string
@@ -194,12 +196,249 @@ function create_standalone_clickhouse($environment_id, $destination_uuid, ?array
     return $database;
 }
 
-function delete_backup_locally(?string $filename, Server $server): void
+function deleteBackupsLocally(string|array|null $filenames, Server $server): void
 {
-    if (empty($filename)) {
+    if (empty($filenames)) {
         return;
     }
-    instant_remote_process(["rm -f \"{$filename}\""], $server, throwError: false);
+
+    if (is_string($filenames)) {
+        $filenames = [$filenames];
+    }
+
+    $quotedFiles = array_map(function ($file) {
+        return "\"$file\"";
+    }, $filenames);
+
+    instant_remote_process(['rm -f '.implode(' ', $quotedFiles)], $server, throwError: false);
+}
+
+function deleteBackupsS3(string|array|null $filenames, Server $server, S3Storage $s3): void
+{
+    if (empty($filenames) || ! $s3) {
+        return;
+    }
+
+    if (is_string($filenames)) {
+        $filenames = [$filenames];
+    }
+
+    // Initialize S3 client using Laravel's Storage facade
+    $disk = Storage::build([
+        'driver' => 's3',
+        'key' => $s3->key,
+        'secret' => $s3->secret,
+        'region' => $s3->region,
+        'bucket' => $s3->bucket,
+        'endpoint' => $s3->endpoint,
+        'use_path_style_endpoint' => true,
+    ]);
+
+    // Delete files in bulk
+    $disk->delete($filenames);
+}
+
+function deleteEmptyBackupFolder($folderPath, Server $server): void
+{
+    // Properly escape the folder path for shell commands
+    $escapedPath = escapeshellarg($folderPath);
+    $escapedParentPath = escapeshellarg(dirname($folderPath));
+
+    // Check if current folder is empty
+    $checkEmpty = instant_remote_process(["[ -d $escapedPath ] && [ -z \"$(ls -A $escapedPath)\" ] && echo 'empty' || echo 'not empty'"], $server, throwError: false);
+
+    if (trim($checkEmpty) === 'empty') {
+        // Remove the empty folder
+        instant_remote_process(["rmdir $escapedPath"], $server, throwError: false);
+
+        // Check if parent folder exists and is empty
+        $checkParentEmpty = instant_remote_process([
+            "[ -d $escapedParentPath ] && [ -z \"$(ls -A $escapedParentPath)\" ] && echo 'empty' || echo 'not empty'",
+        ], $server, throwError: false);
+
+        if (trim($checkParentEmpty) === 'empty') {
+            // Remove the empty parent folder
+            instant_remote_process(["rmdir $escapedParentPath"], $server, throwError: false);
+        }
+    }
+}
+
+function deleteOldBackupsLocally($backup)
+{
+    if (! $backup || ! $backup->executions) {
+        return;
+    }
+
+    $successfulBackups = $backup->executions()
+        ->where('status', 'success')
+        ->orderBy('created_at', 'desc')
+        ->get();
+
+    if ($successfulBackups->isEmpty()) {
+        return;
+    }
+
+    // Get retention limits
+    $retentionAmount = $backup->database_backup_retention_amount_locally;
+    $retentionDays = $backup->database_backup_retention_days_locally;
+
+    if ($retentionAmount === 0 && $retentionDays === 0) {
+        return;
+    }
+
+    $backupsToDelete = collect();
+
+    // Process backups based on retention amount
+    if ($retentionAmount > 0) {
+        $backupsToDelete = $backupsToDelete->merge(
+            $successfulBackups->skip($retentionAmount)
+        );
+    }
+
+    // Process backups based on retention days
+    if ($retentionDays > 0) {
+        $oldestAllowedDate = $successfulBackups->first()->created_at->clone()->utc()->subDays($retentionDays);
+        $oldBackups = $successfulBackups->filter(function ($execution) use ($oldestAllowedDate) {
+            return $execution->created_at->utc() < $oldestAllowedDate;
+        });
+        $backupsToDelete = $backupsToDelete->merge($oldBackups);
+    }
+
+    // Get unique backups to delete and chunk them for parallel processing
+    $backupsToDelete = $backupsToDelete->unique('id');
+
+    // Keep track of folders to check
+    $foldersToCheck = collect();
+
+    // Process deletions in parallel chunks
+    $backupsToDelete->chunk(10)->each(function ($chunk) use ($backup, &$foldersToCheck) {
+        $executionIds = [];
+        $filesToDelete = [];
+
+        foreach ($chunk as $execution) {
+            if ($execution->filename) {
+                $filesToDelete[] = $execution->filename;
+                $executionIds[] = $execution->id;
+                // Add the folder path to check later
+                $foldersToCheck->push(dirname($execution->filename));
+            }
+        }
+
+        if (! empty($filesToDelete)) {
+            deleteBackupsLocally($filesToDelete, $backup->server);
+
+            // Bulk delete executions from database
+            if (! empty($executionIds)) {
+                $backup->executions()->whereIn('id', $executionIds)->delete();
+            }
+        }
+    });
+
+    // Check and clean up empty folders
+    $foldersToCheck->unique()->each(function ($folder) use ($backup) {
+        deleteEmptyBackupFolder($folder, $backup->server);
+    });
+}
+
+function deleteOldBackupsFromS3($backup)
+{
+    if (! $backup || ! $backup->executions || ! $backup->s3) {
+        return;
+    }
+
+    $successfulBackups = $backup->executions()
+        ->where('status', 'success')
+        ->orderBy('created_at', 'desc')
+        ->get();
+
+    if ($successfulBackups->isEmpty()) {
+        return;
+    }
+
+    // Get retention limits
+    $retentionAmount = $backup->database_backup_retention_amount_s3;
+    $retentionDays = $backup->database_backup_retention_days_s3;
+    $maxStorageGB = $backup->database_backup_retention_max_storage_s3;
+
+    if ($retentionAmount === 0 && $retentionDays === 0 && $maxStorageGB === 0) {
+        return;
+    }
+
+    $backupsToDelete = collect();
+
+    // Process backups based on retention amount
+    if ($retentionAmount > 0) {
+        $backupsToDelete = $backupsToDelete->merge(
+            $successfulBackups->skip($retentionAmount)
+        );
+    }
+
+    // Process backups based on retention days
+    if ($retentionDays > 0) {
+        $oldestAllowedDate = $successfulBackups->first()->created_at->clone()->utc()->subDays($retentionDays);
+        $oldBackups = $successfulBackups->filter(function ($execution) use ($oldestAllowedDate) {
+            return $execution->created_at->utc() < $oldestAllowedDate;
+        });
+        $backupsToDelete = $backupsToDelete->merge($oldBackups);
+    }
+
+    // Process backups based on total storage limit
+    if ($maxStorageGB > 0) {
+        $maxStorageBytes = $maxStorageGB * 1024 * 1024 * 1024; // Convert GB to bytes
+        $totalSize = 0;
+        $backupsOverLimit = collect();
+
+        foreach ($successfulBackups as $backup) {
+            $totalSize += (int) $backup->size;
+
+            // If we're over the limit, add this and all older backups to delete list
+            if ($totalSize > $maxStorageBytes) {
+                $backupsOverLimit = $successfulBackups->filter(function ($b) use ($backup) {
+                    return $b->created_at->utc() <= $backup->created_at->utc();
+                });
+                break;
+            }
+        }
+
+        $backupsToDelete = $backupsToDelete->merge($backupsOverLimit);
+    }
+
+    // Get unique backups to delete and chunk them for parallel processing
+    $backupsToDelete = $backupsToDelete->unique('id');
+
+    // Keep track of folders to check
+    $foldersToCheck = collect();
+
+    // Process deletions in parallel chunks
+    $backupsToDelete->chunk(10)->each(function ($chunk) use ($backup, &$foldersToCheck) {
+        $executionIds = [];
+        $filesToDelete = [];
+
+        foreach ($chunk as $execution) {
+            if ($execution->filename) {
+                $filesToDelete[] = $execution->filename;
+                $executionIds[] = $execution->id;
+                // Add the folder path to check later
+                $foldersToCheck->push(dirname($execution->filename));
+            }
+        }
+
+        if (! empty($filesToDelete)) {
+            deleteBackupsS3($filesToDelete, $backup->server, $backup->s3);
+
+            // Update executions to mark S3 backup as deleted
+            if (! empty($executionIds)) {
+                $backup->executions()
+                    ->whereIn('id', $executionIds)
+                    ->update(['s3_backup_deleted_at' => now()]);
+            }
+        }
+    });
+
+    // Check and clean up empty folders
+    $foldersToCheck->unique()->each(function ($folder) use ($backup) {
+        deleteEmptyBackupFolder($folder, $backup->server);
+    });
 }
 
 function isPublicPortAlreadyUsed(Server $server, int $port, ?string $id = null): bool

--- a/bootstrap/helpers/databases.php
+++ b/bootstrap/helpers/databases.php
@@ -17,17 +17,12 @@ use Visus\Cuid2\Cuid2;
 
 function generate_database_name(string $type): string
 {
-    $cuid = new Cuid2;
-
-    return $type.'-database-'.$cuid;
+    return $type.'-database-'.(new Cuid2);
 }
 
 function create_standalone_postgresql($environmentId, $destinationUuid, ?array $otherData = null, string $databaseImage = 'postgres:16-alpine'): StandalonePostgresql
 {
-    $destination = StandaloneDocker::where('uuid', $destinationUuid)->first();
-    if (! $destination) {
-        throw new Exception('Destination not found');
-    }
+    $destination = StandaloneDocker::where('uuid', $destinationUuid)->firstOrFail();
     $database = new StandalonePostgresql;
     $database->name = generate_database_name('postgresql');
     $database->image = $databaseImage;
@@ -45,10 +40,7 @@ function create_standalone_postgresql($environmentId, $destinationUuid, ?array $
 
 function create_standalone_redis($environment_id, $destination_uuid, ?array $otherData = null): StandaloneRedis
 {
-    $destination = StandaloneDocker::where('uuid', $destination_uuid)->first();
-    if (! $destination) {
-        throw new Exception('Destination not found');
-    }
+    $destination = StandaloneDocker::where('uuid', $destination_uuid)->firstOrFail();
     $database = new StandaloneRedis;
     $database->name = generate_database_name('redis');
     $redis_password = \Illuminate\Support\Str::password(length: 64, symbols: false);
@@ -79,10 +71,7 @@ function create_standalone_redis($environment_id, $destination_uuid, ?array $oth
 
 function create_standalone_mongodb($environment_id, $destination_uuid, ?array $otherData = null): StandaloneMongodb
 {
-    $destination = StandaloneDocker::where('uuid', $destination_uuid)->first();
-    if (! $destination) {
-        throw new Exception('Destination not found');
-    }
+    $destination = StandaloneDocker::where('uuid', $destination_uuid)->firstOrFail();
     $database = new StandaloneMongodb;
     $database->name = generate_database_name('mongodb');
     $database->mongo_initdb_root_password = \Illuminate\Support\Str::password(length: 64, symbols: false);
@@ -96,12 +85,10 @@ function create_standalone_mongodb($environment_id, $destination_uuid, ?array $o
 
     return $database;
 }
+
 function create_standalone_mysql($environment_id, $destination_uuid, ?array $otherData = null): StandaloneMysql
 {
-    $destination = StandaloneDocker::where('uuid', $destination_uuid)->first();
-    if (! $destination) {
-        throw new Exception('Destination not found');
-    }
+    $destination = StandaloneDocker::where('uuid', $destination_uuid)->firstOrFail();
     $database = new StandaloneMysql;
     $database->name = generate_database_name('mysql');
     $database->mysql_root_password = \Illuminate\Support\Str::password(length: 64, symbols: false);
@@ -116,12 +103,10 @@ function create_standalone_mysql($environment_id, $destination_uuid, ?array $oth
 
     return $database;
 }
+
 function create_standalone_mariadb($environment_id, $destination_uuid, ?array $otherData = null): StandaloneMariadb
 {
-    $destination = StandaloneDocker::where('uuid', $destination_uuid)->first();
-    if (! $destination) {
-        throw new Exception('Destination not found');
-    }
+    $destination = StandaloneDocker::where('uuid', $destination_uuid)->firstOrFail();
     $database = new StandaloneMariadb;
     $database->name = generate_database_name('mariadb');
     $database->mariadb_root_password = \Illuminate\Support\Str::password(length: 64, symbols: false);
@@ -129,7 +114,6 @@ function create_standalone_mariadb($environment_id, $destination_uuid, ?array $o
     $database->environment_id = $environment_id;
     $database->destination_id = $destination->id;
     $database->destination_type = $destination->getMorphClass();
-
     if ($otherData) {
         $database->fill($otherData);
     }
@@ -137,12 +121,10 @@ function create_standalone_mariadb($environment_id, $destination_uuid, ?array $o
 
     return $database;
 }
+
 function create_standalone_keydb($environment_id, $destination_uuid, ?array $otherData = null): StandaloneKeydb
 {
-    $destination = StandaloneDocker::where('uuid', $destination_uuid)->first();
-    if (! $destination) {
-        throw new Exception('Destination not found');
-    }
+    $destination = StandaloneDocker::where('uuid', $destination_uuid)->firstOrFail();
     $database = new StandaloneKeydb;
     $database->name = generate_database_name('keydb');
     $database->keydb_password = \Illuminate\Support\Str::password(length: 64, symbols: false);
@@ -159,10 +141,7 @@ function create_standalone_keydb($environment_id, $destination_uuid, ?array $oth
 
 function create_standalone_dragonfly($environment_id, $destination_uuid, ?array $otherData = null): StandaloneDragonfly
 {
-    $destination = StandaloneDocker::where('uuid', $destination_uuid)->first();
-    if (! $destination) {
-        throw new Exception('Destination not found');
-    }
+    $destination = StandaloneDocker::where('uuid', $destination_uuid)->firstOrFail();
     $database = new StandaloneDragonfly;
     $database->name = generate_database_name('dragonfly');
     $database->dragonfly_password = \Illuminate\Support\Str::password(length: 64, symbols: false);
@@ -176,12 +155,10 @@ function create_standalone_dragonfly($environment_id, $destination_uuid, ?array 
 
     return $database;
 }
+
 function create_standalone_clickhouse($environment_id, $destination_uuid, ?array $otherData = null): StandaloneClickhouse
 {
-    $destination = StandaloneDocker::where('uuid', $destination_uuid)->first();
-    if (! $destination) {
-        throw new Exception('Destination not found');
-    }
+    $destination = StandaloneDocker::where('uuid', $destination_uuid)->firstOrFail();
     $database = new StandaloneClickhouse;
     $database->name = generate_database_name('clickhouse');
     $database->clickhouse_admin_password = \Illuminate\Support\Str::password(length: 64, symbols: false);
@@ -201,29 +178,22 @@ function deleteBackupsLocally(string|array|null $filenames, Server $server): voi
     if (empty($filenames)) {
         return;
     }
-
     if (is_string($filenames)) {
         $filenames = [$filenames];
     }
-
-    $quotedFiles = array_map(function ($file) {
-        return "\"$file\"";
-    }, $filenames);
-
+    $quotedFiles = array_map(fn ($file) => "\"$file\"", $filenames);
     instant_remote_process(['rm -f '.implode(' ', $quotedFiles)], $server, throwError: false);
 }
 
-function deleteBackupsS3(string|array|null $filenames, Server $server, S3Storage $s3): void
+function deleteBackupsS3(string|array|null $filenames, S3Storage $s3): void
 {
     if (empty($filenames) || ! $s3) {
         return;
     }
-
     if (is_string($filenames)) {
         $filenames = [$filenames];
     }
 
-    // Initialize S3 client using Laravel's Storage facade
     $disk = Storage::build([
         'driver' => 's3',
         'key' => $s3->key,
@@ -232,38 +202,30 @@ function deleteBackupsS3(string|array|null $filenames, Server $server, S3Storage
         'bucket' => $s3->bucket,
         'endpoint' => $s3->endpoint,
         'use_path_style_endpoint' => true,
+        'bucket_endpoint' => $s3->isHetzner() || $s3->isDigitalOcean(),
+        'aws_url' => $s3->awsUrl(),
     ]);
 
-    // Delete files in bulk
     $disk->delete($filenames);
 }
 
 function deleteEmptyBackupFolder($folderPath, Server $server): void
 {
-    // Properly escape the folder path for shell commands
     $escapedPath = escapeshellarg($folderPath);
     $escapedParentPath = escapeshellarg(dirname($folderPath));
 
-    // Check if current folder is empty
     $checkEmpty = instant_remote_process(["[ -d $escapedPath ] && [ -z \"$(ls -A $escapedPath)\" ] && echo 'empty' || echo 'not empty'"], $server, throwError: false);
 
     if (trim($checkEmpty) === 'empty') {
-        // Remove the empty folder
         instant_remote_process(["rmdir $escapedPath"], $server, throwError: false);
-
-        // Check if parent folder exists and is empty
-        $checkParentEmpty = instant_remote_process([
-            "[ -d $escapedParentPath ] && [ -z \"$(ls -A $escapedParentPath)\" ] && echo 'empty' || echo 'not empty'",
-        ], $server, throwError: false);
-
+        $checkParentEmpty = instant_remote_process(["[ -d $escapedParentPath ] && [ -z \"$(ls -A $escapedParentPath)\" ] && echo 'empty' || echo 'not empty'"], $server, throwError: false);
         if (trim($checkParentEmpty) === 'empty') {
-            // Remove the empty parent folder
             instant_remote_process(["rmdir $escapedParentPath"], $server, throwError: false);
         }
     }
 }
 
-function deleteOldBackupsLocally($backup)
+function deleteOldBackupsLocally($backup): void
 {
     if (! $backup || ! $backup->executions) {
         return;
@@ -278,7 +240,6 @@ function deleteOldBackupsLocally($backup)
         return;
     }
 
-    // Get retention limits
     $retentionAmount = $backup->database_backup_retention_amount_locally;
     $retentionDays = $backup->database_backup_retention_days_locally;
 
@@ -288,29 +249,19 @@ function deleteOldBackupsLocally($backup)
 
     $backupsToDelete = collect();
 
-    // Process backups based on retention amount
     if ($retentionAmount > 0) {
-        $backupsToDelete = $backupsToDelete->merge(
-            $successfulBackups->skip($retentionAmount)
-        );
+        $backupsToDelete = $backupsToDelete->merge($successfulBackups->skip($retentionAmount));
     }
 
-    // Process backups based on retention days
     if ($retentionDays > 0) {
         $oldestAllowedDate = $successfulBackups->first()->created_at->clone()->utc()->subDays($retentionDays);
-        $oldBackups = $successfulBackups->filter(function ($execution) use ($oldestAllowedDate) {
-            return $execution->created_at->utc() < $oldestAllowedDate;
-        });
+        $oldBackups = $successfulBackups->filter(fn ($execution) => $execution->created_at->utc() < $oldestAllowedDate);
         $backupsToDelete = $backupsToDelete->merge($oldBackups);
     }
 
-    // Get unique backups to delete and chunk them for parallel processing
     $backupsToDelete = $backupsToDelete->unique('id');
-
-    // Keep track of folders to check
     $foldersToCheck = collect();
 
-    // Process deletions in parallel chunks
     $backupsToDelete->chunk(10)->each(function ($chunk) use ($backup, &$foldersToCheck) {
         $executionIds = [];
         $filesToDelete = [];
@@ -319,28 +270,22 @@ function deleteOldBackupsLocally($backup)
             if ($execution->filename) {
                 $filesToDelete[] = $execution->filename;
                 $executionIds[] = $execution->id;
-                // Add the folder path to check later
                 $foldersToCheck->push(dirname($execution->filename));
             }
         }
 
         if (! empty($filesToDelete)) {
             deleteBackupsLocally($filesToDelete, $backup->server);
-
-            // Bulk delete executions from database
             if (! empty($executionIds)) {
                 $backup->executions()->whereIn('id', $executionIds)->delete();
             }
         }
     });
 
-    // Check and clean up empty folders
-    $foldersToCheck->unique()->each(function ($folder) use ($backup) {
-        deleteEmptyBackupFolder($folder, $backup->server);
-    });
+    $foldersToCheck->unique()->each(fn ($folder) => deleteEmptyBackupFolder($folder, $backup->server));
 }
 
-function deleteOldBackupsFromS3($backup)
+function deleteOldBackupsFromS3($backup): void
 {
     if (! $backup || ! $backup->executions || ! $backup->s3) {
         return;
@@ -355,7 +300,6 @@ function deleteOldBackupsFromS3($backup)
         return;
     }
 
-    // Get retention limits
     $retentionAmount = $backup->database_backup_retention_amount_s3;
     $retentionDays = $backup->database_backup_retention_days_s3;
     $maxStorageGB = $backup->database_backup_retention_max_storage_s3;
@@ -366,36 +310,25 @@ function deleteOldBackupsFromS3($backup)
 
     $backupsToDelete = collect();
 
-    // Process backups based on retention amount
     if ($retentionAmount > 0) {
-        $backupsToDelete = $backupsToDelete->merge(
-            $successfulBackups->skip($retentionAmount)
-        );
+        $backupsToDelete = $backupsToDelete->merge($successfulBackups->skip($retentionAmount));
     }
 
-    // Process backups based on retention days
     if ($retentionDays > 0) {
         $oldestAllowedDate = $successfulBackups->first()->created_at->clone()->utc()->subDays($retentionDays);
-        $oldBackups = $successfulBackups->filter(function ($execution) use ($oldestAllowedDate) {
-            return $execution->created_at->utc() < $oldestAllowedDate;
-        });
+        $oldBackups = $successfulBackups->filter(fn ($execution) => $execution->created_at->utc() < $oldestAllowedDate);
         $backupsToDelete = $backupsToDelete->merge($oldBackups);
     }
 
-    // Process backups based on total storage limit
     if ($maxStorageGB > 0) {
-        $maxStorageBytes = $maxStorageGB * 1024 * 1024 * 1024; // Convert GB to bytes
+        $maxStorageBytes = $maxStorageGB * 1024 * 1024 * 1024;
         $totalSize = 0;
         $backupsOverLimit = collect();
 
         foreach ($successfulBackups as $backup) {
             $totalSize += (int) $backup->size;
-
-            // If we're over the limit, add this and all older backups to delete list
             if ($totalSize > $maxStorageBytes) {
-                $backupsOverLimit = $successfulBackups->filter(function ($b) use ($backup) {
-                    return $b->created_at->utc() <= $backup->created_at->utc();
-                });
+                $backupsOverLimit = $successfulBackups->filter(fn ($b) => $b->created_at->utc() <= $backup->created_at->utc());
                 break;
             }
         }
@@ -403,13 +336,9 @@ function deleteOldBackupsFromS3($backup)
         $backupsToDelete = $backupsToDelete->merge($backupsOverLimit);
     }
 
-    // Get unique backups to delete and chunk them for parallel processing
     $backupsToDelete = $backupsToDelete->unique('id');
-
-    // Keep track of folders to check
     $foldersToCheck = collect();
 
-    // Process deletions in parallel chunks
     $backupsToDelete->chunk(10)->each(function ($chunk) use ($backup, &$foldersToCheck) {
         $executionIds = [];
         $filesToDelete = [];
@@ -418,15 +347,12 @@ function deleteOldBackupsFromS3($backup)
             if ($execution->filename) {
                 $filesToDelete[] = $execution->filename;
                 $executionIds[] = $execution->id;
-                // Add the folder path to check later
                 $foldersToCheck->push(dirname($execution->filename));
             }
         }
 
         if (! empty($filesToDelete)) {
             deleteBackupsS3($filesToDelete, $backup->server, $backup->s3);
-
-            // Update executions to mark S3 backup as deleted
             if (! empty($executionIds)) {
                 $backup->executions()
                     ->whereIn('id', $executionIds)
@@ -435,10 +361,7 @@ function deleteOldBackupsFromS3($backup)
         }
     });
 
-    // Check and clean up empty folders
-    $foldersToCheck->unique()->each(function ($folder) use ($backup) {
-        deleteEmptyBackupFolder($folder, $backup->server);
-    });
+    $foldersToCheck->unique()->each(fn ($folder) => deleteEmptyBackupFolder($folder, $backup->server));
 }
 
 function isPublicPortAlreadyUsed(Server $server, int $port, ?string $id = null): bool

--- a/bootstrap/helpers/databases.php
+++ b/bootstrap/helpers/databases.php
@@ -352,7 +352,7 @@ function deleteOldBackupsFromS3($backup): void
         }
 
         if (! empty($filesToDelete)) {
-            deleteBackupsS3($filesToDelete, $backup->server, $backup->s3);
+            deleteBackupsS3($filesToDelete, $backup->s3);
             if (! empty($executionIds)) {
                 $backup->executions()
                     ->whereIn('id', $executionIds)

--- a/database/migrations/2025_01_13_130238_add_backup_retention_fields_to_scheduled_database_backups_table.php
+++ b/database/migrations/2025_01_13_130238_add_backup_retention_fields_to_scheduled_database_backups_table.php
@@ -12,10 +12,11 @@ return new class extends Migration
             $table->renameColumn('number_of_backups_locally', 'database_backup_retention_amount_locally');
             $table->integer('database_backup_retention_amount_locally')->default(0)->nullable(false)->change();
             $table->integer('database_backup_retention_days_locally')->default(0)->nullable(false);
+            $table->decimal('database_backup_retention_max_storage_locally', 17, 7)->default(0)->nullable(false);
 
             $table->integer('database_backup_retention_amount_s3')->default(0)->nullable(false);
             $table->integer('database_backup_retention_days_s3')->default(0)->nullable(false);
-            $table->integer('database_backup_retention_max_storage_s3')->default(0)->nullable(false);
+            $table->decimal('database_backup_retention_max_storage_s3', 17, 7)->default(0)->nullable(false);
         });
     }
 
@@ -25,6 +26,7 @@ return new class extends Migration
             $table->renameColumn('database_backup_retention_amount_locally', 'number_of_backups_locally')->nullable(true)->change();
             $table->dropColumn([
                 'database_backup_retention_days_locally',
+                'database_backup_retention_max_storage_locally',
                 'database_backup_retention_amount_s3',
                 'database_backup_retention_days_s3',
                 'database_backup_retention_max_storage_s3',

--- a/database/migrations/2025_01_13_130238_add_backup_retention_fields_to_scheduled_database_backups_table.php
+++ b/database/migrations/2025_01_13_130238_add_backup_retention_fields_to_scheduled_database_backups_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('scheduled_database_backups', function (Blueprint $table) {
+            $table->renameColumn('number_of_backups_locally', 'database_backup_retention_amount_locally');
+            $table->integer('database_backup_retention_amount_locally')->default(0)->nullable(false)->change();
+            $table->integer('database_backup_retention_days_locally')->default(0)->nullable(false);
+
+            $table->integer('database_backup_retention_amount_s3')->default(0)->nullable(false);
+            $table->integer('database_backup_retention_days_s3')->default(0)->nullable(false);
+            $table->integer('database_backup_retention_max_storage_s3')->default(0)->nullable(false);
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('scheduled_database_backups', function (Blueprint $table) {
+            $table->renameColumn('database_backup_retention_amount_locally', 'number_of_backups_locally')->nullable(true)->change();
+            $table->dropColumn([
+                'database_backup_retention_days_locally',
+                'database_backup_retention_amount_s3',
+                'database_backup_retention_days_s3',
+                'database_backup_retention_max_storage_s3',
+            ]);
+        });
+    }
+};

--- a/resources/views/livewire/project/database/backup-edit.blade.php
+++ b/resources/views/livewire/project/database/backup-edit.blade.php
@@ -72,7 +72,43 @@
             <x-forms.input label="Frequency" id="frequency" />
             <x-forms.input label="Timezone" id="timezone" disabled
                 helper="The timezone of the server where the backup is scheduled to run (if not set, the instance timezone will be used)" />
-            <x-forms.input label="Number of backups to keep (locally)" id="numberOfBackupsLocally" />
+        </div>
+
+        <h3 class="mt-6 mb-2 text-lg font-medium">Backup Retention Settings</h3>
+        <div class="mb-4">
+            <p>
+                These settings control how long backups are kept.
+                <ul>
+                    <li>Setting a value to 0 means unlimited retention.</li>
+                    <li>The retention rules work independently and whichever limit is reached first will trigger a cleanup of the older backups.</li>
+                </ul>
+            </p>
+        </div>
+        
+        <div class="flex gap-6 flex-col">
+            <div>
+                <h4 class="mb-3 font-medium">Local Backup Retention</h4>
+                <div class="flex gap-4">
+                    <x-forms.input label="Number of backups to keep" id="databaseBackupRetentionAmountLocally" type="number" min="0" 
+                        helper="Keeps only the specified number of most recent backups on the server. Set to 0 for unlimited backups." />
+                    <x-forms.input label="Days to keep backups" id="databaseBackupRetentionDaysLocally" type="number" min="0" 
+                        helper="Automatically removes backups older than the specified number of days. Set to 0 for no time limit." />
+                </div>
+            </div>
+
+            @if ($backup->save_s3)
+                <div>
+                    <h4 class="mb-3 font-medium">S3 Storage Retention</h4>
+                    <div class="flex gap-4">
+                        <x-forms.input label="Number of backups to keep" id="databaseBackupRetentionAmountS3" type="number" min="0" 
+                            helper="Keeps only the specified number of most recent backups on S3 storage. Set to 0 for unlimited backups." />
+                        <x-forms.input label="Days to keep backups" id="databaseBackupRetentionDaysS3" type="number" min="0" 
+                            helper="Automatically removes S3 backups older than the specified number of days. Set to 0 for no time limit." />
+                        <x-forms.input label="Maximum storage (GB)" id="databaseBackupRetentionMaxStorageS3" type="number" min="0" 
+                            helper="When total size of all backups in the current backup job exceeds this limit in GB, the oldest backups will be removed. Set to 0 for unlimited storage." />
+                    </div>
+                </div>
+            @endif
         </div>
     </div>
 </form>

--- a/resources/views/livewire/project/database/backup-edit.blade.php
+++ b/resources/views/livewire/project/database/backup-edit.blade.php
@@ -75,6 +75,13 @@
                 <div class="flex gap-4">
                     <x-forms.input label="Number of backups to keep" id="databaseBackupRetentionAmountLocally" type="number" min="0" helper="Keeps only the specified number of most recent backups on the server. Set to 0 for unlimited backups." />
                     <x-forms.input label="Days to keep backups" id="databaseBackupRetentionDaysLocally" type="number" min="0" helper="Automatically removes backups older than the specified number of days. Set to 0 for no time limit." />
+                    <x-forms.input 
+                        label="Maximum storage (GB)" 
+                        id="databaseBackupRetentionMaxStorageLocally" 
+                        type="number" 
+                        min="0" 
+                        step="0.0000001"
+                        helper="When total size of all backups in the current backup job exceeds this limit in GB, the oldest backups will be removed. Decimal values are supported (e.g. 0.001 for 1MB). Set to 0 for unlimited storage." />
                 </div>
             </div>
 
@@ -84,7 +91,13 @@
                 <div class="flex gap-4">
                     <x-forms.input label="Number of backups to keep" id="databaseBackupRetentionAmountS3" type="number" min="0" helper="Keeps only the specified number of most recent backups on S3 storage. Set to 0 for unlimited backups." />
                     <x-forms.input label="Days to keep backups" id="databaseBackupRetentionDaysS3" type="number" min="0" helper="Automatically removes S3 backups older than the specified number of days. Set to 0 for no time limit." />
-                    <x-forms.input label="Maximum storage (GB)" id="databaseBackupRetentionMaxStorageS3" type="number" min="0" helper="When total size of all backups in the current backup job exceeds this limit in GB, the oldest backups will be removed. Set to 0 for unlimited storage." />
+                    <x-forms.input 
+                        label="Maximum storage (GB)" 
+                        id="databaseBackupRetentionMaxStorageS3" 
+                        type="number" 
+                        min="0" 
+                        step="0.0000001"
+                        helper="When total size of all backups in the current backup job exceeds this limit in GB, the oldest backups will be removed. Decimal values are supported (e.g. 0.5 for 500MB). Set to 0 for unlimited storage." />
                 </div>
             </div>
             @endif

--- a/resources/views/livewire/project/database/backup-edit.blade.php
+++ b/resources/views/livewire/project/database/backup-edit.blade.php
@@ -5,17 +5,13 @@
             Save
         </x-forms.button>
         @if (str($status)->startsWith('running'))
-            <livewire:project.database.backup-now :backup="$backup" />
+        <livewire:project.database.backup-now :backup="$backup" />
         @endif
         @if ($backup->database_id !== 0)
-            <x-modal-confirmation title="Confirm Backup Schedule Deletion?" buttonTitle="Delete Backups and Schedule"
-                isErrorButton submitAction="delete" :checkboxes="$checkboxes" :actions="[
+        <x-modal-confirmation title="Confirm Backup Schedule Deletion?" buttonTitle="Delete Backups and Schedule" isErrorButton submitAction="delete" :checkboxes="$checkboxes" :actions="[
                     'The selected backup schedule will be deleted.',
                     'Scheduled backups for this database will be stopped (if this is the only backup schedule for this database).',
-                ]"
-                confirmationText="{{ $backup->database->name }}"
-                confirmationLabel="Please confirm the execution of the actions by entering the Database Name of the scheduled backups below"
-                shortConfirmationLabel="Database Name" />
+                ]" confirmationText="{{ $backup->database->name }}" confirmationLabel="Please confirm the execution of the actions by entering the Database Name of the scheduled backups below" shortConfirmationLabel="Database Name" />
         @endif
     </div>
     <div class="w-48 pb-2">
@@ -23,91 +19,74 @@
         <x-forms.checkbox instantSave label="S3 Enabled" id="saveS3" />
     </div>
     @if ($backup->save_s3)
-        <div class="pb-6">
-            <x-forms.select id="s3StorageId" label="S3 Storage" required>
-                <option value="default">Select a S3 storage</option>
-                @foreach ($s3s as $s3)
-                    <option value="{{ $s3->id }}">{{ $s3->name }}</option>
-                @endforeach
-            </x-forms.select>
-        </div>
+    <div class="pb-6">
+        <x-forms.select id="s3StorageId" label="S3 Storage" required>
+            <option value="default">Select a S3 storage</option>
+            @foreach ($s3s as $s3)
+            <option value="{{ $s3->id }}">{{ $s3->name }}</option>
+            @endforeach
+        </x-forms.select>
+    </div>
     @endif
     <div class="flex flex-col gap-2">
         <h3>Settings</h3>
         <div class="flex gap-2 flex-col ">
             @if ($backup->database_type === 'App\Models\StandalonePostgresql' && $backup->database_id !== 0)
-                <div class="w-48">
-                    <x-forms.checkbox label="Backup All Databases" id="dumpAll" instantSave />
-                </div>
-                @if (!$backup->dump_all)
-                    <x-forms.input label="Databases To Backup"
-                        helper="Comma separated list of databases to backup. Empty will include the default one."
-                        id="databasesToBackup" />
-                @endif
+            <div class="w-48">
+                <x-forms.checkbox label="Backup All Databases" id="dumpAll" instantSave />
+            </div>
+            @if (!$backup->dump_all)
+            <x-forms.input label="Databases To Backup" helper="Comma separated list of databases to backup. Empty will include the default one." id="databasesToBackup" />
+            @endif
             @elseif($backup->database_type === 'App\Models\StandaloneMongodb')
-                <x-forms.input label="Databases To Include"
-                    helper="A list of databases to backup. You can specify which collection(s) per database to exclude from the backup. Empty will include all databases and collections.<br><br>Example:<br><br>database1:collection1,collection2|database2:collection3,collection4<br><br> database1 will include all collections except collection1 and collection2. <br>database2 will include all collections except collection3 and collection4.<br><br>Another Example:<br><br>database1:collection1|database2<br><br> database1 will include all collections except collection1.<br>database2 will include ALL collections."
-                    id="databasesToBackup" />
+            <x-forms.input label="Databases To Include" helper="A list of databases to backup. You can specify which collection(s) per database to exclude from the backup. Empty will include all databases and collections.<br><br>Example:<br><br>database1:collection1,collection2|database2:collection3,collection4<br><br> database1 will include all collections except collection1 and collection2. <br>database2 will include all collections except collection3 and collection4.<br><br>Another Example:<br><br>database1:collection1|database2<br><br> database1 will include all collections except collection1.<br>database2 will include ALL collections." id="databasesToBackup" />
             @elseif($backup->database_type === 'App\Models\StandaloneMysql')
-                <div class="w-48">
-                    <x-forms.checkbox label="Backup All Databases" id="dumpAll" instantSave />
-                </div>
-                @if (!$backup->dump_all)
-                    <x-forms.input label="Databases To Backup"
-                        helper="Comma separated list of databases to backup. Empty will include the default one."
-                        id="databasesToBackup" />
-                @endif
+            <div class="w-48">
+                <x-forms.checkbox label="Backup All Databases" id="dumpAll" instantSave />
+            </div>
+            @if (!$backup->dump_all)
+            <x-forms.input label="Databases To Backup" helper="Comma separated list of databases to backup. Empty will include the default one." id="databasesToBackup" />
+            @endif
             @elseif($backup->database_type === 'App\Models\StandaloneMariadb')
-                <div class="w-48">
-                    <x-forms.checkbox label="Backup All Databases" id="dumpAll" instantSave />
-                </div>
-                @if (!$backup->dump_all)
-                    <x-forms.input label="Databases To Backup"
-                        helper="Comma separated list of databases to backup. Empty will include the default one."
-                        id="databasesToBackup" />
-                @endif
+            <div class="w-48">
+                <x-forms.checkbox label="Backup All Databases" id="dumpAll" instantSave />
+            </div>
+            @if (!$backup->dump_all)
+            <x-forms.input label="Databases To Backup" helper="Comma separated list of databases to backup. Empty will include the default one." id="databasesToBackup" />
+            @endif
             @endif
         </div>
         <div class="flex gap-2">
             <x-forms.input label="Frequency" id="frequency" />
-            <x-forms.input label="Timezone" id="timezone" disabled
-                helper="The timezone of the server where the backup is scheduled to run (if not set, the instance timezone will be used)" />
+            <x-forms.input label="Timezone" id="timezone" disabled helper="The timezone of the server where the backup is scheduled to run (if not set, the instance timezone will be used)" />
         </div>
 
         <h3 class="mt-6 mb-2 text-lg font-medium">Backup Retention Settings</h3>
         <div class="mb-4">
-            <p>
-                These settings control how long backups are kept.
-                <ul>
-                    <li>Setting a value to 0 means unlimited retention.</li>
-                    <li>The retention rules work independently and whichever limit is reached first will trigger a cleanup of the older backups.</li>
-                </ul>
-            </p>
+            <ul class="list-disc pl-6 space-y-2">
+                <li>Setting a value to 0 means unlimited retention</li>
+                <li>The retention rules work independently - whichever limit is reached first will trigger cleanup</li>
+            </ul>
         </div>
-        
+
         <div class="flex gap-6 flex-col">
             <div>
                 <h4 class="mb-3 font-medium">Local Backup Retention</h4>
                 <div class="flex gap-4">
-                    <x-forms.input label="Number of backups to keep" id="databaseBackupRetentionAmountLocally" type="number" min="0" 
-                        helper="Keeps only the specified number of most recent backups on the server. Set to 0 for unlimited backups." />
-                    <x-forms.input label="Days to keep backups" id="databaseBackupRetentionDaysLocally" type="number" min="0" 
-                        helper="Automatically removes backups older than the specified number of days. Set to 0 for no time limit." />
+                    <x-forms.input label="Number of backups to keep" id="databaseBackupRetentionAmountLocally" type="number" min="0" helper="Keeps only the specified number of most recent backups on the server. Set to 0 for unlimited backups." />
+                    <x-forms.input label="Days to keep backups" id="databaseBackupRetentionDaysLocally" type="number" min="0" helper="Automatically removes backups older than the specified number of days. Set to 0 for no time limit." />
                 </div>
             </div>
 
             @if ($backup->save_s3)
-                <div>
-                    <h4 class="mb-3 font-medium">S3 Storage Retention</h4>
-                    <div class="flex gap-4">
-                        <x-forms.input label="Number of backups to keep" id="databaseBackupRetentionAmountS3" type="number" min="0" 
-                            helper="Keeps only the specified number of most recent backups on S3 storage. Set to 0 for unlimited backups." />
-                        <x-forms.input label="Days to keep backups" id="databaseBackupRetentionDaysS3" type="number" min="0" 
-                            helper="Automatically removes S3 backups older than the specified number of days. Set to 0 for no time limit." />
-                        <x-forms.input label="Maximum storage (GB)" id="databaseBackupRetentionMaxStorageS3" type="number" min="0" 
-                            helper="When total size of all backups in the current backup job exceeds this limit in GB, the oldest backups will be removed. Set to 0 for unlimited storage." />
-                    </div>
+            <div>
+                <h4 class="mb-3 font-medium">S3 Storage Retention</h4>
+                <div class="flex gap-4">
+                    <x-forms.input label="Number of backups to keep" id="databaseBackupRetentionAmountS3" type="number" min="0" helper="Keeps only the specified number of most recent backups on S3 storage. Set to 0 for unlimited backups." />
+                    <x-forms.input label="Days to keep backups" id="databaseBackupRetentionDaysS3" type="number" min="0" helper="Automatically removes S3 backups older than the specified number of days. Set to 0 for no time limit." />
+                    <x-forms.input label="Maximum storage (GB)" id="databaseBackupRetentionMaxStorageS3" type="number" min="0" helper="When total size of all backups in the current backup job exceeds this limit in GB, the oldest backups will be removed. Set to 0 for unlimited storage." />
                 </div>
+            </div>
             @endif
         </div>
     </div>

--- a/resources/views/livewire/project/database/backup-executions.blade.php
+++ b/resources/views/livewire/project/database/backup-executions.blade.php
@@ -47,6 +47,7 @@
                         @endif
                         <x-modal-confirmation title="Confirm Backup Deletion?" buttonTitle="Delete" isErrorButton
                             submitAction="deleteBackup({{ data_get($execution, 'id') }})"
+                            :checkboxes="$checkboxes"
                             :actions="['This backup will be permanently deleted from local storage.']" confirmationText="{{ data_get($execution, 'filename') }}"
                             confirmationLabel="Please confirm the execution of the actions by entering the Backup Filename below"
                             shortConfirmationLabel="Backup Filename" step3ButtonText="Permanently Delete" />


### PR DESCRIPTION
## Changes
- feat: Retention Options (whichever limit is reached first will trigger the cleanup):
    - Number of backups to keep -> A number of backups to keep
    - Days to keep backups -> A number of days to keep backups
    - Maximum storage (GB) -> A number of GB or decimal of maximum allowed storage for this backup job
- feat: add backup retention days, backup amount and max allowed storage to S3 
- feat: add backup retention days and max allowed storage to locally stored backups
- feat: when deleting a backup schedule you can now select to delete all backups form S3 as well
- feat: when deleting a single backup you can now select to delete the backup form S3 as well
- feat: New backup retention UI:
<img width="895" alt="image" src="https://github.com/user-attachments/assets/e7b07717-9d52-4056-9e9b-9a4f0f1dab2b" />

- feat: Multi-delete on S3 and locally stored backups -> Now multiple backup files and backup executions are deleted together in parallel for improved performance and faster executions of deletion...
- fix: only call `removeOldBackups` function in the `DatabaseBackupJob.php` if the backup is completed and successful, this caused problems before
- fix: delete backup folder and parent folder if folders are empty when deleting local backups to cleanup unused folders
- fix: Do not remove executions from DB until both S3 and local backups have been deleted and successfully processed otherwise backups will never be deleted from s3.
- refactor: refactored the UI and DB to make it easier to use - `0` now means unlimited retention (so a value is now required for retention).
- refactor: simplified some code
- refactor: refactored some duplicated code
- refactor: refactored code to be more centralized in one location
- chore: use CamleCase everywhere for new functions
- chore: renamed `number_of_backups_locally` to `database_backup_retention_amount_locally`

### Note
- Most S3 providers have a cooldown of 24 hours or more on files deleted via the API for security reasons, so if you set your retention days in Coolify to 7 days, files older than 7 days will be hidden (deleted) in your bucket (and still consume storage) for 24+ hours more and then they will be permanently deleted on the 8th day or later, depending on the provider.

## Issues
- fix #4782

/claim #4782