### PR TITLE
feat: OAuth self-registration (#8042)

### DIFF
--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\RateLimiter;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class OauthController extends Controller
@@ -20,17 +21,14 @@ class OauthController extends Controller
         try {
             $oauthUser = get_socialite_provider($provider)->user();
             $user = User::whereEmail($oauthUser->email)->first();
-            if (! $user) {
-                $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
-                    abort(403, 'Registration is disabled');
-                }
 
-                $user = User::create([
-                    'name' => $oauthUser->name,
-                    'email' => $oauthUser->email,
-                ]);
+            if (! $user) {
+                $user = $this->handleUserRegistration($oauthUser, $provider);
+            } else {
+                // Update OAuth provider info for existing user if not already set
+                $this->updateExistingUserOauthInfo($user, $oauthUser, $provider);
             }
+
             Auth::login($user);
 
             return redirect('/');
@@ -38,6 +36,57 @@ class OauthController extends Controller
             $errorCode = $e instanceof HttpException ? 'auth.failed' : 'auth.failed.callback';
 
             return redirect()->route('login')->withErrors([__($errorCode)]);
+        }
+    }
+
+    /**
+     * Handle user registration via OAuth.
+     * Checks if general registration or OAuth registration is enabled.
+     */
+    private function handleUserRegistration($oauthUser, string $provider): User
+    {
+        $settings = instanceSettings();
+
+        // Check if general registration or OAuth-specific registration is enabled
+        $canRegister = $settings->is_registration_enabled || $settings->is_oauth_registration_enabled;
+
+        if (! $canRegister) {
+            abort(403, 'Registration is disabled');
+        }
+
+        // Rate limit OAuth registrations
+        $rateLimitKey = 'oauth-registration:'.request()->ip();
+        if (RateLimiter::tooManyAttempts($rateLimitKey, 5)) {
+            abort(429, 'Too many registration attempts. Please try again later.');
+        }
+        RateLimiter::hit($rateLimitKey, 3600); // 1 hour
+
+        // Verify email exists from OAuth provider
+        if (empty($oauthUser->email)) {
+            abort(400, 'Email not provided by OAuth provider. Please ensure your OAuth account has a verified email.');
+        }
+
+        // Create user with OAuth provider info
+        return User::create([
+            'name' => $oauthUser->name ?? $oauthUser->nickname ?? 'User',
+            'email' => $oauthUser->email,
+            'oauth_provider' => $provider,
+            'oauth_id' => $oauthUser->id,
+            'email_verified_at' => now(), // OAuth emails are considered verified
+        ]);
+    }
+
+    /**
+     * Update existing user's OAuth information if not already set.
+     */
+    private function updateExistingUserOauthInfo(User $user, $oauthUser, string $provider): void
+    {
+        // Only update if user doesn't have OAuth info set
+        if (empty($user->oauth_provider)) {
+            $user->update([
+                'oauth_provider' => $provider,
+                'oauth_id' => $oauthUser->id,
+            ]);
         }
     }
 }

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -15,6 +15,9 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $is_oauth_registration_enabled;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -41,6 +44,7 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_registration_enabled' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => 'nullable|string',
@@ -62,6 +66,7 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled ?? false;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -138,6 +143,7 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -31,6 +31,7 @@ class InstanceSettings extends Model
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',
         'is_wire_navigate_enabled' => 'boolean',
+        'is_oauth_registration_enabled' => 'boolean',
     ];
 
     protected static function booted(): void

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -474,4 +474,20 @@ class User extends Authenticatable implements SendsEmail
     {
         return ! empty($this->password);
     }
+
+    /**
+     * Check if the user was created via OAuth.
+     */
+    public function isOauthUser(): bool
+    {
+        return ! empty($this->oauth_provider);
+    }
+
+    /**
+     * Get the OAuth provider the user registered with.
+     */
+    public function getOauthProvider(): ?string
+    {
+        return $this->oauth_provider;
+    }
 }

--- a/database/migrations/2026_02_03_000001_add_oauth_registration_settings_to_instance_settings_table.php
+++ b/database/migrations/2026_02_03_000001_add_oauth_registration_settings_to_instance_settings_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_registration_enabled')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn('is_oauth_registration_enabled');
+        });
+    }
+};

--- a/database/migrations/2026_02_03_000002_add_oauth_provider_to_users_table.php
+++ b/database/migrations/2026_02_03_000002_add_oauth_provider_to_users_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('oauth_provider')->nullable()->after('email');
+            $table->string('oauth_id')->nullable()->after('oauth_provider');
+            $table->index(['oauth_provider', 'oauth_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropIndex(['oauth_provider', 'oauth_id']);
+            $table->dropColumn(['oauth_provider', 'oauth_id']);
+        });
+    }
+};

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -16,10 +16,16 @@
                 <div class="pb-4">Advanced settings for your Coolify instance.</div>
 
                 <div class="flex flex-col gap-1">
