### PR TITLE
feat: add configurable proxy timeout for publicly exposed databases

### DIFF
--- a/app/Actions/Database/StartDatabaseProxy.php
+++ b/app/Actions/Database/StartDatabaseProxy.php
@@ -54,6 +54,12 @@ class StartDatabaseProxy
         if (isDev()) {
             $configuration_dir = '/var/lib/docker/volumes/coolify_dev_coolify_data/_data/databases/'.$database->uuid.'/proxy';
         }
+
+        $proxyTimeout = (int) ($database->public_port_proxy_timeout ?? 0);
+        // 0 means no timeout (use 7 days as effective "unlimited")
+        // Any positive value is the timeout in seconds
+        $proxyTimeoutValue = $proxyTimeout > 0 ? "{$proxyTimeout}s" : '604800s';
+
         $nginxconf = <<<EOF
     user  nginx;
     worker_processes  auto;
@@ -67,6 +73,8 @@ class StartDatabaseProxy
        server {
             listen $database->public_port;
             proxy_pass $containerName:$internalPort;
+            proxy_timeout $proxyTimeoutValue;
+            proxy_connect_timeout 60s;
        }
     }
     EOF;

--- a/app/Livewire/Project/Database/Clickhouse/General.php
+++ b/app/Livewire/Project/Database/Clickhouse/General.php
@@ -36,6 +36,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $proxyTimeout = null;
+
     public ?string $customDockerRunOptions = null;
 
     public ?string $dbUrl = null;
@@ -80,6 +82,7 @@ class General extends Component
             'portsMappings' => 'nullable|string',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'proxyTimeout' => 'nullable|integer|min:0',
             'customDockerRunOptions' => 'nullable|string',
             'dbUrl' => 'nullable|string',
             'dbUrlPublic' => 'nullable|string',
@@ -115,6 +118,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_port_proxy_timeout = $this->proxyTimeout;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->save();
@@ -130,6 +134,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->proxyTimeout = $this->database->public_port_proxy_timeout;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->dbUrl = $this->database->internal_db_url;
@@ -203,8 +208,14 @@ class General extends Component
             if (str($this->publicPort)->isEmpty()) {
                 $this->publicPort = null;
             }
+            $oldProxyTimeout = $this->database->getOriginal('public_port_proxy_timeout');
             $this->syncData(true);
             $this->dispatch('success', 'Database updated.');
