### PR TITLE
Widen upgrade popup and add dev simulation

### DIFF
--- a/app/Livewire/Upgrade.php
+++ b/app/Livewire/Upgrade.php
@@ -17,11 +17,14 @@ class Upgrade extends Component
 
     public string $currentVersion = '';
 
+    public bool $devMode = false;
+
     protected $listeners = ['updateAvailable' => 'checkUpdate'];
 
     public function mount()
     {
         $this->currentVersion = config('constants.coolify.version');
+        $this->devMode = isDev();
     }
 
     public function checkUpdate()

--- a/resources/views/components/upgrade-progress.blade.php
+++ b/resources/views/components/upgrade-progress.blade.php
@@ -9,7 +9,7 @@
 
     The currentStep variable is inherited from parent Alpine component (upgradeModal).
 --}}
-<div class="w-full max-w-md mx-auto" x-data="{ activeStep: {{ $step }} }" x-effect="activeStep = $el.closest('[x-data]')?.__x?.$data?.currentStep ?? {{ $step }}">
+<div class="w-full" x-data="{ activeStep: {{ $step }} }" x-effect="activeStep = $el.closest('[x-data]')?.__x?.$data?.currentStep ?? {{ $step }}">
     <div class="flex items-center justify-between">
         {{-- Step 1: Preparing --}}
         <div class="flex items-center flex-1">


### PR DESCRIPTION
## Changes
- Set modal width to consistent 48rem for both upgrade states
- Remove max-width constraint from progress stepper 
- Add dev mode with Simulate button for local UI testing
- Simulate cycles through upgrade steps with 2-second delays

## Testing
In development mode (isDev()), the "Upgrade Available" popup now shows a "Simulate" button that allows testing the upgrade progress UI without triggering an actual upgrade. The simulated upgrade cycles through all 4 steps before showing the success state.