### PR TITLE
fix(openapi): missing 422 error code in openapi spec

### DIFF
--- a/app/Http/Controllers/Api/DatabasesController.php
+++ b/app/Http/Controllers/Api/DatabasesController.php
@@ -317,6 +317,10 @@ class DatabasesController extends Controller
                 response: 404,
                 ref: '#/components/responses/404',
             ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
+            ),
         ]
     )]
     public function update_by_uuid(Request $request)
@@ -666,6 +670,10 @@ class DatabasesController extends Controller
                 response: 404,
                 ref: '#/components/responses/404',
             ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
+            ),
         ]
     )]
     public function update_backup(Request $request)
@@ -844,6 +852,10 @@ class DatabasesController extends Controller
                 response: 400,
                 ref: '#/components/responses/400',
             ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
+            ),
         ]
     )]
     public function create_database_postgresql(Request $request)
@@ -907,6 +919,10 @@ class DatabasesController extends Controller
                 response: 400,
                 ref: '#/components/responses/400',
             ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
+            ),
         ]
     )]
     public function create_database_clickhouse(Request $request)
@@ -968,6 +984,10 @@ class DatabasesController extends Controller
             new OA\Response(
                 response: 400,
                 ref: '#/components/responses/400',
+            ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
             ),
         ]
     )]
@@ -1032,6 +1052,10 @@ class DatabasesController extends Controller
                 response: 400,
                 ref: '#/components/responses/400',
             ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
+            ),
         ]
     )]
     public function create_database_redis(Request $request)
@@ -1094,6 +1118,10 @@ class DatabasesController extends Controller
             new OA\Response(
                 response: 400,
                 ref: '#/components/responses/400',
+            ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
             ),
         ]
     )]
@@ -1161,6 +1189,10 @@ class DatabasesController extends Controller
                 response: 400,
                 ref: '#/components/responses/400',
             ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
+            ),
         ]
     )]
     public function create_database_mariadb(Request $request)
@@ -1227,6 +1259,10 @@ class DatabasesController extends Controller
                 response: 400,
                 ref: '#/components/responses/400',
             ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
+            ),
         ]
     )]
     public function create_database_mysql(Request $request)
@@ -1289,6 +1325,10 @@ class DatabasesController extends Controller
             new OA\Response(
                 response: 400,
                 ref: '#/components/responses/400',
+            ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
             ),
         ]
     )]
@@ -1941,7 +1981,7 @@ class DatabasesController extends Controller
                 content: new OA\JsonContent(
                     type: 'object',
                     properties: [
-                        'message' => new OA\Schema(type: 'string', example: 'Backup configuration and all executions deleted.'),
+                        new OA\Property(property: 'message', type: 'string', example: 'Backup configuration and all executions deleted.'),
                     ]
                 )
             ),
@@ -1951,7 +1991,7 @@ class DatabasesController extends Controller
                 content: new OA\JsonContent(
                     type: 'object',
                     properties: [
-                        'message' => new OA\Schema(type: 'string', example: 'Backup configuration not found.'),
+                        new OA\Property(property: 'message', type: 'string', example: 'Backup configuration not found.'),
                     ]
                 )
             ),
@@ -2065,7 +2105,7 @@ class DatabasesController extends Controller
                 content: new OA\JsonContent(
                     type: 'object',
                     properties: [
-                        'message' => new OA\Schema(type: 'string', example: 'Backup execution deleted.'),
+                        new OA\Property(property: 'message', type: 'string', example: 'Backup execution deleted.'),
                     ]
                 )
             ),
@@ -2075,7 +2115,7 @@ class DatabasesController extends Controller
                 content: new OA\JsonContent(
                     type: 'object',
                     properties: [
-                        'message' => new OA\Schema(type: 'string', example: 'Backup execution not found.'),
+                        new OA\Property(property: 'message', type: 'string', example: 'Backup execution not found.'),
                     ]
                 )
             ),
