### PR TITLE
Fix container status display: preserve Restarting status

### DIFF
--- a/app/Actions/Docker/GetContainersStatus.php
+++ b/app/Actions/Docker/GetContainersStatus.php
@@ -461,9 +461,10 @@ class GetContainersStatus
         }
 
         // Use ContainerStatusAggregator service for state machine logic
+        // Use preserveRestarting: true so applications show "Restarting" instead of "Degraded"
         $aggregator = new ContainerStatusAggregator;
 
-        return $aggregator->aggregateFromStrings($relevantStatuses, $maxRestartCount);
+        return $aggregator->aggregateFromStrings($relevantStatuses, $maxRestartCount, preserveRestarting: true);
     }
 
     private function aggregateServiceContainerStatuses($services)
@@ -518,8 +519,9 @@ class GetContainersStatus
             }
 
             // Use ContainerStatusAggregator service for state machine logic
+            // Use preserveRestarting: true so individual sub-resources show "Restarting" instead of "Degraded"
             $aggregator = new ContainerStatusAggregator;
-            $aggregatedStatus = $aggregator->aggregateFromStrings($relevantStatuses);
+            $aggregatedStatus = $aggregator->aggregateFromStrings($relevantStatuses, preserveRestarting: true);
 
             // Update service sub-resource status with aggregated result
             if ($aggregatedStatus) {

--- a/app/Jobs/PushServerUpdateJob.php
+++ b/app/Jobs/PushServerUpdateJob.php
@@ -300,8 +300,9 @@ class PushServerUpdateJob implements ShouldBeEncrypted, ShouldQueue, Silenced
             }
 
             // Use ContainerStatusAggregator service for state machine logic
+            // Use preserveRestarting: true so applications show "Restarting" instead of "Degraded"
             $aggregator = new ContainerStatusAggregator;
-            $aggregatedStatus = $aggregator->aggregateFromStrings($relevantStatuses, 0);
+            $aggregatedStatus = $aggregator->aggregateFromStrings($relevantStatuses, 0, preserveRestarting: true);
 
             // Update application status with aggregated result
             if ($aggregatedStatus && $application->status !== $aggregatedStatus) {
@@ -360,8 +361,9 @@ class PushServerUpdateJob implements ShouldBeEncrypted, ShouldQueue, Silenced
 
             // Use ContainerStatusAggregator service for state machine logic
             // NOTE: Sentinel does NOT provide restart count data, so maxRestartCount is always 0
+            // Use preserveRestarting: true so individual sub-resources show "Restarting" instead of "Degraded"
             $aggregator = new ContainerStatusAggregator;
-            $aggregatedStatus = $aggregator->aggregateFromStrings($relevantStatuses, 0);
+            $aggregatedStatus = $aggregator->aggregateFromStrings($relevantStatuses, 0, preserveRestarting: true);
 
             // Update service sub-resource status with aggregated result
             if ($aggregatedStatus && $subResource->status !== $aggregatedStatus) {


### PR DESCRIPTION
## Changes
- Add `preserveRestarting` parameter to `ContainerStatusAggregator` to control how restarting containers are displayed
- Update `GetContainersStatus` and `PushServerUpdateJob` to use `preserveRestarting: true` for applications and service sub-resources
- When `true`, applications and sub-resources display "Restarting" status instead of "Degraded", providing better visibility into restart behavior
- Maintains backward compatibility with default value of `false` for any existing code paths

## Issues
- Improves visibility of container restart status in the UI for users monitoring their deployments