### PR TITLE
fix(ssh): prevent stale key errors by refreshing from DB and validating content

### DIFF
--- a/app/Helpers/SshMultiplexingHelper.php
+++ b/app/Helpers/SshMultiplexingHelper.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Facades\Storage;
 
 class SshMultiplexingHelper
 {
@@ -201,14 +202,67 @@ class SshMultiplexingHelper
         return config('constants.ssh.mux_enabled') && ! config('constants.coolify.is_windows_docker_desktop');
     }
 
+    /**
+     * Validate that the SSH key file exists and contains the correct content.
+     *
+     * This method addresses sporadic "Permission denied (publickey)" errors caused by:
+     * 1. Stale Eloquent model cache - relationship may return outdated key data
+     * 2. File content mismatch - key file may not match current database value
+     * 3. Stale multiplexed connections - existing connections may use old keys
+     *
+     * @see https://github.com/coollabsio/coolify/issues/7724
+     */
     private static function validateSshKey(PrivateKey $privateKey): void
     {
-        $keyLocation = $privateKey->getKeyLocation();
-        $checkKeyCommand = "ls $keyLocation 2>/dev/null";
-        $keyCheckProcess = Process::run($checkKeyCommand);
+        // CRITICAL: Refresh the model from database to avoid stale cached data
+        // This prevents using outdated keys when the Server model was loaded earlier
+        // and the key was subsequently changed in the database
+        $freshPrivateKey = PrivateKey::find($privateKey->id);
+        if (! $freshPrivateKey) {
+            Log::error('SSH key not found in database during validation', [
+                'key_id' => $privateKey->id,
+            ]);
+            throw new \RuntimeException('SSH key not found');
+        }
 
-        if ($keyCheckProcess->exitCode() !== 0) {
-            $privateKey->storeInFileSystem();
+        $disk = Storage::disk('ssh-keys');
+        $filename = "ssh_key@{$freshPrivateKey->uuid}";
+
+        // Check if key file exists
+        if (! $disk->exists($filename)) {
+            Log::debug('SSH key file not found, storing key', [
+                'key_uuid' => $freshPrivateKey->uuid,
+            ]);
+            $freshPrivateKey->storeInFileSystem();
+
+            return;
+        }
+
+        // Verify file content matches database to prevent stale key issues
+        $storedContent = $disk->get($filename);
+        if ($storedContent !== $freshPrivateKey->private_key) {
+            Log::warning('SSH key file content mismatch detected, re-storing key and invalidating connections', [
+                'key_uuid' => $freshPrivateKey->uuid,
+            ]);
+            $freshPrivateKey->storeInFileSystem();
+
+            // Invalidate any multiplexed connections that may be using the old key
+            // This is critical to prevent "Permission denied" errors from stale mux sockets
+            foreach ($freshPrivateKey->servers as $server) {
+                try {
+                    self::removeMuxFile($server);
+                    Log::debug('Invalidated mux connection due to key content mismatch', [
+                        'server_uuid' => $server->uuid,
+                        'key_uuid' => $freshPrivateKey->uuid,
+                    ]);
+                } catch (\Exception $e) {
+                    Log::warning('Failed to invalidate mux connection during key validation', [
+                        'server_uuid' => $server->uuid,
+                        'key_uuid' => $freshPrivateKey->uuid,
+                        'error' => $e->getMessage(),
+                    ]);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
/claim #7724

## Summary

Fixes sporadic 'Permission denied (publickey)' errors caused by stale SSH key data.

## Root Cause Analysis

The bug occurs due to three interconnected issues:

1. **Eloquent Relationship Caching**: When a `Server` model is loaded (especially via `Server::findCached()` or `ownedByCurrentTeamCached()`), the `$server->privateKey` relationship may return stale data if the key was changed in the database after the Server was loaded.

2. **File-Only Validation**: The previous `validateSshKey()` only checked if the key file exists using `ls`, not whether its content matches the database. A corrupted or stale file would pass validation.

3. **Stale Multiplexed Connections**: SSH multiplexing (`ControlMaster`) keeps connections alive that may have authenticated with an old key. When the key changes, these connections aren't invalidated.

## Solution

- **Refresh from DB**: Always fetch a fresh `PrivateKey` model from the database before validation, bypassing any Eloquent caching
- **Content Validation**: Compare file content with database value using `Storage::disk('ssh-keys')`
- **Connection Invalidation**: When a key mismatch is detected, invalidate ALL multiplexed connections for servers using that key

## Changes

- `app/Helpers/SshMultiplexingHelper.php`: Enhanced `validateSshKey()` method with:
  - Fresh database query for PrivateKey
  - File content comparison
  - Mux connection invalidation on mismatch
  - Comprehensive logging for debugging

## Testing

The fix ensures that:
1. Even with a cached Server model, the correct key from DB is used
2. Stale key files are detected and re-stored
3. Old SSH connections are invalidated when keys change

## Related

- Fixes #7724
- Similar approach to PR #7727 but adds critical DB refresh step to handle Eloquent caching