### PR TITLE
perf(server): optimize destinationsByServer query

### DIFF
--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -271,7 +271,7 @@ class Server extends BaseModel
 
     public static function destinationsByServer(string $server_id)
     {
-        $server = Server::ownedByCurrentTeam()->get()->where('id', $server_id)->firstOrFail();
+        $server = Server::ownedByCurrentTeam()->findOrFail($server_id);
         $standaloneDocker = collect($server->standaloneDockers->all());
         $swarmDocker = collect($server->swarmDockers->all());
 


### PR DESCRIPTION
## Summary

- Replace in-memory filtering with database-level query in `Server::destinationsByServer()`
- Uses `findOrFail()` instead of `get()->where()->firstOrFail()`

Fixes #7853