### PR TITLE
feat: Container File Browser - Browse, upload, download files inside containers

### DIFF
--- a/app/Livewire/Project/Shared/ContainerFileBrowser.php
+++ b/app/Livewire/Project/Shared/ContainerFileBrowser.php
@@ -1,0 +1,482 @@
+<?php
+
+namespace App\Livewire\Project\Shared;
+
+use App\Models\Application;
+use App\Models\Server;
+use App\Models\Service;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+use Livewire\Component;
+use Livewire\WithFileUploads;
+use Visus\Cuid2\Cuid2;
+
+class ContainerFileBrowser extends Component
+{
+    use WithFileUploads;
+
+    public $resource;
+
+    public Collection $servers;
+
+    public Collection $containers;
+
+    public string $selectedContainer = '';
+
+    public string $currentPath = '/';
+
+    public array $entries = [];
+
+    public array $breadcrumbs = [];
+
+    public string $newFolderName = '';
+
+    public $uploadFile;
+
+    public bool $isLoading = false;
+
+    public ?string $deleteTarget = null;
+
+    public function mount($resource)
+    {
+        $this->resource = $resource;
+        $this->containers = collect();
+        $this->servers = collect();
+
+        if ($this->resource instanceof Application) {
+            if ($this->resource->destination->server->isFunctional()) {
+                $this->servers = $this->servers->push($this->resource->destination->server);
+            }
+            foreach ($this->resource->additional_servers as $server) {
+                if ($server->isFunctional()) {
+                    $this->servers = $this->servers->push($server);
+                }
+            }
+        } elseif ($this->resource instanceof Service) {
+            if ($this->resource->server->isFunctional()) {
+                $this->servers = $this->servers->push($this->resource->server);
+            }
+        } else {
+            // Database types
+            if ($this->resource->destination->server->isFunctional()) {
+                $this->servers = $this->servers->push($this->resource->destination->server);
+            }
+        }
+
+        $this->loadContainers();
+    }
+
+    public function loadContainers()
+    {
+        $this->containers = collect();
+        foreach ($this->servers as $server) {
+            if ($this->resource instanceof Application) {
+                $containers = getCurrentApplicationContainerStatus($server, $this->resource->id, includePullrequests: true);
+                foreach ($containers as $container) {
+                    if (data_get($container, 'State') === 'running') {
+                        $this->containers->push([
+                            'server' => $server,
+                            'container' => $container,
+                        ]);
+                    }
+                }
+            } elseif ($this->resource instanceof Service) {
+                $this->resource->applications()->get()->each(function ($application) {
+                    if ($application->isRunning()) {
+                        $this->containers->push([
+                            'server' => $this->resource->server,
+                            'container' => [
+                                'Names' => data_get($application, 'name').'-'.data_get($this->resource, 'uuid'),
+                            ],
+                        ]);
+                    }
+                });
+                $this->resource->databases()->get()->each(function ($database) {
+                    if ($database->isRunning()) {
+                        $this->containers->push([
+                            'server' => $this->resource->server,
+                            'container' => [
+                                'Names' => data_get($database, 'name').'-'.data_get($this->resource, 'uuid'),
+                            ],
+                        ]);
+                    }
+                });
+            } else {
+                // Database types
+                if ($this->resource->isRunning()) {
+                    $this->containers->push([
+                        'server' => $server,
+                        'container' => ['Names' => $this->resource->uuid],
+                    ]);
+                }
+            }
+        }
+
+        if ($this->containers->count() === 1) {
+            $this->selectedContainer = data_get($this->containers->first(), 'container.Names');
+            $this->loadDirectory();
+        }
+    }
+
+    public function selectContainer(string $containerName)
+    {
+        $this->selectedContainer = $containerName;
+        $this->currentPath = '/';
+        $this->loadDirectory();
+    }
+
+    private function getServer(): ?Server
+    {
+        $container = $this->containers->firstWhere('container.Names', $this->selectedContainer);
+
+        return data_get($container, 'server');
+    }
+
+    private function sanitizePath(string $path): string
+    {
+        // Normalize the path - resolve .. and . and prevent traversal
+        $path = str_replace('\\', '/', $path);
+        $parts = explode('/', $path);
+        $resolved = [];
+        foreach ($parts as $part) {
+            if ($part === '' || $part === '.') {
+                continue;
+            }
+            if ($part === '..') {
+                array_pop($resolved);
+            } else {
+                $resolved[] = $part;
+            }
+        }
+
+        return '/'.implode('/', $resolved);
+    }
+
+    public function loadDirectory()
+    {
+        if (empty($this->selectedContainer)) {
+            return;
+        }
+
+        $server = $this->getServer();
+        if (! $server) {
+            $this->dispatch('error', 'Server not found.');
+
+            return;
+        }
+
+        $this->isLoading = true;
+        $safePath = escapeshellarg($this->currentPath);
+        $safeContainer = escapeshellarg($this->selectedContainer);
+
+        try {
+            $output = instant_remote_process(
+                ["docker exec {$safeContainer} ls -la --time-style=long-iso {$safePath} 2>/dev/null || echo 'COOLIFY_LS_ERROR'"],
+                $server,
+                throwError: false
+            );
+
+            if (str_contains($output, 'COOLIFY_LS_ERROR') || is_null($output)) {
+                $this->dispatch('error', 'Could not read directory.');
+                $this->entries = [];
+                $this->isLoading = false;
+
+                return;
+            }
+
+            $this->entries = $this->parseLsOutput($output);
+            $this->buildBreadcrumbs();
+        } catch (\Throwable $e) {
+            $this->dispatch('error', 'Failed to list directory: '.$e->getMessage());
+            $this->entries = [];
+        }
+
+        $this->isLoading = false;
+    }
+
+    private function parseLsOutput(string $output): array
+    {
+        $lines = explode("\n", trim($output));
+        $entries = [];
+
+        foreach ($lines as $line) {
+            $line = trim($line);
+            // Skip total line and empty lines
+            if (empty($line) || str_starts_with($line, 'total ')) {
+                continue;
+            }
+
+            // Parse ls -la output:
+            // drwxr-xr-x 2 root root 4096 2024-01-15 10:30 dirname
+            // -rw-r--r-- 1 root root 1234 2024-01-15 10:30 filename
+            if (! preg_match('/^([dlcbsp\-][rwxsStT\-]{9})\s+\d+\s+(\S+)\s+(\S+)\s+(\d+)\s+(\d{4}-\d{2}-\d{2})\s+(\d{2}:\d{2})\s+(.+)$/', $line, $matches)) {
+                continue;
+            }
+
+            $name = $matches[7];
+            // Skip . and .. entries
+            if ($name === '.' || $name === '..') {
+                continue;
+            }
+
+            $permissions = $matches[1];
+            $isDirectory = str_starts_with($permissions, 'd');
+            $isSymlink = str_starts_with($permissions, 'l');
+            $size = (int) $matches[4];
+
+            // For symlinks, extract the target
+            $symlinkTarget = null;
+            if ($isSymlink && str_contains($name, ' -> ')) {
+                [$name, $symlinkTarget] = explode(' -> ', $name, 2);
+            }
+
+            $entries[] = [
+                'name' => $name,
+                'permissions' => $permissions,
+                'owner' => $matches[2],
+                'group' => $matches[3],
+                'size' => $size,
+                'date' => $matches[5],
+                'time' => $matches[6],
+                'is_directory' => $isDirectory,
+                'is_symlink' => $isSymlink,
+                'symlink_target' => $symlinkTarget,
+                'path' => rtrim($this->currentPath, '/').'/'.$name,
+            ];
+        }
+
+        // Sort: directories first, then files, alphabetically
+        usort($entries, function ($a, $b) {
+            if ($a['is_directory'] !== $b['is_directory']) {
+                return $b['is_directory'] <=> $a['is_directory'];
+            }
+
+            return strcasecmp($a['name'], $b['name']);
+        });
+
+        return $entries;
+    }
+
+    private function buildBreadcrumbs()
+    {
+        $parts = array_filter(explode('/', $this->currentPath));
+        $this->breadcrumbs = [];
+        $path = '';
+        foreach ($parts as $part) {
+            $path .= '/'.$part;
+            $this->breadcrumbs[] = ['name' => $part, 'path' => $path];
+        }
+    }
+
+    public function navigateTo(string $path)
+    {
+        $this->currentPath = $this->sanitizePath($path);
+        $this->loadDirectory();
+    }
+
+    public function navigateUp()
+    {
+        if ($this->currentPath === '/') {
+            return;
+        }
+        $this->currentPath = dirname($this->currentPath);
+        if ($this->currentPath === '.') {
+            $this->currentPath = '/';
+        }
+        $this->loadDirectory();
+    }
+
+    public function createFolder()
+    {
+        if (empty($this->newFolderName)) {
+            $this->dispatch('error', 'Folder name cannot be empty.');
+
+            return;
+        }
+
+        // Validate folder name - no slashes or special characters
+        if (preg_match('/[\/\0]/', $this->newFolderName)) {
+            $this->dispatch('error', 'Invalid folder name.');
+
+            return;
+        }
+
+        $server = $this->getServer();
+        if (! $server) {
+            return;
+        }
+
+        $fullPath = rtrim($this->currentPath, '/').'/'.$this->newFolderName;
+        $safePath = escapeshellarg($fullPath);
+        $safeContainer = escapeshellarg($this->selectedContainer);
+
+        try {
+            instant_remote_process(
+                ["docker exec {$safeContainer} mkdir -p {$safePath}"],
+                $server
+            );
+            $this->newFolderName = '';
+            $this->dispatch('success', 'Folder created successfully.');
+            $this->loadDirectory();
+        } catch (\Throwable $e) {
+            $this->dispatch('error', 'Failed to create folder: '.$e->getMessage());
+        }
+    }
+
+    public function confirmDelete(string $path)
+    {
+        $this->deleteTarget = $path;
+    }
+
+    public function cancelDelete()
+    {
+        $this->deleteTarget = null;
+    }
+
+    public function deleteEntry()
+    {
+        if (empty($this->deleteTarget)) {
+            return;
+        }
+
+        $server = $this->getServer();
+        if (! $server) {
+            return;
+        }
+
+        $safePath = escapeshellarg($this->sanitizePath($this->deleteTarget));
+        $safeContainer = escapeshellarg($this->selectedContainer);
+
+        try {
+            instant_remote_process(
+                ["docker exec {$safeContainer} rm -rf {$safePath}"],
+                $server
+            );
+            $this->deleteTarget = null;
+            $this->dispatch('success', 'Deleted successfully.');
+            $this->loadDirectory();
+        } catch (\Throwable $e) {
+            $this->dispatch('error', 'Failed to delete: '.$e->getMessage());
+        }
+    }
+
+    public function prepareDownload(string $path)
+    {
+        $server = $this->getServer();
+        if (! $server) {
+            $this->dispatch('error', 'Server not found.');
+
+            return;
+        }
+
+        $sanitizedPath = $this->sanitizePath($path);
+        $token = (string) new Cuid2;
+        $tempPath = "/tmp/coolify-filebrowser-{$token}";
+        $safePath = escapeshellarg($sanitizedPath);
+        $safeContainer = escapeshellarg($this->selectedContainer);
+        $safeTempPath = escapeshellarg($tempPath);
+
+        try {
+            instant_remote_process(
+                ["docker cp {$safeContainer}:{$safePath} {$safeTempPath}"],
+                $server
+            );
+
+            Cache::put("container-file-download:{$token}", [
+                'server_id' => $server->id,
+                'temp_path' => $tempPath,
+                'filename' => basename($sanitizedPath),
+                'team_id' => auth()->user()->currentTeam()->id,
+            ], now()->addMinutes(5));
+
+            $this->js("window.open('".route('download.container-file', ['token' => $token])."', '_blank')");
+        } catch (\Throwable $e) {
+            $this->dispatch('error', 'Failed to prepare download: '.$e->getMessage());
+        }
+    }
+
+    public function updatedUploadFile()
+    {
+        $this->uploadFileToContainer();
+    }
+
+    public function uploadFileToContainer()
+    {
+        if (! $this->uploadFile) {
+            return;
+        }
+
+        $server = $this->getServer();
+        if (! $server) {
+            $this->dispatch('error', 'Server not found.');
+
+            return;
+        }
+
+        $originalName = $this->uploadFile->getClientOriginalName();
+        // Sanitize filename
+        if (preg_match('/[\/\0]/', $originalName)) {
+            $this->dispatch('error', 'Invalid filename.');
+
+            return;
+        }
+
+        $token = (string) new Cuid2;
+        $localTempPath = $this->uploadFile->getRealPath();
+        $remoteTempPath = "/tmp/coolify-upload-{$token}";
+        $containerDestPath = rtrim($this->currentPath, '/').'/'.$originalName;
+
+        $safeContainer = escapeshellarg($this->selectedContainer);
+        $safeRemoteTempPath = escapeshellarg($remoteTempPath);
+        $safeContainerDestPath = escapeshellarg($containerDestPath);
+
+        try {
+            // Upload to server via SCP using the server's SSH key
+            $privateKeyLocation = $server->privateKey->getKeyLocation();
+            $sshPort = $server->port;
+            $sshUser = $server->user;
+            $sshHost = $server->ip;
+
+            $scpCommand = "scp -P {$sshPort} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i {$privateKeyLocation} ".
+                escapeshellarg($localTempPath)." {$sshUser}@{$sshHost}:{$remoteTempPath}";
+
+            \Illuminate\Support\Facades\Process::timeout(120)->run($scpCommand);
+
+            // docker cp into container
+            instant_remote_process(
+                [
+                    "docker cp {$safeRemoteTempPath} {$safeContainer}:{$safeContainerDestPath}",
+                    "rm -f {$safeRemoteTempPath}",
+                ],
+                $server
+            );
+
+            $this->uploadFile = null;
+            $this->dispatch('success', 'File uploaded successfully.');
+            $this->loadDirectory();
+        } catch (\Throwable $e) {
+            $this->dispatch('error', 'Failed to upload file: '.$e->getMessage());
+            // Cleanup remote temp file
+            try {
+                instant_remote_process(["rm -f {$safeRemoteTempPath}"], $server, throwError: false);
+            } catch (\Throwable) {
+            }
+        }
+    }
+
+    public static function formatSize(int $bytes): string
+    {
+        if ($bytes === 0) {
+            return '0 B';
+        }
+        $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+        $i = floor(log($bytes, 1024));
+
+        return round($bytes / pow(1024, $i), 1).' '.$units[$i];
+    }
+
+    public function render()
+    {
+        return view('livewire.project.shared.container-file-browser');
+    }
+}

