### PR TITLE
Fix PostgreSQL version selection in global search

### DIFF
--- a/app/Livewire/GlobalSearch.php
+++ b/app/Livewire/GlobalSearch.php
@@ -1314,11 +1314,6 @@ class GlobalSearch extends Component
                 'server_id' => $this->selectedServerId,
             ];
 
-            // PostgreSQL requires a database_image parameter
-            if ($this->selectedResourceType === 'postgresql') {
-                $queryParams['database_image'] = 'postgres:16-alpine';
-            }
-
             $this->redirect(route('project.resource.create', [
                 'project_uuid' => $this->selectedProjectUuid,
                 'environment_uuid' => $this->selectedEnvironmentUuid,

--- a/app/Livewire/Project/Resource/Create.php
+++ b/app/Livewire/Project/Resource/Create.php
@@ -35,6 +35,13 @@ class Create extends Component
 
             if (in_array($type, DATABASE_TYPES)) {
                 if ($type->value() === 'postgresql') {
+                    // PostgreSQL requires database_image to be explicitly set
+                    // If not provided, fall through to Select component for version selection
+                    if (! $database_image) {
+                        $this->type = $type->value();
+
+                        return;
+                    }
                     $database = create_standalone_postgresql(
                         environmentId: $environment->id,
                         destinationUuid: $destination_uuid,

--- a/templates/service-templates-latest.json
+++ b/templates/service-templates-latest.json
@@ -3953,6 +3953,22 @@
         "logo": "svgs/default.webp",
         "minversion": "0.0.0"
     },
+    "soju": {
+        "documentation": "https://soju.im/?utm_source=coolify.io",
+        "slogan": "A user-friendly IRC bouncer with a modern web interface",
+        "compose": "c2VydmljZXM6CiAgc29qdToKICAgIGltYWdlOiAnY29kZWJlcmcub3JnL2VtZXJzaW9uL3NvanU6bGF0ZXN0JwogICAgdm9sdW1lczoKICAgICAgLSAnc29qdS1kYjovZGInCiAgICAgIC0gJ3NvanUtdXBsb2FkczovdXBsb2FkcycKICAgICAgLSAnc29qdS1ydW46L3J1bi9zb2p1JwogICAgICAtCiAgICAgICAgdHlwZTogYmluZAogICAgICAgIHNvdXJjZTogLi9zb2p1L2NvbmZpZwogICAgICAgIHRhcmdldDogL3NvanUtY29uZmlnCiAgICAgICAgY29udGVudDogImRiIHNxbGl0ZTMgL2RiL21haW4uZGJcbm1lc3NhZ2Utc3RvcmUgZGJcbmZpbGUtdXBsb2FkIGZzIC91cGxvYWRzL1xubGlzdGVuIGlyYytpbnNlY3VyZTovLzAuMC4wLjA6NjY2N1xubGlzdGVuIHdzK2luc2VjdXJlOi8vMC4wLjAuMDo4MFxubGlzdGVuIHVuaXgrYWRtaW46Ly8vcnVuL3NvanUvYWRtaW5cbiIKICAgIG5ldHdvcmtzOgogICAgICBkZWZhdWx0OgogICAgICAgIGFsaWFzZXM6CiAgICAgICAgICAtIGdhbWphLWJhY2tlbmQKICBnYW1qYToKICAgIGltYWdlOiAnY29kZWJlcmcub3JnL2VtZXJzaW9uL2dhbWphOmxhdGVzdCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9HQU1KQV84MAogICAgZGVwZW5kc19vbjoKICAgICAgLSBzb2p1CnZvbHVtZXM6CiAgc29qdS1kYjogbnVsbAogIHNvanUtdXBsb2FkczogbnVsbAogIHNvanUtcnVuOiBudWxsCg==",
+        "tags": [
+            "irc",
+            "bouncer",
+            "chat",
+            "messaging",
+            "relay"
+        ],
+        "category": "communication",
+        "logo": "svgs/soju.svg",
+        "minversion": "0.0.0",
+        "port": "80"
+    },
     "soketi": {
         "documentation": "https://docs.soketi.app?utm_source=coolify.io",
         "slogan": "Soketi is your simple, fast, and resilient open-source WebSockets server.",

--- a/templates/service-templates.json
+++ b/templates/service-templates.json
@@ -3953,6 +3953,22 @@
         "logo": "svgs/default.webp",
         "minversion": "0.0.0"
     },
+    "soju": {
+        "documentation": "https://soju.im/?utm_source=coolify.io",
+        "slogan": "A user-friendly IRC bouncer with a modern web interface",
+        "compose": "c2VydmljZXM6CiAgc29qdToKICAgIGltYWdlOiAnY29kZWJlcmcub3JnL2VtZXJzaW9uL3NvanU6bGF0ZXN0JwogICAgdm9sdW1lczoKICAgICAgLSAnc29qdS1kYjovZGInCiAgICAgIC0gJ3NvanUtdXBsb2FkczovdXBsb2FkcycKICAgICAgLSAnc29qdS1ydW46L3J1bi9zb2p1JwogICAgICAtCiAgICAgICAgdHlwZTogYmluZAogICAgICAgIHNvdXJjZTogLi9zb2p1L2NvbmZpZwogICAgICAgIHRhcmdldDogL3NvanUtY29uZmlnCiAgICAgICAgY29udGVudDogImRiIHNxbGl0ZTMgL2RiL21haW4uZGJcbm1lc3NhZ2Utc3RvcmUgZGJcbmZpbGUtdXBsb2FkIGZzIC91cGxvYWRzL1xubGlzdGVuIGlyYytpbnNlY3VyZTovLzAuMC4wLjA6NjY2N1xubGlzdGVuIHdzK2luc2VjdXJlOi8vMC4wLjAuMDo4MFxubGlzdGVuIHVuaXgrYWRtaW46Ly8vcnVuL3NvanUvYWRtaW5cbiIKICAgIG5ldHdvcmtzOgogICAgICBkZWZhdWx0OgogICAgICAgIGFsaWFzZXM6CiAgICAgICAgICAtIGdhbWphLWJhY2tlbmQKICBnYW1qYToKICAgIGltYWdlOiAnY29kZWJlcmcub3JnL2VtZXJzaW9uL2dhbWphOmxhdGVzdCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9HQU1KQV84MAogICAgZGVwZW5kc19vbjoKICAgICAgLSBzb2p1CnZvbHVtZXM6CiAgc29qdS1kYjogbnVsbAogIHNvanUtdXBsb2FkczogbnVsbAogIHNvanUtcnVuOiBudWxsCg==",
+        "tags": [
+            "irc",
+            "bouncer",
+            "chat",
+            "messaging",
+            "relay"
+        ],
+        "category": "communication",
+        "logo": "svgs/soju.svg",
+        "minversion": "0.0.0",
+        "port": "80"
+    },
     "soketi": {
         "documentation": "https://docs.soketi.app?utm_source=coolify.io",
         "slogan": "Soketi is your simple, fast, and resilient open-source WebSockets server.",


### PR DESCRIPTION
## Changes
- Remove hardcoded database_image parameter from GlobalSearch
- Update Create.php to fall through to Select component when database_image is not provided
- Add type and destination to Select component query string with proper URL mapping
- Jump directly to PostgreSQL version selection step when navigating from global search

This allows users to select their preferred PostgreSQL version instead of automatically creating postgres:16-alpine when using the global search to add a new PostgreSQL database.