### PR TITLE
chore(service): update Nitropage template

### DIFF
--- a/templates/compose/nitropage-with-postgresql.yaml
+++ b/templates/compose/nitropage-with-postgresql.yaml
@@ -6,7 +6,7 @@
 
 services:
   nitropage:
-    image: codeberg.org/nitropage/nitropage
+    image: nitropage/nitropage
     environment:
       - SERVICE_FQDN_NITROPAGE_3000
       - NP_AUTH_SALT=${SERVICE_BASE64_SALT}

--- a/templates/compose/nitropage.yaml
+++ b/templates/compose/nitropage.yaml
@@ -11,7 +11,7 @@ services:
       - SERVICE_FQDN_NITROPAGE_3000
       - NP_AUTH_SALT=${SERVICE_BASE64_SALT}
       - NP_AUTH_PASSWORD=${SERVICE_PASSWORD_64_SESSION}
-      - DATABASE_URL=file:../../.data/dev.db
+      - DATABASE_URL=file:../.data/dev.db
     volumes:
       - nitropage-data:/app/.data
     healthcheck:

--- a/templates/compose/nitropage.yaml
+++ b/templates/compose/nitropage.yaml
@@ -6,7 +6,7 @@
 
 services:
   nitropage:
-    image: codeberg.org/nitropage/nitropage:sqlite
+    image: nitropage/nitropage:sqlite
     environment:
       - SERVICE_FQDN_NITROPAGE_3000
       - NP_AUTH_SALT=${SERVICE_BASE64_SALT}


### PR DESCRIPTION
## Changes
- Replaced the Codeberg registry with Docker. The Codeberg one still exists and is maintained, but Codeberg has been a bit unreliable recently (downtimes) 🙈.
- Updated the `DATABASE_URL` in the sqlite template. Unfortunately the relative base for said path has changed in Nitropage v0.68
