### PR TITLE
feat(docker): add build secrets

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -2873,8 +2873,9 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
         // Add top-level secrets definition
         $secrets = [];
         foreach ($variables as $env) {
+            $safe_filename = preg_replace('/[^A-Za-z0-9._-]/', '_', (string) $env->key);
             $secrets[$env->key] = [
-                'file' => "{$this->secrets_dir}/{$env->key}",
+                'file' => "{$this->secrets_dir}/{$safe_filename}",
             ];
         }
 
@@ -2904,7 +2905,9 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
 
         // Update the compose file
         $composeFile['services'] = $services;
-        $composeFile['secrets'] = $secrets;
+        // merge with existing secrets if present
+        $existingSecrets = data_get($composeFile, 'secrets', []);
+        $composeFile['secrets'] = array_replace($existingSecrets, $secrets);
 
         $this->application_deployment_queue->addLogEntry('Added build secrets configuration to docker-compose file.');
 

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -2764,19 +2764,6 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
             '',
         ];
 
-        // Get the environment variables to document which secrets are available
-        $envs = $this->pull_request_id === 0
-            ? $this->application->environment_variables()->where('key', 'not like', 'NIXPACKS_%')->get()
-            : $this->application->environment_variables_preview()->where('key', 'not like', 'NIXPACKS_%')->get();
-
-        if ($envs->count() > 0) {
-            $secretsComment[] = '# Available secrets:';
-            foreach ($envs as $env) {
-                $secretsComment[] = "# - {$env->key}";
-            }
-            $secretsComment[] = '';
-        }
-
         // Find where to insert the comments (after FROM statement)
         $fromIndex = $dockerfile->search(function ($line) {
             return str_starts_with(trim(strtoupper($line)), 'FROM');

--- a/app/Livewire/Project/Shared/EnvironmentVariable/All.php
+++ b/app/Livewire/Project/Shared/EnvironmentVariable/All.php
@@ -25,6 +25,8 @@ class All extends Component
 
     public bool $is_env_sorting_enabled = false;
 
+    public bool $use_build_secrets = false;
+
     protected $listeners = [
         'saveKey' => 'submit',
         'refreshEnvs',
@@ -34,6 +36,7 @@ class All extends Component
     public function mount()
     {
         $this->is_env_sorting_enabled = data_get($this->resource, 'settings.is_env_sorting_enabled', false);
+        $this->use_build_secrets = data_get($this->resource, 'settings.use_build_secrets', false);
         $this->resourceClass = get_class($this->resource);
         $resourceWithPreviews = [\App\Models\Application::class];
         $simpleDockerfile = filled(data_get($this->resource, 'dockerfile'));
@@ -49,6 +52,7 @@ class All extends Component
             $this->authorize('manageEnvironment', $this->resource);
 
             $this->resource->settings->is_env_sorting_enabled = $this->is_env_sorting_enabled;
+            $this->resource->settings->use_build_secrets = $this->use_build_secrets;
             $this->resource->settings->save();
             $this->getDevView();
             $this->dispatch('success', 'Environment variable settings updated.');

--- a/database/migrations/2025_09_17_081112_add_use_build_secrets_to_application_settings.php
+++ b/database/migrations/2025_09_17_081112_add_use_build_secrets_to_application_settings.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('application_settings', function (Blueprint $table) {
+            $table->boolean('use_build_secrets')->default(false)->after('is_build_server_enabled');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('application_settings', function (Blueprint $table) {
+            $table->dropColumn('use_build_secrets');
+        });
+    }
+};

--- a/resources/views/livewire/project/shared/environment-variable/all.blade.php
+++ b/resources/views/livewire/project/shared/environment-variable/all.blade.php
@@ -13,17 +13,32 @@
             @endcan
         </div>
         <div>Environment variables (secrets) for this resource. </div>
-        @if ($resourceClass === 'App\Models\Application' && data_get($resource, 'build_pack') !== 'dockercompose')
-            <div class="w-64 pt-2">
-                @can('manageEnvironment', $resource)
-                    <x-forms.checkbox id="is_env_sorting_enabled" label="Sort alphabetically"
-                        helper="Turn this off if one environment is dependent on an other. It will be sorted by creation order (like you pasted them or in the order you created them)."
-                        instantSave></x-forms.checkbox>
-                @else
-                    <x-forms.checkbox id="is_env_sorting_enabled" label="Sort alphabetically"
-                        helper="Turn this off if one environment is dependent on an other. It will be sorted by creation order (like you pasted them or in the order you created them)."
-                        disabled></x-forms.checkbox>
-                @endcan
+        @if ($resourceClass === 'App\Models\Application')
+            <div class="flex flex-col gap-2 pt-2">
+                @if (data_get($resource, 'build_pack') !== 'dockercompose')
+                    <div class="w-64">
+                        @can('manageEnvironment', $resource)
+                            <x-forms.checkbox id="is_env_sorting_enabled" label="Sort alphabetically"
+                                helper="Turn this off if one environment is dependent on an other. It will be sorted by creation order (like you pasted them or in the order you created them)."
+                                instantSave></x-forms.checkbox>
+                        @else
+                            <x-forms.checkbox id="is_env_sorting_enabled" label="Sort alphabetically"
+                                helper="Turn this off if one environment is dependent on an other. It will be sorted by creation order (like you pasted them or in the order you created them)."
+                                disabled></x-forms.checkbox>
+                        @endcan
+                    </div>
+                @endif
+                <div class="w-64">
+                    @can('manageEnvironment', $resource)
+                        <x-forms.checkbox id="use_build_secrets" label="Use Docker Build Secrets"
+                            helper="Enable Docker BuildKit secrets for enhanced security during builds. Secrets won't be exposed in the final image. Requires Docker 18.09+ with BuildKit support."
+                            instantSave></x-forms.checkbox>
+                    @else
+                        <x-forms.checkbox id="use_build_secrets" label="Use Docker Build Secrets"
+                            helper="Enable Docker BuildKit secrets for enhanced security during builds. Secrets won't be exposed in the final image. Requires Docker 18.09+ with BuildKit support."
+                            disabled></x-forms.checkbox>
+                    @endcan
+                </div>
             </div>
         @endif
         @if ($resource->type() === 'service' || $resource?->build_pack === 'dockercompose')


### PR DESCRIPTION
## Changes

- feat(deployment): add support for Docker BuildKit and Docker Build Secrets to all Deployment types with a build step, to enhance security massively when using secrets during building.
- feat(envs): Option to enabled Build Secrets (disabled by default as it is new core feature) - will be enabled by default at some point in the future.
- refactor(static-buildpack): seperate static buildpack for readability.

## Issues

- improves https://github.com/coollabsio/coolify/issues/6632
