### PR TITLE
feat: add bulk import for environment variables

### DIFF
--- a/app/Livewire/Project/Shared/EnvironmentVariable/Add.php
+++ b/app/Livewire/Project/Shared/EnvironmentVariable/Add.php
@@ -33,6 +33,10 @@ class Add extends Component
 
     public array $problematicVariables = [];
 
+    public bool $bulk_mode = false;
+
+    public ?string $bulk_content = null;
+
     protected $listeners = ['clearAddEnv' => 'clear'];
 
     protected $rules = [
@@ -127,6 +131,12 @@ class Add extends Component
 
     public function submit()
     {
+        if ($this->bulk_mode) {
+            $this->submitBulk();
+
+            return;
+        }
+
         $this->validate();
         $this->dispatch('saveKey', [
             'key' => $this->key,
@@ -140,10 +150,44 @@ class Add extends Component
         $this->clear();
     }
 
+    public function submitBulk()
+    {
+        if (empty($this->bulk_content)) {
+            $this->dispatch('error', 'Please paste your environment variables.');
+
+            return;
+        }
+
+        $variables = parseEnvFormatToArray($this->bulk_content);
+
+        if (empty($variables)) {
+            $this->dispatch('error', 'No valid environment variables found. Use KEY=value format.');
+
+            return;
+        }
+
+        foreach ($variables as $key => $value) {
+            $this->dispatch('saveKey', [
+                'key' => $key,
+                'value' => $value,
+                'is_multiline' => false,
+                'is_literal' => $this->is_literal,
+                'is_runtime' => $this->is_runtime,
+                'is_buildtime' => $this->is_buildtime,
+                'is_preview' => $this->is_preview,
+            ]);
+        }
+
+        $count = count($variables);
+        $this->dispatch('success', "Added {$count} environment variable(s).");
+        $this->clear();
+    }
+
     public function clear()
     {
         $this->key = '';
         $this->value = '';
+        $this->bulk_content = '';
         $this->is_multiline = false;
         $this->is_literal = false;
         $this->is_runtime = true;

--- a/resources/views/livewire/project/shared/environment-variable/add.blade.php
+++ b/resources/views/livewire/project/shared/environment-variable/add.blade.php
@@ -1,19 +1,46 @@
 <form class="flex flex-col w-full gap-2 rounded-sm" wire:submit='submit'>
-    <x-forms.input placeholder="NODE_ENV" id="key" label="Name" required />
-    @if ($is_multiline)
-        <x-forms.textarea id="value" label="Value" required />
-    @else
-        <x-forms.env-var-input placeholder="production" id="value" label="Value" required
-            :availableVars="$shared ? [] : $this->availableSharedVariables"
-            :projectUuid="data_get($parameters, 'project_uuid')"
-            :environmentUuid="data_get($parameters, 'environment_uuid')" />
-    @endif
+    <div class="flex items-center gap-2 mb-2">
+        <button type="button" wire:click="$set('bulk_mode', false)"
+            @class([
+                'button',
+                'text-coollabs-200 dark:text-white bg-coollabs-50 dark:bg-coollabs/20 border-coollabs dark:border-coollabs-100' => !$bulk_mode,
+            ])>
+            Single
+        </button>
+        <button type="button" wire:click="$set('bulk_mode', true)"
+            @class([
+                'button',
+                'text-coollabs-200 dark:text-white bg-coollabs-50 dark:bg-coollabs/20 border-coollabs dark:border-coollabs-100' => $bulk_mode,
+            ])>
+            File
+        </button>
+    </div>
 
-    @if (!$shared && !$is_multiline)
+    @if ($bulk_mode)
+        <x-forms.textarea id="bulk_content" label="Paste .env Content" rows="10"
+            placeholder="NODE_ENV=production
+API_KEY=your-api-key
+DATABASE_URL=postgres://..." />
         <div class="text-xs text-neutral-500 dark:text-neutral-400 -mt-1">
-            Tip: Type <span class="font-mono dark:text-warning text-coollabs">{{</span> to reference a shared environment
-            variable
+            Paste multiple environment variables in <span class="font-mono">KEY=value</span> format, one per line. Lines starting with <span class="font-mono">#</span> are ignored. For multiline values, add them individually using Single mode.
         </div>
+    @else
+        <x-forms.input placeholder="NODE_ENV" id="key" label="Name" required />
+        @if ($is_multiline)
+            <x-forms.textarea id="value" label="Value" required />
+        @else
+            <x-forms.env-var-input placeholder="production" id="value" label="Value" required
+                :availableVars="$shared ? [] : $this->availableSharedVariables"
+                :projectUuid="data_get($parameters, 'project_uuid')"
+                :environmentUuid="data_get($parameters, 'environment_uuid')" />
+        @endif
+
+        @if (!$shared && !$is_multiline)
+            <div class="text-xs text-neutral-500 dark:text-neutral-400 -mt-1">
+                Tip: Type <span class="font-mono dark:text-warning text-coollabs">{{</span> to reference a shared environment
+                variable
+            </div>
+        @endif
     @endif
 
     @if (!$shared)
@@ -30,8 +57,11 @@
             label="Is Literal?" />
     @endif
 
-    <x-forms.checkbox id="is_multiline" label="Is Multiline?" />
+    @if (!$bulk_mode)
+        <x-forms.checkbox id="is_multiline" label="Is Multiline?" />
+    @endif
+
     <x-forms.button type="submit" @click="slideOverOpen=false">
-        Save
+        {{ $bulk_mode ? 'Import All' : 'Save' }}
     </x-forms.button>
 </form>


### PR DESCRIPTION
## Changes
- Add bulk import mode to the 'New Environment Variable' modal
- You can paste your entire .env file contents to add multiple variables at once
- Toggle buttons (Single/File) switch between single variable and bulk import modes
- Bulk import parses standard .env format (key=value, one per line, some wiggle room wrt quotations)
- Comments (lines starting with #) and empty lines are ignored

## Issues
- Don't see any referencing this
