### PR TITLE
feat(database): add SurrealDB support

### DIFF
--- a/app/Actions/Database/StartSurrealdb.php
+++ b/app/Actions/Database/StartSurrealdb.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace App\Actions\Database;
+
+use App\Models\StandaloneSurrealdb;
+use Lorisleiva\Actions\Concerns\AsAction;
+use Symfony\Component\Yaml\Yaml;
+
+class StartSurrealdb
+{
+    use AsAction;
+
+    public StandaloneSurrealdb $database;
+
+    public array $commands = [];
+
+    public string $configuration_dir;
+
+    public function handle(StandaloneSurrealdb $database)
+    {
+        $this->database = $database;
+
+        $container_name = $this->database->uuid;
+        $this->configuration_dir = database_configuration_dir().'/'.$container_name;
+
+        $this->commands = [
+            "echo 'Starting database.'",
+            "mkdir -p $this->configuration_dir",
+        ];
+
+        $persistent_storages = $this->generate_local_persistent_volumes();
+        $persistent_file_volumes = $this->database->fileStorages()->get();
+        $volume_names = $this->generate_local_persistent_volumes_only_volume_names();
+        $environment_variables = $this->generate_environment_variables();
+
+        $docker_compose = [
+            'services' => [
+                $container_name => [
+                    'image' => $this->database->image,
+                    'container_name' => $container_name,
+                    'command' => "start --user {$this->database->surrealdb_user} --pass {$this->database->surrealdb_password} rocksdb:/data/database.db",
+                    'environment' => $environment_variables,
+                    'restart' => RESTART_MODE,
+                    'networks' => [
+                        $this->database->destination->network,
+                    ],
+                    'labels' => defaultDatabaseLabels($this->database)->toArray(),
+                    'healthcheck' => [
+                        'test' => ['CMD', 'curl', '-f', 'http://localhost:8000/health'],
+                        'interval' => '5s',
+                        'timeout' => '5s',
+                        'retries' => 10,
+                        'start_period' => '5s',
+                    ],
+                    'mem_limit' => $this->database->limits_memory,
+                    'memswap_limit' => $this->database->limits_memory_swap,
+                    'mem_swappiness' => $this->database->limits_memory_swappiness,
+                    'mem_reservation' => $this->database->limits_memory_reservation,
+                    'cpus' => (float) $this->database->limits_cpus,
+                    'cpu_shares' => $this->database->limits_cpu_shares,
+                ],
+            ],
+            'networks' => [
+                $this->database->destination->network => [
+                    'external' => true,
+                    'name' => $this->database->destination->network,
+                    'attachable' => true,
+                ],
+            ],
+        ];
+
+        if (! is_null($this->database->limits_cpuset)) {
+            data_set($docker_compose, "services.{$container_name}.cpuset", $this->database->limits_cpuset);
+        }
+        if ($this->database->destination->server->isLogDrainEnabled() && $this->database->isLogDrainEnabled()) {
+            $docker_compose['services'][$container_name]['logging'] = generate_fluentd_configuration();
+        }
+        if (count($this->database->ports_mappings_array) > 0) {
+            $docker_compose['services'][$container_name]['ports'] = $this->database->ports_mappings_array;
+        }
+        if (count($persistent_storages) > 0) {
+            $docker_compose['services'][$container_name]['volumes'] = $persistent_storages;
+        }
+        if (count($persistent_file_volumes) > 0) {
+            $docker_compose['services'][$container_name]['volumes'] = $persistent_file_volumes->map(function ($item) {
+                return "$item->fs_path:$item->mount_path";
+            })->toArray();
+        }
+        if (count($volume_names) > 0) {
+            $docker_compose['volumes'] = $volume_names;
+        }
+
+        $docker_run_options = convertDockerRunToCompose($this->database->custom_docker_run_options);
+        $docker_compose = generateCustomDockerRunOptionsForDatabases($docker_run_options, $docker_compose, $container_name, $this->database->destination->network);
+
+        $docker_compose = Yaml::dump($docker_compose, 10);
+        $docker_compose_base64 = base64_encode($docker_compose);
+        $this->commands[] = "echo '{$docker_compose_base64}' | base64 -d | tee $this->configuration_dir/docker-compose.yml > /dev/null";
+        $readme = generate_readme_file($this->database->name, now());
+        $this->commands[] = "echo '{$readme}' > $this->configuration_dir/README.md";
+        $this->commands[] = "echo 'Pulling {$database->image} image.'";
+        $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml pull";
+        $this->commands[] = "docker stop -t 10 $container_name 2>/dev/null || true";
+        $this->commands[] = "docker rm -f $container_name 2>/dev/null || true";
+        $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml up -d";
+        $this->commands[] = "echo 'Database started.'";
+
+        return remote_process($this->commands, $database->destination->server, callEventOnFinish: 'DatabaseStatusChanged');
+    }
+
+    private function generate_local_persistent_volumes()
+    {
+        $local_persistent_volumes = [];
+        foreach ($this->database->persistentStorages as $persistentStorage) {
+            if ($persistentStorage->host_path !== '' && $persistentStorage->host_path !== null) {
+                $local_persistent_volumes[] = $persistentStorage->host_path.':'.$persistentStorage->mount_path;
+            } else {
+                $volume_name = $persistentStorage->name;
+                $local_persistent_volumes[] = $volume_name.':'.$persistentStorage->mount_path;
+            }
+        }
+
+        return $local_persistent_volumes;
+    }
+
+    private function generate_local_persistent_volumes_only_volume_names()
+    {
+        $local_persistent_volumes_names = [];
+        foreach ($this->database->persistentStorages as $persistentStorage) {
+            if ($persistentStorage->host_path) {
+                continue;
+            }
+            $name = $persistentStorage->name;
+            $local_persistent_volumes_names[$name] = [
+                'name' => $name,
+                'external' => false,
+            ];
+        }
+
+        return $local_persistent_volumes_names;
+    }
+
+    private function generate_environment_variables()
+    {
+        $environment_variables = collect();
+        foreach ($this->database->runtime_environment_variables as $env) {
+            $environment_variables->push("$env->key=$env->real_value");
+        }
+
+        add_coolify_default_environment_variables($this->database, $environment_variables, $environment_variables);
+
+        return $environment_variables->all();
+    }
+}

