### PR TITLE
toggle for .git cleanup during deployment

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -1502,9 +1502,12 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
 
     private function cleanup_git()
     {
-        $this->execute_remote_command(
-            [executeInDocker($this->deployment_uuid, "rm -fr {$this->basedir}/.git")],
-        );
+        // Only remove .git if enabled (default: true for backward compatibility)
+        if ($this->application->settings->is_git_cleanup_enabled ?? true) {
+            $this->execute_remote_command(
+                [executeInDocker($this->deployment_uuid, "rm -fr {$this->basedir}/.git")],
+            );
+        }
     }
 
     private function generate_nixpacks_confs()

--- a/app/Livewire/Project/Application/Advanced.php
+++ b/app/Livewire/Project/Application/Advanced.php
@@ -70,7 +70,7 @@ class Advanced extends Component
     #[Validate(['boolean'])]
     public bool $isGitCleanupEnabled = true;
 
-    public $showGitRemovalWarningModal = false;
+    public bool $showGitRemovalWarningModal = false;
 
     public function mount()
     {
@@ -127,8 +127,41 @@ class Advanced extends Component
             $this->isRawComposeDeploymentEnabled = $this->application->settings->is_raw_compose_deployment_enabled;
             $this->isConnectToDockerNetworkEnabled = $this->application->settings->connect_to_docker_network;
             $this->disableBuildCache = $this->application->settings->disable_build_cache;
-            $this->isGitCleanupEnabled = $this->application->settings->is_git_cleanup_enabled ?? true;
+            $this->isGitCleanupEnabled = $this->application->settings->is_git_cleanup_enabled ?? false;
         }
+    }
+
+    public function handleGitCleanupToggle()
+    {
+        if ($this->isGitCleanupEnabled) {
+            $this->showGitRemovalWarningModal = true;
+
+        } else {
+            $this->updateGitCleanupSetting(true);
+        }
+    }
+
+    public function confirmGitRemoval()
+    {
+
+        $this->updateGitCleanupSetting(false);
+        $this->showGitRemovalWarningModal = false;
+        $this->dispatch('success', '.git removal disabled.');
+    }
+
+    public function cancelGitRemoval()
+    {
+        // User canceled unchecking, keep checkbox checked
+        $this->isGitCleanupEnabled = true;
+        $this->showGitRemovalWarningModal = false;
+    }
+
+    protected function updateGitCleanupSetting($value)
+    {
+        $this->application->settings->is_git_cleanup_enabled = $value;
+        $this->application->settings->save();
+        $this->isGitCleanupEnabled = $value;
+        $this->dispatch('saved');
     }
 
     private function resetDefaultLabels()
@@ -177,39 +210,6 @@ class Advanced extends Component
         } catch (\Throwable $e) {
             return handleError($e, $this);
         }
-    }
-    // Add these properties
-
-    // Add these methods
-    public function showGitRemovalWarning()
-    {
-        if (! $this->isGitCleanupEnabled) {
-            $this->showGitRemovalWarningModal = true;
-
-            return;
-        }
-
-        $this->updateGitCleanupSetting(false);
-    }
-
-    public function confirmGitRemoval()
-    {
-        $this->updateGitCleanupSetting(true);
-        $this->showGitRemovalWarningModal = false;
-    }
-
-    public function cancelGitRemoval()
-    {
-        $this->isGitCleanupEnabled = false;
-        $this->showGitRemovalWarningModal = false;
-    }
-
-    protected function updateGitCleanupSetting($value)
-    {
-        $this->application->settings->is_git_cleanup_enabled = $value;
-        $this->application->settings->save();
-        $this->isGitCleanupEnabled = $value;
-        $this->dispatch('saved');
     }
 
     public function submit()

--- a/app/Livewire/Project/Application/Advanced.php
+++ b/app/Livewire/Project/Application/Advanced.php
@@ -67,6 +67,11 @@ class Advanced extends Component
     #[Validate(['boolean'])]
     public bool $isConnectToDockerNetworkEnabled = false;
 
+    #[Validate(['boolean'])]
+    public bool $isGitCleanupEnabled = true;
+
+    public $showGitRemovalWarningModal = false;
+
     public function mount()
     {
         try {
@@ -99,6 +104,7 @@ class Advanced extends Component
             $this->application->settings->is_raw_compose_deployment_enabled = $this->isRawComposeDeploymentEnabled;
             $this->application->settings->connect_to_docker_network = $this->isConnectToDockerNetworkEnabled;
             $this->application->settings->disable_build_cache = $this->disableBuildCache;
+            $this->application->settings->is_git_cleanup_enabled = $this->isGitCleanupEnabled;
             $this->application->settings->save();
         } else {
             $this->isForceHttpsEnabled = $this->application->isForceHttpsEnabled();
@@ -121,6 +127,7 @@ class Advanced extends Component
             $this->isRawComposeDeploymentEnabled = $this->application->settings->is_raw_compose_deployment_enabled;
             $this->isConnectToDockerNetworkEnabled = $this->application->settings->connect_to_docker_network;
             $this->disableBuildCache = $this->application->settings->disable_build_cache;
+            $this->isGitCleanupEnabled = $this->application->settings->is_git_cleanup_enabled ?? true;
         }
     }
 
