### PR TITLE
fix(service): beszel missing required environment variables

### DIFF
--- a/templates/compose/beszel.yaml
+++ b/templates/compose/beszel.yaml
@@ -6,19 +6,24 @@
 # port: 8090
 
 # When adding a System in the UI, the Host/IP must be beszel-agent (or the container name, ex: beszel-agent-pswog4s8wks4o8osw44cw0k8)
-# Add the public Key in "Key" env variable below
+# Add the public Key in "Key" env variable and token in the "Token" variable below (These are obtained from Beszel UI)
 services:
   beszel:
-    image: henrygd/beszel:latest
+    image: 'henrygd/beszel:0.12.10'
     environment:
       - SERVICE_URL_BESZEL_8090
     volumes:
-      - beszel_data:/beszel_data
-
+      - 'beszel_data:/beszel_data'
+      - 'beszel_socket:/beszel_socket'
   beszel-agent:
-    image: henrygd/beszel-agent
+    image: 'henrygd/beszel-agent:0.12.10'
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - beszel_agent_data:/var/lib/beszel-agent
+      - beszel_socket:/beszel_socket
+      - '/var/run/docker.sock:/var/run/docker.sock:ro'
     environment:
-      - PORT=45876
-      - KEY=${KEY}
+      - LISTEN=/beszel_socket/beszel.sock
+      - HUB_URL=http://beszel:8090
+      - 'TOKEN=${TOKEN}'
+      - 'KEY=${KEY}'
+


### PR DESCRIPTION
A recent update to Beszel introduced changes that require additional environment variables and volume mounts. This PR updates the template to include the necessary configuration to support the new version.

### Note:
The Beszel image version has been explicitly pinned to `0.12.10` (the latest at the time of this PR) instead of using the `latest` tag. This prevents future breaking changes from affecting the template unexpectedly.

### Issues
fix #6674 