### PR TITLE
feat: Enable database detection and backup support for Docker Compose via GitHub App

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -247,6 +247,11 @@ class Application extends BaseModel
             foreach ($application->deployment_queue as $deployment) {
                 $deployment->delete();
             }
+            // Delete associated ServiceDatabase records (for docker-compose database detection)
+            // @see https://github.com/coollabsio/coolify/issues/7528
+            foreach ($application->databases as $database) {
+                $database->delete();
+            }
         });
     }
 
@@ -498,6 +503,17 @@ class Application extends BaseModel
     public function fileStorages()
     {
         return $this->morphMany(LocalFileVolume::class, 'resource');
+    }
+
+    /**
+     * Get the databases associated with this application (for docker-compose deployments).
+     * Enables database detection and backup support for GitHub App deployments.
+     *
+     * @see https://github.com/coollabsio/coolify/issues/7528
+     */
+    public function databases(): HasMany
+    {
+        return $this->hasMany(ServiceDatabase::class);
     }
 
     public function type()

--- a/app/Models/Environment.php
+++ b/app/Models/Environment.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Traits\ClearsGlobalSearchCache;
 use App\Traits\HasSafeStringAttribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use OpenApi\Attributes as OA;
 
 #[OA\Schema(
@@ -21,6 +22,7 @@ use OpenApi\Attributes as OA;
 class Environment extends BaseModel
 {
     use ClearsGlobalSearchCache;
+    use HasFactory;
     use HasSafeStringAttribute;
 
     protected $guarded = [];

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Traits\ClearsGlobalSearchCache;
 use App\Traits\HasSafeStringAttribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use OpenApi\Attributes as OA;
 use Visus\Cuid2\Cuid2;
 
@@ -20,6 +21,7 @@ use Visus\Cuid2\Cuid2;
 class Project extends BaseModel
 {
     use ClearsGlobalSearchCache;
+    use HasFactory;
     use HasSafeStringAttribute;
 
     protected $guarded = [];

--- a/app/Models/ServiceDatabase.php
+++ b/app/Models/ServiceDatabase.php
@@ -27,7 +27,11 @@ class ServiceDatabase extends BaseModel
 
     public static function ownedByCurrentTeamAPI(int $teamId)
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', $teamId)->orderBy('name');
+        // Include both service-based and application-based databases
+        return ServiceDatabase::where(function ($query) use ($teamId) {
+            $query->whereRelation('service.environment.project.team', 'id', $teamId)
+                ->orWhereRelation('application.environment.project.team', 'id', $teamId);
+        })->orderBy('name');
     }
 
     /**
@@ -36,7 +40,11 @@ class ServiceDatabase extends BaseModel
      */
     public static function ownedByCurrentTeam()
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', currentTeam()->id)->orderBy('name');
+        // Include both service-based and application-based databases
+        return ServiceDatabase::where(function ($query) {
+            $query->whereRelation('service.environment.project.team', 'id', currentTeam()->id)
+                ->orWhereRelation('application.environment.project.team', 'id', currentTeam()->id);
+        })->orderBy('name');
     }
 
     /**
@@ -49,10 +57,44 @@ class ServiceDatabase extends BaseModel
         });
     }
 
+    /**
+     * Get the parent resource (Service or Application).
+     */
+    public function getParentResource()
+    {
+        return $this->service ?? $this->application;
+    }
+
+    /**
+     * Get the server for this database.
+     */
+    public function getServer()
+    {
+        $parent = $this->getParentResource();
+        if (! $parent) {
+            return null;
+        }
+
+        if ($parent instanceof Service) {
+            return $parent->server;
+        }
+
+        // Application
+        return $parent->destination?->server;
+    }
+
     public function restart()
     {
-        $container_id = $this->name.'-'.$this->service->uuid;
-        remote_process(["docker restart {$container_id}"], $this->service->server);
+        $parent = $this->getParentResource();
+        if (! $parent) {
+            return;
+        }
+
+        $container_id = $this->name.'-'.$parent->uuid;
+        $server = $this->getServer();
+        if ($server) {
+            remote_process(["docker restart {$container_id}"], $server);
+        }
     }
 
     public function isRunning()
