### PR TITLE
feat: pgBackRest integration for PostgreSQL incremental backups

### DIFF
--- a/app/Actions/Database/PgBackRest/GetPgBackRestInfo.php
+++ b/app/Actions/Database/PgBackRest/GetPgBackRestInfo.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Actions\Database\PgBackRest;
+
+use App\Models\Server;
+use App\Models\StandalonePostgresql;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class GetPgBackRestInfo
+{
+    use AsAction;
+
+    public function handle(
+        StandalonePostgresql $database,
+        Server $server,
+        string $containerName,
+    ): array {
+        $stanza = $database->pgbackrest_stanza ?? 'db-'.$database->uuid;
+
+        // Check if pgBackRest is available
+        $checkCmd = "docker exec {$containerName} which pgbackrest 2>/dev/null || echo 'NOT_FOUND'";
+        $result = instant_remote_process([$checkCmd], $server, false, false, null, disableMultiplexing: true);
+
+        if (str($result)->contains('NOT_FOUND')) {
+            return [
+                'installed' => false,
+                'configured' => false,
+                'stanza' => $stanza,
+                'backups' => [],
+                'wal_archiving' => false,
+            ];
+        }
+
+        // Check if config exists
+        $checkConf = "docker exec {$containerName} test -f /etc/pgbackrest/pgbackrest.conf && echo 'EXISTS' || echo 'NOT_FOUND'";
+        $confResult = instant_remote_process([$checkConf], $server, false, false, null, disableMultiplexing: true);
+        $configured = ! str($confResult)->contains('NOT_FOUND');
+
+        // Get backup info
+        $backups = [];
+        if ($configured) {
+            try {
+                $cmd = "docker exec {$containerName} su - postgres -c \"pgbackrest info --stanza={$stanza} --output=json\" 2>/dev/null";
+                $output = instant_remote_process([$cmd], $server, false, false, 30, disableMultiplexing: true);
+
+                if (filled($output)) {
+                    $parsed = json_decode(trim($output), true);
+                    if (! empty($parsed)) {
+                        $stanzaInfo = $parsed[0] ?? [];
+                        $rawBackups = $stanzaInfo['backup'] ?? [];
+
+                        foreach ($rawBackups as $backup) {
+                            $backups[] = [
+                                'label' => $backup['label'] ?? null,
+                                'type' => $backup['type'] ?? null,
+                                'timestamp_start' => isset($backup['timestamp']['start']) ? date('Y-m-d H:i:s', $backup['timestamp']['start']) : null,
+                                'timestamp_stop' => isset($backup['timestamp']['stop']) ? date('Y-m-d H:i:s', $backup['timestamp']['stop']) : null,
+                                'size' => $backup['info']['size'] ?? 0,
+                                'delta_size' => $backup['info']['delta']['size'] ?? 0,
+                                'repository_size' => $backup['info']['repository']['size'] ?? 0,
+                                'repository_delta_size' => $backup['info']['repository']['delta']['size'] ?? 0,
+                                'wal_start' => $backup['lsn']['start'] ?? null,
+                                'wal_stop' => $backup['lsn']['stop'] ?? null,
+                                'database_ref' => $backup['database']['ref'] ?? [],
+                            ];
+                        }
+                    }
+                }
+            } catch (\Throwable $e) {
+                // Info retrieval failed, return what we have
+            }
+        }
+
+        // Check WAL archiving status
+        $walArchiving = false;
+        try {
+            $walCmd = "docker exec {$containerName} su - postgres -c \"psql -tAc \\\"SHOW archive_mode;\\\"\"";
+            $walResult = trim(instant_remote_process([$walCmd], $server, false, false, null, disableMultiplexing: true));
+            $walArchiving = ($walResult === 'on');
+        } catch (\Throwable $e) {
+            // Ignore
+        }
+
+        return [
+            'installed' => true,
+            'configured' => $configured,
+            'stanza' => $stanza,
+            'backups' => $backups,
+            'wal_archiving' => $walArchiving,
+            'backup_count' => count($backups),
+        ];
+    }
+}

--- a/app/Actions/Database/PgBackRest/RunPgBackRestBackup.php
+++ b/app/Actions/Database/PgBackRest/RunPgBackRestBackup.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Actions\Database\PgBackRest;
+
+use App\Models\Server;
+use App\Models\StandalonePostgresql;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class RunPgBackRestBackup
+{
+    use AsAction;
+
+    public function handle(
+        StandalonePostgresql $database,
+        Server $server,
+        string $containerName,
+        string $backupType = 'full',
+        ?int $timeout = 3600,
+    ): array {
+        $stanza = $database->pgbackrest_stanza ?? 'db-'.$database->uuid;
+
+        // Ensure pgBackRest is installed and configured
+        $this->ensureSetup($server, $containerName, $stanza);
+
+        // Run the backup
+        $output = $this->runBackup($server, $containerName, $stanza, $backupType, $timeout);
+
+        // Get backup info
+        $info = $this->getBackupInfo($server, $containerName, $stanza);
+
+        // Parse the latest backup's size
+        $size = $this->parseBackupSize($info);
+        $location = "pgbackrest://{$stanza}/{$backupType}";
+
+        return [
+            'output' => $output,
+            'location' => $location,
+            'size' => $size,
+            'info' => $info,
+            'type' => $backupType,
+            'stanza' => $stanza,
+        ];
+    }
+
+    private function ensureSetup(Server $server, string $containerName, string $stanza): void
+    {
+        // Check if pgBackRest is installed
+        $checkCmd = "docker exec {$containerName} which pgbackrest 2>/dev/null || echo 'NOT_FOUND'";
+        $result = instant_remote_process([$checkCmd], $server, false, false, null, disableMultiplexing: true);
+
+        if (str($result)->contains('NOT_FOUND')) {
+            throw new \RuntimeException(
+                'pgBackRest is not installed in the container. Please run setup first via the database configuration page or API.'
+            );
+        }
+
+        // Verify stanza exists by checking pgbackrest.conf
+        $checkConf = "docker exec {$containerName} test -f /etc/pgbackrest/pgbackrest.conf && echo 'EXISTS' || echo 'NOT_FOUND'";
+        $result = instant_remote_process([$checkConf], $server, false, false, null, disableMultiplexing: true);
+
+        if (str($result)->contains('NOT_FOUND')) {
+            throw new \RuntimeException(
+                'pgBackRest configuration not found. Please run setup first.'
+            );
+        }
+    }
+
+    private function runBackup(Server $server, string $containerName, string $stanza, string $backupType, ?int $timeout): string
+    {
+        $validTypes = ['full', 'diff', 'incr'];
+        if (! in_array($backupType, $validTypes)) {
+            throw new \InvalidArgumentException("Invalid backup type: {$backupType}. Must be one of: ".implode(', ', $validTypes));
+        }
+
+        $cmd = "docker exec {$containerName} su - postgres -c \"pgbackrest backup --stanza={$stanza} --type={$backupType} --compress-type=lz4\"";
+        $output = instant_remote_process([$cmd], $server, true, false, $timeout, disableMultiplexing: true);
+
+        return trim($output ?? '');
+    }
+
+    private function getBackupInfo(Server $server, string $containerName, string $stanza): ?array
+    {
+        $cmd = "docker exec {$containerName} su - postgres -c \"pgbackrest info --stanza={$stanza} --output=json\"";
+        $output = instant_remote_process([$cmd], $server, false, false, 30, disableMultiplexing: true);
+
+        if (blank($output)) {
+            return null;
+        }
+
+        $parsed = json_decode(trim($output), true);
+
+        return $parsed;
+    }
+
+    private function parseBackupSize(?array $info): int
+    {
+        if (empty($info)) {
+            return 0;
+        }
+
+        // pgBackRest info JSON returns an array of stanzas
+        // Each stanza has a 'backup' array with individual backups
+        $stanzaInfo = $info[0] ?? [];
+        $backups = $stanzaInfo['backup'] ?? [];
+
+        if (empty($backups)) {
+            return 0;
+        }
+
+        // Get the latest backup (last in the array)
+        $latestBackup = end($backups);
+        $dbInfo = $latestBackup['info'] ?? [];
+        $size = $dbInfo['size'] ?? 0;
+
+        return (int) $size;
+    }
+}

