### PR TITLE
fix(service): mattermost failing healthcheck

### DIFF
--- a/templates/compose/mattermost.yaml
+++ b/templates/compose/mattermost.yaml
@@ -27,7 +27,7 @@ services:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:8065"]
+      test: ["CMD", "/mattermost/bin/mmctl", "system", "status"]
       interval: 5s
       timeout: 20s
       retries: 10


### PR DESCRIPTION
On the latest release of mattermost-team-edition:release-10 they removed shell access to existing curl command fails for healthcheck.

I checked the layers of new image and found they have an Healthcheck command:
<img width="960" height="466" alt="image" src="https://github.com/user-attachments/assets/0eeef4e7-b7b2-4414-937b-86180368e169" />

> Source: https://hub.docker.com/layers/mattermost/mattermost-team-edition/release-10/images/sha256-2f00f862f9205d06a871cecc5a7291de880794a953d9aeaec2ce61d4cb80fe37

So I have updated the healthcheck command to make the healthcheck work again.

Tested on v4.0.0-beta.426 and health check is passing!

https://github.com/user-attachments/assets/2ae17d6f-da1e-4500-b665-f11e8066e6cc

- Closes #6537
