### PR TITLE
fix: handle redis_password in API database creation

### DIFF
--- a/bootstrap/helpers/databases.php
+++ b/bootstrap/helpers/databases.php
@@ -41,7 +41,13 @@ function create_standalone_redis($environment_id, $destination_uuid, ?array $oth
     $database = new StandaloneRedis;
     $database->uuid = (new Cuid2);
     $database->name = 'redis-database-'.$database->uuid;
+
     $redis_password = \Illuminate\Support\Str::password(length: 64, symbols: false);
+    if ($otherData && isset($otherData['redis_password'])) {
+        $redis_password = $otherData['redis_password'];
+        unset($otherData['redis_password']);
+    }
+
     $database->environment_id = $environment_id;
     $database->destination_id = $destination->id;
     $database->destination_type = $destination->getMorphClass();


### PR DESCRIPTION
## 🐛 Bug Fix

This PR fixes an SQL error when creating Redis databases via the API endpoint.

### Problem

The `redis_password` column was removed from the `standalone_redis` table in October 2024 (migration `2024_10_16_120026_move_redis_password_to_envs.php`), moving password storage to the `environment_variables` table. However, the API endpoint continued to accept `redis_password` as a parameter and attempted to mass-assign it via `fill()`, causing:

```
SQLSTATE[42703]: Undefined column: 7 ERROR: column "redis_password" of relation "standalone_redis" does not exist
```

### Solution

- Extract `redis_password` from `$otherData` before calling `fill()`
- Use the provided password (or generate one) when creating the `REDIS_PASSWORD` environment variable
- Follows the same pattern as the original migration that moved passwords to environment variables

### Changes

- Modified `create_standalone_redis()` in `bootstrap/helpers/databases.php`
- Password now properly stored in `environment_variables` table instead of trying to insert into non-existent column

---

## 📈 Statistics
- **1 commit**
- **6 additions / 1 file changed**

---

Generated by Andras & Jean-Claude, hand-in-hand.