### PR TITLE
fix:(service) Remov depreciated env and services on Penpot

### DIFF
--- a/templates/compose/penpot.yaml
+++ b/templates/compose/penpot.yaml
@@ -7,7 +7,7 @@
 
 services:
   frontend:
-    image: penpotapp/frontend:latest
+    image: penpotapp/frontend:2.11.1 # Released on 13 Nov 2025
     volumes:
       - penpot-assets:/opt/data/assets
     depends_on:
@@ -25,16 +25,16 @@ services:
       retries: 15
 
   penpot-backend:
-    image: penpotapp/backend:latest
+    image: penpotapp/backend:2.11.1 # Released on 13 Nov 2025
     volumes:
       - penpot-assets:/opt/data/assets
     depends_on:
       postgres:
         condition: service_healthy
-      redis:
+      penpot-valkey:
         condition: service_healthy
     environment:
-      - PENPOT_FLAGS=${PENPOT_BACKEND_FLAGS:-enable-login-with-password enable-smtp enable-prepl-server}
+      - PENPOT_FLAGS=${PENPOT_BACKEND_FLAGS:-enable-login-with-password enable-smtp}
       - PENPOT_HTTP_SERVER_PORT=6060
       - PENPOT_SECRET_KEY=$SERVICE_REALBASE64_64_PENPOT
       - PENPOT_PUBLIC_URI=$SERVICE_URL_FRONTEND_8080
@@ -43,9 +43,9 @@ services:
       - PENPOT_DATABASE_URI=postgresql://postgres/${POSTGRES_DB:-penpot}
       - PENPOT_DATABASE_USERNAME=${SERVICE_USER_POSTGRES}
       - PENPOT_DATABASE_PASSWORD=${SERVICE_PASSWORD_POSTGRES}
-      - PENPOT_REDIS_URI=redis://redis/0
-      - PENPOT_ASSETS_STORAGE_BACKEND=assets-fs
-      - PENPOT_STORAGE_ASSETS_FS_DIRECTORY=/opt/data/assets
+      - 'PENPOT_REDIS_URI=redis://penpot-valkey/0'
+      - PENPOT_OBJECTS_STORAGE_BACKEND=fs
+      - PENPOT_OBJECTS_STORAGE_FS_DIRECTORY=/opt/data/assets
       - PENPOT_TELEMETRY_ENABLED=${PENPOT_TELEMETRY_ENABLED:-false}
       - PENPOT_SMTP_DEFAULT_FROM=${PENPOT_SMTP_DEFAULT_FROM:-no-reply@example.com}
       - PENPOT_SMTP_DEFAULT_REPLY_TO=${PENPOT_SMTP_DEFAULT_REPLY_TO:-no-reply@example.com}
@@ -62,10 +62,10 @@ services:
       retries: 15
 
   penpot-exporter:
-    image: penpotapp/exporter:latest
+    image: penpotapp/exporter:2.11.1 # Released on 13 Nov 2025
     environment:
       - PENPOT_PUBLIC_URI=$SERVICE_URL_FRONTEND_8080
-      - PENPOT_REDIS_URI=redis://redis/0
+      - 'PENPOT_REDIS_URI=redis://penpot-valkey/0'
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://127.0.0.1:6061/readyz']
       interval: 2s
@@ -73,7 +73,7 @@ services:
       retries: 15
 
   mailpit:
-    image: axllent/mailpit:latest
+    image: axllent/mailpit:v1.28 # Released on 26 Nov 2025
     environment:
       - SERVICE_URL_MAILPIT_8025
     healthcheck:
@@ -96,14 +96,18 @@ services:
       interval: 5s
       timeout: 20s
       retries: 10
-
-  redis:
-    image: redis:7-alpine
-    command: redis-server --appendonly yes
+      
+  penpot-valkey:
+    image: 'valkey/valkey:8.1'
     volumes:
-      - penpot-redis-data:/data
+      - 'penpot-valkey-data:/data'
+    environment:
+      - 'VALKEY_EXTRA_FLAGS=--maxmemory 128mb --maxmemory-policy volatile-lfu'
     healthcheck:
-      test: ['CMD', 'redis-cli', 'ping']
-      interval: 5s
-      timeout: 20s
-      retries: 10
+      test:
+        - CMD-SHELL
+        - 'valkey-cli ping | grep PONG'
+      interval: 1s
+      timeout: 3s
+      retries: 5
+      start_period: 3s


### PR DESCRIPTION
## Changes
- Renamed depreciated env (more info about depreciation on https://github.com/penpot/penpot/releases/tag/2.11.0 )
- Pinned apps to static version instead of `latest` (to prevent breakage from upstream updates)
- Removed `enable-prepl-server` flag, it's for dev stuff so not needed for production use
- Replaced `redis` with `valkey` - Penpot migrated to Valkey on v2.8.0 (https://github.com/penpot/penpot/releases/tag/2.8.0)

