### PR TITLE
Update GHCR cleanup to be manual and comprehensive

### DIFF
--- a/.github/workflows/cleanup-ghcr-untagged.yml
+++ b/.github/workflows/cleanup-ghcr-untagged.yml
@@ -1,24 +1,25 @@
 name: Cleanup Untagged GHCR Images
 
 on:
-  workflow_dispatch: # Allow manual trigger
-  schedule:
-    - cron: '0 */6 * * *' # Run every 6 hours to handle large volume (16k+ images)
+  workflow_dispatch: # Manual trigger only
 
 env:
   GITHUB_REGISTRY: ghcr.io
 
 jobs:
-  cleanup-testing-host:
+  cleanup-all-packages:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    strategy:
+      matrix:
+        package: ['coolify', 'coolify-helper', 'coolify-realtime', 'coolify-testing-host']
     steps:
-      - name: Delete untagged coolify-testing-host images
+      - name: Delete untagged ${{ matrix.package }} images
         uses: actions/delete-package-versions@v5
         with:
-          package-name: 'coolify-testing-host'
+          package-name: ${{ matrix.package }}
           package-type: 'container'
           min-versions-to-keep: 0
           delete-only-untagged-versions: 'true'


### PR DESCRIPTION
## Changes
- Modified `.github/workflows/cleanup-ghcr-untagged.yml` to be manually triggered only by removing the `schedule` cron job.
- Implemented a matrix strategy to allow the cleanup action to run for all relevant packages: `coolify`, `coolify-helper`, `coolify-realtime`, and `coolify-testing-host`.
- The `actions/delete-package-versions@v5` action is now configured to use the package name from the matrix.

## Issues
- Manually triggers cleanup for all GHCR packages.
