### PR TITLE
fix(parser): prevent SERVICE_NAME with dashes from breaking env parsing

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -1112,8 +1112,8 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                         $coolifyScheme = $coolifyUrl->getScheme();
                         $coolifyFqdn = $coolifyUrl->getHost();
                         $coolifyUrl = $coolifyUrl->withScheme($coolifyScheme)->withHost($coolifyFqdn)->withPort(null);
-                        $envs->push('SERVICE_URL_'.str($forServiceName)->upper().'='.$coolifyUrl->__toString());
-                        $envs->push('SERVICE_FQDN_'.str($forServiceName)->upper().'='.$coolifyFqdn);
+                        $envs->push('SERVICE_URL_'.str($forServiceName)->replace('-', '_')->replace('.', '_')->upper().'='.$coolifyUrl->__toString());
+                        $envs->push('SERVICE_FQDN_'.str($forServiceName)->replace('-', '_')->replace('.', '_')->upper().'='.$coolifyFqdn);
                     }
                 }
 
@@ -1125,7 +1125,14 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                 }
                 $services = data_get($dockerCompose, 'services', []);
                 foreach ($services as $serviceName => $_) {
-                    $envs->push('SERVICE_NAME_'.str($serviceName)->replace('-', '_')->replace('.', '_')->upper().'='.$serviceName);
+                    $sanitizedKey = str($serviceName)->replace('-', '_')->replace('.', '_')->upper();
+                    $envKey = sprintf('SERVICE_NAME_%s', $sanitizedKey);
+
+                    if ($envs->contains(fn($env) => str($env)->startsWith(sprintf('%s=', $envKey)))) {
+                        $this->application_deployment_queue->addLogEntry("Warning: SERVICE_NAME collision detected for service '{$serviceName}' (sanitized to {$sanitizedKey})", 'warning');
+                    }
+
+                    $envs->push(sprintf('%s=%s', $envKey, $serviceName));
                 }
             }
 

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -1125,7 +1125,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                 }
                 $services = data_get($dockerCompose, 'services', []);
                 foreach ($services as $serviceName => $_) {
-                    $envs->push('SERVICE_NAME_'.str($serviceName)->upper().'='.$serviceName);
+                    $envs->push('SERVICE_NAME_'.str($serviceName)->replace('-', '_')->replace('.', '_')->upper().'='.$serviceName);
                 }
             }
 


### PR DESCRIPTION
## Changes
- In the `ApplicationDeploymentJob.php@generate_runtime_environment_variables()` the recently added `SERVICE_NAME` `.env` value can contain dashes, causing dotEnv parsers to break on deployment. In the linked issue, people are mentioning both Symfony and Bun apps breaking. Upon inspection, I saw that the service name does not take into account characters like `-` or `.` which causes the parser to break upon deployment. 

In order to fix it, I have added the replace functions in the exact way they are added in `App\Models\Service.php` for example.

## Issues
- https://github.com/coollabsio/coolify/issues/6856

**Example:**
<img width="1854" height="301" alt="image" src="https://github.com/user-attachments/assets/d4486dcd-0937-4311-a238-9474cb7bc6ce" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deployment environment variable generation to properly sanitize service names. Service names containing dashes or dots are now correctly converted to valid shell identifiers for docker-compose builds, ensuring that deployments work correctly regardless of whether service names contain these special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->