### PR TITLE
fix: move base directory path normalization to frontend

### DIFF
--- a/app/Livewire/Project/New/GithubPrivateRepository.php
+++ b/app/Livewire/Project/New/GithubPrivateRepository.php
@@ -75,16 +75,6 @@ class GithubPrivateRepository extends Component
         $this->github_apps = GithubApp::private();
     }
 
-    public function updatedBaseDirectory()
-    {
-        if ($this->base_directory) {
-            $this->base_directory = rtrim($this->base_directory, '/');
-            if (! str($this->base_directory)->startsWith('/')) {
-                $this->base_directory = '/'.$this->base_directory;
-            }
-        }
-    }
-
     public function updatedBuildPack()
     {
         if ($this->build_pack === 'nixpacks') {

--- a/app/Livewire/Project/New/PublicGitRepository.php
+++ b/app/Livewire/Project/New/PublicGitRepository.php
@@ -107,26 +107,6 @@ class PublicGitRepository extends Component
         $this->query = request()->query();
     }
 
-    public function updatedBaseDirectory()
-    {
-        if ($this->base_directory) {
-            $this->base_directory = rtrim($this->base_directory, '/');
-            if (! str($this->base_directory)->startsWith('/')) {
-                $this->base_directory = '/'.$this->base_directory;
-            }
-        }
-    }
-
-    public function updatedDockerComposeLocation()
-    {
-        if ($this->docker_compose_location) {
-            $this->docker_compose_location = rtrim($this->docker_compose_location, '/');
-            if (! str($this->docker_compose_location)->startsWith('/')) {
-                $this->docker_compose_location = '/'.$this->docker_compose_location;
-            }
-        }
-    }
-
     public function updatedBuildPack()
     {
         if ($this->build_pack === 'nixpacks') {

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -1511,9 +1511,11 @@ class Application extends BaseModel
         }
     }
 
-    public function loadComposeFile($isInit = false)
+    public function loadComposeFile($isInit = false, ?string $restoreBaseDirectory = null, ?string $restoreDockerComposeLocation = null)
     {
-        $initialDockerComposeLocation = $this->docker_compose_location;
+        // Use provided restore values or capture current values as fallback
+        $initialDockerComposeLocation = $restoreDockerComposeLocation ?? $this->docker_compose_location;
+        $initialBaseDirectory = $restoreBaseDirectory ?? $this->base_directory;
         if ($isInit && $this->docker_compose_raw) {
             return;
         }
@@ -1580,6 +1582,7 @@ class Application extends BaseModel
             throw new \RuntimeException($e->getMessage());
         } finally {
             $this->docker_compose_location = $initialDockerComposeLocation;
+            $this->base_directory = $initialBaseDirectory;
             $this->save();
             $commands = collect([
                 "rm -rf /tmp/{$uuid}",

--- a/resources/views/livewire/project/application/general.blade.php
+++ b/resources/views/livewire/project/application/general.blade.php
@@ -241,12 +241,32 @@
                             @else
                                     <div class="flex flex-col gap-2">
                                 @endcan
-                                    <div class="flex gap-2">
-                                        <x-forms.input x-bind:disabled="shouldDisable()" placeholder="/" id="baseDirectory"
-                                            label="Base Directory" helper="Directory to use as root. Useful for monorepos." />
+                                    <div x-data="{
+                                        baseDir: '{{ $application->base_directory }}',
+                                        composeLocation: '{{ $application->docker_compose_location }}',
+                                        normalizePath(path) {
+                                            if (!path || path.trim() === '') return '/';
+                                            path = path.trim();
+                                            path = path.replace(/\/+$/, '');
+                                            if (!path.startsWith('/')) {
+                                                path = '/' + path;
+                                            }
+                                            return path;
+                                        },
+                                        normalizeBaseDir() {
+                                            this.baseDir = this.normalizePath(this.baseDir);
+                                        },
+                                        normalizeComposeLocation() {
+                                            this.composeLocation = this.normalizePath(this.composeLocation);
+                                        }
+                                    }" class="flex gap-2">
+                                        <x-forms.input x-bind:disabled="shouldDisable()" placeholder="/" wire:model.defer="baseDirectory"
+                                            label="Base Directory" helper="Directory to use as root. Useful for monorepos."
+                                            x-model="baseDir" @blur="normalizeBaseDir()" />
                                         <x-forms.input x-bind:disabled="shouldDisable()" placeholder="/docker-compose.yaml"
-                                            id="dockerComposeLocation" label="Docker Compose Location"
-                                            helper="It is calculated together with the Base Directory:<br><span class='dark:text-warning'>{{ Str::start($application->base_directory . $application->docker_compose_location, '/') }}</span>" />
+                                            wire:model.defer="dockerComposeLocation" label="Docker Compose Location"
+                                            helper="It is calculated together with the Base Directory:<br><span class='dark:text-warning'>{{ Str::start($application->base_directory . $application->docker_compose_location, '/') }}</span>"
+                                            x-model="composeLocation" @blur="normalizeComposeLocation()" />
                                     </div>
                                     <div class="w-96">
                                         <x-forms.checkbox instantSave id="isPreserveRepositoryEnabled"
@@ -293,13 +313,32 @@
                                     @endif
                                 </div>
                         @else
-                                <div class="flex flex-col gap-2 xl:flex-row">
-                                    <x-forms.input placeholder="/" id="baseDirectory" label="Base Directory"
-                                        helper="Directory to use as root. Useful for monorepos." x-bind:disabled="!canUpdate" />
+                                <div x-data="{
+                                    baseDir: '{{ $application->base_directory }}',
+                                    dockerfileLocation: '{{ $application->dockerfile_location }}',
+                                    normalizePath(path) {
+                                        if (!path || path.trim() === '') return '/';
+                                        path = path.trim();
+                                        path = path.replace(/\/+$/, '');
+                                        if (!path.startsWith('/')) {
+                                            path = '/' + path;
+                                        }
+                                        return path;
+                                    },
+                                    normalizeBaseDir() {
+                                        this.baseDir = this.normalizePath(this.baseDir);
+                                    },
+                                    normalizeDockerfileLocation() {
+                                        this.dockerfileLocation = this.normalizePath(this.dockerfileLocation);
+                                    }
+                                }" class="flex flex-col gap-2 xl:flex-row">
+                                    <x-forms.input placeholder="/" wire:model.defer="baseDirectory" label="Base Directory"
+                                        helper="Directory to use as root. Useful for monorepos." x-bind:disabled="!canUpdate"
+                                        x-model="baseDir" @blur="normalizeBaseDir()" />
                                     @if ($application->build_pack === 'dockerfile' && !$application->dockerfile)
-                                        <x-forms.input placeholder="/Dockerfile" id="dockerfileLocation" label="Dockerfile Location"
+                                        <x-forms.input placeholder="/Dockerfile" wire:model.defer="dockerfileLocation" label="Dockerfile Location"
                                             helper="It is calculated together with the Base Directory:<br><span class='dark:text-warning'>{{ Str::start($application->base_directory . $application->dockerfile_location, '/') }}</span>"
-                                            x-bind:disabled="!canUpdate" />
+                                            x-bind:disabled="!canUpdate" x-model="dockerfileLocation" @blur="normalizeDockerfileLocation()" />
                                     @endif
 
                                     @if ($application->build_pack === 'dockerfile')

--- a/resources/views/livewire/project/new/github-private-repository-deploy-key.blade.php
+++ b/resources/views/livewire/project/new/github-private-repository-deploy-key.blade.php
@@ -61,12 +61,33 @@
                     @endif
                 </div>
                 @if ($build_pack === 'dockercompose')
-                    <div x-data="{ baseDir: '{{ $base_directory }}', composeLocation: '{{ $docker_compose_location }}' }" class="gap-2 flex flex-col">
-                        <x-forms.input placeholder="/" wire:model.blur="base_directory" label="Base Directory"
-                            helper="Directory to use as root. Useful for monorepos." x-model="baseDir" />
-                        <x-forms.input placeholder="/docker-compose.yaml" wire:model.blur="docker_compose_location"
+                    <div x-data="{
+                        baseDir: '{{ $base_directory }}',
+                        composeLocation: '{{ $docker_compose_location }}',
+                        normalizePath(path) {
+                            if (!path || path.trim() === '') return '/';
+                            path = path.trim();
+                            // Remove trailing slashes
+                            path = path.replace(/\/+$/, '');
+                            // Ensure leading slash
+                            if (!path.startsWith('/')) {
+                                path = '/' + path;
+                            }
+                            return path;
+                        },
+                        normalizeBaseDir() {
+                            this.baseDir = this.normalizePath(this.baseDir);
+                        },
+                        normalizeComposeLocation() {
+                            this.composeLocation = this.normalizePath(this.composeLocation);
+                        }
+                    }" class="gap-2 flex flex-col">
+                        <x-forms.input placeholder="/" wire:model.defer="base_directory" label="Base Directory"
+                            helper="Directory to use as root. Useful for monorepos." x-model="baseDir"
+                            @blur="normalizeBaseDir()" />
+                        <x-forms.input placeholder="/docker-compose.yaml" wire:model.defer="docker_compose_location"
                             label="Docker Compose Location" helper="It is calculated together with the Base Directory."
-                            x-model="composeLocation" />
+                            x-model="composeLocation" @blur="normalizeComposeLocation()" />
                         <div class="pt-2">
                             <span>
                                 Compose file location in your repository: </span><span class='dark:text-warning'

--- a/resources/views/livewire/project/new/github-private-repository.blade.php
+++ b/resources/views/livewire/project/new/github-private-repository.blade.php
@@ -95,15 +95,35 @@
                                     @endif
                                 </div>
                                 @if ($build_pack === 'dockercompose')
-                                    <div x-data="{ baseDir: '{{ $base_directory }}', composeLocation: '{{ $docker_compose_location }}' }" class="gap-2 flex flex-col">
-                                        <x-forms.input placeholder="/" wire:model.blur="base_directory"
+                                    <div x-data="{
+                                        baseDir: '{{ $base_directory }}',
+                                        composeLocation: '{{ $docker_compose_location }}',
+                                        normalizePath(path) {
+                                            if (!path || path.trim() === '') return '/';
+                                            path = path.trim();
+                                            // Remove trailing slashes
+                                            path = path.replace(/\/+$/, '');
+                                            // Ensure leading slash
+                                            if (!path.startsWith('/')) {
+                                                path = '/' + path;
+                                            }
+                                            return path;
+                                        },
+                                        normalizeBaseDir() {
+                                            this.baseDir = this.normalizePath(this.baseDir);
+                                        },
+                                        normalizeComposeLocation() {
+                                            this.composeLocation = this.normalizePath(this.composeLocation);
+                                        }
+                                    }" class="gap-2 flex flex-col">
+                                        <x-forms.input placeholder="/" wire:model.defer="base_directory"
                                             label="Base Directory"
                                             helper="Directory to use as root. Useful for monorepos."
