### PR TITLE
feat: Add database backup support for Docker Compose applications

### DIFF
--- a/app/Livewire/Project/Application/DatabaseBackups.php
+++ b/app/Livewire/Project/Application/DatabaseBackups.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Livewire\Project\Application;
+
+use App\Models\Application;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Component;
+
+class DatabaseBackups extends Component
+{
+    use AuthorizesRequests;
+
+    public Application $application;
+
+    public function mount()
+    {
+        $this->authorize('view', $this->application);
+    }
+
+    public function render()
+    {
+        return view('livewire.project.application.database-backups', [
+            'databases' => $this->application->databases()->get(),
+        ]);
+    }
+}

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -500,6 +500,15 @@ class Application extends BaseModel
         return $this->morphMany(LocalFileVolume::class, 'resource');
     }
 
+    /**
+     * Get databases detected in this application's Docker Compose file.
+     * Only applicable for dockercompose build pack.
+     */
+    public function databases()
+    {
+        return $this->hasMany(ServiceDatabase::class);
+    }
+
     public function type()
     {
         return 'application';

--- a/app/Models/ServiceDatabase.php
+++ b/app/Models/ServiceDatabase.php
@@ -27,16 +27,25 @@ class ServiceDatabase extends BaseModel
 
     public static function ownedByCurrentTeamAPI(int $teamId)
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', $teamId)->orderBy('name');
+        return ServiceDatabase::where(function ($query) use ($teamId) {
+            $query->whereRelation('service.environment.project.team', 'id', $teamId)
+                ->orWhereRelation('application.environment.project.team', 'id', $teamId);
+        })->orderBy('name');
     }
 
     /**
      * Get query builder for service databases owned by current team.
      * If you need all service databases without further query chaining, use ownedByCurrentTeamCached() instead.
+     * Supports both Service-based and Application-based databases.
      */
     public static function ownedByCurrentTeam()
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', currentTeam()->id)->orderBy('name');
+        $teamId = currentTeam()->id;
+
+        return ServiceDatabase::where(function ($query) use ($teamId) {
+            $query->whereRelation('service.environment.project.team', 'id', $teamId)
+                ->orWhereRelation('application.environment.project.team', 'id', $teamId);
+        })->orderBy('name');
     }
 
     /**
@@ -51,8 +60,9 @@ class ServiceDatabase extends BaseModel
 
     public function restart()
     {
-        $container_id = $this->name.'-'.$this->service->uuid;
-        remote_process(["docker restart {$container_id}"], $this->service->server);
+        $parent = $this->getParentResource();
+        $container_id = $this->name.'-'.$parent->uuid;
+        remote_process(["docker restart {$container_id}"], $this->getServer());
     }
 
     public function isRunning()
@@ -114,8 +124,9 @@ class ServiceDatabase extends BaseModel
     public function getServiceDatabaseUrl()
     {
         $port = $this->public_port;
-        $realIp = $this->service->server->ip;
-        if ($this->service->server->isLocalhost() || isDev()) {
+        $server = $this->getServer();
+        $realIp = $server->ip;
+        if ($server->isLocalhost() || isDev()) {
             $realIp = base_ip();
         }
 
@@ -129,12 +140,43 @@ class ServiceDatabase extends BaseModel
 
     public function workdir()
     {
-        return service_configuration_dir()."/{$this->service->uuid}";
+        $parent = $this->getParentResource();
+        if ($this->service_id) {
+            return service_configuration_dir()."/{$parent->uuid}";
+        }
+
+        return application_configuration_dir()."/{$parent->uuid}";
     }
 
     public function service()
     {
         return $this->belongsTo(Service::class);
+    }
+
+    public function application()
+    {
+        return $this->belongsTo(Application::class);
+    }
+
+    /**
+     * Get the parent resource (Service or Application).
+     */
+    public function getParentResource()
+    {
+        return $this->service ?? $this->application;
+    }
+
+    /**
+     * Get the server for this database.
+     * Works for both Service-based and Application-based databases.
+     */
+    public function getServer()
+    {
+        if ($this->service_id) {
+            return $this->service->server;
+        }
+
+        return $this->application?->destination?->server;
     }
 
     public function persistentStorages()

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -2418,6 +2418,34 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
             $isDatabase = isDatabaseImage($image, $service);
             data_set($service, 'is_database', $isDatabase);
 
