### PR TITLE
fix(api): infinite loop when number of github repos > 100

### DIFF
--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -1344,21 +1344,20 @@ class ApplicationsController extends Controller
                 return response()->json(['message' => 'Failed to generate Github App token.'], 400);
             }
 
-            $repositories = collect();
-            $page = 1;
-            $repositories = loadRepositoryByPage($githubApp, $token, $page);
-            if ($repositories['total_count'] > 0) {
-                while (count($repositories['repositories']) < $repositories['total_count']) {
-                    $page++;
-                    $repositories = loadRepositoryByPage($githubApp, $token, $page);
-                }
-            }
-
             $gitRepository = $request->git_repository;
             if (str($gitRepository)->startsWith('http') || str($gitRepository)->contains('github.com')) {
                 $gitRepository = str($gitRepository)->replace('https://', '')->replace('http://', '')->replace('github.com/', '');
             }
-            $gitRepositoryFound = collect($repositories['repositories'])->firstWhere('full_name', $gitRepository);
+
+            $repoResponse = \Illuminate\Support\Facades\Http::withHeaders([
+                'Authorization' => "Bearer {$token}",
+                'Accept' => 'application/vnd.github+json',
+            ])->get("{$githubApp->api_url}/repos/{$gitRepository}");
+
+            if (! $repoResponse->successful()) {
+                return response()->json(['message' => 'Repository not found or not accessible via this GitHub App.'], 404);
+            }
+            $gitRepositoryFound = $repoResponse->json();
             if (! $gitRepositoryFound) {
                 return response()->json(['message' => 'Repository not found.'], 404);
             }


### PR DESCRIPTION
### Changes
Fixed infinite loop cause when github account has > 100 github repos using the API.

### Category
- [x] Bug fix

### AI Usage
- [x] AI is used in the process of creating this PR


### Steps to Test
 Prerequisites:
  1. Coolify instance with GitHub App configured
  2. GitHub App installed with access to >100 repositories (e.g., "All repositories" on an account with 101+ repos)

  Steps:
  1. Get your GitHub App installation's repository count:
```sh
# Should return total_count > 100
curl -H "Authorization: token <INSTALLATION_TOKEN>" \
    "https://api.github.com/installation/repositories?per_page=1" | jq .total_count
```
  2. Call the private-github-app API:
 ```
  curl -X POST "https://<COOLIFY_URL>/api/v1/applications/private-github-app" \
    -H "Authorization: Bearer <COOLIFY_TOKEN>" \
    -H "Content-Type: application/json" \
    -d '{
      "project_uuid": "<PROJECT_UUID>",
      "server_uuid": "<SERVER_UUID>",
      "environment_name": "production",
      "github_app_uuid": "<GITHUB_APP_UUID>",
      "git_repository": "owner/repo",
      "git_branch": "main",
      "build_pack": "nixpacks",
      "ports_exposes": "3000"
    }'
```

  Expected: Returns `{"uuid": "...", "domains": "..."}`

  Actual: 504 Gateway Timeout after ~99 seconds, exhausts GitHub API rate limit

### Contributor Agreement
- [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
- [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them
 
