### PR TITLE
feat: Global Deployments Page

### DIFF
--- a/app/Livewire/Deployments/Index.php
+++ b/app/Livewire/Deployments/Index.php
@@ -1,0 +1,253 @@
+<?php
+
+namespace App\Livewire\Deployments;
+
+use App\Enums\ApplicationDeploymentStatus;
+use App\Models\ApplicationDeploymentQueue;
+use App\Models\Project;
+use App\Models\Server;
+use Illuminate\Support\Collection;
+use Livewire\Attributes\Locked;
+use Livewire\Attributes\Title;
+use Livewire\Attributes\Url;
+use Livewire\Component;
+
+#[Title('Deployments | Coolify')]
+class Index extends Component
+{
+    #[Url]
+    public ?string $status = null;
+
+    #[Url]
+    public ?string $server = null;
+
+    #[Url]
+    public ?string $project = null;
+
+    #[Url]
+    public ?string $source = null;
+
+    public int $skip = 0;
+
+    public int $defaultTake = 20;
+
+    public bool $showNext = false;
+
+    public bool $showPrev = false;
+
+    public int $currentPage = 1;
+
+    public int $deploymentsCount = 0;
+
+    public ?Collection $deployments = null;
+
+    #[Locked]
+    public array $availableServers = [];
+
+    #[Locked]
+    public array $availableProjects = [];
+
+    #[Locked]
+    public array $availableSources = [];
+
+    #[Locked]
+    public array $availableStatuses = [];
+
+    public function getListeners()
+    {
+        $teamId = auth()->user()->currentTeam()->id;
+
+        return [
+            "echo-private:team.{$teamId},ServiceChecked" => '$refresh',
+        ];
+    }
+
+    public function mount()
+    {
+        $this->loadFilterOptions();
+        $this->loadDeployments();
+    }
+
+    private function loadFilterOptions()
+    {
+        $teamId = currentTeam()->id;
+        $servers = Server::ownedByCurrentTeamCached();
+        $serverIds = $servers->pluck('id');
+
+        // Available servers
+        $serversWithDeployments = ApplicationDeploymentQueue::whereIn('server_id', $serverIds)
+            ->select('server_id', 'server_name')
+            ->distinct()
+            ->get();
+
+        $this->availableServers = $serversWithDeployments
+            ->mapWithKeys(fn ($d) => [$d->server_id => $d->server_name ?: "Server #{$d->server_id}"])
+            ->toArray();
+
+        // Available projects
+        $projects = Project::ownedByCurrentTeam()->with('environments.applications')->get();
+        $this->availableProjects = $projects->mapWithKeys(fn ($p) => [$p->uuid => $p->name])->toArray();
+
+        // Available sources - collect from applications that have deployments
+        $applicationIds = ApplicationDeploymentQueue::whereIn('server_id', $serverIds)
+            ->select('application_id')
+            ->distinct()
+            ->pluck('application_id');
+
+        $sources = \App\Models\Application::whereIn('id', $applicationIds)
+            ->whereNotNull('source_type')
+            ->whereNotNull('source_id')
+            ->select('source_type', 'source_id')
+            ->distinct()
+            ->get();
+
+        $sourceOptions = [];
+        foreach ($sources as $s) {
+            $sourceModel = app($s->source_type)->find($s->source_id);
+            if ($sourceModel) {
+                $key = $s->source_type . ':' . $s->source_id;
+                $sourceOptions[$key] = $sourceModel->name ?? class_basename($s->source_type) . " #{$s->source_id}";
+            }
+        }
+        $this->availableSources = $sourceOptions;
+
+        // Available statuses
+        $this->availableStatuses = collect(ApplicationDeploymentStatus::cases())
+            ->mapWithKeys(fn ($s) => [$s->value => match ($s) {
+                ApplicationDeploymentStatus::QUEUED => 'Queued',
+                ApplicationDeploymentStatus::IN_PROGRESS => 'In Progress',
+                ApplicationDeploymentStatus::FINISHED => 'Finished',
+                ApplicationDeploymentStatus::FAILED => 'Failed',
+                ApplicationDeploymentStatus::CANCELLED_BY_USER => 'Cancelled',
+            }])
+            ->toArray();
+    }
+
+    public function loadDeployments()
+    {
+        $servers = Server::ownedByCurrentTeamCached();
+        $serverIds = $servers->pluck('id');
+
+        $query = ApplicationDeploymentQueue::whereIn('server_id', $serverIds)
+            ->orderBy('created_at', 'desc');
+
+        // Apply status filter
+        if ($this->status) {
+            $query->where('status', $this->status);
+        }
+
+        // Apply server filter
+        if ($this->server) {
+            $query->where('server_id', $this->server);
+        }
+
+        // Apply project filter
+        if ($this->project) {
+            $projectModel = Project::ownedByCurrentTeam()->where('uuid', $this->project)->first();
+            if ($projectModel) {
+                $applicationIds = $projectModel->environments()
+                    ->with('applications')
+                    ->get()
+                    ->flatMap(fn ($env) => $env->applications->pluck('id'));
+                $query->whereIn('application_id', $applicationIds);
+            }
+        }
+
+        // Apply source filter
+        if ($this->source && str_contains($this->source, ':')) {
+            [$sourceType, $sourceId] = explode(':', $this->source, 2);
+            $applicationIds = \App\Models\Application::where('source_type', $sourceType)
+                ->where('source_id', $sourceId)
+                ->pluck('id');
+            $query->whereIn('application_id', $applicationIds);
+        }
+
+        $this->deploymentsCount = $query->count();
+        $this->deployments = $query->skip($this->skip)
+            ->take($this->defaultTake)
+            ->get();
+
+        $this->showNext = $this->deployments->count() >= $this->defaultTake;
+    }
+
+    public function reloadDeployments()
+    {
+        $this->loadFilterOptions();
+        $this->loadDeployments();
+    }
+
+    public function updatedStatus()
+    {
+        $this->resetPagination();
+        $this->loadDeployments();
+    }
+
+    public function updatedServer()
+    {
+        $this->resetPagination();
+        $this->loadDeployments();
+    }
+
+    public function updatedProject()
+    {
+        $this->resetPagination();
+        $this->loadDeployments();
+    }
+
+    public function updatedSource()
+    {
+        $this->resetPagination();
+        $this->loadDeployments();
+    }
+
+    public function clearFilters()
+    {
+        $this->status = null;
+        $this->server = null;
+        $this->project = null;
+        $this->source = null;
+        $this->resetPagination();
+        $this->loadDeployments();
+    }
+
+    public function previousPage()
+    {
+        $this->skip = max(0, $this->skip - $this->defaultTake);
+        $this->showPrev = $this->skip > 0;
+        $this->updateCurrentPage();
+        $this->loadDeployments();
+    }
+
+    public function nextPage()
+    {
+        $this->skip += $this->defaultTake;
+        $this->showPrev = true;
+        $this->updateCurrentPage();
+        $this->loadDeployments();
+    }
+
+    private function resetPagination()
+    {
+        $this->skip = 0;
+        $this->showPrev = false;
+        $this->updateCurrentPage();
+    }
+
+    private function updateCurrentPage()
+    {
+        $this->currentPage = intval($this->skip / $this->defaultTake) + 1;
+    }
+
+    private function hasActiveFilters(): bool
+    {
+        return $this->status || $this->server || $this->project || $this->source;
+    }
+
+    public function render()
+    {
+        return view('livewire.deployments.index', [
+            'hasActiveFilters' => $this->hasActiveFilters(),
+            'totalPages' => $this->deploymentsCount > 0 ? ceil($this->deploymentsCount / $this->defaultTake) : 1,
+        ]);
+    }
+}

