### PR TITLE
Fix/matrix service server name

### DIFF
--- a/templates/compose/matrix.yaml
+++ b/templates/compose/matrix.yaml
@@ -10,12 +10,11 @@ services:
     image: matrixdotorg/synapse:latest
     environment:
       - SERVICE_URL_MATRIX_8008
-      - SYNAPSE_SERVER_NAME=${SERVICE_FQDN_MATRIX}
+      - SYNAPSE_SERVER_NAME=${SYNAPSE_SERVER_NAME:?}
       - SYNAPSE_REPORT_STATS=${SYNAPSE_REPORT_STATS:-no}
       - ENABLE_REGISTRATION=${ENABLE_REGISTRATION:-false}
       - RECAPTCHA_PUBLIC_KEY=${RECAPTCHA_PUBLIC_KEY}
       - RECAPTCHA_PRIVATE_KEY=${RECAPTCHA_PRIVATE_KEY}
-      - _SERVER_NAME=${SERVICE_FQDN_MATRIX}
       - _ADMIN_NAME=${SERVICE_USER_ADMIN}
       - _ADMIN_PASS=${SERVICE_PASSWORD_ADMIN}
     volumes:
@@ -44,7 +43,7 @@ services:
         #                        #
         ##########################
         cat <<EOF > /data/homeserver.yaml
-        server_name: "${SERVICE_FQDN_MATRIX}"
+        server_name: "${SYNAPSE_SERVER_NAME}"
         pid_file: /data/homeserver.pid
 
         # server
@@ -64,7 +63,7 @@ services:
             database: /data/homeserver.db
 
         # general
-        log_config: "/data/${SERVICE_FQDN_MATRIX}.log.config"
+        log_config: "/data/${SYNAPSE_SERVER_NAME}.log.config"
         media_store_path: /data/media_store
         report_stats: false
 
@@ -72,11 +71,11 @@ services:
         registration_shared_secret: $(<./registration_shared_secret)
         macaroon_secret_key: $(<./macaroon_secret_key)
         form_secret: $(<./form_secret)
-        signing_key_path: "/data/${SERVICE_FQDN_MATRIX}.signing.key"
+        signing_key_path: "/data/${SYNAPSE_SERVER_NAME}.signing.key"
 
         #rooms
         auto_join_rooms:
-          - "#general:${SERVICE_FQDN_MATRIX}"
+          - "#general:${SYNAPSE_SERVER_NAME}"
 
         # federation
         trusted_key_servers:


### PR DESCRIPTION
> Maybe consider this [alternative PR](https://github.com/coollabsio/coolify/pull/7560), making two compose files, one for deploy with `sqlite` and one for `postgresql`.

> Also discussed on [Discord](https://discord.com/channels/459365938081431553/1447648076327288943).

On a self hosted Coolify, trying to deploy a [Matrix synapse server service](https://coolify.io/docs/services/matrix) at `matrix.example.org`, but would like to use `example.org` as synapse `server_name` so the matrix user and room IDs generated follow the form `@user:example.org` and `#room-alias:example.org`. 

# Changes
Instead of `SERVICE_FQDN_MATRIX` assigned to the "synapse `server_name`", this PR uses `SYNAPSE_SERVER_NAME` that must be set by the user manually.

# Docs
Updated the [Coolify docs (PR)](https://github.com/coollabsio/coolify-docs/pull/465) to reflect these changes, and explain further how to finish setting up a working server.

# Issues and experimentations
##  A. With setting domain and environment variables 
In the service configuration, set the domain to `matrix.example.org:8008`

Set the following environment variable:
- `SERVER_NAME=example.org`

Issue: each time I try with a new deploy (deleting the resource), all these environment variables are being replaced, so when the server is deployed, the domain works `https://matrix.example.org` but the environment variables now all have the value `matrix.example.org` instead of `example.org`.

> Unfortunately, Matrix synapse does [not allow changing the server name](https://matrix-org.github.io/synapse/latest/setup/installation.html#choosing-your-server-name) **after the initial build of the site**. 

## B. With setting the environment variables in the service's compose file 
```
services:
  matrix:
    environment:
      - 'SYNAPSE_SERVER_NAME=example.org'
```
Issue: there are errors in the service deployments logs.

```
 File "/usr/local/lib/python3.13/logging/handlers.py", line 223, in __init__ [...truncated]
```

## C. With using `example.org` as the deploy domain then updating it to `matrix.example.org` after the first deploy

1. deploy with `example.org` as domain
2. when deployed, updated the domain to be `matrix.example.org`
3. update the resource environment variable to be `'SYNAPSE_SERVER_NAME=example.org'`

Issue: `https://matrix.example.org` is not reachable and the service logs shows the errors:
```
BaseRotatingHandler.__init__(self, filename, 'a', encoding=encoding [redact]
```

# Solution
As explained in the "changes" section, one solution is to change the docker compose file, so instead of `SERVICE_FQDN_MATRIX` assigned to the synapse server name, we let the user fill in the now required `SYNAPSE_SERVER_NAME`.