### PR TITLE
feat(api): improve services API

### DIFF
--- a/app/Http/Controllers/Api/ServicesController.php
+++ b/app/Http/Controllers/Api/ServicesController.php
@@ -380,6 +380,190 @@ class ServicesController extends Controller
         return response()->json(['message' => 'Invalid service type.'], 400);
     }
 
+    #[OA\Post(
+        summary: 'Create (compose)',
+        description: 'Create a service',
+        path: '/services',
+        operationId: 'compose-service',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Services'],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\MediaType(
+                mediaType: 'application/json',
+                schema: new OA\Schema(
+                    type: 'object',
+                    required: ['server_uuid', 'project_uuid', 'environment_name', 'environment_uuid', 'docker_compose_raw'],
+                    properties: [
+                        'name' => ['type' => 'string', 'maxLength' => 255, 'description' => 'Name of the service.'],
+                        'description' => ['type' => 'string', 'nullable' => true, 'description' => 'Description of the service.'],
+                        'project_uuid' => ['type' => 'string', 'description' => 'Project UUID.'],
+                        'environment_name' => ['type' => 'string', 'description' => 'Environment name. You need to provide at least one of environment_name or environment_uuid.'],
+                        'environment_uuid' => ['type' => 'string', 'description' => 'Environment UUID. You need to provide at least one of environment_name or environment_uuid.'],
+                        'server_uuid' => ['type' => 'string', 'description' => 'Server UUID.'],
+                        'destination_uuid' => ['type' => 'string', 'description' => 'Destination UUID. Required if server has multiple destinations.'],
+                        'instant_deploy' => ['type' => 'boolean', 'default' => false, 'description' => 'Start the service immediately after creation.'],
+                        'connect_to_docker_network' => ['type' => 'boolean', 'description' => 'The flag to connect the service to the predefined Docker network.'],
+                        'docker_compose_raw' => ['type' => 'string', 'description' => 'The Docker Compose raw content.'],
+
+                    ],
+                ),
+            ),
+        ),
+        responses: [
+            new OA\Response(
+                response: 201,
+                description: 'Create a service.',
+                content: [
+                    new OA\MediaType(
+                        mediaType: 'application/json',
+                        schema: new OA\Schema(
+                            type: 'object',
+                            properties: [
+                                'uuid' => ['type' => 'string', 'description' => 'Service UUID.'],
+                                'domains' => ['type' => 'array', 'items' => ['type' => 'string'], 'description' => 'Service domains.'],
+                            ]
+                        )
+                    ),
+                ]
+            ),
+            new OA\Response(
+                response: 401,
+                ref: '#/components/responses/401',
+            ),
+            new OA\Response(
+                response: 400,
+                ref: '#/components/responses/400',
+            ),
+        ]
+    )]
+    public function compose_service(Request $request)
+    {
+        $allowedFields = ['name', 'description', 'project_uuid', 'environment_name', 'environment_uuid', 'server_uuid', 'destination_uuid', 'instant_deploy', "docker_compose_raw", "connect_to_docker_network"];
+
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+
+        $return = validateIncomingRequest($request);
+        if ($return instanceof \Illuminate\Http\JsonResponse) {
+            return $return;
+        }
+        $validator = customApiValidator($request->all(), [
+            'project_uuid' => 'string|required',
+            'environment_name' => 'string|nullable',
+            'environment_uuid' => 'string|nullable',
+            'server_uuid' => 'string|required',
+            'destination_uuid' => 'string',
+            'name' => 'string|max:255',
+            'description' => 'string|nullable',
+            'instant_deploy' => 'boolean',
+            'connect_to_docker_network' => 'boolean',
+            'docker_compose_raw' => 'string|required',
+
+        ]);
+
+        $extraFields = array_diff(array_keys($request->all()), $allowedFields);
+        if ($validator->fails() || ! empty($extraFields)) {
+            $errors = $validator->errors();
+            if (! empty($extraFields)) {
+                foreach ($extraFields as $field) {
+                    $errors->add($field, 'This field is not allowed.');
+                }
+            }
+
+            return response()->json([
+                'message' => 'Validation failed.',
+                'errors' => $errors,
+            ], 422);
+        }
+        $environmentUuid = $request->environment_uuid;
+        $environmentName = $request->environment_name;
+        if (blank($environmentUuid) && blank($environmentName)) {
+            return response()->json(['message' => 'You need to provide at least one of environment_name or environment_uuid.'], 422);
+        }
+        $serverUuid = $request->server_uuid;
+        $instantDeploy = $request->instant_deploy ?? false;
+        if ($request->is_public && ! $request->public_port) {
+            $request->offsetSet('is_public', false);
+        }
+        $project = Project::whereTeamId($teamId)->whereUuid($request->project_uuid)->first();
+        if (! $project) {
+            return response()->json(['message' => 'Project not found.'], 404);
+        }
+        $environment = $project->environments()->where('name', $environmentName)->first();
+        if (! $environment) {
+            $environment = $project->environments()->where('uuid', $environmentUuid)->first();
+        }
+        if (! $environment) {
+            return response()->json(['message' => 'Environment not found.'], 404);
+        }
+        $server = Server::whereTeamId($teamId)->whereUuid($serverUuid)->first();
+        if (! $server) {
+            return response()->json(['message' => 'Server not found.'], 404);
+        }
+        $destinations = $server->destinations();
+        if ($destinations->count() == 0) {
+            return response()->json(['message' => 'Server has no destinations.'], 400);
+        }
+        if ($destinations->count() > 1 && ! $request->has('destination_uuid')) {
+            return response()->json(['message' => 'Server has multiple destinations and you do not set destination_uuid.'], 400);
+        }
+        $destination = $destinations->first();
+        if (! isBase64Encoded($request->docker_compose_raw)) {
+            return response()->json([
+                'message' => 'Validation failed.',
+                'errors' => [
+                    'docker_compose_raw' => 'The docker_compose_raw should be base64 encoded.',
+                ],
+            ], 422);
+        }
+        $dockerComposeRaw = base64_decode($request->docker_compose_raw);
+        if (mb_detect_encoding($dockerComposeRaw, 'ASCII', true) === false) {
+            return response()->json([
+                'message' => 'Validation failed.',
+                'errors' => [
+                    'docker_compose_raw' => 'The docker_compose_raw should be base64 encoded.',
+                ],
+            ], 422);
+        }
+        $dockerCompose = base64_decode($request->docker_compose_raw);
+        $dockerComposeRaw = Yaml::dump(Yaml::parse($dockerCompose), 10, 2, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK);
+
+        $service = new Service;
+        $service->fill($request->all());
+
+        $service->docker_compose_raw = $dockerComposeRaw;
+        $service->environment_id = $environment->id;
+        $service->server_id = $server->id;
+        $service->destination_id = $destination->id;
+        $service->destination_type = $destination->getMorphClass();
+        $service->save();
+
+
+        $service->parse(isNew: true);
+        if ($instantDeploy) {
+            StartService::dispatch($service);
+        }
+
+        $domains = $service->applications()->get()->pluck('fqdn')->sort();
+        $domains = $domains->map(function ($domain) {
+            if (count(explode(':', $domain)) > 2) {
+                return str($domain)->beforeLast(':')->value();
+            }
+
+            return $domain;
+        });
+
+        return response()->json([
+            'uuid' => $service->uuid,
+            'domains' => $domains,
+        ]);
+    }
+
     #[OA\Get(
         summary: 'Get',
         description: 'Get service by UUID.',

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1494,6 +1494,49 @@ paths:
       security:
         -
           bearerAuth: []
