### PR TITLE
Fix execution time tooltip maximum value

### DIFF
--- a/resources/views/livewire/project/shared/scheduled-task/add.blade.php
+++ b/resources/views/livewire/project/shared/scheduled-task/add.blade.php
@@ -5,7 +5,7 @@
         helper="You can use every_minute, hourly, daily, weekly, monthly, yearly or a cron expression." id="frequency"
         label="Frequency" />
     <x-forms.input type="number" placeholder="300" id="timeout"
-        helper="Maximum execution time in seconds (60-3600). Default is 300 seconds (5 minutes)."
+        helper="Maximum execution time in seconds (60-36000). Default is 300 seconds (5 minutes)."
         label="Timeout (seconds)" />
     @if ($type === 'application')
         @if ($containerNames->count() > 1)

--- a/resources/views/livewire/project/shared/scheduled-task/show.blade.php
+++ b/resources/views/livewire/project/shared/scheduled-task/show.blade.php
@@ -36,7 +36,7 @@
                 <x-forms.input placeholder="php artisan schedule:run" id="command" label="Command" required />
                 <x-forms.input placeholder="0 0 * * * or daily" id="frequency" label="Frequency" required />
                 <x-forms.input type="number" placeholder="300" id="timeout"
-                    helper="Maximum execution time in seconds (60-3600)." label="Timeout (seconds)" required />
+                    helper="Maximum execution time in seconds (60-36000)." label="Timeout (seconds)" required />
                 @if ($type === 'application')
                     <x-forms.input placeholder="php"
                         helper="You can leave this empty if your resource only has one container." id="container"


### PR DESCRIPTION
## Changes
- Fixed tooltip text in scheduled task timeout input fields to show correct maximum value of 36000 seconds (10 hours) instead of 3600 seconds.

## Files Modified
- `resources/views/livewire/project/shared/scheduled-task/add.blade.php` - Updated helper text
- `resources/views/livewire/project/shared/scheduled-task/show.blade.php` - Updated helper text

The validation already allowed up to 36000 seconds, but the UI tooltip was displaying incorrect information. This change aligns the tooltip with the actual validation limits.