### PR TITLE
fix(install.sh): use IPV4_PUBLIC_IP variable in output instead of repeated curl

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -844,7 +844,7 @@ IPV6_PUBLIC_IP=$(curl -6s https://ifconfig.io || true)
 
 echo -e "\nYour instance is ready to use!\n"
 if [ -n "$IPV4_PUBLIC_IP" ]; then
-    echo -e "You can access Coolify through your Public IPV4: http://$(curl -4s https://ifconfig.io):8000"
+    echo -e "You can access Coolify through your Public IPV4: http://[$IPV4_PUBLIC_IP]:8000"
 fi
 if [ -n "$IPV6_PUBLIC_IP" ]; then
     echo -e "You can access Coolify through your Public IPv6: http://[$IPV6_PUBLIC_IP]:8000"


### PR DESCRIPTION
## Changes
- Use stored IPV4_PUBLIC_IP variable in public address output instead of redundant curl call.

## Issues
- fix: use IPV4_PUBLIC_IP variable in output instead of repeated curl

![image](https://github.com/user-attachments/assets/c3eb158b-9507-433c-b9da-2c16b77e01cd)