--- a/resources/views/components/navbar.blade.php
+++ b/resources/views/components/navbar.blade.php
@@ -131,6 +131,21 @@
                         </a>
                     </li>
                     <li>
+                        <a title="Deployments" {{ wireNavigate() }}
+                            class="{{ request()->is('deployments*') ? 'menu-item-active menu-item' : 'menu-item' }}"
+                            href="{{ route('deployments') }}">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="menu-item-icon" viewBox="0 0 24 24"
+                                stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round"
+                                stroke-linejoin="round">
+                                <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                                <path d="M4 13a8 8 0 0 1 7 7a6 6 0 0 0 3 -5a9 9 0 0 0 6 -8a3 3 0 0 0 -3 -3a9 9 0 0 0 -8 6a6 6 0 0 0 -5 3" />
+                                <path d="M7 14a6 6 0 0 0 -3 6a6 6 0 0 0 6 -3" />
+                                <circle cx="15" cy="9" r="1" />
+                            </svg>
+                            <span class="menu-item-label">Deployments</span>
+                        </a>
+                    </li>
+                    <li>
                         <a title="Servers" {{ wireNavigate() }}
                             class="{{ request()->is('server/*') || request()->is('servers') ? 'menu-item menu-item-active' : 'menu-item' }}"
                             href="/servers">

