### PR TITLE
chore(ui): improve docker cleanup page 

### DIFF
--- a/resources/views/components/callout.blade.php
+++ b/resources/views/components/callout.blade.php
@@ -1,0 +1,59 @@
+@props(['type' => 'warning', 'title' => 'Warning', 'class' => ''])
+
+@php
+    $icons = [
+        'warning' => '<svg class="w-5 h-5 text-yellow-600 dark:text-yellow-400" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"></path></svg>',
+        
+        'danger' => '<svg class="w-5 h-5 text-red-600 dark:text-red-400" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"></path></svg>',
+        
+        'info' => '<svg class="w-5 h-5 text-blue-600 dark:text-blue-400" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"></path></svg>',
+        
+        'success' => '<svg class="w-5 h-5 text-green-600 dark:text-green-400" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path></svg>'
+    ];
+
+    $colors = [
+        'warning' => [
+            'bg' => 'bg-yellow-50 dark:bg-yellow-900/30',
+            'border' => 'border-yellow-300 dark:border-yellow-800',
+            'title' => 'text-yellow-800 dark:text-yellow-300',
+            'text' => 'text-yellow-700 dark:text-yellow-200'
+        ],
+        'danger' => [
+            'bg' => 'bg-red-50 dark:bg-red-900/30',
+            'border' => 'border-red-300 dark:border-red-800',
+            'title' => 'text-red-800 dark:text-red-300',
+            'text' => 'text-red-700 dark:text-red-200'
+        ],
+        'info' => [
+            'bg' => 'bg-blue-50 dark:bg-blue-900/30',
+            'border' => 'border-blue-300 dark:border-blue-800',
+            'title' => 'text-blue-800 dark:text-blue-300',
+            'text' => 'text-blue-700 dark:text-blue-200'
+        ],
+        'success' => [
+            'bg' => 'bg-green-50 dark:bg-green-900/30',
+            'border' => 'border-green-300 dark:border-green-800',
+            'title' => 'text-green-800 dark:text-green-300',
+            'text' => 'text-green-700 dark:text-green-200'
+        ]
+    ];
+
+    $colorScheme = $colors[$type] ?? $colors['warning'];
+    $icon = $icons[$type] ?? $icons['warning'];
+@endphp
+
+<div {{ $attributes->merge(['class' => 'p-4 border rounded-lg ' . $colorScheme['bg'] . ' ' . $colorScheme['border'] . ' ' . $class]) }}>
+    <div class="flex items-start">
+        <div class="flex-shrink-0">
+            {!! $icon !!}
+        </div>
+        <div class="ml-3">
+            <div class="text-base font-bold {{ $colorScheme['title'] }}">
+                {{ $title }}
+            </div>
+            <div class="mt-2 text-sm {{ $colorScheme['text'] }}">
+                {{ $slot }}
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/livewire/server/docker-cleanup.blade.php
+++ b/resources/views/livewire/server/docker-cleanup.blade.php
@@ -11,13 +11,6 @@
                     <div class="flex items-center gap-2">
                         <h2>Docker Cleanup</h2>
                         <x-forms.button type="submit" canGate="update" :canResource="$server">Save</x-forms.button>
-                    </div>
-                    <div class="mt-3 mb-4">Configure Docker cleanup settings for your server.</div>
-                </div>
-
-                <div class="flex flex-col gap-2">
-                    <div class="flex gap-4">
-                        <h3>Docker Cleanup</h3>
                         @can('update', $server)
                             <x-modal-confirmation title="Confirm Docker Cleanup?" buttonTitle="Trigger Manual Cleanup"
                                 isHighlightedButton submitAction="manualCleanup" :actions="[
@@ -31,7 +24,14 @@
                                 :confirmWithPassword="false" step2ButtonText="Trigger Docker Cleanup" />
                         @endcan
                     </div>
-                    <div class="flex flex-wrap items-center gap-4">
+                    <div class="mt-1 mb-6">Configure Docker cleanup settings for your server.</div>
+                </div>
+
+                <div class="flex flex-col gap-2">
+                    <div class="flex gap-4">
+                        <h3>Cleanup Configuration</h3>
+                    </div>
+                    <div class="flex items-center gap-4">
                         <x-forms.input canGate="update" :canResource="$server" placeholder="*/10 * * * *"
                             id="dockerCleanupFrequency" label="Docker cleanup frequency" required
                             helper="Cron expression for Docker Cleanup.<br>You can use every_minute, hourly, daily, weekly, monthly, yearly.<br><br>Default is every night at midnight." />
@@ -40,43 +40,48 @@
                                 label="Docker cleanup threshold (%)" required
                                 helper="The Docker cleanup tasks will run when the disk usage exceeds this threshold." />
                         @endif
-                        <div class="w-96">
-                            <x-forms.checkbox canGate="update" :canResource="$server"
-                                helper="Enabling Force Docker Cleanup or manually triggering a cleanup will perform the following actions:
-                        <ul class='list-disc pl-4 mt-2'>
-                            <li>Removes stopped containers managed by Coolify (as containers are none persistent, no data will be lost).</li>
-                            <li>Deletes unused images.</li>
-                            <li>Clears build cache.</li>
-                            <li>Removes old versions of the Coolify helper image.</li>
-                            <li>Optionally delete unused volumes (if enabled in advanced options).</li>
-                            <li>Optionally remove unused networks (if enabled in advanced options).</li>
-                        </ul>"
-                                instantSave id="forceDockerCleanup" label="Force Docker Cleanup" />
-                        </div>
                     </div>
