### PR TITLE
v4.0.0-beta.420.10

### DIFF
--- a/config/constants.php
+++ b/config/constants.php
@@ -2,8 +2,8 @@
 
 return [
     'coolify' => [
-        'version' => '4.0.0-beta.420.9',
-        'helper_version' => '1.0.9',
+        'version' => '4.0.0-beta.420.10',
+        'helper_version' => '1.0.10',
         'realtime_version' => '1.0.10',
         'self_hosted' => env('SELF_HOSTED', true),
         'autoupdate' => env('AUTOUPDATE'),

--- a/docker/coolify-helper/Dockerfile
+++ b/docker/coolify-helper/Dockerfile
@@ -12,7 +12,7 @@ ARG PACK_VERSION=0.38.2
 # https://github.com/railwayapp/nixpacks/releases
 ARG NIXPACKS_VERSION=1.39.0
 # https://github.com/minio/mc/releases
-ARG MINIO_VERSION=RELEASE.2025-05-21T01-59-54Z
+ARG MINIO_VERSION=RELEASE.2025-03-12T17-29-24Z
 
 FROM minio/mc:${MINIO_VERSION} AS minio-client
 

--- a/other/nightly/versions.json
+++ b/other/nightly/versions.json
@@ -7,7 +7,7 @@
             "version": "4.0.0-beta.420.11"
         },
         "helper": {
-            "version": "1.0.9"
+            "version": "1.0.10"
         },
         "realtime": {
             "version": "1.0.10"

--- a/versions.json
+++ b/versions.json
@@ -1,13 +1,13 @@
 {
     "coolify": {
         "v4": {
-            "version": "4.0.0-beta.420.9"
-        },
-        "nightly": {
             "version": "4.0.0-beta.420.10"
         },
+        "nightly": {
+            "version": "4.0.0-beta.420.11"
+        },
         "helper": {
-            "version": "1.0.9"
+            "version": "1.0.10"
         },
         "realtime": {
             "version": "1.0.10"


### PR DESCRIPTION
## Changes

- fix(backups): rollback helper version update as Coolify Cloud version is still using the old way for s3 uploads.
