### PR TITLE
fix(domains) url validation silently fails with surrounding whitespace

### DIFF
--- a/app/Livewire/Project/Application/General.php
+++ b/app/Livewire/Project/Application/General.php
@@ -547,9 +547,10 @@ class General extends Component
             $this->application->fqdn = str($this->application->fqdn)->replaceEnd(',', '')->trim();
             $this->application->fqdn = str($this->application->fqdn)->replaceStart(',', '')->trim();
             $this->application->fqdn = str($this->application->fqdn)->trim()->explode(',')->map(function ($domain) {
+                $domain = trim($domain);
                 Url::fromString($domain, ['http', 'https']);
 
-                return str($domain)->trim()->lower();
+                return str($domain)->lower();
             });
 
             $this->application->fqdn = $this->application->fqdn->unique()->implode(',');

--- a/app/Livewire/Project/Service/EditDomain.php
+++ b/app/Livewire/Project/Service/EditDomain.php
@@ -41,9 +41,10 @@ class EditDomain extends Component
             $this->application->fqdn = str($this->application->fqdn)->replaceEnd(',', '')->trim();
             $this->application->fqdn = str($this->application->fqdn)->replaceStart(',', '')->trim();
             $this->application->fqdn = str($this->application->fqdn)->trim()->explode(',')->map(function ($domain) {
+                $domain = trim($domain);
                 Url::fromString($domain, ['http', 'https']);
 
-                return str($domain)->trim()->lower();
+                return str($domain)->lower();
             });
             $this->application->fqdn = $this->application->fqdn->unique()->implode(',');
             $warning = sslipDomainWarning($this->application->fqdn);

--- a/app/Livewire/Project/Service/ServiceApplicationView.php
+++ b/app/Livewire/Project/Service/ServiceApplicationView.php
@@ -149,9 +149,10 @@ class ServiceApplicationView extends Component
             $this->application->fqdn = str($this->application->fqdn)->replaceEnd(',', '')->trim();
             $this->application->fqdn = str($this->application->fqdn)->replaceStart(',', '')->trim();
             $this->application->fqdn = str($this->application->fqdn)->trim()->explode(',')->map(function ($domain) {
+                $domain = trim($domain);
                 Url::fromString($domain, ['http', 'https']);
 
-                return str($domain)->trim()->lower();
+                return str($domain)->lower();
             });
             $this->application->fqdn = $this->application->fqdn->unique()->implode(',');
             $warning = sslipDomainWarning($this->application->fqdn);


### PR DESCRIPTION
## Changes
- move domain trimming to before url validating

## Issues
- fix #6478

Allows you to have a space between URLs (before it was silently failing)

Now when you hit save with a space, the space is trimmed. Tested and both URLs still accessible.
<img width="658" height="309" alt="image" src="https://github.com/user-attachments/assets/be7bb902-f68e-42e3-ad12-7e6ec0de03bf" />

*Note: Had a duplicate PR open, but had to close it, cause I made some other changes that accidentally got merged into that PR
