### PR TITLE
feat: include coolify.tags in autogenerated container labels

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -2487,7 +2487,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                 return escapeDollarSign($value);
             });
         }
-        $labels = $labels->merge(defaultLabels($this->application->id, $this->application->uuid, $this->application->project()->name, $this->application->name, $this->application->environment->name, $this->pull_request_id))->toArray();
+        $labels = $labels->merge(defaultLabels($this->application->id, $this->application->uuid, $this->application->project()->name, $this->application->name, $this->application->environment->name, $this->pull_request_id, tags: $this->application->tags))->toArray();
 
         // Check for custom HEALTHCHECK
         if ($this->application->build_pack === 'dockerfile' || $this->application->dockerfile) {

--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -209,6 +209,23 @@ function get_port_from_dockerfile($dockerfile): ?int
     return null;
 }
 
+function formatTagsForDockerLabel($tags, int $limit = 50): string
+{
+    if (! $tags || $tags->isEmpty()) {
+        return '';
+    }
+
+    return $tags->take($limit)
+        ->pluck('name')
+        ->map(function ($tag) {
+            // Sanitize to only allow characters safe for Docker labels
+            // Allows: alphanumeric, hyphens, underscores, periods, colons, forward slashes
+            return preg_replace('/[^a-zA-Z0-9\-_.:\/]/', '', $tag);
+        })
+        ->filter() // Remove empty strings after sanitization
+        ->implode(' ');
+}
+
 function defaultDatabaseLabels($database)
 {
     $labels = collect([]);
@@ -221,10 +238,15 @@ function defaultDatabaseLabels($database)
     $labels->push('coolify.environmentName='.Str::slug($database->environment->name));
     $labels->push('coolify.database.subType='.$database->type());
 
+    $tagsLabel = formatTagsForDockerLabel($database->tags ?? collect());
+    if ($tagsLabel) {
+        $labels->push('coolify.tags='.$tagsLabel);
+    }
+
     return $labels;
 }
 
-function defaultLabels($id, $name, string $projectName, string $resourceName, string $environment, $pull_request_id = 0, string $type = 'application', $subType = null, $subId = null, $subName = null)
+function defaultLabels($id, $name, string $projectName, string $resourceName, string $environment, $pull_request_id = 0, string $type = 'application', $subType = null, $subId = null, $subName = null, $tags = null)
 {
     $labels = collect([]);
     $labels->push('coolify.managed=true');
@@ -242,6 +264,13 @@ function defaultLabels($id, $name, string $projectName, string $resourceName, st
         $subId && $labels->push('coolify.service.subId='.$subId);
         $subType && $labels->push('coolify.service.subType='.$subType);
         $subName && $labels->push('coolify.service.subName='.Str::slug($subName));
+    }
+
+    if ($tags) {
+        $tagsLabel = formatTagsForDockerLabel($tags);
+        if ($tagsLabel) {
+            $labels->push('coolify.tags='.$tagsLabel);
+        }
     }
 
     return $labels;

--- a/bootstrap/helpers/parsers.php
+++ b/bootstrap/helpers/parsers.php
@@ -1168,6 +1168,7 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
             pull_request_id: $pullRequestId,
             type: 'application',
             environment: $resource->environment->name,
+            tags: $resource->tags,
         );
 
         $isDatabase = isDatabaseImage($image, $service);
@@ -2272,6 +2273,7 @@ function serviceParser(Service $resource): Collection
             subId: $savedService->id,
             subName: $savedService->human_name ?? $savedService->name,
             environment: $resource->environment->name,
+            tags: $resource->tags,
         );
 
         // Add COOLIFY_FQDN & COOLIFY_URL to environment

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -1918,6 +1918,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                     subId: $savedService->id,
                     subName: $savedService->name,
                     environment: $resource->environment->name,
+                    tags: $resource->tags,
                 );
                 $serviceLabels = $serviceLabels->merge($defaultLabels);
                 if (! $isDatabase && $fqdns->count() > 0) {
@@ -2765,7 +2766,8 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                 resourceName: $resource->name,
                 environment: $resource->environment->name,
                 pull_request_id: $pull_request_id,
-                type: 'application'
+                type: 'application',
+                tags: $resource->tags,
             );
             $serviceLabels = $serviceLabels->merge($defaultLabels);
 


### PR DESCRIPTION
## Changes
- auto generated labels now include a ``coolify.tags``
- includes the first 50 tags (so things dont break if a user adds 1000s of tags to a single application)
- each tag is seperated by a space, since tag's don't support a space
- only has the label if there is a tag
- sanitizes tags for characters that docker labels don't support

## Issues
- feature request: https://github.com/coollabsio/coolify/discussions/7920

<img width="1778" height="635" alt="image" src="https://github.com/user-attachments/assets/a6b7cc4e-b18c-4222-b43f-217959eb7f48" />


