### PR TITLE
feat: Add configurable timeout for public database proxies (fixes #7743)

### DIFF
--- a/app/Actions/Database/StartDatabaseProxy.php
+++ b/app/Actions/Database/StartDatabaseProxy.php
@@ -54,6 +54,15 @@ class StartDatabaseProxy
         if (isDev()) {
             $configuration_dir = '/var/lib/docker/volumes/coolify_dev_coolify_data/_data/databases/'.$database->uuid.'/proxy';
         }
+
+        // Get the proxy timeout setting (0 = no timeout/infinite)
+        $proxyTimeout = $database->public_port_timeout ?? 0;
+
+        // Build the timeout configuration
+        // When timeout is 0, we set a very large value (1 year) to effectively disable the timeout
+        // Otherwise, use the configured timeout in seconds
+        $timeoutValue = $proxyTimeout === 0 ? '31536000s' : "{$proxyTimeout}s";
+
         $nginxconf = <<<EOF
     user  nginx;
     worker_processes  auto;
@@ -67,6 +76,8 @@ class StartDatabaseProxy
        server {
             listen $database->public_port;
             proxy_pass $containerName:$internalPort;
+            proxy_timeout $timeoutValue;
+            proxy_connect_timeout 60s;
        }
     }
     EOF;

--- a/app/Livewire/Project/Database/Clickhouse/General.php
+++ b/app/Livewire/Project/Database/Clickhouse/General.php
@@ -36,6 +36,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $publicPortTimeout = null;
+
     public ?string $customDockerRunOptions = null;
 
     public ?string $dbUrl = null;
@@ -80,6 +82,7 @@ class General extends Component
             'portsMappings' => 'nullable|string',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'publicPortTimeout' => 'nullable|integer|min:0',
             'customDockerRunOptions' => 'nullable|string',
             'dbUrl' => 'nullable|string',
             'dbUrlPublic' => 'nullable|string',
@@ -115,6 +118,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_port_timeout = $this->publicPortTimeout;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->save();
@@ -130,6 +134,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->publicPortTimeout = $this->database->public_port_timeout;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->dbUrl = $this->database->internal_db_url;

--- a/app/Livewire/Project/Database/Dragonfly/General.php
+++ b/app/Livewire/Project/Database/Dragonfly/General.php
@@ -36,6 +36,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $publicPortTimeout = null;
+
     public ?string $customDockerRunOptions = null;
 
     public ?string $dbUrl = null;
@@ -91,6 +93,7 @@ class General extends Component
             'portsMappings' => 'nullable|string',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'publicPortTimeout' => 'nullable|integer|min:0',
             'customDockerRunOptions' => 'nullable|string',
             'dbUrl' => 'nullable|string',
             'dbUrlPublic' => 'nullable|string',
@@ -124,6 +127,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_port_timeout = $this->publicPortTimeout;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->enable_ssl = $this->enable_ssl;
@@ -139,6 +143,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->publicPortTimeout = $this->database->public_port_timeout;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->enable_ssl = $this->database->enable_ssl;

--- a/app/Livewire/Project/Database/Keydb/General.php
+++ b/app/Livewire/Project/Database/Keydb/General.php
@@ -38,6 +38,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $publicPortTimeout = null;
+
     public ?string $customDockerRunOptions = null;
 
     public ?string $dbUrl = null;
@@ -94,6 +96,7 @@ class General extends Component
             'portsMappings' => 'nullable|string',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'publicPortTimeout' => 'nullable|integer|min:0',
             'customDockerRunOptions' => 'nullable|string',
             'dbUrl' => 'nullable|string',
             'dbUrlPublic' => 'nullable|string',
@@ -130,6 +133,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_port_timeout = $this->publicPortTimeout;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->enable_ssl = $this->enable_ssl;
@@ -146,6 +150,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->publicPortTimeout = $this->database->public_port_timeout;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->enable_ssl = $this->database->enable_ssl;

--- a/app/Livewire/Project/Database/Mariadb/General.php
+++ b/app/Livewire/Project/Database/Mariadb/General.php
@@ -44,6 +44,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $publicPortTimeout = null;
+
     public bool $isLogDrainEnabled = false;
 
     public ?string $customDockerRunOptions = null;
