### PR TITLE
fix(template): disable healthcheck logging for gotenberg

### DIFF
--- a/templates/compose/gotenberg.yaml
+++ b/templates/compose/gotenberg.yaml
@@ -12,13 +12,15 @@ services:
       # NOTE: requires the --api-enable-basic-auth option in "command"
       - GOTENBERG_API_BASIC_AUTH_USERNAME=${SERVICE_USER_GOTENBERG}
       - GOTENBERG_API_BASIC_AUTH_PASSWORD=${SERVICE_PASSWORD_GOTENBERG}
-    command: [
-      "gotenberg",
+    command:
+      - gotenberg
       # See the full list of options at https://gotenberg.dev/docs/configuration
-      "--api-enable-basic-auth"
-      #"--api-timeout=60s",
-      #"--chromium-auto-start"
-    ]
+
+      # Examples:
+      # - --api-timeout=60s
+      # - --chromium-auto-start
+      - --api-enable-basic-auth
+      - --api-disable-health-check-logging
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:3000/health"]
       interval: 5s


### PR DESCRIPTION
## Changes
- Disable healthcheck logging for gotenberg (too verbose + takes up space)
