### PR TITLE
fix(backups): large database backups are not working

### DIFF
--- a/app/Livewire/Project/Database/BackupEdit.php
+++ b/app/Livewire/Project/Database/BackupEdit.php
@@ -73,6 +73,9 @@ class BackupEdit extends Component
     #[Validate(['required', 'boolean'])]
     public bool $dumpAll = false;
 
+    #[Validate(['required', 'int', 'min:1', 'max:36000'])]
+    public int $timeout = 3600;
+
     public function mount()
     {
         try {
@@ -98,6 +101,7 @@ class BackupEdit extends Component
             $this->backup->s3_storage_id = $this->s3StorageId;
             $this->backup->databases_to_backup = $this->databasesToBackup;
             $this->backup->dump_all = $this->dumpAll;
+            $this->backup->timeout = $this->timeout;
             $this->customValidate();
             $this->backup->save();
         } else {
@@ -114,6 +118,7 @@ class BackupEdit extends Component
             $this->s3StorageId = $this->backup->s3_storage_id;
             $this->databasesToBackup = $this->backup->databases_to_backup;
             $this->dumpAll = $this->backup->dump_all;
+            $this->timeout = $this->backup->timeout;
         }
     }
 

--- a/database/migrations/2025_07_16_202201_add_timeout_to_scheduled_database_backups_table.php
+++ b/database/migrations/2025_07_16_202201_add_timeout_to_scheduled_database_backups_table.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('scheduled_database_backups', function (Blueprint $table) {
+            $table->integer('timeout')->default(3600);
+        });
+    }
+};

--- a/resources/views/livewire/project/database/backup-edit.blade.php
+++ b/resources/views/livewire/project/database/backup-edit.blade.php
@@ -77,6 +77,7 @@
             <x-forms.input label="Frequency" id="frequency" />
             <x-forms.input label="Timezone" id="timezone" disabled
                 helper="The timezone of the server where the backup is scheduled to run (if not set, the instance timezone will be used)" />
+            <x-forms.input label="Timeout" id="timeout" helper="The timeout of the backup job in seconds."/>
         </div>
 
         <h3 class="mt-6 mb-2 text-lg font-medium">Backup Retention Settings</h3>


### PR DESCRIPTION
## Changes
- feat(backups): added the ability to set a backup job `timeout` in seconds. This was needed as large backups can take much longer to complete, so users should be able to set the `timeout` themselves
- fix(backups): backup execution can be stuck in `In Progress`
- fix(backups): If the backup job fails because the `timeout`  is hit there will now be an error shown in the UI.
- fix(backups): Backups sometimes fail when the database is larger than 40GB

### Preview
**Timeout setting:**
<img width="1888" height="349" alt="image" src="https://github.com/user-attachments/assets/b371d1c4-eb03-46b6-b2fe-fe555998930f" />
**Timeout error:**
<img width="910" height="301" alt="image" src="https://github.com/user-attachments/assets/382f9793-0170-45ec-90cf-a5c4f3b6bd33" />

### Tests

I tested backups with a 58GB Postgres DB, which created a 1GB backup file successfully.

<img width="890" height="110" alt="image" src="https://github.com/user-attachments/assets/a99da4b2-59c4-4fa4-b563-5ca423031cfd" />

## Issues
- fix https://github.com/coollabsio/coolify/issues/3325
- fix https://github.com/coollabsio/coolify/issues/2687

/claim #3325
/claim #2687