### PR TITLE
Decouple ServerStorageCheckJob from Sentinel sync

### DIFF
--- a/app/Jobs/ServerManagerJob.php
+++ b/app/Jobs/ServerManagerJob.php
@@ -120,7 +120,7 @@ class ServerManagerJob implements ShouldQueue
         // Check if we should run sentinel-based checks
         $lastSentinelUpdate = $server->sentinel_updated_at;
         $waitTime = $server->waitBeforeDoingSshCheck();
-        $sentinelOutOfSync = Carbon::parse($lastSentinelUpdate)->isBefore($this->executionTime->subSeconds($waitTime));
+        $sentinelOutOfSync = Carbon::parse($lastSentinelUpdate)->isBefore($this->executionTime->copy()->subSeconds($waitTime));
 
         if ($sentinelOutOfSync) {
             // Dispatch ServerCheckJob if Sentinel is out of sync

--- a/app/Jobs/ServerManagerJob.php
+++ b/app/Jobs/ServerManagerJob.php
@@ -124,7 +124,7 @@ class ServerManagerJob implements ShouldQueue
 
         if ($sentinelOutOfSync) {
             // Dispatch ServerCheckJob if Sentinel is out of sync
-            if ($this->shouldRunNow($this->checkFrequency)) {
+            if ($this->shouldRunNow($this->checkFrequency, $serverTimezone)) {
                 ServerCheckJob::dispatch($server);
             }
         }

--- a/tests/Feature/ServerStorageCheckIndependenceTest.php
+++ b/tests/Feature/ServerStorageCheckIndependenceTest.php
@@ -1,0 +1,188 @@
+<?php
+
+use App\Jobs\ServerCheckJob;
+use App\Jobs\ServerManagerJob;
+use App\Jobs\ServerStorageCheckJob;
+use App\Models\Server;
+use App\Models\Team;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Queue::fake();
+});
+
+afterEach(function () {
+    Carbon::setTestNow();
+});
+
+it('dispatches storage check when sentinel is in sync', function () {
+    // Given: A server with Sentinel recently updated (in sync)
+    $team = Team::factory()->create();
+    $server = Server::factory()->create([
+        'team_id' => $team->id,
+        'sentinel_updated_at' => now(),
+    ]);
+
+    $server->settings->update([
+        'server_disk_usage_check_frequency' => '0 23 * * *',
+        'server_timezone' => 'UTC',
+    ]);
+
+    // When: ServerManagerJob runs at 11 PM
+    Carbon::setTestNow(Carbon::parse('2025-01-15 23:00:00', 'UTC'));
+    $job = new ServerManagerJob;
+    $job->handle();
+
+    // Then: ServerStorageCheckJob should be dispatched
+    Queue::assertPushed(ServerStorageCheckJob::class, function ($job) use ($server) {
+        return $job->server->id === $server->id;
+    });
+});
+
+it('dispatches storage check when sentinel is out of sync', function () {
+    // Given: A server with Sentinel out of sync (last update 10 minutes ago)
+    $team = Team::factory()->create();
+    $server = Server::factory()->create([
+        'team_id' => $team->id,
+        'sentinel_updated_at' => now()->subMinutes(10),
+    ]);
+
+    $server->settings->update([
+        'server_disk_usage_check_frequency' => '0 23 * * *',
+        'server_timezone' => 'UTC',
+    ]);
+
+    // When: ServerManagerJob runs at 11 PM
+    Carbon::setTestNow(Carbon::parse('2025-01-15 23:00:00', 'UTC'));
+    $job = new ServerManagerJob;
+    $job->handle();
+
+    // Then: Both ServerCheckJob and ServerStorageCheckJob should be dispatched
+    Queue::assertPushed(ServerCheckJob::class);
+    Queue::assertPushed(ServerStorageCheckJob::class, function ($job) use ($server) {
+        return $job->server->id === $server->id;
+    });
+});
+
+it('dispatches storage check when sentinel is disabled', function () {
+    // Given: A server with Sentinel disabled
+    $team = Team::factory()->create();
+    $server = Server::factory()->create([
+        'team_id' => $team->id,
+        'sentinel_updated_at' => now()->subHours(24),
+    ]);
+
+    $server->settings->update([
+        'server_disk_usage_check_frequency' => '0 23 * * *',
+        'server_timezone' => 'UTC',
+        'is_metrics_enabled' => false,
+    ]);
+
+    // When: ServerManagerJob runs at 11 PM
+    Carbon::setTestNow(Carbon::parse('2025-01-15 23:00:00', 'UTC'));
+    $job = new ServerManagerJob;
+    $job->handle();
+
+    // Then: ServerStorageCheckJob should be dispatched
+    Queue::assertPushed(ServerStorageCheckJob::class, function ($job) use ($server) {
+        return $job->server->id === $server->id;
+    });
+});
+
+it('respects custom hourly storage check frequency', function () {
+    // Given: A server with hourly storage check frequency
+    $team = Team::factory()->create();
+    $server = Server::factory()->create([
+        'team_id' => $team->id,
+        'sentinel_updated_at' => now(),
+    ]);
+
+    $server->settings->update([
+        'server_disk_usage_check_frequency' => '0 * * * *',
+        'server_timezone' => 'UTC',
+    ]);
+
+    // When: ServerManagerJob runs at the top of the hour (23:00)
+    Carbon::setTestNow(Carbon::parse('2025-01-15 23:00:00', 'UTC'));
+    $job = new ServerManagerJob;
+    $job->handle();
+
+    // Then: ServerStorageCheckJob should be dispatched
+    Queue::assertPushed(ServerStorageCheckJob::class, function ($job) use ($server) {
+        return $job->server->id === $server->id;
+    });
+});
+
+it('handles VALID_CRON_STRINGS mapping correctly', function () {
+    // Given: A server with 'hourly' string (should be converted to '0 * * * *')
+    $team = Team::factory()->create();
+    $server = Server::factory()->create([
+        'team_id' => $team->id,
+        'sentinel_updated_at' => now(),
+    ]);
+
+    $server->settings->update([
+        'server_disk_usage_check_frequency' => 'hourly',
+        'server_timezone' => 'UTC',
+    ]);
+
+    // When: ServerManagerJob runs at the top of the hour
+    Carbon::setTestNow(Carbon::parse('2025-01-15 23:00:00', 'UTC'));
+    $job = new ServerManagerJob;
+    $job->handle();
+
+    // Then: ServerStorageCheckJob should be dispatched (hourly was converted to cron)
+    Queue::assertPushed(ServerStorageCheckJob::class, function ($job) use ($server) {
+        return $job->server->id === $server->id;
+    });
+});
+
+it('respects server timezone for storage checks', function () {
+    // Given: A server in America/New_York timezone (UTC-5) configured for 11 PM local time
+    $team = Team::factory()->create();
+    $server = Server::factory()->create([
+        'team_id' => $team->id,
+        'sentinel_updated_at' => now(),
+    ]);
+
+    $server->settings->update([
+        'server_disk_usage_check_frequency' => '0 23 * * *',
+        'server_timezone' => 'America/New_York',
+    ]);
+
+    // When: ServerManagerJob runs at 11 PM New York time (4 AM UTC next day)
+    Carbon::setTestNow(Carbon::parse('2025-01-16 04:00:00', 'UTC'));
+    $job = new ServerManagerJob;
+    $job->handle();
+
+    // Then: ServerStorageCheckJob should be dispatched
+    Queue::assertPushed(ServerStorageCheckJob::class, function ($job) use ($server) {
+        return $job->server->id === $server->id;
+    });
+});
+
+it('does not dispatch storage check outside schedule', function () {
+    // Given: A server with daily storage check at 11 PM
+    $team = Team::factory()->create();
+    $server = Server::factory()->create([
+        'team_id' => $team->id,
+        'sentinel_updated_at' => now(),
+    ]);
+
+    $server->settings->update([
+        'server_disk_usage_check_frequency' => '0 23 * * *',
+        'server_timezone' => 'UTC',
+    ]);
+
+    // When: ServerManagerJob runs at 10 PM (not 11 PM)
+    Carbon::setTestNow(Carbon::parse('2025-01-15 22:00:00', 'UTC'));
+    $job = new ServerManagerJob;
+    $job->handle();
+
+    // Then: ServerStorageCheckJob should NOT be dispatched
+    Queue::assertNotPushed(ServerStorageCheckJob::class);
+});

