### PR TITLE
feat(services): update convex service to include postgres

### DIFF
--- a/templates/compose/convex.yaml
+++ b/templates/compose/convex.yaml
@@ -6,28 +6,49 @@
 
 services:
   backend:
-    image: ghcr.io/get-convex/convex-backend:5143fec81f146ca67495c12c6b7a15c5802c37e2
+    image: "ghcr.io/get-convex/convex-backend:5143fec81f146ca67495c12c6b7a15c5802c37e2"
     volumes:
-      - data:/convex/data
+      - "data:/convex/data"
     environment:
       - SERVICE_FQDN_BACKEND_3210
-      - INSTANCE_NAME=${INSTANCE_NAME:-self-hosted-convex}
-      - INSTANCE_SECRET=${SERVICE_HEX_32_SECRET}
-      - CONVEX_RELEASE_VERSION_DEV=${CONVEX_RELEASE_VERSION_DEV:-}
-      - ACTIONS_USER_TIMEOUT_SECS=${ACTIONS_USER_TIMEOUT_SECS:-}
-      - CONVEX_CLOUD_ORIGIN=${SERVICE_FQDN_CONVEX_3210}
-      - CONVEX_SITE_ORIGIN=${SERVICE_FQDN_CONVEX_3211}
-      - DATABASE_URL=${DATABASE_URL:-}
-      - DISABLE_BEACON=${DISABLE_BEACON:-}
-      - REDACT_LOGS_TO_CLIENT=${REDACT_LOGS_TO_CLIENT:-}
-      - CONVEX_SELF_HOSTED_URL=${SERVICE_FQDN_CONVEX_6791}
+      - "INSTANCE_NAME=${INSTANCE_NAME:-self-hosted-convex}"
+      - "INSTANCE_SECRET=${SERVICE_HEX_32_SECRET}"
+      - "CONVEX_RELEASE_VERSION_DEV=${CONVEX_RELEASE_VERSION_DEV:-}"
+      - "ACTIONS_USER_TIMEOUT_SECS=${ACTIONS_USER_TIMEOUT_SECS:-}"
+      - "CONVEX_CLOUD_ORIGIN=${SERVICE_FQDN_CONVEX_3210}"
+      - "CONVEX_SITE_ORIGIN=${SERVICE_FQDN_CONVEX_3211}"
+      - "DATABASE_URL=${DATABASE_URL:-}"
+      - "POSTGRES_URL=postgresql://${SERVICE_USER_POSTGRES}:${SERVICE_PASSWORD_POSTGRES}@convex-db:5432"
+      - "DO_NOT_REQUIRE_SSL=${DO_NOT_REQUIRE_SSL:-}"
+      - "DISABLE_BEACON=${DISABLE_BEACON:-}"
+      - "REDACT_LOGS_TO_CLIENT=${REDACT_LOGS_TO_CLIENT:-}"
+      - "CONVEX_SELF_HOSTED_URL=${SERVICE_FQDN_CONVEX_6791}"
+    depends_on:
+      convex-db:
+        condition: service_healthy
     healthcheck:
-      test: curl -f http://127.0.0.1:3210/version
+      test: "curl -f http://127.0.0.1:3210/version"
       interval: 5s
       start_period: 5s
 
+  convex-db:
+    image: "postgres:16-alpine"
+    volumes:
+      - "postgres_data:/var/lib/postgresql/data"
+    environment:
+      - "POSTGRES_DB=self_hosted_convex"
+      - "POSTGRES_USER=${SERVICE_USER_POSTGRES}"
+      - "POSTGRES_PASSWORD=${SERVICE_PASSWORD_POSTGRES}"
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"
+      interval: 5s
+      timeout: 20s
+      retries: 10
+
   dashboard:
-    image: ghcr.io/get-convex/convex-dashboard:5143fec81f146ca67495c12c6b7a15c5802c37e2
+    image: "ghcr.io/get-convex/convex-dashboard:5143fec81f146ca67495c12c6b7a15c5802c37e2"
     environment:
       - SERVICE_FQDN_CONVEX_6791
       - NEXT_PUBLIC_DEPLOYMENT_URL=$SERVICE_FQDN_BACKEND_3210
@@ -35,6 +56,6 @@ services:
       backend:
         condition: service_healthy
     healthcheck:
-      test: wget -qO- http://127.0.0.1:6791/
+      test: "wget -qO- http://127.0.0.1:6791/"
       interval: 5s
       start_period: 5s


### PR DESCRIPTION
so apparently convex template was using sqlite which is by default but we can add postgres to convex. also to add postgres we need to have a particular name database which is `self_hosted_convex`.

- also added some other env varibles which were given in the convex docs

https://github.com/get-convex/convex-backend/tree/main/self-hosted#running-the-database-on-postgres


---
also I don't know whether we should make another service for it.
For e.g: `nextcloud with postgres`

please let me know if we want that I will add a new template :smile: 