--- a/resources/views/livewire/project/application/configuration.blade.php
+++ b/resources/views/livewire/project/application/configuration.blade.php
@@ -20,6 +20,8 @@
                 href="{{ route('project.application.environment-variables', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Environment Variables</span></a>
             <a class='sub-menu-item' {{ wireNavigate() }} wire:current.exact="menu-item-active"
                 href="{{ route('project.application.persistent-storage', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Persistent Storage</span></a>
+            <a class='sub-menu-item' {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                href="{{ route('project.application.file-browser', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">File Browser</span></a>
             @if ($application->git_based())
                 <a class='sub-menu-item' {{ wireNavigate() }} wire:current.exact="menu-item-active"
                     href="{{ route('project.application.source', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Git Source</span></a>
@@ -78,6 +80,8 @@
                 <livewire:project.shared.environment-variable.all :resource="$application" />
             @elseif ($currentRoute === 'project.application.persistent-storage')
                 <livewire:project.service.storage :resource="$application" />
+            @elseif ($currentRoute === 'project.application.file-browser')
+                <livewire:project.shared.container-file-browser :resource="$application" />
             @elseif ($currentRoute === 'project.application.source' && $application->git_based())
                 <livewire:project.application.source :application="$application" />
             @elseif ($currentRoute === 'project.application.servers')

--- a/resources/views/livewire/project/database/configuration.blade.php
+++ b/resources/views/livewire/project/database/configuration.blade.php
@@ -15,6 +15,8 @@
                 href="{{ route('project.database.servers', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'database_uuid' => $database->uuid]) }}"><span class="menu-item-label">Servers</span></a>
             <a class='sub-menu-item' {{ wireNavigate() }} wire:current.exact="menu-item-active"
                 href="{{ route('project.database.persistent-storage', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'database_uuid' => $database->uuid]) }}"><span class="menu-item-label">Persistent Storage</span></a>
+            <a class='sub-menu-item' {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                href="{{ route('project.database.file-browser', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'database_uuid' => $database->uuid]) }}"><span class="menu-item-label">File Browser</span></a>
             @can('update', $database)
                 <a class='sub-menu-item' wire:current.exact="menu-item-active"
                     href="{{ route('project.database.import-backup', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'database_uuid' => $database->uuid]) }}"><span class="menu-item-label">Import Backup</span></a>
@@ -57,6 +59,8 @@
                 <livewire:project.shared.destination :resource="$database" />
             @elseif ($currentRoute === 'project.database.persistent-storage')
                 <livewire:project.service.storage :resource="$database" />
+            @elseif ($currentRoute === 'project.database.file-browser')
+                <livewire:project.shared.container-file-browser :resource="$database" />
             @elseif ($currentRoute === 'project.database.import-backup')
                 <livewire:project.database.import :resource="$database" />
             @elseif ($currentRoute === 'project.database.webhooks')

--- a/resources/views/livewire/project/service/configuration.blade.php
+++ b/resources/views/livewire/project/service/configuration.blade.php
@@ -15,6 +15,8 @@
             <a class='sub-menu-item' wire:current.exact="menu-item-active" {{ wireNavigate() }}
                 href="{{ route('project.service.storages', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'service_uuid' => $service->uuid]) }}"><span class="menu-item-label">Persistent Storages</span></a>
             <a class='sub-menu-item' wire:current.exact="menu-item-active" {{ wireNavigate() }}
+                href="{{ route('project.service.file-browser', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'service_uuid' => $service->uuid]) }}"><span class="menu-item-label">File Browser</span></a>
+            <a class='sub-menu-item' wire:current.exact="menu-item-active" {{ wireNavigate() }}
                 href="{{ route('project.service.scheduled-tasks.show', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'service_uuid' => $service->uuid]) }}"><span class="menu-item-label">Scheduled Tasks</span></a>
             <a class='sub-menu-item' wire:current.exact="menu-item-active" {{ wireNavigate() }}
                 href="{{ route('project.service.webhooks', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'service_uuid' => $service->uuid]) }}"><span class="menu-item-label">Webhooks</span></a>
@@ -188,6 +190,8 @@
                 @foreach ($databases as $database)
                     <livewire:project.service.storage wire:key="database-{{ $database->id }}" :resource="$database" />
                 @endforeach
+            @elseif ($currentRoute === 'project.service.file-browser')
+                <livewire:project.shared.container-file-browser :resource="$service" />
             @elseif ($currentRoute === 'project.service.scheduled-tasks.show')
                 <livewire:project.shared.scheduled-task.all :resource="$service" />
             @elseif ($currentRoute === 'project.service.webhooks')

--- a/resources/views/livewire/project/shared/container-file-browser.blade.php
+++ b/resources/views/livewire/project/shared/container-file-browser.blade.php
@@ -1,0 +1,231 @@
+<div>
+    <div x-data="{
+        showNewFolderInput: false,
+    }">
+
+        {{-- Container Selector --}}
+        @if ($containers->count() === 0)
+            <div class="pt-4">
+                <p>No running containers found. Deploy the resource first.</p>
+            </div>
+        @elseif ($containers->count() > 1 && empty($selectedContainer))
+            <div class="pt-4">
+                <h3 class="pb-2">Select a Container</h3>
+                <div class="flex flex-wrap gap-2">
+                    @foreach ($containers as $container)
+                        <x-forms.button
+                            wire:click="selectContainer('{{ data_get($container, 'container.Names') }}')"
+                        >
+                            {{ data_get($container, 'container.Names') }}
+                            <span class="text-xs opacity-60">({{ data_get($container, 'server.name') }})</span>
+                        </x-forms.button>
+                    @endforeach
+                </div>
+            </div>
+        @endif
+
+        @if (!empty($selectedContainer))
+            {{-- Toolbar --}}
+            <div class="flex flex-wrap items-center gap-2 pb-4">
+                @if ($containers->count() > 1)
+                    <select wire:change="selectContainer($event.target.value)"
+                        class="px-3 py-1.5 text-sm border rounded bg-coolgray-100 border-coolgray-300 dark:bg-coolgray-100 dark:border-coolgray-300">
+                        @foreach ($containers as $container)
+                            <option value="{{ data_get($container, 'container.Names') }}"
+                                @selected(data_get($container, 'container.Names') === $selectedContainer)>
+                                {{ data_get($container, 'container.Names') }}
+                            </option>
+                        @endforeach
+                    </select>
+                @endif
+
+                <x-forms.button wire:click="loadDirectory" title="Refresh">
+                    <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182M2.985 19.644l3.181-3.182" />
+                    </svg>
+                    Refresh
+                </x-forms.button>
+
+                <x-forms.button @click="showNewFolderInput = !showNewFolderInput" title="New Folder">
+                    <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 10.5v6m3-3H9m4.06-7.19l-2.12-2.12a1.5 1.5 0 00-1.06-.44H4.5A2.25 2.25 0 002.25 6v12a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9a2.25 2.25 0 00-2.25-2.25h-5.379a1.5 1.5 0 01-1.06-.44z" />
+                    </svg>
+                    New Folder
+                </x-forms.button>
+
+                <label class="button cursor-pointer" title="Upload File">
+                    <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" />
+                    </svg>
+                    Upload
+                    <input type="file" wire:model="uploadFile" class="hidden" />
+                </label>
+            </div>
+
+            {{-- Upload progress --}}
+            <div wire:loading wire:target="uploadFile" class="pb-2 text-sm text-warning">
+                Uploading file...
+            </div>
+
+            {{-- New Folder Input --}}
+            <div x-show="showNewFolderInput" x-cloak class="flex items-center gap-2 pb-4">
+                <input type="text" wire:model="newFolderName" wire:keydown.enter="createFolder"
+                    placeholder="Folder name"
+                    class="px-3 py-1.5 text-sm border rounded bg-coolgray-100 border-coolgray-300 dark:bg-coolgray-100 dark:border-coolgray-300 w-64">
+                <x-forms.button wire:click="createFolder" @click="showNewFolderInput = false">Create</x-forms.button>
+                <x-forms.button @click="showNewFolderInput = false; $wire.set('newFolderName', '')">Cancel</x-forms.button>
+            </div>
+
+            {{-- Breadcrumb Navigation --}}
+            <div class="flex items-center gap-1 pb-3 text-sm flex-wrap">
+                <button wire:click="navigateTo('/')" class="hover:text-white transition-colors"
+                    title="Go to root">
+                    <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12l8.954-8.955a1.126 1.126 0 011.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
+                    </svg>
+                </button>
+                <span class="opacity-40">/</span>
+                @foreach ($breadcrumbs as $crumb)
+                    <button wire:click="navigateTo('{{ $crumb['path'] }}')"
+                        class="hover:text-white transition-colors hover:underline">
+                        {{ $crumb['name'] }}
+                    </button>
+                    @if (!$loop->last)
+                        <span class="opacity-40">/</span>
+                    @endif
+                @endforeach
+                @if ($currentPath !== '/')
+                    <button wire:click="navigateUp" class="ml-2 opacity-60 hover:opacity-100 transition-opacity" title="Go up">
+                        <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M9 15L3 9m0 0l6-6M3 9h12a6 6 0 010 12h-3" />
+                        </svg>
+                    </button>
+                @endif
+            </div>
+
+            {{-- Loading State --}}
+            <div wire:loading wire:target="navigateTo,loadDirectory,deleteEntry,createFolder" class="pb-2 text-sm opacity-60">
+                Loading...
+            </div>
+
+            {{-- Delete Confirmation --}}
+            @if ($deleteTarget)
+                <div class="flex items-center gap-3 p-3 mb-3 border rounded border-error/50 bg-error/10">
+                    <svg class="w-5 h-5 text-error shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+                    </svg>
+                    <span class="text-sm">Delete <strong>{{ basename($deleteTarget) }}</strong>?</span>
+                    <x-forms.button isError wire:click="deleteEntry">Delete</x-forms.button>
+                    <x-forms.button wire:click="cancelDelete">Cancel</x-forms.button>
+                </div>
+            @endif
+
+            {{-- File Table --}}
+            <div class="overflow-x-auto">
+                <table class="w-full text-sm">
+                    <thead>
+                        <tr class="text-left border-b border-coolgray-300">
+                            <th class="pb-2 pr-4 font-medium w-8"></th>
+                            <th class="pb-2 pr-4 font-medium">Name</th>
+                            <th class="pb-2 pr-4 font-medium w-24 hidden sm:table-cell">Size</th>
+                            <th class="pb-2 pr-4 font-medium w-40 hidden md:table-cell">Modified</th>
+                            <th class="pb-2 pr-4 font-medium w-28 hidden lg:table-cell">Permissions</th>
+                            <th class="pb-2 font-medium w-24 text-right">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse ($entries as $entry)
+                            <tr class="border-b border-coolgray-300/30 hover:bg-coolgray-200/30 transition-colors group">
+                                {{-- Icon --}}
+                                <td class="py-2 pr-2">
+                                    @if ($entry['is_directory'])
+                                        <svg class="w-5 h-5 text-warning" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.75V12A2.25 2.25 0 014.5 9.75h15A2.25 2.25 0 0121.75 12v.75m-8.69-6.44l-2.12-2.12a1.5 1.5 0 00-1.06-.44H4.5A2.25 2.25 0 002.25 6v12a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9a2.25 2.25 0 00-2.25-2.25h-5.379a1.5 1.5 0 01-1.06-.44z" />
+                                        </svg>
+                                    @elseif ($entry['is_symlink'])
+                                        <svg class="w-5 h-5 text-info" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M13.19 8.688a4.5 4.5 0 011.242 7.244l-4.5 4.5a4.5 4.5 0 01-6.364-6.364l1.757-1.757m9.86-2.439a4.5 4.5 0 00-1.242-7.244l-4.5-4.5a4.5 4.5 0 10-6.364 6.364l1.757 1.757" />
+                                        </svg>
+                                    @else
+                                        <svg class="w-5 h-5 opacity-60" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
+                                        </svg>
+                                    @endif
+                                </td>
+
+                                {{-- Name --}}
+                                <td class="py-2 pr-4">
+                                    @if ($entry['is_directory'])
+                                        <button wire:click="navigateTo('{{ $entry['path'] }}')"
+                                            class="hover:text-white hover:underline transition-colors font-medium">
+                                            {{ $entry['name'] }}
+                                        </button>
+                                    @else
+                                        <span>{{ $entry['name'] }}</span>
+                                    @endif
+                                    @if ($entry['is_symlink'] && $entry['symlink_target'])
+                                        <span class="text-xs opacity-40 ml-1">→ {{ $entry['symlink_target'] }}</span>
+                                    @endif
+                                </td>
+
+                                {{-- Size --}}
+                                <td class="py-2 pr-4 opacity-60 hidden sm:table-cell">
+                                    @if (!$entry['is_directory'])
+                                        {{ \App\Livewire\Project\Shared\ContainerFileBrowser::formatSize($entry['size']) }}
+                                    @else
+                                        —
+                                    @endif
+                                </td>
+
+                                {{-- Modified --}}
+                                <td class="py-2 pr-4 opacity-60 hidden md:table-cell">
+                                    {{ $entry['date'] }} {{ $entry['time'] }}
+                                </td>
+
+                                {{-- Permissions --}}
+                                <td class="py-2 pr-4 font-mono text-xs opacity-60 hidden lg:table-cell">
+                                    {{ $entry['permissions'] }}
+                                </td>
+
+                                {{-- Actions --}}
+                                <td class="py-2 text-right">
+                                    <div class="flex items-center justify-end gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                                        @if (!$entry['is_directory'])
+                                            <button wire:click="prepareDownload('{{ $entry['path'] }}')"
+                                                class="p-1 rounded hover:bg-coolgray-300 transition-colors" title="Download">
+                                                <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
+                                                </svg>
+                                            </button>
+                                        @endif
+                                        <button wire:click="confirmDelete('{{ $entry['path'] }}')"
+                                            class="p-1 rounded hover:bg-error/20 text-error transition-colors" title="Delete">
+                                            <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
+                                            </svg>
+                                        </button>
+                                    </div>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="6" class="py-8 text-center opacity-60">
+                                    @if ($isLoading)
+                                        Loading directory contents...
+                                    @else
+                                        This directory is empty.
+                                    @endif
+                                </td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+
+            {{-- Current path display --}}
+            <div class="pt-3 text-xs opacity-40">
+                Container: {{ $selectedContainer }} · Path: {{ $currentPath }}
+            </div>
+        @endif
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -212,6 +212,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/deployment', DeploymentIndex::class)->name('project.application.deployment.index');
         Route::get('/deployment/{deployment_uuid}', DeploymentShow::class)->name('project.application.deployment.show');
         Route::get('/logs', Logs::class)->name('project.application.logs');
+        Route::get('/file-browser', ApplicationConfiguration::class)->name('project.application.file-browser');
         Route::get('/terminal', ExecuteContainerCommand::class)->name('project.application.command')->middleware('can.access.terminal');
         Route::get('/tasks/{task_uuid}', ScheduledTaskShow::class)->name('project.application.scheduled-tasks');
     });
