### PR TITLE
fix(ui): back arrow navigation in resource selection flow

### DIFF
--- a/app/Livewire/GlobalSearch.php
+++ b/app/Livewire/GlobalSearch.php
@@ -1336,6 +1336,27 @@ class GlobalSearch extends Component
         $this->autoOpenResource = null;
     }
 
+    public function goBackInSelection()
+    {
+        // Navigate back through selection steps: environment → project → destination → server → cancel
+        if ($this->selectedProjectUuid !== null && $this->selectedEnvironmentUuid === null) {
+            // Currently selecting environment, go back to project selection
+            $this->selectedProjectUuid = null;
+            $this->availableEnvironments = [];
+        } elseif ($this->selectedDestinationUuid !== null && $this->selectedProjectUuid === null) {
+            // Currently selecting project, go back to destination selection
+            $this->selectedDestinationUuid = null;
+            $this->availableProjects = [];
+        } elseif ($this->selectedServerId !== null && $this->selectedDestinationUuid === null) {
+            // Currently selecting destination, go back to server selection
+            $this->selectedServerId = null;
+            $this->availableDestinations = [];
+        } else {
+            // At server selection or initial state, cancel the whole selection
+            $this->cancelResourceSelection();
+        }
+    }
+
     public function getFilteredCreatableItemsProperty()
     {
         $query = strtolower(trim($this->searchQuery));

--- a/resources/views/livewire/global-search.blade.php
+++ b/resources/views/livewire/global-search.blade.php
@@ -323,7 +323,7 @@
                                     <div class="mb-4" x-init="selectedIndex = -1">
                                         <div class="flex items-center gap-3 mb-3">
                                             <button type="button"
-                                                @click="$wire.set('searchQuery', ''); setTimeout(() => $refs.searchInput.focus(), 100)"
+                                                @click="$wire.goBackInSelection(); setTimeout(() => $refs.searchInput.focus(), 100)"
                                                 class="text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white">
                                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none"
                                                     viewBox="0 0 24 24" stroke="currentColor">
@@ -398,7 +398,7 @@
                                     <div class="mb-4" x-init="selectedIndex = -1">
                                         <div class="flex items-center gap-3 mb-3">
                                             <button type="button"
-                                                @click="$wire.set('searchQuery', ''); setTimeout(() => $refs.searchInput.focus(), 100)"
+                                                @click="$wire.goBackInSelection(); setTimeout(() => $refs.searchInput.focus(), 100)"
                                                 class="text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white">
                                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none"
                                                     viewBox="0 0 24 24" stroke="currentColor">
@@ -467,7 +467,7 @@
                                     <div class="mb-4" x-init="selectedIndex = -1">
                                         <div class="flex items-center gap-3 mb-3">
                                             <button type="button"
-                                                @click="$wire.set('searchQuery', ''); setTimeout(() => $refs.searchInput.focus(), 100)"
+                                                @click="$wire.goBackInSelection(); setTimeout(() => $refs.searchInput.focus(), 100)"
                                                 class="text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white">
                                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none"
                                                     viewBox="0 0 24 24" stroke="currentColor">
@@ -542,7 +542,7 @@
                                     <div class="mb-4" x-init="selectedIndex = -1">
                                         <div class="flex items-center gap-3 mb-3">
                                             <button type="button"
-                                                @click="$wire.set('searchQuery', ''); setTimeout(() => $refs.searchInput.focus(), 100)"
+                                                @click="$wire.goBackInSelection(); setTimeout(() => $refs.searchInput.focus(), 100)"
                                                 class="text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white">
                                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none"
                                                     viewBox="0 0 24 24" stroke="currentColor">


### PR DESCRIPTION
## Description
Fixes #7739

The back arrow buttons in the resource selection screens (Select Server, Select Destination, Select Project, Select Environment) were not working correctly. They only cleared the search query instead of navigating back to the previous step.

## Changes
- Added `goBackInSelection()` method to `GlobalSearch.php` that properly navigates back through selection steps: environment → project → destination → server → cancel
- Updated all 4 back arrow button click handlers in `global-search.blade.php` to use the new method

## Testing
1. Open the global search (Cmd+K or /)
2. Type "new postgresql" to create a new database
3. Select Server → Destination → Project
4. Click the back arrow (←) at each step
5. Verify it navigates back to the previous selection screen