### PR TITLE
fix: make modals scrollable on small screens

### DIFF
--- a/resources/views/components/modal-confirmation.blade.php
+++ b/resources/views/components/modal-confirmation.blade.php
@@ -177,7 +177,7 @@
     @endif
     <template x-teleport="body">
         <div x-show="modalOpen"
-            class="fixed top-0 lg:pt-10 left-0 z-99 flex items-start justify-center w-screen h-screen" x-cloak>
+            class="fixed top-0 left-0 z-99 flex items-center justify-center w-screen h-screen p-4" x-cloak>
             <div x-show="modalOpen" class="absolute inset-0 w-full h-full bg-black/20 backdrop-blur-xs">
             </div>
             <div x-show="modalOpen" x-trap.inert.noscroll="modalOpen" x-transition:enter="ease-out duration-100"
@@ -186,8 +186,8 @@
                 x-transition:leave="ease-in duration-100"
                 x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
                 x-transition:leave-end="opacity-0 -translate-y-2 sm:scale-95"
-                class="relative w-full py-6 border rounded-sm min-w-full lg:min-w-[36rem] max-w-[48rem] bg-neutral-100 border-neutral-400 dark:bg-base px-7 dark:border-coolgray-300">
-                <div class="flex justify-between items-center pb-3">
+                class="relative w-full border rounded-sm min-w-full lg:min-w-[36rem] max-w-[48rem] max-h-[calc(100vh-2rem)] bg-neutral-100 border-neutral-400 dark:bg-base dark:border-coolgray-300 flex flex-col">
+                <div class="flex justify-between items-center py-6 px-7 shrink-0">
                     <h3 class="pr-8 text-2xl font-bold">{{ $title }}</h3>
                     <button @click="modalOpen = false; resetModal()"
                         class="flex absolute top-2 right-2 justify-center items-center w-8 h-8 rounded-full dark:text-white hover:bg-coolgray-300">
@@ -197,7 +197,7 @@
                         </svg>
                     </button>
                 </div>
-                <div class="relative w-auto">
+                <div class="relative w-auto overflow-y-auto px-7 pb-6" style="-webkit-overflow-scrolling: touch;">
                     @if (!empty($checkboxes))
                         <!-- Step 1: Select actions -->
                         <div x-show="step === 1">

--- a/resources/views/components/modal-input.blade.php
+++ b/resources/views/components/modal-input.blade.php
@@ -32,7 +32,7 @@
     <template x-teleport="body">
         <div x-show="modalOpen"
             x-init="$watch('modalOpen', value => { if(value) { $nextTick(() => { const firstInput = $el.querySelector('input, textarea, select'); firstInput?.focus(); }) } })"
-            class="fixed top-0 left-0 lg:px-0 px-4 z-99 flex items-center justify-center w-screen h-screen">
+            class="fixed top-0 left-0 z-99 flex items-center justify-center w-screen h-screen p-4">
             <div x-show="modalOpen" x-transition:enter="ease-out duration-100" x-transition:enter-start="opacity-0"
                 x-transition:enter-end="opacity-100" x-transition:leave="ease-in duration-100"
                 x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0"
@@ -45,8 +45,8 @@
                 x-transition:leave="ease-in duration-100"
                 x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
                 x-transition:leave-end="opacity-0 -translate-y-2 sm:scale-95"
-                class="relative w-full py-6 border rounded-sm drop-shadow-sm min-w-full lg:min-w-[{{ $minWidth }}] max-w-fit bg-white border-neutral-200 dark:bg-base px-6 dark:border-coolgray-300">
-                <div class="flex items-center justify-between pb-3">
+                class="relative w-full border rounded-sm drop-shadow-sm min-w-full lg:min-w-[{{ $minWidth }}] max-w-fit max-h-[calc(100vh-2rem)] bg-white border-neutral-200 dark:bg-base dark:border-coolgray-300 flex flex-col">
+                <div class="flex items-center justify-between py-6 px-6 shrink-0">
                     <h3 class="text-2xl font-bold">{{ $title }}</h3>
                     <button @click="modalOpen=false"
                         class="absolute top-0 right-0 flex items-center justify-center w-8 h-8 mt-5 mr-5 rounded-full dark:text-white hover:bg-neutral-100 dark:hover:bg-coolgray-300 outline-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coollabs dark:focus-visible:ring-warning focus-visible:ring-offset-2 dark:focus-visible:ring-offset-base">
@@ -56,7 +56,7 @@
                         </svg>
                     </button>
                 </div>
-                <div class="relative flex items-center justify-center w-auto">
+                <div class="relative flex items-center justify-center w-auto overflow-y-auto px-6 pb-6" style="-webkit-overflow-scrolling: touch;">
                     {{ $slot }}
                 </div>
             </div>

--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -1,7 +1,7 @@
 <dialog id="{{ $modalId }}" class="modal">
     @if ($yesOrNo)
-        <form method="dialog" class="rounded-sm modal-box" @if (!$noSubmit) wire:submit='submit' @endif>
-            <div class="flex items-start">
+        <form method="dialog" class="rounded-sm modal-box max-h-[calc(100vh-5rem)] flex flex-col" @if (!$noSubmit) wire:submit='submit' @endif>
+            <div class="flex items-start overflow-y-auto" style="-webkit-overflow-scrolling: touch;">
                 <div class="flex items-center justify-center shrink-0 w-10 h-10 mr-4 rounded-full">
                     <svg class="w-8 h-8 text-error" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
                         stroke="currentColor" aria-hidden="true">
@@ -33,7 +33,8 @@
             </div>
         </form>
     @else
-        <form method="dialog" class="flex flex-col w-11/12 max-w-5xl gap-2 rounded-sm modal-box"
+        <form method="dialog" class="flex flex-col w-11/12 max-w-5xl max-h-[calc(100vh-5rem)] gap-2 rounded-sm modal-box overflow-y-auto"
+            style="-webkit-overflow-scrolling: touch;"
             @if ($submitWireAction) wire:submit={{ $submitWireAction }} @endif
             @if (!$noSubmit && !$submitWireAction) wire:submit='submit' @endif>
             @isset($modalTitle)


### PR DESCRIPTION
## Summary
Fixes #6974 - Users cannot see buttons on confirmation modals when using small screen devices.

## Changes
This PR makes all modal components scrollable on small screen sizes by:

1. **Adding max-height constraints** - `max-h-[calc(100vh-2rem)]` prevents modals from exceeding viewport height
2. **Enabling vertical scrolling** - `overflow-y-auto` on content areas with iOS touch scrolling support
3. **Restructuring layout** - Using flexbox to separate fixed header from scrollable content
4. **Improving mobile responsiveness** - Consistent padding across all screen sizes

## Files Modified
- `resources/views/components/modal-confirmation.blade.php` - Multi-step confirmation modal
- `resources/views/components/modal-input.blade.php` - Generic input modal  
- `resources/views/components/modal.blade.php` - Base dialog modal

## Technical Details
- Modal container uses `flex flex-col` for proper layout structure
- Header/title area uses `shrink-0` to remain fixed and visible
- Content area is scrollable with proper padding distribution
- Added `-webkit-overflow-scrolling: touch` for smooth iOS scrolling
- Changed outer container alignment from `items-start` to `items-center` for better centering

## Testing
This ensures that on small devices, users can now scroll modal content to access all buttons including "Back" and "Continue" buttons that were previously hidden off-screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)