+            // Create ServiceDatabase record for detected databases (enables backup support)
+            if ($isDatabase) {
+                if ($isNew) {
+                    $savedDatabase = ServiceDatabase::create([
+                        'name' => $serviceName,
+                        'image' => $image,
+                        'application_id' => $resource->id,
+                    ]);
+                } else {
+                    $savedDatabase = ServiceDatabase::where([
+                        'name' => $serviceName,
+                        'application_id' => $resource->id,
+                    ])->first();
+                    if (is_null($savedDatabase)) {
+                        $savedDatabase = ServiceDatabase::create([
+                            'name' => $serviceName,
+                            'image' => $image,
+                            'application_id' => $resource->id,
+                        ]);
+                    } elseif ($savedDatabase->image !== $image) {
+                        // Update image if changed
+                        $savedDatabase->image = $image;
+                        $savedDatabase->save();
+                    }
+                }
+                data_set($service, 'service_database_id', $savedDatabase->id);
+            }
+
             // Collect/create/update networks
             if ($serviceNetworks->count() > 0) {
                 foreach ($serviceNetworks as $networkName => $networkDetails) {

--- a/database/migrations/2026_02_02_000000_add_application_id_to_service_databases.php
+++ b/database/migrations/2026_02_02_000000_add_application_id_to_service_databases.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * This migration adds application_id to service_databases table to support
+     * database detection for Docker Compose deployments via GitHub App.
+     *
+     * Previously, ServiceDatabase only supported Service model (one-click services,
+     * Empty Docker Compose). Now it also supports Application model (GitHub App
+     * with dockercompose buildpack).
+     */
+    public function up(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            // Add nullable application_id for GitHub App deployments
+            $table->foreignId('application_id')->nullable()->after('service_id');
+
+            // Add index for efficient queries
+            $table->index('application_id');
+        });
+
+        // Make service_id nullable since we now support either service_id OR application_id
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->foreignId('service_id')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->dropIndex(['application_id']);
+            $table->dropColumn('application_id');
+        });
+
+        // Restore service_id to non-nullable (this may fail if there are rows with null service_id)
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->foreignId('service_id')->nullable(false)->change();
+        });
+    }
+};

--- a/resources/views/livewire/project/application/configuration.blade.php
+++ b/resources/views/livewire/project/application/configuration.blade.php
@@ -54,6 +54,10 @@
                 <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
                     href="{{ route('project.application.healthcheck', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Healthcheck</span></a>
             @endif
+            @if ($application->build_pack === 'dockercompose' && $application->databases()->exists())
+                <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                    href="{{ route('project.application.database-backups', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Database Backups</span></a>
+            @endif
             <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
                 href="{{ route('project.application.rollback', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Rollback</span></a>
             <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
@@ -90,6 +94,8 @@
                 <livewire:project.application.previews :application="$application" />
             @elseif ($currentRoute === 'project.application.healthcheck' && $application->build_pack !== 'dockercompose')
                 <livewire:project.shared.health-checks :resource="$application" />
+            @elseif ($currentRoute === 'project.application.database-backups' && $application->build_pack === 'dockercompose')
+                <livewire:project.application.database-backups :application="$application" />
             @elseif ($currentRoute === 'project.application.rollback')
                 <livewire:project.application.rollback :application="$application" />
             @elseif ($currentRoute === 'project.application.resource-limits')

