### PR TITLE
fix: isolate environment variables per container in Docker Compose services

### DIFF
--- a/app/Http/Controllers/Api/ServicesController.php
+++ b/app/Http/Controllers/Api/ServicesController.php
@@ -1128,6 +1128,7 @@ class ServicesController extends Controller
                             'is_literal' => ['type' => 'boolean', 'description' => 'The flag to indicate if the environment variable is a literal, nothing espaced.'],
                             'is_multiline' => ['type' => 'boolean', 'description' => 'The flag to indicate if the environment variable is multiline.'],
                             'is_shown_once' => ['type' => 'boolean', 'description' => 'The flag to indicate if the environment variable\'s value is shown on the UI.'],
+                            'container_name' => ['type' => 'string', 'nullable' => true, 'description' => 'The container name this variable is scoped to. Null or empty means all containers (default).'],
                         ],
                     ),
                 ),
@@ -1249,6 +1250,7 @@ class ServicesController extends Controller
                                         'is_literal' => ['type' => 'boolean', 'description' => 'The flag to indicate if the environment variable is a literal, nothing espaced.'],
                                         'is_multiline' => ['type' => 'boolean', 'description' => 'The flag to indicate if the environment variable is multiline.'],
                                         'is_shown_once' => ['type' => 'boolean', 'description' => 'The flag to indicate if the environment variable\'s value is shown on the UI.'],
+                                        'container_name' => ['type' => 'string', 'nullable' => true, 'description' => 'The container name this variable is scoped to. Null or empty means all containers (default).'],
                                     ],
                                 ),
                             ],
@@ -1318,6 +1320,7 @@ class ServicesController extends Controller
                 'is_literal' => 'boolean',
                 'is_multiline' => 'boolean',
                 'is_shown_once' => 'boolean',
+                'container_name' => 'string|nullable',
             ]);
 
             if ($validator->fails()) {
@@ -1372,6 +1375,7 @@ class ServicesController extends Controller
                         'is_literal' => ['type' => 'boolean', 'description' => 'The flag to indicate if the environment variable is a literal, nothing espaced.'],
                         'is_multiline' => ['type' => 'boolean', 'description' => 'The flag to indicate if the environment variable is multiline.'],
                         'is_shown_once' => ['type' => 'boolean', 'description' => 'The flag to indicate if the environment variable\'s value is shown on the UI.'],
+                        'container_name' => ['type' => 'string', 'nullable' => true, 'description' => 'The container name this variable is scoped to. Null or empty means all containers (default).'],
                     ],
                 ),
             ),
@@ -1430,6 +1434,7 @@ class ServicesController extends Controller
             'is_literal' => 'boolean',
             'is_multiline' => 'boolean',
             'is_shown_once' => 'boolean',
+            'container_name' => 'string|nullable',
         ]);
 
         if ($validator->fails()) {

--- a/app/Livewire/Project/Shared/EnvironmentVariable/Add.php
+++ b/app/Livewire/Project/Shared/EnvironmentVariable/Add.php
@@ -33,6 +33,17 @@ class Add extends Component
 
     public array $problematicVariables = [];
 
+    /**
+     * Container names from Docker Compose services.
+     * Empty array for non-Docker Compose resources.
+     */
+    public array $containerNames = [];
+
+    /**
+     * Selected container name. Empty string means "all containers".
+     */
+    public string $container_name = '';
+
     protected $listeners = ['clearAddEnv' => 'clear'];
 
     protected $rules = [
@@ -42,6 +53,7 @@ class Add extends Component
         'is_literal' => 'required|boolean',
         'is_runtime' => 'required|boolean',
         'is_buildtime' => 'required|boolean',
+        'container_name' => 'nullable|string',
     ];
 
     protected $validationAttributes = [
@@ -51,6 +63,7 @@ class Add extends Component
         'is_literal' => 'literal',
         'is_runtime' => 'runtime',
         'is_buildtime' => 'buildtime',
+        'container_name' => 'container',
     ];
 
     public function mount()
@@ -136,6 +149,7 @@ class Add extends Component
             'is_runtime' => $this->is_runtime,
             'is_buildtime' => $this->is_buildtime,
             'is_preview' => $this->is_preview,
+            'container_name' => $this->container_name,
         ]);
         $this->clear();
     }