@@ -229,6 +230,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/danger', DatabaseConfiguration::class)->name('project.database.danger');
 
         Route::get('/logs', Logs::class)->name('project.database.logs');
+        Route::get('/file-browser', DatabaseConfiguration::class)->name('project.database.file-browser');
         Route::get('/terminal', ExecuteContainerCommand::class)->name('project.database.command')->middleware('can.access.terminal');
         Route::get('/backups', DatabaseBackupIndex::class)->name('project.database.backup.index');
         Route::get('/backups/{backup_uuid}', DatabaseBackupExecution::class)->name('project.database.backup.execution');
@@ -243,6 +245,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/resource-operations', ServiceConfiguration::class)->name('project.service.resource-operations');
         Route::get('/tags', ServiceConfiguration::class)->name('project.service.tags');
         Route::get('/danger', ServiceConfiguration::class)->name('project.service.danger');
+        Route::get('/file-browser', ServiceConfiguration::class)->name('project.service.file-browser');
         Route::get('/terminal', ExecuteContainerCommand::class)->name('project.service.command')->middleware('can.access.terminal');
         Route::get('/{stack_service_uuid}/backups', ServiceDatabaseBackups::class)->name('project.service.database.backups');
         Route::get('/{stack_service_uuid}/import', ServiceIndex::class)->name('project.service.database.import')->middleware('can.update.resource');