+
+            if ($this->isPublic && $this->database->public_port_proxy_timeout !== $oldProxyTimeout) {
+                StartDatabaseProxy::run($this->database);
+                $this->dispatch('success', 'Proxy restarted with updated timeout.');
+            }
         } catch (Exception $e) {
             return handleError($e, $this);
         } finally {

--- a/app/Livewire/Project/Database/Dragonfly/General.php
+++ b/app/Livewire/Project/Database/Dragonfly/General.php
@@ -36,6 +36,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $proxyTimeout = null;
+
     public ?string $customDockerRunOptions = null;
 
     public ?string $dbUrl = null;
@@ -91,6 +93,7 @@ class General extends Component
             'portsMappings' => 'nullable|string',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'proxyTimeout' => 'nullable|integer|min:0',
             'customDockerRunOptions' => 'nullable|string',
             'dbUrl' => 'nullable|string',
             'dbUrlPublic' => 'nullable|string',
@@ -124,6 +127,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_port_proxy_timeout = $this->proxyTimeout;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->enable_ssl = $this->enable_ssl;
@@ -139,6 +143,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->proxyTimeout = $this->database->public_port_proxy_timeout;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->enable_ssl = $this->database->enable_ssl;
@@ -213,8 +218,14 @@ class General extends Component
             if (str($this->publicPort)->isEmpty()) {
                 $this->publicPort = null;
             }
+            $oldProxyTimeout = $this->database->getOriginal('public_port_proxy_timeout');
             $this->syncData(true);
             $this->dispatch('success', 'Database updated.');
+
+            if ($this->isPublic && $this->database->public_port_proxy_timeout !== $oldProxyTimeout) {
+                StartDatabaseProxy::run($this->database);
+                $this->dispatch('success', 'Proxy restarted with updated timeout.');
+            }
         } catch (Exception $e) {
             return handleError($e, $this);
         } finally {

--- a/app/Livewire/Project/Database/Keydb/General.php
+++ b/app/Livewire/Project/Database/Keydb/General.php
@@ -38,6 +38,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $proxyTimeout = null;
+
     public ?string $customDockerRunOptions = null;
 
     public ?string $dbUrl = null;
@@ -94,6 +96,7 @@ class General extends Component
             'portsMappings' => 'nullable|string',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'proxyTimeout' => 'nullable|integer|min:0',
             'customDockerRunOptions' => 'nullable|string',
             'dbUrl' => 'nullable|string',
             'dbUrlPublic' => 'nullable|string',
@@ -130,6 +133,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_port_proxy_timeout = $this->proxyTimeout;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->enable_ssl = $this->enable_ssl;
@@ -146,6 +150,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->proxyTimeout = $this->database->public_port_proxy_timeout;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->enable_ssl = $this->database->enable_ssl;
@@ -220,8 +225,14 @@ class General extends Component
             if (str($this->publicPort)->isEmpty()) {
                 $this->publicPort = null;
             }
+            $oldProxyTimeout = $this->database->getOriginal('public_port_proxy_timeout');
             $this->syncData(true);
             $this->dispatch('success', 'Database updated.');
+
+            if ($this->isPublic && $this->database->public_port_proxy_timeout !== $oldProxyTimeout) {
+                StartDatabaseProxy::run($this->database);
+                $this->dispatch('success', 'Proxy restarted with updated timeout.');
+            }
         } catch (Exception $e) {
             return handleError($e, $this);
         } finally {

--- a/app/Livewire/Project/Database/Mariadb/General.php
+++ b/app/Livewire/Project/Database/Mariadb/General.php
@@ -44,6 +44,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $proxyTimeout = null;
+
     public bool $isLogDrainEnabled = false;
 
     public ?string $customDockerRunOptions = null;
@@ -79,6 +81,7 @@ class General extends Component
             'portsMappings' => 'nullable',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'proxyTimeout' => 'nullable|integer|min:0',
             'isLogDrainEnabled' => 'nullable|boolean',
             'customDockerRunOptions' => 'nullable',
             'enableSsl' => 'boolean',
@@ -113,6 +116,7 @@ class General extends Component
         'portsMappings' => 'Port Mapping',
         'isPublic' => 'Is Public',
         'publicPort' => 'Public Port',
+        'proxyTimeout' => 'Proxy Timeout',
         'customDockerRunOptions' => 'Custom Docker Options',
         'enableSsl' => 'Enable SSL',
     ];
@@ -154,6 +158,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_port_proxy_timeout = $this->proxyTimeout;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->enable_ssl = $this->enableSsl;
@@ -173,6 +178,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->proxyTimeout = $this->database->public_port_proxy_timeout;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->enableSsl = $this->database->enable_ssl;
@@ -192,8 +198,14 @@ class General extends Component
 
                 return;
             }
+            $oldProxyTimeout = $this->database->getOriginal('public_port_proxy_timeout');
             $this->syncData(true);
             $this->dispatch('success', 'Database updated.');
+
+            if ($this->isPublic && $this->database->public_port_proxy_timeout !== $oldProxyTimeout) {
+                StartDatabaseProxy::run($this->database);
+                $this->dispatch('success', 'Proxy restarted with updated timeout.');
+            }
             $this->dispatch('success', 'You need to restart the service for the changes to take effect.');
         } catch (Exception $e) {
             return handleError($e, $this);
@@ -208,8 +220,14 @@ class General extends Component
             if (str($this->publicPort)->isEmpty()) {
                 $this->publicPort = null;
             }
+            $oldProxyTimeout = $this->database->getOriginal('public_port_proxy_timeout');
             $this->syncData(true);
             $this->dispatch('success', 'Database updated.');
+
+            if ($this->isPublic && $this->database->public_port_proxy_timeout !== $oldProxyTimeout) {
+                StartDatabaseProxy::run($this->database);
+                $this->dispatch('success', 'Proxy restarted with updated timeout.');
+            }
         } catch (Exception $e) {
             return handleError($e, $this);
         } finally {

--- a/app/Livewire/Project/Database/Mongodb/General.php
+++ b/app/Livewire/Project/Database/Mongodb/General.php
@@ -42,6 +42,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $proxyTimeout = null;
+
     public bool $isLogDrainEnabled = false;
 
     public ?string $customDockerRunOptions = null;
@@ -78,6 +80,7 @@ class General extends Component
             'portsMappings' => 'nullable',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'proxyTimeout' => 'nullable|integer|min:0',
             'isLogDrainEnabled' => 'nullable|boolean',
             'customDockerRunOptions' => 'nullable',
             'enableSsl' => 'boolean',
@@ -112,6 +115,7 @@ class General extends Component
         'portsMappings' => 'Port Mapping',
         'isPublic' => 'Is Public',
         'publicPort' => 'Public Port',
+        'proxyTimeout' => 'Proxy Timeout',
         'customDockerRunOptions' => 'Custom Docker Run Options',
         'enableSsl' => 'Enable SSL',
         'sslMode' => 'SSL Mode',
@@ -153,6 +157,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_port_proxy_timeout = $this->proxyTimeout;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->enable_ssl = $this->enableSsl;
@@ -172,6 +177,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->proxyTimeout = $this->database->public_port_proxy_timeout;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->enableSsl = $this->database->enable_ssl;
@@ -192,8 +198,14 @@ class General extends Component
 
                 return;
             }
