### PR TITLE
docs: remove git worktree symlink instructions from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,42 +10,6 @@ This file provides guidance to **Claude Code** (claude.ai/code) when working wit
 
 Coolify is an open-source, self-hostable platform for deploying applications and managing servers - an alternative to Heroku/Netlify/Vercel. It's built with Laravel (PHP) and uses Docker for containerization.
 
-## Git Worktree Shared Dependencies
-
-This repository uses git worktrees for parallel development with **automatic shared dependency setup** via Conductor.
-
-### How It Works
-
-The `conductor.json` setup script (`scripts/conductor-setup.sh`) automatically:
-1. Creates symlinks from worktree's `node_modules` and `vendor` to the main repository's directories
-2. All worktrees share the same dependencies from the main repository
-3. This happens automatically when Conductor creates a new worktree
-
-### Benefits
-
-- **Save disk space**: Only one copy of dependencies across all worktrees
-- **Faster setup**: No need to run `npm install` or `composer install` for each worktree
-- **Consistent versions**: All worktrees use the same dependency versions
-- **Auto-configured**: Handled by Conductor's setup script
-- **Simple**: Uses the main repo's existing directories, no extra folders
-
-### Manual Setup (If Needed)
-
-If you need to set up symlinks manually or for non-Conductor worktrees:
-
-```bash
-# From the worktree directory
-rm -rf node_modules vendor
-ln -sf ../../node_modules node_modules
-ln -sf ../../vendor vendor
-```
-
-### Important Notes
-
-- Dependencies are shared from the main repository (`$CONDUCTOR_ROOT_PATH`)
-- Run `npm install` or `composer install` from the main repo or any worktree to update all
-- If different branches need different dependency versions, this won't work - remove symlinks and use separate directories
-
 ## Development Commands
 
 ### Frontend Development


### PR DESCRIPTION
STRAWBERRY

### Changes
> Remove the "Git Worktree Shared Dependencies" section from CLAUDE.md. This section contained Conductor-specific worktree setup instructions (symlinks for node_modules and vendor directories) that are not relevant to the main repository documentation.

### Issue 
> - N/A (documentation cleanup)

### Category
> - [x] Bug fix

### AI Usage
> - [x] AI is used in the process of creating this PR

### Steps to Test
> - Step 1 – Open CLAUDE.md in the repository
> - Step 2 – Verify the "Git Worktree Shared Dependencies" section no longer exists
> - Step 3 – Confirm the document flows directly from "Project Overview" to "Development Commands"
> - Step 4 – Verify no formatting issues (proper spacing between sections)

### Contributor Agreement
> [!IMPORTANT]
 > - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
 > - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them