### PR TITLE
add "/admin" to route .slip domain to login screen

### DIFF
--- a/templates/compose/directus-with-postgresql.yaml
+++ b/templates/compose/directus-with-postgresql.yaml
@@ -12,7 +12,7 @@ services:
       - directus-extensions:/directus/extensions
       - directus-templates:/directus/templates
     environment:
-      - SERVICE_FQDN_DIRECTUS_8055
+      - SERVICE_FQDN_DIRECTUS_8055=/admin
       - KEY=$SERVICE_BASE64_64_KEY
       - SECRET=$SERVICE_BASE64_64_SECRET
       - ADMIN_EMAIL=${ADMIN_EMAIL:-admin@example.com}


### PR DESCRIPTION
Very small modification but it works. With current template, the user will be brought to a blank page. However when they are diverted properly to /admin path on the url it will fix this problem

ENV Variables 
Original App URL was SERVICE_FQDN_DIRECTUS_8055
I changed it to SERVICE_FQDN_DIRECTUS_8055=/admin

I can confirm it worked with my tests. For example, I used the template to create a slip domain. In the Directus Gui you will see the regular .slip domain without the /admin path, however, when you go to the generated domain, it will route you to the /admin path to the proper login screen.

## Submit Checklist (REMOVE THIS SECTION BEFORE SUBMITTING)
- [x] I have selected the `next` branch as the destination for my PR, not `main`.
- [ ] I have listed all changes in the `Changes` section.
- [ ] I have filled out the `Issues` section with the issue/discussion link(s) (if applicable).
- [ ] I have tested my changes.
- [ ] I have considered backwards compatibility.
- [ ] I have removed this checklist and any unused sections.

## Changes
- 

## Issues
- fix #
