### PR TITLE
feat(service): enable and implement PATCH'ing services through api, for the api 

### DIFF
--- a/app/Http/Controllers/Api/ServicesController.php
+++ b/app/Http/Controllers/Api/ServicesController.php
@@ -1258,4 +1258,174 @@ class ServicesController extends Controller
             200
         );
     }
+
+    #[OA\Patch(
+        summary: 'Update by UUID',
+        description: 'Update service by UUID.',
+        path: '/services/{uuid}',
+        operationId: 'update-service-by-uuid',
+        security: [['bearerAuth' => []]],
+        tags: ['Services'],
+        parameters: [
+            new OA\Parameter(name: 'uuid', description: 'Service UUID', in: 'path', required: true, schema: new OA\Schema(type: 'string')),
+        ],
+        requestBody: new OA\RequestBody(
+            required: false,
+            content: new OA\MediaType(
+                mediaType: 'application/json',
+                schema: new OA\Schema(
+                    type: 'object',
+                    properties: [
+                        'name' => new OA\Property(property: 'name', description: 'Service name', type: 'string'),
+                        'description' => new OA\Property(property: 'description', description: 'Service description', type: 'string'),
+                        'applications' => new OA\Property(
+                            property: 'applications',
+                            description: 'Service applications to update',
+                            type: 'array',
+                            items: new OA\Items(
+                                type: 'object',
+                                properties: [
+                                    'uuid' => new OA\Property(property: 'uuid', description: 'Application UUID', type: 'string'),
+                                    'fqdn' => new OA\Property(property: 'fqdn', description: 'Application FQDN', type: 'string'),
+                                    'human_name' => new OA\Property(property: 'human_name', description: 'Human-readable name', type: 'string'),
+                                    'description' => new OA\Property(property: 'description', description: 'Application description', type: 'string'),
+                                    'required_fqdn' => new OA\Property(property: 'required_fqdn', description: 'Whether FQDN is required', type: 'boolean'),
+                                ]
+                            )
+                        ),
+                    ]
+                )
+            )
+        ),
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Service updated.',
+                content: new OA\MediaType(
+                    mediaType: 'application/json',
+                    schema: new OA\Schema(
+                        type: 'object',
+                        properties: [
+                            'uuid' => new OA\Property(property: 'uuid', type: 'string'),
+                        ]
+                    )
+                )
+            ),
+            new OA\Response(response: 400, ref: '#/components/responses/400'),
+            new OA\Response(response: 401, ref: '#/components/responses/401'),
+            new OA\Response(response: 404, ref: '#/components/responses/404'),
+        ]
+    )]
+    public function update_by_uuid(Request $request)
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+
+        if ($request->collect()->count() == 0) {
+            return response()->json([
+                'message' => 'Invalid request.',
+            ], 400);
+        }
+
+        $return = validateIncomingRequest($request);
+        if ($return instanceof \Illuminate\Http\JsonResponse) {
+            return $return;
+        }
+
+        $service = Service::whereRelation('environment.project.team', 'id', $teamId)->whereUuid($request->uuid)->first();
+        if (! $service) {
+            return response()->json([
+                'message' => 'Service not found.',
+            ], 404);
+        }
+
+        // Handle service-level updates
+        $allowedServiceFields = ['name', 'description'];
+        $serviceValidationRules = [
+            'name' => 'string|max:255',
+            'description' => 'string|nullable',
+        ];
+
+        foreach ($request->all() as $key => $value) {
+            if (in_array($key, $allowedServiceFields)) {
+                $service->{$key} = $value;
+            }
+        }
+
+        // Handle application updates
+        if ($request->has('applications') && is_array($request->applications)) {
+            $appValidationRules = [
+                'applications.*.uuid' => 'required|string',
+                'applications.*.fqdn' => 'nullable|string',
+                'applications.*.human_name' => 'nullable|string',
+                'applications.*.description' => 'nullable|string',
+                'applications.*.required_fqdn' => 'boolean',
+            ];
+
+            $validator = customApiValidator($request->all(), array_merge($serviceValidationRules, $appValidationRules));
+
+            if ($validator->fails()) {
+                return response()->json([
+                    'message' => 'Validation failed.',
+                    'errors' => $validator->errors(),
+                ], 422);
+            }
+
+            foreach ($request->applications as $appData) {
+                if (isset($appData['uuid'])) {
+                    $application = $service->applications()->where('uuid', $appData['uuid'])->first();
+
+                    if (! $application) {
+                        return response()->json([
+                            'message' => "Service application with UUID {$appData['uuid']} not found.",
+                        ], 404);
+                    }
+
+                    $allowedAppFields = ['fqdn', 'human_name', 'description', 'required_fqdn'];
+                    $updated = false;
+
+                    foreach ($appData as $key => $value) {
+                        if (in_array($key, $allowedAppFields) && $key !== 'uuid') {
+                            if ($key === 'fqdn' && ! is_null($value)) {
+                                // Sanitize FQDN like Livewire does
+                                $value = str($value)->replaceEnd(',', '')->trim();
+                                $value = str($value)->replaceStart(',', '')->trim();
+                                $value = str($value)->trim()->explode(',')->map(function ($domain) {
+                                    return str($domain)->trim()->lower();
+                                })->unique()->implode(',');
+                            }
+
+                            if ($application->{$key} !== $value) {
+                                $application->{$key} = $value;
+                                $updated = true;
+                            }
+                        }
+                    }
+
+                    if ($updated) {
+                        $application->save();
+                        updateCompose($application); // Regenerate Docker Compose
+                    }
+                }
+            }
+        } else {
+            // Validate service-only updates
+            $validator = customApiValidator($request->all(), $serviceValidationRules);
+
+            if ($validator->fails()) {
+                return response()->json([
+                    'message' => 'Validation failed.',
+                    'errors' => $validator->errors(),
+                ], 422);
+            }
+        }
+
+        $service->save();
+
+        return response()->json([
+            'uuid' => $service->uuid,
+        ], 200);
+    }
 }

