### PR TITLE
fixes: default template of Redis Insight

### DIFF
--- a/templates/compose/redis-insight.yaml
+++ b/templates/compose/redis-insight.yaml
@@ -23,7 +23,7 @@ services:
         - CMD
         - wget
         - '--spider'
-        - 'http://localhost:5540'
+        - 'http://0.0.0.0:5540/api/health'
       interval: 10s
       retries: 3
       timeout: 10s


### PR DESCRIPTION
this PR refers the issue generated that , caused by untested template issue no : #7166

Redis Insight is inaccessible when installed with default configuration until manually change the test url

## Changes
- Change the test health check url for template to work

## Issues
- fix #7166
