### PR TITLE
fix: add Arch Linux support for Docker installation

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -78,6 +78,8 @@ class InstallDocker
                 $command = $command->merge([$this->getRhelDockerInstallCommand()]);
             } elseif ($supported_os_type->contains('sles')) {
                 $command = $command->merge([$this->getSuseDockerInstallCommand()]);
+            } elseif ($supported_os_type->contains('arch')) {
+                $command = $command->merge([$this->getArchDockerInstallCommand()]);
             } else {
                 $command = $command->merge([$this->getGenericDockerInstallCommand()]);
             }
@@ -144,6 +146,14 @@ class InstallDocker
             'systemctl start docker && '.
             'systemctl enable docker'.
             ')';
+    }
+
+    private function getArchDockerInstallCommand(): string
+    {
+        return 'pacman -Syyy --noconfirm && '.
+            'pacman -S docker docker-compose --noconfirm && '.
+            'systemctl start docker && '.
+            'systemctl enable docker';
     }
 
     private function getGenericDockerInstallCommand(): string


### PR DESCRIPTION
## Summary

Arch Linux was listed in `SUPPORTED_OS` constant but `InstallDocker.php` had no specific handler for it, causing 'Unsupported OS' errors when trying to add Arch Linux servers as remote servers.

## Changes

Added Arch Linux support to `app/Actions/Server/InstallDocker.php`:

1. Added `arch` detection in the OS type switch
2. New `getArchDockerInstallCommand()` method using pacman:
   - `pacman -Syyy --noconfirm` - Refresh package databases
   - `pacman -S docker docker-compose --noconfirm` - Install Docker and docker-compose
   - `systemctl start docker && systemctl enable docker` - Start and enable Docker service

## Testing

- Tested syntax and logic flow
- Follows the same pattern as other OS-specific install commands (RHEL, SLES, Debian)

## Notes

- Uses `--noconfirm` flag for non-interactive installation
- Installs both `docker` and `docker-compose` packages from official Arch repositories

Fixes #4523

/claim #4523