--- a/app/Actions/Database/PgBackRest/RunPgBackRestRestore.php
+++ b/app/Actions/Database/PgBackRest/RunPgBackRestRestore.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Actions\Database\PgBackRest;
+
+use App\Models\Server;
+use App\Models\StandalonePostgresql;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class RunPgBackRestRestore
+{
+    use AsAction;
+
+    public function handle(
+        StandalonePostgresql $database,
+        Server $server,
+        string $containerName,
+        bool $delta = true,
+        ?string $targetTime = null,
+        ?int $timeout = 7200,
+    ): array {
+        $stanza = $database->pgbackrest_stanza ?? 'db-'.$database->uuid;
+
+        // Step 1: Stop PostgreSQL
+        $this->stopPostgres($server, $containerName);
+
+        try {
+            // Step 2: Run restore
+            $output = $this->runRestore($server, $containerName, $stanza, $delta, $targetTime, $timeout);
+
+            // Step 3: Start PostgreSQL
+            $this->startPostgres($server, $containerName);
+
+            return [
+                'success' => true,
+                'output' => $output,
+                'message' => 'Restore completed successfully.',
+            ];
+        } catch (\Throwable $e) {
+            // Always try to restart PostgreSQL even if restore fails
+            try {
+                $this->startPostgres($server, $containerName);
+            } catch (\Throwable $restartError) {
+                // Log but don't override the original exception
+            }
+
+            throw $e;
+        }
+    }
+
+    private function stopPostgres(Server $server, string $containerName): void
+    {
+        $cmd = "docker exec {$containerName} su - postgres -c \"pg_ctl stop -D /var/lib/postgresql/data -m fast -w -t 60\"";
+        instant_remote_process([$cmd], $server, true, false, 120, disableMultiplexing: true);
+    }
+
+    private function startPostgres(Server $server, string $containerName): void
+    {
+        $cmd = "docker exec {$containerName} su - postgres -c \"pg_ctl start -D /var/lib/postgresql/data -w -t 60\"";
+        instant_remote_process([$cmd], $server, true, false, 120, disableMultiplexing: true);
+    }
+
+    private function runRestore(Server $server, string $containerName, string $stanza, bool $delta, ?string $targetTime, ?int $timeout): string
+    {
+        $restoreArgs = "--stanza={$stanza}";
+
+        if ($delta) {
+            $restoreArgs .= ' --delta';
+        }
+
+        if ($targetTime) {
+            // Point-in-Time Recovery
+            $escapedTarget = escapeshellarg($targetTime);
+            $restoreArgs .= " --type=time --target={$escapedTarget}";
+        }
+
+        $cmd = "docker exec {$containerName} su - postgres -c \"pgbackrest restore {$restoreArgs}\"";
+        $output = instant_remote_process([$cmd], $server, true, false, $timeout, disableMultiplexing: true);
+
+        return trim($output ?? '');
+    }
+}

--- a/app/Actions/Database/PgBackRest/SetupPgBackRest.php
+++ b/app/Actions/Database/PgBackRest/SetupPgBackRest.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace App\Actions\Database\PgBackRest;
+
+use App\Models\S3Storage;
+use App\Models\Server;
+use App\Models\StandalonePostgresql;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class SetupPgBackRest
+{
+    use AsAction;
+
+    public function handle(
+        StandalonePostgresql $database,
+        Server $server,
+        string $containerName,
+    ): array {
+        $stanza = $database->pgbackrest_stanza ?? 'db-'.$database->uuid;
+
+        // Step 1: Install pgBackRest if not present
+        $this->installPgBackRest($server, $containerName);
+
+        // Step 2: Generate pgbackrest.conf
+        $config = $this->generateConfig($database, $stanza);
+        $this->writeConfig($server, $containerName, $config);
+
+        // Step 3: Create necessary directories
+        $this->createDirectories($server, $containerName, $database);
+
+        // Step 4: Configure WAL archiving in PostgreSQL
+        $this->configureWalArchiving($server, $containerName, $stanza, $database);
+
+        // Step 5: Create stanza
+        $this->createStanza($server, $containerName, $stanza);
+
+        // Step 6: Update database model
+        $database->update([
+            'pgbackrest_enabled' => true,
+            'pgbackrest_stanza' => $stanza,
+        ]);
+
+        return [
+            'success' => true,
+            'stanza' => $stanza,
+            'message' => 'pgBackRest setup completed successfully.',
+        ];
+    }
+
+    private function installPgBackRest(Server $server, string $containerName): void
+    {
+        // Check if pgBackRest is already installed
+        $checkCmd = "docker exec {$containerName} which pgbackrest 2>/dev/null || echo 'NOT_FOUND'";
+        $result = instant_remote_process([$checkCmd], $server, false, false, null, disableMultiplexing: true);
+
+        if (str($result)->contains('NOT_FOUND')) {
+            // Install pgBackRest inside the container
+            $installCommands = [
+                "docker exec {$containerName} sh -c 'apt-get update -qq && apt-get install -y -qq pgbackrest > /dev/null 2>&1'",
+            ];
+            instant_remote_process($installCommands, $server, true, false, 120, disableMultiplexing: true);
+        }
+    }
+
+    private function generateConfig(StandalonePostgresql $database, string $stanza): string
+    {
+        $retentionFull = $database->pgbackrest_retention_full ?? 2;
+        $retentionDiff = $database->pgbackrest_retention_diff ?? 7;
+
+        $config = "[global]\n";
+        $config .= "compress-type=lz4\n";
+        $config .= "compress-level=6\n";
+        $config .= "process-max=2\n";
+        $config .= "log-level-console=info\n";
+        $config .= "log-level-file=detail\n";
+        $config .= "repo1-retention-full={$retentionFull}\n";
+        $config .= "repo1-retention-diff={$retentionDiff}\n";
+
+        if ($database->pgbackrest_repo_type === 's3' && $database->pgbackrest_s3_storage_id) {
+            $s3 = S3Storage::find($database->pgbackrest_s3_storage_id);
+            if ($s3) {
+                $config .= "repo1-type=s3\n";
+                $config .= "repo1-s3-endpoint=".str($s3->endpoint)->replace('https://', '')->replace('http://', '')."\n";
+                $config .= "repo1-s3-bucket={$s3->bucket}\n";
+                $config .= "repo1-s3-key={$s3->key}\n";
+                $config .= "repo1-s3-key-secret={$s3->secret}\n";
+                $config .= "repo1-s3-region=".($s3->region ?: 'us-east-1')."\n";
+                $config .= 'repo1-path='.($s3->path ?: '/backups')."/{$stanza}\n";
+
+                // Use URI style if endpoint is not AWS
+                if (! str($s3->endpoint)->contains('amazonaws.com')) {
+                    $config .= "repo1-s3-uri-style=path\n";
+                }
+                // Verify TLS by default, but allow non-TLS endpoints
+                if (str($s3->endpoint)->startsWith('http://')) {
+                    $config .= "repo1-storage-verify-tls=n\n";
+                }
+            }
+        } else {
+            $config .= "repo1-path=/var/lib/pgbackrest\n";
+        }
+
+        // Stanza section
+        $config .= "\n[{$stanza}]\n";
+        $config .= "pg1-path=/var/lib/postgresql/data\n";
+
+        return $config;
+    }
+
+    private function writeConfig(Server $server, string $containerName, string $config): void
+    {
+        $escapedConfig = escapeshellarg($config);
+        $commands = [
+            "docker exec {$containerName} sh -c 'mkdir -p /etc/pgbackrest'",
+            "docker exec {$containerName} sh -c 'echo {$escapedConfig} > /etc/pgbackrest/pgbackrest.conf'",
+            "docker exec {$containerName} sh -c 'chmod 640 /etc/pgbackrest/pgbackrest.conf'",
+            "docker exec {$containerName} sh -c 'chown postgres:postgres /etc/pgbackrest/pgbackrest.conf'",
+        ];
+        instant_remote_process($commands, $server, true, false, null, disableMultiplexing: true);
+    }
+
+    private function createDirectories(Server $server, string $containerName, StandalonePostgresql $database): void
+    {
+        if ($database->pgbackrest_repo_type !== 's3') {
+            $commands = [
+                "docker exec {$containerName} sh -c 'mkdir -p /var/lib/pgbackrest && chown -R postgres:postgres /var/lib/pgbackrest'",
+            ];
+            instant_remote_process($commands, $server, true, false, null, disableMultiplexing: true);
+        }
+
+        // Create log directory
+        $commands = [
+            "docker exec {$containerName} sh -c 'mkdir -p /var/log/pgbackrest && chown -R postgres:postgres /var/log/pgbackrest'",
+        ];
+        instant_remote_process($commands, $server, true, false, null, disableMultiplexing: true);
+    }
+
+    private function configureWalArchiving(Server $server, string $containerName, string $stanza, StandalonePostgresql $database): void
+    {
+        // Check current archive_mode
+        $checkCmd = "docker exec {$containerName} su - postgres -c \"psql -tAc \\\"SHOW archive_mode;\\\"\"";
+        $currentMode = trim(instant_remote_process([$checkCmd], $server, false, false, null, disableMultiplexing: true));
+
+        // Configure WAL archiving
+        $archiveCommand = "pgbackrest --stanza={$stanza} archive-push %p";
+        $escapedArchiveCommand = str_replace("'", "''", $archiveCommand);
+
+        $sqlCommands = [
+            "docker exec {$containerName} su - postgres -c \"psql -c \\\"ALTER SYSTEM SET archive_mode = 'on';\\\"\"",
+            "docker exec {$containerName} su - postgres -c \"psql -c \\\"ALTER SYSTEM SET archive_command = '{$escapedArchiveCommand}';\\\"\"",
+            "docker exec {$containerName} su - postgres -c \"psql -c \\\"ALTER SYSTEM SET wal_level = 'replica';\\\"\"",
+        ];
+        instant_remote_process($sqlCommands, $server, true, false, null, disableMultiplexing: true);
+
+        // Reload configuration (archive_mode requires restart, but archive_command is immediate)
+        $reloadCmd = "docker exec {$containerName} su - postgres -c \"psql -c \\\"SELECT pg_reload_conf();\\\"\"";
+        instant_remote_process([$reloadCmd], $server, false, false, null, disableMultiplexing: true);
+
+        // If archive_mode was 'off', a full restart is needed
+        if ($currentMode === 'off') {
+            // Restart PostgreSQL inside the container
+            $restartCmd = "docker exec {$containerName} su - postgres -c \"pg_ctl restart -D /var/lib/postgresql/data -w -t 60\"";
+            instant_remote_process([$restartCmd], $server, true, false, 120, disableMultiplexing: true);
+        }
+    }
+
+    private function createStanza(Server $server, string $containerName, string $stanza): void
+    {
+        $cmd = "docker exec {$containerName} su - postgres -c \"pgbackrest stanza-create --stanza={$stanza}\"";
+        instant_remote_process([$cmd], $server, true, false, 120, disableMultiplexing: true);
+    }
+}

