### PR TITLE
fix: explicitly delete -build tagged images during Docker cleanup

### DIFF
--- a/app/Actions/Server/CleanupDocker.php
+++ b/app/Actions/Server/CleanupDocker.php
@@ -177,9 +177,10 @@ class CleanupDocker
                 ->filter(fn ($image) => ! empty($image['tag']));
 
             // Separate images into categories
-            // PR images (pr-*) and build images (*-build) are excluded from retention
-            // Build images will be cleaned up by docker image prune -af
+            // PR images (pr-*) are for preview deployments
+            // Build images (*-build) are intermediate build artifacts
             $prImages = $images->filter(fn ($image) => str_starts_with($image['tag'], 'pr-'));
+            $buildImages = $images->filter(fn ($image) => str_ends_with($image['tag'], '-build'));
             $regularImages = $images->filter(fn ($image) => ! str_starts_with($image['tag'], 'pr-') && ! str_ends_with($image['tag'], '-build'));
 
             // Always delete all PR images
@@ -189,6 +190,17 @@ class CleanupDocker
                 $cleanupLog[] = [
                     'command' => $deleteCommand,
                     'output' => $deleteOutput ?? 'PR image removed or was in use',
+                ];
+            }
+
+            // Always delete all build images (-build suffix)
+            // These are intermediate build artifacts that can accumulate over time
+            foreach ($buildImages as $image) {
+                $deleteCommand = "docker rmi {$image['image_ref']} 2>/dev/null || true";
+                $deleteOutput = instant_remote_process([$deleteCommand], $server, false);
+                $cleanupLog[] = [
+                    'command' => $deleteCommand,
+                    'output' => $deleteOutput ?? 'Build image removed or was in use',
                 ];
             }
 


### PR DESCRIPTION
## Description

This PR fixes #8020 where Docker cleanup was not removing -build tagged images generated during React/Vite project builds.

## Root Cause

In `CleanupDocker.php`, images with `-build` suffix were excluded from the retention policy:

```php
$regularImages = $images->filter(fn ($image) => ... && ! str_ends_with($image['tag'], '-build'));
```

The code comment stated these would be cleaned by `docker image prune -af`, but only `docker image prune -f` (without `-a`) is actually called. This only removes **dangling** (untagged) images, not tagged `-build` images.

## Solution

Explicitly delete `-build` images during the application image cleanup process, similar to how PR images (`pr-*`) are already handled.

## Changes

- Added `$buildImages` filter to capture all images ending with `-build`
- Added explicit deletion loop for build images
- Updated comments to reflect the new behavior

## Testing

- [x] Build images are now explicitly deleted during cleanup
- [x] Regular image retention still works as expected
- [x] PR image cleanup continues to work

## Related Issues

Fixes #8020