--- a/tests/Feature/ServerStorageCheckIndependenceTest.php
+++ b/tests/Feature/ServerStorageCheckIndependenceTest.php
@@ -20,6 +20,9 @@ afterEach(function () {
 });
 
 it('does not dispatch storage check when sentinel is in sync', function () {
+    // When: ServerManagerJob runs at 11 PM
+    Carbon::setTestNow(Carbon::parse('2025-01-15 23:00:00', 'UTC'));
+
     // Given: A server with Sentinel recently updated (in sync)
     $team = Team::factory()->create();
     $server = Server::factory()->create([
@@ -31,9 +34,6 @@ it('does not dispatch storage check when sentinel is in sync', function () {
         'server_disk_usage_check_frequency' => '0 23 * * *',
         'server_timezone' => 'UTC',
     ]);
-
-    // When: ServerManagerJob runs at 11 PM
-    Carbon::setTestNow(Carbon::parse('2025-01-15 23:00:00', 'UTC'));
     $job = new ServerManagerJob;
     $job->handle();
 
@@ -42,6 +42,9 @@ it('does not dispatch storage check when sentinel is in sync', function () {
 });
 
 it('dispatches storage check when sentinel is out of sync', function () {
+    // When: ServerManagerJob runs at 11 PM
+    Carbon::setTestNow(Carbon::parse('2025-01-15 23:00:00', 'UTC'));
+
     // Given: A server with Sentinel out of sync (last update 10 minutes ago)
     $team = Team::factory()->create();
     $server = Server::factory()->create([
@@ -53,9 +56,6 @@ it('dispatches storage check when sentinel is out of sync', function () {
         'server_disk_usage_check_frequency' => '0 23 * * *',
         'server_timezone' => 'UTC',
     ]);
-
-    // When: ServerManagerJob runs at 11 PM
-    Carbon::setTestNow(Carbon::parse('2025-01-15 23:00:00', 'UTC'));
     $job = new ServerManagerJob;
     $job->handle();
 
@@ -67,6 +67,9 @@ it('dispatches storage check when sentinel is out of sync', function () {
 });
 
 it('dispatches storage check when sentinel is disabled', function () {
+    // When: ServerManagerJob runs at 11 PM
+    Carbon::setTestNow(Carbon::parse('2025-01-15 23:00:00', 'UTC'));
+
     // Given: A server with Sentinel disabled
     $team = Team::factory()->create();
     $server = Server::factory()->create([
@@ -79,9 +82,6 @@ it('dispatches storage check when sentinel is disabled', function () {
         'server_timezone' => 'UTC',
         'is_metrics_enabled' => false,
     ]);
-
-    // When: ServerManagerJob runs at 11 PM
-    Carbon::setTestNow(Carbon::parse('2025-01-15 23:00:00', 'UTC'));
     $job = new ServerManagerJob;
     $job->handle();
 
@@ -92,6 +92,9 @@ it('dispatches storage check when sentinel is disabled', function () {
 });
 
 it('respects custom hourly storage check frequency when sentinel is out of sync', function () {
+    // When: ServerManagerJob runs at the top of the hour (23:00)
+    Carbon::setTestNow(Carbon::parse('2025-01-15 23:00:00', 'UTC'));
+
     // Given: A server with hourly storage check frequency and Sentinel out of sync
     $team = Team::factory()->create();
     $server = Server::factory()->create([
@@ -103,9 +106,6 @@ it('respects custom hourly storage check frequency when sentinel is out of sync'
         'server_disk_usage_check_frequency' => '0 * * * *',
         'server_timezone' => 'UTC',
     ]);
-
-    // When: ServerManagerJob runs at the top of the hour (23:00)
-    Carbon::setTestNow(Carbon::parse('2025-01-15 23:00:00', 'UTC'));
     $job = new ServerManagerJob;
     $job->handle();
 
@@ -116,6 +116,9 @@ it('respects custom hourly storage check frequency when sentinel is out of sync'
 });
 
 it('handles VALID_CRON_STRINGS mapping correctly when sentinel is out of sync', function () {
+    // When: ServerManagerJob runs at the top of the hour
+    Carbon::setTestNow(Carbon::parse('2025-01-15 23:00:00', 'UTC'));
+
     // Given: A server with 'hourly' string (should be converted to '0 * * * *') and Sentinel out of sync
     $team = Team::factory()->create();
     $server = Server::factory()->create([
@@ -127,9 +130,6 @@ it('handles VALID_CRON_STRINGS mapping correctly when sentinel is out of sync', 
         'server_disk_usage_check_frequency' => 'hourly',
         'server_timezone' => 'UTC',
     ]);
-
-    // When: ServerManagerJob runs at the top of the hour
-    Carbon::setTestNow(Carbon::parse('2025-01-15 23:00:00', 'UTC'));
     $job = new ServerManagerJob;
     $job->handle();
 
@@ -140,6 +140,9 @@ it('handles VALID_CRON_STRINGS mapping correctly when sentinel is out of sync', 
 });
 
 it('respects server timezone for storage checks when sentinel is out of sync', function () {
+    // When: ServerManagerJob runs at 11 PM New York time (4 AM UTC next day)
+    Carbon::setTestNow(Carbon::parse('2025-01-16 04:00:00', 'UTC'));
+
     // Given: A server in America/New_York timezone (UTC-5) configured for 11 PM local time and Sentinel out of sync
     $team = Team::factory()->create();
     $server = Server::factory()->create([
@@ -151,9 +154,6 @@ it('respects server timezone for storage checks when sentinel is out of sync', f
         'server_disk_usage_check_frequency' => '0 23 * * *',
         'server_timezone' => 'America/New_York',
     ]);
-
-    // When: ServerManagerJob runs at 11 PM New York time (4 AM UTC next day)
-    Carbon::setTestNow(Carbon::parse('2025-01-16 04:00:00', 'UTC'));
     $job = new ServerManagerJob;
     $job->handle();
 
@@ -164,6 +164,9 @@ it('respects server timezone for storage checks when sentinel is out of sync', f
 });
 
 it('does not dispatch storage check outside schedule', function () {
+    // When: ServerManagerJob runs at 10 PM (not 11 PM)
+    Carbon::setTestNow(Carbon::parse('2025-01-15 22:00:00', 'UTC'));
+
     // Given: A server with daily storage check at 11 PM
     $team = Team::factory()->create();
     $server = Server::factory()->create([
@@ -175,9 +178,6 @@ it('does not dispatch storage check outside schedule', function () {
         'server_disk_usage_check_frequency' => '0 23 * * *',
         'server_timezone' => 'UTC',
     ]);
-
-    // When: ServerManagerJob runs at 10 PM (not 11 PM)
-    Carbon::setTestNow(Carbon::parse('2025-01-15 22:00:00', 'UTC'));
     $job = new ServerManagerJob;
     $job->handle();
 

--- a/tests/Unit/ServerManagerJobExecutionTimeTest.php
+++ b/tests/Unit/ServerManagerJobExecutionTimeTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use Illuminate\Support\Carbon;
+
+afterEach(function () {
+    Carbon::setTestNow();
+});
+
+it('does not mutate Carbon instance when using copy() before subSeconds()', function () {
+    // This test verifies the fix for the bug where subSeconds() was mutating executionTime
+    $originalTime = Carbon::parse('2024-12-02 12:00:00');
+    $originalTimeString = $originalTime->toDateTimeString();
+
+    // Simulate what happens in processServerTasks() with the FIX applied
+    $waitTime = 360;
+    $threshold = $originalTime->copy()->subSeconds($waitTime);
+
+    // The original time should remain unchanged after using copy()
+    expect($originalTime->toDateTimeString())->toBe($originalTimeString);
+    expect($threshold->toDateTimeString())->toBe('2024-12-02 11:54:00');
+});
+
+it('demonstrates mutation bug when not using copy()', function () {
+    // This test shows what would happen WITHOUT the fix (the bug)
+    $originalTime = Carbon::parse('2024-12-02 12:00:00');
+
+    // Simulate what would happen WITHOUT copy() (the bug)
+    $waitTime = 360;
+    $threshold = $originalTime->subSeconds($waitTime);
+
+    // Without copy(), the original time is mutated!
+    expect($originalTime->toDateTimeString())->toBe('2024-12-02 11:54:00');
+    expect($threshold->toDateTimeString())->toBe('2024-12-02 11:54:00');
+    expect($originalTime)->toBe($threshold); // They're the same object
+});
+
+it('preserves executionTime across multiple subSeconds calls with copy()', function () {
+    // Simulate processing multiple servers with different wait times
+    $executionTime = Carbon::parse('2024-12-02 12:00:00');
+    $originalTimeString = $executionTime->toDateTimeString();
+
+    // Server 1: waitTime = 360s
+    $threshold1 = $executionTime->copy()->subSeconds(360);
+    expect($executionTime->toDateTimeString())->toBe($originalTimeString);
+    expect($threshold1->toDateTimeString())->toBe('2024-12-02 11:54:00');
+
+    // Server 2: waitTime = 300s (should still use original time)
+    $threshold2 = $executionTime->copy()->subSeconds(300);
+    expect($executionTime->toDateTimeString())->toBe($originalTimeString);
+    expect($threshold2->toDateTimeString())->toBe('2024-12-02 11:55:00');
+
+    // Server 3: waitTime = 360s (should still use original time)
+    $threshold3 = $executionTime->copy()->subSeconds(360);
+    expect($executionTime->toDateTimeString())->toBe($originalTimeString);
+    expect($threshold3->toDateTimeString())->toBe('2024-12-02 11:54:00');
+
+    // Server 4: waitTime = 300s (should still use original time)
+    $threshold4 = $executionTime->copy()->subSeconds(300);
+    expect($executionTime->toDateTimeString())->toBe($originalTimeString);
+    expect($threshold4->toDateTimeString())->toBe('2024-12-02 11:55:00');
+
+    // Server 5: waitTime = 360s (should still use original time)
+    $threshold5 = $executionTime->copy()->subSeconds(360);
+    expect($executionTime->toDateTimeString())->toBe($originalTimeString);
+    expect($threshold5->toDateTimeString())->toBe('2024-12-02 11:54:00');
+
+    // The executionTime should STILL be exactly the original time
+    expect($executionTime->toDateTimeString())->toBe('2024-12-02 12:00:00');
+});
+
+it('demonstrates compounding bug without copy() across multiple calls', function () {
+    // This shows the compounding bug that happens WITHOUT the fix
+    $executionTime = Carbon::parse('2024-12-02 12:00:00');
+
+    // Server 1: waitTime = 360s
+    $threshold1 = $executionTime->subSeconds(360);
+    expect($executionTime->toDateTimeString())->toBe('2024-12-02 11:54:00'); // MUTATED!
+
+    // Server 2: waitTime = 300s (uses already-mutated time)
+    $threshold2 = $executionTime->subSeconds(300);
+    expect($executionTime->toDateTimeString())->toBe('2024-12-02 11:49:00'); // Further mutated!
+
+    // Server 3: waitTime = 360s (uses even more mutated time)
+    $threshold3 = $executionTime->subSeconds(360);
+    expect($executionTime->toDateTimeString())->toBe('2024-12-02 11:43:00'); // Even more mutated!
+
+    // Server 4: waitTime = 300s
+    $threshold4 = $executionTime->subSeconds(300);
+    expect($executionTime->toDateTimeString())->toBe('2024-12-02 11:38:00');
+
+    // Server 5: waitTime = 360s
+    $threshold5 = $executionTime->subSeconds(360);
+    expect($executionTime->toDateTimeString())->toBe('2024-12-02 11:32:00');
+
+    // The executionTime is now 1680 seconds (28 minutes) earlier than it should be!
+    expect($executionTime->diffInSeconds(Carbon::parse('2024-12-02 12:00:00')))->toEqual(1680);
+});


### PR DESCRIPTION
## Changes
- Moved server timezone calculation to top of `processServerTasks()` for reusability
- Extracted `ServerStorageCheckJob` dispatch from Sentinel conditional block
- Fixed default frequency to `'0 23 * * *'` (11 PM daily, matching migration)
- Added timezone parameter to storage check scheduling (consistent with patch checks)
- Added comprehensive Feature test suite with 7 test cases validating independence

## Issues
- Fixes monitoring blind spots where disk usage checks fail to run when Sentinel is offline, out of sync, or disabled