-                    <p class="text-sm text-gray-600 dark:text-gray-400 mb-2">
-                        <span class="dark:text-warning font-bold">Warning: Enable these
-                            options only if you fully understand their implications and
-                            consequences!</span><br>Improper use will result in data loss and could cause
-                        functional issues.
-                    </p>
+                    <div class="w-96">
+                        <x-forms.checkbox canGate="update" :canResource="$server"
+                            helper="Enabling Force Docker Cleanup or manually triggering a cleanup will perform the following actions:
+                            <ul class='list-disc pl-4 mt-2'>
+                                <li>Removes stopped containers managed by Coolify (as containers are none persistent, no data will be lost).</li>
+                                <li>Deletes unused images.</li>
+                                <li>Clears build cache.</li>
+                                <li>Removes old versions of the Coolify helper image.</li>
+                                <li>Optionally delete unused volumes (if enabled in advanced options).</li>
+                                <li>Optionally remove unused networks (if enabled in advanced options).</li>
+                            </ul>"
+                            instantSave id="forceDockerCleanup" label="Force Docker Cleanup" 
+                        />
+                    </div>
+
+                </div>
+
+                <div class="flex flex-col gap-2 mt-6">
+                    <h3>Advanced</h3>
+                    <x-callout type="warning" title="Caution">
+                        <p>These options can cause permanent data loss and functional issues. Only enable if you fully understand the consequences</p>
+                    </x-callout>
                     <div class="w-96">
                         <x-forms.checkbox canGate="update" :canResource="$server" instantSave id="deleteUnusedVolumes"
                             label="Delete Unused Volumes"
-                            helper="This option will remove all unused Docker volumes during cleanup.<br><br><strong>Warning: Data form stopped containers will be lost!</strong><br><br>Consequences include:<br>
-                    <ul class='list-disc pl-4 mt-2'>
-                    <li>Volumes not attached to running containers will be deleted and data will be permanently lost (stopped containers are affected).</li>
-                    <li>Data from stopped containers volumes will be permanently lost.</li>
-                    <li>No way to recover deleted volume data.</li>
-                    </ul>" />
+                            helper="This option will remove all unused Docker volumes during cleanup.<br><br><strong>Warning: Data from stopped containers will be lost!</strong><br><br>Consequences include:<br>
+                            <ul class='list-disc pl-4 mt-2'>
+                                <li>Volumes not attached to running containers will be deleted and data will be permanently lost (stopped containers are affected).</li>
+                                <li>Data from stopped containers volumes will be permanently lost.</li>
+                                <li>No way to recover deleted volume data.</li>
+                            </ul>" 
+                        />
                         <x-forms.checkbox canGate="update" :canResource="$server" instantSave id="deleteUnusedNetworks"
                             label="Delete Unused Networks"
                             helper="This option will remove all unused Docker networks during cleanup.<br><br><strong>Warning: Functionality may be lost and containers may not be able to communicate with each other!</strong><br><br>Consequences include:<br>
-                    <ul class='list-disc pl-4 mt-2'>
-                    <li>Networks not attached to running containers will be permanently deleted (stopped containers are affected).</li>
-                    <li>Custom networks for stopped containers will be permanently deleted.</li>
-                    <li>Functionality may be lost and containers may not be able to communicate with each other.</li>
-                    </ul>" />
+                            <ul class='list-disc pl-4 mt-2'>
+                                <li>Networks not attached to running containers will be permanently deleted (stopped containers are affected).</li>
+                                <li>Custom networks for stopped containers will be permanently deleted.</li>
+                                <li>Functionality may be lost and containers may not be able to communicate with each other.</li>
+                            </ul>" 
+                        />
                     </div>
                 </div>
             </form>


### PR DESCRIPTION
## Changes

#### Docker Cleanup page
<table>
  <tr>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/96167117-eb22-447f-80f7-a8bdcc8993a5" width="400" /><br/>
      Current
    </td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/5bdfdf85-22cb-401e-a659-feeff58ce7ae" width="400" /><br/>
      New
    </td>
  </tr>
  </tr>
</table>

---

## New

#### Callout Component
<img width="1666" height="1086" alt="image" src="https://github.com/user-attachments/assets/c9c80fd1-0356-41f9-ab2d-05f8c696e6d4" />

Works well for Light mode tooo
<img width="1638" height="1076" alt="image" src="https://github.com/user-attachments/assets/da24c87e-19bd-4609-90fe-f6d16272cb3a" />

Usage:
```blade
  <x-callout type="danger" title="This is Danger">
      <p>These options can cause permanent data loss and functional issues. </p>
  </x-callout>
```

---

## Notes
- Added a new reusable callout component so we can have consistent warning or info messages on the entire product
- 95% of the changes are done by AI, but fully tested the changes locally and it's working without any issues. 
