### PR TITLE
fix(slack): Notification settings URL in `HighDiskUsage` message

### DIFF
--- a/app/Notifications/Server/HighDiskUsage.php
+++ b/app/Notifications/Server/HighDiskUsage.php
@@ -80,7 +80,7 @@ class HighDiskUsage extends CustomEmailNotification
         $description .= "Tips for cleanup: https://coolify.io/docs/knowledge-base/server/automated-cleanup\n";
         $description .= "Change settings:\n";
         $description .= '- Threshold: '.base_url().'/server/'.$this->server->uuid."#advanced\n";
-        $description .= '- Notifications: '.base_url().'/notifications/discord';
+        $description .= '- Notifications: '.base_url().'/notifications/slack';
 
         return new SlackMessage(
             title: 'High disk usage detected',


### PR DESCRIPTION
## Changes
- Change notification settings URL in Slack message from `/notifications/discord` to `/notifications/slack`