@@ -114,8 +156,13 @@ class ServiceDatabase extends BaseModel
     public function getServiceDatabaseUrl()
     {
         $port = $this->public_port;
-        $realIp = $this->service->server->ip;
-        if ($this->service->server->isLocalhost() || isDev()) {
+        $server = $this->getServer();
+        if (! $server) {
+            return null;
+        }
+
+        $realIp = $server->ip;
+        if ($server->isLocalhost() || isDev()) {
             $realIp = base_ip();
         }
 
@@ -124,17 +171,42 @@ class ServiceDatabase extends BaseModel
 
     public function team()
     {
-        return data_get($this, 'environment.project.team');
+        $parent = $this->getParentResource();
+        if (! $parent) {
+            return null;
+        }
+
+        return data_get($parent, 'environment.project.team');
     }
 
     public function workdir()
     {
-        return service_configuration_dir()."/{$this->service->uuid}";
+        $parent = $this->getParentResource();
+        if (! $parent) {
+            return null;
+        }
+
+        if ($parent instanceof Service) {
+            return service_configuration_dir()."/{$parent->uuid}";
+        }
+
+        // Application - use application configuration directory
+        return application_configuration_dir()."/{$parent->uuid}";
     }
 
     public function service()
     {
         return $this->belongsTo(Service::class);
+    }
+
+    /**
+     * Get the application that owns this database (for GitHub App docker-compose deployments).
+     *
+     * @see https://github.com/coollabsio/coolify/issues/7528
+     */
+    public function application()
+    {
+        return $this->belongsTo(Application::class);
     }
 
     public function persistentStorages()

--- a/app/Models/StandaloneDocker.php
+++ b/app/Models/StandaloneDocker.php
@@ -4,9 +4,11 @@ namespace App\Models;
 
 use App\Jobs\ConnectProxyToNetworksJob;
 use App\Traits\HasSafeStringAttribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class StandaloneDocker extends BaseModel
 {
+    use HasFactory;
     use HasSafeStringAttribute;
 
     protected $guarded = [];

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -2418,6 +2418,29 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
             $isDatabase = isDatabaseImage($image, $service);
             data_set($service, 'is_database', $isDatabase);
 
+            // Create ServiceDatabase records for detected databases in Application docker-compose deployments
+            // This enables backup functionality for databases deployed via GitHub App
+            // @see https://github.com/coollabsio/coolify/issues/7528
+            if ($isDatabase && $pull_request_id === 0) {
+                $existingDatabase = ServiceDatabase::where('name', $serviceName)
+                    ->where('application_id', $resource->id)
+                    ->first();
+
+                if (is_null($existingDatabase)) {
+                    ServiceDatabase::create([
+                        'name' => $serviceName,
+                        'image' => $image,
+                        'application_id' => $resource->id,
+                    ]);
+                } else {
+                    // Update image if changed
+                    if ($existingDatabase->image !== $image) {
+                        $existingDatabase->image = $image;
+                        $existingDatabase->save();
+                    }
+                }
+            }
+
             // Collect/create/update networks
             if ($serviceNetworks->count() > 0) {
                 foreach ($serviceNetworks as $networkName => $networkDetails) {

--- a/database/factories/EnvironmentFactory.php
+++ b/database/factories/EnvironmentFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class EnvironmentFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->randomElement(['production', 'staging', 'development']),
+            'project_id' => 1,
+        ];
+    }
+}

--- a/database/factories/ProjectFactory.php
+++ b/database/factories/ProjectFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ProjectFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->unique()->company(),
+            'team_id' => 1,
+        ];
+    }
+}

--- a/database/factories/StandaloneDockerFactory.php
+++ b/database/factories/StandaloneDockerFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class StandaloneDockerFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->unique()->word(),
+            'network' => 'coolify',
+            'server_id' => 1,
+        ];
+    }
+}

--- a/database/migrations/2026_02_08_000000_add_application_id_to_service_databases.php
+++ b/database/migrations/2026_02_08_000000_add_application_id_to_service_databases.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Enable database detection and backup support for Docker Compose deployments via GitHub App.
+     * This adds application_id to allow ServiceDatabase records to be associated with Applications
+     * (not just Services), enabling backup functionality for databases in GitHub App deployments.
+     *
+     * @see https://github.com/coollabsio/coolify/issues/7528
+     */
+    public function up(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            // Add application_id for GitHub App docker-compose deployments
+            $table->foreignId('application_id')->nullable()->after('service_id');
+
+            // Make service_id nullable since we can now have either service_id OR application_id
+            $table->foreignId('service_id')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->dropColumn('application_id');
+            $table->foreignId('service_id')->nullable(false)->change();
+        });
+    }
+};

