### PR TITLE
fix: add cuid2 format to openapi definitions

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -376,7 +376,8 @@
                                 "schema": {
                                     "properties": {
                                         "uuid": {
-                                            "type": "string"
+                                            "type": "string",
+                                            "format": "uuid"
                                         }
                                     },
                                     "type": "object"

--- a/openapi.json
+++ b/openapi.json
@@ -377,7 +377,7 @@
                                     "properties": {
                                         "uuid": {
                                             "type": "string",
-                                            "format": "uuid"
+                                            "format": "cuid2"
                                         }
                                     },
                                     "type": "object"


### PR DESCRIPTION
In the original version of this PR, I added format: uuid, assuming the IDs were UUIDs. However, Coolify uses Cuid2, not UUID, so this update replaces that incorrect format with a custom format: cuid2.

Using a custom Cuid2 format improves the accuracy of the API documentation and helps client libraries interpret these ID fields correctly.

Changes
Replaced the previously added format: uuid with format: cuid2 for all ID fields in openapi.json.

Issues
Fixes #7043.