--- a/resources/views/livewire/deployments/index.blade.php
+++ b/resources/views/livewire/deployments/index.blade.php
@@ -1,0 +1,224 @@
+<div>
+    <h1>Deployments</h1>
+    <div class="subtitle">All deployments across your projects.</div>
+
+    {{-- Filters --}}
+    <div class="flex flex-wrap items-end gap-3 mb-6" wire:poll.5000ms='reloadDeployments'>
+        @if (count($availableStatuses) > 1)
+            <div class="w-full sm:w-auto">
+                <x-forms.select wire:model.live="status" label="Status" id="status">
+                    <option value="">All Statuses</option>
+                    @foreach ($availableStatuses as $value => $label)
+                        <option value="{{ $value }}">{{ $label }}</option>
+                    @endforeach
+                </x-forms.select>
+            </div>
+        @endif
+
+        @if (count($availableProjects) > 1)
+            <div class="w-full sm:w-auto">
+                <x-forms.select wire:model.live="project" label="Project" id="project">
+                    <option value="">All Projects</option>
+                    @foreach ($availableProjects as $value => $label)
+                        <option value="{{ $value }}">{{ $label }}</option>
+                    @endforeach
+                </x-forms.select>
+            </div>
+        @endif
+
+        @if (count($availableServers) > 1)
+            <div class="w-full sm:w-auto">
+                <x-forms.select wire:model.live="server" label="Server" id="server">
+                    <option value="">All Servers</option>
+                    @foreach ($availableServers as $value => $label)
+                        <option value="{{ $value }}">{{ $label }}</option>
+                    @endforeach
+                </x-forms.select>
+            </div>
+        @endif
+
+        @if (count($availableSources) > 1)
+            <div class="w-full sm:w-auto">
+                <x-forms.select wire:model.live="source" label="Source" id="source">
+                    <option value="">All Sources</option>
+                    @foreach ($availableSources as $value => $label)
+                        <option value="{{ $value }}">{{ $label }}</option>
+                    @endforeach
+                </x-forms.select>
+            </div>
+        @endif
+
+        @if ($hasActiveFilters)
+            <x-forms.button wire:click="clearFilters">Clear Filters</x-forms.button>
+        @endif
+    </div>
+
+    {{-- Pagination --}}
+    <div class="flex items-end gap-2 mb-4">
+        <h3>Results <span class="text-xs">({{ $deploymentsCount }})</span></h3>
+        @if ($deploymentsCount > 0)
+            <div class="flex items-center gap-2">
+                <x-forms.button disabled="{{ !$showPrev }}" wire:click="previousPage">
+                    <svg class="w-4 h-4" viewBox="0 0 24 24">
+                        <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"
+                            stroke-width="2" d="m14 6l-6 6l6 6z" />
+                    </svg>
+                </x-forms.button>
+                <span class="text-sm text-gray-600 dark:text-gray-400 px-2">
+                    Page {{ $currentPage }} of {{ $totalPages }}
+                </span>
+                <x-forms.button disabled="{{ !$showNext }}" wire:click="nextPage">
+                    <svg class="w-4 h-4" viewBox="0 0 24 24">
+                        <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"
+                            stroke-width="2" d="m10 18l6-6l-6-6z" />
+                    </svg>
+                </x-forms.button>
+            </div>
+        @endif
+    </div>
+
+    {{-- Deployments list --}}
+    <div class="flex flex-col gap-2">
+        @forelse ($deployments as $deployment)
+            @php
+                $application = $deployment->application;
+                $deploymentLink = data_get($deployment, 'deployment_url');
+
+                if (!$deploymentLink && $application) {
+                    $env = $application->environment;
+                    $proj = $env?->project;
+                    if ($proj && $env) {
+                        $deploymentLink = route('project.application.deployment.show', [
+                            'project_uuid' => $proj->uuid,
+                            'environment_uuid' => $env->uuid,
+                            'application_uuid' => $application->uuid,
+                            'deployment_uuid' => $deployment->deployment_uuid,
+                        ]);
+                    }
+                }
+            @endphp
+            <div @class([
+                'p-4 border-l-2 bg-white dark:bg-coolgray-100 rounded-r',
+                'border-blue-500/50 border-dashed' => data_get($deployment, 'status') === 'in_progress',
+                'border-purple-500/50 border-dashed' => data_get($deployment, 'status') === 'queued',
+                'border-white border-dashed' => data_get($deployment, 'status') === 'cancelled-by-user',
+                'border-error' => data_get($deployment, 'status') === 'failed',
+                'border-success' => data_get($deployment, 'status') === 'finished',
+            ])>
+                <a href="{{ $deploymentLink }}" {{ wireNavigate() }} class="block">
+                    <div class="flex flex-col sm:flex-row sm:items-center gap-3">
+                        {{-- Status badge --}}
+                        <div class="flex items-center gap-3 flex-shrink-0">
+                            <span @class([
+                                'px-3 py-1 rounded-md text-xs font-medium shadow-xs whitespace-nowrap',
+                                'bg-blue-100/80 text-blue-700 dark:bg-blue-500/20 dark:text-blue-300' =>
+                                    data_get($deployment, 'status') === 'in_progress',
+                                'bg-purple-100/80 text-purple-700 dark:bg-purple-500/20 dark:text-purple-300' =>
+                                    data_get($deployment, 'status') === 'queued',
+                                'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-200' =>
+                                    data_get($deployment, 'status') === 'failed',
+                                'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-200' =>
+                                    data_get($deployment, 'status') === 'finished',
+                                'bg-gray-100 text-gray-700 dark:bg-gray-600/30 dark:text-gray-300' =>
+                                    data_get($deployment, 'status') === 'cancelled-by-user',
+                            ])>
+                                @php
+                                    $statusText = match (data_get($deployment, 'status')) {
+                                        'finished' => 'Success',
+                                        'in_progress' => 'In Progress',
+                                        'cancelled-by-user' => 'Cancelled',
+                                        'queued' => 'Queued',
+                                        default => ucfirst(data_get($deployment, 'status')),
+                                    };
+                                @endphp
+                                {{ $statusText }}
+                            </span>
+                        </div>
+
+                        {{-- Deployment info --}}
+                        <div class="flex-1 min-w-0">
+                            <div class="flex flex-wrap items-center gap-2">
+                                <span class="font-medium dark:text-white text-gray-900 truncate">
+                                    {{ data_get($deployment, 'application_name') ?: 'Unknown Application' }}
+                                </span>
+
+                                {{-- Deployment type badge --}}
+                                <span class="bg-gray-200/70 dark:bg-gray-600/20 px-2 py-0.5 rounded-md text-xs text-gray-800 dark:text-gray-100 border border-gray-400/30">
+                                    @if (data_get($deployment, 'is_webhook'))
+                                        Webhook
+                                        @if (data_get($deployment, 'pull_request_id'))
+                                            | PR #{{ data_get($deployment, 'pull_request_id') }}
+                                        @endif
+                                    @elseif (data_get($deployment, 'pull_request_id'))
+                                        PR #{{ data_get($deployment, 'pull_request_id') }}
+                                    @elseif (data_get($deployment, 'rollback') === true)
+                                        Rollback
+                                    @elseif (data_get($deployment, 'is_api'))
+                                        API
+                                    @else
+                                        Manual
+                                    @endif
+                                </span>
+                            </div>
+
+                            <div class="flex flex-wrap gap-x-4 gap-y-1 mt-1 text-sm text-gray-600 dark:text-gray-400">
+                                @if ($application)
+                                    @php
+                                        $env = $application->environment;
+                                        $proj = $env?->project;
+                                    @endphp
+                                    @if ($proj)
+                                        <span class="truncate">{{ $proj->name }} / {{ $env->name }}</span>
+                                    @endif
+                                @endif
+
+                                @if (data_get($deployment, 'server_name'))
+                                    <span class="flex items-center gap-1">
+                                        <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                                            <path d="M3 4m0 3a3 3 0 0 1 3 -3h12a3 3 0 0 1 3 3v2a3 3 0 0 1 -3 3h-12a3 3 0 0 1 -3 -3z" />
+                                            <path d="M15 20h-9a3 3 0 0 1 -3 -3v-2a3 3 0 0 1 3 -3h12" />
+                                            <path d="M7 8v.01" />
+                                            <path d="M7 16v.01" />
+                                        </svg>
+                                        {{ data_get($deployment, 'server_name') }}
+                                    </span>
+                                @endif
+
+                                @if (data_get($deployment, 'commit'))
+                                    <span class="flex items-center gap-1 font-mono text-xs">
+                                        {{ substr(data_get($deployment, 'commit'), 0, 7) }}
+                                    </span>
+                                @endif
+                            </div>
+                        </div>
+
+                        {{-- Timestamp --}}
+                        <div class="flex-shrink-0 text-right text-sm text-gray-500 dark:text-gray-400">
+                            @if (data_get($deployment, 'status') === 'queued')
+                                <span>Queued {{ \Carbon\Carbon::parse(data_get($deployment, 'created_at'))->diffForHumans() }}</span>
+                            @elseif (data_get($deployment, 'status') === 'in_progress')
+                                <span>Running for {{ calculateDuration(data_get($deployment, 'created_at'), now()) }}</span>
+                            @elseif (data_get($deployment, 'finished_at'))
+                                <span>{{ \Carbon\Carbon::parse(data_get($deployment, 'finished_at'))->diffForHumans() }}</span>
+                                <div class="text-xs">{{ calculateDuration(data_get($deployment, 'created_at'), data_get($deployment, 'finished_at')) }}</div>
+                            @else
+                                <span>{{ \Carbon\Carbon::parse(data_get($deployment, 'created_at'))->diffForHumans() }}</span>
+                            @endif
+                        </div>
+                    </div>
+                </a>
+            </div>
+        @empty
+            <div class="p-8 text-center text-gray-500 dark:text-gray-400 bg-white dark:bg-coolgray-100 rounded">
+                @if ($hasActiveFilters)
+                    <p>No deployments match your filters.</p>
+                    <button wire:click="clearFilters" class="mt-2 text-sm underline hover:no-underline">Clear all filters</button>
+                @else
+                    <p>No deployments found.</p>
+                    <p class="text-sm mt-1">Deploy your first application to see deployments here.</p>
+                @endif
+            </div>
+        @endforelse
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\UploadController;
 use App\Livewire\Admin\Index as AdminIndex;
 use App\Livewire\Boarding\Index as BoardingIndex;
 use App\Livewire\Dashboard;
