### PR TITLE
Fix team invitation email case sensitivity bug

### DIFF
--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -10,6 +10,7 @@ use App\Notifications\Channels\SendsSlack;
 use App\Traits\HasNotificationSettings;
 use App\Traits\HasSafeStringAttribute;
 use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Notifiable;
 use OpenApi\Attributes as OA;
@@ -37,7 +38,7 @@ use OpenApi\Attributes as OA;
 
 class Team extends Model implements SendsDiscord, SendsEmail, SendsPushover, SendsSlack
 {
-    use HasNotificationSettings, HasSafeStringAttribute, Notifiable;
+    use HasFactory, HasNotificationSettings, HasSafeStringAttribute, Notifiable;
 
     protected $guarded = [];
 

--- a/app/Models/TeamInvitation.php
+++ b/app/Models/TeamInvitation.php
@@ -15,6 +15,14 @@ class TeamInvitation extends Model
         'via',
     ];
 
+    /**
+     * Set the email attribute to lowercase.
+     */
+    public function setEmailAttribute($value)
+    {
+        $this->attributes['email'] = strtolower($value);
+    }
+
     public function team()
     {
         return $this->belongsTo(Team::class);

--- a/database/factories/TeamFactory.php
+++ b/database/factories/TeamFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Team;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Team>
+ */
+class TeamFactory extends Factory
+{
+    protected $model = Team::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->company() . ' Team',
+            'description' => $this->faker->sentence(),
+            'personal_team' => false,
+            'show_boarding' => false,
+        ];
+    }
+
+    /**
+     * Indicate that the team is a personal team.
+     */
+    public function personal(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'personal_team' => true,
+            'name' => $this->faker->firstName() . "'s Team",
+        ]);
+    }
+}

--- a/tests/Feature/TeamInvitationEmailNormalizationTest.php
+++ b/tests/Feature/TeamInvitationEmailNormalizationTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Team;
+use App\Models\TeamInvitation;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TeamInvitationEmailNormalizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_team_invitation_normalizes_email_to_lowercase()
+    {
+        // Create a team
+        $team = Team::factory()->create();
+
+        // Create invitation with mixed case email
+        $invitation = TeamInvitation::create([
+            'team_id' => $team->id,
+            'uuid' => 'test-uuid-123',
+            'email' => 'Test@Example.com', // Mixed case
+            'role' => 'member',
+            'link' => 'https://example.com/invite/test-uuid-123',
+            'via' => 'link'
+        ]);
+
+        // Verify email was normalized to lowercase
+        $this->assertEquals('test@example.com', $invitation->email);
+    }
+
+    public function test_team_invitation_works_with_existing_user_email()
+    {
+        // Create a team
+        $team = Team::factory()->create();
+
+        // Create a user with lowercase email
+        $user = User::factory()->create([
+            'email' => 'test@example.com',
+            'name' => 'Test User'
+        ]);
+
+        // Create invitation with mixed case email
+        $invitation = TeamInvitation::create([
+            'team_id' => $team->id,
+            'uuid' => 'test-uuid-123',
+            'email' => 'Test@Example.com', // Mixed case
+            'role' => 'member',
+            'link' => 'https://example.com/invite/test-uuid-123',
+            'via' => 'link'
+        ]);
+
+        // Verify the invitation email matches the user email (both normalized)
+        $this->assertEquals($user->email, $invitation->email);
+
+        // Verify user lookup works
+        $foundUser = User::whereEmail($invitation->email)->first();
+        $this->assertNotNull($foundUser);
+        $this->assertEquals($user->id, $foundUser->id);
+    }
+}


### PR DESCRIPTION
## Description

This PR fixes the email case sensitivity bug in team invitations that was causing users to not be able to see teams they were invited to when invitations were sent with mixed case emails.

## Problem

When a team invitation was created with a mixed case email (e.g., 'Test@example.com') but the user already existed with a lowercase email ('test@example.com'), the system would fail to find the user during invitation acceptance due to case mismatch.

## Root Cause

The issue occurred because:
- The `User` model normalizes emails to lowercase via `setEmailAttribute()`
- The `TeamInvitation` model did not normalize emails
- When an invitation was created with mixed case, it was stored as-is
- User lookup failed due to case mismatch during invitation acceptance
- This caused users to not be able to see teams they were invited to

## Solution

- Added email normalization to `TeamInvitation` model using `setEmailAttribute()` method
- Added `HasFactory` trait to `Team` model for testing support
- Created `TeamFactory` for testing
- Added tests to verify email normalization works correctly

## Changes

- **app/Models/TeamInvitation.php**: Added email normalization
- **app/Models/Team.php**: Added HasFactory trait
- **database/factories/TeamFactory.php**: Created Team factory for testing
- **tests/Feature/TeamInvitationEmailNormalizationTest.php**: Tests for email normalization

## Testing

All tests pass, including:
- Email normalization works correctly
- Invitation flow works with mixed case emails
- Existing users can be found regardless of case

## Fixes

Resolves #6291