### PR TITLE
Instance Name persistence

### DIFF
--- a/resources/views/components/emails/footer.blade.php
+++ b/resources/views/components/emails/footer.blade.php
@@ -1,6 +1,8 @@
 {{ Illuminate\Mail\Markdown::parse('---') }}
 
 Thank you,<br>
-{{ config('app.name') ?? 'Coolify' }}
+{{ config('app.name') ?? instanceSettings()->instance_name ?? 'Coolify' }}
 
+@if(instanceSettings()->contact_support_enabled ?? false)
 {{ Illuminate\Mail\Markdown::parse('[Contact Support](https://coolify.io/docs/contact)') }}
+@endif

--- a/resources/views/components/emails/header.blade.php
+++ b/resources/views/components/emails/header.blade.php
@@ -1,1 +1,2 @@
 Hello,
+{{ instanceSettings()->instance_name ?? 'Coolify' }}

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -21,19 +21,10 @@
     <meta property="og:image" content="https://cdn.coollabs.io/assets/coolify/og-image.png" />
     @use('App\Models\InstanceSettings')
     @php
-
         $instanceSettings = instanceSettings();
-        $name = null;
-
-        if ($instanceSettings) {
-            $displayName = $instanceSettings->getTitleDisplayName();
-
-            if (strlen($displayName) > 0) {
-                $name = $displayName . ' ';
-            }
-        }
+        $name = $instanceSettings->instance_name ?? 'Coolify';
     @endphp
-    <title>{{ $name }}{{ $title ?? 'Coolify' }}</title>
+    <title>{{ $name }}{{ $title ?? '' }}</title>
     @env('local')
     <link rel="icon" href="{{ asset('coolify-logo-dev-transparent.png') }}" type="image/x-icon" />
 @else

--- a/resources/views/livewire/settings/index.blade.php
+++ b/resources/views/livewire/settings/index.blade.php
@@ -19,7 +19,8 @@
                     <x-forms.input id="fqdn" label="Instance's Domain"
                         helper="Enter the full domain name (FQDN) of the instance, including 'https://' if you want to secure the dashboard with HTTPS. Setting this will make the dashboard accessible via this domain, secured by HTTPS, instead of just the IP address."
                         placeholder="https://coolify.yourdomain.com" />
-                    <x-forms.input id="instance_name" label="Instance's Name" placeholder="Coolify" />
+                    <x-forms.input id="instance_name" label="Instance's Name" placeholder="Coolify"
+                        wire:model="instance_name" />
                     <div class="w-full" x-data="{
                         open: false,
                         search: '{{ $settings->instance_timezone ?: '' }}',
@@ -153,5 +154,10 @@
                     the risk of accidental actions. This is not recommended for production servers.</p>
             </div>
         @endif
+
+        <h4 class="pt-6">Support</h4>
+        <div class="md:w-96 pb-2">
+            <x-forms.checkbox id="contact_support_enabled" label="Enable Contact Support in Emails" wire:model="settings.contact_support_enabled" />
+        </div>
     </form>
 </div>


### PR DESCRIPTION
## Changes
-  Allows instance name to apply site-wide, emails & header. 
- Adds a checkbox for adding the contact support in the email footer

## Issues
- No current issues.