@@ -148,5 +162,6 @@ class Add extends Component
         $this->is_literal = false;
         $this->is_runtime = true;
         $this->is_buildtime = true;
+        $this->container_name = '';
     }
 }

--- a/app/Livewire/Project/Shared/EnvironmentVariable/All.php
+++ b/app/Livewire/Project/Shared/EnvironmentVariable/All.php
@@ -5,7 +5,9 @@ namespace App\Livewire\Project\Shared\EnvironmentVariable;
 use App\Models\EnvironmentVariable;
 use App\Traits\EnvironmentVariableProtection;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Attributes\Computed;
 use Livewire\Component;
+use Symfony\Component\Yaml\Yaml;
 
 class All extends Component
 {
@@ -32,6 +34,33 @@ class All extends Component
         'refreshEnvs',
         'environmentVariableDeleted' => 'refreshEnvs',
     ];
+
+    /**
+     * Get available container names for Docker Compose services.
+     * Returns empty array for non-Docker Compose resources.
+     */
+    #[Computed]
+    public function containerNames(): array
+    {
+        // Only Services and Docker Compose Applications have multiple containers
+        if ($this->resource->type() !== 'service' && data_get($this->resource, 'build_pack') !== 'dockercompose') {
+            return [];
+        }
+
+        $dockerCompose = data_get($this->resource, 'docker_compose');
+        if (! $dockerCompose) {
+            return [];
+        }
+
+        try {
+            $parsed = Yaml::parse($dockerCompose);
+            $services = data_get($parsed, 'services', []);
+
+            return array_keys($services);
+        } catch (\Exception $e) {
+            return [];
+        }
+    }
 
     public function mount()
     {
@@ -242,6 +271,13 @@ class All extends Component
         $environment->is_preview = $data['is_preview'] ?? false;
         $environment->resourceable_id = $this->resource->id;
         $environment->resourceable_type = $this->resource->getMorphClass();
+
+        // Set container_name for Docker Compose services (null means all containers)
+        $containerName = $data['container_name'] ?? null;
+        if ($containerName === '' || $containerName === 'all') {
+            $containerName = null;
+        }
+        $environment->container_name = $containerName;
 
         return $environment;
     }

--- a/app/Livewire/Project/Shared/EnvironmentVariable/Show.php
+++ b/app/Livewire/Project/Shared/EnvironmentVariable/Show.php
@@ -54,6 +54,11 @@ class Show extends Component
 
     public array $problematicVariables = [];
 
+    /**
+     * Container name this variable is scoped to (null = all containers).
+     */
+    public ?string $container_name = null;
+
     protected $listeners = [
         'refreshEnvs' => 'refresh',
         'refresh',
@@ -70,6 +75,7 @@ class Show extends Component
         'is_buildtime' => 'required|boolean',
         'real_value' => 'nullable',
         'is_required' => 'required|boolean',
+        'container_name' => 'nullable|string',
     ];
 
     public function mount()
@@ -115,6 +121,12 @@ class Show extends Component
                 $this->env->is_runtime = $this->is_runtime;
                 $this->env->is_buildtime = $this->is_buildtime;
                 $this->env->is_shared = $this->is_shared;
+                // Handle container_name (empty string or 'all' means null = all containers)
+                $containerName = $this->container_name;
+                if ($containerName === '' || $containerName === 'all') {
+                    $containerName = null;
+                }
+                $this->env->container_name = $containerName;
             }
             $this->env->key = $this->key;
             $this->env->value = $this->value;
@@ -134,6 +146,7 @@ class Show extends Component
             $this->is_really_required = $this->env->is_really_required ?? false;
             $this->is_shared = $this->env->is_shared ?? false;
             $this->real_value = $this->env->real_value;
+            $this->container_name = $this->env->container_name;
         }
     }
 

