### PR TITLE
feat:(service) Add Redis Insight to predefined docker networks by default

### DIFF
--- a/bootstrap/helpers/constants.php
+++ b/bootstrap/helpers/constants.php
@@ -70,6 +70,7 @@ const SUPPORTED_OS = [
 const NEEDS_TO_CONNECT_TO_PREDEFINED_NETWORK = [
     'pgadmin',
     'postgresus',
+    'redis-insight',
 ];
 const NEEDS_TO_DISABLE_GZIP = [
     'beszel' => ['beszel'],


### PR DESCRIPTION
## Issue
Redis Insight is a GUI to manage redis instances, so if user wants to access the one click database from Redis Insight dashboard it doesn't work out of the box so they have to manually enable the "Connect to Predefined Networks"  option.

## Notes
This PR is to eliminate the manual work of users having to enable Connect to Predefined Networks by connecting it to Predefined Networks ourself in code.