### PR TITLE
feat(queues): improve Horizon config to reduce CPU and RAM usage

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -182,14 +182,15 @@ return [
     'defaults' => [
         's6' => [
             'connection' => 'redis',
-            'queue' => explode(',', env('HORIZON_QUEUES', 'high,default')),
-            'balance' => env('HORIZON_BALANCE', 'auto'),
-            'maxTime' => 0,
-            'maxJobs' => 0,
+            'balance' => env('HORIZON_BALANCE', 'false'),
+            'queue' => env('HORIZON_QUEUES', 'high,default'),
+            'maxTime' => 3600,
+            'maxJobs' => 400,
             'memory' => 128,
             'tries' => 1,
-            'timeout' => 3560,
             'nice' => 0,
+            'sleep' => 3,
+            'timeout' => 3600,
         ],
     ],
 
@@ -198,7 +199,7 @@ return [
             's6' => [
                 'autoScalingStrategy' => 'size',
                 'minProcesses' => env('HORIZON_MIN_PROCESSES', 1),
-                'maxProcesses' => env('HORIZON_MAX_PROCESSES', 6),
+                'maxProcesses' => env('HORIZON_MAX_PROCESSES', 4),
                 'balanceMaxShift' => env('HORIZON_BALANCE_MAX_SHIFT', 1),
                 'balanceCooldown' => env('HORIZON_BALANCE_COOLDOWN', 1),
             ],
@@ -208,7 +209,7 @@ return [
             's6' => [
                 'autoScalingStrategy' => 'size',
                 'minProcesses' => env('HORIZON_MIN_PROCESSES', 1),
-                'maxProcesses' => env('HORIZON_MAX_PROCESSES', 6),
+                'maxProcesses' => env('HORIZON_MAX_PROCESSES', 4),
                 'balanceMaxShift' => env('HORIZON_BALANCE_MAX_SHIFT', 1),
                 'balanceCooldown' => env('HORIZON_BALANCE_COOLDOWN', 1),
             ],

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -189,7 +189,7 @@ return [
             'memory' => 128,
             'tries' => 1,
             'nice' => 0,
-            'sleep' => 5,
+            'sleep' => 3,
             'timeout' => 3600,
         ],
     ],

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -189,7 +189,7 @@ return [
             'memory' => 128,
             'tries' => 1,
             'nice' => 0,
-            'sleep' => 3,
+            'sleep' => 5,
             'timeout' => 3600,
         ],
     ],


### PR DESCRIPTION
## Changes

These changes may seem minor, but each line was specifically crafted and benchmarked over the course of 2.5 weeks. All of these changes will help improve performance and reduce load of the servers CPU and RAM.

- `maxTime` and `maxJobs` ensure that each worker is stopped (and immediately started again by `s6-overlay`, as they are long-running) after either 400 jobs or 1 hour has passed. This helps free up accumulated Memory and CPU. Previously, we were not restarting workers at all, which caused some to consume far more CPU and Memory than they should have (`memory` was already limited though). Users mentioned that rebooting the server fixed this issue https://github.com/coollabsio/coolify/issues/2110#issuecomment-3057768791, which makes sense because rebooting restarts the workers as a side effect of Docker restarting the `coolify` container. Now this is no longer needed and is handled automatically.
- `sleep` -> when a worker is idle, it now waits 3 seconds before polling again, which helps reduce small CPU spikes.
- `balance` is now set to `false` by default. This allows us to strictly prioritize `high` queued jobs over `default` queued jobs. Previously, we used `auto` which simply assigned workers to the queue with the most jobs (by `size` - `autoScalingStrategy`). Which by default in most cases will be the `default` queue which is not ideal as then `default` jobs will be process before `high` jobs.
- `balance` set to `false` also reduces idle running workers form 2 workers to 1 worker
- After a lot of testing and I think most users run Coolify on a 2-core server. We should reduce the default `maxProcesses` to 4, as having more workers than 2x the number of CPU cores does not help and only causes higher CPU load during job runs.

## Issues

- improves https://github.com/coollabsio/coolify/issues/2110
