### PR TITLE
Add STORE_MODEL_IN_DB to LiteLLM environment variables

### DIFF
--- a/templates/compose/litellm.yaml
+++ b/templates/compose/litellm.yaml
@@ -32,6 +32,7 @@ services:
       - ANTHROPIC_API_BASE=${ANTHROPIC_API_BASE}
       - VOYAGE_API_KEY=${VOYAGE_API_KEY}
       - VOYAGE_API_BASE=${VOYAGE_API_BASE}
+      - STORE_MODEL_IN_DB=${STORE_MODEL_IN_DB}
     volumes:
       - type: bind
         source: ./litellm-config.yaml


### PR DESCRIPTION
## Changes
- Add the `STORE_MODEL_IN_DB` variable to the LiteLLM template. This flag is required in order to save models and API keys to the database. Not saving them defeats the purpose of using the LiteLLM proxy. 

Configuration docs for LiteLLM: https://docs.litellm.ai/docs/proxy/config_settings