### PR TITLE
feat(env): added COOLIFY_RESOURCE_UUID environment variable

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -923,6 +923,9 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                 if ($this->application->environment_variables_preview->where('key', 'COOLIFY_BRANCH')->isEmpty()) {
                     $envs->push("COOLIFY_BRANCH=\"{$local_branch}\"");
                 }
+                if ($this->application->environment_variables_preview->where('key', 'COOLIFY_RESOURCE_UUID')->isEmpty()) {
+                    $envs->push("COOLIFY_RESOURCE_UUID={$this->application->uuid}");
+                }
                 if ($this->application->environment_variables_preview->where('key', 'COOLIFY_CONTAINER_NAME')->isEmpty()) {
                     $envs->push("COOLIFY_CONTAINER_NAME=\"{$this->container_name}\"");
                 }
@@ -981,6 +984,9 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             if ($this->application->build_pack !== 'dockercompose' || $this->application->compose_parsing_version === '1' || $this->application->compose_parsing_version === '2') {
                 if ($this->application->environment_variables->where('key', 'COOLIFY_BRANCH')->isEmpty()) {
                     $envs->push("COOLIFY_BRANCH=\"{$local_branch}\"");
+                }
+                if ($this->application->environment_variables->where('key', 'COOLIFY_RESOURCE_UUID')->isEmpty()) {
+                    $envs->push("COOLIFY_RESOURCE_UUID={$this->application->uuid}");
                 }
                 if ($this->application->environment_variables->where('key', 'COOLIFY_CONTAINER_NAME')->isEmpty()) {
                     $envs->push("COOLIFY_CONTAINER_NAME=\"{$this->container_name}\"");

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -2115,6 +2115,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                         $parsedServiceVariables->put($key, $value);
                     }
                 }
+                $parsedServiceVariables->put('COOLIFY_RESOURCE_UUID', "{$resource->uuid}");
                 $parsedServiceVariables->put('COOLIFY_CONTAINER_NAME', "$serviceName-{$resource->uuid}");
 
                 // TODO: move this in a shared function
@@ -3604,6 +3605,11 @@ function newParser(Application|Service $resource, int $pull_request_id = 0, ?int
             if ($originalResource->environment_variables->where('key', 'COOLIFY_BRANCH')->isEmpty()) {
                 $coolifyEnvironments->put('COOLIFY_BRANCH', "\"{$branch}\"");
             }
+        }
+
+        // Add COOLIFY_RESOURCE_UUID to environment
+        if ($resource->environment_variables->where('key', 'COOLIFY_RESOURCE_UUID')->isEmpty()) {
+            $coolifyEnvironments->put('COOLIFY_RESOURCE_UUID', "{$resource->uuid}");
         }
 
         // Add COOLIFY_CONTAINER_NAME to environment


### PR DESCRIPTION
## Changes
- injects the `COOLIFY_RESOURCE_UUID`  environment variable

## Issues
- relates to #2545

---

**Use Case**

When a docker compose stack has the following:
1. uses  `redis`
2. have [Connect to Predefined Networks](https://coolify.io/docs/knowledge-base/docker/compose/#connect-to-predefined-networks) enabled
3. has a file mount config (e.g. `superset_config.py`) which needs to reference the `redis` service

Because of (2), the docker compose's redis service will be overshadowed by Coolify's redis when referenced in (3), the file mount config.

The workaround is as described in my https://github.com/coollabsio/coolify/pull/4891#issuecomment-2607319398 - basically, in the file mount config, extract the `UUID` such as:

```python
# superset_config.py
 
COOLIFY_UUID = os.getenv('COOLIFY_CONTAINER_NAME').strip('"').split('-')[-1]
```

Then use this to reference the correct `redis` (and `postgres`) containers, e.g.

```python
# use redis-{COOLIFY_UUID}
CACHE_REDIS_URL =  f"redis://:{os.getenv('REDIS_PASSWORD')}@redis-{COOLIFY_UUID}:6379/1"

# use db-{COOLIFY_UUID}
SQLALCHEMY_DATABASE_URI = f"postgresql+psycopg2://{os.getenv('POSTGRES_USER')}:{os.getenv('POSTGRES_PASSWORD')}@db-{COOLIFY_UUID}:5432/{os.getenv('POSTGRES_DB')}"
```

This pull request simplifies this process by providing the UUID directly as an environment variable, rather than requiring manual parsing from `COOLIFY_CONTAINER_NAME` to extract this value.