### PR TITLE
fix(settings): prevent false positives in allowed IPs validation

### DIFF
--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -85,14 +85,8 @@ class Advanced extends Component
             // Handle allowed IPs with subnet support and 0.0.0.0 special case
             $this->allowed_ips = str($this->allowed_ips)->replaceEnd(',', '')->trim();
 
-            // Check if user entered 0.0.0.0 or left field empty (both allow access from anywhere)
-            $allowsFromAnywhere = false;
-            if (empty($this->allowed_ips)) {
-                $allowsFromAnywhere = true;
-            } elseif (in_array('0.0.0.0', array_map('trim', explode(',', $this->allowed_ips)))) {
-                $allowsFromAnywhere = true;
-            } else {
-                // Validate and clean up the entries
+            // Only validate and clean up if we have IPs and it's not 0.0.0.0 (allow all)
+            if (! empty($this->allowed_ips) && ! in_array('0.0.0.0', array_map('trim', explode(',', $this->allowed_ips)))) {
                 $invalidEntries = [];
                 $validEntries = str($this->allowed_ips)->trim()->explode(',')->map(function ($entry) use (&$invalidEntries) {
                     $entry = str($entry)->trim()->toString();
@@ -128,7 +122,6 @@ class Advanced extends Component
                     return;
                 }
 
-                // Also check if we have no valid entries after filtering
                 if ($validEntries->isEmpty()) {
                     $this->dispatch('error', 'No valid IP addresses or subnets provided');
 
@@ -139,14 +132,6 @@ class Advanced extends Component
             }
 
             $this->instantSave();
-
-            // Show security warning if allowing access from anywhere
-            if ($allowsFromAnywhere) {
-                $message = empty($this->allowed_ips)
-                    ? 'Empty IP allowlist allows API access from anywhere.<br><br>This is not recommended for production environments!'
-                    : 'Using 0.0.0.0 allows API access from anywhere.<br><br>This is not recommended for production environments!';
-                $this->dispatch('warning', $message);
-            }
         } catch (\Exception $e) {
             return handleError($e, $this);
         }

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -89,7 +89,7 @@ class Advanced extends Component
             $allowsFromAnywhere = false;
             if (empty($this->allowed_ips)) {
                 $allowsFromAnywhere = true;
-            } elseif ($this->allowed_ips === '0.0.0.0' || str_contains($this->allowed_ips, '0.0.0.0')) {
+            } elseif ($this->allowed_ips === '0.0.0.0' || in_array('0.0.0.0', array_map('trim', explode(',', $this->allowed_ips)))) {
                 $allowsFromAnywhere = true;
             }
 

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -89,13 +89,8 @@ class Advanced extends Component
             $allowsFromAnywhere = false;
             if (empty($this->allowed_ips)) {
                 $allowsFromAnywhere = true;
-            } elseif ($this->allowed_ips === '0.0.0.0' || in_array('0.0.0.0', array_map('trim', explode(',', $this->allowed_ips)))) {
+            } elseif (in_array('0.0.0.0', array_map('trim', explode(',', $this->allowed_ips)))) {
                 $allowsFromAnywhere = true;
-            }
-
-            // Check if it's 0.0.0.0 (allow all) or empty
-            if ($this->allowed_ips === '0.0.0.0' || empty($this->allowed_ips)) {
-                // Keep as is - empty means no restriction, 0.0.0.0 means allow all
             } else {
                 // Validate and clean up the entries
                 $invalidEntries = [];

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -46,7 +46,7 @@
                         placeholder="192.168.1.100,10.0.0.0/8,203.0.113.0/24" />
                     @if (empty($allowed_ips) || in_array('0.0.0.0', array_map('trim', explode(',', $allowed_ips ?? ''))))
                         <x-callout type="warning" title="Warning" class="mt-2">
-                            Using 0.0.0.0 allows API access from anywhere. This is not recommended for production
+                            Using 0.0.0.0 (or empty) allows API access from anywhere. This is not recommended for production
                             environments!
                         </x-callout>
                     @endif

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -1,77 +1,93 @@
 <div>
     <x-slot:title>
         Advanced Settings | Coolify
-    </x-slot>
-    <x-settings.navbar />
-    <div x-data="{ activeTab: window.location.hash ? window.location.hash.substring(1) : 'general' }" class="flex flex-col h-full gap-8 sm:flex-row">
-        <x-settings.sidebar activeMenu="advanced" />
-        <form wire:submit='submit' class="flex flex-col">
-            <div class="flex items-center gap-2">
-                <h2>Advanced</h2>
-                <x-forms.button type="submit">
-                    Save
-                </x-forms.button>
-            </div>
-            <div class="pb-4">Advanced settings for your Coolify instance.</div>
-
-            <div class="flex flex-col gap-1 md:w-96">
-                <x-forms.checkbox instantSave id="is_registration_enabled"
-                    helper="If enabled, users can register themselves. If disabled, only administrators can create new users."
-                    label="Registration Allowed" />
-                <x-forms.checkbox instantSave id="do_not_track"
-                    helper="If enabled, Coolify will not track any data. This is useful if you are concerned about privacy."
-                    label="Do Not Track" />
-                <h4 class="pt-4">DNS Settings</h4>
-                <x-forms.checkbox instantSave id="is_dns_validation_enabled"
-                    helper="If you set a custom domain, Coolify will validate the domain in your DNS provider."
-                    label="DNS Validation" />
-                <x-forms.input id="custom_dns_servers" label="Custom DNS Servers"
-                    helper="DNS servers to validate domains against. A comma separated list of DNS servers."
-                    placeholder="1.1.1.1,8.8.8.8" />
-                <h4 class="pt-4">API Settings</h4>
-                <x-forms.checkbox instantSave id="is_api_enabled" label="API Access"
-                    helper="If enabled, the API will be enabled. If disabled, the API will be disabled." />
-                <x-forms.input id="allowed_ips" label="Allowed IPs for API Access"
-                    helper="Allowed IP addresses or subnets for API access.<br>Supports single IPs (192.168.1.100) and CIDR notation (192.168.1.0/24).<br>Use comma to separate multiple entries.<br>Use 0.0.0.0 or leave empty to allow from anywhere."
-                    placeholder="192.168.1.100,10.0.0.0/8,203.0.113.0/24" />
-                <h4 class="pt-4">Confirmation Settings</h4>
-                <div class="md:w-96 pb-1">
-                    <x-forms.checkbox instantSave id="is_sponsorship_popup_enabled" label="Show Sponsorship Popup"
-                        helper="When enabled, sponsorship popups will be shown monthly to users. When disabled, the sponsorship popup will be permanently hidden for all users." />
+        </x-slot>
+        <x-settings.navbar />
+        <div x-data="{ activeTab: window.location.hash ? window.location.hash.substring(1) : 'general' }"
+            class="flex flex-col h-full gap-8 sm:flex-row">
+            <x-settings.sidebar activeMenu="advanced" />
+            <form wire:submit='submit' class="flex flex-col w-full">
+                <div class="flex items-center gap-2">
+                    <h2>Advanced</h2>
+                    <x-forms.button type="submit">
+                        Save
+                    </x-forms.button>
                 </div>
-            </div>
-            <div class="flex flex-col gap-1">
-                @if ($disable_two_step_confirmation)
-                    <div class="md:w-96 pb-4" wire:key="two-step-confirmation-enabled">
-                        <x-forms.checkbox instantSave id="disable_two_step_confirmation"
-                            label="Disable Two Step Confirmation"
-                            helper="When disabled, you will not need to confirm actions with a text and user password. This significantly reduces security and may lead to accidental deletions or unwanted changes. Use with extreme caution, especially on production servers." />
+                <div class="pb-4">Advanced settings for your Coolify instance.</div>
+
+                <div class="flex flex-col gap-1">
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_registration_enabled"
+                            helper="If enabled, users can register themselves. If disabled, only administrators can create new users."
+                            label="Registration Allowed" />
                     </div>
-                @else
-                    <div class="md:w-96 pb-4 flex items-center justify-between gap-2"
-                        wire:key="two-step-confirmation-disabled">
-                        <label class="flex items-center gap-2">
-                            Disable Two Step Confirmation
-                            <x-helper
-                                helper="When disabled, you will not need to confirm actions with a text and user password. This significantly reduces security and may lead to accidental deletions or unwanted changes. Use with extreme caution, especially on production servers.">
-                            </x-helper>
-                        </label>
-                        <x-modal-confirmation title="Disable Two Step Confirmation?" buttonTitle="Disable" isErrorButton
-                            submitAction="toggleTwoStepConfirmation" :actions="[
-                                'Two Step confirmation will be disabled globally.',
-                                'Disabling two step confirmation reduces security (as anyone can easily delete anything).',
-                                'The risk of accidental actions will increase.',
-                            ]"
-                            confirmationText="DISABLE TWO STEP CONFIRMATION"
-                            confirmationLabel="Please type the confirmation text to disable two step confirmation."
-                            shortConfirmationLabel="Confirmation text" />
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="do_not_track"
+                            helper="If enabled, Coolify will not track any data. This is useful if you are concerned about privacy."
+                            label="Do Not Track" />
                     </div>
-                    <x-callout type="danger" title="Warning!" class="mb-4">
-                        Disabling two step confirmation reduces security (as anyone can easily delete anything) and
-                        increases the risk of accidental actions. This is not recommended for production servers.
-                    </x-callout>
-                @endif
-            </div>
-        </form>
-    </div>
+                    <h4 class="pt-4">DNS Settings</h4>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_dns_validation_enabled"
+                            helper="If you set a custom domain, Coolify will validate the domain in your DNS provider."
+                            label="DNS Validation" />
+                    </div>
+
+                    <x-forms.input id="custom_dns_servers" label="Custom DNS Servers"
+                        helper="DNS servers to validate domains against. A comma separated list of DNS servers."
+                        placeholder="1.1.1.1,8.8.8.8" />
+                    <h4 class="pt-4">API Settings</h4>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_api_enabled" label="API Access"
+                            helper="If enabled, the API will be enabled. If disabled, the API will be disabled." />
+                    </div>
+                    <x-forms.input id="allowed_ips" label="Allowed IPs for API Access"
+                        helper="Allowed IP addresses or subnets for API access.<br>Supports single IPs (192.168.1.100) and CIDR notation (192.168.1.0/24).<br>Use comma to separate multiple entries.<br>Use 0.0.0.0 or leave empty to allow from anywhere."
+                        placeholder="192.168.1.100,10.0.0.0/8,203.0.113.0/24" />
+                    @if (empty($allowed_ips) || in_array('0.0.0.0', array_map('trim', explode(',', $allowed_ips ?? ''))))
+                        <x-callout type="warning" title="Warning" class="mt-2">
+                            Using 0.0.0.0 allows API access from anywhere. This is not recommended for production
+                            environments!
+                        </x-callout>
+                    @endif
+                    <h4 class="pt-4">Confirmation Settings</h4>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id=" is_sponsorship_popup_enabled" label="Show Sponsorship Popup"
+                            helper="When enabled, sponsorship popups will be shown monthly to users. When disabled, the sponsorship popup will be permanently hidden for all users." />
+                    </div>
+                </div>
+                <div class="flex flex-col gap-1">
+                    @if ($disable_two_step_confirmation)
+                        <div class="pb-4 md:w-96" wire:key="two-step-confirmation-enabled">
+                            <x-forms.checkbox instantSave id="disable_two_step_confirmation"
+                                label="Disable Two Step Confirmation"
+                                helper="When disabled, you will not need to confirm actions with a text and user password. This significantly reduces security and may lead to accidental deletions or unwanted changes. Use with extreme caution, especially on production servers." />
+                        </div>
+                    @else
+                                    <div class="pb-4 flex items-center justify-between gap-2 md:w-96"
+                                        wire:key="two-step-confirmation-disabled">
+                                        <label class="flex items-center gap-2">
+                                            Disable Two Step Confirmation
+                                            <x-helper
+                                                helper="When disabled, you will not need to confirm actions with a text and user password. This significantly reduces security and may lead to accidental deletions or unwanted changes. Use with extreme caution, especially on production servers.">
+                                            </x-helper>
+                                        </label>
+                                        <x-modal-confirmation title="Disable Two Step Confirmation?" buttonTitle="Disable" isErrorButton
+                                            submitAction="toggleTwoStepConfirmation" :actions="[
+                            'Two Step confirmation will be disabled globally.',
+                            'Disabling two step confirmation reduces security (as anyone can easily delete anything).',
+                            'The risk of accidental actions will increase.',
+                        ]"
+                                            confirmationText="DISABLE TWO STEP CONFIRMATION"
+                                            confirmationLabel="Please type the confirmation text to disable two step confirmation."
+                                            shortConfirmationLabel="Confirmation text" />
+                                    </div>
+                                    <x-callout type="danger" title="Warning!" class="mb-4">
+                                        Disabling two step confirmation reduces security (as anyone can easily delete anything) and
+                                        increases the risk of accidental actions. This is not recommended for production servers.
+                                    </x-callout>
+                    @endif
+                </div>
+            </form>
+        </div>
 </div>


### PR DESCRIPTION
## Summary
- Fixed allowed IPs validation to correctly detect `0.0.0.0` without false positives
- Removed redundant validation checks for cleaner code flow

## Problem
The previous implementation used `str_contains($this->allowed_ips, '0.0.0.0')` which incorrectly matched valid IPs like `10.0.0.0`, as the "allow all" special value, triggering false security warnings.

## Solution
- Replaced substring check with array-based approach using `in_array('0.0.0.0', array_map('trim', explode(',', $this->allowed_ips)))` to match `0.0.0.0` as a discrete entry in the comma-separated list
- Removed redundant `$this->allowed_ips === '0.0.0.0'` check since the array approach handles this case
- Removed duplicate validation block that was checking the same conditions

## Changes
- `app/Livewire/Settings/Advanced.php`: Updated `0.0.0.0` detection logic and removed redundant code

## Testing
- [ ] `0.0.0.0` correctly triggers "allow all" warning
- [ ] `1.1.1.1,0.0.0.0` correctly triggers "allow all" warning  
- [ ] `10.0.0.0` does NOT trigger false warning
- [ ] `192.168.0.0,10.0.0.0` does NOT trigger false warnin

## Issues
- [Discord from 22-10-2025 at 10:14 UTC](https://discord.com/channels/459365938081431553/1009177753230245928/1430499665387978794)