--- a/app/Enums/NewDatabaseTypes.php
+++ b/app/Enums/NewDatabaseTypes.php
@@ -12,4 +12,5 @@ enum NewDatabaseTypes: string
     case KEYDB = 'keydb';
     case DRAGONFLY = 'dragonfly';
     case CLICKHOUSE = 'clickhouse';
+    case SURREALDB = 'surrealdb';
 }

--- a/app/Enums/NewResourceTypes.php
+++ b/app/Enums/NewResourceTypes.php
@@ -19,4 +19,5 @@ enum NewResourceTypes: string
     case KEYDB = 'keydb';
     case DRAGONFLY = 'dragonfly';
     case CLICKHOUSE = 'clickhouse';
+    case SURREALDB = 'surrealdb';
 }

--- a/app/Livewire/Project/Database/Surrealdb/General.php
+++ b/app/Livewire/Project/Database/Surrealdb/General.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace App\Livewire\Project\Database\Surrealdb;
+
+use App\Actions\Database\StartDatabaseProxy;
+use App\Actions\Database\StopDatabaseProxy;
+use App\Models\Server;
+use App\Models\StandaloneSurrealdb;
+use App\Support\ValidationPatterns;
+use Exception;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Component;
+
+class General extends Component
+{
+    use AuthorizesRequests;
+
+    public ?Server $server = null;
+
+    public StandaloneSurrealdb $database;
+
+    public string $name;
+
+    public ?string $description = null;
+
+    public string $surrealdbUser;
+
+    public string $surrealdbPassword;
+
+    public string $image;
+
+    public ?string $portsMappings = null;
+
+    public ?bool $isPublic = null;
+
+    public ?int $publicPort = null;
+
+    public ?string $customDockerRunOptions = null;
+
+    public ?string $dbUrl = null;
+
+    public ?string $dbUrlPublic = null;
+
+    public bool $isLogDrainEnabled = false;
+
+    public function getListeners()
+    {
+        $teamId = Auth::user()->currentTeam()->id;
+
+        return [
+            "echo-private:team.{$teamId},DatabaseProxyStopped" => 'databaseProxyStopped',
+        ];
+    }
+
+    public function mount()
+    {
+        try {
+            $this->authorize('view', $this->database);
+            $this->syncData();
+            $this->server = data_get($this->database, 'destination.server');
+            if (! $this->server) {
+                $this->dispatch('error', 'Database destination server is not configured.');
+
+                return;
+            }
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    protected function rules(): array
+    {
+        return [
+            'name' => ValidationPatterns::nameRules(),
+            'description' => ValidationPatterns::descriptionRules(),
+            'surrealdbUser' => 'required|string',
+            'surrealdbPassword' => 'required|string',
+            'image' => 'required|string',
+            'portsMappings' => 'nullable|string',
+            'isPublic' => 'nullable|boolean',
+            'publicPort' => 'nullable|integer',
+            'customDockerRunOptions' => 'nullable|string',
+            'dbUrl' => 'nullable|string',
+            'dbUrlPublic' => 'nullable|string',
+            'isLogDrainEnabled' => 'nullable|boolean',
+        ];
+    }
+
+    protected function messages(): array
+    {
+        return array_merge(
+            ValidationPatterns::combinedMessages(),
+            [
+                'surrealdbUser.required' => 'The User field is required.',
+                'surrealdbUser.string' => 'The User must be a string.',
+                'surrealdbPassword.required' => 'The Password field is required.',
+                'surrealdbPassword.string' => 'The Password must be a string.',
+                'image.required' => 'The Docker Image field is required.',
+                'image.string' => 'The Docker Image must be a string.',
+                'publicPort.integer' => 'The Public Port must be an integer.',
+            ]
+        );
+    }
+
+    public function syncData(bool $toModel = false)
+    {
+        if ($toModel) {
+            $this->validate();
+            $this->database->name = $this->name;
+            $this->database->description = $this->description;
+            $this->database->surrealdb_user = $this->surrealdbUser;
+            $this->database->surrealdb_password = $this->surrealdbPassword;
+            $this->database->image = $this->image;
+            $this->database->ports_mappings = $this->portsMappings;
+            $this->database->is_public = $this->isPublic;
+            $this->database->public_port = $this->publicPort;
+            $this->database->custom_docker_run_options = $this->customDockerRunOptions;
+            $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
+            $this->database->save();
+
+            $this->dbUrl = $this->database->internal_db_url;
+            $this->dbUrlPublic = $this->database->external_db_url;
+        } else {
+            $this->name = $this->database->name;
+            $this->description = $this->database->description;
+            $this->surrealdbUser = $this->database->surrealdb_user;
+            $this->surrealdbPassword = $this->database->surrealdb_password;
+            $this->image = $this->database->image;
+            $this->portsMappings = $this->database->ports_mappings;
+            $this->isPublic = $this->database->is_public;
+            $this->publicPort = $this->database->public_port;
+            $this->customDockerRunOptions = $this->database->custom_docker_run_options;
+            $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
+            $this->dbUrl = $this->database->internal_db_url;
+            $this->dbUrlPublic = $this->database->external_db_url;
+        }
+    }
+
+    public function instantSaveAdvanced()
+    {
+        try {
+            $this->authorize('update', $this->database);
+
+            if (! $this->server->isLogDrainEnabled()) {
+                $this->isLogDrainEnabled = false;
+                $this->dispatch('error', 'Log drain is not enabled on the server. Please enable it first.');
+
+                return;
+            }
+            $this->syncData(true);
+
+            $this->dispatch('success', 'Database updated.');
+            $this->dispatch('success', 'You need to restart the service for the changes to take effect.');
+        } catch (Exception $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function instantSave()
+    {
+        try {
+            $this->authorize('update', $this->database);
+
+            if ($this->isPublic && ! $this->publicPort) {
+                $this->dispatch('error', 'Public port is required.');
+                $this->isPublic = false;
+
+                return;
+            }
+            if ($this->isPublic && ! str($this->database->status)->startsWith('running')) {
+                $this->dispatch('error', 'Database must be started to be publicly accessible.');
+                $this->isPublic = false;
+
+                return;
+            }
+            $this->syncData(true);
+            if ($this->isPublic) {
+                StartDatabaseProxy::run($this->database);
+                $this->dispatch('success', 'Database is now publicly accessible.');
+            } else {
+                StopDatabaseProxy::run($this->database);
+                $this->dispatch('success', 'Database is no longer publicly accessible.');
+            }
+        } catch (\Throwable $e) {
+            $this->isPublic = ! $this->isPublic;
+            $this->syncData(true);
+
+            return handleError($e, $this);
+        }
+    }
+
+    public function databaseProxyStopped()
+    {
+        $this->syncData();
+    }
+
+    public function submit()
+    {
+        try {
+            $this->authorize('update', $this->database);
+
+            if (str($this->publicPort)->isEmpty()) {
+                $this->publicPort = null;
+            }
+            $this->syncData(true);
+            $this->dispatch('success', 'Database updated.');
+        } catch (Exception $e) {
+            return handleError($e, $this);
+        } finally {
+            if (is_null($this->database->config_hash)) {
+                $this->database->isConfigurationChanged(true);
+            } else {
+                $this->dispatch('configurationChanged');
+            }
+        }
+    }
+}

--- a/app/Livewire/Project/New/Select.php
+++ b/app/Livewire/Project/New/Select.php
@@ -243,6 +243,12 @@ class Select extends Component
                 'description' => 'ClickHouse is a column-oriented database that supports real-time analytics, business intelligence, observability, ML and GenAI, and more.',
                 'logo' => '<div class="w-[4.5rem] h-[4.5rem] p-2 transition-all duration-200 bg-black/10 dark:bg-white/10"><svg width="215" height="90" viewBox="0 0 100 43" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><g clip-path="url(#clip0_378_10860)"><rect x="2.70837" y="2.875" width="2.24992" height="20.2493" rx="0.236664" fill="currentColor"/><rect x="7.2085" y="2.875" width="2.24992" height="20.2493" rx="0.236664" fill="currentColor"/><rect x="11.7086" y="2.875" width="2.24992" height="20.2493" rx="0.236664" fill="currentColor"/><rect x="16.2076" y="2.875" width="2.24992" height="20.2493" rx="0.236664" fill="currentColor"/><rect x="20.7087" y="10.7502" width="2.24992" height="4.49985" rx="0.236664" fill="currentColor"/></g></svg></div>',
             ],
+            [
+                'id' => 'surrealdb',
+                'name' => 'SurrealDB',
+                'description' => 'SurrealDB is a multi-model database that combines the best of relational, document, graph, and time-series databases.',
+                'logo' => '<div class="w-[4.5rem] h-[4.5rem] p-2 transition-all duration-200 bg-black/10 dark:bg-white/10"><svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12 12-5.373 12-12S18.627 0 12 0zm0 2.4c5.302 0 9.6 4.298 9.6 9.6s-4.298 9.6-9.6 9.6S2.4 17.302 2.4 12 6.698 2.4 12 2.4zm0 2.4a7.2 7.2 0 100 14.4 7.2 7.2 0 000-14.4zm0 2.4a4.8 4.8 0 110 9.6 4.8 4.8 0 010-9.6z"/></svg></div>',
+            ],
 
         ];
 

--- a/app/Livewire/Project/Resource/Create.php
+++ b/app/Livewire/Project/Resource/Create.php
@@ -61,6 +61,8 @@ class Create extends Component
                     $database = create_standalone_dragonfly($environment->id, $destination_uuid);
                 } elseif ($type->value() === 'clickhouse') {
                     $database = create_standalone_clickhouse($environment->id, $destination_uuid);
+                } elseif ($type->value() === 'surrealdb') {
+                    $database = create_standalone_surrealdb($environment->id, $destination_uuid);
                 }
 
                 return redirect()->route('project.database.configuration', [

--- a/app/Models/Environment.php
+++ b/app/Models/Environment.php
@@ -49,6 +49,7 @@ class Environment extends BaseModel
             $this->keydbs()->count() == 0 &&
             $this->dragonflies()->count() == 0 &&
             $this->clickhouses()->count() == 0 &&
+            $this->surrealdbs()->count() == 0 &&
             $this->mariadbs()->count() == 0 &&
             $this->mongodbs()->count() == 0 &&
             $this->services()->count() == 0;
@@ -104,6 +105,11 @@ class Environment extends BaseModel
         return $this->hasMany(StandaloneClickhouse::class);
     }
 
+    public function surrealdbs()
+    {
+        return $this->hasMany(StandaloneSurrealdb::class);
+    }
+
     public function databases()
     {
         $postgresqls = $this->postgresqls;
@@ -114,8 +120,9 @@ class Environment extends BaseModel
         $keydbs = $this->keydbs;
         $dragonflies = $this->dragonflies;
         $clickhouses = $this->clickhouses;
+        $surrealdbs = $this->surrealdbs;
 
-        return $postgresqls->concat($redis)->concat($mongodbs)->concat($mysqls)->concat($mariadbs)->concat($keydbs)->concat($dragonflies)->concat($clickhouses);
+        return $postgresqls->concat($redis)->concat($mongodbs)->concat($mysqls)->concat($mariadbs)->concat($keydbs)->concat($dragonflies)->concat($clickhouses)->concat($surrealdbs);
     }
 
     public function project()

--- a/app/Models/StandaloneSurrealdb.php
+++ b/app/Models/StandaloneSurrealdb.php
@@ -1,0 +1,293 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\ClearsGlobalSearchCache;
+use App\Traits\HasMetrics;
+use App\Traits\HasSafeStringAttribute;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class StandaloneSurrealdb extends BaseModel
+{
+    use ClearsGlobalSearchCache, HasFactory, HasMetrics, HasSafeStringAttribute, SoftDeletes;
+
+    protected $guarded = [];
+
+    protected $appends = ['internal_db_url', 'external_db_url', 'database_type', 'server_status'];
+
+    protected $casts = [
+        'surrealdb_password' => 'encrypted',
+    ];
+
+    protected static function booted()
+    {
+        static::created(function ($database) {
+            LocalPersistentVolume::create([
+                'name' => 'surrealdb-data-'.$database->uuid,
+                'mount_path' => '/data',
+                'host_path' => null,
+                'resource_id' => $database->id,
+                'resource_type' => $database->getMorphClass(),
+            ]);
+        });
+        static::forceDeleting(function ($database) {
+            $database->persistentStorages()->delete();
+            $database->environment_variables()->delete();
+            $database->tags()->detach();
+        });
+        static::saving(function ($database) {
+            if ($database->isDirty('status')) {
+                $database->forceFill(['last_online_at' => now()]);
+            }
+        });
+    }
+
+    public static function ownedByCurrentTeam()
+    {
+        return StandaloneSurrealdb::whereRelation('environment.project.team', 'id', currentTeam()->id)->orderBy('name');
+    }
+
+    public static function ownedByCurrentTeamCached()
+    {
+        return once(function () {
+            return StandaloneSurrealdb::ownedByCurrentTeam()->get();
+        });
+    }
+
+    protected function serverStatus(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => $this->destination->server->isFunctional()
+        );
+    }
+
+    public function isConfigurationChanged(bool $save = false)
+    {
+        $newConfigHash = $this->image.$this->ports_mappings;
+        $newConfigHash .= json_encode($this->environment_variables()->get('value')->sort());
+        $newConfigHash = md5($newConfigHash);
+        $oldConfigHash = data_get($this, 'config_hash');
+        if ($oldConfigHash === null) {
+            if ($save) {
+                $this->config_hash = $newConfigHash;
+                $this->save();
+            }
+
+            return true;
+        }
+        if ($oldConfigHash === $newConfigHash) {
+            return false;
+        }
+        if ($save) {
+            $this->config_hash = $newConfigHash;
+            $this->save();
+        }
+
+        return true;
+    }
+
+    public function isRunning()
+    {
+        return (bool) str($this->status)->contains('running');
+    }
+
+    public function isExited()
+    {
+        return (bool) str($this->status)->startsWith('exited');
+    }
+
+    public function workdir()
+    {
+        return database_configuration_dir()."/{$this->uuid}";
+    }
+
+    public function deleteConfigurations()
+    {
+        $server = data_get($this, 'destination.server');
+        $workdir = $this->workdir();
+        if (str($workdir)->endsWith($this->uuid)) {
+            instant_remote_process(['rm -rf '.$this->workdir()], $server, false);
+        }
+    }
+
+    public function deleteVolumes()
+    {
+        $persistentStorages = $this->persistentStorages()->get() ?? collect();
+        if ($persistentStorages->count() === 0) {
+            return;
+        }
+        $server = data_get($this, 'destination.server');
+        foreach ($persistentStorages as $storage) {
+            instant_remote_process(["docker volume rm -f $storage->name"], $server, false);
+        }
+    }
+
+    public function realStatus()
+    {
+        return $this->getRawOriginal('status');
+    }
+
+    public function status(): Attribute
+    {
+        return Attribute::make(
+            set: function ($value) {
+                if (str($value)->contains('(')) {
+                    $status = str($value)->before('(')->trim()->value();
+                    $health = str($value)->after('(')->before(')')->trim()->value() ?? 'unhealthy';
+                } elseif (str($value)->contains(':')) {
+                    $status = str($value)->before(':')->trim()->value();
+                    $health = str($value)->after(':')->trim()->value() ?? 'unhealthy';
+                } else {
+                    $status = $value;
+                    $health = 'unhealthy';
+                }
+
+                return "$status:$health";
+            },
+            get: function ($value) {
+                if (str($value)->contains('(')) {
+                    $status = str($value)->before('(')->trim()->value();
+                    $health = str($value)->after('(')->before(')')->trim()->value() ?? 'unhealthy';
+                } elseif (str($value)->contains(':')) {
+                    $status = str($value)->before(':')->trim()->value();
+                    $health = str($value)->after(':')->trim()->value() ?? 'unhealthy';
+                } else {
+                    $status = $value;
+                    $health = 'unhealthy';
+                }
+
+                return "$status:$health";
+            },
+        );
+    }
+
+    public function tags()
+    {
+        return $this->morphToMany(Tag::class, 'taggable');
+    }
+
+    public function project()
+    {
+        return data_get($this, 'environment.project');
+    }
+
+    public function link()
+    {
+        if (data_get($this, 'environment.project.uuid')) {
+            return route('project.database.configuration', [
+                'project_uuid' => data_get($this, 'environment.project.uuid'),
+                'environment_uuid' => data_get($this, 'environment.uuid'),
+                'database_uuid' => data_get($this, 'uuid'),
+            ]);
+        }
+
+        return null;
+    }
+
+    public function isLogDrainEnabled()
+    {
+        return data_get($this, 'is_log_drain_enabled', false);
+    }
+
+    public function portsMappings(): Attribute
+    {
+        return Attribute::make(
+            set: fn ($value) => $value === '' ? null : $value,
+        );
+    }
+
+    public function portsMappingsArray(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => is_null($this->ports_mappings)
+                ? []
+                : explode(',', $this->ports_mappings),
+        );
+    }
+
+    public function team()
+    {
+        return data_get($this, 'environment.project.team');
+    }
+
+    public function databaseType(): Attribute
+    {
+        return new Attribute(
+            get: fn () => $this->type(),
+        );
+    }
+
+    public function type(): string
+    {
+        return 'standalone-surrealdb';
+    }
+
+    protected function internalDbUrl(): Attribute
+    {
+        return new Attribute(
+            get: function () {
+                return "ws://{$this->uuid}:8000/rpc";
+            },
+        );
+    }
+
+    protected function externalDbUrl(): Attribute
+    {
+        return new Attribute(
+            get: function () {
+                if ($this->is_public && $this->public_port) {
+                    $serverIp = $this->destination->server->getIp;
+                    if (empty($serverIp)) {
+                        return null;
+                    }
+
+                    return "ws://{$serverIp}:{$this->public_port}/rpc";
+                }
+
+                return null;
+            }
+        );
+    }
+
+    public function environment()
+    {
+        return $this->belongsTo(Environment::class);
+    }
+
+    public function fileStorages()
+    {
+        return $this->morphMany(LocalFileVolume::class, 'resource');
+    }
+
+    public function destination()
+    {
+        return $this->morphTo();
+    }
+
+    public function environment_variables()
+    {
+        return $this->morphMany(EnvironmentVariable::class, 'resourceable');
+    }
+
+    public function runtime_environment_variables()
+    {
+        return $this->morphMany(EnvironmentVariable::class, 'resourceable');
+    }
+
+    public function persistentStorages()
+    {
+        return $this->morphMany(LocalPersistentVolume::class, 'resource');
+    }
+
+    public function scheduledBackups()
+    {
+        return $this->morphMany(ScheduledDatabaseBackup::class, 'database');
+    }
+
+    public function isBackupSolutionAvailable()
+    {
+        return false;
+    }
+}

