### PR TITLE
chore(service): add `NOT_SECURED` env to Postiz

### DIFF
--- a/templates/compose/postiz.yaml
+++ b/templates/compose/postiz.yaml
@@ -77,6 +77,7 @@ services:
       - NEXT_PUBLIC_POLOTNO=${NEXT_PUBLIC_POLOTNO}
       - IS_GENERAL=true
       - NX_ADD_PLUGINS=${NX_ADD_PLUGINS:-false}
+      - NOT_SECURED=${NOT_SECURED:-false}
       
       # Payment Settings
       - FEE_AMOUNT=${FEE_AMOUNT:-0.05}


### PR DESCRIPTION
## Changes
- Add support for NOT_SECURED env var in Postiz service. See docs about it here https://docs.postiz.com/installation/docker-compose