+            $oldProxyTimeout = $this->database->getOriginal('public_port_proxy_timeout');
             $this->syncData(true);
             $this->dispatch('success', 'Database updated.');
+
+            if ($this->isPublic && $this->database->public_port_proxy_timeout !== $oldProxyTimeout) {
+                StartDatabaseProxy::run($this->database);
+                $this->dispatch('success', 'Proxy restarted with updated timeout.');
+            }
             $this->dispatch('success', 'You need to restart the service for the changes to take effect.');
         } catch (Exception $e) {
             return handleError($e, $this);
@@ -211,8 +223,14 @@ class General extends Component
             if (str($this->mongoConf)->isEmpty()) {
                 $this->mongoConf = null;
             }
+            $oldProxyTimeout = $this->database->getOriginal('public_port_proxy_timeout');
             $this->syncData(true);
             $this->dispatch('success', 'Database updated.');
+
+            if ($this->isPublic && $this->database->public_port_proxy_timeout !== $oldProxyTimeout) {
+                StartDatabaseProxy::run($this->database);
+                $this->dispatch('success', 'Proxy restarted with updated timeout.');
+            }
         } catch (Exception $e) {
             return handleError($e, $this);
         } finally {

--- a/app/Livewire/Project/Database/Mysql/General.php
+++ b/app/Livewire/Project/Database/Mysql/General.php
@@ -44,6 +44,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $proxyTimeout = null;
+
     public bool $isLogDrainEnabled = false;
 
     public ?string $customDockerRunOptions = null;
@@ -81,6 +83,7 @@ class General extends Component
             'portsMappings' => 'nullable',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'proxyTimeout' => 'nullable|integer|min:0',
             'isLogDrainEnabled' => 'nullable|boolean',
             'customDockerRunOptions' => 'nullable',
             'enableSsl' => 'boolean',
@@ -117,6 +120,7 @@ class General extends Component
         'portsMappings' => 'Port Mapping',
         'isPublic' => 'Is Public',
         'publicPort' => 'Public Port',
+        'proxyTimeout' => 'Proxy Timeout',
         'customDockerRunOptions' => 'Custom Docker Run Options',
         'enableSsl' => 'Enable SSL',
         'sslMode' => 'SSL Mode',
@@ -159,6 +163,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_port_proxy_timeout = $this->proxyTimeout;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->enable_ssl = $this->enableSsl;
@@ -179,6 +184,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->proxyTimeout = $this->database->public_port_proxy_timeout;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->enableSsl = $this->database->enable_ssl;
@@ -199,8 +205,14 @@ class General extends Component
 
                 return;
             }
+            $oldProxyTimeout = $this->database->getOriginal('public_port_proxy_timeout');
             $this->syncData(true);
             $this->dispatch('success', 'Database updated.');
