### PR TITLE
fix(ui): improve docker registry image helper text clarity

### DIFF
--- a/resources/views/livewire/project/application/general.blade.php
+++ b/resources/views/livewire/project/application/general.blade.php
@@ -187,7 +187,7 @@
                                 x-bind:disabled="!canUpdate" />
                         @else
                             <x-forms.input id="application.docker_registry_image_name"
-                                helper="Empty means it won't push the image to a docker registry."
+                                helper="Empty means it won't push the image to a docker registry. Pre-tag the image with your registry url if you want to push it to a private registry (default: Dockerhub). <br><br>Example: ghcr.io/myimage"
                                 placeholder="Empty means it won't push the image to a docker registry."
                                 label="Docker Image" x-bind:disabled="!canUpdate" />
                             <x-forms.input id="application.docker_registry_image_tag"


### PR DESCRIPTION
## Summary
- Update docker registry image helper text to provide clearer guidance for users
- Add example showing how to specify custom registries (e.g., ghcr.io/myimage)
- Improve user experience by clarifying that images need to be pre-tagged with registry URL for private registries

## Background
Users often struggle to understand where and how to specify custom docker registries when deploying applications. The previous helper text was unclear about the requirement to pre-tag images with the registry URL.

## Changes
- Enhanced helper text in `resources/views/livewire/project/application/general.blade.php`
- Added practical example: `ghcr.io/myimage`
- Clarified that Dockerhub is the default when no registry is specified

## Test plan
- [ ] Verify the updated helper text displays correctly in the application general settings
- [ ] Confirm the tooltip provides clear guidance to users about custom registry usage
- [ ] Test that the form functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)