### PR TITLE
fix: add syncthing web ui port

### DIFF
--- a/templates/compose/syncthing.yaml
+++ b/templates/compose/syncthing.yaml
@@ -17,6 +17,7 @@ services:
       - syncthing_data1:/data1
       - syncthing_data2:/data2
     ports:
+      - 8384:8384/tcp
       - 22000:22000/tcp
       - 22000:22000/udp
       - 21027:21027/udp


### PR DESCRIPTION
The syncthing.yaml docker compose file was missing the port for the web interface.

## Changes
- Add port 8384 to the docker compose file
