### PR TITLE
Set deployment status to IN_PROGRESS when queuing builds

### DIFF
--- a/bootstrap/helpers/applications.php
+++ b/bootstrap/helpers/applications.php
@@ -68,10 +68,16 @@ function queue_application_deployment(Application $application, string $deployme
     ]);
 
     if ($no_questions_asked) {
+        $deployment->update([
+            'status' => ApplicationDeploymentStatus::IN_PROGRESS->value,
+        ]);
         ApplicationDeploymentJob::dispatch(
             application_deployment_queue_id: $deployment->id,
         );
     } elseif (next_queuable($server_id, $application_id, $commit, $pull_request_id)) {
+        $deployment->update([
+            'status' => ApplicationDeploymentStatus::IN_PROGRESS->value,
+        ]);
         ApplicationDeploymentJob::dispatch(
             application_deployment_queue_id: $deployment->id,
         );


### PR DESCRIPTION
## Changes
- Updated deployment status to IN_PROGRESS immediately when builds are queued
- Status updates apply to both immediate deployments and queued deployments

## Issues
Improves deployment status accuracy by reflecting the queued state immediately in the UI.

- fix #6708