+  '/applications/{uuid}/logs':
+    get:
+      tags:
+        - Applications
+      summary: 'Get application logs.'
+      description: 'Get application logs by UUID.'
+      operationId: get-application-logs-by-uuid
+      parameters:
+        -
+          name: uuid
+          in: path
+          description: 'UUID of the application.'
+          required: true
+          schema:
+            type: string
+            format: uuid
+        -
+          name: lines
+          in: query
+          description: 'Number of lines to show from the end of the logs.'
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 100
+      responses:
+        '200':
+          description: 'Get application logs by UUID.'
+          content:
+            application/json:
+              schema:
+                properties:
+                  logs: { type: string }
+                type: object
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+        '404':
+          $ref: '#/components/responses/404'
+      security:
+        -
+          bearerAuth: []
   '/applications/{uuid}/envs':
     get:
       tags:
@@ -3953,8 +3996,79 @@ paths:
       tags:
         - Services
       summary: Create
-      description: 'Create a one-click service'
+      description: 'Create a service'
       operationId: create-service
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - server_uuid
+                - project_uuid
+                - environment_name
+                - environment_uuid
+                - docker_compose_raw
+              properties:
+                name:
+                  type: string
+                  maxLength: 255
+                  description: 'Name of the service.'
+                description:
+                  type: string
+                  nullable: true
+                  description: 'Description of the service.'
+                project_uuid:
+                  type: string
+                  description: 'Project UUID.'
+                environment_name:
+                  type: string
+                  description: 'Environment name. You need to provide at least one of environment_name or environment_uuid.'
+                environment_uuid:
+                  type: string
+                  description: 'Environment UUID. You need to provide at least one of environment_name or environment_uuid.'
+                server_uuid:
+                  type: string
+                  description: 'Server UUID.'
+                destination_uuid:
+                  type: string
+                  description: 'Destination UUID. Required if server has multiple destinations.'
+                instant_deploy:
+                  type: boolean
+                  default: false
+                  description: 'Start the service immediately after creation.'
+                connect_to_docker_network:
+                  type: boolean
+                  default: false
+                  description: 'The flag to connect the service to the predefined Docker network.'
+                docker_compose_raw:
+                  type: string
+                  description: 'The Docker Compose raw content.'
+              type: object
+      responses:
+        '201':
+          description: 'Service created successfully.'
+          content:
+            application/json:
+              schema:
+                properties:
+                  uuid: { type: string, description: 'Service UUID.' }
+                  domains: { type: array, items: { type: string }, description: 'Service domains.' }
+                type: object
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+      security:
+        -
+          bearerAuth: []
+  /services/one-click:
+    post:
+      tags:
+        - Services
+      summary: 'Create one-click'
+      description: 'Create a one-click service'
+      operationId: create-one-click-service
       requestBody:
         required: true
         content:
