### PR TITLE
(fatal): Add back validateDataApplications

### DIFF
--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -3006,73 +3006,73 @@ class ApplicationsController extends Controller
     //     ]);
     // }
 
-    // private function validateDataApplications(Request $request, Server $server)
-    // {
-    //     $teamId = getTeamIdFromToken();
+     private function validateDataApplications(Request $request, Server $server)
+     {
+         $teamId = getTeamIdFromToken();
 
-    //     // Validate ports_mappings
-    //     if ($request->has('ports_mappings')) {
-    //         $ports = [];
-    //         foreach (explode(',', $request->ports_mappings) as $portMapping) {
-    //             $port = explode(':', $portMapping);
-    //             if (in_array($port[0], $ports)) {
-    //                 return response()->json([
-    //                     'message' => 'Validation failed.',
-    //                     'errors' => [
-    //                         'ports_mappings' => 'The first number before : should be unique between mappings.',
-    //                     ],
-    //                 ], 422);
-    //             }
-    //             $ports[] = $port[0];
-    //         }
-    //     }
-    //     // Validate custom_labels
-    //     if ($request->has('custom_labels')) {
-    //         if (! isBase64Encoded($request->custom_labels)) {
-    //             return response()->json([
-    //                 'message' => 'Validation failed.',
-    //                 'errors' => [
-    //                     'custom_labels' => 'The custom_labels should be base64 encoded.',
-    //                 ],
-    //             ], 422);
-    //         }
-    //         $customLabels = base64_decode($request->custom_labels);
-    //         if (mb_detect_encoding($customLabels, 'ASCII', true) === false) {
-    //             return response()->json([
-    //                 'message' => 'Validation failed.',
-    //                 'errors' => [
-    //                     'custom_labels' => 'The custom_labels should be base64 encoded.',
-    //                 ],
-    //             ], 422);
-    //         }
-    //     }
-    //     if ($request->has('domains') && $server->isProxyShouldRun()) {
-    //         $uuid = $request->uuid;
-    //         $fqdn = $request->domains;
-    //         $fqdn = str($fqdn)->replaceEnd(',', '')->trim();
-    //         $fqdn = str($fqdn)->replaceStart(',', '')->trim();
-    //         $errors = [];
-    //         $fqdn = str($fqdn)->trim()->explode(',')->map(function ($domain) use (&$errors) {
-    //             if (filter_var($domain, FILTER_VALIDATE_URL) === false) {
-    //                 $errors[] = 'Invalid domain: '.$domain;
-    //             }
+         // Validate ports_mappings
+         if ($request->has('ports_mappings')) {
+             $ports = [];
+             foreach (explode(',', $request->ports_mappings) as $portMapping) {
+                 $port = explode(':', $portMapping);
+                 if (in_array($port[0], $ports)) {
+                     return response()->json([
+                         'message' => 'Validation failed.',
+                         'errors' => [
+                             'ports_mappings' => 'The first number before : should be unique between mappings.',
+                         ],
+                     ], 422);
+                 }
+                 $ports[] = $port[0];
+             }
+         }
+         // Validate custom_labels
+         if ($request->has('custom_labels')) {
+             if (! isBase64Encoded($request->custom_labels)) {
+                 return response()->json([
+                     'message' => 'Validation failed.',
+                     'errors' => [
+                         'custom_labels' => 'The custom_labels should be base64 encoded.',
+                     ],
+                 ], 422);
+             }
+             $customLabels = base64_decode($request->custom_labels);
+             if (mb_detect_encoding($customLabels, 'ASCII', true) === false) {
+                 return response()->json([
+                     'message' => 'Validation failed.',
+                     'errors' => [
+                         'custom_labels' => 'The custom_labels should be base64 encoded.',
+                     ],
+                 ], 422);
+             }
+         }
+         if ($request->has('domains') && $server->isProxyShouldRun()) {
+             $uuid = $request->uuid;
+             $fqdn = $request->domains;
+             $fqdn = str($fqdn)->replaceEnd(',', '')->trim();
+             $fqdn = str($fqdn)->replaceStart(',', '')->trim();
+             $errors = [];
+             $fqdn = str($fqdn)->trim()->explode(',')->map(function ($domain) use (&$errors) {
+                 if (filter_var($domain, FILTER_VALIDATE_URL) === false) {
+                     $errors[] = 'Invalid domain: '.$domain;
+                 }
 
-    //             return str($domain)->trim()->lower();
-    //         });
-    //         if (count($errors) > 0) {
-    //             return response()->json([
-    //                 'message' => 'Validation failed.',
-    //                 'errors' => $errors,
-    //             ], 422);
-    //         }
-    //         if (checkIfDomainIsAlreadyUsed($fqdn, $teamId, $uuid)) {
-    //             return response()->json([
-    //                 'message' => 'Validation failed.',
-    //                 'errors' => [
-    //                     'domains' => 'One of the domain is already used.',
-    //                 ],
-    //             ], 422);
-    //         }
-    //     }
-    // }
+                 return str($domain)->trim()->lower();
+             });
+             if (count($errors) > 0) {
+                 return response()->json([
+                     'message' => 'Validation failed.',
+                     'errors' => $errors,
+                 ], 422);
+             }
+             if (checkIfDomainIsAlreadyUsed($fqdn, $teamId, $uuid)) {
+                 return response()->json([
+                     'message' => 'Validation failed.',
+                     'errors' => [
+                         'domains' => 'One of the domain is already used.',
+                     ],
+                 ], 422);
+             }
+         }
+     }
 }


### PR DESCRIPTION
@peaklabs-dev

## Changes
- Revert removal of `validateDataApplications` which happened in https://github.com/coollabsio/coolify/commit/1384de7566df186c90e7c0c9030fa4289b1d3931
  - This method is used in several locations and thus causes fatal errors on call
    - https://github.com/coollabsio/coolify/blob/eda9a16e4b18483f70eb1fdcf4265778f3c1065d/app/Http/Controllers/Api/ApplicationsController.php#L831
    - https://github.com/coollabsio/coolify/blob/eda9a16e4b18483f70eb1fdcf4265778f3c1065d/app/Http/Controllers/Api/ApplicationsController.php#L927
    - https://github.com/coollabsio/coolify/blob/eda9a16e4b18483f70eb1fdcf4265778f3c1065d/app/Http/Controllers/Api/ApplicationsController.php#L1052
    - https://github.com/coollabsio/coolify/blob/eda9a16e4b18483f70eb1fdcf4265778f3c1065d/app/Http/Controllers/Api/ApplicationsController.php#L1137
    - https://github.com/coollabsio/coolify/blob/eda9a16e4b18483f70eb1fdcf4265778f3c1065d/app/Http/Controllers/Api/ApplicationsController.php#L1223
    - https://github.com/coollabsio/coolify/blob/eda9a16e4b18483f70eb1fdcf4265778f3c1065d/app/Http/Controllers/Api/ApplicationsController.php#L1301
    - https://github.com/coollabsio/coolify/blob/eda9a16e4b18483f70eb1fdcf4265778f3c1065d/app/Http/Controllers/Api/ApplicationsController.php#L1792
