### PR TITLE
fix(ui): missing underline in link to docs

### DIFF
--- a/resources/views/livewire/server/new/by-ip.blade.php
+++ b/resources/views/livewire/server/new/by-ip.blade.php
@@ -31,7 +31,7 @@
             </div>
             <div class="">
                 <h3 class="pt-6">Swarm <span class="text-xs text-neutral-500">(experimental)</span></h3>
-                <div class="pb-4">Read the docs <a class='dark:text-white'
+                <div class="pb-4">Read the docs <a class='underline dark:text-white'
                         href='https://coolify.io/docs/knowledge-base/docker/swarm' target='_blank'>here</a>.</div>
                 @if ($is_swarm_worker || $is_build_server)
                     <x-forms.checkbox disabled instantSave type="checkbox" id="is_swarm_manager"


### PR DESCRIPTION
## Changes
- Add missing underline in link to docs in the Swarm section

## Before
<img width="175" alt="Screenshot 2025-01-18 at 7 12 07 PM" src="https://github.com/user-attachments/assets/5e4e2673-8ed3-4905-bf04-910125845ad6" />

## After
<img width="230" alt="Screenshot 2025-01-18 at 7 11 58 PM" src="https://github.com/user-attachments/assets/a1d5ff86-dd7a-4c87-8e0b-6f9575111349" />

