### PR TITLE
FIX: Workaround for supabase template setup failures (migration error, permission error, Kong config error)

### DIFF
--- a/templates/compose/supabase.yaml
+++ b/templates/compose/supabase.yaml
@@ -8,17 +8,17 @@
 services:
   supabase-kong:
     image: kong:2.8.1
-    # https://unix.stackexchange.com/a/294837
-    entrypoint: bash -c 'eval "echo \"$$(cat ~/temp.yml)\"" > ~/kong.yml && /docker-entrypoint.sh kong docker-start'
     depends_on:
       supabase-analytics:
         condition: service_healthy
+    user: "root"
+    entrypoint: bash -c 'eval "echo \"$$(cat /root/temp.yml)\"" > /usr/local/kong/kong.yml && chown -R kong:kong /usr/local/kong && exec su kong -s /bin/sh -c "/docker-entrypoint.sh kong start"'
     environment:
       - SERVICE_FQDN_SUPABASEKONG_8000
       - KONG_PORT_MAPS=443:8000
       - JWT_SECRET=${SERVICE_PASSWORD_JWT}
       - KONG_DATABASE=off
-      - KONG_DECLARATIVE_CONFIG=/home/kong/kong.yml
+      - KONG_DECLARATIVE_CONFIG=/usr/local/kong/kong.yml
       # https://github.com/supabase/cli/issues/14
       - KONG_DNS_ORDER=LAST,A,CNAME
       - KONG_PLUGINS=request-transformer,cors,key-auth,acl,basic-auth
@@ -32,7 +32,7 @@ services:
       # https://github.com/supabase/supabase/issues/12661
       - type: bind
         source: ./volumes/api/kong.yml
-        target: /home/kong/temp.yml
+        target: /root/temp.yml
         content: |
           _format_version: '2.1'
           _transform: true
@@ -328,11 +328,17 @@ services:
       supabase-vector:
         condition: service_healthy
     command:
-      - postgres
+      - bash
       - -c
-      - config_file=/etc/postgresql/postgresql.conf
-      - -c
-      - log_min_messages=fatal
+      - |
+        # Adjust ownership and permissions
+        chown -R postgres:postgres /docker-entrypoint-initdb.d
+        find /docker-entrypoint-initdb.d -type f -name "*.sh" -exec chmod 755 {} +
+        find /docker-entrypoint-initdb.d -type f -name "*.sql" -exec chmod 644 {} +
+        chmod 755 /docker-entrypoint-initdb.d
+
+        # Then execute the entry point
+        exec /usr/local/bin/docker-entrypoint.sh postgres -c config_file=/etc/postgresql/postgresql.conf -c log_min_messages=fatal
     environment:
       - POSTGRES_HOST=/var/run/postgresql
       - PGPORT=${POSTGRES_PORT:-5432}
@@ -615,6 +621,112 @@ services:
           \c postgres
       # Use named volume to persist pgsodium decryption key between restarts
       - supabase-db-config:/etc/postgresql-custom
