### PR TITLE
fix(sentinel): Add missing instantSave method and prevent duplicate notifications

### DIFF
--- a/app/Livewire/Server/Sentinel.php
+++ b/app/Livewire/Server/Sentinel.php
@@ -110,26 +110,6 @@ class Sentinel extends Component
         }
     }
 
-    public function updatedIsSentinelDebugEnabled($value)
-    {
-        try {
-            $this->submit();
-            $this->restartSentinel();
-        } catch (\Throwable $e) {
-            return handleError($e, $this);
-        }
-    }
-
-    public function updatedIsMetricsEnabled($value)
-    {
-        try {
-            $this->submit();
-            $this->restartSentinel();
-        } catch (\Throwable $e) {
-            return handleError($e, $this);
-        }
-    }
-
     public function updatedIsSentinelEnabled($value)
     {
         try {
@@ -170,6 +150,16 @@ class Sentinel extends Component
         try {
             $this->syncData(true);
             $this->dispatch('success', 'Sentinel settings updated.');
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function instantSave()
+    {
+        try {
+            $this->syncData(true);
+            $this->restartSentinel();
         } catch (\Throwable $e) {
             return handleError($e, $this);
         }


### PR DESCRIPTION
## Changes
- Add public `instantSave()` method to handle instant saves from checkbox clicks
- Remove redundant `updatedIsMetricsEnabled()` and `updatedIsSentinelDebugEnabled()` hooks that were causing duplicate notifications

## Issues
- Fixes error: "Unable to call component method. Public method [instantSave] not found on component"
- Prevents duplicate notifications when toggling metrics or debug checkboxes