### PR TITLE
fix(templates/supabase): Add missing SERVICE_URL_SUPABASEKONG environment variable definition

### DIFF
--- a/templates/compose/supabase.yaml
+++ b/templates/compose/supabase.yaml
@@ -15,6 +15,7 @@ services:
       supabase-analytics:
         condition: service_healthy
     environment:
+      - SERVICE_URL_SUPABASEKONG
       - SERVICE_URL_SUPABASEKONG_8000
       - KONG_PORT_MAPS=443:8000
       - JWT_SECRET=${SERVICE_PASSWORD_JWT}


### PR DESCRIPTION
This variable is present when deploying Supabase on Coolify, but does not react to changes made to Kong's domain name. Currently, it will remain with the initially generated coolify domain name value and cannot be edited manually (regular env edit view grays the field out, dev mode ignores the changes).

Declaring it in the compose makes it react to the changes, just like `SERVICE_URL_SUPABASEKONG_8000` which was already setup accordingly.

## Changes
- Adds `SERVICE_URL_SUPABASEKONG` to the explicitly-declared Supabase environment variables in the compose template
