### PR TITLE
feat:(database/backups) implement pgbackrest as a backup backend

### DIFF
--- a/app/Http/Controllers/Api/DatabasesController.php
+++ b/app/Http/Controllers/Api/DatabasesController.php
@@ -633,6 +633,8 @@ class DatabasesController extends Controller
                         's3_storage_uuid' => ['type' => 'string', 'description' => 'S3 storage UUID (required if save_s3 is true)'],
                         'databases_to_backup' => ['type' => 'string', 'description' => 'Comma separated list of databases to backup'],
                         'dump_all' => ['type' => 'boolean', 'description' => 'Whether to dump all databases', 'default' => false],
+                        'postgres_backup_tool' => ['type' => 'string', 'description' => 'Engine used for Postgres backups', 'enum' => ['pgbackrest', 'pg_dump'], 'default' => 'pgbackrest'],
+                        'pgbackrest_backup_type' => ['type' => 'string', 'description' => 'pgBackRest backup type (full, diff, incr)', 'enum' => ['full', 'diff', 'incr'], 'default' => 'incr'],
                         'backup_now' => ['type' => 'boolean', 'description' => 'Whether to trigger backup immediately after creation'],
                         'database_backup_retention_amount_locally' => ['type' => 'integer', 'description' => 'Number of backups to retain locally'],
                         'database_backup_retention_days_locally' => ['type' => 'integer', 'description' => 'Number of days to retain backups locally'],
@@ -676,7 +678,7 @@ class DatabasesController extends Controller
     )]
     public function create_backup(Request $request)
     {
-        $backupConfigFields = ['save_s3', 'enabled', 'dump_all', 'frequency', 'databases_to_backup', 'database_backup_retention_amount_locally', 'database_backup_retention_days_locally', 'database_backup_retention_max_storage_locally', 'database_backup_retention_amount_s3', 'database_backup_retention_days_s3', 'database_backup_retention_max_storage_s3', 's3_storage_uuid'];
+        $backupConfigFields = ['save_s3', 'enabled', 'dump_all', 'frequency', 'databases_to_backup', 'database_backup_retention_amount_locally', 'database_backup_retention_days_locally', 'database_backup_retention_max_storage_locally', 'database_backup_retention_amount_s3', 'database_backup_retention_days_s3', 'database_backup_retention_max_storage_s3', 's3_storage_uuid', 'postgres_backup_tool', 'pgbackrest_backup_type'];
 
         $teamId = getTeamIdFromToken();
         if (is_null($teamId)) {
@@ -697,6 +699,8 @@ class DatabasesController extends Controller
             'backup_now' => 'boolean|nullable',
             's3_storage_uuid' => 'string|exists:s3_storages,uuid|nullable',
             'databases_to_backup' => 'string|nullable',
+            'postgres_backup_tool' => 'string|in:pgbackrest,pg_dump|nullable',
+            'pgbackrest_backup_type' => 'string|in:full,diff,incr|nullable',
             'database_backup_retention_amount_locally' => 'integer|min:0',
             'database_backup_retention_days_locally' => 'integer|min:0',
             'database_backup_retention_max_storage_locally' => 'integer|min:0',
@@ -792,6 +796,11 @@ class DatabasesController extends Controller
             }
         }
 
+        if ($database->type() === 'standalone-postgresql') {
+            $backupData['postgres_backup_tool'] = $backupData['postgres_backup_tool'] ?? 'pgbackrest';
+            $backupData['pgbackrest_backup_type'] = $backupData['pgbackrest_backup_type'] ?? 'incr';
+        }
+
         // Add required fields
         $backupData['database_id'] = $database->id;
         $backupData['database_type'] = $database->getMorphClass();
@@ -860,6 +869,8 @@ class DatabasesController extends Controller
                         'enabled' => ['type' => 'boolean', 'description' => 'Whether the backup is enabled or not'],
                         'databases_to_backup' => ['type' => 'string', 'description' => 'Comma separated list of databases to backup'],
                         'dump_all' => ['type' => 'boolean', 'description' => 'Whether all databases are dumped or not'],
