### PR TITLE
fix: gotenberg template healthcheck

### DIFF
--- a/templates/compose/gotenberg.yaml
+++ b/templates/compose/gotenberg.yaml
@@ -20,7 +20,7 @@ services:
       #"--chromium-auto-start"
     ]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:3000/version"]
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:3000/health"]
       interval: 5s
       timeout: 20s
       retries: 10


### PR DESCRIPTION
## Changes
- Use `/health` instead of `/version` for healthcheck

Apologies, I didn't realise the [health-check-route](https://gotenberg.dev/docs/routes#health-check-route) existed when submitting the original PR.