--- a/app/Http/Controllers/Api/DatabasesController.php
+++ b/app/Http/Controllers/Api/DatabasesController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Actions\Database\PgBackRest\GetPgBackRestInfo;
+use App\Actions\Database\PgBackRest\SetupPgBackRest;
 use App\Actions\Database\RestartDatabase;
 use App\Actions\Database\StartDatabase;
 use App\Actions\Database\StartDatabaseProxy;
@@ -636,6 +638,8 @@ class DatabasesController extends Controller
                         'database_backup_retention_amount_s3' => ['type' => 'integer', 'description' => 'Number of backups to retain in S3'],
                         'database_backup_retention_days_s3' => ['type' => 'integer', 'description' => 'Number of days to retain backups in S3'],
                         'database_backup_retention_max_storage_s3' => ['type' => 'integer', 'description' => 'Max storage (MB) for S3 backups'],
+                        'backup_engine' => ['type' => 'string', 'description' => 'Backup engine to use: pg_dump (default) or pgbackrest (PostgreSQL only)', 'enum' => ['pg_dump', 'pgbackrest']],
+                        'backup_type' => ['type' => 'string', 'description' => 'Backup type for pgBackRest: full, diff (differential), or incr (incremental)', 'enum' => ['full', 'diff', 'incr']],
                     ],
                 ),
             )
@@ -672,7 +676,7 @@ class DatabasesController extends Controller
     )]
     public function create_backup(Request $request)
     {
-        $backupConfigFields = ['save_s3', 'enabled', 'dump_all', 'frequency', 'databases_to_backup', 'database_backup_retention_amount_locally', 'database_backup_retention_days_locally', 'database_backup_retention_max_storage_locally', 'database_backup_retention_amount_s3', 'database_backup_retention_days_s3', 'database_backup_retention_max_storage_s3', 's3_storage_uuid'];
+        $backupConfigFields = ['save_s3', 'enabled', 'dump_all', 'frequency', 'databases_to_backup', 'database_backup_retention_amount_locally', 'database_backup_retention_days_locally', 'database_backup_retention_max_storage_locally', 'database_backup_retention_amount_s3', 'database_backup_retention_days_s3', 'database_backup_retention_max_storage_s3', 's3_storage_uuid', 'backup_engine', 'backup_type'];
 
         $teamId = getTeamIdFromToken();
         if (is_null($teamId)) {
@@ -699,6 +703,8 @@ class DatabasesController extends Controller
             'database_backup_retention_amount_s3' => 'integer|min:0',
             'database_backup_retention_days_s3' => 'integer|min:0',
             'database_backup_retention_max_storage_s3' => 'integer|min:0',
+            'backup_engine' => 'string|in:pg_dump,pgbackrest|nullable',
+            'backup_type' => 'string|in:full,diff,incr|nullable',
         ]);
 
         if ($validator->fails()) {
@@ -861,6 +867,8 @@ class DatabasesController extends Controller
                         'database_backup_retention_amount_s3' => ['type' => 'integer', 'description' => 'Retention amount of the backup in s3'],
                         'database_backup_retention_days_s3' => ['type' => 'integer', 'description' => 'Retention days of the backup in s3'],
                         'database_backup_retention_max_storage_s3' => ['type' => 'integer', 'description' => 'Max storage of the backup in S3'],
+                        'backup_engine' => ['type' => 'string', 'description' => 'Backup engine: pg_dump (default) or pgbackrest (PostgreSQL only)', 'enum' => ['pg_dump', 'pgbackrest']],
+                        'backup_type' => ['type' => 'string', 'description' => 'Backup type for pgBackRest: full, diff, or incr', 'enum' => ['full', 'diff', 'incr']],
                     ],
                 ),
             )