@@ -372,6 +375,70 @@ Route::middleware(['auth'])->group(function () {
             return response()->json(['message' => $e->getMessage()], 500);
         }
     })->name('download.backup');
+
+    Route::get('/download/container-file/{token}', function () {
+        try {
+            $user = auth()->user();
+            $team = $user->currentTeam();
+            if (is_null($team)) {
+                return response()->json(['message' => 'Team not found.'], 404);
+            }
+
+            $token = request()->route('token');
+            $downloadInfo = \Illuminate\Support\Facades\Cache::pull("container-file-download:{$token}");
+            if (is_null($downloadInfo)) {
+                return response()->json(['message' => 'Download link expired or invalid.'], 404);
+            }
+
+            if ($team->id !== data_get($downloadInfo, 'team_id')) {
+                return response()->json(['message' => 'Permission denied.'], 403);
+            }
+
+            $server = \App\Models\Server::findOrFail(data_get($downloadInfo, 'server_id'));
+            $tempPath = data_get($downloadInfo, 'temp_path');
+            $filename = data_get($downloadInfo, 'filename');
+
+            $privateKeyLocation = $server->privateKey->getKeyLocation();
+            $disk = Storage::build([
+                'driver' => 'sftp',
+                'host' => $server->ip,
+                'port' => (int) $server->port,
+                'username' => $server->user,
+                'privateKey' => $privateKeyLocation,
+                'root' => '/',
+            ]);
+
+            if (! $disk->exists($tempPath)) {
+                return response()->json(['message' => 'File not found on server.'], 404);
+            }
+
+            return new StreamedResponse(function () use ($disk, $tempPath, $server) {
+                if (ob_get_level()) {
+                    ob_end_clean();
+                }
+                $stream = $disk->readStream($tempPath);
+                if ($stream === false || is_null($stream)) {
+                    abort(500, 'Failed to open stream for the requested file.');
+                }
+                while (! feof($stream)) {
+                    echo fread($stream, 2048);
+                    flush();
+                }
+                fclose($stream);
+
+                // Cleanup temp file on server
+                try {
+                    instant_remote_process(['rm -f '.escapeshellarg($tempPath)], $server, throwError: false);
+                } catch (\Throwable) {
+                }
+            }, 200, [
+                'Content-Type' => 'application/octet-stream',
+                'Content-Disposition' => 'attachment; filename="'.$filename.'"',
+            ]);
+        } catch (\Throwable $e) {
+            return response()->json(['message' => $e->getMessage()], 500);
+        }
+    })->name('download.container-file');
 
 });
 


