### PR TITLE
feat: Detect databases in Docker Compose applications and enable backup scheduling

### DIFF
--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -93,7 +93,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $this->database = data_get($this->backup, 'database');
-                $this->server = $this->database->service->server;
+                $this->server = $this->database->getServer();
                 $this->s3 = $this->backup->s3;
             } else {
                 $this->database = data_get($this->backup, 'database');
@@ -111,14 +111,45 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
 
             $status = str(data_get($this->database, 'status'));
             if (! $status->startsWith('running') && $this->database->id !== 0) {
-                return;
+                // For Application-based ServiceDatabase, the status field is not updated
+                // by the container monitoring system. Check the actual Docker container.
+                if ($this->database instanceof \App\Models\ServiceDatabase && $this->database->isApplicationDatabase()) {
+                    try {
+                        $containerName = $this->database->getContainerName();
+                        $containerStatus = instant_remote_process(
+                            ["docker inspect --format='{{.State.Status}}' {$containerName} 2>/dev/null || echo 'not_found'"],
+                            $this->server,
+                            throwError: false
+                        );
+                        if (! str(trim($containerStatus))->startsWith('running')) {
+                            return;
+                        }
+                    } catch (\Throwable) {
+                        return;
+                    }
+                } else {
+                    return;
+                }
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $databaseType = $this->database->databaseType();
-                $serviceUuid = $this->database->service->uuid;
-                $serviceName = str($this->database->service->name)->slug();
+                // Support both Service-based and Application-based ServiceDatabase records
+                if ($this->database->isApplicationDatabase()) {
+                    $serviceUuid = $this->database->application->uuid;
+                    $serviceName = str($this->database->application->name)->slug();
+                    // For Application compose databases, resolve the actual running container name
+                    // since non-consistent naming may include a timestamp suffix
+                    $resolvedContainerName = $this->database->getContainerName();
+                } else {
+                    $serviceUuid = $this->database->service->uuid;
+                    $serviceName = str($this->database->service->name)->slug();
+                    $resolvedContainerName = null;
+                }
+                // For all database types, determine the container name
+                $baseContainerName = $resolvedContainerName ?? "{$this->database->name}-$serviceUuid";
+
                 if (str($databaseType)->contains('postgres')) {
-                    $this->container_name = "{$this->database->name}-$serviceUuid";
+                    $this->container_name = $baseContainerName;
                     $this->directory_name = $serviceName.'-'.$this->container_name;
                     $commands[] = "docker exec $this->container_name env | grep POSTGRES_";
                     $envs = instant_remote_process($commands, $this->server, true, false, null, disableMultiplexing: true);
@@ -149,7 +180,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                         $this->postgres_password = str($this->postgres_password)->after('POSTGRES_PASSWORD=')->value();
                     }
                 } elseif (str($databaseType)->contains('mysql')) {
-                    $this->container_name = "{$this->database->name}-$serviceUuid";
+                    $this->container_name = $baseContainerName;
                     $this->directory_name = $serviceName.'-'.$this->container_name;
                     $commands[] = "docker exec $this->container_name env | grep MYSQL_";
                     $envs = instant_remote_process($commands, $this->server, true, false, null, disableMultiplexing: true);
@@ -172,7 +203,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                         throw new \Exception('MYSQL_DATABASE not found');
                     }
                 } elseif (str($databaseType)->contains('mariadb')) {
-                    $this->container_name = "{$this->database->name}-$serviceUuid";
+                    $this->container_name = $baseContainerName;
                     $this->directory_name = $serviceName.'-'.$this->container_name;
                     $commands[] = "docker exec $this->container_name env";
                     $envs = instant_remote_process($commands, $this->server, true, false, null, disableMultiplexing: true);
@@ -210,7 +241,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                     }
                 } elseif (str($databaseType)->contains('mongo')) {
                     $databasesToBackup = ['*'];
-                    $this->container_name = "{$this->database->name}-$serviceUuid";
+                    $this->container_name = $baseContainerName;
                     $this->directory_name = $serviceName.'-'.$this->container_name;
 
                     // Try to extract MongoDB credentials from environment variables
@@ -630,7 +661,11 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             $endpoint = $this->s3->endpoint;
             $this->s3->testConnection(shouldSave: true);
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
-                $network = $this->database->service->destination->network;
+                if ($this->database->isApplicationDatabase()) {
+                    $network = $this->database->application->destination->network;
+                } else {
+                    $network = $this->database->service->destination->network;
+                }
             } else {
                 $network = $this->database->destination->network;
             }

