### PR TITLE
fix: prevent sporadic SSH Permission denied (publickey,password)

### DIFF
--- a/app/Helpers/SshMultiplexingHelper.php
+++ b/app/Helpers/SshMultiplexingHelper.php
@@ -158,7 +158,13 @@ class SshMultiplexingHelper
         $sshConfig = self::serverSshConfiguration($server);
         $sshKeyLocation = $sshConfig['sshKeyLocation'];
 
-        self::validateSshKey($server->privateKey);
+        $keyWasRewritten = self::validateSshKey($server->privateKey);
+
+        // If the key file was rewritten (stale content detected), invalidate the
+        // existing mux connection since it was authenticated with the old key.
+        if ($keyWasRewritten) {
+            self::removeMuxFile($server);
+        }
 
         $muxSocket = $sshConfig['muxFilename'];
 
@@ -201,20 +207,43 @@ class SshMultiplexingHelper
         return config('constants.ssh.mux_enabled') && ! config('constants.coolify.is_windows_docker_desktop');
     }
 
-    private static function validateSshKey(PrivateKey $privateKey): void
+    /**
+     * Validate that the SSH key file exists on disk and its content matches the
+     * current key stored in the database. If the file is missing or stale
+     * (e.g. after key regeneration), it is rewritten from the database.
+     *
+     * @return bool True if the key file was (re)written, false if it was already valid.
+     */
+    private static function validateSshKey(PrivateKey $privateKey): bool
     {
         $keyLocation = $privateKey->getKeyLocation();
-        $checkKeyCommand = "ls $keyLocation 2>/dev/null";
-        $keyCheckProcess = Process::run($checkKeyCommand);
+        $needsWrite = false;
 
-        if ($keyCheckProcess->exitCode() !== 0) {
-            $privateKey->storeInFileSystem();
+        if (! file_exists($keyLocation)) {
+            $needsWrite = true;
+        } else {
+            // Verify the file content matches the current key in the database.
+            // This prevents using a stale key file after the key has been
+            // regenerated in the database but the old file still exists on disk.
+            $diskContent = file_get_contents($keyLocation);
+            if ($diskContent === false || trim($diskContent) !== trim($privateKey->private_key)) {
+                $needsWrite = true;
+            }
         }
+
+        if ($needsWrite) {
+            $privateKey->storeInFileSystem();
+
+            return true;
+        }
+
+        return false;
     }
 
     private static function getCommonSshOptions(Server $server, string $sshKeyLocation, int $connectionTimeout, int $serverInterval, bool $isScp = false): string
     {
         $options = "-i {$sshKeyLocation} "
+            .'-o IdentitiesOnly=yes '
             .'-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null '
             .'-o PasswordAuthentication=no '
             ."-o ConnectTimeout=$connectionTimeout "


### PR DESCRIPTION
/claim #7724

## Problem

Coolify sporadically sends the wrong SSH key when connecting to servers, causing `Permission denied (publickey,password)` errors. Regenerating the key temporarily fixes it, then it breaks again.

## Root Cause Analysis

I identified **three interrelated bugs** in `SshMultiplexingHelper.php` that together explain the sporadic behavior:

### 1. `validateSshKey()` only checks file existence, not content (primary cause)

When a user regenerates their SSH private key, the new key is saved to the database but `validateSshKey()` only checks if the key **file** exists on disk:

```php
// Before: only checks existence
$checkKeyCommand = "ls $keyLocation 2>/dev/null";
$keyCheckProcess = Process::run($checkKeyCommand);
if ($keyCheckProcess->exitCode() !== 0) {
    $privateKey->storeInFileSystem();
}
```

If the old key file still exists (which it does — same UUID means same filename), the stale file is never updated. SSH then uses the **old key** from disk while the server expects the **new key** from the database.

This explains why regenerating the key "temporarily fixes it" — the `changePrivateKey` flow calls `refresh_server_connection()` → `removeMuxFile()` and `storeInFileSystem()`, which writes the correct key. But subsequent operations that go through `validateSshKey()` only check existence and never detect the stale content.

### 2. Missing `-o IdentitiesOnly=yes` SSH option

Without `IdentitiesOnly=yes`, SSH will try **all available identity files** (e.g., `~/.ssh/id_rsa`, `~/.ssh/id_ed25519`) in addition to the one specified with `-i`. This can:
- Exhaust authentication attempts with wrong keys before trying the correct one
- Trigger `Too many authentication failures` or `Permission denied` if the server has a low `MaxAuthTries`

### 3. Stale multiplexed connections not invalidated on key change

When `validateSshKey()` detects and rewrites a stale key file, the existing SSH multiplexed (mux) connection — which was authenticated with the **old** key — is not torn down. Subsequent SSH commands reuse this stale mux connection, which effectively uses wrong credentials.

## Fix

All changes are in `app/Helpers/SshMultiplexingHelper.php`:

1. **`validateSshKey()` now compares file content against the database** — reads the key file and compares it to the decrypted value from the database. Only rewrites when content differs (or file is missing). Also uses native `file_exists()` instead of shelling out to `ls`.

2. **Added `-o IdentitiesOnly=yes` to `getCommonSshOptions()`** — ensures SSH only offers the specified key file, preventing interference from any other keys on the system.

3. **Mux connection is invalidated when a stale key is detected** — if `validateSshKey()` had to rewrite the key file, `removeMuxFile()` is called before establishing a new connection, ensuring the new connection uses the correct key.

## Testing

This is a race-condition/state-desync bug that requires a multi-server Coolify Cloud environment to reproduce naturally. The fix is defensive — it ensures key file content is always validated before use and stale connections are always torn down.