### PR TITLE
fix(mongodb): Also apply custom config when SSL is enabled

### DIFF
--- a/app/Actions/Database/StartMongodb.php
+++ b/app/Actions/Database/StartMongodb.php
@@ -217,6 +217,10 @@ class StartMongodb
         if ($this->database->enable_ssl) {
             $commandParts = ['mongod'];
 
+            if (! empty($this->database->mongo_conf)) {
+                $commandParts = ['mongod', '--config', '/etc/mongo/mongod.conf'];
+            }
+
             $sslConfig = match ($this->database->ssl_mode) {
                 'allow' => [
                     '--tlsMode=allowTLS',


### PR DESCRIPTION
## Changes
- When a custom mongo config is supplied, also add the `--config` option to the command. Without this, enabling SSL wouldn't start up mongodb with the custom configuration enabled.

## Issues
- fix #5456
