### PR TITLE
Auto-create MinIO bucket in development

### DIFF
--- a/database/seeders/S3StorageSeeder.php
+++ b/database/seeders/S3StorageSeeder.php
@@ -20,6 +20,7 @@ class S3StorageSeeder extends Seeder
             'bucket' => 'local',
             'endpoint' => 'http://coolify-minio:9000',
             'team_id' => 0,
+            'is_usable' => true,
         ]);
     }
 }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -118,6 +118,26 @@ services:
       - dev_minio_data:/data
     networks:
       - coolify
+  minio-init:
+    image: minio/mc:latest
+    pull_policy: always
+    container_name: coolify-minio-init
+    restart: no
+    depends_on:
+      - minio
+    entrypoint: >
+      /bin/sh -c "
+      echo 'Waiting for MinIO to be ready...';
+      until mc alias set local http://coolify-minio:9000 minioadmin minioadmin 2>/dev/null; do
+        echo 'MinIO not ready yet, waiting...';
+        sleep 2;
+      done;
+      echo 'MinIO is ready, creating bucket if needed...';
+      mc mb local/local --ignore-existing;
+      echo 'MinIO initialization complete - bucket local is ready';
+      "
+    networks:
+      - coolify
 
 volumes:
   dev_backups_data:


### PR DESCRIPTION
## Summary
Adds automatic MinIO bucket creation and S3 storage validation in development. Developers no longer need to manually set up the bucket or validate the storage in the UI.

## Changes
- Added `minio-init` service to auto-create the `local` bucket on startup
- Mark seeded S3Storage as `is_usable` by default for immediate use

🤖 Generated with [Claude Code](https://claude.com/claude-code)