### PR TITLE
fix: set correct permissions for custom MySQL/MariaDB config files

### DIFF
--- a/app/Actions/Database/StartMariadb.php
+++ b/app/Actions/Database/StartMariadb.php
@@ -288,5 +288,6 @@ class StartMariadb
         $content = $this->database->mariadb_conf;
         $content_base64 = base64_encode($content);
         $this->commands[] = "echo '{$content_base64}' | base64 -d | tee $this->configuration_dir/{$filename} > /dev/null";
+        $this->commands[] = "chmod 644 $this->configuration_dir/{$filename}";
     }
 }

--- a/app/Actions/Database/StartMysql.php
+++ b/app/Actions/Database/StartMysql.php
@@ -291,5 +291,6 @@ class StartMysql
         $content = $this->database->mysql_conf;
         $content_base64 = base64_encode($content);
         $this->commands[] = "echo '{$content_base64}' | base64 -d | tee $this->configuration_dir/{$filename} > /dev/null";
+        $this->commands[] = "chmod 644 $this->configuration_dir/{$filename}";
     }
 }


### PR DESCRIPTION
## Summary

The `custom-config.cnf` file was being created with incorrect permissions (owned by user 1000), preventing the mysql user (uid 999) from reading it. This caused custom MariaDB/MySQL configurations to be silently ignored.

## Problem

```bash
# Current (broken):
-rw-r----- 1 1000 110 32 Oct 19 10:54 custom-config.cnf

# Expected:
-rw-r--r-- 1 root root 20 Feb 1 12:58 custom-config.cnf
```

The mysql user cannot read the config file, so custom database configurations are ignored.

## Solution

Added `chmod 644` after creating the config file in both:
- `StartMariadb.php`
- `StartMysql.php`

This matches the standard permissions used for other MySQL config files like `mariadb.cnf`.

## Testing

After this fix, custom MySQL/MariaDB configurations will be properly read by the database container.

Fixes #1697