### PR TITLE
chore: update Nixpacks version to 1.41.0

### DIFF
--- a/docker/coolify-helper/Dockerfile
+++ b/docker/coolify-helper/Dockerfile
@@ -10,7 +10,7 @@ ARG DOCKER_BUILDX_VERSION=0.25.0
 # https://github.com/buildpacks/pack/releases
 ARG PACK_VERSION=0.38.2
 # https://github.com/railwayapp/nixpacks/releases
-ARG NIXPACKS_VERSION=1.40.0
+ARG NIXPACKS_VERSION=1.41.0
 # https://github.com/minio/mc/releases
 ARG MINIO_VERSION=RELEASE.2025-08-13T08-35-41Z
 


### PR DESCRIPTION
## Changes
- Update Nixpacks version to [1.41.0](https://github.com/railwayapp/nixpacks/releases/tag/v1.41.0) to support Node 24 (at least before we change to railpack)