@@ -890,7 +898,7 @@ class DatabasesController extends Controller
     )]
     public function update_backup(Request $request)
     {
-        $backupConfigFields = ['save_s3', 'enabled', 'dump_all', 'frequency', 'databases_to_backup', 'database_backup_retention_amount_locally', 'database_backup_retention_days_locally', 'database_backup_retention_max_storage_locally', 'database_backup_retention_amount_s3', 'database_backup_retention_days_s3', 'database_backup_retention_max_storage_s3', 's3_storage_uuid'];
+        $backupConfigFields = ['save_s3', 'enabled', 'dump_all', 'frequency', 'databases_to_backup', 'database_backup_retention_amount_locally', 'database_backup_retention_days_locally', 'database_backup_retention_max_storage_locally', 'database_backup_retention_amount_s3', 'database_backup_retention_days_s3', 'database_backup_retention_max_storage_s3', 's3_storage_uuid', 'backup_engine', 'backup_type'];
 
         $teamId = getTeamIdFromToken();
         if (is_null($teamId)) {
@@ -915,6 +923,8 @@ class DatabasesController extends Controller
             'database_backup_retention_amount_s3' => 'integer|min:0',
             'database_backup_retention_days_s3' => 'integer|min:0',
             'database_backup_retention_max_storage_s3' => 'integer|min:0',
+            'backup_engine' => 'string|in:pg_dump,pgbackrest|nullable',
+            'backup_type' => 'string|in:full,diff,incr|nullable',
         ]);
         if ($validator->fails()) {
             return response()->json([
@@ -2738,5 +2748,204 @@ class DatabasesController extends Controller
             ],
             200
         );
+    }
+
+    #[OA\Get(
+        summary: 'Get pgBackRest Info',
+        description: 'Get pgBackRest status and backup history for a PostgreSQL database.',
+        path: '/databases/{uuid}/pgbackrest/info',
+        operationId: 'get-database-pgbackrest-info',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Databases'],
+        parameters: [
+            new OA\Parameter(
+                name: 'uuid',
+                in: 'path',
+                description: 'UUID of the database.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'pgBackRest info retrieved successfully.',
+            ),
+            new OA\Response(response: 401, ref: '#/components/responses/401'),
+            new OA\Response(response: 400, ref: '#/components/responses/400'),
+            new OA\Response(response: 404, ref: '#/components/responses/404'),
+        ]
+    )]
+    public function pgbackrest_info(Request $request)
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+
+        if (! $request->uuid) {
+            return response()->json(['message' => 'UUID is required.'], 404);
+        }
+
+        $database = queryDatabaseByUuidWithinTeam($request->uuid, $teamId);
+        if (! $database) {
+            return response()->json(['message' => 'Database not found.'], 404);
+        }
+
+        if (! ($database instanceof StandalonePostgresql)) {
+            return response()->json(['message' => 'pgBackRest is only available for PostgreSQL databases.'], 400);
+        }
+
+        if (! $database->isPgBackRestEnabled()) {
+            return response()->json(['message' => 'pgBackRest is not enabled for this database.'], 400);
+        }
+
+        $this->authorize('view', $database);
+
+        try {
+            $server = $database->destination->server;
+            $containerName = $database->uuid;
+
+            $info = GetPgBackRestInfo::run(
+                database: $database,
+                server: $server,
+                containerName: $containerName,
+            );
+
+            return response()->json($info);
+        } catch (\Throwable $e) {
+            return response()->json(['message' => 'Failed to retrieve pgBackRest info: '.$e->getMessage()], 500);
+        }
+    }
+
+    #[OA\Post(
+        summary: 'Setup pgBackRest',
+        description: 'Install and configure pgBackRest for a PostgreSQL database.',
+        path: '/databases/{uuid}/pgbackrest/setup',
+        operationId: 'setup-database-pgbackrest',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Databases'],
+        parameters: [
+            new OA\Parameter(
+                name: 'uuid',
+                in: 'path',
+                description: 'UUID of the database.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+        ],
+        requestBody: new OA\RequestBody(
+            description: 'pgBackRest configuration (optional, uses database defaults if not provided)',
+            required: false,
+            content: new OA\MediaType(
+                mediaType: 'application/json',
+                schema: new OA\Schema(
+                    type: 'object',
+                    properties: [
+                        'stanza' => ['type' => 'string', 'description' => 'Stanza name (auto-generated if not provided)'],
+                        'repo_type' => ['type' => 'string', 'description' => 'Repository type: posix or s3', 'enum' => ['posix', 's3']],
+                        's3_storage_uuid' => ['type' => 'string', 'description' => 'S3 storage UUID (required if repo_type is s3)'],
+                        'retention_full' => ['type' => 'integer', 'description' => 'Number of full backups to retain', 'default' => 2],
+                        'retention_diff' => ['type' => 'integer', 'description' => 'Number of differential backups to retain', 'default' => 7],
+                    ],
+                ),
+            )
+        ),
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'pgBackRest setup completed successfully.',
+            ),
+            new OA\Response(response: 401, ref: '#/components/responses/401'),
+            new OA\Response(response: 400, ref: '#/components/responses/400'),
+            new OA\Response(response: 404, ref: '#/components/responses/404'),
+        ]
+    )]
+    public function pgbackrest_setup(Request $request)
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+
+        $return = validateIncomingRequest($request);
+        if ($return instanceof \Illuminate\Http\JsonResponse) {
+            return $return;
+        }
+
+        if (! $request->uuid) {
+            return response()->json(['message' => 'UUID is required.'], 404);
+        }
+
+        $database = queryDatabaseByUuidWithinTeam($request->uuid, $teamId);
+        if (! $database) {
+            return response()->json(['message' => 'Database not found.'], 404);
+        }
+
+        if (! ($database instanceof StandalonePostgresql)) {
+            return response()->json(['message' => 'pgBackRest is only available for PostgreSQL databases.'], 400);
+        }
+
+        $this->authorize('update', $database);
+
+        // Check database is running
+        if (! str($database->status)->startsWith('running')) {
+            return response()->json(['message' => 'Database must be running to setup pgBackRest.'], 400);
+        }
+
+        $validator = customApiValidator($request->all(), [
+            'stanza' => 'string|nullable',
+            'repo_type' => 'string|in:posix,s3|nullable',
+            's3_storage_uuid' => 'string|exists:s3_storages,uuid|nullable',
+            'retention_full' => 'integer|min:1|nullable',
+            'retention_diff' => 'integer|min:1|nullable',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'message' => 'Validation failed.',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        // Update database pgBackRest settings from request
+        if ($request->filled('stanza')) {
+            $database->pgbackrest_stanza = $request->stanza;
+        }
+        if ($request->filled('repo_type')) {
+            $database->pgbackrest_repo_type = $request->repo_type;
+        }
+        if ($request->filled('s3_storage_uuid')) {
+            $s3Storage = S3Storage::ownedByCurrentTeam()->where('uuid', $request->s3_storage_uuid)->first();
+            if ($s3Storage) {
+                $database->pgbackrest_s3_storage_id = $s3Storage->id;
+            }
+        }
+        if ($request->filled('retention_full')) {
+            $database->pgbackrest_retention_full = $request->retention_full;
+        }
+        if ($request->filled('retention_diff')) {
+            $database->pgbackrest_retention_diff = $request->retention_diff;
+        }
+        $database->save();
+
+        try {
+            $server = $database->destination->server;
+            $containerName = $database->uuid;
+
+            $result = SetupPgBackRest::run(
+                database: $database,
+                server: $server,
+                containerName: $containerName,
+            );
+
+            return response()->json($result);
+        } catch (\Throwable $e) {
+            return response()->json(['message' => 'pgBackRest setup failed: '.$e->getMessage()], 500);
+        }
     }
 }

--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\Actions\Database\PgBackRest\RunPgBackRestBackup;
 use App\Events\BackupCreated;
 use App\Models\S3Storage;
 use App\Models\ScheduledDatabaseBackup;
