### PR TITLE
feat:(service) Add Beszel Agent as standalone template

### DIFF
--- a/templates/compose/beszel-agent.yaml
+++ b/templates/compose/beszel-agent.yaml
@@ -1,0 +1,18 @@
+# documentation: https://www.beszel.dev/guide/agent-installation
+# slogan: Monitoring agent for Beszel
+# category: monitoring
+# tags: beszel,monitoring,server,stats,alerts
+# logo: svgs/beszel.svg
+
+services:
+  beszel-agent:
+    image: 'henrygd/beszel-agent:0.16.1' # Released on 14 Nov 2025
+    environment:
+      - LISTEN=/beszel_socket/beszel.sock
+      - HUB_URL=${HUB_URL?}
+      - 'TOKEN=${TOKEN?}'
+      - 'KEY=${KEY?}'
+    volumes:
+      - beszel_agent_data:/var/lib/beszel-agent
+      - beszel_socket:/beszel_socket
+      - '/var/run/docker.sock:/var/run/docker.sock:ro'


### PR DESCRIPTION
We already have `Beszel` template which have both Hub (dashboard) and agent which works if the user just want to monitor the server where the Hub is running on but to monitor other servers the user has to manually deploy Beszel Agent on those servers, so I have added this new Beszel Agent template which users can use to deploy the agent on the servers connected to Coolify very easily.