### PR TITLE
[v5.x] chore(config): configure logging

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,22 +1,21 @@
+APP_NAME=Coolify
 APP_ENV=local
 APP_DEBUG=true
-APP_NAME=Coolify
 APP_URL=http://localhost
-APP_PORT=8000
-APP_FORCE_HTTPS=false
 APP_KEY=
 
+LOG_STACK=single
+LOG_DEPRECATIONS_CHANNEL=single
+
 DB_DATABASE=coolify-db
-DB_USERNAME=coolify
-DB_PASSWORD=Password
 DB_HOST=host.docker.internal
 DB_PORT=5432
-
-REDIS_PASSWORD=Password
+DB_USERNAME=coolify
+DB_PASSWORD=password
 
 RAY_ENABLED=true
 # RAY_PORT=
 
-# Special Keys for Andras
+# Special Keys for Andras & Peak
 BUNNY_API_KEY=
 BUNNY_STORAGE_API_KEY=

--- a/config/logging.php
+++ b/config/logging.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
-use Monolog\Handler\SyslogUdpHandler;
 use Monolog\Processor\PsrLogMessageProcessor;
 
 return [
@@ -73,27 +72,6 @@ return [
             'replace_placeholders' => true,
         ],
 
-        'slack' => [
-            'driver' => 'slack',
-            'url' => env('LOG_SLACK_WEBHOOK_URL'),
-            'username' => env('LOG_SLACK_USERNAME', 'Laravel Log'),
-            'emoji' => env('LOG_SLACK_EMOJI', ':boom:'),
-            'level' => env('LOG_LEVEL', 'critical'),
-            'replace_placeholders' => true,
-        ],
-
-        'papertrail' => [
-            'driver' => 'monolog',
-            'level' => env('LOG_LEVEL', 'debug'),
-            'handler' => env('LOG_PAPERTRAIL_HANDLER', SyslogUdpHandler::class),
-            'handler_with' => [
-                'host' => env('PAPERTRAIL_URL'),
-                'port' => env('PAPERTRAIL_PORT'),
-                'connectionString' => 'tls://'.env('PAPERTRAIL_URL').':'.env('PAPERTRAIL_PORT'),
-            ],
-            'processors' => [PsrLogMessageProcessor::class],
-        ],
-
         'stderr' => [
             'driver' => 'monolog',
             'level' => env('LOG_LEVEL', 'debug'),
@@ -103,19 +81,6 @@ return [
             ],
             'formatter' => env('LOG_STDERR_FORMATTER'),
             'processors' => [PsrLogMessageProcessor::class],
-        ],
-
-        'syslog' => [
-            'driver' => 'syslog',
-            'level' => env('LOG_LEVEL', 'debug'),
-            'facility' => env('LOG_SYSLOG_FACILITY', LOG_USER),
-            'replace_placeholders' => true,
-        ],
-
-        'errorlog' => [
-            'driver' => 'errorlog',
-            'level' => env('LOG_LEVEL', 'debug'),
-            'replace_placeholders' => true,
         ],
 
         'null' => [

--- a/config/logging.php
+++ b/config/logging.php
@@ -53,7 +53,7 @@ return [
     'channels' => [
         'stack' => [
             'driver' => 'stack',
-            'channels' => explode(',', (string) env('LOG_STACK', 'single')),
+            'channels' => explode(',', (string) env('LOG_STACK', 'stderr,daily')),
             'ignore_exceptions' => false,
         ],
 
@@ -67,14 +67,14 @@ return [
         'daily' => [
             'driver' => 'daily',
             'path' => storage_path('logs/laravel.log'),
-            'level' => env('LOG_LEVEL', 'debug'),
-            'days' => env('LOG_DAILY_DAYS', 14),
+            'level' => env('LOG_LEVEL', 'warning'),
+            'days' => env('LOG_DAILY_DAYS', 10),
             'replace_placeholders' => true,
         ],
 
         'stderr' => [
             'driver' => 'monolog',
-            'level' => env('LOG_LEVEL', 'debug'),
+            'level' => env('LOG_LEVEL', 'warning'),
             'handler' => StreamHandler::class,
             'handler_with' => [
                 'stream' => 'php://stderr',


### PR DESCRIPTION
## Changes

- Set up production logging
  - Use `stderr` in addition to the `daily` logging channel so Laravel logs are passed to the container logs (`docker logs`)
  - Use the `daily` channel with local `laravel.log` to persist logs to disk for 10 days, ensuring a persistent copy even if the `coolify` container is removed or updated
  - Rotate logs in production every 10 days and only log warnings instead of debug to prevent an excessively large `laravel.log` file
  - Keep `LOG_LEVEL=debug` for the `single` channel as it is used in development
- Improve `.env.local.example`
  - Reorder the file, improve comments and remove unused variables
  - Use `LOG_STACK=single` for local development
  - Log deprecations in local development
- Remove unused logging options

## Issues

- Fixes https://github.com/coollabsio/coolify/issues/3578