### PR TITLE
Update Pterodactyl + Wings template to expose port 2022 for SFTP access

### DIFF
--- a/templates/compose/pterodactyl-with-wings.yaml
+++ b/templates/compose/pterodactyl-with-wings.yaml
@@ -111,6 +111,8 @@ services:
   wings:
     image: 'ghcr.io/pterodactyl/wings:v1.11.13'
     restart: unless-stopped
+    ports:
+      - "2022:2022"
     environment:
       - SERVICE_URL_WINGS_8443
       - 'TZ=${TIMEZONE:-UTC}'


### PR DESCRIPTION
## Changes
- Expose port 2022 in the compose file for Pterodactyl + Wings. This allows SFTP access through Wings, as it does not work without this port open. This how it is intended, as the standalone Wings template has this clause.