+                    <h4>Registration Settings</h4>
                     <div class="md:w-96">
                         <x-forms.checkbox instantSave id="is_registration_enabled"
                             helper="Allow users to self-register. If disabled, only administrators can create accounts."
                             label="Registration Allowed" />
+                    </div>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_registration_enabled"
+                            helper="Allow users to self-register via OAuth providers (GitHub, GitLab, Google, etc.) even when general registration is disabled. This enables you to control registration through your OAuth provider while blocking direct email/password signups."
+                            label="OAuth Registration Allowed" />
                     </div>
                     <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"

--- a/tests/Unit/OauthSelfRegistrationTest.php
+++ b/tests/Unit/OauthSelfRegistrationTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * Tests for OAuth self-registration feature
+ *
+ * These tests verify that the OAuth registration logic works correctly
+ * when the is_oauth_registration_enabled setting is used.
+ */
+
+use App\Models\InstanceSettings;
+use App\Models\User;
+
+it('has is_oauth_registration_enabled cast to boolean in InstanceSettings', function () {
+    $settings = new InstanceSettings;
+    $casts = $settings->getCasts();
+
+    expect($casts)->toHaveKey('is_oauth_registration_enabled')
+        ->and($casts['is_oauth_registration_enabled'])->toBe('boolean');
+});
+
+it('defaults is_oauth_registration_enabled to false', function () {
+    $settings = new InstanceSettings;
+    $settings->is_oauth_registration_enabled = false;
+
+    expect($settings->is_oauth_registration_enabled)->toBeFalse()
+        ->and($settings->is_oauth_registration_enabled)->toBeBool();
+});
+
+it('casts is_oauth_registration_enabled from string "1" to boolean true', function () {
+    $settings = new InstanceSettings;
+    $settings->is_oauth_registration_enabled = '1';
+
+    expect($settings->is_oauth_registration_enabled)->toBeTrue()
+        ->and($settings->is_oauth_registration_enabled)->toBeBool();
+});
+
+it('casts is_oauth_registration_enabled from string "0" to boolean false', function () {
+    $settings = new InstanceSettings;
+    $settings->is_oauth_registration_enabled = '0';
+
+    expect($settings->is_oauth_registration_enabled)->toBeFalse()
+        ->and($settings->is_oauth_registration_enabled)->toBeBool();
+});
+
+it('user can be identified as oauth user when oauth_provider is set', function () {
+    $user = new User;
+    $user->oauth_provider = 'github';
+    $user->oauth_id = '12345';
+
+    expect($user->isOauthUser())->toBeTrue()
+        ->and($user->getOauthProvider())->toBe('github');
+});
+
+it('user is not oauth user when oauth_provider is null', function () {
+    $user = new User;
+    $user->oauth_provider = null;
+
+    expect($user->isOauthUser())->toBeFalse()
+        ->and($user->getOauthProvider())->toBeNull();
+});
+
+it('user is not oauth user when oauth_provider is empty string', function () {
+    $user = new User;
+    $user->oauth_provider = '';
+
+    expect($user->isOauthUser())->toBeFalse();
+});
+
+it('user has no password when created via oauth', function () {
+    $user = new User;
+    $user->name = 'Test User';
+    $user->email = 'test@example.com';
+    $user->oauth_provider = 'github';
+    $user->password = null;
+
+    expect($user->hasPassword())->toBeFalse();
+});
+
+it('user has password when set', function () {
+    $user = new User;
+    $user->name = 'Test User';
+    $user->email = 'test@example.com';
+    $user->password = 'hashed_password';
+
+    expect($user->hasPassword())->toBeTrue();
+});


### PR DESCRIPTION
## Summary
Implements OAuth self-registration feature for #8042

## Changes
- Add `is_oauth_registration_enabled` setting to control OAuth-only registration
- Track OAuth users with `oauth_provider` and `oauth_id` columns
- Add admin UI toggle in Settings > Advanced
- Rate limit OAuth registrations (5/hour/IP)
- Auto-verify email for OAuth users

## Testing
- Unit tests added in `tests/Unit/OauthSelfRegistrationTest.php`
- Feature tested with GitHub OAuth provider
- Rate limiting verified

## Security
- Feature disabled by default (secure-by-default)
- Rate limiting prevents abuse
- OAuth emails are auto-verified (trusted from provider)

Claiming bounty via @algora - $50

Fixes #8042