### PR TITLE
fix: update API docs for list projects endpoint

### DIFF
--- a/app/Http/Controllers/Api/ProjectController.php
+++ b/app/Http/Controllers/Api/ProjectController.php
@@ -29,7 +29,7 @@ class ProjectController extends Controller
                         mediaType: 'application/json',
                         schema: new OA\Schema(
                             type: 'array',
-                            items: new OA\Items(ref: '#/components/schemas/Project')
+                            items: new OA\Items(ref: '#/components/schemas/ProjectListItem')
                         )
                     ),
                 ]),

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4194,7 +4194,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Project'
+                  $ref: '#/components/schemas/ProjectListItem'
         '401':
           $ref: '#/components/responses/401'
         '400':
@@ -6249,6 +6249,18 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Environment'
+      type: object
+    ProjectListItem:
+      description: 'Project list item model (used in list endpoints, does not include environments)'
+      properties:
+        id:
+          type: integer
+        uuid:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
       type: object
     Server:
       description: 'Server model'


### PR DESCRIPTION
## Summary
The `GET /api/v1/projects` endpoint documentation incorrectly referenced the full `Project` schema which includes `environments`, but the actual API only returns `id`, `uuid`, `name`, and `description`.

## Changes
- Added a new `ProjectListItem` schema for the list endpoint
- Updated the `/projects` endpoint to reference `ProjectListItem` 
- Updated the PHP OpenAPI annotation to match

## Related Issue
Fixes #7702