### PR TITLE
fix: add persistent storage for Dolibarr documents and custom modules

### DIFF
--- a/templates/compose/dolibarr.yaml
+++ b/templates/compose/dolibarr.yaml
@@ -22,6 +22,9 @@ services:
       - DOLI_CRON=${DOLI_CRON:-0}
       - DOLI_INIT_DEMO=${DOLI_INIT_DEMO:-0}
       - DOLI_COMPANY_NAME=${DOLI_COMPANY_NAME:-MyBigCompany}
+    volumes:
+      - dolibarr_docs:/var/www/documents
+      - dolibarr_custom:/var/www/html/custom
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:80"]
       interval: 2s


### PR DESCRIPTION
Fixes #5950

## Changes
Added persistent volumes for Dolibarr service:
- `dolibarr_docs:/var/www/documents` - stores generated documents
- `dolibarr_custom:/var/www/html/custom` - stores custom modules

Without these volumes, documents and custom modules are lost when the container restarts.