### PR TITLE
feat(proxy): upgrade Traefik image to v3.6

### DIFF
--- a/bootstrap/helpers/proxy.php
+++ b/bootstrap/helpers/proxy.php
@@ -212,7 +212,7 @@ function generateDefaultProxyConfiguration(Server $server, array $custom_command
             'services' => [
                 'traefik' => [
                     'container_name' => 'coolify-proxy',
-                    'image' => 'traefik:v3.5',
+                    'image' => 'traefik:v3.6',
                     'restart' => RESTART_MODE,
                     'extra_hosts' => [
                         'host.docker.internal:host-gateway',

--- a/config/constants.php
+++ b/config/constants.php
@@ -2,7 +2,7 @@
 
 return [
     'coolify' => [
-        'version' => '4.0.0-beta.443',
+        'version' => '4.0.0-beta.444',
         'helper_version' => '1.0.12',
         'realtime_version' => '1.0.10',
         'self_hosted' => env('SELF_HOSTED', true),

--- a/versions.json
+++ b/versions.json
@@ -1,10 +1,10 @@
 {
     "coolify": {
         "v4": {
-            "version": "4.0.0-beta.443"
+            "version": "4.0.0-beta.444"
         },
         "nightly": {
-            "version": "4.0.0-beta.444"
+            "version": "4.0.0-beta.445"
         },
         "helper": {
             "version": "1.0.11"


### PR DESCRIPTION
## Summary
Upgrade default Traefik proxy configuration from v3.5 to v3.6 with Coolify version bump to beta.444. This brings the latest Traefik improvements and fixes to the proxy layer.

🤖 Generated with Claude Code