### PR TITLE
fix(template/filebrowser): correct healthcheck for Filebrowser

### DIFF
--- a/templates/compose/filebrowser.yaml
+++ b/templates/compose/filebrowser.yaml
@@ -29,8 +29,3 @@ services:
             "address": "0.0.0.0",
             "port": 80
           }
-    healthcheck:
-      test: ["CMD-SHELL", "wget -q --spider http://localhost:80 || exit 1"]
-      interval: 10s
-      timeout: 3s
-      retries: 10

--- a/templates/compose/filebrowser.yaml
+++ b/templates/compose/filebrowser.yaml
@@ -30,7 +30,7 @@ services:
             "port": 80
           }
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:80"]
-      interval: 2s
-      timeout: 10s
-      retries: 15
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:80 || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 10


### PR DESCRIPTION
fix(template/filebrowser): correct healthcheck for Filebrowser

## Changes
- remove healthcheck in compose

## Issues
- healthcheck is already defined in the image, keeping healthcheck command as-is in compose broke since wget should be used instead of curl