### PR TITLE
Add Server Info Widget to Dashboard (Live Updating)

### DIFF
--- a/app/Livewire/SystemInfoWidget.php
+++ b/app/Livewire/SystemInfoWidget.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Services\SystemInfoService;
+use Livewire\Component;
+
+class SystemInfoWidget extends Component
+{
+    public array $info = [];
+
+    public function render()
+    {
+        $this->info = app(SystemInfoService::class)->get();
+
+        return view('livewire.system-info-widget');
+    }
+}

--- a/app/Services/SystemInfoService.php
+++ b/app/Services/SystemInfoService.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * SystemInfoService
+ * -----------------
+ * This service provides system-level information for the dashboard widget,
+ * including memory, uptime, disk usage, Docker stats, and more.
+ *
+ * Created by Mustafa Ramadan (Steve-Sy)
+ * Last updated: 26-07-2025
+ * Purpose: Used in Coolify dashboard to show real-time server info.
+ */
+
+namespace App\Services;
+
+class SystemInfoService
+{
+    public function get(): array
+    {
+        $static = $this->getStaticInfo();
+
+        return [
+            ...$static,
+            'memory' => $this->getMemoryInfo(),
+            'uptime' => $this->getUptime(),
+            'datetime' => now()->format('Y-m-d H:i:s'),
+            'disk_usage' => $this->getDiskUsage(),
+            'load_average' => $this->getLoadAverage(),
+            'containers' => $this->getContainerStats(),
+            'swap_usage' => $this->getSwapUsage(),
+        ];
+    }
+
+    private function getOsName(): string
+    {
+        // Works on most Linux distros
+        if (file_exists('/etc/os-release')) {
+            $content = file_get_contents('/etc/os-release');
+            if (preg_match('/^PRETTY_NAME="(.+)"$/m', $content, $matches)) {
+                return $matches[1]; // e.g. Ubuntu 24.04 LTS
+            }
+        }
+
+        return php_uname('s'); // fallback
+    }
+
+    private function getPublicIP(): ?string
+    {
+        return trim(@file_get_contents('https://api.ipify.org'));
+    }
+
+    private function getCpuCores(): int
+    {
+        return (int) shell_exec('nproc') ?: 0;
+    }
+
+    private function getMemoryInfo(): array
+    {
+        $mem = explode("\n", trim(shell_exec("grep -E 'MemTotal|MemAvailable' /proc/meminfo")));
+        $total = (int) filter_var($mem[0], FILTER_SANITIZE_NUMBER_INT);
+        $available = (int) filter_var($mem[1], FILTER_SANITIZE_NUMBER_INT);
+        $used = $total - $available;
+
+        return [
+            'total' => round($total / 1024 / 1024, 2),     // GB
+            'used' => round($used / 1024 / 1024, 2),        // GB
+        ];
+    }
+
+    private function getUptime(): string
+    {
+        $seconds = (int) shell_exec("cat /proc/uptime | awk '{print int($1)}'");
+        $hours = floor($seconds / 3600);
+        $minutes = floor(($seconds % 3600) / 60);
+
+        return "{$hours}h {$minutes}m";
+    }
+
+    private function getDiskUsage(): string
+    {
+        return trim(shell_exec("df -h / | awk 'NR==2 {print $3 \"/\" $2}'"));
+    }
+
+    private function getLoadAverage(): string
+    {
+        return trim(shell_exec("uptime | awk -F'load average:' '{ print $2 }'"));
+    }
+
+    private function getCpuModel(): string
+    {
+        $lscpu = shell_exec('which lscpu');
+        if ($lscpu) {
+            return trim(shell_exec("lscpu | grep 'Model name' | awk -F ':' '{print $2}'"));
+        }
+
+        // Fallback to /proc/cpuinfo (works on all Linux distros)
+        $cpuInfo = shell_exec("grep 'model name' /proc/cpuinfo | head -n 1");
+
+        return $cpuInfo ? trim(explode(':', $cpuInfo)[1]) : 'Unknown';
+    }
+
+    private function getContainerStats(): array
+    {
+        $running = (int) shell_exec('docker ps -q | wc -l');
+        $total = (int) shell_exec('docker ps -aq | wc -l');
+
+        return ['running' => $running, 'total' => $total];
+    }
+
+    private function getSwapUsage(): string
+    {
+        $output = shell_exec('free -h | grep Swap');
+        if (! $output) {
+            return 'N/A';
+        }
+
+        [$label, $total, $used] = preg_split('/\s+/', trim($output));
+
+        return "$used / $total";
+    }
+
+    // This method caches the static info for 24 hours, clear by cache()->forget('server_static_info');
+    private function getStaticInfo(): array
+    {
+        return cache()->remember('server_static_info', now()->addDay(), function () {
+            return [
+                'os' => $this->getOsName(),
+                'hostname' => gethostname(),
+                'public_ip' => $this->getPublicIP(),
+                'cpu_cores' => $this->getCpuCores(),
+                'cpu_model' => $this->getCpuModel(),
+            ];
+        });
+    }
+}

