### PR TITLE
Fix static site publish directory double slash in build logs

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -2705,7 +2705,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                     ]
                 );
             }
-            $publishDir = ltrim($this->application->publish_directory, '/');
+            $publishDir = trim($this->application->publish_directory, '/');
             $publishDir = $publishDir ? "/{$publishDir}" : '';
             $dockerfile = base64_encode("FROM {$this->application->static_image}
 WORKDIR /usr/share/nginx/html/

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -2705,10 +2705,12 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                     ]
                 );
             }
+            $publishDir = ltrim($this->application->publish_directory, '/');
+            $publishDir = $publishDir ? "/{$publishDir}" : '';
             $dockerfile = base64_encode("FROM {$this->application->static_image}
 WORKDIR /usr/share/nginx/html/
 LABEL coolify.deploymentId={$this->deployment_uuid}
-COPY --from=$this->build_image_name /app/{$this->application->publish_directory} .
+COPY --from=$this->build_image_name /app{$publishDir} .
 COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
             if (str($this->application->custom_nginx_configuration)->isNotEmpty()) {
                 $nginx_config = base64_encode($this->application->custom_nginx_configuration);


### PR DESCRIPTION
Fixes double slash issue in static site deployments where COPY command shows /app// instead of /app or /app/dist.

The issue was in ApplicationDeploymentJob.php where publish_directory wasn't properly sanitized, leading to paths like /app// when the directory was empty or started with a slash.

**Changes:**
- Strip leading slashes from publish_directory
- Only add slash prefix if directory is not empty
- Ensures clean paths in Docker build output