### PR TITLE
feat: add container file browser

### DIFF
--- a/app/Livewire/Project/Shared/FileBrowser.php
+++ b/app/Livewire/Project/Shared/FileBrowser.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Livewire\Project\Shared;
+
+use App\Models\Server;
+use Livewire\Component;
+use Illuminate\Support\Collection;
+
+class FileBrowser extends Component
+{
+    public Server $server;
+    public string $containerName;
+    public string $currentPath = '/';
+    public Collection $files;
+    public ?string $selectedFileContent = null;
+    public ?string $selectedFileName = null;
+    public bool $loading = false;
+
+    public function mount()
+    {
+        $this->files = collect([]);
+        $this->loadFiles();
+    }
+
+    public function loadFiles()
+    {
+        $this->loading = true;
+        try {
+            $command = "docker exec {$this->containerName} ls -Fp --group-directories-first {$this->currentPath}";
+            $output = instant_remote_process([$command], $this->server, false);
+            
+            $this->files = collect(explode("\n", trim($output)))->filter()->map(function ($item) {
+                $isDirectory = str_ends_with($item, '/');
+                return [
+                    'name' => rtrim($item, '/'),
+                    'is_directory' => $isDirectory,
+                    'path' => $this->currentPath === '/' ? "/{$item}" : "{$this->currentPath}/{$item}"
+                ];
+            });
+        } catch (\Throwable $e) {
+            handleError($e, $this);
+        }
+        $this->loading = false;
+    }
+
+    public function changeDirectory(string $path)
+    {
+        $this->currentPath = rtrim($path, '/');
+        if (empty($this->currentPath)) $this->currentPath = '/';
+        $this->selectedFileContent = null;
+        $this->loadFiles();
+    }
+
+    public function goUp()
+    {
+        if ($this->currentPath === '/') return;
+        $parts = explode('/', rtrim($this->currentPath, '/'));
+        array_pop($parts);
+        $this->currentPath = implode('/', $parts);
+        if (empty($this->currentPath)) $this->currentPath = '/';
+        $this->loadFiles();
+    }
+
+    public function readFile(string $fileName)
+    {
+        $this->loading = true;
+        $filePath = $this->currentPath === '/' ? "/{$fileName}" : "{$this->currentPath}/{$fileName}";
+        try {
+            $command = "docker exec {$this->containerName} cat {$filePath}";
+            $this->selectedFileContent = instant_remote_process([$command], $this->server, false);
+            $this->selectedFileName = $fileName;
+        } catch (\Throwable $e) {
+            handleError($e, $this);
+        }
+        $this->loading = false;
+    }
+
+    public function render()
+    {
+        return view('livewire.project.shared.file-browser');
+    }
+}

--- a/resources/views/livewire/project/shared/file-browser.blade.php
+++ b/resources/views/livewire/project/shared/file-browser.blade.php
@@ -1,0 +1,46 @@
+<div class="p-4 border rounded-lg dark:border-coolgray-200 bg-white dark:bg-base">
+    <div class="flex items-center justify-between mb-4">
+        <div class="flex items-center gap-2">
+            <button wire:click="goUp" class="p-2 rounded hover:bg-neutral-100 dark:hover:bg-coolgray-100 disabled:opacity-50" @if($currentPath === '/') disabled @endif>
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 15l-3-3m0 0l3-3m-3 3h8M3 12a9 9 0 1118 0 9 9 0 01-18 0z"/></svg>
+            </button>
+            <span class="font-mono text-sm dark:text-neutral-300">{{ $currentPath }}</span>
+        </div>
+        <button wire:click="loadFiles" class="btn-primary btn-sm">Refresh</button>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div class="border rounded h-96 overflow-y-auto dark:border-coolgray-200">
+            <table class="w-full text-sm text-left">
+                <tbody class="divide-y dark:divide-coolgray-200">
+                    @foreach ($files as $file)
+                        <tr class="hover:bg-neutral-50 dark:hover:bg-coolgray-200 cursor-pointer" 
+                            wire:click="{{ $file['is_directory'] ? 'changeDirectory(\''.$file['path'].'\')' : 'readFile(\''.$file['name'].'\')' }}">
+                            <td class="p-2 flex items-center gap-2">
+                                @if ($file['is_directory'])
+                                    <svg class="w-4 h-4 text-yellow-500" fill="currentColor" viewBox="0 0 20 20"><path d="M2 6a2 2 0 012-2h5l2 2h5a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6z"/></svg>
+                                @else
+                                    <svg class="w-4 h-4 text-neutral-400" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" clip-rule="evenodd"/></svg>
+                                @endif
+                                <span class="truncate">{{ $file['name'] }}</span>
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+
+        <div class="border rounded h-96 flex flex-col dark:border-coolgray-200">
+            @if ($selectedFileContent !== null)
+                <div class="p-2 bg-neutral-100 dark:bg-coolgray-100 border-bottom text-xs font-bold truncate">
+                    {{ $selectedFileName }}
+                </div>
+                <pre class="p-4 flex-1 overflow-auto font-mono text-xs whitespace-pre-wrap dark:text-neutral-300">{{ $selectedFileContent }}</pre>
+            @else
+                <div class="flex items-center justify-center h-full text-neutral-400 italic text-sm">
+                    Select a file to view content
+                </div>
+            @endif
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Fixes #6519

This PR introduces a built-in file browser for containers, allowing users to explore and view files directly from the Coolify UI using `docker exec`.

### Features:
- Navigate directories within a running container.
- View file contents directly in the dashboard.
- Group directories first and handle symbolic links/file types.

### Changes:
- Added `FileBrowser` Livewire component.
- Implemented file listing and reading logic via SSH/Docker commands.