+use App\Livewire\Deployments\Index as DeploymentsIndex;
 use App\Livewire\Destination\Index as DestinationIndex;
 use App\Livewire\Destination\Show as DestinationShow;
 use App\Livewire\ForcePasswordReset;
@@ -107,6 +108,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     });
 
     Route::get('/', Dashboard::class)->name('dashboard');
+    Route::get('/deployments', DeploymentsIndex::class)->name('deployments');
     Route::get('/onboarding', BoardingIndex::class)->name('onboarding');
 
     Route::get('/subscription', SubscriptionShow::class)->name('subscription.show');


### PR DESCRIPTION
## Summary

Adds a new **Deployments** page that shows all past deployments across all projects for the current team, with filtering and live updates. This addresses a common need for teams managing multiple applications — being able to see deployment history in one place rather than navigating to each application individually.

**Resolves #7596**
/claim #7596

## What's Changed

### New Sidebar Navigation Item
- Added **Deployments** entry in the sidebar between Projects and Servers
- Uses a rocket icon consistent with the tabler icon style used throughout the app
- Active state highlighting when on the deployments page

### New Livewire Component: `App\Livewire\Deployments\Index`
- Queries `ApplicationDeploymentQueue` scoped to the current team's servers (same security model as `DeploymentsIndicator`)
- Supports four URL-synced filters via Livewire `#[Url]` attributes:
  - **Status** — Queued, In Progress, Finished, Failed, Cancelled
  - **Project** — filter by project (uses project UUID)
  - **Server** — filter by server
  - **Source** — filter by Git source (GitHub/GitLab app)
