### PR TITLE
Fix docker-compose GitHub App DB backups (#7528)

### DIFF
--- a/app/Actions/Docker/GetContainersStatus.php
+++ b/app/Actions/Docker/GetContainersStatus.php
@@ -90,10 +90,18 @@ class GetContainersStatus
         $databases = $this->server->databases();
         $services = $this->server->services()->get();
         $previews = $this->server->previews();
+        $composeServiceDatabases = ServiceDatabase::query()
+            ->whereNotNull('application_id')
+            ->whereIn('application_id', $this->applications->pluck('id'))
+            ->get();
+        $composeServiceDatabasesByKey = $composeServiceDatabases->keyBy(function (ServiceDatabase $db) {
+            return "{$db->application_id}:{$db->name}";
+        });
         $foundApplications = [];
         $foundApplicationPreviews = [];
         $foundDatabases = [];
         $foundServices = [];
+        $foundComposeServiceDatabaseIds = [];
 
         foreach ($this->containers as $container) {
             if ($this->server->isSwarm()) {
@@ -153,6 +161,19 @@ class GetContainersStatus
                         }
                         if ($containerName) {
                             $this->applicationContainerStatuses->get($applicationId)->put($containerName, $containerStatus);
+                        }
+                        if ($containerName) {
+                            $composeDbKey = "{$applicationId}:{$containerName}";
+                            $composeDb = $composeServiceDatabasesByKey->get($composeDbKey);
+                            if ($composeDb) {
+                                $foundComposeServiceDatabaseIds[] = $composeDb->id;
+                                $statusFromDb = $composeDb->status;
+                                if ($statusFromDb !== $containerStatus) {
+                                    $composeDb->update(['status' => $containerStatus]);
+                                } else {
+                                    $composeDb->update(['last_online_at' => now()]);
+                                }
+                            }
                         }
 
                         // Track restart counts for applications
@@ -408,6 +429,21 @@ class GetContainersStatus
                 $url = null;
             }
             // $this->server->team?->notify(new ContainerStopped($containerName, $this->server, $url));
+        }
+
+        // Mark docker-compose Application databases as exited if no matching container is running.
+        if ($composeServiceDatabases->isNotEmpty()) {
+            $notRunningComposeDatabaseIds = $composeServiceDatabases->pluck('id')->diff(collect($foundComposeServiceDatabaseIds));
+            foreach ($notRunningComposeDatabaseIds as $composeDbId) {
+                $composeDb = $composeServiceDatabases->firstWhere('id', $composeDbId);
+                if (! $composeDb) {
+                    continue;
+                }
+                if (str($composeDb->status)->startsWith('exited')) {
+                    continue;
+                }
+                $composeDb->update(['status' => 'exited']);
+            }
         }
 
         // Aggregate multi-container application statuses

