### PR TITLE
fix: prevent duplicate environment variables in Developer View

### DIFF
--- a/app/Livewire/Project/Shared/EnvironmentVariable/All.php
+++ b/app/Livewire/Project/Shared/EnvironmentVariable/All.php
@@ -285,7 +285,21 @@ class All extends Component
                 continue;
             }
             $method = $isPreview ? 'environment_variables_preview' : 'environment_variables';
-            $found = $this->resource->$method()->where('key', $key)->first();
+            
+            // Get ALL existing variables with this key (not just first)
+            $existingVars = $this->resource->$method()->where('key', $key)->get();
+            
+            if ($existingVars->count() > 1) {
+                // Duplicates exist! Keep the first one, delete the rest
+                $first = $existingVars->shift();
+                foreach ($existingVars as $duplicate) {
+                    $duplicate->delete();
+                }
+                $found = $first;
+                $count++; // Count this as a change since we cleaned up duplicates
+            } else {
+                $found = $existingVars->first();
+            }
 
             if ($found) {
                 if (! $found->is_shown_once && ! $found->is_multiline) {


### PR DESCRIPTION
## Description

This PR fixes #8041 where environment variables were being duplicated when saving from the Developer View.

## Root Cause

The `updateOrCreateVariables` function in `All.php` was using `first()` to find existing variables by key. If duplicates already existed in the database, only the first one was found and updated, while the rest remained untouched. This led to duplicate entries accumulating over time.

## Solution

Modified `updateOrCreateVariables` to:
1. Fetch **all** existing variables with the same key (using `get()` instead of `first()`)
2. If duplicates exist (count > 1), keep only the first one and delete the rest
3. Then proceed with the normal update/create logic

## Testing

- [x] When saving from Developer View, duplicate keys are now automatically cleaned up
- [x] Normal save operations continue to work as expected
- [x] Protected variables (`is_shown_once`, `is_multiline`) are preserved correctly

## Related Issues

Fixes #8041