### PR TITLE
fix: custom docker options parser truncates hyphenated values

### DIFF
--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -985,7 +985,7 @@ function convertDockerRunToCompose(?string $custom_docker_run_options = null)
 {
     $options = [];
     $compose_options = collect([]);
-    preg_match_all('/(--\w+(?:-\w+)*)(?:\s|=)?([^\s-]+)?/', $custom_docker_run_options, $matches, PREG_SET_ORDER);
+    preg_match_all('/(--\w+(?:-\w+)*)(?:\s|=)?((?!--)[^\s]+)?/', $custom_docker_run_options, $matches, PREG_SET_ORDER);
     $list_options = collect([
         '--cap-add',
         '--cap-drop',


### PR DESCRIPTION
### Changes
> Fixes parsing of hyphenated values in custom Docker options.
> 
> Example:
> --security-opt no-new-privileges:true
> 
> Previously parsed as:
> no
> 
> Now correctly preserved as:
> no-new-privileges:true

### Issue
> Resolves #8173

### Category
> - [x] Bug fix

### AI Usage
> - [x] AI is used in the process of creating this PR

### Steps to Test
> - Step 1 – Go to application settings.
> - Step 2 – Add a custom Docker option:
>   --security-opt no-new-privileges:true
> - Step 3 – Deploy the application.
> - Step 4 – Verify that the value is not truncated.

### Contributor Agreement
> [!IMPORTANT]
> - [x] I have read and understood the contributor guidelines.
> - [x] I have tested the changes thoroughly and am confident that they will work as expected.
