### PR TITLE
Fix:(service) Appwrite too many redirects error

### DIFF
--- a/app/Livewire/Project/Resource/Create.php
+++ b/app/Livewire/Project/Resource/Create.php
@@ -102,13 +102,25 @@ class Create extends Component
                             }
                         });
                     }
-                    $service->parse(isNew: true);
+                     $service->parse(isNew: true);
 
-                    return redirect()->route('project.service.configuration', [
-                        'service_uuid' => $service->uuid,
-                        'environment_uuid' => $environment->uuid,
-                        'project_uuid' => $project->uuid,
-                    ]);
+                     // For Appwrite services, disable strip prefix for services that handle domain requests
+                     if ($oneClickServiceName === 'appwrite') {
+                         $servicesToDisableStripPrefix = ['appwrite', 'appwrite-console', 'appwrite-realtime'];
+                         foreach ($servicesToDisableStripPrefix as $serviceName) {
+                             $appService = $service->applications()->whereName($serviceName)->first();
+                             if ($appService) {
+                                 $appService->is_stripprefix_enabled = false;
+                                 $appService->save();
+                             }
+                         }
+                     }
+
+                     return redirect()->route('project.service.configuration', [
+                         'service_uuid' => $service->uuid,
+                         'environment_uuid' => $environment->uuid,
+                         'project_uuid' => $project->uuid,
+                     ]);
                 }
             }
             $this->type = $type->value();


### PR DESCRIPTION
## Issue
The appwrite service doesn't work out of the box because visiting the app url shows the error "too many redirects" on the browser.

## Fix
Disable "Strip Prefix" option on all appwrite services that have domains ( `appwrite`, `appwrite-console`, `appwrite-realtime`)

## Note
- This is an issue for few months and users manually disable "Strip Prefix" option to make the service work, we can eliminate this manual work by disabling strip prefix ourself in code.
- This fix is generated by AI, tested locally with appwrite and 4 other services (beszel, grafana, umami, glances) and everything is working without any issues.