+                        'postgres_backup_tool' => ['type' => 'string', 'description' => 'Engine used for Postgres backups', 'enum' => ['pgbackrest', 'pg_dump']],
+                        'pgbackrest_backup_type' => ['type' => 'string', 'description' => 'pgBackRest backup type (full, diff, incr)', 'enum' => ['full', 'diff', 'incr']],
                         'frequency' => ['type' => 'string', 'description' => 'Frequency of the backup'],
                         'database_backup_retention_amount_locally' => ['type' => 'integer', 'description' => 'Retention amount of the backup locally'],
                         'database_backup_retention_days_locally' => ['type' => 'integer', 'description' => 'Retention days of the backup locally'],
@@ -896,7 +907,7 @@ class DatabasesController extends Controller
     )]
     public function update_backup(Request $request)
     {
-        $backupConfigFields = ['save_s3', 'enabled', 'dump_all', 'frequency', 'databases_to_backup', 'database_backup_retention_amount_locally', 'database_backup_retention_days_locally', 'database_backup_retention_max_storage_locally', 'database_backup_retention_amount_s3', 'database_backup_retention_days_s3', 'database_backup_retention_max_storage_s3', 's3_storage_uuid'];
+        $backupConfigFields = ['save_s3', 'enabled', 'dump_all', 'frequency', 'databases_to_backup', 'database_backup_retention_amount_locally', 'database_backup_retention_days_locally', 'database_backup_retention_max_storage_locally', 'database_backup_retention_amount_s3', 'database_backup_retention_days_s3', 'database_backup_retention_max_storage_s3', 's3_storage_uuid', 'postgres_backup_tool', 'pgbackrest_backup_type'];
 
         $teamId = getTeamIdFromToken();
         if (is_null($teamId)) {
@@ -915,6 +926,8 @@ class DatabasesController extends Controller
             's3_storage_uuid' => 'string|exists:s3_storages,uuid|nullable',
             'databases_to_backup' => 'string|nullable',
             'frequency' => 'string|in:every_minute,hourly,daily,weekly,monthly,yearly',
+            'postgres_backup_tool' => 'string|in:pgbackrest,pg_dump|nullable',
+            'pgbackrest_backup_type' => 'string|in:full,diff,incr|nullable',
             'database_backup_retention_amount_locally' => 'integer|min:0',
             'database_backup_retention_days_locally' => 'integer|min:0',
             'database_backup_retention_max_storage_locally' => 'integer|min:0',
@@ -997,6 +1010,11 @@ class DatabasesController extends Controller
                 ], 422);
             }
             unset($backupData['s3_storage_uuid']);
+        }
+
+        if ($database->type() === 'standalone-postgresql') {
+            $backupData['postgres_backup_tool'] = $backupData['postgres_backup_tool'] ?? $backupConfig->postgres_backup_tool ?? 'pgbackrest';
+            $backupData['pgbackrest_backup_type'] = $backupData['pgbackrest_backup_type'] ?? $backupConfig->pgbackrest_backup_type ?? 'incr';
         }
 
         $backupConfig->update($backupData);

--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -283,11 +283,22 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                 }
             }
             $this->backup_dir = backup_dir().'/databases/'.str($this->team->name)->slug().'-'.$this->team->id.'/'.$this->directory_name;