--- a/openapi.json
+++ b/openapi.json
@@ -2105,6 +2105,70 @@
                 ]
             }
         },
+        "\/applications\/{uuid}\/logs": {
+            "get": {
+                "tags": [
+                    "Applications"
+                ],
+                "summary": "Get application logs.",
+                "description": "Get application logs by UUID.",
+                "operationId": "get-application-logs-by-uuid",
+                "parameters": [
+                    {
+                        "name": "uuid",
+                        "in": "path",
+                        "description": "UUID of the application.",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    {
+                        "name": "lines",
+                        "in": "query",
+                        "description": "Number of lines to show from the end of the logs.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32",
+                            "default": 100
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Get application logs by UUID.",
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "properties": {
+                                        "logs": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "$ref": "#\/components\/responses\/401"
+                    },
+                    "400": {
+                        "$ref": "#\/components\/responses\/400"
+                    },
+                    "404": {
+                        "$ref": "#\/components\/responses\/404"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
         "\/applications\/{uuid}\/envs": {
             "get": {
                 "tags": [
@@ -6167,6 +6231,105 @@
                     },
                     "400": {
                         "$ref": "#\/components\/responses\/400"
+                    },
+                    "404": {
+                        "$ref": "#\/components\/responses\/404"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "patch": {
+                "tags": [
+                    "Services"
+                ],
+                "summary": "Update by UUID",
+                "description": "Update service by UUID.",
+                "operationId": "update-service-by-uuid",
+                "parameters": [
+                    {
+                        "name": "uuid",
+                        "in": "path",
+                        "description": "Service UUID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "properties": {
+                                    "name": {
+                                        "description": "Service name",
+                                        "type": "string"
+                                    },
+                                    "description": {
+                                        "description": "Service description",
+                                        "type": "string"
+                                    },
+                                    "applications": {
+                                        "description": "Service applications to update",
+                                        "type": "array",
+                                        "items": {
+                                            "properties": {
+                                                "uuid": {
+                                                    "description": "Application UUID",
+                                                    "type": "string"
+                                                },
+                                                "fqdn": {
+                                                    "description": "Application FQDN",
+                                                    "type": "string"
+                                                },
+                                                "human_name": {
+                                                    "description": "Human-readable name",
+                                                    "type": "string"
+                                                },
+                                                "description": {
+                                                    "description": "Application description",
+                                                    "type": "string"
+                                                },
+                                                "required_fqdn": {
+                                                    "description": "Whether FQDN is required",
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Service updated.",
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "properties": {
+                                        "uuid": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#\/components\/responses\/400"
+                    },
+                    "401": {
+                        "$ref": "#\/components\/responses\/401"
                     },
                     "404": {
                         "$ref": "#\/components\/responses\/404"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1494,6 +1494,49 @@ paths:
       security:
         -
           bearerAuth: []
+  '/applications/{uuid}/logs':
+    get:
+      tags:
+        - Applications
+      summary: 'Get application logs.'
+      description: 'Get application logs by UUID.'
+      operationId: get-application-logs-by-uuid
+      parameters:
+        -
+          name: uuid
+          in: path
+          description: 'UUID of the application.'
+          required: true
+          schema:
+            type: string
+            format: uuid
+        -
+          name: lines
+          in: query
+          description: 'Number of lines to show from the end of the logs.'
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 100
+      responses:
+        '200':
+          description: 'Get application logs by UUID.'
+          content:
+            application/json:
+              schema:
+                properties:
+                  logs: { type: string }
+                type: object
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+        '404':
+          $ref: '#/components/responses/404'
+      security:
+        -
+          bearerAuth: []
   '/applications/{uuid}/envs':
     get:
       tags:
@@ -4106,6 +4149,55 @@ paths:
           $ref: '#/components/responses/401'
         '400':
           $ref: '#/components/responses/400'
+        '404':
+          $ref: '#/components/responses/404'
+      security:
+        -
+          bearerAuth: []
+    patch:
+      tags:
+        - Services
+      summary: 'Update by UUID'
+      description: 'Update service by UUID.'
+      operationId: update-service-by-uuid
+      parameters:
+        -
+          name: uuid
+          in: path
+          description: 'Service UUID'
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  description: 'Service name'
+                  type: string
+                description:
+                  description: 'Service description'
+                  type: string
+                applications:
+                  description: 'Service applications to update'
+                  type: array
+                  items: { properties: { uuid: { description: 'Application UUID', type: string }, fqdn: { description: 'Application FQDN', type: string }, human_name: { description: 'Human-readable name', type: string }, description: { description: 'Application description', type: string }, required_fqdn: { description: 'Whether FQDN is required', type: boolean } }, type: object }
+              type: object
+      responses:
+        '200':
+          description: 'Service updated.'
+          content:
+            application/json:
+              schema:
+                properties:
+                  uuid: { type: string }
+                type: object
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
         '404':
           $ref: '#/components/responses/404'
       security:

--- a/routes/api.php
+++ b/routes/api.php
@@ -116,7 +116,7 @@ Route::group([
     Route::post('/services', [ServicesController::class, 'create_service'])->middleware(['api.ability:write']);
 
     Route::get('/services/{uuid}', [ServicesController::class, 'service_by_uuid'])->middleware(['api.ability:read']);
-    // Route::patch('/services/{uuid}', [ServicesController::class, 'update_by_uuid'])->middleware(['ability:write']);
+    Route::patch('/services/{uuid}', [ServicesController::class, 'update_by_uuid'])->middleware(['api.ability:write']);
     Route::delete('/services/{uuid}', [ServicesController::class, 'delete_by_uuid'])->middleware(['api.ability:write']);
 
     Route::get('/services/{uuid}/envs', [ServicesController::class, 'envs'])->middleware(['api.ability:read']);


### PR DESCRIPTION
Motivation: New patch endpoint allows for updating the fqdn of a service through the api
Changes:
  - Enable PATCH /services/{uuid} endpoint for updating service applications
  - Add complete update_by_uuid method to ServicesController with application support
  - Add FQDN sanitization matching Livewire behavior
  - Include full OpenAPI documentation for the endpoint

## Submit Checklist (REMOVE THIS SECTION BEFORE SUBMITTING)
- [x] I have selected the `next` branch as the destination for my PR, not `main`.
- [x] I have listed all changes in the `Changes` section.
- [x] I have filled out the `Issues` section with the issue/discussion link(s) (if applicable).
- [x] I have tested my changes.
- [x] I have considered backwards compatibility.
- [x] I have removed this checklist and any unused sections.

## Changes
- Enable PATCH /services/{uuid} - was previously commented out in `routes/api.php`
- Add complimentary controller code

## Issues
- fix #