+      # NOTE: Bug fix: The original migration script tries to connect to the _supabase database by default based on environment variables,
+      # but an error occurs if the _supabase database does not exist yet.
+      # Therefore, replace the migration script to connect to the default database first when creating the _supabase database.
+      - type: bind
+        source: ./volumes/scripts/migrate.sh
+        target: /docker-entrypoint-initdb.d/migrate.sh
+        permissions: 0755
+        content: |
+          #!/bin/sh
+          set -eu
+
+          #######################################
+          # Used by both ami and docker builds to initialise database schema.
+          # Env vars:
+          #   POSTGRES_DB        defaults to postgres
+          #   POSTGRES_HOST      defaults to localhost
+          #   POSTGRES_PORT      defaults to 5432
+          #   POSTGRES_PASSWORD  defaults to ""
+          #   USE_DBMATE         defaults to ""
+          # Exit code:
+          #   0 if migration succeeds, non-zero on error.
+          #######################################
+
+          export PGDATABASE="${POSTGRES_DB:-postgres}"
+          export PGHOST="${POSTGRES_HOST:-localhost}"
+          export PGPORT="${POSTGRES_PORT:-5432}"
+          export PGPASSWORD="${POSTGRES_PASSWORD:-}"
+
+          connect="$PGPASSWORD@$PGHOST:$PGPORT/$PGDATABASE?sslmode=disable"
+
+          # If dbmate command is passed, execute dbmate directly
+          if [ "$#" -ne 0 ]; then
+              export DATABASE_URL="${DATABASE_URL:-postgres://supabase_admin:$connect}"
+              exec dbmate "$@"
+              exit 0
+          fi
+
+          db=$( cd -- "$( dirname -- "$0" )" > /dev/null 2>&1 && pwd )
+
+          # First, run 97-_supabase.sql alone (create _supabase database)
+          echo "$0: 🎯 ensuring _supabase database exists via 97-_supabase.sql"
+          psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U supabase_admin -d postgres -f "$db/migrations/97-_supabase.sql"
+
+          if [ -z "${USE_DBMATE:-}" ]; then
+              echo "$0: 🎯 creating postgres role if not exists"
+              psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U supabase_admin <<EOSQL
+          do \$\$
+          begin
+            if not exists (select from pg_roles where rolname = 'postgres') then
+              create role postgres superuser login password '$PGPASSWORD';
+              alter database postgres owner to postgres;
+            end if;
+          end \$\$
+          EOSQL
+
+              echo "$0: 🎯 running init-scripts"
+              for sql in "$db"/init-scripts/*.sql; do
+                  echo "$0: running init script $sql"
+                  psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U postgres -f "$sql"
+              done
+
+              echo "$0: 🎯 running migrations (excluding 97-_supabase.sql)"
+              for sql in "$db"/migrations/*.sql; do
+                  if [ "$(basename "$sql")" = "97-_supabase.sql" ]; then
+                      continue
+                  fi
+                  echo "$0: running migration $sql"
+                  psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U supabase_admin -f "$sql"
+              done
+
+              echo "$0: 🎯 resetting supabase_admin password (self-reset)"
+              psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U supabase_admin -c "ALTER USER supabase_admin WITH PASSWORD '$PGPASSWORD'"
+
+          else
+              echo "$0: 🎯 running init-scripts using dbmate"
+              DBMATE_MIGRATIONS_DIR="$db/init-scripts" DATABASE_URL="postgres://postgres:$connect" dbmate --no-dump-schema migrate
+
+              echo "$0: 🎯 running migrations (excluding 97-_supabase.sql) using dbmate"
+              DBMATE_MIGRATIONS_DIR="$db/migrations" DATABASE_URL="postgres://supabase_admin:$connect" dbmate --no-dump-schema up --exclude 97-_supabase.sql
+
+              echo "$0: 🎯 creating postgres role if not exists"
+              psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U supabase_admin <<EOSQL
+          do \$\$
+          begin
+            if not exists (select from pg_roles where rolname = 'postgres') then
+              create role postgres superuser login password '$PGPASSWORD';
+              alter database postgres owner to postgres;
+            end if;
+          end \$\$
+          EOSQL
+
+              echo "$0: 🎯 resetting supabase_admin password (self-reset)"
+              psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U supabase_admin -c "ALTER USER supabase_admin WITH PASSWORD '$PGPASSWORD'"
+          fi
+
+          # execute postinit script (if it exists)
+          postinit="/etc/postgresql.schema.sql"
+          if [ -e "$postinit" ]; then
+              echo "$0: running $postinit"
+              psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U supabase_admin -f "$postinit"
+          fi
+
+          # Reset statistics (continue even if it fails)
+          psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U supabase_admin -c 'SELECT extensions.pg_stat_statements_reset(); SELECT pg_stat_reset();' || true
+
+          echo "$0: ✅ database migrations completed."
 
   supabase-analytics:
     image: supabase/logflare:1.4.0


### PR DESCRIPTION
## Changes

- Customized `migrate.sh` to avoid early connection failures.
- Added permission-fixing steps for initialization scripts.
- Fixed Kong startup failure due to config file ownership.

---

## ✨ Overview

This pull request addresses multiple issues encountered when setting up a Supabase environment using the official **template YAML** provided by the project.  
Without this fix, the initial setup process would fail at various stages.

## 📋 Problem Summary

- During the initial setup, the migration script attempts to connect to the `_supabase` database, which does not exist yet, and fails.
- Permission errors occur because scripts under `/docker-entrypoint-initdb.d` do not have the appropriate file permissions, causing them to be ignored.
- Kong fails to start because its configuration file cannot be accessed due to improper file ownership.

These issues prevented a successful `docker-compose up` deployment of Supabase.

## 🐛 Main Problems and Error Logs

### 1. Migration script connection error

**Details**  
The `migrate.sh` script tries to connect to the `_supabase` database at the very beginning, even though the database has not been created yet.

**Eerror log**

```bash
psql: error: connection to server at "127.0.0.1" (::1), port 5432 failed: FATAL:  database "_supabase" does not exist
```

In the original `migrate.sh`, the script was designed to connect to the database specified by the `$POSTGRES_DB` environment variable (e.g., `_supabase`) by default.  
It did not explicitly set the `-d` (database) option for `psql`, so it relied on the value of `$PGDATABASE`.

As a result, during the initial setup:
- The `_supabase` database had not been created yet.
- However, the script tried to connect to `$POSTGRES_DB` (`_supabase`),  


---

### 2. Migration script permission issues

**Details**  
Files under `/docker-entrypoint-initdb.d` (`*.sh`, `*.sql`) did not have the correct executable/readable permissions, causing them to be skipped by the entrypoint.

**Error log**

```bash
/usr/local/bin/docker-entrypoint.sh: ignoring /docker-entrypoint-initdb.d/migrate.sh
```

---

### 3. Kong configuration file permission error

**Details**  
At startup, Kong tries to load `/usr/local/kong/kong.yml`, but it fails because the file is still owned by `root` and not accessible by the `kong` user.

**Error log**

```bash
Error: permission denied while opening file /usr/local/kong/kong.yml
```

---

## ✅ Changes Made

| Problem                          | What I Did                                                                                   |
|:----------------------------------|:---------------------------------------------------------------------------------------------|
| Migration connection error        | Customized `migrate.sh` to connect to the `postgres` database first when creating `_supabase`. |
| Script permission issues          | Set permissions to `755` for `.sh` files and `644` for `.sql` files at container startup.     |
| Kong configuration permission error | Changed ownership of `/usr/local/kong` to `kong:kong` before starting Kong.                   |

---

## 🛠️ About Migration Script Changes

To address the initial setup issue,  
I **overrode** the official `migrate.sh` script with a modified version.

- The modified script connects to the default `postgres` database first,  
  creates the `_supabase` database,  
  and **then** continues with the usual migration steps.
- This change successfully bypasses the "database does not exist" error.

However, **this is a temporary solution**:  
- If the official `migrate.sh` gets updated in future releases,  
  this customization **would require manual synchronization**.
- Ideally, it would be better to patch it in a more maintainable way (e.g., applying minimal diffs, using entrypoint hooks, etc.).

For now, I chose this approach to prioritize **getting the environment up and running reliably**.

---

## 📜 Notes

- This pull request is a **workaround**, not a final ideal solution.
- Future updates to the official template may conflict with this change, so further adjustments may become necessary.

---

## 🙏 Acknowledgment

Thank you very much for providing such a great project.  
I'm happy to contribute to improving the developer experience.  

This is my first time submitting a pull request to an open-source project.  
If there are any mistakes or better ways to contribute, I sincerely apologize and would greatly appreciate any guidance!

While this pull request may not be perfect, I would sincerely appreciate any help in refining or improving it if needed.

I truly appreciate how incredibly useful Coolify is — having a stable and reliable way to host Supabase would make a tremendous difference for me!

---


## Related Issues

- https://github.com/coollabsio/coolify/issues/4911
- https://github.com/coollabsio/coolify/issues/4665
