### PR TITLE
Run proxy restart as background job with real-time logs

### DIFF
--- a/app/Events/ProxyStatusChangedUI.php
+++ b/app/Events/ProxyStatusChangedUI.php
@@ -14,12 +14,15 @@ class ProxyStatusChangedUI implements ShouldBroadcast
 
     public ?int $teamId = null;
 
-    public function __construct(?int $teamId = null)
+    public ?int $activityId = null;
+
+    public function __construct(?int $teamId = null, ?int $activityId = null)
     {
         if (is_null($teamId) && auth()->check() && auth()->user()->currentTeam()) {
             $teamId = auth()->user()->currentTeam()->id;
         }
         $this->teamId = $teamId;
+        $this->activityId = $activityId;
     }
 
     public function broadcastOn(): array

--- a/app/Jobs/RestartProxyJob.php
+++ b/app/Jobs/RestartProxyJob.php
@@ -4,6 +4,8 @@ namespace App\Jobs;
 
 use App\Actions\Proxy\StartProxy;
 use App\Actions\Proxy\StopProxy;
+use App\Enums\ProxyTypes;
+use App\Events\ProxyStatusChangedUI;
 use App\Models\Server;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeEncrypted;
@@ -12,6 +14,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
 
 class RestartProxyJob implements ShouldBeEncrypted, ShouldQueue
 {
@@ -20,6 +23,8 @@ class RestartProxyJob implements ShouldBeEncrypted, ShouldQueue
     public $tries = 1;
 
     public $timeout = 60;
+
+    public ?int $activity_id = null;
 
     public function middleware(): array
     {
@@ -31,14 +36,45 @@ class RestartProxyJob implements ShouldBeEncrypted, ShouldQueue
     public function handle()
     {
         try {
+            $teamId = $this->server->team_id;
+
+            // Stop proxy
             StopProxy::run($this->server, restarting: true);
 
+            // Clear force_stop flag
             $this->server->proxy->force_stop = false;
             $this->server->save();
 
-            StartProxy::run($this->server, force: true, restarting: true);
+            // Start proxy asynchronously to get activity
+            $activity = StartProxy::run($this->server, force: true, restarting: true);
+
+            // Store activity ID and dispatch event with it
+            if ($activity && is_object($activity)) {
+                $this->activity_id = $activity->id;
+                ProxyStatusChangedUI::dispatch($teamId, $this->activity_id);
+            }
+
+            // Check Traefik version after restart (same as original behavior)
+            if ($this->server->proxyType() === ProxyTypes::TRAEFIK->value) {
+                $traefikVersions = get_traefik_versions();
+                if ($traefikVersions !== null) {
+                    CheckTraefikVersionForServerJob::dispatch($this->server, $traefikVersions);
+                } else {
+                    Log::warning('Traefik version check skipped: versions.json data unavailable', [
+                        'server_id' => $this->server->id,
+                        'server_name' => $this->server->name,
+                    ]);
+                }
+            }
 
         } catch (\Throwable $e) {
+            // Set error status
+            $this->server->proxy->status = 'error';
+            $this->server->save();
+
+            // Notify UI of error
+            ProxyStatusChangedUI::dispatch($this->server->team_id);
+
             return handleError($e);
         }
     }

--- a/app/Jobs/RestartProxyJob.php
+++ b/app/Jobs/RestartProxyJob.php
@@ -46,9 +46,11 @@ class RestartProxyJob implements ShouldBeEncrypted, ShouldQueue
             // listener that handles UI updates and Traefik version checks
             $activity = StartProxy::run($this->server, force: true, restarting: true);
 
-            // Store activity ID for reference
+            // Store activity ID and dispatch event with it so UI can open activity monitor
             if ($activity && is_object($activity)) {
                 $this->activity_id = $activity->id;
+                // Dispatch event with activity ID so the UI can show logs
+                ProxyStatusChangedUI::dispatch($this->server->team_id, $this->activity_id);
             }
 
         } catch (\Throwable $e) {

--- a/app/Jobs/RestartProxyJob.php
+++ b/app/Jobs/RestartProxyJob.php
@@ -2,10 +2,12 @@
 
 namespace App\Jobs;
 
-use App\Actions\Proxy\StartProxy;
-use App\Actions\Proxy\StopProxy;
+use App\Actions\Proxy\GetProxyConfiguration;
+use App\Actions\Proxy\SaveProxyConfiguration;
+use App\Enums\ProxyTypes;
 use App\Events\ProxyStatusChangedUI;
 use App\Models\Server;
+use App\Services\ProxyDashboardCacheService;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -20,13 +22,13 @@ class RestartProxyJob implements ShouldBeEncrypted, ShouldQueue
 
     public $tries = 1;
 
-    public $timeout = 60;
+    public $timeout = 120;
 
     public ?int $activity_id = null;
 
     public function middleware(): array
     {
-        return [(new WithoutOverlapping('restart-proxy-'.$this->server->uuid))->expireAfter(60)->dontRelease()];
+        return [(new WithoutOverlapping('restart-proxy-'.$this->server->uuid))->expireAfter(120)->dontRelease()];
     }
 
     public function __construct(public Server $server) {}
@@ -34,28 +36,26 @@ class RestartProxyJob implements ShouldBeEncrypted, ShouldQueue
     public function handle()
     {
         try {
-            // Set status to restarting and notify UI immediately
+            // Set status to restarting
             $this->server->proxy->status = 'restarting';
-            $this->server->save();
-            ProxyStatusChangedUI::dispatch($this->server->team_id);
-
-            // Stop proxy
-            StopProxy::run($this->server, restarting: true);
-
-            // Clear force_stop flag
             $this->server->proxy->force_stop = false;
             $this->server->save();
 
-            // Start proxy asynchronously - returns Activity immediately
-            // The ProxyStatusChanged event will be dispatched when the remote process completes,
-            // which triggers ProxyStatusChangedNotification listener
-            $activity = StartProxy::run($this->server, force: true, restarting: true);
+            // Build combined stop + start commands for a single activity
+            $commands = $this->buildRestartCommands();
 
-            // Dispatch event with activity ID immediately so UI can show logs in real-time
-            if ($activity && is_object($activity)) {
-                $this->activity_id = $activity->id;
-                ProxyStatusChangedUI::dispatch($this->server->team_id, $this->activity_id);
-            }
+            // Create activity and dispatch immediately - returns Activity right away
+            // The remote_process runs asynchronously, so UI gets activity ID instantly
+            $activity = remote_process(
+                $commands,
+                $this->server,
+                callEventOnFinish: 'ProxyStatusChanged',
+                callEventData: $this->server->id
+            );
+
+            // Store activity ID and notify UI immediately with it
+            $this->activity_id = $activity->id;
+            ProxyStatusChangedUI::dispatch($this->server->team_id, $this->activity_id);
 
         } catch (\Throwable $e) {
             // Set error status
@@ -65,7 +65,100 @@ class RestartProxyJob implements ShouldBeEncrypted, ShouldQueue
             // Notify UI of error
             ProxyStatusChangedUI::dispatch($this->server->team_id);
 
+            // Clear dashboard cache on error
+            ProxyDashboardCacheService::clearCache($this->server);
+
             return handleError($e);
         }
+    }
+
+    /**
+     * Build combined stop + start commands for proxy restart.
+     * This creates a single command sequence that shows all logs in one activity.
+     */
+    private function buildRestartCommands(): array
+    {
+        $proxyType = $this->server->proxyType();
+        $containerName = $this->server->isSwarm() ? 'coolify-proxy_traefik' : 'coolify-proxy';
+        $proxy_path = $this->server->proxyPath();
+        $stopTimeout = 30;
+
+        // Get proxy configuration
+        $configuration = GetProxyConfiguration::run($this->server);
+        if (! $configuration) {
+            throw new \Exception('Configuration is not synced');
+        }
+        SaveProxyConfiguration::run($this->server, $configuration);
+        $docker_compose_yml_base64 = base64_encode($configuration);
+        $this->server->proxy->last_applied_settings = str($docker_compose_yml_base64)->pipe('md5')->value();
+        $this->server->save();
+
+        $commands = collect([]);
+
+        // === STOP PHASE ===
+        $commands = $commands->merge([
+            "echo '>>> Stopping proxy...'",
+            "docker stop -t=$stopTimeout $containerName 2>/dev/null || true",
+            "docker rm -f $containerName 2>/dev/null || true",
+            '# Wait for container to be fully removed',
+            'for i in {1..10}; do',
+            "    if ! docker ps -a --format \"{{.Names}}\" | grep -q \"^$containerName$\"; then",
+            '        break',
+            '    fi',
+            '    sleep 1',
+            'done',
+            "echo '>>> Proxy stopped successfully.'",
+        ]);
+
+        // === START PHASE ===
+        if ($this->server->isSwarmManager()) {
+            $commands = $commands->merge([
+                "echo '>>> Starting proxy (Swarm mode)...'",
+                "mkdir -p $proxy_path/dynamic",
+                "cd $proxy_path",
+                "echo 'Creating required Docker Compose file.'",
+                "echo 'Starting coolify-proxy.'",
+                'docker stack deploy --detach=true -c docker-compose.yml coolify-proxy',
+                "echo '>>> Successfully started coolify-proxy.'",
+            ]);
+        } else {
+            if (isDev() && $proxyType === ProxyTypes::CADDY->value) {
+                $proxy_path = '/data/coolify/proxy/caddy';
+            }
+            $caddyfile = 'import /dynamic/*.caddy';
+            $commands = $commands->merge([
+                "echo '>>> Starting proxy...'",
+                "mkdir -p $proxy_path/dynamic",
+                "cd $proxy_path",
+                "echo '$caddyfile' > $proxy_path/dynamic/Caddyfile",
+                "echo 'Creating required Docker Compose file.'",
+                "echo 'Pulling docker image.'",
+                'docker compose pull',
+                'if docker ps -a --format "{{.Names}}" | grep -q "^coolify-proxy$"; then',
+                "    echo 'Stopping and removing existing coolify-proxy.'",
+                '    docker stop coolify-proxy 2>/dev/null || true',
+                '    docker rm -f coolify-proxy 2>/dev/null || true',
+                '    # Wait for container to be fully removed',
+                '    for i in {1..10}; do',
+                '        if ! docker ps -a --format "{{.Names}}" | grep -q "^coolify-proxy$"; then',
+                '            break',
+                '        fi',
+                '        echo "Waiting for coolify-proxy to be removed... ($i/10)"',
+                '        sleep 1',
+                '    done',
+                "    echo 'Successfully stopped and removed existing coolify-proxy.'",
+                'fi',
+            ]);
+            // Ensure required networks exist BEFORE docker compose up
+            $commands = $commands->merge(ensureProxyNetworksExist($this->server));
+            $commands = $commands->merge([
+                "echo 'Starting coolify-proxy.'",
+                'docker compose up -d --wait --remove-orphans',
+                "echo '>>> Successfully started coolify-proxy.'",
+            ]);
+            $commands = $commands->merge(connectProxyToNetworks($this->server));
+        }
+
+        return $commands->toArray();
     }
 }

--- a/app/Jobs/RestartProxyJob.php
+++ b/app/Jobs/RestartProxyJob.php
@@ -4,7 +4,6 @@ namespace App\Jobs;
 
 use App\Actions\Proxy\StartProxy;
 use App\Actions\Proxy\StopProxy;
-use App\Enums\ProxyTypes;
 use App\Events\ProxyStatusChangedUI;
 use App\Models\Server;
 use Illuminate\Bus\Queueable;
@@ -14,7 +13,6 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Log;
 
 class RestartProxyJob implements ShouldBeEncrypted, ShouldQueue
 {
@@ -36,8 +34,6 @@ class RestartProxyJob implements ShouldBeEncrypted, ShouldQueue
     public function handle()
     {
         try {
-            $teamId = $this->server->team_id;
-
             // Stop proxy
             StopProxy::run($this->server, restarting: true);
 
@@ -45,26 +41,14 @@ class RestartProxyJob implements ShouldBeEncrypted, ShouldQueue
             $this->server->proxy->force_stop = false;
             $this->server->save();
 
-            // Start proxy asynchronously to get activity
+            // Start proxy asynchronously - the ProxyStatusChanged event will be dispatched
+            // when the remote process completes, which triggers ProxyStatusChangedNotification
+            // listener that handles UI updates and Traefik version checks
             $activity = StartProxy::run($this->server, force: true, restarting: true);
 
-            // Store activity ID and dispatch event with it
+            // Store activity ID for reference
             if ($activity && is_object($activity)) {
                 $this->activity_id = $activity->id;
-                ProxyStatusChangedUI::dispatch($teamId, $this->activity_id);
-            }
-
-            // Check Traefik version after restart (same as original behavior)
-            if ($this->server->proxyType() === ProxyTypes::TRAEFIK->value) {
-                $traefikVersions = get_traefik_versions();
-                if ($traefikVersions !== null) {
-                    CheckTraefikVersionForServerJob::dispatch($this->server, $traefikVersions);
-                } else {
-                    Log::warning('Traefik version check skipped: versions.json data unavailable', [
-                        'server_id' => $this->server->id,
-                        'server_name' => $this->server->name,
-                    ]);
-                }
             }
 
         } catch (\Throwable $e) {

--- a/app/Livewire/Server/Navbar.php
+++ b/app/Livewire/Server/Navbar.php
@@ -75,7 +75,7 @@ class Navbar extends Component
 
             // Always use background job for all servers
             RestartProxyJob::dispatch($this->server);
-            $this->dispatch('info', 'Proxy restart initiated.');
+            // $this->dispatch('info', 'Proxy restart initiated.');
 
             // Reset the flag after a short delay to allow future restarts
             $this->restartInitiated = false;
@@ -171,15 +171,15 @@ class Navbar extends Component
                 }
                 break;
             case 'stopping':
-                $this->dispatch('info', 'Proxy is stopping.');
+                // $this->dispatch('info', 'Proxy is stopping.');
                 $this->lastNotifiedStatus = $this->proxyStatus;
                 break;
             case 'starting':
-                $this->dispatch('info', 'Proxy is starting.');
+                // $this->dispatch('info', 'Proxy is starting.');
                 $this->lastNotifiedStatus = $this->proxyStatus;
                 break;
             case 'restarting':
-                $this->dispatch('info', 'Proxy is restarting.');
+                // $this->dispatch('info', 'Proxy is restarting.');
                 $this->lastNotifiedStatus = $this->proxyStatus;
                 break;
             case 'error':

--- a/app/Livewire/Server/Navbar.php
+++ b/app/Livewire/Server/Navbar.php
@@ -6,6 +6,8 @@ use App\Actions\Proxy\CheckProxy;
 use App\Actions\Proxy\StartProxy;
 use App\Actions\Proxy\StopProxy;
 use App\Enums\ProxyTypes;
+use App\Jobs\CheckTraefikVersionForServerJob;
+use App\Jobs\RestartProxyJob;
 use App\Models\Server;
 use App\Services\ProxyDashboardCacheService;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
@@ -61,13 +63,11 @@ class Navbar extends Component
     {
         try {
             $this->authorize('manageProxy', $this->server);
-            StopProxy::run($this->server, restarting: true);
 
-            $this->server->proxy->force_stop = false;
-            $this->server->save();
+            // Always use background job for all servers
+            RestartProxyJob::dispatch($this->server);
+            $this->dispatch('info', 'Proxy restart initiated. Monitor progress in activity logs.');
 
-            $activity = StartProxy::run($this->server, force: true, restarting: true);
-            $this->dispatch('activityMonitor', $activity->id);
         } catch (\Throwable $e) {
             return handleError($e, $this);
         }
@@ -122,11 +122,16 @@ class Navbar extends Component
         }
     }
 
-    public function showNotification()
+    public function showNotification($event = null)
     {
         $previousStatus = $this->proxyStatus;
         $this->server->refresh();
         $this->proxyStatus = $this->server->proxy->status ?? 'unknown';
+
+        // If event contains activityId, open activity monitor
+        if ($event && isset($event['activityId'])) {
+            $this->dispatch('activityMonitor', $event['activityId']);
+        }
 
         switch ($this->proxyStatus) {
             case 'running':
@@ -149,6 +154,12 @@ class Navbar extends Component
                 break;
             case 'starting':
                 $this->dispatch('info', 'Proxy is starting.');
+                break;
+            case 'restarting':
+                $this->dispatch('info', 'Proxy is restarting.');
+                break;
+            case 'error':
+                $this->dispatch('error', 'Proxy restart failed. Check logs.');
                 break;
             case 'unknown':
                 $this->dispatch('info', 'Proxy status is unknown.');

--- a/resources/views/livewire/server/navbar.blade.php
+++ b/resources/views/livewire/server/navbar.blade.php
@@ -181,6 +181,7 @@
                         }
                     });
                     $wire.$on('restartEvent', () => {
+                        if ($wire.restartInitiated) return;
                         window.dispatchEvent(new CustomEvent('startproxy'))
                         $wire.$call('restart');
                     });

--- a/resources/views/livewire/server/navbar.blade.php
+++ b/resources/views/livewire/server/navbar.blade.php
@@ -2,6 +2,13 @@
     <x-slide-over @startproxy.window="slideOverOpen = true" fullScreen closeWithX>
         <x-slot:title>Proxy Startup Logs</x-slot:title>
         <x-slot:content>
+            @if ($server->id === 0)
+                <div class="mb-4 p-3 text-sm bg-warning/10 border border-warning/30 rounded-lg text-warning">
+                    <span class="font-semibold">Note:</span> This is the localhost server where Coolify runs.
+                    During proxy restart, the connection may be temporarily lost.
+                    If logs stop updating, please refresh the browser after a few minutes.
+                </div>
+            @endif
             <livewire:activity-monitor header="Logs" fullHeight />
         </x-slot:content>
     </x-slide-over>

--- a/tests/Feature/Proxy/RestartProxyTest.php
+++ b/tests/Feature/Proxy/RestartProxyTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Tests\Feature\Proxy;
+
+use App\Jobs\RestartProxyJob;
+use App\Models\Server;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class RestartProxyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+
+    protected Team $team;
+
+    protected Server $server;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create test user and team
+        $this->user = User::factory()->create();
+        $this->team = Team::factory()->create(['name' => 'Test Team']);
+        $this->user->teams()->attach($this->team);
+
+        // Create test server
+        $this->server = Server::factory()->create([
+            'team_id' => $this->team->id,
+            'name' => 'Test Server',
+            'ip' => '192.168.1.100',
+        ]);
+
+        // Authenticate user
+        $this->actingAs($this->user);
+    }
+
+    public function test_restart_dispatches_job_for_all_servers()
+    {
+        Queue::fake();
+
+        Livewire::test('server.navbar', ['server' => $this->server])
+            ->call('restart');
+
+        // Assert job was dispatched
+        Queue::assertPushed(RestartProxyJob::class, function ($job) {
+            return $job->server->id === $this->server->id;
+        });
+    }
+
+    public function test_restart_dispatches_job_for_localhost_server()
+    {
+        Queue::fake();
+
+        // Create localhost server (id = 0)
+        $localhostServer = Server::factory()->create([
+            'id' => 0,
+            'team_id' => $this->team->id,
+            'name' => 'Localhost',
+            'ip' => 'host.docker.internal',
+        ]);
+
+        Livewire::test('server.navbar', ['server' => $localhostServer])
+            ->call('restart');
+
+        // Assert job was dispatched
+        Queue::assertPushed(RestartProxyJob::class, function ($job) use ($localhostServer) {
+            return $job->server->id === $localhostServer->id;
+        });
+    }
+
+    public function test_restart_shows_info_message()
+    {
+        Queue::fake();
+
+        Livewire::test('server.navbar', ['server' => $this->server])
+            ->call('restart')
+            ->assertDispatched('info', 'Proxy restart initiated. Monitor progress in activity logs.');
+    }
+
+    public function test_unauthorized_user_cannot_restart_proxy()
+    {
+        Queue::fake();
+
+        // Create another user without access
+        $unauthorizedUser = User::factory()->create();
+        $this->actingAs($unauthorizedUser);
+
+        Livewire::test('server.navbar', ['server' => $this->server])
+            ->call('restart')
+            ->assertForbidden();
+
+        // Assert job was NOT dispatched
+        Queue::assertNotPushed(RestartProxyJob::class);
+    }
+
+    public function test_restart_prevents_concurrent_jobs_via_without_overlapping()
+    {
+        Queue::fake();
+
+        // Dispatch job twice
+        Livewire::test('server.navbar', ['server' => $this->server])
+            ->call('restart');
+
+        Livewire::test('server.navbar', ['server' => $this->server])
+            ->call('restart');
+
+        // Assert job was pushed twice (WithoutOverlapping middleware will handle deduplication)
+        Queue::assertPushed(RestartProxyJob::class, 2);
+
+        // Get the jobs
+        $jobs = Queue::pushed(RestartProxyJob::class);
+
+        // Verify both jobs have WithoutOverlapping middleware
+        foreach ($jobs as $job) {
+            $middleware = $job['job']->middleware();
+            $this->assertCount(1, $middleware);
+            $this->assertInstanceOf(\Illuminate\Queue\Middleware\WithoutOverlapping::class, $middleware[0]);
+        }
+    }
+
+    public function test_restart_uses_server_team_id()
+    {
+        Queue::fake();
+
+        Livewire::test('server.navbar', ['server' => $this->server])
+            ->call('restart');
+
+        Queue::assertPushed(RestartProxyJob::class, function ($job) {
+            return $job->server->team_id === $this->team->id;
+        });
+    }
+}

