### PR TITLE
fix(api): duplicated logs in application endpoint

### DIFF
--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -1101,7 +1101,7 @@ function getContainerLogs(Server $server, string $container_id, int $lines = 100
         ], $server);
     }
 
-    $output .= removeAnsiColors($output);
+    $output = removeAnsiColors($output);
 
     return $output;
 }


### PR DESCRIPTION
The application logs endpoint was returning duplicated log content due to an incorrect assignment operation in the `getContainerLogs` function. The issue was in `bootstrap/helpers/docker.php` where the ANSI color removal was being appended to the output instead of reassigning it.

## Changes
- Fixed logs duplication by using the correct assignment operation in `getContainerLogs` function