### PR TITLE
Fix database status flickering and add restart tracking

### DIFF
--- a/app/Actions/Docker/GetContainersStatus.php
+++ b/app/Actions/Docker/GetContainersStatus.php
@@ -206,27 +206,18 @@ class GetContainersStatus
 
                             if ($statusFromDb !== $containerStatus) {
                                 $updateData = ['status' => $containerStatus];
-
-                                // Update restart tracking if restart count increased
-                                if ($restartCount > $previousRestartCount) {
-                                    $updateData['restart_count'] = $restartCount;
-                                    $updateData['last_restart_at'] = now();
-                                    $updateData['last_restart_type'] = 'crash';
-                                }
-
-                                $database->update($updateData);
                             } else {
                                 $updateData = ['last_online_at' => now()];
-
-                                // Update restart tracking even if status unchanged
-                                if ($restartCount > $previousRestartCount) {
-                                    $updateData['restart_count'] = $restartCount;
-                                    $updateData['last_restart_at'] = now();
-                                    $updateData['last_restart_type'] = 'crash';
-                                }
-
-                                $database->update($updateData);
                             }
+
+                            // Update restart tracking if restart count increased
+                            if ($restartCount > $previousRestartCount) {
+                                $updateData['restart_count'] = $restartCount;
+                                $updateData['last_restart_at'] = now();
+                                $updateData['last_restart_type'] = 'crash';
+                            }
+
+                            $database->update($updateData);
 
                             if ($isPublic) {
                                 $foundTcpProxy = $this->containers->filter(function ($value, $key) use ($uuid) {

--- a/app/Actions/Docker/GetContainersStatus.php
+++ b/app/Actions/Docker/GetContainersStatus.php
@@ -199,10 +199,33 @@ class GetContainersStatus
                             $isPublic = data_get($database, 'is_public');
                             $foundDatabases[] = $database->id;
                             $statusFromDb = $database->status;
+
+                            // Track restart count for databases (single-container)
+                            $restartCount = data_get($container, 'RestartCount', 0);
+                            $previousRestartCount = $database->restart_count ?? 0;
+
                             if ($statusFromDb !== $containerStatus) {
-                                $database->update(['status' => $containerStatus]);
+                                $updateData = ['status' => $containerStatus];
+
+                                // Update restart tracking if restart count increased
+                                if ($restartCount > $previousRestartCount) {
+                                    $updateData['restart_count'] = $restartCount;
+                                    $updateData['last_restart_at'] = now();
+                                    $updateData['last_restart_type'] = 'crash';
+                                }
+
+                                $database->update($updateData);
                             } else {
-                                $database->update(['last_online_at' => now()]);
+                                $updateData = ['last_online_at' => now()];
+
+                                // Update restart tracking even if status unchanged
+                                if ($restartCount > $previousRestartCount) {
+                                    $updateData['restart_count'] = $restartCount;
+                                    $updateData['last_restart_at'] = now();
+                                    $updateData['last_restart_type'] = 'crash';
+                                }
+
+                                $database->update($updateData);
                             }
 
                             if ($isPublic) {
@@ -365,7 +388,13 @@ class GetContainersStatus
             if (str($database->status)->startsWith('exited')) {
                 continue;
             }
-            $database->update(['status' => 'exited']);
+            // Reset restart tracking when database exits completely
+            $database->update([
+                'status' => 'exited',
+                'restart_count' => 0,
+                'last_restart_at' => null,
+                'last_restart_type' => null,
+            ]);
 
             $name = data_get($database, 'name');
             $fqdn = data_get($database, 'fqdn');

--- a/app/Models/StandaloneClickhouse.php
+++ b/app/Models/StandaloneClickhouse.php
@@ -20,6 +20,7 @@ class StandaloneClickhouse extends BaseModel
         'clickhouse_password' => 'encrypted',
         'restart_count' => 'integer',
         'last_restart_at' => 'datetime',
+        'last_restart_type' => 'string',
     ];
 
     protected static function booted()

--- a/app/Models/StandaloneClickhouse.php
+++ b/app/Models/StandaloneClickhouse.php
@@ -18,6 +18,8 @@ class StandaloneClickhouse extends BaseModel
 
     protected $casts = [
         'clickhouse_password' => 'encrypted',
+        'restart_count' => 'integer',
+        'last_restart_at' => 'datetime',
     ];
 
     protected static function booted()
@@ -247,6 +249,7 @@ class StandaloneClickhouse extends BaseModel
                 $encodedUser = rawurlencode($this->clickhouse_admin_user);
                 $encodedPass = rawurlencode($this->clickhouse_admin_password);
                 $database = $this->clickhouse_db ?? 'default';
+
                 return "clickhouse://{$encodedUser}:{$encodedPass}@{$this->uuid}:9000/{$database}";
             },
         );
@@ -264,6 +267,7 @@ class StandaloneClickhouse extends BaseModel
                     $encodedUser = rawurlencode($this->clickhouse_admin_user);
                     $encodedPass = rawurlencode($this->clickhouse_admin_password);
                     $database = $this->clickhouse_db ?? 'default';
+
                     return "clickhouse://{$encodedUser}:{$encodedPass}@{$serverIp}:{$this->public_port}/{$database}";
                 }
 

