### PR TITLE
feat: Add pgBackRest support for PostgreSQL backups

### DIFF
--- a/app/Http/Controllers/Api/DatabasesController.php
+++ b/app/Http/Controllers/Api/DatabasesController.php
@@ -676,7 +676,8 @@ class DatabasesController extends Controller
     )]
     public function create_backup(Request $request)
     {
-        $backupConfigFields = ['save_s3', 'enabled', 'dump_all', 'frequency', 'databases_to_backup', 'database_backup_retention_amount_locally', 'database_backup_retention_days_locally', 'database_backup_retention_max_storage_locally', 'database_backup_retention_amount_s3', 'database_backup_retention_days_s3', 'database_backup_retention_max_storage_s3', 's3_storage_uuid'];
+        $backupConfigFields = ['save_s3', 'enabled', 'dump_all', 'frequency', 'databases_to_backup', 'database_backup_retention_amount_locally', 'database_backup_retention_days_locally', 'database_backup_retention_max_storage_locally', 'database_backup_retention_amount_s3', 'database_backup_retention_days_s3', 'database_backup_retention_max_storage_s3', 's3_storage_uuid', 'backup_type', 'pgbackrest_type', 'pgbackrest_stanza', 'pgbackrest_retention_full', 'pgbackrest_retention_diff', 'pgbackrest_block_incremental', 'pgbackrest_process_max'];
+
 
         $teamId = getTeamIdFromToken();
         if (is_null($teamId)) {
@@ -703,6 +704,13 @@ class DatabasesController extends Controller
             'database_backup_retention_amount_s3' => 'integer|min:0',
             'database_backup_retention_days_s3' => 'integer|min:0',
             'database_backup_retention_max_storage_s3' => 'integer|min:0',
+            'backup_type' => 'string|in:pg_dump,pgbackrest',
+            'pgbackrest_type' => 'string|in:full,diff,incr|nullable',
+            'pgbackrest_stanza' => 'string|nullable',
+            'pgbackrest_retention_full' => 'integer|min:1|nullable',
+            'pgbackrest_retention_diff' => 'integer|min:0|nullable',
+            'pgbackrest_block_incremental' => 'boolean',
+            'pgbackrest_process_max' => 'integer|min:1|max:16|nullable',
         ]);
 
         if ($validator->fails()) {
@@ -780,6 +788,54 @@ class DatabasesController extends Controller
             }
             unset($backupData['s3_storage_uuid']);
         }
+
+        // Validate pgBackRest is only used with PostgreSQL
+        if (isset($backupData['backup_type']) && $backupData['backup_type'] === 'pgbackrest') {
+            $databaseType = $database->type();
+            $isPostgres = $databaseType === 'standalone-postgresql' || str_contains($databaseType, 'postgres');
+
+            if (! $isPostgres) {
+                return response()->json([
+                    'message' => 'Validation failed.',
+                    'errors' => ['backup_type' => ['pgBackRest backup type is only supported for PostgreSQL databases.']],
+                ], 422);
+            }
+        }
+
+        // Default to pgBackRest for PostgreSQL databases if backup_type not specified
+        if (! isset($backupData['backup_type']) || empty($backupData['backup_type'])) {
+            $databaseType = $database->type();
+            $isPostgres = $databaseType === 'standalone-postgresql' || str_contains($databaseType, 'postgres');
+
+            if ($isPostgres) {
+                $backupData['backup_type'] = 'pgbackrest';
+                // Set default pgBackRest type if not specified
+                if (! isset($backupData['pgbackrest_type'])) {
+                    $backupData['pgbackrest_type'] = 'incr';
+                }
+            } else {
+                $backupData['backup_type'] = 'pg_dump';
+            }
+        }
+
+
+        // Validate S3 connectivity for pgBackRest with S3 repository
+        if (isset($backupData['backup_type']) && $backupData['backup_type'] === 'pgbackrest' && $request->boolean('save_s3')) {
+            if (isset($backupData['s3_storage_id'])) {
+                $s3Storage = S3Storage::find($backupData['s3_storage_id']);
+                if ($s3Storage) {
+                    try {
+                        $s3Storage->testConnection(shouldSave: false);
+                    } catch (\Throwable $e) {
+                        return response()->json([
+                            'message' => 'Validation failed.',
+                            'errors' => ['s3_storage_uuid' => ['S3 connectivity test failed: '.$e->getMessage()]],
+                        ], 422);
+                    }
+                }
+            }
+        }
+
 
         // Set default databases_to_backup based on database type if not provided
         if (! isset($backupData['databases_to_backup']) || empty($backupData['databases_to_backup'])) {
@@ -896,7 +952,7 @@ class DatabasesController extends Controller
     )]
     public function update_backup(Request $request)
     {
-        $backupConfigFields = ['save_s3', 'enabled', 'dump_all', 'frequency', 'databases_to_backup', 'database_backup_retention_amount_locally', 'database_backup_retention_days_locally', 'database_backup_retention_max_storage_locally', 'database_backup_retention_amount_s3', 'database_backup_retention_days_s3', 'database_backup_retention_max_storage_s3', 's3_storage_uuid'];
+        $backupConfigFields = ['save_s3', 'enabled', 'dump_all', 'frequency', 'databases_to_backup', 'database_backup_retention_amount_locally', 'database_backup_retention_days_locally', 'database_backup_retention_max_storage_locally', 'database_backup_retention_amount_s3', 'database_backup_retention_days_s3', 'database_backup_retention_max_storage_s3', 's3_storage_uuid','backup_type', 'pgbackrest_type', 'pgbackrest_stanza', 'pgbackrest_retention_full', 'pgbackrest_retention_diff', 'pgbackrest_block_incremental', 'pgbackrest_process_max'];
 
         $teamId = getTeamIdFromToken();
         if (is_null($teamId)) {
@@ -1007,6 +1063,160 @@ class DatabasesController extends Controller
 
         return response()->json([
             'message' => 'Database backup configuration updated',
+        ]);
+    }
+
+
+    #[OA\Post(
+        summary: 'Restore Database',
+        description: 'Restore a database from a specific backup execution',
+        path: '/databases/{uuid}/backups/{scheduled_backup_uuid}/restore/{execution_uuid}',
+        operationId: 'restore-database-backup',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Databases'],
+        parameters: [
+            new OA\Parameter(
+                name: 'uuid',
+                in: 'path',
+                description: 'UUID of the database.',
+                required: true,
+                schema: new OA\Schema(
+                    type: 'string',
+                    format: 'uuid',
+                )
+            ),
+            new OA\Parameter(
+                name: 'scheduled_backup_uuid',
+                in: 'path',
+                description: 'UUID of the backup configuration.',
+                required: true,
+                schema: new OA\Schema(
+                    type: 'string',
+                    format: 'uuid',
+                )
+            ),
+            new OA\Parameter(
+                name: 'execution_uuid',
+                in: 'path',
+                description: 'UUID of the backup execution to restore from.',
+                required: true,
+                schema: new OA\Schema(
+                    type: 'string',
+                    format: 'uuid',
+                )
+            ),
+        ],
+        requestBody: new OA\RequestBody(
+            description: 'Restore options',
+            required: false,
+            content: new OA\MediaType(
+                mediaType: 'application/json',
+                schema: new OA\Schema(
+                    type: 'object',
+                    properties: [
+                        'target_database' => ['type' => 'string', 'description' => 'Target database name (optional, defaults to original database)'],
+                    ],
+                )
+            )
+        ),
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Restore initiated successfully',
+            ),
+            new OA\Response(
+                response: 400,
+                ref: '#/components/responses/400',
+            ),
+            new OA\Response(
+                response: 401,
+                ref: '#/components/responses/401',
+            ),
+            new OA\Response(
+                response: 404,
+                ref: '#/components/responses/404',
+            ),
+        ]
+    )]
+    public function restore_backup(Request $request)
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+
+        $return = validateIncomingRequest($request);
+        if ($return instanceof \Illuminate\Http\JsonResponse) {
+            return $return;
+        }
+
+        $validator = customApiValidator($request->all(), [
+            'target_database' => 'string|nullable',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'message' => 'Validation failed.',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        if (! $request->uuid) {
+            return response()->json(['message' => 'Database UUID is required.'], 404);
+        }
+
+        if (! $request->scheduled_backup_uuid) {
+            return response()->json(['message' => 'Backup configuration UUID is required.'], 404);
+        }
+
+        if (! $request->execution_uuid) {
+            return response()->json(['message' => 'Backup execution UUID is required.'], 404);
+        }
+
+        $database = queryDatabaseByUuidWithinTeam($request->uuid, $teamId);
+        if (! $database) {
+            return response()->json(['message' => 'Database not found.'], 404);
+        }
+
+        $this->authorize('update', $database);
+
+        $backupConfig = ScheduledDatabaseBackup::ownedByCurrentTeamAPI($teamId)
+            ->where('database_id', $database->id)
+            ->where('uuid', $request->scheduled_backup_uuid)
+            ->first();
+
+        if (! $backupConfig) {
+            return response()->json(['message' => 'Backup configuration not found.'], 404);
+        }
+
+        $backupExecution = ScheduledDatabaseBackupExecution::where('scheduled_database_backup_id', $backupConfig->id)
+            ->where('uuid', $request->execution_uuid)
+            ->where('status', 'success')
+            ->first();
+
+        if (! $backupExecution) {
+            return response()->json(['message' => 'Backup execution not found or backup was not successful.'], 404);
+        }
+
+        $databaseType = $database->type();
+        $isPostgres = $databaseType === 'standalone-postgresql' || str_contains($databaseType, 'postgres');
+
+        if (! $isPostgres) {
+            return response()->json([
+                'message' => 'Restore is currently only supported for PostgreSQL databases.',
+            ], 422);
+        }
+
+        dispatch(new \App\Jobs\DatabaseRestoreJob(
+            $backupConfig,
+            $backupExecution,
+            $request->input('target_database')
+        ));
+
+        return response()->json([
+            'message' => 'Database restore initiated successfully. You will be notified when it completes.',
         ]);
     }
 
@@ -2274,6 +2484,15 @@ class DatabasesController extends Controller
                 $execution->delete();
             }
 
