### PR TITLE
fix(docker): use dynamic OS ID for Docker repository URL

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -117,11 +117,11 @@ class InstallDocker
     private function getDebianDockerInstallCommand(): string
     {
         return "curl --max-time 300 --retry 3 https://releases.rancher.com/install-docker/{$this->dockerVersion}.sh | sh || curl --max-time 300 --retry 3 https://get.docker.com | sh -s -- --version {$this->dockerVersion} || (".
-            'install -m 0755 -d /etc/apt/keyrings && '.
-            'curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc && '.
-            'chmod a+r /etc/apt/keyrings/docker.asc && '.
             '. /etc/os-release && '.
-            'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian ${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list && '.
+            'install -m 0755 -d /etc/apt/keyrings && '.
+            'curl -fsSL https://download.docker.com/linux/${ID}/gpg -o /etc/apt/keyrings/docker.asc && '.
+            'chmod a+r /etc/apt/keyrings/docker.asc && '.
+            'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${ID} ${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list && '.
             'apt-get update && '.
             'apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin'.
             ')';


### PR DESCRIPTION
STRAWBERRY

### Changes
> Fix Docker installation on Ubuntu servers by using the dynamic `${ID}` variable from `/etc/os-release` instead of hardcoded "debian" in the Docker repository URL. This was causing Ubuntu servers to incorrectly use `download.docker.com/linux/debian` instead of `download.docker.com/linux/ubuntu`.


### Issue 
> - Reported via Discord - Ubuntu servers failing with: `The repository 'https://download.docker.com/linux/debian noble Release' does not have a Release file`


### Category
> - [x] Bug fix


### AI Usage
> - [x] AI is used in the process of creating this PR


### Steps to Test
> - Step 1 – Add an Ubuntu 24.04 (noble) server to Coolify
> - Step 2 – Navigate to Server Settings and trigger Docker installation/validation
> - Step 3 – Verify Docker installs successfully without repository errors
> - Step 4 – SSH into the server and check `/etc/apt/sources.list.d/docker.list` contains `download.docker.com/linux/ubuntu` (not debian)
> - Step 5 – Repeat test on Debian server to ensure it still uses `download.docker.com/linux/debian`


### Contributor Agreement
> [!IMPORTANT]
 > - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
 > - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them