### PR TITLE
fix(deployment): Remove redundant docker rm when using --rm flag

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -3176,8 +3176,7 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
         try {
             $timeout = isDev() ? 1 : 30;
             $this->execute_remote_command(
-                ["docker stop -t $timeout $containerName", 'hidden' => true, 'ignore_errors' => true],
-                ["docker rm -f $containerName", 'hidden' => true, 'ignore_errors' => true]
+                ["docker stop -t $timeout $containerName", 'hidden' => true, 'ignore_errors' => true]
             );
         } catch (Exception $error) {
             $this->application_deployment_queue->addLogEntry("Error stopping container $containerName: ".$error->getMessage(), 'stderr');

--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -669,7 +669,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             $this->add_to_error_output($e->getMessage());
             throw $e;
         } finally {
-            $command = "docker rm -f backup-of-{$this->backup_log_uuid}";
+            $command = "docker stop backup-of-{$this->backup_log_uuid}";
             instant_remote_process([$command], $this->server, true, false, null, disableMultiplexing: true);
         }
     }


### PR DESCRIPTION
## Changes
- Removed redundant `docker rm` from `graceful_shutdown_container()` in ApplicationDeploymentJob since containers are started with `--rm` flag
- Changed `docker rm -f` to `docker stop` in DatabaseBackupJob's S3 upload cleanup since the container runs in detached mode and needs to be stopped (the `--rm` flag automatically removes it)

## Details
Helper containers started with the `--rm` flag are automatically removed when they stop. The previous implementation was trying to explicitly remove containers that had already been auto-removed, causing error messages in deployment logs.