### PR TITLE
fix(env): respect manual order when alphabetical sorting is disabled

### DIFF
--- a/app/Livewire/Project/Shared/EnvironmentVariable/All.php
+++ b/app/Livewire/Project/Shared/EnvironmentVariable/All.php
@@ -64,7 +64,9 @@ class All extends Component
     public function getEnvironmentVariablesProperty()
     {
         if ($this->is_env_sorting_enabled === false) {
-            return $this->resource->environment_variables()->orderBy('order')->get();
+            // Use reorder() to remove the model's default alphabetical ordering
+            // and replace it with manual order
+            return $this->resource->environment_variables()->reorder('order', 'asc')->get();
         }
 
         return $this->resource->environment_variables;
@@ -73,7 +75,9 @@ class All extends Component
     public function getEnvironmentVariablesPreviewProperty()
     {
         if ($this->is_env_sorting_enabled === false) {
-            return $this->resource->environment_variables_preview()->orderBy('order')->get();
+            // Use reorder() to remove the model's default alphabetical ordering
+            // and replace it with manual order
+            return $this->resource->environment_variables_preview()->reorder('order', 'asc')->get();
         }
 
         return $this->resource->environment_variables_preview;


### PR DESCRIPTION
## Changes

- fix(env): respect manual order when alphabetical sorting is disabled

## Reproduction

1. Go to any Application → Environment Variables
2. Ensure "Alphabetically sort Environment Variables" is **disabled** in settings
3. Reorder variables manually (e.g., move VAR_Z to top)
4. Click Save
5. Verify variables remain in manual order after save (no reordering)

### Root cause

- The model's `environment_variables()` relationship has a default `orderByRaw('LOWER(key) ASC')` sorting. When `orderBy('order')` was added in the Livewire component, it was **appended** to the existing sort rather than replacing it

## Issues

- fixes https://github.com/coollabsio/coolify/issues/7772