### PR TITLE
(service): disable posthog 

### DIFF
--- a/templates/compose/posthog.yaml
+++ b/templates/compose/posthog.yaml
@@ -1,3 +1,4 @@
+# ignore: true
 # documentation: https://posthog.com
 # slogan: The single platform to analyze, test, observe, and deploy new features
 # category: analytics


### PR DESCRIPTION
The web service is returning a 500 status code due to a migration issue with the ClickHouse service. As a result, the template is broken. We've received several reports about the broken template, with suggestions to remove it if it's not functional.