### PR TITLE
Add SurrealDB one-click service templates (RocksDB + TiKV)

### DIFF
--- a/templates/compose/surrealdb-tikv.yaml
+++ b/templates/compose/surrealdb-tikv.yaml
@@ -1,0 +1,51 @@
+# documentation: https://surrealdb.com/docs/surrealdb/installation/running/tikv
+# category: Database
+# tags: surrealdb, tikv, database, distributed
+# port: 8000
+
+services:
+  pd:
+    image: pingcap/pd:latest
+    command: >
+      --name=pd0
+      --data-dir=/data
+      --client-urls=http://0.0.0.0:2379
+      --peer-urls=http://0.0.0.0:2380
+      --advertise-client-urls=http://pd:2379
+      --advertise-peer-urls=http://pd:2380
+      --initial-cluster=pd0=http://pd:2380
+    volumes:
+      - pd_data:/data
+
+  tikv:
+    image: pingcap/tikv:latest
+    depends_on:
+      - pd
+    command: >
+      --addr=0.0.0.0:20160
+      --advertise-addr=tikv:20160
+      --data-dir=/data
+      --pd=pd:2379
+    volumes:
+      - tikv_data:/data
+
+  surrealdb:
+    image: surrealdb/surrealdb:latest
+    depends_on:
+      - pd
+      - tikv
+    command: >
+      start
+      --bind 0.0.0.0:8000
+      --user ${SERVICE_USER_SURREALDB}
+      --pass ${SERVICE_PASSWORD_SURREALDB}
+      tikv://pd:2379
+    healthcheck:
+      test: ["CMD", "surreal", "isready", "--conn", "http://127.0.0.1:8000"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  pd_data:
+  tikv_data:

--- a/templates/compose/surrealdb.yaml
+++ b/templates/compose/surrealdb.yaml
@@ -1,0 +1,24 @@
+# documentation: https://surrealdb.com/docs/surrealdb/installation/running/docker
+# category: Database
+# tags: surrealdb, database, nosql, graph
+# port: 8000
+
+services:
+  surrealdb:
+    image: surrealdb/surrealdb:latest
+    command: >
+      start
+      --bind 0.0.0.0:8000
+      --user ${SERVICE_USER_SURREALDB}
+      --pass ${SERVICE_PASSWORD_SURREALDB}
+      rocksdb:/data
+    volumes:
+      - surrealdb_data:/data
+    healthcheck:
+      test: ["CMD", "surreal", "isready", "--conn", "http://127.0.0.1:8000"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  surrealdb_data:

--- a/templates/service-templates-latest.json
+++ b/templates/service-templates-latest.json
@@ -5196,5 +5196,25 @@
         "logo": "svgs/marimo.svg",
         "minversion": "0.0.0",
         "port": "8080"
-    }
+    },
+      "surrealdb": {
+    "documentation": "https://surrealdb.com/docs",
+    "slogan": "Multi-model database (graph, document, key-value) with built-in web UI.",
+    "compose": "c2VydmljZXM6CiAgc3VycmVhbGRiOgogICAgaW1hZ2U6IHN1cnJlYWxkYi9zdXJyZWFsZGI6bGF0ZXN0CiAgICBjb21tYW5kOiA+CiAgICAgIHN0YXJ0CiAgICAgIC0tYmluZCAwLjAuMC4wOjgwMDAKICAgICAgLS11c2VyICR7U0VSVklDRV9VU0VSX1NVUlJFQUxEQn0KICAgICAgLS1wYXNzICR7U0VSVklDRV9QQVNTV09SRF9TVVJSRUFMREJ9CiAgICAgIHJvY2tzZGI6L2RhdGEKICAgIHZvbHVtZXM6CiAgICAgIC0gc3VycmVhbGRiX2RhdGE6L2RhdGEKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OiBbIkNNRCIsICJzdXJyZWFsIiwgImlzcmVhZHkiLCAiLS1jb25uIiwgImh0dHA6Ly8xMjcuMC4wLjE6ODAwMCJdCiAgICAgIGludGVydmFsOiAxMHMKICAgICAgdGltZW91dDogNXMKICAgICAgcmV0cmllczogMTAKCnZvbHVtZXM6CiAgc3VycmVhbGRiX2RhdGE6Cg==",
+    "tags": ["database", "nosql", "graph", "document", "kv"],
+    "category": "database",
+    "logo": "svgs/surrealdb.svg",
+    "minversion": "0.0.0",
+    "port": "8000"
+  },
+  "surrealdb-tikv": {
+    "documentation": "https://surrealdb.com/docs/surrealdb/installation/running/tikv",
+    "slogan": "SurrealDB backed by TiKV (distributed storage).",
+    "compose": "c2VydmljZXM6CiAgcGQ6CiAgICBpbWFnZTogcGluZ2NhcC9wZDpsYXRlc3QKICAgIGNvbW1hbmQ6ID4KICAgICAgLS1uYW1lPXBkMAogICAgICAtLWRhdGEtZGlyPS9kYXRhCiAgICAgIC0tY2xpZW50LXVybHM9aHR0cDovLzAuMC4wLjA6MjM3OQogICAgICAtLXBlZXItdXJscz1odHRwOi8vMC4wLjAuMDoyMzgwCiAgICAgIC0tYWR2ZXJ0aXNlLWNsaWVudC11cmxzPWh0dHA6Ly9wZDoyMzc5CiAgICAgIC0tYWR2ZXJ0aXNlLXBlZXItdXJscz1odHRwOi8vcGQ6MjM4MAogICAgICAtLWluaXRpYWwtY2x1c3Rlcj1wZDA9aHR0cDovL3BkOjIzODAKICAgIHZvbHVtZXM6CiAgICAgIC0gc3VycmVhbGRiX3BkX2RhdGE6L2RhdGEKCiAgdGlrdjoKICAgIGltYWdlOiBwaW5nY2FwL3Rpa3Y6bGF0ZXN0CiAgICBkZXBlbmRzX29uOgogICAgICAtIHBkCiAgICBjb21tYW5kOiA+CiAgICAgIC0tYWRkcj0wLjAuMC4wOjIwMTYwCiAgICAgIC0tYWR2ZXJ0aXNlLWFkZHI9dGlrdjoyMDE2MAogICAgICAtLWRhdGEtZGlyPS9kYXRhCiAgICAgIC0tcGQ9cGQ6MjM3OQogICAgdm9sdW1lczoKICAgICAgLSBzdXJyZWFsZGJfdGlrdl9kYXRhOi9kYXRhCgogIHN1cnJlYWxkYjoKICAgIGltYWdlOiBzdXJyZWFsZGIvc3VycmVhbGRiOmxhdGVzdAogICAgZGVwZW5kc19vbjoKICAgICAgLSBwZAogICAgICAtIHRpa3YKICAgIGNvbW1hbmQ6ID4KICAgICAgc3RhcnQKICAgICAgLS1iaW5kIDAuMC4wLjA6ODAwMAogICAgICAtLXVzZXIgJHtTRVJWSUNFX1VTRVJfU1VSUkVBTERCfQogICAgICAtLXBhc3MgJHtTRVJWSUNFX1BBU1NXT1JEX1NVUlJFQUxEQn0KICAgICAgdGlrdjovL3BkOjIzNzkKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OiBbIkNNRCIsICJzdXJyZWFsIiwgImlzcmVhZHkiLCAiLS1jb25uIiwgImh0dHA6Ly8xMjcuMC4wLjE6ODAwMCJdCiAgICAgIGludGVydmFsOiAxMHMKICAgICAgdGltZW91dDogNXMKICAgICAgcmV0cmllczogMTAKCnZvbHVtZXM6CiAgc3VycmVhbGRiX3BkX2RhdGE6CiAgc3VycmVhbGRiX3Rpa3ZfZGF0YToK",
+    "tags": ["database", "nosql", "graph", "document", "kv", "tikv"],
+    "category": "database",
+    "logo": "svgs/surrealdb.svg",
+    "minversion": "0.0.0",
+    "port": "8000"
+  }
 }

