### PR TITLE
fix(docker): use `--timeout` instead of `--time`

### DIFF
--- a/app/Actions/Application/StopApplication.php
+++ b/app/Actions/Application/StopApplication.php
@@ -39,7 +39,7 @@ class StopApplication
 
                 foreach ($containersToStop as $containerName) {
                     instant_remote_process(command: [
-                        "docker stop --time=30 $containerName",
+                        "docker stop --timeout=30 $containerName",
                         "docker rm -f $containerName",
                     ], server: $server, throwError: false);
                 }

--- a/app/Actions/Application/StopApplicationOneServer.php
+++ b/app/Actions/Application/StopApplicationOneServer.php
@@ -26,7 +26,7 @@ class StopApplicationOneServer
                     if ($containerName) {
                         instant_remote_process(
                             [
-                                "docker stop --time=30 $containerName",
+                                "docker stop --timeout=30 $containerName",
                                 "docker rm -f $containerName",
                             ],
                             $server

--- a/app/Actions/Database/StopDatabase.php
+++ b/app/Actions/Database/StopDatabase.php
@@ -49,7 +49,7 @@ class StopDatabase
     {
         $server = $database->destination->server;
         instant_remote_process(command: [
-            "docker stop --time=$timeout $containerName",
+            "docker stop --timeout=$timeout $containerName",
             "docker rm -f $containerName",
         ], server: $server, throwError: false);
     }

--- a/app/Actions/Proxy/StopProxy.php
+++ b/app/Actions/Proxy/StopProxy.php
@@ -21,7 +21,7 @@ class StopProxy
             ProxyStatusChangedUI::dispatch($server->team_id);
 
             instant_remote_process(command: [
-                "docker stop --time=$timeout $containerName",
+                "docker stop --timeout=$timeout $containerName",
                 "docker rm -f $containerName",
             ], server: $server, throwError: false);
 

--- a/app/Actions/Service/StopService.php
+++ b/app/Actions/Service/StopService.php
@@ -54,7 +54,7 @@ class StopService
         $timeout = count($containersToStop) > 5 ? 10 : 30;
         $commands = [];
         $containerList = implode(' ', $containersToStop);
-        $commands[] = "docker stop --time=$timeout $containerList";
+        $commands[] = "docker stop --timeout=$timeout $containerList";
         $commands[] = "docker rm -f $containerList";
         instant_remote_process(
             command: $commands,

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -2257,7 +2257,7 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
     {
         try {
             $this->execute_remote_command(
-                ["docker stop --time=$timeout $containerName", 'hidden' => true, 'ignore_errors' => true],
+                ["docker stop --timeout=$timeout $containerName", 'hidden' => true, 'ignore_errors' => true],
                 ["docker rm -f $containerName", 'hidden' => true, 'ignore_errors' => true]
             );
         } catch (Exception $error) {

--- a/app/Livewire/Project/Application/Previews.php
+++ b/app/Livewire/Project/Application/Previews.php
@@ -249,7 +249,7 @@ class Previews extends Component
 
         $containerList = implode(' ', array_map('escapeshellarg', $containerNames));
         $commands = [
-            "docker stop --time=$timeout $containerList",
+            "docker stop --timeout=$timeout $containerList",
             "docker rm -f $containerList",
         ];
 


### PR DESCRIPTION
## Changes
- Replaced `docker stop --time=X` with `docker stop --timeout=X` to fix some deployment warnings

![image](https://github.com/user-attachments/assets/853d9244-7cca-4fbb-8d11-de62907e5da0)