+
+            if ($this->isPublic && $this->database->public_port_proxy_timeout !== $oldProxyTimeout) {
+                StartDatabaseProxy::run($this->database);
+                $this->dispatch('success', 'Proxy restarted with updated timeout.');
+            }
             $this->dispatch('success', 'You need to restart the service for the changes to take effect.');
         } catch (Exception $e) {
             return handleError($e, $this);
@@ -215,8 +227,14 @@ class General extends Component
             if (str($this->publicPort)->isEmpty()) {
                 $this->publicPort = null;
             }
+            $oldProxyTimeout = $this->database->getOriginal('public_port_proxy_timeout');
             $this->syncData(true);
             $this->dispatch('success', 'Database updated.');
+
+            if ($this->isPublic && $this->database->public_port_proxy_timeout !== $oldProxyTimeout) {
+                StartDatabaseProxy::run($this->database);
+                $this->dispatch('success', 'Proxy restarted with updated timeout.');
+            }
         } catch (Exception $e) {
             return handleError($e, $this);
         } finally {

--- a/app/Livewire/Project/Database/Postgresql/General.php
+++ b/app/Livewire/Project/Database/Postgresql/General.php
@@ -48,6 +48,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $proxyTimeout = null;
+
     public bool $isLogDrainEnabled = false;
 
     public ?string $customDockerRunOptions = null;
@@ -93,6 +95,7 @@ class General extends Component
             'portsMappings' => 'nullable',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'proxyTimeout' => 'nullable|integer|min:0',
             'isLogDrainEnabled' => 'nullable|boolean',
             'customDockerRunOptions' => 'nullable',
             'enableSsl' => 'boolean',
@@ -130,6 +133,7 @@ class General extends Component
         'portsMappings' => 'Port Mapping',
         'isPublic' => 'Is Public',
         'publicPort' => 'Public Port',
+        'proxyTimeout' => 'Proxy Timeout',
         'customDockerRunOptions' => 'Custom Docker Run Options',
         'enableSsl' => 'Enable SSL',
         'sslMode' => 'SSL Mode',
@@ -174,6 +178,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_port_proxy_timeout = $this->proxyTimeout;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->enable_ssl = $this->enableSsl;
@@ -196,6 +201,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->proxyTimeout = $this->database->public_port_proxy_timeout;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->enableSsl = $this->database->enable_ssl;
@@ -216,8 +222,14 @@ class General extends Component
 
                 return;
             }
+            $oldProxyTimeout = $this->database->getOriginal('public_port_proxy_timeout');
             $this->syncData(true);
             $this->dispatch('success', 'Database updated.');
+
+            if ($this->isPublic && $this->database->public_port_proxy_timeout !== $oldProxyTimeout) {
+                StartDatabaseProxy::run($this->database);
+                $this->dispatch('success', 'Proxy restarted with updated timeout.');
+            }
             $this->dispatch('success', 'You need to restart the service for the changes to take effect.');
         } catch (Exception $e) {
             return handleError($e, $this);
@@ -451,8 +463,14 @@ class General extends Component
             if (str($this->publicPort)->isEmpty()) {
                 $this->publicPort = null;
             }
+            $oldProxyTimeout = $this->database->getOriginal('public_port_proxy_timeout');
             $this->syncData(true);
             $this->dispatch('success', 'Database updated.');
+
+            if ($this->isPublic && $this->database->public_port_proxy_timeout !== $oldProxyTimeout) {
+                StartDatabaseProxy::run($this->database);
+                $this->dispatch('success', 'Proxy restarted with updated timeout.');
+            }
         } catch (Exception $e) {
             return handleError($e, $this);
         } finally {

--- a/app/Livewire/Project/Database/Redis/General.php
+++ b/app/Livewire/Project/Database/Redis/General.php
@@ -36,6 +36,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $proxyTimeout = null;
+
     public bool $isLogDrainEnabled = false;
 
     public ?string $customDockerRunOptions = null;
@@ -74,6 +76,7 @@ class General extends Component
             'portsMappings' => 'nullable',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'proxyTimeout' => 'nullable|integer|min:0',
             'isLogDrainEnabled' => 'nullable|boolean',
             'customDockerRunOptions' => 'nullable',
             'redisUsername' => 'required',
@@ -104,6 +107,7 @@ class General extends Component
         'portsMappings' => 'Port Mapping',
         'isPublic' => 'Is Public',
         'publicPort' => 'Public Port',
+        'proxyTimeout' => 'Proxy Timeout',
         'customDockerRunOptions' => 'Custom Docker Options',
         'redisUsername' => 'Redis Username',
         'redisPassword' => 'Redis Password',
@@ -143,6 +147,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_port_proxy_timeout = $this->proxyTimeout;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->enable_ssl = $this->enableSsl;
@@ -158,6 +163,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->proxyTimeout = $this->database->public_port_proxy_timeout;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->enableSsl = $this->database->enable_ssl;
@@ -180,8 +186,14 @@ class General extends Component
 
                 return;
             }
+            $oldProxyTimeout = $this->database->getOriginal('public_port_proxy_timeout');
             $this->syncData(true);
             $this->dispatch('success', 'Database updated.');
