### PR TITLE
fix(ssh): Prevent sporadic Permission denied by validating SSH key matches

### DIFF
--- a/app/Helpers/SshMultiplexingHelper.php
+++ b/app/Helpers/SshMultiplexingHelper.php
@@ -44,6 +44,16 @@ class SshMultiplexingHelper
             return self::establishNewMultiplexedConnection($server);
         }
 
+        // Connection exists - check if the SSH key has changed since connection was established
+        // This prevents using a multiplexed connection that was made with a different key
+        if (self::isKeyMismatch($server)) {
+            Log::warning('SSH key mismatch detected for multiplexed connection, refreshing', [
+                'server' => $server->name ?? $server->uuid,
+                'server_uuid' => $server->uuid,
+            ]);
+            return self::refreshMultiplexedConnection($server);
+        }
+
         // Connection exists, ensure we have metadata for age tracking
         if (self::getConnectionAge($server) === null) {
             // Existing connection but no metadata, store current time as fallback
@@ -204,10 +214,46 @@ class SshMultiplexingHelper
     private static function validateSshKey(PrivateKey $privateKey): void
     {
         $keyLocation = $privateKey->getKeyLocation();
+        
+        // Check if the key file exists
         $checkKeyCommand = "ls $keyLocation 2>/dev/null";
         $keyCheckProcess = Process::run($checkKeyCommand);
-
-        if ($keyCheckProcess->exitCode() !== 0) {
+        $keyFileExists = $keyCheckProcess->exitCode() === 0;
+        
+        if (! $keyFileExists) {
+            // File doesn't exist, create it
+            Log::debug('SSH key file does not exist, creating it', [
+                'key_uuid' => $privateKey->uuid,
+                'location' => $keyLocation,
+            ]);
+            $privateKey->storeInFileSystem();
+            return;
+        }
+        
+        // File exists - verify the content matches the database
+        // This prevents using stale/wrong keys when the key was updated
+        $readKeyCommand = "cat $keyLocation 2>/dev/null";
+        $readKeyProcess = Process::run($readKeyCommand);
+        
+        if ($readKeyProcess->exitCode() === 0) {
+            $fileContent = trim($readKeyProcess->output());
+            $expectedContent = trim($privateKey->private_key);
+            
+            if ($fileContent !== $expectedContent) {
+                Log::warning('SSH key file content mismatch detected, refreshing key file', [
+                    'key_uuid' => $privateKey->uuid,
+                    'location' => $keyLocation,
+                    'file_fingerprint' => substr(md5($fileContent), 0, 8),
+                    'expected_fingerprint' => substr(md5($expectedContent), 0, 8),
+                ]);
+                $privateKey->storeInFileSystem();
+            }
+        } else {
+            // Couldn't read the file, try to recreate it
+            Log::warning('Could not read SSH key file, recreating', [
+                'key_uuid' => $privateKey->uuid,
+                'location' => $keyLocation,
+            ]);
             $privateKey->storeInFileSystem();
         }
     }
@@ -265,6 +311,45 @@ class SshMultiplexingHelper
     }
 
     /**
+     * Check if the server's current SSH key is different from the one used to establish the multiplexed connection.
+     * This detects when a user has changed the server's SSH key and the old connection should not be reused.
+     */
+    public static function isKeyMismatch(Server $server): bool
+    {
+        $fingerprintCacheKey = "ssh_mux_key_fingerprint_{$server->uuid}";
+        $cachedFingerprint = Cache::get($fingerprintCacheKey);
+        
+        // If no cached fingerprint, we can't verify - assume it's okay but log it
+        if ($cachedFingerprint === null) {
+            return false;
+        }
+        
+        // Get the current key's fingerprint
+        $privateKey = PrivateKey::find($server->private_key_id);
+        if (! $privateKey) {
+            Log::warning('Server has no valid private key', [
+                'server_uuid' => $server->uuid,
+                'private_key_id' => $server->private_key_id,
+            ]);
+            return true; // Force refresh to get proper error
+        }
+        
+        $currentFingerprint = $privateKey->fingerprint;
+        
+        // Compare fingerprints
+        if ($cachedFingerprint !== $currentFingerprint) {
+            Log::info('SSH key fingerprint mismatch detected', [
+                'server_uuid' => $server->uuid,
+                'cached_fingerprint' => substr($cachedFingerprint ?? '', 0, 16) . '...',
+                'current_fingerprint' => substr($currentFingerprint ?? '', 0, 16) . '...',
+            ]);
+            return true;
+        }
+        
+        return false;
+    }
+
+    /**
      * Get the age of the current connection in seconds
      */
     public static function getConnectionAge(Server $server): ?int
@@ -298,6 +383,14 @@ class SshMultiplexingHelper
     {
         $cacheKey = "ssh_mux_connection_time_{$server->uuid}";
         Cache::put($cacheKey, time(), config('constants.ssh.mux_persist_time') + 300); // Cache slightly longer than persist time
+        
+        // Also store the key fingerprint used for this connection
+        // This allows us to detect when a different key should be used
+        $privateKey = PrivateKey::find($server->private_key_id);
+        if ($privateKey) {
+            $fingerprintCacheKey = "ssh_mux_key_fingerprint_{$server->uuid}";
+            Cache::put($fingerprintCacheKey, $privateKey->fingerprint, config('constants.ssh.mux_persist_time') + 300);
+        }
     }
 
     /**
@@ -307,5 +400,9 @@ class SshMultiplexingHelper
     {
         $cacheKey = "ssh_mux_connection_time_{$server->uuid}";
         Cache::forget($cacheKey);
+        
+        // Also clear the key fingerprint cache
+        $fingerprintCacheKey = "ssh_mux_key_fingerprint_{$server->uuid}";
+        Cache::forget($fingerprintCacheKey);
     }
 }

--- a/app/Helpers/SshMultiplexingHelper.php
+++ b/app/Helpers/SshMultiplexingHelper.php
@@ -213,6 +213,10 @@ class SshMultiplexingHelper
 
     private static function validateSshKey(PrivateKey $privateKey): void
     {
+        // Refresh from database to bypass Eloquent's in-memory caching
+        // This ensures we always have the latest key content after updates
+        $privateKey = PrivateKey::find($privateKey->id);
+        
         $keyLocation = $privateKey->getKeyLocation();
         
         // Check if the key file exists

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -134,8 +134,21 @@ class Server extends BaseModel
             $server->forceFill($payload);
         });
         static::saved(function ($server) {
+            // Refresh SSH connection if the key content changed
             if ($server->privateKey?->isDirty()) {
                 refresh_server_connection($server->privateKey);
+            }
+            
+            // Also refresh if the server switched to a different key (private_key_id changed)
+            // This fixes the bug where changing a server's SSH key wouldn't invalidate
+            // the existing multiplexed connection, causing "Permission denied" errors
+            if ($server->wasChanged('private_key_id')) {
+                \App\Helpers\SshMultiplexingHelper::removeMuxFile($server);
+                \Illuminate\Support\Facades\Log::info('SSH multiplexed connection invalidated due to key change', [
+                    'server_uuid' => $server->uuid,
+                    'old_key_id' => $server->getOriginal('private_key_id'),
+                    'new_key_id' => $server->private_key_id,
+                ]);
             }
         });
         static::created(function ($server) {


### PR DESCRIPTION
/claim #7724

## Summary
This PR fixes the sporadic SSH 'Permission denied (publickey,password)' errors that occur when Coolify sends the wrong SSH key.

## Root Causes Identified

1. **SSH key file validation was inadequate**: The validateSshKey method only checked if the key file existed, not whether its content matched the database. If a key was updated in the database but the file was not refreshed, stale/wrong keys would be used.

2. **Server key change did not invalidate multiplexing**: When a servers private_key_id was changed to point to a different key, the existing SSH multiplexed connection was not closed. The old connection would continue using the old (now invalid) key.

3. **No key tracking in mux metadata**: The multiplexing metadata only tracked connection age, not which SSH key was used. This made it impossible to detect when a connection should be refreshed due to key changes.

## Changes Made

### app/Helpers/SshMultiplexingHelper.php
- validateSshKey: Now compares file content with database content and refreshes the key file if there is a mismatch
- storeConnectionMetadata: Now also stores the SSH key fingerprint used for the connection
- clearConnectionMetadata: Now also clears the key fingerprint cache
- isKeyMismatch: New method to detect when the servers current key differs from the one used to establish the multiplexed connection
- ensureMultiplexedConnection: Now checks for key mismatches before reusing an existing connection

### app/Models/Server.php
- saved event: Now also invalidates the SSH mux connection when private_key_id changes (not just when key content changes)

## How This Fixes the Bug

1. When a user changes a servers SSH key, the multiplexed connection is immediately invalidated
2. Before reusing any multiplexed connection, we verify the key fingerprint matches
3. Before using any SSH key file, we verify its content matches the database
4. Added logging to help diagnose any future SSH key issues

## Testing
- Test changing a servers SSH key and verify connections work immediately
- Test updating a private keys content and verify all servers using it get fresh connections
- Test concurrent SSH operations during key changes

Fixes #7724