### PR TITLE
feat: add OAuth-only registration setting

### DIFF
--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -22,7 +22,9 @@ class OauthController extends Controller
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                // Allow registration if general registration is enabled OR OAuth-specific registration is enabled
+                $canRegister = $settings->is_registration_enabled || $settings->is_oauth_registration_enabled;
+                if (! $canRegister) {
                     abort(403, 'Registration is disabled');
                 }
 

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -15,6 +15,9 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $is_oauth_registration_enabled;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -41,6 +44,7 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_registration_enabled' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => 'nullable|string',
@@ -62,6 +66,7 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled ?? false;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -138,6 +143,7 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -31,6 +31,7 @@ class InstanceSettings extends Model
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',
         'is_wire_navigate_enabled' => 'boolean',
+        'is_oauth_registration_enabled' => 'boolean',
     ];
 
     protected static function booted(): void

--- a/database/migrations/2026_02_05_000001_add_oauth_registration_settings.php
+++ b/database/migrations/2026_02_05_000001_add_oauth_registration_settings.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            // Allow users to self-register via OAuth even when general registration is disabled
+            $table->boolean('is_oauth_registration_enabled')->default(false)->after('is_registration_enabled');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn('is_oauth_registration_enabled');
+        });
+    }
+};

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -22,6 +22,11 @@
                             label="Registration Allowed" />
                     </div>
                     <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_registration_enabled"
+                            helper="Allow users to self-register via OAuth providers (GitHub, GitLab, etc.) even when general registration is disabled. Useful for controlling access through external identity providers."
+                            label="OAuth Registration Allowed" />
+                    </div>
+                    <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"
                             helper="Opt out of reporting this instance to coolify.io's installation count. No other data is collected."
                             label="Do Not Track" />


### PR DESCRIPTION
## Summary
Implements #8042 - Allow OAuth registration when general registration is disabled

## Problem
Currently, users can only self-register via OAuth when general self-registration is enabled. This makes it impossible to restrict registration to OAuth providers only.

## Solution
Added a new setting `is_oauth_registration_enabled` that allows users to self-register via OAuth providers (GitHub, GitLab, Authentik, etc.) even when general registration is disabled.

## Changes
- **Migration**: Added `is_oauth_registration_enabled` column to `instance_settings` table
- **OauthController**: Updated callback to check both registration settings
- **InstanceSettings Model**: Added boolean cast for new setting
- **Advanced Livewire Component**: Added property, validation, and persistence for new setting
- **Advanced Settings View**: Added checkbox with helper text

## Use Case
This is useful for organizations that want to:
- Control access through external identity providers (Authentik, Keycloak, etc.)
- Prevent password-based registration while allowing OAuth
- Easily suspend users across multiple Coolify instances by removing them from the IdP

## Testing
- [x] New migration creates column correctly
- [x] Setting can be toggled from UI
- [x] OAuth registration works when setting is enabled (even with general registration disabled)
- [x] OAuth registration blocked when both settings are disabled

## Related Issue
Closes #8042

/bounty $50