### PR TITLE
fix: inject environment variables into custom Docker Compose build commands

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -41,7 +41,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
 {
     use Dispatchable, EnvironmentVariableAnalyzer, ExecuteRemoteCommand, InteractsWithQueue, Queueable, SerializesModels;
 
-    private const BUILD_TIME_ENV_PATH = '/artifacts/build-time.env';
+    public const BUILD_TIME_ENV_PATH = '/artifacts/build-time.env';
 
     private const BUILD_SCRIPT_PATH = '/artifacts/build.sh';
 

--- a/app/Livewire/Project/Application/General.php
+++ b/app/Livewire/Project/Application/General.php
@@ -1005,4 +1005,34 @@ class General extends Component
             'isEmpty' => $isEmpty,
         ];
     }
+
+    public function getDockerComposeBuildCommandPreviewProperty(): string
+    {
+        if (! $this->dockerComposeCustomBuildCommand) {
+            return '';
+        }
+
+        // Use relative path for clarity in preview (e.g., ./backend/docker-compose.yaml)
+        // Actual deployment uses absolute path: /artifacts/{deployment_uuid}{base_directory}{docker_compose_location}
+        return injectDockerComposeFlags(
+            $this->dockerComposeCustomBuildCommand,
+            ".{$this->baseDirectory}{$this->dockerComposeLocation}",
+            '/artifacts/build-time.env'
+        );
+    }
+
+    public function getDockerComposeStartCommandPreviewProperty(): string
+    {
+        if (! $this->dockerComposeCustomStartCommand) {
+            return '';
+        }
+
+        // Use relative path for clarity in preview (e.g., ./backend/docker-compose.yaml)
+        // Placeholder {workdir}/.env shows it's the workdir .env file (runtime env, not build-time)
+        return injectDockerComposeFlags(
+            $this->dockerComposeCustomStartCommand,
+            ".{$this->baseDirectory}{$this->dockerComposeLocation}",
+            '{workdir}/.env'
+        );
+    }
 }

--- a/app/Livewire/Project/Application/General.php
+++ b/app/Livewire/Project/Application/General.php
@@ -1012,12 +1012,16 @@ class General extends Component
             return '';
         }
 
+        // Normalize baseDirectory to prevent double slashes (e.g., when baseDirectory is '/')
+        $normalizedBase = $this->baseDirectory === '/' ? '' : rtrim($this->baseDirectory, '/');
+
         // Use relative path for clarity in preview (e.g., ./backend/docker-compose.yaml)
         // Actual deployment uses absolute path: /artifacts/{deployment_uuid}{base_directory}{docker_compose_location}
+        // Build-time env path references ApplicationDeploymentJob::BUILD_TIME_ENV_PATH as source of truth
         return injectDockerComposeFlags(
             $this->dockerComposeCustomBuildCommand,
-            ".{$this->baseDirectory}{$this->dockerComposeLocation}",
-            '/artifacts/build-time.env'
+            ".{$normalizedBase}{$this->dockerComposeLocation}",
+            \App\Jobs\ApplicationDeploymentJob::BUILD_TIME_ENV_PATH
         );
     }
 
@@ -1027,11 +1031,14 @@ class General extends Component
             return '';
         }
 
+        // Normalize baseDirectory to prevent double slashes (e.g., when baseDirectory is '/')
+        $normalizedBase = $this->baseDirectory === '/' ? '' : rtrim($this->baseDirectory, '/');
+
         // Use relative path for clarity in preview (e.g., ./backend/docker-compose.yaml)
         // Placeholder {workdir}/.env shows it's the workdir .env file (runtime env, not build-time)
         return injectDockerComposeFlags(
             $this->dockerComposeCustomStartCommand,
-            ".{$this->baseDirectory}{$this->dockerComposeLocation}",
+            ".{$normalizedBase}{$this->dockerComposeLocation}",
             '{workdir}/.env'
         );
     }

--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -1272,3 +1272,31 @@ function generateDockerEnvFlags($variables): string
         })
         ->implode(' ');
 }
+
+/**
+ * Auto-inject -f and --env-file flags into a docker compose command if not already present
+ *
+ * @param  string  $command  The docker compose command to modify
+ * @param  string  $composeFilePath  The path to the compose file
+ * @param  string  $envFilePath  The path to the .env file
+ * @return string The modified command with injected flags
+ */
+function injectDockerComposeFlags(string $command, string $composeFilePath, string $envFilePath): string
+{
+    $dockerComposeReplacement = 'docker compose';
+
+    // Add -f flag if not present (checks for both -f and --file with various formats)
+    // Detects: -f path, -f=path, -fpath (concatenated), --file path, --file=path with any whitespace (space, tab, newline)
+    if (! preg_match('/(?:^|\s)(?:-f(?:[=\s]|\S)|--file(?:=|\s))/', $command)) {
+        $dockerComposeReplacement .= " -f {$composeFilePath}";
+    }
+
+    // Add --env-file flag if not present (checks for --env-file with various formats)
+    // Detects: --env-file path, --env-file=path with any whitespace
+    if (! preg_match('/(?:^|\s)--env-file(?:=|\s)/', $command)) {
+        $dockerComposeReplacement .= " --env-file {$envFilePath}";
+    }
+
+    // Replace only first occurrence to avoid modifying comments/strings/chained commands
+    return preg_replace('/docker\s+compose/', $dockerComposeReplacement, $command, 1);
+}

--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -1280,14 +1280,19 @@ function generateDockerEnvFlags($variables): string
  * @param  string  $composeFilePath  The path to the compose file
  * @param  string  $envFilePath  The path to the .env file
  * @return string The modified command with injected flags
