### PR TITLE
fix(ui): non-error deployment debug log lines appear red in light mode

### DIFF
--- a/resources/views/livewire/project/application/deployment/show.blade.php
+++ b/resources/views/livewire/project/application/deployment/show.blade.php
@@ -113,7 +113,7 @@
                         ])>
                             <span x-show="showTimestamps" class="shrink-0 text-gray-500">{{ $line['timestamp'] }}</span>
                             <span @class([
-                                'text-coollabs dark:text-warning' => $line['hidden'],
+                                'text-success dark:text-warning' => $line['hidden'],
                                 'text-red-500' => $line['stderr'],
                                 'font-bold' => isset($line['command']) && $line['command'],
                                 'whitespace-pre-wrap',


### PR DESCRIPTION
### Issue:
Only in light mode, the deployment debug logs show non-error messages (like warnings or info) in red text, which makes the user think the deployment is failing — even though it’s not!
<img width="1919" height="1044" alt="image" src="https://github.com/user-attachments/assets/9d75ebec-9ab3-428f-b3c4-ef3e3c9ed344" />

### Fix:
<img width="1919" height="1047" alt="image" src="https://github.com/user-attachments/assets/87d9d901-999c-4956-89b9-f220ce3b7110" />

### Notes:
- On `resources/views/livewire/project/application/deployment/show.blade.php` we’re using `'text-coollabs dark:text-warning' => $line['hidden'],` at line `116`, so `text-coollabs` should show the non-error log lines in purple (`#6b16ed`) — but it's not!
- Spent some time trying to figure out why `text-coollabs` is showing red instead of purple, but didn’t get anywhere. Easiest fix for now is to just show a non-error color, so I switched it to `text-success` to show the non-error logs in green.
