### PR TITLE
 Add Debian 13 (trixie) support for Docker installation (fixes #8154)

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -116,11 +116,15 @@ class InstallDocker
 
     private function getDebianDockerInstallCommand(): string
     {
+        // Source /etc/os-release for ID, VERSION_ID, VERSION_CODENAME. Docker APT repo requires
+        // codename (e.g. trixie) not version number (13). Prefer VERSION_CODENAME; if missing or
+        // numeric, map VERSION_ID to codename so the repo URL never uses a number.
         return "curl --max-time 300 --retry 3 https://releases.rancher.com/install-docker/{$this->dockerVersion}.sh | sh || curl --max-time 300 --retry 3 https://get.docker.com | sh -s -- --version {$this->dockerVersion} || (".
             '. /etc/os-release && '.
             'install -m 0755 -d /etc/apt/keyrings && '.
             'curl -fsSL https://download.docker.com/linux/${ID}/gpg -o /etc/apt/keyrings/docker.asc && '.
             'chmod a+r /etc/apt/keyrings/docker.asc && '.
+            'if [ -z "${VERSION_CODENAME:-}" ] || case "${VERSION_CODENAME:-}" in 11|12|13) true ;; *) false ;; esac; then v="${VERSION_ID:-${VERSION_CODENAME:-}}"; v="${v%%.*}"; case "$v" in 11) VERSION_CODENAME=bullseye ;; 12) VERSION_CODENAME=bookworm ;; 13) VERSION_CODENAME=trixie ;; esac; fi && '.
             'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${ID} ${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list && '.
             'apt-get update && '.
             'apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin'.

--- a/bootstrap/helpers/constants.php
+++ b/bootstrap/helpers/constants.php
@@ -70,6 +70,13 @@ const SUPPORTED_OS = [
     'alpine',
 ];
 
+// Debian VERSION_ID => VERSION_CODENAME (used by /etc/os-release)
+const SUPPORTED_DEBIAN_VERSION_CODENAMES = [
+    '11' => 'bullseye',
+    '12' => 'bookworm',
+    '13' => 'trixie',
+];
+
 const NEEDS_TO_CONNECT_TO_PREDEFINED_NETWORK = [
     'pgadmin',
     'databasus',


### PR DESCRIPTION
## Summary
Adds support for Debian 13 (trixie) when installing Docker via Coolify so the Docker APT repository is configured with the correct codename instead of the version number.

Fixes #8154

## Problem
On Debian 13, the Docker APT repository URL was being built with the version number (`13`) instead of the release codename (`trixie`). Docker’s repository expects codenames (e.g. `trixie`, `bookworm`, `bullseye`), so this could cause Docker installation to fail on Debian 13.

## Solution
- **`app/Actions/Server/InstallDocker.php`**: Before writing the `deb` line to `/etc/apt/sources.list.d/docker.list`, we now ensure the suite is always a codename. If `VERSION_CODENAME` from `/etc/os-release` is empty or numeric (11, 12, 13), we map `VERSION_ID` to the correct codename (11→bullseye, 12→bookworm, 13→trixie) so the repository URL uses the codename.
- **`bootstrap/helpers/constants.php`**: Added `SUPPORTED_DEBIAN_VERSION_CODENAMES` to document the Debian version→codename mapping used for Docker installation.

## Files changed
- `app/Actions/Server/InstallDocker.php` – codename mapping logic in `getDebianDockerInstallCommand()`
- `bootstrap/helpers/constants.php` – `SUPPORTED_DEBIAN_VERSION_CODENAMES` constant

## Testing
- [ ] Docker installation succeeds on a Debian 13 (trixie) server when adding a server and using “Validate & Install” / “Install Docker”.
- [ ] Existing Debian 11/12 and Ubuntu flows are unchanged (codename from `VERSION_CODENAME` is used when present).