### PR TITLE
fix: allow Unicode characters in description fields

### DIFF
--- a/app/Support/ValidationPatterns.php
+++ b/app/Support/ValidationPatterns.php
@@ -14,10 +14,10 @@ class ValidationPatterns
     public const NAME_PATTERN = '/^[a-zA-Z0-9\s\-_.:\/()]+$/';
 
     /**
-     * Pattern for descriptions (allows more characters including quotes, commas, etc.)
-     * More permissive than names but still restricts dangerous characters
+     * Pattern for descriptions (allows Unicode letters/numbers including quotes, commas, etc.)
+     * Uses Unicode character classes to support non-ASCII characters (Japanese, Turkish, Chinese, etc.)
      */
-    public const DESCRIPTION_PATTERN = '/^[a-zA-Z0-9\s\-_.:\/()\'\",.!?@#%&+=\[\]{}|~`*]+$/';
+    public const DESCRIPTION_PATTERN = '/^[\p{L}\p{N}\s\-_.:\/()\'\",.!?@#%&+=\[\]{}|~`*]+$/u';
 
     /**
      * Get validation rules for name fields
@@ -78,7 +78,7 @@ class ValidationPatterns
     public static function descriptionMessages(): array
     {
         return [
-            'description.regex' => 'The description contains invalid characters. Only letters, numbers, spaces, and common punctuation (- _ . : / () \' " , ! ? @ # % & + = [] {} | ~ ` *) are allowed.',
+            'description.regex' => 'The description contains invalid characters. Letters (including Unicode), numbers, spaces, and common punctuation (- _ . : / () \' " , ! ? @ # % & + = [] {} | ~ ` *) are allowed.',
             'description.max' => 'The description may not be greater than :max characters.',
         ];
     }


### PR DESCRIPTION
## Description
Fixes #6904

The `DESCRIPTION_PATTERN` regex was too restrictive, only allowing ASCII letters (`a-zA-Z`) and numbers (`0-9`). This prevented users from writing descriptions in non-English languages like Japanese, Turkish, Chinese, etc.

## Changes
- Updated regex to use Unicode character classes: `\p{L}` for letters and `\p{N}` for numbers
- Added `u` (Unicode) modifier to the regex pattern
- Updated error message to reflect that Unicode characters are allowed

## Before
```php
'/^[a-zA-Z0-9\s\-_.:\/()\'\",.!?@#%&+=[\]{}|~`*]+$/'
```

## After
```php
'/^[\p{L}\p{N}\s\-_.:\/()\'\",.!?@#%&+=[\]{}|~`*]+$/u'
```

## Testing
Users can now write descriptions in their native languages (Japanese: こんにちは, Turkish: Türkçe, Chinese: 中文) while still maintaining security by restricting dangerous special characters.