### PR TITLE
fix: arithmetic syntax error in postgres restore #7987

### DIFF
--- a/app/Livewire/Project/Database/Import.php
+++ b/app/Livewire/Project/Database/Import.php
@@ -147,7 +147,7 @@ class Import extends Component
 
     public ?int $activityId = null;
 
-    public string $postgresqlRestoreCommand = 'pg_restore -U $POSTGRES_USER -d ${POSTGRES_DB:\${POSTGRES_USER:-postgres}}';
+    public string $postgresqlRestoreCommand = 'pg_restore -U $POSTGRES_USER -d ${POSTGRES_DB:-${POSTGRES_USER:-postgres}}';
 
     public string $mysqlRestoreCommand = 'mysql -u $MYSQL_USER -p$MYSQL_PASSWORD $MYSQL_DATABASE';
 
@@ -261,11 +261,11 @@ EOD;
                     $this->postgresqlRestoreCommand = <<<'EOD'
 psql -U ${POSTGRES_USER} -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname IS NOT NULL AND pid <> pg_backend_pid()" && \
 psql -U ${POSTGRES_USER} -t -c "SELECT datname FROM pg_database WHERE NOT datistemplate" | xargs -I {} dropdb -U ${POSTGRES_USER} --if-exists {} && \
-createdb -U ${POSTGRES_USER} ${POSTGRES_DB:\${POSTGRES_USER:-postgres}}
+createdb -U ${POSTGRES_USER} ${POSTGRES_DB:-${POSTGRES_USER:-postgres}}
 EOD;
-                    $this->restoreCommandText = $this->postgresqlRestoreCommand.' && (gunzip -cf <temp_backup_file> 2>/dev/null || cat <temp_backup_file>) | psql -U ${POSTGRES_USER} -d ${POSTGRES_DB:\${POSTGRES_USER:-postgres}}';
+                    $this->restoreCommandText = $this->postgresqlRestoreCommand.' && (gunzip -cf <temp_backup_file> 2>/dev/null || cat <temp_backup_file>) | psql -U ${POSTGRES_USER} -d ${POSTGRES_DB:-${POSTGRES_USER:-postgres}}';
                 } else {
-                    $this->postgresqlRestoreCommand = 'pg_restore -U ${POSTGRES_USER} -d ${POSTGRES_DB:\${POSTGRES_USER:-postgres}}';
+                    $this->postgresqlRestoreCommand = 'pg_restore -U ${POSTGRES_USER} -d ${POSTGRES_DB:-${POSTGRES_USER:-postgres}}';
                 }
                 break;
         }
@@ -757,7 +757,7 @@ EOD;
             case 'postgresql':
                 $restoreCommand = $this->postgresqlRestoreCommand;
                 if ($this->dumpAll) {
-                    $restoreCommand .= " && (gunzip -cf {$tmpPath} 2>/dev/null || cat {$tmpPath}) | psql -U \${POSTGRES_USER} -d \${POSTGRES_DB:\${POSTGRES_USER:-postgres}}";
+                    $restoreCommand .= " && (gunzip -cf {$tmpPath} 2>/dev/null || cat {$tmpPath}) | psql -U \${POSTGRES_USER} -d \${POSTGRES_DB:-\${POSTGRES_USER:-postgres}}";
                 } else {
                     $restoreCommand .= " {$tmpPath}";
                 }


### PR DESCRIPTION
STRAWBERRY
### Changes
Fixed an `arithmetic syntax error` that occurred during PostgreSQL database restoration.
The error was caused by an incorrect parameter expansion syntax `${POSTGRES_DB:\${POSTGRES_USER:-postgres}}` in the [Import.php](cci:7://file:///d:/source/coolify/app/Livewire/Project/Database/Import.php:0:0-0:0) file. The shell interpreted the colon followed by `\` as an arithmetic context.
I replaced it with the correct default value syntax `${POSTGRES_DB:-${POSTGRES_USER:-postgres}}` in both the standard restore and `dumpAll` restore commands.
### Issue 
- Resolves #7987
### Category
- [x] Bug fix
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service
### AI Usage
- [x] AI is used in the process of creating this PR
- [ ] AI is NOT used in the process of creating this PR
### Steps to Test
1. Create a PostgreSQL service in a project.
2. Add some data to the database.
3. Create a backup (ensure it finishes successfully).
4. Go to the "Backups" tab and click "Restore" on the backup you just created.
5. Check the restore logs. Before this fix, it would fail with `/tmp/restore_....sh: line 1: arithmetic syntax error`.
6. Verify that the restore now completes successfully (exit code 0) and the data is restored.
7. (Optional) Test with "Backup includes all databases" option enabled to verify the fix works for that scenario as well.
### Contributor Agreement
<!-- This section must not be removed. PRs that do not include the exact contributor agreement will not be reviewed and will be closed. -->
> [!IMPORTANT]
 > - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
 > - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them