--- a/app/Models/StandaloneDragonfly.php
+++ b/app/Models/StandaloneDragonfly.php
@@ -20,6 +20,7 @@ class StandaloneDragonfly extends BaseModel
         'dragonfly_password' => 'encrypted',
         'restart_count' => 'integer',
         'last_restart_at' => 'datetime',
+        'last_restart_type' => 'string',
     ];
 
     protected static function booted()

--- a/app/Models/StandaloneDragonfly.php
+++ b/app/Models/StandaloneDragonfly.php
@@ -18,6 +18,8 @@ class StandaloneDragonfly extends BaseModel
 
     protected $casts = [
         'dragonfly_password' => 'encrypted',
+        'restart_count' => 'integer',
+        'last_restart_at' => 'datetime',
     ];
 
     protected static function booted()

--- a/app/Models/StandaloneKeydb.php
+++ b/app/Models/StandaloneKeydb.php
@@ -18,6 +18,8 @@ class StandaloneKeydb extends BaseModel
 
     protected $casts = [
         'keydb_password' => 'encrypted',
+        'restart_count' => 'integer',
+        'last_restart_at' => 'datetime',
     ];
 
     protected static function booted()

--- a/app/Models/StandaloneKeydb.php
+++ b/app/Models/StandaloneKeydb.php
@@ -20,6 +20,7 @@ class StandaloneKeydb extends BaseModel
         'keydb_password' => 'encrypted',
         'restart_count' => 'integer',
         'last_restart_at' => 'datetime',
+        'last_restart_type' => 'string',
     ];
 
     protected static function booted()

--- a/app/Models/StandaloneMariadb.php
+++ b/app/Models/StandaloneMariadb.php
@@ -21,6 +21,7 @@ class StandaloneMariadb extends BaseModel
         'mariadb_password' => 'encrypted',
         'restart_count' => 'integer',
         'last_restart_at' => 'datetime',
+        'last_restart_type' => 'string',
     ];
 
     protected static function booted()

--- a/app/Models/StandaloneMariadb.php
+++ b/app/Models/StandaloneMariadb.php
@@ -19,6 +19,8 @@ class StandaloneMariadb extends BaseModel
 
     protected $casts = [
         'mariadb_password' => 'encrypted',
+        'restart_count' => 'integer',
+        'last_restart_at' => 'datetime',
     ];
 
     protected static function booted()

--- a/app/Models/StandaloneMongodb.php
+++ b/app/Models/StandaloneMongodb.php
@@ -19,6 +19,7 @@ class StandaloneMongodb extends BaseModel
     protected $casts = [
         'restart_count' => 'integer',
         'last_restart_at' => 'datetime',
+        'last_restart_type' => 'string',
     ];
 
     protected static function booted()

--- a/app/Models/StandaloneMongodb.php
+++ b/app/Models/StandaloneMongodb.php
@@ -16,6 +16,11 @@ class StandaloneMongodb extends BaseModel
 
     protected $appends = ['internal_db_url', 'external_db_url', 'database_type', 'server_status'];
 
