### PR TITLE
migrate deprecated `--time` flag to `--timeout`

### DIFF
--- a/app/Actions/Database/StopDatabase.php
+++ b/app/Actions/Database/StopDatabase.php
@@ -42,7 +42,7 @@ class StopDatabase
     {
         $server = $database->destination->server;
         instant_remote_process(command: [
-            "docker stop --time=$timeout $containerName",
+            "docker stop --timeout=$timeout $containerName",
             "docker rm -f $containerName",
         ], server: $server, throwError: false);
     }

--- a/app/Actions/Proxy/StopProxy.php
+++ b/app/Actions/Proxy/StopProxy.php
@@ -15,7 +15,7 @@ class StopProxy
             $containerName = $server->isSwarm() ? 'coolify-proxy_traefik' : 'coolify-proxy';
 
             instant_remote_process(command: [
-                "docker stop --time=$timeout $containerName",
+                "docker stop --timeout=$timeout $containerName",
                 "docker rm -f $containerName",
             ], server: $server, throwError: false);
 

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -2249,7 +2249,7 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
     {
         try {
             $this->execute_remote_command(
-                ["docker stop --time=$timeout $containerName", 'hidden' => true, 'ignore_errors' => true],
+                ["docker stop --timeout=$timeout $containerName", 'hidden' => true, 'ignore_errors' => true],
                 ["docker rm -f $containerName", 'hidden' => true, 'ignore_errors' => true]
             );
         } catch (Exception $error) {

--- a/app/Livewire/Project/Application/Previews.php
+++ b/app/Livewire/Project/Application/Previews.php
@@ -237,7 +237,7 @@ class Previews extends Component
         foreach ($containers as $container) {
             $containerName = str_replace('/', '', $container['Names']);
             instant_remote_process(command: [
-                "docker stop --time=$timeout $containerName",
+                "docker stop --timeout=$timeout $containerName",
                 "docker rm -f $containerName",
             ], server: $server, throwError: false);
         }

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -272,7 +272,7 @@ class Application extends BaseModel
     {
         foreach ($containerNames as $containerName) {
             instant_remote_process(command: [
-                "docker stop --time=$timeout $containerName",
+                "docker stop --timeout=$timeout $containerName",
                 "docker rm -f $containerName",
             ], server: $server, throwError: false);
         }

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -160,7 +160,7 @@ class Service extends BaseModel
     {
         foreach ($containerNames as $containerName) {
             instant_remote_process(command: [
-                "docker stop --time=$timeout $containerName",
+                "docker stop --timeout=$timeout $containerName",
                 "docker rm -f $containerName",
             ], server: $server, throwError: false);
         }


### PR DESCRIPTION
## Changes
- Migrate from the deprecated `--time` flag to `--timeout` (https://docs.docker.com/engine/deprecated/#--time-option-on-docker-stop-and-docker-restart)
