### PR TITLE
fix(service): use the same volume between chatwoot and sidekiq

### DIFF
--- a/templates/compose/chatwoot.yaml
+++ b/templates/compose/chatwoot.yaml
@@ -80,7 +80,7 @@ services:
       - ACTIVE_STORAGE_SERVICE=${ACTIVE_STORAGE_SERVICE:-local}
     command: ['bundle', 'exec', 'sidekiq', '-C', 'config/sidekiq.yml']
     volumes:
-      - sidekiq-data:/app/storage
+      - rails-data:/app/storage
     healthcheck:
       test: ["CMD-SHELL", "bundle exec rails runner 'puts Sidekiq.redis(&:info)' > /dev/null 2>&1"]
       interval: 30s


### PR DESCRIPTION


## Changes
- Updated the `chatwoot.yaml` Coolify template to ensure both `chatwoot` and `sidekiq` services share the same `/app/storage` volume (`rails-data`).
- This resolves media display issues when receiving attachments via WhatsApp through Twilio.

## Context
Previously, the Chatwoot `sidekiq` service used its own `sidekiq-data` volume, separate from the `chatwoot` container's `rails-data`. This caused downloaded media (like images/files from WhatsApp via Twilio) to not be visible in the Chatwoot UI due to ActiveStorage storing them in a non-shared location.

This change aligns with best practices for Chatwoot Docker deployments.

## Reference
- Chatwoot issue context: https://github.com/chatwoot/chatwoot/issues/8396
- Chatwoot issue context: https://github.com/chatwoot/chatwoot/issues/9738
- Verified and tested on `Chatwoot v4.1.0` with Twilio WhatsApp integration.

---

✅ Fix tested in a real deployment.
