### PR TITLE
fix: prevent env_file .env leakage between docker compose services

### DIFF
--- a/bootstrap/helpers/parsers.php
+++ b/bootstrap/helpers/parsers.php
@@ -1317,15 +1317,19 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
         if ($depends_on->count() > 0) {
             $payload['depends_on'] = $depends_on;
         }
-        // Auto-inject .env file so Coolify environment variables are available inside containers
-        // This makes Applications behave consistently with manual .env file usage
-        $existingEnvFiles = data_get($service, 'env_file');
-        $envFiles = collect(is_null($existingEnvFiles) ? [] : (is_array($existingEnvFiles) ? $existingEnvFiles : [$existingEnvFiles]))
-            ->push('.env')
-            ->unique()
-            ->values();
+        // Prevent automatic .env injection.
+        // This avoids leaking environment variables between services.
+        // User-defined env_file entries are preserved, except for .env.
 
-        $payload['env_file'] = $envFiles;
+        $existingEnvFiles = data_get($service, 'env_file');
+        if ($existingEnvFiles !== null) {
+            $envFiles = collect(is_array($existingEnvFiles) ? $existingEnvFiles : [$existingEnvFiles])
+                ->filter(fn ($file) => $file !== '.env')
+                ->values();
+            if ($envFiles->isNotEmpty()) {
+                $payload['env_file'] = $envFiles;
+            }
+        }
 
         // Inject commit-based image tag for services with build directive (for rollback support)
         // Only inject if service has build but no explicit image defined
@@ -2416,15 +2420,19 @@ function serviceParser(Service $resource): Collection
         if ($depends_on->count() > 0) {
             $payload['depends_on'] = $depends_on;
         }
-        // Auto-inject .env file so Coolify environment variables are available inside containers
-        // This makes Services behave consistently with Applications
+        // Do NOT auto-inject .env file to containers
+        // This was causing all environment variables to leak to every container in Docker Compose projects
+        // Environment variables are already correctly set per-container in the 'environment' section above
+        // Preserve user-specified env_file entries but filter out .env to prevent leakage
         $existingEnvFiles = data_get($service, 'env_file');
-        $envFiles = collect(is_null($existingEnvFiles) ? [] : (is_array($existingEnvFiles) ? $existingEnvFiles : [$existingEnvFiles]))
-            ->push('.env')
-            ->unique()
-            ->values();
-
-        $payload['env_file'] = $envFiles;
+        if ($existingEnvFiles !== null) {
+            $envFiles = collect(is_array($existingEnvFiles) ? $existingEnvFiles : [$existingEnvFiles])
+                ->filter(fn ($file) => $file !== '.env')
+                ->values();
+            if ($envFiles->isNotEmpty()) {
+                $payload['env_file'] = $envFiles;
+            }
+        }
 
         $parsedServices->put($serviceName, $payload);
     }

--- a/tests/Unit/EnvFileIsolationSecurityTest.php
+++ b/tests/Unit/EnvFileIsolationSecurityTest.php
@@ -1,0 +1,71 @@
+<?php
+
+it('does not auto-inject .env into env_file', function () {
+    $parsersFile = file_get_contents(__DIR__ . '/../../bootstrap/helpers/parsers.php');
+
+    // Old vulnerable behavior must not exist
+    expect($parsersFile)->not->toContain("->push('.env')");
+    expect($parsersFile)->not->toContain('->push(\'.env\')');
+});
+
+it('filters .env from env_file entries', function () {
+    $existingEnvFiles = ['./custom.env', '.env', './another.env'];
+
+    $envFiles = collect($existingEnvFiles)
+        ->filter(fn ($file) => $file !== '.env')
+        ->values();
+
+    expect($envFiles->toArray())->toBe(['./custom.env', './another.env']);
+});
+
+it('handles null env_file gracefully', function () {
+    $existingEnvFiles = null;
+
+    if ($existingEnvFiles !== null) {
+        $envFiles = collect(is_array($existingEnvFiles) ? $existingEnvFiles : [$existingEnvFiles])
+            ->filter(fn ($file) => $file !== '.env')
+            ->values();
+
+        $result = $envFiles->isNotEmpty() ? $envFiles->toArray() : null;
+    } else {
+        $result = null;
+    }
+
+    expect($result)->toBeNull();
+});
+
+it('handles empty env_file array gracefully', function () {
+    $existingEnvFiles = [];
+
+    $envFiles = collect($existingEnvFiles)
+        ->filter(fn ($file) => $file !== '.env')
+        ->values();
+
+    expect($envFiles->isEmpty())->toBeTrue();
+});
+
+it('handles env_file with only .env', function () {
+    $existingEnvFiles = ['.env'];
+
+    $envFiles = collect($existingEnvFiles)
+        ->filter(fn ($file) => $file !== '.env')
+        ->values();
+
+    expect($envFiles->isEmpty())->toBeTrue();
+});
+
+it('handles string env_file value', function () {
+    $existingEnvFiles = './custom.env';
+
+    $envFiles = collect(is_array($existingEnvFiles) ? $existingEnvFiles : [$existingEnvFiles])
+        ->filter(fn ($file) => $file !== '.env')
+        ->values();
+
+    expect($envFiles->toArray())->toBe(['./custom.env']);
+});
+
+it('still sets environment variables per service', function () {
+    $parsersFile = file_get_contents(__DIR__ . '/../../bootstrap/helpers/parsers.php');
+
+    expect($parsersFile)->toContain("\$payload['environment'] = \$environment->merge");
+});


### PR DESCRIPTION
### Changes
- Prevents automatic injection of a shared `.env` file into every Docker Compose service.
- Ensures environment variables remain scoped to their respective services.
- Preserves user-defined `env_file` entries while explicitly filtering out `.env`.
- Applies the fix consistently to both application and service compose parsers.

---

### Issue
- Resolves #7655 

---

### Category
- [x] Bug fix
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

---

### Screenshots or Video (if applicable)
N/A – This change affects Docker Compose generation logic and does not introduce UI-visible changes.  
Verification is done by inspecting the generated compose configuration.

---

### AI Usage
- [ ] AI is used in the process of creating this PR
- [x] AI is NOT used in the process of creating this PR

---

### Steps to Test
1. Use a Docker Compose project with multiple services and distinct environment variables.
2. Deploy or regenerate the Docker Compose configuration using Coolify.
3. Inspect the generated compose output and confirm that `.env` is not automatically added to `env_file`.
4. Verify that each service only contains its own variables under the `environment:` section.
5. Define a custom `env_file` (other than `.env`) for a service and confirm it is preserved.

---

### Contributor Agreement
[!IMPORTANT]
- [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
- [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them.
