### PR TITLE
Container Image Fix for Kimai

### DIFF
--- a/templates/compose/kimai.yaml
+++ b/templates/compose/kimai.yaml
@@ -21,7 +21,7 @@ services:
       timeout: 20s
       retries: 10
   kimai:
-    image: kimai/kimai2:apache-latest
+    image: kimai/kimai2:apache
     container_name: kimai
     depends_on:
       mysql:


### PR DESCRIPTION
## Changes
-  use kimai/kimai2:apache instead of the not updated kimai/kimai2:apache-latest container image
