### PR TITLE
Fix 419 session expired errors on login/logout with Redis

### DIFF
--- a/app/Http/Responses/LoginResponse.php
+++ b/app/Http/Responses/LoginResponse.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Responses;
+
+use Laravel\Fortify\Contracts\LoginResponse as LoginResponseContract;
+
+class LoginResponse implements LoginResponseContract
+{
+    public function toResponse($request)
+    {
+        // Force session save before redirect to prevent race condition with Redis
+        // This ensures the session is fully persisted before the browser follows the redirect
+        session()->save();
+
+        return redirect()->intended(config('fortify.home'));
+    }
+}

--- a/app/Http/Responses/LogoutResponse.php
+++ b/app/Http/Responses/LogoutResponse.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Responses;
+
+use Laravel\Fortify\Contracts\LogoutResponse as LogoutResponseContract;
+
+class LogoutResponse implements LogoutResponseContract
+{
+    public function toResponse($request)
+    {
+        // Force session save before redirect to prevent race condition with Redis
+        // This ensures the new session state is fully persisted before the browser follows the redirect
+        session()->save();
+
+        return redirect('/');
+    }
+}

--- a/app/Http/Responses/TwoFactorLoginResponse.php
+++ b/app/Http/Responses/TwoFactorLoginResponse.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Responses;
+
+use Illuminate\Http\JsonResponse;
+use Laravel\Fortify\Contracts\TwoFactorLoginResponse as TwoFactorLoginResponseContract;
+use Laravel\Fortify\Fortify;
+
+class TwoFactorLoginResponse implements TwoFactorLoginResponseContract
+{
+    public function toResponse($request)
+    {
+        // Force session save before redirect to prevent race condition with Redis
+        // This ensures the session is fully persisted before the browser follows the redirect
+        session()->save();
+
+        return $request->wantsJson()
+            ? new JsonResponse('', 204)
+            : redirect()->intended(Fortify::redirects('login'));
+    }
+}

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -6,6 +6,9 @@ use App\Actions\Fortify\CreateNewUser;
 use App\Actions\Fortify\ResetUserPassword;
 use App\Actions\Fortify\UpdateUserPassword;
 use App\Actions\Fortify\UpdateUserProfileInformation;
+use App\Http\Responses\LoginResponse;
+use App\Http\Responses\LogoutResponse;
+use App\Http\Responses\TwoFactorLoginResponse;
 use App\Models\OauthSetting;
 use App\Models\User;
 use Illuminate\Cache\RateLimiting\Limit;
@@ -13,7 +16,10 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Fortify\Contracts\LoginResponse as LoginResponseContract;
+use Laravel\Fortify\Contracts\LogoutResponse as LogoutResponseContract;
 use Laravel\Fortify\Contracts\RegisterResponse;
+use Laravel\Fortify\Contracts\TwoFactorLoginResponse as TwoFactorLoginResponseContract;
 use Laravel\Fortify\Fortify;
 
 class FortifyServiceProvider extends ServiceProvider
@@ -35,6 +41,11 @@ class FortifyServiceProvider extends ServiceProvider
                 return redirect(RouteServiceProvider::HOME);
             }
         });
+
+        // Custom login/logout responses to fix Redis session race condition (419 errors)
+        $this->app->singleton(LoginResponseContract::class, LoginResponse::class);
+        $this->app->singleton(LogoutResponseContract::class, LogoutResponse::class);
+        $this->app->singleton(TwoFactorLoginResponseContract::class, TwoFactorLoginResponse::class);
     }
 
     /**


### PR DESCRIPTION
## Changes
- Add custom `LoginResponse`, `LogoutResponse`, and `TwoFactorLoginResponse` classes
- These responses explicitly call `session()->save()` before redirecting
- Fixes race condition where browser follows redirect before session is written to Redis

## Issues
Fixes intermittent 419 "Page Expired" errors on login/logout, especially with 2FA enabled.