### PR TITLE
feat: custom docker entrypoint

### DIFF
--- a/tests/Feature/DockerCustomCommandsTest.php
+++ b/tests/Feature/DockerCustomCommandsTest.php
@@ -125,3 +125,52 @@ test('ConvertGpusWithQuotes', function () {
         ],
     ]);
 });
+
+test('ConvertEntrypointSimple', function () {
+    $input = '--entrypoint /bin/sh';
+    $output = convertDockerRunToCompose($input);
+    expect($output)->toBe([
+        'entrypoint' => '/bin/sh',
+    ]);
+});
+
+test('ConvertEntrypointWithEquals', function () {
+    $input = '--entrypoint=/bin/bash';
+    $output = convertDockerRunToCompose($input);
+    expect($output)->toBe([
+        'entrypoint' => '/bin/bash',
+    ]);
+});
+
+test('ConvertEntrypointWithArguments', function () {
+    $input = '--entrypoint "sh -c npm install"';
+    $output = convertDockerRunToCompose($input);
+    expect($output)->toBe([
+        'entrypoint' => 'sh -c npm install',
+    ]);
+});
+
+test('ConvertEntrypointWithSingleQuotes', function () {
+    $input = "--entrypoint 'memcached -m 256'";
+    $output = convertDockerRunToCompose($input);
+    expect($output)->toBe([
+        'entrypoint' => 'memcached -m 256',
+    ]);
+});
+
+test('ConvertEntrypointWithOtherOptions', function () {
+    $input = '--entrypoint /bin/bash --cap-add SYS_ADMIN --privileged';
+    $output = convertDockerRunToCompose($input);
+    expect($output)->toHaveKeys(['entrypoint', 'cap_add', 'privileged'])
+        ->and($output['entrypoint'])->toBe('/bin/bash')
+        ->and($output['cap_add'])->toBe(['SYS_ADMIN'])
+        ->and($output['privileged'])->toBe(true);
+});
+
+test('ConvertEntrypointComplex', function () {
+    $input = '--entrypoint "sh -c \'npm install && npm start\'"';
+    $output = convertDockerRunToCompose($input);
+    expect($output)->toBe([
+        'entrypoint' => "sh -c 'npm install && npm start'",
+    ]);
+});

--- a/tests/Feature/DockerCustomCommandsTest.php
+++ b/tests/Feature/DockerCustomCommandsTest.php
@@ -174,3 +174,27 @@ test('ConvertEntrypointComplex', function () {
         'entrypoint' => "sh -c 'npm install && npm start'",
     ]);
 });
+
+test('ConvertEntrypointWithEscapedDoubleQuotes', function () {
+    $input = '--entrypoint "python -c \"print(\'hi\')\""';
+    $output = convertDockerRunToCompose($input);
+    expect($output)->toBe([
+        'entrypoint' => "python -c \"print('hi')\"",
+    ]);
+});
+
+test('ConvertEntrypointWithEscapedSingleQuotesInDoubleQuotes', function () {
+    $input = '--entrypoint "sh -c \"echo \'hello\'\""';
+    $output = convertDockerRunToCompose($input);
+    expect($output)->toBe([
+        'entrypoint' => "sh -c \"echo 'hello'\"",
+    ]);
+});
+
+test('ConvertEntrypointSingleQuotedWithDoubleQuotesInside', function () {
+    $input = '--entrypoint \'python -c "print(\"hi\")"\'';
+    $output = convertDockerRunToCompose($input);
+    expect($output)->toBe([
+        'entrypoint' => 'python -c "print(\"hi\")"',
+    ]);
+});


### PR DESCRIPTION
## Changes
- Extended `convertDockerRunToCompose()` to parse and convert `--entrypoint` options

### Notes
- Supports simple entrypoints: `--entrypoint /bin/sh`
- Supports quoted commands: `--entrypoint "sh -c 'npm start'"`
- Supports both `--entrypoint=value` and `--entrypoint value` syntax

## Why?
Many images, such as ServerSideUp PHP offers multiple docker entrypoints for inertia, horizon, worker, scheduler, etc. Without a custom entrypoint option, we'd have to manually build the image with each entrypoint already specified.

Here's it working properly without custom image:
<img width="496" height="220" alt="image" src="https://github.com/user-attachments/assets/5abee72b-e2cb-4b78-9efd-5a60fe0cc8bb" />

## Issues
- Resolves https://github.com/coollabsio/coolify/discussions/1689


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker entrypoint options are now properly supported when converting Docker run commands to Docker Compose format, handling various quoting styles and option formats while maintaining compatibility with other Docker options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->