### PR TITLE
fix(service): seafile cannot upload files due to network errors

### DIFF
--- a/templates/compose/seafile.yaml
+++ b/templates/compose/seafile.yaml
@@ -12,7 +12,7 @@ services:
       - seafile-data:/shared
     environment:
       - SERVICE_URL_SEAFILE_80
-      - SEAFILE_SERVER_HOSTNAME=${SERVICE_URL_SEAFILE_80}
+      - SEAFILE_SERVER_HOSTNAME=${SERVICE_FQDN_SEAFILE}
       - DB_HOST=mariadb
       - DB_PORT=3306
       - DB_ROOT_PASSWD=${SERVICE_PASSWORD_MYSQLROOT}
@@ -24,11 +24,12 @@ services:
       - TIME_ZONE=${TIME_ZONE:-UTC}
       - INIT_SEAFILE_ADMIN_EMAIL=${INIT_SEAFILE_ADMIN_EMAIL:-test@example.com}
       - INIT_SEAFILE_ADMIN_PASSWORD=${SERVICE_PASSWORD_ADMIN}
-      - SEAFILE_SERVER_PROTOCOL=${SEAFILE_SERVER_PROTOCOL:-http}
+      - SEAFILE_SERVER_PROTOCOL=https
       - SITE_ROOT=${SITE_ROOT:-/}
       - NON_ROOT=${NON_ROOT:-false}
       - JWT_PRIVATE_KEY=${SERVICE_PASSWORD_64_JWT}
       - SEAFILE_LOG_TO_STDOUT=${SEAFILE_LOG_TO_STDOUT:-true}
+      - 'FILE_SERVER_ROOT=${SERVICE_URL_SEAFILE}/seafhttp'
     depends_on:
       mariadb:
         condition: service_healthy
@@ -36,9 +37,9 @@ services:
         condition: service_started
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:80/api2/ping"]
-      interval: 20s
-      timeout: 5s
-      retries: 10
+      interval: 10s
+      timeout: 20s
+      retries: 5
 
   mariadb:
     image: mariadb:11
@@ -51,9 +52,9 @@ services:
       - MYSQL_DATABASE=${MYSQL_DATABASE:-seafile-db}
     healthcheck:
       test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
-      interval: 5s
+      interval: 10s
       timeout: 20s
-      retries: 10
+      retries: 5
 
   memcached:
     image: memcached:latest
@@ -64,6 +65,6 @@ services:
           "CMD-SHELL",
           'bash -c "echo version | (exec 3<>/dev/tcp/localhost/11211; cat >&3; timeout 0.5 cat <&3; exec 3<&-)"',
         ]
-      interval: 20s
-      timeout: 5s
-      retries: 10
+      interval: 10s
+      timeout: 20s
+      retries: 5


### PR DESCRIPTION
## Changes
- Set `SEAFILE_SERVER_PROTOCOL` to `https` -> Fixes mixed content error
- Set `SEAFILE_SERVER_HOSTNAME` to `SERVICE_FQDN_SEAFILE` -> Fixes invalid HTTPS URL (by default seafile adds `http` protocol so we need to set value as FQDN instead of full URL
- Added `FILE_SERVER_ROOT=${SERVICE_URL_SEAFILE}/seafhttp` -> Fixes CORS errors
- Updated Health check intervals and timeouts (to be bit more strict)

---

## Issues
- Fixes #6943

---

## Note
If you're a regular Coolify user and want to deploy this service before this PR gets merged into Coolify, just follow these steps:
1. Create a new resource in Coolify and choose `Docker Compose Empty`. 
2. It will show an input field where you can paste the Docker Compose content from this PR (I’ll include it below so you can easily copy and paste). 
3. After that, just click the deploy button and visit the URL. 


```yaml
# documentation: https://manual.seafile.com
# slogan: Open source cloud storage system for file sync, share and document collaboration
# category: storage
# tags: file-manager,file-sharing,storage
# logo: svgs/seafile.svg
# port: 80

services:
  seafile:
    image: seafileltd/seafile-mc:12.0-latest
    volumes:
      - seafile-data:/shared
    environment:
      - SERVICE_URL_SEAFILE_80
      - SEAFILE_SERVER_HOSTNAME=${SERVICE_FQDN_SEAFILE}
      - DB_HOST=mariadb
      - DB_PORT=3306
      - DB_ROOT_PASSWD=${SERVICE_PASSWORD_MYSQLROOT}
      - DB_USER=${SERVICE_USER_MYSQL}
      - DB_PASSWORD=${SERVICE_PASSWORD_MYSQL}
      - SEAFILE_MYSQL_DB_CCNET_DB_NAME=${SEAFILE_MYSQL_DB_CCNET_DB_NAME:-ccnet_db}
      - SEAFILE_MYSQL_DB_SEAFILE_DB_NAME=${SEAFILE_MYSQL_DB_SEAFILE_DB_NAME:-seafile_db}
      - SEAFILE_MYSQL_DB_SEAHUB_DB_NAME=${SEAFILE_MYSQL_DB_SEAHUB_DB_NAME:-seahub_db}
      - TIME_ZONE=${TIME_ZONE:-UTC}
      - INIT_SEAFILE_ADMIN_EMAIL=${INIT_SEAFILE_ADMIN_EMAIL:-test@example.com}
      - INIT_SEAFILE_ADMIN_PASSWORD=${SERVICE_PASSWORD_ADMIN}
      - SEAFILE_SERVER_PROTOCOL=https
      - SITE_ROOT=${SITE_ROOT:-/}
      - NON_ROOT=${NON_ROOT:-false}
      - JWT_PRIVATE_KEY=${SERVICE_PASSWORD_64_JWT}
      - SEAFILE_LOG_TO_STDOUT=${SEAFILE_LOG_TO_STDOUT:-true}
      - 'FILE_SERVER_ROOT=${SERVICE_URL_SEAFILE}/seafhttp'
    depends_on:
      mariadb:
        condition: service_healthy
      memcached:
        condition: service_started
    healthcheck:
      test: ["CMD", "curl", "-f", "http://127.0.0.1:80/api2/ping"]
      interval: 10s
      timeout: 20s
      retries: 5

  mariadb:
    image: mariadb:11
    volumes:
      - seafile_mariadb_data:/var/lib/mysql
    environment:
      - MYSQL_ROOT_PASSWORD=${SERVICE_PASSWORD_MYSQLROOT}
      - MYSQL_USER=${SERVICE_USER_MYSQL}
      - MYSQL_PASSWORD=${SERVICE_PASSWORD_MYSQL}
      - MYSQL_DATABASE=${MYSQL_DATABASE:-seafile-db}
    healthcheck:
      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
      interval: 10s
      timeout: 20s
      retries: 5

  memcached:
    image: memcached:latest
    entrypoint: memcached -m 256
    healthcheck:
      test:
        [
          "CMD-SHELL",
          'bash -c "echo version | (exec 3<>/dev/tcp/localhost/11211; cat >&3; timeout 0.5 cat <&3; exec 3<&-)"',
        ]
      interval: 10s
      timeout: 20s
      retries: 5
```