### PR TITLE
Always show PR deployments public option

### DIFF
--- a/resources/views/livewire/project/application/advanced.blade.php
+++ b/resources/views/livewire/project/application/advanced.blade.php
@@ -13,12 +13,10 @@
                     helper="Allow to automatically deploy Preview Deployments for all opened PR's.<br><br>Closing a PR will delete Preview Deployments."
                     instantSave id="isPreviewDeploymentsEnabled" label="Preview Deployments" canGate="update"
                     :canResource="$application" />
-                @if ($isPreviewDeploymentsEnabled)
-                    <x-forms.checkbox
-                        helper="When enabled, anyone can trigger PR deployments. When disabled, only repository members, collaborators, and contributors can trigger PR deployments."
-                        instantSave id="isPrDeploymentsPublicEnabled" label="Allow Public PR Deployments" canGate="update"
-                        :canResource="$application" />
-                @endif
+                <x-forms.checkbox
+                    helper="When enabled, anyone can trigger PR deployments. When disabled, only repository members, collaborators, and contributors can trigger PR deployments."
+                    instantSave id="isPrDeploymentsPublicEnabled" label="Allow Public PR Deployments" canGate="update"
+                    :canResource="$application" :disabled="!$isPreviewDeploymentsEnabled" />
             @endif
             <x-forms.checkbox helper="Disable Docker build cache on every deployment." instantSave
                 id="disableBuildCache" label="Disable Build Cache" canGate="update" :canResource="$application" />


### PR DESCRIPTION
## Changes
- Always show "Allow Public PR Deployments" option in Advanced settings for git-based applications
- Checkbox is disabled when Preview Deployments are disabled, preventing configuration until that feature is enabled
- Improves discoverability by making this security option always visible

## Issues
- always show non-member pr advanced option