### PR TITLE
feat(api):  fqdn on service creation and update via api

### DIFF
--- a/app/Livewire/Project/Service/EditDomain.php
+++ b/app/Livewire/Project/Service/EditDomain.php
@@ -38,14 +38,11 @@ class EditDomain extends Component
     public function submit()
     {
         try {
-            $this->application->fqdn = str($this->application->fqdn)->replaceEnd(',', '')->trim();
-            $this->application->fqdn = str($this->application->fqdn)->replaceStart(',', '')->trim();
-            $this->application->fqdn = str($this->application->fqdn)->trim()->explode(',')->map(function ($domain) {
+            $this->application->fqdn = str(sanitizeFqdn($this->application->fqdn))->explode(',')->map(function ($domain) {
                 Url::fromString($domain, ['http', 'https']);
 
                 return str($domain)->trim()->lower();
-            });
-            $this->application->fqdn = $this->application->fqdn->unique()->implode(',');
+            })->unique()->implode(',');
             $warning = sslipDomainWarning($this->application->fqdn);
             if ($warning) {
                 $this->dispatch('warning', __('warning.sslipdomain'));

--- a/app/Livewire/Project/Service/ServiceApplicationView.php
+++ b/app/Livewire/Project/Service/ServiceApplicationView.php
@@ -146,14 +146,11 @@ class ServiceApplicationView extends Component
     {
         try {
             $this->authorize('update', $this->application);
-            $this->application->fqdn = str($this->application->fqdn)->replaceEnd(',', '')->trim();
-            $this->application->fqdn = str($this->application->fqdn)->replaceStart(',', '')->trim();
-            $this->application->fqdn = str($this->application->fqdn)->trim()->explode(',')->map(function ($domain) {
+            $this->application->fqdn = str(sanitizeFqdn($this->application->fqdn))->explode(',')->map(function ($domain) {
                 Url::fromString($domain, ['http', 'https']);
 
                 return str($domain)->trim()->lower();
-            });
-            $this->application->fqdn = $this->application->fqdn->unique()->implode(',');
+            })->unique()->implode(',');
             $warning = sslipDomainWarning($this->application->fqdn);
             if ($warning) {
                 $this->dispatch('warning', __('warning.sslipdomain'));

--- a/openapi.json
+++ b/openapi.json
@@ -6795,6 +6795,35 @@
                                     "docker_compose_raw": {
                                         "type": "string",
                                         "description": "The Docker Compose raw content."
+                                    },
+                                    "applications": {
+                                        "description": "Service applications to update during creation",
+                                        "type": "array",
+                                        "items": {
+                                            "properties": {
+                                                "uuid": {
+                                                    "description": "Application UUID",
+                                                    "type": "string"
+                                                },
+                                                "fqdn": {
+                                                    "description": "Application FQDN",
+                                                    "type": "string"
+                                                },
+                                                "human_name": {
+                                                    "description": "Human-readable name",
+                                                    "type": "string"
+                                                },
+                                                "description": {
+                                                    "description": "Application description",
+                                                    "type": "string"
+                                                },
+                                                "required_fqdn": {
+                                                    "description": "Whether FQDN is required",
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
                                     }
                                 },
                                 "type": "object"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4364,6 +4364,10 @@ paths:
                 docker_compose_raw:
                   type: string
                   description: 'The Docker Compose raw content.'
+                applications:
+                  description: 'Service applications to update during creation'
+                  type: array
+                  items: { properties: { uuid: { description: 'Application UUID', type: string }, fqdn: { description: 'Application FQDN', type: string }, human_name: { description: 'Human-readable name', type: string }, description: { description: 'Application description', type: string }, required_fqdn: { description: 'Whether FQDN is required', type: boolean } }, type: object }
               type: object
       responses:
         '201':


### PR DESCRIPTION
   > refactor/feat(api):  fqdn on application/service creation AND update via api

## Motivation
to make it possible to include a fqdn on application/service creation AND update via api


## Changes

- Create sanitizeFqdn() helper function for consistent FQDN normalization
- Create configureServiceApplications() helper for bulk application updates
- Update Livewire components to use shared sanitizeFqdn() helper

