### PR TITLE
Enable API by default in development mode

### DIFF
--- a/database/seeders/InstanceSettingsSeeder.php
+++ b/database/seeders/InstanceSettingsSeeder.php
@@ -16,6 +16,7 @@ class InstanceSettingsSeeder extends Seeder
         InstanceSettings::create([
             'id' => 0,
             'is_registration_enabled' => true,
+            'is_api_enabled' => isDev(),
             'smtp_enabled' => true,
             'smtp_host' => 'coolify-mail',
             'smtp_port' => 1025,


### PR DESCRIPTION
This PR ensures that the Coolify API is enabled by default when running in development mode, while keeping it disabled in production environments.

---

## 🔨 Changes

### Instance Settings Seeder
- **Enable API in development mode** - Added `is_api_enabled => isDev()` to the InstanceSettingsSeeder
- API is automatically enabled when `APP_ENV=local` or development mode is detected
- Production instances retain the secure default of API disabled
- Uses existing `isDev()` helper function for environment detection

---

## 🎯 Motivation

Developers working on Coolify need API access for testing and development purposes. Previously, the API had to be manually enabled after seeding, which added friction to the development workflow. This change streamlines the developer experience while maintaining security for production instances.

---

## 📊 Technical Details

**File Modified**: `database/seeders/InstanceSettingsSeeder.php`
- **1 addition** / 1 file changed
- Single commit with focused scope

**Environment Detection**: Uses the `isDev()` helper which checks:
- `APP_ENV === 'local'`
- Or other development environment indicators

---

## ✅ Testing

This change affects seeding behavior only. To verify:
1. Run `php artisan db:seed --class=InstanceSettingsSeeder` in a development environment
2. Check `instance_settings` table - `is_api_enabled` should be `true`
3. Run the same in a production-like environment
4. Verify `is_api_enabled` is `false`

---

Generated by Andras & Jean-Claude, hand-in-hand.