### PR TITLE
docs(templates): reword nitropage url and slogan

### DIFF
--- a/templates/compose/nitropage-with-postgresql.yaml
+++ b/templates/compose/nitropage-with-postgresql.yaml
@@ -1,5 +1,5 @@
-# documentation: https://nitropage.com
-# slogan: Nitropage is an extensible visual website builder, offering a growing collection of versatile building blocks, focal-point image cropping and sovereign font management.
+# documentation: https://nitropage.org
+# slogan: Nitropage is an extensible, visual website builder, offering a growing library of versatile building blocks, focal-point image cropping and sovereign font management.
 # tags: nitropage, builder, editor, wysiwyg, cms, content, management
 # logo: svgs/nitropage.svg
 # port: 3000

--- a/templates/compose/nitropage.yaml
+++ b/templates/compose/nitropage.yaml
@@ -1,5 +1,5 @@
-# documentation: https://nitropage.com
-# slogan: Nitropage is an extensible visual website builder, offering a growing collection of versatile building blocks, focal-point image cropping and sovereign font management.
+# documentation: https://nitropage.org
+# slogan: Nitropage is an extensible, visual website builder, offering a growing library of versatile building blocks, focal-point image cropping and sovereign font management.
 # tags: nitropage, builder, editor, wysiwyg, cms, content, management
 # logo: svgs/nitropage.svg
 # port: 3000


### PR DESCRIPTION
## Changes
- Renamed the nitropage url to `.org` (the new main TLD)
- Slightly reworded the slogan

## Refs
- Related: coollabsio/documentation-coolify#156
