### PR TITLE
Fix healthcheck reset when removed from Dockerfile

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -1804,7 +1804,9 @@ class Application extends BaseModel
     public function parseHealthcheckFromDockerfile($dockerfile, bool $isInit = false)
     {
         $dockerfile = str($dockerfile)->trim()->explode("\n");
-        if (str($dockerfile)->contains('HEALTHCHECK') && ($this->isHealthcheckDisabled() || $isInit)) {
+        $hasHealthcheck = str($dockerfile)->contains('HEALTHCHECK');
+
+        if ($hasHealthcheck && ($this->isHealthcheckDisabled() || $isInit)) {
             $healthcheckCommand = null;
             $lines = $dockerfile->toArray();
             foreach ($lines as $line) {
@@ -1845,6 +1847,14 @@ class Application extends BaseModel
                     $this->save();
                 }
             }
+        } elseif (! $hasHealthcheck && $this->custom_healthcheck_found) {
+            // HEALTHCHECK was removed from Dockerfile, reset to defaults
+            $this->custom_healthcheck_found = false;
+            $this->health_check_interval = 5;
+            $this->health_check_timeout = 5;
+            $this->health_check_retries = 10;
+            $this->health_check_start_period = 5;
+            $this->save();
         }
     }
 


### PR DESCRIPTION
## Changes
- When `parseHealthcheckFromDockerfile` detects that the `HEALTHCHECK` instruction has been removed from the Dockerfile, it now correctly resets the application's healthcheck-related properties (`custom_healthcheck_found`, `health_check_interval`, `health_check_timeout`, `health_check_retries`, `health_check_start_period`) to their default values and saves the application. This prevents the application from continuing to use stale custom healthcheck configurations after the instruction is no longer present in the Dockerfile.

## Issues
- fix #
