### PR TITLE
Add coolify-minio-init to docker cleanup

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,7 +1,7 @@
 {
     "scripts": {
         "setup": "./scripts/conductor-setup.sh",
-        "run": "docker rm -f coolify coolify-realtime coolify-minio coolify-testing-host coolify-redis coolify-db coolify-mail coolify-vite; spin up; spin down"
+        "run": "docker rm -f coolify coolify-minio-init coolify-realtime coolify-minio coolify-testing-host coolify-redis coolify-db coolify-mail coolify-vite; spin up; spin down"
     },
     "runScriptMode": "nonconcurrent"
 }


### PR DESCRIPTION
Adds the minio-init container to the docker cleanup command in conductor.json.

This ensures the MinIO initialization container is properly cleaned up alongside other containers during conductor operations.

🤖 Generated with Claude Code