### PR TITLE
migrate openpanel to v2

### DIFF
--- a/templates/compose/openpanel.yaml
+++ b/templates/compose/openpanel.yaml
@@ -130,6 +130,8 @@ services:
 
   clickhouse:
     image: clickhouse/clickhouse-server:25.10.2.65
+    environment:
+      - CLICKHOUSE_SKIP_USER_SETUP=1
     volumes:
       - openpanel_clickhouse_data:/var/lib/clickhouse
       - openpanel_clickhouse_logs:/var/log/clickhouse-server

--- a/templates/compose/openpanel.yaml
+++ b/templates/compose/openpanel.yaml
@@ -7,13 +7,13 @@
 
 services:
   openpanel-dashboard:
-    image: lindesvard/openpanel-dashboard:latest
+    image: lindesvard/openpanel-dashboard:2.0.0
     environment:
       - NODE_ENV=production
-      - NEXT_PUBLIC_SELF_HOSTED=true
+      - SELF_HOSTED=true
       - SERVICE_URL_OPDASHBOARD_3000
-      - NEXT_PUBLIC_API_URL=${SERVICE_URL_OPAPI}
-      - NEXT_PUBLIC_DASHBOARD_URL=${SERVICE_URL_OPDASHBOARD}
+      - API_URL=${SERVICE_URL_OPAPI}
+      - DASHBOARD_URL=${SERVICE_URL_OPDASHBOARD}
       - DATABASE_URL=postgres://${SERVICE_USER_POSTGRES}:${SERVICE_PASSWORD_POSTGRES}@postgres:5432/${OPENPANEL_POSTGRES_DB:-openpanel-db}?schema=public
       - REDIS_URL=redis://default:${SERVICE_PASSWORD_REDIS}@redis:6379
       - CLICKHOUSE_URL=http://clickhouse:8123/openpanel
@@ -37,7 +37,7 @@ services:
       start_period: 15s
 
   openpanel-api:
-    image: lindesvard/openpanel-api:latest
+    image: lindesvard/openpanel-api:2.0.0
     command: >
       sh -c "
         echo 'Running migrations...'
@@ -47,10 +47,10 @@ services:
       "
     environment:
       - NODE_ENV=production
-      - NEXT_PUBLIC_SELF_HOSTED=true
+      - SELF_HOSTED=true
       - SERVICE_URL_OPAPI
-      - NEXT_PUBLIC_API_URL=${SERVICE_URL_OPAPI}
-      - NEXT_PUBLIC_DASHBOARD_URL=${SERVICE_URL_OPDASHBOARD}
+      - API_URL=${SERVICE_URL_OPAPI}
+      - DASHBOARD_URL=${SERVICE_URL_OPDASHBOARD}
       - DATABASE_URL=postgres://${SERVICE_USER_POSTGRES}:${SERVICE_PASSWORD_POSTGRES}@postgres:5432/${OPENPANEL_POSTGRES_DB:-openpanel-db}?schema=public
       - DATABASE_URL_DIRECT=postgres://${SERVICE_USER_POSTGRES}:${SERVICE_PASSWORD_POSTGRES}@postgres:5432/${OPENPANEL_POSTGRES_DB:-openpanel-db}?schema=public
       - REDIS_URL=redis://default:${SERVICE_PASSWORD_REDIS}@redis:6379
@@ -74,13 +74,13 @@ services:
       retries: 5
 
   openpanel-worker:
-    image: lindesvard/openpanel-worker:latest
+    image: lindesvard/openpanel-worker:2.0.0
     environment:
       - DISABLE_BULLBOARD=${DISABLE_BULLBOARD:-1}
       - NODE_ENV=production
-      - NEXT_PUBLIC_SELF_HOSTED=true
+      - SELF_HOSTED=true
       - SERVICE_URL_OPBULLBOARD
-      - NEXT_PUBLIC_API_URL=${SERVICE_URL_OPAPI}
+      - API_URL=${SERVICE_URL_OPAPI}
       - DATABASE_URL=postgres://${SERVICE_USER_POSTGRES}:${SERVICE_PASSWORD_POSTGRES}@postgres:5432/${OPENPANEL_POSTGRES_DB:-openpanel-db}?schema=public
       - DATABASE_URL_DIRECT=postgres://${SERVICE_USER_POSTGRES}:${SERVICE_PASSWORD_POSTGRES}@postgres:5432/${OPENPANEL_POSTGRES_DB:-openpanel-db}?schema=public
       - REDIS_URL=redis://default:${SERVICE_PASSWORD_REDIS}@redis:6379
@@ -129,7 +129,7 @@ services:
       retries: 5
 
   clickhouse:
-    image: clickhouse/clickhouse-server:24.3.2-alpine
+    image: clickhouse/clickhouse-server:25.10.2.65
     volumes:
       - openpanel_clickhouse_data:/var/lib/clickhouse
       - openpanel_clickhouse_logs:/var/log/clickhouse-server


### PR DESCRIPTION
## Changes
- updated clickhouse 24 -> 25
- updated envs (removed NEXT_PUBLIC_ prefix)
- updated openpanel images tags