### PR TITLE
fix: back navigation in global search resource selection

### DIFF
--- a/app/Livewire/GlobalSearch.php
+++ b/app/Livewire/GlobalSearch.php
@@ -1336,6 +1336,42 @@ class GlobalSearch extends Component
         $this->autoOpenResource = null;
     }
 
+    public function goBack()
+    {
+        // From Environment Selection → go back to Project (if multiple) or further
+        if ($this->selectedProjectUuid !== null) {
+            $this->selectedProjectUuid = null;
+            $this->selectedEnvironmentUuid = null;
+            if (count($this->availableProjects) > 1) {
+                return; // Stop here - user can choose a project
+            }
+        }
+
+        // From Project Selection → go back to Destination (if multiple) or further
+        if ($this->selectedDestinationUuid !== null) {
+            $this->selectedDestinationUuid = null;
+            $this->selectedProjectUuid = null;
+            $this->selectedEnvironmentUuid = null;
+            if (count($this->availableDestinations) > 1) {
+                return; // Stop here - user can choose a destination
+            }
+        }
+
+        // From Destination Selection → go back to Server (if multiple) or cancel
+        if ($this->selectedServerId !== null) {
+            $this->selectedServerId = null;
+            $this->selectedDestinationUuid = null;
+            $this->selectedProjectUuid = null;
+            $this->selectedEnvironmentUuid = null;
+            if (count($this->availableServers) > 1) {
+                return; // Stop here - user can choose a server
+            }
+        }
+
+        // All previous steps were auto-selected, cancel entirely
+        $this->cancelResourceSelection();
+    }
+
     public function getFilteredCreatableItemsProperty()
     {
         $query = strtolower(trim($this->searchQuery));

--- a/resources/views/livewire/global-search.blade.php
+++ b/resources/views/livewire/global-search.blade.php
@@ -323,7 +323,7 @@
                                     <div class="mb-4" x-init="selectedIndex = -1">
                                         <div class="flex items-center gap-3 mb-3">
                                             <button type="button"
-                                                @click="$wire.set('searchQuery', ''); setTimeout(() => $refs.searchInput.focus(), 100)"
+                                                @click="$wire.goBack()"
                                                 class="text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white">
                                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none"
                                                     viewBox="0 0 24 24" stroke="currentColor">
@@ -398,7 +398,7 @@
                                     <div class="mb-4" x-init="selectedIndex = -1">
                                         <div class="flex items-center gap-3 mb-3">
                                             <button type="button"
-                                                @click="$wire.set('searchQuery', ''); setTimeout(() => $refs.searchInput.focus(), 100)"
+                                                @click="$wire.goBack()"
                                                 class="text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white">
                                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none"
                                                     viewBox="0 0 24 24" stroke="currentColor">
@@ -467,7 +467,7 @@
                                     <div class="mb-4" x-init="selectedIndex = -1">
                                         <div class="flex items-center gap-3 mb-3">
                                             <button type="button"
-                                                @click="$wire.set('searchQuery', ''); setTimeout(() => $refs.searchInput.focus(), 100)"
+                                                @click="$wire.goBack()"
                                                 class="text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white">
                                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none"
                                                     viewBox="0 0 24 24" stroke="currentColor">
@@ -542,7 +542,7 @@
                                     <div class="mb-4" x-init="selectedIndex = -1">
                                         <div class="flex items-center gap-3 mb-3">
                                             <button type="button"
-                                                @click="$wire.set('searchQuery', ''); setTimeout(() => $refs.searchInput.focus(), 100)"
+                                                @click="$wire.goBack()"
                                                 class="text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white">
                                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none"
                                                     viewBox="0 0 24 24" stroke="currentColor">


### PR DESCRIPTION
## Changes
- Add smart `goBack()` method that handles back navigation through the resource selection flow
- Method skips over auto-selected steps (steps with only 1 option) to prevent navigation loops
- All four back buttons now use the unified `goBack()` method for consistent behavior

## Issues
- Fixes #7739