### PR TITLE
add "/admin" to route .slip domain to login screen

### DIFF
--- a/templates/compose/directus-with-postgresql.yaml
+++ b/templates/compose/directus-with-postgresql.yaml
@@ -12,7 +12,7 @@ services:
       - directus-extensions:/directus/extensions
       - directus-templates:/directus/templates
     environment:
-      - SERVICE_FQDN_DIRECTUS_8055
+      - SERVICE_FQDN_DIRECTUS_8055=/admin
       - KEY=$SERVICE_BASE64_64_KEY
       - SECRET=$SERVICE_BASE64_64_SECRET
       - ADMIN_EMAIL=${ADMIN_EMAIL:-admin@example.com}


### PR DESCRIPTION
## Changes
-Original Directus App URL was SERVICE_FQDN_DIRECTUS_8055
I changed it to SERVICE_FQDN_DIRECTUS_8055=/admin

## Issues
- fix # Very small modification but it works. With current coolify template after deploying the stack, the user will be brought to a blank page on the auto-generated .slip URL. However with my fix, they are diverted properly to /admin path on the auto generated url and then they can see the login screen.  Tested with .slip auto generated coolify domain, as well as my own HTTPS:// domain and it worked on both with my fix :). 
