### PR TITLE
fix(ui): incorrect proxy config file path

### DIFF
--- a/app/Livewire/Server/Proxy.php
+++ b/app/Livewire/Server/Proxy.php
@@ -45,7 +45,7 @@ class Proxy extends Component
 
     public function getConfigurationFilePathProperty()
     {
-        return $this->server->proxyPath().'/docker-compose.yml';
+        return $this->server->proxyPath().'docker-compose.yml';
     }
 
     public function changeProxy()

--- a/resources/views/livewire/server/proxy.blade.php
+++ b/resources/views/livewire/server/proxy.blade.php
@@ -56,7 +56,7 @@
                             <div class="flex flex-col gap-2 pt-4">
                                 <x-forms.textarea canGate="update" :canResource="$server" useMonacoEditor
                                     monacoEditorLanguage="yaml"
-                                    label="Configuration file ({{ $this->configurationFilePath }})" name="proxySettings"
+                                    label="Configuration file ( {{ $this->configurationFilePath }} )" name="proxySettings"
                                     id="proxySettings" rows="30" />
                                 @can('update', $server)
                                     <x-modal-confirmation title="Reset Proxy Configuration?"


### PR DESCRIPTION
### Issue:
<img width="1539" height="1018" alt="image" src="https://github.com/user-attachments/assets/3eade0b9-f488-4911-ab44-5786425093dc" />

### Notes:
- Added some spacing between the brackets so the file path will look like `Configuration file ( /data/coolify/proxy/docker-compose.yml )` instead of Configuration file `(/data/coolify/proxy/docker-compose.yml)` - looks bit better visually
