### PR TITLE
feat(hetzner): add CPU vendor information to server types in Hetzner integration

### DIFF
--- a/app/Livewire/Server/New/ByHetzner.php
+++ b/app/Livewire/Server/New/ByHetzner.php
@@ -290,6 +290,23 @@ class ByHetzner extends Component
         }
     }
 
+    private function getCpuVendorInfo(array $serverType): array
+    {
+        $name = strtolower($serverType['name'] ?? '');
+
+        if (str_starts_with($name, 'ccx')) {
+            return ['vendor_info' => 'AMD Milan EPYC™'];
+        } elseif (str_starts_with($name, 'cpx')) {
+            return ['vendor_info' => 'AMD EPYC™'];
+        } elseif (str_starts_with($name, 'cx')) {
+            return ['vendor_info' => 'Intel® Xeon®'];
+        } elseif (str_starts_with($name, 'cax')) {
+            return ['vendor_info' => 'Ampere® Altra®'];
+        }
+
+        return ['vendor_info' => null];
+    }
+
     public function getAvailableServerTypesProperty()
     {
         ray('Getting available server types', [
@@ -310,6 +327,12 @@ class ByHetzner extends Component
                 $locationNames = collect($type['locations'])->pluck('name')->toArray();
 
                 return in_array($this->selected_location, $locationNames);
+            })
+            ->map(function ($serverType) {
+                $cpuInfo = $this->getCpuVendorInfo($serverType);
+                $serverType['cpu_vendor_info'] = $cpuInfo['vendor_info'];
+
+                return $serverType;
             })
             ->values()
             ->toArray();

--- a/app/Livewire/Server/New/ByHetzner.php
+++ b/app/Livewire/Server/New/ByHetzner.php
@@ -290,21 +290,21 @@ class ByHetzner extends Component
         }
     }
 
-    private function getCpuVendorInfo(array $serverType): array
+    private function getCpuVendorInfo(array $serverType): string|null
     {
         $name = strtolower($serverType['name'] ?? '');
 
         if (str_starts_with($name, 'ccx')) {
-            return ['vendor_info' => 'AMD Milan EPYC™'];
+            return 'AMD Milan EPYC™';
         } elseif (str_starts_with($name, 'cpx')) {
-            return ['vendor_info' => 'AMD EPYC™'];
+            return 'AMD EPYC™';
         } elseif (str_starts_with($name, 'cx')) {
-            return ['vendor_info' => 'Intel® Xeon®'];
+            return 'Intel® Xeon®';
         } elseif (str_starts_with($name, 'cax')) {
-            return ['vendor_info' => 'Ampere® Altra®'];
+            return 'Ampere® Altra®';
         }
 
-        return ['vendor_info' => null];
+        return null;
     }
 
     public function getAvailableServerTypesProperty()
@@ -329,8 +329,7 @@ class ByHetzner extends Component
                 return in_array($this->selected_location, $locationNames);
             })
             ->map(function ($serverType) {
-                $cpuInfo = $this->getCpuVendorInfo($serverType);
-                $serverType['cpu_vendor_info'] = $cpuInfo['vendor_info'];
+                $serverType['cpu_vendor_info'] = $this->getCpuVendorInfo($serverType);
 
                 return $serverType;
             })

--- a/resources/views/livewire/server/new/by-hetzner.blade.php
+++ b/resources/views/livewire/server/new/by-hetzner.blade.php
@@ -68,11 +68,14 @@
                             @foreach ($this->availableServerTypes as $serverType)
                                 <option value="{{ $serverType['name'] }}">
                                     {{ $serverType['description'] }} -
-                                    {{ $serverType['cores'] }} vCPU,
-                                    {{ $serverType['memory'] }}GB RAM,
+                                    {{ $serverType['cores'] }} vCPU
+                                    @if (isset($serverType['cpu_vendor_info']) && $serverType['cpu_vendor_info'])
+                                        ({{ $serverType['cpu_vendor_info'] }})
+                                    @endif
+                                    , {{ $serverType['memory'] }}GB RAM, 
                                     {{ $serverType['disk'] }}GB
                                     @if (isset($serverType['architecture']))
-                                        ({{ $serverType['architecture'] }})
+                                        [{{ $serverType['architecture'] }}]
                                     @endif
                                     @if (isset($serverType['prices']))
                                         -


### PR DESCRIPTION
## Changes
- Since the Hetzner API doesn't give out the vendor for different servers (somehow only internally, not with a public API key), I hardcoded it.

Just thought it would be a nice addition, but feel free to reject this PR if you think it isn't really needed :)