@@ -170,6 +177,39 @@ class Advanced extends Component
         } catch (\Throwable $e) {
             return handleError($e, $this);
         }
+    }
+    // Add these properties
+
+    // Add these methods
+    public function showGitRemovalWarning()
+    {
+        if (! $this->isGitCleanupEnabled) {
+            $this->showGitRemovalWarningModal = true;
+
+            return;
+        }
+
+        $this->updateGitCleanupSetting(false);
+    }
+
+    public function confirmGitRemoval()
+    {
+        $this->updateGitCleanupSetting(true);
+        $this->showGitRemovalWarningModal = false;
+    }
+
+    public function cancelGitRemoval()
+    {
+        $this->isGitCleanupEnabled = false;
+        $this->showGitRemovalWarningModal = false;
+    }
+
+    protected function updateGitCleanupSetting($value)
+    {
+        $this->application->settings->is_git_cleanup_enabled = $value;
+        $this->application->settings->save();
+        $this->isGitCleanupEnabled = $value;
+        $this->dispatch('saved');
     }
 
     public function submit()

--- a/app/Models/ApplicationSetting.php
+++ b/app/Models/ApplicationSetting.php
@@ -15,6 +15,7 @@ class ApplicationSetting extends Model
         'is_preview_deployments_enabled' => 'boolean',
         'is_git_submodules_enabled' => 'boolean',
         'is_git_lfs_enabled' => 'boolean',
+        'is_git_cleanup_enabled' => 'boolean',
     ];
 
     protected $guarded = [];

--- a/database/migrations/2025_08_12_171102_add_is_git_cleanup_enabled_to_applications_table.php
+++ b/database/migrations/2025_08_12_171102_add_is_git_cleanup_enabled_to_applications_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('applications', function (Blueprint $table) {
+            $table->boolean('is_git_cleanup_enabled')->default(true);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('applications', function (Blueprint $table) {
+            $table->dropColumn('is_git_cleanup_enabled');
+        });
+    }
+};

--- a/resources/views/livewire/project/application/advanced.blade.php
+++ b/resources/views/livewire/project/application/advanced.blade.php
@@ -91,7 +91,7 @@
         ]" 
         :confirmWithText="false" 
         :confirmWithPassword="false"
-        step2ButtonText="Permanently Remove .git Folder" 
+        step2ButtonText="Do not Remove .git Folder" 
         :dispatchEvent="true"
         dispatchEventType="success" 
         dispatchEventMessage="Git cleanup enabled successfully." 

--- a/resources/views/livewire/project/application/advanced.blade.php
+++ b/resources/views/livewire/project/application/advanced.blade.php
@@ -77,54 +77,25 @@
         wire:click.prevent="handleGitCleanupToggle"
     />
 
-    <!-- Warning Modal -->
-    <div x-data="{ showModal: @entangle('showGitRemovalWarningModal') }" x-cloak>
-        <!-- Modal Backdrop -->
-        <div x-show="showModal" class="fixed inset-0 z-50 bg-black bg-opacity-50 transition-opacity"></div>
-
-        <!-- Modal -->
-        <div x-show="showModal" class="fixed inset-0 z-50 flex items-center justify-center p-4"
-            x-transition:enter="ease-out duration-300"
-            x-transition:enter-start="opacity-0 scale-95"
-            x-transition:enter-end="opacity-100 scale-100"
-            x-transition:leave="ease-in duration-200"
-            x-transition:leave-start="opacity-100 scale-100"
-            x-transition:leave-end="opacity-0 scale-95">
-            <div class="w-full max-w-md bg-white dark:bg-coolgray-100 rounded-lg shadow-xl overflow-hidden">
-                <!-- Modal Header -->
-                <div class="px-6 py-4 border-b border-gray-200 dark:border-coolgray-200">
-                    <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">Security Warning: Remove .git Folder?</h2>
-                </div>
-
-                <!-- Modal Content -->
-                <div class="p-6">
-                    <div class="space-y-4">
-                        <p class="text-red-500 dark:text-red-400 font-semibold">This action has significant security implications!</p>
-                        <ul class="list-disc pl-5 space-y-2">
-                            <li>Exposes your full source code, commit history, and even deleted files to the public</li>
-                            <li>Often .git contains secrets or SSH keys from git or other services</li>
-                            <li>This action cannot be undone once performed</li>
-                            <li>Proceed only if you understand the risks</li>
-                        </ul>
-                    </div>
-                </div>
-
-                <!-- Modal Footer -->
-                <div class="px-6 py-4 bg-gray-50 dark:bg-coolgray-200 text-right space-x-3">
-                    <button type="button" 
-                        class="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 focus:outline-none"
-                        wire:click="confirmGitRemoval">
-                        I Understand - Remove .git
-                    </button>
-                    <button type="button" 
-                        class="px-4 py-2 bg-gray-300 dark:bg-coolgray-300 text-gray-700 dark:text-gray-200 rounded hover:bg-gray-400 focus:outline-none"
-                        wire:click="cancelGitRemoval">
-                        Cancel
-                    </button>
-                </div>
-            </div>
-        </div>
-    </div>
+    <!-- Warning Modal using same component as dashboard -->
+    <x-modal-confirmation 
+        title="Security Warning: Remove .git Folder?" 
+        buttonTitle="I Understand - Do not Remove .git" 
+        isErrorButton
+        submitAction="confirmGitRemoval" 
+        :actions="[
+            'Exposes your full source code, commit history, and even deleted files to the public',
+            'Often .git contains secrets or SSH keys from git or other services', 
+            'This action cannot be undone once performed',
+            'Proceed only if you understand the risks'
+        ]" 
+        :confirmWithText="false" 
+        :confirmWithPassword="false"
+        step2ButtonText="Permanently Remove .git Folder" 
+        :dispatchEvent="true"
+        dispatchEventType="success" 
+        dispatchEventMessage="Git cleanup enabled successfully." 
+    />
 @endif
         </div>
     </div>

