### PR TITLE
Fix introduced whitespace on s3 key

### DIFF
--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -654,6 +654,11 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                 $commands[] = "docker run -d --network {$network} --name backup-of-{$this->backup_log_uuid} --rm -v $this->backup_location:$this->backup_location:ro {$fullImageName}";
             }
 
+            // Remove introduced whitespace
+            $endpoint = preg_replace('/\s+/', '', $endpoint);                                                                                                                                                   
+            $key = preg_replace('/\s+/', '', $key);                                                                                                                                                             
+            $secret = preg_replace('/\s+/', '', $secret);
+
             // Escape S3 credentials to prevent command injection
             $escapedEndpoint = escapeshellarg($endpoint);
             $escapedKey = escapeshellarg($key);


### PR DESCRIPTION
key section seems introduce a whitespace that cause a malformed id

- [X] I have listed all changes in the `Changes` section.
- [ ] I have filled out the `Issues` section with the issue/discussion link(s) (if applicable).
- [X] I have tested my changes.
- [ ] I have considered backwards compatibility.
- [ ] I have removed this checklist and any unused sections.

## Changes
- added a regex to remove newline 

## Issues
- fix #7469 and #7594
