### PR TITLE
fix: validate cron expression in Scheduled Task update

### DIFF
--- a/app/Livewire/Project/Shared/ScheduledTask/Show.php
+++ b/app/Livewire/Project/Shared/ScheduledTask/Show.php
@@ -77,6 +77,10 @@ class Show extends Component
     {
         if ($toModel) {
             $this->validate();
+            $isValid = validate_cron_expression($this->frequency);
+            if (! $isValid) {
+                throw new \Exception('Invalid Cron / Human expression.');
+            }
             $this->task->enabled = $this->isEnabled;
             $this->task->name = str($this->name)->trim()->value();
             $this->task->command = str($this->command)->trim()->value();
@@ -109,7 +113,7 @@ class Show extends Component
             $this->syncData(true);
             $this->dispatch('success', 'Scheduled task updated.');
         } catch (\Exception $e) {
-            return handleError($e);
+            return handleError($e, $this);
         }
     }
 


### PR DESCRIPTION
## Changes
- Validate the corn expression not only in Scheduled Task create but also in update.

I ran into this issue when I made a typo while I was updating one of my Scheduled Tasks' corn expression, and I couldn't figure out why it wasn't running anymore.