### PR TITLE
Infiscal latest

### DIFF
--- a/templates/compose/infisical.yaml
+++ b/templates/compose/infisical.yaml
@@ -8,7 +8,7 @@
 
 services:
   backend:
-    image: "infisical/infisical:latest"
+    image: "infisical/infisical:v0.154.6"
     environment:
       - SERVICE_URL_BACKEND_8080
       - SITE_URL=${SERVICE_URL_BACKEND_8080}

--- a/templates/compose/infisical.yaml
+++ b/templates/compose/infisical.yaml
@@ -8,7 +8,7 @@
 
 services:
   backend:
-    image: "infisical/infisical:latest-postgres"
+    image: "infisical/infisical:latest"
     environment:
       - SERVICE_URL_BACKEND_8080
       - SITE_URL=${SERVICE_URL_BACKEND_8080}

--- a/templates/test-database-detection.yaml
+++ b/templates/test-database-detection.yaml
@@ -233,7 +233,7 @@ services:
 
   # Infisical - secret management with postgres variant
   application-infisical-postgres:
-    image: infisical/infisical:latest-postgres
+    image: infisical/infisical:latest
     depends_on:
       database-postgres-main:
         condition: service_healthy

--- a/templates/test-database-detection.yaml
+++ b/templates/test-database-detection.yaml
@@ -233,7 +233,7 @@ services:
 
   # Infisical - secret management with postgres variant
   application-infisical-postgres:
-    image: infisical/infisical:latest
+    image: infisical/infisical:v0.154.6
     depends_on:
       database-postgres-main:
         condition: service_healthy


### PR DESCRIPTION
## Changes
- Changing the default tag for infiscal from `latest-postgres` to `v0.154.6` as mentioned on the release notes for `1.147.0` https://github.com/Infisical/infisical/releases/tag/v0.147.0

## Note
I changed the tag on my coolify instance and the upgrade was seamless from `latest-postgres`, but I have not ran any test suite from coolify, since this is the first time I am making a PR here, let me know if there's anything in particular you'd need me to do. 