--- a/tests/Feature/ApplicationDatabaseDetectionTest.php
+++ b/tests/Feature/ApplicationDatabaseDetectionTest.php
@@ -1,0 +1,308 @@
+<?php
+
+/**
+ * Tests for database detection in Docker Compose deployments via GitHub App.
+ *
+ * @see https://github.com/coollabsio/coolify/issues/7528
+ */
+
+use App\Models\Application;
+use App\Models\ApplicationSetting;
+use App\Models\Environment;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\ServiceDatabase;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    // Create the basic entities needed for an Application
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+
+    $this->project = Project::factory()->create([
+        'team_id' => $this->team->id,
+    ]);
+
+    $this->environment = Environment::factory()->create([
+        'project_id' => $this->project->id,
+    ]);
+
+    $this->server = Server::factory()->create([
+        'team_id' => $this->team->id,
+    ]);
+
+    $this->destination = StandaloneDocker::factory()->create([
+        'server_id' => $this->server->id,
+    ]);
+});
+
+describe('ServiceDatabase model with Application support', function () {
+    test('ServiceDatabase can be associated with an Application', function () {
+        $application = Application::factory()->create([
+            'environment_id' => $this->environment->id,
+            'destination_id' => $this->destination->id,
+            'destination_type' => StandaloneDocker::class,
+            'build_pack' => 'dockercompose',
+        ]);
+
+        $database = ServiceDatabase::create([
+            'name' => 'postgres',
+            'image' => 'postgres:15',
+            'application_id' => $application->id,
+        ]);
+
+        expect($database->application_id)->toBe($application->id);
+        expect($database->application)->toBeInstanceOf(Application::class);
+        expect($database->application->id)->toBe($application->id);
+    });
+
+    test('ServiceDatabase getParentResource returns Application when application_id is set', function () {
+        $application = Application::factory()->create([
+            'environment_id' => $this->environment->id,
+            'destination_id' => $this->destination->id,
+            'destination_type' => StandaloneDocker::class,
+            'build_pack' => 'dockercompose',
+        ]);
+
+        $database = ServiceDatabase::create([
+            'name' => 'mysql',
+            'image' => 'mysql:8',
+            'application_id' => $application->id,
+        ]);
+
+        expect($database->getParentResource())->toBeInstanceOf(Application::class);
+        expect($database->getParentResource()->id)->toBe($application->id);
+    });
+
+    test('ServiceDatabase team() returns correct team for Application-based database', function () {
+        $application = Application::factory()->create([
+            'environment_id' => $this->environment->id,
+            'destination_id' => $this->destination->id,
+            'destination_type' => StandaloneDocker::class,
+            'build_pack' => 'dockercompose',
+        ]);
+
+        $database = ServiceDatabase::create([
+            'name' => 'postgres',
+            'image' => 'postgres:15',
+            'application_id' => $application->id,
+        ]);
+
+        expect($database->team())->not->toBeNull();
+        expect($database->team()->id)->toBe($this->team->id);
+    });
+
+    test('ServiceDatabase workdir returns application configuration directory', function () {
+        $application = Application::factory()->create([
+            'environment_id' => $this->environment->id,
+            'destination_id' => $this->destination->id,
+            'destination_type' => StandaloneDocker::class,
+            'build_pack' => 'dockercompose',
+        ]);
+
+        $database = ServiceDatabase::create([
+            'name' => 'postgres',
+            'image' => 'postgres:15',
+            'application_id' => $application->id,
+        ]);
+
+        $workdir = $database->workdir();
+        expect($workdir)->toContain($application->uuid);
+        expect($workdir)->toContain('applications');
+    });
+
+    test('ServiceDatabase getServer returns server for Application-based database', function () {
+        $application = Application::factory()->create([
+            'environment_id' => $this->environment->id,
+            'destination_id' => $this->destination->id,
+            'destination_type' => StandaloneDocker::class,
+            'build_pack' => 'dockercompose',
+        ]);
+
+        $database = ServiceDatabase::create([
+            'name' => 'postgres',
+            'image' => 'postgres:15',
+            'application_id' => $application->id,
+        ]);
+
+        expect($database->getServer())->not->toBeNull();
+        expect($database->getServer()->id)->toBe($this->server->id);
+    });
+});
+
+describe('Application model with databases relationship', function () {
+    test('Application has databases relationship', function () {
+        $application = Application::factory()->create([
+            'environment_id' => $this->environment->id,
+            'destination_id' => $this->destination->id,
+            'destination_type' => StandaloneDocker::class,
+            'build_pack' => 'dockercompose',
+        ]);
+
+        expect($application->databases())->toBeInstanceOf(\Illuminate\Database\Eloquent\Relations\HasMany::class);
+    });
+
+    test('Application databases returns associated ServiceDatabase records', function () {
+        $application = Application::factory()->create([
+            'environment_id' => $this->environment->id,
+            'destination_id' => $this->destination->id,
+            'destination_type' => StandaloneDocker::class,
+            'build_pack' => 'dockercompose',
+        ]);
+
+        ServiceDatabase::create([
+            'name' => 'postgres',
+            'image' => 'postgres:15',
+            'application_id' => $application->id,
+        ]);
+
+        ServiceDatabase::create([
+            'name' => 'redis',
+            'image' => 'redis:7',
+            'application_id' => $application->id,
+        ]);
+
+        expect($application->databases->count())->toBe(2);
+        expect($application->databases->pluck('name')->toArray())->toContain('postgres', 'redis');
+    });
+
+    test('ServiceDatabase records are deleted when Application is force deleted', function () {
+        $application = Application::factory()->create([
+            'environment_id' => $this->environment->id,
+            'destination_id' => $this->destination->id,
+            'destination_type' => StandaloneDocker::class,
+            'build_pack' => 'dockercompose',
+        ]);
+
+        $database = ServiceDatabase::create([
+            'name' => 'postgres',
+            'image' => 'postgres:15',
+            'application_id' => $application->id,
+        ]);
+
+        $databaseId = $database->id;
+
+        $application->forceDelete();
+
+        expect(ServiceDatabase::find($databaseId))->toBeNull();
+    });
+});
+
+describe('ServiceDatabase backup support for Application databases', function () {
+    test('Application-based ServiceDatabase supports scheduled backups', function () {
+        $application = Application::factory()->create([
+            'environment_id' => $this->environment->id,
+            'destination_id' => $this->destination->id,
+            'destination_type' => StandaloneDocker::class,
+            'build_pack' => 'dockercompose',
+        ]);
+
+        $database = ServiceDatabase::create([
+            'name' => 'postgres',
+            'image' => 'postgres:15',
+            'application_id' => $application->id,
+        ]);
+
+        // Verify that scheduledBackups relationship exists
+        expect($database->scheduledBackups())->toBeInstanceOf(\Illuminate\Database\Eloquent\Relations\MorphMany::class);
+    });
+
+    test('Application-based ServiceDatabase isBackupSolutionAvailable returns true for supported databases', function () {
+        $application = Application::factory()->create([
+            'environment_id' => $this->environment->id,
+            'destination_id' => $this->destination->id,
+            'destination_type' => StandaloneDocker::class,
+            'build_pack' => 'dockercompose',
+        ]);
+
+        $postgresDb = ServiceDatabase::create([
+            'name' => 'postgres',
+            'image' => 'postgres:15',
+            'application_id' => $application->id,
+        ]);
+
+        $mysqlDb = ServiceDatabase::create([
+            'name' => 'mysql',
+            'image' => 'mysql:8',
+            'application_id' => $application->id,
+        ]);
+
+        $mariaDb = ServiceDatabase::create([
+            'name' => 'mariadb',
+            'image' => 'mariadb:10',
+            'application_id' => $application->id,
+        ]);
+
+        $mongoDb = ServiceDatabase::create([
+            'name' => 'mongo',
+            'image' => 'mongo:6',
+            'application_id' => $application->id,
+        ]);
+
+        expect($postgresDb->isBackupSolutionAvailable())->toBeTrue();
+        expect($mysqlDb->isBackupSolutionAvailable())->toBeTrue();
+        expect($mariaDb->isBackupSolutionAvailable())->toBeTrue();
+        expect($mongoDb->isBackupSolutionAvailable())->toBeTrue();
+    });
+
+    test('Application-based ServiceDatabase databaseType returns correct type', function () {
+        $application = Application::factory()->create([
+            'environment_id' => $this->environment->id,
+            'destination_id' => $this->destination->id,
+            'destination_type' => StandaloneDocker::class,
+            'build_pack' => 'dockercompose',
+        ]);
+
+        $database = ServiceDatabase::create([
+            'name' => 'postgres',
+            'image' => 'postgres:15',
+            'application_id' => $application->id,
+        ]);
+
+        expect($database->databaseType())->toBe('standalone-postgresql');
+    });
+});
+
+describe('parseDockerComposeFile database detection for Application', function () {
+    test('isDatabaseImage detects PostgreSQL', function () {
+        expect(isDatabaseImage('postgres:15', []))->toBeTrue();
+        expect(isDatabaseImage('postgres:latest', []))->toBeTrue();
+        expect(isDatabaseImage('postgres', []))->toBeTrue();
+    });
+
+    test('isDatabaseImage detects MySQL', function () {
+        expect(isDatabaseImage('mysql:8', []))->toBeTrue();
+        expect(isDatabaseImage('mysql:latest', []))->toBeTrue();
+        expect(isDatabaseImage('mysql', []))->toBeTrue();
+    });
+
+    test('isDatabaseImage detects MariaDB', function () {
+        expect(isDatabaseImage('mariadb:10', []))->toBeTrue();
+        expect(isDatabaseImage('mariadb:latest', []))->toBeTrue();
+        expect(isDatabaseImage('mariadb', []))->toBeTrue();
+    });
+
+    test('isDatabaseImage detects MongoDB', function () {
+        expect(isDatabaseImage('mongo:6', []))->toBeTrue();
+        expect(isDatabaseImage('mongo:latest', []))->toBeTrue();
+        expect(isDatabaseImage('mongo', []))->toBeTrue();
+    });
+
+    test('isDatabaseImage detects Redis', function () {
+        expect(isDatabaseImage('redis:7', []))->toBeTrue();
+        expect(isDatabaseImage('redis:latest', []))->toBeTrue();
+        expect(isDatabaseImage('redis', []))->toBeTrue();
+    });
+
+    test('isDatabaseImage returns false for non-database images', function () {
+        expect(isDatabaseImage('nginx:latest', []))->toBeFalse();
+        expect(isDatabaseImage('node:18', []))->toBeFalse();
+        expect(isDatabaseImage('php:8.2', []))->toBeFalse();
+    });
+});


