### PR TITLE
fix(ui): empty destinations select on clone resource page

### DIFF
--- a/resources/views/livewire/project/shared/resource-operations.blade.php
+++ b/resources/views/livewire/project/shared/resource-operations.blade.php
@@ -9,7 +9,7 @@
         selectedMoveEnvironment: null,
         currentProjectId: {{ $resource->environment->project->id }},
         currentEnvironmentId: {{ $resource->environment->id }},
-        servers: @js(
+        servers: Object.values(@js(
     $servers->map(
         fn($s) => [
             'id' => $s->id,
@@ -24,8 +24,8 @@
             ),
         ],
     ),
-),
-        projects: @js(
+)),
+        projects: Object.values(@js(
     $projects->map(
         fn($p) => [
             'id' => $p->id,
@@ -39,7 +39,7 @@
             ),
         ],
     ),
-),
+)),
         get availableDestinations() {
             if (!this.selectedCloneServer) return [];
             const server = this.servers.find(s => s.id == this.selectedCloneServer);


### PR DESCRIPTION
## Changes
- treat Laravel collections as JS arrays, not objects (in some specific cases) on move/clone resource page

## Issues
- fix [#7102](https://github.com/coollabsio/coolify/issues/7102)
