### PR TITLE
fix: resolve uncloseable database restore modal

### DIFF
--- a/app/Livewire/ActivityMonitor.php
+++ b/app/Livewire/ActivityMonitor.php
@@ -10,7 +10,7 @@ class ActivityMonitor extends Component
 {
     public ?string $header = null;
 
-    public $activityId;
+    public $activityId = null;
 
     public $eventToDispatch = 'activityFinished';
 
@@ -49,7 +49,22 @@ class ActivityMonitor extends Component
 
     public function hydrateActivity()
     {
+        if ($this->activityId === null) {
+            $this->activity = null;
+
+            return;
+        }
+
         $this->activity = Activity::find($this->activityId);
+    }
+
+    public function updatedActivityId($value)
+    {
+        if ($value) {
+            $this->hydrateActivity();
+            $this->isPollingActive = true;
+            self::$eventDispatched = false;
+        }
     }
 
     public function polling()

--- a/app/Livewire/Project/Database/Import.php
+++ b/app/Livewire/Project/Database/Import.php
@@ -133,6 +133,8 @@ class Import extends Component
 
     public string $customLocation = '';
 
+    public ?int $activityId = null;
+
     public string $postgresqlRestoreCommand = 'pg_restore -U $POSTGRES_USER -d $POSTGRES_DB';
 
     public string $mysqlRestoreCommand = 'mysql -u $MYSQL_USER -p$MYSQL_PASSWORD $MYSQL_DATABASE';
@@ -156,7 +158,13 @@ class Import extends Component
 
         return [
             "echo-private:user.{$userId},DatabaseStatusChanged" => '$refresh',
+            'slideOverClosed' => 'resetActivityId',
         ];
+    }
+
+    public function resetActivityId()
+    {
+        $this->activityId = null;
     }
 
     public function mount()
@@ -326,6 +334,9 @@ EOD;
                     'container' => $this->container,
                     'serverId' => $this->server->id,
                 ]);
+
+                // Track the activity ID
+                $this->activityId = $activity->id;
 
                 // Dispatch activity to the monitor and open slide-over
                 $this->dispatch('activityMonitor', $activity->id);
@@ -547,6 +558,9 @@ EOD;
                 'container' => $this->container,
                 'serverId' => $this->server->id,
             ]);
+
+            // Track the activity ID
+            $this->activityId = $activity->id;
 
             // Dispatch activity to the monitor and open slide-over
             $this->dispatch('activityMonitor', $activity->id);

--- a/resources/views/components/slide-over.blade.php
+++ b/resources/views/components/slide-over.blade.php
@@ -1,7 +1,13 @@
 @props(['closeWithX' => false, 'fullScreen' => false])
 <div x-data="{
     slideOverOpen: false
-}" {{ $attributes->merge(['class' => 'relative w-auto h-auto']) }}>
+}"
+x-init="$watch('slideOverOpen', value => {
+    if (!value) {
+        $dispatch('slideOverClosed')
+    }
+})"
+{{ $attributes->merge(['class' => 'relative w-auto h-auto']) }}>
     {{ $slot }}
     <template x-teleport="body">
         <div x-show="slideOverOpen" @if (!$closeWithX) @keydown.window.escape="slideOverOpen=false" @endif


### PR DESCRIPTION
## Changes
- Add `updatedActivityId()` lifecycle hook to ActivityMonitor for proper Livewire hydration
- Add defensive null check in `hydrateActivity()` to prevent errors with undefined activityId
- Track `activityId` in Import component for state management during restore operations
- Add `slideOverClosed` event dispatch in slide-over component for lifecycle management
- Add event listener in Import component to reset activityId when slide-over closes

## Issues
- fix #7335