### PR TITLE
fix(vikunja): add nginx proxy for SPA routing support

### DIFF
--- a/templates/compose/vikunja.yaml
+++ b/templates/compose/vikunja.yaml
@@ -3,9 +3,68 @@
 # category: productivity
 # tags: productivity,todo
 # logo: svgs/vikunja.svg
-# port: 3456
+# port: 80
 
 services:
+  nginx:
+    image: nginx:alpine
+    volumes:
+      - nginx-config:/etc/nginx/conf.d:ro
+    depends_on:
+      - vikunja
+      - nginx-init
+
+  nginx-init:
+    image: busybox
+    restart: "no"
+    volumes:
+      - nginx-config:/etc/nginx/conf.d
+    command:
+      - sh
+      - -c
+      - |
+        cat > /etc/nginx/conf.d/default.conf << 'NGINX'
+        server {
+            listen 80;
+            server_name _;
+            client_max_body_size 20M;
+
+            location ~ ^/(api|dav|\.well-known)/ {
+                proxy_pass http://vikunja:3456;
+                proxy_http_version 1.1;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+            }
+
+            location ~ \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|map|json|webmanifest)$ {
+                proxy_pass http://vikunja:3456;
+                proxy_http_version 1.1;
+                proxy_set_header Host $host;
+            }
+
+            location / {
+                proxy_pass http://vikunja:3456;
+                proxy_http_version 1.1;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_intercept_errors on;
+                error_page 404 = /index.html;
+            }
+
+            location = /index.html {
+                proxy_pass http://vikunja:3456;
+                proxy_http_version 1.1;
+                proxy_set_header Host $host;
+                internal;
+            }
+        }
+        NGINX
+        echo "Nginx config created"
+
   vikunja:
     image: vikunja/vikunja
     environment:
@@ -20,9 +79,11 @@ services:
       - vikunja-sqlite-data:/db
     depends_on:
       - init
+
   init:
     image: busybox
-    restart: no
+    restart: "no"
     volumes:
       - vikunja-sqlite-data:/db
-    command: ["sh", "-c", "touch /db/vikunja.db && chown -R 1000 /db"]
+      - vikunja-data:/app/vikunja
+    command: ["sh", "-c", "mkdir -p /app/vikunja/files && touch /db/vikunja.db && chown -R 1000:1000 /db /app/vikunja"]


### PR DESCRIPTION
## Problem

The current Vikunja template directly exposes the Vikunja container on port 3456. However, Vikunja's embedded web server doesn't properly handle SPA (Single Page Application) routing. When users refresh the page on any route other than `/` (e.g., `/projects/1`, `/tasks/123`), they get a JSON error:

```json
{"message":"Not Found"}
```

This is because Vikunja's Go backend returns a 404 for unknown routes instead of serving `index.html` to let the Vue.js frontend handle client-side routing.

## Solution

Add an nginx reverse proxy in front of Vikunja that:

1. Passes API routes (`/api/`, `/dav/`, `/.well-known/`) directly to Vikunja
2. Passes static assets directly to Vikunja  
3. Intercepts 404 errors on other routes and serves `/index.html` instead, enabling proper SPA routing

## Changes

- Added `nginx` service as the main entry point (port 80)
- Added `nginx-init` service to generate the nginx configuration
- Changed exposed port from 3456 to 80
- Vikunja container now only accessible internally via nginx

## Testing

Tested on a production Coolify instance:
- ✅ Page refresh on `/projects/1` now works correctly
- ✅ API endpoints (`/api/v1/info`, etc.) still work
- ✅ CalDAV (`/dav/`) still works
- ✅ Static assets load correctly
- ✅ Login/registration flows work

## Related

This is a known limitation of the Vikunja combined Docker image. The Vikunja documentation recommends using a reverse proxy with `try_files` for production deployments, but this wasn't implemented in the Coolify template.