### PR TITLE
fix: cast docker version to int for proper comparison

### DIFF
--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -129,8 +129,8 @@ function format_docker_envs_to_json($rawOutput)
 }
 function checkMinimumDockerEngineVersion($dockerVersion)
 {
-    $majorDockerVersion = str($dockerVersion)->before('.')->value();
-    $requiredDockerVersion = str(config('constants.docker.minimum_required_version'))->before('.')->value();
+    $majorDockerVersion = (int) str($dockerVersion)->before('.')->value();
+    $requiredDockerVersion = (int) str(config('constants.docker.minimum_required_version'))->before('.')->value();
     if ($majorDockerVersion < $requiredDockerVersion) {
         $dockerVersion = null;
     }


### PR DESCRIPTION
## Changes

- fix: `checkMinimumDockerEngineVersion` function comparing Docker major versions as strings, which could lead to incorrect comparisons in some edge cases

## Issues

- fixes: https://github.com/coollabsio/coolify/issues/6610