### PR TITLE
fix: show shared env scopes dropdown even when no variables exist

### DIFF
--- a/resources/views/components/forms/env-var-input.blade.php
+++ b/resources/views/components/forms/env-var-input.blade.php
@@ -20,21 +20,11 @@
             availableVars: @js($availableVars),
             scopeUrls: @js($scopeUrls),
 
-            isAutocompleteDisabled() {
-                const hasAnyVars = Object.values(this.availableVars).some(vars => vars.length > 0);
-                return !hasAnyVars;
-            },
-
             handleInput() {
                 const input = this.$refs.input;
                 if (!input) return;
 
                 const value = input.value || '';
-
-                if (this.isAutocompleteDisabled()) {
-                    this.showDropdown = false;
-                    return;
-                }
 
                 this.cursorPosition = input.selectionStart || 0;
                 const textBeforeCursor = value.substring(0, this.cursorPosition);


### PR DESCRIPTION
## Changes
- Removed `isAutocompleteDisabled()` method that blocked dropdown visibility
- Removed early return check that prevented showing scopes
- Dropdown now always shows available scopes (team, project, environment)
- Users see helpful "No shared variables found" message with creation links when a scope is empty

## Issues
Fixes the issue where the shared environment variables dropdown would not appear when no variables existed in any scope, making the feature appear broken.