### PR TITLE
fix(service): plausible compose parsing error

### DIFF
--- a/templates/compose/plausible.yaml
+++ b/templates/compose/plausible.yaml
@@ -70,7 +70,7 @@ services:
         source: ./clickhouse/clickhouse-config.xml
         target: /etc/clickhouse-server/config.d/logging.xml
         read_only: true
-        content: "<clickhouse><logger><level>warning</level><console>true</console></logger><query_thread_log remove="remove"/><query_log remove="remove"/><text_log remove="remove"/><trace_log remove="remove"/><metric_log remove="remove"/><asynchronous_metric_log remove="remove"/><session_log remove="remove"/><part_log remove="remove"/></clickhouse>"
+        content: '<clickhouse><logger><level>warning</level><console>true</console></logger><query_thread_log remove="remove"/><query_log remove="remove"/><text_log remove="remove"/><trace_log remove="remove"/><metric_log remove="remove"/><asynchronous_metric_log remove="remove"/><session_log remove="remove"/><part_log remove="remove"/></clickhouse>'
       - type: bind
         source: ./clickhouse/clickhouse-user-config.xml
         target: /etc/clickhouse-server/users.d/logging.xml


### PR DESCRIPTION
## Issue
<img width="1200" height="751" alt="image" src="https://github.com/user-attachments/assets/07a2601d-a3a9-4284-9c8c-a14423887bea" />

The issue is nested double quotes on line 73. YAML uses double quotes for the string, but the XML inside also uses double quotes (remove="remove"), which breaks the YAML parser. So it complains about “Unexpected characters near remove”.

Used single quotes for the outer YAML string so it doesn't break the parser