### PR TITLE
feat: improve validation patterns

### DIFF
--- a/app/Console/Commands/CleanupNames.php
+++ b/app/Console/Commands/CleanupNames.php
@@ -32,7 +32,7 @@ class CleanupNames extends Command
                             {--backup : Create database backup before changes}
                             {--force : Skip confirmation prompt}';
 
-    protected $description = 'Sanitize name fields by removing invalid characters (keeping only letters, numbers, spaces, dashes, underscores, dots, slashes, colons, parentheses)';
+    protected $description = 'Sanitize name fields by removing dangerous characters';
 
     protected array $modelsToClean = [
         'Project' => Project::class,

--- a/app/Livewire/Project/Application/General.php
+++ b/app/Livewire/Project/Application/General.php
@@ -232,8 +232,6 @@ class General extends Component
             ValidationPatterns::combinedMessages(),
             [
                 'name.required' => 'The Name field is required.',
-                'name.regex' => 'The Name may only contain letters, numbers, spaces, dashes (-), underscores (_), dots (.), slashes (/), colons (:), and parentheses ().',
-                'description.regex' => 'The Description contains invalid characters. Only letters, numbers, spaces, and common punctuation (- _ . : / () \' " , ! ? @ # % & + = [] {} | ~ ` *) are allowed.',
                 'gitRepository.required' => 'The Git Repository field is required.',
                 'gitBranch.required' => 'The Git Branch field is required.',
                 'buildPack.required' => 'The Build Pack field is required.',

--- a/app/Livewire/Project/Database/Mariadb/General.php
+++ b/app/Livewire/Project/Database/Mariadb/General.php
@@ -91,8 +91,6 @@ class General extends Component
             ValidationPatterns::combinedMessages(),
             [
                 'name.required' => 'The Name field is required.',
-                'name.regex' => 'The Name may only contain letters, numbers, spaces, dashes (-), underscores (_), dots (.), slashes (/), colons (:), and parentheses ().',
-                'description.regex' => 'The Description contains invalid characters. Only letters, numbers, spaces, and common punctuation (- _ . : / () \' " , ! ? @ # % & + = [] {} | ~ ` *) are allowed.',
                 'mariadbRootPassword.required' => 'The Root Password field is required.',
                 'mariadbUser.required' => 'The MariaDB User field is required.',
                 'mariadbPassword.required' => 'The MariaDB Password field is required.',

--- a/app/Livewire/Project/Database/Mongodb/General.php
+++ b/app/Livewire/Project/Database/Mongodb/General.php
@@ -91,8 +91,6 @@ class General extends Component
             ValidationPatterns::combinedMessages(),
             [
                 'name.required' => 'The Name field is required.',
-                'name.regex' => 'The Name may only contain letters, numbers, spaces, dashes (-), underscores (_), dots (.), slashes (/), colons (:), and parentheses ().',
-                'description.regex' => 'The Description contains invalid characters. Only letters, numbers, spaces, and common punctuation (- _ . : / () \' " , ! ? @ # % & + = [] {} | ~ ` *) are allowed.',
                 'mongoInitdbRootUsername.required' => 'The Root Username field is required.',
                 'mongoInitdbRootPassword.required' => 'The Root Password field is required.',
                 'mongoInitdbDatabase.required' => 'The MongoDB Database field is required.',

--- a/app/Livewire/Project/Database/Mysql/General.php
+++ b/app/Livewire/Project/Database/Mysql/General.php
@@ -94,8 +94,6 @@ class General extends Component
             ValidationPatterns::combinedMessages(),
             [
                 'name.required' => 'The Name field is required.',
-                'name.regex' => 'The Name may only contain letters, numbers, spaces, dashes (-), underscores (_), dots (.), slashes (/), colons (:), and parentheses ().',
-                'description.regex' => 'The Description contains invalid characters. Only letters, numbers, spaces, and common punctuation (- _ . : / () \' " , ! ? @ # % & + = [] {} | ~ ` *) are allowed.',
                 'mysqlRootPassword.required' => 'The Root Password field is required.',
                 'mysqlUser.required' => 'The MySQL User field is required.',
                 'mysqlPassword.required' => 'The MySQL Password field is required.',

--- a/app/Livewire/Project/Database/Postgresql/General.php
+++ b/app/Livewire/Project/Database/Postgresql/General.php
@@ -106,8 +106,6 @@ class General extends Component
             ValidationPatterns::combinedMessages(),
             [
                 'name.required' => 'The Name field is required.',
-                'name.regex' => 'The Name may only contain letters, numbers, spaces, dashes (-), underscores (_), dots (.), slashes (/), colons (:), and parentheses ().',
-                'description.regex' => 'The Description contains invalid characters. Only letters, numbers, spaces, and common punctuation (- _ . : / () \' " , ! ? @ # % & + = [] {} | ~ ` *) are allowed.',
                 'postgresUser.required' => 'The Postgres User field is required.',
                 'postgresPassword.required' => 'The Postgres Password field is required.',
                 'postgresDb.required' => 'The Postgres Database field is required.',

--- a/app/Livewire/Project/Database/Redis/General.php
+++ b/app/Livewire/Project/Database/Redis/General.php
@@ -88,8 +88,6 @@ class General extends Component
             ValidationPatterns::combinedMessages(),
             [
                 'name.required' => 'The Name field is required.',
-                'name.regex' => 'The Name may only contain letters, numbers, spaces, dashes (-), underscores (_), dots (.), slashes (/), colons (:), and parentheses ().',
-                'description.regex' => 'The Description contains invalid characters. Only letters, numbers, spaces, and common punctuation (- _ . : / () \' " , ! ? @ # % & + = [] {} | ~ ` *) are allowed.',
                 'image.required' => 'The Docker Image field is required.',
                 'publicPort.integer' => 'The Public Port must be an integer.',
                 'redisUsername.required' => 'The Redis Username field is required.',

--- a/app/Livewire/Project/Service/StackForm.php
+++ b/app/Livewire/Project/Service/StackForm.php
@@ -52,8 +52,6 @@ class StackForm extends Component
             ValidationPatterns::combinedMessages(),
             [
                 'name.required' => 'The Name field is required.',
-                'name.regex' => 'The Name may only contain letters, numbers, spaces, dashes (-), underscores (_), dots (.), slashes (/), colons (:), and parentheses ().',
-                'description.regex' => 'The Description contains invalid characters. Only letters, numbers, spaces, and common punctuation (- _ . : / () \' " , ! ? @ # % & + = [] {} | ~ ` *) are allowed.',
                 'dockerComposeRaw.required' => 'The Docker Compose Raw field is required.',
                 'dockerCompose.required' => 'The Docker Compose field is required.',
             ]

--- a/app/Livewire/Security/PrivateKey/Show.php
+++ b/app/Livewire/Security/PrivateKey/Show.php
@@ -40,8 +40,6 @@ class Show extends Component
             ValidationPatterns::combinedMessages(),
             [
                 'name.required' => 'The Name field is required.',
-                'name.regex' => 'The Name may only contain letters, numbers, spaces, dashes (-), underscores (_), dots (.), slashes (/), colons (:), and parentheses ().',
-                'description.regex' => 'The Description contains invalid characters. Only letters, numbers, spaces, and common punctuation (- _ . : / () \' " , ! ? @ # % & + = [] {} | ~ ` *) are allowed.',
                 'privateKeyValue.required' => 'The Private Key field is required.',
                 'privateKeyValue.string' => 'The Private Key must be a valid string.',
             ]

--- a/app/Livewire/Storage/Form.php
+++ b/app/Livewire/Storage/Form.php
@@ -50,8 +50,6 @@ class Form extends Component
         return array_merge(
             ValidationPatterns::combinedMessages(),
             [
-                'name.regex' => 'The Name may only contain letters, numbers, spaces, dashes (-), underscores (_), dots (.), slashes (/), colons (:), and parentheses ().',
-                'description.regex' => 'The Description contains invalid characters. Only letters, numbers, spaces, and common punctuation (- _ . : / () \' " , ! ? @ # % & + = [] {} | ~ ` *) are allowed.',
                 'region.required' => 'The Region field is required.',
                 'region.max' => 'The Region may not be greater than 255 characters.',
                 'key.required' => 'The Access Key field is required.',

--- a/app/Livewire/Team/Index.php
+++ b/app/Livewire/Team/Index.php
@@ -37,8 +37,6 @@ class Index extends Component
             ValidationPatterns::combinedMessages(),
             [
                 'name.required' => 'The Name field is required.',
-                'name.regex' => 'The Name may only contain letters, numbers, spaces, dashes (-), underscores (_), dots (.), slashes (/), colons (:), and parentheses ().',
-                'description.regex' => 'The Description contains invalid characters. Only letters, numbers, spaces, and common punctuation (- _ . : / () \' " , ! ? @ # % & + = [] {} | ~ ` *) are allowed.',
             ]
         );
     }

--- a/app/Support/ValidationPatterns.php
+++ b/app/Support/ValidationPatterns.php
@@ -8,16 +8,14 @@ namespace App\Support;
 class ValidationPatterns
 {
     /**
-     * Pattern for names (allows letters, numbers, spaces, dashes, underscores, dots, slashes, colons, parentheses)
-     * Matches CleanupNames::sanitizeName() allowed characters
-     */
-    public const NAME_PATTERN = '/^[a-zA-Z0-9\s\-_.:\/()]+$/';
+     * Pattern for names excluding all dangerous characters
+    */
+    public const NAME_PATTERN = '/^[\p{L}\p{M}\p{N}\s\-_.]+$/u';
 
     /**
-     * Pattern for descriptions (allows more characters including quotes, commas, etc.)
-     * More permissive than names but still restricts dangerous characters
+     * Pattern for descriptions excluding all dangerous characters with some additional allowed characters
      */
-    public const DESCRIPTION_PATTERN = '/^[a-zA-Z0-9\s\-_.:\/()\'\",.!?@#%&+=\[\]{}|~`*]+$/';
+    public const DESCRIPTION_PATTERN = '/^[\p{L}\p{M}\p{N}\s\-_.,!?()\'\"+=*]+$/u';
 
     /**
      * Get validation rules for name fields
@@ -66,7 +64,7 @@ class ValidationPatterns
     public static function nameMessages(): array
     {
         return [
-            'name.regex' => 'The name may only contain letters, numbers, spaces, dashes (-), underscores (_), dots (.), slashes (/), colons (:), and parentheses ().',
+            'name.regex' => "The name may only contain letters (including Unicode), numbers, spaces, dashes (-), underscores (_) and dots (.).",
             'name.min' => 'The name must be at least :min characters.',
             'name.max' => 'The name may not be greater than :max characters.',
         ];
@@ -78,12 +76,12 @@ class ValidationPatterns
     public static function descriptionMessages(): array
     {
         return [
-            'description.regex' => 'The description contains invalid characters. Only letters, numbers, spaces, and common punctuation (- _ . : / () \' " , ! ? @ # % & + = [] {} | ~ ` *) are allowed.',
+            'description.regex' => "The description may only contain letters (including Unicode), numbers, spaces, and common punctuation (- _ . , ! ? ( ) ' \" + = *).",
             'description.max' => 'The description may not be greater than :max characters.',
         ];
     }
 
-    /**
+    /** 
      * Get combined validation messages for both name and description fields
      */
     public static function combinedMessages(): array


### PR DESCRIPTION
## Changes

- feat: allow more characters specifically Unicode alpha-numeric characters contained in [\p{L}](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AL%3A%5D&g=&i=), [\p{M}](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AM%3A%5D&g=&i=), [\p{N}](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3AN%3A%5D&g=&i=) when validating while still not allowing any unsafe characters
- feat: remove some more medium risk characters form name and description pattern
- refactor: remove duplicated validation messages from a few files
