### PR TITLE
fix(ui): empty network destinations when cloning a resource

### DIFF
--- a/resources/views/livewire/project/shared/resource-operations.blade.php
+++ b/resources/views/livewire/project/shared/resource-operations.blade.php
@@ -23,7 +23,7 @@
                 ],
             ),
         ],
-    ),
+    )->values(),
 ),
         projects: @js(
     $projects->map(


### PR DESCRIPTION
## Changes

- fix(ui): empty network destinations when cloning a resource by correcting the servers data structure

### Additional Details

<img width="560" height="405" alt="image" src="https://github.com/user-attachments/assets/0ccc9858-17bc-4445-9932-aa02cdacc8c4" />

Coolify with build server setup is filter out during select server for clone resource. During filter process, sometime it transform array to numeric key based object like **case 1** above (idk why). Therefore, it continue render to json like `{"0": {...}, "1": {...}}` instead of **case 2** as following `[{...}, {...}]`  . 

## Issues

- fixes https://github.com/coollabsio/coolify/issues/7102
