### PR TITLE
Change default session driver from Redis to database

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -18,7 +18,7 @@ return [
     |
     */
 
-    'driver' => env('SESSION_DRIVER', 'redis'),
+    'driver' => env('SESSION_DRIVER', 'database'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
## Changes
- Change default session driver from `redis` to `database` in `config/session.php`

## Issues
Fixes intermittent 419 "Page Expired" errors on login/logout. The issue was caused by a race condition with Redis sessions where the browser could follow a redirect before the session was fully written to Redis.

Database sessions are synchronous and don't have this problem. Users who want Redis sessions can still set `SESSION_DRIVER=redis`.