### PR TITLE
SSRF (Server-Side Request Forgery) via User-Controlled API URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1190,7 +1190,16 @@ All notable changes to this project will be documented in this file.
 - *(service)* Update autobase to version 2.5 (#7923)
 - *(service)* Add chibisafe template (#5808)
 - *(ui)* Improve sidebar menu items styling (#7928)
-- *(service)* Improve open-archiver
+- *(template)* Add open archiver template (#6593)
+- *(service)* Add linkding template (#6651)
+- *(service)* Add glip template (#7937)
+- *(templates)* Add Sessy docker compose template (#7951)
+- *(api)* Add update urls support to services api
+- *(api)* Improve service urls update
+- *(api)* Add url update support to services api (#7929)
+- *(api)* Improve docker_compose_domains
+- *(api)* Add more allowed fields
+- *(notifications)* Add mattermost notifications (#7963)
 
 ### 🐛 Bug Fixes
 
@@ -3773,6 +3782,7 @@ All notable changes to this project will be documented in this file.
 - *(scheduling)* Change redis cleanup command frequency from hourly to weekly for better resource management
 - *(versions)* Update coolify version numbers in versions.json and constants.php to 4.0.0-beta.420.5 and 4.0.0-beta.420.6
 - *(database)* Ensure internal port defaults correctly for unsupported database types in StartDatabaseProxy
+- *(git)* Tracking issue due to case sensitivity
 - *(versions)* Update coolify version numbers in versions.json and constants.php to 4.0.0-beta.420.6 and 4.0.0-beta.420.7
 - *(scheduling)* Remove unnecessary padding from scheduled task form layout for improved UI consistency
 - *(horizon)* Update queue configuration to use environment variable for dynamic queue management
@@ -3796,7 +3806,6 @@ All notable changes to this project will be documented in this file.
 - *(service)* Triliumnext platform and link
 - *(application)* Update service environment variables when generating domain for Docker Compose
 - *(application)* Add option to suppress toast notifications when loading compose file
-- *(git)* Tracking issue due to case sensitivity
 - *(git)* Tracking issue due to case sensitivity
 - *(git)* Tracking issue due to case sensitivity
 - *(ui)* Delete button width on small screens (#6308)
@@ -4422,6 +4431,23 @@ All notable changes to this project will be documented in this file.
 - *(api)* Deprecate applications compose endpoint
 - *(api)* Applications post and patch endpoints
 - *(api)* Applications create and patch endpoints (#7917)
+- *(service)* Sftpgo port
+- *(env)* Only cat .env file in dev
+- *(api)* Encoding checks (#7944)
+- *(env)* Only show nixpacks plan variables section in dev
+- Switch custom labels check to UTF-8
+- *(api)* One click service name and description cannot be set during creation
+- *(ui)* Improve volume mount warning for compose applications (#7947)
+- *(api)* Show an error if the same 2 urls are provided
+- *(preview)* Docker compose preview URLs (#7959)
+- *(api)* Check domain conflicts within the request
+- *(api)* Include docker_compose_domains in domain conflict check
+- *(api)* Is_static and docker network missing
+- *(api)* If domains field is empty clear the fqdn column
+- *(api)* Application endpoint issues part 2 (#7948)
+- Optimize queries and caching for projects and environments
+- *(perf)* Eliminate N+1 queries from InstanceSettings and Server lookups (#7966)
+- Update version numbers to 4.0.0-beta.462 and 4.0.0-beta.463
 
 ### 💼 Other
 
@@ -5510,6 +5536,7 @@ All notable changes to this project will be documented in this file.
 - Move all env sorting to one place
 - *(api)* Make docker_compose_raw description more clear
 - *(api)* Update application create endpoints docs
+- *(api)* Application urls validation
 
 ### 📚 Documentation
 
@@ -5616,7 +5643,6 @@ All notable changes to this project will be documented in this file.
 - Update changelog
 - *(tests)* Update testing guidelines for unit and feature tests
 - *(sync)* Create AI Instructions Synchronization Guide and update CLAUDE.md references
-- Update changelog
 - *(database-patterns)* Add critical note on mass assignment protection for new columns
 - Clarify cloud-init script compatibility
 - Update changelog
@@ -5647,7 +5673,9 @@ All notable changes to this project will be documented in this file.
 - Update application architecture and database patterns for request-level caching best practices
 - Remove git worktree symlink instructions from CLAUDE.md
 - Remove git worktree symlink instructions from CLAUDE.md (#7908)
-- Update changelog
+- Add transcript lol link and logo to readme (#7331)
+- *(api)* Change domains to urls
+- *(api)* Improve domains API docs
 
 ### ⚡ Performance
 
@@ -6293,10 +6321,10 @@ All notable changes to this project will be documented in this file.
 - *(versions)* Update Coolify versions to 4.0.0-beta.420.2 and 4.0.0-beta.420.3 in multiple files
 - *(versions)* Bump coolify and nightly versions to 4.0.0-beta.420.3 and 4.0.0-beta.420.4 respectively
 - *(versions)* Update coolify and nightly versions to 4.0.0-beta.420.4 and 4.0.0-beta.420.5 respectively
-- *(service)* Update Nitropage template (#6181)
-- *(versions)* Update all version
 - *(bump)* Update composer deps
 - *(version)* Bump Coolify version to 4.0.0-beta.420.6
+- *(service)* Update Nitropage template (#6181)
+- *(versions)* Update all version
 - *(service)* Improve matrix service
 - *(service)* Format runner service
 - *(service)* Improve sequin
@@ -6399,6 +6427,10 @@ All notable changes to this project will be documented in this file.
 - *(services)* Upgrade service template json files
 - *(api)* Update openapi json and yaml
 - *(api)* Regenerate openapi docs
+- Prepare for PR
+- *(api)* Improve current request error message
+- *(api)* Improve current request error message
+- *(api)* Update openapi files
 
 ### ◀️ Revert
 

--- a/app/Http/Controllers/Api/GithubController.php
+++ b/app/Http/Controllers/Api/GithubController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Models\GithubApp;
 use App\Models\PrivateKey;
+use App\Rules\ValidGithubUrl;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
@@ -204,8 +205,8 @@ class GithubController extends Controller
         $validator = customApiValidator($request->all(), [
             'name' => 'required|string|max:255',
             'organization' => 'nullable|string|max:255',
-            'api_url' => 'required|string|url',
-            'html_url' => 'required|string|url',
+            'api_url' => ['required', 'string', 'url', new ValidGithubUrl],
+            'html_url' => ['required', 'string', 'url', new ValidGithubUrl],
             'custom_user' => 'nullable|string|max:255',
             'custom_port' => 'nullable|integer|min:1|max:65535',
             'app_id' => 'required|integer',
@@ -587,10 +588,10 @@ class GithubController extends Controller
                 $rules['organization'] = 'nullable|string';
             }
             if (isset($payload['api_url'])) {
-                $rules['api_url'] = 'url';
+                $rules['api_url'] = ['url', new ValidGithubUrl];
             }
             if (isset($payload['html_url'])) {
-                $rules['html_url'] = 'url';
+                $rules['html_url'] = ['url', new ValidGithubUrl];
             }
             if (isset($payload['custom_user'])) {
                 $rules['custom_user'] = 'string';

--- a/app/Rules/ValidGithubUrl.php
+++ b/app/Rules/ValidGithubUrl.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Support\Facades\Log;
+
+class ValidGithubUrl implements ValidationRule
+{
+    /**
+     * Run the validation rule.
+     *
+     * Validates that a GitHub API or HTML URL is safe from SSRF attacks:
+     * - Must use HTTPS scheme
+     * - Must not point to private/internal IP ranges
+     * - Must not point to cloud metadata endpoints
+     * - Must not point to localhost or loopback addresses
+     * - Must have a valid public hostname
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (empty($value)) {
+            return;
+        }
+
+        $value = trim($value);
+
+        $parsed = parse_url($value);
+
+        if ($parsed === false || empty($parsed['scheme']) || empty($parsed['host'])) {
+            $fail('The :attribute is not a valid URL.');
+
+            return;
+        }
+
+        // Must use HTTPS
+        if (strtolower($parsed['scheme']) !== 'https') {
+            $fail('The :attribute must use HTTPS.');
+
+            return;
+        }
+
+        $host = strtolower($parsed['host']);
+
+        // Block localhost and loopback addresses
+        $blockedHosts = ['localhost', '127.0.0.1', '0.0.0.0', '::1', '[::1]'];
+        if (in_array($host, $blockedHosts) || str_ends_with($host, '.local') || str_ends_with($host, '.internal')) {
+            $this->logAttempt($attribute, $value, 'internal host');
+            $fail('The :attribute must not point to internal hosts.');
+
+            return;
+        }
+
+        // If the host is an IP address, validate it's not in a private/reserved range
+        if (filter_var($host, FILTER_VALIDATE_IP)) {
+            if (! filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
+                $this->logAttempt($attribute, $value, 'private/reserved IP');
+                $fail('The :attribute must not point to private or reserved IP addresses.');
+
+                return;
+            }
+
+            // Block cloud metadata IP (169.254.169.254)
+            if ($host === '169.254.169.254') {
+                $this->logAttempt($attribute, $value, 'cloud metadata endpoint');
+                $fail('The :attribute must not point to cloud metadata endpoints.');
+
+                return;
+            }
+        }
+
+        // Block cloud metadata hostnames
+        $metadataHosts = [
+            'metadata.google.internal',
+            'metadata.google.com',
+            'instance-data',
+        ];
+        foreach ($metadataHosts as $metadataHost) {
+            if ($host === $metadataHost) {
+                $this->logAttempt($attribute, $value, 'cloud metadata hostname');
+                $fail('The :attribute must not point to cloud metadata endpoints.');
+
+                return;
+            }
+        }
+
+        // Ensure no userinfo component (can be used for URL confusion attacks)
+        if (! empty($parsed['user']) || ! empty($parsed['pass'])) {
+            $this->logAttempt($attribute, $value, 'URL with credentials');
+            $fail('The :attribute must not contain user credentials.');
+
+            return;
+        }
+    }
+
+    private function logAttempt(string $attribute, string $value, string $reason): void
+    {
+        try {
+            $logData = [
+                'attribute' => $attribute,
+                'url' => $value,
+                'reason' => $reason,
+            ];
+
+            if (function_exists('request') && app()->has('request')) {
+                $logData['ip'] = request()->ip();
+            }
+
+            if (function_exists('auth') && app()->has('auth')) {
+                $logData['user_id'] = auth()->id();
+            }
+
+            Log::warning('GitHub URL validation failed - potential SSRF attempt', $logData);
+        } catch (\Throwable $e) {
+            // Ignore errors when facades are not available (e.g., in unit tests)
+        }
+    }
+}

--- a/tests/Unit/Rules/ValidGithubUrlTest.php
+++ b/tests/Unit/Rules/ValidGithubUrlTest.php
@@ -1,0 +1,212 @@
+<?php
+
+use App\Rules\ValidGithubUrl;
+
+it('accepts valid github.com API URL', function () {
+    $rule = new ValidGithubUrl;
+    $valid = true;
+
+    $rule->validate('api_url', 'https://api.github.com', function ($message) use (&$valid) {
+        $valid = false;
+    });
+
+    expect($valid)->toBeTrue();
+});
+
+it('accepts valid github.com HTML URL', function () {
+    $rule = new ValidGithubUrl;
+    $valid = true;
+
+    $rule->validate('html_url', 'https://github.com', function ($message) use (&$valid) {
+        $valid = false;
+    });
+
+    expect($valid)->toBeTrue();
+});
+
+it('accepts valid GitHub Enterprise URL', function () {
+    $rule = new ValidGithubUrl;
+    $valid = true;
+
+    $rule->validate('api_url', 'https://github.example.com/api/v3', function ($message) use (&$valid) {
+        $valid = false;
+    });
+
+    expect($valid)->toBeTrue();
+});
+
+it('accepts empty value', function () {
+    $rule = new ValidGithubUrl;
+    $valid = true;
+
+    $rule->validate('api_url', '', function ($message) use (&$valid) {
+        $valid = false;
+    });
+
+    expect($valid)->toBeTrue();
+});
+
+it('rejects HTTP URLs', function () {
+    $rule = new ValidGithubUrl;
+    $valid = true;
+
+    $rule->validate('api_url', 'http://api.github.com', function ($message) use (&$valid) {
+        $valid = false;
+    });
+
+    expect($valid)->toBeFalse();
+});
+
+it('rejects localhost URLs', function () {
+    $rule = new ValidGithubUrl;
+    $valid = true;
+
+    $rule->validate('api_url', 'https://localhost', function ($message) use (&$valid) {
+        $valid = false;
+    });
+
+    expect($valid)->toBeFalse();
+});
+
+it('rejects 127.0.0.1 URLs', function () {
+    $rule = new ValidGithubUrl;
+    $valid = true;
+
+    $rule->validate('api_url', 'https://127.0.0.1', function ($message) use (&$valid) {
+        $valid = false;
+    });
+
+    expect($valid)->toBeFalse();
+});
+
+it('rejects 0.0.0.0 URLs', function () {
+    $rule = new ValidGithubUrl;
+    $valid = true;
+
+    $rule->validate('api_url', 'https://0.0.0.0', function ($message) use (&$valid) {
+        $valid = false;
+    });
+
+    expect($valid)->toBeFalse();
+});
+
+it('rejects AWS metadata endpoint IP', function () {
+    $rule = new ValidGithubUrl;
+    $valid = true;
+
+    $rule->validate('api_url', 'https://169.254.169.254', function ($message) use (&$valid) {
+        $valid = false;
+    });
+
+    expect($valid)->toBeFalse();
+});
+
+it('rejects private IP 10.x.x.x', function () {
+    $rule = new ValidGithubUrl;
+    $valid = true;
+
+    $rule->validate('api_url', 'https://10.0.0.1', function ($message) use (&$valid) {
+        $valid = false;
+    });
+
+    expect($valid)->toBeFalse();
+});
+
+it('rejects private IP 192.168.x.x', function () {
+    $rule = new ValidGithubUrl;
+    $valid = true;
+
+    $rule->validate('api_url', 'https://192.168.1.1', function ($message) use (&$valid) {
+        $valid = false;
+    });
+
+    expect($valid)->toBeFalse();
+});
+
+it('rejects private IP 172.16.x.x', function () {
+    $rule = new ValidGithubUrl;
+    $valid = true;
+
+    $rule->validate('api_url', 'https://172.16.0.1', function ($message) use (&$valid) {
+        $valid = false;
+    });
+
+    expect($valid)->toBeFalse();
+});
+
+it('rejects .local domains', function () {
+    $rule = new ValidGithubUrl;
+    $valid = true;
+
+    $rule->validate('api_url', 'https://myhost.local', function ($message) use (&$valid) {
+        $valid = false;
+    });
+
+    expect($valid)->toBeFalse();
+});
+
+it('rejects .internal domains', function () {
+    $rule = new ValidGithubUrl;
+    $valid = true;
+
+    $rule->validate('api_url', 'https://metadata.google.internal', function ($message) use (&$valid) {
+        $valid = false;
+    });
+
+    expect($valid)->toBeFalse();
+});
+
+it('rejects URLs with user credentials', function () {
+    $rule = new ValidGithubUrl;
+    $valid = true;
+
+    $rule->validate('api_url', 'https://user:pass@github.com', function ($message) use (&$valid) {
+        $valid = false;
+    });
+
+    expect($valid)->toBeFalse();
+});
+
+it('rejects FTP scheme', function () {
+    $rule = new ValidGithubUrl;
+    $valid = true;
+
+    $rule->validate('api_url', 'ftp://github.com', function ($message) use (&$valid) {
+        $valid = false;
+    });
+
+    expect($valid)->toBeFalse();
+});
+
+it('rejects invalid URL format', function () {
+    $rule = new ValidGithubUrl;
+    $valid = true;
+
+    $rule->validate('api_url', 'not-a-url', function ($message) use (&$valid) {
+        $valid = false;
+    });
+
+    expect($valid)->toBeFalse();
+});
+
+it('accepts HTTPS URL with port', function () {
+    $rule = new ValidGithubUrl;
+    $valid = true;
+
+    $rule->validate('api_url', 'https://github.example.com:8443/api/v3', function ($message) use (&$valid) {
+        $valid = false;
+    });
+
+    expect($valid)->toBeTrue();
+});
+
+it('rejects IPv6 loopback', function () {
+    $rule = new ValidGithubUrl;
+    $valid = true;
+
+    $rule->validate('api_url', 'https://[::1]', function ($message) use (&$valid) {
+        $valid = false;
+    });
+
+    expect($valid)->toBeFalse();
+});


### PR DESCRIPTION
*Vulnerability identified and fix provided by [[Kolega.dev](https://kolega.dev/)](https://kolega.dev/)*

## SSRF (Server-Side Request Forgery) via User-Controlled API URLs

### Issue 
> - **Location:** `app/Http/Controllers/Api/GithubController.php:207-351`
> - **Description:** The `api_url` parameter from user input is validated only with basic `'url'` validation, then stored and used in HTTP requests. This allows attackers to redirect API calls to internal services, cloud metadata endpoints, or arbitrary network hosts.
> - **Analysis Notes:** This is a potentially an SSRF vulnerability. The `api_url` parameter is validated only with Laravel's basic `'url'` validation rule (line 207: `'api_url' => 'required|string|url'`), which accepts any valid URL including internal IPs and cloud metadata endpoints. The URL is then stored in the database and used in `Http::GitHub()` macro calls (`AppServiceProvider.php` line 68-79) which sets it as `baseUrl` for HTTP requests. An authenticated API user can: 1) Create a GitHub App with `api_url` pointing to internal services (e.g., `http://169.254.169.254/latest/meta-data/` for AWS metadata, `http://localhost:6379` for Redis, etc.). 2) Call `load_repositories` or `load_branches` endpoints which make HTTP requests to the attacker-controlled URL. 3) Receive responses from internal services. Mitigating factors: Requires valid API authentication token, and the GitHub token is included in requests (limiting usefulness for some attacks). However, cloud metadata endpoints don't require authentication. Recommendation: Validate `api_url` against a whitelist pattern (must be HTTPS, must match github.com or configured GitHub Enterprise domains), and reject private IP ranges.

### Category
> - [x] Bug fix
> - [ ] New feature
> - [ ] Adding new one click service
> - [ ] Fixing or updating existing one click service

### Screenshots or Video (if applicable) 
<!-- Not applicable for this security fix. -->

### AI Usage
> - [x] AI is used in the process of creating this PR
> - [ ] AI is NOT used in the process of creating this PR

### Steps to Test
> - Step 1 – Verify the new validation rule exists: Open `app/Rules/ValidGithubUrl.php` and confirm it enforces HTTPS scheme, blocks private/reserved IP ranges (10.x, 172.16.x, 192.168.x), cloud metadata endpoints (169.254.169.254, metadata.google.internal), localhost/loopback addresses, `.local`/`.internal` domains, and URLs containing embedded credentials.
> - Step 2 – Verify controller integration: Open `app/Http/Controllers/Api/GithubController.php` and confirm the `ValidGithubUrl` rule is applied to both `api_url` and `html_url` validation in the create and update endpoints.
> - Step 3 – Run new unit tests: Execute `./vendor/bin/pest tests/Unit/Rules/ValidGithubUrlTest.php` and confirm all 19 tests pass (19 assertions).
> - Step 4 – Test SSRF blocking: Via the API, attempt to create a GitHub App with `api_url` set to `http://169.254.169.254/latest/meta-data/` — confirm the request is rejected with a validation error.
> - Step 5 – Test private IP blocking: Attempt to create a GitHub App with `api_url` set to `http://localhost:6379` or `http://10.0.0.1` — confirm both are rejected.
> - Step 6 – Test valid URL acceptance: Create a GitHub App with `api_url` set to `https://api.github.com` — confirm it is accepted and functions correctly.
> - Step 7 – Run Laravel Pint: Execute `./vendor/bin/pint --test` on all 3 modified/new files and confirm no formatting issues.
> - Step 8 – Run PHPStan: Execute static analysis on `ValidGithubUrl.php` and `GithubController.php` and confirm no errors.
> - Step 9 – Run full unit test suite: Execute `./vendor/bin/pest tests/Unit` and confirm 1059 tests pass (78 pre-existing `ValidGitRepositoryUrlTest` failures due to missing app key are unrelated and identical before and after this change).

### Contributor Agreement
> [!IMPORTANT]
> - [x] I have read and understood the [[contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md)](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them