### PR TITLE
Fix: Pass backup timeout to remote SSH process

### DIFF
--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -508,7 +508,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                     }
                 }
             }
-            $this->backup_output = instant_remote_process($commands, $this->server);
+            $this->backup_output = instant_remote_process($commands, $this->server, true, false, $this->timeout);
             $this->backup_output = trim($this->backup_output);
             if ($this->backup_output === '') {
                 $this->backup_output = null;
@@ -537,7 +537,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
 
             $commands[] = $backupCommand;
-            $this->backup_output = instant_remote_process($commands, $this->server);
+            $this->backup_output = instant_remote_process($commands, $this->server, true, false, $this->timeout);
             $this->backup_output = trim($this->backup_output);
             if ($this->backup_output === '') {
                 $this->backup_output = null;
@@ -560,7 +560,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                 $escapedDatabase = escapeshellarg($database);
                 $commands[] = "docker exec $this->container_name mysqldump -u root -p\"{$this->database->mysql_root_password}\" $escapedDatabase > $this->backup_location";
             }
-            $this->backup_output = instant_remote_process($commands, $this->server);
+            $this->backup_output = instant_remote_process($commands, $this->server, true, false, $this->timeout);
             $this->backup_output = trim($this->backup_output);
             if ($this->backup_output === '') {
                 $this->backup_output = null;
@@ -583,7 +583,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                 $escapedDatabase = escapeshellarg($database);
                 $commands[] = "docker exec $this->container_name mariadb-dump -u root -p\"{$this->database->mariadb_root_password}\" $escapedDatabase > $this->backup_location";
             }
-            $this->backup_output = instant_remote_process($commands, $this->server);
+            $this->backup_output = instant_remote_process($commands, $this->server, true, false, $this->timeout);
             $this->backup_output = trim($this->backup_output);
             if ($this->backup_output === '') {
                 $this->backup_output = null;

--- a/app/Jobs/ScheduledTaskJob.php
+++ b/app/Jobs/ScheduledTaskJob.php
@@ -139,7 +139,7 @@ class ScheduledTaskJob implements ShouldQueue
                 if (count($this->containers) == 1 || str_starts_with($containerName, $this->task->container.'-'.$this->resource->uuid)) {
                     $cmd = "sh -c '".str_replace("'", "'\''", $this->task->command)."'";
                     $exec = "docker exec {$containerName} {$cmd}";
-                    $this->task_output = instant_remote_process([$exec], $this->server, true);
+                    $this->task_output = instant_remote_process([$exec], $this->server, true, false, $this->timeout);
                     $this->task_log->update([
                         'status' => 'success',
                         'message' => $this->task_output,

--- a/app/Livewire/Project/Shared/ScheduledTask/Add.php
+++ b/app/Livewire/Project/Shared/ScheduledTask/Add.php
@@ -41,7 +41,7 @@ class Add extends Component
         'command' => 'required|string',
         'frequency' => 'required|string',
         'container' => 'nullable|string',
-        'timeout' => 'required|integer|min:60|max:3600',
+        'timeout' => 'required|integer|min:60|max:36000',
     ];
 
     protected $validationAttributes = [

--- a/app/Livewire/Project/Shared/ScheduledTask/Show.php
+++ b/app/Livewire/Project/Shared/ScheduledTask/Show.php
@@ -40,7 +40,7 @@ class Show extends Component
     #[Validate(['string', 'nullable'])]
     public ?string $container = null;
 
-    #[Validate(['integer', 'required', 'min:60', 'max:3600'])]
+    #[Validate(['integer', 'required', 'min:60', 'max:36000'])]
     public $timeout = 300;
 
     #[Locked]


### PR DESCRIPTION
## Changes

- Added optional `?int $timeout` parameter to `instant_remote_process()` function to support custom timeouts for long-running operations
- Updated all 4 database backup methods in `DatabaseBackupJob` to pass the configured backup timeout to remote SSH commands
- Increased scheduled task timeout limit from 3600 to 36000 seconds (10 hours)
- Updated `ScheduledTaskJob` to pass the configured timeout to `instant_remote_process()`
- Updated `ExecuteRemoteCommand` trait to use the job's `$timeout` property (from server's `dynamic_timeout` setting) for deployment SSH processes instead of hardcoded 3600 seconds

## Issues

Fixes issue where backups, scheduled tasks, and deployments with timeout > 3600 seconds would fail due to hardcoded SSH process timeout, even though users could set larger timeout values in the UI.