### PR TITLE
feat (template): use new homarr image

### DIFF
--- a/templates/compose/homarr.yaml
+++ b/templates/compose/homarr.yaml
@@ -10,11 +10,11 @@ services:
     image: ghcr.io/ajnart/homarr:latest
     environment:
       - SERVICE_URL_HOMARR_7575
+      - SERVICE_HEX_32_HOMARR
+      - 'SECRET_ENCRYPTION_KEY=${SERVICE_HEX_32_HOMARR}'
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ./homarr/configs:/app/data/configs
-      - ./homarr/icons:/app/public/icons
-      - ./homarr/data:/data
+      - ./homarr/appdata:/appdata
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:7575"]
       interval: 5s

--- a/templates/compose/homarr.yaml
+++ b/templates/compose/homarr.yaml
@@ -7,7 +7,7 @@
 
 services:
   homarr:
-    image: ghcr.io/homarr-labs/homarr:latest
+    image: ghcr.io/homarr-labs/homarr:v1.40.0
     environment:
       - SERVICE_URL_HOMARR_7575
       - SERVICE_HEX_32_HOMARR

--- a/templates/compose/homarr.yaml
+++ b/templates/compose/homarr.yaml
@@ -7,7 +7,7 @@
 
 services:
   homarr:
-    image: ghcr.io/ajnart/homarr:latest
+    image: ghcr.io/homarr-labs/homarr:latest
     environment:
       - SERVICE_URL_HOMARR_7575
       - SERVICE_HEX_32_HOMARR


### PR DESCRIPTION
Updated image, environment variables and volume paths according to the new version 1.40.0

## Changes
- update image from ajnart/homarr (0.x) to homarr-labs/homarr (1.x) because ajnart deprecated the old version (https://github.com/ajnart/homarr/releases/tag/v0.16.0)
- update env and volume paths according to current docs v1.40.0 (https://homarr.dev/docs/getting-started/installation/docker)