### PR TITLE
fix(service): wireguard easy host to use fqdn

### DIFF
--- a/templates/compose/wireguard-easy.yaml
+++ b/templates/compose/wireguard-easy.yaml
@@ -10,7 +10,7 @@ services:
     image: ghcr.io/wg-easy/wg-easy:latest
     environment:
       - SERVICE_URL_WIREGUARDEASY_51821
-      - WG_HOST=${SERVICE_URL_WIREGUARDEASY}
+      - WG_HOST=${SERVICE_FQDN_WIREGUARDEASY}
       - LANG=${LANG:-en}
       - WG_PORT=51820
       - _PASSWORD=${SERVICE_PASSWORD_ADMIN}


### PR DESCRIPTION
## Changes

- fix(service): wireguard easy host to use fqdn instead of URL. This will enable the correct import of the configurations when using QR code scan or importing the JSON on the desktop client.