### PR TITLE
fix: system-wide GitHub apps

### DIFF
--- a/app/Models/GithubApp.php
+++ b/app/Models/GithubApp.php
@@ -39,18 +39,20 @@ class GithubApp extends BaseModel
     public static function public()
     {
         return GithubApp::where(function ($query) {
-            $query->where('team_id', currentTeam()->id)
-                ->where('is_public', true)
-                ->orWhere('is_system_wide', true);
+            $query->where(function ($q) {
+                $q->where('team_id', currentTeam()->id)
+                    ->orWhere('is_system_wide', true);
+            })->where('is_public', true);
         })->whereNotNull('app_id')->get();
     }
 
     public static function private()
     {
         return GithubApp::where(function ($query) {
-            $query->where('team_id', currentTeam()->id)
-                ->where('is_public', false)
-                ->orWhere('is_system_wide', true);
+            $query->where(function ($q) {
+                $q->where('team_id', currentTeam()->id)
+                    ->orWhere('is_system_wide', true);
+            })->where('is_public', false);
         })->whereNotNull('app_id')->get();
     }
 

--- a/app/Models/GithubApp.php
+++ b/app/Models/GithubApp.php
@@ -33,7 +33,10 @@ class GithubApp extends BaseModel
 
     public static function ownedByCurrentTeam()
     {
-        return GithubApp::whereTeamId(currentTeam()->id);
+        return GithubApp::where(function ($query) {
+            $query->where('team_id', currentTeam()->id)
+                ->orWhere('is_system_wide', true);
+        });
     }
 
     public static function public()

--- a/app/Models/GithubApp.php
+++ b/app/Models/GithubApp.php
@@ -38,12 +38,20 @@ class GithubApp extends BaseModel
 
     public static function public()
     {
-        return GithubApp::whereTeamId(currentTeam()->id)->whereisPublic(true)->whereNotNull('app_id')->get();
+        return GithubApp::where(function ($query) {
+            $query->where('team_id', currentTeam()->id)
+                ->where('is_public', true)
+                ->orWhere('is_system_wide', true);
+        })->whereNotNull('app_id')->get();
     }
 
     public static function private()
     {
-        return GithubApp::whereTeamId(currentTeam()->id)->whereisPublic(false)->whereNotNull('app_id')->get();
+        return GithubApp::where(function ($query) {
+            $query->where('team_id', currentTeam()->id)
+                ->where('is_public', false)
+                ->orWhere('is_system_wide', true);
+        })->whereNotNull('app_id')->get();
     }
 
     public function team()

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -248,15 +248,17 @@ class Team extends Model implements SendsDiscord, SendsEmail, SendsPushover, Sen
     {
         $sources = collect([]);
         $github_apps = GithubApp::where(function ($query) {
-            $query->where('team_id', $this->id)
-                ->Where('is_public', false)
-                ->orWhere('is_system_wide', true);
+            $query->where(function ($q) {
+                $q->where('team_id', $this->id)
+                    ->orWhere('is_system_wide', true);
+            })->where('is_public', false);
         })->get();
 
         $gitlab_apps = GitlabApp::where(function ($query) {
-            $query->where('team_id', $this->id)
-                ->Where('is_public', false)
-                ->orWhere('is_system_wide', true);
+            $query->where(function ($q) {
+                $q->where('team_id', $this->id)
+                    ->orWhere('is_system_wide', true);
+            })->where('is_public', false);
         })->get();
 
         return $sources->merge($github_apps)->merge($gitlab_apps);


### PR DESCRIPTION
## Changes
- fix(ui): system-wide GitHub Apps are not shown in the create a new Application dialog
- fix: query logic error that shows all system-wide apps, regardless of whether they are public or private.
- fix: clicking on a system-wide GitHub app from a team other than the one that created it resulted in a 404 error.
