### PR TITLE
feat: replace terminal dropdown with searchable datalist component

### DIFF
--- a/app/Livewire/Terminal/Index.php
+++ b/app/Livewire/Terminal/Index.php
@@ -61,6 +61,10 @@ class Index extends Component
 
     public function updatedSelectedUuid()
     {
+        if ($this->selected_uuid === 'default') {
+            // When cleared to default, do nothing (no error message)
+            return;
+        }
         $this->connectToContainer();
     }
 

--- a/resources/views/livewire/terminal/index.blade.php
+++ b/resources/views/livewire/terminal/index.blade.php
@@ -17,7 +17,7 @@
             @if ($servers->count() > 0)
                 <form class="flex flex-col gap-2 justify-center xl:items-end xl:flex-row"
                     wire:submit="$dispatchSelf('connectToContainer')">
-                    <x-forms.select id="server" required wire:model.live="selected_uuid">
+                    <x-forms.datalist id="selected_uuid" required wire:model.live="selected_uuid" placeholder="Search servers or containers...">
                         @foreach ($servers as $server)
                             @if ($loop->first)
                                 <option disabled value="default">Select a server or container</option>
@@ -31,7 +31,7 @@
                                 @endif
                             @endforeach
                         @endforeach
-                    </x-forms.select>
+                    </x-forms.datalist>
                     <x-forms.button type="submit">Connect</x-forms.button>
                 </form>
             @else


### PR DESCRIPTION
## Overview

This PR enhances the terminal server/container selection interface by replacing the standard dropdown with an advanced searchable datalist component. Users can now quickly find and select servers or containers by typing, improving UX especially when dealing with many options.

---

## ✨ Core Features

- **Searchable Datalist Component**: Implemented Alpine.js-powered single selection mode with real-time search filtering
- **Terminal Integration**: Replaced `x-forms.select` with `x-forms.datalist` for server/container selection
- **Smart Option Filtering**: Automatically filters out disabled options from the list
- **Form Validation Support**: Added hidden input for proper HTML5 validation without breaking UX
- **Clear Selection Handling**: Prevents error messages when clearing selection (resets to 'default')

---

## 🔄 UI/UX Enhancements

**Visual Improvements:**
- Visual dropdown arrow with smooth rotation animation when opened/closed
- Proper entangle binding for seamless `wire:model` support
- Click outside to close behavior
- Keyboard support (Escape key to close dropdown)
- Selected value display with proper text colors

**Styling Consistency:**
- Matches input/textarea components exactly in both light and dark modes
- Explicit background colors: `bg-white` (light), `dark:bg-coolgray-100` (dark)
- Proper ring borders: `ring-1 ring-inset ring-neutral-200 dark:ring-coolgray-300`
- Focus states: `focus-within:ring-2 focus-within:ring-coollabs dark:focus-within:ring-warning`
- Text colors: `text-black dark:text-white`
- Custom scrollbar styling applied to dropdown lists
- Wire:dirty state support for visual feedback on changes
- Consistent padding and spacing (`py-1.5`, `px-1`, `px-2`)

**Multiple Selection Mode:**
- Updated for styling consistency with single selection
- Custom scrollbar support for long lists
- Proper background colors and focus states

---

## 📊 Statistics

- **Commits**: 1
- **Files Changed**: 3
- **Additions**: +136 lines
- **Deletions**: -21 lines

---

## 🧪 Testing Checklist

- [x] Select a server from the dropdown
- [x] Search for servers/containers by typing
- [x] Connect to a selected server
- [x] Click outside to close dropdown
- [x] Press Escape to close dropdown
- [x] Verify styling matches input components in light/dark mode
- [x] Test with many servers/containers (scrollbar visible)
- [x] Verify form validation works (required field)
- [x] Test clearing selection doesn't show error

---

Generated by Andras & Jean-Claude, hand-in-hand.