+            $usePgBackRest = false;
+
             if ($this->database->name === 'coolify-db') {
                 $databasesToBackup = ['coolify'];
                 $this->directory_name = $this->container_name = 'coolify-db';
                 $ip = Str::slug($this->server->ip);
                 $this->backup_dir = backup_dir().'/coolify'."/coolify-db-$ip";
+            }
+
+            if (str($databaseType)->contains('postgres')) {
+                $usePgBackRest = data_get($this->backup, 'postgres_backup_tool', 'pgbackrest') === 'pgbackrest';
+
+                if ($usePgBackRest) {
+                    $primaryDatabase = $databasesToBackup[0] ?? $this->database->postgres_user ?? 'postgres';
+                    $databasesToBackup = [$primaryDatabase];
+                }
             }
             foreach ($databasesToBackup as $database) {
                 // Generate unique UUID for each database backup execution
@@ -309,7 +320,9 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                 try {
                     if (str($databaseType)->contains('postgres')) {
                         $this->backup_file = "/pg-dump-$database-".Carbon::now()->timestamp.'.dmp';
-                        if ($this->backup->dump_all) {
+                        if ($usePgBackRest) {
+                            $this->backup_file = "/pgbackrest-$database-".Carbon::now()->timestamp.'.tar.gz';
+                        } elseif ($this->backup->dump_all) {
                             $this->backup_file = '/pg-dump-all-'.Carbon::now()->timestamp.'.gz';
                         }
                         $this->backup_location = $this->backup_dir.$this->backup_file;
@@ -320,7 +333,11 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                             'scheduled_database_backup_id' => $this->backup->id,
                             'local_storage_deleted' => false,
                         ]);
-                        $this->backup_standalone_postgresql($database);
+                        if ($usePgBackRest) {
+                            $this->backup_standalone_postgresql_pgbackrest($database);
+                        } else {
+                            $this->backup_standalone_postgresql($database);
+                        }
                     } elseif (str($databaseType)->contains('mongo')) {
                         if ($database === '*') {
                             $database = 'all';
@@ -508,6 +525,73 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                     }
                 }
             }
