### PR TITLE
fix(ui): make the deployments indicator toast in the bottom-left above the sidebar

### DIFF
--- a/resources/views/livewire/deployments-indicator.blade.php
+++ b/resources/views/livewire/deployments-indicator.blade.php
@@ -1,6 +1,6 @@
 <div wire:poll.3000ms x-data="{
     expanded: @entangle('expanded')
-}" class="fixed bottom-0 z-50 mb-4 left-0 lg:left-56 ml-4">
+}" class="fixed bottom-0 z-60 mb-4 left-0 lg:left-56 ml-4">
     @if ($this->deploymentCount > 0)
         <div class="relative">
             <!-- Indicator Button -->


### PR DESCRIPTION
## Changes
- As per #6782 , the issue fixed by adding higher z-index using Tailwind CSS class to make it stack on top of the sidebar.

|  Previous | Now  |
|---|---|
| <img width="333" height="170" alt="image" src="https://github.com/user-attachments/assets/7b2307f7-acd7-45b1-b089-491ecd1f080c" />  | <img width="249" height="140" alt="image" src="https://github.com/user-attachments/assets/a98a3f9d-b3db-4ded-8747-3e3cd86c8020" />  |
|  <img width="445" height="228" alt="image" src="https://github.com/user-attachments/assets/e1d073ad-0e4e-41ba-af93-c2538c6f9e20" /> | <img width="553" height="381" alt="image" src="https://github.com/user-attachments/assets/bf903953-17dd-41d3-978c-3d1e829c68fe" />  |

## Issues
- fix #6782 