-                                            x-model="baseDir" />
+                                            x-model="baseDir" @blur="normalizeBaseDir()" />
                                         <x-forms.input placeholder="/docker-compose.yaml"
-                                            wire:model.blur="docker_compose_location" label="Docker Compose Location"
+                                            wire:model.defer="docker_compose_location" label="Docker Compose Location"
                                             helper="It is calculated together with the Base Directory."
-                                            x-model="composeLocation" />
+                                            x-model="composeLocation" @blur="normalizeComposeLocation()" />
                                         <div class="pt-2">
                                             <span>
                                                 Compose file location in your repository: </span><span

--- a/resources/views/livewire/project/new/public-git-repository.blade.php
+++ b/resources/views/livewire/project/new/public-git-repository.blade.php
@@ -52,12 +52,33 @@
                     @endif
                 </div>
                 @if ($build_pack === 'dockercompose')
-                    <div x-data="{ baseDir: '{{ $base_directory }}', composeLocation: '{{ $docker_compose_location }}' }" class="gap-2 flex flex-col">
-                        <x-forms.input placeholder="/" wire:model.blur="base_directory" label="Base Directory"
-                            helper="Directory to use as root. Useful for monorepos." x-model="baseDir" />
-                        <x-forms.input placeholder="/docker-compose.yaml" wire:model.blur="docker_compose_location"
+                    <div x-data="{
+                        baseDir: '{{ $base_directory }}',
+                        composeLocation: '{{ $docker_compose_location }}',
+                        normalizePath(path) {
+                            if (!path || path.trim() === '') return '/';
+                            path = path.trim();
+                            // Remove trailing slashes
+                            path = path.replace(/\/+$/, '');
+                            // Ensure leading slash
+                            if (!path.startsWith('/')) {
+                                path = '/' + path;
+                            }
+                            return path;
+                        },
+                        normalizeBaseDir() {
+                            this.baseDir = this.normalizePath(this.baseDir);
+                        },
+                        normalizeComposeLocation() {
+                            this.composeLocation = this.normalizePath(this.composeLocation);
+                        }
+                    }" class="gap-2 flex flex-col">
+                        <x-forms.input placeholder="/" wire:model.defer="base_directory" label="Base Directory"
+                            helper="Directory to use as root. Useful for monorepos." x-model="baseDir"
+                            @blur="normalizeBaseDir()" />
+                        <x-forms.input placeholder="/docker-compose.yaml" wire:model.defer="docker_compose_location"
                             label="Docker Compose Location" helper="It is calculated together with the Base Directory."
-                            x-model="composeLocation" />
+                            x-model="composeLocation" @blur="normalizeComposeLocation()" />
                         <div class="pt-2">
                             <span>
                                 Compose file location in your repository: </span><span class='dark:text-warning'


### PR DESCRIPTION
## Changes

- Move path normalization from backend `updatedBaseDirectory()` and `updatedDockerComposeLocation()` lifecycle methods to Alpine.js on the frontend
- Replace `wire:model.blur` with `wire:model.defer` to prevent backend requests during form navigation
- Add Alpine.js `normalizePath()` function that ensures leading slash, removes trailing slashes, and trims whitespace
- Add `@blur` event handlers to trigger frontend-only path normalization

## Issues

- Fixes tab focus blur issue in public/GitHub repository application creation forms when pressing Tab after entering Base Directory