### PR TITLE
fix(service): correct POSTGRES_HOST in freshrss

### DIFF
--- a/templates/compose/freshrss-with-postgresql.yaml
+++ b/templates/compose/freshrss-with-postgresql.yaml
@@ -14,7 +14,7 @@ services:
       - POSTGRES_DB=${POSTGRESQL_DATABASE:-freshrss}
       - POSTGRES_USER=${SERVICE_USER_POSTGRESQL}
       - POSTGRES_PASSWORD=${SERVICE_PASSWORD_POSTGRESQL}
-      - POSTGRES_HOST=postgresql
+      - POSTGRES_HOST=freshrss-db
     volumes:
       - freshrss-data:/var/www/FreshRSS/data
       - freshrss-extensions:/var/www/FreshRSS/extensions


### PR DESCRIPTION
## Changes

- fix(service): `POSTGRES_HOST` environment variable in `freshrss-with-postgresql.yaml` was pointing to `postgresql` but the actual PostgreSQL service is named `freshrss-db`

## Issues

- fixes https://github.com/coollabsio/coolify/issues/6885