### PR TITLE
Feat:(service) Add postgresus to predefined docker networks by default

### DIFF
--- a/app/Livewire/Project/Resource/Create.php
+++ b/app/Livewire/Project/Resource/Create.php
@@ -81,7 +81,7 @@ class Create extends Component
                         'destination_id' => $destination->id,
                         'destination_type' => $destination->getMorphClass(),
                     ];
-                    if ($oneClickServiceName === 'cloudflared' || $oneClickServiceName === 'pgadmin') {
+                    if ($oneClickServiceName === 'cloudflared' || $oneClickServiceName === 'pgadmin' || $oneClickServiceName === 'postgresus') {
                         data_set($service_payload, 'connect_to_docker_network', true);
                     }
                     $service = Service::create($service_payload);


### PR DESCRIPTION
## Issue
Postgresus is a database backup tool with a dashboard, so if user wants to access the one click database from Postgresus dashboard it doesn't work out of the box so they have to manually enable the "Connect to Predefined Networks"  option.

## Fix
Enable "Connect to Predefined Networks" by default

## Notes
This PR is to eliminate the manual work of users having to enable Connect to Predefined Networks by connecting it to Predefined Networks ourself in code.