@@ -308,19 +309,38 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                 // Step 1: Create local backup
                 try {
                     if (str($databaseType)->contains('postgres')) {
-                        $this->backup_file = "/pg-dump-$database-".Carbon::now()->timestamp.'.dmp';
-                        if ($this->backup->dump_all) {
-                            $this->backup_file = '/pg-dump-all-'.Carbon::now()->timestamp.'.gz';
+                        // pgBackRest engine: uses native pgBackRest for incremental backups
+                        if ($this->backup->backup_engine === 'pgbackrest'
+                            && $this->database instanceof StandalonePostgresql
+                            && $this->database->isPgBackRestEnabled()
+                        ) {
+                            $backupType = $this->backup->backup_type ?? 'full';
+                            $this->backup_file = "/pgbackrest-{$backupType}-".Carbon::now()->timestamp;
+                            $this->backup_location = "pgbackrest://{$this->database->pgbackrest_stanza}/{$backupType}/".Carbon::now()->timestamp;
+                            $this->backup_log = ScheduledDatabaseBackupExecution::create([
+                                'uuid' => $this->backup_log_uuid,
+                                'database_name' => $database,
+                                'filename' => $this->backup_location,
+                                'scheduled_database_backup_id' => $this->backup->id,
+                                'local_storage_deleted' => false,
+                            ]);
+                            $this->backup_standalone_postgresql_pgbackrest($backupType);
+                        } else {
+                            // Default pg_dump engine
+                            $this->backup_file = "/pg-dump-$database-".Carbon::now()->timestamp.'.dmp';
+                            if ($this->backup->dump_all) {
+                                $this->backup_file = '/pg-dump-all-'.Carbon::now()->timestamp.'.gz';
+                            }
+                            $this->backup_location = $this->backup_dir.$this->backup_file;
+                            $this->backup_log = ScheduledDatabaseBackupExecution::create([
+                                'uuid' => $this->backup_log_uuid,
+                                'database_name' => $database,
+                                'filename' => $this->backup_location,
+                                'scheduled_database_backup_id' => $this->backup->id,
+                                'local_storage_deleted' => false,
+                            ]);
+                            $this->backup_standalone_postgresql($database);
                         }
-                        $this->backup_location = $this->backup_dir.$this->backup_file;
-                        $this->backup_log = ScheduledDatabaseBackupExecution::create([
-                            'uuid' => $this->backup_log_uuid,
-                            'database_name' => $database,
-                            'filename' => $this->backup_location,
-                            'scheduled_database_backup_id' => $this->backup->id,
-                            'local_storage_deleted' => false,
-                        ]);
-                        $this->backup_standalone_postgresql($database);
                     } elseif (str($databaseType)->contains('mongo')) {
                         if ($database === '*') {
                             $database = 'all';
@@ -374,10 +394,18 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                         throw new \Exception('Unsupported database type');
                     }
 
-                    $size = $this->calculate_size();
+                    // For pgBackRest, size is set by the backup method; for others, calculate from file
+                    if ($this->backup->backup_engine === 'pgbackrest' && $this->size > 0) {
+                        $size = $this->size;
+                    } else {
+                        $size = $this->calculate_size();
+                    }
 
                     // Verify local backup succeeded
                     if ($size > 0) {
+                        $localBackupSucceeded = true;
+                    } elseif ($this->backup->backup_engine === 'pgbackrest') {
+                        // pgBackRest may report 0 size for incremental with no changes; still valid
                         $localBackupSucceeded = true;
                     } else {
                         throw new \Exception('Local backup file is empty or was not created');
@@ -399,8 +427,9 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                 }
 
                 // Step 2: Upload to S3 if enabled (independent of local backup)
+                // pgBackRest handles S3 natively via its repo configuration — skip MinIO upload
                 $localStorageDeleted = false;
-                if ($this->backup->save_s3 && $localBackupSucceeded) {
+                if ($this->backup->save_s3 && $localBackupSucceeded && $this->backup->backup_engine !== 'pgbackrest') {
                     try {
                         $this->upload_to_s3();
 
@@ -415,6 +444,15 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                     }
                 }
 
+                // pgBackRest with S3 repo handles upload natively
+                if ($this->backup->backup_engine === 'pgbackrest'
+                    && $localBackupSucceeded
+                    && $this->database instanceof StandalonePostgresql
+                    && $this->database->pgbackrest_repo_type === 's3'
+                ) {
+                    $this->s3_uploaded = true;
+                }
+
                 // Step 3: Update status and send notifications based on results
                 if ($localBackupSucceeded) {
                     $message = $this->backup_output;
@@ -425,11 +463,17 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                             : 'Warning: S3 upload failed: '.$s3UploadError;
                     }
 
+                    // For pgBackRest, determine s3_uploaded based on repo type
+                    $s3UploadedStatus = $this->backup->save_s3 ? $this->s3_uploaded : null;
+                    if ($this->backup->backup_engine === 'pgbackrest' && $this->database instanceof StandalonePostgresql) {
+                        $s3UploadedStatus = $this->database->pgbackrest_repo_type === 's3' ? true : null;
+                    }
+
                     $this->backup_log->update([
                         'status' => 'success',
                         'message' => $message,
                         'size' => $size,
-                        's3_uploaded' => $this->backup->save_s3 ? $this->s3_uploaded : null,
+                        's3_uploaded' => $s3UploadedStatus,
                         'local_storage_deleted' => $localStorageDeleted,
                     ]);
 
@@ -542,6 +586,26 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             if ($this->backup_output === '') {
                 $this->backup_output = null;
             }
+        } catch (\Throwable $e) {
+            $this->add_to_error_output($e->getMessage());
+            throw $e;
+        }
+    }
+
+    private function backup_standalone_postgresql_pgbackrest(string $backupType): void
+    {
+        try {
+            $result = RunPgBackRestBackup::run(
+                database: $this->database,
+                server: $this->server,
+                containerName: $this->container_name,
+                backupType: $backupType,
+                timeout: $this->timeout,
+            );
+
+            $this->backup_output = $result['output'];
+            $this->backup_location = $result['location'];
+            $this->size = $result['size'];
         } catch (\Throwable $e) {
             $this->add_to_error_output($e->getMessage());
             throw $e;

--- a/app/Livewire/Project/Database/BackupEdit.php
+++ b/app/Livewire/Project/Database/BackupEdit.php
@@ -78,11 +78,23 @@ class BackupEdit extends Component
     #[Validate(['required', 'int', 'min:60', 'max:36000'])]
     public int $timeout = 3600;
 
+    #[Validate(['required', 'string', 'in:pg_dump,pgbackrest'])]
+    public string $backupEngine = 'pg_dump';
+
+    #[Validate(['required', 'string', 'in:full,diff,incr'])]
+    public string $backupType = 'full';
+
+    public bool $isPostgresql = false;
+
+    public bool $pgbackrestAvailable = false;
+
     public function mount()
     {
         try {
             $this->authorize('view', $this->backup->database);
             $this->parameters = get_route_parameters();
+            $this->isPostgresql = $this->backup->database instanceof \App\Models\StandalonePostgresql;
+            $this->pgbackrestAvailable = $this->isPostgresql && $this->backup->database->isPgBackRestEnabled();
             $this->syncData();
         } catch (Exception $e) {
             return handleError($e, $this);
@@ -125,6 +137,8 @@ class BackupEdit extends Component
             $this->backup->databases_to_backup = $this->databasesToBackup;
             $this->backup->dump_all = $this->dumpAll;
             $this->backup->timeout = $this->timeout;
+            $this->backup->backup_engine = $this->backupEngine;
+            $this->backup->backup_type = $this->backupEngine === 'pgbackrest' ? $this->backupType : 'full';
             $this->customValidate();
             $this->backup->save();
         } else {
@@ -143,6 +157,8 @@ class BackupEdit extends Component
             $this->databasesToBackup = $this->backup->databases_to_backup;
             $this->dumpAll = $this->backup->dump_all;
             $this->timeout = $this->backup->timeout;
+            $this->backupEngine = $this->backup->backup_engine ?? 'pg_dump';
+            $this->backupType = $this->backup->backup_type ?? 'full';
         }
     }
 

--- a/app/Livewire/Project/Database/CreateScheduledBackup.php
+++ b/app/Livewire/Project/Database/CreateScheduledBackup.php
@@ -27,7 +27,17 @@ class CreateScheduledBackup extends Component
     #[Validate(['nullable', 'integer'])]
     public ?int $s3StorageId = null;
 
+    #[Validate(['required', 'string', 'in:pg_dump,pgbackrest'])]
+    public string $backupEngine = 'pg_dump';
+
+    #[Validate(['required', 'string', 'in:full,diff,incr'])]
+    public string $backupType = 'full';
+
     public Collection $definedS3s;
+
+    public bool $isPostgresql = false;
+
+    public bool $pgbackrestAvailable = false;
 
     public function mount()
     {
@@ -36,6 +46,8 @@ class CreateScheduledBackup extends Component
             if ($this->definedS3s->count() > 0) {
                 $this->s3StorageId = $this->definedS3s->first()->id;
             }
+            $this->isPostgresql = $this->database instanceof \App\Models\StandalonePostgresql;
+            $this->pgbackrestAvailable = $this->isPostgresql && $this->database->isPgBackRestEnabled();
         } catch (\Throwable $e) {
             return handleError($e, $this);
         }
@@ -55,6 +67,13 @@ class CreateScheduledBackup extends Component
                 return;
             }
 
+            // Validate pgBackRest is enabled on the database if selected
+            if ($this->backupEngine === 'pgbackrest' && ! $this->pgbackrestAvailable) {
+                $this->dispatch('error', 'pgBackRest must be enabled and configured on the database first.');
+
+                return;
+            }
+
             $payload = [
                 'enabled' => true,
                 'frequency' => $this->frequency,
@@ -63,6 +82,8 @@ class CreateScheduledBackup extends Component
                 'database_id' => $this->database->id,
                 'database_type' => $this->database->getMorphClass(),
                 'team_id' => currentTeam()->id,
+                'backup_engine' => $this->backupEngine,
+                'backup_type' => $this->backupEngine === 'pgbackrest' ? $this->backupType : 'full',
             ];
 
             if ($this->database->type() === 'standalone-postgresql') {

--- a/app/Livewire/Project/Database/Postgresql/General.php
+++ b/app/Livewire/Project/Database/Postgresql/General.php
@@ -2,6 +2,8 @@
 
 namespace App\Livewire\Project\Database\Postgresql;
 
+use App\Actions\Database\PgBackRest\GetPgBackRestInfo;
+use App\Actions\Database\PgBackRest\SetupPgBackRest;
 use App\Actions\Database\StartDatabaseProxy;
 use App\Actions\Database\StopDatabaseProxy;
 use App\Helpers\SslHelper;
@@ -65,6 +67,25 @@ class General extends Component
     public ?string $db_url_public = null;
 
     public ?Carbon $certificateValidUntil = null;
+
+    // pgBackRest properties
+    public bool $pgbackrestEnabled = false;
+
+    public ?string $pgbackrestStanza = null;
+
+    public string $pgbackrestRepoType = 'posix';
+
+    public ?int $pgbackrestS3StorageId = null;
+
+    public int $pgbackrestRetentionFull = 2;
+
+    public int $pgbackrestRetentionDiff = 7;
+
+    public ?array $pgbackrestInfo = null;
+
+    public bool $pgbackrestSetupLoading = false;
+
+    public $s3Storages;
 
     public function getListeners()
     {
@@ -152,6 +173,14 @@ class General extends Component
             if ($existingCert) {
                 $this->certificateValidUntil = $existingCert->valid_until;
             }
+
+            // Load S3 storages for pgBackRest configuration
+            $this->s3Storages = currentTeam()->s3s;
+
+            // Load pgBackRest info if enabled and running
+            if ($this->pgbackrestEnabled && str($this->database->status)->startsWith('running')) {
+                $this->loadPgBackRestInfo();
+            }
         } catch (Exception $e) {
             return handleError($e, $this);
         }
@@ -178,6 +207,12 @@ class General extends Component
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->enable_ssl = $this->enableSsl;
             $this->database->ssl_mode = $this->sslMode;
+            $this->database->pgbackrest_enabled = $this->pgbackrestEnabled;
+            $this->database->pgbackrest_stanza = $this->pgbackrestStanza;
+            $this->database->pgbackrest_repo_type = $this->pgbackrestRepoType;
+            $this->database->pgbackrest_s3_storage_id = $this->pgbackrestS3StorageId;
+            $this->database->pgbackrest_retention_full = $this->pgbackrestRetentionFull;
+            $this->database->pgbackrest_retention_diff = $this->pgbackrestRetentionDiff;
             $this->database->save();
 
             $this->db_url = $this->database->internal_db_url;
@@ -202,6 +237,12 @@ class General extends Component
             $this->sslMode = $this->database->ssl_mode;
             $this->db_url = $this->database->internal_db_url;
             $this->db_url_public = $this->database->external_db_url;
+            $this->pgbackrestEnabled = (bool) $this->database->pgbackrest_enabled;
+            $this->pgbackrestStanza = $this->database->pgbackrest_stanza ?? 'db-'.$this->database->uuid;
+            $this->pgbackrestRepoType = $this->database->pgbackrest_repo_type ?? 'posix';
+            $this->pgbackrestS3StorageId = $this->database->pgbackrest_s3_storage_id;
+            $this->pgbackrestRetentionFull = $this->database->pgbackrest_retention_full ?? 2;
+            $this->pgbackrestRetentionDiff = $this->database->pgbackrest_retention_diff ?? 7;
         }
     }
 
@@ -461,6 +502,83 @@ class General extends Component
             } else {
                 $this->dispatch('configurationChanged');
             }
+        }
+    }
+
+    public function savePgBackRestSettings()
+    {
+        try {
+            $this->authorize('update', $this->database);
+
+            $this->database->pgbackrest_enabled = $this->pgbackrestEnabled;
+            $this->database->pgbackrest_stanza = $this->pgbackrestStanza;
+            $this->database->pgbackrest_repo_type = $this->pgbackrestRepoType;
+            $this->database->pgbackrest_s3_storage_id = $this->pgbackrestRepoType === 's3' ? $this->pgbackrestS3StorageId : null;
+            $this->database->pgbackrest_retention_full = $this->pgbackrestRetentionFull;
+            $this->database->pgbackrest_retention_diff = $this->pgbackrestRetentionDiff;
+            $this->database->save();
+
+            $this->dispatch('success', 'pgBackRest settings saved.');
+        } catch (Exception $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function setupPgBackRest()
+    {
+        try {
+            $this->authorize('update', $this->database);
+
+            if (! str($this->database->status)->startsWith('running')) {
+                $this->dispatch('error', 'Database must be running to setup pgBackRest.');
+
+                return;
+            }
+
+            $this->pgbackrestSetupLoading = true;
+
+            // Save settings first
+            $this->savePgBackRestSettings();
+
+            $containerName = $this->database->uuid;
+
+            $result = SetupPgBackRest::run(
+                database: $this->database,
+                server: $this->server,
+                containerName: $containerName,
+            );
+
+            $this->pgbackrestEnabled = true;
+            $this->database->refresh();
+            $this->syncData();
+
+            // Reload info
+            $this->loadPgBackRestInfo();
+
+            $this->dispatch('success', $result['message'] ?? 'pgBackRest setup completed successfully.');
+        } catch (Exception $e) {
+            return handleError($e, $this);
+        } finally {
+            $this->pgbackrestSetupLoading = false;
+        }
+    }
+
+    public function loadPgBackRestInfo()
+    {
+        try {
+            if (! $this->server || ! str($this->database->status)->startsWith('running')) {
+                return;
+            }
+
+            $containerName = $this->database->uuid;
+
+            $this->pgbackrestInfo = GetPgBackRestInfo::run(
+                database: $this->database,
+                server: $this->server,
+                containerName: $containerName,
+            );
+        } catch (Exception $e) {
+            $this->pgbackrestInfo = null;
         }
     }
 }

--- a/app/Models/StandalonePostgresql.php
+++ b/app/Models/StandalonePostgresql.php
@@ -23,6 +23,7 @@ class StandalonePostgresql extends BaseModel
         'restart_count' => 'integer',
         'last_restart_at' => 'datetime',
         'last_restart_type' => 'string',
+        'pgbackrest_enabled' => 'boolean',
     ];
 
     protected static function booted()
