### PR TITLE
feat: Database detection & backup support for Docker Compose applications

### DIFF
--- a/app/Actions/Database/StartDatabaseProxy.php
+++ b/app/Actions/Database/StartDatabaseProxy.php
@@ -31,9 +31,9 @@ class StartDatabaseProxy
 
         if ($database->getMorphClass() === \App\Models\ServiceDatabase::class) {
             $databaseType = $database->databaseType();
-            $network = $database->service->uuid;
-            $server = data_get($database, 'service.destination.server');
-            $containerName = "{$database->name}-{$database->service->uuid}";
+            $network = $database->parentUuid();
+            $server = $database->server();
+            $containerName = "{$database->name}-{$database->parentUuid()}";
         }
         $internalPort = match ($databaseType) {
             'standalone-mariadb', 'standalone-mysql' => 3306,

--- a/app/Actions/Database/StopDatabaseProxy.php
+++ b/app/Actions/Database/StopDatabaseProxy.php
@@ -25,8 +25,8 @@ class StopDatabaseProxy
         $server = data_get($database, 'destination.server');
         $uuid = $database->uuid;
         if ($database->getMorphClass() === \App\Models\ServiceDatabase::class) {
-            $uuid = $database->service->uuid;
-            $server = data_get($database, 'service.server');
+            $uuid = $database->parentUuid();
+            $server = $database->server();
         }
         instant_remote_process(["docker rm -f {$uuid}-proxy"], $server);
 

--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -93,7 +93,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $this->database = data_get($this->backup, 'database');
-                $this->server = $this->database->service->server;
+                $this->server = $this->database->server();
                 $this->s3 = $this->backup->s3;
             } else {
                 $this->database = data_get($this->backup, 'database');
@@ -115,8 +115,9 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $databaseType = $this->database->databaseType();
-                $serviceUuid = $this->database->service->uuid;
-                $serviceName = str($this->database->service->name)->slug();
+                $serviceUuid = $this->database->parentUuid();
+                $parentResource = $this->database->parentResource();
+                $serviceName = str($parentResource->name)->slug();
                 if (str($databaseType)->contains('postgres')) {
                     $this->container_name = "{$this->database->name}-$serviceUuid";
                     $this->directory_name = $serviceName.'-'.$this->container_name;
@@ -630,7 +631,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             $endpoint = $this->s3->endpoint;
             $this->s3->testConnection(shouldSave: true);
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
-                $network = $this->database->service->destination->network;
+                $network = $this->database->destination()->network;
             } else {
                 $network = $this->database->destination->network;
             }

--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -115,8 +115,11 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $databaseType = $this->database->databaseType();
-                $serviceUuid = $this->database->parentUuid();
                 $parentResource = $this->database->parentResource();
+                if (is_null($parentResource)) {
+                    throw new \Exception('Parent resource (Service or Application) not found for ServiceDatabase #'.$this->database->id);
+                }
+                $serviceUuid = $parentResource->uuid;
                 $serviceName = str($parentResource->name)->slug();
                 if (str($databaseType)->contains('postgres')) {
                     $this->container_name = "{$this->database->name}-$serviceUuid";
@@ -631,7 +634,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             $endpoint = $this->s3->endpoint;
             $this->s3->testConnection(shouldSave: true);
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
-                $network = $this->database->destination()->network;
+                $network = $this->database->getDestination()->network;
             } else {
                 $network = $this->database->destination->network;
             }

--- a/app/Livewire/Project/Application/DatabaseBackups.php
+++ b/app/Livewire/Project/Application/DatabaseBackups.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Livewire\Project\Application;
+
+use App\Models\Application;
+use App\Models\ServiceDatabase;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Component;
+
+class DatabaseBackups extends Component
+{
+    use AuthorizesRequests;
+
+    public ?Application $application = null;
+
+    public ?ServiceDatabase $serviceDatabase = null;
+
+    public array $parameters;
+
+    public array $query;
+
+    public bool $isImportSupported = false;
+
+    protected $listeners = ['refreshScheduledBackups' => '$refresh'];
+
+    public function mount()
+    {
+        try {
+            $this->parameters = get_route_parameters();
+            $this->query = request()->query();
+            $this->application = Application::whereUuid($this->parameters['application_uuid'])->first();
+            if (! $this->application) {
+                return redirect()->route('dashboard');
+            }
+            $this->authorize('view', $this->application);
+
+            $this->serviceDatabase = $this->application->databases()->whereUuid($this->parameters['database_uuid'])->first();
+            if (! $this->serviceDatabase) {
+                return redirect()->route('project.application.configuration', [
+                    'project_uuid' => $this->parameters['project_uuid'],
+                    'environment_uuid' => $this->parameters['environment_uuid'],
+                    'application_uuid' => $this->parameters['application_uuid'],
+                ]);
+            }
+
+            if (! $this->serviceDatabase->isBackupSolutionAvailable()) {
+                return redirect()->route('project.application.configuration', $this->parameters);
+            }
+
+            $dbType = $this->serviceDatabase->databaseType();
+            $supportedTypes = ['mysql', 'mariadb', 'postgres', 'mongo'];
+            $this->isImportSupported = collect($supportedTypes)->contains(fn ($type) => str_contains($dbType, $type));
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function render()
+    {
+        return view('livewire.project.application.database-backups');
+    }
+}

--- a/app/Livewire/Project/Database/BackupEdit.php
+++ b/app/Livewire/Project/Database/BackupEdit.php
@@ -157,7 +157,7 @@ class BackupEdit extends Component
         try {
             $server = null;
             if ($this->backup->database instanceof \App\Models\ServiceDatabase) {
-                $server = $this->backup->database->service->destination->server;
+                $server = $this->backup->database->server();
             } elseif ($this->backup->database->destination && $this->backup->database->destination->server) {
                 $server = $this->backup->database->destination->server;
             }
@@ -184,6 +184,15 @@ class BackupEdit extends Component
 
             if ($this->backup->database->getMorphClass() === \App\Models\ServiceDatabase::class) {
                 $serviceDatabase = $this->backup->database;
+
+                if ($serviceDatabase->application_id) {
+                    return redirect()->route('project.application.database.backups', [
+                        'project_uuid' => $this->parameters['project_uuid'],
+                        'environment_uuid' => $this->parameters['environment_uuid'],
+                        'application_uuid' => $serviceDatabase->application->uuid,
+                        'database_uuid' => $serviceDatabase->uuid,
+                    ]);
+                }
 
                 return redirect()->route('project.service.database.backups', [
                     'project_uuid' => $this->parameters['project_uuid'],

--- a/app/Livewire/Project/Database/BackupExecutions.php
+++ b/app/Livewire/Project/Database/BackupExecutions.php
@@ -78,9 +78,10 @@ class BackupExecutions extends Component
             return;
         }
 
-        $server = $execution->scheduledDatabaseBackup->database->getMorphClass() === \App\Models\ServiceDatabase::class
-            ? $execution->scheduledDatabaseBackup->database->service->destination->server
-            : $execution->scheduledDatabaseBackup->database->destination->server;
+        $database = $execution->scheduledDatabaseBackup->database;
+        $server = $database instanceof \App\Models\ServiceDatabase
+            ? $database->server()
+            : $database->destination->server;
 
         try {
             if ($execution->filename) {
@@ -179,15 +180,11 @@ class BackupExecutions extends Component
     public function server()
     {
         if ($this->database) {
-            $server = null;
-
             if ($this->database instanceof \App\Models\ServiceDatabase) {
-                $server = $this->database->service->destination->server;
-            } elseif ($this->database->destination && $this->database->destination->server) {
-                $server = $this->database->destination->server;
+                return $this->database->server();
             }
-            if ($server) {
-                return $server;
+            if ($this->database->destination && $this->database->destination->server) {
+                return $this->database->destination->server;
             }
         }
 

--- a/app/Livewire/Project/Database/Import.php
+++ b/app/Livewire/Project/Database/Import.php
@@ -633,7 +633,7 @@ EOD;
 
             // Get the database destination network
             if ($this->resource->getMorphClass() === \App\Models\ServiceDatabase::class) {
-                $destination = $this->resource->destination();
+                $destination = $this->resource->getDestination();
                 $destinationNetwork = $destination ? ($destination->network ?? 'coolify') : 'coolify';
             } else {
                 $destinationNetwork = $this->resource->destination->network ?? 'coolify';

--- a/app/Livewire/Project/Database/Import.php
+++ b/app/Livewire/Project/Database/Import.php
@@ -319,7 +319,7 @@ EOD;
                 abort(404, 'Server not found for this service database.');
             }
             $this->serverId = $server->id;
-            $this->container = $resource->name.'-'.$resource->service->uuid;
+            $this->container = $resource->name.'-'.$resource->parentUuid();
             $this->resourceUuid = $resource->uuid; // Use ServiceDatabase's own UUID
 
             // Determine database type for ServiceDatabase
@@ -633,7 +633,8 @@ EOD;
 
             // Get the database destination network
             if ($this->resource->getMorphClass() === \App\Models\ServiceDatabase::class) {
-                $destinationNetwork = $this->resource->service->destination->network ?? 'coolify';
+                $destination = $this->resource->destination();
+                $destinationNetwork = $destination ? ($destination->network ?? 'coolify') : 'coolify';
             } else {
                 $destinationNetwork = $this->resource->destination->network ?? 'coolify';
             }

--- a/app/Livewire/Project/Service/Index.php
+++ b/app/Livewire/Project/Service/Index.php
@@ -137,7 +137,7 @@ class Index extends Component
 
     private function initializeDatabaseProperties(): void
     {
-        $this->server = $this->serviceDatabase->service->destination->server;
+        $this->server = $this->serviceDatabase->server();
         if ($this->serviceDatabase->is_public) {
             $this->db_url_public = $this->serviceDatabase->getServiceDatabaseUrl();
         }
@@ -221,7 +221,7 @@ class Index extends Component
     {
         try {
             $this->authorize('update', $this->serviceDatabase);
-            if (! $this->serviceDatabase->service->destination->server->isLogDrainEnabled()) {
+            if (! $this->serviceDatabase->server()->isLogDrainEnabled()) {
                 $this->isLogDrainEnabled = false;
                 $this->dispatch('error', 'Log drain is not enabled on the server. Please enable it first.');
 

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -490,6 +490,11 @@ class Application extends BaseModel
         return $this->hasOne(ApplicationSetting::class);
     }
 
+    public function databases()
+    {
+        return $this->hasMany(ServiceDatabase::class);
+    }
+
     public function persistentStorages()
     {
         return $this->morphMany(LocalPersistentVolume::class, 'resource');

--- a/app/Models/ScheduledDatabaseBackup.php
+++ b/app/Models/ScheduledDatabaseBackup.php
@@ -67,12 +67,10 @@ class ScheduledDatabaseBackup extends BaseModel
     {
         if ($this->database) {
             if ($this->database instanceof ServiceDatabase) {
-                $destination = data_get($this->database->service, 'destination');
-                $server = data_get($destination, 'server');
-            } else {
-                $destination = data_get($this->database, 'destination');
-                $server = data_get($destination, 'server');
+                return $this->database->server();
             }
+            $destination = data_get($this->database, 'destination');
+            $server = data_get($destination, 'server');
             if ($server) {
                 return $server;
             }

--- a/app/Models/ServiceDatabase.php
+++ b/app/Models/ServiceDatabase.php
@@ -191,13 +191,10 @@ class ServiceDatabase extends BaseModel
     /**
      * Get the destination (network) for this database.
      */
-    public function destination()
+    public function getDestination()
     {
         $parent = $this->parentResource();
-        if ($parent instanceof Service) {
-            return $parent->destination;
-        }
-        if ($parent instanceof Application) {
+        if ($parent) {
             return $parent->destination;
         }
 

--- a/app/Models/ServiceDatabase.php
+++ b/app/Models/ServiceDatabase.php
@@ -27,7 +27,10 @@ class ServiceDatabase extends BaseModel
 
     public static function ownedByCurrentTeamAPI(int $teamId)
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', $teamId)->orderBy('name');
+        return ServiceDatabase::where(function ($query) use ($teamId) {
+            $query->whereRelation('service.environment.project.team', 'id', $teamId)
+                ->orWhereRelation('application.environment.project.team', 'id', $teamId);
+        })->orderBy('name');
     }
 
     /**
@@ -36,7 +39,12 @@ class ServiceDatabase extends BaseModel
      */
     public static function ownedByCurrentTeam()
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', currentTeam()->id)->orderBy('name');
+        $teamId = currentTeam()->id;
+
+        return ServiceDatabase::where(function ($query) use ($teamId) {
+            $query->whereRelation('service.environment.project.team', 'id', $teamId)
+                ->orWhereRelation('application.environment.project.team', 'id', $teamId);
+        })->orderBy('name');
     }
 
     /**
@@ -51,8 +59,8 @@ class ServiceDatabase extends BaseModel
 
     public function restart()
     {
-        $container_id = $this->name.'-'.$this->service->uuid;
-        remote_process(["docker restart {$container_id}"], $this->service->server);
+        $container_id = $this->name.'-'.$this->parentUuid();
+        remote_process(["docker restart {$container_id}"], $this->server());
     }
 
     public function isRunning()
@@ -82,7 +90,7 @@ class ServiceDatabase extends BaseModel
 
     public function type()
     {
-        return 'service';
+        return $this->application_id ? 'application' : 'service';
     }
 
     public function serviceType()
@@ -114,8 +122,12 @@ class ServiceDatabase extends BaseModel
     public function getServiceDatabaseUrl()
     {
         $port = $this->public_port;
-        $realIp = $this->service->server->ip;
-        if ($this->service->server->isLocalhost() || isDev()) {
+        $server = $this->server();
+        if (! $server) {
+            return null;
+        }
+        $realIp = $server->ip;
+        if ($server->isLocalhost() || isDev()) {
             $realIp = base_ip();
         }
 
@@ -124,17 +136,80 @@ class ServiceDatabase extends BaseModel
 
     public function team()
     {
-        return data_get($this, 'environment.project.team');
+        $parent = $this->parentResource();
+        if ($parent) {
+            return data_get($parent, 'environment.project.team');
+        }
+
+        return null;
     }
 
     public function workdir()
     {
-        return service_configuration_dir()."/{$this->service->uuid}";
+        $uuid = $this->parentUuid();
+        if ($this->application_id) {
+            return application_configuration_dir()."/{$uuid}";
+        }
+
+        return service_configuration_dir()."/{$uuid}";
     }
 
     public function service()
     {
         return $this->belongsTo(Service::class);
+    }
+
+    public function application()
+    {
+        return $this->belongsTo(Application::class);
+    }
+
+    /**
+     * Get the parent resource (Service or Application) that owns this database.
+     */
+    public function parentResource(): Service|Application|null
+    {
+        return $this->service ?? $this->application;
+    }
+
+    /**
+     * Get the server this database runs on.
+     */
+    public function server()
+    {
+        $parent = $this->parentResource();
+        if ($parent instanceof Service) {
+            return $parent->server;
+        }
+        if ($parent instanceof Application) {
+            return $parent->destination?->server;
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the destination (network) for this database.
+     */
+    public function destination()
+    {
+        $parent = $this->parentResource();
+        if ($parent instanceof Service) {
+            return $parent->destination;
+        }
+        if ($parent instanceof Application) {
+            return $parent->destination;
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the parent UUID used for container naming.
+     */
+    public function parentUuid(): ?string
+    {
+        return $this->parentResource()?->uuid;
     }
 
     public function persistentStorages()

--- a/bootstrap/helpers/databases.php
+++ b/bootstrap/helpers/databases.php
@@ -346,7 +346,7 @@ function deleteOldBackupsLocally($backup): Collection
 
     $server = null;
     if ($backup->database_type === \App\Models\ServiceDatabase::class) {
-        $server = $backup->database->service->server;
+        $server = $backup->database->server();
     } else {
         $server = $backup->database->destination->server;
     }

--- a/bootstrap/helpers/services.php
+++ b/bootstrap/helpers/services.php
@@ -28,6 +28,9 @@ function getFilesystemVolumesFromServer(ServiceApplication|ServiceDatabase|Appli
         if ($oneService->getMorphClass() === \App\Models\Application::class) {
             $workdir = $oneService->workdir();
             $server = $oneService->destination->server;
+        } elseif ($oneService instanceof \App\Models\ServiceDatabase) {
+            $workdir = $oneService->workdir();
+            $server = $oneService->server();
         } else {
             $workdir = $oneService->service->workdir();
             $server = $oneService->service->server;

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -2418,6 +2418,32 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
             $isDatabase = isDatabaseImage($image, $service);
             data_set($service, 'is_database', $isDatabase);
 
+            // Create ServiceDatabase record for detected databases in compose applications
+            if ($isDatabase) {
+                if ($isNew) {
+                    ServiceDatabase::create([
+                        'name' => $serviceName,
+                        'image' => $image,
+                        'application_id' => $resource->id,
+                    ]);
+                } else {
+                    $existingDb = ServiceDatabase::where([
+                        'name' => $serviceName,
+                        'application_id' => $resource->id,
+                    ])->first();
+                    if (is_null($existingDb)) {
+                        ServiceDatabase::create([
+                            'name' => $serviceName,
+                            'image' => $image,
+                            'application_id' => $resource->id,
+                        ]);
+                    } elseif ($existingDb->image !== $image) {
+                        $existingDb->image = $image;
+                        $existingDb->save();
+                    }
+                }
+            }
+
             // Collect/create/update networks
             if ($serviceNetworks->count() > 0) {
                 foreach ($serviceNetworks as $networkName => $networkDetails) {

--- a/database/migrations/2026_02_06_000001_add_application_id_to_service_databases.php
+++ b/database/migrations/2026_02_06_000001_add_application_id_to_service_databases.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -16,10 +17,18 @@ return new class extends Migration
         Schema::table('service_databases', function (Blueprint $table) {
             $table->foreignId('service_id')->nullable()->change();
         });
+
+        // Ensure exactly one parent is set
+        DB::statement('ALTER TABLE service_databases ADD CONSTRAINT chk_single_parent CHECK (service_id IS NOT NULL OR application_id IS NOT NULL)');
     }
 
     public function down(): void
     {
+        DB::statement('ALTER TABLE service_databases DROP CONSTRAINT IF EXISTS chk_single_parent');
+
+        // Remove Application-linked records before making service_id non-nullable
+        DB::table('service_databases')->whereNull('service_id')->delete();
+
         Schema::table('service_databases', function (Blueprint $table) {
             $table->dropForeign(['application_id']);
             $table->dropColumn('application_id');

--- a/database/migrations/2026_02_06_000001_add_application_id_to_service_databases.php
+++ b/database/migrations/2026_02_06_000001_add_application_id_to_service_databases.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->foreignId('application_id')->nullable()->after('service_id')->constrained()->cascadeOnDelete();
+        });
+
+        // Make service_id nullable so Application-linked databases don't need it
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->foreignId('service_id')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->dropForeign(['application_id']);
+            $table->dropColumn('application_id');
+        });
+
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->foreignId('service_id')->nullable(false)->change();
+        });
+    }
+};

--- a/resources/views/livewire/project/application/database-backups.blade.php
+++ b/resources/views/livewire/project/application/database-backups.blade.php
@@ -1,10 +1,10 @@
 <div>
+    <x-slot:title>
+        {{ data_get_str($application, 'name')->limit(10) }} >
+        {{ data_get_str($serviceDatabase, 'name')->limit(10) }} > Backups | Coolify
+    </x-slot>
     <livewire:project.application.heading :application="$application" :parameters="$parameters" />
     <div class="w-full">
-        <x-slot:title>
-            {{ data_get_str($application, 'name')->limit(10) }} >
-            {{ data_get_str($serviceDatabase, 'name')->limit(10) }} > Backups | Coolify
-        </x-slot>
         <div class="flex gap-2">
             <h2 class="pb-4">Scheduled Backups</h2>
             @can('update', $serviceDatabase)

--- a/resources/views/livewire/project/application/database-backups.blade.php
+++ b/resources/views/livewire/project/application/database-backups.blade.php
@@ -1,0 +1,18 @@
+<div>
+    <livewire:project.application.heading :application="$application" :parameters="$parameters" />
+    <div class="w-full">
+        <x-slot:title>
+            {{ data_get_str($application, 'name')->limit(10) }} >
+            {{ data_get_str($serviceDatabase, 'name')->limit(10) }} > Backups | Coolify
+        </x-slot>
+        <div class="flex gap-2">
+            <h2 class="pb-4">Scheduled Backups</h2>
+            @can('update', $serviceDatabase)
+                <x-modal-input buttonTitle="+ Add" title="New Scheduled Backup">
+                    <livewire:project.database.create-scheduled-backup :database="$serviceDatabase" />
+                </x-modal-input>
+            @endcan
+        </div>
+        <livewire:project.database.scheduled-backups :database="$serviceDatabase" />
+    </div>
+</div>

--- a/resources/views/livewire/project/application/general.blade.php
+++ b/resources/views/livewire/project/application/general.blade.php
@@ -68,7 +68,7 @@
                         @endif
                     @endif
 
-                    @if ($application->databases()->count() > 0)
+                    @if ($application->databases->count() > 0)
                         <h3 class="pt-6">Databases</h3>
                         <div class="flex flex-col gap-2">
                             @foreach ($application->databases as $db)

--- a/resources/views/livewire/project/application/general.blade.php
+++ b/resources/views/livewire/project/application/general.blade.php
@@ -68,6 +68,28 @@
                         @endif
                     @endif
 
+                    @if ($application->databases()->count() > 0)
+                        <h3 class="pt-6">Databases</h3>
+                        <div class="flex flex-col gap-2">
+                            @foreach ($application->databases as $db)
+                                <div class="flex items-center gap-2">
+                                    <span>{{ $db->name }} ({{ $db->databaseType() }})</span>
+                                    @if ($db->isBackupSolutionAvailable())
+                                        <a href="{{ route('project.application.database.backups', [
+                                            'project_uuid' => $application->environment->project->uuid,
+                                            'environment_uuid' => $application->environment->uuid,
+                                            'application_uuid' => $application->uuid,
+                                            'database_uuid' => $db->uuid,
+                                        ]) }}"
+                                            class="text-xs underline">
+                                            Backups
+                                        </a>
+                                    @endif
+                                </div>
+                            @endforeach
+                        </div>
+                    @endif
+
                 </div>
             @endif
             @if ($isStatic || $buildPack === 'static')

--- a/routes/web.php
+++ b/routes/web.php
@@ -329,10 +329,11 @@ Route::middleware(['auth'])->group(function () {
                 }
             }
             $filename = data_get($execution, 'filename');
-            if ($execution->scheduledDatabaseBackup->database->getMorphClass() === \App\Models\ServiceDatabase::class) {
-                $server = $execution->scheduledDatabaseBackup->database->service->destination->server;
+            $database = $execution->scheduledDatabaseBackup->database;
+            if ($database instanceof \App\Models\ServiceDatabase) {
+                $server = $database->server();
             } else {
-                $server = $execution->scheduledDatabaseBackup->database->destination->server;
+                $server = $database->destination->server;
             }
 
             $privateKeyLocation = $server->privateKey->getKeyLocation();

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,7 @@ use App\Livewire\Notifications\Telegram as NotificationTelegram;
 use App\Livewire\Notifications\Webhook as NotificationWebhook;
 use App\Livewire\Profile\Index as ProfileIndex;
 use App\Livewire\Project\Application\Configuration as ApplicationConfiguration;
+use App\Livewire\Project\Application\DatabaseBackups as ApplicationDatabaseBackups;
 use App\Livewire\Project\Application\Deployment\Index as DeploymentIndex;
 use App\Livewire\Project\Application\Deployment\Show as DeploymentShow;
 use App\Livewire\Project\CloneMe as ProjectCloneMe;
@@ -214,6 +215,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/logs', Logs::class)->name('project.application.logs');
         Route::get('/terminal', ExecuteContainerCommand::class)->name('project.application.command')->middleware('can.access.terminal');
         Route::get('/tasks/{task_uuid}', ScheduledTaskShow::class)->name('project.application.scheduled-tasks');
+        Route::get('/database/{database_uuid}/backups', ApplicationDatabaseBackups::class)->name('project.application.database.backups');
     });
     Route::prefix('project/{project_uuid}/environment/{environment_uuid}/database/{database_uuid}')->group(function () {
         Route::get('/', DatabaseConfiguration::class)->name('project.database.configuration');


### PR DESCRIPTION
/claim #7528

STRAWBERRY

### Changes

Add database detection and backup support for Docker Compose applications deployed via GitHub App (`dockercompose` buildpack). Previously, `parseDockerComposeFile()` only created `ServiceDatabase` records in the Service code path — the Application code path detected databases but never persisted them, making backups impossible.

This PR adds the full chain: detection → record creation → backup scheduling → backup execution → UI.

Key changes:
- Migration adds nullable `application_id` FK to `service_databases`, makes `service_id` nullable, adds CHECK constraint ensuring at least one parent
- `ServiceDatabase` model gets `application()` relationship + `parentResource()`, `server()`, `getDestination()`, `parentUuid()` helpers for polymorphic parent resolution
- `parseDockerComposeFile()` Application path now creates `ServiceDatabase` records when `isDatabaseImage()` returns true
- `Application` model gets `databases()` relationship
- All backup infrastructure (`DatabaseBackupJob`, `ScheduledDatabaseBackup`, `BackupEdit`, `BackupExecutions`, `Import`, `StartDatabaseProxy`, `StopDatabaseProxy`, backup download route, cleanup helper, filesystem volumes helper) updated to use new helpers instead of hardcoded `->service->` chains
- New `ApplicationDatabaseBackups` Livewire component, blade view, and route
- Compose application general view shows detected databases with backup links


### Issue
> - Resolves #7528


### Category
> - [x] New feature


### Screenshots or Video (if applicable)
Screen recording demonstrating the full flow (login → dashboard → application with detected database → backup page → add backup modal) will be attached as a comment.


### AI Usage
> - [x] AI is used in the process of creating this PR


### Steps to Test
> - Step 1 – Create a new project, add a new Application resource using "Docker Compose" via GitHub App (not "Empty Docker Compose" which uses Service model)
> - Step 2 – Use a docker-compose.yml that includes a database service (e.g. `postgres:16` or `mysql:8`) alongside an app service
> - Step 3 – Deploy the application and verify the compose general view now shows a "Databases" section listing the detected database with its type
> - Step 4 – Click the "Backups" link next to the detected database and verify the backup scheduling page loads correctly
> - Step 5 – Create a scheduled backup, wait for it to execute, and verify the backup completes successfully
> - Step 6 – Verify existing Service-type compose deployments still work as before (no regression)


### Contributor Agreement
> [!IMPORTANT]
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them