### PR TITLE
Bump version to v455

### DIFF
--- a/config/constants.php
+++ b/config/constants.php
@@ -2,7 +2,7 @@
 
 return [
     'coolify' => [
-        'version' => '4.0.0-beta.454',
+        'version' => '4.0.0-beta.455',
         'helper_version' => '1.0.12',
         'realtime_version' => '1.0.10',
         'self_hosted' => env('SELF_HOSTED', true),

--- a/other/nightly/versions.json
+++ b/other/nightly/versions.json
@@ -1,10 +1,10 @@
 {
     "coolify": {
         "v4": {
-            "version": "4.0.0-beta.454"
+            "version": "4.0.0-beta.455"
         },
         "nightly": {
-            "version": "4.0.0-beta.455"
+            "version": "4.0.0-beta.456"
         },
         "helper": {
             "version": "1.0.12"

--- a/versions.json
+++ b/versions.json
@@ -1,10 +1,10 @@
 {
     "coolify": {
         "v4": {
-            "version": "4.0.0-beta.454"
+            "version": "4.0.0-beta.455"
         },
         "nightly": {
-            "version": "4.0.0-beta.455"
+            "version": "4.0.0-beta.456"
         },
         "helper": {
             "version": "1.0.12"


### PR DESCRIPTION
## Changes
- Updated Coolify version from 4.0.0-beta.454 to 4.0.0-beta.455
- Updated nightly version from 4.0.0-beta.455 to 4.0.0-beta.456

Version changes applied to all version definition files.