### PR TITLE
feat:  ✨  Add Soju IRC bouncer service

### DIFF
--- a/public/svgs/soju.svg
+++ b/public/svgs/soju.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="none">
+  <!-- Background circle -->
+  <circle cx="128" cy="128" r="120" fill="#2A2E3A"/>
+  
+  <!-- IRC-style connection nodes -->
+  <g stroke="#00D9FF" stroke-width="3" fill="none">
+    <!-- Central hub -->
+    <circle cx="128" cy="128" r="20" fill="#00D9FF"/>
+    
+    <!-- Connection lines -->
+    <line x1="128" y1="108" x2="128" y2="60" stroke-linecap="round"/>
+    <line x1="148" y1="128" x2="196" y2="128" stroke-linecap="round"/>
+    <line x1="108" y1="128" x2="60" y2="128" stroke-linecap="round"/>
+    <line x1="128" y1="148" x2="128" y2="196" stroke-linecap="round"/>
+    
+    <!-- Diagonal connections -->
+    <line x1="143" y1="113" x2="175" y2="81" stroke-linecap="round"/>
+    <line x1="113" y1="113" x2="81" y2="81" stroke-linecap="round"/>
+    <line x1="143" y1="143" x2="175" y2="175" stroke-linecap="round"/>
+    <line x1="113" y1="143" x2="81" y2="175" stroke-linecap="round"/>
+    
+    <!-- Outer connection nodes -->
+    <circle cx="128" cy="60" r="8" fill="#00D9FF"/>
+    <circle cx="196" cy="128" r="8" fill="#00D9FF"/>
+    <circle cx="60" cy="128" r="8" fill="#00D9FF"/>
+    <circle cx="128" cy="196" r="8" fill="#00D9FF"/>
+    <circle cx="175" cy="81" r="8" fill="#00D9FF"/>
+    <circle cx="81" cy="81" r="8" fill="#00D9FF"/>
+    <circle cx="175" cy="175" r="8" fill="#00D9FF"/>
+    <circle cx="81" cy="175" r="8" fill="#00D9FF"/>
+  </g>
+  
+  <!-- Soju text -->
+  <text x="128" y="235" font-family="Arial, sans-serif" font-size="24" font-weight="bold" fill="#00D9FF" text-anchor="middle">SOJU</text>
+</svg>

--- a/templates/compose/soju.yaml
+++ b/templates/compose/soju.yaml
@@ -1,0 +1,47 @@
+# documentation: https://soju.im
+# slogan: Soju is a user-friendly IRC bouncer that keeps you connected to your IRC channels.
+# category: messaging
+# tags: irc,bouncer,chat,messaging,open,source
+# logo: svgs/soju.svg
+# port: 6667
+
+services:
+  soju:
+    image: "mpldr/soju:latest"
+    container_name: "${SERVICE_NAME:-soju}"
+    restart: unless-stopped
+    ports:
+      - "${SERVICE_PORT_SOJU:-6667}:6667"
+    environment:
+      - SERVICE_URL_SOJU
+      - SOJU_HOSTNAME=${SOJU_HOSTNAME:-localhost}
+    volumes:
+      - 'soju-data:/data'
+    entrypoint: ["/bin/sh"]
+    command: 
+      - -c
+      - |
+        mkdir -p /data /data/logs
+        
+        # Create config if it doesn't exist
+        if [ ! -f /data/config ]; then
+          cat > /data/config <<EOF
+        listen irc+insecure://:6667
+        hostname ${SOJU_HOSTNAME}
+        db sqlite3 /data/soju.db
+        message-store fs /data/logs
+        title "Soju IRC Bouncer"
+        accept-proxy-ip localhost
+        EOF
+        fi
+        
+        # Start soju
+        exec soju -config /data/config
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z 127.0.0.1 6667 || exit 1"]
+      interval: 5s
+      timeout: 20s
+      retries: 3
+
+volumes:
+  soju-data:


### PR DESCRIPTION
  ### 🎯 What's New

  Added **Soju IRC Bouncer** to Coolify's service marketplace for one-click deployment.

  Soju is a modern IRC bouncer that keeps you connected to IRC networks 24/7. When you reconnect, you receive the full chat history, allowing you to never miss a conversation.

  ### ✨ Key Features

  - **Always Online**: Maintains persistent connections to IRC networks
  - **Multi-Network Support**: Connect to multiple IRC servers simultaneously
  - **Message History**: Never miss conversations with persistent logging
  - **Modern Protocol**: Compatible with IRCv3 extensions
  - **Lightweight**: Minimal resource usage with SQLite backend
  - **Easy Deployment**: One-click install from Coolify marketplace

  ### 📦 What's Added

  - Docker Compose template (`templates/compose/soju.yaml`)
  - Service logo SVG (`public/svgs/soju.svg`)

  ## How to Test

  1. Navigate to Services → New Service in Coolify
  2. Find "Soju IRC Bouncer" in the marketplace
  3. Click deploy
  4. Connect your IRC client to `your-server:6667`
  5. Configure authentication in your IRC client (Soju requires authentication)

  ## Related Issues

  Closes #6567

  ## Screenshots / Demo

  🎥 **[Video demonstration available in comments]** - Shows Soju in Coolify marketplace and successful deployment

  ## Additional Notes

  The service includes:
  - Persistent volumes for data and message logs
  - Health checks with automatic restart capability
  - Plain IRC connection on port 6667 (customizable via `SERVICE_PORT_SOJU`)
  - Configurable hostname via `SOJU_HOSTNAME` environment variable
  - SQLite database for user management and configuration

  ## Checklist

  - [x] I have performed a self-review of my code
  - [x] I have tested the deployment locally
  - [x] The service appears correctly in the marketplace
  - [x] One-click deployment works as expected
  - [x] The service starts successfully after deployment
