### PR TITLE
fix(service): Snapdrop `no matching manifest` error

### DIFF
--- a/templates/compose/snapdrop.yaml
+++ b/templates/compose/snapdrop.yaml
@@ -4,7 +4,7 @@
 
 services:
   snapdrop:
-    image: lscr.io/linuxserver/snapdrop:latest
+    image: 'linuxserver/snapdrop:version-b8b78cc2'
     environment:
       - SERVICE_FQDN_SNAPDROP
       - PUID=1000


### PR DESCRIPTION
The current image `image: lscr.io/linuxserver/snapdrop:latest` shows error while deploying "cpu arch is not in manifest list" (for both `arm` and `amd`)
![image](https://github.com/user-attachments/assets/70a6b700-c190-40ce-a8a1-9e2cf0acdba8)

I tried using the latest version shown in the below image but all of them throws same error on Coolify:
![image](https://github.com/user-attachments/assets/3fa13a12-da5c-4cb4-b816-763c9ba0c169)

So the solution is to use a image form docker hub which has the support for both `amd` and `arm`
![image](https://github.com/user-attachments/assets/a30b38b9-803c-4d77-8926-ba8b4fe7f341)

