### PR TITLE
Update sponsors list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,40 +53,40 @@ Thank you so much!
 
 ## Big Sponsors
 
-* [CubePath](https://cubepath.com/?ref=coolify.io) - Dedicated Servers & Instant Deploy
-* [GlueOps](https://www.glueops.dev?ref=coolify.io) - DevOps automation and infrastructure management
+* [23M](https://23m.com?ref=coolify.io) - Your experts for high-availability hosting solutions!
 * [Algora](https://algora.io?ref=coolify.io) - Open source contribution platform
-* [Ubicloud](https://www.ubicloud.com?ref=coolify.io) - Open source cloud infrastructure platform
-* [LiquidWeb](https://liquidweb.com?ref=coolify.io) - Premium managed hosting solutions
-* [Convex](https://convex.link/coolify.io) - Open-source reactive database for web app developers
-* [Arcjet](https://arcjet.com?ref=coolify.io) - Advanced web security and performance solutions
-* [SaasyKit](https://saasykit.com?ref=coolify.io) - Complete SaaS starter kit for developers
-* [SupaGuide](https://supa.guide?ref=coolify.io) - Your comprehensive guide to Supabase
-* [Logto](https://logto.io?ref=coolify.io) - The better identity infrastructure for developers
-* [Trieve](https://trieve.ai?ref=coolify.io) - AI-powered search and analytics
-* [Supadata AI](https://supadata.ai/?ref=coolify.io) - Scrape YouTube, web, and files. Get AI-ready, clean data
-* [Darweb](https://darweb.nl/?ref=coolify.io) - Design. Develop. Deliver. Specialized in 3D CPQ Solutions
-* [Hetzner](http://htznr.li/CoolifyXHetzner) - Server, cloud, hosting, and data center solutions
-* [COMIT](https://comit.international?ref=coolify.io) - New York Times award–winning contractor
-* [Blacksmith](https://blacksmith.sh?ref=coolify.io) - Infrastructure automation platform
-* [WZ-IT](https://wz-it.com/?ref=coolify.io) - German agency for customised cloud solutions
-* [BC Direct](https://bc.direct?ref=coolify.io) - Your trusted technology consulting partner
-* [Tigris](https://www.tigrisdata.com?ref=coolify.io) - Modern developer data platform
-* [Hostinger](https://www.hostinger.com/vps/coolify-hosting?ref=coolify.io) - Web hosting and VPS solutions
-* [QuantCDN](https://www.quantcdn.io?ref=coolify.io) - Enterprise-grade content delivery network
-* [PFGLabs](https://pfglabs.com?ref=coolify.io) - Build Real Projects with Golang
-* [JobsCollider](https://jobscollider.com/remote-jobs?ref=coolify.io) - 30,000+ remote jobs for developers
-* [Juxtdigital](https://juxtdigital.com?ref=coolify.io) - Digital PR & AI Authority Building Agency
-* [Cloudify.ro](https://cloudify.ro?ref=coolify.io) - Cloud hosting solutions
-* [CodeRabbit](https://coderabbit.ai?ref=coolify.io) - Cut Code Review Time & Bugs in Half
 * [American Cloud](https://americancloud.com?ref=coolify.io) - US-based cloud infrastructure services
-* [MassiveGrid](https://massivegrid.com?ref=coolify.io) - Enterprise cloud hosting solutions
-* [Syntax.fm](https://syntax.fm?ref=coolify.io) - Podcast for web developers
-* [Tolgee](https://tolgee.io?ref=coolify.io) - The open source localization platform
+* [Arcjet](https://arcjet.com?ref=coolify.io) - Advanced web security and performance solutions
+* [BC Direct](https://bc.direct?ref=coolify.io) - Your trusted technology consulting partner
+* [Blacksmith](https://blacksmith.sh?ref=coolify.io) - Infrastructure automation platform
+* [Brand.dev](https://brand.dev?ref=coolify.io) - API to personalize your product with logos, colors, and company info from any domain
+* [ByteBase](https://www.bytebase.com?ref=coolify.io) - Database CI/CD and Security at Scale
+* [CodeRabbit](https://coderabbit.ai?ref=coolify.io) - Cut Code Review Time & Bugs in Half
+* [COMIT](https://comit.international?ref=coolify.io) - New York Times award–winning contractor
 * [CompAI](https://www.trycomp.ai?ref=coolify.io) - Open source compliance automation platform
+* [Convex](https://convex.link/coolify.io) - Open-source reactive database for web app developers
+* [CubePath](https://cubepath.com/?ref=coolify.io) - Dedicated Servers & Instant Deploy
+* [Darweb](https://darweb.nl/?ref=coolify.io) - Design. Develop. Deliver. Specialized in 3D CPQ Solutions
+* [Formbricks](https://formbricks.com?ref=coolify.io) - The open source feedback platform
 * [GoldenVM](https://billing.goldenvm.com?ref=coolify.io) - Premium virtual machine hosting solutions
 * [Gozunga](https://gozunga.com?ref=coolify.io) - Seriously Simple Cloud Infrastructure
+* [Hetzner](http://htznr.li/CoolifyXHetzner) - Server, cloud, hosting, and data center solutions
+* [Hostinger](https://www.hostinger.com/vps/coolify-hosting?ref=coolify.io) - Web hosting and VPS solutions
+* [JobsCollider](https://jobscollider.com/remote-jobs?ref=coolify.io) - 30,000+ remote jobs for developers
+* [Juxtdigital](https://juxtdigital.com?ref=coolify.io) - Digital PR & AI Authority Building Agency
+* [LiquidWeb](https://liquidweb.com?ref=coolify.io) - Premium managed hosting solutions
+* [Logto](https://logto.io?ref=coolify.io) - The better identity infrastructure for developers
 * [Macarne](https://macarne.com?ref=coolify.io) - Best IP Transit & Carrier Ethernet Solutions for Simplified Network Connectivity
+* [Mobb](https://vibe.mobb.ai/?ref=coolify.io) - Secure Your AI-Generated Code to Unlock Dev Productivity
+* [PFGLabs](https://pfglabs.com?ref=coolify.io) - Build Real Projects with Golang
+* [Ramnode](https://ramnode.com/?ref=coolify.io) - High Performance Cloud VPS Hosting
+* [SaasyKit](https://saasykit.com?ref=coolify.io) - Complete SaaS starter kit for developers
+* [SupaGuide](https://supa.guide?ref=coolify.io) - Your comprehensive guide to Supabase
+* [Supadata AI](https://supadata.ai/?ref=coolify.io) - Scrape YouTube, web, and files. Get AI-ready, clean data
+* [Syntax.fm](https://syntax.fm?ref=coolify.io) - Podcast for web developers
+* [Tigris](https://www.tigrisdata.com?ref=coolify.io) - Modern developer data platform
+* [Tolgee](https://tolgee.io?ref=coolify.io) - The open source localization platform
+* [Ubicloud](https://www.ubicloud.com?ref=coolify.io) - Open source cloud infrastructure platform
 
 
 ## Small Sponsors


### PR DESCRIPTION
## Summary
- Added 6 new sponsors: 23M, Brand.dev, ByteBase, Formbricks, Mobb, and Ramnode
- Removed 6 inactive sponsors that were commented out in the website code: Cloudify.ro, GlueOps, MassiveGrid, QuantCDN, Trieve, and WZ-IT
- Reorganized all sponsors in alphabetical order for easier maintenance

## Changes
### New Sponsors Added
- **23M** - Your experts for high-availability hosting solutions
- **Brand.dev** - API to personalize your product with logos, colors, and company info from any domain
- **ByteBase** - Database CI/CD and Security at Scale
- **Formbricks** - The open source feedback platform
- **Mobb** - Secure Your AI-Generated Code to Unlock Dev Productivity
- **Ramnode** - High Performance Cloud VPS Hosting

### Sponsors Removed
These sponsors were commented out in the website's sponsor list, indicating they are no longer active:
- Cloudify.ro
- GlueOps
- MassiveGrid
- QuantCDN
- Trieve
- WZ-IT

### Other Changes
- Reorganized the Big Sponsors section in alphabetical order to make it easier to maintain and update in the future

## Test plan
- [x] Verified all new sponsors exist in the provided sponsors data
- [x] Confirmed removed sponsors are commented out in the website code
- [x] Ensured all URLs are properly formatted with `?ref=coolify.io` parameters
- [x] Verified alphabetical ordering is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)