### PR TITLE
fix(proxy): write docker-compose.yml before starting proxy on remote servers

### DIFF
--- a/app/Actions/Proxy/StartProxy.php
+++ b/app/Actions/Proxy/StartProxy.php
@@ -42,6 +42,7 @@ class StartProxy
             $commands = $commands->merge([
                 "mkdir -p $proxy_path/dynamic",
                 "cd $proxy_path",
+                "echo '$docker_compose_yml_base64' | base64 -d > docker-compose.yml",
                 "echo 'Creating required Docker Compose file.'",
                 "echo 'Starting coolify-proxy.'",
                 'docker stack deploy --detach=true -c docker-compose.yml coolify-proxy',
@@ -57,6 +58,7 @@ class StartProxy
             $commands = $commands->merge([
                 "mkdir -p $proxy_path/dynamic",
                 "cd $proxy_path",
+                "echo '$docker_compose_yml_base64' | base64 -d > docker-compose.yml",
                 "echo '$caddyfile' > $proxy_path/dynamic/Caddyfile",
                 "echo 'Creating required Docker Compose file.'",
                 "echo 'Pulling docker image.'",


### PR DESCRIPTION
### Changes
Fix proxy startup on remote servers where docker-compose.yml
was never written to disk before running docker compose.

Previously, the proxy start flow generated the configuration
in memory but never created the docker-compose.yml file
on the remote server. As a result, `docker compose up`
was never executed and the proxy silently failed to start.

This change writes the docker-compose.yml file from the
generated base64 configuration before running any
docker compose or docker stack commands.

### Issue
- Resolves #8186

### Category
- [x] Bug fix
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

### AI Usage
- [x] AI is used in the process of creating this PR
- [ ] AI is NOT used in the process of creating this PR

### Steps to Test
- Step 1 – Add a remote server in Coolify Cloud.
- Step 2 – Click “Start Proxy”.
- Step 3 – Verify that `/data/coolify/proxy/docker-compose.yml` is created.
- Step 4 – Verify that the `coolify-proxy` container starts and status becomes “Proxy Running”.

### Contributor Agreement
[!IMPORTANT]
- [x] I have read and understood the contributor guidelines. If I have failed to follow any guideline, I understand that this PR may be closed without review.
- [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them
