### PR TITLE
fix(supabase): update Postgres image to 15.8.1.065

### DIFF
--- a/templates/compose/supabase.yaml
+++ b/templates/compose/supabase.yaml
@@ -318,7 +318,7 @@ services:
       # NEXT_ANALYTICS_BACKEND_PROVIDER=bigquery
       - 'OPENAI_API_KEY=${OPENAI_API_KEY}'
   supabase-db:
-    image: supabase/postgres:15.8.1.048
+    image: supabase/postgres:15.8.1.065
     healthcheck:
       test: pg_isready -U postgres -h 127.0.0.1
       interval: 5s


### PR DESCRIPTION
## Changes
- Updated Supabase/Postgres Docker image to `15.8.1.065` to remove the unwanted miner (`xmrig`) included in the Nix packages.

## Issues
- Fixes an issue where some dependencies in the Supabase/Postgres Docker image included a cryptocurrency miner (`xmrig`).
- Reported by Coolify users.

## Notes
- The updated image is `supabase/postgres:15.8.1.065`, which is the latest stable release.
- This change ensures security and prevents unnecessary resource usage.

