### PR TITLE
fix(ssh): validate key file content and invalidate stale mux connections

### DIFF
--- a/app/Helpers/SshMultiplexingHelper.php
+++ b/app/Helpers/SshMultiplexingHelper.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Facades\Storage;
 
 class SshMultiplexingHelper
 {
@@ -42,6 +43,17 @@ class SshMultiplexingHelper
 
         if ($process->exitCode() !== 0) {
             return self::establishNewMultiplexedConnection($server);
+        }
+
+        // Connection exists – verify the key hasn't changed since the mux was established.
+        // If the server was switched to a different private key the cached fingerprint
+        // will no longer match, and we must refresh the connection.
+        if (self::isKeyMismatch($server)) {
+            Log::warning('SSH key fingerprint mismatch on existing mux connection, refreshing', [
+                'server_uuid' => $server->uuid,
+            ]);
+
+            return self::refreshMultiplexedConnection($server);
         }
 
         // Connection exists, ensure we have metadata for age tracking
@@ -201,14 +213,79 @@ class SshMultiplexingHelper
         return config('constants.ssh.mux_enabled') && ! config('constants.coolify.is_windows_docker_desktop');
     }
 
+    /**
+     * Validate that the SSH key file exists and its content matches the database.
+     *
+     * The previous implementation only checked file existence via `ls`. This could
+     * cause sporadic "Permission denied (publickey)" errors when the key file on
+     * disk became stale (e.g., key updated in the database but not on disk, or
+     * multiple Horizon workers with separate storage volumes).
+     *
+     * When a content mismatch is detected the key file is re-written and all
+     * multiplexed connections that may have been authenticated with the old key
+     * are torn down so the next SSH command establishes a fresh connection.
+     *
+     * @see https://github.com/coollabsio/coolify/issues/7724
+     */
     private static function validateSshKey(PrivateKey $privateKey): void
     {
-        $keyLocation = $privateKey->getKeyLocation();
-        $checkKeyCommand = "ls $keyLocation 2>/dev/null";
-        $keyCheckProcess = Process::run($checkKeyCommand);
+        // Refresh from the database to bypass any Eloquent in-memory cache that
+        // might hold a stale version of the key loaded earlier in the request.
+        $freshKey = PrivateKey::find($privateKey->id);
+        if (! $freshKey) {
+            Log::error('SSH private key not found in database during validation', [
+                'key_id' => $privateKey->id,
+            ]);
 
-        if ($keyCheckProcess->exitCode() !== 0) {
-            $privateKey->storeInFileSystem();
+            return;
+        }
+
+        $disk = Storage::disk('ssh-keys');
+        $filename = "ssh_key@{$freshKey->uuid}";
+
+        if (! $disk->exists($filename)) {
+            Log::debug('SSH key file missing from disk, storing key', [
+                'key_uuid' => $freshKey->uuid,
+            ]);
+            $freshKey->storeInFileSystem();
+
+            return;
+        }
+
+        // Compare the file content with the database value to detect stale keys.
+        $storedContent = $disk->get($filename);
+        if ($storedContent !== $freshKey->private_key) {
+            Log::warning('SSH key file content does not match database, refreshing key and invalidating connections', [
+                'key_uuid' => $freshKey->uuid,
+            ]);
+
+            $freshKey->storeInFileSystem();
+
+            // Invalidate multiplexed connections for every server that uses this
+            // key so they do not keep authenticating with the old (stale) key.
+            self::invalidateConnectionsForKey($freshKey);
+        }
+    }
+
+    /**
+     * Close multiplexed connections for all servers that use the given key.
+     */
+    private static function invalidateConnectionsForKey(PrivateKey $privateKey): void
+    {
+        foreach ($privateKey->servers as $server) {
+            try {
+                self::removeMuxFile($server);
+                Log::debug('Invalidated mux connection due to SSH key content change', [
+                    'server_uuid' => $server->uuid,
+                    'key_uuid' => $privateKey->uuid,
+                ]);
+            } catch (\Exception $e) {
+                Log::warning('Failed to invalidate mux connection during key validation', [
+                    'server_uuid' => $server->uuid,
+                    'key_uuid' => $privateKey->uuid,
+                    'error' => $e->getMessage(),
+                ]);
+            }
         }
     }
 
@@ -265,6 +342,32 @@ class SshMultiplexingHelper
     }
 
     /**
+     * Detect whether the server's current SSH key differs from the one that was
+     * used when the multiplexed connection was established.
+     *
+     * Returns false when no cached fingerprint exists (e.g. connections created
+     * before this logic was deployed) to avoid unnecessary churn.
+     *
+     * @see https://github.com/coollabsio/coolify/issues/7724
+     */
+    public static function isKeyMismatch(Server $server): bool
+    {
+        $fingerprintCacheKey = "ssh_mux_key_fingerprint_{$server->uuid}";
+        $cachedFingerprint = Cache::get($fingerprintCacheKey);
+
+        if ($cachedFingerprint === null) {
+            return false;
+        }
+
+        $privateKey = PrivateKey::find($server->private_key_id);
+        if (! $privateKey) {
+            return true; // Key was deleted – force refresh to surface a clear error
+        }
+
+        return $cachedFingerprint !== $privateKey->fingerprint;
+    }
+
+    /**
      * Get the age of the current connection in seconds
      */
     public static function getConnectionAge(Server $server): ?int
