### PR TITLE
Fix deployment follow logs stopping mid-deployment

### DIFF
--- a/app/Livewire/Project/Application/Deployment/Show.php
+++ b/app/Livewire/Project/Application/Deployment/Show.php
@@ -20,6 +20,8 @@ class Show extends Component
 
     public bool $is_debug_enabled = false;
 
+    private bool $deploymentFinishedDispatched = false;
+
     public function getListeners()
     {
         return [
@@ -92,8 +94,9 @@ class Show extends Component
         $this->horizon_job_status = $this->application_deployment_queue->getHorizonJobStatus();
         $this->isKeepAliveOn();
 
-        // Dispatch event when deployment finishes to stop auto-scroll
-        if (! $this->isKeepAliveOn) {
+        // Dispatch event when deployment finishes to stop auto-scroll (only once)
+        if (! $this->isKeepAliveOn && ! $this->deploymentFinishedDispatched) {
+            $this->deploymentFinishedDispatched = true;
             $this->dispatch('deploymentFinished');
         }
     }

--- a/app/Livewire/Project/Application/Deployment/Show.php
+++ b/app/Livewire/Project/Application/Deployment/Show.php
@@ -22,10 +22,7 @@ class Show extends Component
 
     public function getListeners()
     {
-        $teamId = auth()->user()->currentTeam()->id;
-
         return [
-            "echo-private:team.{$teamId},ServiceChecked" => '$refresh',
             'refreshQueue',
         ];
     }
@@ -91,10 +88,14 @@ class Show extends Component
 
     public function polling()
     {
-        $this->dispatch('deploymentFinished');
         $this->application_deployment_queue->refresh();
         $this->horizon_job_status = $this->application_deployment_queue->getHorizonJobStatus();
         $this->isKeepAliveOn();
+
+        // Dispatch event when deployment finishes to stop auto-scroll
+        if (! $this->isKeepAliveOn) {
+            $this->dispatch('deploymentFinished');
+        }
     }
 
     public function getLogLinesProperty()


### PR DESCRIPTION
## Changes
- Removed scroll detection that disabled follow logs when scrolling >50px from bottom
- Removed fullscreen exit handler that disabled follow logs
- Removed ServiceChecked event listener causing unnecessary flickers
- Follow logs now only stops when user clicks button or deployment finishes
- Added auto-scroll to end with 500ms delay when deployment finishes
- Improved get-logs component with memory optimizations (2000 line limit)
- Added debounced search (300ms) and scroll handling (150ms) in get-logs

## Issues
- Fixes deployment log viewer stopping unexpectedly during deployment