### PR TITLE
fix(ui): Delete button width on small screens

### DIFF
--- a/resources/views/livewire/project/shared/environment-variable/show.blade.php
+++ b/resources/views/livewire/project/shared/environment-variable/show.blade.php
@@ -88,6 +88,7 @@
                     <x-modal-confirmation title="Confirm Environment Variable Deletion?" isErrorButton
                         buttonTitle="Delete" submitAction="delete" :actions="['The selected environment variable will be permanently deleted.']"
                         confirmationText="{{ $key }}"
+                        buttonFullWidth="true"
                         confirmationLabel="Please confirm the execution of the actions by entering the Environment Variable Name below"
                         shortConfirmationLabel="Environment Variable Name" :confirmWithPassword="false"
                         step2ButtonText="Permanently Delete" />
@@ -101,6 +102,7 @@
                     <x-modal-confirmation title="Confirm Environment Variable Deletion?" isErrorButton
                         buttonTitle="Delete" submitAction="delete" :actions="['The selected environment variable will be permanently deleted.']"
                         confirmationText="{{ $key }}"
+                        buttonFullWidth="true"
                         confirmationLabel="Please confirm the execution of the actions by entering the Environment Variable Name below"
                         shortConfirmationLabel="Environment Variable Name" :confirmWithPassword="false"
                         step2ButtonText="Permanently Delete" />


### PR DESCRIPTION
## Changes
- Fix "Delete" button width on small screens

Small screen: before
<img width="400px" height="auto" alt="before-small" src="https://github.com/user-attachments/assets/57f00fcb-d966-45dc-b07c-61f1d5c09196" />

Small screen: after
<img width="400px" height="auto" alt="after-small" src="https://github.com/user-attachments/assets/6439f48c-5b46-4091-ba0a-a0320c24e956" />

Wide screen: before
<img width="400px" height="auto" alt="before-big" src="https://github.com/user-attachments/assets/206f871c-b386-4112-acc6-57a71483592a" />

Wide screen: after
<img width="400px" height="auto" alt="after-big" src="https://github.com/user-attachments/assets/391a0f89-fd16-4b7f-a9ed-ea93e87bdbbc" />
