### PR TITLE
feat: add application logs link to preview deployments PR comment

### DIFF
--- a/app/Jobs/ApplicationPullRequestUpdateJob.php
+++ b/app/Jobs/ApplicationPullRequestUpdateJob.php
@@ -54,8 +54,9 @@ class ApplicationPullRequestUpdateJob implements ShouldBeEncrypted, ShouldQueue
                 ProcessStatus::CLOSED => '', // Already handled above, but included for completeness
             };
             $this->build_logs_url = base_url()."/project/{$this->application->environment->project->uuid}/environment/{$this->application->environment->uuid}/application/{$this->application->uuid}/deployment/{$this->deployment_uuid}";
+            $application_logs_url = base_url()."/project/{$this->application->environment->project->uuid}/environment/{$this->application->environment->uuid}/application/{$this->application->uuid}/logs";
 
-            $this->body .= '[Open Build Logs]('.$this->build_logs_url.")\n\n\n";
+            $this->body .= '[Open Build Logs]('.$this->build_logs_url.') | [Open Application Logs]('.$application_logs_url.")\n\n\n";
             $this->body .= 'Last updated at: '.now()->toDateTimeString().' CET';
             if ($this->preview->pull_request_issue_comment_id) {
                 $this->update_comment();


### PR DESCRIPTION
## Changes

- feat: add application logs link to preview deployments PR comment
  - When debugging preview deployments, developers often need to check both build logs and application runtime logs. The old PR comment only included a link to build logs, requiring users to manually navigate to find application logs.