--- a/resources/views/livewire/project/application/advanced.blade.php
+++ b/resources/views/livewire/project/application/advanced.blade.php
@@ -62,47 +62,70 @@
             <x-forms.checkbox helper="Drain logs to your configured log drain endpoint in your Server settings."
                 instantSave id="isLogDrainEnabled" label="Drain Logs" />
             @if ($application->git_based())
-                <h3>Git</h3>
-                <x-forms.checkbox instantSave id="isGitSubmodulesEnabled" label="Submodules"
-                    helper="Allow Git Submodules during build process." />
-                <x-forms.checkbox instantSave id="isGitLfsEnabled" label="LFS"
-                    helper="Allow Git LFS during build process." />
-                    
-                <!-- .git Removal Checkbox with Warning Modal -->
-                <x-forms.checkbox 
-                    id="isGitCleanupEnabled" 
-                    label="Remove .git after import"
-                    helper="If enabled, the .git directory will be removed from the deployment folder after importing the repository."
-                    wire:model="isGitCleanupEnabled"
-                    wire:click.prevent="showGitRemovalWarning"
-                />
+    <h3>Git</h3>
+    <x-forms.checkbox instantSave id="isGitSubmodulesEnabled" label="Submodules"
+        helper="Allow Git Submodules during build process." />
+    <x-forms.checkbox instantSave id="isGitLfsEnabled" label="LFS"
+        helper="Allow Git LFS during build process." />
+        
+    <!-- .git Removal Checkbox with Warning Modal -->
+    <x-forms.checkbox 
+        id="isGitCleanupEnabled" 
+        label="Remove .git after import"
+        helper="If enabled, the .git directory will be removed from the deployment folder after importing the repository."
+        wire:model="isGitCleanupEnabled"
+        wire:click.prevent="handleGitCleanupToggle"
+    />
 