+ *
+ * @example
+ * Input:  "docker compose build"
+ * Output: "docker compose -f ./docker-compose.yml --env-file .env build"
  */
 function injectDockerComposeFlags(string $command, string $composeFilePath, string $envFilePath): string
 {
     $dockerComposeReplacement = 'docker compose';
 
     // Add -f flag if not present (checks for both -f and --file with various formats)
-    // Detects: -f path, -f=path, -fpath (concatenated), --file path, --file=path with any whitespace (space, tab, newline)
-    if (! preg_match('/(?:^|\s)(?:-f(?:[=\s]|\S)|--file(?:=|\s))/', $command)) {
+    // Detects: -f path, -f=path, -fpath (concatenated with path chars: . / ~), --file path, --file=path
+    // Note: Uses [.~/]|$ instead of \S to prevent false positives with flags like -foo, -from, -feature
+    if (! preg_match('/(?:^|\s)(?:-f(?:[=\s]|[.\/~]|$)|--file(?:=|\s))/', $command)) {
         $dockerComposeReplacement .= " -f {$composeFilePath}";
     }
 

--- a/resources/views/livewire/project/application/general.blade.php
+++ b/resources/views/livewire/project/application/general.blade.php
@@ -259,13 +259,31 @@
                                     <div class="flex gap-2">
                                         <x-forms.input x-bind:disabled="shouldDisable()"
                                             placeholder="docker compose build" id="dockerComposeCustomBuildCommand"
-                                            helper="If you use this, you need to specify paths relatively and should use the same compose file in the custom command, otherwise the automatically configured labels / etc won't work.<br><br>Environment variables are automatically injected via <span class='dark:text-warning'>--env-file</span> flag. If you need custom env handling, include your own <span class='dark:text-warning'>--env-file</span> flag in the command.<br><br>So in your case, use: <span class='dark:text-warning'>docker compose -f .{{ Str::start($application->base_directory . $application->docker_compose_location, '/') }} build</span>"
+                                            helper="The compose file path (<span class='dark:text-warning'>-f</span> flag) and environment variables (<span class='dark:text-warning'>--env-file</span> flag) are automatically injected based on your Base Directory and Docker Compose Location settings. You can override by providing your own <span class='dark:text-warning'>-f</span> or <span class='dark:text-warning'>--env-file</span> flags.<br><br>If you use this, you need to specify paths relatively and should use the same compose file in the custom command, otherwise the automatically configured labels / etc won't work.<br><br>Example usage: <span class='dark:text-warning'>docker compose build</span>"
                                             label="Custom Build Command" />
                                         <x-forms.input x-bind:disabled="shouldDisable()"
                                             placeholder="docker compose up -d" id="dockerComposeCustomStartCommand"
-                                            helper="If you use this, you need to specify paths relatively and should use the same compose file in the custom command, otherwise the automatically configured labels / etc won't work.<br><br>So in your case, use: <span class='dark:text-warning'>docker compose -f .{{ Str::start($application->base_directory . $application->docker_compose_location, '/') }} up -d</span>"
+                                            helper="The compose file path (<span class='dark:text-warning'>-f</span> flag) and environment variables (<span class='dark:text-warning'>--env-file</span> flag) are automatically injected based on your Base Directory and Docker Compose Location settings. You can override by providing your own <span class='dark:text-warning'>-f</span> or <span class='dark:text-warning'>--env-file</span> flags.<br><br>If you use this, you need to specify paths relatively and should use the same compose file in the custom command, otherwise the automatically configured labels / etc won't work.<br><br>Example usage: <span class='dark:text-warning'>docker compose up -d</span>"
                                             label="Custom Start Command" />
                                     </div>
+                                    @if ($this->dockerComposeCustomBuildCommand)
+                                        <div wire:key="preview-{{ $this->dockerComposeCustomBuildCommand }}">
+                                            <x-forms.input
+                                                readonly
+                                                value="{{ $this->dockerComposeBuildCommandPreview }}"
+                                                label="Final Build Command (Preview)"
+                                                helper="This shows the actual command that will be executed with auto-injected flags." />
+                                        </div>
+                                    @endif
+                                    @if ($this->dockerComposeCustomStartCommand)
+                                        <div wire:key="start-preview-{{ $this->dockerComposeCustomStartCommand }}">
+                                            <x-forms.input
+                                                readonly
+                                                value="{{ $this->dockerComposeStartCommandPreview }}"
+                                                label="Final Start Command (Preview)"
+                                                helper="This shows the actual command that will be executed with auto-injected flags." />
+                                        </div>
+                                    @endif
                                     @if ($this->application->is_github_based() && !$this->application->is_public_repository())
                                         <div class="pt-4">
                                             <x-forms.textarea

--- a/resources/views/livewire/project/application/general.blade.php
+++ b/resources/views/livewire/project/application/general.blade.php
@@ -259,7 +259,7 @@
                                     <div class="flex gap-2">
                                         <x-forms.input x-bind:disabled="shouldDisable()"
                                             placeholder="docker compose build" id="dockerComposeCustomBuildCommand"
-                                            helper="If you use this, you need to specify paths relatively and should use the same compose file in the custom command, otherwise the automatically configured labels / etc won't work.<br><br>So in your case, use: <span class='dark:text-warning'>docker compose -f .{{ Str::start($application->base_directory . $application->docker_compose_location, '/') }} build</span>"
+                                            helper="If you use this, you need to specify paths relatively and should use the same compose file in the custom command, otherwise the automatically configured labels / etc won't work.<br><br>Environment variables are automatically injected via <span class='dark:text-warning'>--env-file</span> flag. If you need custom env handling, include your own <span class='dark:text-warning'>--env-file</span> flag in the command.<br><br>So in your case, use: <span class='dark:text-warning'>docker compose -f .{{ Str::start($application->base_directory . $application->docker_compose_location, '/') }} build</span>"
                                             label="Custom Build Command" />
                                         <x-forms.input x-bind:disabled="shouldDisable()"
                                             placeholder="docker compose up -d" id="dockerComposeCustomStartCommand"

--- a/resources/views/livewire/project/application/general.blade.php
+++ b/resources/views/livewire/project/application/general.blade.php
@@ -267,7 +267,7 @@
                                             label="Custom Start Command" />
                                     </div>
                                     @if ($this->dockerComposeCustomBuildCommand)
-                                        <div wire:key="preview-{{ $this->dockerComposeCustomBuildCommand }}">
+                                        <div wire:key="docker-compose-build-preview">
                                             <x-forms.input
                                                 readonly
                                                 value="{{ $this->dockerComposeBuildCommandPreview }}"
@@ -276,7 +276,7 @@
                                         </div>
                                     @endif
                                     @if ($this->dockerComposeCustomStartCommand)
-                                        <div wire:key="start-preview-{{ $this->dockerComposeCustomStartCommand }}">
+                                        <div wire:key="docker-compose-start-preview">
                                             <x-forms.input
                                                 readonly
                                                 value="{{ $this->dockerComposeStartCommandPreview }}"

--- a/tests/Unit/ApplicationDeploymentCustomBuildCommandTest.php
+++ b/tests/Unit/ApplicationDeploymentCustomBuildCommandTest.php
@@ -1,16 +1,17 @@
 <?php
 
 /**
- * Test to verify that custom Docker Compose build commands properly inject environment variables.
+ * Test to verify that custom Docker Compose build commands properly inject flags.
  *
  * This test suite verifies that when using a custom build command, the system automatically
- * injects the --env-file flag to ensure build-time environment variables are available during
- * the build process. This fixes the issue where environment variables were lost when using
- * custom build commands.
+ * injects the -f (compose file path) and --env-file flags to ensure the correct compose file
+ * is used and build-time environment variables are available during the build process.
  *
  * The fix ensures that:
+ * - -f flag with compose file path is automatically injected after 'docker compose'
  * - --env-file /artifacts/build-time.env is automatically injected after 'docker compose'
- * - Users can still provide their own --env-file flag to override the default behavior
+ * - Users can still provide their own -f or --env-file flags to override the default behavior
+ * - Both flags are injected in a single str_replace operation
  * - Build arguments are appended when not using build secrets
  */
 it('injects --env-file flag into custom build command', function () {
@@ -130,4 +131,361 @@ it('handles DOCKER_BUILDKIT prefix with env-file injection', function () {
     expect($customCommand)->toBe('DOCKER_BUILDKIT=1 docker compose --env-file /artifacts/build-time.env -f ./docker-compose.yaml build');
     expect($customCommand)->toStartWith('DOCKER_BUILDKIT=1');
     expect($customCommand)->toContain('--env-file /artifacts/build-time.env');
+});
+
+// Tests for -f flag injection
+
+it('injects -f flag with compose file path into custom build command', function () {
+    $customCommand = 'docker compose build';
+    $composeFilePath = '/artifacts/deployment-uuid/backend/docker-compose.yaml';
+
+    // Use the helper function
+    $customCommand = injectDockerComposeFlags($customCommand, $composeFilePath, '/artifacts/build-time.env');
+
+    expect($customCommand)->toBe('docker compose -f /artifacts/deployment-uuid/backend/docker-compose.yaml --env-file /artifacts/build-time.env build');
+    expect($customCommand)->toContain('-f /artifacts/deployment-uuid/backend/docker-compose.yaml');
+    expect($customCommand)->toContain('--env-file /artifacts/build-time.env');
+});
+
+it('does not duplicate -f flag when already present', function () {
+    $customCommand = 'docker compose -f ./custom/docker-compose.yaml build';
+
+    // Use the helper function
+    $customCommand = injectDockerComposeFlags($customCommand, '/artifacts/deployment-uuid/docker-compose.yaml', '/artifacts/build-time.env');
+
+    expect($customCommand)->toBe('docker compose --env-file /artifacts/build-time.env -f ./custom/docker-compose.yaml build');
+    expect(substr_count($customCommand, ' -f '))->toBe(1);
+    expect($customCommand)->toContain('--env-file /artifacts/build-time.env');
+});
+
+it('does not duplicate --file flag when already present', function () {
+    $customCommand = 'docker compose --file ./custom/docker-compose.yaml build';
+
+    // Use the helper function
+    $customCommand = injectDockerComposeFlags($customCommand, '/artifacts/deployment-uuid/docker-compose.yaml', '/artifacts/build-time.env');
+
+    expect($customCommand)->toBe('docker compose --env-file /artifacts/build-time.env --file ./custom/docker-compose.yaml build');
+    expect(substr_count($customCommand, '--file '))->toBe(1);
+    expect($customCommand)->toContain('--env-file /artifacts/build-time.env');
+});
+
+it('injects both -f and --env-file flags in single operation', function () {
+    $customCommand = 'docker compose build --no-cache';
+
+    // Use the helper function
+    $customCommand = injectDockerComposeFlags($customCommand, '/artifacts/uuid/app/docker-compose.prod.yaml', '/artifacts/build-time.env');
+
+    expect($customCommand)->toBe('docker compose -f /artifacts/uuid/app/docker-compose.prod.yaml --env-file /artifacts/build-time.env build --no-cache');
+    expect($customCommand)->toContain('-f /artifacts/uuid/app/docker-compose.prod.yaml');
+    expect($customCommand)->toContain('--env-file /artifacts/build-time.env');
+    expect($customCommand)->toContain('build --no-cache');
+});
+
+it('respects user-provided -f and --env-file flags', function () {
+    $customCommand = 'docker compose -f ./my-compose.yaml --env-file .env build';
+
+    // Use the helper function - should not inject anything since both flags are already present
+    $customCommand = injectDockerComposeFlags($customCommand, '/artifacts/deployment-uuid/docker-compose.yaml', '/artifacts/build-time.env');
+
+    expect($customCommand)->toBe('docker compose -f ./my-compose.yaml --env-file .env build');
+    expect(substr_count($customCommand, ' -f '))->toBe(1);
+    expect(substr_count($customCommand, '--env-file'))->toBe(1);
+});
+
+// Tests for custom start command -f and --env-file injection
+
+it('injects -f and --env-file flags into custom start command', function () {
+    $customCommand = 'docker compose up -d';
+    $serverWorkdir = '/var/lib/docker/volumes/coolify-data/_data/applications/app-uuid';
+    $composeLocation = '/docker-compose.yaml';
+
+    // Use the helper function
+    $customCommand = injectDockerComposeFlags($customCommand, "{$serverWorkdir}{$composeLocation}", "{$serverWorkdir}/.env");
+
+    expect($customCommand)->toBe('docker compose -f /var/lib/docker/volumes/coolify-data/_data/applications/app-uuid/docker-compose.yaml --env-file /var/lib/docker/volumes/coolify-data/_data/applications/app-uuid/.env up -d');
+    expect($customCommand)->toContain('-f /var/lib/docker/volumes/coolify-data/_data/applications/app-uuid/docker-compose.yaml');
+    expect($customCommand)->toContain('--env-file /var/lib/docker/volumes/coolify-data/_data/applications/app-uuid/.env');
+});
+
+it('does not duplicate -f flag in start command when already present', function () {
+    $customCommand = 'docker compose -f ./custom-compose.yaml up -d';
+    $serverWorkdir = '/var/lib/docker/volumes/coolify-data/_data/applications/app-uuid';
+    $composeLocation = '/docker-compose.yaml';
+
+    // Use the helper function
+    $customCommand = injectDockerComposeFlags($customCommand, "{$serverWorkdir}{$composeLocation}", "{$serverWorkdir}/.env");
+
+    expect($customCommand)->toBe('docker compose --env-file /var/lib/docker/volumes/coolify-data/_data/applications/app-uuid/.env -f ./custom-compose.yaml up -d');
+    expect(substr_count($customCommand, ' -f '))->toBe(1);
+    expect($customCommand)->toContain('--env-file');
+});
+
+it('does not duplicate --env-file flag in start command when already present', function () {
+    $customCommand = 'docker compose --env-file ./my.env up -d';
+    $serverWorkdir = '/var/lib/docker/volumes/coolify-data/_data/applications/app-uuid';
+    $composeLocation = '/docker-compose.yaml';
+
+    // Use the helper function
+    $customCommand = injectDockerComposeFlags($customCommand, "{$serverWorkdir}{$composeLocation}", "{$serverWorkdir}/.env");
+
+    expect($customCommand)->toBe('docker compose -f /var/lib/docker/volumes/coolify-data/_data/applications/app-uuid/docker-compose.yaml --env-file ./my.env up -d');
+    expect(substr_count($customCommand, '--env-file'))->toBe(1);
+    expect($customCommand)->toContain('-f');
+});
+
+it('respects both user-provided flags in start command', function () {
+    $customCommand = 'docker compose -f ./my-compose.yaml --env-file ./.env up -d';
+    $serverWorkdir = '/var/lib/docker/volumes/coolify-data/_data/applications/app-uuid';
+    $composeLocation = '/docker-compose.yaml';
+
+    // Use the helper function - should not inject anything since both flags are already present
+    $customCommand = injectDockerComposeFlags($customCommand, "{$serverWorkdir}{$composeLocation}", "{$serverWorkdir}/.env");
+
+    expect($customCommand)->toBe('docker compose -f ./my-compose.yaml --env-file ./.env up -d');
+    expect(substr_count($customCommand, ' -f '))->toBe(1);
+    expect(substr_count($customCommand, '--env-file'))->toBe(1);
+});
+
+it('injects both flags in start command with additional parameters', function () {
+    $customCommand = 'docker compose up -d --remove-orphans';
+    $serverWorkdir = '/workdir/app';
+    $composeLocation = '/backend/docker-compose.prod.yaml';
+
+    // Use the helper function
+    $customCommand = injectDockerComposeFlags($customCommand, "{$serverWorkdir}{$composeLocation}", "{$serverWorkdir}/.env");
+
+    expect($customCommand)->toBe('docker compose -f /workdir/app/backend/docker-compose.prod.yaml --env-file /workdir/app/.env up -d --remove-orphans');
+    expect($customCommand)->toContain('-f /workdir/app/backend/docker-compose.prod.yaml');
+    expect($customCommand)->toContain('--env-file /workdir/app/.env');
+    expect($customCommand)->toContain('--remove-orphans');
+});
+
+// Security tests: Prevent bypass vectors for flag detection
+
+it('detects -f flag with equals sign format (bypass vector)', function () {
+    $customCommand = 'docker compose -f=./custom/docker-compose.yaml build';
+
+    // Use the helper function
+    $customCommand = injectDockerComposeFlags($customCommand, '/artifacts/deployment-uuid/docker-compose.yaml', '/artifacts/build-time.env');
+
+    // Should NOT inject -f flag since -f= is already present
+    expect($customCommand)->toBe('docker compose --env-file /artifacts/build-time.env -f=./custom/docker-compose.yaml build');
+    expect($customCommand)->not->toContain('-f /artifacts/deployment-uuid/docker-compose.yaml');
+    expect($customCommand)->toContain('--env-file /artifacts/build-time.env');
+});
+
+it('detects --file flag with equals sign format (bypass vector)', function () {
+    $customCommand = 'docker compose --file=./custom/docker-compose.yaml build';
+
+    // Use the helper function
+    $customCommand = injectDockerComposeFlags($customCommand, '/artifacts/deployment-uuid/docker-compose.yaml', '/artifacts/build-time.env');
+
+    // Should NOT inject -f flag since --file= is already present
+    expect($customCommand)->toBe('docker compose --env-file /artifacts/build-time.env --file=./custom/docker-compose.yaml build');
+    expect($customCommand)->not->toContain('-f /artifacts/deployment-uuid/docker-compose.yaml');
+    expect($customCommand)->toContain('--env-file /artifacts/build-time.env');
+});
+
+it('detects --env-file flag with equals sign format (bypass vector)', function () {
+    $customCommand = 'docker compose --env-file=./custom/.env build';
+
+    // Use the helper function
+    $customCommand = injectDockerComposeFlags($customCommand, '/artifacts/deployment-uuid/docker-compose.yaml', '/artifacts/build-time.env');
+
+    // Should NOT inject --env-file flag since --env-file= is already present
+    expect($customCommand)->toBe('docker compose -f /artifacts/deployment-uuid/docker-compose.yaml --env-file=./custom/.env build');
+    expect($customCommand)->toContain('-f /artifacts/deployment-uuid/docker-compose.yaml');
+    expect($customCommand)->not->toContain('--env-file /artifacts/build-time.env');
+});
+
+it('detects -f flag with tab character whitespace (bypass vector)', function () {
+    $customCommand = "docker compose\t-f\t./custom/docker-compose.yaml build";
+
+    // Use the helper function
+    $customCommand = injectDockerComposeFlags($customCommand, '/artifacts/deployment-uuid/docker-compose.yaml', '/artifacts/build-time.env');
+
+    // Should NOT inject -f flag since -f with tab is already present
+    expect($customCommand)->toBe("docker compose --env-file /artifacts/build-time.env\t-f\t./custom/docker-compose.yaml build");
+    expect($customCommand)->not->toContain('-f /artifacts/deployment-uuid/docker-compose.yaml');
+    expect($customCommand)->toContain('--env-file /artifacts/build-time.env');
+});
+
+it('detects --env-file flag with tab character whitespace (bypass vector)', function () {
+    $customCommand = "docker compose\t--env-file\t./custom/.env build";
+
+    // Use the helper function
+    $customCommand = injectDockerComposeFlags($customCommand, '/artifacts/deployment-uuid/docker-compose.yaml', '/artifacts/build-time.env');
+
+    // Should NOT inject --env-file flag since --env-file with tab is already present
+    expect($customCommand)->toBe("docker compose -f /artifacts/deployment-uuid/docker-compose.yaml\t--env-file\t./custom/.env build");
+    expect($customCommand)->toContain('-f /artifacts/deployment-uuid/docker-compose.yaml');
+    expect($customCommand)->not->toContain('--env-file /artifacts/build-time.env');
+});
+
+it('detects -f flag with multiple spaces (bypass vector)', function () {
+    $customCommand = 'docker compose  -f  ./custom/docker-compose.yaml build';
+
+    // Use the helper function
+    $customCommand = injectDockerComposeFlags($customCommand, '/artifacts/deployment-uuid/docker-compose.yaml', '/artifacts/build-time.env');
+
+    // Should NOT inject -f flag since -f with multiple spaces is already present
+    expect($customCommand)->toBe('docker compose --env-file /artifacts/build-time.env  -f  ./custom/docker-compose.yaml build');
+    expect($customCommand)->not->toContain('-f /artifacts/deployment-uuid/docker-compose.yaml');
+    expect($customCommand)->toContain('--env-file /artifacts/build-time.env');
+});
+
+it('detects --file flag with multiple spaces (bypass vector)', function () {
+    $customCommand = 'docker compose  --file  ./custom/docker-compose.yaml build';
+
+    // Use the helper function
+    $customCommand = injectDockerComposeFlags($customCommand, '/artifacts/deployment-uuid/docker-compose.yaml', '/artifacts/build-time.env');
+
+    // Should NOT inject -f flag since --file with multiple spaces is already present
+    expect($customCommand)->toBe('docker compose --env-file /artifacts/build-time.env  --file  ./custom/docker-compose.yaml build');
+    expect($customCommand)->not->toContain('-f /artifacts/deployment-uuid/docker-compose.yaml');
+    expect($customCommand)->toContain('--env-file /artifacts/build-time.env');
+});
+
+it('detects -f flag at start of command (edge case)', function () {
+    $customCommand = '-f ./custom/docker-compose.yaml docker compose build';
+
+    // Use the helper function
+    $customCommand = injectDockerComposeFlags($customCommand, '/artifacts/deployment-uuid/docker-compose.yaml', '/artifacts/build-time.env');
+
+    // Should NOT inject -f flag since -f is at start of command
+    expect($customCommand)->toBe('-f ./custom/docker-compose.yaml docker compose --env-file /artifacts/build-time.env build');
+    expect($customCommand)->not->toContain('-f /artifacts/deployment-uuid/docker-compose.yaml');
+    expect($customCommand)->toContain('--env-file /artifacts/build-time.env');
+});
+
+it('detects --env-file flag at start of command (edge case)', function () {
+    $customCommand = '--env-file=./custom/.env docker compose build';
+
+    // Use the helper function
+    $customCommand = injectDockerComposeFlags($customCommand, '/artifacts/deployment-uuid/docker-compose.yaml', '/artifacts/build-time.env');
+
+    // Should NOT inject --env-file flag since --env-file is at start of command
+    expect($customCommand)->toBe('--env-file=./custom/.env docker compose -f /artifacts/deployment-uuid/docker-compose.yaml build');
+    expect($customCommand)->toContain('-f /artifacts/deployment-uuid/docker-compose.yaml');
+    expect($customCommand)->not->toContain('--env-file /artifacts/build-time.env');
+});
+
+it('handles mixed whitespace correctly (comprehensive test)', function () {
+    $customCommand = "docker compose\t-f=./custom/docker-compose.yaml  --env-file\t./custom/.env build";
+
+    // Use the helper function
+    $customCommand = injectDockerComposeFlags($customCommand, '/artifacts/deployment-uuid/docker-compose.yaml', '/artifacts/build-time.env');
+
+    // Should NOT inject any flags since both are already present with various whitespace
+    expect($customCommand)->toBe("docker compose\t-f=./custom/docker-compose.yaml  --env-file\t./custom/.env build");
+    expect($customCommand)->not->toContain('-f /artifacts/deployment-uuid/docker-compose.yaml');
+    expect($customCommand)->not->toContain('--env-file /artifacts/build-time.env');
+});
+
+// Tests for concatenated -f flag format (no space, no equals)
+
+it('detects -f flag in concatenated format -fvalue (bypass vector)', function () {
+    $customCommand = 'docker compose -f./custom/docker-compose.yaml build';
+
+    // Use the helper function
+    $customCommand = injectDockerComposeFlags($customCommand, '/artifacts/deployment-uuid/docker-compose.yaml', '/artifacts/build-time.env');
+
+    // Should NOT inject -f flag since -f is concatenated with value
+    expect($customCommand)->toBe('docker compose --env-file /artifacts/build-time.env -f./custom/docker-compose.yaml build');
+    expect($customCommand)->not->toContain('-f /artifacts/deployment-uuid/docker-compose.yaml');
+    expect($customCommand)->toContain('--env-file /artifacts/build-time.env');
+});
+
+it('detects -f flag concatenated with path containing slash', function () {
+    $customCommand = 'docker compose -f/path/to/compose.yml up -d';
+
+    // Use the helper function
+    $customCommand = injectDockerComposeFlags($customCommand, '/artifacts/deployment-uuid/docker-compose.yaml', '/artifacts/build-time.env');
+
+    // Should NOT inject -f flag since -f is concatenated
+    expect($customCommand)->toBe('docker compose --env-file /artifacts/build-time.env -f/path/to/compose.yml up -d');
+    expect($customCommand)->not->toContain('-f /artifacts/deployment-uuid/docker-compose.yaml');
+    expect($customCommand)->toContain('-f/path/to/compose.yml');
+});
+
+it('detects -f flag concatenated at start of command', function () {
+    $customCommand = '-f./compose.yaml docker compose build';
+
+    // Use the helper function
+    $customCommand = injectDockerComposeFlags($customCommand, '/artifacts/deployment-uuid/docker-compose.yaml', '/artifacts/build-time.env');
+
+    // Should NOT inject -f flag since -f is already present (even at start)
+    expect($customCommand)->toBe('-f./compose.yaml docker compose --env-file /artifacts/build-time.env build');
+    expect($customCommand)->not->toContain('-f /artifacts/deployment-uuid/docker-compose.yaml');
+});
+
+it('detects concatenated -f flag with relative path', function () {
+    $customCommand = 'docker compose -f../docker-compose.prod.yaml build --no-cache';
+
+    // Use the helper function
+    $customCommand = injectDockerComposeFlags($customCommand, '/artifacts/deployment-uuid/docker-compose.yaml', '/artifacts/build-time.env');
+
+    // Should NOT inject -f flag
+    expect($customCommand)->toBe('docker compose --env-file /artifacts/build-time.env -f../docker-compose.prod.yaml build --no-cache');
+    expect($customCommand)->not->toContain('-f /artifacts/deployment-uuid/docker-compose.yaml');
+    expect($customCommand)->toContain('-f../docker-compose.prod.yaml');
+});
+
+it('correctly injects when no -f flag is present (sanity check after concatenated fix)', function () {
+    $customCommand = 'docker compose build --no-cache';
+
+    // Use the helper function
+    $customCommand = injectDockerComposeFlags($customCommand, '/artifacts/deployment-uuid/docker-compose.yaml', '/artifacts/build-time.env');
+
+    // SHOULD inject both flags
+    expect($customCommand)->toBe('docker compose -f /artifacts/deployment-uuid/docker-compose.yaml --env-file /artifacts/build-time.env build --no-cache');
+    expect($customCommand)->toContain('-f /artifacts/deployment-uuid/docker-compose.yaml');
+    expect($customCommand)->toContain('--env-file /artifacts/build-time.env');
+});
+
+// Edge case tests: First occurrence only replacement
+
+it('only replaces first docker compose occurrence in chained commands', function () {
+    $customCommand = 'docker compose pull && docker compose build';
+
+    // Use the helper function
+    $customCommand = injectDockerComposeFlags($customCommand, '/artifacts/uuid/docker-compose.yaml', '/artifacts/build-time.env');
+
+    // Only the FIRST 'docker compose' should get the flags
+    expect($customCommand)->toBe('docker compose -f /artifacts/uuid/docker-compose.yaml --env-file /artifacts/build-time.env pull && docker compose build');
+    expect($customCommand)->toContain('docker compose -f /artifacts/uuid/docker-compose.yaml --env-file /artifacts/build-time.env pull');
+    expect($customCommand)->toContain(' && docker compose build');
+    // Verify the second occurrence is NOT modified
+    expect(substr_count($customCommand, '-f /artifacts/uuid/docker-compose.yaml'))->toBe(1);
+    expect(substr_count($customCommand, '--env-file /artifacts/build-time.env'))->toBe(1);
+});
+
+it('does not modify docker compose string in echo statements', function () {
+    $customCommand = 'docker compose build && echo "docker compose finished successfully"';
+
+    // Use the helper function
+    $customCommand = injectDockerComposeFlags($customCommand, '/artifacts/uuid/docker-compose.yaml', '/artifacts/build-time.env');
+
+    // Only the FIRST 'docker compose' (the command) should get flags, NOT the echo message
+    expect($customCommand)->toBe('docker compose -f /artifacts/uuid/docker-compose.yaml --env-file /artifacts/build-time.env build && echo "docker compose finished successfully"');
+    expect($customCommand)->toContain('docker compose -f /artifacts/uuid/docker-compose.yaml --env-file /artifacts/build-time.env build');
+    expect($customCommand)->toContain('echo "docker compose finished successfully"');
+    // Verify echo message is NOT modified
+    expect(substr_count($customCommand, 'docker compose', 0))->toBe(2); // Two total occurrences
+    expect(substr_count($customCommand, '-f /artifacts/uuid/docker-compose.yaml'))->toBe(1); // Only first has flags
+});
+
+it('does not modify docker compose string in bash comments', function () {
+    $customCommand = 'docker compose build # This runs docker compose to build the image';
+
+    // Use the helper function
+    $customCommand = injectDockerComposeFlags($customCommand, '/artifacts/uuid/docker-compose.yaml', '/artifacts/build-time.env');
+
+    // Only the FIRST 'docker compose' (the command) should get flags, NOT the comment
+    expect($customCommand)->toBe('docker compose -f /artifacts/uuid/docker-compose.yaml --env-file /artifacts/build-time.env build # This runs docker compose to build the image');
+    expect($customCommand)->toContain('docker compose -f /artifacts/uuid/docker-compose.yaml --env-file /artifacts/build-time.env build');
+    expect($customCommand)->toContain('# This runs docker compose to build the image');
+    // Verify comment is NOT modified
+    expect(substr_count($customCommand, 'docker compose', 0))->toBe(2); // Two total occurrences
+    expect(substr_count($customCommand, '-f /artifacts/uuid/docker-compose.yaml'))->toBe(1); // Only first has flags
 });

--- a/tests/Unit/ApplicationDeploymentCustomBuildCommandTest.php
+++ b/tests/Unit/ApplicationDeploymentCustomBuildCommandTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * Test to verify that custom Docker Compose build commands properly inject environment variables.
+ *
+ * This test suite verifies that when using a custom build command, the system automatically
+ * injects the --env-file flag to ensure build-time environment variables are available during
+ * the build process. This fixes the issue where environment variables were lost when using
+ * custom build commands.
+ *
+ * The fix ensures that:
+ * - --env-file /artifacts/build-time.env is automatically injected after 'docker compose'
+ * - Users can still provide their own --env-file flag to override the default behavior
+ * - Build arguments are appended when not using build secrets
+ */
+it('injects --env-file flag into custom build command', function () {
+    $customCommand = 'docker compose -f ./docker-compose.yaml build';
+
+    // Simulate the injection logic from ApplicationDeploymentJob
+    if (! str_contains($customCommand, '--env-file')) {
+        $customCommand = str_replace(
+            'docker compose',
+            'docker compose --env-file /artifacts/build-time.env',
+            $customCommand
+        );
+    }
+
+    expect($customCommand)->toBe('docker compose --env-file /artifacts/build-time.env -f ./docker-compose.yaml build');
+    expect($customCommand)->toContain('--env-file /artifacts/build-time.env');
+});
+
+it('does not duplicate --env-file flag when already present', function () {
+    $customCommand = 'docker compose --env-file /custom/.env -f ./docker-compose.yaml build';
+
+    // Simulate the injection logic from ApplicationDeploymentJob
+    if (! str_contains($customCommand, '--env-file')) {
+        $customCommand = str_replace(
+            'docker compose',
+            'docker compose --env-file /artifacts/build-time.env',
+            $customCommand
+        );
+    }
+
+    expect($customCommand)->toBe('docker compose --env-file /custom/.env -f ./docker-compose.yaml build');
+    expect(substr_count($customCommand, '--env-file'))->toBe(1);
+});
+
+it('preserves custom build command structure with env-file injection', function () {
+    $customCommand = 'docker compose -f ./custom/path/docker-compose.prod.yaml build --no-cache';
+
+    // Simulate the injection logic from ApplicationDeploymentJob
+    if (! str_contains($customCommand, '--env-file')) {
+        $customCommand = str_replace(
+            'docker compose',
+            'docker compose --env-file /artifacts/build-time.env',
+            $customCommand
+        );
+    }
+
+    expect($customCommand)->toBe('docker compose --env-file /artifacts/build-time.env -f ./custom/path/docker-compose.prod.yaml build --no-cache');
+    expect($customCommand)->toContain('--env-file /artifacts/build-time.env');
+    expect($customCommand)->toContain('-f ./custom/path/docker-compose.prod.yaml');
+    expect($customCommand)->toContain('build --no-cache');
+});
+
+it('handles multiple docker compose commands in custom build command', function () {
+    // Edge case: Only the first 'docker compose' should get the env-file flag
+    $customCommand = 'docker compose -f ./docker-compose.yaml build';
+
+    // Simulate the injection logic from ApplicationDeploymentJob
+    if (! str_contains($customCommand, '--env-file')) {
+        $customCommand = str_replace(
+            'docker compose',
+            'docker compose --env-file /artifacts/build-time.env',
+            $customCommand
+        );
+    }
+
+    // Note: str_replace replaces ALL occurrences, which is acceptable in this case
+    // since you typically only have one 'docker compose' command
+    expect($customCommand)->toContain('docker compose --env-file /artifacts/build-time.env');
+});
+
+it('verifies build args would be appended correctly', function () {
+    $customCommand = 'docker compose --env-file /artifacts/build-time.env -f ./docker-compose.yaml build';
+    $buildArgs = collect([
+        '--build-arg NODE_ENV=production',
+        '--build-arg API_URL=https://api.example.com',
+    ]);
+
+    // Simulate build args appending logic
+    $buildArgsString = $buildArgs->implode(' ');
+    $buildArgsString = str_replace("'", "'\\''", $buildArgsString);
+    $customCommand .= " {$buildArgsString}";
+
+    expect($customCommand)->toContain('--build-arg NODE_ENV=production');
+    expect($customCommand)->toContain('--build-arg API_URL=https://api.example.com');
+    expect($customCommand)->toBe(
+        'docker compose --env-file /artifacts/build-time.env -f ./docker-compose.yaml build --build-arg NODE_ENV=production --build-arg API_URL=https://api.example.com'
+    );
+});
+
+it('properly escapes single quotes in build args', function () {
+    $buildArg = "--build-arg MESSAGE='Hello World'";
+
+    // Simulate the escaping logic from ApplicationDeploymentJob
+    $escapedBuildArg = str_replace("'", "'\\''", $buildArg);
+
+    expect($escapedBuildArg)->toBe("--build-arg MESSAGE='\\''Hello World'\\''");
+});
+
+it('handles DOCKER_BUILDKIT prefix with env-file injection', function () {
+    $customCommand = 'docker compose -f ./docker-compose.yaml build';
+
+    // Simulate the injection logic from ApplicationDeploymentJob
+    if (! str_contains($customCommand, '--env-file')) {
+        $customCommand = str_replace(
+            'docker compose',
+            'docker compose --env-file /artifacts/build-time.env',
+            $customCommand
+        );
+    }
+
+    // Simulate BuildKit support
+    $dockerBuildkitSupported = true;
+    if ($dockerBuildkitSupported) {
+        $customCommand = "DOCKER_BUILDKIT=1 {$customCommand}";
+    }
+
+    expect($customCommand)->toBe('DOCKER_BUILDKIT=1 docker compose --env-file /artifacts/build-time.env -f ./docker-compose.yaml build');
+    expect($customCommand)->toStartWith('DOCKER_BUILDKIT=1');
+    expect($customCommand)->toContain('--env-file /artifacts/build-time.env');
+});

--- a/tests/Unit/Livewire/ApplicationGeneralPreviewTest.php
+++ b/tests/Unit/Livewire/ApplicationGeneralPreviewTest.php
@@ -1,0 +1,156 @@
+<?php
+
+use App\Jobs\ApplicationDeploymentJob;
+use App\Livewire\Project\Application\General;
+
+it('prevents double slashes in build command preview when baseDirectory is root', function () {
+    // Mock the component with properties
+    $component = Mockery::mock(General::class)->makePartial();
+    $component->baseDirectory = '/';
+    $component->dockerComposeLocation = '/docker-compose.yaml';
+    $component->dockerComposeCustomBuildCommand = 'docker compose build';
+
+    $preview = $component->getDockerComposeBuildCommandPreviewProperty();
+
+    // Should be ./docker-compose.yaml, NOT .//docker-compose.yaml
+    expect($preview)
+        ->toBeString()
+        ->toContain('./docker-compose.yaml')
+        ->not->toContain('.//');
+});
+
+it('correctly formats build command preview with nested baseDirectory', function () {
+    $component = Mockery::mock(General::class)->makePartial();
+    $component->baseDirectory = '/backend';
+    $component->dockerComposeLocation = '/docker-compose.yaml';
+    $component->dockerComposeCustomBuildCommand = 'docker compose build';
+
+    $preview = $component->getDockerComposeBuildCommandPreviewProperty();
+
+    // Should be ./backend/docker-compose.yaml
+    expect($preview)
+        ->toBeString()
+        ->toContain('./backend/docker-compose.yaml');
+});
+
+it('correctly formats build command preview with deeply nested baseDirectory', function () {
+    $component = Mockery::mock(General::class)->makePartial();
+    $component->baseDirectory = '/apps/api/backend';
+    $component->dockerComposeLocation = '/docker-compose.prod.yaml';
+    $component->dockerComposeCustomBuildCommand = 'docker compose build';
+
+    $preview = $component->getDockerComposeBuildCommandPreviewProperty();
+
+    expect($preview)
+        ->toBeString()
+        ->toContain('./apps/api/backend/docker-compose.prod.yaml');
+});
+
+it('uses BUILD_TIME_ENV_PATH constant instead of hardcoded path in build command preview', function () {
+    $component = Mockery::mock(General::class)->makePartial();
+    $component->baseDirectory = '/';
+    $component->dockerComposeLocation = '/docker-compose.yaml';
+    $component->dockerComposeCustomBuildCommand = 'docker compose build';
+
+    $preview = $component->getDockerComposeBuildCommandPreviewProperty();
+
+    // Should contain the path from the constant
+    expect($preview)
+        ->toBeString()
+        ->toContain(ApplicationDeploymentJob::BUILD_TIME_ENV_PATH);
+});
+
+it('returns empty string for build command preview when no custom build command is set', function () {
+    $component = Mockery::mock(General::class)->makePartial();
+    $component->baseDirectory = '/backend';
+    $component->dockerComposeLocation = '/docker-compose.yaml';
+    $component->dockerComposeCustomBuildCommand = null;
+
+    $preview = $component->getDockerComposeBuildCommandPreviewProperty();
+
+    expect($preview)->toBe('');
+});
+
+it('prevents double slashes in start command preview when baseDirectory is root', function () {
+    $component = Mockery::mock(General::class)->makePartial();
+    $component->baseDirectory = '/';
+    $component->dockerComposeLocation = '/docker-compose.yaml';
+    $component->dockerComposeCustomStartCommand = 'docker compose up -d';
+
+    $preview = $component->getDockerComposeStartCommandPreviewProperty();
+
+    // Should be ./docker-compose.yaml, NOT .//docker-compose.yaml
+    expect($preview)
+        ->toBeString()
+        ->toContain('./docker-compose.yaml')
+        ->not->toContain('.//');
+});
+
+it('correctly formats start command preview with nested baseDirectory', function () {
+    $component = Mockery::mock(General::class)->makePartial();
+    $component->baseDirectory = '/frontend';
+    $component->dockerComposeLocation = '/compose.yaml';
+    $component->dockerComposeCustomStartCommand = 'docker compose up -d';
+
+    $preview = $component->getDockerComposeStartCommandPreviewProperty();
+
+    expect($preview)
+        ->toBeString()
+        ->toContain('./frontend/compose.yaml');
+});
+
+it('uses workdir env placeholder in start command preview', function () {
+    $component = Mockery::mock(General::class)->makePartial();
+    $component->baseDirectory = '/';
+    $component->dockerComposeLocation = '/docker-compose.yaml';
+    $component->dockerComposeCustomStartCommand = 'docker compose up -d';
+
+    $preview = $component->getDockerComposeStartCommandPreviewProperty();
+
+    // Start command should use {workdir}/.env, not build-time env
+    expect($preview)
+        ->toBeString()
+        ->toContain('{workdir}/.env')
+        ->not->toContain(ApplicationDeploymentJob::BUILD_TIME_ENV_PATH);
+});
+
+it('returns empty string for start command preview when no custom start command is set', function () {
+    $component = Mockery::mock(General::class)->makePartial();
+    $component->baseDirectory = '/backend';
+    $component->dockerComposeLocation = '/docker-compose.yaml';
+    $component->dockerComposeCustomStartCommand = null;
+
+    $preview = $component->getDockerComposeStartCommandPreviewProperty();
+
+    expect($preview)->toBe('');
+});
+
+it('handles baseDirectory with trailing slash correctly in build command', function () {
+    $component = Mockery::mock(General::class)->makePartial();
+    $component->baseDirectory = '/backend/';
+    $component->dockerComposeLocation = '/docker-compose.yaml';
+    $component->dockerComposeCustomBuildCommand = 'docker compose build';
+
+    $preview = $component->getDockerComposeBuildCommandPreviewProperty();
+
+    // rtrim should remove trailing slash to prevent double slashes
+    expect($preview)
+        ->toBeString()
+        ->toContain('./backend/docker-compose.yaml')
+        ->not->toContain('backend//');
+});
+
+it('handles baseDirectory with trailing slash correctly in start command', function () {
+    $component = Mockery::mock(General::class)->makePartial();
+    $component->baseDirectory = '/backend/';
+    $component->dockerComposeLocation = '/docker-compose.yaml';
+    $component->dockerComposeCustomStartCommand = 'docker compose up -d';
+
+    $preview = $component->getDockerComposeStartCommandPreviewProperty();
+
+    // rtrim should remove trailing slash to prevent double slashes
+    expect($preview)
+        ->toBeString()
+        ->toContain('./backend/docker-compose.yaml')
+        ->not->toContain('backend//');
+});


### PR DESCRIPTION
## Summary
This fix auto-injects the `-f` (compose file path) and `--env-file` flags into custom Docker Compose build and start commands. Additionally, it fixes an edge case in flag replacement to only modify the first occurrence of "docker compose" to avoid unintended modifications to comments or chained commands.

## Changes
- **Helper function** `injectDockerComposeFlags()` automatically injects `-f` and `--env-file` flags with smart detection of existing flags
- **Edge case fix** uses `preg_replace()` with limit=1 to replace only first "docker compose" occurrence, preventing modification of comments/strings/chained commands
- **Constants** for artifact paths improve maintainability and reduce duplication
- **Preview fields** in UI show users the final command that will be executed with injected flags

## Testing
All 35+ tests passing, including 3 new edge case tests validating first-occurrence-only replacement behavior.

fix #7120