### PR TITLE
Update authentik server and worker images to version 2025.2.1

### DIFF
--- a/templates/compose/authentik.yaml
+++ b/templates/compose/authentik.yaml
@@ -6,7 +6,7 @@
 
 services:
   authentik-server:
-    image: ghcr.io/goauthentik/server:${AUTHENTIK_TAG:-2025.2.0}
+    image: ghcr.io/goauthentik/server:${AUTHENTIK_TAG:-2025.2.1}
     restart: unless-stopped
     command: server
     environment:
@@ -35,7 +35,7 @@ services:
       redis:
         condition: service_healthy
   authentik-worker:
-    image: ghcr.io/goauthentik/server:${AUTHENTIK_TAG:-2025.2.0}
+    image: ghcr.io/goauthentik/server:${AUTHENTIK_TAG:-2025.2.1}
     restart: unless-stopped
     command: worker
     environment:


### PR DESCRIPTION
This pull request includes updates to the `templates/compose/authentik.yaml` file to ensure the use of the latest version of the Authentik server image.

Version updates:

* Updated `authentik-server` service image to use version `2025.2.1` instead of `2025.2.0`.
* Updated `authentik-worker` service image to use version `2025.2.1` instead of `2025.2.0`.
