### PR TITLE
feat: add onboarding guide link to global search no results state

### DIFF
--- a/resources/views/livewire/global-search.blade.php
+++ b/resources/views/livewire/global-search.blade.php
@@ -869,6 +869,14 @@
                                     <p class="mt-2 text-xs text-neutral-400 dark:text-neutral-500">
                                         💡 Tip: Search for service names like "wordpress", "postgres", or "redis"
                                     </p>
+                                    <div class="mt-4">
+                                        <a href="{{ route('onboarding') }}" class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-coollabs dark:bg-warning hover:bg-coollabs-100 dark:hover:bg-warning/90 rounded-lg transition-colors">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+                                            </svg>
+                                            View Onboarding Guide
+                                        </a>
+                                    </div>
                                 </div>
                             </div>
                         </template>


### PR DESCRIPTION
## Summary

This PR adds a prominent onboarding guide link to the global search component's "no results found" state to help users discover documentation when they can't find what they're searching for.

## Changes

- Added a styled call-to-action button linking to the onboarding guide
- Button appears when search returns no results
- Uses existing brand colors (coollabs/warning) with proper dark mode support
- Includes a book icon to indicate it's a learning resource

## UI/UX Impact

When users search in the global search modal and get no results, they'll now see a "View Onboarding Guide" button that directs them to helpful documentation. This improves the new user experience by providing a clear next step when they're stuck.

Generated by Andras & Jean-Claude, hand-in-hand.