### PR TITLE
fix api - set destination_uuid when creating databases

### DIFF
--- a/app/Http/Controllers/Api/DatabasesController.php
+++ b/app/Http/Controllers/Api/DatabasesController.php
@@ -1619,6 +1619,18 @@ class DatabasesController extends Controller
             return response()->json(['message' => 'Server has multiple destinations and you do not set destination_uuid.'], 400);
         }
         $destination = $destinations->first();
+        if ($destinations->count() > 1 && $request->has('destination_uuid')) {
+            $destination = $destinations->where('uuid', $request->destination_uuid)->first();
+            if (! $destination) {
+                return response()->json([
+                    'message' => 'Validation failed.',
+                    'errors' => [
+                        'destination_uuid' => 'Provided destination_uuid does not belong to the specified server.',
+                    ],
+                ], 422);
+            }
+        }
+
         if ($request->has('public_port') && $request->is_public) {
             if (isPublicPortAlreadyUsed($server, $request->public_port)) {
                 return response()->json(['message' => 'Public port already used by another database.'], 400);


### PR DESCRIPTION
## Summary
Fix the API creating databases always on the server's first destination, even when `destination_uuid` is provided.

## Changes
- In `DatabasesController::create_database`, even when `destination_uuid` is provided, the code always selected `$destinations->first()`, causing the database to be created on the server's first destination.

## Issues
- fix #6972 
