### PR TITLE
fix: make environment variable forms responsive

### DIFF
--- a/resources/views/livewire/project/shared/environment-variable/show.blade.php
+++ b/resources/views/livewire/project/shared/environment-variable/show.blade.php
@@ -23,7 +23,7 @@
             </div>
             @can('update', $this->env)
                 <div class="flex flex-col w-full gap-3">
-                    <div class="flex w-full items-center gap-4 overflow-x-auto whitespace-nowrap">
+                    <div class="flex flex-wrap w-full items-center gap-4">
                         @if (!$is_redis_credential)
                             @if ($type === 'service')
                                 <x-forms.checkbox instantSave id="is_buildtime"
@@ -69,7 +69,7 @@
                 </div>
             @else
                 <div class="flex flex-col w-full gap-3">
-                    <div class="flex w-full items-center gap-4 overflow-x-auto whitespace-nowrap">
+                    <div class="flex flex-wrap w-full items-center gap-4">
                         @if (!$is_redis_credential)
                             @if ($type === 'service')
                                 <x-forms.checkbox disabled id="is_buildtime"
@@ -145,7 +145,7 @@
             @endcan
             @can('update', $this->env)
                 <div class="flex flex-col w-full gap-3">
-                    <div class="flex w-full items-center gap-4 overflow-x-auto whitespace-nowrap">
+                    <div class="flex flex-wrap w-full items-center gap-4">
                         @if (!$is_redis_credential)
                             @if ($type === 'service')
                                 <x-forms.checkbox instantSave id="is_buildtime"
@@ -213,7 +213,7 @@
                 </div>
             @else
                 <div class="flex flex-col w-full gap-3">
-                    <div class="flex w-full items-center gap-4 overflow-x-auto whitespace-nowrap">
+                    <div class="flex flex-wrap w-full items-center gap-4">
                         @if (!$is_redis_credential)
                             @if ($type === 'service')
                                 <x-forms.checkbox disabled id="is_buildtime"


### PR DESCRIPTION
## Summary
- Replaced horizontal scrolling with flex-wrap for checkbox containers in environment variable forms
- Checkboxes now wrap to the next line on smaller screens instead of forcing horizontal scrolling
- Improves mobile and medium-sized screen responsiveness

## Test plan
- [ ] View environment variables page on mobile/small screens - verify no horizontal scrolling
- [ ] View environment variables page on medium screens - verify checkboxes wrap properly
- [ ] Verify all checkbox functionality still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)