### PR TITLE
Bugsink: add health check to 'web' image

### DIFF
--- a/templates/compose/bugsink.yaml
+++ b/templates/compose/bugsink.yaml
@@ -36,6 +36,11 @@ services:
     depends_on:
       mysql:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "python -c 'import requests; requests.get(\"http://localhost:8000/\").raise_for_status()'"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
 
 volumes:
   my-datavolume:


### PR DESCRIPTION
Discussed here: https://github.com/bugsink/bugsink/issues/46

A minimal healthcheck (just fetch the homepage).

## Changes

- Adds a healthcheck to the Bugsink compose template. 