### PR TITLE
Fix GitHub App deleting private key in use by other resources

### DIFF
--- a/app/Models/GithubApp.php
+++ b/app/Models/GithubApp.php
@@ -28,7 +28,20 @@ class GithubApp extends BaseModel
             if ($applications_count > 0) {
                 throw new \Exception('You cannot delete this GitHub App because it is in use by '.$applications_count.' application(s). Delete them first.');
             }
-            $github_app->privateKey()->delete();
+
+            $privateKey = $github_app->privateKey;
+            if ($privateKey) {
+                // Check if key is used by anything EXCEPT this GitHub app
+                $isUsedElsewhere = $privateKey->servers()->exists()
+                    || $privateKey->applications()->exists()
+                    || $privateKey->githubApps()->where('id', '!=', $github_app->id)->exists()
+                    || $privateKey->gitlabApps()->exists();
+
+                if (! $isUsedElsewhere) {
+                    $privateKey->delete();
+                } else {
+                }
+            }
         });
     }
 


### PR DESCRIPTION
When deleting GitHub apps, private keys were being deleted without checking if they were still in use by other resources (servers, apps, etc.), leading to accidental removal of important keys like the localhost private key.

## Changes
Now, we check if the key is used by other resources. If it is, only the app is deleted, leaving the key untouched. If it's only used by the app, the key is deleted as well.

## Issues
* Fixes #6555
