### PR TITLE
fix(ui): incorrect caddy proxy config file path on proxy page

### DIFF
--- a/app/Livewire/Server/Proxy.php
+++ b/app/Livewire/Server/Proxy.php
@@ -43,9 +43,9 @@ class Proxy extends Component
         $this->redirectUrl = data_get($this->server, 'proxy.redirect_url');
     }
 
-    public function getConfigurationFilePathProperty()
+    public function getConfigurationFilePathProperty(): string
     {
-        return $this->server->proxyPath().'docker-compose.yml';
+        return rtrim($this->server->proxyPath(), '/') . '/docker-compose.yml';
     }
 
     public function changeProxy()


### PR DESCRIPTION
## Issue
<img width="761" height="561" alt="image" src="https://github.com/user-attachments/assets/d95fc869-fddd-402b-9880-6e4ad711e00a" />

This issue is caused by my previous PR https://github.com/coollabsio/coolify/pull/6666 now the config file path shows correctly for both traefik and caddy