### PR TITLE
fix: custom docker options parser truncates hyphenated values

### DIFF
--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -985,7 +985,7 @@ function convertDockerRunToCompose(?string $custom_docker_run_options = null)
 {
     $options = [];
     $compose_options = collect([]);
-    preg_match_all('/(--\w+(?:-\w+)*)(?:\s|=)?([^\s-]+)?/', $custom_docker_run_options, $matches, PREG_SET_ORDER);
+    preg_match_all('/(--\w+(?:-\w+)*)(?:\s|=)?((?!--)[^\s]+)?/', $custom_docker_run_options, $matches, PREG_SET_ORDER);
     $list_options = collect([
         '--cap-add',
         '--cap-drop',


### PR DESCRIPTION
### Changes
> Fix parsing of hyphenated values in Custom Docker Options (e.g. --security-opt no-new-privileges:true).

### Issue
> Resolves #8173

### Category
> - [x] Bug fix

### AI Usage
> - [x] AI is used in the process of creating this PR

### Steps to Test
> - Step 1 – Go to Application → General → Custom Docker Options.
> - Step 2 – Add: --cap-drop ALL --security-opt no-new-privileges:true
> - Step 3 – Save and deploy.
> - Step 4 – Verify generated compose contains security_opt: - no-new-privileges:true (not "no").

### Contributor Agreement
> [!IMPORTANT]
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them

 