--- a/tests/Unit/Jobs/RestartProxyJobTest.php
+++ b/tests/Unit/Jobs/RestartProxyJobTest.php
@@ -43,7 +43,7 @@ class RestartProxyJobTest extends TestCase
         $job = new RestartProxyJob($server);
 
         $this->assertEquals(1, $job->tries);
-        $this->assertEquals(60, $job->timeout);
+        $this->assertEquals(120, $job->timeout);
         $this->assertNull($job->activity_id);
     }
 

--- a/tests/Unit/Jobs/RestartProxyJobTest.php
+++ b/tests/Unit/Jobs/RestartProxyJobTest.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Tests\Unit\Jobs;
+
+use App\Actions\Proxy\StartProxy;
+use App\Actions\Proxy\StopProxy;
+use App\Enums\ProxyTypes;
+use App\Events\ProxyStatusChangedUI;
+use App\Jobs\CheckTraefikVersionForServerJob;
+use App\Jobs\RestartProxyJob;
+use App\Models\Server;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Queue;
+use Mockery;
+use Spatie\Activitylog\Models\Activity;
+use Tests\TestCase;
+
+class RestartProxyJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_job_has_without_overlapping_middleware()
+    {
+        $server = Mockery::mock(Server::class);
+        $server->uuid = 'test-uuid';
+
+        $job = new RestartProxyJob($server);
+        $middleware = $job->middleware();
+
+        $this->assertCount(1, $middleware);
+        $this->assertInstanceOf(WithoutOverlapping::class, $middleware[0]);
+    }
+
+    public function test_job_stops_and_starts_proxy()
+    {
+        // Mock Server
+        $server = Mockery::mock(Server::class);
+        $server->shouldReceive('getAttribute')->with('team_id')->andReturn(1);
+        $server->shouldReceive('getAttribute')->with('proxy')->andReturn((object) ['force_stop' => true]);
+        $server->shouldReceive('save')->once();
+        $server->shouldReceive('proxyType')->andReturn(ProxyTypes::TRAEFIK->value);
+        $server->shouldReceive('getAttribute')->with('id')->andReturn(1);
+        $server->shouldReceive('getAttribute')->with('name')->andReturn('test-server');
+
+        // Mock Activity
+        $activity = Mockery::mock(Activity::class);
+        $activity->id = 123;
+
+        // Mock Actions
+        $stopProxyMock = Mockery::mock('alias:'.StopProxy::class);
+        $stopProxyMock->shouldReceive('run')
+            ->once()
+            ->with($server, restarting: true);
+
+        $startProxyMock = Mockery::mock('alias:'.StartProxy::class);
+        $startProxyMock->shouldReceive('run')
+            ->once()
+            ->with($server, force: true, restarting: true)
+            ->andReturn($activity);
+
+        // Mock Events
+        Event::fake();
+        Queue::fake();
+
+        // Mock get_traefik_versions helper
+        $this->app->instance('traefik_versions', ['latest' => '2.10']);
+
+        // Execute job
+        $job = new RestartProxyJob($server);
+        $job->handle();
+
+        // Assert activity ID was set
+        $this->assertEquals(123, $job->activity_id);
+
+        // Assert event was dispatched
+        Event::assertDispatched(ProxyStatusChangedUI::class, function ($event) {
+            return $event->teamId === 1 && $event->activityId === 123;
+        });
+
+        // Assert Traefik version check was dispatched
+        Queue::assertPushed(CheckTraefikVersionForServerJob::class);
+    }
+
+    public function test_job_handles_errors_gracefully()
+    {
+        // Mock Server
+        $server = Mockery::mock(Server::class);
+        $server->shouldReceive('getAttribute')->with('team_id')->andReturn(1);
+        $server->shouldReceive('getAttribute')->with('proxy')->andReturn((object) ['status' => 'running']);
+        $server->shouldReceive('save')->once();
+
+        // Mock StopProxy to throw exception
+        $stopProxyMock = Mockery::mock('alias:'.StopProxy::class);
+        $stopProxyMock->shouldReceive('run')
+            ->once()
+            ->andThrow(new \Exception('Test error'));
+
+        Event::fake();
+
+        // Execute job
+        $job = new RestartProxyJob($server);
+        $job->handle();
+
+        // Assert error event was dispatched
+        Event::assertDispatched(ProxyStatusChangedUI::class, function ($event) {
+            return $event->teamId === 1 && $event->activityId === null;
+        });
+    }
+
+    public function test_job_skips_traefik_version_check_for_non_traefik_proxies()
+    {
+        // Mock Server with non-Traefik proxy
+        $server = Mockery::mock(Server::class);
+        $server->shouldReceive('getAttribute')->with('team_id')->andReturn(1);
+        $server->shouldReceive('getAttribute')->with('proxy')->andReturn((object) ['force_stop' => true]);
+        $server->shouldReceive('save')->once();
+        $server->shouldReceive('proxyType')->andReturn(ProxyTypes::CADDY->value);
+
+        // Mock Activity
+        $activity = Mockery::mock(Activity::class);
+        $activity->id = 123;
+
+        // Mock Actions
+        $stopProxyMock = Mockery::mock('alias:'.StopProxy::class);
+        $stopProxyMock->shouldReceive('run')->once();
+
+        $startProxyMock = Mockery::mock('alias:'.StartProxy::class);
+        $startProxyMock->shouldReceive('run')->once()->andReturn($activity);
+
+        Event::fake();
+        Queue::fake();
+
+        // Execute job
+        $job = new RestartProxyJob($server);
+        $job->handle();
+
+        // Assert Traefik version check was NOT dispatched
+        Queue::assertNotPushed(CheckTraefikVersionForServerJob::class);
+    }
+
+    public function test_job_clears_force_stop_flag()
+    {
+        // Mock Server
+        $proxy = (object) ['force_stop' => true];
+        $server = Mockery::mock(Server::class);
+        $server->shouldReceive('getAttribute')->with('team_id')->andReturn(1);
+        $server->shouldReceive('getAttribute')->with('proxy')->andReturn($proxy);
+        $server->shouldReceive('save')->once();
+        $server->shouldReceive('proxyType')->andReturn('NONE');
+
+        // Mock Activity
+        $activity = Mockery::mock(Activity::class);
+        $activity->id = 123;
+
+        // Mock Actions
+        Mockery::mock('alias:'.StopProxy::class)
+            ->shouldReceive('run')->once();
+
+        Mockery::mock('alias:'.StartProxy::class)
+            ->shouldReceive('run')->once()->andReturn($activity);
+
+        Event::fake();
+
+        // Execute job
+        $job = new RestartProxyJob($server);
+        $job->handle();
+
+        // Assert force_stop was set to false
+        $this->assertFalse($proxy->force_stop);
+    }
+}


### PR DESCRIPTION
## Changes
- Rewrite `RestartProxyJob` to combine stop+start into single `remote_process()` call for immediate Activity ID and real-time log streaming
- Enhance container cleanup with retry logic (15 iterations) to prevent "container name already in use" errors during restart
- Add localhost warning banner in proxy logs sidebar advising users to refresh browser if connection is lost
- Clean up notification noise by removing intermediate status messages (restarting, starting, stopping)

## Issues
- Fixes proxy restart causing localhost lockout by running as background job instead of blocking UI
- Fixes container name conflict errors that occurred during restart
- Provides user guidance for localhost proxy restart scenarios