### PR TITLE
fix: prevent misleading commit links for HEAD deployments

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -565,6 +565,11 @@ class Application extends BaseModel
 
     public function gitCommitLink($link): string
     {
+        // Return empty string for HEAD or empty links to prevent misleading URLs
+        if (empty($link) || $link === 'HEAD') {
+            return '';
+        }
+
         if (! is_null(data_get($this, 'source.html_url')) && ! is_null(data_get($this, 'git_repository')) && ! is_null(data_get($this, 'git_branch'))) {
             if (str($this->source->html_url)->contains('bitbucket')) {
                 return "{$this->source->html_url}/{$this->git_repository}/commits/{$link}";

--- a/resources/views/livewire/project/application/deployment/index.blade.php
+++ b/resources/views/livewire/project/application/deployment/index.blade.php
@@ -96,10 +96,16 @@
                                 <div x-data="{ expanded: false }">
                                     <div class="flex items-center gap-2">
                                         <span class="font-medium">Commit:</span>
-                                        <a href="{{ $application->gitCommitLink(data_get($deployment, 'commit')) }}"
-                                            target="_blank" class="underline">
-                                            {{ substr(data_get($deployment, 'commit'), 0, 7) }}
-                                        </a>
+                                        @if (data_get($deployment, 'commit') !== 'HEAD')
+                                            <a href="{{ $application->gitCommitLink(data_get($deployment, 'commit')) }}"
+                                                target="_blank" class="underline">
+                                                {{ substr(data_get($deployment, 'commit'), 0, 7) }}
+                                            </a>
+                                        @else
+                                            <span class="text-gray-500 dark:text-gray-400" title="Commit hash not available">
+                                                HEAD
+                                            </span>
+                                        @endif
                                         @if (!$deployment->commitMessage())
                                             <span
                                                 class="bg-gray-200/70 dark:bg-gray-600/20 px-2 py-0.5 rounded-md text-xs text-gray-800 dark:text-gray-100 border border-gray-400/30">
@@ -121,11 +127,17 @@
                                         @endif
                                         @if ($deployment->commitMessage())
                                             <span class="text-gray-600 dark:text-gray-400">-</span>
-                                            <a href="{{ $application->gitCommitLink(data_get($deployment, 'commit')) }}"
-                                                target="_blank"
-                                                class="text-gray-600 dark:text-gray-400 truncate max-w-md underline">
-                                                {{ Str::before($deployment->commitMessage(), "\n") }}
-                                            </a>
+                                            @if (data_get($deployment, 'commit') !== 'HEAD')
+                                                <a href="{{ $application->gitCommitLink(data_get($deployment, 'commit')) }}"
+                                                    target="_blank"
+                                                    class="text-gray-600 dark:text-gray-400 truncate max-w-md underline">
+                                                    {{ Str::before($deployment->commitMessage(), "\n") }}
+                                                </a>
+                                            @else
+                                                <span class="text-gray-600 dark:text-gray-400 truncate max-w-md">
+                                                    {{ Str::before($deployment->commitMessage(), "\n") }}
+                                                </span>
+                                            @endif
                                             @if ($deployment->commitMessage() !== Str::before($deployment->commitMessage(), "\n"))
                                                 <button @click="expanded = !expanded"
                                                     class="text-gray-600 dark:text-gray-400 flex items-center gap-1">


### PR DESCRIPTION
## Summary

When a deployment's commit is stored as 'HEAD' (before the actual commit hash is resolved), clicking the commit link would navigate to the latest commit of the branch, not the actual deployed commit. This was confusing users about which commit was actually deployed.

## Changes

1. **View (deployment/index.blade.php)**:
   - Shows 'HEAD' as non-clickable text when commit hash is not available
   - Adds tooltip explaining that commit hash is not available

2. **Model (Application.php)**:
   - Added guard in `gitCommitLink()` to return empty string for HEAD/empty links
   - Prevents generating misleading URLs like `/commit/HEAD`

## Testing

- Deployments with resolved commit hashes still show clickable links
- Deployments with 'HEAD' commit show non-clickable text
- Commit messages are displayed regardless of commit hash availability

## Screenshots

N/A - Text change only, no visual regression

Fixes #6946