### PR TITLE
Feat(api): Add Pull Request deployment support to WebHooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ All notable changes to this project will be documented in this file.
 
 ### 🚀 Features
 
+- *(database)* Disable MongoDB SSL by default in migration
+
+### 🚜 Refactor
+
+- *(proxy)* Improve port availability checks with multiple methods
+- *(database)* Update MongoDB SSL configuration for improved security
+- *(database)* Enhance SSL configuration handling for various databases
+- *(notifications)* Update Telegram button URL for staging environment
+- *(models)* Remove unnecessary cloud check in isEnabled method
+- *(database)* Streamline event listeners in Redis General component
+- *(database)* Remove redundant database status display in MongoDB view
+- *(database)* Update import statements for Auth in database components
+- *(database)* Require PEM key file for SSL certificate regeneration
+- *(database)* Change MySQL daemon command to MariaDB daemon
+
+## [4.0.0-beta.399] - 2025-03-25
+
+### 🚀 Features
+
 - *(service)* Neon
 - *(migration)* Add `ssl_certificates` table and model
 - *(migration)* Add ssl setting to `standalone_postgresqls` table
@@ -159,12 +178,15 @@ All notable changes to this project will be documented in this file.
 - *(invite-link)* Adjust layout for better responsiveness in form
 - *(invite-link)* Enhance form layout for improved responsiveness
 - *(network)* Enhance docker network creation with ipv6 fallback
+- *(network)* Check for existing coolify network before creation
+- *(database)* Enhance encryption process for local file volumes
 
 ### 📚 Documentation
 
 - Update changelog
 - Update changelog
 - *(CONTRIBUTING)* Add note about Laravel Horizon accessibility
+- Update changelog
 
 ### ⚙️ Miscellaneous Tasks
 
@@ -176,6 +198,7 @@ All notable changes to this project will be documented in this file.
 - *(ui)* Improve valid until handling
 - Improve code quality suggested by code rabbit
 - *(supabase)* Update Supabase service template and Postgres image version
+- *(versions)* Update version numbers for coolify and nightly
 
 ## [4.0.0-beta.398] - 2025-03-01
 

--- a/app/Http/Controllers/Api/DeployController.php
+++ b/app/Http/Controllers/Api/DeployController.php
@@ -188,7 +188,7 @@ class DeployController extends Controller
         $uuids = $request->query->get('uuid');
         $tags = $request->query->get('tag');
         $force = $request->query->get('force') ?? false;
-        $pr = $request->query->get('pr');
+        $pr = $request->query->get('pr') ? (int) $request->query->get('pr') : 0;
 
 
         if ($uuids && $tags) {

--- a/app/Http/Controllers/Api/DeployController.php
+++ b/app/Http/Controllers/Api/DeployController.php
@@ -188,8 +188,7 @@ class DeployController extends Controller
         $uuids = $request->query->get('uuid');
         $tags = $request->query->get('tag');
         $force = $request->query->get('force') ?? false;
-        $pr = $request->query->get('pr') ? (int) $request->query->get('pr') : 0;
-
+        $pr = $request->query->get('pr') ? max((int) $request->query->get('pr'), 0) : 0;
 
         if ($uuids && $tags) {
             return response()->json(['message' => 'You can only use uuid or tag, not both.'], 400);

--- a/app/Http/Controllers/Api/DeployController.php
+++ b/app/Http/Controllers/Api/DeployController.php
@@ -142,7 +142,7 @@ class DeployController extends Controller
             new OA\Parameter(name: 'tag', in: 'query', description: 'Tag name(s). Comma separated list is also accepted.', schema: new OA\Schema(type: 'string')),
             new OA\Parameter(name: 'uuid', in: 'query', description: 'Resource UUID(s). Comma separated list is also accepted.', schema: new OA\Schema(type: 'string')),
             new OA\Parameter(name: 'force', in: 'query', description: 'Force rebuild (without cache)', schema: new OA\Schema(type: 'boolean')),
-            new OA\Parameter(name: 'pr', in: 'query', description: 'Pull Request Id', schema: new OA\Schema(type: 'integer')),
+            new OA\Parameter(name: 'pr', in: 'query', description: 'Pull Request Id for deploying specific PR builds. Cannot be used with tag parameter.', schema: new OA\Schema(type: 'integer')),
         ],
 
         responses: [

--- a/app/Http/Controllers/Api/DeployController.php
+++ b/app/Http/Controllers/Api/DeployController.php
@@ -185,6 +185,11 @@ class DeployController extends Controller
     public function deploy(Request $request)
     {
         $teamId = getTeamIdFromToken();
+
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+
         $uuids = $request->query->get('uuid');
         $tags = $request->query->get('tag');
         $force = $request->query->get('force') ?? false;
@@ -192,9 +197,6 @@ class DeployController extends Controller
 
         if ($uuids && $tags) {
             return response()->json(['message' => 'You can only use uuid or tag, not both.'], 400);
-        }
-        if (is_null($teamId)) {
-            return invalidTokenResponse();
         }
         if ($tags && $pr) {
             return response()->json(['message' => 'You can only use tag or pr, not both.'], 400);

--- a/openapi.json
+++ b/openapi.json
@@ -4477,6 +4477,14 @@
                         "schema": {
                             "type": "boolean"
                         }
+                    },
+                    {
+                        "name": "pr",
+                        "in": "query",
+                        "description": "Pull request ID",
+                        "schema": {
+                            "type": "integer"
+                        }
                     }
                 ],
                 "responses": {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3152,6 +3152,12 @@ paths:
           description: 'Force rebuild (without cache)'
           schema:
             type: boolean
+        -
+          name: pr
+          in: query
+          description: 'Pull request id'
+          schema:
+            type: integer
       responses:
         '200':
           description: "Get deployment(s) UUID's"


### PR DESCRIPTION
## Changes
- Added pr query parameter to /deploy endpoint to allow deploying specific Pull Requests
- Updated OpenAPI documentation to include the new parameter
- Added validation to prevent using both tag and pr parameters together
- Modified deployment logic to pass Pull Request ID to the deployment queue
- Ensured backward compatibility with existing API consumers