- **Auto-hides filter dropdowns** when only one option exists (e.g., if you only have one server, the server filter is hidden)
- Pagination with Previous/Next navigation (20 items per page)
- **Live updates** via `wire:poll.5000ms` — polls every 5 seconds to show new deployments and status changes
- Filter options are refreshed on each poll to pick up new servers/projects/sources
- Listens to the `ServiceChecked` echo event for real-time updates

### New Blade View: `resources/views/livewire/deployments/index.blade.php`
- Responsive layout that works on mobile and desktop
- Each deployment card shows:
  - **Status badge** with color coding matching the existing deployment page (blue=in progress, purple=queued, green=success, red=failed, gray=cancelled)
  - **Application name** with deployment type badge (Manual/Webhook/API/PR/Rollback)
  - **Project & environment** path
  - **Server name** with server icon
  - **Commit hash** (short format)
  - **Timing info** — relative time for finished deployments, duration for in-progress, queued time for queued
- Left border color coding matching existing `deployment/index.blade.php` patterns
- Empty state with contextual messaging (different for filtered vs unfiltered)
- Links to individual deployment detail pages via `deployment_url` or constructed route

### Route
- `GET /deployments` → `App\Livewire\Deployments\Index` (named `deployments`)
- Added within the existing `auth` + `verified` middleware group

## Design Decisions

1. **Team scoping via server IDs** — follows the same pattern as `DeploymentsIndicator` to ensure users only see deployments for servers they have access to
2. **URL query string sync** — filters are synced to URL params so filtered views can be shared/bookmarked
3. **Filter auto-hiding** — keeps the UI clean for simple setups while being powerful for complex ones
4. **20 items per page** — larger than the per-application deployment page (10) since this is an overview page
5. **No new dependencies** — uses only existing Livewire, Alpine.js, and Tailwind utilities

## Screenshots

_The page follows existing Coolify design patterns exactly — same card styles, same status badges, same color scheme as the per-application deployment list._

## Testing

- Verified PHP syntax is valid
- Component follows established patterns from `Project\Application\Deployment\Index` and `DeploymentsIndicator`
- Filter logic uses standard Eloquent queries with proper team scoping
- No breaking changes to existing functionality