### PR TITLE
feat(services): Add Clawdbot personal AI assistant

### DIFF
--- a/public/svgs/clawdbot.svg
+++ b/public/svgs/clawdbot.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
+  <defs>
+    <linearGradient id="lobsterGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#FF6B6B;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#C92A2A;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient id="shellGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#FF8787;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#E03131;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  
+  <!-- Background circle -->
+  <circle cx="50" cy="50" r="48" fill="#1a1a2e" stroke="#FF6B6B" stroke-width="2"/>
+  
+  <!-- Lobster body (simplified) -->
+  <ellipse cx="50" cy="55" rx="22" ry="18" fill="url(#lobsterGrad)"/>
+  
+  <!-- Lobster head -->
+  <ellipse cx="50" cy="38" rx="15" ry="12" fill="url(#shellGrad)"/>
+  
+  <!-- Eyes -->
+  <circle cx="43" cy="35" r="4" fill="#fff"/>
+  <circle cx="57" cy="35" r="4" fill="#fff"/>
+  <circle cx="43" cy="35" r="2" fill="#1a1a2e"/>
+  <circle cx="57" cy="35" r="2" fill="#1a1a2e"/>
+  
+  <!-- Antennae -->
+  <path d="M 42 28 Q 35 18 28 15" stroke="#FF6B6B" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M 58 28 Q 65 18 72 15" stroke="#FF6B6B" stroke-width="2" fill="none" stroke-linecap="round"/>
+  
+  <!-- Claws -->
+  <ellipse cx="25" cy="50" rx="10" ry="7" fill="url(#lobsterGrad)" transform="rotate(-30 25 50)"/>
+  <ellipse cx="75" cy="50" rx="10" ry="7" fill="url(#lobsterGrad)" transform="rotate(30 75 50)"/>
+  
+  <!-- Claw pincers -->
+  <path d="M 18 42 L 12 38 M 18 42 L 14 48" stroke="#FF6B6B" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <path d="M 82 42 L 88 38 M 82 42 L 86 48" stroke="#FF6B6B" stroke-width="3" fill="none" stroke-linecap="round"/>
+  
+  <!-- Tail segments -->
+  <ellipse cx="50" cy="70" rx="16" ry="6" fill="url(#shellGrad)"/>
+  <ellipse cx="50" cy="78" rx="12" ry="5" fill="url(#lobsterGrad)"/>
+  <ellipse cx="50" cy="85" rx="8" ry="4" fill="url(#shellGrad)"/>
+  
+  <!-- AI sparkle accent -->
+  <circle cx="75" cy="25" r="3" fill="#4dabf7"/>
+  <circle cx="78" cy="22" r="1.5" fill="#4dabf7"/>
+  <circle cx="72" cy="28" r="1.5" fill="#4dabf7"/>
+</svg>

