### PR TITLE
Fix: Allow test emails to be sent to any email address

### DIFF
--- a/app/Notifications/Channels/EmailChannel.php
+++ b/app/Notifications/Channels/EmailChannel.php
@@ -43,21 +43,26 @@ class EmailChannel
                 throw new Exception('No email recipients found');
             }
 
-            foreach ($recipients as $recipient) {
-                // Check if the recipient is part of the team
-                if (! $members->contains('email', $recipient)) {
-                    $emailSettings = $notifiable->emailNotificationSettings;
-                    data_set($emailSettings, 'smtp_password', '********');
-                    data_set($emailSettings, 'resend_api_key', '********');
-                    send_internal_notification(sprintf(
-                        "Recipient is not part of the team: %s\nTeam: %s\nNotification: %s\nNotifiable: %s\nEmail Settings:\n%s",
-                        $recipient,
-                        $team,
-                        get_class($notification),
-                        get_class($notifiable),
-                        json_encode($emailSettings, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
-                    ));
-                    throw new Exception('Recipient is not part of the team');
+            // Skip team membership validation for test notifications
+            $isTestNotification = data_get($notification, 'isTestNotification', false);
+
+            if (! $isTestNotification) {
+                foreach ($recipients as $recipient) {
+                    // Check if the recipient is part of the team
+                    if (! $members->contains('email', $recipient)) {
+                        $emailSettings = $notifiable->emailNotificationSettings;
+                        data_set($emailSettings, 'smtp_password', '********');
+                        data_set($emailSettings, 'resend_api_key', '********');
+                        send_internal_notification(sprintf(
+                            "Recipient is not part of the team: %s\nTeam: %s\nNotification: %s\nNotifiable: %s\nEmail Settings:\n%s",
+                            $recipient,
+                            $team,
+                            get_class($notification),
+                            get_class($notifiable),
+                            json_encode($emailSettings, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+                        ));
+                        throw new Exception('Recipient is not part of the team');
+                    }
                 }
             }
 

--- a/app/Notifications/Test.php
+++ b/app/Notifications/Test.php
@@ -23,6 +23,8 @@ class Test extends Notification implements ShouldQueue
 
     public $tries = 5;
 
+    public bool $isTestNotification = true;
+
     public function __construct(public ?string $emails = null, public ?string $channel = null, public ?bool $ping = false)
     {
         $this->onQueue('high');

--- a/app/Notifications/TransactionalEmails/Test.php
+++ b/app/Notifications/TransactionalEmails/Test.php
@@ -8,6 +8,8 @@ use Illuminate\Notifications\Messages\MailMessage;
 
 class Test extends CustomEmailNotification
 {
+    public bool $isTestNotification = true;
+
     public function __construct(public string $emails, public bool $isTransactionalEmail = true)
     {
         $this->onQueue('high');


### PR DESCRIPTION
## Changes
- Added `isTestNotification` flag to both `Test` notification classes (`App\Notifications\Test` and `App\Notifications\TransactionalEmails\Test`)
- Modified `EmailChannel` to skip team membership validation when sending test notifications
- Test emails can now be sent to any valid email address, not just team members

## Issues
- Fixes the issue where sending a test email to a non-team email address would fail with "Recipient is not part of the team"