### PR TITLE
fix: preserve :80 in FQDN when explicitly defined (fixes #7156)

### DIFF
--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -49,20 +49,32 @@ class InstanceSettings extends Model
             }
         });
     }
-
     public function fqdn(): Attribute
-    {
-        return Attribute::make(
-            set: function ($value) {
-                if ($value) {
-                    $url = Url::fromString($value);
-                    $host = $url->getHost();
+{
+    return Attribute::make(
+        set: function ($value) {
+            if ($value) {
+                $url = Url::fromString($value);
+                $host = $url->getHost();
+                $scheme = $url->getScheme();
+                $port = $url->getPort();
 
-                    return $url->getScheme().'://'.$host;
+                // keep :80 or :443 only if explicitly defined
+                if ($port && !in_array($port, [80, 443])) {
+                    return "{$scheme}://{$host}:{$port}";
                 }
+
+                // explicitly keep :80 if user/template provided it
+                if ($port === 80 && str_contains($value, ':80')) {
+                    return "{$scheme}://{$host}:{$port}";
+                }
+
+                return "{$scheme}://{$host}";
             }
-        );
-    }
+        }
+    );
+}
+
 
     public function updateCheckFrequency(): Attribute
     {


### PR DESCRIPTION
Fixes #7156

Problem:
Templates using port 80 (like Paymenter, GitLab, and Pterodactyl) were losing the :80 part in their URLs.
Example: http://example.com:80 became http://example.com.

Reason:
The fqdn() function in InstanceSettings was removing ports, keeping only the scheme and host.

Fix:
Updated fqdn() to:
- Keep :80 if it’s explicitly defined in the input.
- Keep all custom ports (e.g. :8080).
- Skip default HTTPS :443 for clean URLs.

Tested:
✅ Paymenter on port 80 → shows example.com:80
✅ GitLab on port 80 → shows example.com:80
✅ HTTPS and custom ports still work correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed domain name configuration to properly handle custom ports and URL schemes, ensuring explicit ports are preserved when specified and standard ports are formatted correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->