+            // Clean up pgBackRest stanza if using pgBackRest
+            if ($backup->isPgBackRest()) {
+                try {
+                    $this->cleanup_pgbackrest_stanza($backup, $database);
+                } catch (\Throwable $e) {
+                    \Log::warning('Failed to clean up pgBackRest stanza: '.$e->getMessage());
+                }
+            }
+
             // Delete the backup configuration itself
             $backup->delete();
             DB::commit();
@@ -2286,6 +2505,39 @@ class DatabasesController extends Controller
 
             return response()->json(['message' => 'Failed to delete backup: '.$e->getMessage()], 500);
         }
+
+        private function cleanup_pgbackrest_stanza($backup, $database): void
+    {
+        $stanzaName = $backup->getStanzaName();
+        $pgbackrestImage = 'woblerr/pgbackrest:2.48';
+
+        if (data_get($backup, 'database_type') === \App\Models\ServiceDatabase::class) {
+            $server = $database->service->destination->server;
+        } else {
+            $server = $database->destination->server;
+        }
+
+        $databaseName = str($database->name)->slug()->value();
+        $containerName = $database->uuid;
+        $directoryName = $databaseName.'-'.$containerName;
+        $team = Team::find($backup->team_id);
+        $backupDir = backup_dir().'/databases/'.str($team->name)->slug().'-'.$team->id.'/'.$directoryName;
+
+        $pgbackrestConfigDir = escapeshellarg($backupDir.'/.pgbackrest');
+        $configPath = trim($pgbackrestConfigDir, "'").'/'.'pgbackrest.conf';
+        $quotedConfigPath = escapeshellarg($configPath);
+        $quotedStanzaName = escapeshellarg($stanzaName);
+        $quotedBackupDir = escapeshellarg($backupDir);
+
+        $stanzaDeleteCommand = "docker run --rm ";
+        $stanzaDeleteCommand .= "-v $quotedConfigPath:/etc/pgbackrest/pgbackrest.conf:ro ";
+        $stanzaDeleteCommand .= "-v $quotedBackupDir:/var/lib/pgbackrest:rw ";
+        $stanzaDeleteCommand .= "$pgbackrestImage ";
+        $stanzaDeleteCommand .= "pgbackrest stanza-delete --stanza=$quotedStanzaName --log-level-console=info";
+
+        instant_remote_process([$stanzaDeleteCommand], $server, false);
+
+        deleteBackupsLocally("$backupDir/.pgbackrest", $server);
     }
 
     #[OA\Delete(

