### PR TITLE
fix(docker): migrate database start actions from --time to -t flag

### DIFF
--- a/app/Actions/Database/StartClickhouse.php
+++ b/app/Actions/Database/StartClickhouse.php
@@ -105,7 +105,7 @@ class StartClickhouse
         $this->commands[] = "echo '{$readme}' > $this->configuration_dir/README.md";
         $this->commands[] = "echo 'Pulling {$database->image} image.'";
         $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml pull";
-        $this->commands[] = "docker stop --time=10 $container_name 2>/dev/null || true";
+        $this->commands[] = "docker stop -t 10 $container_name 2>/dev/null || true";
         $this->commands[] = "docker rm -f $container_name 2>/dev/null || true";
         $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml up -d";
         $this->commands[] = "echo 'Database started.'";

--- a/app/Actions/Database/StartDragonfly.php
+++ b/app/Actions/Database/StartDragonfly.php
@@ -192,7 +192,7 @@ class StartDragonfly
         if ($this->database->enable_ssl) {
             $this->commands[] = "chown -R 999:999 $this->configuration_dir/ssl/server.key $this->configuration_dir/ssl/server.crt";
         }
-        $this->commands[] = "docker stop --time=10 $container_name 2>/dev/null || true";
+        $this->commands[] = "docker stop -t 10 $container_name 2>/dev/null || true";
         $this->commands[] = "docker rm -f $container_name 2>/dev/null || true";
         $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml up -d";
         $this->commands[] = "echo 'Database started.'";

--- a/app/Actions/Database/StartKeydb.php
+++ b/app/Actions/Database/StartKeydb.php
@@ -208,7 +208,7 @@ class StartKeydb
         if ($this->database->enable_ssl) {
             $this->commands[] = "chown -R 999:999 $this->configuration_dir/ssl/server.key $this->configuration_dir/ssl/server.crt";
         }
-        $this->commands[] = "docker stop --time=10 $container_name 2>/dev/null || true";
+        $this->commands[] = "docker stop -t 10 $container_name 2>/dev/null || true";
         $this->commands[] = "docker rm -f $container_name 2>/dev/null || true";
         $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml up -d";
         $this->commands[] = "echo 'Database started.'";

--- a/app/Actions/Database/StartMariadb.php
+++ b/app/Actions/Database/StartMariadb.php
@@ -209,7 +209,7 @@ class StartMariadb
         $this->commands[] = "echo '{$readme}' > $this->configuration_dir/README.md";
         $this->commands[] = "echo 'Pulling {$database->image} image.'";
         $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml pull";
-        $this->commands[] = "docker stop --time=10 $container_name 2>/dev/null || true";
+        $this->commands[] = "docker stop -t 10 $container_name 2>/dev/null || true";
         $this->commands[] = "docker rm -f $container_name 2>/dev/null || true";
         $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml up -d";
         $this->commands[] = "echo 'Database started.'";

--- a/app/Actions/Database/StartMongodb.php
+++ b/app/Actions/Database/StartMongodb.php
@@ -260,7 +260,7 @@ class StartMongodb
         $this->commands[] = "echo '{$readme}' > $this->configuration_dir/README.md";
         $this->commands[] = "echo 'Pulling {$database->image} image.'";
         $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml pull";