@@ -2171,17 +2211,18 @@ class DatabasesController extends Controller
                 content: new OA\JsonContent(
                     type: 'object',
                     properties: [
-                        'executions' => new OA\Schema(
+                        new OA\Property(
+                            property: 'executions',
                             type: 'array',
                             items: new OA\Items(
                                 type: 'object',
                                 properties: [
-                                    'uuid' => ['type' => 'string'],
-                                    'filename' => ['type' => 'string'],
-                                    'size' => ['type' => 'integer'],
-                                    'created_at' => ['type' => 'string'],
-                                    'message' => ['type' => 'string'],
-                                    'status' => ['type' => 'string'],
+                                    new OA\Property(property: 'uuid', type: 'string'),
+                                    new OA\Property(property: 'filename', type: 'string'),
+                                    new OA\Property(property: 'size', type: 'integer'),
+                                    new OA\Property(property: 'created_at', type: 'string'),
+                                    new OA\Property(property: 'message', type: 'string'),
+                                    new OA\Property(property: 'status', type: 'string'),
                                 ]
                             )
                         ),

--- a/app/Http/Controllers/Api/GithubController.php
+++ b/app/Http/Controllers/Api/GithubController.php
@@ -219,7 +219,8 @@ class GithubController extends Controller
                     schema: new OA\Schema(
                         type: 'object',
                         properties: [
-                            'repositories' => new OA\Schema(
+                            new OA\Property(
+                                property: 'repositories',
                                 type: 'array',
                                 items: new OA\Items(type: 'object')
                             ),
@@ -335,7 +336,8 @@ class GithubController extends Controller
                     schema: new OA\Schema(
                         type: 'object',
                         properties: [
-                            'branches' => new OA\Schema(
+                            new OA\Property(
+                                property: 'branches',
                                 type: 'array',
                                 items: new OA\Items(type: 'object')
                             ),
@@ -457,7 +459,7 @@ class GithubController extends Controller
             ),
             new OA\Response(response: 401, description: 'Unauthorized'),
             new OA\Response(response: 404, description: 'GitHub app not found'),
-            new OA\Response(response: 422, description: 'Validation error'),
+            new OA\Response(response: 422, ref: '#/components/responses/422'),
         ]
     )]
     public function update_github_app(Request $request, $github_app_id)

--- a/app/Http/Controllers/Api/OpenApi.php
+++ b/app/Http/Controllers/Api/OpenApi.php
@@ -40,6 +40,27 @@ use OpenApi\Attributes as OA;
                     new OA\Property(property: 'message', type: 'string', example: 'Resource not found.'),
                 ]
             )),
+        new OA\Response(
+            response: 422,
+            description: 'Validation error.',
+            content: new OA\JsonContent(
+                type: 'object',
+                properties: [
+                    new OA\Property(property: 'message', type: 'string', example: 'Validation error.'),
+                    new OA\Property(
+                        property: 'errors',
+                        type: 'object',
+                        additionalProperties: new OA\AdditionalProperties(
+                            type: 'array',
+                            items: new OA\Items(type: 'string')
+                        ),
+                        example: [
+                            'name' => ['The name field is required.'],
+                            'api_url' => ['The api url field is required.', 'The api url format is invalid.'],
+                        ]
+                    ),
+                ]
+            )),
     ],
 )]
 class OpenApi

--- a/app/Http/Controllers/Api/OtherController.php
+++ b/app/Http/Controllers/Api/OtherController.php
@@ -21,8 +21,9 @@ class OtherController extends Controller
             new OA\Response(
                 response: 200,
                 description: 'Returns the version of the application',
-                content: new OA\JsonContent(
-                    type: 'string',
+                content: new OA\MediaType(
+                    mediaType: 'text/html',
+                    schema: new OA\Schema(type: 'string'),
                     example: 'v4.0.0',
                 )),
             new OA\Response(
@@ -166,8 +167,9 @@ class OtherController extends Controller
             new OA\Response(
                 response: 200,
                 description: 'Healthcheck endpoint.',
-                content: new OA\JsonContent(
-                    type: 'string',
+                content: new OA\MediaType(
+                    mediaType: 'text/html',
+                    schema: new OA\Schema(type: 'string'),
                     example: 'OK',
                 )),
             new OA\Response(

--- a/app/Http/Controllers/Api/ProjectController.php
+++ b/app/Http/Controllers/Api/ProjectController.php
@@ -134,6 +134,10 @@ class ProjectController extends Controller
                 response: 404,
                 ref: '#/components/responses/404',
             ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
+            ),
         ]
     )]
     public function environment_details(Request $request)
