### PR TITLE
fix(postgresql): allow custom config and SSL to work together

### DIFF
--- a/app/Actions/Database/StartPostgresql.php
+++ b/app/Actions/Database/StartPostgresql.php
@@ -203,15 +203,13 @@ class StartPostgresql
         }
 
         if ($this->database->enable_ssl) {
-            $docker_compose['services'][$container_name]['command'] = [
-                'postgres',
-                '-c',
-                'ssl=on',
-                '-c',
-                'ssl_cert_file=/var/lib/postgresql/certs/server.crt',
-                '-c',
-                'ssl_key_file=/var/lib/postgresql/certs/server.key',
-            ];
+            $docker_compose['services'][$container_name]['command'] ??= ['postgres'];
+            array_push(
+                $docker_compose['services'][$container_name]['command'],
+                '-c', 'ssl=on',
+                '-c', 'ssl_cert_file=/var/lib/postgresql/certs/server.crt',
+                '-c', 'ssl_key_file=/var/lib/postgresql/certs/server.key'
+            );
         }
 
         // Add custom docker run options


### PR DESCRIPTION
Changes
Fixed an issue where PostgreSQL custom configuration (postgresql.conf) was ignored when SSL was enabled.

Updated the startup command logic to append SSL options (-c ssl=on, ssl_cert_file, ssl_key_file) instead of overwriting existing custom configuration commands.

This allows both config_file and SSL parameters to work together as expected.

Issues
Fixes [#6230](https://github.com/coollabsio/coolify/issues/6230)