### PR TITLE
Update zipline to use new Database env var.

### DIFF
--- a/templates/compose/zipline.yaml
+++ b/templates/compose/zipline.yaml
@@ -11,7 +11,7 @@ services:
       - SERVICE_FQDN_ZIPLINE_3000
       - CORE_RETURN_HTTPS=${CORE_RETURN_HTTPS:-false}
       - CORE_SECRET=${SERVICE_PASSWORD_64_ZIPLINE}
-      - CORE_DATABASE_URL=postgres://${SERVICE_USER_POSTGRES}:${SERVICE_PASSWORD_POSTGRES}@postgres/${POSTGRES_DB:-zipline-db}
+      - DATABASE_URL=postgres://${SERVICE_USER_POSTGRES}:${SERVICE_PASSWORD_POSTGRES}@postgres/${POSTGRES_DB:-zipline-db}
       - CORE_LOGGER=${CORE_LOGGER:-true}
       # Default credentials are "administrator" and "password"
     volumes:

--- a/templates/compose/zipline.yaml
+++ b/templates/compose/zipline.yaml
@@ -12,6 +12,7 @@ services:
       - CORE_RETURN_HTTPS=${CORE_RETURN_HTTPS:-false}
       - CORE_SECRET=${SERVICE_PASSWORD_64_ZIPLINE}
       - DATABASE_URL=postgres://${SERVICE_USER_POSTGRES}:${SERVICE_PASSWORD_POSTGRES}@postgres/${POSTGRES_DB:-zipline-db}
+      - CORE_DATABASE_URL=postgres://${SERVICE_USER_POSTGRES}:${SERVICE_PASSWORD_POSTGRES}@postgres/${POSTGRES_DB:-zipline-db}
       - CORE_LOGGER=${CORE_LOGGER:-true}
       # Default credentials are "administrator" and "password"
     volumes:


### PR DESCRIPTION
## Changes
- Changed Database environment var to new one for newest version of zipline.
- Left old env for backwards compatibility. 

Link to new config docs: https://zipline.diced.sh/docs/config
