### PR TITLE
fix: pass custom timeout to SSH command for database backups

### DIFF
--- a/app/Helpers/SshMultiplexingHelper.php
+++ b/app/Helpers/SshMultiplexingHelper.php
@@ -149,7 +149,7 @@ class SshMultiplexingHelper
         return $scp_command;
     }
 
-    public static function generateSshCommand(Server $server, string $command, bool $disableMultiplexing = false)
+    public static function generateSshCommand(Server $server, string $command, bool $disableMultiplexing = false, ?int $timeout = null)
     {
         if ($server->settings->force_disabled) {
             throw new \RuntimeException('Server is disabled.');
@@ -162,7 +162,7 @@ class SshMultiplexingHelper
 
         $muxSocket = $sshConfig['muxFilename'];
 
-        $timeout = config('constants.ssh.command_timeout');
+        $timeout = $timeout ?? config('constants.ssh.command_timeout');
         $muxPersistTime = config('constants.ssh.mux_persist_time');
 
         $ssh_command = "timeout $timeout ssh ";

--- a/bootstrap/helpers/remoteProcess.php
+++ b/bootstrap/helpers/remoteProcess.php
@@ -130,7 +130,7 @@ function instant_remote_process(Collection|array $command, Server $server, bool 
 
     return \App\Helpers\SshRetryHandler::retry(
         function () use ($server, $command_string, $effectiveTimeout, $disableMultiplexing) {
-            $sshCommand = SshMultiplexingHelper::generateSshCommand($server, $command_string, $disableMultiplexing);
+            $sshCommand = SshMultiplexingHelper::generateSshCommand($server, $command_string, $disableMultiplexing, $effectiveTimeout);
             $process = Process::timeout($effectiveTimeout)->run($sshCommand);
 
             $output = trim($process->output());


### PR DESCRIPTION
## Problem

This fixes the regression reported in #7473 where database backups were not using the custom timeout setting in the SSH command.

When users configured a custom timeout for database backups (e.g., 10800 seconds for large databases), the backup would still fail after 3600 seconds because the SSH command wrapper was using the hardcoded default timeout:

```
The process "timeout 3600 ssh -i /var/www/html/storage/app/ssh/keys/ssh_key@..." exceeded the timeout of 3600 seconds.
```

## Root Cause

In `instant_remote_process()`, the custom timeout was correctly passed to the Laravel `Process::timeout()` call, but `SshMultiplexingHelper::generateSshCommand()` was generating the SSH command with a hardcoded timeout from `config('constants.ssh.command_timeout')` (3600 seconds).

## Solution

1. Added an optional `$timeout` parameter to `SshMultiplexingHelper::generateSshCommand()`
2. Updated `instant_remote_process()` to pass the effective timeout to `generateSshCommand()`

This ensures that when a custom timeout is configured for database backups, it will be used for both:
- The Laravel Process timeout
- The `timeout` command wrapper around SSH

## Changes

- `app/Helpers/SshMultiplexingHelper.php`: Added optional `$timeout` parameter to `generateSshCommand()` method
- `bootstrap/helpers/remoteProcess.php`: Pass the effective timeout to `generateSshCommand()`

## Backwards Compatibility

The change is backwards compatible - the `$timeout` parameter is optional and defaults to `null`, in which case the config value is used (same as before).

Fixes #7473