### PR TITLE
Fix Traefik warning persistence after proxy configuration update

### DIFF
--- a/app/Listeners/ProxyStatusChangedNotification.php
+++ b/app/Listeners/ProxyStatusChangedNotification.php
@@ -2,10 +2,13 @@
 
 namespace App\Listeners;
 
+use App\Enums\ProxyTypes;
 use App\Events\ProxyStatusChanged;
 use App\Events\ProxyStatusChangedUI;
+use App\Jobs\CheckTraefikVersionForServerJob;
 use App\Models\Server;
 use Illuminate\Contracts\Queue\ShouldQueueAfterCommit;
+use Illuminate\Support\Facades\Log;
 
 class ProxyStatusChangedNotification implements ShouldQueueAfterCommit
 {
@@ -32,6 +35,19 @@ class ProxyStatusChangedNotification implements ShouldQueueAfterCommit
             $server->setupDynamicProxyConfiguration();
             $server->proxy->force_stop = false;
             $server->save();
+
+            // Check Traefik version after proxy is running
+            if ($server->proxyType() === ProxyTypes::TRAEFIK->value) {
+                $traefikVersions = get_traefik_versions();
+                if ($traefikVersions !== null) {
+                    CheckTraefikVersionForServerJob::dispatch($server, $traefikVersions);
+                } else {
+                    Log::warning('Traefik version check skipped after proxy status change: versions.json data unavailable', [
+                        'server_id' => $server->id,
+                        'server_name' => $server->name,
+                    ]);
+                }
+            }
         }
         if ($status === 'created') {
             instant_remote_process([

--- a/app/Livewire/Server/Navbar.php
+++ b/app/Livewire/Server/Navbar.php
@@ -5,12 +5,9 @@ namespace App\Livewire\Server;
 use App\Actions\Proxy\CheckProxy;
 use App\Actions\Proxy\StartProxy;
 use App\Actions\Proxy\StopProxy;
-use App\Enums\ProxyTypes;
-use App\Jobs\CheckTraefikVersionForServerJob;
 use App\Models\Server;
 use App\Services\ProxyDashboardCacheService;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
-use Illuminate\Support\Facades\Log;
 use Livewire\Component;
 
 class Navbar extends Component
@@ -70,19 +67,6 @@ class Navbar extends Component
 
             $activity = StartProxy::run($this->server, force: true, restarting: true);
             $this->dispatch('activityMonitor', $activity->id);
-
-            // Check Traefik version after restart to provide immediate feedback
-            if ($this->server->proxyType() === ProxyTypes::TRAEFIK->value) {
-                $traefikVersions = get_traefik_versions();
-                if ($traefikVersions !== null) {
-                    CheckTraefikVersionForServerJob::dispatch($this->server, $traefikVersions);
-                } else {
-                    Log::warning('Traefik version check skipped: versions.json data unavailable', [
-                        'server_id' => $this->server->id,
-                        'server_name' => $this->server->name,
-                    ]);
-                }
-            }
         } catch (\Throwable $e) {
             return handleError($e, $this);
         }

--- a/app/Livewire/Server/Navbar.php
+++ b/app/Livewire/Server/Navbar.php
@@ -5,6 +5,7 @@ namespace App\Livewire\Server;
 use App\Actions\Proxy\CheckProxy;
 use App\Actions\Proxy\StartProxy;
 use App\Actions\Proxy\StopProxy;
+use App\Enums\ProxyTypes;
 use App\Models\Server;
 use App\Services\ProxyDashboardCacheService;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;


### PR DESCRIPTION
## Summary
Fixes the issue where the Traefik warning triangle icon persists after updating proxy configuration and restarting until the weekly scheduled job runs.

## Problem
When users updated Traefik configuration or version and restarted the proxy, the warning triangle icon showing outdated version info remained visible until the weekly `CheckTraefikVersionJob` ran (Sundays at 00:00).

**Root Cause**: The UI warning indicators read from cached database columns (`detected_traefik_version`, `traefik_outdated_info`) that were only updated by the weekly scheduled job, not after proxy restarts.

## Solution
Add Traefik version check to the existing `ProxyStatusChangedNotification` event listener that triggers automatically after the proxy status changes to "running", plus real-time UI updates via WebSocket.

## Changes

### 1. Event-Driven Version Check
**Modified**: `app/Listeners/ProxyStatusChangedNotification.php`
- Added Traefik version check when proxy status = "running"
- Dispatches `CheckTraefikVersionForServerJob` automatically
- Gracefully handles missing `versions.json` data with warning log

**Modified**: `app/Livewire/Server/Navbar.php`
- Removed duplicate version check from `restart()` method
- Now handled centrally by event listener

### 2. Real-Time UI Updates
**Modified**: `app/Jobs/CheckTraefikVersionForServerJob.php`
- Added `ProxyStatusChangedUI::dispatch()` at all exit points
- UI updates automatically via WebSocket when version check completes
- No page refresh needed - warning clears in real-time

## How It Works

### Event Flow:
1. User updates Traefik config and restarts proxy (or manually restarts)
2. `StartProxy` action completes async, dispatches `ProxyStatusChanged` event
3. `ProxyStatusChangedNotification` listener receives event
4. Listener checks if proxy status = "running" AND proxy type = Traefik
5. Dispatches `CheckTraefikVersionForServerJob` to queue
6. Job detects version via SSH, updates database columns
7. **Job dispatches `ProxyStatusChangedUI` event**
8. **UI updates in real-time via WebSocket** - warning disappears automatically!

### Why This Approach?
- ✅ **Correct timing**: Version check happens AFTER proxy is confirmed running (more accurate)
- ✅ **Real-time updates**: Warning clears automatically without page refresh (WebSocket)
- ✅ **Single source of truth**: Centralized in event listener, no duplicate checks
- ✅ **Reuses existing infrastructure**: Leverages `ProxyStatusChanged` and `ProxyStatusChangedUI` events
- ✅ **Works for all scenarios**: Manual restart, config save + restart, etc.
- ✅ **No performance impact**: Async job dispatch via Horizon
- ✅ **Cloud scale ready**: Event-driven architecture handles thousands of servers

## Benefits
- ✅ Warning clears automatically after any proxy restart (not just weekly job)
- ✅ **Real-time UI updates** - no page refresh required
- ✅ Accurate version detection from running container via SSH
- ✅ Built-in retry logic (3 attempts, 60s timeout)
- ✅ No code duplication - single place to maintain
- ✅ Follows Coolify's event-driven architecture patterns

## Testing
### Manual Test Steps:
1. Set up server with Traefik running outdated version (e.g., v3.5.0)
2. Verify warning triangle appears in Proxy UI
3. Update docker-compose config to use `traefik:v3.6`
4. **Restart the proxy** (important!)
5. Wait 10-15 seconds for job to complete
6. **Expected**: Warning triangle disappears **automatically** (no refresh needed!)

### Verification:
```bash
# Check job was dispatched
php artisan horizon:list

# Verify database updated
SELECT detected_traefik_version, traefik_outdated_info FROM servers WHERE id = <server_id>;

# Watch browser console for WebSocket event
# Should see ProxyStatusChangedUI event fire
```

## User Experience Flow
```
User clicks "Restart Proxy"
    ↓
[Wait 5-10 seconds]
    ↓
⚡ Warning disappears automatically (WebSocket)
    ↓
✅ No refresh needed!
```

## Code Quality
- ✅ Laravel Pint: Passed
- ✅ PHPStan: No new errors
- ✅ Follows existing event listener patterns
- ✅ Reuses WebSocket infrastructure

🤖 Generated with [Claude Code](https://claude.com/claude-code)