### PR TITLE
fix: prevent Livewire snapshot error in database restore

### DIFF
--- a/resources/views/livewire/project/database/heading.blade.php
+++ b/resources/views/livewire/project/database/heading.blade.php
@@ -3,7 +3,9 @@
     <x-slide-over @startdatabase.window="slideOverOpen = true" closeWithX fullScreen>
         <x-slot:title>Database Startup</x-slot:title>
         <x-slot:content>
-            <livewire:activity-monitor header="Logs" fullHeight />
+            <div wire:ignore>
+                <livewire:activity-monitor header="Logs" fullHeight />
+            </div>
         </x-slot:content>
     </x-slide-over>
     <div class="navbar-main">

--- a/resources/views/livewire/project/database/import.blade.php
+++ b/resources/views/livewire/project/database/import.blade.php
@@ -225,7 +225,9 @@
             <x-slide-over @databaserestore.window="slideOverOpen = true" closeWithX fullScreen>
                 <x-slot:title>Database Restore Output</x-slot:title>
                 <x-slot:content>
-                    <livewire:activity-monitor wire:key="database-restore-{{ $resource->uuid }}" header="Logs" fullHeight />
+                    <div wire:ignore>
+                        <livewire:activity-monitor wire:key="database-restore-{{ $resource->uuid }}" header="Logs" fullHeight />
+                    </div>
                 </x-slot:content>
             </x-slide-over>
         @else


### PR DESCRIPTION
## Changes
- Wrap ActivityMonitor in `wire:ignore` in database restore modal to prevent parent re-renders from destroying the component
- Apply same preventative fix to database startup modal

## Issues
- Fixes #7335

The issue occurred when toggling the "Backup includes all databases" checkbox during database restore operations. The checkbox uses `wire:model.live` which triggers immediate parent re-renders, destroying the nested ActivityMonitor component in production mode.

`wire:ignore` prevents Livewire from re-rendering the DOM while preserving event listeners and functionality.