### PR TITLE
Fix loading icon showing during automatic status checks

### DIFF
--- a/app/Livewire/Project/Application/Heading.php
+++ b/app/Livewire/Project/Application/Heading.php
@@ -58,6 +58,11 @@ class Heading extends Component
         }
     }
 
+    public function manualCheckStatus()
+    {
+        $this->checkStatus();
+    }
+
     public function force_deploy_without_cache()
     {
         $this->authorize('deploy', $this->application);

--- a/app/Livewire/Project/Database/Heading.php
+++ b/app/Livewire/Project/Database/Heading.php
@@ -62,6 +62,11 @@ class Heading extends Component
         }
     }
 
+    public function manualCheckStatus()
+    {
+        $this->checkStatus();
+    }
+
     public function mount()
     {
         $this->parameters = get_route_parameters();

--- a/app/Livewire/Project/Service/Heading.php
+++ b/app/Livewire/Project/Service/Heading.php
@@ -54,6 +54,11 @@ class Heading extends Component
         }
     }
 
+    public function manualCheckStatus()
+    {
+        $this->checkStatus();
+    }
+
     public function serviceChecked()
     {
         try {

--- a/resources/views/components/status/index.blade.php
+++ b/resources/views/components/status/index.blade.php
@@ -13,14 +13,14 @@
     <x-status.stopped :status="$resource->status" />
 @endif
 @if (!str($resource->status)->contains('exited') && $showRefreshButton)
-    <button wire:loading.remove title="Refresh Status" wire:click='checkStatus'
+    <button wire:loading.remove.delay.shortest wire:target="manualCheckStatus" title="Refresh Status" wire:click='manualCheckStatus'
         class="mx-1 dark:hover:fill-white fill-black dark:fill-warning">
         <svg class="w-4 h-4" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path
                 d="M12 2a10.016 10.016 0 0 0-7 2.877V3a1 1 0 1 0-2 0v4.5a1 1 0 0 0 1 1h4.5a1 1 0 0 0 0-2H6.218A7.98 7.98 0 0 1 20 12a1 1 0 0 0 2 0A10.012 10.012 0 0 0 12 2zm7.989 13.5h-4.5a1 1 0 0 0 0 2h2.293A7.98 7.98 0 0 1 4 12a1 1 0 0 0-2 0a9.986 9.986 0 0 0 16.989 7.133V21a1 1 0 0 0 2 0v-4.5a1 1 0 0 0-1-1z" />
         </svg>
     </button>
-    <button wire:loading title="Refreshing Status" wire:click='checkStatus'
+    <button wire:loading.delay.shortest wire:target="manualCheckStatus" title="Refreshing Status" wire:click='manualCheckStatus'
         class="mx-1 dark:hover:fill-white fill-black dark:fill-warning">
         <svg class="w-4 h-4 animate-spin" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path

--- a/resources/views/components/status/services.blade.php
+++ b/resources/views/components/status/services.blade.php
@@ -10,14 +10,14 @@
     <x-status.stopped :status="$complexStatus" />
 @endif
 @if (!str($complexStatus)->contains('exited') && $showRefreshButton)
-    <button wire:loading.remove title="Refresh Status" wire:click='checkStatus'
+    <button wire:loading.remove.delay.shortest wire:target="manualCheckStatus" title="Refresh Status" wire:click='manualCheckStatus'
         class="mx-1 dark:hover:fill-white fill-black dark:fill-warning">
         <svg class="w-4 h-4" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path
                 d="M12 2a10.016 10.016 0 0 0-7 2.877V3a1 1 0 1 0-2 0v4.5a1 1 0 0 0 1 1h4.5a1 1 0 0 0 0-2H6.218A7.98 7.98 0 0 1 20 12a1 1 0 0 0 2 0A10.012 10.012 0 0 0 12 2zm7.989 13.5h-4.5a1 1 0 0 0 0 2h2.293A7.98 7.98 0 0 1 4 12a1 1 0 0 0-2 0a9.986 9.986 0 0 0 16.989 7.133V21a1 1 0 0 0 2 0v-4.5a1 1 0 0 0-1-1z" />
         </svg>
     </button>
-    <button wire:loading title="Refreshing Status" wire:click='checkStatus'
+    <button wire:loading.delay.shortest wire:target="manualCheckStatus" title="Refreshing Status" wire:click='manualCheckStatus'
         class="mx-1 dark:hover:fill-white fill-black dark:fill-warning">
         <svg class="w-4 h-4 animate-spin" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path


### PR DESCRIPTION
This PR fixes a UX issue where the loading/refresh icon was showing during automatic background status checks, causing confusion for users who thought something was running when they didn't trigger any action.

---

## 🎯 Problem

The status refresh icon in the heading of Applications, Databases, and Services was showing a spinning animation during automatic background polling (every 10 seconds via `wire:poll.10000ms`). This happened because the `wire:loading` directive was responding to **any** Livewire action, including the automatic `checkStatus()` calls.

Users reported this was confusing, especially on first load before deployment when the status checks were running but nothing was actually deploying. It created uncertainty about whether something was stuck or accidentally running.

---

## ✅ Solution

Separated manual user-triggered status checks from automatic background polling:

### Backend Changes
- **Added `manualCheckStatus()` method** to three Livewire heading components:
  - `app/Livewire/Project/Application/Heading.php`
  - `app/Livewire/Project/Database/Heading.php`
  - `app/Livewire/Project/Service/Heading.php`
- This method simply wraps the existing `checkStatus()` call but provides a separate target for loading state

### Frontend Changes
- **Updated refresh button targeting** in status components:
  - `resources/views/components/status/index.blade.php`
  - `resources/views/components/status/services.blade.php`
- Changed `wire:click='checkStatus'` to `wire:click='manualCheckStatus'`
- Added `wire:target="manualCheckStatus"` to loading directives
- Added `wire:loading.delay.shortest` to prevent flickering on fast operations

---

## 🎨 Behavior

**Before:**
- ❌ Loading icon spins every 10 seconds during automatic polling
- ❌ Users confused about what's running
- ❌ Appears constantly on undeployed resources

**After:**
- ✅ Automatic polling (`wire:poll.10000ms="checkStatus"`) runs silently
- ✅ Loading icon **only** shows when user clicks the refresh button
- ✅ Clear visual feedback for manual actions, quiet background updates

---

## 📊 Statistics

- **1 commit** by @andrasbacsai and Claude
- **5 files changed**: +19 additions / -4 deletions
- **Components affected**: Applications, Databases, Services

---

## 🙏 Credits

Thank you to the user who reported this UX issue - your feedback makes Coolify better!

Generated by Andras & Jean-Claude, hand-in-hand.