### PR TITLE
fix(template): add PGDATA env to Activepieces PostgreSQL 18

### DIFF
--- a/templates/compose/activepieces.yaml
+++ b/templates/compose/activepieces.yaml
@@ -46,6 +46,7 @@ services:
       - POSTGRES_PASSWORD=${SERVICE_PASSWORD_POSTGRES}
       - POSTGRES_USER=${SERVICE_USER_POSTGRES}
       - POSTGRES_PORT=${POSTGRES_PORT:-5432}
+      - PGDATA=/var/lib/postgresql/data
     volumes:
       - "pg-data:/var/lib/postgresql/data"
     healthcheck:


### PR DESCRIPTION
## Summary

Fixes #8097

PostgreSQL 18 changed the default data directory from `/var/lib/postgresql/data` to `/var/lib/postgresql/18/docker`. This caused data loss after container restarts because the volume was mounted to the old path while PostgreSQL wrote to the new path.

## Changes

- Added `PGDATA=/var/lib/postgresql/data` environment variable to the Activepieces PostgreSQL service

This explicitly sets the data directory to the mounted volume path, ensuring compatibility regardless of PostgreSQL version.

## Test plan

1. Deploy Activepieces using the one-click service template
2. Create test data (e.g., a flow)
3. Restart the service via Coolify
4. Verify data persists after restart


Made with [Cursor](https://cursor.com)