### PR TITLE
fix(git): trigger deployments when watch_paths is empty or unset

### DIFF
--- a/app/Http/Controllers/Webhook/Github.php
+++ b/app/Http/Controllers/Webhook/Github.php
@@ -343,8 +343,9 @@ class Github extends Controller
                     }
                     if ($x_github_event === 'push') {
                         if ($application->isDeployable()) {
+                            $has_watch_paths = ! blank($application->watch_paths);
                             $is_watch_path_triggered = $application->isWatchPathsTriggered($changed_files);
-                            if ($is_watch_path_triggered || is_null($application->watch_paths)) {
+                            if (! $has_watch_paths || $is_watch_path_triggered) {
                                 $deployment_uuid = new Cuid2;
                                 $result = queue_application_deployment(
                                     application: $application,


### PR DESCRIPTION
## Changes
- Treat empty/blank `watch_paths` as "no watch paths" using `blank()`.
- Introduce `$has_watch_paths = ! blank($application->watch_paths)`.
- Trigger deployment when there are no watch paths or when a change matches the watch paths: `if (! $has_watch_paths || $is_watch_path_triggered)`.

## Context
Previously, only `null` was checked, so empty/blank `watch_paths` incorrectly prevented deployments on push. This aligns behavior: if no paths are configured, any push can trigger a deployment.

## Backwards Compatibility
No breaking changes. When `watch_paths` is configured, deployments still require matching changes.

## Issues
fix #
