### PR TITLE
Fix: Traefik proxy startup issues

### DIFF
--- a/app/Livewire/Server/Proxy.php
+++ b/app/Livewire/Server/Proxy.php
@@ -79,12 +79,11 @@ class Proxy extends Component
 
         // Load from global cached helper (Redis + filesystem)
         $versionsData = get_versions_data();
-        $this->cachedVersionsFile = $versionsData;
-
         if (! $versionsData) {
             return null;
         }
 
+        $this->cachedVersionsFile = $versionsData;
         $traefikVersions = data_get($versionsData, 'traefik');
 
         return is_array($traefikVersions) ? $traefikVersions : null;

--- a/bootstrap/helpers/proxy.php
+++ b/bootstrap/helpers/proxy.php
@@ -6,6 +6,20 @@ use App\Models\Application;
 use App\Models\Server;
 use Symfony\Component\Yaml\Yaml;
 
+/**
+ * Check if a network name is a Docker predefined system network.
+ * These networks cannot be created, modified, or managed by docker network commands.
+ *
+ * @param  string  $network  Network name to check
+ * @return bool True if it's a predefined network that should be skipped
+ */
+function isDockerPredefinedNetwork(string $network): bool
+{
+    // Only filter 'default' and 'host' to match existing codebase patterns
+    // See: bootstrap/helpers/parsers.php:891, bootstrap/helpers/shared.php:689,748
+    return in_array($network, ['default', 'host'], true);
+}
+
 function collectProxyDockerNetworksByServer(Server $server)
 {
     if (! $server->isFunctional()) {
@@ -66,8 +80,12 @@ function collectDockerNetworksByServer(Server $server)
         $networks->push($network);
         $allNetworks->push($network);
     }
-    $networks = collect($networks)->flatten()->unique();
-    $allNetworks = $allNetworks->flatten()->unique();
+    $networks = collect($networks)->flatten()->unique()->filter(function ($network) {
+        return ! isDockerPredefinedNetwork($network);
+    });
+    $allNetworks = $allNetworks->flatten()->unique()->filter(function ($network) {
+        return ! isDockerPredefinedNetwork($network);
+    });
     if ($server->isSwarm()) {
         if ($networks->count() === 0) {
             $networks = collect(['coolify-overlay']);
@@ -219,8 +237,8 @@ function generateDefaultProxyConfiguration(Server $server, array $custom_command
     $array_of_networks = collect([]);
     $filtered_networks = collect([]);
     $networks->map(function ($network) use ($array_of_networks, $filtered_networks) {
-        if ($network === 'host') {
-            return; // network-scoped alias is supported only for containers in user defined networks
+        if (isDockerPredefinedNetwork($network)) {
+            return; // Predefined networks cannot be used in network configuration
         }
 
         $array_of_networks[$network] = [

--- a/tests/Unit/ProxyHelperTest.php
+++ b/tests/Unit/ProxyHelperTest.php
@@ -153,3 +153,39 @@ it('compares branches for minor upgrades', function () {
 
     expect($result)->toBeTrue();
 });
+
+it('identifies default as predefined network', function () {
+    expect(isDockerPredefinedNetwork('default'))->toBeTrue();
+});
+
+it('identifies host as predefined network', function () {
+    expect(isDockerPredefinedNetwork('host'))->toBeTrue();
+});
+
+it('identifies coolify as not predefined network', function () {
+    expect(isDockerPredefinedNetwork('coolify'))->toBeFalse();
+});
+
+it('identifies coolify-overlay as not predefined network', function () {
+    expect(isDockerPredefinedNetwork('coolify-overlay'))->toBeFalse();
+});
+
+it('identifies custom networks as not predefined', function () {
+    $customNetworks = ['my-network', 'app-network', 'custom-123'];
+
+    foreach ($customNetworks as $network) {
+        expect(isDockerPredefinedNetwork($network))->toBeFalse();
+    }
+});
+
+it('identifies bridge as not predefined (per codebase pattern)', function () {
+    // 'bridge' is technically a Docker predefined network, but existing codebase
+    // only filters 'default' and 'host', so we maintain consistency
+    expect(isDockerPredefinedNetwork('bridge'))->toBeFalse();
+});
+
+it('identifies none as not predefined (per codebase pattern)', function () {
+    // 'none' is technically a Docker predefined network, but existing codebase
+    // only filters 'default' and 'host', so we maintain consistency
+    expect(isDockerPredefinedNetwork('none'))->toBeFalse();
+});


### PR DESCRIPTION
## Changes
- Add null check before dispatching CheckTraefikVersionForServerJob to prevent TypeError
- Add isDockerPredefinedNetwork() helper to filter Docker predefined networks
- Apply network filtering in collectDockerNetworksByServer() and generateDefaultProxyConfiguration()
- Add 7 unit tests for network filtering functionality

## Issues
- Fixes: TypeError on proxy restart: `Argument #2 ($traefikVersions) must be of type array, null given`
- Fixes: Docker error: `operation is not permitted on predefined default network`

These changes are backward compatible and defensive in nature, preventing edge case failures that occur when versions.json is unavailable or when Docker destinations have predefined network names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)