--- a/app/Console/Commands/CleanupStuckedResources.php
+++ b/app/Console/Commands/CleanupStuckedResources.php
@@ -431,10 +431,10 @@ class CleanupStuckedResources extends Command
         }
         try {
             $serviceDatabases = ServiceDatabase::all();
-            foreach ($serviceDatabases as $service) {
-                if (! data_get($service, 'service')) {
-                    echo 'ServiceDatabase without service: '.$service->name.'\n';
-                    $service->forceDelete();
+            foreach ($serviceDatabases as $serviceDatabase) {
+                if (! data_get($serviceDatabase, 'service') && ! data_get($serviceDatabase, 'application')) {
+                    echo 'ServiceDatabase without parent: '.$serviceDatabase->name.'\n';
+                    $serviceDatabase->forceDelete();
 
                     continue;
                 }

--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -93,7 +93,8 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $this->database = data_get($this->backup, 'database');
-                $this->server = $this->database->service->server;
+                $this->server = $this->database->service?->server
+                    ?? $this->database->application?->destination?->server;
                 $this->s3 = $this->backup->s3;
             } else {
                 $this->database = data_get($this->backup, 'database');
@@ -110,16 +111,40 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             BackupCreated::dispatch($this->team->id);
 
             $status = str(data_get($this->database, 'status'));
-            if (! $status->startsWith('running') && $this->database->id !== 0) {
-                return;
+            $serviceDatabaseIsFromApplication =
+                data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class &&
+                $this->database instanceof ServiceDatabase &&
+                $this->database->application &&
+                ! $this->database->service;
+
+            // For docker-compose Application databases, status updates are best-effort; resolve running container instead.
+            if (! $serviceDatabaseIsFromApplication) {
+                if (! $status->startsWith('running') && $this->database->id !== 0) {
+                    return;
+                }
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $databaseType = $this->database->databaseType();
-                $serviceUuid = $this->database->service->uuid;
-                $serviceName = str($this->database->service->name)->slug();
-                if (str($databaseType)->contains('postgres')) {
+                if ($this->database->service) {
+                    $serviceUuid = $this->database->service->uuid;
+                    $parentName = str($this->database->service->name)->slug();
                     $this->container_name = "{$this->database->name}-$serviceUuid";
-                    $this->directory_name = $serviceName.'-'.$this->container_name;
+                    $this->directory_name = $parentName.'-'.$this->container_name;
+                } elseif ($this->database->application) {
+                    $parentName = str($this->database->application->name)->slug();
+                    $prefix = "{$this->database->name}-{$this->database->application->uuid}";
+                    $this->container_name = instant_remote_process([
+                        "docker ps --format '{{.Names}}' --filter \"name={$prefix}\" | grep -v -- '-pr-' | head -n 1",
+                    ], $this->server, false, false, null, disableMultiplexing: true);
+                    $this->container_name = trim((string) $this->container_name);
+                    if ($this->container_name === '') {
+                        return;
+                    }
+                    $this->directory_name = $parentName.'-'.$this->container_name;
+                } else {
+                    throw new \Exception('ServiceDatabase parent not found (Service or Application).');
+                }
+                if (str($databaseType)->contains('postgres')) {
                     $commands[] = "docker exec $this->container_name env | grep POSTGRES_";
                     $envs = instant_remote_process($commands, $this->server, true, false, null, disableMultiplexing: true);
                     $envs = str($envs)->explode("\n");
@@ -149,8 +174,6 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                         $this->postgres_password = str($this->postgres_password)->after('POSTGRES_PASSWORD=')->value();
                     }
                 } elseif (str($databaseType)->contains('mysql')) {
-                    $this->container_name = "{$this->database->name}-$serviceUuid";
-                    $this->directory_name = $serviceName.'-'.$this->container_name;
                     $commands[] = "docker exec $this->container_name env | grep MYSQL_";
                     $envs = instant_remote_process($commands, $this->server, true, false, null, disableMultiplexing: true);
                     $envs = str($envs)->explode("\n");
@@ -172,8 +195,6 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                         throw new \Exception('MYSQL_DATABASE not found');
                     }
                 } elseif (str($databaseType)->contains('mariadb')) {
-                    $this->container_name = "{$this->database->name}-$serviceUuid";
-                    $this->directory_name = $serviceName.'-'.$this->container_name;
                     $commands[] = "docker exec $this->container_name env";
                     $envs = instant_remote_process($commands, $this->server, true, false, null, disableMultiplexing: true);
                     $envs = str($envs)->explode("\n");
@@ -210,8 +231,6 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                     }
                 } elseif (str($databaseType)->contains('mongo')) {
                     $databasesToBackup = ['*'];
-                    $this->container_name = "{$this->database->name}-$serviceUuid";
-                    $this->directory_name = $serviceName.'-'.$this->container_name;
 
                     // Try to extract MongoDB credentials from environment variables
                     try {
@@ -630,9 +649,13 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             $endpoint = $this->s3->endpoint;
             $this->s3->testConnection(shouldSave: true);
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
-                $network = $this->database->service->destination->network;
+                $network = data_get($this->database, 'service.destination.network')
+                    ?? data_get($this->database, 'application.destination.network');
             } else {
                 $network = $this->database->destination->network;
+            }
+            if (blank($network)) {
+                throw new \Exception('Network not found?!');
             }
 
             $fullImageName = $this->getFullImageName();

--- a/app/Livewire/Project/Application/Backups.php
+++ b/app/Livewire/Project/Application/Backups.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Livewire\Project\Application;
+
+use App\Models\Application;
+use App\Models\ServiceDatabase;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Collection;
+use Livewire\Component;
+
+class Backups extends Component
+{
+    use AuthorizesRequests;
+
+    public Application $application;
+
+    public Collection $databases;
+
+    public ?ServiceDatabase $selectedDatabase = null;
+
+    public ?string $selectedDatabaseUuid = null;
+
+    public array $parameters = [];
+
+    protected $queryString = ['selectedDatabaseUuid'];
+
+    public function mount(): void
+    {
+        $this->authorize('view', $this->application);
+
+        $this->parameters = get_route_parameters();
+
+        // Ensure compose databases are detected and persisted.
+        // This is idempotent and keeps the Backups UI in sync with the compose file.
+        try {
+            if ($this->application->build_pack === 'dockercompose' && filled($this->application->docker_compose_raw)) {
+                $this->application->parse();
+            }
+        } catch (\Throwable) {
+            // Parsing errors are shown on the General page; backups can still render with whatever is available.
+        }
+
+        $this->databases = $this->application->serviceDatabases()->orderBy('name')->get();
+
+        if (! $this->selectedDatabaseUuid && $this->databases->isNotEmpty()) {
+            $this->selectedDatabaseUuid = $this->databases->first()->uuid;
+        }
+
+        $this->selectedDatabase = $this->databases->firstWhere('uuid', $this->selectedDatabaseUuid)
+            ?? $this->databases->first();
+    }
+
+    public function selectDatabase(string $uuid): void
+    {
+        $this->selectedDatabaseUuid = $uuid;
+        $this->selectedDatabase = $this->databases->firstWhere('uuid', $uuid);
+    }
+
+    public function render()
+    {
+        return view('livewire.project.application.backups');
+    }
+}
+

--- a/app/Livewire/Project/Database/BackupEdit.php
+++ b/app/Livewire/Project/Database/BackupEdit.php
@@ -155,12 +155,7 @@ class BackupEdit extends Component
         }
 
         try {
-            $server = null;
-            if ($this->backup->database instanceof \App\Models\ServiceDatabase) {
-                $server = $this->backup->database->service->destination->server;
-            } elseif ($this->backup->database->destination && $this->backup->database->destination->server) {
-                $server = $this->backup->database->destination->server;
-            }
+            $server = $this->backup->server();
 
             $filenames = $this->backup->executions()
                 ->whereNotNull('filename')
@@ -185,12 +180,23 @@ class BackupEdit extends Component
             if ($this->backup->database->getMorphClass() === \App\Models\ServiceDatabase::class) {
                 $serviceDatabase = $this->backup->database;
 
-                return redirect()->route('project.service.database.backups', [
-                    'project_uuid' => $this->parameters['project_uuid'],
-                    'environment_uuid' => $this->parameters['environment_uuid'],
-                    'service_uuid' => $serviceDatabase->service->uuid,
-                    'stack_service_uuid' => $serviceDatabase->uuid,
-                ]);
+                if ($serviceDatabase->service) {
+                    return redirect()->route('project.service.database.backups', [
+                        'project_uuid' => $this->parameters['project_uuid'],
+                        'environment_uuid' => $this->parameters['environment_uuid'],
+                        'service_uuid' => $serviceDatabase->service->uuid,
+                        'stack_service_uuid' => $serviceDatabase->uuid,
+                    ]);
+                }
+                if ($serviceDatabase->application) {
+                    return redirect()->route('project.application.backups', [
+                        'project_uuid' => $this->parameters['project_uuid'],
+                        'environment_uuid' => $this->parameters['environment_uuid'],
+                        'application_uuid' => $serviceDatabase->application->uuid,
+                    ]);
+                }
+
+                return redirect()->route('project.resource.index', $this->parameters);
             } else {
                 return redirect()->route('project.database.backup.index', $this->parameters);
             }

--- a/app/Livewire/Project/Database/BackupExecutions.php
+++ b/app/Livewire/Project/Database/BackupExecutions.php
@@ -78,9 +78,12 @@ class BackupExecutions extends Component
             return;
         }
 
-        $server = $execution->scheduledDatabaseBackup->database->getMorphClass() === \App\Models\ServiceDatabase::class
-            ? $execution->scheduledDatabaseBackup->database->service->destination->server
-            : $execution->scheduledDatabaseBackup->database->destination->server;
+        $server = $execution->scheduledDatabaseBackup->server();
+        if (! $server) {
+            $this->dispatch('error', 'Server not found.');
+
+            return;
+        }
 
         try {
             if ($execution->filename) {
@@ -178,20 +181,7 @@ class BackupExecutions extends Component
 
     public function server()
     {
-        if ($this->database) {
-            $server = null;
-
-            if ($this->database instanceof \App\Models\ServiceDatabase) {
-                $server = $this->database->service->destination->server;
-            } elseif ($this->database->destination && $this->database->destination->server) {
-                $server = $this->database->destination->server;
-            }
-            if ($server) {
-                return $server;
-            }
-        }
-
-        return null;
+        return $this->backup?->server();
     }
 
     public function render()

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -905,6 +905,11 @@ class Application extends BaseModel
         return $this->belongsTo(Environment::class);
     }
 
+    public function serviceDatabases()
+    {
+        return $this->hasMany(ServiceDatabase::class);
+    }
+
     public function previews()
     {
         return $this->hasMany(ApplicationPreview::class)->orderBy('pull_request_id', 'desc');

--- a/app/Models/ScheduledDatabaseBackup.php
+++ b/app/Models/ScheduledDatabaseBackup.php
@@ -67,8 +67,8 @@ class ScheduledDatabaseBackup extends BaseModel
     {
         if ($this->database) {
             if ($this->database instanceof ServiceDatabase) {
-                $destination = data_get($this->database->service, 'destination');
-                $server = data_get($destination, 'server');
+                $server = data_get($this->database, 'service.destination.server')
+                    ?? data_get($this->database, 'application.destination.server');
             } else {
                 $destination = data_get($this->database, 'destination');
                 $server = data_get($destination, 'server');

--- a/app/Models/ServiceDatabase.php
+++ b/app/Models/ServiceDatabase.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class ServiceDatabase extends BaseModel
@@ -27,7 +28,11 @@ class ServiceDatabase extends BaseModel
 
     public static function ownedByCurrentTeamAPI(int $teamId)
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', $teamId)->orderBy('name');
+        return ServiceDatabase::where(function ($query) use ($teamId) {
+            $query
+                ->whereRelation('service.environment.project.team', 'id', $teamId)
+                ->orWhereRelation('application.environment.project.team', 'id', $teamId);
+        })->orderBy('name');
     }
 
     /**
@@ -36,7 +41,11 @@ class ServiceDatabase extends BaseModel
      */
     public static function ownedByCurrentTeam()
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', currentTeam()->id)->orderBy('name');
+        return ServiceDatabase::where(function ($query) {
+            $query
+                ->whereRelation('service.environment.project.team', 'id', currentTeam()->id)
+                ->orWhereRelation('application.environment.project.team', 'id', currentTeam()->id);
+        })->orderBy('name');
     }
 
     /**
@@ -51,8 +60,29 @@ class ServiceDatabase extends BaseModel
 
     public function restart()
     {
-        $container_id = $this->name.'-'.$this->service->uuid;
-        remote_process(["docker restart {$container_id}"], $this->service->server);
+        if ($this->service) {
+            $container_id = $this->name.'-'.$this->service->uuid;
+            remote_process(["docker restart {$container_id}"], $this->service->server);
+
+            return;
+        }
+        if ($this->application) {
+            // For docker-compose Applications, the container name can include a deployment suffix,
+            // so we resolve it on the server from the stable prefix "<serviceName>-<applicationUuid>".
+            $prefix = "{$this->name}-{$this->application->uuid}";
+            $server = $this->application->destination?->server;
+            if (! $server) {
+                return;
+            }
+            $container_id = instant_remote_process([
+                "docker ps --format '{{.Names}}' --filter \"name={$prefix}\" | grep -v -- '-pr-' | head -n 1",
+            ], $server, false);
+            $container_id = trim((string) $container_id);
+            if ($container_id === '') {
+                return;
+            }
+            remote_process(["docker restart {$container_id}"], $server);
+        }
     }
 
     public function isRunning()
@@ -114,8 +144,12 @@ class ServiceDatabase extends BaseModel
     public function getServiceDatabaseUrl()
     {
         $port = $this->public_port;
-        $realIp = $this->service->server->ip;
-        if ($this->service->server->isLocalhost() || isDev()) {
+        $server = $this->service?->server ?? $this->application?->destination?->server;
+        if (! $server) {
+            return '';
+        }
+        $realIp = $server->ip;
+        if ($server->isLocalhost() || isDev()) {
             $realIp = base_ip();
         }
 
@@ -124,17 +158,30 @@ class ServiceDatabase extends BaseModel
 
     public function team()
     {
-        return data_get($this, 'environment.project.team');
+        return $this->service?->environment?->project?->team
+            ?? $this->application?->environment?->project?->team;
     }
 
     public function workdir()
     {
-        return service_configuration_dir()."/{$this->service->uuid}";
+        if ($this->service) {
+            return service_configuration_dir()."/{$this->service->uuid}";
+        }
+        if ($this->application) {
+            return application_configuration_dir()."/{$this->application->uuid}";
+        }
+
+        return service_configuration_dir().'/';
     }
 
-    public function service()
+    public function service(): BelongsTo
     {
         return $this->belongsTo(Service::class);
+    }
+
+    public function application(): BelongsTo
+    {
+        return $this->belongsTo(Application::class);
     }
 
     public function persistentStorages()

--- a/bootstrap/helpers/databases.php
+++ b/bootstrap/helpers/databases.php
@@ -344,12 +344,7 @@ function deleteOldBackupsLocally($backup): Collection
     $backupsToDelete = $backupsToDelete->unique('id');
     $processedBackups = collect();
 
-    $server = null;
-    if ($backup->database_type === \App\Models\ServiceDatabase::class) {
-        $server = $backup->database->service->server;
-    } else {
-        $server = $backup->database->destination->server;
-    }
+    $server = $backup->server();
 
     if (! $server) {
         return collect();

--- a/bootstrap/helpers/parsers.php
+++ b/bootstrap/helpers/parsers.php
@@ -647,6 +647,8 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
         $serviceNameEnvironments = generateDockerComposeServiceName($services, $pullRequestId);
     }
 
+    $persistComposeDatabases = $resource->build_pack === 'dockercompose' && ! $isPullRequest;
+
     // Parse the rest of the services
     foreach ($services as $serviceName => $service) {
         $image = data_get_str($service, 'image');
@@ -681,6 +683,26 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
         $coolifyEnvironments = collect([]);
 
         $isDatabase = isDatabaseImage($image, $service);
+        if ($persistComposeDatabases) {
+            if ($isDatabase) {
+                ServiceDatabase::withTrashed()
+                    ->where('application_id', $resource->id)
+                    ->where('name', $serviceName)
+                    ->restore();
+
+                ServiceDatabase::updateOrCreate([
+                    'application_id' => $resource->id,
+                    'name' => $serviceName,
+                ], [
+                    'service_id' => null,
+                    'image' => $image,
+                ]);
+            } else {
+                ServiceDatabase::where('application_id', $resource->id)
+                    ->where('name', $serviceName)
+                    ->delete();
+            }
+        }
         $volumesParsed = collect([]);
 
         $baseName = generateApplicationContainerName(
@@ -1345,6 +1367,14 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
         }
 
         $parsedServices->put($serviceName, $payload);
+    }
+
+    if ($persistComposeDatabases) {
+        // Remove stale database records if a service was removed or no longer detected as a database.
+        $currentServiceNames = collect($services)->keys()->values();
+        ServiceDatabase::where('application_id', $resource->id)
+            ->whereNotIn('name', $currentServiceNames->toArray())
+            ->delete();
     }
     $topLevel->put('services', $parsedServices);
 

--- a/bootstrap/helpers/services.php
+++ b/bootstrap/helpers/services.php
@@ -29,8 +29,8 @@ function getFilesystemVolumesFromServer(ServiceApplication|ServiceDatabase|Appli
             $workdir = $oneService->workdir();
             $server = $oneService->destination->server;
         } else {
-            $workdir = $oneService->service->workdir();
-            $server = $oneService->service->server;
+            $workdir = $oneService->workdir();
+            $server = $oneService->service?->server ?? $oneService->application?->destination?->server;
         }
         $fileVolumes = $oneService->fileStorages()->get();
         $commands = collect([

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -557,7 +557,7 @@ function getResourceByUuid(string $uuid, ?int $teamId = null)
 
     // ServiceDatabase has a different relationship path: service->environment->project->team_id
     if ($resource instanceof \App\Models\ServiceDatabase) {
-        if ($resource->service?->environment?->project?->team_id === $teamId) {
+        if ($resource->service?->environment?->project?->team_id === $teamId || $resource->application?->environment?->project?->team_id === $teamId) {
             return $resource;
         }
 
@@ -2418,6 +2418,29 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
             $isDatabase = isDatabaseImage($image, $service);
             data_set($service, 'is_database', $isDatabase);
 
+            // For docker-compose Applications (GitHub App path), persist detected databases so backups can be scheduled.
+            // Previews are excluded from backups, so we only create records for the main deployment.
+            if ($resource instanceof Application && $resource->build_pack === 'dockercompose' && $pull_request_id === 0) {
+                if ($isDatabase) {
+                    ServiceDatabase::withTrashed()
+                        ->where('application_id', $resource->id)
+                        ->where('name', $serviceName)
+                        ->restore();
+
+                    ServiceDatabase::updateOrCreate([
+                        'application_id' => $resource->id,
+                        'name' => $serviceName,
+                    ], [
+                        'service_id' => null,
+                        'image' => $image,
+                    ]);
+                } else {
+                    ServiceDatabase::where('application_id', $resource->id)
+                        ->where('name', $serviceName)
+                        ->delete();
+                }
+            }
+
             // Collect/create/update networks
             if ($serviceNetworks->count() > 0) {
                 foreach ($serviceNetworks as $networkName => $networkDetails) {
@@ -2795,6 +2818,13 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
 
             return $service;
         });
+        if ($resource instanceof Application && $resource->build_pack === 'dockercompose' && $pull_request_id === 0) {
+            // Remove stale database records if a service was removed or no longer detected as a database.
+            $currentServiceNames = $services->keys()->values();
+            ServiceDatabase::where('application_id', $resource->id)
+                ->whereNotIn('name', $currentServiceNames->toArray())
+                ->delete();
+        }
         if ($pull_request_id !== 0) {
             $services->each(function ($service, $serviceName) use ($pull_request_id, $services) {
                 $services[addPreviewDeploymentSuffix($serviceName, $pull_request_id)] = $service;

--- a/database/migrations/2026_02_06_190000_add_application_id_to_service_databases_table.php
+++ b/database/migrations/2026_02_06_190000_add_application_id_to_service_databases_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->unsignedBigInteger('application_id')->nullable()->after('service_id');
+            $table->unsignedBigInteger('service_id')->nullable()->change();
+            $table->index(['application_id', 'name']);
+            $table->index(['service_id', 'name']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->dropIndex(['application_id', 'name']);
+            $table->dropIndex(['service_id', 'name']);
+            $table->dropColumn('application_id');
+            $table->unsignedBigInteger('service_id')->nullable(false)->change();
+        });
+    }
+};
+

--- a/resources/views/livewire/project/application/backups.blade.php
+++ b/resources/views/livewire/project/application/backups.blade.php
@@ -1,0 +1,47 @@
+<div class="flex flex-col h-full gap-8 sm:flex-row">
+    <div class="sub-menu-wrapper">
+        <div class="px-4 py-2 text-xs text-gray-500 dark:text-gray-400">
+            Databases
+        </div>
+        @forelse ($databases as $db)
+            <button type="button"
+                class="sub-menu-item w-full text-left {{ $selectedDatabase?->uuid === $db->uuid ? 'menu-item-active' : '' }}"
+                wire:click="selectDatabase('{{ $db->uuid }}')">
+                <span class="menu-item-label">{{ $db->name }}</span>
+            </button>
+        @empty
+            <div class="px-4 py-2 text-sm text-gray-600 dark:text-gray-400">
+                No database services detected in this docker-compose.
+            </div>
+        @endforelse
+    </div>
+
+    <div class="w-full">
+        @if ($selectedDatabase)
+            <div class="flex items-center gap-2">
+                <h2 class="pb-4">Scheduled Backups</h2>
+                @if ($selectedDatabase->isBackupSolutionAvailable() || $selectedDatabase->is_migrated)
+                    @if (filled($selectedDatabase->custom_type) || ! $selectedDatabase->is_migrated)
+                        @can('update', $selectedDatabase)
+                            <x-modal-input buttonTitle="+ Add" title="New Scheduled Backup">
+                                <livewire:project.database.create-scheduled-backup :database="$selectedDatabase" />
+                            </x-modal-input>
+                        @endcan
+                    @endif
+                @else
+                    <span class="text-sm text-gray-600 dark:text-gray-400">
+                        (Backups not supported for this database type.)
+                    </span>
+                @endif
+            </div>
+
+            <livewire:project.database.scheduled-backups :database="$selectedDatabase" />
+        @else
+            <div class="text-sm text-gray-600 dark:text-gray-400">
+                No database services detected. Ensure your docker-compose has a supported database service image (e.g.
+                Postgres/MySQL/MariaDB/MongoDB) and redeploy.
+            </div>
+        @endif
+    </div>
+</div>
+

--- a/resources/views/livewire/project/application/configuration.blade.php
+++ b/resources/views/livewire/project/application/configuration.blade.php
@@ -20,6 +20,10 @@
                 href="{{ route('project.application.environment-variables', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Environment Variables</span></a>
             <a class='sub-menu-item' {{ wireNavigate() }} wire:current.exact="menu-item-active"
                 href="{{ route('project.application.persistent-storage', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Persistent Storage</span></a>
+            @if ($application->build_pack === 'dockercompose')
+                <a class='sub-menu-item' {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                    href="{{ route('project.application.backups', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Backups</span></a>
+            @endif
             @if ($application->git_based())
                 <a class='sub-menu-item' {{ wireNavigate() }} wire:current.exact="menu-item-active"
                     href="{{ route('project.application.source', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Git Source</span></a>
@@ -78,6 +82,8 @@
                 <livewire:project.shared.environment-variable.all :resource="$application" />
             @elseif ($currentRoute === 'project.application.persistent-storage')
                 <livewire:project.service.storage :resource="$application" />
+            @elseif ($currentRoute === 'project.application.backups' && $application->build_pack === 'dockercompose')
+                <livewire:project.application.backups :application="$application" />
             @elseif ($currentRoute === 'project.application.source' && $application->git_based())
                 <livewire:project.application.source :application="$application" />
             @elseif ($currentRoute === 'project.application.servers')

--- a/routes/web.php
+++ b/routes/web.php
@@ -196,6 +196,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/advanced', ApplicationConfiguration::class)->name('project.application.advanced');
         Route::get('/environment-variables', ApplicationConfiguration::class)->name('project.application.environment-variables');
         Route::get('/persistent-storage', ApplicationConfiguration::class)->name('project.application.persistent-storage');
+        Route::get('/backups', ApplicationConfiguration::class)->name('project.application.backups');
         Route::get('/source', ApplicationConfiguration::class)->name('project.application.source');
         Route::get('/servers', ApplicationConfiguration::class)->name('project.application.servers');
         Route::get('/scheduled-tasks', ApplicationConfiguration::class)->name('project.application.scheduled-tasks.show');
@@ -327,10 +328,9 @@ Route::middleware(['auth'])->group(function () {
                 }
             }
             $filename = data_get($execution, 'filename');
-            if ($execution->scheduledDatabaseBackup->database->getMorphClass() === \App\Models\ServiceDatabase::class) {
-                $server = $execution->scheduledDatabaseBackup->database->service->destination->server;
-            } else {
-                $server = $execution->scheduledDatabaseBackup->database->destination->server;
+            $server = $execution->scheduledDatabaseBackup->server();
+            if (! $server) {
+                return response()->json(['message' => 'Server not found.'], 404);
             }
 
             $privateKeyLocation = $server->privateKey->getKeyLocation();


### PR DESCRIPTION
/claim #7528

Fixes database detection and backup support for Docker Compose deployments via GitHub App (`build_pack=dockercompose`).

## Summary
- Add `application_id` to `service_databases` and allow `service_id` to be nullable so ServiceDatabase records can belong to either a Service stack or a docker-compose Application.
- Persist detected compose databases during the docker-compose Application parsing path via `isDatabaseImage()` (keyed by `(application_id, name)`; previews excluded).
- Add a **Backups** tab to docker-compose Application configuration to manage scheduled backups for detected DB services.
- Update backup execution + status update paths to support application-owned ServiceDatabase records (server/container resolution; avoid matching preview containers).
- Prevent the cleanup command from deleting application-owned ServiceDatabase records.

## Demo Video
TBD (will add)
