### PR TITLE
Fix: Expose Mailpit Web UI (Port 8025)

### DIFF
--- a/templates/compose/mailpit.yaml
+++ b/templates/compose/mailpit.yaml
@@ -9,6 +9,10 @@ services:
     image: axllent/mailpit
     ports:
       - 1025:1025
+      - 8025:8025
+    labels:
+      - 'traefik.http.services.mailpit.loadbalancer.server.port=8025'
+      - 'caddy_0.handle_path.1_reverse_proxy={{upstreams 8025}}'
     volumes:
       - "mailpit-data:/data"
       - type: bind


### PR DESCRIPTION
## Changes

This PR fixes an issue where the Mailpit Web UI (port 8025) was not accessible in Coolify deployments. Previously, only the SMTP port (1025) was exposed, preventing users from accessing Mailpit's web interface for viewing captured emails.

 Changes:
Added port 8025:8025 in Mailpit's deployment to expose the web UI.
Updated Traefik and Caddy configurations to properly route traffic to Mailpit's web interface.

Fixes:
Users can now access Mailpit UI at https://your-domain.com or http://<server-ip>:8025.
No more manual port overrides required for accessing Mailpit’s web inbox.
