### PR TITLE
Fix Garage service: TOML config and healthcheck

### DIFF
--- a/templates/compose/garage.yaml
+++ b/templates/compose/garage.yaml
@@ -53,7 +53,7 @@ services:
           admin_token_file = "env:GARAGE_ADMIN_TOKEN"
           metrics_token_file = "env:GARAGE_METRICS_TOKEN"
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:3903/health"]
+      test: ["CMD", "/garage", "stats", "-a"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/templates/compose/garage.yaml
+++ b/templates/compose/garage.yaml
@@ -35,8 +35,7 @@ services:
           compression_level = 1
           block_size = "1M"
 
-          [rpc]
-          bind_addr = "[::]:3901"
+          rpc_bind_addr = "[::]:3901"
           rpc_secret_file = "env:GARAGE_RPC_SECRET"
           bootstrap_peers = []
 


### PR DESCRIPTION
## Changes
- Move RPC settings (`rpc_bind_addr`, `rpc_secret_file`, `bootstrap_peers`) to root level in TOML config (Garage v2.x expects these at root, not inside a `[rpc]` section)
- Replace `wget` healthcheck with `/garage stats -a` command (wget is not available in the Garage container)

## Issues
- Fixes configuration and healthcheck issues in #7508