### PR TITLE
fix: make proxy logs page responsive

### DIFF
--- a/resources/views/livewire/project/shared/get-logs.blade.php
+++ b/resources/views/livewire/project/shared/get-logs.blade.php
@@ -46,14 +46,16 @@
                 <x-loading wire:poll.2000ms='getLogs(true)' />
             @endif
         </div>
-        <form wire:submit='getLogs(true)' class="flex flex-col gap-4 sm:flex-row sm:gap-2 sm:items-end">
+        <form wire:submit='getLogs(true)' class="flex flex-col gap-4">
             <div class="w-full sm:w-96">
                 <x-forms.input label="Only Show Number of Lines" placeholder="100" type="number" required
                     id="numberOfLines" :readonly="$streamLogs"></x-forms.input>
             </div>
-            <x-forms.button type="submit">Refresh</x-forms.button>
-            <x-forms.checkbox instantSave label="Stream Logs" id="streamLogs"></x-forms.checkbox>
-            <x-forms.checkbox instantSave label="Include Timestamps" id="showTimeStamps"></x-forms.checkbox>
+            <div class="flex flex-col gap-4 sm:flex-row sm:flex-wrap sm:gap-2 sm:items-center">
+                <x-forms.button type="submit">Refresh</x-forms.button>
+                <x-forms.checkbox instantSave label="Stream Logs" id="streamLogs"></x-forms.checkbox>
+                <x-forms.checkbox instantSave label="Include Timestamps" id="showTimeStamps"></x-forms.checkbox>
+            </div>
         </form>
         <div :class="fullscreen ? 'fullscreen' : 'relative w-full py-4 mx-auto'">
             <div class="flex overflow-y-auto flex-col-reverse px-4 py-2 w-full bg-white dark:text-white dark:bg-coolgray-100 scrollbar dark:border-coolgray-300 border-neutral-200"

--- a/resources/views/livewire/project/shared/get-logs.blade.php
+++ b/resources/views/livewire/project/shared/get-logs.blade.php
@@ -58,7 +58,7 @@
             </div>
         </form>
         <div :class="fullscreen ? 'fullscreen' : 'relative w-full py-4 mx-auto'">
-            <div class="flex overflow-y-auto overflow-x-hidden flex-col-reverse px-4 py-2 w-full bg-white dark:text-white dark:bg-coolgray-100 scrollbar dark:border-coolgray-300 border-neutral-200"
+            <div class="flex overflow-y-auto overflow-x-hidden flex-col-reverse px-4 py-2 w-full min-w-0 bg-white dark:text-white dark:bg-coolgray-100 scrollbar dark:border-coolgray-300 border-neutral-200"
                 :class="fullscreen ? '' : 'max-h-96 border border-solid rounded-sm'">
                 <div :class="fullscreen ? 'fixed top-4 right-4' : 'absolute top-6 right-0'">
                     <div class="flex justify-end gap-4" :class="fullscreen ? 'fixed' : ''"
@@ -100,9 +100,9 @@
                     </div>
                 </div>
                 @if ($outputs)
-                    <pre id="logs" class="font-mono whitespace-pre-wrap break-words overflow-wrap-anywhere">{{ $outputs }}</pre>
+                    <pre id="logs" class="font-mono whitespace-pre-wrap break-all max-w-full">{{ $outputs }}</pre>
                 @else
-                    <pre id="logs" class="font-mono whitespace-pre-wrap break-words">Refresh to get the logs...</pre>
+                    <pre id="logs" class="font-mono whitespace-pre-wrap break-all max-w-full">Refresh to get the logs...</pre>
                 @endif
             </div>
         </div>

--- a/resources/views/livewire/project/shared/get-logs.blade.php
+++ b/resources/views/livewire/project/shared/get-logs.blade.php
@@ -58,7 +58,7 @@
             </div>
         </form>
         <div :class="fullscreen ? 'fullscreen' : 'relative w-full py-4 mx-auto'">
-            <div class="flex overflow-y-auto flex-col-reverse px-4 py-2 w-full bg-white dark:text-white dark:bg-coolgray-100 scrollbar dark:border-coolgray-300 border-neutral-200"
+            <div class="flex overflow-y-auto overflow-x-hidden flex-col-reverse px-4 py-2 w-full bg-white dark:text-white dark:bg-coolgray-100 scrollbar dark:border-coolgray-300 border-neutral-200"
                 :class="fullscreen ? '' : 'max-h-96 border border-solid rounded-sm'">
                 <div :class="fullscreen ? 'fixed top-4 right-4' : 'absolute top-6 right-0'">
                     <div class="flex justify-end gap-4" :class="fullscreen ? 'fixed' : ''"
@@ -100,9 +100,9 @@
                     </div>
                 </div>
                 @if ($outputs)
-                    <pre id="logs" class="font-mono whitespace-pre-wrap">{{ $outputs }}</pre>
+                    <pre id="logs" class="font-mono whitespace-pre-wrap break-words overflow-wrap-anywhere">{{ $outputs }}</pre>
                 @else
-                    <pre id="logs" class="font-mono whitespace-pre-wrap">Refresh to get the logs...</pre>
+                    <pre id="logs" class="font-mono whitespace-pre-wrap break-words">Refresh to get the logs...</pre>
                 @endif
             </div>
         </div>

--- a/resources/views/livewire/project/shared/get-logs.blade.php
+++ b/resources/views/livewire/project/shared/get-logs.blade.php
@@ -46,8 +46,8 @@
                 <x-loading wire:poll.2000ms='getLogs(true)' />
             @endif
         </div>
-        <form wire:submit='getLogs(true)' class="flex gap-2 items-end">
-            <div class="w-96">
+        <form wire:submit='getLogs(true)' class="flex flex-col gap-4 sm:flex-row sm:gap-2 sm:items-end">
+            <div class="w-full sm:w-96">
                 <x-forms.input label="Only Show Number of Lines" placeholder="100" type="number" required
                     id="numberOfLines" :readonly="$streamLogs"></x-forms.input>
             </div>


### PR DESCRIPTION
## Summary
- Fixed proxy logs page form controls to be responsive on mobile devices
- Form now stacks vertically on mobile and displays horizontally on larger screens

## Changes
- Changed form layout from `flex` to `flex flex-col gap-4 sm:flex-row sm:gap-2 sm:items-end`
- Made input field responsive: `w-full sm:w-96` (full width on mobile, fixed width on desktop)
- Adjusted gap spacing for better mobile experience

## Test plan
- [ ] Test on mobile viewport (< 640px)
- [ ] Verify form elements stack vertically on mobile
- [ ] Test on desktop viewport (>= 640px)
- [ ] Verify form elements display horizontally on desktop
- [ ] Ensure all form controls remain functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)