### PR TITLE
Fix logs not loading for single container services

### DIFF
--- a/app/Livewire/Project/Shared/GetLogs.php
+++ b/app/Livewire/Project/Shared/GetLogs.php
@@ -122,7 +122,7 @@ class GetLogs extends Component
         if (! $this->server->isFunctional()) {
             return;
         }
-        if (! $refresh && ($this->resource?->getMorphClass() === \App\Models\Service::class || str($this->container)->contains('-pr-'))) {
+        if (! $refresh && ! $this->expandByDefault && ($this->resource?->getMorphClass() === \App\Models\Service::class || str($this->container)->contains('-pr-'))) {
             return;
         }
         if ($this->numberOfLines <= 0 || is_null($this->numberOfLines)) {

--- a/resources/views/livewire/project/shared/get-logs.blade.php
+++ b/resources/views/livewire/project/shared/get-logs.blade.php
@@ -2,7 +2,7 @@
     <div id="screen" x-data="{
         collapsible: {{ $collapsible ? 'true' : 'false' }},
         expanded: {{ ($expandByDefault || !$collapsible) ? 'true' : 'false' }},
-        logsLoaded: {{ ($expandByDefault || !$collapsible) ? 'true' : 'false' }},
+        logsLoaded: false,
         fullscreen: false,
         alwaysScroll: false,
         intervalId: null,
@@ -156,7 +156,10 @@
             URL.revokeObjectURL(url);
         },
         init() {
-            if (this.expanded) { this.$wire.getLogs(); }
+            if (this.expanded) {
+                this.$wire.getLogs();
+                this.logsLoaded = true;
+            }
             // Re-render logs after Livewire updates
             Livewire.hook('commit', ({ succeed }) => {
                 succeed(() => {


### PR DESCRIPTION
## Changes
- Initialize `logsLoaded` as `false` to ensure `init()` triggers log loading
- Set `logsLoaded=true` after calling `getLogs()` in init
- Allow services/PRs to load logs automatically when `expandByDefault=true` (single container)
- Previously services would skip initial load unless `refresh=true`

## Testing
- Single container applications now load logs automatically
- Single container services (e.g., WordPress without database) now load logs automatically
- Multi-container resources still require manual expansion