### PR TITLE
fix: instance public ips initialization validation

### DIFF
--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -1164,7 +1164,7 @@ function get_public_ips()
         $ipv4 = $first->output();
         if ($ipv4) {
             $ipv4 = trim($ipv4);
-            $validate_ipv4 = filter_var($ipv4, FILTER_VALIDATE_IP);
+            $validate_ipv4 = filter_var($ipv4, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4);
             if ($validate_ipv4 == false) {
                 echo "Invalid ipv4: $ipv4\n";
 
@@ -1179,7 +1179,7 @@ function get_public_ips()
         $ipv6 = $second->output();
         if ($ipv6) {
             $ipv6 = trim($ipv6);
-            $validate_ipv6 = filter_var($ipv6, FILTER_VALIDATE_IP);
+            $validate_ipv6 = filter_var($ipv6, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6);
             if ($validate_ipv6 == false) {
                 echo "Invalid ipv6: $ipv6\n";
 


### PR DESCRIPTION
## Changes

- fix: `get_public_ips()` function only using `FILTER_VALIDATE_IP` without specific flags, which accepts both IPv4 and IPv6 addresses. This could cause IPv6 addresses to be stored in the `public_ipv4` field and vice versa during initialization.

## Issues

- fixes https://github.com/coollabsio/coolify/issues/6888
