### PR TITLE
feat: add preview and PR buttons to deployment page

### DIFF
--- a/app/Livewire/Project/Application/Deployment/Show.php
+++ b/app/Livewire/Project/Application/Deployment/Show.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Project\Application\Deployment;
 
 use App\Models\Application;
 use App\Models\ApplicationDeploymentQueue;
+use App\Models\ApplicationPreview;
 use Livewire\Component;
 
 class Show extends Component
@@ -17,6 +18,8 @@ class Show extends Component
     public string $horizon_job_status;
 
     public $isKeepAliveOn = true;
+
+    public ?ApplicationPreview $preview = null;
 
     public function getListeners()
     {
@@ -57,6 +60,12 @@ class Show extends Component
         $this->horizon_job_status = $this->application_deployment_queue->getHorizonJobStatus();
         $this->deployment_uuid = $deploymentUuid;
         $this->isKeepAliveOn();
+
+        if ($this->application_deployment_queue->pull_request_id && $this->application_deployment_queue->pull_request_id > 0) {
+            $this->preview = ApplicationPreview::where('application_id', $this->application->id)
+                ->where('pull_request_id', $this->application_deployment_queue->pull_request_id)
+                ->first();
+        }
     }
 
     public function refreshQueue()
@@ -79,6 +88,12 @@ class Show extends Component
         $this->application_deployment_queue->refresh();
         $this->horizon_job_status = $this->application_deployment_queue->getHorizonJobStatus();
         $this->isKeepAliveOn();
+
+        if ($this->application_deployment_queue->pull_request_id && $this->application_deployment_queue->pull_request_id > 0) {
+            $this->preview = ApplicationPreview::where('application_id', $this->application->id)
+                ->where('pull_request_id', $this->application_deployment_queue->pull_request_id)
+                ->first();
+        }
     }
 
     public function getLogLinesProperty()

--- a/resources/views/livewire/project/application/deployment/show.blade.php
+++ b/resources/views/livewire/project/application/deployment/show.blade.php
@@ -54,6 +54,24 @@
                     class="dark:text-warning">{{ Str::headline(data_get($application_deployment_queue, 'status')) }}</span>.
             </div>
         @endif
+
+        @if ($preview)
+            <div class="flex gap-2 pt-2">
+                @if ($preview->status !== 'exited' && $preview->fqdn)
+                    <a target="_blank" href="{{ $preview->fqdn }}" class="flex items-center gap-1 text-sm hover:underline">
+                        Open Preview
+                        <x-external-link />
+                    </a>
+                    |
+                @endif
+                @if ($preview->pull_request_html_url)
+                    <a target="_blank" href="{{ $preview->pull_request_html_url }}" class="flex items-center gap-1 text-sm hover:underline">
+                        Open PR on Git
+                        <x-external-link />
+                    </a>
+                @endif
+            </div>
+        @endif
         <div id="screen" :class="fullscreen ? 'fullscreen' : 'relative'">
             <div @if ($isKeepAliveOn) wire:poll.2000ms="polling" @endif
                 class="flex flex-col-reverse w-full p-2 px-4 mt-4 overflow-y-auto bg-white dark:text-white dark:bg-coolgray-100 scrollbar dark:border-coolgray-300"


### PR DESCRIPTION
## Changes
- Added "Open Preview" and "Open PR on Git" buttons to the deployment page
- Buttons update automatically during deployment (no page reload needed)
- Preview link only shows when the deployment is running

<img width="1424" height="631" alt="Capture d’écran 2025-10-06 à 01 25 59" src="https://github.com/user-attachments/assets/9671227a-77a8-4032-ae5e-1d87cc7e7a81" />


## Why?
Honestly, I was getting tired of the constant back-and-forth when working with PR deployments. Every time I wanted to check the preview or look at the PR comments, I had to navigate back to the previews tab, find the right deployment, then click the link. 

Since the deployment page already has all the logs and status, it felt weird that I couldn't just open the preview or PR from there. The buttons already exist on the previews page anyway, so I just added them to the deployment view too.

Should make the DX smoother when you're actively debugging or reviewing a PR deployment - everything's in one spot instead of juggling tabs.

## Testing
- Tested with local dev setup
- Works fine with PR deployments, regular deployments unaffected
- Buttons appear/update automatically as deployment progresses