### PR TITLE
fix: enable database detection and backup support for Docker Compose deployments

### DIFF
--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -93,7 +93,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $this->database = data_get($this->backup, 'database');
-                $this->server = $this->database->service->server;
+                $this->server = $this->database->getServer();
                 $this->s3 = $this->backup->s3;
             } else {
                 $this->database = data_get($this->backup, 'database');
@@ -115,8 +115,9 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $databaseType = $this->database->databaseType();
-                $serviceUuid = $this->database->service->uuid;
-                $serviceName = str($this->database->service->name)->slug();
+                $parentResource = $this->database->getParentResource();
+                $serviceUuid = $parentResource->uuid;
+                $serviceName = str($parentResource->name)->slug();
                 if (str($databaseType)->contains('postgres')) {
                     $this->container_name = "{$this->database->name}-$serviceUuid";
                     $this->directory_name = $serviceName.'-'.$this->container_name;
@@ -630,7 +631,11 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             $endpoint = $this->s3->endpoint;
             $this->s3->testConnection(shouldSave: true);
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
-                $network = $this->database->service->destination->network;
+                if ($this->database->isApplicationDatabase()) {
+                    $network = $this->database->application->destination->network;
+                } else {
+                    $network = $this->database->service->destination->network;
+                }
             } else {
                 $network = $this->database->destination->network;
             }

--- a/app/Livewire/Project/Application/DatabaseBackupDetail.php
+++ b/app/Livewire/Project/Application/DatabaseBackupDetail.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Livewire\Project\Application;
+
+use App\Models\Application;
+use App\Models\ServiceDatabase;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Component;
+
+class DatabaseBackupDetail extends Component
+{
+    use AuthorizesRequests;
+
+    public Application $application;
+
+    public ServiceDatabase $serviceDatabase;
+
+    public bool $isImportSupported = false;
+
+    protected $listeners = ['refreshScheduledBackups' => '$refresh'];
+
+    public function mount()
+    {
+        $this->authorize('view', $this->application);
+
+        if (! $this->serviceDatabase->isBackupSolutionAvailable()) {
+            return redirect()->route('project.application.database-backups', [
+                'project_uuid' => $this->application->environment->project->uuid,
+                'environment_uuid' => $this->application->environment->uuid,
+                'application_uuid' => $this->application->uuid,
+            ]);
+        }
+
+        // Check if import is supported for this database type
+        $dbType = $this->serviceDatabase->databaseType();
+        $supportedTypes = ['mysql', 'mariadb', 'postgres', 'mongo'];
+        $this->isImportSupported = collect($supportedTypes)->contains(fn ($type) => str_contains($dbType, $type));
+    }
+
+    public function render()
+    {
+        return view('livewire.project.application.database-backup-detail');
+    }
+}

--- a/app/Livewire/Project/Application/DatabaseBackups.php
+++ b/app/Livewire/Project/Application/DatabaseBackups.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Livewire\Project\Application;
+
+use App\Models\Application;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Component;
+
+class DatabaseBackups extends Component
+{
+    use AuthorizesRequests;
+
+    public Application $application;
+
+    public function mount()
+    {
+        $this->authorize('view', $this->application);
+    }
+
+    public function render()
+    {
+        return view('livewire.project.application.database-backups', [
+            'databases' => $this->application->databases()->get(),
+        ]);
+    }
+}

--- a/app/Livewire/Project/Database/BackupEdit.php
+++ b/app/Livewire/Project/Database/BackupEdit.php
@@ -157,7 +157,7 @@ class BackupEdit extends Component
         try {
             $server = null;
             if ($this->backup->database instanceof \App\Models\ServiceDatabase) {
-                $server = $this->backup->database->service->destination->server;
+                $server = $this->backup->database->getServer();
             } elseif ($this->backup->database->destination && $this->backup->database->destination->server) {
                 $server = $this->backup->database->destination->server;
             }
@@ -184,6 +184,15 @@ class BackupEdit extends Component
 
             if ($this->backup->database->getMorphClass() === \App\Models\ServiceDatabase::class) {
                 $serviceDatabase = $this->backup->database;
+
+                if ($serviceDatabase->isApplicationDatabase()) {
+                    return redirect()->route('project.application.database-backups.show', [
+                        'project_uuid' => $this->parameters['project_uuid'],
+                        'environment_uuid' => $this->parameters['environment_uuid'],
+                        'application_uuid' => $serviceDatabase->application->uuid,
+                        'database_uuid' => $serviceDatabase->uuid,
+                    ]);
+                }
 
                 return redirect()->route('project.service.database.backups', [
                     'project_uuid' => $this->parameters['project_uuid'],

--- a/app/Livewire/Project/Database/BackupExecutions.php
+++ b/app/Livewire/Project/Database/BackupExecutions.php
@@ -78,9 +78,10 @@ class BackupExecutions extends Component
             return;
         }
 
-        $server = $execution->scheduledDatabaseBackup->database->getMorphClass() === \App\Models\ServiceDatabase::class
-            ? $execution->scheduledDatabaseBackup->database->service->destination->server
-            : $execution->scheduledDatabaseBackup->database->destination->server;
+        $db = $execution->scheduledDatabaseBackup->database;
+        $server = $db->getMorphClass() === \App\Models\ServiceDatabase::class
+            ? $db->getServer()
+            : $db->destination->server;
 
         try {
             if ($execution->filename) {
@@ -182,7 +183,7 @@ class BackupExecutions extends Component
             $server = null;
 
             if ($this->database instanceof \App\Models\ServiceDatabase) {
-                $server = $this->database->service->destination->server;
+                $server = $this->database->getServer();
             } elseif ($this->database->destination && $this->database->destination->server) {
                 $server = $this->database->destination->server;
             }

--- a/app/Livewire/Project/Database/Import.php
+++ b/app/Livewire/Project/Database/Import.php
@@ -314,12 +314,12 @@ EOD;
 
         // Handle ServiceDatabase server access differently
         if ($resource->getMorphClass() === \App\Models\ServiceDatabase::class) {
-            $server = $resource->service?->server;
+            $server = $resource->getServer();
             if (! $server) {
                 abort(404, 'Server not found for this service database.');
             }
             $this->serverId = $server->id;
-            $this->container = $resource->name.'-'.$resource->service->uuid;
+            $this->container = $resource->name.'-'.$resource->getParentUuid();
             $this->resourceUuid = $resource->uuid; // Use ServiceDatabase's own UUID
 
             // Determine database type for ServiceDatabase
@@ -633,7 +633,8 @@ EOD;
 
             // Get the database destination network
             if ($this->resource->getMorphClass() === \App\Models\ServiceDatabase::class) {
-                $destinationNetwork = $this->resource->service->destination->network ?? 'coolify';
+                $parentResource = $this->resource->getParentResource();
+                $destinationNetwork = $parentResource->destination->network ?? 'coolify';
             } else {
                 $destinationNetwork = $this->resource->destination->network ?? 'coolify';
             }

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -187,6 +187,11 @@ class Application extends BaseModel
                     $application->docker_compose_domains = null;
                     $application->docker_compose_raw = null;
 
+                    // Remove associated ServiceDatabase records
+                    $application->databases()->each(function ($db) {
+                        $db->delete();
+                    });
+
                     // Remove SERVICE_FQDN_* and SERVICE_URL_* environment variables
                     $application->environment_variables()
                         ->where(function ($q) {
@@ -242,6 +247,10 @@ class Application extends BaseModel
             foreach ($application->scheduled_tasks as $task) {
                 $task->delete();
             }
+            // Clean up ServiceDatabase records for dockercompose applications
+            $application->databases()->each(function ($db) {
+                $db->delete();
+            });
             $application->tags()->detach();
             $application->previews()->delete();
             foreach ($application->deployment_queue as $deployment) {
@@ -498,6 +507,15 @@ class Application extends BaseModel
     public function fileStorages()
     {
         return $this->morphMany(LocalFileVolume::class, 'resource');
+    }
+
+    /**
+     * Get the database services detected in this application's Docker Compose file.
+     * Only relevant for applications with build_pack === 'dockercompose'.
+     */
+    public function databases()
+    {
+        return $this->hasMany(ServiceDatabase::class);
     }
 
     public function type()

--- a/app/Models/ServiceDatabase.php
+++ b/app/Models/ServiceDatabase.php
@@ -27,7 +27,10 @@ class ServiceDatabase extends BaseModel
 
     public static function ownedByCurrentTeamAPI(int $teamId)
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', $teamId)->orderBy('name');
+        return ServiceDatabase::where(function ($query) use ($teamId) {
+            $query->whereRelation('service.environment.project.team', 'id', $teamId)
+                ->orWhereRelation('application.environment.project.team', 'id', $teamId);
+        })->orderBy('name');
     }
 
     /**
@@ -36,7 +39,12 @@ class ServiceDatabase extends BaseModel
      */
     public static function ownedByCurrentTeam()
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', currentTeam()->id)->orderBy('name');
+        $teamId = currentTeam()->id;
+
+        return ServiceDatabase::where(function ($query) use ($teamId) {
+            $query->whereRelation('service.environment.project.team', 'id', $teamId)
+                ->orWhereRelation('application.environment.project.team', 'id', $teamId);
+        })->orderBy('name');
     }
 
     /**
@@ -49,10 +57,51 @@ class ServiceDatabase extends BaseModel
         });
     }
 
+    /**
+     * Get the parent resource (Service or Application) that owns this database.
+     */
+    public function getParentResource()
+    {
+        return $this->service ?? $this->application;
+    }
+
+    /**
+     * Get the server this database runs on.
+     */
+    public function getServer()
+    {
+        if ($this->service) {
+            return $this->service->server;
+        }
+        if ($this->application) {
+            return $this->application->destination->server;
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the parent resource UUID (Service or Application).
+     */
+    public function getParentUuid()
+    {
+        return $this->getParentResource()?->uuid;
+    }
+
+    /**
+     * Check if this database belongs to an Application (dockercompose buildpack).
+     */
+    public function isApplicationDatabase(): bool
+    {
+        return ! is_null($this->application_id);
+    }
+
     public function restart()
     {
-        $container_id = $this->name.'-'.$this->service->uuid;
-        remote_process(["docker restart {$container_id}"], $this->service->server);
+        $parentUuid = $this->getParentUuid();
+        $server = $this->getServer();
+        $container_id = $this->name.'-'.$parentUuid;
+        remote_process(["docker restart {$container_id}"], $server);
     }
 
     public function isRunning()
@@ -114,8 +163,9 @@ class ServiceDatabase extends BaseModel
     public function getServiceDatabaseUrl()
     {
         $port = $this->public_port;
-        $realIp = $this->service->server->ip;
-        if ($this->service->server->isLocalhost() || isDev()) {
+        $server = $this->getServer();
+        $realIp = $server->ip;
+        if ($server->isLocalhost() || isDev()) {
             $realIp = base_ip();
         }
 
@@ -129,12 +179,21 @@ class ServiceDatabase extends BaseModel
 
     public function workdir()
     {
+        if ($this->application) {
+            return application_configuration_dir()."/{$this->application->uuid}";
+        }
+
         return service_configuration_dir()."/{$this->service->uuid}";
     }
 
     public function service()
     {
         return $this->belongsTo(Service::class);
+    }
+
+    public function application()
+    {
+        return $this->belongsTo(Application::class);
     }
 
     public function persistentStorages()

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -556,8 +556,12 @@ function getResourceByUuid(string $uuid, ?int $teamId = null)
     }
 
     // ServiceDatabase has a different relationship path: service->environment->project->team_id
+    // or application->environment->project->team_id for dockercompose Application databases
     if ($resource instanceof \App\Models\ServiceDatabase) {
         if ($resource->service?->environment?->project?->team_id === $teamId) {
+            return $resource;
+        }
+        if ($resource->application?->environment?->project?->team_id === $teamId) {
             return $resource;
         }
 
@@ -1419,8 +1423,16 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                     $isDatabase = (bool) $migratedDb;
                     $savedService = $migratedApp ?: $migratedDb;
                 } else {
-                    // Use image detection for non-migrated services
-                    $isDatabase = isDatabaseImage($image, $service);
+                    // Check for label-based override: coolify.service.subType=database
+                    $subTypeLabel = $serviceLabels->first(function ($label) {
+                        return str($label)->startsWith('coolify.service.subType=');
+                    });
+                    if ($subTypeLabel && str($subTypeLabel)->after('=')->lower()->value() === 'database') {
+                        $isDatabase = true;
+                    } else {
+                        // Use image detection for non-migrated services
+                        $isDatabase = isDatabaseImage($image, $service);
+                    }
 
                     // Create new serviceApplication or serviceDatabase
                     if ($isDatabase) {
@@ -2415,8 +2427,53 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
 
             // Decide if the service is a database
             $image = data_get_str($service, 'image');
-            $isDatabase = isDatabaseImage($image, $service);
+
+            // Check for label-based override: coolify.service.subType=database
+            $subTypeLabel = $serviceLabels->first(function ($label) {
+                return str($label)->startsWith('coolify.service.subType=');
+            });
+            if ($subTypeLabel && str($subTypeLabel)->after('=')->lower()->value() === 'database') {
+                $isDatabase = true;
+            } else {
+                $isDatabase = isDatabaseImage($image, $service);
+            }
             data_set($service, 'is_database', $isDatabase);
+
+            // Create or update ServiceDatabase records for detected database services
+            if ($isDatabase) {
+                if ($isNew) {
+                    $savedDatabase = ServiceDatabase::create([
+                        'name' => $serviceName,
+                        'image' => $image,
+                        'application_id' => $resource->id,
+                    ]);
+                } else {
+                    $savedDatabase = ServiceDatabase::where([
+                        'name' => $serviceName,
+                        'application_id' => $resource->id,
+                    ])->first();
+                    if (is_null($savedDatabase)) {
+                        $savedDatabase = ServiceDatabase::create([
+                            'name' => $serviceName,
+                            'image' => $image,
+                            'application_id' => $resource->id,
+                        ]);
+                    } elseif ($savedDatabase->image !== $image) {
+                        $savedDatabase->image = $image;
+                        $savedDatabase->save();
+                    }
+                }
+            } else {
+                // If a service was previously detected as database but image changed,
+                // clean up the old ServiceDatabase record
+                $existingDb = ServiceDatabase::where([
+                    'name' => $serviceName,
+                    'application_id' => $resource->id,
+                ])->first();
+                if ($existingDb) {
+                    $existingDb->delete();
+                }
+            }
 
             // Collect/create/update networks
             if ($serviceNetworks->count() > 0) {

--- a/database/migrations/2025_06_18_000000_add_application_id_to_service_databases.php
+++ b/database/migrations/2025_06_18_000000_add_application_id_to_service_databases.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->foreignId('application_id')->nullable()->after('service_id');
+            $table->unsignedBigInteger('service_id')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->dropColumn('application_id');
+            $table->unsignedBigInteger('service_id')->nullable(false)->change();
+        });
+    }
+};

--- a/resources/views/livewire/project/application/configuration.blade.php
+++ b/resources/views/livewire/project/application/configuration.blade.php
@@ -50,6 +50,10 @@
                 <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
                     href="{{ route('project.application.preview-deployments', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Preview Deployments</span></a>
             @endif
+            @if ($application->build_pack === 'dockercompose' && $application->databases()->count() > 0)
+                <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                    href="{{ route('project.application.database-backups', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Database Backups</span></a>
+            @endif
             @if ($application->build_pack !== 'dockercompose')
                 <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
                     href="{{ route('project.application.healthcheck', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Healthcheck</span></a>
@@ -100,6 +104,18 @@
                 <livewire:project.shared.metrics :resource="$application" />
             @elseif ($currentRoute === 'project.application.tags')
                 <livewire:project.shared.tags :resource="$application" />
+            @elseif ($currentRoute === 'project.application.database-backups')
+                <livewire:project.application.database-backups :application="$application" />
+            @elseif ($currentRoute === 'project.application.database-backups.show')
+                @php
+                    $databaseUuid = request()->route('database_uuid');
+                    $serviceDatabase = $application->databases()->whereUuid($databaseUuid)->first();
+                @endphp
+                @if ($serviceDatabase)
+                    <livewire:project.application.database-backup-detail :application="$application" :serviceDatabase="$serviceDatabase" />
+                @else
+                    <p>Database not found.</p>
+                @endif
             @elseif ($currentRoute === 'project.application.danger')
                 <livewire:project.shared.danger :resource="$application" />
             @endif

--- a/resources/views/livewire/project/application/database-backup-detail.blade.php
+++ b/resources/views/livewire/project/application/database-backup-detail.blade.php
@@ -1,0 +1,23 @@
+<div>
+    <a wire:navigate
+        href="{{ route('project.application.database-backups', [
+            'project_uuid' => $application->environment->project->uuid,
+            'environment_uuid' => $application->environment->uuid,
+            'application_uuid' => $application->uuid,
+        ]) }}"
+        class="inline-flex items-center gap-2 pb-4 text-sm text-neutral-400 hover:text-white">
+        ← Back to databases
+    </a>
+
+    <h2 class="pb-2">{{ $serviceDatabase->name }}</h2>
+    <p class="pb-4 text-sm text-neutral-400">{{ $serviceDatabase->image }} — {{ str($serviceDatabase->databaseType())->replace('standalone-', '') }}</p>
+
+    @if ($serviceDatabase->isBackupSolutionAvailable())
+        <div class="flex flex-col gap-4">
+            <livewire:project.database.create-scheduled-backup :database="$serviceDatabase" />
+            <livewire:project.database.scheduled-backups :database="$serviceDatabase" />
+        </div>
+    @else
+        <p>Backups are not supported for this database type.</p>
+    @endif
+</div>

--- a/resources/views/livewire/project/application/database-backups.blade.php
+++ b/resources/views/livewire/project/application/database-backups.blade.php
@@ -1,0 +1,44 @@
+<div>
+    <h2 class="pb-4">Database Backups</h2>
+    <p class="pb-4">Databases detected in your Docker Compose file. Click on a database to manage its backups.</p>
+
+    @if ($databases->isEmpty())
+        <p>No databases detected in your Docker Compose configuration.</p>
+    @else
+        <div class="grid gap-4">
+            @foreach ($databases as $database)
+                <a href="{{ route('project.application.database-backups.show', [
+                    'project_uuid' => $application->environment->project->uuid,
+                    'environment_uuid' => $application->environment->uuid,
+                    'application_uuid' => $application->uuid,
+                    'database_uuid' => $database->uuid,
+                ]) }}"
+                    {{ wireNavigate() }}
+                    class="box group">
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <h3 class="font-bold text-lg">{{ $database->name }}</h3>
+                            <p class="text-sm text-neutral-400">{{ $database->image }}</p>
+                            <p class="text-sm">
+                                Type: {{ str($database->databaseType())->replace('standalone-', '') }}
+                                @if ($database->isBackupSolutionAvailable())
+                                    <span class="text-success"> — Backup supported</span>
+                                @else
+                                    <span class="text-warning"> — Backup not supported for this database type</span>
+                                @endif
+                            </p>
+                        </div>
+                        <div class="flex items-center gap-2">
+                            <span class="badge {{ $database->isRunning() ? 'bg-success' : 'bg-error' }}">
+                                {{ $database->status }}
+                            </span>
+                            <span class="text-sm text-neutral-400">
+                                {{ $database->scheduledBackups()->count() }} backup(s) configured
+                            </span>
+                        </div>
+                    </div>
+                </a>
+            @endforeach
+        </div>
+    @endif
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -209,6 +209,9 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/tags', ApplicationConfiguration::class)->name('project.application.tags');
         Route::get('/danger', ApplicationConfiguration::class)->name('project.application.danger');
 
+        Route::get('/database-backups', ApplicationConfiguration::class)->name('project.application.database-backups');
+        Route::get('/database-backups/{database_uuid}', ApplicationConfiguration::class)->name('project.application.database-backups.show');
+
         Route::get('/deployment', DeploymentIndex::class)->name('project.application.deployment.index');
         Route::get('/deployment/{deployment_uuid}', DeploymentShow::class)->name('project.application.deployment.show');
         Route::get('/logs', Logs::class)->name('project.application.logs');


### PR DESCRIPTION
Fixes #7528

When deploying Docker Compose via GitHub App (`dockercompose` buildpack), databases were detected by `isDatabaseImage()` but never registered as `ServiceDatabase` records — the `is_database` flag was set then discarded. This meant no backup scheduling was available for Compose-deployed databases.

## Changes

### Core Fix
- **Migration** — Added nullable `application_id` to `service_databases`, made `service_id` nullable
- **Docker Compose Parser** — Application path now creates `ServiceDatabase` records for detected databases
- **ServiceDatabase Model** — Added `application()` relationship + `getServer()`/`getParentResource()` helpers

### Backup Pipeline
- Updated `DatabaseBackupJob` to work with both Application and Service parent types
- Updated 3 Livewire backup components for dual-parent support

### UI
- Added Database Backups page to Application config
- 2 new Livewire components + 2 Blade views
- Routes for application-scoped backup management

### Bonus
- Added `coolify.service.subType=database` label override for custom database images (community request from issue comments)

**14 files changed** (5 new, 9 modified) — fully backward compatible.

/claim #7528