### PR TITLE
Fix: Don't timeout public database proxies after 10 min

### DIFF
--- a/app/Actions/Database/StartDatabaseProxy.php
+++ b/app/Actions/Database/StartDatabaseProxy.php
@@ -68,6 +68,8 @@ class StartDatabaseProxy
        server {
             listen $database->public_port;
             proxy_pass $containerName:$internalPort;
+            proxy_connect_timeout 60s;
+            proxy_timeout 0;
        }
     }
     EOF;


### PR DESCRIPTION
## Summary

Fixes #7743

### The Problem
The TCP proxy in front of databases (when marked "Expose publicly") was timing out after about 10 minutes. This prevented long-running queries (30+ minutes) from completing.

### Root Cause
The nginx stream proxy configuration had no explicit timeout settings. Nginx's default `proxy_timeout` for stream proxies is 10 minutes.

### The Fix
Added nginx stream directives:

```nginx
proxy_connect_timeout 60s;  # Connection establishment timeout
proxy_timeout 0;            # Disable idle connection timeout
```

Setting `proxy_timeout` to 0 disables idle timeout entirely, allowing queries of any duration.

## Testing
- [x] Long-running queries no longer timeout
- [x] Connection still establishes within 60 seconds
- [x] Backwards compatible

## AI Disclosure
This PR was developed with AI assistance:
- **Opus 4.5** for planning and code review
- **GLM 4.7** for code execution
- **GitHub PR review** for quality assurance