### PR TITLE
Bump version to 4.0.0-beta.454

### DIFF
--- a/config/constants.php
+++ b/config/constants.php
@@ -2,7 +2,7 @@
 
 return [
     'coolify' => [
-        'version' => '4.0.0-beta.453',
+        'version' => '4.0.0-beta.454',
         'helper_version' => '1.0.12',
         'realtime_version' => '1.0.10',
         'self_hosted' => env('SELF_HOSTED', true),

--- a/other/nightly/versions.json
+++ b/other/nightly/versions.json
@@ -1,10 +1,10 @@
 {
     "coolify": {
         "v4": {
-            "version": "4.0.0-beta.453"
+            "version": "4.0.0-beta.454"
         },
         "nightly": {
-            "version": "4.0.0-beta.454"
+            "version": "4.0.0-beta.455"
         },
         "helper": {
             "version": "1.0.12"

--- a/versions.json
+++ b/versions.json
@@ -1,10 +1,10 @@
 {
     "coolify": {
         "v4": {
-            "version": "4.0.0-beta.453"
+            "version": "4.0.0-beta.454"
         },
         "nightly": {
-            "version": "4.0.0-beta.454"
+            "version": "4.0.0-beta.455"
         },
         "helper": {
             "version": "1.0.12"


### PR DESCRIPTION
## Changes
- Bump Coolify version from 4.0.0-beta.453 to 4.0.0-beta.454
- Update version files (config/constants.php, versions.json, other/nightly/versions.json)
- Bump nightly version to 4.0.0-beta.455