@@ -292,20 +395,33 @@ class SshMultiplexingHelper
     }
 
     /**
-     * Store connection metadata when a new connection is established
+     * Store connection metadata when a new connection is established.
+     *
+     * Persists both the connection timestamp and the SSH key fingerprint so that
+     * future calls to isKeyMismatch() can detect when the server was switched to
+     * a different key.
      */
     private static function storeConnectionMetadata(Server $server): void
     {
+        $cacheTtl = config('constants.ssh.mux_persist_time') + 300; // slightly longer than persist time
+
         $cacheKey = "ssh_mux_connection_time_{$server->uuid}";
-        Cache::put($cacheKey, time(), config('constants.ssh.mux_persist_time') + 300); // Cache slightly longer than persist time
+        Cache::put($cacheKey, time(), $cacheTtl);
+
+        // Record which key was used so we can detect key changes later.
+        $privateKey = PrivateKey::find($server->private_key_id);
+        if ($privateKey && $privateKey->fingerprint) {
+            $fingerprintCacheKey = "ssh_mux_key_fingerprint_{$server->uuid}";
+            Cache::put($fingerprintCacheKey, $privateKey->fingerprint, $cacheTtl);
+        }
     }
 
     /**
-     * Clear connection metadata from cache
+     * Clear connection metadata (timestamp and key fingerprint) from cache.
      */
     private static function clearConnectionMetadata(Server $server): void
     {
-        $cacheKey = "ssh_mux_connection_time_{$server->uuid}";
-        Cache::forget($cacheKey);
+        Cache::forget("ssh_mux_connection_time_{$server->uuid}");
+        Cache::forget("ssh_mux_key_fingerprint_{$server->uuid}");
     }
 }

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -9,6 +9,7 @@ use App\Actions\Server\StartSentinel;
 use App\Actions\Server\ValidatePrerequisites;
 use App\Enums\ProxyTypes;
 use App\Events\ServerReachabilityChanged;
+use App\Helpers\SshMultiplexingHelper;
 use App\Helpers\SslHelper;
 use App\Jobs\CheckAndStartSentinelJob;
 use App\Jobs\RegenerateSslCertJob;
@@ -25,6 +26,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Stringable;
 use OpenApi\Attributes as OA;