@@ -79,6 +81,7 @@ class General extends Component
             'portsMappings' => 'nullable',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'publicPortTimeout' => 'nullable|integer|min:0',
             'isLogDrainEnabled' => 'nullable|boolean',
             'customDockerRunOptions' => 'nullable',
             'enableSsl' => 'boolean',
@@ -113,6 +116,7 @@ class General extends Component
         'portsMappings' => 'Port Mapping',
         'isPublic' => 'Is Public',
         'publicPort' => 'Public Port',
+        'publicPortTimeout' => 'Public Port Timeout',
         'customDockerRunOptions' => 'Custom Docker Options',
         'enableSsl' => 'Enable SSL',
     ];
@@ -154,6 +158,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_port_timeout = $this->publicPortTimeout;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->enable_ssl = $this->enableSsl;
@@ -173,6 +178,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->publicPortTimeout = $this->database->public_port_timeout;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->enableSsl = $this->database->enable_ssl;

--- a/app/Livewire/Project/Database/Mongodb/General.php
+++ b/app/Livewire/Project/Database/Mongodb/General.php
@@ -42,6 +42,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $publicPortTimeout = null;
+
     public bool $isLogDrainEnabled = false;
 
     public ?string $customDockerRunOptions = null;
@@ -78,6 +80,7 @@ class General extends Component
             'portsMappings' => 'nullable',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'publicPortTimeout' => 'nullable|integer|min:0',
             'isLogDrainEnabled' => 'nullable|boolean',
             'customDockerRunOptions' => 'nullable',
             'enableSsl' => 'boolean',
@@ -112,6 +115,7 @@ class General extends Component
         'portsMappings' => 'Port Mapping',
         'isPublic' => 'Is Public',
         'publicPort' => 'Public Port',
+        'publicPortTimeout' => 'Public Port Timeout',
         'customDockerRunOptions' => 'Custom Docker Run Options',
         'enableSsl' => 'Enable SSL',
         'sslMode' => 'SSL Mode',
@@ -153,6 +157,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_port_timeout = $this->publicPortTimeout;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->enable_ssl = $this->enableSsl;
@@ -172,6 +177,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->publicPortTimeout = $this->database->public_port_timeout;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->enableSsl = $this->database->enable_ssl;

--- a/app/Livewire/Project/Database/Mysql/General.php
+++ b/app/Livewire/Project/Database/Mysql/General.php
@@ -44,6 +44,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $publicPortTimeout = null;
+
     public bool $isLogDrainEnabled = false;
 
     public ?string $customDockerRunOptions = null;
@@ -81,6 +83,7 @@ class General extends Component
             'portsMappings' => 'nullable',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'publicPortTimeout' => 'nullable|integer|min:0',
             'isLogDrainEnabled' => 'nullable|boolean',
             'customDockerRunOptions' => 'nullable',
             'enableSsl' => 'boolean',
@@ -117,6 +120,7 @@ class General extends Component
         'portsMappings' => 'Port Mapping',
         'isPublic' => 'Is Public',
         'publicPort' => 'Public Port',
+        'publicPortTimeout' => 'Public Port Timeout',
         'customDockerRunOptions' => 'Custom Docker Run Options',
         'enableSsl' => 'Enable SSL',
         'sslMode' => 'SSL Mode',
@@ -159,6 +163,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_port_timeout = $this->publicPortTimeout;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->enable_ssl = $this->enableSsl;
@@ -179,6 +184,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->publicPortTimeout = $this->database->public_port_timeout;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->enableSsl = $this->database->enable_ssl;

--- a/app/Livewire/Project/Database/Postgresql/General.php
+++ b/app/Livewire/Project/Database/Postgresql/General.php
@@ -48,6 +48,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $publicPortTimeout = null;
+
     public bool $isLogDrainEnabled = false;
 
     public ?string $customDockerRunOptions = null;
@@ -93,6 +95,7 @@ class General extends Component
             'portsMappings' => 'nullable',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'publicPortTimeout' => 'nullable|integer|min:0',
             'isLogDrainEnabled' => 'nullable|boolean',
             'customDockerRunOptions' => 'nullable',
             'enableSsl' => 'boolean',
