### PR TITLE
fix: use original_server for log drain config in generate_compose_file

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -2613,7 +2613,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         } else {
             $docker_compose['services'][$this->container_name]['labels'] = $labels;
         }
-        if ($this->server->isLogDrainEnabled() && $this->application->isLogDrainEnabled()) {
+        if ($this->original_server->isLogDrainEnabled() && $this->application->isLogDrainEnabled()) {
             $docker_compose['services'][$this->container_name]['logging'] = generate_fluentd_configuration();
         }
         if ($this->application->settings->is_gpu_enabled) {


### PR DESCRIPTION
## Summary
When build server is enabled, `$this->server` is switched to point to `$this->build_server` before calling `generate_compose_file()`. Inside `generate_compose_file()`, the log drain configuration check was using `$this->server` which would incorrectly check the build server's settings instead of the deployment server where the container actually runs.

## Changes
- Changed `$this->server->isLogDrainEnabled()` to `$this->original_server->isLogDrainEnabled()` on line 2616

## Root Cause
The `$this->original_server` variable is explicitly initialized to preserve the deployment server reference before any build server switching occurs. Log draining is a runtime concern for the deployment server, not a build-time concern for the build server.

## User Impact
Users with build server enabled who have different configurations between their build and deployment servers will experience incorrect behavior. For example, enabling log draining on the deployment server has no effect because Coolify checks the build server's log drain settings instead.

## Testing
- Verified the change only affects the log drain configuration check
- The fix ensures log drain configuration correctly references the deployment server