### PR TITLE
fix: URL encode basic auth credentials in Git HTTP URLs

### DIFF
--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -3047,6 +3047,34 @@ NGINX;
 function convertGitUrl(string $gitRepository, string $deploymentType, ?GithubApp $source = null): array
 {
     $repository = $gitRepository;
+
+    // URL encode basic auth credentials in HTTP(S) URLs to handle special characters like @ in usernames
+    if (preg_match('/^https?:\/\//', $gitRepository)) {
+        $parsedUrl = parse_url($gitRepository);
+        if ($parsedUrl !== false && (isset($parsedUrl['user']) || isset($parsedUrl['pass']))) {
+            $host = $parsedUrl['host'] ?? '';
+            if ($host !== '') {
+                $scheme = $parsedUrl['scheme'] ?? 'https';
+                $port = isset($parsedUrl['port']) ? ':'.$parsedUrl['port'] : '';
+                $path = $parsedUrl['path'] ?? '';
+                $query = isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '';
+                $fragment = isset($parsedUrl['fragment']) ? '#'.$parsedUrl['fragment'] : '';
+
+                // Re-wrap IPv6 hosts with brackets (parse_url strips them)
+                $isIpv6 = str_contains($host, ':');
+                $hostFormatted = $isIpv6 ? '['.$host.']' : $host;
+
+                $user = isset($parsedUrl['user']) ? rawurlencode(rawurldecode($parsedUrl['user'])) : '';
+                $pass = isset($parsedUrl['pass']) ? ':'.rawurlencode(rawurldecode($parsedUrl['pass'])) : '';
+                $hasAuth = ($user !== '' || $pass !== '');
+                $auth = $hasAuth ? $user.$pass.'@' : '';
+
+                $repository = $scheme.'://'.$auth.$hostFormatted.$port.$path.$query.$fragment;
+                $gitRepository = $repository;
+            }
+        }
+    }
+
     $providerInfo = [
         'host' => null,
         'user' => 'git',


### PR DESCRIPTION
## Summary

When using HTTP(S) Git URLs with basic authentication, special characters in username or password (like `@` in email addresses) were not being URL encoded, causing git clone to fail.

## Problem

```
# This fails because @ in username is not encoded:
https://user@email.com:pass@git.example.com/repo.git

# User had to manually encode to make it work:
https://user%40email.com:pass@git.example.com/repo.git
```

## Solution

Added automatic URL encoding of basic auth credentials in `convertGitUrl()` function:
- Parses HTTP(S) URLs and extracts user/pass components
- Applies `rawurlencode()` to properly encode special characters
- Uses `rawurldecode()` first to prevent double-encoding already-encoded values
- Reconstructs the URL with encoded credentials

## Testing

- URLs without auth: unchanged behavior
- URLs with simple auth: unchanged behavior  
- URLs with special chars in auth (e.g., `@`, `:`, `#`): now properly encoded

Fixes #5295