### PR TITLE
fix(service): Neon WS Proxy service not working on ARM64

### DIFF
--- a/templates/compose/neon-ws-proxy.yaml
+++ b/templates/compose/neon-ws-proxy.yaml
@@ -27,7 +27,6 @@ services:
 
   postgres:
     image: 'postgres:17-alpine'
-    platform: linux/amd64
     volumes:
       - 'postgresql-data:/var/lib/postgresql/data'
     environment:


### PR DESCRIPTION
The platform for postgres is hard-coded on the compose to be `linux/amd64` so deploying this compose on a arm64 server is causing the postgres service to be unhealthy because amd64 image can't run on arm64.

![image](https://github.com/user-attachments/assets/3e132e98-12ca-4bad-9728-53de77dfe13c)


So removing the `platform: linux/amd64` will make docker pull the correct image based on the CPU of the server where the user is deploying this service