### PR TITLE
fix(proxy): remove hardcoded port 80/443 checks

### DIFF
--- a/app/Actions/Proxy/CheckProxy.php
+++ b/app/Actions/Proxy/CheckProxy.php
@@ -66,7 +66,7 @@ class CheckProxy
             if ($server->id === 0) {
                 $ip = 'host.docker.internal';
             }
-            $portsToCheck = ['80', '443'];
+            $portsToCheck = [];
 
             try {
                 if ($server->proxyType() !== ProxyTypes::NONE->value) {


### PR DESCRIPTION
## Summary

This PR fixes an issue where the Coolify proxy fails to start via the web UI if port 80 is in use by another service, even when the proxy is configured to use different ports.

## Problem

Previously, the `CheckProxy.php` action had hardcoded port checks for ports 80 and 443:

```php
$portsToCheck = ['80', '443'];
```

This caused the proxy startup to fail with the error "Port 80 is in use" even when users had configured their proxy to use alternative ports (e.g., 5080/5443).

## Solution

The fix removes the hardcoded port initialization and lets the existing configuration parsing logic determine which ports to check based on the actual proxy configuration in `docker-compose.yml`.

```php
$portsToCheck = [];
```

Now the proxy only checks ports that are actually configured for use, preventing false failures when standard ports are occupied by other services.

## Testing

To test this fix:

1. Configure your proxy to use non-standard ports (e.g., 5080/5443)
2. Start another service on port 80
3. Attempt to restart the proxy via the web UI
4. The proxy should now start successfully without complaining about port 80

## Related Issues

Fixes #6234

## Breaking Changes

None. This change maintains backward compatibility while fixing the reported issue.