### PR TITLE
fix: remove quotes in COOLIFY_CONTAINER_NAME

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -924,7 +924,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                     $envs->push("COOLIFY_BRANCH=\"{$local_branch}\"");
                 }
                 if ($this->application->environment_variables_preview->where('key', 'COOLIFY_CONTAINER_NAME')->isEmpty()) {
-                    $envs->push("COOLIFY_CONTAINER_NAME=\"{$this->container_name}\"");
+                    $envs->push("COOLIFY_CONTAINER_NAME={$this->container_name}");
                 }
             }
 
@@ -983,7 +983,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                     $envs->push("COOLIFY_BRANCH=\"{$local_branch}\"");
                 }
                 if ($this->application->environment_variables->where('key', 'COOLIFY_CONTAINER_NAME')->isEmpty()) {
-                    $envs->push("COOLIFY_CONTAINER_NAME=\"{$this->container_name}\"");
+                    $envs->push("COOLIFY_CONTAINER_NAME={$this->container_name}");
                 }
             }
 

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -3608,7 +3608,7 @@ function newParser(Application|Service $resource, int $pull_request_id = 0, ?int
 
         // Add COOLIFY_CONTAINER_NAME to environment
         if ($resource->environment_variables->where('key', 'COOLIFY_CONTAINER_NAME')->isEmpty()) {
-            $coolifyEnvironments->put('COOLIFY_CONTAINER_NAME', "\"{$containerName}\"");
+            $coolifyEnvironments->put('COOLIFY_CONTAINER_NAME', "{$containerName}");
         }
 
         if ($isApplication) {


### PR DESCRIPTION
## Changes
- remove quotes from COOLIFY_CONTAINER_NAME quotes

Before:
![image](https://github.com/user-attachments/assets/e526ac21-6090-4d02-8b3d-1fbfa396ef5f)


After:
![it-tools-container-name-after](https://github.com/user-attachments/assets/d8ff731e-29fa-4e4d-9e45-c53d4dc3b673)


## Issues
- fix #4931 
- relevant to PR #4891

## Note:

Seeing that container names are generated using `service-<uuid>`, and that it is being escaped in places like:
https://github.com/coollabsio/coolify/blob/08f7fa280627fe66c1d1e3cc61c4765e83621892/app/Jobs/ApplicationDeploymentJob.php#L938-L942
    
I assume this is okay. 