### PR TITLE
Fix port discovery with Home Assistant

### DIFF
--- a/templates/compose/home-assistant.yaml
+++ b/templates/compose/home-assistant.yaml
@@ -32,6 +32,7 @@ services:
             ip_ban_enabled: true
             login_attempts_threshold: 5
     privileged: true
+    network_mode: host
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8123"]
       interval: 30s


### PR DESCRIPTION
### Changes
Looking at the [Home Assistant Docu](https://www.home-assistant.io/installation/linux#docker-compose) provides the necessary hint `network_mode: host`.

Which in turn leads to the [Docker Compose Docu](https://docs.docker.com/reference/compose-file/services/#network_mode).

> host: Gives the container raw access to the host's network interface.

With that option activated the port `8123` is available and any connection via the localhost works.

```
root@Egghead:~# ss -tulpen | grep 8123
tcp LISTEN 0 128 0.0.0.0:8123 0.0.0.0:* users:(("python3",pid=2043900,fd=11))
```

### Issue 
Fix #8109 

### Category
- [ ] Bug fix
- [ ] New feature
- [ ] Adding new one click service
- [x] Fixing or updating existing one click service

### AI Usage
- [ ] AI is used in the process of creating this PR
- [x] AI is NOT used in the process of creating this PR


### Steps to Test
See steps to reproduce in #8109

Additionally, you can check the ports

```
root@Egghead:~# ss -tulpen | grep 8123
tcp LISTEN 0 128 0.0.0.0:8123 0.0.0.0:* users:(("python3",pid=2043900,fd=11))
```

### Contributor Agreement
- [x] I have read and understood the [contributor guidelines]
- [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them
 
