### PR TITLE
fix: Supabase PostgreSQL external connections blocked (issue #5574)

### DIFF
--- a/templates/compose/supabase.yaml
+++ b/templates/compose/supabase.yaml
@@ -334,6 +334,8 @@ services:
       - config_file=/etc/postgresql/postgresql.conf
       - -c
       - log_min_messages=fatal
+      - -c
+      - listen_addresses='*'
     environment:
       - POSTGRES_HOST=/var/run/postgresql
       - PGPORT=${POSTGRES_PORT:-5432}


### PR DESCRIPTION
## Description
Add listen_addresses='*' to Supabase PostgreSQL command to allow external connections. PostgreSQL was binding to 127.0.0.1 instead of 0.0.0.0, blocking external access even when port was exposed.

## Changes
- Add `-c listen_addresses='*'` to `supabase-db` service command in `templates/compose/supabase.yaml`
- Ensures PostgreSQL listens on all interfaces (0.0.0.0) regardless of SSL settings
- Template-only change, does not affect standalone PostgreSQL databases or core code

## Issues
- Fixes #5574

## Testing
- [ ] Tested on fresh Supabase deployment (unable to test on Windows, requires Linux environment)
- Template configuration change only (no code logic modified)
- Fix verified against issue discussion and PostgreSQL configuration best practices
- Analyzed core code to confirm template-only fix is sufficient (StartPostgresql.php handles StandalonePostgresql, not Supabase ServiceDatabase)

## Analysis
Initial investigation suggested modifying core PostgreSQL handling code (StartPostgresql.php), but further analysis revealed:
- StartPostgresql only handles StandalonePostgresql instances
- Supabase uses ServiceDatabase from templates (different code path)
- Template-only fix is sufficient and safer
- Avoids potential security implications of changing core database behavior

## Backwards Compatibility
- Adding command argument only
- No changes to existing configuration or logic
- No breaking changes
- Does not affect other PostgreSQL databases in Coolify