### PR TITLE
fix(restart): reset restart count when resource is manually stopped

### DIFF
--- a/app/Actions/Application/StopApplication.php
+++ b/app/Actions/Application/StopApplication.php
@@ -55,6 +55,14 @@ class StopApplication
                 return $e->getMessage();
             }
         }
+
+        // Reset restart tracking when application is manually stopped
+        $application->update([
+            'restart_count' => 0,
+            'last_restart_at' => null,
+            'last_restart_type' => null,
+        ]);
+
         ServiceStatusChanged::dispatch($application->environment->project->team->id);
     }
 }

--- a/app/Actions/Database/StopDatabase.php
+++ b/app/Actions/Database/StopDatabase.php
@@ -28,6 +28,13 @@ class StopDatabase
 
             $this->stopContainer($database, $database->uuid, 30);
 
+            // Reset restart tracking when database is manually stopped
+            $database->update([
+                'restart_count' => 0,
+                'last_restart_at' => null,
+                'last_restart_type' => null,
+            ]);
+
             if ($dockerCleanup) {
                 CleanupDocker::dispatch($server, false, false);
             }


### PR DESCRIPTION
## Changes
- Reset restart count when user manually stops a database (StopDatabase action)
- Reset restart count when user manually stops an application (StopApplication action)
- Fixes issue where restart loop indicator persisted after user intervention

## Issues
- Fixes restart count not being reset when databases/applications are manually stopped