### PR TITLE
Fix restart counter persistence and add crash loop example

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -3980,6 +3980,15 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
      */
     private function handleSuccessfulDeployment(): void
     {
+        // Reset restart count after successful deployment
+        // This is done here (not in Livewire) to avoid race conditions
+        // with GetContainersStatus reading old container restart counts
+        $this->application->update([
+            'restart_count' => 0,
+            'last_restart_at' => null,
+            'last_restart_type' => null,
+        ]);
+
         event(new ApplicationConfigurationChanged($this->application->team()->id));
 
         if (! $this->only_this_server) {

--- a/app/Livewire/Project/Application/Heading.php
+++ b/app/Livewire/Project/Application/Heading.php
@@ -106,13 +106,6 @@ class Heading extends Component
             return;
         }
 
-        // Reset restart count on successful deployment
-        $this->application->update([
-            'restart_count' => 0,
-            'last_restart_at' => null,
-            'last_restart_type' => null,
-        ]);
-
         return $this->redirectRoute('project.application.deployment.show', [
             'project_uuid' => $this->parameters['project_uuid'],
             'application_uuid' => $this->parameters['application_uuid'],
@@ -156,13 +149,6 @@ class Heading extends Component
 
             return;
         }
-
-        // Reset restart count on manual restart
-        $this->application->update([
-            'restart_count' => 0,
-            'last_restart_at' => now(),
-            'last_restart_type' => 'manual',
-        ]);
 
         return $this->redirectRoute('project.application.deployment.show', [
             'project_uuid' => $this->parameters['project_uuid'],

--- a/database/seeders/ApplicationSeeder.php
+++ b/database/seeders/ApplicationSeeder.php
@@ -77,5 +77,21 @@ EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]
 ',
         ]);
+        Application::create([
+            'name' => 'Crash Loop Example',
+            'git_repository' => 'coollabsio/coolify',
+            'git_branch' => 'v4.x',
+            'git_commit_sha' => 'HEAD',
+            'build_pack' => 'dockerfile',
+            'ports_exposes' => '80',
+            'environment_id' => 1,
+            'destination_id' => 0,
+            'destination_type' => StandaloneDocker::class,
+            'source_id' => 0,
+            'source_type' => GithubApp::class,
+            'dockerfile' => 'FROM alpine
+CMD ["sh", "-c", "echo Crashing in 5 seconds... && sleep 5 && exit 1"]
+',
+        ]);
     }
 }


### PR DESCRIPTION
## Changes
- Move restart counter reset from Livewire component to `ApplicationDeploymentJob.handleSuccessfulDeployment()` to prevent race conditions with `GetContainersStatus`
- Remove artificial `restart_type = 'manual'` tracking (value was written but never read)
- Add "Crash Loop Example" seeded application for testing restart tracking UI

## Details
The race condition occurred because resetting the counter in Livewire happened immediately when the user clicked deploy, but `GetContainersStatus` could read stale Docker container restart counts during deployment. Moving the reset to after successful deployment ensures consistency between the database and container state.

The "Crash Loop Example" is a minimal Alpine container that crashes every 5 seconds, allowing natural restart tracking detection via Docker's restart count mechanism.