### PR TITLE
Feature: Add OpenID authentication

### DIFF
--- a/.ai/patterns/security-patterns.md
+++ b/.ai/patterns/security-patterns.md
@@ -13,6 +13,7 @@ Coolify implements **defense-in-depth security** with multiple layers of protect
 
 ### OAuth Integration
 - **[OauthSetting.php](mdc:app/Models/OauthSetting.php)** - OAuth provider configurations
+- **[OpenIDConnect Provider](mdc:app/Socialite/OpenIDConnect/Provider.php)** - Generic OIDC provider implementation
 - **Supported Providers**:
   - Google OAuth
   - Microsoft Azure AD
@@ -21,6 +22,30 @@ Coolify implements **defense-in-depth security** with multiple layers of protect
   - Discord
   - GitHub (via GitHub Apps)
   - GitLab
+  - Bitbucket
+  - Infomaniak
+  - Zitadel
+  - **OpenID Connect** (Generic OIDC - works with Keycloak, Auth0, Okta, etc.)
+
+### Custom Login Button Labels
+All OAuth providers support custom login button labels via:
+1. **Database**: Set `custom_label` in OAuth settings UI (Settings > OAuth)
+2. **Environment Variables**: e.g., `OPENID_LOGIN_LABEL="Login with Platform Shape"`
+
+**Priority**: Database > Environment Variable > Default Translation
+
+**Available Environment Variables**:
+- `AZURE_LOGIN_LABEL`
+- `AUTHENTIK_LOGIN_LABEL`
+- `BITBUCKET_LOGIN_LABEL`
+- `CLERK_LOGIN_LABEL`
+- `DISCORD_LOGIN_LABEL`
+- `GITHUB_LOGIN_LABEL`
+- `GITLAB_LOGIN_LABEL`
+- `GOOGLE_LOGIN_LABEL`
+- `INFOMANIAK_LOGIN_LABEL`
+- `OPENID_LOGIN_LABEL`
+- `ZITADEL_LOGIN_LABEL`
 
 ### Authentication Models
 ```php

--- a/.ai/patterns/security-patterns.md
+++ b/.ai/patterns/security-patterns.md
@@ -30,7 +30,7 @@ Coolify implements **defense-in-depth security** with multiple layers of protect
 ### Custom Login Button Labels
 All OAuth providers support custom login button labels via:
 1. **Database**: Set `custom_label` in OAuth settings UI (Settings > OAuth)
-2. **Environment Variables**: e.g., `OPENID_LOGIN_LABEL="Login with Platform Shape"`
+2. **Environment Variables**: e.g., `OPENID_LOGIN_LABEL="Login with SSO"`
 
 **Priority**: Database > Environment Variable > Default Translation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### 🚀 Features
 
 - Add generic OpenID Connect (OIDC) authentication provider supporting Keycloak, Auth0, Okta, and other OIDC-compliant identity providers
-- Add custom login button labels for all OAuth providers via database settings or environment variables (e.g., `OPENID_LOGIN_LABEL="Login with Platform Shape"`)
+- Add custom login button labels for all OAuth providers via database settings or environment variables (e.g., `OPENID_LOGIN_LABEL="Login with SSO"`)
 
 ### 🐛 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+### 🚀 Features
+
+- Add generic OpenID Connect (OIDC) authentication provider supporting Keycloak, Auth0, Okta, and other OIDC-compliant identity providers
+- Add custom login button labels for all OAuth providers via database settings or environment variables (e.g., `OPENID_LOGIN_LABEL="Login with Platform Shape"`)
+
 ### 🐛 Bug Fixes
 
 - Update syncData method to use data_get for safer property access

--- a/app/Livewire/SettingsOauth.php
+++ b/app/Livewire/SettingsOauth.php
@@ -18,6 +18,7 @@ class SettingsOauth extends Component
             $carry["oauth_settings_map.$setting->provider.redirect_uri"] = 'nullable';
             $carry["oauth_settings_map.$setting->provider.tenant"] = 'nullable';
             $carry["oauth_settings_map.$setting->provider.base_url"] = 'nullable';
+            $carry["oauth_settings_map.$setting->provider.custom_label"] = 'nullable';
 
             return $carry;
         }, []);
@@ -38,6 +39,7 @@ class SettingsOauth extends Component
                 'redirect_uri' => $setting->redirect_uri,
                 'tenant' => $setting->tenant,
                 'base_url' => $setting->base_url,
+                'custom_label' => $setting->custom_label,
             ];
 
             return $carry;
@@ -61,6 +63,7 @@ class SettingsOauth extends Component
                 'redirect_uri' => $oauthData['redirect_uri'],
                 'tenant' => $oauthData['tenant'],
                 'base_url' => $oauthData['base_url'],
+                'custom_label' => $oauthData['custom_label'],
             ]);
 
             if (! $oauth->couldBeEnabled()) {
@@ -79,6 +82,7 @@ class SettingsOauth extends Component
                 'redirect_uri' => $oauth->redirect_uri,
                 'tenant' => $oauth->tenant,
                 'base_url' => $oauth->base_url,
+                'custom_label' => $oauth->custom_label,
             ];
 
             $this->dispatch('success', 'OAuth settings for '.$oauth->provider.' updated successfully!');
@@ -100,6 +104,7 @@ class SettingsOauth extends Component
                     'redirect_uri' => $settingData['redirect_uri'],
                     'tenant' => $settingData['tenant'],
                     'base_url' => $settingData['base_url'],
+                    'custom_label' => $settingData['custom_label'],
                 ]);
 
                 if ($settingData['enabled'] && ! $oauth->couldBeEnabled()) {
@@ -119,6 +124,7 @@ class SettingsOauth extends Component
                     'redirect_uri' => $oauth->redirect_uri,
                     'tenant' => $oauth->tenant,
                     'base_url' => $oauth->base_url,
+                    'custom_label' => $oauth->custom_label,
                 ];
             }
 

--- a/app/Models/OauthSetting.php
+++ b/app/Models/OauthSetting.php
@@ -11,7 +11,7 @@ class OauthSetting extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['provider', 'client_id', 'client_secret', 'redirect_uri', 'tenant', 'base_url', 'enabled'];
+    protected $fillable = ['provider', 'client_id', 'client_secret', 'redirect_uri', 'tenant', 'base_url', 'enabled', 'custom_label'];
 
     protected function clientSecret(): Attribute
     {
@@ -28,9 +28,28 @@ class OauthSetting extends Model
                 return filled($this->client_id) && filled($this->client_secret) && filled($this->tenant);
             case 'authentik':
             case 'clerk':
+            case 'openid':
                 return filled($this->client_id) && filled($this->client_secret) && filled($this->base_url);
             default:
                 return filled($this->client_id) && filled($this->client_secret);
         }
+    }
+
+    /**
+     * Get the display label for the login button.
+     * Priority: database custom_label > env custom_label > translation
+     */
+    public function getLoginLabel(): string
+    {
+        if (filled($this->custom_label)) {
+            return $this->custom_label;
+        }
+
+        $envLabel = config("services.{$this->provider}.custom_label");
+        if (filled($envLabel)) {
+            return $envLabel;
+        }
+
+        return __("auth.login.{$this->provider}");
     }
 }

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Socialite\OpenIDConnect\OpenIDConnectExtendSocialite;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 use SocialiteProviders\Authentik\AuthentikExtendSocialite;
 use SocialiteProviders\Azure\AzureExtendSocialite;
@@ -23,6 +24,7 @@ class EventServiceProvider extends ServiceProvider
             GoogleExtendSocialite::class.'@handle',
             InfomaniakExtendSocialite::class.'@handle',
             ZitadelExtendSocialite::class.'@handle',
+            OpenIDConnectExtendSocialite::class.'@handle',
         ],
     ];
 

--- a/app/Socialite/OpenIDConnect/OpenIDConnectExtendSocialite.php
+++ b/app/Socialite/OpenIDConnect/OpenIDConnectExtendSocialite.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Socialite\OpenIDConnect;
+
+use SocialiteProviders\Manager\SocialiteWasCalled;
+
+class OpenIDConnectExtendSocialite
+{
+    public function handle(SocialiteWasCalled $socialiteWasCalled): void
+    {
+        $socialiteWasCalled->extendSocialite('openid', Provider::class);
+    }
+}

--- a/app/Socialite/OpenIDConnect/Provider.php
+++ b/app/Socialite/OpenIDConnect/Provider.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Socialite\OpenIDConnect;
+
+use GuzzleHttp\RequestOptions;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Cache;
+use SocialiteProviders\Manager\OAuth2\AbstractProvider;
+use SocialiteProviders\Manager\OAuth2\User;
+
+class Provider extends AbstractProvider
+{
+    public const IDENTIFIER = 'OPENID';
+
+    protected $scopeSeparator = ' ';
+
+    protected $scopes = ['openid', 'profile', 'email'];
+
+    /**
+     * The cached OpenID configuration.
+     */
+    protected ?array $openidConfiguration = null;
+
+    public static function additionalConfigKeys(): array
+    {
+        return ['base_url'];
+    }
+
+    /**
+     * Get the OpenID Connect discovery document.
+     */
+    protected function getOpenidConfiguration(): array
+    {
+        if ($this->openidConfiguration !== null) {
+            return $this->openidConfiguration;
+        }
+
+        $baseUrl = rtrim($this->getConfig('base_url'), '/');
+        $cacheKey = 'oauth.openid.configuration.'.md5($baseUrl);
+
+        $this->openidConfiguration = Cache::remember($cacheKey, 3600, function () use ($baseUrl) {
+            $response = $this->getHttpClient()->get($baseUrl.'/.well-known/openid-configuration');
+
+            return json_decode((string) $response->getBody(), true);
+        });
+
+        return $this->openidConfiguration;
+    }
+
+    protected function getAuthUrl($state): string
+    {
+        $config = $this->getOpenidConfiguration();
+
+        return $this->buildAuthUrlFromBase($config['authorization_endpoint'], $state);
+    }
+
+    protected function getTokenUrl(): string
+    {
+        $config = $this->getOpenidConfiguration();
+
+        return $config['token_endpoint'];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getUserByToken($token)
+    {
+        $config = $this->getOpenidConfiguration();
+
+        $response = $this->getHttpClient()->get($config['userinfo_endpoint'], [
+            RequestOptions::HEADERS => [
+                'Authorization' => 'Bearer '.$token,
+            ],
+        ]);
+
+        return json_decode((string) $response->getBody(), true);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function mapUserToObject(array $user): User
+    {
+        return (new User)->setRaw($user)->map([
+            'id' => Arr::get($user, 'sub'),
+            'nickname' => Arr::get($user, 'preferred_username'),
+            'name' => Arr::get($user, 'name'),
+            'email' => Arr::get($user, 'email'),
+            'avatar' => Arr::get($user, 'picture'),
+        ]);
+    }
+}

--- a/bootstrap/helpers/socialite.php
+++ b/bootstrap/helpers/socialite.php
@@ -56,6 +56,17 @@ function get_socialite_provider(string $provider)
             ->with(['hd' => $oauth_setting->tenant]);
     }
 
+    if ($provider == 'openid') {
+        $openid_config = new \SocialiteProviders\Manager\Config(
+            $oauth_setting->client_id,
+            $oauth_setting->client_secret,
+            $oauth_setting->redirect_uri,
+            ['base_url' => $oauth_setting->base_url],
+        );
+
+        return Socialite::driver('openid')->setConfig($openid_config);
+    }
+
     $config = [
         'client_id' => $oauth_setting->client_id,
         'client_secret' => $oauth_setting->client_secret,

--- a/config/services.php
+++ b/config/services.php
@@ -31,12 +31,33 @@ return [
         'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
     ],
 
+    'bitbucket' => [
+        'custom_label' => env('BITBUCKET_LOGIN_LABEL'),
+    ],
+
+    'discord' => [
+        'custom_label' => env('DISCORD_LOGIN_LABEL'),
+    ],
+
+    'github' => [
+        'custom_label' => env('GITHUB_LOGIN_LABEL'),
+    ],
+
+    'gitlab' => [
+        'custom_label' => env('GITLAB_LOGIN_LABEL'),
+    ],
+
+    'infomaniak' => [
+        'custom_label' => env('INFOMANIAK_LOGIN_LABEL'),
+    ],
+
     'azure' => [
         'client_id' => env('AZURE_CLIENT_ID'),
         'client_secret' => env('AZURE_CLIENT_SECRET'),
         'redirect' => env('AZURE_REDIRECT_URI'),
         'tenant' => env('AZURE_TENANT_ID'),
         'proxy' => env('AZURE_PROXY'),
+        'custom_label' => env('AZURE_LOGIN_LABEL'),
     ],
 
     'authentik' => [
@@ -44,6 +65,7 @@ return [
         'client_id' => env('AUTHENTIK_CLIENT_ID'),
         'client_secret' => env('AUTHENTIK_CLIENT_SECRET'),
         'redirect' => env('AUTHENTIK_REDIRECT_URI'),
+        'custom_label' => env('AUTHENTIK_LOGIN_LABEL'),
     ],
 
     'clerk' => [
@@ -51,6 +73,15 @@ return [
         'client_secret' => env('CLERK_CLIENT_SECRET'),
         'redirect' => env('CLERK_REDIRECT_URI'),
         'base_url' => env('CLERK_BASE_URL'),
+        'custom_label' => env('CLERK_LOGIN_LABEL'),
+    ],
+
+    'openid' => [
+        'client_id' => env('OPENID_CLIENT_ID'),
+        'client_secret' => env('OPENID_CLIENT_SECRET'),
+        'redirect' => env('OPENID_REDIRECT_URI'),
+        'base_url' => env('OPENID_BASE_URL'),
+        'custom_label' => env('OPENID_LOGIN_LABEL'),
     ],
 
     'google' => [
@@ -58,6 +89,7 @@ return [
         'client_secret' => env('GOOGLE_CLIENT_SECRET'),
         'redirect' => env('GOOGLE_REDIRECT_URI'),
         'tenant' => env('GOOGLE_TENANT'),
+        'custom_label' => env('GOOGLE_LOGIN_LABEL'),
     ],
 
     'zitadel' => [
@@ -65,6 +97,7 @@ return [
         'client_secret' => env('ZITADEL_CLIENT_SECRET'),
         'redirect' => env('ZITADEL_REDIRECT_URI'),
         'base_url' => env('ZITADEL_BASE_URL'),
+        'custom_label' => env('ZITADEL_LOGIN_LABEL'),
     ],
 
 ];

--- a/database/migrations/2025_12_12_165952_add_openid_oauth_provider_settings.php
+++ b/database/migrations/2025_12_12_165952_add_openid_oauth_provider_settings.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Models\OauthSetting;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('oauth_settings', function (Blueprint $table) {
+            $table->string('custom_label')->nullable()->after('enabled');
+        });
+
+        OauthSetting::updateOrCreate([
+            'provider' => 'openid',
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        OauthSetting::where('provider', 'openid')->delete();
+
+        Schema::table('oauth_settings', function (Blueprint $table) {
+            $table->dropColumn('custom_label');
+        });
+    }
+};

--- a/database/seeders/OauthSettingSeeder.php
+++ b/database/seeders/OauthSettingSeeder.php
@@ -22,6 +22,7 @@ class OauthSettingSeeder extends Seeder
                 'github',
                 'gitlab',
                 'google',
+                'openid',
                 'authentik',
                 'infomaniak',
                 'zitadel',
@@ -61,7 +62,6 @@ class OauthSettingSeeder extends Seeder
                     'provider' => $provider,
                 ]);
             }
-
         } catch (\Exception $e) {
             Log::error($e->getMessage());
         }

--- a/lang/en.json
+++ b/lang/en.json
@@ -7,6 +7,7 @@
     "auth.login.discord": "Login with Discord",
     "auth.login.github": "Login with GitHub",
     "auth.login.gitlab": "Login with Gitlab",
+    "auth.login.openid": "Login with OpenID",
     "auth.login.google": "Login with Google",
     "auth.login.infomaniak": "Login with Infomaniak",
     "auth.login.zitadel": "Login with Zitadel",

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -90,7 +90,7 @@
                             @foreach ($enabled_oauth_providers as $provider_setting)
                                 <x-forms.button class="w-full justify-center" type="button"
                                     onclick="document.location.href='/auth/{{ $provider_setting->provider }}/redirect'">
-                                    {{ __("auth.login.$provider_setting->provider") }}
+                                    {{ $provider_setting->getLoginLabel() }}
                                 </x-forms.button>
                             @endforeach
                         </div>

--- a/resources/views/livewire/settings-oauth.blade.php
+++ b/resources/views/livewire/settings-oauth.blade.php
@@ -47,7 +47,7 @@
                                 label="Base URL" />
                         @endif
                         <x-forms.input id="oauth_settings_map.{{ $oauth_setting['provider'] }}.custom_label"
-                            helper="Override the default login button text (e.g., 'Login with Platform Shape')"
+                            helper="Override the default login button text (e.g., 'Login with SSO')"
                             placeholder="{{ __('auth.login.' . $oauth_setting['provider']) }}"
                             label="Custom Button Label" />
                     </div>

--- a/resources/views/livewire/settings-oauth.blade.php
+++ b/resources/views/livewire/settings-oauth.blade.php
@@ -41,10 +41,15 @@
                             $oauth_setting['provider'] == 'authentik' ||
                                 $oauth_setting['provider'] == 'clerk' ||
                                 $oauth_setting['provider'] == 'zitadel' ||
+                                $oauth_setting['provider'] == 'openid' ||
                                 $oauth_setting['provider'] == 'gitlab')
                             <x-forms.input id="oauth_settings_map.{{ $oauth_setting['provider'] }}.base_url"
                                 label="Base URL" />
                         @endif
+                        <x-forms.input id="oauth_settings_map.{{ $oauth_setting['provider'] }}.custom_label"
+                            helper="Override the default login button text (e.g., 'Login with Platform Shape')"
+                            placeholder="{{ __('auth.login.' . $oauth_setting['provider']) }}"
+                            label="Custom Button Label" />
                     </div>
                 </div>
             @endforeach


### PR DESCRIPTION
## Changes
  - Add generic OpenID Connect (OIDC) authentication provider that works with any OIDC-compliant identity
  provider (Keycloak, Auth0, Okta, etc.)
  - Add automatic discovery of OIDC endpoints via `.well-known/openid-configuration`
  - Add support for custom login button labels for all OAuth providers
    - Configurable via UI in Settings > OAuth
    - Configurable via environment variables (e.g., `OPENID_LOGIN_LABEL="Login with Company SSO"`)
    - Priority: Database setting > Environment variable > Default translation
  - Add `custom_label` column to `oauth_settings` table via migration
  - Cache OIDC configuration for 1 hour to reduce API calls

  ## Implementation Details
  - Created custom OIDC provider in `app/Socialite/OpenIDConnect/` following Laravel Socialite patterns
  - Extended all form components to support custom labels
  - Updated login view to use dynamic labels via `getLoginLabel()` method
  - Added environment variable support for all OAuth providers (not just OpenID)

  ## Testing
  - Tested with Keycloak instance
  - Verified custom labels work via both UI and environment variables
  - Confirmed OIDC discovery endpoint caching works correctly
  - Tested migration rollback functionality

  ## Backwards Compatibility
  - All existing OAuth providers continue to work unchanged
  - Migration is non-breaking (adds nullable column)
  - Default behavior unchanged if custom labels not configured
  - Existing translations still used as fallback

  ## Documentation Updates
  - Updated `.ai/patterns/security-patterns.md` with OpenID provider details
  - Added OAuth configuration examples to `.env.development.example`
  - Updated CHANGELOG.md with feature additions

  ## Use Case
  This enables organizations to use their existing OIDC identity providers (like Keycloak, Auth0, or
  corporate SSO systems) with Coolify, while also being able to customize the login button text to match
  their branding (e.g., "Login with SSO" instead of generic "Login with OpenID").
