### PR TITLE
fixed the Sentinel bug

### DIFF
--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -230,10 +230,9 @@ function get_route_parameters(): array
 function get_latest_sentinel_version(): string
 {
     try {
-        $response = Http::get(config('constants.coolify.versions_url'));
-        $versions = $response->json();
+        $versions = get_versions_data();
 
-        return data_get($versions, 'coolify.sentinel.version');
+        return data_get($versions, 'coolify.sentinel.version', '0.0.0');
     } catch (\Throwable) {
         return '0.0.0';
     }

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -230,11 +230,17 @@ function get_route_parameters(): array
 function get_latest_sentinel_version(): string
 {
     try {
+        $response = Http::get(config('constants.coolify.versions_url'));
+        $versions = $response->json();
+        $version = data_get($versions, 'coolify.sentinel.version');
+        if ($version) {
+            return $version;
+        }
+        throw new \Exception("Remote version not found");
+    } catch (\Throwable) {
         $versions = get_versions_data();
 
         return data_get($versions, 'coolify.sentinel.version', '0.0.0');
-    } catch (\Throwable) {
-        return '0.0.0';
     }
 }
 function get_latest_version_of_coolify(): string


### PR DESCRIPTION
This pull request fixes the issue described in #7420.
Fix: Sentinel failing to start due to version 0.0.0
Sentinel was using the fallback version 0.0.0 when the external version check failed, causing the container to pull a non-existent image.
I updated get_latest_sentinel_version in bootstrap/helpers/shared.php to read the version from the local versions.json instead of relying on a network request.
This ensures Sentinel always uses a valid version and starts correctly, even offline.