### PR TITLE
fix google setup in plausible template

### DIFF
--- a/templates/compose/plausible.yaml
+++ b/templates/compose/plausible.yaml
@@ -15,6 +15,8 @@ services:
       - BASE_URL=${SERVICE_FQDN_PLAUSIBLE}
       - SECRET_KEY_BASE=${SERVICE_BASE64_64_PLAUSIBLE}
       - TOTP_VAULT_KEY=${SERVICE_REALBASE64_32_TOTP}
+      - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
+      - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
     depends_on:
       plausible-db:
         condition: service_healthy


### PR DESCRIPTION
I have had some issues getting the google oauth to work.

According to the Plausible [docs](https://github.com/plausible/community-edition/wiki/google-integration) you need to set the following environment variables:
```
GOOGLE_CLIENT_ID=
GOOGLE_CLIENT_SECRET=
```
These were not passed to the container, so that is what I did and it fixed the issue for me. Contributing the fix now so other people do not have to debug this.

## Changes
- Passed GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET to plausible container in template
