### PR TITLE
fix: Contribute Service URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,7 +238,7 @@ After completing these steps, you'll have a fresh development setup.
 ### Contributing a New Service
 
 To add a new service to Coolify, please refer to our documentation:
-[Adding a New Service](https://coolify.io/docs/knowledge-base/contribute/service)
+[Adding a New Service](https://coolify.io/docs/get-started/contribute/service)
 
 ### Contributing to Documentation
 


### PR DESCRIPTION
## Changes
- URL in the `CONTRIBUTING.md` for adding a service 404'd so replaced with the working link