--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -307,10 +307,19 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
 
                 // Step 1: Create local backup
                 try {
+                    $backupResult = ['uses_native_s3' => false, 'backup_size' => 0, 's3_uploaded' => false];
+
                     if (str($databaseType)->contains('postgres')) {
-                        $this->backup_file = "/pg-dump-$database-".Carbon::now()->timestamp.'.dmp';
-                        if ($this->backup->dump_all) {
-                            $this->backup_file = '/pg-dump-all-'.Carbon::now()->timestamp.'.gz';
+                        // For pgBackRest, use repository directory instead of single file
+                        if ($this->backup->isPgBackRest()) {
+                            $stanzaName = $this->backup->getStanzaName();
+                            $backupType = $this->backup->getPgBackRestType();
+                            $this->backup_file = "/.pgbackrest/stanza-$stanzaName-$backupType-".Carbon::now()->timestamp;
+                        } else {
+                            $this->backup_file = "/pg-dump-$database-".Carbon::now()->timestamp.'.dmp';
+                            if ($this->backup->dump_all) {
+                                $this->backup_file = '/pg-dump-all-'.Carbon::now()->timestamp.'.gz';
+                            }
                         }
                         $this->backup_location = $this->backup_dir.$this->backup_file;
                         $this->backup_log = ScheduledDatabaseBackupExecution::create([
@@ -320,7 +329,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                             'scheduled_database_backup_id' => $this->backup->id,
                             'local_storage_deleted' => false,
                         ]);
-                        $this->backup_standalone_postgresql($database);
+                        $backupResult = $this->backup_standalone_postgresql($database);
                     } elseif (str($databaseType)->contains('mongo')) {
                         if ($database === '*') {
                             $database = 'all';
@@ -374,13 +383,21 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                         throw new \Exception('Unsupported database type');
                     }
 
-                    $size = $this->calculate_size();
-
-                    // Verify local backup succeeded
-                    if ($size > 0) {
+                    // For pgBackRest with native S3, use size from backup info
+                    if ($backupResult['uses_native_s3'] && $backupResult['backup_size'] > 0) {
+                        $size = $backupResult['backup_size'];
+                        $this->s3_uploaded = true;
                         $localBackupSucceeded = true;
                     } else {
-                        throw new \Exception('Local backup file is empty or was not created');
+                        // Standard backup or pgBackRest with local repository
+                        $size = $this->calculate_size();
+
+                        // Verify local backup succeeded
+                        if ($size > 0) {
+                            $localBackupSucceeded = true;
+                        } else {
+                            throw new \Exception('Local backup file is empty or was not created');
+                        }
                     }
                 } catch (\Throwable $e) {
                     // Local backup failed
@@ -400,7 +417,8 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
 
                 // Step 2: Upload to S3 if enabled (independent of local backup)
                 $localStorageDeleted = false;
-                if ($this->backup->save_s3 && $localBackupSucceeded) {
+                if ($this->backup->save_s3 && $localBackupSucceeded && !$backupResult['uses_native_s3']) {
+                    // Only upload manually if not using pgBackRest native S3
                     try {
                         $this->upload_to_s3();
 
@@ -413,6 +431,9 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                         // S3 upload failed but local backup succeeded
                         $s3UploadError = $e->getMessage();
                     }
+                } elseif ($backupResult['uses_native_s3']) {
+                    // pgBackRest native S3 - backup is already in S3, mark as uploaded
+                    $this->s3_uploaded = true;
                 }
 
                 // Step 3: Update status and send notifications based on results
@@ -514,9 +535,14 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
         }
     }
 
-    private function backup_standalone_postgresql(string $database): void
+    private function backup_standalone_postgresql(string $database): array
     {
         try {
+            // Check if pgBackRest is enabled for this backup
+            if ($this->backup->isPgBackRest()) {
+                return $this->backup_pgbackrest_postgresql($database);
+            }
+
             $commands[] = 'mkdir -p '.$this->backup_dir;
             $backupCommand = 'docker exec';
             if ($this->postgres_password) {
@@ -529,6 +555,205 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
 
             $commands[] = $backupCommand;
+            $this->backup_output = instant_remote_process($commands, $this->server);
+            $this->backup_output = trim($this->backup_output);
+            if ($this->backup_output === '') {
+                $this->backup_output = null;
+            }
+
+            return ['uses_native_s3' => false];
+
+        } catch (\Throwable $e) {
+            $this->add_to_error_output($e->getMessage());
+            throw $e;
+        }
+    }
+
+     private function backup_pgbackrest_postgresql(string $database): array
+    {
+        try {
+            $commands = [];
+            $stanzaName = $this->backup->getStanzaName();
+            $backupType = $this->backup->getPgBackRestType();
+            $processMax = $this->backup->pgbackrest_process_max ?? 1;
+            $usesNativeS3 = $this->s3 !== null;
+
+            // Use versioned pgBackRest image for stability
+            $pgbackrestImage = 'woblerr/pgbackrest:2.48';
+
+            // Create pgBackRest configuration directory
+            $pgbackrestConfigDir = escapeshellarg($this->backup_dir.'/.pgbackrest');
+            $commands[] = "mkdir -p $pgbackrestConfigDir";
+
+            // Generate pgBackRest configuration
+            $config = $this->generate_pgbackrest_config($stanzaName, $database);
+            $configPath = trim($pgbackrestConfigDir, "'").'/'.'pgbackrest.conf';
+            $quotedConfigPath = escapeshellarg($configPath);
+
+            // Write config file to server (safely using base64)
+            $escapedConfig = base64_encode($config);
+            $commands[] = "echo ".escapeshellarg($escapedConfig)." | base64 -d > $quotedConfigPath";
+
+            // Get PostgreSQL container's data directory
+            $containerName = escapeshellarg($this->container_name);
+            $pgDataDir = instant_remote_process(["docker inspect $containerName --format='{{range .Mounts}}{{if eq .Destination \"/var/lib/postgresql/data\"}}{{.Source}}{{end}}{{end}}'"], $this->server, false);
+            $pgDataDir = trim($pgDataDir);
+
+            if (empty($pgDataDir)) {
+                throw new \Exception('Could not determine PostgreSQL data directory');
+            }
+
+            $quotedPgDataDir = escapeshellarg($pgDataDir);
+            $quotedBackupDir = escapeshellarg($this->backup_dir);
+            $quotedStanzaName = escapeshellarg($stanzaName);
+            $quotedBackupType = escapeshellarg($backupType);
+
+            // S3 credentials are now safely stored in the config file (generate_pgbackrest_config)            
+
+            // Check if stanza exists, create if not
+            $stanzaCheckCommand = "docker run --rm ";
+            $stanzaCheckCommand .= "-v $quotedConfigPath:/etc/pgbackrest/pgbackrest.conf:ro ";
+            $stanzaCheckCommand .= "-v $quotedPgDataDir:/var/lib/postgresql/data:ro ";
+            if ($this->s3) {
+                $stanzaCheckCommand .= "-v $quotedBackupDir:/var/lib/pgbackrest:ro ";
+            } else {
+                $stanzaCheckCommand .= "-v $quotedBackupDir:/var/lib/pgbackrest:rw ";
+            }
+            $stanzaCheckCommand .= "$pgbackrestImage pgbackrest info --stanza=$quotedStanzaName 2>&1";
+
+            $stanzaInfo = instant_remote_process([$stanzaCheckCommand], $this->server, false);
+
+            if (str_contains($stanzaInfo, 'does not exist') || str_contains($stanzaInfo, 'unable to find')) {
+                // Initialize stanza
+                $this->add_to_backup_output("Initializing pgBackRest stanza: $stanzaName");
+
+                $stanzaCreateCommand = "docker run --rm ";
+                $stanzaCreateCommand .= "-v $quotedConfigPath:/etc/pgbackrest/pgbackrest.conf:ro ";
+                $stanzaCreateCommand .= "-v $quotedPgDataDir:/var/lib/postgresql/data:rw ";
+                $stanzaCreateCommand .= "-v $quotedBackupDir:/var/lib/pgbackrest:rw ";
+                $stanzaCreateCommand .= "$pgbackrestImage ";
+                $stanzaCreateCommand .= "pgbackrest stanza-create --stanza=$quotedStanzaName --log-level-console=info";
+
+                $commands[] = $stanzaCreateCommand;
+                $stanzaOutput = instant_remote_process([$stanzaCreateCommand], $this->server);
+                $this->add_to_backup_output($stanzaOutput);
+            }
+
+            // Perform backup
+            $this->add_to_backup_output("Starting pgBackRest $backupType backup for stanza: $stanzaName");
+
+            $backupCommand = "docker run --rm ";
+            $backupCommand .= "-v $quotedConfigPath:/etc/pgbackrest/pgbackrest.conf:ro ";
+            $backupCommand .= "-v $quotedPgDataDir:/var/lib/postgresql/data:rw ";
+            $backupCommand .= "-v $quotedBackupDir:/var/lib/pgbackrest:rw ";
+            $backupCommand .= "$pgbackrestImage ";
+            $backupCommand .= "pgbackrest backup --stanza=$quotedStanzaName --type=$quotedBackupType ";
+            $backupCommand .= '--process-max='.escapeshellarg((string) $processMax).' --log-level-console=info';
+
+            $commands[] = $backupCommand;
+            $backupOutput = instant_remote_process($commands, $this->server);
+            $this->add_to_backup_output($backupOutput);
+
+            // Get backup info to verify success
+            $infoCommand = "docker run --rm ";
+            $infoCommand .= "-v $quotedConfigPath:/etc/pgbackrest/pgbackrest.conf:ro ";
+            $infoCommand .= "-v $quotedBackupDir:/var/lib/pgbackrest:ro ";
+            $infoCommand .= "$pgbackrestImage pgbackrest info --stanza=$quotedStanzaName --output=json";
+
+            $infoOutput = instant_remote_process([$infoCommand], $this->server, false);
+
+            // Store backup info in output
+            $this->add_to_backup_output("\n=== Backup Info ===\n".$infoOutput);
+
+            // Extract backup size from info JSON
+            $backupSize = 0;
+            try {
+                $infoData = json_decode($infoOutput, true);
+                if (isset($infoData[0]['backup']) && is_array($infoData[0]['backup'])) {
+                    $lastBackup = end($infoData[0]['backup']);
+                    if (isset($lastBackup['info']['size'])) {
+                        $backupSize = $lastBackup['info']['size'];
+                    }
+                }
+            } catch (\Throwable $e) {
+                // Failed to parse JSON, size will remain 0
+                $this->add_to_backup_output("\nWarning: Could not extract backup size from info output");
+            }
+
+            $this->backup_output = trim($this->backup_output);
+            if ($this->backup_output === '') {
+                $this->backup_output = null;
+            }
+
+            return [
+                'uses_native_s3' => $usesNativeS3,
+                'backup_size' => $backupSize,
+                's3_uploaded' => $usesNativeS3,
+            ];
+        } catch (\Throwable $e) {
+            $this->add_to_error_output($e->getMessage());
+            throw $e;
+        }
+    }
+
+    private function generate_pgbackrest_config(string $stanzaName, string $database): string
+    {
+        $config = "[global]\n";
+        $config .= "log-level-console=info\n";
+        $config .= "log-level-file=info\n";
+        $config .= "process-max={$this->backup->pgbackrest_process_max}\n";
+
+        // Retention settings
+        if ($this->backup->pgbackrest_retention_full) {
+            $config .= "repo1-retention-full={$this->backup->pgbackrest_retention_full}\n";
+        }
+
+        if ($this->backup->pgbackrest_retention_diff) {
+            $config .= "repo1-retention-diff={$this->backup->pgbackrest_retention_diff}\n";
+        }
+
+        // Repository configuration
+        if ($this->s3) {
+            // S3 repository with credentials in config file (secure)
+            $config .= "repo1-type=s3\n";
+            $config .= "repo1-s3-bucket={$this->s3->bucket}\n";
+            $config .= "repo1-s3-endpoint={$this->s3->endpoint}\n";
+            $config .= "repo1-s3-region={$this->s3->region}\n";
+            $config .= "repo1-path=/pgbackrest/{$stanzaName}\n";
+
+            // Store credentials directly in config file (more secure than env vars)
+            $config .= "repo1-s3-key={$this->s3->key}\n";
+            $config .= "repo1-s3-key-secret={$this->s3->secret}\n";
+        } else {
+            // Local repository
+            $config .= "repo1-path=/var/lib/pgbackrest\n";
+        }
+
+        // Block incremental backup (if enabled and supported)
+        if ($this->backup->pgbackrest_block_incremental) {
+            $config .= "repo1-block=y\n";
+        }
+
+        // Stanza configuration
+        $config .= "\n[{$stanzaName}]\n";
+        $config .= "pg1-path=/var/lib/postgresql/data\n";
+
+        if ($this->postgres_password) {
+            $config .= "pg1-port=5432\n";
+        }
+
+        return $config;
+    }
+
+    private function backup_standalone_mysql(string $database): void
+    {
+        try {
+            $commands[] = 'mkdir -p '.$this->backup_dir;
+            if ($this->backup->dump_all) {
+                $commands[] = "docker exec $this->container_name mysqldump -u root -p\"{$this->database->mysql_root_password}\" --all-databases --single-transaction --quick --lock-tables=false --compress | gzip > $this->backup_location";
+            } else {
+                $commands[] = "docker exec $this->container_name mysqldump -u root -p\"{$this->database->mysql_root_password}\" $database > $this->backup_location";
+            }
             $this->backup_output = instant_remote_process($commands, $this->server);
             $this->backup_output = trim($this->backup_output);
             if ($this->backup_output === '') {

--- a/app/Jobs/DatabaseRestoreJob.php
+++ b/app/Jobs/DatabaseRestoreJob.php
@@ -1,0 +1,294 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\S3Storage;
+use App\Models\ScheduledDatabaseBackup;
+use App\Models\ScheduledDatabaseBackupExecution;
+use App\Models\Server;
+use App\Models\ServiceDatabase;
+use App\Models\StandaloneMariadb;
+use App\Models\StandaloneMongodb;
+use App\Models\StandaloneMysql;
+use App\Models\StandalonePostgresql;
+use App\Models\Team;
+use App\Notifications\Database\RestoreFailed;
+use App\Notifications\Database\RestoreSuccess;
+use Carbon\Carbon;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeEncrypted;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Str;
+
+class DatabaseRestoreJob implements ShouldBeEncrypted, ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public $timeout = 3600;
+
+    public $maxExceptions = 1;
+
+    public ?Team $team = null;
+
+    public Server $server;
+
+    public StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|ServiceDatabase $database;
+
+    public ?string $container_name = null;
+
+    public ?string $restore_output = null;
+
+    public ?string $error_output = null;
+
+    public ?S3Storage $s3 = null;
+
+    public ?string $postgres_password = null;
+
+    public ?string $mongo_root_username = null;
+
+    public ?string $mongo_root_password = null;
+
+    public bool $s3_uploaded = false;
+
+    public string $backup_log_uuid;
+
+    public function __construct(
+        public ScheduledDatabaseBackup $backup,
+        public ScheduledDatabaseBackupExecution $backupExecution,
+        public ?string $targetDatabase = null
+    ) {
+        $this->team = Team::find($backup->team_id);
+    }
+
+    public function handle(): void
+    {
+        try {
+            $this->restore_output = "Starting database restore...\n";
+
+            $this->database = $this->backup->database;
+            if (is_null($this->database)) {
+                throw new \Exception('Database not found');
+            }
+
+            if (data_get($this->backup, 'database_type') === ServiceDatabase::class) {
+                $this->server = $this->database->service->destination->server;
+            } else {
+                $this->server = $this->database->destination->server;
+            }
+
+            if ($this->backup->save_s3) {
+                $this->s3 = $this->backup->s3;
+            }
+
+            $databaseType = $this->database->type();
+
+            if (str($databaseType)->contains('postgres')) {
+                $this->postgres_password = $this->database->postgres_password;
+                $databaseName = str($this->database->name)->slug()->value();
+                $this->container_name = $this->database->uuid;
+
+                if ($this->backup->isPgBackRest()) {
+                    $this->restore_pgbackrest_postgresql();
+                } else {
+                    $this->restore_pg_dump_postgresql();
+                }
+
+                $this->team?->notify(new RestoreSuccess($this->backup, $this->database, $this->backupExecution));
+            } else {
+                throw new \Exception('Restore is currently only supported for PostgreSQL databases');
+            }
+        } catch (\Throwable $e) {
+            $this->add_to_error_output($e->getMessage());
+            $this->team?->notify(new RestoreFailed($this->backup, $this->database, $this->error_output ?? $this->restore_output ?? $e->getMessage()));
+            throw $e;
+        }
+    }
+
+    private function restore_pgbackrest_postgresql(): void
+    {
+        try {
+            $commands = [];
+            $stanzaName = $this->backup->getStanzaName();
+            $processMax = $this->backup->pgbackrest_process_max ?? 1;
+            $pgbackrestImage = 'woblerr/pgbackrest:2.48';
+
+            $databaseName = str($this->database->name)->slug()->value();
+            $this->directory_name = $databaseName.'-'.$this->container_name;
+            $backup_dir = backup_dir().'/databases/'.str($this->team->name)->slug().'-'.$this->team->id.'/'.$this->directory_name;
+
+            $pgbackrestConfigDir = escapeshellarg($backup_dir.'/.pgbackrest');
+            $config = $this->generate_pgbackrest_config($stanzaName);
+            $configPath = trim($pgbackrestConfigDir, "'").'/'.'pgbackrest.conf';
+            $quotedConfigPath = escapeshellarg($configPath);
+
+            $escapedConfig = base64_encode($config);
+            $commands[] = "echo ".escapeshellarg($escapedConfig)." | base64 -d > $quotedConfigPath";
+
+            $containerName = escapeshellarg($this->container_name);
+            $pgDataDir = instant_remote_process(["docker inspect $containerName --format='{{range .Mounts}}{{if eq .Destination \"/var/lib/postgresql/data\"}}{{.Source}}{{end}}{{end}}'"], $this->server, false);
+            $pgDataDir = trim($pgDataDir);
+
+            if (empty($pgDataDir)) {
+                throw new \Exception('Could not determine PostgreSQL data directory');
+            }
+
+            $quotedPgDataDir = escapeshellarg($pgDataDir);
+            $quotedBackupDir = escapeshellarg($backup_dir);
+            $quotedStanzaName = escapeshellarg($stanzaName);
+
+            $this->add_to_restore_output("Stopping PostgreSQL container for restore...");
+            $commands[] = "docker stop $containerName";
+            instant_remote_process($commands, $this->server);
+            $commands = [];
+
+            $this->add_to_restore_output("Restoring database from pgBackRest backup...");
+
+            $restoreCommand = "docker run --rm ";
+            $restoreCommand .= "-v $quotedConfigPath:/etc/pgbackrest/pgbackrest.conf:ro ";
+            $restoreCommand .= "-v $quotedPgDataDir:/var/lib/postgresql/data:rw ";
+            if ($this->s3) {
+                $restoreCommand .= "-v $quotedBackupDir:/var/lib/pgbackrest:ro ";
+            } else {
+                $restoreCommand .= "-v $quotedBackupDir:/var/lib/pgbackrest:rw ";
+            }
+            $restoreCommand .= "$pgbackrestImage ";
+            $restoreCommand .= "pgbackrest restore --stanza=$quotedStanzaName ";
+            $restoreCommand .= '--process-max='.escapeshellarg((string) $processMax).' ';
+            $restoreCommand .= '--delta --log-level-console=info';
+
+            $commands[] = $restoreCommand;
+            $restoreOutput = instant_remote_process($commands, $this->server);
+            $this->add_to_restore_output($restoreOutput);
+            $commands = [];
+
+            $this->add_to_restore_output("Starting PostgreSQL container after restore...");
+            $commands[] = "docker start $containerName";
+            instant_remote_process($commands, $this->server);
+
+            $this->add_to_restore_output("Waiting for PostgreSQL to be ready...");
+            sleep(5);
+
+            $this->add_to_restore_output("Database restore completed successfully");
+
+            $this->restore_output = trim($this->restore_output);
+            if ($this->restore_output === '') {
+                $this->restore_output = null;
+            }
+        } catch (\Throwable $e) {
+            $startCommand = "docker start ".escapeshellarg($this->container_name);
+            instant_remote_process([$startCommand], $this->server, false);
+
+            $this->add_to_error_output($e->getMessage());
+            throw $e;
+        }
+    }
+
+    private function restore_pg_dump_postgresql(): void
+    {
+        try {
+            $backupFile = $this->backupExecution->filename;
+
+            if (empty($backupFile)) {
+                throw new \Exception('Backup file not found in execution record');
+            }
+
+            $this->add_to_restore_output("Checking if backup file exists: $backupFile");
+
+            $checkCommand = "[ -f ".escapeshellarg($backupFile)." ] && echo 'exists' || echo 'missing'";
+            $fileCheck = instant_remote_process([$checkCommand], $this->server, false);
+
+            if (! str_contains($fileCheck, 'exists')) {
+                throw new \Exception('Backup file does not exist on server: '.$backupFile);
+            }
+
+            $targetDb = $this->targetDatabase ?? $this->database->postgres_db;
+            $this->add_to_restore_output("Restoring database: $targetDb from pg_dump backup");
+
+            $restoreCommand = 'docker exec';
+            if ($this->postgres_password) {
+                $restoreCommand .= " -e PGPASSWORD=\"{$this->postgres_password}\"";
+            }
+
+            if (str_contains($backupFile, 'pg-dump-all')) {
+                $restoreCommand .= " -i {$this->container_name} psql --username {$this->database->postgres_user} < $backupFile";
+            } else {
+                $restoreCommand .= " -i {$this->container_name} pg_restore --username {$this->database->postgres_user} --dbname=$targetDb --clean --if-exists --no-owner --no-acl < $backupFile";
+            }
+
+            $commands[] = $restoreCommand;
+            $this->restore_output = instant_remote_process($commands, $this->server);
+
+            $this->add_to_restore_output("Database restore completed successfully");
+
+            $this->restore_output = trim($this->restore_output);
+            if ($this->restore_output === '') {
+                $this->restore_output = null;
+            }
+        } catch (\Throwable $e) {
+            $this->add_to_error_output($e->getMessage());
+            throw $e;
+        }
+    }
+
+    private function generate_pgbackrest_config(string $stanzaName): string
+    {
+        $config = "[global]\n";
+        $config .= "log-level-console=info\n";
+        $config .= "log-level-file=info\n";
+        $config .= "process-max={$this->backup->pgbackrest_process_max}\n";
+
+        if ($this->backup->pgbackrest_retention_full) {
+            $config .= "repo1-retention-full={$this->backup->pgbackrest_retention_full}\n";
+        }
+
+        if ($this->backup->pgbackrest_retention_diff) {
+            $config .= "repo1-retention-diff={$this->backup->pgbackrest_retention_diff}\n";
+        }
+
+        if ($this->s3) {
+            $config .= "repo1-type=s3\n";
+            $config .= "repo1-s3-bucket={$this->s3->bucket}\n";
+            $config .= "repo1-s3-endpoint={$this->s3->endpoint}\n";
+            $config .= "repo1-s3-region={$this->s3->region}\n";
+            $config .= "repo1-path=/pgbackrest/{$stanzaName}\n";
+            $config .= "repo1-s3-key={$this->s3->key}\n";
+            $config .= "repo1-s3-key-secret={$this->s3->secret}\n";
+        } else {
+            $config .= "repo1-path=/var/lib/pgbackrest\n";
+        }
+
+        if ($this->backup->pgbackrest_block_incremental) {
+            $config .= "repo1-block=y\n";
+        }
+
+        $config .= "\n[{$stanzaName}]\n";
+        $config .= "pg1-path=/var/lib/postgresql/data\n";
+
+        if ($this->postgres_password) {
+            $config .= "pg1-port=5432\n";
+        }
+
+        return $config;
+    }
+
+    private function add_to_restore_output($output): void
+    {
+        if ($this->restore_output) {
+            $this->restore_output = $this->restore_output."\n".$output;
+        } else {
+            $this->restore_output = $output;
+        }
+    }
+
+    private function add_to_error_output($output): void
+    {
+        if ($this->error_output) {
+            $this->error_output = $this->error_output."\n".$output;
+        } else {
+            $this->error_output = $output;
+        }
+    }
+}

--- a/app/Models/ScheduledDatabaseBackup.php
+++ b/app/Models/ScheduledDatabaseBackup.php
@@ -10,6 +10,16 @@ class ScheduledDatabaseBackup extends BaseModel
 {
     protected $guarded = [];
 
+    protected function casts(): array
+    {
+        return [
+            'pgbackrest_block_incremental' => 'boolean',
+            'pgbackrest_retention_full' => 'integer',
+            'pgbackrest_retention_diff' => 'integer',
+            'pgbackrest_process_max' => 'integer',
+        ];
+    }
+
     public static function ownedByCurrentTeam()
     {
         return ScheduledDatabaseBackup::whereRelation('team', 'id', currentTeam()->id)->orderBy('created_at', 'desc');

--- a/app/Notifications/Database/RestoreFailed.php
+++ b/app/Notifications/Database/RestoreFailed.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Notifications\Database;
+
+use App\Models\ScheduledDatabaseBackup;
+use App\Notifications\CustomEmailNotification;
+use App\Notifications\Dto\DiscordMessage;
+use App\Notifications\Dto\PushoverMessage;
+use App\Notifications\Dto\SlackMessage;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class RestoreFailed extends CustomEmailNotification
+{
+    public string $name;
+
+    public function __construct(ScheduledDatabaseBackup $backup, public $database, public ?string $output = null)
+    {
+        $this->onQueue('high');
+        $this->name = $database->name;
+    }
+
+    public function via(object $notifiable): array
+    {
+        return $notifiable->getEnabledChannels('backup_failed');
+    }
+
+    public function toMail(): MailMessage
+    {
+        $mail = new MailMessage;
+        $mail->subject("Coolify: Database restore failed for {$this->database->name}");
+        $mail->view('emails.restore-failed', [
+            'name' => $this->name,
+            'output' => $this->output,
+        ]);
+
+        return $mail;
+    }
+
+    public function toDiscord(): DiscordMessage
+    {
+        $message = new DiscordMessage(
+            title: ':x: Database restore failed',
+            description: "Database restore for {$this->name} failed.",
+            color: DiscordMessage::errorColor(),
+        );
+
+        if ($this->output) {
+            $message->addField('Error Output', substr($this->output, 0, 1000), false);
+        }
+
+        return $message;
+    }
+
+    public function toTelegram(): array
+    {
+        $message = "Coolify: Database restore for {$this->name} failed.";
+        if ($this->output) {
+            $message .= "\n\nError: ".substr($this->output, 0, 500);
+        }
+
+        return [
+            'message' => $message,
+        ];
+    }
+
+    public function toPushover(): PushoverMessage
+    {
+        $errorMessage = $this->output ? '<br/><br/><b>Error:</b> '.substr($this->output, 0, 500) : '';
+
+        return new PushoverMessage(
+            title: 'Database restore failed',
+            level: 'error',
+            message: "Database restore for {$this->name} failed.{$errorMessage}",
+        );
+    }
+
+    public function toSlack(): SlackMessage
+    {
+        $title = 'Database restore failed';
+        $description = "Database restore for {$this->name} failed.";
+
+        if ($this->output) {
+            $description .= "\n\n*Error:* ".substr($this->output, 0, 1000);
+        }
+
+        return new SlackMessage(
+            title: $title,
+            description: $description,
+            color: SlackMessage::errorColor()
+        );
+    }
+
+    public function toWebhook(): array
+    {
+        $url = base_url().'/project/'.data_get($this->database, 'environment.project.uuid').'/environment/'.data_get($this->database, 'environment.uuid').'/database/'.$this->database->uuid;
+
+        return [
+            'success' => false,
+            'message' => 'Database restore failed',
+            'event' => 'restore_failed',
+            'database_name' => $this->name,
+            'database_uuid' => $this->database->uuid,
+            'error_output' => $this->output,
+            'url' => $url,
+        ];
+    }
+}

--- a/app/Notifications/Database/RestoreSuccess.php
+++ b/app/Notifications/Database/RestoreSuccess.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Notifications\Database;
+
+use App\Models\ScheduledDatabaseBackup;
+use App\Models\ScheduledDatabaseBackupExecution;
+use App\Notifications\CustomEmailNotification;
+use App\Notifications\Dto\DiscordMessage;
+use App\Notifications\Dto\PushoverMessage;
+use App\Notifications\Dto\SlackMessage;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class RestoreSuccess extends CustomEmailNotification
+{
+    public string $name;
+
+    public string $backupDate;
+
+    public function __construct(
+        ScheduledDatabaseBackup $backup,
+        public $database,
+        public ScheduledDatabaseBackupExecution $backupExecution
+    ) {
+        $this->onQueue('high');
+
+        $this->name = $database->name;
+        $this->backupDate = $backupExecution->created_at->toDateTimeString();
+    }
+
+    public function via(object $notifiable): array
+    {
+        return $notifiable->getEnabledChannels('backup_success');
+    }
+
+    public function toMail(): MailMessage
+    {
+        $mail = new MailMessage;
+        $mail->subject("Coolify: Database restore successful for {$this->database->name}");
+        $mail->view('emails.restore-success', [
+            'name' => $this->name,
+            'backup_date' => $this->backupDate,
+        ]);
+
+        return $mail;
+    }
+
+    public function toDiscord(): DiscordMessage
+    {
+        $message = new DiscordMessage(
+            title: ':white_check_mark: Database restore successful',
+            description: "Database restore for {$this->name} was successful.",
+            color: DiscordMessage::successColor(),
+        );
+
+        $message->addField('Backup Date', $this->backupDate, true);
+
+        return $message;
+    }
+
+    public function toTelegram(): array
+    {
+        $message = "Coolify: Database restore for {$this->name} from backup created at {$this->backupDate} was successful.";
+
+        return [
+            'message' => $message,
+        ];
+    }
+
+    public function toPushover(): PushoverMessage
+    {
+        return new PushoverMessage(
+            title: 'Database restore successful',
+            level: 'success',
+            message: "Database restore for {$this->name} was successful.<br/><br/><b>Backup Date:</b> {$this->backupDate}.",
+        );
+    }
+
+    public function toSlack(): SlackMessage
+    {
+        $title = 'Database restore successful';
+        $description = "Database restore for {$this->name} was successful.";
+
+        $description .= "\n\n*Backup Date:* {$this->backupDate}";
+
+        return new SlackMessage(
+            title: $title,
+            description: $description,
+            color: SlackMessage::successColor()
+        );
+    }
+
+    public function toWebhook(): array
+    {
+        $url = base_url().'/project/'.data_get($this->database, 'environment.project.uuid').'/environment/'.data_get($this->database, 'environment.uuid').'/database/'.$this->database->uuid;
+
+        return [
+            'success' => true,
+            'message' => 'Database restore successful',
+            'event' => 'restore_success',
+            'database_name' => $this->name,
+            'database_uuid' => $this->database->uuid,
+            'backup_date' => $this->backupDate,
+            'url' => $url,
+        ];
+    }
+}

--- a/database/migrations/2025_11_17_120000_add_pgbackrest_support_to_scheduled_database_backups_table.php
+++ b/database/migrations/2025_11_17_120000_add_pgbackrest_support_to_scheduled_database_backups_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('scheduled_database_backups', function (Blueprint $table) {
+            // Backup method: pg_dump (default) or pgbackrest
+            $table->string('backup_type')->default('pg_dump')->after('timeout');
+
+            // pgBackRest specific settings
+            $table->string('pgbackrest_type')->nullable()->after('backup_type'); // full, diff, incr
+            $table->string('pgbackrest_stanza')->nullable()->after('pgbackrest_type');
+
+            // pgBackRest retention settings (separate from legacy retention)
+            $table->integer('pgbackrest_retention_full')->default(2)->nullable()->after('pgbackrest_stanza');
+            $table->integer('pgbackrest_retention_diff')->nullable()->after('pgbackrest_retention_full');
+
+            // Enable block-level incremental backup (pgBackRest 2.36+)
+            $table->boolean('pgbackrest_block_incremental')->default(false)->after('pgbackrest_retention_diff');
+
+            // Process max for parallel backup/restore
+            $table->integer('pgbackrest_process_max')->default(1)->after('pgbackrest_block_incremental');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('scheduled_database_backups', function (Blueprint $table) {
+            $table->dropColumn([
+                'backup_type',
+                'pgbackrest_type',
+                'pgbackrest_stanza',
+                'pgbackrest_retention_full',
+                'pgbackrest_retention_diff',
+                'pgbackrest_block_incremental',
+                'pgbackrest_process_max',
+            ]);
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -128,6 +128,7 @@ Route::group([
     Route::patch('/databases/{uuid}', [DatabasesController::class, 'update_by_uuid'])->middleware(['api.ability:write']);
     Route::post('/databases/{uuid}/backups', [DatabasesController::class, 'create_backup'])->middleware(['api.ability:write']);
     Route::patch('/databases/{uuid}/backups/{scheduled_backup_uuid}', [DatabasesController::class, 'update_backup'])->middleware(['api.ability:write']);
+    Route::post('/databases/{uuid}/backups/{scheduled_backup_uuid}/restore/{execution_uuid}', [DatabasesController::class, 'restore_backup'])->middleware(['api.ability:write']);
     Route::delete('/databases/{uuid}', [DatabasesController::class, 'delete_by_uuid'])->middleware(['api.ability:write']);
     Route::delete('/databases/{uuid}/backups/{scheduled_backup_uuid}', [DatabasesController::class, 'delete_backup_by_uuid'])->middleware(['api.ability:write']);
     Route::delete('/databases/{uuid}/backups/{scheduled_backup_uuid}/executions/{execution_uuid}', [DatabasesController::class, 'delete_execution_by_uuid'])->middleware(['api.ability:write']);

--- a/tests/Feature/PgBackRestBackupTest.php
+++ b/tests/Feature/PgBackRestBackupTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use App\Models\ScheduledDatabaseBackup;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+
+uses(RefreshDatabase::class);
+
+test('scheduled_database_backups table has pgbackrest columns', function () {
+    expect(Schema::hasColumn('scheduled_database_backups', 'backup_type'))->toBeTrue();
+    expect(Schema::hasColumn('scheduled_database_backups', 'pgbackrest_type'))->toBeTrue();
+    expect(Schema::hasColumn('scheduled_database_backups', 'pgbackrest_stanza'))->toBeTrue();
+    expect(Schema::hasColumn('scheduled_database_backups', 'pgbackrest_retention_full'))->toBeTrue();
+    expect(Schema::hasColumn('scheduled_database_backups', 'pgbackrest_retention_diff'))->toBeTrue();
+    expect(Schema::hasColumn('scheduled_database_backups', 'pgbackrest_block_incremental'))->toBeTrue();
+    expect(Schema::hasColumn('scheduled_database_backups', 'pgbackrest_process_max'))->toBeTrue();
+});
+
+test('backup_type column has correct default', function () {
+    $columns = Schema::getColumns('scheduled_database_backups');
+    $backupTypeColumn = collect($columns)->firstWhere('name', 'backup_type');
+
+    expect($backupTypeColumn)->not->toBeNull();
+    expect($backupTypeColumn['default'])->toBe('pg_dump');
+});
+
+test('pgbackrest columns are nullable', function () {
+    $columns = Schema::getColumns('scheduled_database_backups');
+    $pgbackrestTypeColumn = collect($columns)->firstWhere('name', 'pgbackrest_type');
+    $pgbackrestStanzaColumn = collect($columns)->firstWhere('name', 'pgbackrest_stanza');
+    $pgbackrestRetentionDiffColumn = collect($columns)->firstWhere('name', 'pgbackrest_retention_diff');
+
+    expect($pgbackrestTypeColumn['nullable'])->toBeTrue();
+    expect($pgbackrestStanzaColumn['nullable'])->toBeTrue();
+    expect($pgbackrestRetentionDiffColumn['nullable'])->toBeTrue();
+});
+
+test('scheduled database backup model casts pgbackrest fields correctly', function () {
+    $model = new ScheduledDatabaseBackup;
+    $casts = $model->casts();
+
+    expect($casts)->toHaveKey('pgbackrest_block_incremental');
+    expect($casts['pgbackrest_block_incremental'])->toBe('boolean');
+    expect($casts)->toHaveKey('pgbackrest_retention_full');
+    expect($casts['pgbackrest_retention_full'])->toBe('integer');
+    expect($casts)->toHaveKey('pgbackrest_retention_diff');
+    expect($casts['pgbackrest_retention_diff'])->toBe('integer');
+    expect($casts)->toHaveKey('pgbackrest_process_max');
+    expect($casts['pgbackrest_process_max'])->toBe('integer');
+});

--- a/tests/Unit/PgBackRestBackupTest.php
+++ b/tests/Unit/PgBackRestBackupTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use App\Models\ScheduledDatabaseBackup;
+use Mockery;
+
+it('checks if backup is pgBackRest type', function () {
+    $backup = Mockery::mock(ScheduledDatabaseBackup::class)->makePartial();
+    $backup->backup_type = 'pgbackrest';
+
+    expect($backup->isPgBackRest())->toBeTrue();
+});
+
+it('checks if backup is pg_dump type', function () {
+    $backup = Mockery::mock(ScheduledDatabaseBackup::class)->makePartial();
+    $backup->backup_type = 'pg_dump';
+
+    expect($backup->isPgDump())->toBeTrue();
+});
+
+it('defaults to pg_dump when backup_type is null', function () {
+    $backup = Mockery::mock(ScheduledDatabaseBackup::class)->makePartial();
+    $backup->backup_type = null;
+
+    expect($backup->isPgDump())->toBeTrue();
+});
+
+it('generates stanza name from custom stanza', function () {
+    $backup = Mockery::mock(ScheduledDatabaseBackup::class)->makePartial();
+    $backup->pgbackrest_stanza = 'my-custom-stanza';
+    $backup->uuid = 'test-uuid-123';
+
+    expect($backup->getStanzaName())->toBe('my-custom-stanza');
+});
+
+it('auto-generates stanza name from database name', function () {
+    $backup = Mockery::mock(ScheduledDatabaseBackup::class)->makePartial();
+    $backup->pgbackrest_stanza = null;
+    $backup->uuid = 'test-uuid-123';
+
+    $database = Mockery::mock();
+    $database->name = 'production_db';
+    $backup->shouldReceive('getAttribute')->with('database')->andReturn($database);
+
+    $stanzaName = $backup->getStanzaName();
+
+    expect($stanzaName)->toContain('coolify-production-db');
+    expect($stanzaName)->toContain('test-uuid-123');
+});
+
+it('returns default backup type as full', function () {
+    $backup = Mockery::mock(ScheduledDatabaseBackup::class)->makePartial();
+    $backup->pgbackrest_type = null;
+
+    expect($backup->getPgBackRestType())->toBe('full');
+});
+
+it('returns configured backup type', function () {
+    $backup = Mockery::mock(ScheduledDatabaseBackup::class)->makePartial();
+    $backup->pgbackrest_type = 'incr';
+
+    expect($backup->getPgBackRestType())->toBe('incr');
+});
+
+it('supports differential backup type', function () {
+    $backup = Mockery::mock(ScheduledDatabaseBackup::class)->makePartial();
+    $backup->pgbackrest_type = 'diff';
+
+    expect($backup->getPgBackRestType())->toBe('diff');
+});


### PR DESCRIPTION
## Submit Checklist 
- [x] I have selected the `next` branch as the destination for my PR, not `main`.
- [x] I have listed all changes in the `Changes` section.
- [x] I have filled out the `Issues` section with the issue/discussion link(s) (if applicable).
- [x] I have tested my changes.
- [x] I have considered backwards compatibility.
- [x] I have removed this checklist and any unused sections.

## Changes
- ##### Core Features
  - Implement pgBackRest as default backup method for PostgreSQL databases
  - Support for full, differential, and incremental backups with configurable retention policies
  - Native S3 repository support with direct writes (eliminates local intermediate storage)
  - Parallel processing configuration (1-16 processes) for faster operations
  - Block-level incremental backups for up to 50x storage reduction

- ##### Restore Functionality
  - Add DatabaseRestoreJob for PostgreSQL restoration from pgBackRest and pg_dump backups
  - New API endpoint: `POST /api/v1/databases/{uuid}/backups/{backup_uuid}/restore/{execution_uuid}`
  - Delta restore mode for pgBackRest (only restores changed files)
  - Automatic container management with error recovery
  - Restore notifications (RestoreSuccess, RestoreFailed)

- ##### Resource Management
  - Automatic pgBackRest stanza cleanup on backup configuration deletion
  - S3 connectivity validation before creating backup configurations
  - Backup size extraction from pgBackRest metadata for accurate reporting
- #####  API
  - pgBackRest configuration parameters in backup create/update endpoints
  - Restore endpoint with optional target database parameter
  - Validation ensures pgBackRest only used with PostgreSQL databases
- ##### Documentation
  - Comprehensive guide at [gist](https://gist.github.com/developerfred/42ae91bb4da345bafe3a849f88c5d691)
  - API usage examples and configuration reference
  - Backup strategy recommendations by database size
  - Migration guide from[ pg_dump to pgBackRest](https://gist.github.com/developerfred/42ae91bb4da345bafe3a849f88c5d691#migration-from-pg_dump)
- ##### Database Schema
  - Migration adds pgBackRest configuration columns to scheduled_database_backups table
  - Backward compatible with existing pg_dump backups
- #####  Security
  - S3 credentials stored in configuration file (not environment variables)
  - Command injection protection with proper shell escaping
  - S3 endpoint connectivity validation


## Issues
- fix #7172 
/claim  #7172
