### PR TITLE
fix(ui): typo on proxy request handler tooltip

### DIFF
--- a/resources/views/livewire/server/proxy.blade.php
+++ b/resources/views/livewire/server/proxy.blade.php
@@ -29,7 +29,7 @@
                             label="Generate labels only for {{ str($server->proxyType())->title() }}" instantSave />
                         <x-forms.checkbox instantSave="instantSaveRedirect" id="redirect_enabled"
                             label="Override default request handler"
-                            helper="Requests to unknown hosts or stopped services will recieve a 503 response or be redirected to the URL you set below (need to enable this first)." />
+                            helper="Requests to unknown hosts or stopped services will receive a 503 response or be redirected to the URL you set below (need to enable this first)." />
                         @if ($redirect_enabled)
                             <x-forms.input placeholder="https://app.coolify.io" id="redirect_url"
                                 label="Redirect to (optional)" />


### PR DESCRIPTION
## Changes
- Fix typo in the Server->Proxy->Override default request handler tooltip