-        $this->commands[] = "docker stop --time=10 $container_name 2>/dev/null || true";
+        $this->commands[] = "docker stop -t 10 $container_name 2>/dev/null || true";
         $this->commands[] = "docker rm -f $container_name 2>/dev/null || true";
         $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml up -d";
         if ($this->database->enable_ssl) {

--- a/app/Actions/Database/StartMysql.php
+++ b/app/Actions/Database/StartMysql.php
@@ -210,7 +210,7 @@ class StartMysql
         $this->commands[] = "echo '{$readme}' > $this->configuration_dir/README.md";
         $this->commands[] = "echo 'Pulling {$database->image} image.'";
         $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml pull";
-        $this->commands[] = "docker stop --time=10 $container_name 2>/dev/null || true";
+        $this->commands[] = "docker stop -t 10 $container_name 2>/dev/null || true";
         $this->commands[] = "docker rm -f $container_name 2>/dev/null || true";
         $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml up -d";
 

--- a/app/Actions/Database/StartPostgresql.php
+++ b/app/Actions/Database/StartPostgresql.php
@@ -223,7 +223,7 @@ class StartPostgresql
         $this->commands[] = "echo '{$readme}' > $this->configuration_dir/README.md";
         $this->commands[] = "echo 'Pulling {$database->image} image.'";
         $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml pull";
-        $this->commands[] = "docker stop --time=10 $container_name 2>/dev/null || true";
+        $this->commands[] = "docker stop -t 10 $container_name 2>/dev/null || true";
         $this->commands[] = "docker rm -f $container_name 2>/dev/null || true";
         $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml up -d";
         if ($this->database->enable_ssl) {

--- a/app/Actions/Database/StartRedis.php
+++ b/app/Actions/Database/StartRedis.php
@@ -205,7 +205,7 @@ class StartRedis
         if ($this->database->enable_ssl) {
             $this->commands[] = "chown -R 999:999 $this->configuration_dir/ssl/server.key $this->configuration_dir/ssl/server.crt";
         }
-        $this->commands[] = "docker stop --time=10 $container_name 2>/dev/null || true";
+        $this->commands[] = "docker stop -t 10 $container_name 2>/dev/null || true";
         $this->commands[] = "docker rm -f $container_name 2>/dev/null || true";
         $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml up -d";
         $this->commands[] = "echo 'Database started.'";

--- a/tests/Unit/StopProxyTest.php
+++ b/tests/Unit/StopProxyTest.php
@@ -7,7 +7,7 @@ it('ensures stop proxy includes wait loop for container removal', function () {
 
     // Simulate the command sequence from StopProxy
     $commands = [
-        'docker stop --time=30 coolify-proxy 2>/dev/null || true',
+        'docker stop -t 30 coolify-proxy 2>/dev/null || true',
         'docker rm -f coolify-proxy 2>/dev/null || true',
         '# Wait for container to be fully removed',
         'for i in {1..10}; do',
@@ -21,7 +21,7 @@ it('ensures stop proxy includes wait loop for container removal', function () {
     $commandsString = implode("\n", $commands);
 
     // Verify the stop sequence includes all required components
-    expect($commandsString)->toContain('docker stop --time=30 coolify-proxy')
+    expect($commandsString)->toContain('docker stop -t 30 coolify-proxy')
         ->and($commandsString)->toContain('docker rm -f coolify-proxy')
         ->and($commandsString)->toContain('for i in {1..10}; do')
         ->and($commandsString)->toContain('if ! docker ps -a --format "{{.Names}}" | grep -q "^coolify-proxy$"')
@@ -41,7 +41,7 @@ it('includes error suppression in stop proxy commands', function () {
     // Test that stop/remove commands suppress errors gracefully
 
     $commands = [
-        'docker stop --time=30 coolify-proxy 2>/dev/null || true',
+        'docker stop -t 30 coolify-proxy 2>/dev/null || true',
         'docker rm -f coolify-proxy 2>/dev/null || true',
     ];
 
@@ -54,9 +54,9 @@ it('uses configurable timeout for docker stop', function () {
     // Verify that stop command includes the timeout parameter
 
     $timeout = 30;
-    $stopCommand = "docker stop --time=$timeout coolify-proxy 2>/dev/null || true";
+    $stopCommand = "docker stop -t $timeout coolify-proxy 2>/dev/null || true";
 
-    expect($stopCommand)->toContain('--time=30');
+    expect($stopCommand)->toContain('-t 30');
 });
 
 it('waits for swarm service container removal correctly', function () {


### PR DESCRIPTION
## Changes
- Migrated 8 database start action files from deprecated `--time=10` to compatible `-t 10` flag
- Updated test file `StopProxyTest.php` to expect new `-t` syntax
- Ensures Docker v28+ compatibility for database restart operations

## Context
Docker deprecated the `--time` flag in v28.0. The `-t` shorthand works on all Docker versions (pre-28 and 28+), ensuring backward and forward compatibility. This PR addresses the database start actions that were missed in previous migration efforts.

## Files Changed
- StartClickhouse.php, StartDragonfly.php, StartKeydb.php, StartMariadb.php
- StartMongodb.php, StartMysql.php, StartPostgresql.php, StartRedis.php
- StopProxyTest.php (test expectations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)