### PR TITLE
chore(ui): improve application healthcheck page

### DIFF
--- a/app/Livewire/Project/Shared/HealthChecks.php
+++ b/app/Livewire/Project/Shared/HealthChecks.php
@@ -47,6 +47,18 @@ class HealthChecks extends Component
         }
     }
 
+    public function toggleHealthcheck()
+    {
+        try {
+            $this->authorize('update', $this->resource);
+            $this->resource->health_check_enabled = !$this->resource->health_check_enabled;
+            $this->resource->save();
+            $this->dispatch('success', 'Health check ' . ($this->resource->health_check_enabled ? 'enabled' : 'disabled') . '.');
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
     public function render()
     {
         return view('livewire.project.shared.health-checks');

--- a/app/Livewire/Project/Shared/HealthChecks.php
+++ b/app/Livewire/Project/Shared/HealthChecks.php
@@ -51,9 +51,15 @@ class HealthChecks extends Component
     {
         try {
             $this->authorize('update', $this->resource);
+            $wasEnabled = $this->resource->health_check_enabled;
             $this->resource->health_check_enabled = !$this->resource->health_check_enabled;
             $this->resource->save();
-            $this->dispatch('success', 'Health check ' . ($this->resource->health_check_enabled ? 'enabled' : 'disabled') . '.');
+
+            if ($this->resource->health_check_enabled && !$wasEnabled && $this->resource->isRunning()) {
+                $this->dispatch('info', 'Health check has been enabled. A restart is required to apply the new settings.');
+            } else {
+                $this->dispatch('success', 'Health check ' . ($this->resource->health_check_enabled ? 'enabled' : 'disabled') . '.');
+            }
         } catch (\Throwable $e) {
             return handleError($e, $this);
         }

--- a/resources/views/livewire/project/shared/health-checks.blade.php
+++ b/resources/views/livewire/project/shared/health-checks.blade.php
@@ -13,11 +13,12 @@
             <x-forms.button canGate="update" :canResource="$resource" wire:click="toggleHealthcheck">Disable Healthcheck</x-forms.button>
         @endif
     </div>
-    <div class="mt-1 pb-6">Define how your resource's health should be checked.</div>
+    <div class="mt-1 pb-4">Define how your resource's health should be checked.</div>
     <div class="flex flex-col gap-4">
         @if ($resource->custom_healthcheck_found)
-            <div class="dark:text-warning">A custom health check has been found and will be used until you enable this.
-            </div>
+            <x-callout type="warning" title="Caution">
+                <p>A custom health check has been detected. If you enable this health check, it will disable the custom one and use this instead.</p>
+            </x-callout>
         @endif
         <div class="flex gap-2">
             <x-forms.select canGate="update" :canResource="$resource" id="resource.health_check_method" label="Method" required>

--- a/resources/views/livewire/project/shared/health-checks.blade.php
+++ b/resources/views/livewire/project/shared/health-checks.blade.php
@@ -13,7 +13,7 @@
             <x-forms.button canGate="update" :canResource="$resource" wire:click="toggleHealthcheck">Disable Healthcheck</x-forms.button>
         @endif
     </div>
-    <div class="pb-4">Define how your resource's health should be checked.</div>
+    <div class="mt-1 pb-6">Define how your resource's health should be checked.</div>
     <div class="flex flex-col gap-4">
         @if ($resource->custom_healthcheck_found)
             <div class="dark:text-warning">A custom health check has been found and will be used until you enable this.

--- a/resources/views/livewire/project/shared/health-checks.blade.php
+++ b/resources/views/livewire/project/shared/health-checks.blade.php
@@ -17,7 +17,10 @@
                 <option value="GET">GET</option>
                 <option value="POST">POST</option>
             </x-forms.select>
-            <x-forms.input canGate="update" :canResource="$resource" id="resource.health_check_scheme" placeholder="http" label="Scheme" required />
+            <x-forms.select canGate="update" :canResource="$resource" id="resource.health_check_scheme" label="Scheme" required>
+                <option value="http">http</option>
+                <option value="https">https</option>
+            </x-forms.select>
             <x-forms.input canGate="update" :canResource="$resource" id="resource.health_check_host" placeholder="localhost" label="Host" required />
             <x-forms.input canGate="update" :canResource="$resource" type="number" id="resource.health_check_port"
                 helper="If no port is defined, the first exposed port will be used." placeholder="80" label="Port" />

--- a/resources/views/livewire/project/shared/health-checks.blade.php
+++ b/resources/views/livewire/project/shared/health-checks.blade.php
@@ -2,6 +2,16 @@
     <div class="flex items-center gap-2">
         <h2>Healthchecks</h2>
         <x-forms.button canGate="update" :canResource="$resource" type="submit">Save</x-forms.button>
+        @if (!$resource->health_check_enabled)
+            <x-modal-confirmation title="Confirm Healthcheck Enable?" buttonTitle="Enable Healthcheck"
+                submitAction="toggleHealthcheck" :actions="['Enable healthcheck for this resource.']"
+                warningMessage="If the health check fails, your application will become inaccessible. Please review the <a href='https://coolify.io/docs/knowledge-base/health-checks' target='_blank' class='underline text-white'>Health Checks</a> guide before proceeding!"
+                step2ButtonText="Enable Healthcheck" :confirmWithText="false" :confirmWithPassword="false"
+                isHighlightedButton>
+            </x-modal-confirmation>
+        @else
+            <x-forms.button canGate="update" :canResource="$resource" wire:click="toggleHealthcheck">Disable Healthcheck</x-forms.button>
+        @endif
     </div>
     <div class="pb-4">Define how your resource's health should be checked.</div>
     <div class="flex flex-col gap-4">
@@ -9,9 +19,6 @@
             <div class="dark:text-warning">A custom health check has been found and will be used until you enable this.
             </div>
         @endif
-        <div class="w-32">
-            <x-forms.checkbox canGate="update" :canResource="$resource" instantSave id="resource.health_check_enabled" label="Enabled" />
-        </div>
         <div class="flex gap-2">
             <x-forms.select canGate="update" :canResource="$resource" id="resource.health_check_method" label="Method" required>
                 <option value="GET">GET</option>

--- a/resources/views/livewire/project/shared/health-checks.blade.php
+++ b/resources/views/livewire/project/shared/health-checks.blade.php
@@ -13,7 +13,10 @@
             <x-forms.checkbox canGate="update" :canResource="$resource" instantSave id="resource.health_check_enabled" label="Enabled" />
         </div>
         <div class="flex gap-2">
-            <x-forms.input canGate="update" :canResource="$resource" id="resource.health_check_method" placeholder="GET" label="Method" required />
+            <x-forms.select canGate="update" :canResource="$resource" id="resource.health_check_method" label="Method" required>
+                <option value="GET">GET</option>
+                <option value="POST">POST</option>
+            </x-forms.select>
             <x-forms.input canGate="update" :canResource="$resource" id="resource.health_check_scheme" placeholder="http" label="Scheme" required />
             <x-forms.input canGate="update" :canResource="$resource" id="resource.health_check_host" placeholder="localhost" label="Host" required />
             <x-forms.input canGate="update" :canResource="$resource" type="number" id="resource.health_check_port"


### PR DESCRIPTION
## Changes

#### Health check page
<table>
  <tr>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/0d6d4f36-a8a3-45bf-ad05-22bc35e7c149" width="400" /><br/>
      Current
    </td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/f5d3b250-6f33-4374-b532-a9031cbb1b16" width="400" /><br/>
      New
    </td>
  </tr>
  </tr>
</table>

#### Enable Health check confirmation
<table>
  <tr>
    <td align="center">
      <img src="" width="400" /><br/>
      Currently we don't have one
    </td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/c7feaf1e-6c0a-4071-959f-eef582641818" width="400" /><br/>
      New
    </td>
  </tr>
  </tr>
</table>

#### Info Toast
<table>
  <tr>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/85d7d850-4996-4d48-888e-44ba47de4f4f" width="400" /><br/>
      Current
    </td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/51dba138-0865-4f3b-adf9-ccdf3cc491af" width="400" /><br/>
      New
    </td>
  </tr>
  </tr>
</table>

---

## Notes:
- New Healthcheck enable button logic:  If app is running, show info toast with message like a restart is required to apply healthcheck changes, else show healthcheck enabled toast
- Replaced the checkbox to enable health check with a button which is easy to find and triggers a confirmation modal which has warning about failing healthcheck can cause app to be inaccessible and a link to our docs about healthchecks.
- Added dropdown for METHOD and SCHEME since there are only 2 option to pick (user don't have to think too much about what are the input are supported)
- 90% the changes are done by AI, but fully tested the changes locally and it's working without any issues.