### PR TITLE
feat(oauth): set redirect uri as optional and add default value

### DIFF
--- a/app/Models/OauthSetting.php
+++ b/app/Models/OauthSetting.php
@@ -25,11 +25,11 @@ class OauthSetting extends Model
     {
         switch ($this->provider) {
             case 'azure':
-                return filled($this->client_id) && filled($this->client_secret) && filled($this->redirect_uri) && filled($this->tenant);
+                return filled($this->client_id) && filled($this->client_secret) && filled($this->tenant);
             case 'authentik':
-                return filled($this->client_id) && filled($this->client_secret) && filled($this->redirect_uri) && filled($this->base_url);
+                return filled($this->client_id) && filled($this->client_secret) && filled($this->base_url);
             default:
-                return filled($this->client_id) && filled($this->client_secret) && filled($this->redirect_uri);
+                return filled($this->client_id) && filled($this->client_secret);
         }
     }
 }

--- a/bootstrap/helpers/socialite.php
+++ b/bootstrap/helpers/socialite.php
@@ -7,6 +7,10 @@ function get_socialite_provider(string $provider)
 {
     $oauth_setting = OauthSetting::firstWhere('provider', $provider);
 
+    if (! filled($oauth_setting->redirect_uri)) {
+        $oauth_setting->update(['redirect_uri' => route('auth.callback', $provider)]);
+    }
+
     if ($provider === 'azure') {
         $azure_config = new \SocialiteProviders\Manager\Config(
             $oauth_setting->client_id,

--- a/resources/views/livewire/settings-oauth.blade.php
+++ b/resources/views/livewire/settings-oauth.blade.php
@@ -26,7 +26,7 @@
                             label="Client ID" />
                         <x-forms.input id="oauth_settings_map.{{ $oauth_setting->provider }}.client_secret"
                             type="password" label="Client Secret" autocomplete="new-password" />
-                        <x-forms.input id="oauth_settings_map.{{ $oauth_setting->provider }}.redirect_uri"
+                        <x-forms.input id="oauth_settings_map.{{ $oauth_setting->provider }}.redirect_uri" placeholder="{{ route('auth.callback', $oauth_setting->provider) }}"
                             label="Redirect URI" />
                         @if ($oauth_setting->provider == 'azure')
                             <x-forms.input id="oauth_settings_map.{{ $oauth_setting->provider }}.tenant"


### PR DESCRIPTION
Hi, thanks for this project, it's great!
During the OAuth setup on my instance, I got confused by the `redirect_uri` setting, so I made this PR to better guide others with sensible defaults.

## Changes
- Set OAuth provider setting `redirect_uri` as optional and add default value

