### PR TITLE
fix(api): correctly parse force=false as boolean in deploy endpoint

### DIFF
--- a/app/Http/Controllers/Api/DeployController.php
+++ b/app/Http/Controllers/Api/DeployController.php
@@ -349,7 +349,7 @@ class DeployController extends Controller
 
         $uuids = $request->input('uuid');
         $tags = $request->input('tag');
-        $force = $request->input('force') ?? false;
+        $force = filter_var($request->input('force', false), FILTER_VALIDATE_BOOLEAN);
         $pr = $request->input('pr') ? max((int) $request->input('pr'), 0) : 0;
 
         if ($uuids && $tags) {


### PR DESCRIPTION
### Changes
> Fix boolean parsing of `force` in `/api/v1/deploy` so `force=false` does not trigger a forced rebuild.

### Issue
> Resolves #8104

### Category
> - [x] Bug fix

### AI Usage
> - [x] AI is used in the process of creating this PR

### Steps to Test
> - Step 1 – Call: POST /api/v1/deploy?uuid=<uuid>&force=false
> - Step 2 – Verify it does NOT force rebuild.
> - Step 3 – Call: POST /api/v1/deploy?uuid=<uuid>&force=true
> - Step 4 – Verify it DOES force rebuild.

### Contributor Agreement
> [!IMPORTANT]
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them
