### PR TITLE
fix: link webhook button to GitHub docs instead of repo settings

### DIFF
--- a/resources/views/livewire/project/shared/webhooks.blade.php
+++ b/resources/views/livewire/project/shared/webhooks.blade.php
@@ -27,7 +27,7 @@
                                 label="GitHub Webhook Secret" id="githubManualWebhookSecret"></x-forms.input>
                         @endcan
                     </div>
-                    <a target="_blank" class="flex hover:no-underline" href="{{ $resource?->gitWebhook }}">
+                    <a target="_blank" class="flex hover:no-underline" href="https://docs.github.com/en/webhooks/using-webhooks/creating-webhooks">
                         <x-forms.button>Webhook Configuration on GitHub
                             <x-external-link />
                         </x-forms.button>


### PR DESCRIPTION
## Summary
The "Webhook Configuration on GitHub" button was linking to the repository's settings/hooks page which users cannot access for public repositories.

## Changes
Changed the link to point to GitHub's official webhook documentation which is accessible to everyone.

## Related Issue
Fixes #7514