### PR TITLE
feat(slack): Show message title in notification previews

### DIFF
--- a/app/Jobs/SendMessageToSlackJob.php
+++ b/app/Jobs/SendMessageToSlackJob.php
@@ -24,6 +24,7 @@ class SendMessageToSlackJob implements ShouldQueue
     public function handle(): void
     {
         Http::post($this->webhookUrl, [
+            'text' => $this->message->title,
             'blocks' => [
                 [
                     'type' => 'section',


### PR DESCRIPTION
## Changes

This PR updates `SendMessageToSlackJob` to show the message's title in Slack's notification preview. Before, the notification preview was consistently just "Coolify Notification".

<img width="365" alt="image" src="https://github.com/user-attachments/assets/9488b454-d5e9-4038-80de-69bd98dd0fd7" />

This is accomplished by adding a top-level `text` key to the Slack webhook payload (body).

According to the Slack Block Kit documentation:

> When you're using blocks in your message payload, the top-level text field becomes a fallback message displayed in notifications. Blocks should define everything else about the desired visible message.
> [<sub>Learn More</sub>](https://api.slack.com/reference/surfaces/formatting#add_blocks_array:~:text=message%20payload%2C%20the-,top%2Dlevel,field,-becomes%20a%20fallback)

---

Here's another screenshot of the new notification:

<img width="356" alt="image" src="https://github.com/user-attachments/assets/8c4601e5-ab32-486d-a614-7545c16a7ba2" />