+    protected $casts = [
+        'restart_count' => 'integer',
+        'last_restart_at' => 'datetime',
+    ];
+
     protected static function booted()
     {
         static::created(function ($database) {

--- a/app/Models/StandaloneMysql.php
+++ b/app/Models/StandaloneMysql.php
@@ -21,6 +21,7 @@ class StandaloneMysql extends BaseModel
         'mysql_root_password' => 'encrypted',
         'restart_count' => 'integer',
         'last_restart_at' => 'datetime',
+        'last_restart_type' => 'string',
     ];
 
     protected static function booted()

--- a/app/Models/StandaloneMysql.php
+++ b/app/Models/StandaloneMysql.php
@@ -19,6 +19,8 @@ class StandaloneMysql extends BaseModel
     protected $casts = [
         'mysql_password' => 'encrypted',
         'mysql_root_password' => 'encrypted',
+        'restart_count' => 'integer',
+        'last_restart_at' => 'datetime',
     ];
 
     protected static function booted()

--- a/app/Models/StandalonePostgresql.php
+++ b/app/Models/StandalonePostgresql.php
@@ -19,6 +19,8 @@ class StandalonePostgresql extends BaseModel
     protected $casts = [
         'init_scripts' => 'array',
         'postgres_password' => 'encrypted',
+        'restart_count' => 'integer',
+        'last_restart_at' => 'datetime',
     ];
 
     protected static function booted()

--- a/app/Models/StandalonePostgresql.php
+++ b/app/Models/StandalonePostgresql.php
@@ -21,6 +21,7 @@ class StandalonePostgresql extends BaseModel
         'postgres_password' => 'encrypted',
         'restart_count' => 'integer',
         'last_restart_at' => 'datetime',
+        'last_restart_type' => 'string',
     ];
 
     protected static function booted()

--- a/app/Models/StandaloneRedis.php
+++ b/app/Models/StandaloneRedis.php
@@ -16,6 +16,11 @@ class StandaloneRedis extends BaseModel
 
     protected $appends = ['internal_db_url', 'external_db_url', 'database_type', 'server_status'];
 
+    protected $casts = [
+        'restart_count' => 'integer',
+        'last_restart_at' => 'datetime',
+    ];
+
     protected static function booted()
     {
         static::created(function ($database) {

--- a/app/Models/StandaloneRedis.php
+++ b/app/Models/StandaloneRedis.php
@@ -19,6 +19,7 @@ class StandaloneRedis extends BaseModel
     protected $casts = [
         'restart_count' => 'integer',
         'last_restart_at' => 'datetime',
+        'last_restart_type' => 'string',
     ];
 
     protected static function booted()

--- a/database/migrations/2025_12_17_000002_add_restart_tracking_to_standalone_databases.php
+++ b/database/migrations/2025_12_17_000002_add_restart_tracking_to_standalone_databases.php
@@ -1,0 +1,66 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * The standalone database tables to add restart tracking columns to.
+     */
+    private array $tables = [
+        'standalone_postgresqls',
+        'standalone_mysqls',
+        'standalone_mariadbs',
+        'standalone_redis',
+        'standalone_mongodbs',
+        'standalone_keydbs',
+        'standalone_dragonflies',
+        'standalone_clickhouses',
+    ];
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        foreach ($this->tables as $table) {
+            if (! Schema::hasColumn($table, 'restart_count')) {
+                Schema::table($table, function (Blueprint $blueprint) {
+                    $blueprint->integer('restart_count')->default(0)->after('status');
+                });
+            }
+
+            if (! Schema::hasColumn($table, 'last_restart_at')) {
+                Schema::table($table, function (Blueprint $blueprint) {
+                    $blueprint->timestamp('last_restart_at')->nullable()->after('restart_count');
+                });
+            }
+
+            if (! Schema::hasColumn($table, 'last_restart_type')) {
+                Schema::table($table, function (Blueprint $blueprint) {
+                    $blueprint->string('last_restart_type', 10)->nullable()->after('last_restart_at');
+                });
+            }
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $columns = ['restart_count', 'last_restart_at', 'last_restart_type'];
+
+        foreach ($this->tables as $table) {
+            foreach ($columns as $column) {
+                if (Schema::hasColumn($table, $column)) {
+                    Schema::table($table, function (Blueprint $blueprint) use ($column) {
+                        $blueprint->dropColumn($column);
+                    });
+                }
+            }
+        }
+    }
+};

--- a/templates/service-templates-latest.json
+++ b/templates/service-templates-latest.json
@@ -3953,6 +3953,22 @@
         "logo": "svgs/default.webp",
         "minversion": "0.0.0"
     },
+    "soju": {
+        "documentation": "https://soju.im/?utm_source=coolify.io",
+        "slogan": "A user-friendly IRC bouncer with a modern web interface",
+        "compose": "c2VydmljZXM6CiAgc29qdToKICAgIGltYWdlOiAnY29kZWJlcmcub3JnL2VtZXJzaW9uL3NvanU6bGF0ZXN0JwogICAgdm9sdW1lczoKICAgICAgLSAnc29qdS1kYjovZGInCiAgICAgIC0gJ3NvanUtdXBsb2FkczovdXBsb2FkcycKICAgICAgLSAnc29qdS1ydW46L3J1bi9zb2p1JwogICAgICAtCiAgICAgICAgdHlwZTogYmluZAogICAgICAgIHNvdXJjZTogLi9zb2p1L2NvbmZpZwogICAgICAgIHRhcmdldDogL3NvanUtY29uZmlnCiAgICAgICAgY29udGVudDogImRiIHNxbGl0ZTMgL2RiL21haW4uZGJcbm1lc3NhZ2Utc3RvcmUgZGJcbmZpbGUtdXBsb2FkIGZzIC91cGxvYWRzL1xubGlzdGVuIGlyYytpbnNlY3VyZTovLzAuMC4wLjA6NjY2N1xubGlzdGVuIHdzK2luc2VjdXJlOi8vMC4wLjAuMDo4MFxubGlzdGVuIHVuaXgrYWRtaW46Ly8vcnVuL3NvanUvYWRtaW5cbiIKICAgIG5ldHdvcmtzOgogICAgICBkZWZhdWx0OgogICAgICAgIGFsaWFzZXM6CiAgICAgICAgICAtIGdhbWphLWJhY2tlbmQKICBnYW1qYToKICAgIGltYWdlOiAnY29kZWJlcmcub3JnL2VtZXJzaW9uL2dhbWphOmxhdGVzdCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9HQU1KQV84MAogICAgZGVwZW5kc19vbjoKICAgICAgLSBzb2p1CnZvbHVtZXM6CiAgc29qdS1kYjogbnVsbAogIHNvanUtdXBsb2FkczogbnVsbAogIHNvanUtcnVuOiBudWxsCg==",
+        "tags": [
+            "irc",
+            "bouncer",
+            "chat",
+            "messaging",
+            "relay"
+        ],
+        "category": "communication",
+        "logo": "svgs/soju.svg",
+        "minversion": "0.0.0",
+        "port": "80"
+    },
     "soketi": {
         "documentation": "https://docs.soketi.app?utm_source=coolify.io",
         "slogan": "Soketi is your simple, fast, and resilient open-source WebSockets server.",

--- a/templates/service-templates.json
+++ b/templates/service-templates.json
@@ -3953,6 +3953,22 @@
         "logo": "svgs/default.webp",
         "minversion": "0.0.0"
     },
+    "soju": {
+        "documentation": "https://soju.im/?utm_source=coolify.io",
+        "slogan": "A user-friendly IRC bouncer with a modern web interface",
+        "compose": "c2VydmljZXM6CiAgc29qdToKICAgIGltYWdlOiAnY29kZWJlcmcub3JnL2VtZXJzaW9uL3NvanU6bGF0ZXN0JwogICAgdm9sdW1lczoKICAgICAgLSAnc29qdS1kYjovZGInCiAgICAgIC0gJ3NvanUtdXBsb2FkczovdXBsb2FkcycKICAgICAgLSAnc29qdS1ydW46L3J1bi9zb2p1JwogICAgICAtCiAgICAgICAgdHlwZTogYmluZAogICAgICAgIHNvdXJjZTogLi9zb2p1L2NvbmZpZwogICAgICAgIHRhcmdldDogL3NvanUtY29uZmlnCiAgICAgICAgY29udGVudDogImRiIHNxbGl0ZTMgL2RiL21haW4uZGJcbm1lc3NhZ2Utc3RvcmUgZGJcbmZpbGUtdXBsb2FkIGZzIC91cGxvYWRzL1xubGlzdGVuIGlyYytpbnNlY3VyZTovLzAuMC4wLjA6NjY2N1xubGlzdGVuIHdzK2luc2VjdXJlOi8vMC4wLjAuMDo4MFxubGlzdGVuIHVuaXgrYWRtaW46Ly8vcnVuL3NvanUvYWRtaW5cbiIKICAgIG5ldHdvcmtzOgogICAgICBkZWZhdWx0OgogICAgICAgIGFsaWFzZXM6CiAgICAgICAgICAtIGdhbWphLWJhY2tlbmQKICBnYW1qYToKICAgIGltYWdlOiAnY29kZWJlcmcub3JnL2VtZXJzaW9uL2dhbWphOmxhdGVzdCcKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9HQU1KQV84MAogICAgZGVwZW5kc19vbjoKICAgICAgLSBzb2p1CnZvbHVtZXM6CiAgc29qdS1kYjogbnVsbAogIHNvanUtdXBsb2FkczogbnVsbAogIHNvanUtcnVuOiBudWxsCg==",
+        "tags": [
+            "irc",
+            "bouncer",
+            "chat",
+            "messaging",
+            "relay"
+        ],
+        "category": "communication",
+        "logo": "svgs/soju.svg",
+        "minversion": "0.0.0",
+        "port": "80"
+    },
     "soketi": {
         "documentation": "https://docs.soketi.app?utm_source=coolify.io",
         "slogan": "Soketi is your simple, fast, and resilient open-source WebSockets server.",


### PR DESCRIPTION
## Changes

- Fix restarting database status flickering by tracking containers in active/transient states
- Add `isActiveOrTransient()` helper to distinguish active states from terminal states
- Add restart_count tracking to all 8 standalone database types via migration
- Update GetContainersStatus to extract and track restart counts from Docker
- Safeguard updateNotFoundDatabaseStatus against empty container collections

## Issues

Aligns database restart status reporting with how applications handle it.