@@ -4001,7 +4115,7 @@ paths:
               type: object
       responses:
         '201':
-          description: 'Create a service.'
+          description: 'Service created successfully.'
           content:
             application/json:
               schema:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4053,7 +4053,7 @@ paths:
               schema:
                 properties:
                   uuid: { type: string, description: 'Service UUID.' }
-                  domains: { type: array, items: { type: string }, description: 'Service domains.' }
+                  domains: { type: array, items: { type: string, nullable: true }, description: 'Service domains.' }
                 type: object
         '401':
           $ref: '#/components/responses/401'
@@ -4215,6 +4215,76 @@ paths:
               schema:
                 properties:
                   message: { type: string, example: 'Service deletion request queued.' }
+                type: object
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+        '404':
+          $ref: '#/components/responses/404'
+      security:
+        -
+          bearerAuth: []
+    patch:
+      tags:
+        - Services
+      summary: Update
+      description: 'Update service by UUID.'
+      operationId: update-service-by-uuid
+      requestBody:
+        description: 'Service updated.'
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - server_uuid
+                - project_uuid
+                - environment_name
+                - environment_uuid
+                - docker_compose_raw
+              properties:
+                name:
+                  type: string
+                  description: 'The service name.'
+                description:
+                  type: string
+                  description: 'The service description.'
+                project_uuid:
+                  type: string
+                  description: 'The project UUID.'
+                environment_name:
+                  type: string
+                  description: 'The environment name.'
+                environment_uuid:
+                  type: string
+                  description: 'The environment UUID.'
+                server_uuid:
+                  type: string
+                  description: 'The server UUID.'
+                destination_uuid:
+                  type: string
+                  description: 'The destination UUID.'
+                instant_deploy:
+                  type: boolean
+                  description: 'The flag to indicate if the service should be deployed instantly.'
+                connect_to_docker_network:
+                  type: boolean
+                  default: false
+                  description: 'The flag to connect the service to the predefined Docker network.'
+                docker_compose_raw:
+                  type: string
+                  description: 'The Docker Compose raw content.'
+              type: object
+      responses:
+        '200':
+          description: 'Service updated.'
+          content:
+            application/json:
+              schema:
+                properties:
+                  uuid: { type: string, description: 'Service UUID.' }
+                  domains: { type: array, items: { type: string }, description: 'Service domains.' }
                 type: object
         '401':
           $ref: '#/components/responses/401'

