### PR TITLE
Update joplin.yaml

### DIFF
--- a/templates/compose/joplin.yaml
+++ b/templates/compose/joplin.yaml
@@ -8,7 +8,7 @@ services:
   postgres:
     image: 'postgres:16'
     volumes:
-      - joplin-postgresql-data:/var/lib/postgresql/data'
+      - joplin-postgresql-data:/var/lib/postgresql/data
     environment:
       - POSTGRES_PASSWORD=${SERVICE_PASSWORD_64_POSTGRES}
       - POSTGRES_USER=${SERVICE_USER_POSTGRES}


### PR DESCRIPTION
There is was a wrong apostroph. This caused a new volume to be created with each redeploy and the data was deleted.


## Changes
- Deleted the apostroph at the end of the volumes line.

