### PR TITLE
Add handling for docker_compose_raw in request

### DIFF
--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -2305,6 +2305,10 @@ class ApplicationsController extends Controller
             data_set($data, 'fqdn', $domains);
         }
 
+        if($request->has('docker_compose_raw')) {
+            data_set($data, 'docker_compose_raw', base64_decode($request->docker_compose_raw));
+        }
+
         if ($dockerComposeDomainsJson->count() > 0) {
             data_set($data, 'docker_compose_domains', json_encode($dockerComposeDomainsJson));
         }


### PR DESCRIPTION
Fixes #6938

## Changes
- API for PATCH api/v1/applications/ requires base64_encoded docker_compose_raw but does not decode it

## Issues
- fix #6938
