### PR TITLE
fix(api): domain check when updating domain

### DIFF
--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -1681,7 +1681,8 @@ class ApplicationsController extends Controller
             ], 422);
         }
         $domains = $request->domains;
-        if ($request->has('domains') && $server->isProxyShouldRun()) {
+        $requestHasDomains = $request->has('domains');
+        if ($requestHasDomains && $server->isProxyShouldRun()) {
             $uuid = $request->uuid;
             $fqdn = $request->domains;
             $fqdn = str($fqdn)->replaceEnd(',', '')->trim();
@@ -1743,7 +1744,7 @@ class ApplicationsController extends Controller
         removeUnnecessaryFieldsFromRequest($request);
 
         $data = $request->all();
-        if ($request->has('domains') && $server->isProxyShouldRun()) {
+        if ($requestHasDomains && $server->isProxyShouldRun()) {
             data_set($data, 'fqdn', $domains);
         }
 


### PR DESCRIPTION
## Changes
- Fix condition check when updating the application's `domains` through API.

Because the `domains` field was removed in `removeUnnecessaryFieldsFromRequest` on the previous line, make `$request->has('domains')` always `false`.

## Issues
- #4999 