@@ -324,6 +325,16 @@ class StandalonePostgresql extends BaseModel
     public function environment_variables()
     {
         return $this->morphMany(EnvironmentVariable::class, 'resourceable');
+    }
+
+    public function pgbackrestS3()
+    {
+        return $this->belongsTo(S3Storage::class, 'pgbackrest_s3_storage_id');
+    }
+
+    public function isPgBackRestEnabled(): bool
+    {
+        return (bool) $this->pgbackrest_enabled;
     }
 
     public function isBackupSolutionAvailable()

--- a/database/migrations/2025_10_14_000000_add_pgbackrest_support.php
+++ b/database/migrations/2025_10_14_000000_add_pgbackrest_support.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('scheduled_database_backups', function (Blueprint $table) {
+            $table->string('backup_engine')->default('pg_dump')->after('database_type');
+            $table->string('backup_type')->default('full')->after('backup_engine');
+        });
+
+        Schema::table('standalone_postgresqls', function (Blueprint $table) {
+            $table->boolean('pgbackrest_enabled')->default(false)->after('custom_docker_run_options');
+            $table->string('pgbackrest_stanza')->nullable()->after('pgbackrest_enabled');
+            $table->string('pgbackrest_repo_type')->default('posix')->after('pgbackrest_stanza');
+            $table->unsignedBigInteger('pgbackrest_s3_storage_id')->nullable()->after('pgbackrest_repo_type');
+            $table->integer('pgbackrest_retention_full')->default(2)->after('pgbackrest_s3_storage_id');
+            $table->integer('pgbackrest_retention_diff')->default(7)->after('pgbackrest_retention_full');
+
+            $table->foreign('pgbackrest_s3_storage_id')
+                ->references('id')
+                ->on('s3_storages')
+                ->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('scheduled_database_backups', function (Blueprint $table) {
+            $table->dropColumn(['backup_engine', 'backup_type']);
+        });
+
+        Schema::table('standalone_postgresqls', function (Blueprint $table) {
+            $table->dropForeign(['pgbackrest_s3_storage_id']);
+            $table->dropColumn([
+                'pgbackrest_enabled',
+                'pgbackrest_stanza',
+                'pgbackrest_repo_type',
+                'pgbackrest_s3_storage_id',
+                'pgbackrest_retention_full',
+                'pgbackrest_retention_diff',
+            ]);
+        });
+    }
+};

--- a/resources/views/livewire/project/database/backup-edit.blade.php
+++ b/resources/views/livewire/project/database/backup-edit.blade.php
@@ -46,6 +46,36 @@
     @endif
     <div class="flex flex-col gap-2">
         <h3>Settings</h3>