@@ -130,6 +133,7 @@ class General extends Component
         'portsMappings' => 'Port Mapping',
         'isPublic' => 'Is Public',
         'publicPort' => 'Public Port',
+        'publicPortTimeout' => 'Public Port Timeout',
         'customDockerRunOptions' => 'Custom Docker Run Options',
         'enableSsl' => 'Enable SSL',
         'sslMode' => 'SSL Mode',
@@ -174,6 +178,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_port_timeout = $this->publicPortTimeout;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->enable_ssl = $this->enableSsl;
@@ -196,6 +201,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->publicPortTimeout = $this->database->public_port_timeout;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->enableSsl = $this->database->enable_ssl;

--- a/app/Livewire/Project/Database/Redis/General.php
+++ b/app/Livewire/Project/Database/Redis/General.php
@@ -36,6 +36,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $publicPortTimeout = null;
+
     public bool $isLogDrainEnabled = false;
 
     public ?string $customDockerRunOptions = null;
@@ -74,6 +76,7 @@ class General extends Component
             'portsMappings' => 'nullable',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'publicPortTimeout' => 'nullable|integer|min:0',
             'isLogDrainEnabled' => 'nullable|boolean',
             'customDockerRunOptions' => 'nullable',
             'redisUsername' => 'required',
@@ -104,6 +107,7 @@ class General extends Component
         'portsMappings' => 'Port Mapping',
         'isPublic' => 'Is Public',
         'publicPort' => 'Public Port',
+        'publicPortTimeout' => 'Public Port Timeout',
         'customDockerRunOptions' => 'Custom Docker Options',
         'redisUsername' => 'Redis Username',
         'redisPassword' => 'Redis Password',
@@ -143,6 +147,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_port_timeout = $this->publicPortTimeout;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->enable_ssl = $this->enableSsl;
@@ -158,6 +163,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->publicPortTimeout = $this->database->public_port_timeout;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->enableSsl = $this->database->enable_ssl;

--- a/app/Livewire/Project/Service/Index.php
+++ b/app/Livewire/Project/Service/Index.php
@@ -53,6 +53,8 @@ class Index extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $publicPortTimeout = null;
+
     public bool $isPublic = false;
 
     public bool $isLogDrainEnabled = false;
@@ -90,6 +92,7 @@ class Index extends Component
         'image' => 'required',
         'excludeFromStatus' => 'required|boolean',
         'publicPort' => 'nullable|integer',
+        'publicPortTimeout' => 'nullable|integer|min:0',
         'isPublic' => 'required|boolean',
         'isLogDrainEnabled' => 'required|boolean',
         // Application-specific rules
@@ -158,6 +161,7 @@ class Index extends Component
             $this->serviceDatabase->image = $this->image;
             $this->serviceDatabase->exclude_from_status = $this->excludeFromStatus;
             $this->serviceDatabase->public_port = $this->publicPort;
+            $this->serviceDatabase->public_port_timeout = $this->publicPortTimeout;
             $this->serviceDatabase->is_public = $this->isPublic;
             $this->serviceDatabase->is_log_drain_enabled = $this->isLogDrainEnabled;
         } else {
@@ -166,6 +170,7 @@ class Index extends Component
             $this->image = $this->serviceDatabase->image;
             $this->excludeFromStatus = $this->serviceDatabase->exclude_from_status ?? false;
             $this->publicPort = $this->serviceDatabase->public_port;
+            $this->publicPortTimeout = $this->serviceDatabase->public_port_timeout;
             $this->isPublic = $this->serviceDatabase->is_public ?? false;
             $this->isLogDrainEnabled = $this->serviceDatabase->is_log_drain_enabled ?? false;
         }