--- a/resources/views/livewire/project/application/database-backups.blade.php
+++ b/resources/views/livewire/project/application/database-backups.blade.php
@@ -1,0 +1,60 @@
+<div>
+    <h2>Database Backups</h2>
+    <div class="pb-4 text-sm text-gray-400">
+        Manage scheduled backups for databases detected in your Docker Compose file.
+    </div>
+
+    @if ($databases->isEmpty())
+        <div class="text-gray-500">
+            No databases detected in your Docker Compose file.
+        </div>
+    @else
+        <div class="flex flex-col gap-4">
+            @foreach ($databases as $database)
+                <div class="p-4 border rounded-lg border-coolgray-200 bg-coolgray-100">
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <h3 class="text-lg font-semibold">{{ $database->name }}</h3>
+                            <div class="text-sm text-gray-400">
+                                Image: {{ $database->image }}
+                            </div>
+                            <div class="text-sm text-gray-400">
+                                Type: {{ $database->databaseType() }}
+                            </div>
+                        </div>
+                        <div class="flex items-center gap-2">
+                            @if ($database->isBackupSolutionAvailable())
+                                <span class="px-2 py-1 text-xs text-green-400 bg-green-900 rounded">
+                                    Backup Available
+                                </span>
+                            @else
+                                <span class="px-2 py-1 text-xs text-yellow-400 bg-yellow-900 rounded">
+                                    No Backup Support
+                                </span>
+                            @endif
+                        </div>
+                    </div>
+
+                    @if ($database->isBackupSolutionAvailable())
+                        <div class="mt-4">
+                            <div class="flex items-center gap-2 mb-2">
+                                <h4 class="font-medium">Scheduled Backups</h4>
+                                @can('update', $database)
+                                    <x-modal-input buttonTitle="+ Add" title="New Scheduled Backup">
+                                        <livewire:project.database.create-scheduled-backup :database="$database" :key="'create-backup-'.$database->id" />
+                                    </x-modal-input>
+                                @endcan
+                            </div>
+                            <livewire:project.database.scheduled-backups :database="$database" :key="'backups-'.$database->id" />
+                        </div>
+                    @else
+                        <div class="mt-4 text-sm text-gray-500">
+                            Automatic backups are not available for this database type ({{ $database->databaseType() }}).
+                            Supported types: PostgreSQL, MySQL, MariaDB, MongoDB.
+                        </div>
+                    @endif
+                </div>
+            @endforeach
+        </div>
+    @endif
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -202,6 +202,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/webhooks', ApplicationConfiguration::class)->name('project.application.webhooks');
         Route::get('/preview-deployments', ApplicationConfiguration::class)->name('project.application.preview-deployments');
         Route::get('/healthcheck', ApplicationConfiguration::class)->name('project.application.healthcheck');
+        Route::get('/database-backups', ApplicationConfiguration::class)->name('project.application.database-backups');
         Route::get('/rollback', ApplicationConfiguration::class)->name('project.application.rollback');
         Route::get('/resource-limits', ApplicationConfiguration::class)->name('project.application.resource-limits');
         Route::get('/resource-operations', ApplicationConfiguration::class)->name('project.application.resource-operations');


### PR DESCRIPTION
## Summary
Enable database detection and backup functionality for Docker Compose deployments via GitHub App (dockercompose build pack).

- Add `application_id` FK to `service_databases` table
- Update `ServiceDatabase` model with `application()` relationship and helper methods
- Add `databases()` relationship to `Application` model
- Create `ServiceDatabase` records during Docker Compose parsing for detected databases
- Add "Database Backups" UI page for dockercompose applications
- Update configuration sidebar with Database Backups menu item

This enables scheduled backups for databases detected in GitHub App deployments, matching existing functionality for Service-based deployments.

## Test plan
- [ ] Run migration: `sail artisan migrate`
- [ ] Verify `application_id` column exists in `service_databases` table
- [ ] Deploy a dockercompose Application with postgres/mysql service
- [ ] Verify "Database Backups" menu appears for dockercompose apps
- [ ] Create a scheduled backup for detected database
- [ ] Verify existing Service-based database backups still work

## Related Issue
Fixes #7528

/attempt #7528

🤖 Generated with [Claude Code](https://claude.com/claude-code)