### PR TITLE
Improve template defaults

### DIFF
--- a/templates/compose/jitsi.yaml
+++ b/templates/compose/jitsi.yaml
@@ -10,8 +10,8 @@ services:
     container_name: jitsi-web
     restart: unless-stopped
     ports:
-      - "8001:80"
-      - "8443:443"
+      - '127.0.0.1:8001:80'
+      - '127.0.0.1:8443:443'
     volumes:
       - ~/.jitsi-meet-cfg/web:/config:Z
       - ~/.jitsi-meet-cfg/web/crontabs:/var/spool/cron/crontabs:Z
@@ -26,6 +26,9 @@ services:
       - JIGASI_XMPP_PASSWORD=$SERVICE_PASSWORD_JITSI
       - JVB_AUTH_PASSWORD=$SERVICE_PASSWORD_JITSI
       - TZ=UTC
+      - DISABLE_HTTPS=1
+      - ENABLE_HTTP_REDIRECT=0
+      - ENABLE_LETS_ENCRYPT=0
     networks:
       meet.jitsi:
         aliases:
@@ -54,6 +57,8 @@ services:
       - JVB_AUTH_PASSWORD
       - PUBLIC_URL=$SERVICE_FQDN_JITSI
       - TZ
+      - ENABLE_AUTH=1
+      - AUTH_TYPE=internal
     networks:
       meet.jitsi:
         aliases:


### PR DESCRIPTION
As per official documentation HTTPS is not technically needed inside the container and will work fine when bound to localhost behind proxy. Also added the initial config for internal Auth. Will still require the user to manually set up a username and password. via "prosodyctl" but its just one less config change regular users need to make in the template. https://jitsi.github.io/handbook/docs/devops-guide/devops-guide-docker/#authentication

## Changes
- Restrict port usage to localhost
- Disable HTTPS
- Set up starting point for internal Auth