--- a/bootstrap/helpers/databases.php
+++ b/bootstrap/helpers/databases.php
@@ -12,6 +12,7 @@ use App\Models\StandaloneMongodb;
 use App\Models\StandaloneMysql;
 use App\Models\StandalonePostgresql;
 use App\Models\StandaloneRedis;
+use App\Models\StandaloneSurrealdb;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Storage;
 use Visus\Cuid2\Cuid2;
@@ -174,6 +175,24 @@ function create_standalone_clickhouse($environment_id, $destination_uuid, ?array
     $database->uuid = (new Cuid2);
     $database->name = 'clickhouse-database-'.$database->uuid;
     $database->clickhouse_admin_password = \Illuminate\Support\Str::password(length: 64, symbols: false);
+    $database->environment_id = $environment_id;
+    $database->destination_id = $destination->id;
+    $database->destination_type = $destination->getMorphClass();
+    if ($otherData) {
+        $database->fill($otherData);
+    }
+    $database->save();
+
+    return $database;
+}
+
+function create_standalone_surrealdb($environment_id, $destination_uuid, ?array $otherData = null): StandaloneSurrealdb
+{
+    $destination = StandaloneDocker::where('uuid', $destination_uuid)->firstOrFail();
+    $database = new StandaloneSurrealdb;
+    $database->uuid = (new Cuid2);
+    $database->name = 'surrealdb-database-'.$database->uuid;
+    $database->surrealdb_password = \Illuminate\Support\Str::password(length: 64, symbols: false);
     $database->environment_id = $environment_id;
     $database->destination_id = $destination->id;
     $database->destination_type = $destination->getMorphClass();

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -23,6 +23,7 @@ use App\Models\StandaloneMongodb;
 use App\Models\StandaloneMysql;
 use App\Models\StandalonePostgresql;
 use App\Models\StandaloneRedis;
+use App\Models\StandaloneSurrealdb;
 use App\Models\Team;
 use App\Models\User;
 use Carbon\CarbonImmutable;
@@ -605,6 +606,10 @@ function queryDatabaseByUuidWithinTeam(string $uuid, string $teamId)
     if ($clickhouse && $clickhouse->team()->id == $teamId) {
         return $clickhouse->unsetRelation('environment');
     }
+    $surrealdb = StandaloneSurrealdb::whereUuid($uuid)->first();
+    if ($surrealdb && $surrealdb->team()->id == $teamId) {
+        return $surrealdb->unsetRelation('environment');
+    }
 
     return null;
 }
