### PR TITLE
fix(ui): prevent backup popup from opening on checkbox toggle

### DIFF
--- a/resources/views/livewire/project/database/import.blade.php
+++ b/resources/views/livewire/project/database/import.blade.php
@@ -222,7 +222,7 @@
             @endif
 
             {{-- Slide-over for activity monitor (all restore operations) --}}
-            <x-slide-over @databaserestore.window="slideOverOpen = true" closeWithX fullScreen>
+            <x-slide-over @databaserestore.window="if ($wire.activityId !== null) slideOverOpen = true" closeWithX fullScreen>
                 <x-slot:title>Database Restore Output</x-slot:title>
                 <x-slot:content>
                     <div wire:ignore>


### PR DESCRIPTION
## Description
Fixes #7817

The 'Database Restore Output' slide-over was incorrectly opening when clicking the 'Backup includes all databases' checkbox in MariaDB import settings. This popup could not be closed and prevented further interaction.

## Root Cause
The @databaserestore.window event was opening the slide-over regardless of whether an actual restore operation was running. When the checkbox was toggled, something triggered this event while activityId was still null.

## Changes
- Added activityId !== null check before opening the slide-over popup in import.blade.php
- The popup now only opens when an actual restore operation is in progress

## Testing
1. Go to any MariaDB/MySQL/PostgreSQL database settings
2. Click on "Import Backup"
3. Toggle the "Backup includes all databases" checkbox
4. Verify the "Database Restore Output" popup does NOT appear\n1. Go to any MariaDB/MySQL/PostgreSQL database settings\n2. Click on "Import Backup"\n3. Toggle the "Backup includes all databases" checkbox\n4. Verify the "Database Restore Output" popup does NOT appear