### PR TITLE
Replace vulnerable minio docker images with Coollabs Minio

### DIFF
--- a/bootstrap/helpers/constants.php
+++ b/bootstrap/helpers/constants.php
@@ -51,6 +51,7 @@ const DATABASE_DOCKER_IMAGES = [
 const SPECIFIC_SERVICES = [
     'quay.io/minio/minio',
     'minio/minio',
+    'ghcr.io/coollabsio/minio',
     'svhd/logto',
 ];
 

--- a/bootstrap/helpers/constants.php
+++ b/bootstrap/helpers/constants.php
@@ -52,6 +52,7 @@ const SPECIFIC_SERVICES = [
     'quay.io/minio/minio',
     'minio/minio',
     'ghcr.io/coollabsio/minio',
+    'coollabsio/minio',
     'svhd/logto',
 ];
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -104,7 +104,7 @@ services:
     networks:
       - coolify
   minio:
-    image: minio/minio:latest
+    image: ghcr.io/coollabsio/minio:RELEASE.2025-10-15T17-29-55Z # Released on 15 October 2025
     pull_policy: always
     container_name: coolify-minio
     command: server /data --console-address ":9001"

--- a/templates/compose/azimutt.yaml
+++ b/templates/compose/azimutt.yaml
@@ -22,7 +22,7 @@ services:
       retries: 10
 
   minio:
-    image: minio/minio:latest
+    image: ghcr.io/coollabsio/minio:RELEASE.2025-10-15T17-29-55Z # Released on 15 October 2025
     command: server /data --console-address ":9001"
     environment:
       - MINIO_SERVER_URL=$MINIO_SERVER_URL

--- a/templates/compose/budibase.yaml
+++ b/templates/compose/budibase.yaml
@@ -66,7 +66,7 @@ services:
       start_period: 10s
 
   minio-service:
-    image: minio/minio
+    image: ghcr.io/coollabsio/minio:RELEASE.2025-10-15T17-29-55Z # Released on 15 October 2025
     volumes:
       - minio_data:/data
     environment:

--- a/templates/compose/ente-photos-with-s3.yaml
+++ b/templates/compose/ente-photos-with-s3.yaml
@@ -86,7 +86,7 @@ services:
       retries: 5
 
   minio:
-    image: 'quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z' # Released at 2025-09-07T16-13-09Z
+    image: ghcr.io/coollabsio/minio:RELEASE.2025-10-15T17-29-55Z # Released on 15 October 2025
     command: 'server /data --console-address ":9001"'
     environment:
       - MINIO_SERVER_URL=$MINIO_SERVER_URL

--- a/templates/compose/huly.yaml
+++ b/templates/compose/huly.yaml
@@ -15,7 +15,7 @@ services:
     volumes:
       - huly-db:/data/db
   minio:
-    image: "minio/minio"
+    image: ghcr.io/coollabsio/minio:RELEASE.2025-10-15T17-29-55Z # Released on 15 October 2025
     command: server /data --address ":9000" --console-address ":9001"
     volumes:
       - huly-files:/data

--- a/templates/compose/plane.yaml
+++ b/templates/compose/plane.yaml
@@ -211,7 +211,7 @@ services:
 
   plane-minio:
     <<: *app-env
-    image: minio/minio:latest
+    image: ghcr.io/coollabsio/minio:RELEASE.2025-10-15T17-29-55Z # Released on 15 October 2025
     command: server /export --console-address ":9090"
     volumes:
       - uploads:/export

--- a/templates/compose/posthog.yaml
+++ b/templates/compose/posthog.yaml
@@ -1870,7 +1870,7 @@ services:
       - ALLOW_PLAINTEXT_LISTENER=yes
 
   object_storage:
-    image: minio/minio:RELEASE.2022-06-25T15-50-16Z
+    image: ghcr.io/coollabsio/minio:RELEASE.2025-10-15T17-29-55Z # Released on 15 October 2025
     environment:
       - MINIO_ROOT_USER=$SERVICE_USER_MINIO
       - MINIO_ROOT_PASSWORD=$SERVICE_PASSWORD_MINIO

--- a/templates/compose/reactive-resume.yaml
+++ b/templates/compose/reactive-resume.yaml
@@ -46,7 +46,7 @@ services:
       retries: 10
 
   minio:
-    image: quay.io/minio/minio:latest
+    image: ghcr.io/coollabsio/minio:RELEASE.2025-10-15T17-29-55Z # Released on 15 October 2025
     command: server /data --console-address ":9001"
     environment:
       - MINIO_SERVER_URL=$MINIO_SERVER_URL

--- a/templates/compose/supabase.yaml
+++ b/templates/compose/supabase.yaml
@@ -1072,7 +1072,7 @@ services:
     command: >
       sh -c "/app/bin/migrate && /app/bin/realtime eval 'Realtime.Release.seeds(Realtime.Repo)' && /app/bin/server"
   supabase-minio:
-    image: minio/minio
+    image: ghcr.io/coollabsio/minio:RELEASE.2025-10-15T17-29-55Z # Released on 15 October 2025
     environment:
       - MINIO_ROOT_USER=${SERVICE_USER_MINIO}
       - MINIO_ROOT_PASSWORD=${SERVICE_PASSWORD_MINIO}


### PR DESCRIPTION
## Changes
The vulnerable Minio Docker image has been replaced with the updated image from [Coollabs Minio](https://github.com/coollabsio/minio). The following services have been updated with the new image:
* azimutt
* budibase
* plane
* posthog
* supabase
* huly
* ente photos

Additionally, the Coolify dev compose file, which was using the vulnerable Minio image, has been updated to use the [Coollabs Minio](https://github.com/coollabsio/minio) image as well.

## Note
To prevent future issues with Minio updates potentially breaking the templates, I have pinned the version to the latest stable release that includes the fix for the CVE