### PR TITLE
fix(service): netbird client showing wrong host details 

### DIFF
--- a/templates/compose/netbird-client.yaml
+++ b/templates/compose/netbird-client.yaml
@@ -7,6 +7,7 @@
 services:
   netbird-client:
     image: 'netbirdio/netbird:latest'
+    network_mode: host
     environment:
       - 'NB_SETUP_KEY=${NB_SETUP_KEY}'
       - 'NB_ENABLE_ROSENPASS=${NB_ENABLE_ROSENPASS:-false}'


### PR DESCRIPTION
## Issue:
Whenever the container of this app restarts it creates a new peer on the netbird management with new IP and the details about the host system is shown wrong on netbird management and it will reuse the Setup Key on every restart so it will fail to connect if the usage limit for setup key is exhausted.

This is due to the app thinking the container it runs on is the actual host system, so setting network mode to host will tell the app that it's running on the same machine as before so it solves all the issues i mentioned before