--- a/app/Models/EnvironmentVariable.php
+++ b/app/Models/EnvironmentVariable.php
@@ -25,6 +25,7 @@ use OpenApi\Attributes as OA;
         'value' => ['type' => 'string'],
         'real_value' => ['type' => 'string'],
         'version' => ['type' => 'string'],
+        'container_name' => ['type' => 'string', 'nullable' => true, 'description' => 'Container name this variable is scoped to. Null means all containers.'],
         'created_at' => ['type' => 'string'],
         'updated_at' => ['type' => 'string'],
     ]
@@ -43,6 +44,7 @@ class EnvironmentVariable extends BaseModel
         'version' => 'string',
         'resourceable_type' => 'string',
         'resourceable_id' => 'integer',
+        'container_name' => 'string',
     ];
 
     protected $appends = ['real_value', 'is_shared', 'is_really_required', 'is_nixpacks', 'is_coolify'];

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -1511,42 +1511,89 @@ class Service extends BaseModel
         Storage::disk('local')->delete("tmp/{$filename}");
 
         $commands[] = "cd $workdir";
-        $commands[] = 'rm -f .env || true';
+        // Remove old env files (main .env and any per-container .env.* files)
+        $commands[] = 'rm -f .env .env.* || true';
 
-        $envs = collect([]);
-
-        // Generate SERVICE_NAME_* environment variables from docker-compose services
+        // Parse docker-compose to get service names
+        $serviceNames = collect([]);
         if ($this->docker_compose) {
             try {
                 $dockerCompose = \Symfony\Component\Yaml\Yaml::parse($this->docker_compose);
                 $services = data_get($dockerCompose, 'services', []);
-                foreach ($services as $serviceName => $_) {
-                    $envs->push('SERVICE_NAME_'.str($serviceName)->replace('-', '_')->replace('.', '_')->upper().'='.$serviceName);
-                }
+                $serviceNames = collect(array_keys($services));
             } catch (\Exception $e) {
                 ray($e->getMessage());
             }
         }
 
+        // Get all environment variables
         $envs_from_coolify = $this->environment_variables()->get();
