### PR TITLE
fix: preserve order of environment variables

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -228,6 +228,7 @@ class Application extends BaseModel
         static::created(function ($application) {
             ApplicationSetting::create([
                 'application_id' => $application->id,
+                'is_env_sorting_enabled' => false,
             ]);
             $application->compose_parsing_version = self::$parserVersion;
             $application->save();

--- a/database/migrations/2024_05_17_082012_add_env_sorting_toggle.php
+++ b/database/migrations/2024_05_17_082012_add_env_sorting_toggle.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('application_settings', function (Blueprint $table) {
-            $table->boolean('is_env_sorting_enabled')->default(true);
+            $table->boolean('is_env_sorting_enabled')->default(false);
         });
     }
 


### PR DESCRIPTION
**Changes**
- Changed the default value of the is_env_sorting_enabled column in the application_settings table to false in the migration.
- This ensures that new resources will have environment variable sorting disabled by default, preserving the order in which environment variables are defined.

**Issues**
- Fixes the issue where environment variables were being sorted alphabetically by default, causing dependent variables to fail to resolve if they referenced variables defined later in the list.
- Resolves: [https://github.com/coollabsio/coolify/issues/6253](url)