### PR TITLE
feat: add additional server support for Debian 13

### DIFF
--- a/app/Actions/Server/InstallPrerequisites.php
+++ b/app/Actions/Server/InstallPrerequisites.php
@@ -53,6 +53,12 @@ class InstallPrerequisites
                 "echo 'Installing Prerequisites for Arch Linux...'",
                 'pacman -Syu --noconfirm --needed curl wget git jq',
             ]);
+        } elseif ($supported_os_type->contains('alpine')) {
+            $command = $command->merge([
+                "echo 'Installing Prerequisites for Alpine Linux...'",
+                'apk update',
+                'apk add curl wget git jq',
+            ]);
         } else {
             throw new \Exception('Unsupported OS type for prerequisites installation');
         }

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -1047,18 +1047,25 @@ $schema://$host {
         $releaseLines = collect(explode("\n", $os_release));
         $collectedData = collect([]);
         foreach ($releaseLines as $line) {
-            $item = str($line)->trim();
-            $collectedData->put($item->before('=')->value(), $item->after('=')->lower()->replace('"', '')->value());
+            $parts = explode('=', $line, 2);
+            if (count($parts) === 2) {
+                $key = trim($parts[0]);
+                $value = trim($parts[1], " \t\n\r\0\x0B\"");
+                $collectedData->put($key, strtolower($value));
+            }
         }
         $ID = data_get($collectedData, 'ID');
-        // $ID_LIKE = data_get($collectedData, 'ID_LIKE');
-        // $VERSION_ID = data_get($collectedData, 'VERSION_ID');
-        $supported = collect(SUPPORTED_OS)->filter(function ($supportedOs) use ($ID) {
-            if (str($supportedOs)->contains($ID)) {
-                return str($ID);
-            }
+        $ID_LIKE = data_get($collectedData, 'ID_LIKE', '');
+
+        $idsToCheck = collect([$ID])->concat(explode(' ', $ID_LIKE))->filter()->unique();
+
+        $supported = collect(SUPPORTED_OS)->filter(function ($supportedOsGroup) use ($idsToCheck) {
+            return $idsToCheck->contains(function ($id) use ($supportedOsGroup) {
+                return str_contains($supportedOsGroup, $id);
+            });
         });
-        if ($supported->count() === 1) {
+
+        if ($supported->isNotEmpty()) {
             return str($supported->first());
         } else {
             return false;

--- a/bootstrap/helpers/constants.php
+++ b/bootstrap/helpers/constants.php
@@ -63,7 +63,7 @@ const SPECIFIC_SERVICES = [
 
 // Based on /etc/os-release
 const SUPPORTED_OS = [
-    'ubuntu debian raspbian pop',
+    'ubuntu debian raspbian pop trixie',
     'centos fedora rhel ol rocky amzn almalinux',
     'sles opensuse-leap opensuse-tumbleweed',
     'arch',


### PR DESCRIPTION
Fixes #8154

This PR adds support for OS detection and prerequisite installation on Debian 13 (Trixie) and Alpine Linux.

### Changes:
- Added `trixie` to `SUPPORTED_OS` in `constants.php`.
- Improved `validateOS` logic in `Server.php` to handle `ID_LIKE` and better parse `/etc/os-release`.
- Added Alpine Linux prerequisite installation commands in `InstallPrerequisites.php`.