### PR TITLE
fix: resolve webhook notification settings migration conflict

### DIFF
--- a/database/migrations/2025_11_16_000001_create_webhook_notification_settings_table.php
+++ b/database/migrations/2025_11_16_000001_create_webhook_notification_settings_table.php
@@ -35,6 +35,7 @@ return new class extends Migration
                 $table->boolean('server_reachable_webhook_notifications')->default(false);
                 $table->boolean('server_unreachable_webhook_notifications')->default(true);
                 $table->boolean('server_patch_webhook_notifications')->default(false);
+                $table->boolean('traefik_outdated_webhook_notifications')->default(true);
 
                 $table->unique(['team_id']);
             });

--- a/database/migrations/2025_11_17_092707_add_traefik_outdated_to_notification_settings.php
+++ b/database/migrations/2025_11_17_092707_add_traefik_outdated_to_notification_settings.php
@@ -19,9 +19,13 @@ return new class extends Migration
             $table->boolean('traefik_outdated_slack_notifications')->default(true);
         });
 
-        Schema::table('webhook_notification_settings', function (Blueprint $table) {
-            $table->boolean('traefik_outdated_webhook_notifications')->default(true);
-        });
+        // Only add if table exists and column doesn't exist
+        if (Schema::hasTable('webhook_notification_settings') &&
+            ! Schema::hasColumn('webhook_notification_settings', 'traefik_outdated_webhook_notifications')) {
+            Schema::table('webhook_notification_settings', function (Blueprint $table) {
+                $table->boolean('traefik_outdated_webhook_notifications')->default(true);
+            });
+        }
 
         Schema::table('telegram_notification_settings', function (Blueprint $table) {
             $table->boolean('traefik_outdated_telegram_notifications')->default(true);
@@ -45,9 +49,13 @@ return new class extends Migration
             $table->dropColumn('traefik_outdated_slack_notifications');
         });
 
-        Schema::table('webhook_notification_settings', function (Blueprint $table) {
-            $table->dropColumn('traefik_outdated_webhook_notifications');
-        });
+        // Only drop if table and column exist
+        if (Schema::hasTable('webhook_notification_settings') &&
+            Schema::hasColumn('webhook_notification_settings', 'traefik_outdated_webhook_notifications')) {
+            Schema::table('webhook_notification_settings', function (Blueprint $table) {
+                $table->dropColumn('traefik_outdated_webhook_notifications');
+            });
+        }
 
         Schema::table('telegram_notification_settings', function (Blueprint $table) {
             $table->dropColumn('traefik_outdated_telegram_notifications');


### PR DESCRIPTION
## Changes

- Add missing `traefik_outdated_webhook_notifications` column to webhook_notification_settings table schema
- Add safety checks to traefik migration to prevent errors when table doesn't exist yet
- Ensure migrations work correctly with fresh installs and upgrades

## Issues

Fixes migration failure in beta.451 when attempting to add traefik column to webhook_notification_settings table that didn't exist in schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)