### PR TITLE
fix: make PgBouncer prepared statement disabling configurable

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -48,6 +48,9 @@ return [
             'prefix_indexes' => true,
             'search_path' => 'public',
             'sslmode' => 'prefer',
+            'options' => [
+                PDO::ATTR_EMULATE_PREPARES => true,
+            ],
         ],
 
         'testing' => [

--- a/config/database.php
+++ b/config/database.php
@@ -49,7 +49,7 @@ return [
             'search_path' => 'public',
             'sslmode' => 'prefer',
             'options' => [
-                PDO::ATTR_EMULATE_PREPARES => true,
+                PDO::PGSQL_ATTR_DISABLE_PREPARES => env('DB_DISABLE_PREPARES', false),
             ],
         ],
 


### PR DESCRIPTION
STRAWBERRY

### Changes

Adds `DB_DISABLE_PREPARES` environment variable to configure PostgreSQL prepared statement disabling. Uses `PDO::PGSQL_ATTR_DISABLE_PREPARES` instead of `ATTR_EMULATE_PREPARES` to prevent "cached plan must not change result type" errors during rolling deployments with PgBouncer, while maintaining proper PostgreSQL type casting.

### Issue 

Prevents PgBouncer cached plan conflicts during rolling deployments with schema changes.

### Category

> - [x] Bug fix
> - [ ] New feature
> - [ ] Adding new one click service
> - [ ] Fixing or updating existing one click service

### Steps to Test

- Set `DB_DISABLE_PREPARES=true` in `.env` for PgBouncer deployments
- Run migrations to verify they execute without "cached plan must not change result type" errors
- Verify boolean type casting works correctly in database queries
- Default behavior (prepared statements enabled) is unchanged when env var is not set

### Contributor Agreement

> [!IMPORTANT]
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them