### PR TITLE
fix: postgres restore command to support custom database name

### DIFF
--- a/app/Livewire/Project/Database/Import.php
+++ b/app/Livewire/Project/Database/Import.php
@@ -210,8 +210,8 @@ EOD;
             case \App\Models\StandalonePostgresql::class:
                 if ($value === true) {
                     $this->postgresqlRestoreCommand = <<<'EOD'
-psql -U $POSTGRES_USER -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname IS NOT NULL AND pid <> pg_backend_pid()" && \
-psql -U $POSTGRES_USER -t -c "SELECT datname FROM pg_database WHERE NOT datistemplate" | xargs -I {} dropdb -U $POSTGRES_USER --if-exists {} && \
+psql -U $POSTGRES_USER -d postgres -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname IS NOT NULL AND pid <> pg_backend_pid()" && \
+psql -U $POSTGRES_USER -d postgres -t -c "SELECT datname FROM pg_database WHERE NOT datistemplate" | xargs -I {} dropdb -U $POSTGRES_USER --if-exists {} && \
 createdb -U $POSTGRES_USER postgres
 EOD;
                     $this->restoreCommandText = $this->postgresqlRestoreCommand.' && (gunzip -cf <temp_backup_file> 2>/dev/null || cat <temp_backup_file>) | psql -U $POSTGRES_USER postgres';

--- a/tests/Unit/Livewire/Database/S3RestoreTest.php
+++ b/tests/Unit/Livewire/Database/S3RestoreTest.php
@@ -21,7 +21,7 @@ test('buildRestoreCommand handles PostgreSQL with dumpAll', function () {
     $component = new Import;
     $component->dumpAll = true;
     // This is the full dump-all command prefix that would be set in the updatedDumpAll method
-    $component->postgresqlRestoreCommand = 'psql -U $POSTGRES_USER -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname IS NOT NULL AND pid <> pg_backend_pid()" && psql -U $POSTGRES_USER -t -c "SELECT datname FROM pg_database WHERE NOT datistemplate" | xargs -I {} dropdb -U $POSTGRES_USER --if-exists {} && createdb -U $POSTGRES_USER postgres';
+    $component->postgresqlRestoreCommand = 'psql -U $POSTGRES_USER -d postgres -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname IS NOT NULL AND pid <> pg_backend_pid()" && psql -U $POSTGRES_USER -d postgres -t -c "SELECT datname FROM pg_database WHERE NOT datistemplate" | xargs -I {} dropdb -U $POSTGRES_USER --if-exists {} && createdb -U $POSTGRES_USER postgres';
 
     $database = Mockery::mock('App\Models\StandalonePostgresql');
     $database->shouldReceive('getMorphClass')->andReturn('App\Models\StandalonePostgresql');


### PR DESCRIPTION
## Changes
- Updated `StandalonePostgresql` restore commands to explicitly connect to the `postgres` database using `-d postgres`.
- Updated the corresponding unit test to verify the correct command generation.
- This prevents `FATAL: database "user" does not exist` errors when importing data with a custom username that does not have a matching database name.

## Issues
- fix #7438