### PR TITLE
Fix: Use syncFromModel in EditDomain

### DIFF
--- a/app/Livewire/Project/Service/EditDomain.php
+++ b/app/Livewire/Project/Service/EditDomain.php
@@ -83,7 +83,7 @@ class EditDomain extends Component
             $this->validate();
             $this->application->save();
             $this->application->refresh();
-            $this->syncData(false);
+            $this->syncFromModel();
             updateCompose($this->application);
             if (str($this->application->fqdn)->contains(',')) {
                 $this->dispatch('warning', 'Some services do not support multiple domains, which can lead to problems and is NOT RECOMMENDED.<br><br>Only use multiple domains if you know what you are doing.');
@@ -96,7 +96,7 @@ class EditDomain extends Component
             $originalFqdn = $this->application->getOriginal('fqdn');
             if ($originalFqdn !== $this->application->fqdn) {
                 $this->application->fqdn = $originalFqdn;
-                $this->syncData(false);
+                $this->syncFromModel();
             }
 
             return handleError($e, $this);


### PR DESCRIPTION
## Changes
- Replaced calls to non-existent `syncData(false)` method with `syncFromModel()` in `app/Livewire/Project/Service/EditDomain.php`.
    - This resolves the "Method App\Livewire\Project\Service\EditDomain::syncData does not exist" error.
    - The `syncFromModel()` method is provided by the `SynchronizesModelData` trait and correctly syncs data from the model to the component.

## Issues
- fix #
