### PR TITLE
enhance: Add missing UUID to openapi spec

### DIFF
--- a/app/Http/Controllers/Api/DeployController.php
+++ b/app/Http/Controllers/Api/DeployController.php
@@ -333,6 +333,40 @@ class DeployController extends Controller
             ['bearerAuth' => []],
         ],
         tags: ['Deployments'],
+        parameters: [
+            new OA\Parameter(
+                name: 'uuid',
+                in: 'path',
+                description: 'UUID of the application.',
+                required: true,
+                schema: new OA\Schema(
+                    type: 'string',
+                    format: 'uuid',
+                )
+            ),
+            new OA\Parameter(
+                name: 'skip',
+                in: 'query',
+                description: 'Number of records to skip.',
+                required: false,
+                schema: new OA\Schema(
+                    type: 'integer',
+                    minimum: 0,
+                    default: 0,
+                )
+            ),
+            new OA\Parameter(
+                name: 'take',
+                in: 'query',
+                description: 'Number of records to take.',
+                required: false,
+                schema: new OA\Schema(
+                    type: 'integer',
+                    minimum: 1,
+                    default: 10,
+                )
+            ),
+        ],
         responses: [
             new OA\Response(
                 response: 200,

--- a/app/Http/Controllers/Api/ProjectController.php
+++ b/app/Http/Controllers/Api/ProjectController.php
@@ -267,6 +267,18 @@ class ProjectController extends Controller
             ['bearerAuth' => []],
         ],
         tags: ['Projects'],
+        parameters: [
+            new OA\Parameter(
+                name: 'uuid',
+                in: 'path',
+                description: 'UUID of the project.',
+                required: true,
+                schema: new OA\Schema(
+                    type: 'string',
+                    format: 'uuid',
+                )
+            ),
+        ],
         requestBody: new OA\RequestBody(
             required: true,
             description: 'Project updated.',

--- a/app/Http/Controllers/Api/ServicesController.php
+++ b/app/Http/Controllers/Api/ServicesController.php
@@ -527,6 +527,18 @@ class ServicesController extends Controller
             ['bearerAuth' => []],
         ],
         tags: ['Services'],
+        parameters: [
+            new OA\Parameter(
+                name: 'uuid',
+                in: 'path',
+                description: 'UUID of the service.',
+                required: true,
+                schema: new OA\Schema(
+                    type: 'string',
+                    format: 'uuid',
+                )
+            ),
+        ],
         requestBody: new OA\RequestBody(
             description: 'Service updated.',
             required: true,

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1277,6 +1277,15 @@ paths:
       summary: Update
       description: 'Update application by UUID.'
       operationId: update-application-by-uuid
+      parameters:
+        -
+          name: uuid
+          in: path
+          description: 'UUID of the application.'
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         description: 'Application updated.'
         required: true
@@ -3135,6 +3144,33 @@ paths:
       summary: 'List application deployments'
       description: 'List application deployments by using the app uuid'
       operationId: list-deployments-by-app-uuid
+      parameters:
+        -
+          name: uuid
+          in: path
+          description: 'UUID of the application.'
+          required: true
+          schema:
+            type: string
+            format: uuid
+        -
+          name: skip
+          in: query
+          description: 'Number of records to skip.'
+          required: false
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+        -
+          name: take
+          in: query
+          description: 'Number of records to take.'
+          required: false
+          schema:
+            type: integer
+            default: 10
+            minimum: 1
       responses:
         '200':
           description: 'List application deployments by using the app uuid.'
@@ -3377,6 +3413,15 @@ paths:
       summary: Update
       description: 'Update Project.'
       operationId: update-project-by-uuid
+      parameters:
+        -
+          name: uuid
+          in: path
+          description: 'UUID of the project.'
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         description: 'Project updated.'
         required: true
@@ -3630,6 +3675,14 @@ paths:
           $ref: '#/components/responses/400'
         '404':
           description: 'Private Key not found.'
+        '422':
+          description: 'Private Key is in use and cannot be deleted.'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message: { type: string, example: 'Private Key is in use and cannot be deleted.' }
+                type: object
       security:
         -
           bearerAuth: []
@@ -4145,6 +4198,15 @@ paths:
       summary: Update
       description: 'Update service by UUID.'
       operationId: update-service-by-uuid
+      parameters:
+        -
+          name: uuid
+          in: path
+          description: 'UUID of the service.'
+          required: true
+          schema:
+            type: string
+            format: uuid
       requestBody:
         description: 'Service updated.'
         required: true
@@ -4769,6 +4831,10 @@ components:
           type: string
           nullable: true
           description: 'Ports mappings.'
+        custom_network_aliases:
+          type: string
+          nullable: true
+          description: 'Network aliases for Docker container.'
         base_directory:
           type: string
           description: 'Base directory for all commands.'


### PR DESCRIPTION
## Changes
- Add UUID to openapi spec where it is missing
- Regenerate YAML spec but cannot get php working on my machine if somebody could generate it using artisan (for json spec)

The reason for the changes im testing Golang client code generation for the CLI and without these definitions the SDK generation throws an error.

Also sorry for the lint on the code that wasnt modified it just remove the extra space, purely linting.