### PR TITLE
fix(DatabaseBackupJob): escape PostgreSQL password in backup command

### DIFF
--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -390,7 +390,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             $commands[] = 'mkdir -p '.$this->backup_dir;
             $backupCommand = 'docker exec';
             if ($this->postgres_password) {
-                $backupCommand .= " -e PGPASSWORD=$this->postgres_password";
+                $backupCommand .= " -e PGPASSWORD=\"{$this->postgres_password}\"";
             }
             if ($this->backup->dump_all) {
                 $backupCommand .= " $this->container_name pg_dumpall --username {$this->database->postgres_user} | gzip > $this->backup_location";


### PR DESCRIPTION

## Changes
- Escape PostgreSQL password environment variable in backup command
This was already done for MySQL / MariaDB, was only missing from Postgres.

Previously, this could cause errors with special characters.

For instance, with the password `*hwA1&n3lVwJ1bxW`, the following error would occur:
![image](https://github.com/user-attachments/assets/1dbd574d-e106-4364-bd10-a38965c7c449)