+
+            if ($this->isPublic && $this->database->public_port_proxy_timeout !== $oldProxyTimeout) {
+                StartDatabaseProxy::run($this->database);
+                $this->dispatch('success', 'Proxy restarted with updated timeout.');
+            }
             $this->dispatch('success', 'You need to restart the service for the changes to take effect.');
         } catch (Exception $e) {
             return handleError($e, $this);

--- a/database/migrations/2026_01_27_220000_add_public_port_proxy_timeout_to_database_tables.php
+++ b/database/migrations/2026_01_27_220000_add_public_port_proxy_timeout_to_database_tables.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private array $tables = [
+        'standalone_postgresqls',
+        'standalone_mysqls',
+        'standalone_mariadbs',
+        'standalone_mongodbs',
+        'standalone_redis',
+        'standalone_keydbs',
+        'standalone_dragonflies',
+        'standalone_clickhouses',
+        'service_databases',
+    ];
+
+    public function up(): void
+    {
+        foreach ($this->tables as $table) {
+            Schema::table($table, function (Blueprint $table) {
+                $table->integer('public_port_proxy_timeout')->default(0)->after('public_port');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        foreach ($this->tables as $table) {
+            Schema::table($table, function (Blueprint $table) {
+                $table->dropColumn('public_port_proxy_timeout');
+            });
+        }
+    }
+};

--- a/resources/views/livewire/project/database/clickhouse/general.blade.php
+++ b/resources/views/livewire/project/database/clickhouse/general.blade.php
@@ -78,6 +78,10 @@
             </div>
             <x-forms.input placeholder="5432" disabled="{{ $isPublic }}" id="publicPort" label="Public Port"
                 canGate="update" :canResource="$database" />
+            <x-forms.input placeholder="0" disabled="{{ !$isPublic }}" id="proxyTimeout"
+                label="Proxy Timeout (seconds)"
+                helper="Timeout in seconds between successive reads/writes. 0 = no timeout (recommended for long-running queries)."
+                canGate="update" :canResource="$database" />
         </div>
     </form>
     <h3 class="pt-4">Advanced</h3>

--- a/resources/views/livewire/project/database/dragonfly/general.blade.php
+++ b/resources/views/livewire/project/database/dragonfly/general.blade.php
@@ -115,6 +115,10 @@
             </div>
             <x-forms.input placeholder="5432" disabled="{{ $isPublic }}" id="publicPort" label="Public Port"
                 canGate="update" :canResource="$database" />
+            <x-forms.input placeholder="0" disabled="{{ !$isPublic }}" id="proxyTimeout"
+                label="Proxy Timeout (seconds)"
+                helper="Timeout in seconds between successive reads/writes. 0 = no timeout (recommended for long-running queries)."
+                canGate="update" :canResource="$database" />
         </div>
     </form>
     <h3 class="pt-4">Advanced</h3>

--- a/resources/views/livewire/project/database/keydb/general.blade.php
+++ b/resources/views/livewire/project/database/keydb/general.blade.php
@@ -115,6 +115,10 @@
             </div>
             <x-forms.input placeholder="5432" disabled="{{ $isPublic }}" id="publicPort" label="Public Port"
                 canGate="update" :canResource="$database" />
+            <x-forms.input placeholder="0" disabled="{{ !$isPublic }}" id="proxyTimeout"
+                label="Proxy Timeout (seconds)"
+                helper="Timeout in seconds between successive reads/writes. 0 = no timeout (recommended for long-running queries)."
+                canGate="update" :canResource="$database" />
         </div>
         <x-forms.textarea
             helper="<a target='_blank' class='underline dark:text-white' href='https://raw.githubusercontent.com/Snapchat/KeyDB/unstable/keydb.conf'>KeyDB Default Configuration</a>"

--- a/resources/views/livewire/project/database/mariadb/general.blade.php
+++ b/resources/views/livewire/project/database/mariadb/general.blade.php
@@ -139,6 +139,10 @@
             </div>
             <x-forms.input placeholder="5432" disabled="{{ $isPublic }}"
                 id="publicPort" label="Public Port" canGate="update" :canResource="$database" />
+                    <x-forms.input placeholder="0" disabled="{{ !$isPublic }}" id="proxyTimeout"
+                        label="Proxy Timeout (seconds)"
+                        helper="Timeout in seconds between successive reads/writes. 0 = no timeout (recommended for long-running queries)."
+                        canGate="update" :canResource="$database" />
         </div>
         <x-forms.textarea label="Custom MariaDB Configuration" rows="10" id="mariadbConf"
             canGate="update" :canResource="$database" />

--- a/resources/views/livewire/project/database/mongodb/general.blade.php
+++ b/resources/views/livewire/project/database/mongodb/general.blade.php
@@ -153,6 +153,10 @@
                 </div>
                 <x-forms.input placeholder="5432" disabled="{{ $isPublic }}"
                     id="publicPort" label="Public Port" canGate="update" :canResource="$database" />
+                    <x-forms.input placeholder="0" disabled="{{ !$isPublic }}" id="proxyTimeout"
+                        label="Proxy Timeout (seconds)"
+                        helper="Timeout in seconds between successive reads/writes. 0 = no timeout (recommended for long-running queries)."
+                        canGate="update" :canResource="$database" />
             </div>
             <x-forms.textarea label="Custom MongoDB Configuration" rows="10" id="mongoConf"
                 canGate="update" :canResource="$database" />

--- a/resources/views/livewire/project/database/mysql/general.blade.php
+++ b/resources/views/livewire/project/database/mysql/general.blade.php
@@ -155,6 +155,10 @@
             </div>
             <x-forms.input placeholder="5432" disabled="{{ $isPublic }}"
                 id="publicPort" label="Public Port" canGate="update" :canResource="$database" />
+                    <x-forms.input placeholder="0" disabled="{{ !$isPublic }}" id="proxyTimeout"
+                        label="Proxy Timeout (seconds)"
+                        helper="Timeout in seconds between successive reads/writes. 0 = no timeout (recommended for long-running queries)."
+                        canGate="update" :canResource="$database" />
         </div>
         <x-forms.textarea label="Custom Mysql Configuration" rows="10" id="mysqlConf" canGate="update" :canResource="$database" />
         <h3 class="pt-4">Advanced</h3>

--- a/resources/views/livewire/project/database/postgresql/general.blade.php
+++ b/resources/views/livewire/project/database/postgresql/general.blade.php
@@ -165,6 +165,10 @@
                     </div>
                     <x-forms.input placeholder="5432" disabled="{{ $isPublic }}" id="publicPort"
                         label="Public Port" canGate="update" :canResource="$database" />
+                    <x-forms.input placeholder="0" disabled="{{ !$isPublic }}" id="proxyTimeout"
+                        label="Proxy Timeout (seconds)"
+                        helper="Timeout in seconds between successive reads/writes. 0 = no timeout (recommended for long-running queries)."
+                        canGate="update" :canResource="$database" />
                 </div>
 
                 <div class="flex flex-col gap-2">

--- a/resources/views/livewire/project/database/redis/general.blade.php
+++ b/resources/views/livewire/project/database/redis/general.blade.php
@@ -134,6 +134,10 @@
             </div>
             <x-forms.input placeholder="5432" disabled="{{ $isPublic }}"
                 id="publicPort" label="Public Port" canGate="update" :canResource="$database" />
+                    <x-forms.input placeholder="0" disabled="{{ !$isPublic }}" id="proxyTimeout"
+                        label="Proxy Timeout (seconds)"
+                        helper="Timeout in seconds between successive reads/writes. 0 = no timeout (recommended for long-running queries)."
+                        canGate="update" :canResource="$database" />
         </div>
         <x-forms.textarea placeholder="# maxmemory 256mb
 # maxmemory-policy allkeys-lru


### PR DESCRIPTION
## Summary

Resolves #7743
/claim #7743

The nginx stream proxy for publicly exposed databases defaults to a 10-minute timeout (nginx default `proxy_timeout`), causing long-running database operations (e.g. large `SELECT *` queries) to be disconnected prematurely.

## Changes

### Migration
- Adds `public_port_proxy_timeout` column (integer, default 0) to all 9 database tables

### Proxy Configuration (StartDatabaseProxy.php)
- Reads `public_port_proxy_timeout` from the database model
- Injects `proxy_timeout` and `proxy_connect_timeout` into the nginx stream config
- **0 = no timeout** (effective 7-day unlimited); positive integer = custom timeout in seconds

### UI (all 8 database type views)
- Adds **Proxy Timeout (seconds)** input field below Public Port
- Helper text explains 0 = no timeout default
- Field disabled when database is not publicly exposed

### Livewire Components (all 8 General.php files)
- Adds `proxyTimeout` property with validation
- Auto-restarts the proxy on form save when timeout changes

## Behavior

| Value | Behavior |
|-------|----------|
| 0 (default) | No timeout - connections stay open indefinitely |
| > 0 | Timeout in seconds between successive read/write operations |

Default of 0 solves the original issue: long-running queries (30min+) will no longer be disconnected.