### PR TITLE
chore(ui): add accordion UI for project environments

### DIFF
--- a/resources/views/livewire/shared-variables/environment/index.blade.php
+++ b/resources/views/livewire/shared-variables/environment/index.blade.php
@@ -6,25 +6,51 @@
         <h1>Environments</h1>
     </div>
     <div class="subtitle">List of your environments by projects.</div>
-    <div class="flex flex-col gap-2">
+    <div x-data="{
+        activeAccordion: '',
+        setActiveAccordion(id) {
+            this.activeAccordion = (this.activeAccordion == id) ? '' : id
+        }
+    }" class="flex flex-col gap-2">
         @forelse ($projects as $project)
-            <h2>Project: {{ data_get($project, 'name') }}</h2>
-            <div class="pt-0 pb-3">{{ data_get($project, 'description') }}</div>
-            @forelse ($project->environments as $environment)
-                <a class="box group"
-                    href="{{ route('shared-variables.environment.show', [
-                        'project_uuid' => $project->uuid,
-                        'environment_uuid' => $environment->uuid,
-                    ]) }}">
-                    <div class="flex flex-col justify-center flex-1 mx-6 ">
-                        <div class="box-title"> {{ $environment->name }}</div>
-                        <div class="box-description">
-                            {{ $environment->description }}</div>
+            <div x-data="{ id: $id('accordion') }">
+                <button @click="setActiveAccordion(id)"
+                    class="box group flex flex-row justify-between w-full text-left cursor-pointer items-start lg:items-center"
+                    type="button">
+                    <div class="flex items-center gap-3 flex-1 mx-6">
+                        <svg class="w-4 h-4 duration-200 ease-out opacity-60" :class="{ 'rotate-90': activeAccordion == id }"
+                            viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor"
+                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <polyline points="9 18 15 12 9 6"></polyline>
+                        </svg>
+                        <div class="flex flex-col flex-1">
+                            <div class="box-title">{{ data_get($project, 'name') }}</div>
+                            @if (data_get($project, 'description'))
+                                <div class="box-description">{{ data_get($project, 'description') }}</div>
+                            @endif
+                        </div>
                     </div>
-                </a>
-            @empty
-                <p class="pb-4">No environments found.</p>
-            @endforelse
+                    <div class="flex items-center gap-2 pr-4">
+                        <span class="text-xs opacity-50">{{ $project->environments->count() }} {{ Str::plural('environment', $project->environments->count()) }}</span>
+                    </div>
+                </button>
+                <div x-show="activeAccordion==id" x-collapse x-cloak class="flex flex-col gap-2 mt-2 ml-6 pl-4 border-l-2 border-coolgray-200/10">
+                    @forelse ($project->environments as $environment)
+                        <a class="box"
+                            href="{{ route('shared-variables.environment.show', [
+                                'project_uuid' => $project->uuid,
+                                'environment_uuid' => $environment->uuid,
+                            ]) }}">
+                            <div class="flex flex-col justify-center flex-1 mx-6">
+                                <div class="box-title">{{ $environment->name }}</div>
+                                <div class="box-description">{{ $environment->description }}</div>
+                            </div>
+                        </a>
+                    @empty
+                        <p class="text-sm opacity-70 px-2">No environments found.</p>
+                    @endforelse
+                </div>
+            </div>
         @empty
             <div>
                 <div>No project found.</div>


### PR DESCRIPTION
## Changes
| before | after |
|--------|--------|
| <img width="802" height="906" alt="mobile-before" src="https://github.com/user-attachments/assets/6dc9aed5-3589-4f20-a0b0-79e11fe2d7ed" /> | <img width="810" height="1058" alt="mobile-after" src="https://github.com/user-attachments/assets/47056707-5556-4a50-8b03-290840adb611" /> |
| <img width="3616" height="808" alt="desktop-before" src="https://github.com/user-attachments/assets/ed2a1dcc-e92b-43b1-9b6c-1f5dcbfe7162" /> | <img width="3626" height="1046" alt="desktop-after" src="https://github.com/user-attachments/assets/dff269b2-52c9-49cf-8e9a-dcc96954a8f1" /> | 