### PR TITLE
fix(ui): add flex-wrap to prevent overflow on small screens

### DIFF
--- a/resources/views/livewire/project/shared/environment-variable/show.blade.php
+++ b/resources/views/livewire/project/shared/environment-variable/show.blade.php
@@ -21,7 +21,7 @@
             </div>
         @else
             @if ($isDisabled)
-                <div class="flex flex-col w-full gap-2 lg:flex-row">
+                <div class="flex flex-col w-full gap-2 flex-wrap lg:flex-row">
                     <x-forms.input disabled id="key" />
                     <x-forms.input disabled type="password" id="value" />
                     @if ($is_shared)
@@ -29,7 +29,7 @@
                     @endif
                 </div>
             @else
-                <div class="flex flex-col w-full gap-2 lg:flex-row">
+                <div class="flex flex-col w-full gap-2 flex-wrap lg:flex-row">
                     @if ($is_multiline)
                         <x-forms.input :required="$is_redis_credential" isMultiline="{{ $is_multiline }}" id="key" />
                         <x-forms.textarea :required="$is_redis_credential" type="password" id="value" />
@@ -42,7 +42,7 @@
                     @endif
                 </div>
             @endif
-            <div class="flex flex-col w-full gap-2 lg:flex-row">
+            <div class="flex flex-col w-full gap-2 flex-wrap lg:flex-row">
                 @if (!$is_redis_credential)
                     @if ($type === 'service')
                         <x-forms.checkbox instantSave id="is_build_time"


### PR DESCRIPTION
## Changes
- Added flex-wrap to prevent overflow on small screens

## Issues
- fix #6305 

1024px: before
<img width="500px" height="auto" alt="before-1024" src="https://github.com/user-attachments/assets/a6e996cc-c731-45e4-9ad0-543e042a3659" />

1024px: after
<img width="500px" height="auto" alt="after-1024px" src="https://github.com/user-attachments/assets/12422d60-81ba-4d11-9464-0447e575a2bc" />

1260px: before
<img width="500px" height="auto" alt="before-1260" src="https://github.com/user-attachments/assets/74ecccec-fb40-46c1-9e2f-9dc15c8d5c78" />

1260px: after
<img width="500px" height="auto" alt="after-1260" src="https://github.com/user-attachments/assets/cf24e8e7-3dde-4d2a-8522-7944618a26f6" />

1360px: before
<img width="500px" height="auto" alt="before-1360" src="https://github.com/user-attachments/assets/92c4f6f9-bec4-4736-b2b7-205f47b6e6c3" />

1360px: after
<img width="500px" height="auto" alt="after-1360" src="https://github.com/user-attachments/assets/f74b9ba0-5f1a-44f4-9784-7db603796020" />
