### PR TITLE
fix: Updated compose to fix AFFiNE service not starting

### DIFF
--- a/templates/compose/affine.yaml
+++ b/templates/compose/affine.yaml
@@ -7,10 +7,6 @@
 services:
   affine:
     image: ghcr.io/toeverything/affine-graphql:stable
-    command:
-      - sh
-      - '-c'
-      - 'node ./scripts/self-host-predeploy && node ./dist/index.js'
     depends_on:
       redis:
         condition: service_healthy  
@@ -25,7 +21,6 @@ services:
         max-size: 1000m
     environment:
       - SERVICE_FQDN_AFFINE_3010
-      - NODE_OPTIONS=--import=./scripts/register.js
       - AFFINE_CONFIG_PATH=/root/.affine/config
       - REDIS_SERVER_HOST=redis
       - DATABASE_URL=postgres://${SERVICE_USER_POSTGRES}:${SERVICE_PASSWORD_POSTGRES}@postgres:5432/${POSTGRES_DB:-affine}


### PR DESCRIPTION
This solves an issue where Affine no longer starts due to stable compose file contains references to a register.js that no longer exists.

## Changes
- Removed two things from the AFFiNE compose.yml

## Issues
- fix #5932
