### PR TITLE
fix(settings): fix 404 on /settings for root user on cloud

### DIFF
--- a/app/Http/Controllers/Api/TeamController.php
+++ b/app/Http/Controllers/Api/TeamController.php
@@ -218,7 +218,10 @@ class TeamController extends Controller
         if (is_null($teamId)) {
             return invalidTokenResponse();
         }
-        $team = auth()->user()->currentTeam();
+        $team = auth()->user()->teams->where('id', $teamId)->first();
+        if (is_null($team)) {
+            return response()->json(['message' => 'Team not found.'], 404);
+        }
 
         return response()->json(
             $this->removeSensitiveData($team),
@@ -263,7 +266,10 @@ class TeamController extends Controller
         if (is_null($teamId)) {
             return invalidTokenResponse();
         }
-        $team = auth()->user()->currentTeam();
+        $team = auth()->user()->teams->where('id', $teamId)->first();
+        if (is_null($team)) {
+            return response()->json(['message' => 'Team not found.'], 404);
+        }
         $team->members->makeHidden([
             'pivot',
             'email_change_code',

--- a/app/Http/Middleware/DecideWhatToDoWithUser.php
+++ b/app/Http/Middleware/DecideWhatToDoWithUser.php
@@ -27,7 +27,7 @@ class DecideWhatToDoWithUser
             return $next($request);
         }
         // Instance admins can access settings and admin routes regardless of subscription
-        if (isInstanceAdmin() && (Str::startsWith($request->path(), 'settings') || $request->path() === 'admin')) {
+        if (isInstanceAdmin() && ($request->routeIs('settings.*') || $request->routeIs('settings.index') || $request->path() === 'admin')) {
             return $next($request);
         }
         if (! auth()->user()->hasVerifiedEmail()) {

--- a/app/Http/Middleware/DecideWhatToDoWithUser.php
+++ b/app/Http/Middleware/DecideWhatToDoWithUser.php
@@ -27,7 +27,7 @@ class DecideWhatToDoWithUser
             return $next($request);
         }
         // Instance admins can access settings and admin routes regardless of subscription
-        if (isInstanceAdmin() && ($request->routeIs('settings.*') || $request->routeIs('settings.index') || $request->path() === 'admin')) {
+        if (isInstanceAdmin() && ($request->routeIs('settings.*') || $request->path() === 'admin')) {
             return $next($request);
         }
         if (! auth()->user()->hasVerifiedEmail()) {

--- a/app/Http/Middleware/DecideWhatToDoWithUser.php
+++ b/app/Http/Middleware/DecideWhatToDoWithUser.php
@@ -18,6 +18,9 @@ class DecideWhatToDoWithUser
         }
         if (auth()?->user()?->currentTeam()) {
             refreshSession(auth()->user()->currentTeam());
+        } elseif (auth()?->user()?->teams?->count() > 0) {
+            // User's session team is invalid (e.g., removed from team), switch to first available team
+            refreshSession(auth()->user()->teams->first());
         }
         if (! auth()->user() || ! isCloud()) {
             if (! isCloud() && showBoarding() && ! in_array($request->path(), allowedPathsForBoardingAccounts())) {

--- a/app/Http/Middleware/DecideWhatToDoWithUser.php
+++ b/app/Http/Middleware/DecideWhatToDoWithUser.php
@@ -19,11 +19,15 @@ class DecideWhatToDoWithUser
         if (auth()?->user()?->currentTeam()) {
             refreshSession(auth()->user()->currentTeam());
         }
-        if (! auth()->user() || ! isCloud() || isInstanceAdmin()) {
+        if (! auth()->user() || ! isCloud()) {
             if (! isCloud() && showBoarding() && ! in_array($request->path(), allowedPathsForBoardingAccounts())) {
                 return redirect()->route('onboarding');
             }
 
+            return $next($request);
+        }
+        // Instance admins can access settings and admin routes regardless of subscription
+        if (isInstanceAdmin() && (Str::startsWith($request->path(), 'settings') || $request->path() === 'admin')) {
             return $next($request);
         }
         if (! auth()->user()->hasVerifiedEmail()) {

--- a/app/Livewire/ActivityMonitor.php
+++ b/app/Livewire/ActivityMonitor.php
@@ -79,8 +79,10 @@ class ActivityMonitor extends Component
                         $causer_id = data_get($this->activity, 'causer_id');
                         $user = User::find($causer_id);
                         if ($user) {
-                            $teamId = $user->currentTeam()->id;
-                            if (! self::$eventDispatched) {
+                            $teamId = data_get($this->activity, 'properties.team_id')
+                                ?? $user->currentTeam()?->id
+                                ?? $user->teams->first()?->id;
+                            if ($teamId && ! self::$eventDispatched) {
                                 if (filled($this->eventData)) {
                                     $this->eventToDispatch::dispatch($teamId, $this->eventData);
                                 } else {

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -3,15 +3,12 @@
 namespace App\Livewire\Settings;
 
 use App\Models\InstanceSettings;
-use App\Models\Server;
 use App\Rules\ValidIpOrCidr;
 use Livewire\Attributes\Validate;
 use Livewire\Component;
 
 class Advanced extends Component
 {
-    public ?Server $server = null;
-
     public InstanceSettings $settings;
 
     #[Validate('boolean')]
@@ -59,9 +56,6 @@ class Advanced extends Component
     {
         if (! isInstanceAdmin()) {
             return redirect()->route('dashboard');
-        }
-        if (! isCloud()) {
-            $this->server = Server::findOrFail(0);
         }
         $this->settings = instanceSettings();
         $this->custom_dns_servers = $this->settings->custom_dns_servers;

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -10,8 +10,7 @@ use Livewire\Component;
 
 class Advanced extends Component
 {
-    #[Validate('required')]
-    public Server $server;
+    public ?Server $server = null;
 
     public InstanceSettings $settings;
 
@@ -44,7 +43,6 @@ class Advanced extends Component
     public function rules()
     {
         return [
-            'server' => 'required',
             'is_registration_enabled' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
@@ -62,7 +60,9 @@ class Advanced extends Component
         if (! isInstanceAdmin()) {
             return redirect()->route('dashboard');
         }
-        $this->server = Server::findOrFail(0);
+        if (! isCloud()) {
+            $this->server = Server::findOrFail(0);
+        }
         $this->settings = instanceSettings();
         $this->custom_dns_servers = $this->settings->custom_dns_servers;
         $this->allowed_ips = $this->settings->allowed_ips;

--- a/app/Livewire/Settings/Index.php
+++ b/app/Livewire/Settings/Index.php
@@ -12,7 +12,7 @@ class Index extends Component
 {
     public InstanceSettings $settings;
 
-    public Server $server;
+    public ?Server $server = null;
 
     #[Validate('nullable|string|max:255')]
     public ?string $fqdn = null;
@@ -57,7 +57,9 @@ class Index extends Component
             return redirect()->route('dashboard');
         }
         $this->settings = instanceSettings();
-        $this->server = Server::findOrFail(0);
+        if (! isCloud()) {
+            $this->server = Server::findOrFail(0);
+        }
         $this->fqdn = $this->settings->fqdn;
         $this->public_port_min = $this->settings->public_port_min;
         $this->public_port_max = $this->settings->public_port_max;
@@ -121,7 +123,7 @@ class Index extends Component
             }
             $this->validate();
 
-            if ($this->settings->is_dns_validation_enabled && $this->fqdn) {
+            if ($this->settings->is_dns_validation_enabled && $this->fqdn && $this->server) {
                 if (! validateDNSEntry($this->fqdn, $this->server)) {
                     $this->dispatch('error', "Validating DNS failed.<br><br>Make sure you have added the DNS records correctly.<br><br>{$this->fqdn}->{$this->server->ip}<br><br>Check this <a target='_blank' class='underline dark:text-white' href='https://coolify.io/docs/knowledge-base/dns-configuration'>documentation</a> for further help.");
                     $error_show = true;
@@ -145,7 +147,9 @@ class Index extends Component
             $this->instantSave(isSave: false);
 
             $this->settings->save();
-            $this->server->setupDynamicProxyConfiguration();
+            if ($this->server) {
+                $this->server->setupDynamicProxyConfiguration();
+            }
             if (! $error_show) {
                 $this->dispatch('success', 'Instance settings updated successfully!');
             }
@@ -159,6 +163,12 @@ class Index extends Component
         try {
             if (! isDev()) {
                 $this->dispatch('error', 'Building helper image is only available in development mode.');
+
+                return;
+            }
+
+            if (! $this->server) {
+                $this->dispatch('error', 'Server not available.');
 
                 return;
             }

--- a/app/Livewire/Settings/Updates.php
+++ b/app/Livewire/Settings/Updates.php
@@ -12,7 +12,7 @@ class Updates extends Component
 {
     public InstanceSettings $settings;
 
-    public Server $server;
+    public ?Server $server = null;
 
     #[Validate('string')]
     public string $auto_update_frequency;
@@ -25,7 +25,9 @@ class Updates extends Component
 
     public function mount()
     {
-        $this->server = Server::findOrFail(0);
+        if (! isCloud()) {
+            $this->server = Server::findOrFail(0);
+        }
 
         $this->settings = instanceSettings();
         $this->auto_update_frequency = $this->settings->auto_update_frequency;
@@ -76,7 +78,9 @@ class Updates extends Component
             }
 
             $this->instantSave();
-            $this->server->setupDynamicProxyConfiguration();
+            if ($this->server) {
+                $this->server->setupDynamicProxyConfiguration();
+            }
         } catch (\Exception $e) {
             return handleError($e, $this);
         }

--- a/app/Livewire/Team/InviteLink.php
+++ b/app/Livewire/Team/InviteLink.php
@@ -48,7 +48,7 @@ class InviteLink extends Component
 
             // Prevent privilege escalation: users cannot invite someone with higher privileges
             $userRole = auth()->user()->role();
-            if ($userRole === 'member' && in_array($this->role, ['admin', 'owner'])) {
+            if (is_null($userRole) || ($userRole === 'member' && in_array($this->role, ['admin', 'owner']))) {
                 throw new \Exception('Members cannot invite admins or owners.');
             }
             if ($userRole === 'admin' && $this->role === 'owner') {

--- a/app/Livewire/Team/Member.php
+++ b/app/Livewire/Team/Member.php
@@ -71,11 +71,11 @@ class Member extends Component
                 || Role::from($this->getMemberRole())->gt(auth()->user()->role())) {
                 throw new \Exception('You are not authorized to perform this action.');
             }
+            $teamId = currentTeam()->id;
             $this->member->teams()->detach(currentTeam());
+            // Clear cache for the removed user - both old and new key formats
             Cache::forget("team:{$this->member->id}");
-            Cache::remember('team:'.$this->member->id, 3600, function () {
-                return $this->member->teams()->first();
-            });
+            Cache::forget("user:{$this->member->id}:team:{$teamId}");
             $this->dispatch('reloadWindow');
         } catch (\Exception $e) {
             $this->dispatch('error', $e->getMessage());

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Jobs\UpdateStripeCustomerEmailJob;
 use App\Notifications\Channels\SendsEmail;
 use App\Notifications\TransactionalEmails\ResetPassword as TransactionalEmailsResetPassword;
 use App\Traits\DeletesUserSessions;
@@ -437,7 +438,7 @@ class User extends Authenticatable implements SendsEmail
         // For cloud users, dispatch job to update Stripe customer email asynchronously
         $currentTeam = $this->currentTeam();
         if (isCloud() && $currentTeam?->subscription) {
-            dispatch(new \App\Jobs\UpdateStripeCustomerEmailJob(
+            dispatch(new UpdateStripeCustomerEmailJob(
                 $currentTeam,
                 $this->id,
                 $newEmail,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -295,7 +295,7 @@ class User extends Authenticatable implements SendsEmail
 
     public function isInstanceAdmin()
     {
-        $found_root_team = Auth::user()->teams->filter(function ($team) {
+        $found_root_team = $this->teams->filter(function ($team) {
             if ($team->id == 0) {
                 $role = $team->pivot->role;
                 if ($role !== 'admin' && $role !== 'owner') {
@@ -313,9 +313,9 @@ class User extends Authenticatable implements SendsEmail
 
     public function currentTeam()
     {
-        return Cache::remember('team:'.Auth::id(), 3600, function () {
-            if (is_null(data_get(session('currentTeam'), 'id')) && Auth::user()->teams->count() > 0) {
-                return Auth::user()->teams[0];
+        return Cache::remember('team:'.$this->id, 3600, function () {
+            if (is_null(data_get(session('currentTeam'), 'id')) && $this->teams->count() > 0) {
+                return $this->teams[0];
             }
 
             return Team::find(session('currentTeam')->id);
@@ -324,7 +324,7 @@ class User extends Authenticatable implements SendsEmail
 
     public function otherTeams()
     {
-        return Auth::user()->teams->filter(function ($team) {
+        return $this->teams->filter(function ($team) {
             return $team->id != currentTeam()->id;
         });
     }
@@ -334,9 +334,9 @@ class User extends Authenticatable implements SendsEmail
         if (data_get($this, 'pivot')) {
             return $this->pivot->role;
         }
-        $user = Auth::user()->teams->where('id', currentTeam()->id)->first();
+        $team = $this->teams->where('id', currentTeam()->id)->first();
 
-        return data_get($user, 'pivot.role');
+        return data_get($team, 'pivot.role');
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -297,7 +297,8 @@ class User extends Authenticatable implements SendsEmail
     {
         $found_root_team = Auth::user()->teams->filter(function ($team) {
             if ($team->id == 0) {
-                if (! Auth::user()->isAdmin()) {
+                $role = $team->pivot->role;
+                if ($role !== 'admin' && $role !== 'owner') {
                     return false;
                 }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -319,7 +319,7 @@ class User extends Authenticatable implements SendsEmail
             return null;
         }
 
-        return Cache::remember('team:'.$this->id, 3600, function () use ($sessionTeamId) {
+        return Cache::remember('user:'.$this->id.':team:'.$sessionTeamId, 3600, function () use ($sessionTeamId) {
             return Team::find($sessionTeamId);
         });
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -319,6 +319,14 @@ class User extends Authenticatable implements SendsEmail
             return null;
         }
 
+        // Check if user actually belongs to this team
+        if (! $this->teams->contains('id', $sessionTeamId)) {
+            session()->forget('currentTeam');
+            Cache::forget('user:'.$this->id.':team:'.$sessionTeamId);
+
+            return null;
+        }
+
         return Cache::remember('user:'.$this->id.':team:'.$sessionTeamId, 3600, function () use ($sessionTeamId) {
             return Team::find($sessionTeamId);
         });

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -182,8 +182,11 @@ function refreshSession(?Team $team = null): void
             $team = User::find(Auth::id())->teams->first();
         }
     }
+    // Clear old cache key format for backwards compatibility
     Cache::forget('team:'.Auth::id());
-    Cache::remember('team:'.Auth::id(), 3600, function () use ($team) {
+    // Use new cache key format that includes team ID
+    Cache::forget('user:'.Auth::id().':team:'.$team->id);
+    Cache::remember('user:'.Auth::id().':team:'.$team->id, 3600, function () use ($team) {
         return $team;
     });
     session(['currentTeam' => $team]);

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -384,7 +384,7 @@ function base_url(bool $withPort = true): string
 
 function isSubscribed()
 {
-    return isSubscriptionActive() || auth()->user()->isInstanceAdmin();
+    return isSubscriptionActive();
 }
 
 function isProduction(): bool

--- a/bootstrap/helpers/subscriptions.php
+++ b/bootstrap/helpers/subscriptions.php
@@ -13,6 +13,10 @@ function isSubscriptionActive()
         if (! $team) {
             return false;
         }
+        // Root team (id=0) doesn't require subscription
+        if ($team->id === 0) {
+            return true;
+        }
         $subscription = $team?->subscription;
 
         if (is_null($subscription)) {


### PR DESCRIPTION
## Changes
- Make Server property nullable in Settings components (Index, Advanced, Updates) since cloud doesn't have server id=0
- Add conditional server loading: only fetch server when not on cloud instance
- Add null checks before using server for DNS validation and proxy configuration
- Fix `isInstanceAdmin()` to check root team's pivot role directly instead of current team
- Make root team (id=0) bypass subscription check on cloud instance
- Remove `isInstanceAdmin()` from main middleware bypass: only settings/admin routes are exempted
- Update `isSubscribed()` to only check `isSubscriptionActive()` for navbar consistency with middleware

## Issues
- Fixes settings 404 on cloud instance for root user