### PR TITLE
Fix API response to return fqdn instead of non-existent domains attribute

### DIFF
--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -1127,7 +1127,7 @@ class ApplicationsController extends Controller
 
             return response()->json(serializeApiResponse([
                 'uuid' => data_get($application, 'uuid'),
-                'domains' => data_get($application, 'domains'),
+                'domains' => data_get($application, 'fqdn'),
             ]))->setStatusCode(201);
         } elseif ($type === 'private-gh-app') {
             $validationRules = [
@@ -1287,7 +1287,7 @@ class ApplicationsController extends Controller
 
             return response()->json(serializeApiResponse([
                 'uuid' => data_get($application, 'uuid'),
-                'domains' => data_get($application, 'domains'),
+                'domains' => data_get($application, 'fqdn'),
             ]))->setStatusCode(201);
         } elseif ($type === 'private-deploy-key') {
 
@@ -1421,7 +1421,7 @@ class ApplicationsController extends Controller
 
             return response()->json(serializeApiResponse([
                 'uuid' => data_get($application, 'uuid'),
-                'domains' => data_get($application, 'domains'),
+                'domains' => data_get($application, 'fqdn'),
             ]))->setStatusCode(201);
         } elseif ($type === 'dockerfile') {
             $validationRules = [
@@ -1516,7 +1516,7 @@ class ApplicationsController extends Controller
 
             return response()->json(serializeApiResponse([
                 'uuid' => data_get($application, 'uuid'),
-                'domains' => data_get($application, 'domains'),
+                'domains' => data_get($application, 'fqdn'),
             ]))->setStatusCode(201);
         } elseif ($type === 'dockerimage') {
             $validationRules = [
@@ -1614,7 +1614,7 @@ class ApplicationsController extends Controller
 
             return response()->json(serializeApiResponse([
                 'uuid' => data_get($application, 'uuid'),
-                'domains' => data_get($application, 'domains'),
+                'domains' => data_get($application, 'fqdn'),
             ]))->setStatusCode(201);
         } elseif ($type === 'dockercompose') {
             $allowedFields = ['project_uuid', 'environment_name', 'environment_uuid', 'server_uuid', 'destination_uuid', 'type', 'name', 'description', 'instant_deploy', 'docker_compose_raw', 'force_domain_override'];

--- a/openapi.json
+++ b/openapi.json
@@ -361,6 +361,10 @@
                                     "force_domain_override": {
                                         "type": "boolean",
                                         "description": "Force domain usage even if conflicts are detected. Default is false."
+                                    },
+                                    "autogenerate_domain": {
+                                        "type": "boolean",
+                                        "description": "If true and domains is empty, auto-generate a domain using the server's wildcard domain or sslip.io fallback. Default: true."
                                     }
                                 },
                                 "type": "object"
@@ -771,6 +775,10 @@
                                     "force_domain_override": {
                                         "type": "boolean",
                                         "description": "Force domain usage even if conflicts are detected. Default is false."
+                                    },
+                                    "autogenerate_domain": {
+                                        "type": "boolean",
+                                        "description": "If true and domains is empty, auto-generate a domain using the server's wildcard domain or sslip.io fallback. Default: true."
                                     }
                                 },
                                 "type": "object"
@@ -1181,6 +1189,10 @@
                                     "force_domain_override": {
                                         "type": "boolean",
                                         "description": "Force domain usage even if conflicts are detected. Default is false."
+                                    },
+                                    "autogenerate_domain": {
+                                        "type": "boolean",
+                                        "description": "If true and domains is empty, auto-generate a domain using the server's wildcard domain or sslip.io fallback. Default: true."
                                     }
                                 },
                                 "type": "object"
@@ -1520,6 +1532,10 @@
                                     "force_domain_override": {
                                         "type": "boolean",
                                         "description": "Force domain usage even if conflicts are detected. Default is false."
+                                    },
+                                    "autogenerate_domain": {
+                                        "type": "boolean",
+                                        "description": "If true and domains is empty, auto-generate a domain using the server's wildcard domain or sslip.io fallback. Default: true."
                                     }
                                 },
                                 "type": "object"
@@ -1842,6 +1858,10 @@
                                     "force_domain_override": {
                                         "type": "boolean",
                                         "description": "Force domain usage even if conflicts are detected. Default is false."
+                                    },
+                                    "autogenerate_domain": {
+                                        "type": "boolean",
+                                        "description": "If true and domains is empty, auto-generate a domain using the server's wildcard domain or sslip.io fallback. Default: true."
                                     }
                                 },
                                 "type": "object"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -265,6 +265,9 @@ paths:
                 force_domain_override:
                   type: boolean
                   description: 'Force domain usage even if conflicts are detected. Default is false.'
+                autogenerate_domain:
+                  type: boolean
+                  description: "If true and domains is empty, auto-generate a domain using the server's wildcard domain or sslip.io fallback. Default: true."
               type: object
       responses:
         '201':
@@ -531,6 +534,9 @@ paths:
                 force_domain_override:
                   type: boolean
                   description: 'Force domain usage even if conflicts are detected. Default is false.'
+                autogenerate_domain:
+                  type: boolean
+                  description: "If true and domains is empty, auto-generate a domain using the server's wildcard domain or sslip.io fallback. Default: true."
               type: object
       responses:
         '201':
@@ -797,6 +803,9 @@ paths:
                 force_domain_override:
                   type: boolean
                   description: 'Force domain usage even if conflicts are detected. Default is false.'
+                autogenerate_domain:
+                  type: boolean
+                  description: "If true and domains is empty, auto-generate a domain using the server's wildcard domain or sslip.io fallback. Default: true."
               type: object
       responses:
         '201':
@@ -1010,6 +1019,9 @@ paths:
                 force_domain_override:
                   type: boolean
                   description: 'Force domain usage even if conflicts are detected. Default is false.'
+                autogenerate_domain:
+                  type: boolean
+                  description: "If true and domains is empty, auto-generate a domain using the server's wildcard domain or sslip.io fallback. Default: true."
               type: object
       responses:
         '201':
@@ -1214,6 +1226,9 @@ paths:
                 force_domain_override:
                   type: boolean
                   description: 'Force domain usage even if conflicts are detected. Default is false.'
+                autogenerate_domain:
+                  type: boolean
+                  description: "If true and domains is empty, auto-generate a domain using the server's wildcard domain or sslip.io fallback. Default: true."
               type: object
       responses:
         '201':


### PR DESCRIPTION
## Summary
Fixes the API response for application creation endpoints to return the actual `fqdn` value instead of the non-existent `domains` attribute which always returned `null`.

## Changes
- Changed `data_get($application, 'domains')` to `data_get($application, 'fqdn')` in all 5 application creation endpoint responses
- This ensures auto-generated domains (from the `autogenerate_domain` feature) are properly returned to API consumers

## Notes
The Application model stores domain as `fqdn`, not `domains`. The previous code was incorrectly accessing a non-existent attribute.

🤖 Generated with Claude Code