--- a/templates/compose/clawdbot.yaml
+++ b/templates/compose/clawdbot.yaml
@@ -1,0 +1,213 @@
+# documentation: https://github.com/clawdbot/clawdbot
+# slogan: Personal AI assistant for WhatsApp, Telegram, Discord and more
+# category: ai
+# tags: ai, assistant, chatbot, whatsapp, telegram, discord, slack, automation, llm, claude, openai, anthropic, gemini
+# logo: svgs/clawdbot.svg
+# port: 18789
+# minversion: 4.0.0
+
+services:
+  clawdbot:
+    image: node:22-bookworm
+    working_dir: /app
+    command: >
+      /bin/bash -c "
+        set -e;
+
+        # === First run: clone and build Clawdbot from source ===
+        if [ ! -f /app/dist/index.js ]; then
+          echo '=== First run: Installing Clawdbot (this may take ~10 minutes) ===';
+          apt-get update && apt-get install -y --no-install-recommends git curl ca-certificates ffmpeg;
+          corepack enable;
+          git clone --depth 1 https://github.com/clawdbot/clawdbot.git /tmp/clawdbot;
+          cp -r /tmp/clawdbot/* /tmp/clawdbot/.* /app/ 2>/dev/null || true;
+          rm -rf /tmp/clawdbot;
+          pnpm install;
+          pnpm build;
+          pnpm ui:install;
+          pnpm ui:build;
+          echo '=== Clawdbot installed successfully ===';
+        else
+          echo 'Clawdbot already installed, starting...';
+        fi;
+
+        # === Install optional CLI tools (gog, goplaces, wacli) ===
+        if [ ! -f /usr/local/bin/wacli ]; then
+          ARCH=$$(dpkg --print-architecture);
+          if [ \"$$ARCH\" = 'amd64' ]; then ARCH='x86_64'; fi;
+          curl -sL \"https://github.com/steipete/gog/releases/latest/download/gog_Linux_$${ARCH}.tar.gz\" | tar -xz -C /usr/local/bin 2>/dev/null || true;
+          curl -sL \"https://github.com/steipete/goplaces/releases/latest/download/goplaces_Linux_$${ARCH}.tar.gz\" | tar -xz -C /usr/local/bin 2>/dev/null || true;
+          curl -sL \"https://github.com/steipete/wacli/releases/latest/download/wacli_Linux_$${ARCH}.tar.gz\" | tar -xz -C /usr/local/bin 2>/dev/null || true;
+        fi;
+
+        # === Build trusted proxies JSON array ===
+        DEFAULT_PROXIES='10.0.0.1,10.0.1.1,10.0.1.2,10.0.2.1,10.0.2.2,10.0.3.1,10.0.3.2,10.0.4.1,172.17.0.1,172.18.0.1,127.0.0.1';
+        TRUSTED_PROXIES=$${CLAWDBOT_TRUSTED_PROXIES:-$$DEFAULT_PROXIES};
+        PROXIES_JSON=$$(echo \"$$TRUSTED_PROXIES\" | sed 's/,/\", \"/g' | sed 's/^/[\"/' | sed 's/$$/\"]/');
+
+        # === Auto-detect default model from available API keys ===
+        DEFAULT_MODEL='anthropic/claude-sonnet-4-5';
+        if [ -n \"$$ANTHROPIC_API_KEY\" ]; then
+          DEFAULT_MODEL='anthropic/claude-sonnet-4-5';
+        elif [ -n \"$$GEMINI_API_KEY\" ]; then
+          DEFAULT_MODEL='google/gemini-3-pro-preview';
+        elif [ -n \"$$OPENAI_API_KEY\" ]; then
+          DEFAULT_MODEL='openai/gpt-4o';
+        elif [ -n \"$$OPENROUTER_API_KEY\" ]; then
+          DEFAULT_MODEL='openrouter/anthropic/claude-sonnet-4';
+        fi;
+        echo \"Default model: $$DEFAULT_MODEL\";
+
+        # === Generate gateway config (always regenerate to pick up env changes) ===
+        mkdir -p /data/.clawdbot;
+        cat > /data/.clawdbot/clawdbot.json <<EOFCONFIG
+      {
+        \"gateway\": {
+          \"mode\": \"local\",
+          \"bind\": \"lan\",
+          \"port\": 18789,
+          \"auth\": {
+            \"mode\": \"token\",
+            \"token\": \"$$CLAWDBOT_GATEWAY_TOKEN\"
+          },
+          \"trustedProxies\": $$PROXIES_JSON,
+          \"controlUi\": {
+            \"allowInsecureAuth\": true
+          }
+        },
+        \"web\": {
+          \"enabled\": true
+        },
+        \"channels\": {
+          \"whatsapp\": {
+            \"dmPolicy\": \"open\",
+            \"allowFrom\": [\"*\"]
+          },
+          \"discord\": {
+            \"groupPolicy\": \"open\",
+            \"dm\": {
+              \"enabled\": true,
+              \"policy\": \"open\",
+              \"allowFrom\": [\"*\"]
+            },
+            \"guilds\": {
+              \"*\": {
+                \"requireMention\": false
+              }
+            }
+          }
+        },
+        \"agents\": {
+          \"defaults\": {
+            \"workspace\": \"/data/clawd\",
+            \"model\": {
+              \"primary\": \"$$DEFAULT_MODEL\"
+            }
+          }
+        }
+      }
+      EOFCONFIG
+        echo 'Config written to /data/.clawdbot/clawdbot.json';
+
+        # === Generate auth-profiles.json for API keys ===
+        AUTH_DIR='/data/.clawdbot/agents/main/agent';
+        mkdir -p \"$$AUTH_DIR\";
+        AUTH_JSON='{';
+        FIRST=true;
+        if [ -n \"$$ANTHROPIC_API_KEY\" ]; then
+          [ \"$$FIRST\" = false ] && AUTH_JSON=\"$${AUTH_JSON},\";
+          AUTH_JSON=\"$${AUTH_JSON}\\\"anthropic:api\\\":{\\\"provider\\\":\\\"anthropic\\\",\\\"mode\\\":\\\"api_key\\\",\\\"apiKey\\\":\\\"$$ANTHROPIC_API_KEY\\\"}\";
+          FIRST=false;
+        fi;
+        if [ -n \"$$OPENAI_API_KEY\" ]; then
+          [ \"$$FIRST\" = false ] && AUTH_JSON=\"$${AUTH_JSON},\";
+          AUTH_JSON=\"$${AUTH_JSON}\\\"openai:api\\\":{\\\"provider\\\":\\\"openai\\\",\\\"mode\\\":\\\"api_key\\\",\\\"apiKey\\\":\\\"$$OPENAI_API_KEY\\\"}\";
+          FIRST=false;
+        fi;
+        if [ -n \"$$OPENROUTER_API_KEY\" ]; then
+          [ \"$$FIRST\" = false ] && AUTH_JSON=\"$${AUTH_JSON},\";
+          AUTH_JSON=\"$${AUTH_JSON}\\\"openrouter:api\\\":{\\\"provider\\\":\\\"openrouter\\\",\\\"mode\\\":\\\"api_key\\\",\\\"apiKey\\\":\\\"$$OPENROUTER_API_KEY\\\"}\";
+          FIRST=false;
+        fi;
+        if [ -n \"$$GEMINI_API_KEY\" ]; then
+          [ \"$$FIRST\" = false ] && AUTH_JSON=\"$${AUTH_JSON},\";
+          AUTH_JSON=\"$${AUTH_JSON}\\\"google:api\\\":{\\\"provider\\\":\\\"google\\\",\\\"mode\\\":\\\"api_key\\\",\\\"apiKey\\\":\\\"$$GEMINI_API_KEY\\\"}\";
+          FIRST=false;
+        fi;
+        AUTH_JSON=\"$${AUTH_JSON}}\";
+        if [ \"$$FIRST\" = false ]; then
+          echo \"$$AUTH_JSON\" > \"$$AUTH_DIR/auth-profiles.json\";
+          echo 'Auth profiles written';
+        else
+          echo 'WARNING: No API keys configured! Set ANTHROPIC_API_KEY, GEMINI_API_KEY, OPENAI_API_KEY, or OPENROUTER_API_KEY.';
+        fi;
+
+        # === Start the gateway ===
+        echo '=== Starting Clawdbot Gateway ===';
+        exec node dist/index.js gateway --bind lan --port 18789 --allow-unconfigured
+      "
+    environment:
+      - SERVICE_FQDN_CLAWDBOT_18789
+      - NODE_ENV=production
+      - HOME=/home/node
+      - TERM=xterm-256color
+      - CLAWDBOT_CONFIG_PATH=/data/.clawdbot/clawdbot.json
+      - CLAWDBOT_STATE_DIR=/data/.clawdbot
+      - XDG_CONFIG_HOME=/data/.clawdbot
+      - CLAWDBOT_GATEWAY_TOKEN=$SERVICE_PASSWORD_CLAWDBOT
+      - CLAWDBOT_TRUSTED_PROXIES=${CLAWDBOT_TRUSTED_PROXIES:-}
+      # Model API keys (set at least one)
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - GEMINI_API_KEY=${GEMINI_API_KEY:-}
+      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      # Channel tokens (optional)
+      - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN:-}
+      - DISCORD_BOT_TOKEN=${DISCORD_BOT_TOKEN:-}
+      - SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN:-}
+      - SLACK_APP_TOKEN=${SLACK_APP_TOKEN:-}
+      # Browser and search (optional)
+      - CLAWDBOT_BROWSER_ENABLED=${CLAWDBOT_BROWSER_ENABLED:-true}
+      - CLAWDBOT_BROWSER_URL=http://clawdbot-browser:9222
+      - BRAVE_SEARCH_API_KEY=${BRAVE_SEARCH_API_KEY:-}
+      # Redis
+      - REDIS_URL=redis://clawdbot-redis:6379
+      # Gmail integration (optional)
+      - GOG_KEYRING_PASSWORD=${GOG_KEYRING_PASSWORD:-}
+    volumes:
+      - clawdbot-app:/app
+      - clawdbot-config:/data/.clawdbot
+      - clawdbot-workspace:/data/clawd
+    depends_on:
+      clawdbot-redis:
+        condition: service_healthy
+      clawdbot-browser:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:18789/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 300s
+
+  clawdbot-redis:
+    image: redis:7-alpine
+    command: redis-server --appendonly yes --maxmemory 256mb --maxmemory-policy allkeys-lru
+    volumes:
+      - clawdbot-redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  clawdbot-browser:
+    image: chromedp/headless-shell:latest
+    shm_size: 2gb
+
+volumes:
+  clawdbot-app:
+  clawdbot-config:
+  clawdbot-workspace:
+  clawdbot-redis-data:


### PR DESCRIPTION

### Changes

Adds Clawdbot as a one-click service template. [Clawdbot](https://github.com/clawdbot/clawdbot) is an MIT-licensed open-source personal AI assistant that connects to WhatsApp, Telegram, Discord, Slack, and provides a web-based Control UI.

The template deploys 3 services:
- **clawdbot** (`node:22-bookworm`) — Main gateway, builds from source on first run (~10 min), persists via volume
- **clawdbot-redis** (`redis:7-alpine`) — Cache and session storage
- **clawdbot-browser** (`chromedp/headless-shell:latest`) — Headless Chrome for browser automation tool

The inline startup script handles:
- Cloning and building Clawdbot from source (first run only)
- Auto-detecting the default AI model based on which API key is provided (Anthropic/Gemini/OpenAI/OpenRouter)
- Generating gateway config with `mode: "local"`, trusted proxies, and `allowInsecureAuth` for reverse proxy setups
- Creating `auth-profiles.json` for API key authentication
- Pre-configuring all messaging channels with open policies

Uses Coolify magic variables: `SERVICE_FQDN_CLAWDBOT_18789` for FQDN and `SERVICE_PASSWORD_CLAWDBOT` for auto-generated gateway token.

Files added:
- `templates/compose/clawdbot.yaml` — Service template
- `public/svgs/clawdbot.svg` — Logo

### Issue
> - Service Template Request: https://github.com/coollabsio/coolify/discussions/8065

### Category
> - [x] Adding new one click service

### Screenshots or Video (if applicable)
N/A — this is a compose template addition (YAML + SVG), no UI changes.

### AI Usage
> - [x] AI is used in the process of creating this PR

### Steps to Test
> - Step 1 – Go to Coolify dashboard → Services → Add New Service → search for "Clawdbot"
> - Step 2 – The Clawdbot service should appear with its logo and slogan "Personal AI assistant for WhatsApp, Telegram, Discord and more"
> - Step 3 – Click to deploy. Set at least one API key environment variable (e.g. `ANTHROPIC_API_KEY` or `GEMINI_API_KEY`) in the service settings
> - Step 4 – Deploy the service. First startup takes ~10 minutes (building from source). Subsequent restarts are fast (app is persisted in volume)
> - Step 5 – Once healthy, open the service FQDN in a browser. The Clawdbot Control UI should load. Enter the auto-generated gateway token (shown as `SERVICE_PASSWORD_CLAWDBOT` in Coolify) to authenticate
> - Step 6 – Verify the AI responds by sending a message in the web chat interface

### Contributor Agreement
> [!IMPORTANT]
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them