### PR TITLE
Fix temp config file handling in SSL certificate generation

### DIFF
--- a/app/Helpers/SslHelper.php
+++ b/app/Helpers/SslHelper.php
@@ -31,6 +31,7 @@ class SslHelper
         $organizationName = self::DEFAULT_ORGANIZATION_NAME;
         $countryName = self::DEFAULT_COUNTRY_NAME;
         $stateName = self::DEFAULT_STATE_NAME;
+        $tempConfig = null;
 
         try {
             $privateKey = openssl_pkey_new([
@@ -113,6 +114,9 @@ class SslHelper
             CONF;
 
             $tempConfig = tmpfile();
+            if ($tempConfig === false) {
+                throw new \RuntimeException('Failed to create temporary configuration file for SSL generation.');
+            }
             fwrite($tempConfig, $config);
             $tempConfigPath = stream_get_meta_data($tempConfig)['uri'];
 
@@ -227,7 +231,9 @@ class SslHelper
         } catch (\Throwable $e) {
             throw new \RuntimeException('SSL Certificate generation failed: '.$e->getMessage(), 0, $e);
         } finally {
-            fclose($tempConfig);
+            if (is_resource($tempConfig)) {
+                fclose($tempConfig);
+            }
         }
     }
 }


### PR DESCRIPTION
Summary
This PR improves the robustness of the SSL certificate generation flow in SslHelper::generateSslCertificate() by safely handling the temporary OpenSSL configuration file.

What’s changed
$tempConfig is initialized to null before the try block.
The result of tmpfile() is validated; a RuntimeException is thrown if the temporary file cannot be created.

The fclose() call in the finally block is guarded with is_resource($tempConfig) to prevent closing an invalid or undefined handle.
Why this is needed
Previously, if an exception occurred before tmpfile() executed, or if tmpfile() returned false, the finally block would still call fclose($tempConfig), resulting in PHP notices or errors. This update ensures that temporary files are cleaned up safely without triggering secondary errors.

Impact
No behavior changes on the normal path of SSL certificate generation.
Improved error handling and robustness during failure scenarios (e.g., OpenSSL or filesystem issues).

No new dependencies added and no documentation changes.