### PR TITLE
fix(ui): long text on helper popup not wrapping based on screensize

### DIFF
--- a/resources/css/utilities.css
+++ b/resources/css/utilities.css
@@ -199,7 +199,7 @@
 }
 
 @utility info-helper-popup {
-    @apply hidden absolute z-40 text-xs rounded-sm text-neutral-700 group-hover:block dark:border-coolgray-500 border-neutral-900 dark:bg-coolgray-400 bg-neutral-200 dark:text-neutral-300;
+    @apply hidden absolute z-40 text-xs rounded-sm text-neutral-700 group-hover:block dark:border-coolgray-500 border-neutral-900 dark:bg-coolgray-400 bg-neutral-200 dark:text-neutral-300 max-w-xs whitespace-normal break-words;
 }
 
 @utility buyme {


### PR DESCRIPTION
## Fixes

<table>
  <tr>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/01702786-8b89-4553-81d5-cbff9990f293" width="400" /><br/>
      Current
    </td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/144f0a5d-6b09-4b45-b2c5-285b70d2a46d" width="400" /><br/>
      New
    </td>
  </tr>
  </tr>
</table>

## Notes:
- This bug is reported by a user on our community server (support post: https://discord.com/channels/459365938081431553/1421790305132216442 )
- All the changes are done by AI, but fully tested the changes locally and it's working without any issue