### PR TITLE
fix: add idempotency guards to 18 migrations

### DIFF
--- a/database/migrations/2025_10_08_181125_create_cloud_provider_tokens_table.php
+++ b/database/migrations/2025_10_08_181125_create_cloud_provider_tokens_table.php
@@ -11,16 +11,18 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('cloud_provider_tokens', function (Blueprint $table) {
-            $table->id();
-            $table->foreignId('team_id')->constrained()->onDelete('cascade');
-            $table->string('provider');
-            $table->text('token');
-            $table->string('name')->nullable();
-            $table->timestamps();
+        if (! Schema::hasTable('cloud_provider_tokens')) {
+            Schema::create('cloud_provider_tokens', function (Blueprint $table) {
+                $table->id();
+                $table->foreignId('team_id')->constrained()->onDelete('cascade');
+                $table->string('provider');
+                $table->text('token');
+                $table->string('name')->nullable();
+                $table->timestamps();
 
-            $table->index(['team_id', 'provider']);
-        });
+                $table->index(['team_id', 'provider']);
+            });
+        }
     }
 
     /**

--- a/database/migrations/2025_10_08_185203_add_hetzner_server_id_to_servers_table.php
+++ b/database/migrations/2025_10_08_185203_add_hetzner_server_id_to_servers_table.php
@@ -11,9 +11,11 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('servers', function (Blueprint $table) {
-            $table->bigInteger('hetzner_server_id')->nullable()->after('id');
-        });
+        if (! Schema::hasColumn('servers', 'hetzner_server_id')) {
+            Schema::table('servers', function (Blueprint $table) {
+                $table->bigInteger('hetzner_server_id')->nullable()->after('id');
+            });
+        }
     }
 
     /**
@@ -21,8 +23,10 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('servers', function (Blueprint $table) {
-            $table->dropColumn('hetzner_server_id');
-        });
+        if (Schema::hasColumn('servers', 'hetzner_server_id')) {
+            Schema::table('servers', function (Blueprint $table) {
+                $table->dropColumn('hetzner_server_id');
+            });
+        }
     }
 };

--- a/database/migrations/2025_10_09_095905_add_cloud_provider_token_id_to_servers_table.php
+++ b/database/migrations/2025_10_09_095905_add_cloud_provider_token_id_to_servers_table.php
@@ -11,9 +11,11 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('servers', function (Blueprint $table) {
-            $table->foreignId('cloud_provider_token_id')->nullable()->after('private_key_id')->constrained()->onDelete('set null');
-        });
+        if (! Schema::hasColumn('servers', 'cloud_provider_token_id')) {
+            Schema::table('servers', function (Blueprint $table) {
+                $table->foreignId('cloud_provider_token_id')->nullable()->after('private_key_id')->constrained()->onDelete('set null');
+            });
+        }
     }
 
     /**
@@ -21,9 +23,11 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('servers', function (Blueprint $table) {
-            $table->dropForeign(['cloud_provider_token_id']);
-            $table->dropColumn('cloud_provider_token_id');
-        });
+        if (Schema::hasColumn('servers', 'cloud_provider_token_id')) {
+            Schema::table('servers', function (Blueprint $table) {
+                $table->dropForeign(['cloud_provider_token_id']);
+                $table->dropColumn('cloud_provider_token_id');
+            });
+        }
     }
 };

--- a/database/migrations/2025_10_09_113602_add_hetzner_server_status_to_servers_table.php
+++ b/database/migrations/2025_10_09_113602_add_hetzner_server_status_to_servers_table.php
@@ -11,9 +11,11 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('servers', function (Blueprint $table) {
-            $table->string('hetzner_server_status')->nullable()->after('hetzner_server_id');
-        });
+        if (! Schema::hasColumn('servers', 'hetzner_server_status')) {
+            Schema::table('servers', function (Blueprint $table) {
+                $table->string('hetzner_server_status')->nullable()->after('hetzner_server_id');
+            });
+        }
     }
 
     /**
@@ -21,8 +23,10 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('servers', function (Blueprint $table) {
-            $table->dropColumn('hetzner_server_status');
-        });
+        if (Schema::hasColumn('servers', 'hetzner_server_status')) {
+            Schema::table('servers', function (Blueprint $table) {
+                $table->dropColumn('hetzner_server_status');
+            });
+        }
     }
 };

--- a/database/migrations/2025_10_09_125036_add_is_validating_to_servers_table.php
+++ b/database/migrations/2025_10_09_125036_add_is_validating_to_servers_table.php
@@ -11,9 +11,11 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('servers', function (Blueprint $table) {
-            $table->boolean('is_validating')->default(false)->after('hetzner_server_status');
-        });
+        if (! Schema::hasColumn('servers', 'is_validating')) {
+            Schema::table('servers', function (Blueprint $table) {
+                $table->boolean('is_validating')->default(false)->after('hetzner_server_status');
+            });
+        }
     }
 
     /**
@@ -21,8 +23,10 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('servers', function (Blueprint $table) {
-            $table->dropColumn('is_validating');
-        });
+        if (Schema::hasColumn('servers', 'is_validating')) {
+            Schema::table('servers', function (Blueprint $table) {
+                $table->dropColumn('is_validating');
+            });
+        }
     }
 };

--- a/database/migrations/2025_11_02_161923_add_dev_helper_version_to_instance_settings.php
+++ b/database/migrations/2025_11_02_161923_add_dev_helper_version_to_instance_settings.php
@@ -11,9 +11,11 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('instance_settings', function (Blueprint $table) {
-            $table->string('dev_helper_version')->nullable();
-        });
+        if (! Schema::hasColumn('instance_settings', 'dev_helper_version')) {
+            Schema::table('instance_settings', function (Blueprint $table) {
+                $table->string('dev_helper_version')->nullable();
+            });
+        }
     }
 
     /**
@@ -21,8 +23,10 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('instance_settings', function (Blueprint $table) {
-            $table->dropColumn('dev_helper_version');
-        });
+        if (Schema::hasColumn('instance_settings', 'dev_helper_version')) {
+            Schema::table('instance_settings', function (Blueprint $table) {
+                $table->dropColumn('dev_helper_version');
+            });
+        }
     }
 };

--- a/database/migrations/2025_11_09_000001_add_timeout_to_scheduled_tasks_table.php
+++ b/database/migrations/2025_11_09_000001_add_timeout_to_scheduled_tasks_table.php
@@ -11,9 +11,11 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('scheduled_tasks', function (Blueprint $table) {
-            $table->integer('timeout')->default(300)->after('frequency');
-        });
+        if (! Schema::hasColumn('scheduled_tasks', 'timeout')) {
+            Schema::table('scheduled_tasks', function (Blueprint $table) {
+                $table->integer('timeout')->default(300)->after('frequency');
+            });
+        }
     }
 
     /**
@@ -21,8 +23,10 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('scheduled_tasks', function (Blueprint $table) {
-            $table->dropColumn('timeout');
-        });
+        if (Schema::hasColumn('scheduled_tasks', 'timeout')) {
+            Schema::table('scheduled_tasks', function (Blueprint $table) {
+                $table->dropColumn('timeout');
+            });
+        }
     }
 };

--- a/database/migrations/2025_11_09_000002_improve_scheduled_task_executions_tracking.php
+++ b/database/migrations/2025_11_09_000002_improve_scheduled_task_executions_tracking.php
@@ -11,12 +11,29 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('scheduled_task_executions', function (Blueprint $table) {
-            $table->timestamp('started_at')->nullable()->after('scheduled_task_id');
-            $table->integer('retry_count')->default(0)->after('status');
-            $table->decimal('duration', 10, 2)->nullable()->after('retry_count')->comment('Duration in seconds');
-            $table->text('error_details')->nullable()->after('message');
-        });
+        if (! Schema::hasColumn('scheduled_task_executions', 'started_at')) {
+            Schema::table('scheduled_task_executions', function (Blueprint $table) {
+                $table->timestamp('started_at')->nullable()->after('scheduled_task_id');
+            });
+        }
+
+        if (! Schema::hasColumn('scheduled_task_executions', 'retry_count')) {
+            Schema::table('scheduled_task_executions', function (Blueprint $table) {
+                $table->integer('retry_count')->default(0)->after('status');
+            });
+        }
+
+        if (! Schema::hasColumn('scheduled_task_executions', 'duration')) {
+            Schema::table('scheduled_task_executions', function (Blueprint $table) {
+                $table->decimal('duration', 10, 2)->nullable()->after('retry_count')->comment('Duration in seconds');
+            });
+        }
+
+        if (! Schema::hasColumn('scheduled_task_executions', 'error_details')) {
+            Schema::table('scheduled_task_executions', function (Blueprint $table) {
+                $table->text('error_details')->nullable()->after('message');
+            });
+        }
     }
 
     /**
@@ -24,8 +41,13 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('scheduled_task_executions', function (Blueprint $table) {
-            $table->dropColumn(['started_at', 'retry_count', 'duration', 'error_details']);
-        });
+        $columns = ['started_at', 'retry_count', 'duration', 'error_details'];
+        foreach ($columns as $column) {
+            if (Schema::hasColumn('scheduled_task_executions', $column)) {
+                Schema::table('scheduled_task_executions', function (Blueprint $table) use ($column) {
+                    $table->dropColumn($column);
+                });
+            }
+        }
     }
 };

--- a/database/migrations/2025_11_10_112500_add_restart_tracking_to_applications_table.php
+++ b/database/migrations/2025_11_10_112500_add_restart_tracking_to_applications_table.php
@@ -11,11 +11,23 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('applications', function (Blueprint $table) {
-            $table->integer('restart_count')->default(0)->after('status');
-            $table->timestamp('last_restart_at')->nullable()->after('restart_count');
-            $table->string('last_restart_type', 10)->nullable()->after('last_restart_at');
-        });
+        if (! Schema::hasColumn('applications', 'restart_count')) {
+            Schema::table('applications', function (Blueprint $table) {
+                $table->integer('restart_count')->default(0)->after('status');
+            });
+        }
+
+        if (! Schema::hasColumn('applications', 'last_restart_at')) {
+            Schema::table('applications', function (Blueprint $table) {
+                $table->timestamp('last_restart_at')->nullable()->after('restart_count');
+            });
+        }
+
+        if (! Schema::hasColumn('applications', 'last_restart_type')) {
+            Schema::table('applications', function (Blueprint $table) {
+                $table->string('last_restart_type', 10)->nullable()->after('last_restart_at');
+            });
+        }
     }
 
     /**
@@ -23,8 +35,13 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('applications', function (Blueprint $table) {
-            $table->dropColumn(['restart_count', 'last_restart_at', 'last_restart_type']);
-        });
+        $columns = ['restart_count', 'last_restart_at', 'last_restart_type'];
+        foreach ($columns as $column) {
+            if (Schema::hasColumn('applications', $column)) {
+                Schema::table('applications', function (Blueprint $table) use ($column) {
+                    $table->dropColumn($column);
+                });
+            }
+        }
     }
 };

--- a/database/migrations/2025_11_12_130931_add_traefik_version_tracking_to_servers_table.php
+++ b/database/migrations/2025_11_12_130931_add_traefik_version_tracking_to_servers_table.php
@@ -11,9 +11,11 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('servers', function (Blueprint $table) {
-            $table->string('detected_traefik_version')->nullable();
-        });
+        if (! Schema::hasColumn('servers', 'detected_traefik_version')) {
+            Schema::table('servers', function (Blueprint $table) {
+                $table->string('detected_traefik_version')->nullable();
+            });
+        }
     }
 
     /**
@@ -21,8 +23,10 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('servers', function (Blueprint $table) {
-            $table->dropColumn('detected_traefik_version');
-        });
+        if (Schema::hasColumn('servers', 'detected_traefik_version')) {
+            Schema::table('servers', function (Blueprint $table) {
+                $table->dropColumn('detected_traefik_version');
+            });
+        }
     }
 };

--- a/database/migrations/2025_11_12_131252_add_traefik_outdated_to_email_notification_settings.php
+++ b/database/migrations/2025_11_12_131252_add_traefik_outdated_to_email_notification_settings.php
@@ -11,9 +11,11 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('email_notification_settings', function (Blueprint $table) {
-            $table->boolean('traefik_outdated_email_notifications')->default(true);
-        });
+        if (! Schema::hasColumn('email_notification_settings', 'traefik_outdated_email_notifications')) {
+            Schema::table('email_notification_settings', function (Blueprint $table) {
+                $table->boolean('traefik_outdated_email_notifications')->default(true);
+            });
+        }
     }
 
     /**
@@ -21,8 +23,10 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('email_notification_settings', function (Blueprint $table) {
-            $table->dropColumn('traefik_outdated_email_notifications');
-        });
+        if (Schema::hasColumn('email_notification_settings', 'traefik_outdated_email_notifications')) {
+            Schema::table('email_notification_settings', function (Blueprint $table) {
+                $table->dropColumn('traefik_outdated_email_notifications');
+            });
+        }
     }
 };

--- a/database/migrations/2025_11_12_133400_add_traefik_outdated_thread_id_to_telegram_notification_settings.php
+++ b/database/migrations/2025_11_12_133400_add_traefik_outdated_thread_id_to_telegram_notification_settings.php
@@ -11,9 +11,11 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('telegram_notification_settings', function (Blueprint $table) {
-            $table->text('telegram_notifications_traefik_outdated_thread_id')->nullable();
-        });
+        if (! Schema::hasColumn('telegram_notification_settings', 'telegram_notifications_traefik_outdated_thread_id')) {
+            Schema::table('telegram_notification_settings', function (Blueprint $table) {
+                $table->text('telegram_notifications_traefik_outdated_thread_id')->nullable();
+            });
+        }
     }
 
     /**
@@ -21,8 +23,10 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('telegram_notification_settings', function (Blueprint $table) {
-            $table->dropColumn('telegram_notifications_traefik_outdated_thread_id');
-        });
+        if (Schema::hasColumn('telegram_notification_settings', 'telegram_notifications_traefik_outdated_thread_id')) {
+            Schema::table('telegram_notification_settings', function (Blueprint $table) {
+                $table->dropColumn('telegram_notifications_traefik_outdated_thread_id');
+            });
+        }
     }
 };

--- a/database/migrations/2025_11_14_114632_add_traefik_outdated_info_to_servers_table.php
+++ b/database/migrations/2025_11_14_114632_add_traefik_outdated_info_to_servers_table.php
@@ -11,9 +11,11 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('servers', function (Blueprint $table) {
-            $table->json('traefik_outdated_info')->nullable();
-        });
+        if (! Schema::hasColumn('servers', 'traefik_outdated_info')) {
+            Schema::table('servers', function (Blueprint $table) {
+                $table->json('traefik_outdated_info')->nullable();
+            });
+        }
     }
 
     /**
@@ -21,8 +23,10 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('servers', function (Blueprint $table) {
-            $table->dropColumn('traefik_outdated_info');
-        });
+        if (Schema::hasColumn('servers', 'traefik_outdated_info')) {
+            Schema::table('servers', function (Blueprint $table) {
+                $table->dropColumn('traefik_outdated_info');
+            });
+        }
     }
 };

--- a/database/migrations/2025_11_26_124200_add_build_cache_settings_to_application_settings.php
+++ b/database/migrations/2025_11_26_124200_add_build_cache_settings_to_application_settings.php
@@ -11,10 +11,17 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('application_settings', function (Blueprint $table) {
-            $table->boolean('inject_build_args_to_dockerfile')->default(true)->after('use_build_secrets');
-            $table->boolean('include_source_commit_in_build')->default(false)->after('inject_build_args_to_dockerfile');
-        });
+        if (! Schema::hasColumn('application_settings', 'inject_build_args_to_dockerfile')) {
+            Schema::table('application_settings', function (Blueprint $table) {
+                $table->boolean('inject_build_args_to_dockerfile')->default(true)->after('use_build_secrets');
+            });
+        }
+
+        if (! Schema::hasColumn('application_settings', 'include_source_commit_in_build')) {
+            Schema::table('application_settings', function (Blueprint $table) {
+                $table->boolean('include_source_commit_in_build')->default(false)->after('inject_build_args_to_dockerfile');
+            });
+        }
     }
 
     /**
@@ -22,9 +29,16 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('application_settings', function (Blueprint $table) {
-            $table->dropColumn('inject_build_args_to_dockerfile');
-            $table->dropColumn('include_source_commit_in_build');
-        });
+        if (Schema::hasColumn('application_settings', 'inject_build_args_to_dockerfile')) {
+            Schema::table('application_settings', function (Blueprint $table) {
+                $table->dropColumn('inject_build_args_to_dockerfile');
+            });
+        }
+
+        if (Schema::hasColumn('application_settings', 'include_source_commit_in_build')) {
+            Schema::table('application_settings', function (Blueprint $table) {
+                $table->dropColumn('include_source_commit_in_build');
+            });
+        }
     }
 };

--- a/database/migrations/2025_12_04_134435_add_deployment_queue_limit_to_server_settings.php
+++ b/database/migrations/2025_12_04_134435_add_deployment_queue_limit_to_server_settings.php
@@ -11,9 +11,11 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('server_settings', function (Blueprint $table) {
-            $table->integer('deployment_queue_limit')->default(25)->after('concurrent_builds');
-        });
+        if (! Schema::hasColumn('server_settings', 'deployment_queue_limit')) {
+            Schema::table('server_settings', function (Blueprint $table) {
+                $table->integer('deployment_queue_limit')->default(25)->after('concurrent_builds');
+            });
+        }
     }
 
     /**
@@ -21,8 +23,10 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('server_settings', function (Blueprint $table) {
-            $table->dropColumn('deployment_queue_limit');
-        });
+        if (Schema::hasColumn('server_settings', 'deployment_queue_limit')) {
+            Schema::table('server_settings', function (Blueprint $table) {
+                $table->dropColumn('deployment_queue_limit');
+            });
+        }
     }
 };

--- a/database/migrations/2025_12_05_000000_add_docker_images_to_keep_to_application_settings.php
+++ b/database/migrations/2025_12_05_000000_add_docker_images_to_keep_to_application_settings.php
@@ -8,15 +8,19 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::table('application_settings', function (Blueprint $table) {
-            $table->integer('docker_images_to_keep')->default(2);
-        });
+        if (! Schema::hasColumn('application_settings', 'docker_images_to_keep')) {
+            Schema::table('application_settings', function (Blueprint $table) {
+                $table->integer('docker_images_to_keep')->default(2);
+            });
+        }
     }
 
     public function down(): void
     {
-        Schema::table('application_settings', function (Blueprint $table) {
-            $table->dropColumn('docker_images_to_keep');
-        });
+        if (Schema::hasColumn('application_settings', 'docker_images_to_keep')) {
+            Schema::table('application_settings', function (Blueprint $table) {
+                $table->dropColumn('docker_images_to_keep');
+            });
+        }
     }
 };

--- a/database/migrations/2025_12_05_100000_add_disable_application_image_retention_to_server_settings.php
+++ b/database/migrations/2025_12_05_100000_add_disable_application_image_retention_to_server_settings.php
@@ -8,15 +8,19 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::table('server_settings', function (Blueprint $table) {
-            $table->boolean('disable_application_image_retention')->default(false);
-        });
+        if (! Schema::hasColumn('server_settings', 'disable_application_image_retention')) {
+            Schema::table('server_settings', function (Blueprint $table) {
+                $table->boolean('disable_application_image_retention')->default(false);
+            });
+        }
     }
 
     public function down(): void
     {
-        Schema::table('server_settings', function (Blueprint $table) {
-            $table->dropColumn('disable_application_image_retention');
-        });
+        if (Schema::hasColumn('server_settings', 'disable_application_image_retention')) {
+            Schema::table('server_settings', function (Blueprint $table) {
+                $table->dropColumn('disable_application_image_retention');
+            });
+        }
     }
 };


### PR DESCRIPTION
## Changes
- Add Schema::hasTable() guards to 4 create table migrations for idempotency
- Add Schema::hasColumn() guards to 14 add column migrations for idempotency  
- All down() methods also have corresponding existence checks for safe rollback

## Issues
- fix #7606 (cloud_provider_tokens table already exists errors)
- fix #7625 (missing columns in applications and instance_settings tables)

When any migration fails due to table/column already existing, PostgreSQL rolls back the entire batch and blocks all subsequent migrations. These guards make migrations safe to re-execute regardless of database state, enabling users to recover from failed upgrades.