### PR TITLE
Update Fizzy SOLID_QUEUE environment variable

### DIFF
--- a/templates/compose/fizzy.yaml
+++ b/templates/compose/fizzy.yaml
@@ -16,7 +16,7 @@ services:
       - RAILS_LOG_TO_STDOUT=true
       - RAILS_SERVE_STATIC_FILES=true
       - DATABASE_ADAPTER=sqlite
-      - SOLID_QUEUE_CONNECTS_TO=false
+      - SOLID_QUEUE_IN_PUMA=true
       - VAPID_PRIVATE_KEY=$VAPID_PRIVATE_KEY
       - VAPID_PUBLIC_KEY=$VAPID_PUBLIC_KEY
     volumes:


### PR DESCRIPTION
Fixed issue where email is never sent because the queue is not configured correctly.

## Changes
- Update env var to `SOLID_QUEUE_IN_PUMA=true`