--- a/app/Jobs/DeleteResourceJob.php
+++ b/app/Jobs/DeleteResourceJob.php
@@ -96,6 +96,14 @@ class DeleteResourceJob implements ShouldBeEncrypted, ShouldQueue
             }
             $this->resource->environment_variables()->delete();
 
+            // Clean up compose database records and their backups when deleting an Application
+            if ($this->resource instanceof Application) {
+                foreach ($this->resource->composeDatabases as $composeDatabase) {
+                    $composeDatabase->scheduledBackups()->delete();
+                    $composeDatabase->delete();
+                }
+            }
+
             if ($this->deleteConnectedNetworks && $this->resource->type() === 'application') {
                 $this->resource->deleteConnectedNetworks();
             }

--- a/app/Jobs/PushServerUpdateJob.php
+++ b/app/Jobs/PushServerUpdateJob.php
@@ -311,6 +311,19 @@ class PushServerUpdateJob implements ShouldBeEncrypted, ShouldQueue, Silenced
                 $application->status = $aggregatedStatus;
                 $application->save();
             }
+
+            // Update status for compose database records associated with this application.
+            // Application compose databases use the docker-compose service name as their name,
+            // which matches the container name key in applicationContainerStatuses.
+            if ($application->build_pack === 'dockercompose') {
+                foreach ($application->composeDatabases as $composeDb) {
+                    $dbStatus = $containerStatuses->get($composeDb->name);
+                    if ($dbStatus && $composeDb->status !== $dbStatus) {
+                        $composeDb->status = $dbStatus;
+                        $composeDb->save();
+                    }
+                }
+            }
         }
     }
 

