### PR TITLE
fix: Prevent terminal disconnects when browser tab loses focus

### DIFF
--- a/app/Livewire/Project/Shared/Terminal.php
+++ b/app/Livewire/Project/Shared/Terminal.php
@@ -11,20 +11,6 @@ class Terminal extends Component
 {
     public bool $hasShell = true;
 
-    public function getListeners()
-    {
-        $teamId = auth()->user()->currentTeam()->id;
-
-        return [
-            "echo-private:team.{$teamId},ApplicationStatusChanged" => 'closeTerminal',
-        ];
-    }
-
-    public function closeTerminal()
-    {
-        $this->dispatch('reloadWindow');
-    }
-
     private function checkShellAvailability(Server $server, string $container): bool
     {
         $escapedContainer = escapeshellarg($container);


### PR DESCRIPTION
## Changes

- Add visibility API handling to pause heartbeat monitoring when browser tab is hidden
- When tab becomes visible again, verify connection is still alive or reconnect automatically
- Remove ApplicationStatusChanged event listener that was triggering terminal reloads on any team resource status change

This fix prevents false disconnections when switching tabs or minimizing the browser window, while still detecting actual connection losses when needed.