### PR TITLE
fix(templates): Fix new path for glance.yaml config

### DIFF
--- a/templates/compose/glance.yaml
+++ b/templates/compose/glance.yaml
@@ -12,7 +12,7 @@ services:
     volumes:
       - type: bind
         source: ./glance-settings
-        target: /app/glance.yml
+        target: /app/config/glance.yml
         content: |
           pages:
             - name: Home


### PR DESCRIPTION
### Per Glance v 0.7.0, the path for the glance.yml has changed and this current template needs to be updated otherwise every deployment of this service runs into an initial issue.

## Changes
- Change the path of the volume as per the Glance upgrade
- Before when running this template:
![CleanShot 2025-03-24 at 22 35 14@2x](https://github.com/user-attachments/assets/58b292e4-3e9c-4b33-bb8e-2c9d6acff192)

- After when running this template:
![CleanShot 2025-03-24 at 22 38 47@2x](https://github.com/user-attachments/assets/19950720-6a4e-498d-bf1e-09d6ff9275bb)