--- a/routes/api.php
+++ b/routes/api.php
@@ -114,7 +114,7 @@ Route::group([
 
     Route::get('/services', [ServicesController::class, 'services'])->middleware(['api.ability:read']);
     Route::post('/services', [ServicesController::class, 'create_service'])->middleware(['api.ability:write']);
-    Route::post('/services/compose', [ServicesController::class, 'compose_service'])->middleware(['api.ability:write']);
+    Route::post('/services/one-click', [ServicesController::class, 'create_one_click_service'])->middleware(['api.ability:write']);
 
     Route::get('/services/{uuid}', [ServicesController::class, 'service_by_uuid'])->middleware(['api.ability:read']);
     // Route::patch('/services/{uuid}', [ServicesController::class, 'update_by_uuid'])->middleware(['ability:write']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -117,7 +117,7 @@ Route::group([
     Route::post('/services/one-click', [ServicesController::class, 'create_one_click_service'])->middleware(['api.ability:write']);
 
     Route::get('/services/{uuid}', [ServicesController::class, 'service_by_uuid'])->middleware(['api.ability:read']);
-    // Route::patch('/services/{uuid}', [ServicesController::class, 'update_by_uuid'])->middleware(['ability:write']);
+    Route::patch('/services/{uuid}', [ServicesController::class, 'update_by_uuid'])->middleware(['ability:write']);
     Route::delete('/services/{uuid}', [ServicesController::class, 'delete_by_uuid'])->middleware(['api.ability:write']);
 
     Route::get('/services/{uuid}/envs', [ServicesController::class, 'envs'])->middleware(['api.ability:read']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -114,6 +114,7 @@ Route::group([
 
     Route::get('/services', [ServicesController::class, 'services'])->middleware(['api.ability:read']);
     Route::post('/services', [ServicesController::class, 'create_service'])->middleware(['api.ability:write']);
+    Route::post('/services/compose', [ServicesController::class, 'compose_service'])->middleware(['api.ability:write']);
 
     Route::get('/services/{uuid}', [ServicesController::class, 'service_by_uuid'])->middleware(['api.ability:read']);
     // Route::patch('/services/{uuid}', [ServicesController::class, 'update_by_uuid'])->middleware(['ability:write']);


### PR DESCRIPTION
Improve the services API allowing  creating custom services with their own Docker Compose file and updating all other services.

## Changes
- Moves POST /services to /services/one-click
- Adds POST `/services` API to create a custom service with custom Docker Compose
- Adds PATCH `/services/{uuid} to update a service.`
- Adds support for the `connect_to_docker_network` property of Service model 
- Adds private upsert_service function in ServicesController to reuse create/update logic
- Forces returned `domains` to be an Array instead of  sometimes and Object.
- Updates OpenAPI