### PR TITLE
fix(service): rocketchat fails to start due to database version incompatibility

### DIFF
--- a/templates/compose/rocketchat.yaml
+++ b/templates/compose/rocketchat.yaml
@@ -7,42 +7,32 @@
 
 services:
   rocketchat:
-    image: registry.rocket.chat/rocketchat/rocket.chat:latest
+    image: 'registry.rocket.chat/rocketchat/rocket.chat:latest'
     environment:
       - SERVICE_URL_ROCKETCHAT_3000
-      - MONGO_URL=mongodb://${MONGODB_ADVERTISED_HOSTNAME:-mongodb}:${MONGODB_INITIAL_PRIMARY_PORT_NUMBER:-27017}/${MONGODB_DATABASE:-rocketchat}?replicaSet=${MONGODB_REPLICA_SET_NAME:-rs0}
-      - MONGO_OPLOG_URL=mongodb://${MONGODB_ADVERTISED_HOSTNAME:-mongodb}:${MONGODB_INITIAL_PRIMARY_PORT_NUMBER:-27017}/local?replicaSet=${MONGODB_REPLICA_SET_NAME:-rs0}
+      - 'MONGO_URL=mongodb://${MONGODB_ADVERTISED_HOSTNAME:-mongodb}:${MONGODB_INITIAL_PRIMARY_PORT_NUMBER:-27017}/${MONGODB_DATABASE:-rocketchat}?replicaSet=${MONGODB_REPLICA_SET_NAME:-rs0}'
+      - 'MONGO_OPLOG_URL=mongodb://${MONGODB_ADVERTISED_HOSTNAME:-mongodb}:${MONGODB_INITIAL_PRIMARY_PORT_NUMBER:-27017}/local?replicaSet=${MONGODB_REPLICA_SET_NAME:-rs0}'
       - ROOT_URL=$SERVICE_URL_ROCKETCHAT
       - DEPLOY_METHOD=docker
       - REG_TOKEN=$REG_TOKEN
+      - 'MAIL_URL=${MAIL_URL:-test@example.com}'
     depends_on:
       mongodb:
         condition: service_healthy
     healthcheck:
       test:
-        [
-          "CMD",
-          "node",
-          "--eval",
-          "const http = require('http'); const options = { host: '0.0.0.0', port: 3000, timeout: 2000, path: '/health' }; const healthCheck = http.request(options, (res) => { console.log('HEALTHCHECK STATUS:', res.statusCode); if (res.statusCode == 200) { process.exit(0); } else { process.exit(1); } }); healthCheck.on('error', function (err) { console.error('ERROR'); process.exit(1); }); healthCheck.end();",
-        ]
+        - CMD
+        - node
+        - '--eval'
+        - "const http = require('http'); const options = { host: '0.0.0.0', port: 3000, timeout: 2000, path: '/health' }; const healthCheck = http.request(options, (res) => { console.log('HEALTHCHECK STATUS:', res.statusCode); if (res.statusCode == 200) { process.exit(0); } else { process.exit(1); } }); healthCheck.on('error', function (err) { console.error('ERROR'); process.exit(1); }); healthCheck.end();"
       interval: 2s
       timeout: 10s
       retries: 15
-
   mongodb:
-    image: docker.io/bitnamilegacy/mongodb:7.0
+    image: 'mongo:7'
     volumes:
-      - mongodb_data:/bitnami/mongodb
-    environment:
-      - MONGODB_REPLICA_SET_MODE=primary
-      - MONGODB_REPLICA_SET_NAME=${MONGODB_REPLICA_SET_NAME:-rs0}
-      - MONGODB_PORT_NUMBER=${MONGODB_PORT_NUMBER:-27017}
-      - MONGODB_INITIAL_PRIMARY_HOST=${MONGODB_INITIAL_PRIMARY_HOST:-mongodb}
-      - MONGODB_INITIAL_PRIMARY_PORT_NUMBER=${MONGODB_INITIAL_PRIMARY_PORT_NUMBER:-27017}
-      - MONGODB_ADVERTISED_HOSTNAME=${MONGODB_ADVERTISED_HOSTNAME:-mongodb}
-      - MONGODB_ENABLE_JOURNAL=${MONGODB_ENABLE_JOURNAL:-true}
-      - ALLOW_EMPTY_PASSWORD=${ALLOW_EMPTY_PASSWORD:-yes}
+      - 'mongodb_data:/data/db'
+    command: "sh -c \"\n  mongod --replSet ${MONGODB_REPLICA_SET_NAME:-rs0} --bind_ip_all &\n  sleep 5 &&\n  mongosh --eval 'rs.initiate({_id:\\\"${MONGODB_REPLICA_SET_NAME:-rs0}\\\", members:[{_id:0, host:\\\"mongodb:27017\\\"}]})' ||\n  true &&\n  wait\n\"\n"
     healthcheck:
       test:
         - CMD
