### PR TITLE
fix(templates): update Rocket Chat MongoDB for v8 compatibility

### DIFF
--- a/templates/compose/rocketchat.yaml
+++ b/templates/compose/rocketchat.yaml
@@ -31,7 +31,7 @@ services:
       retries: 15
 
   mongodb:
-    image: docker.io/bitnamilegacy/mongodb:5.0
+    image: docker.io/bitnami/mongodb:latest
     volumes:
       - mongodb_data:/bitnami/mongodb
     environment:
@@ -44,7 +44,7 @@ services:
       - MONGODB_ENABLE_JOURNAL=${MONGODB_ENABLE_JOURNAL:-true}
       - ALLOW_EMPTY_PASSWORD=${ALLOW_EMPTY_PASSWORD:-yes}
     healthcheck:
-      test: echo 'db.stats().ok' | mongo localhost:27017/test --quiet
-      interval: 2s
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping')"]
+      interval: 5s
       timeout: 10s
       retries: 15


### PR DESCRIPTION
## Summary

Fixes the Rocket Chat V8 deployment issue where MongoDB container fails healthcheck.

/claim #7941

## Root Cause

1. **Outdated MongoDB image**: `bitnamilegacy/mongodb:5.0` is incompatible with Rocket Chat V8 which requires MongoDB 7.0+
2. **Deprecated healthcheck**: The `mongo` CLI was removed in MongoDB 6.0+, replaced by `mongosh`

## Changes

- Update MongoDB image from `bitnamilegacy/mongodb:5.0` to `bitnami/mongodb:latest`
- Fix healthcheck to use `mongosh` instead of deprecated `mongo` CLI  
- Increase healthcheck interval from 2s to 5s (mongosh startup is slower than legacy mongo shell)

## Testing

Tested locally with Docker Compose:
- MongoDB container starts and becomes healthy
- Rocket Chat connects to MongoDB successfully
- Rocket Chat health endpoint returns `{"status":"ok"}`

## Demo

**Will add demo video in comments**

Fixes #7941