### PR TITLE
Avoid using wrong commit sha if base dir is a submodule

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -1492,9 +1492,25 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             ]
         );
         $this->create_workdir();
+
+        $dirWithCommit = $this->workdir;
+        if ($this->application->settings->is_git_submodules_enabled && $this->basedir !== $this->workdir) {    
+            $this->execute_remote_command(
+                [
+                    executeInDocker($this->deployment_uuid, "if git cat-file -e {$this->commit}^{commit} > /dev/null 2>&1;then echo 'No'; else echo 'Yes';fi"),
+                    'hidden' => true,
+                    'save' => 'workdir_is_submodule',
+                ]
+            );
+            $this->application_deployment_queue->addLogEntry("Workdir is submodule: {$this->saved_outputs->get('workdir_is_submodule')}");
+            if (trim($this->saved_outputs->get('workdir_is_submodule')) === 'Yes') {
+                $dirWithCommit = $this->basedir;
+            }
+        }
+
         $this->execute_remote_command(
             [
-                executeInDocker($this->deployment_uuid, "cd {$this->workdir} && git log -1 {$this->commit} --pretty=%B"),
+                executeInDocker($this->deployment_uuid, "cd {$dirWithCommit} && git log -1 {$this->commit} --pretty=%B"),
                 'hidden' => true,
                 'save' => 'commit_message',
             ]


### PR DESCRIPTION
## Changes
- Added a check if a Base Directory is a Submodule
- In this case use the commit of the original repo and not of the submodule to get the commit message

## Issues
- fix #6481 
