### PR TITLE
Fix Plunk API & health check endpoint

### DIFF
--- a/templates/compose/plunk.yaml
+++ b/templates/compose/plunk.yaml
@@ -25,9 +25,10 @@ services:
       - APP_URI=${SERVICE_FQDN_PLUNK}
       - API_URI=${SERVICE_FQDN_PLUNK}/api
       - DISABLE_SIGNUPS=${DISABLE_SIGNUPS:-False}
+      - NODE_OPTIONS=--no-network-family-autoselection
     entrypoint: [ "/app/entry.sh" ]
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:3000/api/health"]
+      test: ["CMD-SHELL", "(wget -S --spider http://127.0.0.1:3000/api/health 2>&1 | grep -q \"HTTP/1.1 [1-3]\")"]
       interval: 2s
       timeout: 10s
       retries: 15

--- a/templates/compose/plunk.yaml
+++ b/templates/compose/plunk.yaml
@@ -27,7 +27,7 @@ services:
       - DISABLE_SIGNUPS=${DISABLE_SIGNUPS:-False}
     entrypoint: [ "/app/entry.sh" ]
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:3000"]
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:3000/api/health"]
       interval: 2s
       timeout: 10s
       retries: 15


### PR DESCRIPTION
Sometimes Plunk will crash and the API will just stop. The current health check only pings the dashboard which would still be running fine & the container would never be restarted.

## Changes
- Added the ``/api/health`` endpoint for the health check for Plunk (https://github.com/useplunk/plunk/pull/137)
- Added ``NODE_OPTIONS=--no-network-family-autoselection``. This is a known fix for the random crashing of the Plunk server.

## Issues
- fix #4426 