### PR TITLE
fix(service): postiz showing no available server

### DIFF
--- a/templates/compose/postiz.yaml
+++ b/templates/compose/postiz.yaml
@@ -7,7 +7,7 @@
 
 services:
   postiz:
-    image: ghcr.io/gitroomhq/postiz-app:v1.60.1
+    image: ghcr.io/gitroomhq/postiz-app:v2.10.1
     environment:
       - SERVICE_URL_POSTIZ_5000
       - MAIN_URL=${SERVICE_URL_POSTIZ}


### PR DESCRIPTION
The postiz service goes to unhealthy state so traefik show no available server error.

Postiz container logs shows the app is failing due to use of older nodejs version:
<img width="2045" height="1042" alt="image" src="https://github.com/user-attachments/assets/f57161fa-9047-4646-ab99-bafd32d00b9c" />

Latest version of Postiz has fix for this so I have updated the version to the latest working version.

Fix is from our discord community btw:
<img width="1330" height="276" alt="image" src="https://github.com/user-attachments/assets/45295f28-1bd8-402e-96f8-5f9a83e71f26" />