@@ -213,6 +217,10 @@ class ProjectController extends Controller
             new OA\Response(
                 response: 404,
                 ref: '#/components/responses/404',
+            ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
             ),
         ]
     )]
@@ -324,6 +332,10 @@ class ProjectController extends Controller
                 response: 404,
                 ref: '#/components/responses/404',
             ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
+            ),
         ]
     )]
     public function update_project(Request $request)
@@ -425,6 +437,10 @@ class ProjectController extends Controller
                 response: 404,
                 ref: '#/components/responses/404',
             ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
+            ),
         ]
     )]
     public function delete_project(Request $request)
@@ -486,6 +502,10 @@ class ProjectController extends Controller
             new OA\Response(
                 response: 404,
                 description: 'Project not found.',
+            ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
             ),
         ]
     )]
@@ -565,6 +585,10 @@ class ProjectController extends Controller
             new OA\Response(
                 response: 409,
                 description: 'Environment with this name already exists.',
+            ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
             ),
         ]
     )]
@@ -662,6 +686,10 @@ class ProjectController extends Controller
             new OA\Response(
                 response: 404,
                 description: 'Project or environment not found.',
+            ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
             ),
         ]
     )]

--- a/app/Http/Controllers/Api/SecurityController.php
+++ b/app/Http/Controllers/Api/SecurityController.php
@@ -163,6 +163,10 @@ class SecurityController extends Controller
                 response: 400,
                 ref: '#/components/responses/400',
             ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
+            ),
         ]
     )]
     public function create_key(Request $request)
@@ -281,6 +285,10 @@ class SecurityController extends Controller
             new OA\Response(
                 response: 400,
                 ref: '#/components/responses/400',
+            ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
             ),
         ]
     )]

--- a/app/Http/Controllers/Api/ServersController.php
+++ b/app/Http/Controllers/Api/ServersController.php
@@ -447,6 +447,10 @@ class ServersController extends Controller
                 response: 404,
                 ref: '#/components/responses/404',
             ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
+            ),
         ]
     )]
     public function create_server(Request $request)
@@ -604,6 +608,10 @@ class ServersController extends Controller
                 response: 404,
                 ref: '#/components/responses/404',
             ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
+            ),
         ]
     )]
     public function update_server(Request $request)
@@ -722,6 +730,10 @@ class ServersController extends Controller
                 response: 404,
                 ref: '#/components/responses/404',
             ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
+            ),
         ]
     )]
     public function delete_server(Request $request)
@@ -789,6 +801,10 @@ class ServersController extends Controller
             new OA\Response(
                 response: 404,
                 ref: '#/components/responses/404',
+            ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
             ),
         ]
     )]

--- a/app/Http/Controllers/Api/ServicesController.php
+++ b/app/Http/Controllers/Api/ServicesController.php
@@ -235,6 +235,10 @@ class ServicesController extends Controller
                 response: 400,
                 ref: '#/components/responses/400',
             ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
+            ),
         ]
     )]
     public function create_service(Request $request)
@@ -704,6 +708,10 @@ class ServicesController extends Controller
                 response: 404,
                 ref: '#/components/responses/404',
             ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
+            ),
         ]
     )]
     public function update_by_uuid(Request $request)
@@ -954,6 +962,10 @@ class ServicesController extends Controller
                 response: 404,
                 ref: '#/components/responses/404',
             ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
+            ),
         ]
     )]
     public function update_env_by_uuid(Request $request)
@@ -1075,6 +1087,10 @@ class ServicesController extends Controller
                 response: 404,
                 ref: '#/components/responses/404',
             ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
+            ),
         ]
     )]
     public function create_bulk_envs(Request $request)