--- a/templates/service-templates.json
+++ b/templates/service-templates.json
@@ -5196,5 +5196,25 @@
         "logo": "svgs/marimo.svg",
         "minversion": "0.0.0",
         "port": "8080"
-    }
+    },
+      "surrealdb": {
+    "documentation": "https://surrealdb.com/docs",
+    "slogan": "Multi-model database (graph, document, key-value) with built-in web UI.",
+    "compose": "c2VydmljZXM6CiAgc3VycmVhbGRiOgogICAgaW1hZ2U6IHN1cnJlYWxkYi9zdXJyZWFsZGI6bGF0ZXN0CiAgICBjb21tYW5kOiA+CiAgICAgIHN0YXJ0CiAgICAgIC0tYmluZCAwLjAuMC4wOjgwMDAKICAgICAgLS11c2VyICR7U0VSVklDRV9VU0VSX1NVUlJFQUxEQn0KICAgICAgLS1wYXNzICR7U0VSVklDRV9QQVNTV09SRF9TVVJSRUFMREJ9CiAgICAgIHJvY2tzZGI6L2RhdGEKICAgIHZvbHVtZXM6CiAgICAgIC0gc3VycmVhbGRiX2RhdGE6L2RhdGEKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OiBbIkNNRCIsICJzdXJyZWFsIiwgImlzcmVhZHkiLCAiLS1jb25uIiwgImh0dHA6Ly8xMjcuMC4wLjE6ODAwMCJdCiAgICAgIGludGVydmFsOiAxMHMKICAgICAgdGltZW91dDogNXMKICAgICAgcmV0cmllczogMTAKCnZvbHVtZXM6CiAgc3VycmVhbGRiX2RhdGE6Cg==",
+    "tags": ["database", "nosql", "graph", "document", "kv"],
+    "category": "database",
+    "logo": "svgs/surrealdb.svg",
+    "minversion": "0.0.0",
+    "port": "8000"
+  },
+  "surrealdb-tikv": {
+    "documentation": "https://surrealdb.com/docs/surrealdb/installation/running/tikv",
+    "slogan": "SurrealDB backed by TiKV (distributed storage).",
+    "compose": "c2VydmljZXM6CiAgcGQ6CiAgICBpbWFnZTogcGluZ2NhcC9wZDpsYXRlc3QKICAgIGNvbW1hbmQ6ID4KICAgICAgLS1uYW1lPXBkMAogICAgICAtLWRhdGEtZGlyPS9kYXRhCiAgICAgIC0tY2xpZW50LXVybHM9aHR0cDovLzAuMC4wLjA6MjM3OQogICAgICAtLXBlZXItdXJscz1odHRwOi8vMC4wLjAuMDoyMzgwCiAgICAgIC0tYWR2ZXJ0aXNlLWNsaWVudC11cmxzPWh0dHA6Ly9wZDoyMzc5CiAgICAgIC0tYWR2ZXJ0aXNlLXBlZXItdXJscz1odHRwOi8vcGQ6MjM4MAogICAgICAtLWluaXRpYWwtY2x1c3Rlcj1wZDA9aHR0cDovL3BkOjIzODAKICAgIHZvbHVtZXM6CiAgICAgIC0gc3VycmVhbGRiX3BkX2RhdGE6L2RhdGEKCiAgdGlrdjoKICAgIGltYWdlOiBwaW5nY2FwL3Rpa3Y6bGF0ZXN0CiAgICBkZXBlbmRzX29uOgogICAgICAtIHBkCiAgICBjb21tYW5kOiA+CiAgICAgIC0tYWRkcj0wLjAuMC4wOjIwMTYwCiAgICAgIC0tYWR2ZXJ0aXNlLWFkZHI9dGlrdjoyMDE2MAogICAgICAtLWRhdGEtZGlyPS9kYXRhCiAgICAgIC0tcGQ9cGQ6MjM3OQogICAgdm9sdW1lczoKICAgICAgLSBzdXJyZWFsZGJfdGlrdl9kYXRhOi9kYXRhCgogIHN1cnJlYWxkYjoKICAgIGltYWdlOiBzdXJyZWFsZGIvc3VycmVhbGRiOmxhdGVzdAogICAgZGVwZW5kc19vbjoKICAgICAgLSBwZAogICAgICAtIHRpa3YKICAgIGNvbW1hbmQ6ID4KICAgICAgc3RhcnQKICAgICAgLS1iaW5kIDAuMC4wLjA6ODAwMAogICAgICAtLXVzZXIgJHtTRVJWSUNFX1VTRVJfU1VSUkVBTERCfQogICAgICAtLXBhc3MgJHtTRVJWSUNFX1BBU1NXT1JEX1NVUlJFQUxEQn0KICAgICAgdGlrdjovL3BkOjIzNzkKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OiBbIkNNRCIsICJzdXJyZWFsIiwgImlzcmVhZHkiLCAiLS1jb25uIiwgImh0dHA6Ly8xMjcuMC4wLjE6ODAwMCJdCiAgICAgIGludGVydmFsOiAxMHMKICAgICAgdGltZW91dDogNXMKICAgICAgcmV0cmllczogMTAKCnZvbHVtZXM6CiAgc3VycmVhbGRiX3BkX2RhdGE6CiAgc3VycmVhbGRiX3Rpa3ZfZGF0YToK",
+    "tags": ["database", "nosql", "graph", "document", "kv", "tikv"],
+    "category": "database",
+    "logo": "svgs/surrealdb.svg",
+    "minversion": "0.0.0",
+    "port": "8000"
+  }
 }

--- a/templates/svgs/surrealdb.svg
+++ b/templates/svgs/surrealdb.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <ellipse cx="64" cy="26" rx="44" ry="16" fill="#6b7280"/>
+  <path d="M20 26v56c0 8.8 19.7 16 44 16s44-7.2 44-16V26" fill="#9ca3af"/>
+  <ellipse cx="64" cy="82" rx="44" ry="16" fill="#6b7280"/>
+</svg>


### PR DESCRIPTION
### Changes
- Add SurrealDB one-click service templates:
  - SurrealDB (RocksDB)
  - SurrealDB (TiKV)
- Add SurrealDB logo (SVG)
- Register templates in service-templates.json and service-templates-latest.json

### Issue
Closes #7642

### Category
- [x] Adding new one click service