### PR TITLE
Set a custom api throttle limit so internal applications can automate coolify

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -49,7 +49,7 @@ class RouteServiceProvider extends ServiceProvider
                 return Limit::perMinute(1000)->by($request->user()?->id ?: $request->ip());
             }
 
-            return Limit::perMinute(200)->by($request->user()?->id ?: $request->ip());
+            return Limit::perMinute(config('api.throttle'))->by($request->user()?->id ?: $request->ip());
         });
         RateLimiter::for('5', function (Request $request) {
             return Limit::perMinute(5)->by($request->user()?->id ?: $request->ip());

--- a/config/api.php
+++ b/config/api.php
@@ -1,5 +1,5 @@
 <?php
 
 return [
-    'throttle' => env('API_THROTTLE', 5),
+    'throttle' => env('API_THROTTLE', 200),
 ];

--- a/config/api.php
+++ b/config/api.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'throttle' => env('API_THROTTLE', 5),
+];


### PR DESCRIPTION
We are getting a lot of throttle warnings from our internal systems using coolify to automate builds and other integrations.

Thanks!

## Changes

- Made the API rate limiter configurable via a new `config/api.php` config file, which uses the `API_THROTTLE` environment variable (default: 200).

