### PR TITLE
feat: add support for horizontal scaling with replicas

### DIFF
--- a/app/Livewire/Project/Application/General.php
+++ b/app/Livewire/Project/Application/General.php
@@ -110,6 +110,7 @@ class General extends Component
             'application.http_basic_auth_password' => 'string|nullable',
             'application.watch_paths' => 'nullable',
             'application.redirect' => 'string|required',
+            'application.replicas' => 'integer|min:1|max:10',
         ];
     }
 

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -90,6 +90,7 @@ use Visus\Cuid2\Cuid2;
         'docker_compose_custom_build_command' => ['type' => 'string', 'nullable' => true, 'description' => 'Docker compose custom build command.'],
         'swarm_replicas' => ['type' => 'integer', 'nullable' => true, 'description' => 'Swarm replicas. Only used for swarm deployments.'],
         'swarm_placement_constraints' => ['type' => 'string', 'nullable' => true, 'description' => 'Swarm placement constraints. Only used for swarm deployments.'],
+        'replicas' => ['type' => 'integer', 'description' => 'Number of replicas for horizontal scaling. Default is 1. When > 1, container_name is removed and labels are used for tracking.'],
         'custom_docker_run_options' => ['type' => 'string', 'nullable' => true, 'description' => 'Custom docker run options.'],
         'post_deployment_command' => ['type' => 'string', 'nullable' => true, 'description' => 'Post deployment command.'],
         'post_deployment_command_container' => ['type' => 'string', 'nullable' => true, 'description' => 'Post deployment command container.'],

--- a/bootstrap/helpers/parsers.php
+++ b/bootstrap/helpers/parsers.php
@@ -1088,11 +1088,24 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
             return $volume;
         });
 
-        $payload = collect($service)->merge([
-            'container_name' => $containerName,
+        // Build payload - conditionally add container_name based on replicas
+        $payloadData = [
             'restart' => $restart->value(),
             'labels' => $serviceLabels,
-        ]);
+        ];
+
+        // Only add container_name if replicas <= 1 (Docker Compose doesn't allow container_name with replicas > 1)
+        $replicas = data_get($resource, 'replicas', 1);
+        if ($replicas <= 1) {
+            $payloadData['container_name'] = $containerName;
+        } else {
+            // When using replicas, add deploy configuration
+            $payloadData['deploy'] = [
+                'replicas' => $replicas,
+            ];
+        }
+
+        $payload = collect($service)->merge($payloadData);
         if (! $use_network_mode) {
             $payload['networks'] = $networks_temp;
         }
@@ -1973,6 +1986,7 @@ function serviceParser(Service $resource): Collection
             return $volume;
         });
 
+        // Build payload - Services don't currently support replicas, always use container_name
         $payload = collect($service)->merge([
             'container_name' => $containerName,
             'restart' => $restart->value(),

--- a/database/migrations/2025_10_01_000000_add_replicas_to_applications_table.php
+++ b/database/migrations/2025_10_01_000000_add_replicas_to_applications_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('applications', function (Blueprint $table) {
+            $table->integer('replicas')->default(1)->after('swarm_replicas');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('applications', function (Blueprint $table) {
+            $table->dropColumn('replicas');
+        });
+    }
+};

--- a/resources/views/livewire/project/application/advanced.blade.php
+++ b/resources/views/livewire/project/application/advanced.blade.php
@@ -49,7 +49,18 @@
                     helper="WARNING: Advanced use cases only. Your docker compose file will be deployed as-is. Nothing is modified by Coolify. You need to configure the proxy parts. More info in the <a class='underline dark:text-white' href='https://coolify.io/docs/knowledge-base/docker/compose#raw-docker-compose-deployment'>documentation.</a>"
                     canGate="update" :canResource="$application" />
             @endif
-            <h3 class="pt-4">Container Names</h3>
+            <h3 class="pt-4">Container Names & Scaling</h3>
+            @if ($application->build_pack === 'dockercompose' || $application->build_pack === 'dockerfile' || $application->build_pack === 'nixpacks')
+                <x-forms.input
+                    type="number"
+                    min="1"
+                    max="10"
+                    helper="Number of replicas for horizontal scaling (1-10). <span class='font-bold dark:text-warning'>When > 1, container_name is removed and labels are used for tracking. Only use for stateless applications!</span>"
+                    id="application.replicas"
+                    label="Replicas"
+                    canGate="update"
+                    :canResource="$application" />
+            @endif
             <x-forms.checkbox
                 helper="The deployed container will have the same name ({{ $application->uuid }}). <span class='font-bold dark:text-warning'>You will lose the rolling update feature!</span>"
                 instantSave id="isConsistentContainerNameEnabled" label="Consistent Container Names" canGate="update"


### PR DESCRIPTION
## issues

#3862
#2131

  This PR implements support for horizontal scaling using Docker Compose `deploy.replicas`, addressing the discussion in #3862.

  ### Problem
  Coolify injects a mandatory `container_name` which prevents using `deploy.replicas > 1` in Docker Compose deployments.

  ### Solution
  - Conditionally removes `container_name` when `replicas > 1`
  - Adds `replicas` field to Application model (default: 1)
  - Uses labels for container tracking when scaling
  - Provides UI for configuring replicas (1-10)

  ## Changes

  ### Database
  - **Migration:** Added `replicas` field (integer, default: 1) to `applications` table

  ### Backend
  - **Model:** Updated `Application` model with OpenAPI documentation for `replicas`
  - **Parser:** Modified `applicationParser()` to conditionally add/remove `container_name`
  - **Validation:** Added rules: `integer|min:1|max:10`

  ### Frontend
  - **UI:** Added replicas input in Advanced settings
  - **Location:** Configuration → Advanced → "Container Names & Scaling"
  - **Warning:** Clear notice about stateless applications only

  ## Behavior

  ### Replicas = 1 (Default - Backward Compatible)
  ```yaml
  services:
    app:
      container_name: app-xyz123
      restart: always
```

  ### Replicas > 1 (New Behavior)
  ```yaml
  services:
    app:
      # container_name removed
      deploy:
        replicas: 3
      restart: always
```

  Docker Compose will create: app-1, app-2, app-3

  Compatibility

  - ✅ Backward compatible (default replicas=1 maintains current behavior)
  - ✅ Works with: dockercompose, dockerfile, nixpacks
  - ✅ Does not affect existing swarm_replicas feature
  - ⚠️ Only for stateless applications

  Testing

  - Migration tested
  - Code formatted with Pint
  - Static analysis passed
  - Manual deployment tested with replicas=3
  - Verified multiple containers running
  - Confirmed label-based tracking works

  Related

  - Discussion: #3862
  - Related issue: #2131
  - Reference: Dokploy implementation

  Notes

  - Max replicas limited to 10 for safety
  - UI shows warning about stateless apps
  - Container tracking uses Coolify labels instead of fixed names