### PR TITLE
feat: add UTF-8/Unicode support for project descriptions

### DIFF
--- a/app/Support/ValidationPatterns.php
+++ b/app/Support/ValidationPatterns.php
@@ -14,10 +14,11 @@ class ValidationPatterns
     public const NAME_PATTERN = '/^[a-zA-Z0-9\s\-_.:\/()]+$/';
 
     /**
-     * Pattern for descriptions (allows more characters including quotes, commas, etc.)
-     * More permissive than names but still restricts dangerous characters
+     * Pattern for descriptions (allows Unicode letters/numbers and common punctuation)
+     * Uses \p{L} for any Unicode letter and \p{N} for any Unicode number
+     * The /u modifier enables Unicode mode
      */
-    public const DESCRIPTION_PATTERN = '/^[a-zA-Z0-9\s\-_.:\/()\'\",.!?@#%&+=\[\]{}|~`*]+$/';
+    public const DESCRIPTION_PATTERN = '/^[\p{L}\p{N}\s\-_.:\/()\'\\",.!?@#%&+=\[\]{}|~`*]+$/u';
 
     /**
      * Get validation rules for name fields
@@ -78,7 +79,7 @@ class ValidationPatterns
     public static function descriptionMessages(): array
     {
         return [
-            'description.regex' => 'The description contains invalid characters. Only letters, numbers, spaces, and common punctuation (- _ . : / () \' " , ! ? @ # % & + = [] {} | ~ ` *) are allowed.',
+            'description.regex' => 'The description contains invalid characters. Letters (including Unicode), numbers, spaces, and common punctuation (- _ . : / () \' " , ! ? @ # % & + = [] {} | ~ ` *) are allowed.',
             'description.max' => 'The description may not be greater than :max characters.',
         ];
     }


### PR DESCRIPTION
## Summary
Updated `DESCRIPTION_PATTERN` to support Unicode characters so users can write project descriptions in any language (Chinese, Turkish, etc.).

## Changes
- Changed regex pattern to use `\p{L}` (any Unicode letter) and `\p{N}` (any Unicode number)
- Added `/u` modifier to enable Unicode mode
- Updated validation message to reflect Unicode support

## Related Issue
Fixes #7681