### PR TITLE
fix: prevent container name conflict when updating database port mappings

### DIFF
--- a/app/Actions/Database/StartClickhouse.php
+++ b/app/Actions/Database/StartClickhouse.php
@@ -105,6 +105,8 @@ class StartClickhouse
         $this->commands[] = "echo '{$readme}' > $this->configuration_dir/README.md";
         $this->commands[] = "echo 'Pulling {$database->image} image.'";
         $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml pull";
+        $this->commands[] = "docker stop --timeout=10 $container_name 2>/dev/null || true";
+        $this->commands[] = "docker rm -f $container_name 2>/dev/null || true";
         $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml up -d";
         $this->commands[] = "echo 'Database started.'";
 

--- a/app/Actions/Database/StartDragonfly.php
+++ b/app/Actions/Database/StartDragonfly.php
@@ -192,6 +192,8 @@ class StartDragonfly
         if ($this->database->enable_ssl) {
             $this->commands[] = "chown -R 999:999 $this->configuration_dir/ssl/server.key $this->configuration_dir/ssl/server.crt";
         }
+        $this->commands[] = "docker stop --timeout=10 $container_name 2>/dev/null || true";
+        $this->commands[] = "docker rm -f $container_name 2>/dev/null || true";
         $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml up -d";
         $this->commands[] = "echo 'Database started.'";
 

--- a/app/Actions/Database/StartKeydb.php
+++ b/app/Actions/Database/StartKeydb.php
@@ -208,6 +208,8 @@ class StartKeydb
         if ($this->database->enable_ssl) {
             $this->commands[] = "chown -R 999:999 $this->configuration_dir/ssl/server.key $this->configuration_dir/ssl/server.crt";
         }
+        $this->commands[] = "docker stop --timeout=10 $container_name 2>/dev/null || true";
+        $this->commands[] = "docker rm -f $container_name 2>/dev/null || true";
         $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml up -d";
         $this->commands[] = "echo 'Database started.'";
 

--- a/app/Actions/Database/StartMariadb.php
+++ b/app/Actions/Database/StartMariadb.php
@@ -209,6 +209,8 @@ class StartMariadb
         $this->commands[] = "echo '{$readme}' > $this->configuration_dir/README.md";
         $this->commands[] = "echo 'Pulling {$database->image} image.'";
         $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml pull";