--- a/app/Livewire/Project/Application/ComposeDatabaseBackups.php
+++ b/app/Livewire/Project/Application/ComposeDatabaseBackups.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Livewire\Project\Application;
+
+use App\Models\Application;
+use App\Models\ServiceDatabase;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Component;
+
+class ComposeDatabaseBackups extends Component
+{
+    use AuthorizesRequests;
+
+    public Application $application;
+
+    public ServiceDatabase $composeDatabase;
+
+    public array $parameters;
+
+    public bool $isImportSupported = false;
+
+    protected $listeners = ['refreshScheduledBackups' => '$refresh'];
+
+    public function mount()
+    {
+        try {
+            $this->parameters = get_route_parameters();
+
+            $project = currentTeam()
+                ->projects()
+                ->where('uuid', $this->parameters['project_uuid'])
+                ->firstOrFail();
+
+            $environment = $project->environments()
+                ->where('uuid', $this->parameters['environment_uuid'])
+                ->firstOrFail();
+
+            $this->application = $environment->applications()
+                ->where('uuid', $this->parameters['application_uuid'])
+                ->firstOrFail();
+
+            $this->authorize('view', $this->application);
+
+            $this->composeDatabase = $this->application->composeDatabases()
+                ->whereUuid($this->parameters['compose_database_uuid'])
+                ->firstOrFail();
+
+            // Check if backups are supported for this database
+            if (! $this->composeDatabase->isBackupSolutionAvailable()) {
+                return redirect()->route('project.application.database-backups', [
+                    'project_uuid' => $this->parameters['project_uuid'],
+                    'environment_uuid' => $this->parameters['environment_uuid'],
+                    'application_uuid' => $this->parameters['application_uuid'],
+                ]);
+            }
+
+            // Check if import is supported for this database type
+            $dbType = $this->composeDatabase->databaseType();
+            $supportedTypes = ['mysql', 'mariadb', 'postgres', 'mongo'];
+            $this->isImportSupported = collect($supportedTypes)->contains(fn ($type) => str_contains($dbType, $type));
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function render()
+    {
+        return view('livewire.project.application.compose-database-backups');
+    }
+}

--- a/app/Livewire/Project/Application/ComposeDatabaseList.php
+++ b/app/Livewire/Project/Application/ComposeDatabaseList.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Livewire\Project\Application;
+
+use App\Models\Application;
+use Livewire\Component;
+
+class ComposeDatabaseList extends Component
+{
+    public Application $application;
+
+    public $composeDatabases;
+
+    public function mount()
+    {
+        $this->composeDatabases = $this->application->composeDatabases()
+            ->get()
+            ->filter(fn ($db) => $db->isBackupSolutionAvailable());
+    }
+
+    public function render()
+    {
+        return view('livewire.project.application.compose-database-list');
+    }
+}

--- a/app/Livewire/Project/Database/BackupEdit.php
+++ b/app/Livewire/Project/Database/BackupEdit.php
@@ -157,7 +157,7 @@ class BackupEdit extends Component
         try {
             $server = null;
             if ($this->backup->database instanceof \App\Models\ServiceDatabase) {
-                $server = $this->backup->database->service->destination->server;
+                $server = $this->backup->database->getServer();
             } elseif ($this->backup->database->destination && $this->backup->database->destination->server) {
                 $server = $this->backup->database->destination->server;
             }
@@ -184,6 +184,15 @@ class BackupEdit extends Component
 
             if ($this->backup->database->getMorphClass() === \App\Models\ServiceDatabase::class) {
                 $serviceDatabase = $this->backup->database;
+
+                if ($serviceDatabase->isApplicationDatabase()) {
+                    return redirect()->route('project.application.compose-database.backups', [
+                        'project_uuid' => $this->parameters['project_uuid'],
+                        'environment_uuid' => $this->parameters['environment_uuid'],
+                        'application_uuid' => $serviceDatabase->application->uuid,
+                        'compose_database_uuid' => $serviceDatabase->uuid,
+                    ]);
+                }
 
                 return redirect()->route('project.service.database.backups', [
                     'project_uuid' => $this->parameters['project_uuid'],

--- a/app/Livewire/Project/Database/BackupExecutions.php
+++ b/app/Livewire/Project/Database/BackupExecutions.php
@@ -78,9 +78,11 @@ class BackupExecutions extends Component
             return;
         }
 
-        $server = $execution->scheduledDatabaseBackup->database->getMorphClass() === \App\Models\ServiceDatabase::class
-            ? $execution->scheduledDatabaseBackup->database->service->destination->server
-            : $execution->scheduledDatabaseBackup->database->destination->server;
+        if ($execution->scheduledDatabaseBackup->database->getMorphClass() === \App\Models\ServiceDatabase::class) {
+            $server = $execution->scheduledDatabaseBackup->database->getServer();
+        } else {
+            $server = $execution->scheduledDatabaseBackup->database->destination->server;
+        }
 
         try {
             if ($execution->filename) {
@@ -182,7 +184,7 @@ class BackupExecutions extends Component
             $server = null;
 
             if ($this->database instanceof \App\Models\ServiceDatabase) {
-                $server = $this->database->service->destination->server;
+                $server = $this->database->getServer();
             } elseif ($this->database->destination && $this->database->destination->server) {
                 $server = $this->database->destination->server;
             }

--- a/app/Livewire/Project/Database/Import.php
+++ b/app/Livewire/Project/Database/Import.php
@@ -281,6 +281,8 @@ EOD;
         $databaseUuid = data_get($this->parameters, 'database_uuid');
         $stackServiceUuid = data_get($this->parameters, 'stack_service_uuid');
 
+        $composeDatabaseUuid = data_get($this->parameters, 'compose_database_uuid');
+
         $resource = null;
         if ($databaseUuid) {
             // Standalone database route
@@ -299,6 +301,17 @@ EOD;
             if (is_null($resource)) {
                 abort(404);
             }
+        } elseif ($composeDatabaseUuid) {
+            // Application compose database route
+            $applicationUuid = data_get($this->parameters, 'application_uuid');
+            $application = \App\Models\Application::whereUuid($applicationUuid)->first();
+            if (! $application) {
+                abort(404);
+            }
+            $resource = $application->composeDatabases()->whereUuid($composeDatabaseUuid)->first();
+            if (is_null($resource)) {
+                abort(404);
+            }
         } else {
             abort(404);
         }
@@ -314,12 +327,12 @@ EOD;
 
         // Handle ServiceDatabase server access differently
         if ($resource->getMorphClass() === \App\Models\ServiceDatabase::class) {
-            $server = $resource->service?->server;
+            $server = $resource->getServer();
             if (! $server) {
                 abort(404, 'Server not found for this service database.');
             }
             $this->serverId = $server->id;
-            $this->container = $resource->name.'-'.$resource->service->uuid;
+            $this->container = $resource->getContainerName();
             $this->resourceUuid = $resource->uuid; // Use ServiceDatabase's own UUID
 
             // Determine database type for ServiceDatabase
@@ -633,7 +646,11 @@ EOD;
 
             // Get the database destination network
             if ($this->resource->getMorphClass() === \App\Models\ServiceDatabase::class) {
-                $destinationNetwork = $this->resource->service->destination->network ?? 'coolify';
+                if ($this->resource->isApplicationDatabase()) {
+                    $destinationNetwork = $this->resource->application->destination->network ?? 'coolify';
+                } else {
+                    $destinationNetwork = $this->resource->service->destination->network ?? 'coolify';
+                }
             } else {
                 $destinationNetwork = $this->resource->destination->network ?? 'coolify';
             }

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -500,6 +500,15 @@ class Application extends BaseModel
         return $this->morphMany(LocalFileVolume::class, 'resource');
     }
 
+    /**
+     * Get database services detected in Docker Compose files deployed via GitHub App.
+     * These ServiceDatabase records allow backup scheduling for compose databases.
+     */
+    public function composeDatabases(): HasMany
+    {
+        return $this->hasMany(ServiceDatabase::class);
+    }
+
     public function type()
     {
         return 'application';

--- a/app/Models/ScheduledDatabaseBackup.php
+++ b/app/Models/ScheduledDatabaseBackup.php
@@ -67,8 +67,8 @@ class ScheduledDatabaseBackup extends BaseModel
     {
         if ($this->database) {
             if ($this->database instanceof ServiceDatabase) {
-                $destination = data_get($this->database->service, 'destination');
-                $server = data_get($destination, 'server');
+                // Use the getServer() helper which handles both Service and Application contexts
+                $server = $this->database->getServer();
             } else {
                 $destination = data_get($this->database, 'destination');
                 $server = data_get($destination, 'server');

--- a/app/Models/ServiceDatabase.php
+++ b/app/Models/ServiceDatabase.php
@@ -27,7 +27,10 @@ class ServiceDatabase extends BaseModel
 
     public static function ownedByCurrentTeamAPI(int $teamId)
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', $teamId)->orderBy('name');
+        $serviceOwned = ServiceDatabase::whereRelation('service.environment.project.team', 'id', $teamId);
+        $applicationOwned = ServiceDatabase::whereRelation('application.environment.project.team', 'id', $teamId);
+
+        return $serviceOwned->union($applicationOwned)->orderBy('name');
     }
 
     /**
@@ -36,7 +39,11 @@ class ServiceDatabase extends BaseModel
      */
     public static function ownedByCurrentTeam()
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', currentTeam()->id)->orderBy('name');
+        $teamId = currentTeam()->id;
+        $serviceOwned = ServiceDatabase::whereRelation('service.environment.project.team', 'id', $teamId);
+        $applicationOwned = ServiceDatabase::whereRelation('application.environment.project.team', 'id', $teamId);
+
+        return $serviceOwned->union($applicationOwned)->orderBy('name');
     }
 
     /**
@@ -49,10 +56,70 @@ class ServiceDatabase extends BaseModel
         });
     }
 
+    /**
+     * Check if this database belongs to a Docker Compose Application (not a Service).
+     */
+    public function isApplicationDatabase(): bool
+    {
+        return filled($this->application_id) && is_null($this->service_id);
+    }
+
     public function restart()
     {
-        $container_id = $this->name.'-'.$this->service->uuid;
-        remote_process(["docker restart {$container_id}"], $this->service->server);
+        if ($this->isApplicationDatabase()) {
+            $container_id = $this->getContainerName();
+            remote_process(["docker restart {$container_id}"], $this->application->destination->server);
+        } else {
+            $container_id = $this->name.'-'.$this->service->uuid;
+            remote_process(["docker restart {$container_id}"], $this->service->server);
+        }
+    }
+
+    /**
+     * Get the container name for this database.
+     * For Service databases: {name}-{serviceUuid}
+     * For Application compose databases: {name}-{applicationUuid} (consistent naming)
+     *   or resolved dynamically if the container has a timestamp suffix.
+     */
+    public function getContainerName(): string
+    {
+        if ($this->isApplicationDatabase()) {
+            // Try to find the actual running container by matching name prefix.
+            // Docker Compose apps may use timestamps in container names if
+            // consistent naming is not enabled.
+            $server = $this->getServer();
+            if ($server) {
+                try {
+                    $prefix = $this->name.'-'.$this->application->uuid;
+                    $result = instant_remote_process(
+                        ["docker ps -f 'name={$prefix}' --format '{{.Names}}' | head -1"],
+                        $server,
+                        throwError: false
+                    );
+                    if (filled($result)) {
+                        return trim($result);
+                    }
+                } catch (\Throwable) {
+                    // Fall through to default
+                }
+            }
+
+            return $this->name.'-'.$this->application->uuid;
+        }
+
+        return $this->name.'-'.$this->service->uuid;
+    }
+
+    /**
+     * Get the server this database runs on.
+     */
+    public function getServer(): ?Server
+    {
+        if ($this->isApplicationDatabase()) {
+            return $this->application->destination->server ?? null;
+        }
+
+        return $this->service->destination->server ?? null;
     }
 
     public function isRunning()
@@ -82,6 +149,10 @@ class ServiceDatabase extends BaseModel
 
     public function type()
     {
+        if ($this->isApplicationDatabase()) {
+            return 'application';
+        }
+
         return 'service';
     }
 
@@ -114,8 +185,12 @@ class ServiceDatabase extends BaseModel
     public function getServiceDatabaseUrl()
     {
         $port = $this->public_port;
-        $realIp = $this->service->server->ip;
-        if ($this->service->server->isLocalhost() || isDev()) {
+        $server = $this->getServer();
+        if (! $server) {
+            return null;
+        }
+        $realIp = $server->ip;
+        if ($server->isLocalhost() || isDev()) {
             $realIp = base_ip();
         }
 
@@ -124,17 +199,30 @@ class ServiceDatabase extends BaseModel
 
     public function team()
     {
-        return data_get($this, 'environment.project.team');
+        if ($this->isApplicationDatabase()) {
+            return data_get($this, 'application.environment.project.team');
+        }
+
+        return data_get($this, 'service.environment.project.team');
     }
 
     public function workdir()
     {
+        if ($this->isApplicationDatabase()) {
+            return base_configuration_dir().'/applications/'.$this->application->uuid;
+        }
+
         return service_configuration_dir()."/{$this->service->uuid}";
     }
 
     public function service()
     {
         return $this->belongsTo(Service::class);
+    }
+
+    public function application()
+    {
+        return $this->belongsTo(Application::class);
     }
 
     public function persistentStorages()

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -556,9 +556,16 @@ function getResourceByUuid(string $uuid, ?int $teamId = null)
     }
 
     // ServiceDatabase has a different relationship path: service->environment->project->team_id
+    // or application->environment->project->team_id for Application compose databases
     if ($resource instanceof \App\Models\ServiceDatabase) {
-        if ($resource->service?->environment?->project?->team_id === $teamId) {
-            return $resource;
+        if ($resource->isApplicationDatabase()) {
+            if ($resource->application?->environment?->project?->team_id === $teamId) {
+                return $resource;
+            }
+        } else {
+            if ($resource->service?->environment?->project?->team_id === $teamId) {
+                return $resource;
+            }
         }
 
         return null;
@@ -2114,7 +2121,8 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
         if ($pull_request_id !== 0) {
             $definedNetwork = collect(["{$resource->uuid}-$pull_request_id"]);
         }
-        $services = collect($services)->map(function ($service, $serviceName) use ($topLevelVolumes, $topLevelNetworks, $definedNetwork, $isNew, $generatedServiceFQDNS, $resource, $server, $pull_request_id, $preview_id) {
+        $detectedDatabaseServiceNames = collect([]);
+        $services = collect($services)->map(function ($service, $serviceName) use ($topLevelVolumes, $topLevelNetworks, $definedNetwork, $isNew, $generatedServiceFQDNS, $resource, $server, $pull_request_id, $preview_id, $detectedDatabaseServiceNames) {
             $serviceVolumes = collect(data_get($service, 'volumes', []));
             $servicePorts = collect(data_get($service, 'ports', []));
             $serviceNetworks = collect(data_get($service, 'networks', []));
@@ -2417,6 +2425,27 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
             $image = data_get_str($service, 'image');
             $isDatabase = isDatabaseImage($image, $service);
             data_set($service, 'is_database', $isDatabase);
+
+            // Create or update ServiceDatabase records for detected database services
+            // This enables backup scheduling for databases in Docker Compose Applications
+            if ($isDatabase && $pull_request_id === 0) {
+                $detectedDatabaseServiceNames->push($serviceName);
+
+                $existingDb = ServiceDatabase::where('name', $serviceName)
+                    ->where('application_id', $resource->id)
+                    ->first();
+
+                if (is_null($existingDb)) {
+                    ServiceDatabase::create([
+                        'name' => $serviceName,
+                        'image' => $image,
+                        'application_id' => $resource->id,
+                    ]);
+                } elseif ($existingDb->image !== (string) $image) {
+                    $existingDb->image = $image;
+                    $existingDb->save();
+                }
+            }
 
             // Collect/create/update networks
             if ($serviceNetworks->count() > 0) {
@@ -2801,6 +2830,23 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                 data_forget($services, $serviceName);
             });
         }
+        // Remove stale ServiceDatabase records for databases no longer in the compose file
+        if ($pull_request_id === 0 && $detectedDatabaseServiceNames->isNotEmpty()) {
+            ServiceDatabase::where('application_id', $resource->id)
+                ->whereNotIn('name', $detectedDatabaseServiceNames->toArray())
+                ->each(function ($staleDb) {
+                    $staleDb->scheduledBackups()->delete();
+                    $staleDb->delete();
+                });
+        } elseif ($pull_request_id === 0 && $detectedDatabaseServiceNames->isEmpty()) {
+            // No databases detected, clean up all Application-based ServiceDatabase records
+            ServiceDatabase::where('application_id', $resource->id)
+                ->each(function ($staleDb) {
+                    $staleDb->scheduledBackups()->delete();
+                    $staleDb->delete();
+                });
+        }
+
         $finalServices = [
             'services' => $services->toArray(),
             'volumes' => $topLevelVolumes->toArray(),

--- a/database/migrations/2026_01_28_000001_add_application_id_to_service_databases_table.php
+++ b/database/migrations/2026_01_28_000001_add_application_id_to_service_databases_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->foreignId('application_id')->nullable()->after('service_id');
+            // Make service_id nullable so ServiceDatabase can belong to either a Service or an Application
+            $table->foreignId('service_id')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->dropColumn('application_id');
+        });
+    }
+};

--- a/resources/views/livewire/project/application/compose-database-backups.blade.php
+++ b/resources/views/livewire/project/application/compose-database-backups.blade.php
@@ -1,0 +1,35 @@
+<div>
+    <x-slot:title>
+        {{ data_get_str($application, 'name')->limit(10) }} >
+        {{ data_get_str($composeDatabase, 'name')->limit(10) }} > Backups | Coolify
+    </x-slot>
+    <h1>Configuration</h1>
+    <livewire:project.shared.configuration-checker :resource="$application" />
+    <livewire:project.application.heading :application="$application" />
+    <div class="flex flex-col h-full gap-8 sm:flex-row">
+        <div class="sub-menu-wrapper">
+            <a class='sub-menu-item' {{ wireNavigate() }}
+                href="{{ route('project.application.database-backups', $parameters) }}">
+                <span class="menu-item-label">← Back to Databases</span>
+            </a>
+        </div>
+        <div class="w-full">
+            <div class="flex gap-2">
+                <h2 class="pb-4">{{ $composeDatabase->name }} — Scheduled Backups</h2>
+                @can('update', $application)
+                    <x-modal-input buttonTitle="+ Add" title="New Scheduled Backup">
+                        <livewire:project.database.create-scheduled-backup :database="$composeDatabase" />
+                    </x-modal-input>
+                @endcan
+            </div>
+            <livewire:project.database.scheduled-backups :database="$composeDatabase" />
+
+            @if ($isImportSupported)
+                <div class="pt-8">
+                    <h3 class="pb-4">Import Database</h3>
+                    <livewire:project.database.import :database="$composeDatabase" />
+                </div>
+            @endif
+        </div>
+    </div>
+</div>

--- a/resources/views/livewire/project/application/compose-database-list.blade.php
+++ b/resources/views/livewire/project/application/compose-database-list.blade.php
@@ -1,0 +1,42 @@
+<div>
+    <h2 class="pb-4">Compose Database Backups</h2>
+    <p class="pb-4 text-sm text-gray-500">
+        Database services detected in your Docker Compose file. Click on a database to manage its scheduled backups.
+    </p>
+
+    @if ($composeDatabases->isEmpty())
+        <div class="text-sm text-gray-500">
+            No database services with backup support were detected in your Docker Compose file.
+            <br>
+            Supported databases: PostgreSQL, MySQL, MariaDB, MongoDB.
+        </div>
+    @else
+        <div class="grid gap-2">
+            @foreach ($composeDatabases as $database)
+                <a class="box group"
+                    href="{{ route('project.application.compose-database.backups', [
+                        'project_uuid' => $application->environment->project->uuid,
+                        'environment_uuid' => $application->environment->uuid,
+                        'application_uuid' => $application->uuid,
+                        'compose_database_uuid' => $database->uuid,
+                    ]) }}">
+                    <div class="flex items-center gap-2">
+                        <div class="font-bold text-white">{{ $database->name }}</div>
+                        <div class="text-xs text-gray-400">{{ $database->image }}</div>
+                        <div class="text-xs px-2 py-0.5 rounded-full
+                            {{ str($database->databaseType())->contains('postgres') ? 'bg-blue-500/20 text-blue-400' : '' }}
+                            {{ str($database->databaseType())->contains('mysql') ? 'bg-orange-500/20 text-orange-400' : '' }}
+                            {{ str($database->databaseType())->contains('mariadb') ? 'bg-teal-500/20 text-teal-400' : '' }}
+                            {{ str($database->databaseType())->contains('mongo') ? 'bg-green-500/20 text-green-400' : '' }}
+                        ">
+                            {{ str($database->databaseType())->after('standalone-')->value() }}
+                        </div>
+                    </div>
+                    <div class="text-xs text-gray-500">
+                        {{ $database->scheduledBackups()->count() }} scheduled backup(s)
+                    </div>
+                </a>
+            @endforeach
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/project/application/configuration.blade.php
+++ b/resources/views/livewire/project/application/configuration.blade.php
@@ -64,6 +64,10 @@
                 href="{{ route('project.application.metrics', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Metrics</span></a>
             <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
                 href="{{ route('project.application.tags', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Tags</span></a>
+            @if ($application->build_pack === 'dockercompose' && $application->composeDatabases()->exists())
+                <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                    href="{{ route('project.application.database-backups', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Database Backups</span></a>
+            @endif
             <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
                 href="{{ route('project.application.danger', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Danger Zone</span></a>
         </div>
@@ -100,6 +104,8 @@
                 <livewire:project.shared.metrics :resource="$application" />
             @elseif ($currentRoute === 'project.application.tags')
                 <livewire:project.shared.tags :resource="$application" />
+            @elseif ($currentRoute === 'project.application.database-backups')
+                <livewire:project.application.compose-database-list :application="$application" />
             @elseif ($currentRoute === 'project.application.danger')
                 <livewire:project.shared.danger :resource="$application" />
             @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,6 +29,7 @@ use App\Livewire\Project\Index as ProjectIndex;
 use App\Livewire\Project\Resource\Create as ResourceCreate;
 use App\Livewire\Project\Resource\Index as ResourceIndex;
 use App\Livewire\Project\Service\Configuration as ServiceConfiguration;
+use App\Livewire\Project\Application\ComposeDatabaseBackups as ApplicationComposeDatabaseBackups;
 use App\Livewire\Project\Service\DatabaseBackups as ServiceDatabaseBackups;
 use App\Livewire\Project\Service\Index as ServiceIndex;
 use App\Livewire\Project\Shared\ExecuteContainerCommand;
@@ -208,6 +209,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/metrics', ApplicationConfiguration::class)->name('project.application.metrics');
         Route::get('/tags', ApplicationConfiguration::class)->name('project.application.tags');
         Route::get('/danger', ApplicationConfiguration::class)->name('project.application.danger');
+        Route::get('/database-backups', ApplicationConfiguration::class)->name('project.application.database-backups');
+        Route::get('/database-backups/{compose_database_uuid}', ApplicationComposeDatabaseBackups::class)->name('project.application.compose-database.backups');
 
         Route::get('/deployment', DeploymentIndex::class)->name('project.application.deployment.index');
         Route::get('/deployment/{deployment_uuid}', DeploymentShow::class)->name('project.application.deployment.show');
@@ -328,7 +331,7 @@ Route::middleware(['auth'])->group(function () {
             }
             $filename = data_get($execution, 'filename');
             if ($execution->scheduledDatabaseBackup->database->getMorphClass() === \App\Models\ServiceDatabase::class) {
-                $server = $execution->scheduledDatabaseBackup->database->service->destination->server;
+                $server = $execution->scheduledDatabaseBackup->database->getServer();
             } else {
                 $server = $execution->scheduledDatabaseBackup->database->destination->server;
             }


### PR DESCRIPTION
## Summary

This PR adds automatic database detection for Docker Compose Applications (deployed via GitHub App / git-based sources) and enables scheduled backup support for those databases — the same backup functionality that already exists for Service-based Docker Compose resources.

### Problem
When using Docker Compose via the **Application** path (GitHub App, git source, etc.), database containers (PostgreSQL, MySQL, MariaDB, MongoDB) are deployed but Coolify has no awareness they are databases. Users cannot schedule backups for these databases through the UI, unlike databases deployed through the **Service** path.

### Solution

**Database Detection** (\ootstrap/helpers/shared.php\)
- During Application compose parsing, \isDatabaseImage()\ identifies database containers
- Creates \ServiceDatabase\ records with \pplication_id\ (instead of \service_id\)
- Stale records are cleaned up when services are removed from the compose file

**Model & Migration** (\ServiceDatabase\, \Application\)
- Migration adds nullable \pplication_id\ column to \service_databases\ table
- \ServiceDatabase\ gains dual-path resolution: \getServer()\, \getContainerName()\, \	eam()\, \workdir()\ all handle both Service-based and Application-based contexts
- \Application\ model gains \composeDatabases()\ relationship

**Backup Job Support** (\DatabaseBackupJob\)
- Server resolution uses \getServer()\ which handles both paths
- Container name resolution uses \getContainerName()\ with dynamic Docker lookup for Application compose containers (handles non-consistent naming with timestamp suffixes)
- Live Docker container status check for Application-based databases (since status field isn't updated by the Service monitoring path)

**Container Status Monitoring** (\PushServerUpdateJob\)
- Updates \ServiceDatabase\ status for Application compose containers during regular health checks

**UI** (new Livewire components + blade views)
- \Database Backups\ tab added to Application configuration (visible only for \dockercompose\ build pack with detected databases)
- \ComposeDatabaseList\ — lists detected databases with backup support
- \ComposeDatabaseBackups\ — per-database backup scheduling, execution viewing, and import (reuses existing \CreateScheduledBackup\, \ScheduledBackups\, \BackupEdit\, \BackupExecutions\, and \Import\ components)

**Cleanup & Consistency**
- \DeleteResourceJob\ cleans up compose database records + backups on Application deletion
- \BackupEdit\, \BackupExecutions\, \Import\, \ScheduledDatabaseBackup\ all updated to use \getServer()\ instead of hardcoded \service->server\ paths
- \ownedByCurrentTeam()\ queries include Application-based ServiceDatabase records

### Files Changed (17 files, +468/-30)

| File | Change |
|------|--------|
| \database/migrations/2026_01_28_000001_...\ | New: adds \pplication_id\ to \service_databases\ |
| \pp/Models/ServiceDatabase.php\ | Dual-path methods, \pplication()\ relationship |
| \pp/Models/Application.php\ | \composeDatabases()\ relationship |
| \ootstrap/helpers/shared.php\ | Database detection in Application compose parsing |
| \pp/Jobs/DatabaseBackupJob.php\ | Application-aware backup execution |
| \pp/Jobs/PushServerUpdateJob.php\ | Compose database status tracking |
| \pp/Jobs/DeleteResourceJob.php\ | Compose database cleanup on delete |
| \pp/Livewire/Project/Application/ComposeDatabaseList.php\ | New: database list component |
| \pp/Livewire/Project/Application/ComposeDatabaseBackups.php\ | New: backup management page |
| \esources/views/livewire/.../compose-database-list.blade.php\ | New: database list UI |
| \esources/views/livewire/.../compose-database-backups.blade.php\ | New: backup scheduling UI |
| \esources/views/livewire/.../configuration.blade.php\ | Database Backups tab |
| \outes/web.php\ | New routes for compose database backups |
| \pp/Livewire/Project/Database/BackupEdit.php\ | Uses \getServer()\ |
| \pp/Livewire/Project/Database/BackupExecutions.php\ | Uses \getServer()\ |
| \pp/Livewire/Project/Database/Import.php\ | Compose database support |
| \pp/Models/ScheduledDatabaseBackup.php\ | Uses \getServer()\ |

Resolves #7528
/claim #7528