### PR DESCRIPTION
## Summary
Fixes #7528

This PR enables database detection and backup support for Docker Compose deployments via GitHub App, bringing parity with Empty Docker Compose and one-click service deployments.

## Problem
When deploying Docker Compose files via GitHub App (using the dockercompose buildpack), database services were not detected and `ServiceDatabase` records were not created. This meant automated backups were not available for databases in these deployments.

| Deployment Method | Model | Creates ServiceDatabase | Backups Available |
|-------------------|-------|------------------------|-------------------|
| Empty Docker Compose | Service | ✅ Yes | ✅ Yes |
| GitHub App (dockercompose buildpack) | Application | ❌ No | ❌ No |
| One-click Services | Service | ✅ Yes | ✅ Yes |

## Solution

### 1. Database Schema Update
Added `application_id` (nullable) column to `service_databases` table to support Application model associations. Made `service_id` nullable since we can now have either `service_id` OR `application_id`.

### 2. ServiceDatabase Model Updates
Updated the model to work with both Service and Application parents:
- Added `application()` relationship
- Added `getParentResource()` helper method
- Added `getServer()` helper method
- Updated `team()` to handle both parent types
- Updated `workdir()` to use appropriate configuration directory
- Updated `restart()` to work with both parent types
- Updated `ownedByCurrentTeam()` and `ownedByCurrentTeamAPI()` query scopes

