### PR TITLE
fix(api): infinite loop with github app with many repos

### DIFF
--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -20,6 +20,7 @@ use App\Rules\ValidGitRepositoryUrl;
 use App\Services\DockerImageParser;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Validation\Rule;
 use OpenApi\Attributes as OA;
 use Spatie\Url\Url;
@@ -1344,24 +1345,29 @@ class ApplicationsController extends Controller
                 return response()->json(['message' => 'Failed to generate Github App token.'], 400);
             }
 
-            $repositories = collect();
-            $page = 1;
-            $repositories = loadRepositoryByPage($githubApp, $token, $page);
-            if ($repositories['total_count'] > 0) {
-                while (count($repositories['repositories']) < $repositories['total_count']) {
-                    $page++;
-                    $repositories = loadRepositoryByPage($githubApp, $token, $page);
-                }
-            }
-
             $gitRepository = $request->git_repository;
             if (str($gitRepository)->startsWith('http') || str($gitRepository)->contains('github.com')) {
                 $gitRepository = str($gitRepository)->replace('https://', '')->replace('http://', '')->replace('github.com/', '');
             }
-            $gitRepositoryFound = collect($repositories['repositories'])->firstWhere('full_name', $gitRepository);
-            if (! $gitRepositoryFound) {
-                return response()->json(['message' => 'Repository not found.'], 404);
+            // Remove trailing .git if present
+            $gitRepository = str($gitRepository)->trim('/')->replace('.git', '')->toString();
+
+            // Use direct API call to verify repository access instead of loading all repositories
+            // This is much faster and avoids timeouts for GitHub Apps with many repositories
+            $response = Http::GitHub($githubApp->api_url, $token)
+                ->timeout(20)
+                ->retry(3, 200, throw: false)
+                ->get("/repos/{$gitRepository}");
+
+            if ($response->status() === 404) {
+                return response()->json(['message' => 'Repository not found or not accessible by the GitHub App.'], 404);
             }
+
+            if (! $response->successful()) {
+                return response()->json(['message' => 'Failed to verify repository access: '.($response->json()['message'] ?? 'Unknown error')], 400);
+            }
+
+            $gitRepositoryFound = $response->json();
             $repository_project_id = data_get($gitRepositoryFound, 'id');
 
             $application = new Application;

--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -1349,8 +1349,7 @@ class ApplicationsController extends Controller
             if (str($gitRepository)->startsWith('http') || str($gitRepository)->contains('github.com')) {
                 $gitRepository = str($gitRepository)->replace('https://', '')->replace('http://', '')->replace('github.com/', '');
             }
-            // Remove trailing .git if present
-            $gitRepository = str($gitRepository)->trim('/')->replace('.git', '')->toString();
+            $gitRepository = str($gitRepository)->trim('/')->replaceEnd('.git', '')->toString();
 
             // Use direct API call to verify repository access instead of loading all repositories
             // This is much faster and avoids timeouts for GitHub Apps with many repositories
@@ -1359,7 +1358,7 @@ class ApplicationsController extends Controller
                 ->retry(3, 200, throw: false)
                 ->get("/repos/{$gitRepository}");
 
-            if ($response->status() === 404) {
+            if ($response->status() === 404 || $response->status() === 403) {
                 return response()->json(['message' => 'Repository not found or not accessible by the GitHub App.'], 404);
             }
 


### PR DESCRIPTION
### Changes

- fix(api): infinite loop with github app with many repos.
  - When you use API `api/v1/applications/private-github-app` and you have a github app with more than 100 repositories, you get in an infinite loop. This patch addresses that as there is no need for the API to fetch every repository, just check if the provided one is correct.

### Issue 

- fixes: https://github.com/coollabsio/coolify/issues/8028

### Category

- [x] Bug fix

### AI Usage

- [x] AI is used in the process of creating this PR

### Steps to Test

- Have a github app with at least 101 repositories.
- Use the API api/v1/applications/private-github-app 
- It will hang and timeout

### Contributor Agreement

> [!IMPORTANT]
 > - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
 > - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them
 
