### PR TITLE
fix(issue#4746): Do not use setGitImportSettings inside of generateGitLsRemoteCommands

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -1065,7 +1065,6 @@ class Application extends BaseModel
         if ($this->deploymentType() === 'other') {
             $fullRepoUrl = $customRepository;
             $base_command = "{$base_command} {$customRepository}";
-            $base_command = $this->setGitImportSettings($deployment_uuid, $base_command, public: true);
 
             if ($exec_in_docker) {
                 $commands->push(executeInDocker($deployment_uuid, $base_command));


### PR DESCRIPTION
## Changes
Do not add git import settings to `base_command` by calling setGitImportSettings inside of generateGitLsRemoteCommands. This method is adding a command that will attempt to move inside the artifacts directory `cd /artifacts/{uuid}` which does not exist.

## Issues
- fix #4746
