### PR TITLE
fix: prevent duplicate nginx location block for Laravel apps

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -2247,7 +2247,10 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                 $is_laravel = data_get($parsed, 'variables.IS_LARAVEL', false);
                 if ($is_laravel) {
                     $variables = $this->laravel_finetunes();
-                    data_set($parsed, 'variables.NIXPACKS_PHP_FALLBACK_PATH', $variables[0]->value);
+                    // Fix #7867: Do NOT set NIXPACKS_PHP_FALLBACK_PATH for Laravel apps.
+                    // When IS_LARAVEL=true, Nixpacks nginx template already creates "location /" block.
+                    // Setting NIXPACKS_PHP_FALLBACK_PATH would create a duplicate, causing nginx to fail.
+                    // data_set($parsed, 'variables.NIXPACKS_PHP_FALLBACK_PATH', $variables[0]->value);
                     data_set($parsed, 'variables.NIXPACKS_PHP_ROOT_DIR', $variables[1]->value);
                 }
                 if ($this->nixpacks_type === 'elixir') {


### PR DESCRIPTION
Fixes #7867

When deploying Laravel applications with Nixpacks, the nginx configuration was failing with 'duplicate location "/"' error.

Root cause:
- Nixpacks nginx template has two conditional 'location /' blocks:
  1. When IS_LARAVEL=true (detected automatically for Laravel apps)
  2. When NIXPACKS_PHP_FALLBACK_PATH is set
- Coolify was setting NIXPACKS_PHP_FALLBACK_PATH for Laravel apps, causing both conditions to be true and creating duplicate blocks.

Solution:
- Remove NIXPACKS_PHP_FALLBACK_PATH for Laravel apps since IS_LARAVEL=true already configures the correct nginx routing.
- Keep NIXPACKS_PHP_ROOT_DIR to ensure proper public directory configuration.

Tested with TALL stack (Tailwind, Alpine, Livewire, Laravel) project containing both composer.json and package.json - nginx now starts correctly.