--- a/resources/views/livewire/dashboard.blade.php
+++ b/resources/views/livewire/dashboard.blade.php
@@ -15,6 +15,10 @@
     @endif
 
     <section>
+        <livewire:system-info-widget />
+    </section>
+
+    <section>
         <h3 class="pb-2">Projects</h3>
         @if ($projects->count() > 0)
             <div class="grid grid-cols-1 gap-4 xl:grid-cols-2">

--- a/resources/views/livewire/system-info-widget.blade.php
+++ b/resources/views/livewire/system-info-widget.blade.php
@@ -1,0 +1,37 @@
+<div class="grid grid-cols-1 xl:grid-cols-1 gap-4">
+    <div wire:poll.30s class="flex flex-wrap text-sm gap-x-6 gap-y-2">
+        {{-- System --}}
+        <div><strong>OS:</strong> {{ $info['os'] }}</div>
+        <div><strong>Hostname:</strong> {{ $info['hostname'] }}</div>
+        <div><strong>Public IP:</strong> {{ $info['public_ip'] }}</div>
+        <div><strong>CPU:</strong> {{ $info['cpu_cores'] }}(cores) {{ $info['cpu_model'] }}</div>
+        <div><strong>Now:</strong> {{ $info['datetime'] }}</div>
+        <div><strong>Uptime:</strong> <span class="animate-pulse">{{ $info['uptime'] }}</span></div>
+
+        {{-- Memory --}}
+        <div>
+            <strong>Memory:</strong> <span class="animate-pulse">{{ $info['memory']['used'] }} / {{ $info['memory']['total'] }} GB</span>
+        </div>
+        <div><strong>Swap:</strong> <span class="animate-pulse">{{ $info['swap_usage'] }}</span></div>
+
+        {{-- System Load --}}
+        <div><strong>Load Avg:</strong> <span class="animate-pulse">{{ $info['load_average'] }}</span></div>
+        <div><strong>Disk Usage:</strong> <span class="animate-pulse">{{ $info['disk_usage'] }}</span></div>
+
+        {{-- Docker --}}
+        @if ($info['containers']['running'] > 0)
+            <div>
+                <strong>Containers:</strong>
+                {{ $info['containers']['running'] }}/{{ $info['containers']['total'] }}
+            </div>
+        @endif
+        <div>
+            <button wire:click="$refresh" title="Manual refresh (auto every 30s)"
+                class="text-xs text-coollabs hover:text-coollabs-100 hover:scale-110 transition cursor-pointer">
+                ↻
+            </button>
+        </div>
+    </div>
+
+</div>
+


### PR DESCRIPTION
This PR introduces a new Server Info widget to the dashboard. It provides (30s) live system metrics for the host running Coolify.

Coolify users often self-host on bare-metal or VPS/VM environments. This widget makes it easy to monitor real-time server health without needing an external tool.

Notes
• Data gathered from standard Linux shell commands like free, df, uptime, docker ps, etc.
• Lightweight & non-intrusive (only uses safe shell reads)
• Designed to degrade gracefully on minimal distros like Alpine

## Changes
- Added a new **Server Info widget** to the dashboard
- Displays live system info: OS, hostname, IP, uptime, memory, CPU, swap, disk, Docker stats
- Uses `wire:poll.30s` for real-time updates
- Caches static values (OS, hostname, IP, CPU info) for 24h to reduce load
- Includes manual refresh button
- Fallback support for Alpine and minimal distros (e.g., no `lscpu`)

## Issues
- N/A — feature addition

<img width="1134" height="612" alt="Screenshot 2025-07-26 at 5 14 58 pm" src="https://github.com/user-attachments/assets/7c6d5093-8313-4b75-be80-9da18891b68b" />