-        $sorted = $envs_from_coolify->sortBy(function ($env) {
-            if (str($env->key)->startsWith('SERVICE_')) {
-                return 1;
-            }
-            if (str($env->value)->startsWith('$SERVICE_') || str($env->value)->startsWith('${SERVICE_')) {
-                return 2;
+
+        // Sort function for env vars (SERVICE_* first, then $SERVICE_* references, then others)
+        $sortEnvs = function ($envs) {
+            return $envs->sortBy(function ($env) {
+                if (str($env->key)->startsWith('SERVICE_')) {
+                    return 1;
+                }
+                if (str($env->value)->startsWith('$SERVICE_') || str($env->value)->startsWith('${SERVICE_')) {
+                    return 2;
+                }
+
+                return 3;
+            });
+        };
+
+        // Separate global vars (container_name = null) from container-specific vars
+        $globalVars = $envs_from_coolify->whereNull('container_name');
+        $containerVars = $envs_from_coolify->whereNotNull('container_name')->groupBy('container_name');
+
+        // Generate SERVICE_NAME_* variables for all containers (these are always global)
+        $serviceNameVars = collect([]);
+        foreach ($serviceNames as $serviceName) {
+            $serviceNameVars->push('SERVICE_NAME_'.str($serviceName)->replace('-', '_')->replace('.', '_')->upper().'='.$serviceName);
+        }
+
+        // Create per-container env files
+        foreach ($serviceNames as $serviceName) {
+            $containerEnvs = collect([]);
+
+            // Add SERVICE_NAME_* vars
+            $containerEnvs = $containerEnvs->merge($serviceNameVars);
+
+            // Add global vars (available to all containers)
+            foreach ($sortEnvs($globalVars) as $env) {
+                $containerEnvs->push("{$env->key}={$env->real_value}");
             }
 
-            return 3;
-        });
-        foreach ($sorted as $env) {
-            $envs->push("{$env->key}={$env->real_value}");
+            // Add container-specific vars
+            if ($containerVars->has($serviceName)) {
+                foreach ($sortEnvs($containerVars->get($serviceName)) as $env) {
+                    $containerEnvs->push("{$env->key}={$env->real_value}");
+                }
+            }
+
+            // Write per-container env file
+            $envFileName = ".env.{$serviceName}";
+            if ($containerEnvs->count() === 0) {
+                $commands[] = "touch {$envFileName}";
+            } else {
+                $envs_base64 = base64_encode($containerEnvs->implode("\n"));
+                $commands[] = "echo '{$envs_base64}' | base64 -d | tee {$envFileName} > /dev/null";
+            }
         }
-        if ($envs->count() === 0) {
+
+        // Also create a main .env with only global vars for backward compatibility
+        // (some tools may expect a .env file to exist)
+        $globalEnvs = collect([]);
+        $globalEnvs = $globalEnvs->merge($serviceNameVars);
+        foreach ($sortEnvs($globalVars) as $env) {
+            $globalEnvs->push("{$env->key}={$env->real_value}");
+        }
+        if ($globalEnvs->count() === 0) {
             $commands[] = 'touch .env';
         } else {
-            $envs_base64 = base64_encode($envs->implode("\n"));
-            $commands[] = "echo '$envs_base64' | base64 -d | tee .env > /dev/null";
+            $envs_base64 = base64_encode($globalEnvs->implode("\n"));
+            $commands[] = "echo '{$envs_base64}' | base64 -d | tee .env > /dev/null";
         }
 
         instant_remote_process($commands, $this->server);

--- a/bootstrap/helpers/parsers.php
+++ b/bootstrap/helpers/parsers.php
@@ -1317,11 +1317,13 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
         if ($depends_on->count() > 0) {
             $payload['depends_on'] = $depends_on;
         }
-        // Auto-inject .env file so Coolify environment variables are available inside containers
-        // This makes Applications behave consistently with manual .env file usage
+        // Auto-inject per-container .env file so Coolify environment variables are available inside containers
+        // Each container gets its own env file (.env.<serviceName>) with only the variables scoped to it
+        // This prevents container A from accessing container B's secrets (security fix for issue #7655)
         $existingEnvFiles = data_get($service, 'env_file');
+        $containerEnvFile = ".env.{$serviceName}";
         $envFiles = collect(is_null($existingEnvFiles) ? [] : (is_array($existingEnvFiles) ? $existingEnvFiles : [$existingEnvFiles]))
-            ->push('.env')
+            ->push($containerEnvFile)
             ->unique()
             ->values();
 
@@ -2416,11 +2418,13 @@ function serviceParser(Service $resource): Collection
         if ($depends_on->count() > 0) {
             $payload['depends_on'] = $depends_on;
         }
-        // Auto-inject .env file so Coolify environment variables are available inside containers
-        // This makes Services behave consistently with Applications
+        // Auto-inject per-container .env file so Coolify environment variables are available inside containers
+        // Each container gets its own env file (.env.<serviceName>) with only the variables scoped to it
+        // This prevents container A from accessing container B's secrets (security fix for issue #7655)
         $existingEnvFiles = data_get($service, 'env_file');
+        $containerEnvFile = ".env.{$serviceName}";
         $envFiles = collect(is_null($existingEnvFiles) ? [] : (is_array($existingEnvFiles) ? $existingEnvFiles : [$existingEnvFiles]))
-            ->push('.env')
+            ->push($containerEnvFile)
             ->unique()
             ->values();
 

--- a/database/migrations/2026_02_04_230000_add_container_name_to_environment_variables_table.php
+++ b/database/migrations/2026_02_04_230000_add_container_name_to_environment_variables_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Add container_name field to scope environment variables to specific containers
+     * within Docker Compose services. When null, the variable applies to all containers.
+     * This addresses the security issue where all env vars were shared across all containers.
+     *
+     * @see https://github.com/coollabsio/coolify/issues/7655
+     */
+    public function up(): void
+    {
+        Schema::table('environment_variables', function (Blueprint $table) {
+            $table->string('container_name')->nullable()->after('is_shared');
+            $table->index('container_name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('environment_variables', function (Blueprint $table) {
+            $table->dropIndex(['container_name']);
+            $table->dropColumn('container_name');
+        });
+    }
+};

--- a/resources/views/livewire/project/shared/environment-variable/add.blade.php
+++ b/resources/views/livewire/project/shared/environment-variable/add.blade.php
@@ -16,6 +16,16 @@
         </div>
     @endif
 
+    @if (count($containerNames) > 0)
+        <x-forms.select id="container_name" label="Available To"
+            helper="Select which container(s) should have access to this variable. 'All Containers' makes it available everywhere, while selecting a specific container restricts access for security.">
+            <option value="">All Containers</option>
+            @foreach ($containerNames as $name)
+                <option value="{{ $name }}">{{ $name }}</option>
+            @endforeach
+        </x-forms.select>
+    @endif
+
     @if (!$shared)
         <x-forms.checkbox id="is_buildtime"
             helper="Make this variable available during Docker build process. Useful for build secrets and dependencies."

--- a/resources/views/livewire/project/shared/environment-variable/all.blade.php
+++ b/resources/views/livewire/project/shared/environment-variable/all.blade.php
@@ -5,7 +5,7 @@
             @can('manageEnvironment', $resource)
                 <div class="flex flex-col items-center">
                     <x-modal-input buttonTitle="+ Add" title="New Environment Variable" :closeOutside="false">
-                        <livewire:project.shared.environment-variable.add />
+                        <livewire:project.shared.environment-variable.add :containerNames="$this->containerNames" />
                     </x-modal-input>
                 </div>
                 <x-forms.button

--- a/resources/views/livewire/project/shared/environment-variable/show.blade.php
+++ b/resources/views/livewire/project/shared/environment-variable/show.blade.php
@@ -4,6 +4,19 @@
         'border-error' => $is_really_required,
         'dark:border-coolgray-300 border-neutral-200' => !$is_really_required,
     ])>
+        @if ($type === 'service' && $container_name)
+            <div class="flex items-center gap-2 text-xs">
+                <span class="px-2 py-1 rounded bg-coolgray-200 dark:bg-coolgray-400 text-neutral-600 dark:text-neutral-200">
+                    Container: {{ $container_name }}
+                </span>
+            </div>
+        @elseif ($type === 'service' && !$container_name)
+            <div class="flex items-center gap-2 text-xs">
+                <span class="px-2 py-1 rounded bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300">
+                    All Containers
+                </span>
+            </div>
+        @endif
         @if ($isLocked)
             <div class="flex flex-1 w-full gap-2">
                 <x-forms.input disabled id="key" />

--- a/tests/Unit/EnvironmentVariableContainerScopeTest.php
+++ b/tests/Unit/EnvironmentVariableContainerScopeTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Unit tests to verify that environment variables can be scoped to specific containers
+ * within Docker Compose services to prevent security vulnerabilities.
+ *
+ * This addresses issue #7655 where all environment variables were shared
+ * across all containers in a Compose project, allowing one container to
+ * access secrets meant for another container.
+ *
+ * @see https://github.com/coollabsio/coolify/issues/7655
+ */
+
+it('parsers.php uses per-container env files instead of single .env', function () {
+    $parsersFile = file_get_contents(__DIR__.'/../../bootstrap/helpers/parsers.php');
+
+    // Check that the fix is in place - using per-container env files
+    expect($parsersFile)->toContain('.env.{$serviceName}');
+    expect($parsersFile)->toContain('security fix for issue #7655');
+});
+
+it('Service model generates per-container env files', function () {
+    $serviceFile = file_get_contents(__DIR__.'/../../app/Models/Service.php');
+
+    // Check that saveComposeConfigs creates per-container env files
+    expect($serviceFile)->toContain('.env.{$serviceName}');
+    expect($serviceFile)->toContain('whereNull(\'container_name\')');
+    expect($serviceFile)->toContain('whereNotNull(\'container_name\')');
+});
+
+it('EnvironmentVariable model has container_name field', function () {
+    $modelFile = file_get_contents(__DIR__.'/../../app/Models/EnvironmentVariable.php');
+
+    // Check that the model includes container_name
+    expect($modelFile)->toContain('container_name');
+    expect($modelFile)->toContain("'container_name' => 'string'");
+});
+
+it('migration adds container_name column to environment_variables table', function () {
+    $migrations = glob(__DIR__.'/../../database/migrations/*container_name*');
+
+    expect($migrations)->not->toBeEmpty();
+
+    $migrationFile = file_get_contents($migrations[0]);
+
+    // Check migration adds the column
+    expect($migrationFile)->toContain("->string('container_name')");
+    expect($migrationFile)->toContain('->nullable()');
+    expect($migrationFile)->toContain('issue #7655');
+});
+
+it('Add component includes container_name in saveKey dispatch', function () {
+    $addFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/EnvironmentVariable/Add.php');
+
+    // Check that container_name is dispatched
+    expect($addFile)->toContain("'container_name' => \$this->container_name");
+    expect($addFile)->toContain('public array $containerNames = []');
+});
+
+it('All component passes containerNames to Add component', function () {
+    $allViewFile = file_get_contents(__DIR__.'/../../resources/views/livewire/project/shared/environment-variable/all.blade.php');
+
+    // Check that containerNames is passed
+    expect($allViewFile)->toContain(':containerNames="$this->containerNames"');
+});
+
+it('Show component displays container scope for services', function () {
+    $showViewFile = file_get_contents(__DIR__.'/../../resources/views/livewire/project/shared/environment-variable/show.blade.php');
+
+    // Check that container scope is displayed
+    expect($showViewFile)->toContain('Container:');
+    expect($showViewFile)->toContain('All Containers');
+    expect($showViewFile)->toContain('$container_name');
+});
+
+it('createEnvironmentVariable handles container_name correctly', function () {
+    $allFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/EnvironmentVariable/All.php');
+
+    // Check that empty string and 'all' are converted to null
+    expect($allFile)->toContain("\$containerName === ''");
+    expect($allFile)->toContain("\$containerName === 'all'");
+    expect($allFile)->toContain('$environment->container_name = $containerName');
+});
+
+it('add view shows container selector for Docker Compose services', function () {
+    $addViewFile = file_get_contents(__DIR__.'/../../resources/views/livewire/project/shared/environment-variable/add.blade.php');
+
+    // Check that container selector is present
+    expect($addViewFile)->toContain('count($containerNames) > 0');
+    expect($addViewFile)->toContain('Available To');
+    expect($addViewFile)->toContain('<option value="">All Containers</option>');
+});


### PR DESCRIPTION
## Summary

- Fixes security vulnerability where all environment variables were shared across all containers in Docker Compose projects
- Each container now only has access to variables explicitly scoped to it or marked as global
- Prevents container A from accessing secrets meant for container B (e.g., Redis reading PostgreSQL passwords)

## Changes

- **Database**: Add `container_name` column to `environment_variables` table
- **Service Model**: Generate per-container `.env.<serviceName>` files instead of single `.env`
- **Parsers**: Inject container-specific env files (`env_file: .env.<serviceName>`)
- **UI**: Add container selector dropdown when adding/viewing env vars for Docker Compose services
- **API**: Add `container_name` parameter to create/update env endpoints
- **Tests**: Add unit tests verifying implementation

## How It Works

- `container_name = null` (default): Variable available to ALL containers (backward compatible)
- `container_name = "redis"`: Variable only available to the `redis` container

## Test Plan

- [ ] Run database migration
- [ ] Deploy a Docker Compose service with multiple containers
- [ ] Add env var scoped to specific container
- [ ] Verify the variable only appears in that container's env file
- [ ] Verify global variables appear in all container env files
- [ ] Run unit tests: `./vendor/bin/pest tests/Unit/EnvironmentVariableContainerScopeTest.php`

## Screenshots

UI shows container selector when adding env vars to Docker Compose services, and displays which container each variable is scoped to.

Fixes #7655

🤖 Generated with [Claude Code](https://claude.ai/code)