### PR TITLE
fix(templates): Update RustFS template with working configuration

### DIFF
--- a/svgs/rustfs.svg
+++ b/svgs/rustfs.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="#CE422B"/>
+  <path d="M16 18h32v28c0 2.2-1.8 4-4 4H20c-2.2 0-4-1.8-4-4V18z" fill="#fff" opacity="0.9"/>
+  <rect x="20" y="24" width="24" height="4" rx="1" fill="#CE422B"/>
+  <rect x="20" y="32" width="18" height="4" rx="1" fill="#CE422B"/>
+  <rect x="20" y="40" width="20" height="4" rx="1" fill="#CE422B"/>
+  <circle cx="44" cy="42" r="4" fill="#7CCD5A"/>
+  <path d="M16 18c0-2.2 1.8-4 4-4h24c2.2 0 4 1.8 4 4v2H16v-2z" fill="#A63524"/>
+</svg>

--- a/templates/compose/rustfs.yaml
+++ b/templates/compose/rustfs.yaml
@@ -1,35 +1,39 @@
-# ignore: true
-# documentation: https://docs.rustfs.com/installation/docker/
-# slogan: RustFS is a high-performance distributed storage system built with Rust, compatible with Amazon S3 APIs.
+# documentation: https://github.com/rustfs/rustfs
+# slogan: RustFS is a high-performance, S3-compatible object storage system built in Rust.
 # category: storage
-# tags: object, storage, server, s3, api, rust
-# logo: svgs/rustfs.png
+# tags: object, storage, server, s3, api, rust, minio-alternative
+# logo: svgs/rustfs.svg
+# port: 9001
+# minversion: 4.0.0
+# note: Port 9001 serves both the web console (/rustfs/console/) and proxies S3 API requests
 
 services:
   rustfs:
     image: rustfs/rustfs:latest
-    command: /data
     environment:
-      - RUSTFS_SERVER_URL=$RUSTFS_SERVER_URL
-      - RUSTFS_BROWSER_REDIRECT_URL=$RUSTFS_BROWSER_REDIRECT_URL
-      - RUSTFS_ADDRESS=${RUSTFS_ADDRESS:-0.0.0.0:9000}
-      - RUSTFS_CONSOLE_ADDRESS=${RUSTFS_CONSOLE_ADDRESS:-0.0.0.0:9001}
-      - RUSTFS_CORS_ALLOWED_ORIGINS=${RUSTFS_CORS_ALLOWED_ORIGINS:-*}
-      - RUSTFS_CONSOLE_CORS_ALLOWED_ORIGINS=${RUSTFS_CONSOLE_CORS_ALLOWED_ORIGINS:-*}
+      # Core Authentication
       - RUSTFS_ACCESS_KEY=$SERVICE_USER_RUSTFS
       - RUSTFS_SECRET_KEY=$SERVICE_PASSWORD_RUSTFS
-      - RUSTFS_CONSOLE_ENABLE=${RUSTFS_CONSOLE_ENABLE:-true}
-      - RUSTFS_SERVER_DOMAINS=${RUSTFS_SERVER_DOMAINS}
+      # Network Binding
+      - RUSTFS_ADDRESS=${RUSTFS_ADDRESS:-0.0.0.0:9000}
+      - RUSTFS_CONSOLE_ADDRESS=${RUSTFS_CONSOLE_ADDRESS:-0.0.0.0:9001}
+      # URL Configuration (for proxy/external access)
+      - RUSTFS_SERVER_URL=$RUSTFS_SERVER_URL
+      - RUSTFS_BROWSER_REDIRECT_URL=$RUSTFS_BROWSER_REDIRECT_URL
       - RUSTFS_EXTERNAL_ADDRESS=${RUSTFS_EXTERNAL_ADDRESS}
+      - RUSTFS_SERVER_DOMAINS=${RUSTFS_SERVER_DOMAINS}
+      # CORS Settings
+      - RUSTFS_CORS_ALLOWED_ORIGINS=${RUSTFS_CORS_ALLOWED_ORIGINS:-*}
+      - RUSTFS_CONSOLE_CORS_ALLOWED_ORIGINS=${RUSTFS_CONSOLE_CORS_ALLOWED_ORIGINS:-*}
+      # Feature Toggles
+      - RUSTFS_CONSOLE_ENABLE=${RUSTFS_CONSOLE_ENABLE:-true}
     volumes:
       - rustfs-data:/data
     healthcheck:
-      test:
-        [
-          "CMD",
-          "sh", "-c",
-          "curl -f http://127.0.0.1:9000/health && curl -f http://127.0.0.1:9001/rustfs/console/health"
-        ]
-      interval: 5s
-      timeout: 20s
-      retries: 10
+      test: ["CMD", "curl", "-f", "http://localhost:9000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+volumes:
+  rustfs-data:


### PR DESCRIPTION
## Summary
Updates the existing RustFS service template to make it functional:
- Removes `ignore: true` flag to activate the template
- Fixes documentation URL (was pointing to non-existent docs.rustfs.com)
- Replaces PNG logo with proper SVG vector format
- Adds `port: 9001` directive for Coolify proxy integration
- Adds `minversion` and `note` metadata
- Simplifies healthcheck to use verified `/health` endpoint
- Adds organized environment variable comments for clarity

## What is RustFS?
RustFS is a high-performance, S3-compatible object storage system built in Rust. It claims to be 2.3x faster than MinIO for small object workloads (4KB payloads).

- **GitHub**: https://github.com/rustfs/rustfs
- **License**: Apache 2.0

## Port Architecture
- **Port 9001** (exposed): Console web UI + S3 API proxy
- **Port 9000** (internal): Direct S3 API
- The console on port 9001 proxies S3 API requests, so only one port needs to be exposed

## Configuration Groups
The template exposes all configuration options, organized by function:
- **Core Auth**: `RUSTFS_ACCESS_KEY`, `RUSTFS_SECRET_KEY`
- **Network Binding**: API (9000) and Console (9001) addresses
- **URL Config**: Server URL, redirect URL, external address, domains
- **CORS**: API and Console CORS origins (default: *)
- **Features**: Console enable/disable toggle

## Testing Performed
Deployed and verified on a production Coolify instance:

✅ Container starts successfully with health check passing
✅ Health endpoint returns: `{"service":"rustfs-endpoint","status":"ok","version":"0.0.5"}`
✅ Console accessible at `/rustfs/console/index.html`
✅ S3 API responds correctly via port 9001 proxy
✅ Traefik routing works with standard Coolify domain configuration
✅ Volume persistence confirmed

### Test Commands Used
```bash
# Health check
curl https://your-domain/health
# Returns: {"service":"rustfs-endpoint","status":"ok",...}

# Console access
curl -I https://your-domain/rustfs/console/index.html
# Returns: HTTP 200
```

## Files Changed
- `templates/compose/rustfs.yaml` - Updated template configuration
- `svgs/rustfs.svg` - New vector logo (Rust-themed colors)

## Screenshot
Console is accessible after deployment at `/rustfs/console/index.html`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)