### PR TITLE
Update qbittorrent template. Fixed error 500/403 on VueTorrent

### DIFF
--- a/templates/compose/qbittorrent.yaml
+++ b/templates/compose/qbittorrent.yaml
@@ -31,7 +31,7 @@ services:
     environment:
       - SERVICE_FQDN_QBITORRENT_8080
       - PORT=${WEBUI_PORT:-8080}
-      - QBIT_BASE=${SERVICE_FQDN_QBITORRENT}
+      - QBIT_BASE=http://qbit:${WEBUI_PORT:-8080}
       - RELEASE_TYPE=${RELEASE_TYPE:-stable}
       - UPDATE_VT_CRON=${UPDATE_VT_CRON:-"0 * * * *"}
     volumes:


### PR DESCRIPTION
## Submit Checklist
- [x] I have selected the `next` branch as the destination for my PR, not `main`.
- [x] I have listed all changes in the `Changes` section.
- [x] I have filled out the `Issues` section with the issue/discussion link(s) (if applicable).
- [x] I have tested my changes.
- [] I have considered backwards compatibility.


## Changes
- Changed the `QBIT_BASE` environment variable of VueTorrent service, so it points to qbitTorrent properly and not return and error 500 as it's not able to reach qbit.

## Issues
- fixes [this issue](https://discord.com/channels/459365938081431553/1343329431158263848/1343329431158263848) that i've mentioned in the coolLabs discord.

Special thanks to @ruohki which basically figured it out, and helped me out with the problem mentioned in discord.|
LE: I did this twice, as you can see `patch-2` and the second time forgot to select `next` branch, fixed now.