### PR TITLE
feat(service): add pgAdmin

### DIFF
--- a/templates/compose/pgadmin.yaml
+++ b/templates/compose/pgadmin.yaml
@@ -1,0 +1,23 @@
+# documentation: https://www.pgadmin.org/docs/pgadmin4/latest/container_deployment.html
+# slogan: pgAdmin is a web-based database management tool for administering your PostgreSQL databases through a user-friendly interface.
+# category: database
+# tags: database management
+# logo: svgs/postgresql.svg
+# port: 80
+
+services:
+  pgadmin:
+    image: 'dpage/pgadmin4:latest'
+    container_name: pgadmin
+    restart: unless-stopped
+    environment:
+      - SERVICE_URL_PGADMIN
+      - 'PGADMIN_DEFAULT_EMAIL=${PGADMIN_DEFAULT_EMAIL:?}'
+      - 'PGADMIN_DEFAULT_PASSWORD=${PGADMIN_DEFAULT_PASSWORD:?}'
+    volumes:
+      - pgadmin-data:/var/lib/pgadmin
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:80/login"]
+      interval: 5s
+      timeout: 10s
+      retries: 5

--- a/templates/compose/pgadmin.yaml
+++ b/templates/compose/pgadmin.yaml
@@ -8,8 +8,6 @@
 services:
   pgadmin:
     image: 'dpage/pgadmin4:latest'
-    container_name: pgadmin
-    restart: unless-stopped
     environment:
       - SERVICE_URL_PGADMIN
       - 'PGADMIN_DEFAULT_EMAIL=${PGADMIN_DEFAULT_EMAIL:?}'


### PR DESCRIPTION
Added https://www.pgadmin.org/ as a service!

I didn't used `$SERVICE_PASSWORD` magic env for `PGADMIN_DEFAULT_PASSWORD` because the user has to fill the `PGADMIN_DEFAULT_EMAIL` with the email address they want to login to pgAdmin so while they are on the env page they can fill the `PGADMIN_DEFAULT_PASSWORD` with the password they want. 

I made both `PGADMIN_DEFAULT_EMAIL` and `PGADMIN_DEFAULT_PASSWORD` as required because without them they user cannot login to pgAdmin dashboard.

Docs PR: WIP (will add soon)

Note: This discussion -> https://github.com/coollabsio/coolify/discussions/4760 can be closed