### PR TITLE
fix(proxy): write docker-compose.yml before starting proxy on remote servers

### DIFF
--- a/app/Actions/Proxy/StartProxy.php
+++ b/app/Actions/Proxy/StartProxy.php
@@ -42,6 +42,7 @@ class StartProxy
             $commands = $commands->merge([
                 "mkdir -p $proxy_path/dynamic",
                 "cd $proxy_path",
+                "echo '$docker_compose_yml_base64' | base64 -d > docker-compose.yml",
                 "echo 'Creating required Docker Compose file.'",
                 "echo 'Starting coolify-proxy.'",
                 'docker stack deploy --detach=true -c docker-compose.yml coolify-proxy',
@@ -57,6 +58,7 @@ class StartProxy
             $commands = $commands->merge([
                 "mkdir -p $proxy_path/dynamic",
                 "cd $proxy_path",
+                "echo '$docker_compose_yml_base64' | base64 -d > docker-compose.yml",
                 "echo '$caddyfile' > $proxy_path/dynamic/Caddyfile",
                 "echo 'Creating required Docker Compose file.'",
                 "echo 'Pulling docker image.'",


### PR DESCRIPTION
### Changes
Fix proxy startup on remote servers where the docker-compose.yml
was never written to disk before running docker compose.

This change writes the compose file from the generated base64
configuration before running any docker compose or docker stack
commands.

### Issue
Resolves #8186

### Category
- [x] Bug fix

### AI Usage
- [x] AI is used in the process of creating this PR

### Steps to Test
- Step 1 – Add a remote server in Coolify Cloud
- Step 2 – Click “Start Proxy”
- Step 3 – Verify that `$proxy_path/docker-compose.yml` is created
  (default: `/data/coolify/proxy/docker-compose.yml` on Cloud)
- Step 4 – Verify that the proxy container starts and status becomes “Proxy Running”

### Contributor Agreement
[!IMPORTANT]
- [x] I have read and understood the contributor guidelines.
- [x] I have tested the changes thoroughly and am confident they will work as expected.