+
+        @if ($isPostgresql && $backup->database_id !== 0)
+            <div class="flex gap-2 flex-col">
+                <h4 class="font-medium">Backup Engine</h4>
+                <div class="flex gap-2">
+                    <x-forms.select id="backupEngine" label="Engine" wire:model.live="backupEngine">
+                        <option value="pg_dump">pg_dump (default)</option>
+                        @if ($pgbackrestAvailable)
+                            <option value="pgbackrest">pgBackRest (incremental)</option>
+                        @else
+                            <option value="pgbackrest" disabled>pgBackRest (enable in database settings first)</option>
+                        @endif
+                    </x-forms.select>
+                    @if ($backupEngine === 'pgbackrest')
+                        <x-forms.select id="backupType" label="Backup Type"
+                            helper="Full: complete backup. Differential: changes since last full. Incremental: changes since last backup of any type.">
+                            <option value="full">Full</option>
+                            <option value="diff">Differential</option>
+                            <option value="incr">Incremental</option>
+                        </x-forms.select>
+                    @endif
+                </div>
+                @if ($backupEngine === 'pgbackrest')
+                    <div class="text-sm dark:text-gray-400">
+                        pgBackRest manages backups and S3 storage natively. Retention is configured in the database's pgBackRest settings.
+                    </div>
+                @endif
+            </div>
+        @endif
+
         <div class="flex gap-2 flex-col ">
             @if ($backup->database_type === 'App\Models\StandalonePostgresql' && $backup->database_id !== 0)
                 <div class="w-48">

--- a/resources/views/livewire/project/database/create-scheduled-backup.blade.php
+++ b/resources/views/livewire/project/database/create-scheduled-backup.blade.php
@@ -2,17 +2,45 @@
     <x-forms.input placeholder="0 0 * * * or daily" id="frequency"
         helper="You can use every_minute, hourly, daily, weekly, monthly, yearly or a cron expression." label="Frequency"
         required />
+
+    @if ($isPostgresql)
+        <h2>Backup Engine</h2>
+        <x-forms.select id="backupEngine" label="Engine" wire:model.live="backupEngine">
+            <option value="pg_dump">pg_dump (default)</option>
+            @if ($pgbackrestAvailable)
+                <option value="pgbackrest">pgBackRest (incremental)</option>
+            @else
+                <option value="pgbackrest" disabled>pgBackRest (enable in database settings first)</option>
+            @endif
+        </x-forms.select>
+
+        @if ($backupEngine === 'pgbackrest')
+            <x-forms.select id="backupType" label="Backup Type"
+                helper="Full: complete backup. Differential: changes since last full. Incremental: changes since last backup of any type.">
+                <option value="full">Full</option>
+                <option value="diff">Differential</option>
+                <option value="incr">Incremental</option>
+            </x-forms.select>
+        @endif
+    @endif
+
     <h2>S3</h2>
     @if ($definedS3s->count() === 0)
         <div class="text-red-500">No validated S3 Storages found.</div>
     @else
-        <x-forms.checkbox wire:model.live="saveToS3" label="Save to S3" />
-        @if ($saveToS3)
-            <x-forms.select id="s3StorageId" label="Select a S3 Storage">
-                @foreach ($definedS3s as $s3)
-                    <option value="{{ $s3->id }}">{{ $s3->name }}</option>
-                @endforeach
-            </x-forms.select>
+        @if ($backupEngine === 'pgbackrest')
+            <div class="text-sm dark:text-gray-400">
+                pgBackRest handles S3 storage natively via database-level configuration. Configure S3 in the database's pgBackRest settings.
+            </div>
+        @else
+            <x-forms.checkbox wire:model.live="saveToS3" label="Save to S3" />
+            @if ($saveToS3)
+                <x-forms.select id="s3StorageId" label="Select a S3 Storage">
+                    @foreach ($definedS3s as $s3)
+                        <option value="{{ $s3->id }}">{{ $s3->name }}</option>
+                    @endforeach
+                </x-forms.select>
+            @endif
         @endif
     @endif
     <x-forms.button type="submit" @click="modalOpen=false">

--- a/resources/views/livewire/project/database/postgresql/general.blade.php
+++ b/resources/views/livewire/project/database/postgresql/general.blade.php
@@ -175,6 +175,153 @@
         </div>
     </form>
 
+    {{-- pgBackRest Configuration Section --}}
+    <div class="flex flex-col gap-4 pt-4">
+        <div class="flex items-center gap-2">
+            <h3>pgBackRest — Incremental Backups</h3>
+            @if ($pgbackrestEnabled && $pgbackrestInfo && data_get($pgbackrestInfo, 'installed') && data_get($pgbackrestInfo, 'configured'))
+                <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-green-500/20 text-green-400">Configured</span>
+                @if (data_get($pgbackrestInfo, 'wal_archiving'))
+                    <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-blue-500/20 text-blue-400">WAL Archiving Active</span>
+                @endif
+            @elseif ($pgbackrestEnabled)
+                <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-yellow-500/20 text-yellow-400">Needs Setup</span>
+            @else
+                <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-neutral-500/20 text-neutral-400">Disabled</span>
+            @endif
+        </div>
+
+        <div class="text-sm dark:text-gray-400">
+            pgBackRest provides full, differential, and incremental backups for PostgreSQL.
+            Incremental backups can significantly reduce storage costs for large databases (100GB+).
+        </div>
+
+        <div class="w-64">
+            <x-forms.checkbox id="pgbackrestEnabled" label="Enable pgBackRest" wire:model.live="pgbackrestEnabled"
+                canGate="update" :canResource="$database" />
+        </div>
+
+        @if ($pgbackrestEnabled)
+            <div class="flex flex-col gap-4 pl-2">
+                <div class="flex flex-wrap gap-2 sm:flex-nowrap">
+                    <x-forms.input label="Stanza Name" id="pgbackrestStanza"
+                        helper="A unique name for this backup configuration. Auto-generated if empty."
+                        canGate="update" :canResource="$database" />
+                    <x-forms.select id="pgbackrestRepoType" label="Repository Type" wire:model.live="pgbackrestRepoType"
+                        canGate="update" :canResource="$database">
+                        <option value="posix">Local (POSIX filesystem)</option>
+                        <option value="s3">S3-Compatible Storage</option>
+                    </x-forms.select>
+                </div>
+
+                @if ($pgbackrestRepoType === 's3')
+                    <div class="flex flex-wrap gap-2 sm:flex-nowrap">
+                        @if ($s3Storages && $s3Storages->count() > 0)
+                            <x-forms.select id="pgbackrestS3StorageId" label="S3 Storage"
+                                helper="Select an S3 storage configured in your team settings."
+                                canGate="update" :canResource="$database">
+                                <option value="" disabled>Select S3 Storage</option>
+                                @foreach ($s3Storages as $s3)
+                                    <option value="{{ $s3->id }}">{{ $s3->name }}</option>
+                                @endforeach
+                            </x-forms.select>
+                        @else
+                            <div class="text-sm text-red-500">No S3 Storages configured. Add one in your team settings first.</div>
+                        @endif
+                    </div>
+                @endif
+
+                <div class="flex flex-wrap gap-2 sm:flex-nowrap">
+                    <x-forms.input label="Full Backup Retention" id="pgbackrestRetentionFull" type="number" min="1"
+                        helper="Number of full backups to retain."
+                        canGate="update" :canResource="$database" />
+                    <x-forms.input label="Differential Backup Retention" id="pgbackrestRetentionDiff" type="number" min="1"
+                        helper="Number of differential backups to retain per full backup."
+                        canGate="update" :canResource="$database" />
+                </div>
+
+                <div class="flex gap-2">
+                    @can('update', $database)
+                        <x-forms.button wire:click="savePgBackRestSettings">
+                            Save pgBackRest Settings
+                        </x-forms.button>
+                        @if (str($database->status)->startsWith('running'))
+                            <x-forms.button wire:click="setupPgBackRest" isHighlighted
+                                wire:loading.attr="disabled" wire:target="setupPgBackRest">
+                                <span wire:loading.remove wire:target="setupPgBackRest">
+                                    @if ($pgbackrestInfo && data_get($pgbackrestInfo, 'configured'))
+                                        Reconfigure pgBackRest
+                                    @else
+                                        Setup pgBackRest
+                                    @endif
+                                </span>
+                                <span wire:loading wire:target="setupPgBackRest">Setting up...</span>
+                            </x-forms.button>
+                        @else
+                            <x-forms.button disabled helper="Database must be running to setup pgBackRest.">
+                                Setup pgBackRest
+                            </x-forms.button>
+                        @endif
+                        <x-forms.button wire:click="loadPgBackRestInfo"
+                            wire:loading.attr="disabled" wire:target="loadPgBackRestInfo">
+                            <span wire:loading.remove wire:target="loadPgBackRestInfo">Refresh Status</span>
+                            <span wire:loading wire:target="loadPgBackRestInfo">Loading...</span>
+                        </x-forms.button>
+                    @endcan
+                </div>
+
+                {{-- pgBackRest Status & Backup History --}}
+                @if ($pgbackrestInfo)
+                    <div class="flex flex-col gap-2 mt-2">
+                        <h4 class="font-medium">Status</h4>
+                        <div class="flex gap-4 text-sm">
+                            <span>Installed: {{ data_get($pgbackrestInfo, 'installed') ? '✅' : '❌' }}</span>
+                            <span>Configured: {{ data_get($pgbackrestInfo, 'configured') ? '✅' : '❌' }}</span>
+                            <span>WAL Archiving: {{ data_get($pgbackrestInfo, 'wal_archiving') ? '✅ Active' : '❌ Inactive' }}</span>
+                            <span>Total Backups: {{ data_get($pgbackrestInfo, 'backup_count', 0) }}</span>
+                        </div>
+
+                        @if (!empty(data_get($pgbackrestInfo, 'backups', [])))
+                            <h4 class="font-medium mt-2">Recent Backups</h4>
+                            <div class="overflow-x-auto">
+                                <table class="w-full text-sm">
+                                    <thead>
+                                        <tr class="border-b border-neutral-700">
+                                            <th class="text-left py-2 px-2">Type</th>
+                                            <th class="text-left py-2 px-2">Started</th>
+                                            <th class="text-left py-2 px-2">Completed</th>
+                                            <th class="text-right py-2 px-2">Size</th>
+                                            <th class="text-right py-2 px-2">Repo Size</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @foreach (array_reverse(data_get($pgbackrestInfo, 'backups', [])) as $backup)
+                                            <tr class="border-b border-neutral-800">
+                                                <td class="py-1 px-2">
+                                                    <span class="px-1.5 py-0.5 text-xs rounded
+                                                        @if(data_get($backup, 'type') === 'full') bg-green-500/20 text-green-400
+                                                        @elseif(data_get($backup, 'type') === 'diff') bg-blue-500/20 text-blue-400
+                                                        @else bg-purple-500/20 text-purple-400
+                                                        @endif">
+                                                        {{ data_get($backup, 'type', 'unknown') }}
+                                                    </span>
+                                                </td>
+                                                <td class="py-1 px-2">{{ data_get($backup, 'timestamp_start', '-') }}</td>
+                                                <td class="py-1 px-2">{{ data_get($backup, 'timestamp_stop', '-') }}</td>
+                                                <td class="py-1 px-2 text-right">{{ number_format(data_get($backup, 'size', 0) / 1024 / 1024, 1) }} MB</td>
+                                                <td class="py-1 px-2 text-right">{{ number_format(data_get($backup, 'repository_size', 0) / 1024 / 1024, 1) }} MB</td>
+                                            </tr>
+                                        @endforeach
+                                    </tbody>
+                                </table>
+                            </div>
+                        @endif
+                    </div>
+                @endif
+            </div>
+        @endif
+    </div>
+
     <div class="flex flex-col gap-4 pt-4">
         <h3>Advanced</h3>
         <div class="flex flex-col">

