### PR TITLE
feat(ui): Logs color highlight based on log level

### DIFF
--- a/app/Livewire/Project/Shared/GetLogs.php
+++ b/app/Livewire/Project/Shared/GetLogs.php
@@ -39,7 +39,7 @@ class GetLogs extends Component
 
     public ?bool $streamLogs = false;
 
-    public ?bool $showTimeStamps = true;
+    public ?bool $showTimeStamps = false;
 
     public ?int $numberOfLines = 100;
 

--- a/resources/views/livewire/project/shared/get-logs.blade.php
+++ b/resources/views/livewire/project/shared/get-logs.blade.php
@@ -102,9 +102,41 @@
                     </div>
                 </div>
                 @if ($outputs)
-                    <pre id="logs" class="font-mono whitespace-pre-wrap break-all max-w-full">{{ $outputs }}</pre>
+                    <div id="logs" class="font-mono text-sm">
+                        @foreach(explode("\n", trim($outputs)) as $line)
+                            @if(!empty(trim($line)))
+                                @php
+                                    $lowerLine = strtolower($line);
+                                    $isError = str_contains($lowerLine, 'error') || str_contains($lowerLine, 'err') || str_contains($lowerLine, 'failed') || str_contains($lowerLine, 'exception');
+                                    $isWarning = str_contains($lowerLine, 'warn') || str_contains($lowerLine, 'warning') || str_contains($lowerLine, 'wrn');
+                                    $isDebug = str_contains($lowerLine, 'debug') || str_contains($lowerLine, 'dbg') || str_contains($lowerLine, 'trace');
+                                    $barColor = $isError ? 'bg-red-500 dark:bg-red-400' : ($isWarning ? 'bg-yellow-500 dark:bg-yellow-400' : ($isDebug ? 'bg-purple-500 dark:bg-purple-400' : 'bg-blue-500 dark:bg-blue-400'));
+                                    $bgColor = $isError ? 'bg-red-50/50 dark:bg-red-900/20 hover:bg-red-100/50 dark:hover:bg-red-800/30' : ($isWarning ? 'bg-yellow-50/50 dark:bg-yellow-900/20 hover:bg-yellow-100/50 dark:hover:bg-yellow-800/30' : ($isDebug ? 'bg-purple-50/50 dark:bg-purple-900/20 hover:bg-purple-100/50 dark:hover:bg-purple-800/30' : 'bg-blue-50/50 dark:bg-blue-900/20 hover:bg-blue-100/50 dark:hover:bg-blue-800/30'));
+
+                                    // Check for timestamp at the beginning (ISO 8601 format)
+                                    $timestampPattern = '/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z?)\s+/';
+                                    $hasTimestamp = preg_match($timestampPattern, $line, $matches);
+                                    $timestamp = $hasTimestamp ? $matches[1] : null;
+                                    $logContent = $hasTimestamp ? preg_replace($timestampPattern, '', $line) : $line;
+                                @endphp
+                                <div class="flex items-start gap-2 py-1 px-2 rounded-sm">
+                                    <div class="w-1 {{ $barColor }} rounded-full flex-shrink-0 self-stretch"></div>
+                                    <div class="flex-1 {{ $bgColor }} py-1 px-2 -mx-2 rounded-sm">
+                                        @if($hasTimestamp)
+                                            <span class="text-xs text-gray-500 dark:text-gray-400 font-mono mr-2">{{ $timestamp }}</span>
+                                            <span class="whitespace-pre-wrap break-all">{{ $logContent }}</span>
+                                        @else
+                                            <span class="whitespace-pre-wrap break-all">{{ $line }}</span>
+                                        @endif
+                                    </div>
+                                </div>
+                            @endif
+                        @endforeach
+                    </div>
                 @else
-                    <pre id="logs" class="font-mono whitespace-pre-wrap break-all max-w-full">Refresh to get the logs...</pre>
+                    <div id="logs" class="font-mono text-sm py-4 px-2 text-gray-500 dark:text-gray-400">
+                        Refresh to get the logs...
+                    </div>
                 @endif
             </div>
         </div>

--- a/resources/views/livewire/project/shared/get-logs.blade.php
+++ b/resources/views/livewire/project/shared/get-logs.blade.php
@@ -114,7 +114,7 @@
                                     $bgColor = $isError ? 'bg-red-50/50 dark:bg-red-900/20 hover:bg-red-100/50 dark:hover:bg-red-800/30' : ($isWarning ? 'bg-yellow-50/50 dark:bg-yellow-900/20 hover:bg-yellow-100/50 dark:hover:bg-yellow-800/30' : ($isDebug ? 'bg-purple-50/50 dark:bg-purple-900/20 hover:bg-purple-100/50 dark:hover:bg-purple-800/30' : 'bg-blue-50/50 dark:bg-blue-900/20 hover:bg-blue-100/50 dark:hover:bg-blue-800/30'));
 
                                     // Check for timestamp at the beginning (ISO 8601 format)
-                                    $timestampPattern = '/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z?)\s+/';
+                                    $timestampPattern = '/^(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z?)\s+/';
                                     $hasTimestamp = preg_match($timestampPattern, $line, $matches);
                                     $timestamp = $hasTimestamp ? $matches[1] : null;
                                     $logContent = $hasTimestamp ? preg_replace($timestampPattern, '', $line) : $line;


### PR DESCRIPTION
### Proxy Logs:

<table>
  <tr>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/e335c657-f729-45f1-8f4f-99c0ff65808e" width="400" /><br/>
      Current Dark Mode
    </td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/6cc000d5-a244-4cf8-8fa3-d9bf2360ca30" width="400" /><br/>
      New Dark Mode
    </td>
  </tr>
  <tr>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/f5e475e5-22bf-4074-bc40-2e6db35200d7" width="400" /><br/>
      Current Light Mode
    </td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/3f40938b-a413-4fa4-99bd-df492e4c41e0" width="400" /><br/>
      New Light Mode
    </td>
  </tr>
</table>

### Application Logs:

<table>
  <tr>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/9f1b67d5-5815-4f0b-9cb0-9216614e6ed0" width="400" /><br/>
      Current Dark Mode
    </td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/10cb7231-933c-4efb-a310-4ef6e51c470c" width="400" /><br/>
      New Dark Mode
    </td>
  </tr>
  <tr>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/86aaaa52-ae11-45c3-a1fd-cc7403205003" width="400" /><br/>
      Current Light Mode
    </td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/ccdd0a86-2b15-4912-885c-9e9dbaa23e4a" width="400" /><br/>
      New Light Mode
    </td>
  </tr>
</table>


#### How this works:
- We check keywords on logs like "err", "error", "wrn", "warn", and so on, then apply color based on the log type
- The log color shows based on precedence like Error > Warning > Debug > Info -- which means if a log contain both Error and warning keywords then it will show the log in Red color (Error) since Error have higher precedence

#### Colors:
- ERROR - Red
- WARNING - Yellow
- DEBUG - Purple
- INFO - Blue


### Notes:
- I disabled "show timestamp" by default for proxy logs because traefik logs and most applications already include timestamp so having "show timestamp" enabled shows timestamp twice on the logs. Users can manually enable the "show timestamp" option if their app won't show timestamps on logs 😄
- I don't know PHP so all the changes are done by AI, but fully tested the changes locally (with both Traefik and Caddy) and it's working without any issues.