### PR TITLE
fix(service): add ELECTRIC_SECRET to trigger.dev template

### DIFF
--- a/templates/compose/trigger.yaml
+++ b/templates/compose/trigger.yaml
@@ -70,6 +70,7 @@ services:
     image: electricsql/electric
     environment:
       <<: *common-env
+      ELECTRIC_SECRET: $SERVICE_PASSWORD_64_ELECTRIC
     depends_on:
       postgresql:
         condition: service_healthy


### PR DESCRIPTION
## Summary

The Electric service in trigger.dev template was failing to start with the error:
```
RuntimeError: You must set ELECTRIC_SECRET unless ELECTRIC_INSECURE=true
```

## Changes

Added `ELECTRIC_SECRET` environment variable to the `electric` service in `templates/compose/trigger.yaml` using Coolify's auto-generated password pattern.

## Testing

- The variable follows the same pattern as other secrets in the template (`SERVICE_PASSWORD_64_*`)
- Electric will now receive a secure 64-character secret on deployment

Fixes #5648