### PR TITLE
fix: resolve Livewire wire:model binding error in domains input

### DIFF
--- a/resources/views/livewire/project/application/general.blade.php
+++ b/resources/views/livewire/project/application/general.blade.php
@@ -90,12 +90,12 @@
             @if ($application->build_pack !== 'dockercompose')
                 <div class="flex items-end gap-2">
                     @if ($application->settings->is_container_label_readonly_enabled == false)
-                        <x-forms.input placeholder="https://coolify.io" wire:model="application.fqdn"
+                        <x-forms.input placeholder="https://coolify.io" wire:model="fqdn"
                             label="Domains" readonly
                             helper="Readonly labels are disabled. You can set the domains in the labels section."
                             x-bind:disabled="!canUpdate" />
                     @else
-                        <x-forms.input placeholder="https://coolify.io" wire:model="application.fqdn"
+                        <x-forms.input placeholder="https://coolify.io" wire:model="fqdn"
                             label="Domains"
                             helper="You can specify one domain with path or more with comma. You can specify a port to bind the domain to.<br><br><span class='text-helper'>Example</span><br>- http://app.coolify.io,https://cloud.coolify.io/dashboard<br>- http://app.coolify.io/api/v3<br>- http://app.coolify.io:3000 -> app.coolify.io will point to port 3000 inside the container. "
                             x-bind:disabled="!canUpdate" />


### PR DESCRIPTION
This PR fixes a JavaScript error that occurred when typing in the domains input field on the Application General settings page.

---

## 🐛 Bug Fix

### Livewire wire:model Binding Error in Domains Input

**Issue**: When typing in the domains input field, users encountered a JavaScript error:
```
Cannot set properties of null (setting 'fqdn')
at dataSet (livewire.js)
```

**Root Cause**: The Blade view was using `wire:model="application.fqdn"` which attempted to bind directly to a nested property in Livewire's JavaScript state. However, the component uses the `SynchronizesModelData` trait with property mappings via `getModelBindings()`, not direct nested objects. This caused `application` to be `null` in the JavaScript state.

**Solution**: Changed the wire:model binding from `wire:model="application.fqdn"` to `wire:model="fqdn"` to properly use the component property, which is automatically synced with `$application->fqdn` via the `SynchronizesModelData` trait.

**Changes**:
- Updated 2 instances in `resources/views/livewire/project/application/general.blade.php` (lines 93 and 98)
- Verified no other components using `SynchronizesModelData` have similar issues

---

## 📈 Statistics
- **1 commit**
- **2 additions / 2 deletions / 1 file changed**

---

Generated by Andras & Jean-Claude, hand-in-hand.