+            $this->backup_output = instant_remote_process($commands, $this->server);
+            $this->backup_output = trim($this->backup_output);
+            if ($this->backup_output === '') {
+                $this->backup_output = null;
+            }
+        } catch (\Throwable $e) {
+            $this->add_to_error_output($e->getMessage());
+            throw $e;
+        }
+    }
+
+    private function backup_standalone_postgresql_pgbackrest(string $database): void
+    {
+        try {
+            $repoPath = $this->backup_dir.'/pgbackrest';
+            $network = data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class
+                ? data_get($this->database->service, 'destination.network')
+                : data_get($this->database->destination, 'network');
+            $network ??= 'bridge';
+            $stanza = str($this->directory_name.'-'.$database)->slug('_')->value();
+            $helperImage = $this->getFullImageName();
+            $backupType = data_get($this->backup, 'pgbackrest_backup_type', 'incr') ?? 'incr';
+            if (! in_array($backupType, ['full', 'diff', 'incr'], true)) {
+                $backupType = 'incr';
+            }
+            $postgresPort = data_get($this->database, 'public_port', 5432) ?? 5432;
+            $commands = [];
+
+            $configCommand = <<<'BASH'
+cat <<'EOF' > %s/pgbackrest.conf
+[global]
+repo1-path=/backups/repo1
+log-path=/backups/log
+spool-path=/backups/spool
+start-fast=y
+compress-type=zst
+compress-level=6
+
+[%s]
+pg1-path=/var/lib/postgresql/data
+pg1-host=%s
+pg1-port=%s
+pg1-user=%s
+EOF
+BASH;
+            $configCommand = sprintf(
+                $configCommand,
+                $repoPath,
+                $stanza,
+                $this->container_name,
+                $postgresPort,
+                $this->database->postgres_user,
+            );
+
+            $containerOptions = "--rm --name pgbackrest-{$this->backup_log_uuid} --network {$network} --volumes-from {$this->container_name} -v {$repoPath}:/backups";
+            if ($this->postgres_password) {
+                $escapedPassword = escapeshellarg($this->postgres_password);
+                $containerOptions = "-e PGPASSWORD={$escapedPassword} {$containerOptions}";
+            }
+            $runBase = "docker run {$containerOptions} {$helperImage}";
+
+            $commands[] = 'mkdir -p '.$repoPath.'/repo1 '.$repoPath.'/log '.$repoPath.'/spool';
+            $commands[] = $configCommand;
+            $commands[] = "$runBase pgbackrest --config=/backups/pgbackrest.conf --stanza={$stanza} stanza-create --log-level-console=info || true";
+            $commands[] = "$runBase pgbackrest --config=/backups/pgbackrest.conf --stanza={$stanza} backup --type={$backupType} --log-level-console=info";
+            $commands[] = "latest_label=$(ls -1t {$repoPath}/repo1/backup/{$stanza} 2>/dev/null | head -n1) && [ -n \"$latest_label\" ] && tar -czf {$this->backup_location} -C {$repoPath} repo1 log spool pgbackrest.conf";
+
             $this->backup_output = instant_remote_process($commands, $this->server);
             $this->backup_output = trim($this->backup_output);
             if ($this->backup_output === '') {

--- a/app/Livewire/Project/Database/BackupEdit.php
+++ b/app/Livewire/Project/Database/BackupEdit.php
@@ -82,6 +82,12 @@ class BackupEdit extends Component
     #[Validate(['required', 'int', 'min:60', 'max:36000'])]
     public int $timeout = 3600;
 
+    #[Validate(['required', 'string'])]
+    public string $postgresBackupTool = 'pgbackrest';
+
+    #[Validate(['required', 'string'])]
+    public string $pgbackrestBackupType = 'incr';
+
     public function mount()
     {
         try {
@@ -107,6 +113,9 @@ class BackupEdit extends Component
             $this->backup->save_s3 = $this->saveS3;
             $this->backup->disable_local_backup = $this->disableLocalBackup;
             $this->backup->s3_storage_id = $this->s3StorageId;
+            $this->sanitizePostgresBackupFields();
+            $this->backup->postgres_backup_tool = $this->postgresBackupTool;
+            $this->backup->pgbackrest_backup_type = $this->pgbackrestBackupType;
 
             // Validate databases_to_backup to prevent command injection
             if (filled($this->databasesToBackup)) {
@@ -147,6 +156,9 @@ class BackupEdit extends Component
             $this->databasesToBackup = $this->backup->databases_to_backup;
             $this->dumpAll = $this->backup->dump_all;
             $this->timeout = $this->backup->timeout;
+            $this->postgresBackupTool = $this->backup->postgres_backup_tool ?? 'pgbackrest';
+            $this->pgbackrestBackupType = $this->backup->pgbackrest_backup_type ?? 'incr';
+            $this->sanitizePostgresBackupFields();
         }
     }
 
@@ -208,6 +220,20 @@ class BackupEdit extends Component
         }
     }
 
+    private function sanitizePostgresBackupFields(): void
+    {
+        $allowedTools = ['pgbackrest', 'pg_dump'];
+        $allowedTypes = ['full', 'diff', 'incr'];
+
+        if (! in_array($this->postgresBackupTool, $allowedTools, true)) {
+            $this->postgresBackupTool = 'pgbackrest';
+        }
+
+        if (! in_array($this->pgbackrestBackupType, $allowedTypes, true)) {
+            $this->pgbackrestBackupType = 'incr';
+        }
+    }
+
     public function instantSave()
     {
         try {
@@ -229,6 +255,14 @@ class BackupEdit extends Component
         // Validate that disable_local_backup can only be true when S3 backup is enabled
         if ($this->backup->disable_local_backup && ! $this->backup->save_s3) {
             $this->backup->disable_local_backup = $this->disableLocalBackup = false;
+        }
+
+        if (! in_array($this->postgresBackupTool, ['pgbackrest', 'pg_dump'], true)) {
+            throw new \Exception('Invalid Postgres backup tool selected.');
+        }
+
+        if (! in_array($this->pgbackrestBackupType, ['full', 'diff', 'incr'], true)) {
+            throw new \Exception('Invalid pgBackRest backup type selected.');
         }
 
         $isValid = validate_cron_expression($this->backup->frequency);

--- a/app/Livewire/Project/Database/CreateScheduledBackup.php
+++ b/app/Livewire/Project/Database/CreateScheduledBackup.php
@@ -67,6 +67,8 @@ class CreateScheduledBackup extends Component
 
             if ($this->database->type() === 'standalone-postgresql') {
                 $payload['databases_to_backup'] = $this->database->postgres_db;
+                $payload['postgres_backup_tool'] = 'pgbackrest';
+                $payload['pgbackrest_backup_type'] = 'incr';
             } elseif ($this->database->type() === 'standalone-mysql') {
                 $payload['databases_to_backup'] = $this->database->mysql_database;
             } elseif ($this->database->type() === 'standalone-mariadb') {

--- a/app/Livewire/SettingsBackup.php
+++ b/app/Livewire/SettingsBackup.php
@@ -100,6 +100,8 @@ class SettingsBackup extends Component
                 'frequency' => '0 0 * * *',
                 'database_id' => $this->database->id,
                 'database_type' => \App\Models\StandalonePostgresql::class,
+                'postgres_backup_tool' => 'pgbackrest',
+                'pgbackrest_backup_type' => 'incr',
                 'team_id' => currentTeam()->id,
             ]);
             $this->database->refresh();

--- a/database/migrations/2025_11_30_182900_add_pgbackrest_to_backup_table.php
+++ b/database/migrations/2025_11_30_182900_add_pgbackrest_to_backup_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('scheduled_database_backups', function (Blueprint $table) {
+            $table->string('postgres_backup_tool')->default('pgbackrest')->after('dump_all');
+            $table->string('pgbackrest_backup_type')->default('incr')->after('postgres_backup_tool');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('scheduled_database_backups', function (Blueprint $table) {
+            $table->dropColumn('postgres_backup_tool');
+            $table->dropColumn('pgbackrest_backup_type');
+        });
+    }
+};

--- a/openapi.json
+++ b/openapi.json
@@ -3413,6 +3413,25 @@
                                         "description": "Whether to dump all databases",
                                         "default": false
                                     },
+                                    "postgres_backup_tool": {
+                                        "type": "string",
+                                        "description": "Engine used for Postgres backups",
+                                        "enum": [
+                                            "pgbackrest",
+                                            "pg_dump"
+                                        ],
+                                        "default": "pgbackrest"
+                                    },
+                                    "pgbackrest_backup_type": {
+                                        "type": "string",
+                                        "description": "pgBackRest backup type (full, diff, incr)",
+                                        "enum": [
+                                            "full",
+                                            "diff",
+                                            "incr"
+                                        ],
+                                        "default": "incr"
+                                    },
                                     "backup_now": {
                                         "type": "boolean",
                                         "description": "Whether to trigger backup immediately after creation"
@@ -3979,6 +3998,23 @@
                                     "dump_all": {
                                         "type": "boolean",
                                         "description": "Whether all databases are dumped or not"
+                                    },
+                                    "postgres_backup_tool": {
+                                        "type": "string",
+                                        "description": "Engine used for Postgres backups",
+                                        "enum": [
+                                            "pgbackrest",
+                                            "pg_dump"
+                                        ]
+                                    },
+                                    "pgbackrest_backup_type": {
+                                        "type": "string",
+                                        "description": "pgBackRest backup type (full, diff, incr)",
+                                        "enum": [
+                                            "full",
+                                            "diff",
+                                            "incr"
+                                        ]
                                     },
                                     "frequency": {
                                         "type": "string",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2175,6 +2175,16 @@ paths:
                   type: boolean
                   description: 'Whether to dump all databases'
                   default: false
+                postgres_backup_tool:
+                  type: string
+                  description: 'Engine used for Postgres backups'
+                  enum: [pgbackrest, pg_dump]
+                  default: pgbackrest
+                pgbackrest_backup_type:
+                  type: string
+                  description: 'pgBackRest backup type (full, diff, incr)'
+                  enum: [full, diff, incr]
+                  default: incr
                 backup_now:
                   type: boolean
                   description: 'Whether to trigger backup immediately after creation'
@@ -2569,6 +2579,14 @@ paths:
                 dump_all:
                   type: boolean
                   description: 'Whether all databases are dumped or not'
+                postgres_backup_tool:
+                  type: string
+                  description: 'Engine used for Postgres backups'
+                  enum: [pgbackrest, pg_dump]
+                pgbackrest_backup_type:
+                  type: string
+                  description: 'pgBackRest backup type (full, diff, incr)'
+                  enum: [full, diff, incr]
                 frequency:
                   type: string
                   description: 'Frequency of the backup'

--- a/resources/views/livewire/project/database/backup-edit.blade.php
+++ b/resources/views/livewire/project/database/backup-edit.blade.php
@@ -48,14 +48,30 @@
         <h3>Settings</h3>
         <div class="flex gap-2 flex-col ">
             @if ($backup->database_type === 'App\Models\StandalonePostgresql' && $backup->database_id !== 0)
-                <div class="w-48">
-                    <x-forms.checkbox label="Backup All Databases" id="dumpAll" instantSave />
+                <div class="flex flex-col gap-2 w-full md:w-2/3">
+                    <x-forms.select id="postgresBackupTool" label="Backup Engine">
+                        <option value="pgbackrest">pgBackRest (incremental)</option>
+                        <option value="pg_dump">pg_dump (legacy)</option>
+                    </x-forms.select>
+                    @if ($postgresBackupTool === 'pgbackrest')
+                        <x-forms.select id="pgbackrestBackupType" label="pgBackRest Backup Type">
+                            <option value="full">Full</option>
+                            <option value="diff">Differential</option>
+                            <option value="incr">Incremental</option>
+                        </x-forms.select>
+                        <div class="text-xs text-neutral-500">pgBackRest backups capture the full Postgres data directory and
+                            support incremental runs. Database selection is ignored while using pgBackRest.</div>
+                    @else
+                        <div class="w-48">
+                            <x-forms.checkbox label="Backup All Databases" id="dumpAll" instantSave />
+                        </div>
+                        @if (!$backup->dump_all)
+                            <x-forms.input label="Databases To Backup"
+                                helper="Comma separated list of databases to backup. Empty will include the default one."
+                                id="databasesToBackup" />
+                        @endif
+                    @endif
                 </div>
-                @if (!$backup->dump_all)
-                    <x-forms.input label="Databases To Backup"
-                        helper="Comma separated list of databases to backup. Empty will include the default one."
-                        id="databasesToBackup" />
-                @endif
             @elseif($backup->database_type === 'App\Models\StandaloneMongodb')
                 <x-forms.input label="Databases To Include"
                     helper="A list of databases to backup. You can specify which collection(s) per database to exclude from the backup. Empty will include all databases and collections.<br><br>Example:<br><br>database1:collection1,collection2|database2:collection3,collection4<br><br> database1 will include all collections except collection1 and collection2. <br>database2 will include all collections except collection3 and collection4.<br><br>Another Example:<br><br>database1:collection1|database2<br><br> database1 will include all collections except collection1.<br>database2 will include ALL collections."


### PR DESCRIPTION
## Changes
### OpenAPI
- Add new request fields to allow selection of the backup backend that is being used
- When using the pgBackRest backend, you may select the type of backup (full, diff, incremental).
### Backup system
- When creating a backup, the system now checks for what backup backend is being used, it will run the correct backup function to match the backup backend.
- I have also implemented the respective pgBackRest backup backend function. It runs the appropriate commands to create a pgBackRest backup (this **ASSUMES** pgBackRest is set up in the docker container  + db and is accessible by `docker run pgbackrest` (with the right image and options that already comes from the pg_dump backup backend).
- I have not added pgBackRest to the docker container and the user must do that manually (idk docker, and I did not want to learn it for this, the commands I listed in the impl worked for me outside of the container though, so just adding pgBackRest should be trivial to the end-user, or even as an extension for this PR)
### Saftey
- Full type saftey and checking for every user-inputted parameter above.
### UI
- I also added a tiny ui to create backups with this new system, it should integrate nicely with the existing backup creation UI.
### Database Migration
- I also made a migration file to add the new backup backend selection fields.

I hope mixing of "backup" and "backend" isn't that hard to read lol.

## Issues
- addresses, and hopefully fixes #7423

/claim #7423
