### PR TITLE
fix(ssh): pass custom timeout to shell timeout command

### DIFF
--- a/app/Helpers/SshMultiplexingHelper.php
+++ b/app/Helpers/SshMultiplexingHelper.php
@@ -149,7 +149,7 @@ class SshMultiplexingHelper
         return $scp_command;
     }
 
-    public static function generateSshCommand(Server $server, string $command, bool $disableMultiplexing = false)
+    public static function generateSshCommand(Server $server, string $command, bool $disableMultiplexing = false, ?int $timeout = null)
     {
         if ($server->settings->force_disabled) {
             throw new \RuntimeException('Server is disabled.');
@@ -162,7 +162,7 @@ class SshMultiplexingHelper
 
         $muxSocket = $sshConfig['muxFilename'];
 
-        $timeout = config('constants.ssh.command_timeout');
+        $timeout = $timeout ?? config('constants.ssh.command_timeout');
         $muxPersistTime = config('constants.ssh.mux_persist_time');
 
         $ssh_command = "timeout $timeout ssh ";

--- a/bootstrap/helpers/remoteProcess.php
+++ b/bootstrap/helpers/remoteProcess.php
@@ -130,7 +130,7 @@ function instant_remote_process(Collection|array $command, Server $server, bool 
 
     return \App\Helpers\SshRetryHandler::retry(
         function () use ($server, $command_string, $effectiveTimeout, $disableMultiplexing) {
-            $sshCommand = SshMultiplexingHelper::generateSshCommand($server, $command_string, $disableMultiplexing);
+            $sshCommand = SshMultiplexingHelper::generateSshCommand($server, $command_string, $disableMultiplexing, $effectiveTimeout);
             $process = Process::timeout($effectiveTimeout)->run($sshCommand);
 
             $output = trim($process->output());


### PR DESCRIPTION
## Summary
Fixes #7473

## Problem
The custom timeout configured for database backups was only being passed to PHP's `Process::timeout()` but not to the shell-level `timeout` command wrapping SSH. This caused backups to fail at 3600s regardless of the configured timeout.

## Root Cause
In `SshMultiplexingHelper::generateSshCommand()`, the timeout was always hardcoded:
```php
$timeout = config('constants.ssh.command_timeout'); // Always 3600
```

## Solution
- Add optional `$timeout` parameter to `generateSshCommand()`
- Pass `$effectiveTimeout` from `instant_remote_process()` to `generateSshCommand()`

## Changes
| File | Change |
|------|--------|
| `app/Helpers/SshMultiplexingHelper.php` | Added optional `$timeout` parameter |
| `bootstrap/helpers/remoteProcess.php` | Pass `$effectiveTimeout` to `generateSshCommand()` |

## Backward Compatibility
✅ Fully backward compatible - the new `$timeout` parameter is optional with `null` default, falling back to the existing config value.

## Testing
- Syntax validated
- Minimal change (2 files, 3 insertions, 3 deletions)