### PR TITLE
fix(ui): images inside coolify changelog

### DIFF
--- a/app/Services/ChangelogService.php
+++ b/app/Services/ChangelogService.php
@@ -287,7 +287,7 @@ class ChangelogService
         $html = preg_replace('/<a([^>]*)>/', '<a$1 class="text-blue-500 hover:text-blue-600 underline" target="_blank" rel="noopener">', $html);
 
         // Convert plain URLs to clickable links (that aren't already in <a> tags)
-        $html = preg_replace('/(?<!href="|href=\')(?<!>)(?<!\/)(https?:\/\/[^\s<>"]+)(?![^<]*<\/a>)/', '<a href="$1" class="text-blue-500 hover:text-blue-600 underline" target="_blank" rel="noopener">$1</a>', $html);
+        $html = preg_replace('/(?<!href="|href=\')(?<!src="|src=\')(?<!>)(?<!\/)(https?:\/\/[^\s<>"]+)(?![^<]*<\/a>)/', '<a href="$1" class="text-blue-500 hover:text-blue-600 underline" target="_blank" rel="noopener">$1</a>', $html);
 
         // Strong/bold text
         $html = preg_replace('/<strong[^>]*>/', '<strong class="font-semibold dark:text-white">', $html);


### PR DESCRIPTION
Be able to fully enjoy Andras crashouts in the changelog popup 

### Before

<img width="1250" height="781" alt="image" src="https://github.com/user-attachments/assets/59fc6c09-5cdb-4ea9-8fa6-3337f4abef50" />


### After

<img width="1224" height="710" alt="image" src="https://github.com/user-attachments/assets/9a56f0fe-1e47-4c49-9810-05f01a9e333c" />