### PR TITLE
fix(log): preserve leading whitespace in logs

### DIFF
--- a/resources/views/livewire/project/shared/get-logs.blade.php
+++ b/resources/views/livewire/project/shared/get-logs.blade.php
@@ -435,7 +435,7 @@
                                     // Parse timestamp from log line (ISO 8601 format: 2025-12-04T11:48:39.136764033Z)
                                     $timestamp = '';
                                     $logContent = $line;
-                                    if (preg_match('/^(\d{4})-(\d{2})-(\d{2})T(\d{2}:\d{2}:\d{2})(?:\.(\d+))?Z?\s*(.*)$/', $line, $matches)) {
+                                    if (preg_match('/^(\d{4})-(\d{2})-(\d{2})T(\d{2}:\d{2}:\d{2})(?:\.(\d+))?Z?\s(.*)$/', $line, $matches)) {
                                         $year = $matches[1];
                                         $month = $matches[2];
                                         $day = $matches[3];


### PR DESCRIPTION
## Changes

- Updated regex in `resources/views/livewire/project/shared/get-logs.blade.php` to prevent greedy whitespace consumption.
- Changed `\s*` (zero or more whitespace) to `\s` (single whitespace) to consume only the single separator space added by Docker logs between the timestamp and the message.
- This ensures that intended indentation in user logs (e.g. stack traces, formatted JSON) is preserved.

## Issues

- fixes https://github.com/coollabsio/coolify/issues/7862