### PR TITLE
fix(docker): add custom WebSocket headers for n8n service

### DIFF
--- a/templates/compose/n8n-with-postgresql.yaml
+++ b/templates/compose/n8n-with-postgresql.yaml
@@ -21,6 +21,8 @@ services:
       - DB_POSTGRESDB_USER=$SERVICE_USER_POSTGRES
       - DB_POSTGRESDB_SCHEMA=public
       - DB_POSTGRESDB_PASSWORD=$SERVICE_PASSWORD_POSTGRES
+    labels:
+      - traefik.http.middlewares.websocket-headers.headers.customrequestheaders.Origin=wss://${SERVICE_FQDN_N8N}
     volumes:
       - n8n-data:/home/node/.n8n
     depends_on:

--- a/templates/compose/n8n.yaml
+++ b/templates/compose/n8n.yaml
@@ -14,6 +14,8 @@ services:
       - N8N_HOST=${SERVICE_URL_N8N}
       - GENERIC_TIMEZONE=${GENERIC_TIMEZONE:-Europe/Berlin}
       - TZ=${TZ:-Europe/Berlin}
+    labels:
+      - traefik.http.middlewares.websocket-headers.headers.customrequestheaders.Origin=wss://${SERVICE_FQDN_N8N}
     volumes:
       - n8n-data:/home/node/.n8n
     healthcheck:


### PR DESCRIPTION
- for new version of n8n docker, it is needed to set headers in traefik

## Changes
- add label to templates to support newest n8n docker containers

## Issues
- fix #5929 