--- a/database/migrations/2025_12_18_000001_add_public_port_timeout_to_databases.php
+++ b/database/migrations/2025_12_18_000001_add_public_port_timeout_to_databases.php
@@ -1,0 +1,63 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Add public_port_timeout to all standalone database tables
+        // Default is 0 which means no timeout (infinite)
+        $tables = [
+            'standalone_postgresqls',
+            'standalone_mysqls',
+            'standalone_mariadbs',
+            'standalone_redis',
+            'standalone_mongodbs',
+            'standalone_keydbs',
+            'standalone_dragonflies',
+            'standalone_clickhouses',
+            'service_databases',
+        ];
+
+        foreach ($tables as $table) {
+            if (Schema::hasTable($table) && ! Schema::hasColumn($table, 'public_port_timeout')) {
+                Schema::table($table, function (Blueprint $table) {
+                    // Timeout in seconds. 0 = no timeout (infinite), default is 0
+                    $table->integer('public_port_timeout')->default(0)->after('public_port');
+                });
+            }
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $tables = [
+            'standalone_postgresqls',
+            'standalone_mysqls',
+            'standalone_mariadbs',
+            'standalone_redis',
+            'standalone_mongodbs',
+            'standalone_keydbs',
+            'standalone_dragonflies',
+            'standalone_clickhouses',
+            'service_databases',
+        ];
+
+        foreach ($tables as $table) {
+            if (Schema::hasTable($table) && Schema::hasColumn($table, 'public_port_timeout')) {
+                Schema::table($table, function (Blueprint $table) {
+                    $table->dropColumn('public_port_timeout');
+                });
+            }
+        }
+    }
+};

--- a/resources/views/livewire/project/database/clickhouse/general.blade.php
+++ b/resources/views/livewire/project/database/clickhouse/general.blade.php
@@ -76,8 +76,11 @@
                 <x-forms.checkbox instantSave id="isPublic" label="Make it publicly available" canGate="update"
                     :canResource="$database" />
             </div>
-            <x-forms.input placeholder="5432" disabled="{{ $isPublic }}" id="publicPort" label="Public Port"
+            <x-forms.input placeholder="9000" disabled="{{ $isPublic }}" id="publicPort" label="Public Port"
                 canGate="update" :canResource="$database" />
+            <x-forms.input placeholder="0" disabled="{{ $isPublic }}" id="publicPortTimeout"
+                label="Connection Timeout (seconds)" canGate="update" :canResource="$database"
+                helper="Timeout for idle connections in seconds. Set to 0 for no timeout (recommended for long-running queries)." />
         </div>
     </form>
     <h3 class="pt-4">Advanced</h3>

--- a/resources/views/livewire/project/database/dragonfly/general.blade.php
+++ b/resources/views/livewire/project/database/dragonfly/general.blade.php
@@ -113,8 +113,11 @@
                 <x-forms.checkbox instantSave id="isPublic" label="Make it publicly available" canGate="update"
                     :canResource="$database" />
             </div>
-            <x-forms.input placeholder="5432" disabled="{{ $isPublic }}" id="publicPort" label="Public Port"
+            <x-forms.input placeholder="6379" disabled="{{ $isPublic }}" id="publicPort" label="Public Port"
                 canGate="update" :canResource="$database" />
+            <x-forms.input placeholder="0" disabled="{{ $isPublic }}" id="publicPortTimeout"
+                label="Connection Timeout (seconds)" canGate="update" :canResource="$database"
+                helper="Timeout for idle connections in seconds. Set to 0 for no timeout (recommended for long-running queries)." />
         </div>
     </form>
     <h3 class="pt-4">Advanced</h3>

--- a/resources/views/livewire/project/database/keydb/general.blade.php
+++ b/resources/views/livewire/project/database/keydb/general.blade.php
@@ -113,8 +113,11 @@
                 <x-forms.checkbox instantSave id="isPublic" label="Make it publicly available" canGate="update"
                     :canResource="$database" />
             </div>
-            <x-forms.input placeholder="5432" disabled="{{ $isPublic }}" id="publicPort" label="Public Port"
+            <x-forms.input placeholder="6379" disabled="{{ $isPublic }}" id="publicPort" label="Public Port"
                 canGate="update" :canResource="$database" />
