### PR TITLE
BUGFIX: Update `ls-remote` logic to pull correct branch

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -1421,6 +1421,19 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         if ($this->pull_request_id !== 0) {
             $local_branch = "pull/{$this->pull_request_id}/head";
         }
+        // Build an exact refspec for ls-remote so we don't match similarly named branches (e.g., changeset-release/main)
+        if ($this->pull_request_id === 0) {
+            $lsRemoteRef = "refs/heads/{$local_branch}";
+        } else {
+            if ($this->git_type === 'github' || $this->git_type === 'gitea') {
+                $lsRemoteRef = "refs/pull/{$this->pull_request_id}/head";
+            } elseif ($this->git_type === 'gitlab') {
+                $lsRemoteRef = "refs/merge-requests/{$this->pull_request_id}/head";
+            } else {
+                // Fallback to the original value if provider-specific ref is unknown
+                $lsRemoteRef = $local_branch;
+            }
+        }
         $private_key = data_get($this->application, 'private_key.private_key');
         if ($private_key) {
             $private_key = base64_encode($private_key);
@@ -1435,7 +1448,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                     executeInDocker($this->deployment_uuid, 'chmod 600 /root/.ssh/id_rsa'),
                 ],
                 [
-                    executeInDocker($this->deployment_uuid, "GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$this->customPort} -o Port={$this->customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null\" git ls-remote {$this->fullRepoUrl} {$local_branch}"),
+                    executeInDocker($this->deployment_uuid, "GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$this->customPort} -o Port={$this->customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null\" git ls-remote {$this->fullRepoUrl} {$lsRemoteRef}"),
                     'hidden' => true,
                     'save' => 'git_commit_sha',
                 ]
@@ -1443,7 +1456,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         } else {
             $this->execute_remote_command(
                 [
-                    executeInDocker($this->deployment_uuid, "GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$this->customPort} -o Port={$this->customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null\" git ls-remote {$this->fullRepoUrl} {$local_branch}"),
+                    executeInDocker($this->deployment_uuid, "GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$this->customPort} -o Port={$this->customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null\" git ls-remote {$this->fullRepoUrl} {$lsRemoteRef}"),
                     'hidden' => true,
                     'save' => 'git_commit_sha',
                 ],


### PR DESCRIPTION
## Submit Checklist (REMOVE THIS SECTION BEFORE SUBMITTING)

- [ ] I have tested my changes.

I'm not sure how to test this.

## Changes
- Update ls-remote logic to use the exact branch name

## Issues

The bug I am facing is I have configured `coolify` to deploy the `main` branch. It seems to be searching for "main" and picking the first match. If there is another branch with that name in it, it will pick that incorrectly.

```
[CMD]: docker exec xxx bash -c 'GIT_SSH_COMMAND="ssh -o ConnectTimeout=30 -p 22 -o Port=22 -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" git ls-remote [xxx](xxx) main'
a3baa9db6ab4434fd20641b2b901e8ea658636cb	refs/heads/changeset-release/main
a43f2b529b129474b93bbcd3713e5d88fd0c7d14	refs/heads/main
Image not found (xxx:a3baa9db6ab4434fd20641b2b901e8ea658636cb). Building new image.
```
