### PR TITLE
fix(service): Ghost using invalid base url

### DIFF
--- a/templates/compose/ghost.yaml
+++ b/templates/compose/ghost.yaml
@@ -12,7 +12,7 @@ services:
       - ghost-content-data:/var/lib/ghost/content
     environment:
       - SERVICE_URL_GHOST_2368
-      - url=$SERVICE_URL_GHOST_2368
+      - url=$SERVICE_URL_GHOST
       - database__client=mysql
       - database__connection__host=mysql
       - database__connection__user=$SERVICE_USER_MYSQL


### PR DESCRIPTION
## Issue
When someone taps on ghost blog logo it redirect to a url which has port in the end like `https://domain.com:2368` which won't work.  Preview in ghost dashboard is broken as well.

Issue is found and fixed on our discord server btw:
https://discord.com/channels/459365938081431553/1438834004357812264
<img width="973" height="1398" alt="image" src="https://github.com/user-attachments/assets/d33405b5-30e0-431b-9c8f-d74b8484c746" />
