### PR TITLE
fix(ui): align title and add button vertically in various views

### DIFF
--- a/resources/views/livewire/destination/index.blade.php
+++ b/resources/views/livewire/destination/index.blade.php
@@ -2,7 +2,7 @@
     <x-slot:title>
         Destinations | Coolify
     </x-slot>
-    <div class="flex items-start gap-2">
+    <div class="flex items-center gap-2">
         <h1>Destinations</h1>
         @if ($servers->count() > 0)
             <x-modal-input buttonTitle="+ Add" title="New Destination">

--- a/resources/views/livewire/server/index.blade.php
+++ b/resources/views/livewire/server/index.blade.php
@@ -2,7 +2,7 @@
     <x-slot:title>
         Servers | Coolify
     </x-slot>
-    <div class="flex items-start gap-2">
+    <div class="flex items-center gap-2">
         <h1>Servers</h1>
         <x-modal-input buttonTitle="+ Add" title="New Server" :closeOutside="false">
             <livewire:server.create />

--- a/resources/views/livewire/shared-variables/project/show.blade.php
+++ b/resources/views/livewire/shared-variables/project/show.blade.php
@@ -2,7 +2,7 @@
     <x-slot:title>
         Project Variable | Coolify
     </x-slot>
-    <div class="flex gap-2">
+    <div class="flex gap-2 items-center">
         <h1>Shared Variables for {{data_get($project,'name')}}</h1>
         <x-modal-input buttonTitle="+ Add" title="New Shared Variable">
             <livewire:project.shared.environment-variable.add :shared="true" />

--- a/resources/views/livewire/shared-variables/team/index.blade.php
+++ b/resources/views/livewire/shared-variables/team/index.blade.php
@@ -2,7 +2,7 @@
     <x-slot:title>
         Team Variables | Coolify
     </x-slot>
-    <div class="flex gap-2">
+    <div class="flex gap-2 items-center">
         <h1>Team Shared Variables</h1>
         <x-modal-input buttonTitle="+ Add" title="New Shared Variable">
             <livewire:project.shared.environment-variable.add :shared="true" />

--- a/resources/views/livewire/storage/index.blade.php
+++ b/resources/views/livewire/storage/index.blade.php
@@ -2,7 +2,7 @@
     <x-slot:title>
         Storages | Coolify
     </x-slot>
-    <div class="flex items-start gap-2">
+    <div class="flex items-center gap-2">
         <h1>S3 Storages</h1>
         <x-modal-input buttonTitle="+ Add" title="New S3 Storage" :closeOutside="false">
             <livewire:storage.create />

--- a/resources/views/source/all.blade.php
+++ b/resources/views/source/all.blade.php
@@ -2,7 +2,7 @@
     <x-slot:title>
         Sources | Coolify
     </x-slot>
-    <div class="flex items-start gap-2">
+    <div class="flex items-center gap-2">
         <h1>Sources</h1>
         <x-modal-input buttonTitle="+ Add" title="New GitHub App" :closeOutside="false">
             <livewire:source.github.create />


### PR DESCRIPTION
## Changes
- align title and `Add` button vertically in various views
  - this is already the case in many views, but it noticed some inconsistencies.


For example

![image](https://github.com/user-attachments/assets/b08f2346-46f8-4026-96b4-b371ed7baef3)

Instead of 

![image](https://github.com/user-attachments/assets/c940f20d-feec-401d-899b-888a27ebfc8b)
