### PR TITLE
fix(constants): adding 'fedora-asahi-remix' as a supported OS

### DIFF
--- a/bootstrap/helpers/constants.php
+++ b/bootstrap/helpers/constants.php
@@ -47,7 +47,7 @@ const SPECIFIC_SERVICES = [
 // Based on /etc/os-release
 const SUPPORTED_OS = [
     'ubuntu debian raspbian pop',
-    'centos fedora rhel ol rocky amzn almalinux',
+    'centos fedora rhel ol rocky amzn almalinux fedora-asahi-remix',
     'sles opensuse-leap opensuse-tumbleweed',
     'arch',
     'alpine',


### PR DESCRIPTION
## Changes

- Added `fedora-asahi-remix` to the `SUPPORTED_OS` list in `bootstrap/helpers/constants.php`. This allows Coolify to recognize Fedora Asahi Remix, a Fedora-based distribution for Apple Silicon that is fully compatible with Docker.