### PR TITLE
Port Forwarding is needed to access the Qdrant with the QdrantClient Lib

### DIFF
--- a/templates/compose/qdrant.yaml
+++ b/templates/compose/qdrant.yaml
@@ -12,6 +12,8 @@ services:
       - QDRANT__SERVICE__API_KEY=${SERVICE_PASSWORD_QDRANTAPIKEY}
     volumes:
       - "qdrant-storage:/qdrant/storage"
+    ports:
+      - "6333:6333"
     healthcheck:
       test:
         - CMD-SHELL


### PR DESCRIPTION
Without this, will the Libary use 6333 and you will get an "connect ECONNREFUSED" TCP-Error

## Changes
- I put a default port into the qdrant docker-compose 


