### PR TITLE
fix(docker): volumes get delete when stopping a service if `Delete Unused Volumes` is activated

### DIFF
--- a/app/Actions/Application/StopApplication.php
+++ b/app/Actions/Application/StopApplication.php
@@ -49,7 +49,7 @@ class StopApplication
                 }
 
                 if ($dockerCleanup) {
-                    CleanupDocker::dispatch($server, true);
+                    CleanupDocker::dispatch($server, false, false);
                 }
             } catch (\Exception $e) {
                 return $e->getMessage();

--- a/app/Actions/Database/StopDatabase.php
+++ b/app/Actions/Database/StopDatabase.php
@@ -29,7 +29,7 @@ class StopDatabase
             $this->stopContainer($database, $database->uuid, 30);
 
             if ($dockerCleanup) {
-                CleanupDocker::dispatch($server, true);
+                CleanupDocker::dispatch($server, false, false);
             }
 
             if ($database->is_public) {

--- a/app/Actions/Server/CleanupDocker.php
+++ b/app/Actions/Server/CleanupDocker.php
@@ -11,7 +11,7 @@ class CleanupDocker
 
     public string $jobQueue = 'high';
 
-    public function handle(Server $server)
+    public function handle(Server $server, bool $deleteUnusedVolumes = false, bool $deleteUnusedNetworks = false)
     {
         $settings = instanceSettings();
         $realtimeImage = config('constants.coolify.realtime_image');
@@ -36,11 +36,11 @@ class CleanupDocker
             "docker images --filter before=$realtimeImageWithoutPrefixVersion --filter reference=$realtimeImageWithoutPrefix | grep $realtimeImageWithoutPrefix | awk '{print $3}' | xargs -r docker rmi -f",
         ];
 
-        if ($server->settings->delete_unused_volumes) {
+        if ($deleteUnusedVolumes) {
             $commands[] = 'docker volume prune -af';
         }
 
-        if ($server->settings->delete_unused_networks) {
+        if ($deleteUnusedNetworks) {
             $commands[] = 'docker network prune -f';
         }
 

--- a/app/Actions/Server/UpdateCoolify.php
+++ b/app/Actions/Server/UpdateCoolify.php
@@ -29,7 +29,7 @@ class UpdateCoolify
         if (! $this->server) {
             return;
         }
-        CleanupDocker::dispatch($this->server);
+        CleanupDocker::dispatch($this->server, false, false);
         $this->latestVersion = get_latest_version_of_coolify();
         $this->currentVersion = config('constants.coolify.version');
         if (! $manual_update) {

--- a/app/Actions/Service/DeleteService.php
+++ b/app/Actions/Service/DeleteService.php
@@ -11,7 +11,7 @@ class DeleteService
 {
     use AsAction;
 
-    public function handle(Service $service, bool $deleteConfigurations, bool $deleteVolumes, bool $dockerCleanup, bool $deleteConnectedNetworks)
+    public function handle(Service $service, bool $deleteVolumes, bool $deleteConnectedNetworks, bool $deleteConfigurations, bool $dockerCleanup)
     {
         try {
             $server = data_get($service, 'server');
@@ -71,7 +71,7 @@ class DeleteService
             $service->forceDelete();
 
             if ($dockerCleanup) {
-                CleanupDocker::dispatch($server, true);
+                CleanupDocker::dispatch($server, false, false);
             }
         }
     }

--- a/app/Actions/Service/StopService.php
+++ b/app/Actions/Service/StopService.php
@@ -40,7 +40,7 @@ class StopService
                 $service->deleteConnectedNetworks();
             }
             if ($dockerCleanup) {
-                CleanupDocker::dispatch($server, true);
+                CleanupDocker::dispatch($server, false, false);
             }
         } catch (\Exception $e) {
             return $e->getMessage();

--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -1699,10 +1699,10 @@ class ApplicationsController extends Controller
 
         DeleteResourceJob::dispatch(
             resource: $application,
-            deleteConfigurations: $request->query->get('delete_configurations', true),
             deleteVolumes: $request->query->get('delete_volumes', true),
-            dockerCleanup: $request->query->get('docker_cleanup', true),
-            deleteConnectedNetworks: $request->query->get('delete_connected_networks', true)
+            deleteConnectedNetworks: $request->query->get('delete_connected_networks', true),
+            deleteConfigurations: $request->query->get('delete_configurations', true),
+            dockerCleanup: $request->query->get('docker_cleanup', true)
         );
 
         return response()->json([

--- a/app/Http/Controllers/Api/DatabasesController.php
+++ b/app/Http/Controllers/Api/DatabasesController.php
@@ -1608,10 +1608,10 @@ class DatabasesController extends Controller
 
         DeleteResourceJob::dispatch(
             resource: $database,
-            deleteConfigurations: $request->query->get('delete_configurations', true),
             deleteVolumes: $request->query->get('delete_volumes', true),
-            dockerCleanup: $request->query->get('docker_cleanup', true),
-            deleteConnectedNetworks: $request->query->get('delete_connected_networks', true)
+            deleteConnectedNetworks: $request->query->get('delete_connected_networks', true),
+            deleteConfigurations: $request->query->get('delete_configurations', true),
+            dockerCleanup: $request->query->get('docker_cleanup', true)
         );
 
         return response()->json([

--- a/app/Http/Controllers/Api/ServicesController.php
+++ b/app/Http/Controllers/Api/ServicesController.php
@@ -510,10 +510,10 @@ class ServicesController extends Controller
 
         DeleteResourceJob::dispatch(
             resource: $service,
-            deleteConfigurations: $request->query->get('delete_configurations', true),
             deleteVolumes: $request->query->get('delete_volumes', true),
-            dockerCleanup: $request->query->get('docker_cleanup', true),
-            deleteConnectedNetworks: $request->query->get('delete_connected_networks', true)
+            deleteConnectedNetworks: $request->query->get('delete_connected_networks', true),
+            deleteConfigurations: $request->query->get('delete_configurations', true),
+            dockerCleanup: $request->query->get('docker_cleanup', true)
         );
 
         return response()->json([

--- a/app/Jobs/DeleteResourceJob.php
+++ b/app/Jobs/DeleteResourceJob.php
@@ -32,10 +32,10 @@ class DeleteResourceJob implements ShouldBeEncrypted, ShouldQueue
 
     public function __construct(
         public Application|ApplicationPreview|Service|StandalonePostgresql|StandaloneRedis|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse $resource,
-        public bool $deleteConfigurations = true,
         public bool $deleteVolumes = true,
-        public bool $dockerCleanup = true,
-        public bool $deleteConnectedNetworks = true
+        public bool $deleteConnectedNetworks = true,
+        public bool $deleteConfigurations = true,
+        public bool $dockerCleanup = true
     ) {
         $this->onQueue('high');
     }
@@ -66,7 +66,7 @@ class DeleteResourceJob implements ShouldBeEncrypted, ShouldQueue
                     break;
                 case 'service':
                     StopService::run($this->resource, true);
-                    DeleteService::run($this->resource, $this->deleteConfigurations, $this->deleteVolumes, $this->dockerCleanup, $this->deleteConnectedNetworks);
+                    DeleteService::run($this->resource, $this->deleteVolumes, $this->deleteConnectedNetworks, $this->deleteConfigurations, $this->dockerCleanup);
 
                     return;
             }
@@ -106,7 +106,7 @@ class DeleteResourceJob implements ShouldBeEncrypted, ShouldQueue
             if ($this->dockerCleanup) {
                 $server = data_get($this->resource, 'server') ?? data_get($this->resource, 'destination.server');
                 if ($server) {
-                    CleanupDocker::dispatch($server, true);
+                    CleanupDocker::dispatch($server, false, false);
                 }
             }
             Artisan::queue('cleanup:stucked-resources');

--- a/app/Jobs/DockerCleanupJob.php
+++ b/app/Jobs/DockerCleanupJob.php
@@ -34,7 +34,12 @@ class DockerCleanupJob implements ShouldBeEncrypted, ShouldQueue
         return [(new WithoutOverlapping('docker-cleanup-'.$this->server->uuid))->expireAfter(600)->dontRelease()];
     }
 
-    public function __construct(public Server $server, public bool $manualCleanup = false) {}
+    public function __construct(
+        public Server $server,
+        public bool $manualCleanup = false,
+        public bool $deleteUnusedVolumes = false,
+        public bool $deleteUnusedNetworks = false
+    ) {}
 
     public function handle(): void
     {
@@ -50,7 +55,11 @@ class DockerCleanupJob implements ShouldBeEncrypted, ShouldQueue
             $this->usageBefore = $this->server->getDiskUsage();
 
             if ($this->manualCleanup || $this->server->settings->force_docker_cleanup) {
-                $cleanup_log = CleanupDocker::run(server: $this->server);
+                $cleanup_log = CleanupDocker::run(
+                    server: $this->server,
+                    deleteUnusedVolumes: $this->deleteUnusedVolumes,
+                    deleteUnusedNetworks: $this->deleteUnusedNetworks
+                );
                 $usageAfter = $this->server->getDiskUsage();
                 $message = ($this->manualCleanup ? 'Manual' : 'Forced').' Docker cleanup job executed successfully. Disk usage before: '.$this->usageBefore.'%, Disk usage after: '.$usageAfter.'%.';
 
@@ -67,7 +76,11 @@ class DockerCleanupJob implements ShouldBeEncrypted, ShouldQueue
             }
 
             if (str($this->usageBefore)->isEmpty() || $this->usageBefore === null || $this->usageBefore === 0) {
-                $cleanup_log = CleanupDocker::run(server: $this->server);
+                $cleanup_log = CleanupDocker::run(
+                    server: $this->server,
+                    deleteUnusedVolumes: $this->deleteUnusedVolumes,
+                    deleteUnusedNetworks: $this->deleteUnusedNetworks
+                );
                 $message = 'Docker cleanup job executed successfully, but no disk usage could be determined.';
 
                 $this->execution_log->update([
@@ -81,7 +94,11 @@ class DockerCleanupJob implements ShouldBeEncrypted, ShouldQueue
             }
 
             if ($this->usageBefore >= $this->server->settings->docker_cleanup_threshold) {
-                $cleanup_log = CleanupDocker::run(server: $this->server);
+                $cleanup_log = CleanupDocker::run(
+                    server: $this->server,
+                    deleteUnusedVolumes: $this->deleteUnusedVolumes,
+                    deleteUnusedNetworks: $this->deleteUnusedNetworks
+                );
                 $usageAfter = $this->server->getDiskUsage();
                 $diskSaved = $this->usageBefore - $usageAfter;
 

--- a/app/Jobs/ServerResourceManager.php
+++ b/app/Jobs/ServerResourceManager.php
@@ -133,7 +133,7 @@ class ServerResourceManager implements ShouldQueue
             $dockerCleanupFrequency = VALID_CRON_STRINGS[$dockerCleanupFrequency];
         }
         if ($this->shouldRunNow($dockerCleanupFrequency, $serverTimezone)) {
-            DockerCleanupJob::dispatch($server);
+            DockerCleanupJob::dispatch($server, false, $server->settings->delete_unused_volumes, $server->settings->delete_unused_networks);
         }
 
         // Dispatch ServerPatchCheckJob if due (weekly)

--- a/app/Livewire/Project/Shared/Danger.php
+++ b/app/Livewire/Project/Shared/Danger.php
@@ -99,10 +99,10 @@ class Danger extends Component
             $this->resource->delete();
             DeleteResourceJob::dispatch(
                 $this->resource,
-                $this->delete_configurations,
                 $this->delete_volumes,
-                $this->docker_cleanup,
-                $this->delete_connected_networks
+                $this->delete_connected_networks,
+                $this->delete_configurations,
+                $this->docker_cleanup
             );
 
             return redirect()->route('project.resource.index', [

--- a/app/Livewire/Server/DockerCleanup.php
+++ b/app/Livewire/Server/DockerCleanup.php
@@ -71,7 +71,7 @@ class DockerCleanup extends Component
     public function manualCleanup()
     {
         try {
-            DockerCleanupJob::dispatch($this->server, true);
+            DockerCleanupJob::dispatch($this->server, true, $this->deleteUnusedVolumes, $this->deleteUnusedNetworks);
             $this->dispatch('success', 'Manual cleanup job started. Depending on the amount of data, this might take a while.');
         } catch (\Throwable $e) {
             return handleError($e, $this);


### PR DESCRIPTION
## Changes

- fix(storage): ensure that stopping a database or any other container with volumes, when the server setting `Delete Unused Volumes` is enabled, does not cause the database or container to lose its volume data
- fix(docker): Ensure server cleanup settings are only used for manual and scheduled cleanups
- refactor(docker): improve the Docker cleanup action by adding two new arguments `deleteUnusedVolumes` and `deleteUnusedNetworks`, so that volumes and networks are deleted only when explicitly requested  
- refactor(docker): apply these arguments universally to ensure consistant cleanup behavior


## Issues

- fix https://github.com/coollabsio/coolify/issues/6316
