### PR TITLE
refactor(backup): make backup_log_uuid initialization lazy

### DIFF
--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -69,13 +69,12 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
 
     public $timeout = 3600;
 
-    public string $backup_log_uuid;
+    public ?string $backup_log_uuid = null;
 
     public function __construct(public ScheduledDatabaseBackup $backup)
     {
         $this->onQueue('high');
         $this->timeout = $backup->timeout;
-        $this->backup_log_uuid = (string) new Cuid2;
     }
 
     public function handle(): void


### PR DESCRIPTION
## Summary
- Changed `backup_log_uuid` property in `DatabaseBackupJob` to nullable
- Removed eager initialization from constructor
- Allows the ID to be generated when actually needed rather than upfront

## Test plan
- [x] Verify database backup jobs still execute successfully
- [x] Check that backup logs are created with proper UUIDs
- [x] Ensure no breaking changes to existing backup functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)