@@ -1190,6 +1206,10 @@ class ServicesController extends Controller
             new OA\Response(
                 response: 404,
                 ref: '#/components/responses/404',
+            ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
             ),
         ]
     )]

--- a/openapi.json
+++ b/openapi.json
@@ -3698,6 +3698,9 @@
                     },
                     "404": {
                         "$ref": "#\/components\/responses\/404"
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
                     }
                 },
                 "security": [
@@ -3753,7 +3756,7 @@
                             "application\/json": {
                                 "schema": {
                                     "properties": {
-                                        "": {
+                                        "message": {
                                             "type": "string",
                                             "example": "Backup configuration and all executions deleted."
                                         }
@@ -3769,7 +3772,7 @@
                             "application\/json": {
                                 "schema": {
                                     "properties": {
-                                        "": {
+                                        "message": {
                                             "type": "string",
                                             "example": "Backup configuration not found."
                                         }
@@ -3892,6 +3895,9 @@
                     },
                     "404": {
                         "$ref": "#\/components\/responses\/404"
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
                     }
                 },
                 "security": [
@@ -4033,6 +4039,9 @@
                     },
                     "400": {
                         "$ref": "#\/components\/responses\/400"
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
                     }
                 },
                 "security": [
@@ -4158,6 +4167,9 @@
                     },
                     "400": {
                         "$ref": "#\/components\/responses\/400"
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
                     }
                 },
                 "security": [
@@ -4279,6 +4291,9 @@
                     },
                     "400": {
                         "$ref": "#\/components\/responses\/400"
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
                     }
                 },
                 "security": [
@@ -4404,6 +4419,9 @@
                     },
                     "400": {
                         "$ref": "#\/components\/responses\/400"
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
                     }
                 },
                 "security": [
@@ -4529,6 +4547,9 @@
                     },
                     "400": {
                         "$ref": "#\/components\/responses\/400"
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
                     }
                 },
                 "security": [
@@ -4666,6 +4687,9 @@
                     },
                     "400": {
                         "$ref": "#\/components\/responses\/400"
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
                     }
                 },
                 "security": [
@@ -4803,6 +4827,9 @@
                     },
                     "400": {
                         "$ref": "#\/components\/responses\/400"
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
                     }
                 },
                 "security": [
@@ -4928,6 +4955,9 @@
                     },
                     "400": {
                         "$ref": "#\/components\/responses\/400"
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
                     }
                 },
                 "security": [
@@ -4993,7 +5023,7 @@
                             "application\/json": {
                                 "schema": {
                                     "properties": {
-                                        "": {
+                                        "message": {
                                             "type": "string",
                                             "example": "Backup execution deleted."
                                         }
@@ -5009,7 +5039,7 @@
                             "application\/json": {
                                 "schema": {
                                     "properties": {
-                                        "": {
+                                        "message": {
                                             "type": "string",
                                             "example": "Backup execution not found."
                                         }
@@ -5063,7 +5093,7 @@
                             "application\/json": {
                                 "schema": {
                                     "properties": {
-                                        "": {
+                                        "executions": {
                                             "type": "array",
                                             "items": {
                                                 "properties": {
@@ -5690,7 +5720,7 @@
                             "application\/json": {
                                 "schema": {
                                     "properties": {
-                                        "": {
+                                        "repositories": {
                                             "type": "array",
                                             "items": {
                                                 "type": "object"
@@ -5763,7 +5793,7 @@
                             "application\/json": {
                                 "schema": {
                                     "properties": {
-                                        "": {
+                                        "branches": {
                                             "type": "array",
                                             "items": {
                                                 "type": "object"
@@ -5968,7 +5998,7 @@
                         "description": "GitHub app not found"
                     },
                     "422": {
-                        "description": "Validation error"
+                        "$ref": "#\/components\/responses\/422"
                     }
                 },
                 "security": [
@@ -5987,7 +6017,7 @@
                     "200": {
                         "description": "Returns the version of the application",
                         "content": {
-                            "application\/json": {
+                            "text\/html": {
                                 "schema": {
                                     "type": "string"
                                 },
@@ -6122,7 +6152,7 @@
                     "200": {
                         "description": "Healthcheck endpoint.",
                         "content": {
-                            "application\/json": {
+                            "text\/html": {
                                 "schema": {
                                     "type": "string"
                                 },
@@ -6228,6 +6258,9 @@
                     },
                     "404": {
                         "$ref": "#\/components\/responses\/404"
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
                     }
                 },
                 "security": [
@@ -6327,6 +6360,9 @@
                     },
                     "404": {
                         "$ref": "#\/components\/responses\/404"
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
                     }
                 },
                 "security": [
@@ -6408,6 +6444,9 @@
                     },
                     "404": {
                         "$ref": "#\/components\/responses\/404"
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
                     }
                 },
                 "security": [
@@ -6464,6 +6503,9 @@
                     },
                     "404": {
                         "$ref": "#\/components\/responses\/404"
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
                     }
                 },
                 "security": [
@@ -6514,6 +6556,9 @@
                     },
                     "404": {
                         "description": "Project not found."
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
                     }
                 },
                 "security": [
@@ -6586,6 +6631,9 @@
                     },
                     "409": {
                         "description": "Environment with this name already exists."
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
                     }
                 },
                 "security": [
@@ -6648,6 +6696,9 @@
                     },
                     "404": {
                         "description": "Project or environment not found."
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
                     }
                 },
                 "security": [
@@ -6779,6 +6830,9 @@
                     },
                     "400": {
                         "$ref": "#\/components\/responses\/400"
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
                     }
                 },
                 "security": [
@@ -6840,6 +6894,9 @@
                     },
                     "400": {
                         "$ref": "#\/components\/responses\/400"
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
                     }
                 },
                 "security": [
@@ -7094,6 +7151,9 @@
                     },
                     "404": {
                         "$ref": "#\/components\/responses\/404"
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
                     }
                 },
                 "security": [
@@ -7193,6 +7253,9 @@
                     },
                     "404": {
                         "$ref": "#\/components\/responses\/404"
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
                     }
                 },
                 "security": [
@@ -7292,6 +7355,9 @@
                     },
                     "404": {
                         "$ref": "#\/components\/responses\/404"
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
                     }
                 },
                 "security": [
@@ -7473,6 +7539,9 @@
                     },
                     "404": {
                         "$ref": "#\/components\/responses\/404"
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
                     }
                 },
                 "security": [
@@ -7702,6 +7771,9 @@
                     },
                     "400": {
                         "$ref": "#\/components\/responses\/400"
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
                     }
                 },
                 "security": [
@@ -7953,6 +8025,9 @@
                     },
                     "404": {
                         "$ref": "#\/components\/responses\/404"
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
                     }
                 },
                 "security": [
@@ -8093,6 +8168,9 @@
                     },
                     "404": {
                         "$ref": "#\/components\/responses\/404"
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
                     }
                 },
                 "security": [
@@ -8186,6 +8264,9 @@
                     },
                     "404": {
                         "$ref": "#\/components\/responses\/404"
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
                     }
                 },
                 "security": [
@@ -8288,6 +8369,9 @@
                     },
                     "404": {
                         "$ref": "#\/components\/responses\/404"
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
                     }
                 },
                 "security": [
@@ -9744,6 +9828,40 @@
                                 "message": {
                                     "type": "string",
                                     "example": "Resource not found."
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            },
+            "422": {
+                "description": "Validation error.",
+                "content": {
+                    "application\/json": {
+                        "schema": {
+                            "properties": {
+                                "message": {
+                                    "type": "string",
+                                    "example": "Validation error."
+                                },
+                                "errors": {
+                                    "type": "object",
+                                    "example": {
+                                        "name": [
+                                            "The name field is required."
+                                        ],
+                                        "api_url": [
+                                            "The api url field is required.",
+                                            "The api url format is invalid."
+                                        ]
+                                    },
+                                    "additionalProperties": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
                                 }
                             },
                             "type": "object"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2377,6 +2377,8 @@ paths:
           $ref: '#/components/responses/400'
         '404':
           $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         -
           bearerAuth: []
@@ -2418,7 +2420,7 @@ paths:
             application/json:
               schema:
                 properties:
-                  '': { type: string, example: 'Backup configuration and all executions deleted.' }
+                  message: { type: string, example: 'Backup configuration and all executions deleted.' }
                 type: object
         '404':
           description: 'Backup configuration not found.'
@@ -2426,7 +2428,7 @@ paths:
             application/json:
               schema:
                 properties:
-                  '': { type: string, example: 'Backup configuration not found.' }
+                  message: { type: string, example: 'Backup configuration not found.' }
                 type: object
       security:
         -
@@ -2510,6 +2512,8 @@ paths:
           $ref: '#/components/responses/400'
         '404':
           $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         -
           bearerAuth: []
@@ -2612,6 +2616,8 @@ paths:
           $ref: '#/components/responses/401'
         '400':
           $ref: '#/components/responses/400'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         -
           bearerAuth: []
@@ -2702,6 +2708,8 @@ paths:
           $ref: '#/components/responses/401'
         '400':
           $ref: '#/components/responses/400'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         -
           bearerAuth: []
@@ -2789,6 +2797,8 @@ paths:
           $ref: '#/components/responses/401'
         '400':
           $ref: '#/components/responses/400'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         -
           bearerAuth: []
@@ -2879,6 +2889,8 @@ paths:
           $ref: '#/components/responses/401'
         '400':
           $ref: '#/components/responses/400'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         -
           bearerAuth: []
@@ -2969,6 +2981,8 @@ paths:
           $ref: '#/components/responses/401'
         '400':
           $ref: '#/components/responses/400'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         -
           bearerAuth: []
@@ -3068,6 +3082,8 @@ paths:
           $ref: '#/components/responses/401'
         '400':
           $ref: '#/components/responses/400'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         -
           bearerAuth: []
@@ -3167,6 +3183,8 @@ paths:
           $ref: '#/components/responses/401'
         '400':
           $ref: '#/components/responses/400'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         -
           bearerAuth: []
@@ -3257,6 +3275,8 @@ paths:
           $ref: '#/components/responses/401'
         '400':
           $ref: '#/components/responses/400'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         -
           bearerAuth: []
@@ -3306,7 +3326,7 @@ paths:
             application/json:
               schema:
                 properties:
-                  '': { type: string, example: 'Backup execution deleted.' }
+                  message: { type: string, example: 'Backup execution deleted.' }
                 type: object
         '404':
           description: 'Backup execution not found.'
@@ -3314,7 +3334,7 @@ paths:
             application/json:
               schema:
                 properties:
-                  '': { type: string, example: 'Backup execution not found.' }
+                  message: { type: string, example: 'Backup execution not found.' }
                 type: object
       security:
         -
@@ -3349,7 +3369,7 @@ paths:
             application/json:
               schema:
                 properties:
-                  '': { type: array, items: { properties: { uuid: { type: string }, filename: { type: string }, size: { type: integer }, created_at: { type: string }, message: { type: string }, status: { type: string } }, type: object } }
+                  executions: { type: array, items: { properties: { uuid: { type: string }, filename: { type: string }, size: { type: integer }, created_at: { type: string }, message: { type: string }, status: { type: string } }, type: object } }
                 type: object
         '404':
           description: 'Backup configuration not found.'
@@ -3727,7 +3747,7 @@ paths:
             application/json:
               schema:
                 properties:
-                  '': { type: array, items: { type: object } }
+                  repositories: { type: array, items: { type: object } }
                 type: object
         '400':
           $ref: '#/components/responses/400'
@@ -3774,7 +3794,7 @@ paths:
             application/json:
               schema:
                 properties:
-                  '': { type: array, items: { type: object } }
+                  branches: { type: array, items: { type: object } }
                 type: object
         '400':
           $ref: '#/components/responses/400'
@@ -3900,7 +3920,7 @@ paths:
         '404':
           description: 'GitHub app not found'
         '422':
-          description: 'Validation error'
+          $ref: '#/components/responses/422'
       security:
         -
           bearerAuth: []
@@ -3913,7 +3933,7 @@ paths:
         '200':
           description: 'Returns the version of the application'
           content:
-            application/json:
+            text/html:
               schema:
                 type: string
               example: v4.0.0
@@ -3991,7 +4011,7 @@ paths:
         '200':
           description: 'Healthcheck endpoint.'
           content:
-            application/json:
+            text/html:
               schema:
                 type: string
               example: OK
@@ -4057,6 +4077,8 @@ paths:
           $ref: '#/components/responses/400'
         '404':
           $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         -
           bearerAuth: []
@@ -4121,6 +4143,8 @@ paths:
           $ref: '#/components/responses/400'
         '404':
           $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         -
           bearerAuth: []
@@ -4170,6 +4194,8 @@ paths:
           $ref: '#/components/responses/400'
         '404':
           $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         -
           bearerAuth: []
@@ -4208,6 +4234,8 @@ paths:
           $ref: '#/components/responses/400'
         '404':
           $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         -
           bearerAuth: []
@@ -4241,6 +4269,8 @@ paths:
           $ref: '#/components/responses/400'
         '404':
           description: 'Project not found.'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         -
           bearerAuth: []
@@ -4286,6 +4316,8 @@ paths:
           description: 'Project not found.'
         '409':
           description: 'Environment with this name already exists.'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         -
           bearerAuth: []
@@ -4326,6 +4358,8 @@ paths:
           description: 'Environment has resources, so it cannot be deleted.'
         '404':
           description: 'Project or environment not found.'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         -
           bearerAuth: []
@@ -4409,6 +4443,8 @@ paths:
           $ref: '#/components/responses/401'
         '400':
           $ref: '#/components/responses/400'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         -
           bearerAuth: []
@@ -4447,6 +4483,8 @@ paths:
           $ref: '#/components/responses/401'
         '400':
           $ref: '#/components/responses/400'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         -
           bearerAuth: []
@@ -4610,6 +4648,8 @@ paths:
           $ref: '#/components/responses/400'
         '404':
           $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         -
           bearerAuth: []
@@ -4674,6 +4714,8 @@ paths:
           $ref: '#/components/responses/400'
         '404':
           $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         -
           bearerAuth: []
@@ -4740,6 +4782,8 @@ paths:
           $ref: '#/components/responses/400'
         '404':
           $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         -
           bearerAuth: []
@@ -4837,6 +4881,8 @@ paths:
           $ref: '#/components/responses/400'
         '404':
           $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         -
           bearerAuth: []
@@ -4929,6 +4975,8 @@ paths:
           $ref: '#/components/responses/401'
         '400':
           $ref: '#/components/responses/400'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         -
           bearerAuth: []
@@ -5097,6 +5145,8 @@ paths:
           $ref: '#/components/responses/400'
         '404':
           $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         -
           bearerAuth: []
@@ -5190,6 +5240,8 @@ paths:
           $ref: '#/components/responses/400'
         '404':
           $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         -
           bearerAuth: []
@@ -5252,6 +5304,8 @@ paths:
           $ref: '#/components/responses/400'
         '404':
           $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         -
           bearerAuth: []
@@ -5299,6 +5353,8 @@ paths:
           $ref: '#/components/responses/400'
         '404':
           $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
       security:
         -
           bearerAuth: []
@@ -6321,6 +6377,24 @@ components:
               message:
                 type: string
                 example: 'Resource not found.'
+            type: object
+    '422':
+      description: 'Validation error.'
+      content:
+        application/json:
+          schema:
+            properties:
+              message:
+                type: string
+                example: 'Validation error.'
+              errors:
+                type: object
+                example:
+                  name: ['The name field is required.']
+                  api_url: ['The api url field is required.', 'The api url format is invalid.']
+                additionalProperties:
+                  type: array
+                  items: { type: string }
             type: object
   securitySchemes:
     bearerAuth:


### PR DESCRIPTION
## Changes
- Add a 422 error code to the OpenAPI specification.
- Change the return type for /version and /healthcheck from JSON to text/html

Needed to get the coolify cli up to date, since the refactor is generating the client from the openapi spec
