### PR TITLE
fix: use computed imageTag variable for digest-based Docker images

### DIFF
--- a/app/Livewire/Project/New/DockerImage.php
+++ b/app/Livewire/Project/New/DockerImage.php
@@ -79,14 +79,14 @@ class DockerImage extends Component
         $project = Project::where('uuid', $this->parameters['project_uuid'])->first();
         $environment = $project->load(['environments'])->environments->where('uuid', $this->parameters['environment_uuid'])->first();
 
-        // Determine the image tag based on whether it's a hash or regular tag
-        $imageTag = $parser->isImageHash() ? 'sha256-'.$parser->getTag() : $parser->getTag();
-
         // Append @sha256 to image name if using digest and not already present
         $imageName = $parser->getFullImageNameWithoutTag();
         if ($parser->isImageHash() && ! str_ends_with($imageName, '@sha256')) {
             $imageName .= '@sha256';
         }
+
+        // Determine the image tag based on whether it's a hash or regular tag
+        $imageTag = $parser->isImageHash() ? 'sha256-'.$parser->getTag() : $parser->getTag();
 
         $application = Application::create([
             'name' => 'docker-image-'.new Cuid2,
@@ -96,7 +96,7 @@ class DockerImage extends Component
             'build_pack' => 'dockerimage',
             'ports_exposes' => 80,
             'docker_registry_image_name' => $imageName,
-            'docker_registry_image_tag' => $parser->getTag(),
+            'docker_registry_image_tag' => $imageTag,
             'environment_id' => $environment->id,
             'destination_id' => $destination->id,
             'destination_type' => $destination_class,


### PR DESCRIPTION
## Summary

Fixed a bug where digest-based Docker images were not preserving their `sha256-` prefix when stored in the database.

## Changes

- Updated `app/Livewire/Project/New/DockerImage.php` to use the computed `$imageTag` variable instead of calling `$parser->getTag()` directly
- This ensures that when digest-based images are used (e.g., `nginx@sha256:abc123...`), the tag is stored as `sha256-abc123...` instead of just `abc123...`

## Technical Details

The code was computing `$imageTag` with the proper prefix:
```php
$imageTag = $parser->isImageHash() ? 'sha256-'.$parser->getTag() : $parser->getTag();
```

But then using `$parser->getTag()` directly when creating the Application record, bypassing the prefix logic entirely. This fix ensures the computed variable is actually used.

## Impact

- Fixes digest-based Docker image deployments
- No breaking changes to existing functionality

Generated by Andras & Jean-Claude, hand-in-hand.