### PR TITLE
disable(service): minio

### DIFF
--- a/templates/compose/minio.yaml
+++ b/templates/compose/minio.yaml
@@ -1,3 +1,4 @@
+# ignore: true
 # documentation: https://min.io/docs/minio/container/index.html
 # slogan: MinIO is a high performance object storage server compatible with Amazon S3 APIs.
 # category: storage


### PR DESCRIPTION
Minio is source only distribution now, so they won't build and publish docker images anymore, more on: https://github.com/minio/minio/issues/21647#issuecomment-3418675115

About 5 days ago Minio announced a CVE: https://github.com/minio/minio/security/advisories/GHSA-jjjj-jwhf-8rgr and the latest image doesn't have fix for this (they are not going to build an publish the docker image which have fix for this CVE, so all users deploying minio are vulnerable to the CVE)