### PR TITLE
Remove duplicate getArchDockerInstallCommand() method

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -150,19 +150,6 @@ class InstallDocker
 
     private function getArchDockerInstallCommand(): string
     {
-        return 'pacman -Syyy --noconfirm && '.
-            'pacman -S docker docker-compose --noconfirm && '.
-            'systemctl start docker && '.
-            'systemctl enable docker';
-    }
-
-    private function getGenericDockerInstallCommand(): string
-    {
-        return "curl https://releases.rancher.com/install-docker/{$this->dockerVersion}.sh | sh || curl https://get.docker.com | sh -s -- --version {$this->dockerVersion}";
-    }
-
-    private function getArchDockerInstallCommand(): string
-    {
         // Use -Syu to perform full system upgrade before installing Docker
         // Partial upgrades (-Sy without -u) are discouraged on Arch Linux
         // as they can lead to broken dependencies and system instability
@@ -170,5 +157,10 @@ class InstallDocker
         return 'pacman -Syu --noconfirm --needed docker docker-compose && '.
             'systemctl enable docker.service && '.
             'systemctl start docker.service';
+    }
+
+    private function getGenericDockerInstallCommand(): string
+    {
+        return "curl https://releases.rancher.com/install-docker/{$this->dockerVersion}.sh | sh || curl https://get.docker.com | sh -s -- --version {$this->dockerVersion}";
     }
 }


### PR DESCRIPTION
## Changes
- Removed duplicate `getArchDockerInstallCommand()` method definition
- Kept the improved version that uses `pacman -Syu --needed` instead of `-Syyy`
- Properly ordered methods in the class

## Issues
- Fixes duplicate method definition that was causing dead code