### PR TITLE
fix: resolve scroll lock issue after closing quick search modal with escape key

### DIFF
--- a/resources/views/livewire/global-search.blade.php
+++ b/resources/views/livewire/global-search.blade.php
@@ -9,6 +9,8 @@
     closeModal() {
         this.modalOpen = false;
         this.selectedIndex = -1;
+        // Ensure scroll is restored
+        document.body.style.overflow = '';
         @this.closeSearchModal();
     },
     navigateResults(direction) {
@@ -89,7 +91,9 @@
             class="fixed top-0 lg:pt-10 left-0 z-99 flex items-start justify-center w-screen h-screen">
             <div @click="closeModal()" class="absolute inset-0 w-full h-full bg-black/20 backdrop-blur-xs">
             </div>
-            <div x-show="modalOpen" x-trap.inert.noscroll="modalOpen" x-transition:enter="ease-out duration-100"
+            <div x-show="modalOpen" x-trap.inert="modalOpen" 
+                 x-init="$watch('modalOpen', value => { document.body.style.overflow = value ? 'hidden' : '' })" 
+                 x-transition:enter="ease-out duration-100"
                 x-transition:enter-start="opacity-0 -translate-y-2 sm:scale-95"
                 x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"
                 x-transition:leave="ease-in duration-100"


### PR DESCRIPTION
Fixes #6716

The issue was caused by Alpine.js's `x-trap.inert.noscroll` directive not properly restoring scroll when the modal was opened via keyboard shortcuts and closed with the escape key.

### Changes
- Replaced `x-trap.inert.noscroll` with manual scroll management
- Added explicit scroll restoration in `closeModal()` method
- Used Alpine.js `$watch` to monitor modal state changes

### Testing
To test the fix:
1. Navigate to a page that is long enough to enable scrolling
2. Use keyboard to open quick search (ctrl+k, ctrl+/, cmd+k, cmd+/)
3. Press escape to close modal
4. Verify that page scrolling works correctly

Generated with [Claude Code](https://claude.ai/code)