### PR TITLE
Improve duplicati.yaml

### DIFF
--- a/templates/compose/duplicati.yaml
+++ b/templates/compose/duplicati.yaml
@@ -11,7 +11,9 @@ services:
       - SERVICE_FQDN_DUPLICATI_8200
       - PUID=1000
       - PGID=1000
-      - TZ=Europe/Madrid
+      - TZ=${TZ:-Europe/London}
+      - SETTINGS_ENCRYPTION_KEY=${SERVICE_PASSWORD_ENCRYPT}
+      - DUPLICATI__WEBSERVICE_PASSWORD=${SERVICE_PASSWORD_WEB}
     volumes:
       - duplicati-config:/config
       - duplicati-backups:/backups


### PR DESCRIPTION
See https://github.com/coollabsio/coolify/issues/4666

Duplicati service won't start if the encryption secret is empty. It is not possible to log in if the web password is not set.

## Changes

- Generate random encryption secret
- Generate random web login password
- Make TZ show up in the UI

## Issues

- fix #4666
