### PR TITLE
fix: improve Docker image digest handling and add auto-parse feature

### DIFF
--- a/app/Livewire/Project/New/DockerImage.php
+++ b/app/Livewire/Project/New/DockerImage.php
@@ -28,18 +28,60 @@ class DockerImage extends Component
         $this->query = request()->query();
     }
 
+    /**
+     * Auto-parse image name when user pastes a complete Docker image reference
+     * Examples:
+     * - nginx:stable-alpine3.21-perl@sha256:4e272eef...
+     * - ghcr.io/user/app:v1.2.3
+     * - nginx@sha256:abc123...
+     */
+    public function updatedImageName(): void
+    {
+        if (empty($this->imageName)) {
+            return;
+        }
+
+        // Don't auto-parse if user has already manually filled tag or sha256 fields
+        if (! empty($this->imageTag) || ! empty($this->imageSha256)) {
+            return;
+        }
+
+        // Only auto-parse if the image name contains a tag (:) or digest (@)
+        if (! str_contains($this->imageName, ':') && ! str_contains($this->imageName, '@')) {
+            return;
+        }
+
+        try {
+            $parser = new DockerImageParser;
+            $parser->parse($this->imageName);
+
+            // Extract the base image name (without tag/digest)
+            $baseImageName = $parser->getFullImageNameWithoutTag();
+
+            // Only update if parsing resulted in different base name
+            // This prevents unnecessary updates when user types just the name
+            if ($baseImageName !== $this->imageName) {
+                if ($parser->isImageHash()) {
+                    // It's a SHA256 digest (takes priority over tag)
+                    $this->imageSha256 = $parser->getTag();
+                    $this->imageTag = '';
+                } elseif ($parser->getTag() !== 'latest' || str_contains($this->imageName, ':')) {
+                    // It's a regular tag (only set if not default 'latest' or explicitly specified)
+                    $this->imageTag = $parser->getTag();
+                    $this->imageSha256 = '';
+                }
+
+                // Update imageName to just the base name
+                $this->imageName = $baseImageName;
+            }
+        } catch (\Exception $e) {
+            // If parsing fails, leave the image name as-is
+            // User will see validation error on submit
+        }
+    }
+
     public function submit()
     {
-        // Strip 'sha256:' prefix if user pasted it
-        if ($this->imageSha256) {
-            $this->imageSha256 = preg_replace('/^sha256:/i', '', trim($this->imageSha256));
-        }
-
-        // Remove @sha256 from image name if user added it
-        if ($this->imageName) {
-            $this->imageName = preg_replace('/@sha256$/i', '', trim($this->imageName));
-        }
-
         $this->validate([
             'imageName' => ['required', 'string'],
             'imageTag' => ['nullable', 'string', 'regex:/^[a-z0-9][a-z0-9._-]*$/i'],
@@ -56,13 +98,16 @@ class DockerImage extends Component
 
         // Build the full Docker image string
         if ($this->imageSha256) {
-            $dockerImage = $this->imageName.'@sha256:'.$this->imageSha256;
+            // Strip 'sha256:' prefix if user pasted it
+            $sha256Hash = preg_replace('/^sha256:/i', '', trim($this->imageSha256));
+            $dockerImage = $this->imageName.'@sha256:'.$sha256Hash;
         } elseif ($this->imageTag) {
             $dockerImage = $this->imageName.':'.$this->imageTag;
         } else {
             $dockerImage = $this->imageName.':latest';
         }
 
+        // Parse using DockerImageParser to normalize the image reference
         $parser = new DockerImageParser;
         $parser->parse($dockerImage);
 

--- a/resources/views/livewire/project/new/docker-image.blade.php
+++ b/resources/views/livewire/project/new/docker-image.blade.php
@@ -7,8 +7,8 @@
             <x-forms.button type="submit">Save</x-forms.button>
         </div>
         <div class="space-y-4">
-            <x-forms.input id="imageName" label="Image Name" placeholder="nginx or ghcr.io/user/app"
-                helper="Enter the Docker image name with optional registry. Examples: nginx, ghcr.io/user/app, localhost:5000/myapp"
+            <x-forms.input id="imageName" label="Image Name" placeholder="nginx, docker.io/nginx:latest, ghcr.io/user/app:v1.2.3, or nginx:stable@sha256:abc123..."
+                helper="Enter the Docker image name with optional registry. You can also paste a complete reference like 'nginx:stable@sha256:abc123...' and the fields below will be auto-filled."
                 required autofocus />
             <div class="relative grid grid-cols-1 gap-4 md:grid-cols-2">
                 <x-forms.input id="imageTag" label="Tag (optional)" placeholder="latest"

--- a/tests/Unit/DockerImageAutoParseTest.php
+++ b/tests/Unit/DockerImageAutoParseTest.php
@@ -1,0 +1,130 @@
+<?php
+
+use App\Livewire\Project\New\DockerImage;
+
+it('auto-parses complete docker image reference with tag', function () {
+    $component = new DockerImage;
+    $component->imageName = 'nginx:stable-alpine3.21-perl';
+    $component->imageTag = '';
+    $component->imageSha256 = '';
+
+    $component->updatedImageName();
+
+    expect($component->imageName)->toBe('nginx')
+        ->and($component->imageTag)->toBe('stable-alpine3.21-perl')
+        ->and($component->imageSha256)->toBe('');
+});
+
+it('auto-parses complete docker image reference with sha256 digest', function () {
+    $hash = '4e272eef7ec6a7e76b9c521dcf14a3d397f7c370f48cbdbcfad22f041a1449cb';
+    $component = new DockerImage;
+    $component->imageName = "nginx@sha256:{$hash}";
+    $component->imageTag = '';
+    $component->imageSha256 = '';
+
+    $component->updatedImageName();
+
+    expect($component->imageName)->toBe('nginx')
+        ->and($component->imageTag)->toBe('')
+        ->and($component->imageSha256)->toBe($hash);
+});
+
+it('auto-parses complete docker image reference with tag and sha256 digest', function () {
+    $hash = '4e272eef7ec6a7e76b9c521dcf14a3d397f7c370f48cbdbcfad22f041a1449cb';
+    $component = new DockerImage;
+    $component->imageName = "nginx:stable-alpine3.21-perl@sha256:{$hash}";
+    $component->imageTag = '';
+    $component->imageSha256 = '';
+
+    $component->updatedImageName();
+
+    // When both tag and digest are present, Docker keeps the tag in the name
+    // but uses the digest for pulling. The tag becomes part of the image name.
+    expect($component->imageName)->toBe('nginx:stable-alpine3.21-perl')
+        ->and($component->imageTag)->toBe('')
+        ->and($component->imageSha256)->toBe($hash);
+});
+
+it('auto-parses registry image with port and tag', function () {
+    $component = new DockerImage;
+    $component->imageName = 'registry.example.com:5000/myapp:v1.2.3';
+    $component->imageTag = '';
+    $component->imageSha256 = '';
+
+    $component->updatedImageName();
+
+    expect($component->imageName)->toBe('registry.example.com:5000/myapp')
+        ->and($component->imageTag)->toBe('v1.2.3')
+        ->and($component->imageSha256)->toBe('');
+});
+
+it('auto-parses ghcr image with sha256 digest', function () {
+    $hash = 'abc123def456789abcdef123456789abcdef123456789abcdef123456789abc1';
+    $component = new DockerImage;
+    $component->imageName = "ghcr.io/user/app@sha256:{$hash}";
+    $component->imageTag = '';
+    $component->imageSha256 = '';
+
+    $component->updatedImageName();
+
+    expect($component->imageName)->toBe('ghcr.io/user/app')
+        ->and($component->imageTag)->toBe('')
+        ->and($component->imageSha256)->toBe($hash);
+});
+
+it('does not auto-parse if user has manually filled tag field', function () {
+    $component = new DockerImage;
+    $component->imageTag = 'latest'; // User manually set this FIRST
+    $component->imageSha256 = '';
+    $component->imageName = 'nginx:stable'; // Then user enters image name
+
+    $component->updatedImageName();
+
+    // Should not auto-parse because tag is already set
+    expect($component->imageName)->toBe('nginx:stable')
+        ->and($component->imageTag)->toBe('latest')
+        ->and($component->imageSha256)->toBe('');
+});
+
+it('does not auto-parse if user has manually filled sha256 field', function () {
+    $hash = '4e272eef7ec6a7e76b9c521dcf14a3d397f7c370f48cbdbcfad22f041a1449cb';
+    $component = new DockerImage;
+    $component->imageSha256 = $hash; // User manually set this FIRST
+    $component->imageTag = '';
+    $component->imageName = 'nginx:stable'; // Then user enters image name
+
+    $component->updatedImageName();
+
+    // Should not auto-parse because sha256 is already set
+    expect($component->imageName)->toBe('nginx:stable')
+        ->and($component->imageTag)->toBe('')
+        ->and($component->imageSha256)->toBe($hash);
+});
+
+it('does not auto-parse plain image name without tag or digest', function () {
+    $component = new DockerImage;
+    $component->imageName = 'nginx';
+    $component->imageTag = '';
+    $component->imageSha256 = '';
+
+    $component->updatedImageName();
+
+    // Should leave as-is since there's nothing to parse
+    expect($component->imageName)->toBe('nginx')
+        ->and($component->imageTag)->toBe('')
+        ->and($component->imageSha256)->toBe('');
+});
+
+it('handles parsing errors gracefully', function () {
+    $component = new DockerImage;
+    $component->imageName = 'registry.io:5000/myapp:v1.2.3';
+    $component->imageTag = '';
+    $component->imageSha256 = '';
+
+    // Should not throw exception
+    expect(fn () => $component->updatedImageName())->not->toThrow(\Exception::class);
+
+    // Should successfully parse this valid image
+    expect($component->imageName)->toBe('registry.io:5000/myapp')
+        ->and($component->imageTag)->toBe('v1.2.3');
+});


### PR DESCRIPTION
This PR fixes a critical bug in Docker image digest handling and introduces an intelligent auto-parse feature that significantly improves the user experience when deploying Docker images.

---

## 🐛 Critical Bug Fix: Double-Decoration of Docker Image Names

### The Problem

When users provided Docker images with SHA256 digests like `nginx@sha256:abc123...`, the manual regex-based cleanup logic had a critical flaw:

1. **Line 1526** (old code): `preg_replace('/@sha256$/i', '', trim($dockerImageName));`
   - This regex only stripped the literal string `@sha256` at the end
   - **It didn't remove the `:hash` part** that follows in a proper digest reference

2. **Result**: If a user provided `nginx@sha256:abc123def456...`, the code would:
   - Strip only `@sha256` → leaves `nginx:abc123def456...`
   - Then append `@sha256` again → results in `nginx:abc123def456...@sha256`

This created **malformed double-decorated names** that broke Docker deployments.

### The Solution

Replaced all manual regex-based parsing with the robust `DockerImageParser` utility:

**In `ApplicationsController.php`**:
```php
// Build the full Docker image string for parsing
if ($dockerImageTag) {
    $dockerImageString = $dockerImageName.':'.$dockerImageTag;
} else {
    $dockerImageString = $dockerImageName;
}

// Parse using DockerImageParser to normalize the image reference
$parser = new DockerImageParser;
$parser->parse($dockerImageString);

// Get normalized image name and tag
$normalizedImageName = $parser->getFullImageNameWithoutTag();

// Append @sha256 to image name if using digest
if ($parser->isImageHash() && ! str_ends_with($normalizedImageName, '@sha256')) {
    $normalizedImageName .= '@sha256';
}

$request->offsetSet('docker_registry_image_name', $normalizedImageName);
$request->offsetSet('docker_registry_image_tag', $parser->getTag());
```

**Benefits**:
- ✅ Correctly handles `nginx@sha256:hash` format
- ✅ Properly strips the entire `@sha256:hash` tail, not just `@sha256`
- ✅ Prevents double-decoration of image names
- ✅ Handles edge cases like registry URLs with ports
- ✅ Consistent parsing across the entire application

---

## ✨ New Feature: Auto-Parse Docker Image References

### User Experience Enhancement

Users can now paste **complete Docker image references** into the "Image Name" field, and Coolify will automatically parse and populate the appropriate fields:

### Examples

**1. Image with tag and digest:**
```
Input: nginx:stable-alpine3.21-perl@sha256:4e272eef...
Result:
  - Image Name: nginx:stable-alpine3.21-perl
  - SHA256: 4e272eef...
```

**2. Simple image with tag:**
```
Input: nginx:latest
Result:
  - Image Name: nginx
  - Tag: latest
```

**3. Registry with digest:**
```
Input: ghcr.io/user/app@sha256:abc123...
Result:
  - Image Name: ghcr.io/user/app
  - SHA256: abc123...
```

**4. Registry with port and tag:**
```
Input: registry.example.com:5000/myapp:v1.2.3
Result:
  - Image Name: registry.example.com:5000/myapp
  - Tag: v1.2.3
```

### Smart Behavior

- **Respects manual input**: Only auto-parses when tag/sha256 fields are empty
- **Handles all formats**: Works with both `@sha256:hash` and `:hash` formats
- **Registry-aware**: Correctly handles registry URLs with ports (`:5000`)
- **Graceful error handling**: Invalid formats don't crash, validation catches them on submit
- **Real-time parsing**: Uses Livewire's `updatedImageName()` lifecycle hook

### UI Improvements

Updated placeholder text to guide users:
```
nginx, docker.io/nginx:latest, ghcr.io/user/app:v1.2.3, or nginx:stable@sha256:abc123...
```

Helper text:
```
Enter the Docker image name with optional registry. You can also paste a complete 
reference like 'nginx:stable@sha256:abc123...' and the fields below will be auto-filled.
```

---

## 📦 Files Changed

### Core Fixes (2 files)
- **`app/Http/Controllers/Api/ApplicationsController.php`**
  - Replaced manual regex with `DockerImageParser` (lines 1516-1541)
  - Added `use App\Services\DockerImageParser;` import
  
- **`app/Livewire/Project/New/DockerImage.php`**
  - Added `updatedImageName()` lifecycle hook for auto-parsing
  - Simplified submit() method validation flow

### UI Enhancement (1 file)
- **`resources/views/livewire/project/new/docker-image.blade.php`**
  - Updated placeholder with comprehensive examples
  - Added helpful hint about auto-parse feature

### Tests (2 files)
- **`tests/Unit/DockerImageParserTest.php`**
  - Added 2 new test cases for digest handling
  
- **`tests/Unit/DockerImageAutoParseTest.php`** (new file)
  - 9 comprehensive unit tests for auto-parse feature
  - Tests all edge cases: tags, digests, registries, ports, manual input

---

## 🧪 Testing

### All Tests Passing ✅

**DockerImageParser Tests** (11 tests, 46 assertions):
- ✅ Regular image with tag
- ✅ SHA256 hash using colon format
- ✅ SHA256 hash using at sign format
- ✅ Registry image with hash
- ✅ Image without tag defaults to latest
- ✅ Registry with port
- ✅ Registry with port and hash
- ✅ Valid SHA256 hash identification
- ✅ Invalid SHA256 hash identification
- ✅ **NEW**: Parses and normalizes image with full digest including hash
- ✅ **NEW**: Correctly parses digest-decorated name with colon hash

**Auto-Parse Tests** (9 tests, 27 assertions):
- ✅ Auto-parses complete docker image reference with tag
- ✅ Auto-parses complete docker image reference with sha256 digest
- ✅ Auto-parses complete docker image reference with tag and sha256 digest
- ✅ Auto-parses registry image with port and tag
- ✅ Auto-parses ghcr image with sha256 digest
- ✅ Does not auto-parse if user has manually filled tag field
- ✅ Does not auto-parse if user has manually filled sha256 field
- ✅ Does not auto-parse plain image name without tag or digest
- ✅ Handles parsing errors gracefully

**Total**: 20 tests, 73 assertions

---

## 📈 Statistics

- **1 commit** with comprehensive improvements
- **5 files changed**
  - 3 core files (Controller, Livewire, View)
  - 2 test files (1 updated, 1 new)
- **+233 additions / -24 deletions**
- **Code quality**: ✅ Laravel Pint validated

---

## 🎯 Impact

### For Users
- ✅ **Easier Docker image deployment** - Just paste the complete image reference
- ✅ **Fewer deployment errors** - Proper digest handling prevents malformed image names
- ✅ **Better UX** - Clear examples in placeholder text guide users
- ✅ **Time savings** - No need to manually split image names, tags, and digests

### For Developers
- ✅ **Robust parsing** - Uses proven `DockerImageParser` instead of fragile regex
- ✅ **Comprehensive tests** - 20 tests ensure correctness
- ✅ **Maintainable code** - Single source of truth for image parsing
- ✅ **Defensive programming** - Graceful error handling prevents crashes

### For Cloud Instance
- ✅ **Reduced support tickets** - Fewer deployment failures from malformed image names
- ✅ **Better reliability** - Consistent parsing across API and UI
- ✅ **Scalability** - Efficient parsing with no database dependencies

---

## 🔗 Related Context

This PR builds on top of these recent improvements:
- **#6869** - Git redirect handling for tangled.sh
- **#6870** - Database null server TypeError fix
- **#6871** - Static site double slash fix
- **#6872** - Database authorization checks
- **#6873** - Pure Dockerfile deployment fix
- **#6863** - Hetzner CPU vendor information

---

## 🙏 Credits

Special thanks to the Coolify team for maintaining the excellent `DockerImageParser` utility that made this fix possible.

---

Generated by Andras & Jean-Claude, hand-in-hand.