### 3. parseDockerComposeFile() Updates
In `bootstrap/helpers/shared.php`, added logic in the Application model path (around line 2418) to create `ServiceDatabase` records when `isDatabaseImage()` returns true.

### 4. Application Model Updates
- Added `databases()` relationship (`HasMany`)
- Added cleanup of associated `ServiceDatabase` records in `forceDeleting` callback

## Testing
Added comprehensive tests in `tests/Feature/ApplicationDatabaseDetectionTest.php`:
- ServiceDatabase can be associated with Application
- ServiceDatabase `getParentResource()` returns correct parent
- ServiceDatabase team/workdir/server methods work with Application
- Application has databases relationship
- ServiceDatabase records are deleted when Application is force deleted
- Backup support works for Application-based databases
- Database type detection (`isDatabaseImage`) tests

## Files Changed
- `database/migrations/2026_02_08_000000_add_application_id_to_service_databases.php` - New migration
- `app/Models/ServiceDatabase.php` - Updated model
- `app/Models/Application.php` - Added databases relationship and cleanup
- `bootstrap/helpers/shared.php` - Database detection for Application path
- `database/factories/` - Added missing factories for tests
- `app/Models/Environment.php`, `Project.php`, `StandaloneDocker.php` - Added HasFactory trait
- `tests/Feature/ApplicationDatabaseDetectionTest.php` - Comprehensive tests

## Wallet for Bounty
Solana (USDC): `zARG9WZCiRRzghuCzx1kqSynhYanBnGdjfz4kjSjvin`