### PR TITLE
fix(migration): disable transaction for concurrent index creation

### DIFF
--- a/database/migrations/2025_06_26_131350_optimize_activity_log_indexes.php
+++ b/database/migrations/2025_06_26_131350_optimize_activity_log_indexes.php
@@ -7,6 +7,12 @@ use Illuminate\Support\Facades\Log;
 return new class extends Migration
 {
     /**
+     * Disable transactions for this migration because CREATE INDEX CONCURRENTLY
+     * cannot run inside a transaction block in PostgreSQL.
+     */
+    public bool $withinTransaction = false;
+
+    /**
      * Run the migrations.
      */
     public function up(): void

--- a/database/migrations/2025_06_26_131350_optimize_activity_log_indexes.php
+++ b/database/migrations/2025_06_26_131350_optimize_activity_log_indexes.php
@@ -7,25 +7,27 @@ use Illuminate\Support\Facades\Log;
 return new class extends Migration
 {
     /**
-     * Disable transactions for this migration because CREATE INDEX CONCURRENTLY
-     * cannot run inside a transaction block in PostgreSQL.
-     */
-    public bool $withinTransaction = false;
-
-    /**
      * Run the migrations.
      */
     public function up(): void
     {
         try {
+            // CREATE INDEX CONCURRENTLY cannot run inside a transaction block
+            // We need to commit any open transaction first
+            DB::commit();
+
             // Add specific index for type_uuid queries with ordering
-            DB::statement('CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_activity_type_uuid_created_at ON activity_log ((properties->>\'type_uuid\'), created_at DESC)');
+            DB::unprepared('CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_activity_type_uuid_created_at ON activity_log ((properties->>\'type_uuid\'), created_at DESC)');
 
             // Add specific index for status queries on properties
-            DB::statement('CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_activity_properties_status ON activity_log ((properties->>\'status\'))');
+            DB::unprepared('CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_activity_properties_status ON activity_log ((properties->>\'status\'))');
 
+            // Begin a new transaction for subsequent migrations
+            DB::beginTransaction();
         } catch (\Exception $e) {
             Log::error('Error adding optimized indexes to activity_log: '.$e->getMessage());
+            // Ensure we have a transaction for subsequent migrations
+            DB::beginTransaction();
         }
     }
 
@@ -35,10 +37,16 @@ return new class extends Migration
     public function down(): void
     {
         try {
-            DB::statement('DROP INDEX CONCURRENTLY IF EXISTS idx_activity_type_uuid_created_at');
-            DB::statement('DROP INDEX CONCURRENTLY IF EXISTS idx_activity_properties_status');
+            // DROP INDEX CONCURRENTLY cannot run inside a transaction block
+            DB::commit();
+
+            DB::unprepared('DROP INDEX CONCURRENTLY IF EXISTS idx_activity_type_uuid_created_at');
+            DB::unprepared('DROP INDEX CONCURRENTLY IF EXISTS idx_activity_properties_status');
+
+            DB::beginTransaction();
         } catch (\Exception $e) {
             Log::error('Error dropping optimized indexes from activity_log: '.$e->getMessage());
+            DB::beginTransaction();
         }
     }
 };

--- a/database/migrations/2025_06_26_131350_optimize_activity_log_indexes.php
+++ b/database/migrations/2025_06_26_131350_optimize_activity_log_indexes.php
@@ -7,27 +7,25 @@ use Illuminate\Support\Facades\Log;
 return new class extends Migration
 {
     /**
+     * Disable transactions for this migration because CREATE INDEX CONCURRENTLY
+     * cannot run inside a transaction block in PostgreSQL.
+     */
+    public $withinTransaction = false;
+
+    /**
      * Run the migrations.
      */
     public function up(): void
     {
         try {
-            // CREATE INDEX CONCURRENTLY cannot run inside a transaction block
-            // We need to commit any open transaction first
-            DB::commit();
-
             // Add specific index for type_uuid queries with ordering
             DB::unprepared('CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_activity_type_uuid_created_at ON activity_log ((properties->>\'type_uuid\'), created_at DESC)');
 
             // Add specific index for status queries on properties
             DB::unprepared('CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_activity_properties_status ON activity_log ((properties->>\'status\'))');
 
-            // Begin a new transaction for subsequent migrations
-            DB::beginTransaction();
         } catch (\Exception $e) {
             Log::error('Error adding optimized indexes to activity_log: '.$e->getMessage());
-            // Ensure we have a transaction for subsequent migrations
-            DB::beginTransaction();
         }
     }
 
@@ -37,16 +35,10 @@ return new class extends Migration
     public function down(): void
     {
         try {
-            // DROP INDEX CONCURRENTLY cannot run inside a transaction block
-            DB::commit();
-
             DB::unprepared('DROP INDEX CONCURRENTLY IF EXISTS idx_activity_type_uuid_created_at');
             DB::unprepared('DROP INDEX CONCURRENTLY IF EXISTS idx_activity_properties_status');
-
-            DB::beginTransaction();
         } catch (\Exception $e) {
             Log::error('Error dropping optimized indexes from activity_log: '.$e->getMessage());
-            DB::beginTransaction();
         }
     }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -888,8 +888,7 @@
             "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
             "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@tailwindcss/forms": {
             "version": "0.5.10",
@@ -1404,7 +1403,8 @@
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
             "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
@@ -1567,7 +1567,6 @@
             "integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@socket.io/component-emitter": "~3.1.0",
                 "debug": "~4.3.1",
@@ -1582,7 +1581,6 @@
             "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -1601,7 +1599,6 @@
             "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             }
@@ -2376,6 +2373,7 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -2452,6 +2450,7 @@
             "integrity": "sha512-wp3HqIIUc1GRyu1XrP6m2dgyE9MoCsXVsWNlohj0rjSkLf+a0jLvEyVubdg58oMk7bhjBWnFClgp8jfAa6Ak4Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tweetnacl": "^1.0.3"
             }
@@ -2534,7 +2533,6 @@
             "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@socket.io/component-emitter": "~3.1.0",
                 "debug": "~4.3.2",
@@ -2551,7 +2549,6 @@
             "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -2570,7 +2567,6 @@
             "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@socket.io/component-emitter": "~3.1.0",
                 "debug": "~4.3.1"
@@ -2585,7 +2581,6 @@
             "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -2634,7 +2629,8 @@
             "version": "4.1.10",
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.10.tgz",
             "integrity": "sha512-P3nr6WkvKV/ONsTzj6Gb57sWPMX29EPNPopo7+FcpkQaNsrNpZ1pv8QmrYI2RqEKD7mlGqLnGovlcYnBK0IqUA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/tapable": {
             "version": "2.2.2",
@@ -2700,6 +2696,7 @@
             "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.4.4",
@@ -2799,6 +2796,7 @@
             "integrity": "sha512-rjOV2ecxMd5SiAmof2xzh2WxntRcigkX/He4YFJ6WdRvVUrbt6DxC1Iujh10XLl8xCDRDtGKMeO3D+pRQ1PP9w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@vue/compiler-dom": "3.5.16",
                 "@vue/compiler-sfc": "3.5.16",
@@ -2821,7 +2819,6 @@
             "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -2843,7 +2840,6 @@
             "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
             "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.4.0"
             }


### PR DESCRIPTION
## Summary
- Fixed PostgreSQL migration error where `CREATE INDEX CONCURRENTLY` was failing because it cannot run inside a transaction block
- Added `$withinTransaction = false` property to the migration to disable automatic transaction wrapping

## Problem
When running migrations in dev environment, the `optimize_activity_log_indexes` migration was failing with:
```
SQLSTATE[25001]: Active sql transaction: 7 ERROR: CREATE INDEX CONCURRENTLY cannot run inside a transaction block
```

## Solution
PostgreSQL's `CREATE INDEX CONCURRENTLY` command cannot be executed within a transaction. Laravel migrations run inside transactions by default. By setting `public bool $withinTransaction = false` on the migration class, we instruct Laravel to run this migration outside of a transaction, allowing the concurrent index creation to succeed.

## Test plan
- [x] Run `php artisan migrate` in dev environment
- [x] Verify indexes are created successfully without transaction errors
- [x] Confirm migration can be rolled back with `php artisan migrate:rollback`

🤖 Generated with [Claude Code](https://claude.com/claude-code)