### PR TITLE
fix: deprecated hetzner servers

### DIFF
--- a/app/Livewire/Server/New/ByHetzner.php
+++ b/app/Livewire/Server/New/ByHetzner.php
@@ -299,9 +299,9 @@ class ByHetzner extends Component
         } elseif (str_starts_with($name, 'cpx')) {
             return 'AMD EPYC™';
         } elseif (str_starts_with($name, 'cx')) {
-            return 'Intel® Xeon®';
+            return 'Intel®/AMD';
         } elseif (str_starts_with($name, 'cax')) {
-            return 'Ampere® Altra®';
+            return 'Ampere®';
         }
 
         return null;

--- a/app/Services/HetznerService.php
+++ b/app/Services/HetznerService.php
@@ -88,7 +88,14 @@ class HetznerService
 
     public function getServerTypes(): array
     {
-        return $this->requestPaginated('get', '/server_types', 'server_types');
+        $types = $this->requestPaginated('get', '/server_types', 'server_types');
+
+        // Filter out entries where "deprecated" is explicitly true
+        $filtered = array_filter($types, function ($type) {
+            return ! (isset($type['deprecated']) && $type['deprecated'] === true);
+        });
+
+        return array_values($filtered);
     }
 
     public function getSshKeys(): array

--- a/resources/views/livewire/server/new/by-hetzner.blade.php
+++ b/resources/views/livewire/server/new/by-hetzner.blade.php
@@ -61,6 +61,7 @@
 
                     <div>
                         <x-forms.select label="Server Type" id="selected_server_type" wire:model.live="selected_server_type"
+                            helper="Learn more about <a class='inline-block underline dark:text-white' href='https://www.hetzner.com/cloud/' target='_blank'>Hetzner server types</a>"
                             required :disabled="!$selected_location">
                             <option value="">
                                 {{ $selected_location ? 'Select a server type...' : 'Select a location first' }}


### PR DESCRIPTION
## Changes
- Filter out deprecated hetzner server types
- Added a helper link to the server type selector in the Hetzner server creation UI, directing users to Hetzner's page for more information

## Issues
- Hetzner updated some servers and introduced new types https://www.hetzner.com/cloud/
