### PR TITLE
fix(service): Wireguard vpn is on wrong category

### DIFF
--- a/templates/compose/wireguard-easy.yaml
+++ b/templates/compose/wireguard-easy.yaml
@@ -1,6 +1,6 @@
 # documentation: https://github.com/wg-easy/wg-easy
 # slogan: The easiest way to run WireGuard VPN + Web-based Admin UI.
-# category: vps
+# category: vpn
 # tags: wireguard,vpn,web,admin
 # logo: svgs/wireguard.svg
 # port: 8000


### PR DESCRIPTION
<img width="1473" height="908" alt="image" src="https://github.com/user-attachments/assets/5fd81033-bf62-445a-bb2f-d63607ea1f18" />

The service has to be in VPN category instead of VPS