### PR TITLE
fix: async changelog prefetch

### DIFF
--- a/app/Livewire/SettingsDropdown.php
+++ b/app/Livewire/SettingsDropdown.php
@@ -11,6 +11,12 @@ class SettingsDropdown extends Component
 {
     public $showWhatsNewModal = false;
 
+    public bool $shouldPollChangelog = false;
+
+    public bool $changelogFetchRequested = false;
+
+    public int $changelogPollAttempts = 0;
+
     public function getUnreadCountProperty()
     {
         return Auth::user()->getUnreadChangelogCount();
@@ -31,6 +37,53 @@ class SettingsDropdown extends Component
     public function openWhatsNewModal()
     {
         $this->showWhatsNewModal = true;
+
+        $this->prefetchChangelog();
+    }
+
+    public function prefetchChangelog()
+    {
+        $entries = app(ChangelogService::class)->getEntriesForUser(Auth::user());
+        if ($entries->isEmpty()) {
+            if (! $this->changelogFetchRequested) {
+                $this->changelogFetchRequested = true;
+                $this->shouldPollChangelog = true;
+                $this->changelogPollAttempts = 0;
+                PullChangelog::dispatch();
+            }
+
+            return;
+        }
+
+        $this->dispatch('changelog-entries', entries: $entries->values()->all());
+    }
+
+    public function refreshChangelog()
+    {
+        if (! $this->shouldPollChangelog) {
+            return;
+        }
+
+        $this->changelogPollAttempts++;
+        if ($this->changelogPollAttempts > 10) {
+            $this->shouldPollChangelog = false;
+            $this->changelogFetchRequested = false;
+
+            return;
+        }
+
+        $entries = app(ChangelogService::class)->getEntriesForUser(Auth::user());
+        if ($entries->isEmpty()) {
+            return;
+        }
+
+        $this->shouldPollChangelog = false;
+        $this->changelogFetchRequested = false;
+        $this->changelogPollAttempts = 0;
+        $this->dispatch('changelog-entries', entries: $entries->values()->all());
+
+        cache()->forget('user_unread_changelog_count_'.Auth::id());
+        $this->dispatch('$refresh');
     }
 
     public function closeWhatsNewModal()

--- a/resources/views/livewire/settings-dropdown.blade.php
+++ b/resources/views/livewire/settings-dropdown.blade.php
@@ -8,6 +8,9 @@
         this.mounted();
         // Load all entries when component initializes
         this.allEntries = @js($entries->toArray());
+        window.addEventListener('changelog-entries', (event) => {
+            this.allEntries = event.detail.entries ?? [];
+        });
     },
     markEntryAsRead(tagName) {
         // Update the entry in our local Alpine data
@@ -103,7 +106,10 @@
             return new Date(b.published_at) - new Date(a.published_at);
         });
     }
-}" @click.outside="dropdownOpen = false">
+}" @click.outside="dropdownOpen = false" wire:init="prefetchChangelog">
+    @if ($shouldPollChangelog)
+        <span class="hidden" wire:poll.1s="refreshChangelog"></span>
+    @endif
     <!-- Custom Dropdown without arrow -->
     <div class="relative">
         <button @click="dropdownOpen = !dropdownOpen"


### PR DESCRIPTION
### Changes

- Prefetch changelog entries asynchronously on settings dropdown init.
- Start a short polling loop only when entries are missing, then stop once entries load.
- Update the changelog list and unread badge without reopening the modal.

### Issue 

- Resolves https://github.com/coollabsio/coolify/issues/7969

### Category

- [x] Bug fix

### AI Usage

- [x] AI is used in the process of creating this PR

### Steps to Test

- Step 1 - Remove local changelog files: `rm -f changelogs/*.json`.
- Step 2 - Reload the app and wait a few seconds.
- Step 3 - Confirm the unread badge updates without clicking Changelog.
- Step 4 - Open Changelog immediately and confirm entries appear without reopening.
 