--- a/routes/api.php
+++ b/routes/api.php
@@ -151,6 +151,9 @@ Route::group([
     Route::delete('/databases/{uuid}/backups/{scheduled_backup_uuid}', [DatabasesController::class, 'delete_backup_by_uuid'])->middleware(['api.ability:write']);
     Route::delete('/databases/{uuid}/backups/{scheduled_backup_uuid}/executions/{execution_uuid}', [DatabasesController::class, 'delete_execution_by_uuid'])->middleware(['api.ability:write']);
 
+    Route::get('/databases/{uuid}/pgbackrest/info', [DatabasesController::class, 'pgbackrest_info'])->middleware(['api.ability:read']);
+    Route::post('/databases/{uuid}/pgbackrest/setup', [DatabasesController::class, 'pgbackrest_setup'])->middleware(['api.ability:write']);
+
     Route::match(['get', 'post'], '/databases/{uuid}/start', [DatabasesController::class, 'action_deploy'])->middleware(['api.ability:write']);
     Route::match(['get', 'post'], '/databases/{uuid}/restart', [DatabasesController::class, 'action_restart'])->middleware(['api.ability:write']);
     Route::match(['get', 'post'], '/databases/{uuid}/stop', [DatabasesController::class, 'action_stop'])->middleware(['api.ability:write']);


### PR DESCRIPTION
Resolves #7423
/claim #7423

## Summary

Adds **pgBackRest** as an opt-in backup engine for PostgreSQL databases, enabling **full, differential, and incremental backups** with **native S3 support**. This eliminates MinIO helper container overhead for pgBackRest-managed backups while keeping `pg_dump` as the unchanged default.

### Why pgBackRest?
- **Incremental backups** — only changed blocks are backed up, reducing S3 bills for 100GB+ databases
- **Native S3** — pgBackRest writes directly to S3, no MinIO helper container needed
- **WAL archiving** — continuous archiving enables Point-in-Time Recovery (PITR)
- **Compression** — LZ4 compression for fast, efficient backups

## What's Included

### Backend
- **4 new Action classes** (`app/Actions/Database/PgBackRest/`):
  - `SetupPgBackRest` — installs pgBackRest in-container, configures WAL archiving, creates stanza
  - `RunPgBackRestBackup` — executes full/diff/incr backups
  - `RunPgBackRestRestore` — restore with delta and optional PITR
  - `GetPgBackRestInfo` — queries status, history, WAL state
- **Migration** — adds `backup_engine`/`backup_type` to `scheduled_database_backups`, pgBackRest config columns to `standalone_postgresqls`
- **DatabaseBackupJob** — routes PostgreSQL backups through pgBackRest when `backup_engine=pgbackrest`; handles native S3, size tracking

### UI (Livewire + Blade)
- **Create Backup** — engine selector (pg_dump | pgBackRest) with backup type picker (Full/Differential/Incremental)
- **Edit Backup** — show/edit backup engine and type for existing schedules
- **PostgreSQL General Settings** — full pgBackRest configuration panel:
  - Enable/disable toggle
  - Stanza name (auto-generated, editable)
  - Repository type (Local / S3)
  - S3 storage selector (reuses existing team S3 storages)
  - Retention settings (full backup count, differential count)
  - Setup button (installs + configures pgBackRest in the running container)
  - Status indicators (installed, configured, WAL archiving active)
  - Backup history table with type, timestamps, sizes

### API
- `backup_engine` and `backup_type` fields added to `POST/PATCH /databases/{uuid}/backups`
- `GET /databases/{uuid}/pgbackrest/info` — pgBackRest status and backup history
- `POST /databases/{uuid}/pgbackrest/setup` — install and configure pgBackRest
- Full OpenAPI documentation for all new endpoints

## Backward Compatibility
- **pg_dump remains the default** — `backup_engine` defaults to `pg_dump`
- **Zero changes to existing backups** — all current schedules continue working
- **Fully opt-in** — must enable pgBackRest per-database, then select it per-schedule
- **No impact on MySQL, MariaDB, or MongoDB** backup paths

## Files Changed (15 files, +1189/-24)
| File | Change |
|------|--------|
| `app/Actions/Database/PgBackRest/SetupPgBackRest.php` | New |
| `app/Actions/Database/PgBackRest/RunPgBackRestBackup.php` | New |
| `app/Actions/Database/PgBackRest/RunPgBackRestRestore.php` | New |
| `app/Actions/Database/PgBackRest/GetPgBackRestInfo.php` | New |
| `database/migrations/2025_10_14_000000_add_pgbackrest_support.php` | New |
| `app/Jobs/DatabaseBackupJob.php` | Modified |
| `app/Models/StandalonePostgresql.php` | Modified |
| `app/Livewire/Project/Database/CreateScheduledBackup.php` | Modified |
| `app/Livewire/Project/Database/BackupEdit.php` | Modified |
| `app/Livewire/Project/Database/Postgresql/General.php` | Modified |
| `app/Http/Controllers/Api/DatabasesController.php` | Modified |
| `routes/api.php` | Modified |
| 3 Blade views | Modified |