### PR TITLE
fix(api): use name from request payload

### DIFF
--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -1310,7 +1310,6 @@ class ApplicationsController extends Controller
             $service->destination_type = $destination->getMorphClass();
             $service->save();
 
-            $service->name = "service-$service->uuid";
             $service->parse(isNew: true);
             if ($instantDeploy) {
                 StartService::dispatch($service);


### PR DESCRIPTION
In POST `/applications/dockercompose`  the `name` parameter is required. The API thou ignores it and generates its own name for the service.

## Changes
- Remove force auto generating service name in POST to `/applications/dockercompose` 
