### PR TITLE
feat(ui):  Change  theme color

### DIFF
--- a/resources/views/livewire/settings-dropdown.blade.php
+++ b/resources/views/livewire/settings-dropdown.blade.php
@@ -2,6 +2,8 @@
     dropdownOpen: false,
     search: '',
     allEntries: [],
+    darkColorContent: getComputedStyle($el).getPropertyValue('--color-base'),
+    whiteColorContent: getComputedStyle($el).getPropertyValue('--color-white'),
     init() {
         this.mounted();
         // Load all entries when component initializes
@@ -45,11 +47,16 @@
         const darkModePreference = window.matchMedia('(prefers-color-scheme: dark)').matches;
         const userSettings = localStorage.getItem('theme') || 'dark';
         localStorage.setItem('theme', userSettings);
+
+        const themeMetaTag = document.querySelector('meta[name=theme-color]');
+
         if (userSettings === 'dark') {
             document.documentElement.classList.add('dark');
+            themeMetaTag.setAttribute('content', this.darkColorContent);
             this.theme = 'dark';
         } else if (userSettings === 'light') {
             document.documentElement.classList.remove('dark');
+            themeMetaTag.setAttribute('content', this.whiteColorContent);
             this.theme = 'light';
         } else if (darkModePreference) {
             this.theme = 'system';
@@ -302,7 +309,7 @@
                                                         <span x-text="entry.title"></span>
                                                         <x-external-link />
                                                     </a></span>
-                                                <span x-show="entry.tag_name === '{{ $currentVersion }}'" 
+                                                <span x-show="entry.tag_name === '{{ $currentVersion }}'"
                                                     class="px-2 py-1 text-xs font-semibold bg-success text-white rounded-sm">
                                                     CURRENT VERSION
                                                 </span>


### PR DESCRIPTION
 This PR updates the theme-color meta tag to change dynamically when the theme is toggled. This ensures the address bar in mobile browsers matches the app's current theme, improving visual consistency.

example: 

before: 

![photo_2025-09-28_05-02-28](https://github.com/user-attachments/assets/8809fd7e-c522-4fc3-b7d0-0d786a044944)

after:

![photo_2025-09-28_05-02-35](https://github.com/user-attachments/assets/ae0ce547-c90c-45fb-a17d-d2110c092d68)


