### PR TITLE
Fix database restart to skip unnecessary Docker cleanup

### DIFF
--- a/app/Actions/Database/RestartDatabase.php
+++ b/app/Actions/Database/RestartDatabase.php
@@ -22,7 +22,7 @@ class RestartDatabase
         if (! $server->isFunctional()) {
             return 'Server is not functional';
         }
-        StopDatabase::run($database);
+        StopDatabase::run($database, dockerCleanup: false);
 
         return StartDatabase::run($database);
     }


### PR DESCRIPTION
## Changes
- Modified `RestartDatabase` action to skip Docker cleanup during restart by passing `dockerCleanup: false` to `StopDatabase::run()`

## Description
Database restart was removing Docker Hub images (postgres, mysql, redis, etc.) that lack the `coolify.managed=true` label, causing them to be immediately re-pulled. This wasted bandwidth and slowed down restarts.

The fix preserves database images between restarts while still stopping and starting containers normally. Users can still manually trigger cleanup using the Stop button's cleanup checkbox if they need to free disk space.

## Testing
- Change is minimal and doesn't affect any other functionality
- Images are preserved on restart instead of being removed and re-downloaded