### PR TITLE
change cleanup logic when restarting containers

### DIFF
--- a/app/Actions/Database/StopDatabase.php
+++ b/app/Actions/Database/StopDatabase.php
@@ -26,7 +26,7 @@ class StopDatabase
         }
 
         $this->stopContainer($database, $database->uuid, 300);
-        if (! $isDeleteOperation) {
+        if ($isDeleteOperation) {
             if ($dockerCleanup) {
                 CleanupDocker::dispatch($server, true);
             }

--- a/app/Actions/Service/StopService.php
+++ b/app/Actions/Service/StopService.php
@@ -23,7 +23,7 @@ class StopService
             $containersToStop = $service->getContainersToStop();
             $service->stopContainers($containersToStop, $server);
 
-            if (! $isDeleteOperation) {
+            if ($isDeleteOperation) {
                 $service->delete_connected_networks($service->uuid);
                 if ($dockerCleanup) {
                     CleanupDocker::dispatch($server, true);


### PR DESCRIPTION
Currently when restarting containers (service/database) it first stops the containers, then it checks if this is NOT a delete operation and if that's true it then runs docker cleanup, potentially deleting the volumes if this is enabled in cleanup, before the containers are restarted.

This reverses the logic, such that the cleanup is only ran when this IS a delete operation 