### PR TITLE
Add proxyscotch service compose file

### DIFF
--- a/templates/compose/proxyscotch.yaml
+++ b/templates/compose/proxyscotch.yaml
@@ -4,13 +4,9 @@
 # logo: svgs/hoppscotch.png
 # port: 9159
 
-# NOTE IF YOU USE HOPPSCOTCH
-# REMEMBER TO SET THE VITE_PROXYSCOTCH_ACCESS_TOKEN IN YOUR HOPPSCOTCH ENV
-# It should be set to the same as PROXYSCOTCH_TOKEN
-
 services:
   proxyscotch:
-    image: hoppscotch/proxyscotch:latest
+    image: hoppscotch/proxyscotch:v0.1.4
     environment:
       - SERVICE_URL_PROXYSCOTCH_9159
       - PROXYSCOTCH_TOKEN=${SERVICE_PASSWORD_TOKEN}

--- a/templates/compose/proxyscotch.yaml
+++ b/templates/compose/proxyscotch.yaml
@@ -1,0 +1,19 @@
+# documentation: https://github.com/hoppscotch/proxyscotch
+# slogan: A simple proxy server created for https://hoppscotch.io - CORS proxy
+# tags: proxy,hoppscotch,cors
+# logo: svgs/hoppscotch.png
+# port: 9159
+
+# NOTE IF YOU USE HOPPSCOTCH
+# REMEMBER TO SET THE VITE_PROXYSCOTCH_ACCESS_TOKEN IN YOUR HOPPSCOTCH ENV
+# It should be set to the same as PROXYSCOTCH_TOKEN
+
+services:
+  proxyscotch:
+    image: hoppscotch/proxyscotch:latest
+    environment:
+      - SERVICE_URL_PROXYSCOTCH_9159
+      - PROXYSCOTCH_TOKEN=${SERVICE_PASSWORD_TOKEN}
+      - PROXYSCOTCH_ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-*}
+      - PROXYSCOTCH_BANNED_OUTPUTS=${BANNED_OUTPUTS}
+      - PROXYSCOTCH_BANNED_DESTS=${BANNED_DESTS}


### PR DESCRIPTION
## Changes
- Added ProxyScotch as a Coolify service.

 > It uses the same logo as Hoppscotch, so no need to upload it again.

## Related docs:
https://github.com/hoppscotch/proxyscotch

> ENV var should be manually modifed for hoppscotch if token is specifed. - though if wanted i can make a change to [hoppscotch.yaml](https://github.com/xwxfox/coolify/blob/next/templates/compose/hoppscotch.yaml) :3
https://github.com/hoppscotch/hoppscotch/pull/2791/files

### ProxyScotch TLDR:
Proxyscotch is [Hoppscotch's](https://docs.hoppscotch.io) tiny lil CORS proxy. - it for example:
- Supports setting a custom `Access-Control-Allow-Origin` header for the requests it gets.
- Has support for setting a required auth token for the requests - In here it's wired up to `SERVICE_PASSWORD_TOKEN`
- Allows users to specify lists of values to redact from responses - and a list of destination hosts to block / disallow.