### PR TITLE
fix: allow multi-server deployments with volume mounts

### DIFF
--- a/resources/views/livewire/project/shared/destination.blade.php
+++ b/resources/views/livewire/project/shared/destination.blade.php
@@ -78,7 +78,7 @@
     </div>
     @if ($resource->getMorphClass() === 'App\Models\Application' && data_get($resource, 'build_pack') !== 'dockercompose')
         <div class="flex flex-col gap-2">
-            @if ($resource->fileStorages()->count() > 0)
+            @if ($resource->fileStorages()->get()->filter(fn($storage) => $storage->content)->count() > 0)
                 <h3>Add another server</h3>
                 <x-callout type="warning" title="Cannot add additional servers">
                     This application has file mounts configured. Applications with file mounts cannot be deployed to multiple servers as the storage would not be accessible across different servers.

--- a/resources/views/livewire/project/shared/destination.blade.php
+++ b/resources/views/livewire/project/shared/destination.blade.php
@@ -78,12 +78,10 @@
     </div>
     @if ($resource->getMorphClass() === 'App\Models\Application' && data_get($resource, 'build_pack') !== 'dockercompose')
         <div class="flex flex-col gap-2">
-            @if ($resource->persistentStorages()->count() > 0)
+            @if ($resource->fileStorages()->count() > 0)
                 <h3>Add another server</h3>
                 <x-callout type="warning" title="Cannot add additional servers">
-                    This application has persistent storage volumes configured. Applications with persistent
-                    storage cannot be deployed to multiple servers as the storage would not be accessible
-                    across different servers.
+                    This application has file mounts configured. Applications with file mounts cannot be deployed to multiple servers as the storage would not be accessible across different servers.
                 </x-callout>
             @elseif (count($networks) > 0)
                 <h3>Add another server</h3>


### PR DESCRIPTION
## Description

Fixes #7384

Previously, the UI prevented adding multiple servers to an application if any "persistent storage" was configured. This blanket restriction incorrectly blocked **Volume Mounts** (Docker Volumes), which are valid for multi-server deployments (creating independent volumes on each server).

This PR refines the restriction to only block **File Mounts** (Bind Mounts), which require specific host paths to exist and are the intended target of this limitation.

## Changes

- Modified [resources/views/livewire/project/shared/destination.blade.php](cci:7://file:///Users/ayushkumarsingh/Desktop/AP_open_Source/coolify/resources/views/livewire/project/shared/destination.blade.php:0:0-0:0) to check `$resource->fileStorages()` instead of `$resource->persistentStorages()`.
- Updated the warning message to specifically mention "file mounts" instead of "persistent storage volumes".

## Verification

- Created an application with a Volume Mount -> "Add another server" is now visible.
- Created an application with a File Mount -> "Add another server" is correctly hidden with a warning.