### PR TITLE
Add Persistent Volumes for Themes, Extensions, and Storage in Paymenter 

### DIFF
--- a/templates/compose/paymenter.yaml
+++ b/templates/compose/paymenter.yaml
@@ -43,7 +43,7 @@ services:
       timeout: 1s
       retries: 3
   mariadb:
-    image: 'mariadb:11'
+    image: 'mariadb:11.8'
     volumes:
       - 'paymenter_mariadb_data:/var/lib/mysql'
     environment:

--- a/templates/compose/paymenter.yaml
+++ b/templates/compose/paymenter.yaml
@@ -9,11 +9,12 @@ services:
   paymenter:
     image: 'ghcr.io/paymenter/paymenter:v1.4.5'
     volumes:
-      'app_logs:/app/storage/logs'
-      - 'app_public:/app/storage/public'
+      - 'app_logs:/app/storage/logs'
+      - 'app_storage1:/app/storage/public'
       - 'extenstions:/app/extensions'
       - 'themes:/app/themes'
-      - 'app_storage_public:/app/public/storage'
+      - 'app_storage2:/app/public/storage'
+      - 'app_storage3:app/storage/app/public'
     environment:
       SERVICE_URL_PAYMENTER: '${SERVICE_URL_PAYMENTER_80}'
       DB_DATABASE: '${MYSQL_DATABASE:-paymenter-db}'

--- a/templates/compose/paymenter.yaml
+++ b/templates/compose/paymenter.yaml
@@ -7,7 +7,7 @@
 
 services:
   paymenter:
-    image: 'ghcr.io/paymenter/paymenter:latest'
+    image: 'ghcr.io/paymenter/paymenter:v1.4.5'
     volumes:
       - 'app_logs:/app/storage/logs'
       - 'app_public:/app/storage/public'

--- a/templates/compose/paymenter.yaml
+++ b/templates/compose/paymenter.yaml
@@ -9,11 +9,11 @@ services:
   paymenter:
     image: 'ghcr.io/paymenter/paymenter:v1.4.5'
     volumes:
-      - 'app_logs:/app/storage/logs'
+      'app_logs:/app/storage/logs'
       - 'app_public:/app/storage/public'
       - 'extenstions:/app/extensions'
       - 'themes:/app/themes'
-      - 'app_storage_public:/app/storage/app/public'
+      - 'app_storage_public:/app/public/storage'
     environment:
       SERVICE_URL_PAYMENTER: '${SERVICE_URL_PAYMENTER_80}'
       DB_DATABASE: '${MYSQL_DATABASE:-paymenter-db}'

--- a/templates/compose/paymenter.yaml
+++ b/templates/compose/paymenter.yaml
@@ -7,56 +7,65 @@
 
 services:
   paymenter:
-    image: ghcr.io/paymenter/paymenter:latest
+    image: 'ghcr.io/paymenter/paymenter:latest'
     volumes:
-      - app_logs:/app/storage/logs
-      - app_public:/app/storage/public
+      - 'app_logs:/app/storage/logs'
+      - 'app_public:/app/storage/public'
+      - 'extenstions:/app/extensions'
+      - 'themes:/app/themes'
+      - 'app_storage_public:/app/storage/app/public'
     environment:
-      SERVICE_URL_PAYMENTER: ${SERVICE_URL_PAYMENTER_80}
-      DB_DATABASE: ${MYSQL_DATABASE:-paymenter-db}
-      DB_PASSWORD: ${SERVICE_PASSWORD_MYSQL}
-      DB_USERNAME: ${SERVICE_USER_MYSQL}
+      SERVICE_URL_PAYMENTER: '${SERVICE_URL_PAYMENTER_80}'
+      DB_DATABASE: '${MYSQL_DATABASE:-paymenter-db}'
+      DB_PASSWORD: '${SERVICE_PASSWORD_MYSQL}'
+      DB_USERNAME: '${SERVICE_USER_MYSQL}'
       APP_ENV: production
       CACHE_STORE: redis
       SESSION_DRIVER: redis
       QUEUE_CONNECTION: redis
       REDIS_HOST: redis
       REDIS_USERNAME: default
-      REDIS_PASSWORD: ${SERVICE_PASSWORD_64_REDIS}
+      REDIS_PASSWORD: '${SERVICE_PASSWORD_64_REDIS}'
       DB_CONNECTION: mariadb
       DB_HOST: mariadb
       DB_PORT: 3306
-      APP_KEY: ${SERVICE_BASE64_KEY}
+      APP_KEY: '${SERVICE_BASE64_KEY}'
     depends_on:
       mariadb:
         condition: service_healthy
       redis:
         condition: service_started
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:80 || exit 1"]
+      test:
+        - CMD-SHELL
+        - 'curl -sf http://localhost:80 || exit 1'
       interval: 10s
       timeout: 1s
       retries: 3
-
   mariadb:
-    image: mariadb:11
+    image: 'mariadb:11'
     volumes:
-      - paymenter_mariadb_data:/var/lib/mysql
+      - 'paymenter_mariadb_data:/var/lib/mysql'
     environment:
-      - MYSQL_ROOT_PASSWORD=${SERVICE_PASSWORD_MYSQLROOT}
-      - MYSQL_DATABASE=${MYSQL_DATABASE:-paymenter-db}
-      - MYSQL_USER=${SERVICE_USER_MYSQL}
-      - MYSQL_PASSWORD=${SERVICE_PASSWORD_MYSQL}
+      - 'MYSQL_ROOT_PASSWORD=${SERVICE_PASSWORD_MYSQLROOT}'
+      - 'MYSQL_DATABASE=${MYSQL_DATABASE:-paymenter-db}'
+      - 'MYSQL_USER=${SERVICE_USER_MYSQL}'
+      - 'MYSQL_PASSWORD=${SERVICE_PASSWORD_MYSQL}'
     healthcheck:
-      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      test:
+        - CMD
+        - healthcheck.sh
+        - '--connect'
+        - '--innodb_initialized'
       interval: 5s
       timeout: 20s
       retries: 10
-
   redis:
-    image: redis:alpine
+    image: 'redis:alpine'
     healthcheck:
-      test: ["CMD-SHELL", "redis-cli ping || exit 1"]
+      test:
+        - CMD-SHELL
+        - 'redis-cli ping || exit 1'
       interval: 10s
       timeout: 1s
       retries: 3

--- a/templates/compose/paymenter.yaml
+++ b/templates/compose/paymenter.yaml
@@ -10,11 +10,10 @@ services:
     image: 'ghcr.io/paymenter/paymenter:v1.4.5'
     volumes:
       - 'app_logs:/app/storage/logs'
-      - 'app_storage1:/app/storage/public'
       - 'extenstions:/app/extensions'
       - 'themes:/app/themes'
-      - 'app_storage2:/app/public/storage'
-      - 'app_storage3:app/storage/app/public'
+      - 'app_storage:/app/storage/app'
+      - 'app_public_storage:/app/storage/app/public'
     environment:
       SERVICE_URL_PAYMENTER: '${SERVICE_URL_PAYMENTER_80}'
       DB_DATABASE: '${MYSQL_DATABASE:-paymenter-db}'


### PR DESCRIPTION
### Summary
This PR enables saving custom themes, extensions, and storage paths.

### Changes
- Added `themes` volume for theme assets
- Added `extensions` volume for plugin/extension files
- Added `app_storage_public` for public storage data within Paymenter
- Update Mariadb to version `11.8`
### Why?
These volumes ensure that themes, images and extensions arent lost during the restart.


