### PR TITLE
fix: add Debian 13 (Trixie) support

### DIFF
--- a/bootstrap/helpers/constants.php
+++ b/bootstrap/helpers/constants.php
@@ -68,6 +68,7 @@ const SUPPORTED_OS = [
     'sles opensuse-leap opensuse-tumbleweed',
     'arch',
     'alpine',
+    'trixie', // Debian 13
 ];
 
 const NEEDS_TO_CONNECT_TO_PREDEFINED_NETWORK = [


### PR DESCRIPTION
Fixes #8154. Explicitly adds 'trixie' to SUPPORTED_OS constant to prevent installation failure on Debian 13.