### PR TITLE
Added missing variable KEY to Beszel Template

### DIFF
--- a/templates/compose/beszel.yaml
+++ b/templates/compose/beszel.yaml
@@ -20,5 +20,4 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     environment:
       - PORT=45876
-    # Public Key from "Add a new system" in the UI and restart the agent
-    # - KEY=""
+      - KEY=${KEY}


### PR DESCRIPTION
## Changes
- Added a new variable KEY


## Notes:
- The KEY variable is commented out on the compose so coolify UI is not showing the variable which makes the Beszel Agent not run (Throws environment var KEY not set on terminal).
- This change will make the Beszel Agent run without throwing any error + user can add the value for the variable from the UI.
- The official docs says to enclose the variable within quotes but for me it works without adding the quotes (tried deploying 3 different times and works without any issues) 