+        $this->commands[] = "docker stop --timeout=10 $container_name 2>/dev/null || true";
+        $this->commands[] = "docker rm -f $container_name 2>/dev/null || true";
         $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml up -d";
         $this->commands[] = "echo 'Database started.'";
         if ($this->database->enable_ssl) {

--- a/app/Actions/Database/StartMongodb.php
+++ b/app/Actions/Database/StartMongodb.php
@@ -260,6 +260,8 @@ class StartMongodb
         $this->commands[] = "echo '{$readme}' > $this->configuration_dir/README.md";
         $this->commands[] = "echo 'Pulling {$database->image} image.'";
         $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml pull";
+        $this->commands[] = "docker stop --timeout=10 $container_name 2>/dev/null || true";
+        $this->commands[] = "docker rm -f $container_name 2>/dev/null || true";
         $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml up -d";
         if ($this->database->enable_ssl) {
             $this->commands[] = executeInDocker($this->database->uuid, 'chown mongodb:mongodb /etc/mongo/certs/server.pem');

--- a/app/Actions/Database/StartMysql.php
+++ b/app/Actions/Database/StartMysql.php
@@ -210,6 +210,8 @@ class StartMysql
         $this->commands[] = "echo '{$readme}' > $this->configuration_dir/README.md";
         $this->commands[] = "echo 'Pulling {$database->image} image.'";
         $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml pull";
+        $this->commands[] = "docker stop --timeout=10 $container_name 2>/dev/null || true";
+        $this->commands[] = "docker rm -f $container_name 2>/dev/null || true";
         $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml up -d";
 
         if ($this->database->enable_ssl) {

--- a/app/Actions/Database/StartPostgresql.php
+++ b/app/Actions/Database/StartPostgresql.php
@@ -223,6 +223,8 @@ class StartPostgresql
         $this->commands[] = "echo '{$readme}' > $this->configuration_dir/README.md";
         $this->commands[] = "echo 'Pulling {$database->image} image.'";
         $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml pull";
+        $this->commands[] = "docker stop --timeout=10 $container_name 2>/dev/null || true";
+        $this->commands[] = "docker rm -f $container_name 2>/dev/null || true";
         $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml up -d";
         if ($this->database->enable_ssl) {
             $this->commands[] = executeInDocker($this->database->uuid, "chown {$this->database->postgres_user}:{$this->database->postgres_user} /var/lib/postgresql/certs/server.key /var/lib/postgresql/certs/server.crt");

--- a/app/Actions/Database/StartRedis.php
+++ b/app/Actions/Database/StartRedis.php
@@ -205,6 +205,8 @@ class StartRedis
         if ($this->database->enable_ssl) {
             $this->commands[] = "chown -R 999:999 $this->configuration_dir/ssl/server.key $this->configuration_dir/ssl/server.crt";
         }
+        $this->commands[] = "docker stop --timeout=10 $container_name 2>/dev/null || true";
+        $this->commands[] = "docker rm -f $container_name 2>/dev/null || true";
         $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml up -d";
         $this->commands[] = "echo 'Database started.'";
 

--- a/app/Actions/Database/StopDatabase.php
+++ b/app/Actions/Database/StopDatabase.php
@@ -49,7 +49,7 @@ class StopDatabase
     {
         $server = $database->destination->server;
         instant_remote_process(command: [
-            "docker stop --time=$timeout $containerName",
+            "docker stop --timeout=$timeout $containerName",
             "docker rm -f $containerName",
         ], server: $server, throwError: false);
     }


### PR DESCRIPTION
## Overview

This PR fixes a critical issue where changing database port mappings causes container name conflicts during restart. The fix ensures databases can be reconfigured with new port mappings without encountering Docker errors.

---

## 🐛 Bug Fixes

- **Fix container name conflict when updating database port mappings**
  - Prevents "Error response from daemon: Conflict. The container name is already in use" error
  - Occurs when users change port mappings in UI and restart the database
  - System now gracefully stops existing container before recreating with new configuration

---

## 🔨 Refactoring

- **Add graceful container shutdown before recreation**
  - Stop container with 10-second timeout to allow clean database shutdown
  - Remove old container completely to avoid name conflicts
  - Prevents data corruption by allowing databases to flush writes properly

- **Modernize Docker CLI usage**
  - Use `--timeout` flag instead of deprecated `--time` flag
  - Update all database Start actions and StopDatabase action for consistency

---

## 📦 Changes

### Modified Files (9)
- `app/Actions/Database/StartMariadb.php` - Add graceful stop/remove before compose up
- `app/Actions/Database/StartMysql.php` - Add graceful stop/remove before compose up
- `app/Actions/Database/StartPostgresql.php` - Add graceful stop/remove before compose up
- `app/Actions/Database/StartMongodb.php` - Add graceful stop/remove before compose up
- `app/Actions/Database/StartRedis.php` - Add graceful stop/remove before compose up
- `app/Actions/Database/StartKeydb.php` - Add graceful stop/remove before compose up
- `app/Actions/Database/StartDragonfly.php` - Add graceful stop/remove before compose up
- `app/Actions/Database/StartClickhouse.php` - Add graceful stop/remove before compose up
- `app/Actions/Database/StopDatabase.php` - Update to use `--timeout` flag

### Implementation Details
```bash
docker stop --timeout=10 $container_name 2>/dev/null || true
docker rm -f $container_name 2>/dev/null || true
docker compose -f $config/docker-compose.yml up -d
```

**Key Benefits:**
- ✅ Graceful 10-second shutdown prevents data corruption
- ✅ Old container removed before new one created - no conflicts
- ✅ Silent failure handling for first-time starts (container doesn't exist yet)
- ✅ Consistent with existing `StopDatabase` pattern
- ✅ Covers all database types in Coolify

---

## 📊 PR Statistics

- **Commits:** 1
- **Files Changed:** 9
- **Additions:** +17 lines
- **Deletions:** -1 line
- **Database Types Fixed:** 8 (MariaDB, MySQL, PostgreSQL, MongoDB, Redis, KeyDB, Dragonfly, ClickHouse)

---

Generated by Andras & Jean-Claude, hand-in-hand.