### PR TITLE
Fix:(service) Beszel realtime feature not working

### DIFF
--- a/app/Livewire/Project/Resource/Create.php
+++ b/app/Livewire/Project/Resource/Create.php
@@ -102,13 +102,22 @@ class Create extends Component
                             }
                         });
                     }
-                    $service->parse(isNew: true);
+                     $service->parse(isNew: true);
 
-                    return redirect()->route('project.service.configuration', [
-                        'service_uuid' => $service->uuid,
-                        'environment_uuid' => $environment->uuid,
-                        'project_uuid' => $project->uuid,
-                    ]);
+                     // For Beszel service disable gzip (fixes realtime not working issue)
+                     if ($oneClickServiceName === 'beszel') {
+                         $appService = $service->applications()->whereName('beszel')->first();
+                         if ($appService) {
+                             $appService->is_gzip_enabled = false;
+                             $appService->save();
+                         }
+                     }
+
+                     return redirect()->route('project.service.configuration', [
+                         'service_uuid' => $service->uuid,
+                         'environment_uuid' => $environment->uuid,
+                         'project_uuid' => $project->uuid,
+                     ]);
                 }
             }
             $this->type = $type->value();


### PR DESCRIPTION
## Issue
The beszel service have a realtime feature which basically updates the data shown on dashboard in realtime (mainly graphs)

## Fix
Disable "Enable Gzip Compression" option for the `beszel` service in the compose file.

The Beszel team have this on their docs:
https://beszel.dev/guide/common-issues#real-time-stats-not-working-changes-not-saving
<img width="729" height="275" alt="image" src="https://github.com/user-attachments/assets/98559fcc-ff6f-43ef-855b-e0669ac15576" />


## Note
- Users have to  manually disable "Enable Gzip Compression" option to make the realtime feature work, we can eliminate this manual work by disabling gzip compression ourself in code.
- This fix is generated by AI, tested locally with beszel and umami - everything is working without any issues.