### PR TITLE
feat: Relax validation rules for descriptions to allow non-ASCII character input

### DIFF
--- a/app/Support/ValidationPatterns.php
+++ b/app/Support/ValidationPatterns.php
@@ -15,9 +15,9 @@ class ValidationPatterns
 
     /**
      * Pattern for descriptions (allows more characters including quotes, commas, etc.)
-     * More permissive than names but still restricts dangerous characters
+     * only rejects control characters (U+0000-U+001F), <, >, ;, $, \
      */
-    public const DESCRIPTION_PATTERN = '/^[a-zA-Z0-9\s\-_.:\/()\'\",.!?@#%&+=\[\]{}|~`*]+$/';
+    public const DESCRIPTION_PATTERN = '/^[^\x00-\x1F<>;\\$]+$/';
 
     /**
      * Get validation rules for name fields
@@ -78,7 +78,7 @@ class ValidationPatterns
     public static function descriptionMessages(): array
     {
         return [
-            'description.regex' => 'The description contains invalid characters. Only letters, numbers, spaces, and common punctuation (- _ . : / () \' " , ! ? @ # % & + = [] {} | ~ ` *) are allowed.',
+            'description.regex' => 'The description contains invalid characters. Control characters and < > ; $ \ cannot be used.',
             'description.max' => 'The description may not be greater than :max characters.',
         ];
     }


### PR DESCRIPTION
## Changes
- Relax the regular expression rules for "Description" to allow input of non-ASCII characters, etc.

## Issues
- fix #6904 

## Descritpion
I compared the original regular expression with common prohibited input characters and thought it would be sufficient to mainly reject the following items:

* `0x00-0x1F`: Control characters
* `<`, `>`: HTML tags, XSS
* `$`: Command injection
* `;`: SQL injection
* `\`: Escape sequences

Therefore, in this PR, we consider characters other than those listed above to be safe.
If there are any mistakes in the list above, please do leave a comment.