@@ -650,6 +655,10 @@ function queryResourcesByUuid(string $uuid)
     $clickhouse = StandaloneClickhouse::whereUuid($uuid)->first();
     if ($clickhouse) {
         return $clickhouse;
+    }
+    $surrealdb = StandaloneSurrealdb::whereUuid($uuid)->first();
+    if ($surrealdb) {
+        return $surrealdb;
     }
 
     // Check for ServiceDatabase by its own UUID
@@ -2858,7 +2867,7 @@ function isAssociativeArray($array)
  *
  *  Theses variables are added in place to the $where_to_add array.
  */
-function add_coolify_default_environment_variables(StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse|Application|Service $resource, Collection &$where_to_add, ?Collection $where_to_check = null)
+function add_coolify_default_environment_variables(StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse|StandaloneSurrealdb|Application|Service $resource, Collection &$where_to_add, ?Collection $where_to_check = null)
 {
     // Currently disabled
     return;

--- a/database/migrations/2026_01_27_000001_create_standalone_surrealdbs_table.php
+++ b/database/migrations/2026_01_27_000001_create_standalone_surrealdbs_table.php
@@ -1,0 +1,58 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('standalone_surrealdbs', function (Blueprint $table) {
+            $table->id();
+            $table->string('uuid')->unique();
+            $table->string('name');
+            $table->string('description')->nullable();
+
+            $table->string('surrealdb_user')->default('root');
+            $table->text('surrealdb_password');
+            $table->string('surrealdb_database')->default('default');
+            $table->string('surrealdb_namespace')->default('default');
+
+            $table->boolean('is_log_drain_enabled')->default(false);
+            $table->boolean('is_include_timestamps')->default(false);
+            $table->softDeletes();
+
+            $table->string('status')->default('exited');
+
+            $table->string('image')->default('surrealdb/surrealdb:latest');
+
+            $table->boolean('is_public')->default(false);
+            $table->integer('public_port')->nullable();
+            $table->text('ports_mappings')->nullable();
+
+            $table->string('limits_memory')->default('0');
+            $table->string('limits_memory_swap')->default('0');
+            $table->integer('limits_memory_swappiness')->default(60);
+            $table->string('limits_memory_reservation')->default('0');
+
+            $table->string('limits_cpus')->default('0');
+            $table->string('limits_cpuset')->nullable()->default(null);
+            $table->integer('limits_cpu_shares')->default(1024);
+
+            $table->text('custom_docker_run_options')->nullable();
+            $table->string('config_hash')->nullable();
+
+            $table->timestamp('started_at')->nullable();
+            $table->timestamp('last_online_at')->nullable();
+            $table->morphs('destination');
+            $table->foreignId('environment_id')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('standalone_surrealdbs');
+    }
+};

--- a/resources/views/livewire/project/database/configuration.blade.php
+++ b/resources/views/livewire/project/database/configuration.blade.php
@@ -50,6 +50,8 @@
                     <livewire:project.database.dragonfly.general :database="$database" />
                 @elseif ($database->type() === 'standalone-clickhouse')
                     <livewire:project.database.clickhouse.general :database="$database" />
+                @elseif ($database->type() === 'standalone-surrealdb')
+                    <livewire:project.database.surrealdb.general :database="$database" />
                 @endif
             @elseif ($currentRoute === 'project.database.environment-variables')
                 <livewire:project.shared.environment-variable.all :resource="$database" />

--- a/resources/views/livewire/project/database/surrealdb/general.blade.php
+++ b/resources/views/livewire/project/database/surrealdb/general.blade.php
@@ -1,0 +1,89 @@
+<div>
+    <form wire:submit="submit" class="flex flex-col gap-2">
+        <div class="flex items-center gap-2">
+            <h2>General</h2>
+            <x-forms.button type="submit" canGate="update" :canResource="$database">
+                Save
+            </x-forms.button>
+        </div>
+        <div class="flex gap-2">
+            <x-forms.input label="Name" id="name" canGate="update" :canResource="$database" />
+            <x-forms.input label="Description" id="description" canGate="update" :canResource="$database" />
+            <x-forms.input label="Image" id="image" required canGate="update" :canResource="$database"
+                helper="For all available images, check here:<br><br><a target='_blank' href='https://hub.docker.com/r/surrealdb/surrealdb'>https://hub.docker.com/r/surrealdb/surrealdb</a>" />
+        </div>
+
+        @if ($database->started_at)
+            <div class="flex gap-2">
+                <x-forms.input label="Initial Username" id="surrealdbUser" placeholder="If empty: root"
+                    readonly helper="You can only change this in the database." canGate="update" :canResource="$database" />
+                <x-forms.input label="Initial Password" id="surrealdbPassword" type="password" required readonly
+                    helper="You can only change this in the database." canGate="update" :canResource="$database" />
+            </div>
+        @else
+            <div class=" dark:text-warning">Please verify these values. You can only modify them before the initial
+                start. After that, you need to modify it in the database.
+            </div>
+            <div class="flex gap-2">
+                <x-forms.input label="Username" id="surrealdbUser" required canGate="update" :canResource="$database" />
+                <x-forms.input label="Password" id="surrealdbPassword" type="password" required canGate="update"
+                    :canResource="$database" />
+            </div>
+        @endif
+        <x-forms.input
+            helper="You can add custom docker run options that will be used when your container is started.<br>Note: Not all options are supported, as they could mess up Coolify's automation and could cause bad experience for users.<br><br>Check the <a class='underline dark:text-white' href='https://coolify.io/docs/knowledge-base/docker/custom-commands'>docs.</a>"
+            placeholder="--cap-add SYS_ADMIN --device=/dev/fuse --security-opt apparmor:unconfined --ulimit nofile=1024:1024 --tmpfs /run:rw,noexec,nosuid,size=65536k"
+            id="customDockerRunOptions" label="Custom Docker Options" canGate="update" :canResource="$database" />
+        <div class="flex flex-col gap-2">
+            <h3 class="py-2">Network</h3>
+            <div class="flex items-end gap-2">
+                <x-forms.input placeholder="3000:8000" id="portsMappings" label="Ports Mappings"
+                    helper="A comma separated list of ports you would like to map to the host system.<br><span class='inline-block font-bold dark:text-warning'>Example</span>3000:8000,3002:8001"
+                    canGate="update" :canResource="$database" />
+            </div>
+            <x-forms.input label="SurrealDB URL (internal)"
+                helper="If you change the user/password/port, this could be different. This is with the default values."
+                type="password" readonly wire:model="dbUrl" canGate="update" :canResource="$database" />
+            @if ($dbUrlPublic)
+                <x-forms.input label="SurrealDB URL (public)"
+                    helper="If you change the user/password/port, this could be different. This is with the default values."
+                    type="password" readonly wire:model="dbUrlPublic" canGate="update" :canResource="$database" />
+            @else
+                <x-forms.input label="SurrealDB URL (public)"
+                    helper="If you change the user/password/port, this could be different. This is with the default values."
+                    readonly value="Starting the database will generate this." canGate="update" :canResource="$database" />
+            @endif
+        </div>
+        <div>
+            <div class="flex flex-col py-2 w-64">
+                <div class="flex items-center gap-2 pb-2">
+                    <div class="flex items-center">
+                        <h3>Proxy</h3>
+                        <x-loading wire:loading wire:target="instantSave" />
+                    </div>
+                    @if ($isPublic)
+                        <x-slide-over fullScreen>
+                            <x-slot:title>Proxy Logs</x-slot:title>
+                            <x-slot:content>
+                                <livewire:project.shared.get-logs :server="$server" :resource="$database"
+                                    container="{{ data_get($database, 'uuid') }}-proxy" :collapsible="false" lazy />
+                            </x-slot:content>
+                            <x-forms.button disabled="{{ !$isPublic }}"
+                                @click="slideOverOpen=true">Logs</x-forms.button>
+                        </x-slide-over>
+                    @endif
+                </div>
+                <x-forms.checkbox instantSave id="isPublic" label="Make it publicly available" canGate="update"
+                    :canResource="$database" />
+            </div>
+            <x-forms.input placeholder="8000" disabled="{{ $isPublic }}" id="publicPort" label="Public Port"
+                canGate="update" :canResource="$database" />
+        </div>
+    </form>
+    <h3 class="pt-4">Advanced</h3>
+    <div class="w-64">
+        <x-forms.checkbox helper="Drain logs to your configured log drain endpoint in your Server settings."
+            instantSave="instantSaveAdvanced" id="isLogDrainEnabled" label="Drain Logs" canGate="update"
+            :canResource="$database" />
+    </div>
+</div>


### PR DESCRIPTION
## Description

This PR adds SurrealDB as a new standalone database option in Coolify.

/claim #7642

## Changes

### New Files
- `app/Models/StandaloneSurrealdb.php` - Model with all necessary attributes and relationships
- `app/Actions/Database/StartSurrealdb.php` - Docker container management action
- `app/Livewire/Project/Database/Surrealdb/General.php` - Livewire component for configuration
- `resources/views/livewire/project/database/surrealdb/general.blade.php` - Blade view
- `database/migrations/2026_01_27_000001_create_standalone_surrealdbs_table.php` - Migration

### Modified Files
- `app/Models/Environment.php` - Added `surrealdbs()` relationship and updated `databases()` method
- `app/Enums/NewDatabaseTypes.php` - Added SURREALDB enum
- `app/Enums/NewResourceTypes.php` - Added SURREALDB enum
- `bootstrap/helpers/databases.php` - Added `create_standalone_surrealdb()` function
- `bootstrap/helpers/shared.php` - Updated query functions and type unions
- `app/Livewire/Project/New/Select.php` - Added SurrealDB to database list
- `app/Livewire/Project/Resource/Create.php` - Added SurrealDB creation handler
- `resources/views/livewire/project/database/configuration.blade.php` - Added SurrealDB component rendering

## SurrealDB Features
- User/password authentication (`--user` / `--pass` flags)
- RocksDB persistence at `/data`
- Health check via `/health` endpoint
- WebSocket RPC endpoint at port 8000
- Public proxy support
- Log drain support

## Testing
- Followed existing patterns from ClickHouse implementation (most recent database addition)
- All model relationships and helper functions follow established conventions

## Screenshots
N/A - Backend implementation only

## Checklist
- [x] Code follows the project's coding standards
- [x] Changes are documented
- [x] No breaking changes introduced