### PR TITLE
Fix: Concurrent builds ignored & add deployment queue limit

### DIFF
--- a/app/Http/Controllers/Api/DeployController.php
+++ b/app/Http/Controllers/Api/DeployController.php
@@ -390,7 +390,7 @@ class DeployController extends Controller
                 }
                 $result = $this->deploy_resource($resource, $force, $pr);
                 if (isset($result['status']) && $result['status'] === 429) {
-                    return response()->json(['message' => $result['message']], 429);
+                    return response()->json(['message' => $result['message']], 429)->header('Retry-After', 60);
                 }
                 ['message' => $return_message, 'deployment_uuid' => $deployment_uuid] = $result;
                 if ($deployment_uuid) {
@@ -436,7 +436,7 @@ class DeployController extends Controller
             foreach ($applications as $resource) {
                 $result = $this->deploy_resource($resource, $force);
                 if (isset($result['status']) && $result['status'] === 429) {
-                    return response()->json(['message' => $result['message']], 429);
+                    return response()->json(['message' => $result['message']], 429)->header('Retry-After', 60);
                 }
                 ['message' => $return_message, 'deployment_uuid' => $deployment_uuid] = $result;
                 if ($deployment_uuid) {

--- a/app/Http/Controllers/Webhook/Bitbucket.php
+++ b/app/Http/Controllers/Webhook/Bitbucket.php
@@ -108,7 +108,7 @@ class Bitbucket extends Controller
                             is_webhook: true
                         );
                         if ($result['status'] === 'queue_full') {
-                            return response($result['message'], 429);
+                            return response($result['message'], 429)->header('Retry-After', 60);
                         } elseif ($result['status'] === 'skipped') {
                             $return_payloads->push([
                                 'application' => $application->name,
@@ -164,7 +164,7 @@ class Bitbucket extends Controller
                             git_type: 'bitbucket'
                         );
                         if ($result['status'] === 'queue_full') {
-                            return response($result['message'], 429);
+                            return response($result['message'], 429)->header('Retry-After', 60);
                         } elseif ($result['status'] === 'skipped') {
                             $return_payloads->push([
                                 'application' => $application->name,

--- a/app/Http/Controllers/Webhook/Bitbucket.php
+++ b/app/Http/Controllers/Webhook/Bitbucket.php
@@ -107,7 +107,9 @@ class Bitbucket extends Controller
                             force_rebuild: false,
                             is_webhook: true
                         );
-                        if ($result['status'] === 'skipped') {
+                        if ($result['status'] === 'queue_full') {
+                            return response($result['message'], 429);
+                        } elseif ($result['status'] === 'skipped') {
                             $return_payloads->push([
                                 'application' => $application->name,
                                 'status' => 'skipped',
@@ -161,7 +163,9 @@ class Bitbucket extends Controller
                             is_webhook: true,
                             git_type: 'bitbucket'
                         );
-                        if ($result['status'] === 'skipped') {
+                        if ($result['status'] === 'queue_full') {
+                            return response($result['message'], 429);
+                        } elseif ($result['status'] === 'skipped') {
                             $return_payloads->push([
                                 'application' => $application->name,
                                 'status' => 'skipped',

--- a/app/Http/Controllers/Webhook/Gitea.php
+++ b/app/Http/Controllers/Webhook/Gitea.php
@@ -124,7 +124,7 @@ class Gitea extends Controller
                                 is_webhook: true,
                             );
                             if ($result['status'] === 'queue_full') {
-                                return response($result['message'], 429);
+                                return response($result['message'], 429)->header('Retry-After', 60);
                             } elseif ($result['status'] === 'skipped') {
                                 $return_payloads->push([
                                     'application' => $application->name,
@@ -196,7 +196,7 @@ class Gitea extends Controller
                                 git_type: 'gitea'
                             );
                             if ($result['status'] === 'queue_full') {
-                                return response($result['message'], 429);
+                                return response($result['message'], 429)->header('Retry-After', 60);
                             } elseif ($result['status'] === 'skipped') {
                                 $return_payloads->push([
                                     'application' => $application->name,

--- a/app/Http/Controllers/Webhook/Gitea.php
+++ b/app/Http/Controllers/Webhook/Gitea.php
@@ -123,7 +123,9 @@ class Gitea extends Controller
                                 commit: data_get($payload, 'after', 'HEAD'),
                                 is_webhook: true,
                             );
-                            if ($result['status'] === 'skipped') {
+                            if ($result['status'] === 'queue_full') {
+                                return response($result['message'], 429);
+                            } elseif ($result['status'] === 'skipped') {
                                 $return_payloads->push([
                                     'application' => $application->name,
                                     'status' => 'skipped',
@@ -193,7 +195,9 @@ class Gitea extends Controller
                                 is_webhook: true,
                                 git_type: 'gitea'
                             );
-                            if ($result['status'] === 'skipped') {
+                            if ($result['status'] === 'queue_full') {
+                                return response($result['message'], 429);
+                            } elseif ($result['status'] === 'skipped') {
                                 $return_payloads->push([
                                     'application' => $application->name,
                                     'status' => 'skipped',

--- a/app/Http/Controllers/Webhook/Github.php
+++ b/app/Http/Controllers/Webhook/Github.php
@@ -136,7 +136,9 @@ class Github extends Controller
                                     commit: data_get($payload, 'after', 'HEAD'),
                                     is_webhook: true,
                                 );
-                                if ($result['status'] === 'skipped') {
+                                if ($result['status'] === 'queue_full') {
+                                    return response($result['message'], 429);
+                                } elseif ($result['status'] === 'skipped') {
                                     $return_payloads->push([
                                         'application' => $application->name,
                                         'status' => 'skipped',
@@ -222,7 +224,9 @@ class Github extends Controller
                                     is_webhook: true,
                                     git_type: 'github'
                                 );
-                                if ($result['status'] === 'skipped') {
+                                if ($result['status'] === 'queue_full') {
+                                    return response($result['message'], 429);
+                                } elseif ($result['status'] === 'skipped') {
                                     $return_payloads->push([
                                         'application' => $application->name,
                                         'status' => 'skipped',
@@ -427,12 +431,15 @@ class Github extends Controller
                                     force_rebuild: false,
                                     is_webhook: true,
                                 );
+                                if ($result['status'] === 'queue_full') {
+                                    return response($result['message'], 429);
+                                }
                                 $return_payloads->push([
                                     'status' => $result['status'],
                                     'message' => $result['message'],
                                     'application_uuid' => $application->uuid,
                                     'application_name' => $application->name,
-                                    'deployment_uuid' => $result['deployment_uuid'],
+                                    'deployment_uuid' => $result['deployment_uuid'] ?? null,
                                 ]);
                             } else {
                                 $paths = str($application->watch_paths)->explode("\n");
@@ -491,7 +498,9 @@ class Github extends Controller
                                     is_webhook: true,
                                     git_type: 'github'
                                 );
-                                if ($result['status'] === 'skipped') {
+                                if ($result['status'] === 'queue_full') {
+                                    return response($result['message'], 429);
+                                } elseif ($result['status'] === 'skipped') {
                                     $return_payloads->push([
                                         'application' => $application->name,
                                         'status' => 'skipped',

--- a/app/Http/Controllers/Webhook/Github.php
+++ b/app/Http/Controllers/Webhook/Github.php
@@ -137,7 +137,7 @@ class Github extends Controller
                                     is_webhook: true,
                                 );
                                 if ($result['status'] === 'queue_full') {
-                                    return response($result['message'], 429);
+                                    return response($result['message'], 429)->header('Retry-After', 60);
                                 } elseif ($result['status'] === 'skipped') {
                                     $return_payloads->push([
                                         'application' => $application->name,
@@ -225,7 +225,7 @@ class Github extends Controller
                                     git_type: 'github'
                                 );
                                 if ($result['status'] === 'queue_full') {
-                                    return response($result['message'], 429);
+                                    return response($result['message'], 429)->header('Retry-After', 60);
                                 } elseif ($result['status'] === 'skipped') {
                                     $return_payloads->push([
                                         'application' => $application->name,
@@ -432,7 +432,7 @@ class Github extends Controller
                                     is_webhook: true,
                                 );
                                 if ($result['status'] === 'queue_full') {
-                                    return response($result['message'], 429);
+                                    return response($result['message'], 429)->header('Retry-After', 60);
                                 }
                                 $return_payloads->push([
                                     'status' => $result['status'],
@@ -499,7 +499,7 @@ class Github extends Controller
                                     git_type: 'github'
                                 );
                                 if ($result['status'] === 'queue_full') {
-                                    return response($result['message'], 429);
+                                    return response($result['message'], 429)->header('Retry-After', 60);
                                 } elseif ($result['status'] === 'skipped') {
                                     $return_payloads->push([
                                         'application' => $application->name,

--- a/app/Http/Controllers/Webhook/Gitlab.php
+++ b/app/Http/Controllers/Webhook/Gitlab.php
@@ -149,7 +149,9 @@ class Gitlab extends Controller
                                 force_rebuild: false,
                                 is_webhook: true,
                             );
-                            if ($result['status'] === 'skipped') {
+                            if ($result['status'] === 'queue_full') {
+                                return response($result['message'], 429);
+                            } elseif ($result['status'] === 'skipped') {
                                 $return_payloads->push([
                                     'status' => $result['status'],
                                     'message' => $result['message'],
@@ -220,7 +222,9 @@ class Gitlab extends Controller
                                 is_webhook: true,
                                 git_type: 'gitlab'
                             );
-                            if ($result['status'] === 'skipped') {
+                            if ($result['status'] === 'queue_full') {
+                                return response($result['message'], 429);
+                            } elseif ($result['status'] === 'skipped') {
                                 $return_payloads->push([
                                     'application' => $application->name,
                                     'status' => 'skipped',

--- a/app/Http/Controllers/Webhook/Gitlab.php
+++ b/app/Http/Controllers/Webhook/Gitlab.php
@@ -150,7 +150,7 @@ class Gitlab extends Controller
                                 is_webhook: true,
                             );
                             if ($result['status'] === 'queue_full') {
-                                return response($result['message'], 429);
+                                return response($result['message'], 429)->header('Retry-After', 60);
                             } elseif ($result['status'] === 'skipped') {
                                 $return_payloads->push([
                                     'status' => $result['status'],
@@ -223,7 +223,7 @@ class Gitlab extends Controller
                                 git_type: 'gitlab'
                             );
                             if ($result['status'] === 'queue_full') {
-                                return response($result['message'], 429);
+                                return response($result['message'], 429)->header('Retry-After', 60);
                             } elseif ($result['status'] === 'skipped') {
                                 $return_payloads->push([
                                     'application' => $application->name,

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -1813,7 +1813,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                             $this->application->update(['status' => 'running']);
                             $this->application_deployment_queue->addLogEntry('New container is healthy.');
                             break;
-                        }  elseif (str($this->saved_outputs->get('health_check'))->replace('"', '')->value() === 'unhealthy') {
+                        } elseif (str($this->saved_outputs->get('health_check'))->replace('"', '')->value() === 'unhealthy') {
                             $this->newVersionIsHealthy = false;
                             $this->application_deployment_queue->addLogEntry('New container is unhealthy.', type: 'error');
                             $this->query_logs();

--- a/app/Livewire/Project/Application/Heading.php
+++ b/app/Livewire/Project/Application/Heading.php
@@ -100,6 +100,11 @@ class Heading extends Component
             deployment_uuid: $this->deploymentUuid,
             force_rebuild: $force_rebuild,
         );
+        if ($result['status'] === 'queue_full') {
+            $this->dispatch('error', 'Deployment queue full', $result['message']);
+
+            return;
+        }
         if ($result['status'] === 'skipped') {
             $this->dispatch('error', 'Deployment skipped', $result['message']);
 
@@ -151,6 +156,11 @@ class Heading extends Component
             deployment_uuid: $this->deploymentUuid,
             restart_only: true,
         );
+        if ($result['status'] === 'queue_full') {
+            $this->dispatch('error', 'Deployment queue full', $result['message']);
+
+            return;
+        }
         if ($result['status'] === 'skipped') {
             $this->dispatch('success', 'Deployment skipped', $result['message']);
 

--- a/app/Livewire/Project/Application/Previews.php
+++ b/app/Livewire/Project/Application/Previews.php
@@ -249,6 +249,11 @@ class Previews extends Component
                 pull_request_id: $pull_request_id,
                 git_type: $found->git_type ?? null,
             );
+            if ($result['status'] === 'queue_full') {
+                $this->dispatch('error', 'Deployment queue full', $result['message']);
+
+                return;
+            }
             if ($result['status'] === 'skipped') {
                 $this->dispatch('success', 'Deployment skipped', $result['message']);
 

--- a/app/Livewire/Project/Application/Rollback.php
+++ b/app/Livewire/Project/Application/Rollback.php
@@ -30,13 +30,19 @@ class Rollback extends Component
 
         $deployment_uuid = new Cuid2;
 
-        queue_application_deployment(
+        $result = queue_application_deployment(
             application: $this->application,
             deployment_uuid: $deployment_uuid,
             commit: $commit,
             rollback: true,
             force_rebuild: false,
         );
+
+        if ($result['status'] === 'queue_full') {
+            $this->dispatch('error', 'Deployment queue full', $result['message']);
+
+            return;
+        }
 
         return redirect()->route('project.application.deployment.show', [
             'project_uuid' => $this->parameters['project_uuid'],

--- a/app/Livewire/Project/Shared/Destination.php
+++ b/app/Livewire/Project/Shared/Destination.php
@@ -89,6 +89,11 @@ class Destination extends Component
                 only_this_server: true,
                 no_questions_asked: true,
             );
+            if ($result['status'] === 'queue_full') {
+                $this->dispatch('error', 'Deployment queue full', $result['message']);
+
+                return;
+            }
             if ($result['status'] === 'skipped') {
                 $this->dispatch('success', 'Deployment skipped', $result['message']);
 

--- a/app/Livewire/Server/Advanced.php
+++ b/app/Livewire/Server/Advanced.php
@@ -24,6 +24,9 @@ class Advanced extends Component
     #[Validate(['integer', 'min:1'])]
     public int $dynamicTimeout = 1;
 
+    #[Validate(['integer', 'min:1'])]
+    public int $deploymentQueueLimit = 25;
+
     public function mount(string $server_uuid)
     {
         try {
@@ -43,12 +46,14 @@ class Advanced extends Component
             $this->validate();
             $this->server->settings->concurrent_builds = $this->concurrentBuilds;
             $this->server->settings->dynamic_timeout = $this->dynamicTimeout;
+            $this->server->settings->deployment_queue_limit = $this->deploymentQueueLimit;
             $this->server->settings->server_disk_usage_notification_threshold = $this->serverDiskUsageNotificationThreshold;
             $this->server->settings->server_disk_usage_check_frequency = $this->serverDiskUsageCheckFrequency;
             $this->server->settings->save();
         } else {
             $this->concurrentBuilds = $this->server->settings->concurrent_builds;
             $this->dynamicTimeout = $this->server->settings->dynamic_timeout;
+            $this->deploymentQueueLimit = $this->server->settings->deployment_queue_limit;
             $this->serverDiskUsageNotificationThreshold = $this->server->settings->server_disk_usage_notification_threshold;
             $this->serverDiskUsageCheckFrequency = $this->server->settings->server_disk_usage_check_frequency;
         }

--- a/app/Models/ServerSetting.php
+++ b/app/Models/ServerSetting.php
@@ -13,6 +13,7 @@ use OpenApi\Attributes as OA;
     properties: [
         'id' => ['type' => 'integer'],
         'concurrent_builds' => ['type' => 'integer'],
+        'deployment_queue_limit' => ['type' => 'integer'],
         'dynamic_timeout' => ['type' => 'integer'],
         'force_disabled' => ['type' => 'boolean'],
         'force_server_cleanup' => ['type' => 'boolean'],

--- a/database/migrations/2025_12_04_134435_add_deployment_queue_limit_to_server_settings.php
+++ b/database/migrations/2025_12_04_134435_add_deployment_queue_limit_to_server_settings.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('server_settings', function (Blueprint $table) {
+            $table->integer('deployment_queue_limit')->default(25)->after('concurrent_builds');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('server_settings', function (Blueprint $table) {
+            $table->dropColumn('deployment_queue_limit');
+        });
+    }
+};

--- a/openapi.json
+++ b/openapi.json
@@ -9816,6 +9816,9 @@
                     "concurrent_builds": {
                         "type": "integer"
                     },
+                    "deployment_queue_limit": {
+                        "type": "integer"
+                    },
                     "dynamic_timeout": {
                         "type": "integer"
                     },

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6312,6 +6312,8 @@ components:
           type: integer
         concurrent_builds:
           type: integer
+        deployment_queue_limit:
+          type: integer
         dynamic_timeout:
           type: integer
         force_disabled:

--- a/resources/views/livewire/server/advanced.blade.php
+++ b/resources/views/livewire/server/advanced.blade.php
@@ -36,6 +36,9 @@
                         <x-forms.input canGate="update" :canResource="$server" id="dynamicTimeout"
                             label="Deployment timeout (seconds)" required
                             helper="You can define the maximum duration for a deployment to run before timing it out." />
+                        <x-forms.input canGate="update" :canResource="$server" id="deploymentQueueLimit"
+                            label="Deployment queue limit" required
+                            helper="Maximum number of queued deployments allowed. New deployments will be rejected with a 429 status when the limit is reached." />
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- **Fixed race condition**: Deployments now set status to `IN_PROGRESS` immediately when queued (not when job starts), preventing multiple builds from bypassing the concurrent limit
- **Added queue bombing protection**: New configurable `deployment_queue_limit` server setting (default: 25) prevents excessive queued deployments
- **Different responses by source**:
  - Webhooks & API: Return HTTP 429 (allows GitHub/GitLab to auto-retry)
  - UI: Shows error toast to user

## Test plan
- [ ] Set concurrent builds to 1, trigger multiple deployments rapidly via webhook
- [ ] Verify only one build runs at a time
- [ ] Set deployment_queue_limit to a low value (e.g., 3)
- [ ] Trigger many deployments and verify 429 is returned when limit reached
- [ ] Verify UI shows error toast when manually deploying with full queue
- [ ] Run database migration and verify new setting appears in Server > Advanced

Fixes #6708

🤖 Generated with [Claude Code](https://claude.com/claude-code)