@@ -53,3 +43,5 @@ services:
       interval: 2s
       timeout: 10s
       retries: 15
+volumes:
+  mongodb_data: null

--- a/templates/compose/rocketchat.yaml
+++ b/templates/compose/rocketchat.yaml
@@ -7,7 +7,7 @@
 
 services:
   rocketchat:
-    image: 'registry.rocket.chat/rocketchat/rocket.chat:latest'
+    image: 'registry.rocket.chat/rocketchat/rocket.chat:8.0.1'
     environment:
       - SERVICE_URL_ROCKETCHAT_3000
       - 'MONGO_URL=mongodb://${MONGODB_ADVERTISED_HOSTNAME:-mongodb}:${MONGODB_INITIAL_PRIMARY_PORT_NUMBER:-27017}/${MONGODB_DATABASE:-rocketchat}?replicaSet=${MONGODB_REPLICA_SET_NAME:-rs0}'
@@ -43,5 +43,3 @@ services:
       interval: 2s
       timeout: 10s
       retries: 15
-volumes:
-  mongodb_data: null

--- a/templates/compose/rocketchat.yaml
+++ b/templates/compose/rocketchat.yaml
@@ -31,7 +31,7 @@ services:
       retries: 15
 
   mongodb:
-    image: docker.io/bitnamilegacy/mongodb:5.0
+    image: docker.io/bitnamilegacy/mongodb:7.0
     volumes:
       - mongodb_data:/bitnami/mongodb
     environment:
@@ -44,7 +44,12 @@ services:
       - MONGODB_ENABLE_JOURNAL=${MONGODB_ENABLE_JOURNAL:-true}
       - ALLOW_EMPTY_PASSWORD=${ALLOW_EMPTY_PASSWORD:-yes}
     healthcheck:
-      test: echo 'db.stats().ok' | mongo localhost:27017/test --quiet
+      test:
+        - CMD
+        - mongosh
+        - '--quiet'
+        - '--eval'
+        - "db.adminCommand('ping')"
       interval: 2s
       timeout: 10s
       retries: 15


### PR DESCRIPTION
### Changes

- fix(service): rocketchat fails to start due to database version incompatibilty
> Beware: The official MongoDB image doesn't include the replication script, so here it's solved with the `command` part in the MongoDB service

### Issue 

- fixes https://github.com/coollabsio/coolify/issues/7941
- /claim #7941
- https://discord.com/channels/459365938081431553/1462066145371885629 (discord support post)

### Category

- [x] Fixing or updating existing one click service

### AI Usage

- [x] AI is NOT used in the process of creating this PR

### Steps to Test

- Step 1 – Create a new resource and select 'Docker compose Empty' as deployment type, then paste the compose on this PR as the content.
- Step 2 – Setup a domain name for RocketChat
- Step 3 – Deploy
- Step 4 – After some time (migration takes some time - more than a minute), check if both MongoDB and RocketChat are healty

### Note

Rocketchat takes over a minute to load on first boot so you will see 404 page from Coolify proxy until the service is ready, once the service is ready you will see `SERVER RUNNING` message on the rocket chat container logs.
<img width="1911" height="1209" alt="image" src="https://github.com/user-attachments/assets/78c4275e-99b6-4a64-a2f7-bfaf045becf6" />

### Contributor Agreement

> [!IMPORTANT]
 > - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
 > - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them
 
