### PR TITLE
fix(service): traccar no available server error

### DIFF
--- a/templates/compose/traccar.yaml
+++ b/templates/compose/traccar.yaml
@@ -30,7 +30,7 @@ services:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:8082/ping"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:8082"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Issue
Visiting the service url shows `no available server` error due to the service container being unhealthy. 

The reason for container being unhealthy is the failing healthcheck because the `/ping` endpoint doesn't exist.

### Note
This issue is reported by a user on our discord community server (link to the support post: https://discord.com/channels/459365938081431553/1420814628866232382)