### PR TITLE
fix: prevent cleanup exceptions from marking successful deployments as failed

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -3194,7 +3194,6 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
                     'stderr',
                     hidden: true
                 );
-                \Log::warning("Failed to stop running container {$this->container_name}: {$e->getMessage()}");
 
                 return; // Don't re-throw - cleanup failures shouldn't fail successful deployments
             }

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -1813,9 +1813,9 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                             $this->application->update(['status' => 'running']);
                             $this->application_deployment_queue->addLogEntry('New container is healthy.');
                             break;
-                        }
-                        if (str($this->saved_outputs->get('health_check'))->replace('"', '')->value() === 'unhealthy') {
+                        }  elseif (str($this->saved_outputs->get('health_check'))->replace('"', '')->value() === 'unhealthy') {
                             $this->newVersionIsHealthy = false;
+                            $this->application_deployment_queue->addLogEntry('New container is unhealthy.', type: 'error');
                             $this->query_logs();
                             break;
                         }


### PR DESCRIPTION
## Changes
- Add conditional handling in `stop_running_container()` catch block to detect when deployment has already succeeded
- Log cleanup warnings with `hidden: true` to avoid cluttering deployment logs
- Only re-throw exceptions if the deployment hasn't succeeded yet

## Issues
- Fixes #7439

## Description
Successful deployments were being marked as FAILED due to exceptions during old container cleanup. When old containers are already removed (a common scenario), the "No such container" error was propagating and failing the entire deployment.

The fix checks if the new version is healthy before re-throwing cleanup exceptions, allowing the deployment to succeed while still logging the cleanup issues for debugging.