### PR TITLE
feat(api): update OpenAPI def for services

### DIFF
--- a/app/Http/Controllers/Api/ServicesController.php
+++ b/app/Http/Controllers/Api/ServicesController.php
@@ -103,7 +103,7 @@ class ServicesController extends Controller
                 mediaType: 'application/json',
                 schema: new OA\Schema(
                     type: 'object',
-                    required: ['server_uuid', 'project_uuid', 'environment_name', 'environment_uuid', 'type'],
+                    required: ['server_uuid', 'project_uuid', 'environment_name', 'environment_uuid'],
                     properties: [
                         'type' => [
                             'description' => 'The one-click service type',
@@ -205,6 +205,7 @@ class ServicesController extends Controller
                         'server_uuid' => ['type' => 'string', 'description' => 'Server UUID.'],
                         'destination_uuid' => ['type' => 'string', 'description' => 'Destination UUID. Required if server has multiple destinations.'],
                         'instant_deploy' => ['type' => 'boolean', 'default' => false, 'description' => 'Start the service immediately after creation.'],
+                        'docker_compose_raw' => ['type' => 'string', 'description' => 'The Docker Compose raw content.'],
                     ],
                 ),
             ),

--- a/app/Http/Controllers/Api/ServicesController.php
+++ b/app/Http/Controllers/Api/ServicesController.php
@@ -257,7 +257,7 @@ class ServicesController extends Controller
             'environment_name' => 'string|nullable',
             'environment_uuid' => 'string|nullable',
             'server_uuid' => 'string|required',
-            'destination_uuid' => 'string',
+            'destination_uuid' => 'string|nullable',
             'name' => 'string|max:255',
             'description' => 'string|nullable',
             'instant_deploy' => 'boolean',

--- a/openapi.json
+++ b/openapi.json
@@ -5974,8 +5974,7 @@
                                     "server_uuid",
                                     "project_uuid",
                                     "environment_name",
-                                    "environment_uuid",
-                                    "type"
+                                    "environment_uuid"
                                 ],
                                 "properties": {
                                     "type": {
@@ -6104,6 +6103,10 @@
                                         "type": "boolean",
                                         "default": false,
                                         "description": "Start the service immediately after creation."
+                                    },
+                                    "docker_compose_raw": {
+                                        "type": "string",
+                                        "description": "The Docker Compose raw content."
                                     }
                                 },
                                 "type": "object"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4037,7 +4037,6 @@ paths:
                 - project_uuid
                 - environment_name
                 - environment_uuid
-                - type
               properties:
                 type:
                   description: 'The one-click service type'
@@ -4070,6 +4069,9 @@ paths:
                   type: boolean
                   default: false
                   description: 'Start the service immediately after creation.'
+                docker_compose_raw:
+                  type: string
+                  description: 'The Docker Compose raw content.'
               type: object
       responses:
         '201':


### PR DESCRIPTION
Update the OpenAPI definition for services:
 - Adds `docker_compose_raw`
 - Make `type` and `docker_compose_raw` optional in OpenAPI defs althou one of the is required by validation.
