### PR TITLE
fix: add authorization checks to database Livewire components

### DIFF
--- a/app/Livewire/Project/Database/BackupEdit.php
+++ b/app/Livewire/Project/Database/BackupEdit.php
@@ -85,6 +85,7 @@ class BackupEdit extends Component
     public function mount()
     {
         try {
+            $this->authorize('view', $this->backup->database);
             $this->parameters = get_route_parameters();
             $this->syncData();
         } catch (Exception $e) {

--- a/app/Livewire/Project/Database/Clickhouse/General.php
+++ b/app/Livewire/Project/Database/Clickhouse/General.php
@@ -56,6 +56,7 @@ class General extends Component
     public function mount()
     {
         try {
+            $this->authorize('view', $this->database);
             $this->syncData();
             $this->server = data_get($this->database, 'destination.server');
             if (! $this->server) {

--- a/app/Livewire/Project/Database/Configuration.php
+++ b/app/Livewire/Project/Database/Configuration.php
@@ -3,10 +3,12 @@
 namespace App\Livewire\Project\Database;
 
 use Auth;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Livewire\Component;
 
 class Configuration extends Component
 {
+    use AuthorizesRequests;
     public $currentRoute;
 
     public $database;
@@ -41,6 +43,8 @@ class Configuration extends Component
             $database = $environment->databases()
                 ->where('uuid', request()->route('database_uuid'))
                 ->firstOrFail();
+
+            $this->authorize('view', $database);
 
             $this->database = $database;
             $this->project = $project;

--- a/app/Livewire/Project/Database/Dragonfly/General.php
+++ b/app/Livewire/Project/Database/Dragonfly/General.php
@@ -62,6 +62,7 @@ class General extends Component
     public function mount()
     {
         try {
+            $this->authorize('view', $this->database);
             $this->syncData();
             $this->server = data_get($this->database, 'destination.server');
             if (! $this->server) {

--- a/app/Livewire/Project/Database/Import.php
+++ b/app/Livewire/Project/Database/Import.php
@@ -131,6 +131,7 @@ EOD;
         if (is_null($resource)) {
             abort(404);
         }
+        $this->authorize('view', $resource);
         $this->resource = $resource;
         $this->server = $this->resource->destination->server;
         $this->container = $this->resource->uuid;

--- a/app/Livewire/Project/Database/Keydb/General.php
+++ b/app/Livewire/Project/Database/Keydb/General.php
@@ -64,6 +64,7 @@ class General extends Component
     public function mount()
     {
         try {
+            $this->authorize('view', $this->database);
             $this->syncData();
             $this->server = data_get($this->database, 'destination.server');
             if (! $this->server) {

--- a/app/Livewire/Project/Database/Mariadb/General.php
+++ b/app/Livewire/Project/Database/Mariadb/General.php
@@ -122,6 +122,7 @@ class General extends Component
     public function mount()
     {
         try {
+            $this->authorize('view', $this->database);
             $this->syncData();
             $this->server = data_get($this->database, 'destination.server');
             if (! $this->server) {

--- a/app/Livewire/Project/Database/Mongodb/General.php
+++ b/app/Livewire/Project/Database/Mongodb/General.php
@@ -122,6 +122,7 @@ class General extends Component
     public function mount()
     {
         try {
+            $this->authorize('view', $this->database);
             $this->syncData();
             $this->server = data_get($this->database, 'destination.server');
             if (! $this->server) {

--- a/app/Livewire/Project/Database/Mysql/General.php
+++ b/app/Livewire/Project/Database/Mysql/General.php
@@ -127,6 +127,7 @@ class General extends Component
     public function mount()
     {
         try {
+            $this->authorize('view', $this->database);
             $this->syncData();
             $this->server = data_get($this->database, 'destination.server');
             if (! $this->server) {

--- a/app/Livewire/Project/Database/Postgresql/General.php
+++ b/app/Livewire/Project/Database/Postgresql/General.php
@@ -140,6 +140,7 @@ class General extends Component
     public function mount()
     {
         try {
+            $this->authorize('view', $this->database);
             $this->syncData();
             $this->server = data_get($this->database, 'destination.server');
             if (! $this->server) {

--- a/app/Livewire/Project/Database/Redis/General.php
+++ b/app/Livewire/Project/Database/Redis/General.php
@@ -115,6 +115,7 @@ class General extends Component
     public function mount()
     {
         try {
+            $this->authorize('view', $this->database);
             $this->syncData();
             $this->server = data_get($this->database, 'destination.server');
             if (! $this->server) {


### PR DESCRIPTION
This PR adds critical authorization checks to database-related Livewire components that were previously loading sensitive configuration data without verifying user permissions.

---

## 🔒 Security Enhancement

This fix prevents unauthorized users from accessing sensitive database information by adding authorization checks before loading database configuration data.

---

## 📝 Changes

### Database Type General Components (8 files)
All database type General.php components now include `$this->authorize('view', $this->database);` at the start of the `mount()` method, before calling `syncData()`:

- **MySQL** - `app/Livewire/Project/Database/Mysql/General.php`
- **PostgreSQL** - `app/Livewire/Project/Database/Postgresql/General.php`
- **MariaDB** - `app/Livewire/Project/Database/Mariadb/General.php`
- **MongoDB** - `app/Livewire/Project/Database/Mongodb/General.php`
- **Redis** - `app/Livewire/Project/Database/Redis/General.php`
- **Clickhouse** - `app/Livewire/Project/Database/Clickhouse/General.php`
- **KeyDB** - `app/Livewire/Project/Database/Keydb/General.php`
- **Dragonfly** - `app/Livewire/Project/Database/Dragonfly/General.php`

### Other Database Components (3 files)

- **Configuration.php** - Added `AuthorizesRequests` trait and authorization check after loading database from route parameters
- **BackupEdit.php** - Added authorization check before loading backup configuration via `syncData()`
- **Import.php** - Added authorization check in `getContainers()` method after loading database resource

---

## 🛡️ What This Prevents

Unauthorized access to:
- Database credentials (passwords, usernames, root passwords)
- Database connection strings (internal and external URLs)
- Database configuration details (ports, mappings, custom options)
- SSL certificate information and validation dates
- Backup configurations and retention settings
- Database import functionality

---

## ✅ Implementation Details

- All components already had the `AuthorizesRequests` trait imported (or it was added where missing)
- Authorization uses the existing `view` gate from database policies
- Authorization exceptions are properly handled by existing `catch` blocks using `handleError($e, $this)`
- No breaking changes - maintains backward compatibility with existing authorization policies
- Follows project patterns for authorization in Livewire components

---

## 📈 Statistics

- **1 commit**
- **14 additions / 11 files changed**
- **0 deletions** (purely additive security enhancement)

---

Generated by Andras & Jean-Claude, hand-in-hand.