-                <!-- Warning Modal -->
-                <x-modal wire:model="showGitRemovalWarningModal">
-                    <x-modal.header>
-                        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">Security Warning: Remove .git Folder?</h2>
-                    </x-modal.header>
-                    <x-modal.content>
-                        <div class="space-y-4">
-                            <p class="text-red-500 dark:text-red-400 font-semibold">This action has significant security implications!</p>
-                            <ul class="list-disc pl-5 space-y-2">
-                                <li>Exposes your full source code, commit history, and even deleted files to the public</li>
-                                <li>Often .git contains secrets or SSH keys from git or other services</li>
-                                <li>This action cannot be undone once performed</li>
-                                <li>Proceed only if you understand the risks</li>
-                            </ul>
-                        </div>
-                    </x-modal.content>
-                    <x-modal.footer>
-                        <x-button type="button" color="red" wire:click="confirmGitRemoval">
-                            I Understand - Remove .git
-                        </x-button>
-                        <x-button type="button" color="gray" wire:click="cancelGitRemoval">
-                            Cancel
-                        </x-button>
-                    </x-modal.footer>
-                </x-modal>
-            @endif
+    <!-- Warning Modal -->
+    <div x-data="{ showModal: @entangle('showGitRemovalWarningModal') }" x-cloak>
+        <!-- Modal Backdrop -->
+        <div x-show="showModal" class="fixed inset-0 z-50 bg-black bg-opacity-50 transition-opacity"></div>
+
+        <!-- Modal -->
+        <div x-show="showModal" class="fixed inset-0 z-50 flex items-center justify-center p-4"
+            x-transition:enter="ease-out duration-300"
+            x-transition:enter-start="opacity-0 scale-95"
+            x-transition:enter-end="opacity-100 scale-100"
+            x-transition:leave="ease-in duration-200"
+            x-transition:leave-start="opacity-100 scale-100"
+            x-transition:leave-end="opacity-0 scale-95">
+            <div class="w-full max-w-md bg-white dark:bg-coolgray-100 rounded-lg shadow-xl overflow-hidden">
+                <!-- Modal Header -->
+                <div class="px-6 py-4 border-b border-gray-200 dark:border-coolgray-200">
+                    <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">Security Warning: Remove .git Folder?</h2>
+                </div>
+
+                <!-- Modal Content -->
+                <div class="p-6">
+                    <div class="space-y-4">
+                        <p class="text-red-500 dark:text-red-400 font-semibold">This action has significant security implications!</p>
+                        <ul class="list-disc pl-5 space-y-2">
+                            <li>Exposes your full source code, commit history, and even deleted files to the public</li>
+                            <li>Often .git contains secrets or SSH keys from git or other services</li>
+                            <li>This action cannot be undone once performed</li>
+                            <li>Proceed only if you understand the risks</li>
+                        </ul>
+                    </div>
+                </div>
+
+                <!-- Modal Footer -->
+                <div class="px-6 py-4 bg-gray-50 dark:bg-coolgray-200 text-right space-x-3">
+                    <button type="button" 
+                        class="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 focus:outline-none"
+                        wire:click="confirmGitRemoval">
+                        I Understand - Remove .git
+                    </button>
+                    <button type="button" 
+                        class="px-4 py-2 bg-gray-300 dark:bg-coolgray-300 text-gray-700 dark:text-gray-200 rounded hover:bg-gray-400 focus:outline-none"
+                        wire:click="cancelGitRemoval">
+                        Cancel
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+@endif
         </div>
     </div>
     <form wire:submit="submit" class="flex flex-col gap-2">

--- a/resources/views/livewire/project/application/advanced.blade.php
+++ b/resources/views/livewire/project/application/advanced.blade.php
@@ -67,9 +67,43 @@
                     helper="Allow Git Submodules during build process." />
                 <x-forms.checkbox instantSave id="isGitLfsEnabled" label="LFS"
                     helper="Allow Git LFS during build process." />
+                    
+                <!-- .git Removal Checkbox with Warning Modal -->
+                <x-forms.checkbox 
+                    id="isGitCleanupEnabled" 
+                    label="Remove .git after import"
+                    helper="If enabled, the .git directory will be removed from the deployment folder after importing the repository."
+                    wire:model="isGitCleanupEnabled"
+                    wire:click.prevent="showGitRemovalWarning"
+                />
+
+                <!-- Warning Modal -->
+                <x-modal wire:model="showGitRemovalWarningModal">
+                    <x-modal.header>
+                        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">Security Warning: Remove .git Folder?</h2>
+                    </x-modal.header>
+                    <x-modal.content>
+                        <div class="space-y-4">
+                            <p class="text-red-500 dark:text-red-400 font-semibold">This action has significant security implications!</p>
+                            <ul class="list-disc pl-5 space-y-2">
+                                <li>Exposes your full source code, commit history, and even deleted files to the public</li>
+                                <li>Often .git contains secrets or SSH keys from git or other services</li>
+                                <li>This action cannot be undone once performed</li>
+                                <li>Proceed only if you understand the risks</li>
+                            </ul>
+                        </div>
+                    </x-modal.content>
+                    <x-modal.footer>
+                        <x-button type="button" color="red" wire:click="confirmGitRemoval">
+                            I Understand - Remove .git
+                        </x-button>
+                        <x-button type="button" color="gray" wire:click="cancelGitRemoval">
+                            Cancel
+                        </x-button>
+                    </x-modal.footer>
+                </x-modal>
             @endif
         </div>
-
     </div>
     <form wire:submit="submit" class="flex flex-col gap-2">
         @if ($application->build_pack !== 'dockercompose')


### PR DESCRIPTION
/claim #6241

Fix .git Removal Toggle Warning Modal and Resolve Merge Conflicts
- Implemented a warning modal that appears only when the user tries to disable the .git removal toggle.
- Default state of the toggle is now enabled (checked) by default.
- User must confirm disabling .git removal via the modal to proceed.
- Canceling the modal reverts the toggle back to enabled.
- Fixed merge conflicts with the target branch to ensure smooth integration.

Demo video attached:

https://github.com/user-attachments/assets/0b5c6e3a-3a3a-4439-8f32-6fdfc03e8659



#6241 


