### PR TITLE
Add env file to custom start command

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -540,6 +540,9 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         if ($this->application->settings->is_raw_compose_deployment_enabled) {
             if ($this->docker_compose_custom_start_command) {
                 $this->write_deployment_configurations();
+                if (! str($this->docker_compose_custom_start_command)->contains('--env-file') && $this->env_filename) {
+                    $this->docker_compose_custom_start_command = str($this->docker_compose_custom_start_command)->replaceFirst('compose', 'compose --env-file '.$this->workdir.'/'.$this->env_filename)->value();
+                }
                 $this->execute_remote_command(
                     [executeInDocker($this->deployment_uuid, "cd {$this->workdir} && {$this->docker_compose_custom_start_command}"), 'hidden' => true],
                 );
@@ -559,6 +562,9 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         } else {
             if ($this->docker_compose_custom_start_command) {
                 $this->write_deployment_configurations();
+                if (! str($this->docker_compose_custom_start_command)->contains('--env-file') && $this->env_filename) {
+                    $this->docker_compose_custom_start_command = str($this->docker_compose_custom_start_command)->replaceFirst('compose', 'compose --env-file '.$this->workdir.'/'.$this->env_filename)->value();
+                }
                 $this->execute_remote_command(
                     [executeInDocker($this->deployment_uuid, "cd {$this->basedir} && {$this->docker_compose_custom_start_command}"), 'hidden' => true],
                 );

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -497,6 +497,9 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         $this->application_deployment_queue->addLogEntry('Pulling & building required images.');
 
         if ($this->docker_compose_custom_build_command) {
+            if (! str($this->docker_compose_custom_build_command)->contains('--env-file') && $this->env_filename) {
+                    $this->docker_compose_custom_build_command = str($this->docker_compose_custom_build_command)->replaceFirst('compose', 'compose --env-file '.$this->workdir.'/'.$this->env_filename)->value();
+                }
             $this->execute_remote_command(
                 [executeInDocker($this->deployment_uuid, "cd {$this->basedir} && {$this->docker_compose_custom_build_command}"), 'hidden' => true],
             );


### PR DESCRIPTION
for custom docker compose build/start commands, we check earlier if the --project-directory is included and if not we add it to the custom start command

however we don't check if there is a --env-file flag

for normal deployments this is ok since the .env file is just .env and read automatically, but for preview deployments, the .env file is named something like .env-pr-xxxx since the user can't know what this will be in their custom build/start command,  we instead inject it into their command if it is missing otherwise no env file is used.