### PR TITLE
feat(deployment): add force start and cancel functionality for deployments list

### DIFF
--- a/app/Livewire/Project/Application/Deployment/Index.php
+++ b/app/Livewire/Project/Application/Deployment/Index.php
@@ -2,7 +2,10 @@
 
 namespace App\Livewire\Project\Application\Deployment;
 
+use App\Enums\ApplicationDeploymentStatus;
 use App\Models\Application;
+use App\Models\ApplicationDeploymentQueue;
+use App\Models\Server;
 use Illuminate\Support\Collection;
 use Livewire\Component;
 
@@ -158,6 +161,71 @@ class Index extends Component
     private function updateCurrentPage()
     {
         $this->currentPage = intval($this->skip / $this->defaultTake) + 1;
+    }
+
+    public function force_start($deployment_uuid)
+    {
+        try {
+            $deployment = ApplicationDeploymentQueue::where('deployment_uuid', $deployment_uuid)->first();
+            if ($deployment) {
+                force_start_deployment($deployment);
+                $this->loadDeployments();
+            }
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function cancel($deployment_uuid)
+    {
+        try {
+            $deployment = ApplicationDeploymentQueue::where('deployment_uuid', $deployment_uuid)->first();
+            if (! $deployment) {
+                return;
+            }
+
+            $kill_command = "docker rm -f {$deployment_uuid}";
+            $build_server_id = $deployment->build_server_id ?? $this->application->destination->server_id;
+            $server_id = $deployment->server_id ?? $this->application->destination->server_id;
+
+            // First, mark the deployment as cancelled to prevent further processing
+            $deployment->update([
+                'status' => ApplicationDeploymentStatus::CANCELLED_BY_USER->value,
+            ]);
+
+            if ($this->application->settings->is_build_server_enabled) {
+                $server = Server::ownedByCurrentTeam()->find($build_server_id);
+            } else {
+                $server = Server::ownedByCurrentTeam()->find($server_id);
+            }
+
+            // Add cancellation log entry
+            if ($deployment->logs) {
+                $previous_logs = json_decode($deployment->logs, associative: true, flags: JSON_THROW_ON_ERROR);
+
+                $new_log_entry = [
+                    'command' => $kill_command,
+                    'output' => 'Deployment cancelled by user.',
+                    'type' => 'stderr',
+                    'timestamp' => now()->toIso8601String(),
+                    'hidden' => false,
+                    'batch' => 0,
+                ];
+                $previous_logs[] = $new_log_entry;
+                $deployment->update([
+                    'logs' => json_encode($previous_logs, flags: JSON_THROW_ON_ERROR),
+                ]);
+            }
+
+            if ($server) {
+                instant_remote_process([$kill_command], $server, false);
+            }
+
+            $this->loadDeployments();
+            $this->dispatch('success', 'Deployment cancelled.');
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
     }
 
     public function render()

--- a/resources/views/livewire/project/application/deployment/index.blade.php
+++ b/resources/views/livewire/project/application/deployment/index.blade.php
@@ -173,6 +173,18 @@
                                 Server: {{ data_get($deployment, 'server_name') }}
                             </div>
                         @endif
+
+                        <a href='#' class='flex items-center gap-2 mt-2'>
+                            @if (data_get($deployment, 'status') === 'queued')
+                                <x-forms.button wire:click.stop.prevent="force_start('{{ data_get($deployment, 'deployment_uuid') }}')">Force Start</x-forms.button>    
+                            @endif
+                            @if (
+                                data_get($deployment, 'status') === 'in_progress' ||
+                                data_get($deployment, 'status') === 'queued'
+                            )
+                                <x-forms.button isError wire:click.stop.prevent="cancel('{{ data_get($deployment, 'deployment_uuid') }}')">Cancel</x-forms.button>
+                            @endif
+                        </a>
                     </div>
                 </a>
             </div>


### PR DESCRIPTION
I've added a force start button for queued deployments and a cancel button for queued and progress deployments in the deployments list. 

This creates a shortcut to avoid entering in each deployment to do an action. 

## Changes
- Added force_start and cancel methods in the deployment index
- added a force start and cancel button in the deployments list item, at the bottom as the global <a> was causing issues.

<img width="547" height="182" alt="Screenshot 2026-01-06 223206" src="https://github.com/user-attachments/assets/f2da73df-76c8-468f-800a-a314e0846fb7" />
