### PR TITLE
Update Umami image tag to latest version

### DIFF
--- a/templates/compose/umami.yaml
+++ b/templates/compose/umami.yaml
@@ -7,7 +7,7 @@
 
 services:
   umami:
-    image: ghcr.io/umami-software/umami:3.0.1
+    image: ghcr.io/umami-software/umami:3.0.2
     environment:
       - SERVICE_URL_UMAMI_3000
       - DATABASE_URL=postgres://$SERVICE_USER_POSTGRES:$SERVICE_PASSWORD_POSTGRES@postgresql:5432/$POSTGRES_DB

--- a/templates/compose/umami.yaml
+++ b/templates/compose/umami.yaml
@@ -7,7 +7,7 @@
 
 services:
   umami:
-    image: ghcr.io/umami-software/umami:postgresql-latest
+    image: ghcr.io/umami-software/umami:latest
     environment:
       - SERVICE_URL_UMAMI_3000
       - DATABASE_URL=postgres://$SERVICE_USER_POSTGRES:$SERVICE_PASSWORD_POSTGRES@postgresql:5432/$POSTGRES_DB

--- a/templates/compose/umami.yaml
+++ b/templates/compose/umami.yaml
@@ -7,7 +7,7 @@
 
 services:
   umami:
-    image: ghcr.io/umami-software/umami:latest
+    image: ghcr.io/umami-software/umami:3.0.1
     environment:
       - SERVICE_URL_UMAMI_3000
       - DATABASE_URL=postgres://$SERVICE_USER_POSTGRES:$SERVICE_PASSWORD_POSTGRES@postgresql:5432/$POSTGRES_DB


### PR DESCRIPTION
The [umami repo](https://github.com/umami-software/umami) lists the `umami:postgres-latest` image as deprecated with the new 3.0 release.

_"If you are updating from Umami V2, image "postgresql-latest" is deprecated. You must change it to "latest". e.g., rename docker.umami.is/umami-software/umami:postgresql-latest to docker.umami.is/umami-software/umami:latest."_

## Changes
- Changed the umami image tag to `umami:latest` from the now deprecated `umami:postgres-latest`.