@@ -136,6 +138,26 @@ class Server extends BaseModel
         static::saved(function ($server) {
             if ($server->privateKey?->isDirty()) {
                 refresh_server_connection($server->privateKey);
+            }
+
+            // When the server is switched to a different SSH key, tear down the
+            // existing multiplexed connection so it is re-established with the
+            // new key on the next SSH command.
+            // @see https://github.com/coollabsio/coolify/issues/7724
+            if ($server->wasChanged('private_key_id')) {
+                try {
+                    SshMultiplexingHelper::removeMuxFile($server);
+                    Log::info('Invalidated SSH mux connection after private_key_id change', [
+                        'server_uuid' => $server->uuid,
+                        'old_key_id' => $server->getOriginal('private_key_id'),
+                        'new_key_id' => $server->private_key_id,
+                    ]);
+                } catch (\Exception $e) {
+                    Log::warning('Failed to invalidate SSH mux connection after key change', [
+                        'server_uuid' => $server->uuid,
+                        'error' => $e->getMessage(),
+                    ]);
+                }
             }
         });
         static::created(function ($server) {

--- a/tests/Unit/SshKeyContentValidationTest.php
+++ b/tests/Unit/SshKeyContentValidationTest.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Helpers\SshMultiplexingHelper;
+use App\Models\PrivateKey;
+use App\Models\Server;
+use Tests\TestCase;
+
+/**
+ * Unit tests for the SSH key content validation and mux invalidation fix.
+ *
+ * These tests verify the structural changes made to SshMultiplexingHelper and
+ * Server to address sporadic "Permission denied (publickey)" errors caused by
+ * stale SSH key files and stale multiplexed connections.
+ *
+ * @see https://github.com/coollabsio/coolify/issues/7724
+ */
+class SshKeyContentValidationTest extends TestCase
+{
+    /**
+     * Verify validateSshKey uses the Storage disk instead of shell `ls`.
+     */
+    public function test_validate_ssh_key_uses_storage_disk(): void
+    {
+        $source = file_get_contents(
+            (new \ReflectionClass(SshMultiplexingHelper::class))->getFileName()
+        );
+
+        $this->assertStringContainsString("Storage::disk('ssh-keys')", $source);
+        $this->assertStringContainsString('$disk->exists($filename)', $source);
+        $this->assertStringContainsString('$disk->get($filename)', $source);
+    }
+
+    /**
+     * Verify that validateSshKey compares file content against the database.
+     */
+    public function test_validate_ssh_key_compares_file_content_with_database(): void
+    {
+        $source = file_get_contents(
+            (new \ReflectionClass(SshMultiplexingHelper::class))->getFileName()
+        );
+
+        $this->assertStringContainsString(
+            '$storedContent !== $freshKey->private_key',
+            $source
+        );
+    }
+
+    /**
+     * Verify that validateSshKey refreshes the PrivateKey from the database to
+     * bypass Eloquent's in-memory cache.
+     */
+    public function test_validate_ssh_key_refreshes_key_from_database(): void
+    {
+        $source = file_get_contents(
+            (new \ReflectionClass(SshMultiplexingHelper::class))->getFileName()
+        );
+
+        $this->assertStringContainsString('$freshKey = PrivateKey::find($privateKey->id)', $source);
+    }
+
+    /**
+     * Verify that the helper invalidates mux connections when key content changes.
+     */
+    public function test_validate_ssh_key_invalidates_mux_on_content_mismatch(): void
+    {
+        $source = file_get_contents(
+            (new \ReflectionClass(SshMultiplexingHelper::class))->getFileName()
+        );
+
+        $this->assertStringContainsString('self::invalidateConnectionsForKey($freshKey)', $source);
+    }
+
+    /**
+     * Verify the invalidateConnectionsForKey method exists and is private static.
+     */
+    public function test_invalidate_connections_for_key_method_exists(): void
+    {
+        $method = new \ReflectionMethod(SshMultiplexingHelper::class, 'invalidateConnectionsForKey');
+
+        $this->assertTrue($method->isPrivate());
+        $this->assertTrue($method->isStatic());
+    }
+
+    /**
+     * Verify that invalidateConnectionsForKey iterates through servers using the key.
+     */
+    public function test_invalidate_connections_for_key_removes_mux_for_all_servers(): void
+    {
+        $source = file_get_contents(
+            (new \ReflectionClass(SshMultiplexingHelper::class))->getFileName()
+        );
+
+        $this->assertStringContainsString('foreach ($privateKey->servers as $server)', $source);
+        $this->assertStringContainsString('self::removeMuxFile($server)', $source);
+    }
+
+    /**
+     * Verify the isKeyMismatch method exists and is public static.
+     */
+    public function test_is_key_mismatch_method_exists(): void
+    {
+        $method = new \ReflectionMethod(SshMultiplexingHelper::class, 'isKeyMismatch');
+
+        $this->assertTrue($method->isPublic());
+        $this->assertTrue($method->isStatic());
+    }
+
+    /**
+     * Verify that isKeyMismatch compares cached fingerprint with current key fingerprint.
+     */
+    public function test_is_key_mismatch_compares_fingerprints(): void
+    {
+        $source = file_get_contents(
+            (new \ReflectionClass(SshMultiplexingHelper::class))->getFileName()
+        );
+
+        $this->assertStringContainsString('ssh_mux_key_fingerprint_', $source);
+        $this->assertStringContainsString('$cachedFingerprint !== $privateKey->fingerprint', $source);
+    }
+
+    /**
+     * Verify that ensureMultiplexedConnection checks for key mismatch.
+     */
+    public function test_ensure_multiplexed_connection_checks_key_mismatch(): void
+    {
+        $source = file_get_contents(
+            (new \ReflectionClass(SshMultiplexingHelper::class))->getFileName()
+        );
+
+        $this->assertStringContainsString('self::isKeyMismatch($server)', $source);
+    }
+
+    /**
+     * Verify that storeConnectionMetadata persists the key fingerprint.
+     */
+    public function test_store_connection_metadata_includes_key_fingerprint(): void
+    {
+        $source = file_get_contents(
+            (new \ReflectionClass(SshMultiplexingHelper::class))->getFileName()
+        );
+
+        $this->assertStringContainsString(
+            'Cache::put($fingerprintCacheKey, $privateKey->fingerprint',
+            $source
+        );
+    }
+
+    /**
+     * Verify that clearConnectionMetadata also clears the fingerprint cache.
+     */
+    public function test_clear_connection_metadata_clears_fingerprint(): void
+    {
+        $source = file_get_contents(
+            (new \ReflectionClass(SshMultiplexingHelper::class))->getFileName()
+        );
+
+        // Must clear both connection time and fingerprint
+        $this->assertStringContainsString('Cache::forget("ssh_mux_connection_time_{$server->uuid}")', $source);
+        $this->assertStringContainsString('Cache::forget("ssh_mux_key_fingerprint_{$server->uuid}")', $source);
+    }
+
+    /**
+     * Verify that the Server model invalidates mux when private_key_id changes.
+     */
+    public function test_server_model_invalidates_mux_on_key_id_change(): void
+    {
+        $source = file_get_contents(
+            (new \ReflectionClass(Server::class))->getFileName()
+        );
+
+        $this->assertStringContainsString("wasChanged('private_key_id')", $source);
+        $this->assertStringContainsString('SshMultiplexingHelper::removeMuxFile($server)', $source);
+    }
+
+    /**
+     * Verify that the Server model imports SshMultiplexingHelper.
+     */
+    public function test_server_model_imports_ssh_multiplexing_helper(): void
+    {
+        $source = file_get_contents(
+            (new \ReflectionClass(Server::class))->getFileName()
+        );
+
+        $this->assertStringContainsString('use App\Helpers\SshMultiplexingHelper;', $source);
+    }
+
+    /**
+     * Verify that validateSshKey logs warnings on content mismatch.
+     */
+    public function test_validate_ssh_key_logs_on_mismatch(): void
+    {
+        $source = file_get_contents(
+            (new \ReflectionClass(SshMultiplexingHelper::class))->getFileName()
+        );
+
+        $this->assertStringContainsString(
+            "Log::warning('SSH key file content does not match database",
+            $source
+        );
+        $this->assertStringContainsString(
+            "Log::debug('SSH key file missing from disk, storing key",
+            $source
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #7724 -- Sporadic "Permission denied (publickey,password)" errors caused by stale SSH key files on disk and stale multiplexed connections.

### Root Cause

The existing `validateSshKey()` method only checked whether the key **file existed** (via a shell `ls` command) but never verified that its **content matched the database**. This caused three failure scenarios:

1. **Stale key file on disk** -- When a user updates their SSH key in Coolify, the database is updated but the file on disk may retain old content. The next SSH command uses the wrong key and fails with "Permission denied".
2. **Multiple Horizon workers** -- In Coolify Cloud with multiple worker servers, each worker has its own filesystem. Worker A updates the key file successfully but Worker B still has the old key file, causing sporadic failures.
3. **Changed `private_key_id` on a server** -- When a server is switched to use a different SSH key, the multiplexed connection (authenticated with the old key) was not invalidated and would continue to be reused.

### Changes

- **`SshMultiplexingHelper::validateSshKey()`** -- Now uses `Storage::disk('ssh-keys')` to compare file content against a fresh database read (bypasses Eloquent in-memory cache). On mismatch: re-writes the key file and invalidates all mux connections for servers using that key.
- **`SshMultiplexingHelper::ensureMultiplexedConnection()`** -- Checks whether the SSH key fingerprint has changed since the mux was established and forces a connection refresh if it has.
- **`SshMultiplexingHelper::storeConnectionMetadata()`** -- Now also stores the key fingerprint alongside the connection timestamp for future mismatch detection.
- **`SshMultiplexingHelper::clearConnectionMetadata()`** -- Clears both connection time and fingerprint cache entries.
- **`Server` model `saved` event** -- Now invalidates the mux connection when `private_key_id` is changed on a server.

### Files Modified

- `app/Helpers/SshMultiplexingHelper.php` -- Core fix: content validation, fingerprint tracking, mux invalidation
- `app/Models/Server.php` -- Invalidate mux when `private_key_id` changes
- `tests/Unit/SshKeyContentValidationTest.php` -- Unit tests verifying the structural changes

### Security Considerations

- No key content is logged -- only UUIDs and fingerprints appear in log entries
- Uses Laravel's `Storage::disk()` API instead of shell commands for file operations
- Fresh database reads bypass Eloquent cache to prevent using stale key data

### Test Plan

- [x] Unit tests for all structural changes (method existence, content comparison, fingerprint tracking, mux invalidation)
- [x] Backward compatible -- connections established before this fix (without cached fingerprint) are not disrupted
- [x] No breaking changes to public API

/claim #7724

