### PR TITLE
Fix: Remove content from docker_compose_raw to prevent file overwrites

### DIFF
--- a/bootstrap/helpers/parsers.php
+++ b/bootstrap/helpers/parsers.php
@@ -1297,7 +1297,11 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
         return array_search($key, $customOrder);
     });
 
-    $resource->docker_compose = Yaml::dump(convertToArray($topLevel), 10, 2);
+    $cleanedCompose = Yaml::dump(convertToArray($topLevel), 10, 2);
+    $resource->docker_compose = $cleanedCompose;
+    // Also update docker_compose_raw to remove content: from volumes
+    // This prevents content from being reapplied on subsequent deployments
+    $resource->docker_compose_raw = $cleanedCompose;
     data_forget($resource, 'environment_variables');
     data_forget($resource, 'environment_variables_preview');
     $resource->save();
@@ -2220,7 +2224,11 @@ function serviceParser(Service $resource): Collection
         return array_search($key, $customOrder);
     });
 
-    $resource->docker_compose = Yaml::dump(convertToArray($topLevel), 10, 2);
+    $cleanedCompose = Yaml::dump(convertToArray($topLevel), 10, 2);
+    $resource->docker_compose = $cleanedCompose;
+    // Also update docker_compose_raw to remove content: from volumes
+    // This prevents content from being reapplied on subsequent deployments
+    $resource->docker_compose_raw = $cleanedCompose;
     data_forget($resource, 'environment_variables');
     data_forget($resource, 'environment_variables_preview');
     $resource->save();


### PR DESCRIPTION
## Summary
Fixes an issue where files defined with `content:` in compose files were being overwritten on every deployment/save, preventing users from editing files in the persistent storage view.

## Problem
When users define volumes with `content:` in their compose file (Coolify's special syntax):
1. The parser was removing `content:` from `docker_compose` (processed version)
2. But `docker_compose_raw` (user-editable version) still contained `content:`
3. When users saved the compose file, it would re-parse and overwrite their file edits

## Solution
Updated the parser to update **both** `docker_compose` and `docker_compose_raw` with the cleaned version (without `content:`).

### Changes
- `bootstrap/helpers/parsers.php` (line ~1300): Updated `applicationParser` to clean both compose fields
- `bootstrap/helpers/parsers.php` (line ~2224): Updated `serviceParser` to clean both compose fields

## Behavior After Fix
1. User defines volume with `content:` in compose file
2. First deployment creates the `LocalFileVolume` with that content
3. Parser removes `content:` from **both** `docker_compose` and `docker_compose_raw`
4. User can now edit the file in persistent storage view
5. Future deployments/saves won't overwrite the file

The `content:` field now acts as an **initial value only** - it sets up the file once, then gets removed so users have full control.

## Testing
- Verify that after first deployment, `docker_compose_raw` no longer contains `content:` for volumes
- Verify that editing files in persistent storage view persists across deployments
- Verify that saving the compose file doesn't reintroduce the `content:` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)