### PR DESCRIPTION
## Summary

Resolves #6519
/claim #6519

Adds a **file browser UI** for containers that lets users browse, upload, download, create, and delete files directly from the Coolify dashboard.

## Features

- **Browse files** inside running containers with a familiar explorer-style interface
- **Navigate** with breadcrumb path navigation and click-to-enter directories
- **Upload files** into containers (Livewire upload → SCP → docker cp)
- **Download files** from containers (docker cp → SFTP stream)
- **Create folders** inside containers
- **Delete files/folders** with confirmation prompt
- **View details**: permissions, owner/group, size, modification date
- **Symlink detection** and display
- **Multi-container support**: select which container to browse when multiple are running
- Works with **applications, databases, and services**

## Technical Details

- **New Livewire component**: `App\Livewire\Project\Shared\ContainerFileBrowser`
- All file operations use `docker exec` / `docker cp` via existing `instant_remote_process()`
- **Security**: Path traversal prevention, all user inputs escaped with `escapeshellarg()`
- File downloads use **cache-based tokens** with 5-minute expiry + SFTP streaming (matches existing backup download pattern)
- Integrated as a **sidebar tab** ("File Browser") in application, database, and service configuration views
- Follows existing Coolify Livewire/Blade patterns and dark theme

## Files Changed (792 lines)

| File | Change |
|------|--------|
| `app/Livewire/Project/Shared/ContainerFileBrowser.php` | New Livewire component |
| `resources/views/livewire/project/shared/container-file-browser.blade.php` | New Blade view |
| `routes/web.php` | Added file-browser routes + download endpoint |
| `resources/views/livewire/project/application/configuration.blade.php` | Added sidebar menu item |
| `resources/views/livewire/project/database/configuration.blade.php` | Added sidebar menu item |
| `resources/views/livewire/project/service/configuration.blade.php` | Added sidebar menu item |

## UI Preview

The file browser appears as a new tab in the configuration sidebar, right after "Persistent Storage". It provides:
- Toolbar with Refresh, New Folder, and Upload buttons
- Breadcrumb path navigation
- File/folder table with icons, names, sizes, dates, permissions, and action buttons
- Confirmation dialog for deletions
- Container selector when multiple containers are running
