### PR TITLE
perf: Remove dead server filtering code from Kernel scheduler

### DIFF
--- a/app/Jobs/ServerManagerJob.php
+++ b/app/Jobs/ServerManagerJob.php
@@ -160,13 +160,10 @@ class ServerManagerJob implements ShouldQueue
             ServerPatchCheckJob::dispatch($server);
         }
 
-        // Check for sentinel updates hourly (independent of user-configurable update_check_frequency)
-        if ($server->isSentinelEnabled()) {
-            $shouldCheckSentinel = $this->shouldRunNow('0 * * * *', $serverTimezone);
-
-            if ($shouldCheckSentinel) {
-                CheckAndStartSentinelJob::dispatch($server);
-            }
+        // Sentinel update checks (hourly) - check for updates to Sentinel version
+        // No timezone needed for hourly - runs at top of every hour
+        if ($isSentinelEnabled && $this->shouldRunNow('0 * * * *')) {
+            CheckAndStartSentinelJob::dispatch($server);
         }
     }
 


### PR DESCRIPTION
## Changes

- Remove unused server filtering logic in `Kernel.php` that was querying servers but never using the results
- Simplify Sentinel update checks in `ServerManagerJob` by reusing existing `$isSentinelEnabled` variable
- Remove unnecessary timezone parameter for hourly Sentinel check cron

This removes unnecessary database queries from the scheduler to reduce CPU usage on cloud instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)