### PR TITLE
Pg vector fix for chatwoot

### DIFF
--- a/templates/compose/chatwoot.yaml
+++ b/templates/compose/chatwoot.yaml
@@ -88,7 +88,7 @@ services:
       retries: 3
 
   postgres:
-    image: postgres:12
+    image: pgvector/pgvector:pg12
     restart: always
     volumes:
       - postgres-data:/var/lib/postgresql/data


### PR DESCRIPTION
## Changes
- Change postgres image from `postgres:12` to `pgvector/pgvector:pg12`

## Issues
- fix pgvector requirement as described https://www.chatwoot.com/docs/self-hosted/runbooks/upgrade-to-chatwoot-v4#docker-container
