### PR TITLE
Add Arch Linux server support and fix package sanitization

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -78,6 +78,8 @@ class InstallDocker
                 $command = $command->merge([$this->getRhelDockerInstallCommand()]);
             } elseif ($supported_os_type->contains('sles')) {
                 $command = $command->merge([$this->getSuseDockerInstallCommand()]);
+            } elseif ($supported_os_type->contains('arch')) {
+                $command = $command->merge([$this->getArchDockerInstallCommand()]);
             } else {
                 $command = $command->merge([$this->getGenericDockerInstallCommand()]);
             }
@@ -149,5 +151,15 @@ class InstallDocker
     private function getGenericDockerInstallCommand(): string
     {
         return "curl https://releases.rancher.com/install-docker/{$this->dockerVersion}.sh | sh || curl https://get.docker.com | sh -s -- --version {$this->dockerVersion}";
+    }
+
+    private function getArchDockerInstallCommand(): string
+    {
+        // Use -Syu to perform full system upgrade before installing Docker
+        // Partial upgrades (-Sy without -u) are discouraged on Arch Linux
+        // as they can lead to broken dependencies and system instability
+        return 'pacman -Syu --noconfirm docker docker-compose && '.
+            'systemctl enable docker.service && '.
+            'systemctl start docker.service';
     }
 }

--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -158,7 +158,8 @@ class InstallDocker
         // Use -Syu to perform full system upgrade before installing Docker
         // Partial upgrades (-Sy without -u) are discouraged on Arch Linux
         // as they can lead to broken dependencies and system instability
-        return 'pacman -Syu --noconfirm docker docker-compose && '.
+        // Use --needed to skip reinstalling packages that are already up-to-date (idempotent)
+        return 'pacman -Syu --noconfirm --needed docker docker-compose && '.
             'systemctl enable docker.service && '.
             'systemctl start docker.service';
     }

--- a/app/Actions/Server/InstallPrerequisites.php
+++ b/app/Actions/Server/InstallPrerequisites.php
@@ -46,6 +46,13 @@ class InstallPrerequisites
                 'command -v git >/dev/null || zypper install -y git',
                 'command -v jq >/dev/null || zypper install -y jq',
             ]);
+        } elseif ($supported_os_type->contains('arch')) {
+            // Use -Syu for full system upgrade to avoid partial upgrade issues on Arch Linux
+            // --needed flag skips packages that are already installed and up-to-date
+            $command = $command->merge([
+                "echo 'Installing Prerequisites for Arch Linux...'",
+                'pacman -Syu --noconfirm --needed curl wget git jq',
+            ]);
         } else {
             throw new \Exception('Unsupported OS type for prerequisites installation');
         }

--- a/app/Actions/Server/UpdatePackage.php
+++ b/app/Actions/Server/UpdatePackage.php
@@ -21,6 +21,13 @@ class UpdatePackage
                 ];
             }
 
+            // Validate that package name is provided when not updating all packages
+            if (! $all && ($package === null || $package === '')) {
+                return [
+                    'error' => "Package name required when 'all' is false.",
+                ];
+            }
+
             // Sanitize package name to prevent command injection
             // Only allow alphanumeric characters, hyphens, underscores, periods, plus signs, and colons
             // These are valid characters in package names across most package managers

--- a/app/Actions/Server/UpdatePackage.php
+++ b/app/Actions/Server/UpdatePackage.php
@@ -20,18 +20,36 @@ class UpdatePackage
                     'error' => 'Server is not reachable or not ready.',
                 ];
             }
+
+            // Sanitize package name to prevent command injection
+            // Only allow alphanumeric characters, hyphens, underscores, periods, plus signs, and colons
+            // These are valid characters in package names across most package managers
+            $sanitizedPackage = '';
+            if ($package !== null && ! $all) {
+                if (! preg_match('/^[a-zA-Z0-9._+:-]+$/', $package)) {
+                    return [
+                        'error' => 'Invalid package name. Package names can only contain alphanumeric characters, hyphens, underscores, periods, plus signs, and colons.',
+                    ];
+                }
+                $sanitizedPackage = escapeshellarg($package);
+            }
+
             switch ($packageManager) {
                 case 'zypper':
                     $commandAll = 'zypper update -y';
-                    $commandInstall = 'zypper install -y '.$package;
+                    $commandInstall = 'zypper install -y '.$sanitizedPackage;
                     break;
                 case 'dnf':
                     $commandAll = 'dnf update -y';
-                    $commandInstall = 'dnf update -y '.$package;
+                    $commandInstall = 'dnf update -y '.$sanitizedPackage;
                     break;
                 case 'apt':
                     $commandAll = 'apt update && apt upgrade -y';
-                    $commandInstall = 'apt install -y '.$package;
+                    $commandInstall = 'apt install -y '.$sanitizedPackage;
+                    break;
+                case 'pacman':
+                    $commandAll = 'pacman -Syu --noconfirm';
+                    $commandInstall = 'pacman -S --noconfirm '.$sanitizedPackage;
                     break;
                 default:
                     return [


### PR DESCRIPTION
## Changes
- Add Arch Linux (pacman) support to server operations: CheckUpdates, InstallDocker, InstallPrerequisites, UpdatePackage
- Implement `parsePacmanOutput()` to parse `pacman -Qu` output format with proper debugging for unparsed lines
- Add security improvement: package name sanitization to prevent command injection across all package managers
- Initialize variables in CheckUpdates to prevent undefined variable errors in exception handling
- Use proper Arch-specific pacman flags: `-Syu` for full system upgrade before operations

## Testing
This adds support for Arch Linux and Arch derivatives (Manjaro, EndeavourOS). The changes follow the same patterns as existing package manager support (apt, dnf, zypper) and include proper error handling and logging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)