### PR TITLE
fix(service): wireguard dynamic FQDN + URL change

### DIFF
--- a/templates/compose/wireguard-easy.yaml
+++ b/templates/compose/wireguard-easy.yaml
@@ -5,11 +5,11 @@
 # port: 8000
 
 services:
-  wg-easy:
+  wgeasy:
     image: ghcr.io/wg-easy/wg-easy:latest
     environment:
-      - SERVICE_FQDN_WIREGUARDEASY_8000
-      - WG_HOST=${SERVICE_FQDN_WIREGUARDEASY}
+      - SERVICE_FQDN_WGEASY_8000
+      - WG_HOST=${SERVICE_URL_WGEASY}
       - LANG=${LANG:-en}
       - PORT=8000
       - WG_PORT=51820


### PR DESCRIPTION
## Changes
- fix wireguard configurations to recognize the FQDN generated by coolify
- also matches the wireguard format of [domain]:port (for this the `SERVICE_URL_*` is used)
- now the magic variables matches correctly the docker compose service (when you change them on the UI those change on the container) 🪄🪄

## Issues
- fix #5417

## Notes
With these changes now when you hop into the UI, (if you have the port forwarded correctly) you should be good to go by scanning the QR code with your phone 🪄