### PR TITLE
fix(ui): handle null values in postgres metrics

### DIFF
--- a/app/Models/StandalonePostgresql.php
+++ b/app/Models/StandalonePostgresql.php
@@ -320,7 +320,10 @@ class StandalonePostgresql extends BaseModel
         }
         $metrics = json_decode($metrics, true);
         $parsedCollection = collect($metrics)->map(function ($metric) {
-            return [(int) $metric['time'], (float) $metric['percent']];
+            return [
+                (int) $metric['time'],
+                (float) ($metric['percent'] ?? 0.0)
+            ];
         });
 
         return $parsedCollection->toArray();


### PR DESCRIPTION
## Changes
- Updated `StandalonePostgresql.php` to handle `NULL` values for the `percent` metric.
- Applied the null coalescing operator (`??`) to default missing values to `0.0`.
- Ensures a float is always returned, preventing the `converting NULL to float64 is unsupported` error.

## Issues
- Fixes #6266

## Notes
Since the code explicitly converts the `percent` metric into a float, it implies the expected type is always numeric.  
Using `0.0` as the default is both safe and consistent with this intent — a `NULL` value has no semantic meaning in this context, so defaulting avoids errors while preserving the metric's numeric nature.
