### PR TITLE
fix: allow / and @ in project names

### DIFF
--- a/app/Http/Controllers/Api/ProjectController.php
+++ b/app/Http/Controllers/Api/ProjectController.php
@@ -238,9 +238,9 @@ class ProjectController extends Controller
             return $return;
         }
         $validator = Validator::make($request->all(), [
-            'name' => ValidationPatterns::nameRules(),
+            'name' => ValidationPatterns::projectNameRules(),
             'description' => ValidationPatterns::descriptionRules(),
-        ], ValidationPatterns::combinedMessages());
+        ], ValidationPatterns::projectCombinedMessages());
 
         $extraFields = array_diff(array_keys($request->all()), $allowedFields);
         if ($validator->fails() || ! empty($extraFields)) {
@@ -351,9 +351,9 @@ class ProjectController extends Controller
             return $return;
         }
         $validator = Validator::make($request->all(), [
-            'name' => ValidationPatterns::nameRules(required: false),
+            'name' => ValidationPatterns::projectNameRules(required: false),
             'description' => ValidationPatterns::descriptionRules(),
-        ], ValidationPatterns::combinedMessages());
+        ], ValidationPatterns::projectCombinedMessages());
 
         $extraFields = array_diff(array_keys($request->all()), $allowedFields);
         if ($validator->fails() || ! empty($extraFields)) {

--- a/app/Livewire/Project/AddEmpty.php
+++ b/app/Livewire/Project/AddEmpty.php
@@ -16,14 +16,14 @@ class AddEmpty extends Component
     protected function rules(): array
     {
         return [
-            'name' => ValidationPatterns::nameRules(),
+            'name' => ValidationPatterns::projectNameRules(),
             'description' => ValidationPatterns::descriptionRules(),
         ];
     }
 
     protected function messages(): array
     {
-        return ValidationPatterns::combinedMessages();
+        return ValidationPatterns::projectCombinedMessages();
     }
 
     public function submit()

--- a/app/Livewire/Project/CloneMe.php
+++ b/app/Livewire/Project/CloneMe.php
@@ -91,9 +91,13 @@ class CloneMe extends Component
     public function clone(string $type)
     {
         try {
+            $nameRules = $type === 'project'
+                ? ValidationPatterns::projectNameRules()
+                : ValidationPatterns::nameRules();
+
             $this->validate([
                 'selectedDestination' => 'required',
-                'newName' => ValidationPatterns::nameRules(),
+                'newName' => $nameRules,
             ]);
             if ($type === 'project') {
                 $foundProject = Project::where('name', $this->newName)->first();

--- a/app/Livewire/Project/Edit.php
+++ b/app/Livewire/Project/Edit.php
@@ -17,14 +17,14 @@ class Edit extends Component
     protected function rules(): array
     {
         return [
-            'name' => ValidationPatterns::nameRules(),
+            'name' => ValidationPatterns::projectNameRules(),
             'description' => ValidationPatterns::descriptionRules(),
         ];
     }
 
     protected function messages(): array
     {
-        return ValidationPatterns::combinedMessages();
+        return ValidationPatterns::projectCombinedMessages();
     }
 
     public function mount(string $project_uuid)

--- a/app/Support/ValidationPatterns.php
+++ b/app/Support/ValidationPatterns.php
@@ -9,8 +9,13 @@ class ValidationPatterns
 {
     /**
      * Pattern for names excluding all dangerous characters
-    */
+     */
     public const NAME_PATTERN = '/^[\p{L}\p{M}\p{N}\s\-_.]+$/u';
+
+    /**
+     * Pattern for project names allowing slashes and at signs
+     */
+    public const PROJECT_NAME_PATTERN = '/^[\p{L}\p{M}\p{N}\s\-_.\/@]+$/u';
 
     /**
      * Pattern for descriptions excluding all dangerous characters with some additional allowed characters
@@ -34,6 +39,27 @@ class ValidationPatterns
         $rules[] = "min:$minLength";
         $rules[] = "max:$maxLength";
         $rules[] = 'regex:'.self::NAME_PATTERN;
+
+        return $rules;
+    }
+
+    /**
+     * Get validation rules for project name fields
+     */
+    public static function projectNameRules(bool $required = true, int $minLength = 3, int $maxLength = 255): array
+    {
+        $rules = [];
+
+        if ($required) {
+            $rules[] = 'required';
+        } else {
+            $rules[] = 'nullable';
+        }
+
+        $rules[] = 'string';
+        $rules[] = "min:$minLength";
+        $rules[] = "max:$maxLength";
+        $rules[] = 'regex:'.self::PROJECT_NAME_PATTERN;
 
         return $rules;
     }
@@ -64,7 +90,19 @@ class ValidationPatterns
     public static function nameMessages(): array
     {
         return [
-            'name.regex' => "The name may only contain letters (including Unicode), numbers, spaces, dashes (-), underscores (_) and dots (.).",
+            'name.regex' => 'The name may only contain letters (including Unicode), numbers, spaces, dashes (-), underscores (_) and dots (.).',
+            'name.min' => 'The name must be at least :min characters.',
+            'name.max' => 'The name may not be greater than :max characters.',
+        ];
+    }
+
+    /**
+     * Get validation messages for project name fields
+     */
+    public static function projectNameMessages(): array
+    {
+        return [
+            'name.regex' => 'The name may only contain letters (including Unicode), numbers, spaces, dashes (-), underscores (_), dots (.), slashes (/), and at signs (@).',
             'name.min' => 'The name must be at least :min characters.',
             'name.max' => 'The name may not be greater than :max characters.',
         ];
@@ -81,11 +119,19 @@ class ValidationPatterns
         ];
     }
 
-    /** 
+    /**
      * Get combined validation messages for both name and description fields
      */
     public static function combinedMessages(): array
     {
         return array_merge(self::nameMessages(), self::descriptionMessages());
+    }
+
+    /**
+     * Get combined validation messages for project name and description fields
+     */
+    public static function projectCombinedMessages(): array
+    {
+        return array_merge(self::projectNameMessages(), self::descriptionMessages());
     }
 }


### PR DESCRIPTION
### Changes

- Allow `/` and `@` in project names via project-specific validation rules.
- Keep existing name restrictions for non-project resources.
- Apply the rules to project create/edit (UI + API) and project cloning.

### Issue 

- Resolves https://github.com/coollabsio/coolify/issues/7976

### Category

- [x] Bug fix

### AI Usage

- [x] AI is used in the process of creating this PR

### Steps to Test

- Step 1 – Open app
- Step 2 – Create a project with / or @ in the name (e.g., mahad/converge or owner@service)
- Step 3 – Confirm it saves successfully without validation errors
 