### PR TITLE
chore(service): Update Evolution API image to the official one

### DIFF
--- a/templates/compose/evolution-api.yaml
+++ b/templates/compose/evolution-api.yaml
@@ -7,7 +7,7 @@
 version: '3.8'
 services:
   api:
-    image: 'atendai/evolution-api:latest' # Change to specific version if needed.
+    image: 'evoapicloud/evolution-api:latest' # Change to specific version if needed.
     restart: always
     depends_on:
       - redis


### PR DESCRIPTION
## Changes

The atendai/evolution-api:latest image is no longer maintained; the maintained version is now hosted under the evoapicloud organization.