### PR TITLE
fix: allow all environment variable fields in API endpoints

### DIFF
--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -2492,7 +2492,7 @@ class ApplicationsController extends Controller
     )]
     public function update_env_by_uuid(Request $request)
     {
-        $allowedFields = ['key', 'value', 'is_preview', 'is_literal'];
+        $allowedFields = ['key', 'value', 'is_preview', 'is_literal', 'is_multiline', 'is_shown_once', 'is_runtime', 'is_buildtime'];
         $teamId = getTeamIdFromToken();
 
         if (is_null($teamId)) {
@@ -2520,6 +2520,8 @@ class ApplicationsController extends Controller
             'is_literal' => 'boolean',
             'is_multiline' => 'boolean',
             'is_shown_once' => 'boolean',
+            'is_runtime' => 'boolean',
+            'is_buildtime' => 'boolean',
         ]);
 
         $extraFields = array_diff(array_keys($request->all()), $allowedFields);
@@ -2715,7 +2717,7 @@ class ApplicationsController extends Controller
             ], 400);
         }
         $bulk_data = collect($bulk_data)->map(function ($item) {
-            return collect($item)->only(['key', 'value', 'is_preview',  'is_literal']);
+            return collect($item)->only(['key', 'value', 'is_preview', 'is_literal', 'is_multiline', 'is_shown_once', 'is_runtime', 'is_buildtime']);
         });
         $returnedEnvs = collect();
         foreach ($bulk_data as $item) {
@@ -2726,6 +2728,8 @@ class ApplicationsController extends Controller
                 'is_literal' => 'boolean',
                 'is_multiline' => 'boolean',
                 'is_shown_once' => 'boolean',
+                'is_runtime' => 'boolean',
+                'is_buildtime' => 'boolean',
             ]);
             if ($validator->fails()) {
                 return response()->json([
@@ -2885,7 +2889,7 @@ class ApplicationsController extends Controller
     )]
     public function create_env(Request $request)
     {
-        $allowedFields = ['key', 'value', 'is_preview',  'is_literal'];
+        $allowedFields = ['key', 'value', 'is_preview', 'is_literal', 'is_multiline', 'is_shown_once', 'is_runtime', 'is_buildtime'];
         $teamId = getTeamIdFromToken();
 
         if (is_null($teamId)) {
@@ -2908,6 +2912,8 @@ class ApplicationsController extends Controller
             'is_literal' => 'boolean',
             'is_multiline' => 'boolean',
             'is_shown_once' => 'boolean',
+            'is_runtime' => 'boolean',
+            'is_buildtime' => 'boolean',
         ]);
 
         $extraFields = array_diff(array_keys($request->all()), $allowedFields);


### PR DESCRIPTION
## Overview

This PR fixes a critical bug in the API where environment variable endpoints were rejecting valid fields with 422 "not allowed" errors. The issue affected users trying to set build-time/runtime flags and other important environment variable properties via the API.

---

## 🐛 Bug Fixes

- **Fixed API validation mismatch in environment variable endpoints**
  - `create_env()` endpoint now accepts all valid environment variable fields
  - `update_env_by_uuid()` endpoint now accepts all valid environment variable fields  
  - `create_bulk_envs()` endpoint now properly filters and validates all fields
  - Added validation rules for `is_runtime` and `is_buildtime` boolean fields

---

## 🔄 Technical Changes

**Updated `$allowedFields` arrays to include:**
- `is_buildtime` - Controls if variable is available at build time
- `is_runtime` - Controls if variable is available at runtime
- `is_multiline` - Indicates multiline values
- `is_shown_once` - Security flag for sensitive values

**Fixed methods:**
- `ApplicationsController::create_env()` - Line 2888
- `ApplicationsController::update_env_by_uuid()` - Line 2495
- `ApplicationsController::create_bulk_envs()` - Line 2720

---

## 📊 Statistics

- **Commits:** 1
- **Files Changed:** 1
- **Additions:** +9 lines
- **Deletions:** -3 lines

---

## 🔗 Related Issues

Closes #6847

---

Generated by Andras & Jean-Claude, hand-in-hand.