+            <x-forms.input placeholder="0" disabled="{{ $isPublic }}" id="publicPortTimeout"
+                label="Connection Timeout (seconds)" canGate="update" :canResource="$database"
+                helper="Timeout for idle connections in seconds. Set to 0 for no timeout (recommended for long-running queries)." />
         </div>
         <x-forms.textarea
             helper="<a target='_blank' class='underline dark:text-white' href='https://raw.githubusercontent.com/Snapchat/KeyDB/unstable/keydb.conf'>KeyDB Default Configuration</a>"

--- a/resources/views/livewire/project/database/mariadb/general.blade.php
+++ b/resources/views/livewire/project/database/mariadb/general.blade.php
@@ -137,8 +137,11 @@
                 <x-forms.checkbox instantSave id="isPublic" label="Make it publicly available"
                     canGate="update" :canResource="$database" />
             </div>
-            <x-forms.input placeholder="5432" disabled="{{ $isPublic }}"
+            <x-forms.input placeholder="3306" disabled="{{ $isPublic }}"
                 id="publicPort" label="Public Port" canGate="update" :canResource="$database" />
+            <x-forms.input placeholder="0" disabled="{{ $isPublic }}" id="publicPortTimeout"
+                label="Connection Timeout (seconds)" canGate="update" :canResource="$database"
+                helper="Timeout for idle connections in seconds. Set to 0 for no timeout (recommended for long-running queries)." />
         </div>
         <x-forms.textarea label="Custom MariaDB Configuration" rows="10" id="mariadbConf"
             canGate="update" :canResource="$database" />

--- a/resources/views/livewire/project/database/mongodb/general.blade.php
+++ b/resources/views/livewire/project/database/mongodb/general.blade.php
@@ -151,8 +151,11 @@
                     <x-forms.checkbox instantSave id="isPublic" label="Make it publicly available"
                         canGate="update" :canResource="$database" />
                 </div>
-                <x-forms.input placeholder="5432" disabled="{{ $isPublic }}"
+                <x-forms.input placeholder="27017" disabled="{{ $isPublic }}"
                     id="publicPort" label="Public Port" canGate="update" :canResource="$database" />
+                <x-forms.input placeholder="0" disabled="{{ $isPublic }}" id="publicPortTimeout"
+                    label="Connection Timeout (seconds)" canGate="update" :canResource="$database"
+                    helper="Timeout for idle connections in seconds. Set to 0 for no timeout (recommended for long-running queries)." />
             </div>
             <x-forms.textarea label="Custom MongoDB Configuration" rows="10" id="mongoConf"
                 canGate="update" :canResource="$database" />

--- a/resources/views/livewire/project/database/mysql/general.blade.php
+++ b/resources/views/livewire/project/database/mysql/general.blade.php
@@ -153,8 +153,11 @@
                 </div>
                 <x-forms.checkbox instantSave id="isPublic" label="Make it publicly available" canGate="update" :canResource="$database" />
             </div>
-            <x-forms.input placeholder="5432" disabled="{{ $isPublic }}"
+            <x-forms.input placeholder="3306" disabled="{{ $isPublic }}"
                 id="publicPort" label="Public Port" canGate="update" :canResource="$database" />
+            <x-forms.input placeholder="0" disabled="{{ $isPublic }}" id="publicPortTimeout"
+                label="Connection Timeout (seconds)" canGate="update" :canResource="$database"
+                helper="Timeout for idle connections in seconds. Set to 0 for no timeout (recommended for long-running queries)." />
         </div>
         <x-forms.textarea label="Custom Mysql Configuration" rows="10" id="mysqlConf" canGate="update" :canResource="$database" />
         <h3 class="pt-4">Advanced</h3>

--- a/resources/views/livewire/project/database/postgresql/general.blade.php
+++ b/resources/views/livewire/project/database/postgresql/general.blade.php
@@ -165,6 +165,9 @@
                     </div>
                     <x-forms.input placeholder="5432" disabled="{{ $isPublic }}" id="publicPort"
                         label="Public Port" canGate="update" :canResource="$database" />
+                    <x-forms.input placeholder="0" disabled="{{ $isPublic }}" id="publicPortTimeout"
+                        label="Connection Timeout (seconds)" canGate="update" :canResource="$database"
+                        helper="Timeout for idle connections in seconds. Set to 0 for no timeout (recommended for long-running queries)." />
                 </div>
 
                 <div class="flex flex-col gap-2">

