### PR TITLE
feat: add public port validation and saving in instantSave method

### DIFF
--- a/app/Livewire/Project/Database/Clickhouse/General.php
+++ b/app/Livewire/Project/Database/Clickhouse/General.php
@@ -162,6 +162,12 @@ class General extends Component
         try {
             $this->authorize('update', $this->database);
 
+            if ($this->publicPort) {
+                $this->validate(['publicPort' => 'nullable|integer']);
+                $this->database->public_port = $this->publicPort;
+                $this->database->save();
+            }
+
             if ($this->isPublic && ! $this->publicPort) {
                 $this->dispatch('error', 'Public port is required.');
                 $this->isPublic = false;

--- a/app/Livewire/Project/Database/Dragonfly/General.php
+++ b/app/Livewire/Project/Database/Dragonfly/General.php
@@ -172,6 +172,12 @@ class General extends Component
         try {
             $this->authorize('update', $this->database);
 
+            if ($this->publicPort) {
+                $this->validate(['publicPort' => 'nullable|integer']);
+                $this->database->public_port = $this->publicPort;
+                $this->database->save();
+            }
+
             if ($this->isPublic && ! $this->publicPort) {
                 $this->dispatch('error', 'Public port is required.');
                 $this->isPublic = false;

--- a/app/Livewire/Project/Database/Keydb/General.php
+++ b/app/Livewire/Project/Database/Keydb/General.php
@@ -179,6 +179,12 @@ class General extends Component
         try {
             $this->authorize('update', $this->database);
 
+            if ($this->publicPort) {
+                $this->validate(['publicPort' => 'nullable|integer']);
+                $this->database->public_port = $this->publicPort;
+                $this->database->save();
+            }
+
             if ($this->isPublic && ! $this->publicPort) {
                 $this->dispatch('error', 'Public port is required.');
                 $this->isPublic = false;

--- a/app/Livewire/Project/Database/Mariadb/General.php
+++ b/app/Livewire/Project/Database/Mariadb/General.php
@@ -228,6 +228,12 @@ class General extends Component
         try {
             $this->authorize('update', $this->database);
 
+            if ($this->publicPort) {
+                $this->validate(['publicPort' => 'nullable|integer']);
+                $this->database->public_port = $this->publicPort;
+                $this->database->save();
+            }
+
             if ($this->isPublic && ! $this->publicPort) {
                 $this->dispatch('error', 'Public port is required.');
                 $this->isPublic = false;

--- a/app/Livewire/Project/Database/Mongodb/General.php
+++ b/app/Livewire/Project/Database/Mongodb/General.php
@@ -231,6 +231,12 @@ class General extends Component
         try {
             $this->authorize('update', $this->database);
 
+            if ($this->publicPort) {
+                $this->validate(['publicPort' => 'nullable|integer']);
+                $this->database->public_port = $this->publicPort;
+                $this->database->save();
+            }
+
             if ($this->isPublic && ! $this->publicPort) {
                 $this->dispatch('error', 'Public port is required.');
                 $this->isPublic = false;

--- a/app/Livewire/Project/Database/Mysql/General.php
+++ b/app/Livewire/Project/Database/Mysql/General.php
@@ -235,6 +235,12 @@ class General extends Component
         try {
             $this->authorize('update', $this->database);
 
+            if ($this->publicPort) {
+                $this->validate(['publicPort' => 'nullable|integer']);
+                $this->database->public_port = $this->publicPort;
+                $this->database->save();
+            }
+
             if ($this->isPublic && ! $this->publicPort) {
                 $this->dispatch('error', 'Public port is required.');
                 $this->isPublic = false;

--- a/app/Livewire/Project/Database/Postgresql/General.php
+++ b/app/Livewire/Project/Database/Postgresql/General.php
@@ -282,6 +282,12 @@ class General extends Component
         try {
             $this->authorize('update', $this->database);
 
+            if ($this->publicPort) {
+                $this->validate(['publicPort' => 'nullable|integer']);
+                $this->database->public_port = $this->publicPort;
+                $this->database->save();
+            }
+
             if ($this->isPublic && ! $this->publicPort) {
                 $this->dispatch('error', 'Public port is required.');
                 $this->isPublic = false;

--- a/app/Livewire/Project/Database/Redis/General.php
+++ b/app/Livewire/Project/Database/Redis/General.php
@@ -221,6 +221,12 @@ class General extends Component
         try {
             $this->authorize('update', $this->database);
 
+            if ($this->publicPort) {
+                $this->validate(['publicPort' => 'nullable|integer']);
+                $this->database->public_port = $this->publicPort;
+                $this->database->save();
+            }
+
             if ($this->isPublic && ! $this->publicPort) {
                 $this->dispatch('error', 'Public port is required.');
                 $this->isPublic = false;


### PR DESCRIPTION
## Changes
- Added Public Port Validation & Saving in instantSave method for DBs.

These changes allow checking the "Make it publicly available" immediately after filling the Public Port input, this way user doesn't have to first hit Save button before activating the checkbox.