### PR TITLE
fix: 500 status code when trying to clone an environment

### DIFF
--- a/app/Livewire/Project/CloneMe.php
+++ b/app/Livewire/Project/CloneMe.php
@@ -56,7 +56,6 @@ class CloneMe extends Component
         $this->project_id = $this->project->id;
         $this->servers = currentTeam()
             ->servers()
-            ->with('destinations')
             ->get()
             ->reject(fn ($server) => $server->isBuildServer());
         $this->newName = str($this->project->name.'-clone-'.(string) new Cuid2)->slug();


### PR DESCRIPTION
## Changes
- Removed `->with('destinations')` since it seems unnecessary and it was causing an error reported in https://github.com/coollabsio/coolify/issues/6022

## Issues
- fix #6022 

## Notes

- The one who created the issue identified a workaround to make it work and I've identified that the workaround could be the actual solution and built a patch for it, that's all!
- To the people who created Coolify, thank you very much. Coolify is great and sometimes I feel on debt when I don't support this tool somehow, that's why I took some time to setup my development environment and tried to contribute.