--- a/resources/views/livewire/project/database/redis/general.blade.php
+++ b/resources/views/livewire/project/database/redis/general.blade.php
@@ -132,8 +132,11 @@
                 <x-forms.checkbox instantSave id="isPublic" label="Make it publicly available"
                     canGate="update" :canResource="$database" />
             </div>
-            <x-forms.input placeholder="5432" disabled="{{ $isPublic }}"
+            <x-forms.input placeholder="6379" disabled="{{ $isPublic }}"
                 id="publicPort" label="Public Port" canGate="update" :canResource="$database" />
+            <x-forms.input placeholder="0" disabled="{{ $isPublic }}" id="publicPortTimeout"
+                label="Connection Timeout (seconds)" canGate="update" :canResource="$database"
+                helper="Timeout for idle connections in seconds. Set to 0 for no timeout (recommended for long-running queries)." />
         </div>
         <x-forms.textarea placeholder="# maxmemory 256mb
 # maxmemory-policy allkeys-lru

--- a/resources/views/livewire/project/service/index.blade.php
+++ b/resources/views/livewire/project/service/index.blade.php
@@ -235,6 +235,10 @@
                                 </div>
                                 <x-forms.input canGate="update" :canResource="$serviceDatabase" placeholder="5432"
                                     disabled="{{ $serviceDatabase->is_public }}" id="publicPort" label="Public Port" />
+                                <x-forms.input canGate="update" :canResource="$serviceDatabase" placeholder="0"
+                                    disabled="{{ $serviceDatabase->is_public }}" id="publicPortTimeout"
+                                    label="Connection Timeout (seconds)"
+                                    helper="Timeout for idle connections in seconds. Set to 0 for no timeout (recommended for long-running queries)." />
                                 @if ($db_url_public)
                                     <x-forms.input label="Database IP:PORT (public)"
                                         helper="Your credentials are available in your environment variables." type="password"


### PR DESCRIPTION
## Summary

This PR addresses issue #7743 by making the TCP proxy timeout configurable for publicly exposed databases. 

### Problem
Currently, the TCP proxy (nginx) in front of databases times out after ~10 minutes when "Expose publicly" is enabled. This prevents users from running long queries (e.g., SELECT statements that take 30+ minutes to download results).

### Solution
Added a configurable "Connection Timeout" setting for public database proxies:

- **Default: 0 (no timeout)** - Sets nginx `proxy_timeout` to 1 year (31536000 seconds), effectively disabling the timeout
- **Custom value** - Uses the exact timeout value in seconds

### Changes Made

#### Migration
- Added `public_port_timeout` column to all database tables:
  - `standalone_postgresqls`
  - `standalone_mysqls`
  - `standalone_mariadbs`
  - `standalone_redis`
  - `standalone_mongodbs`
  - `standalone_keydbs`
  - `standalone_dragonflies`
  - `standalone_clickhouses`
  - `service_databases`

#### Backend
- Updated `StartDatabaseProxy.php` to use configurable `proxy_timeout` in nginx config
- Added `proxy_connect_timeout 60s` for reliable connection establishment
- Updated all standalone database Livewire components (PostgreSQL, MySQL, MariaDB, Redis, MongoDB, KeyDB, Dragonfly, ClickHouse)
- Updated ServiceDatabase handling for databases in services

#### UI
- Added "Connection Timeout (seconds)" input field in all database configuration forms
- Input shows helper text explaining the setting
- Default value of 0 means no timeout (recommended for long-running queries)

### Testing
To test this change:
1. Create a database (e.g., PostgreSQL)
2. Enable "Make it publicly available"
3. Leave "Connection Timeout" at 0 (default)
4. Connect externally and run a long query
5. Verify the connection stays alive beyond 10 minutes

### Bounty
Resolves #7743 - $100 USD bounty from [Hack Club](https://hackclub.com)

### Screenshots
The UI adds a simple "Connection Timeout (seconds)" field below the "Public Port" input in the Proxy section of database configuration.