### PR TITLE
fix: handle migration rename errors for v444→v445 upgrades

### DIFF
--- a/database/migrations/2025_10_10_120002_create_cloud_init_scripts_table.php
+++ b/database/migrations/2025_10_10_120002_create_cloud_init_scripts_table.php
@@ -11,6 +11,12 @@ return new class extends Migration
      */
     public function up(): void
     {
+        // Check if table already exists (handles upgrades from v444 where this migration
+        // was named 2025_10_10_120000_create_cloud_init_scripts_table.php)
+        if (Schema::hasTable('cloud_init_scripts')) {
+            return;
+        }
+
         Schema::create('cloud_init_scripts', function (Blueprint $table) {
             $table->id();
             $table->foreignId('team_id')->constrained()->onDelete('cascade');

--- a/database/migrations/2025_10_10_120002_create_webhook_notification_settings_table.php
+++ b/database/migrations/2025_10_10_120002_create_webhook_notification_settings_table.php
@@ -11,6 +11,12 @@ return new class extends Migration
      */
     public function up(): void
     {
+        // Check if table already exists (handles upgrades from v444 where this migration
+        // was named 2025_10_10_120000_create_webhook_notification_settings_table.php)
+        if (Schema::hasTable('webhook_notification_settings')) {
+            return;
+        }
+
         Schema::create('webhook_notification_settings', function (Blueprint $table) {
             $table->id();
             $table->foreignId('team_id')->constrained()->cascadeOnDelete();


### PR DESCRIPTION
## Changes

- Added table existence checks to `cloud_init_scripts` migration to handle rename from `120000` to `120002`
- Added table existence checks to `webhook_notification_settings` migration to handle rename from `120000` to `120002`
- Both migrations were renamed on Nov 17, 2025, causing "duplicate table" errors for users upgrading from v444

## Issues

Fixes: Users unable to upgrade from v4.0.0-beta.444 to v4.0.0-beta.445 due to "SQLSTATE[42P07]: Duplicate table" errors