### PR TITLE
fix: replace inline styles with Tailwind classes in modal-input

### DIFF
--- a/resources/views/components/modal-input.blade.php
+++ b/resources/views/components/modal-input.blade.php
@@ -16,17 +16,6 @@
     $modalId = 'modal-' . uniqid();
 @endphp
 
-<style>
-    #{{ $modalId }} {
-        max-height: calc(100vh - 2rem);
-    }
-    @media (min-width: 1024px) {
-        #{{ $modalId }} {
-            min-width: {{ $minWidth }};
-            max-width: {{ $maxWidth }};
-        }
-    }
-</style>
 
 <div x-data="{ modalOpen: false }"
     x-init="$watch('modalOpen', value => { if (!value) { $wire.dispatch('modalClosed') } })"
@@ -63,7 +52,7 @@
                 x-transition:leave="ease-in duration-100"
                 x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
                 x-transition:leave-end="opacity-0 -translate-y-2 sm:scale-95"
-                class="relative w-full border rounded-sm drop-shadow-sm min-w-full bg-white border-neutral-200 dark:bg-base dark:border-coolgray-300 flex flex-col">
+                class="relative w-full min-w-full lg:min-w-[{{ $minWidth }}] max-w-[{{ $maxWidth }}] max-h-[calc(100vh-2rem)] border rounded-sm drop-shadow-sm bg-white border-neutral-200 dark:bg-base dark:border-coolgray-300 flex flex-col">
                 <div class="flex items-center justify-between py-6 px-6 shrink-0">
                     <h3 class="text-2xl font-bold">{{ $title }}</h3>
                     <button @click="modalOpen=false"


### PR DESCRIPTION
## Summary
Fixes modal-input component appearing full-width by replacing inline `<style>` blocks with Tailwind utility classes.

## Changes
- Removed inline `<style>` block with media queries and ID selectors
- Added Tailwind classes: `min-w-full lg:min-w-[{minWidth}] max-w-[{maxWidth}] max-h-[calc(100vh-2rem)]`
- Follows the same pattern as modal-confirmation component for consistent behavior

## Issue
The modal-input component was using inline styles with ID selectors that had inconsistent specificity and only applied on lg+ breakpoints, causing modals to appear full-width instead of being properly constrained to 36-48rem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)