### PR TITLE
Fix inconsistent modal height in Edit Docker Compose dialog

### DIFF
--- a/resources/views/livewire/project/service/edit-compose.blade.php
+++ b/resources/views/livewire/project/service/edit-compose.blade.php
@@ -1,23 +1,30 @@
+<style>
+    .compose-editor-container .coolify-monaco-editor>div>div>div {
+        height: 512px !important;
+        min-height: 512px !important;
+    }
+</style>
 <div x-data="{ raw: true, showNormalTextarea: false }">
     <div class="pb-4">Volume names are updated upon save. The service UUID will be added as a prefix to all volumes, to
         prevent
         name collision. <br>To see the actual volume names, check the Deployable Compose file, or go to Storage
         menu.</div>
 
-    <div x-cloak x-show="raw" class="font-mono">
-        <div x-cloak x-show="showNormalTextarea">
-            <x-forms.textarea rows="20" id="dockerComposeRaw">
+    <div class="compose-editor-container">
+        <div x-cloak x-show="raw" class="font-mono">
+            <div x-cloak x-show="showNormalTextarea">
+                <x-forms.textarea rows="25" id="dockerComposeRaw">
+                </x-forms.textarea>
+            </div>
+            <div x-cloak x-show="!showNormalTextarea">
+                <x-forms.textarea allowTab useMonacoEditor monacoEditorLanguage="yaml" id="dockerComposeRaw">
+                </x-forms.textarea>
+            </div>
+        </div>
+        <div x-cloak x-show="raw === false" class="font-mono">
+            <x-forms.textarea rows="25" readonly id="dockerCompose">
             </x-forms.textarea>
         </div>
-        <div x-cloak x-show="!showNormalTextarea">
-            <x-forms.textarea allowTab useMonacoEditor monacoEditorLanguage="yaml" rows="20"
-                id="dockerComposeRaw">
-            </x-forms.textarea>
-        </div>
-    </div>
-    <div x-cloak x-show="raw === false" class="font-mono">
-        <x-forms.textarea rows="20" readonly id="dockerCompose">
-        </x-forms.textarea>
     </div>
     <div class="pt-2 flex gap-2">
         <div class="flex flex-col gap-2">


### PR DESCRIPTION
This PR fixes an inconsistent modal height issue in the "Edit Docker Compose" dialog. Previously, the modal would resize when switching between "Source Compose" and "Deployable Compose" views, creating a jarring UX.

---

## 🐛 Bug Fix

### Edit Docker Compose Modal Height Inconsistency
The modal height was changing dynamically when switching between views due to different rendered heights between the Monaco editor and regular textareas.

**Changes:**
- 🎨 Set fixed height (512px) for Monaco editor via scoped CSS
- 📏 Increased textarea rows to 25 to match Monaco editor height
- 🔧 Wrapped both views in a consistent container structure
- ✅ Modal now maintains the same height regardless of which view is active

**Impact:**
- Better UX when toggling between Source and Deployable compose views
- No more jarring modal resize animations
- Consistent visual experience

---

## 📈 Statistics
- **1 commit**
- **19 additions / 12 deletions**
- **1 file changed**: `resources/views/livewire/project/service/edit-compose.blade.php`

---

Generated by Andras & Jean-Claude, hand-in-hand.