### PR TITLE
chore(service): update Immich service

### DIFF
--- a/templates/compose/immich.yaml
+++ b/templates/compose/immich.yaml
@@ -6,7 +6,7 @@
 
 services:
   immich:
-    image: ghcr.io/immich-app/immich-server:release
+    image: ghcr.io/immich-app/immich-server:${IMMICH_VERSION:-release}
     # extends:
     #   file: hwaccel.transcoding.yml
     #   service: cpu # set to one of [nvenc, quicksync, rkmpp, vaapi, vaapi-wsl] for accelerated transcoding
@@ -33,7 +33,7 @@ services:
     container_name: immich_machine_learning
     # For hardware acceleration, add one of -[armnn, cuda, openvino] to the image tag.
     # Example tag: ${IMMICH_VERSION:-release}-cuda
-    image: ghcr.io/immich-app/immich-machine-learning:release
+    image: ghcr.io/immich-app/immich-machine-learning:${IMMICH_VERSION:-release}
     # extends: # uncomment this section for hardware acceleration - see https://immich.app/docs/features/ml-hardware-acceleration
     #   file: hwaccel.ml.yml
     #   service: cpu # set to one of [armnn, cuda, openvino, openvino-wsl] for accelerated inference - use the `-wsl` version for WSL2 where applicable
@@ -61,12 +61,14 @@ services:
       retries: 20
 
   database:
-    image: docker.io/tensorchord/pgvecto-rs:pg14-v0.2.0@sha256:90724186f0a3517cf6914295b5ab410db9ce23190a2d9d0b9dd6463e3fa298f0
+    image: ghcr.io/immich-app/postgres:14-vectorchord0.3.0-pgvectors0.2.0
     environment:
       POSTGRES_PASSWORD: ${SERVICE_PASSWORD_POSTGRES}
       POSTGRES_USER: ${SERVICE_USER_POSTGRES}
       POSTGRES_DB: ${DB_DATABASE_NAME:-immich}
-      POSTGRES_INITDB_ARGS: '--data-checksums'
+      POSTGRES_INITDB_ARGS: "--data-checksums"
+      # Use 'HDD' if your database isn't stored on SSDs
+      DB_STORAGE_TYPE: ${DB_STORAGE_TYPE:-SSD}
     volumes:
       - immich-postgres-data:/var/lib/postgresql/data
     healthcheck:


### PR DESCRIPTION
## Changes
- Replace the docker image for PostgreSQL with the new one (see the breaking changes note [here](https://github.com/immich-app/immich/discussions/18429))
- added IMMICH_VERSION env flag
- added DB_STORAGE_TYPE env flag

This change also allows one to use Coolify's automatic backup feature for the PostgreSQL database.

## Migration notes
I have already migrated my personal Immich instance to the new database.
The only "problem" I encountered was that Coolify didn't automatically recreate the database container. I had to delete the old one manually so that it gets recreated with the new image after restarting. The new database is working fine with the volume data from the previous one.