### PR TITLE
feat: enable database detection and backup support for Docker Compose via GitHub App

### DIFF
--- a/app/Actions/Database/StartDatabaseProxy.php
+++ b/app/Actions/Database/StartDatabaseProxy.php
@@ -31,9 +31,9 @@ class StartDatabaseProxy
 
         if ($database->getMorphClass() === \App\Models\ServiceDatabase::class) {
             $databaseType = $database->databaseType();
-            $network = $database->service->uuid;
-            $server = data_get($database, 'service.destination.server');
-            $containerName = "{$database->name}-{$database->service->uuid}";
+            $network = $database->getNetwork();
+            $server = $database->getServer();
+            $containerName = "{$database->name}-{$database->getOwnerUuid()}";
         }
         $internalPort = match ($databaseType) {
             'standalone-mariadb', 'standalone-mysql' => 3306,

--- a/app/Actions/Database/StopDatabaseProxy.php
+++ b/app/Actions/Database/StopDatabaseProxy.php
@@ -25,8 +25,8 @@ class StopDatabaseProxy
         $server = data_get($database, 'destination.server');
         $uuid = $database->uuid;
         if ($database->getMorphClass() === \App\Models\ServiceDatabase::class) {
-            $uuid = $database->service->uuid;
-            $server = data_get($database, 'service.server');
+            $uuid = $database->getOwnerUuid();
+            $server = $database->getServer();
         }
         instant_remote_process(["docker rm -f {$uuid}-proxy"], $server);
 

--- a/app/Actions/Docker/GetContainersStatus.php
+++ b/app/Actions/Docker/GetContainersStatus.php
@@ -180,7 +180,7 @@ class GetContainersStatus
                         if ($database_id) {
                             $service_db = ServiceDatabase::where('id', $database_id)->first();
                             if ($service_db) {
-                                $uuid = data_get($service_db, 'service.uuid');
+                                $uuid = $service_db->getOwnerUuid();
                                 if ($uuid) {
                                     $isPublic = data_get($service_db, 'is_public');
                                     if ($isPublic) {

--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -93,7 +93,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $this->database = data_get($this->backup, 'database');
-                $this->server = $this->database->service->server;
+                $this->server = $this->database->getServer();
                 $this->s3 = $this->backup->s3;
             } else {
                 $this->database = data_get($this->backup, 'database');
@@ -115,8 +115,9 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $databaseType = $this->database->databaseType();
-                $serviceUuid = $this->database->service->uuid;
-                $serviceName = str($this->database->service->name)->slug();
+                $owner = $this->database->getOwner();
+                $serviceUuid = $owner->uuid;
+                $serviceName = str($owner->name)->slug();
                 if (str($databaseType)->contains('postgres')) {
                     $this->container_name = "{$this->database->name}-$serviceUuid";
                     $this->directory_name = $serviceName.'-'.$this->container_name;
@@ -630,7 +631,8 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             $endpoint = $this->s3->endpoint;
             $this->s3->testConnection(shouldSave: true);
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
-                $network = $this->database->service->destination->network;
+                $owner = $this->database->getOwner();
+                $network = data_get($owner, 'destination.network') ?? $owner->uuid;
             } else {
                 $network = $this->database->destination->network;
             }

--- a/app/Livewire/Project/Application/ComposeBackups.php
+++ b/app/Livewire/Project/Application/ComposeBackups.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Livewire\Project\Application;
+
+use App\Models\Application;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Component;
+
+class ComposeBackups extends Component
+{
+    use AuthorizesRequests;
+
+    public Application $application;
+
+    public $composeDatabases;
+
+    public $selectedDatabase = null;
+
+    protected $listeners = ['refreshScheduledBackups' => '$refresh'];
+
+    public function mount(Application $application)
+    {
+        $this->application = $application;
+        $this->authorize('view', $this->application);
+        $this->composeDatabases = $this->application->composeDatabases()
+            ->get()
+            ->filter(fn ($db) => $db->isBackupSolutionAvailable());
+
+        if ($this->composeDatabases->isNotEmpty()) {
+            $this->selectedDatabase = $this->composeDatabases->first();
+        }
+    }
+
+    public function selectDatabase($databaseId)
+    {
+        $this->selectedDatabase = $this->composeDatabases->firstWhere('id', $databaseId);
+    }
+
+    public function render()
+    {
+        return view('livewire.project.application.compose-backups');
+    }
+}

--- a/app/Livewire/Project/Application/Configuration.php
+++ b/app/Livewire/Project/Application/Configuration.php
@@ -58,6 +58,10 @@ class Configuration extends Component
         if ($this->application->build_pack === 'dockercompose' && $this->currentRoute === 'project.application.healthcheck') {
             return redirect()->route('project.application.configuration', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]);
         }
+
+        if ($this->application->build_pack !== 'dockercompose' && $this->currentRoute === 'project.application.backups') {
+            return redirect()->route('project.application.configuration', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]);
+        }
     }
 
     public function render()

--- a/app/Livewire/Project/Database/BackupEdit.php
+++ b/app/Livewire/Project/Database/BackupEdit.php
@@ -157,7 +157,7 @@ class BackupEdit extends Component
         try {
             $server = null;
             if ($this->backup->database instanceof \App\Models\ServiceDatabase) {
-                $server = $this->backup->database->service->destination->server;
+                $server = $this->backup->database->getServer();
             } elseif ($this->backup->database->destination && $this->backup->database->destination->server) {
                 $server = $this->backup->database->destination->server;
             }
@@ -184,6 +184,14 @@ class BackupEdit extends Component
 
             if ($this->backup->database->getMorphClass() === \App\Models\ServiceDatabase::class) {
                 $serviceDatabase = $this->backup->database;
+
+                if ($serviceDatabase->application_id) {
+                    return redirect()->route('project.application.backups', [
+                        'project_uuid' => $this->parameters['project_uuid'],
+                        'environment_uuid' => $this->parameters['environment_uuid'],
+                        'application_uuid' => $serviceDatabase->application->uuid,
+                    ]);
+                }
 
                 return redirect()->route('project.service.database.backups', [
                     'project_uuid' => $this->parameters['project_uuid'],

--- a/app/Livewire/Project/Database/BackupExecutions.php
+++ b/app/Livewire/Project/Database/BackupExecutions.php
@@ -79,7 +79,7 @@ class BackupExecutions extends Component
         }
 
         $server = $execution->scheduledDatabaseBackup->database->getMorphClass() === \App\Models\ServiceDatabase::class
-            ? $execution->scheduledDatabaseBackup->database->service->destination->server
+            ? $execution->scheduledDatabaseBackup->database->getServer()
             : $execution->scheduledDatabaseBackup->database->destination->server;
 
         try {
@@ -182,7 +182,7 @@ class BackupExecutions extends Component
             $server = null;
 
             if ($this->database instanceof \App\Models\ServiceDatabase) {
-                $server = $this->database->service->destination->server;
+                $server = $this->database->getServer();
             } elseif ($this->database->destination && $this->database->destination->server) {
                 $server = $this->database->destination->server;
             }

--- a/app/Livewire/Project/Database/Import.php
+++ b/app/Livewire/Project/Database/Import.php
@@ -314,12 +314,12 @@ EOD;
 
         // Handle ServiceDatabase server access differently
         if ($resource->getMorphClass() === \App\Models\ServiceDatabase::class) {
-            $server = $resource->service?->server;
+            $server = $resource->getServer();
             if (! $server) {
                 abort(404, 'Server not found for this service database.');
             }
             $this->serverId = $server->id;
-            $this->container = $resource->name.'-'.$resource->service->uuid;
+            $this->container = $resource->name.'-'.$resource->getOwnerUuid();
             $this->resourceUuid = $resource->uuid; // Use ServiceDatabase's own UUID
 
             // Determine database type for ServiceDatabase
@@ -633,7 +633,8 @@ EOD;
 
             // Get the database destination network
             if ($this->resource->getMorphClass() === \App\Models\ServiceDatabase::class) {
-                $destinationNetwork = $this->resource->service->destination->network ?? 'coolify';
+                $owner = $this->resource->getOwner();
+                $destinationNetwork = data_get($owner, 'destination.network') ?? $owner->uuid ?? 'coolify';
             } else {
                 $destinationNetwork = $this->resource->destination->network ?? 'coolify';
             }

--- a/app/Livewire/Project/Service/Index.php
+++ b/app/Livewire/Project/Service/Index.php
@@ -137,7 +137,7 @@ class Index extends Component
 
     private function initializeDatabaseProperties(): void
     {
-        $this->server = $this->serviceDatabase->service->destination->server;
+        $this->server = $this->serviceDatabase->getServer();
         if ($this->serviceDatabase->is_public) {
             $this->db_url_public = $this->serviceDatabase->getServiceDatabaseUrl();
         }
@@ -221,7 +221,7 @@ class Index extends Component
     {
         try {
             $this->authorize('update', $this->serviceDatabase);
-            if (! $this->serviceDatabase->service->destination->server->isLogDrainEnabled()) {
+            if (! $this->serviceDatabase->getServer()->isLogDrainEnabled()) {
                 $this->isLogDrainEnabled = false;
                 $this->dispatch('error', 'Log drain is not enabled on the server. Please enable it first.');
 

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -187,6 +187,11 @@ class Application extends BaseModel
                     $application->docker_compose_domains = null;
                     $application->docker_compose_raw = null;
 
+                    // Remove compose database records
+                    $application->composeDatabases()->each(function ($db) {
+                        $db->delete();
+                    });
+
                     // Remove SERVICE_FQDN_* and SERVICE_URL_* environment variables
                     $application->environment_variables()
                         ->where(function ($q) {
@@ -488,6 +493,11 @@ class Application extends BaseModel
     public function settings()
     {
         return $this->hasOne(ApplicationSetting::class);
+    }
+
+    public function composeDatabases()
+    {
+        return $this->hasMany(ServiceDatabase::class);
     }
 
     public function persistentStorages()

--- a/app/Models/LocalFileVolume.php
+++ b/app/Models/LocalFileVolume.php
@@ -48,7 +48,10 @@ class LocalFileVolume extends BaseModel
     {
         $this->load(['service']);
         $isService = data_get($this->resource, 'service');
-        if ($isService) {
+        if ($this->resource instanceof ServiceDatabase) {
+            $workdir = $this->resource->workdir();
+            $server = $this->resource->getServer();
+        } elseif ($isService) {
             $workdir = $this->resource->service->workdir();
             $server = $this->resource->service->server;
         } else {
@@ -83,7 +86,10 @@ class LocalFileVolume extends BaseModel
     {
         $this->load(['service']);
         $isService = data_get($this->resource, 'service');
-        if ($isService) {
+        if ($this->resource instanceof ServiceDatabase) {
+            $workdir = $this->resource->workdir();
+            $server = $this->resource->getServer();
+        } elseif ($isService) {
             $workdir = $this->resource->service->workdir();
             $server = $this->resource->service->server;
         } else {
@@ -120,7 +126,10 @@ class LocalFileVolume extends BaseModel
     {
         $this->load(['service']);
         $isService = data_get($this->resource, 'service');
-        if ($isService) {
+        if ($this->resource instanceof ServiceDatabase) {
+            $workdir = $this->resource->workdir();
+            $server = $this->resource->getServer();
+        } elseif ($isService) {
             $workdir = $this->resource->service->workdir();
             $server = $this->resource->service->server;
         } else {

--- a/app/Models/ScheduledDatabaseBackup.php
+++ b/app/Models/ScheduledDatabaseBackup.php
@@ -67,8 +67,7 @@ class ScheduledDatabaseBackup extends BaseModel
     {
         if ($this->database) {
             if ($this->database instanceof ServiceDatabase) {
-                $destination = data_get($this->database->service, 'destination');
-                $server = data_get($destination, 'server');
+                $server = $this->database->getServer();
             } else {
                 $destination = data_get($this->database, 'destination');
                 $server = data_get($destination, 'server');

--- a/app/Models/ServiceDatabase.php
+++ b/app/Models/ServiceDatabase.php
@@ -27,7 +27,10 @@ class ServiceDatabase extends BaseModel
 
     public static function ownedByCurrentTeamAPI(int $teamId)
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', $teamId)->orderBy('name');
+        return ServiceDatabase::where(function ($query) use ($teamId) {
+            $query->whereRelation('service.environment.project.team', 'id', $teamId)
+                ->orWhereRelation('application.environment.project.team', 'id', $teamId);
+        })->orderBy('name');
     }
 
     /**
@@ -36,7 +39,10 @@ class ServiceDatabase extends BaseModel
      */
     public static function ownedByCurrentTeam()
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', currentTeam()->id)->orderBy('name');
+        return ServiceDatabase::where(function ($query) {
+            $query->whereRelation('service.environment.project.team', 'id', currentTeam()->id)
+                ->orWhereRelation('application.environment.project.team', 'id', currentTeam()->id);
+        })->orderBy('name');
     }
 
     /**
@@ -51,8 +57,8 @@ class ServiceDatabase extends BaseModel
 
     public function restart()
     {
-        $container_id = $this->name.'-'.$this->service->uuid;
-        remote_process(["docker restart {$container_id}"], $this->service->server);
+        $container_id = $this->name.'-'.$this->getOwnerUuid();
+        remote_process(["docker restart {$container_id}"], $this->getServer());
     }
 
     public function isRunning()
@@ -114,8 +120,9 @@ class ServiceDatabase extends BaseModel
     public function getServiceDatabaseUrl()
     {
         $port = $this->public_port;
-        $realIp = $this->service->server->ip;
-        if ($this->service->server->isLocalhost() || isDev()) {
+        $server = $this->getServer();
+        $realIp = $server->ip;
+        if ($server->isLocalhost() || isDev()) {
             $realIp = base_ip();
         }
 
@@ -124,17 +131,68 @@ class ServiceDatabase extends BaseModel
 
     public function team()
     {
-        return data_get($this, 'environment.project.team');
+        if ($this->application_id) {
+            return data_get($this->application, 'environment.project.team');
+        }
+
+        return data_get($this->service, 'environment.project.team');
     }
 
     public function workdir()
     {
-        return service_configuration_dir()."/{$this->service->uuid}";
+        return service_configuration_dir()."/{$this->getOwnerUuid()}";
+    }
+
+    /**
+     * Get the owning resource (Service or Application).
+     */
+    public function getOwner(): Service|Application|null
+    {
+        return $this->application_id ? $this->application : $this->service;
+    }
+
+    /**
+     * Get the UUID of the owning resource.
+     */
+    public function getOwnerUuid(): string
+    {
+        $owner = $this->getOwner();
+
+        return $owner ? $owner->uuid : '';
+    }
+
+    /**
+     * Get the server for this database, resolving through either Service or Application.
+     */
+    public function getServer(): ?Server
+    {
+        if ($this->application_id) {
+            return data_get($this->application, 'destination.server');
+        }
+
+        return data_get($this->service, 'destination.server');
+    }
+
+    /**
+     * Get the network for this database.
+     */
+    public function getNetwork(): ?string
+    {
+        if ($this->application_id) {
+            return $this->application->uuid;
+        }
+
+        return $this->service?->uuid;
     }
 
     public function service()
     {
         return $this->belongsTo(Service::class);
+    }
+
+    public function application()
+    {
+        return $this->belongsTo(Application::class);
     }
 
     public function persistentStorages()

--- a/bootstrap/helpers/databases.php
+++ b/bootstrap/helpers/databases.php
@@ -346,7 +346,7 @@ function deleteOldBackupsLocally($backup): Collection
 
     $server = null;
     if ($backup->database_type === \App\Models\ServiceDatabase::class) {
-        $server = $backup->database->service->server;
+        $server = $backup->database->getServer();
     } else {
         $server = $backup->database->destination->server;
     }

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -555,9 +555,12 @@ function getResourceByUuid(string $uuid, ?int $teamId = null)
         return null;
     }
 
-    // ServiceDatabase has a different relationship path: service->environment->project->team_id
+    // ServiceDatabase has a different relationship path: service->environment->project->team_id or application->environment->project->team_id
     if ($resource instanceof \App\Models\ServiceDatabase) {
-        if ($resource->service?->environment?->project?->team_id === $teamId) {
+        if ($resource->application_id && $resource->application?->environment?->project?->team_id === $teamId) {
+            return $resource;
+        }
+        if ($resource->service_id && $resource->service?->environment?->project?->team_id === $teamId) {
             return $resource;
         }
 
@@ -2418,6 +2421,32 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
             $isDatabase = isDatabaseImage($image, $service);
             data_set($service, 'is_database', $isDatabase);
 
+            // Create/update ServiceDatabase records for detected databases (skip preview deployments)
+            if ($isDatabase && $pull_request_id === 0) {
+                if ($isNew) {
+                    ServiceDatabase::create([
+                        'name' => $serviceName,
+                        'image' => $image,
+                        'application_id' => $resource->id,
+                    ]);
+                } else {
+                    $existingDb = ServiceDatabase::where([
+                        'name' => $serviceName,
+                        'application_id' => $resource->id,
+                    ])->first();
+                    if (is_null($existingDb)) {
+                        ServiceDatabase::create([
+                            'name' => $serviceName,
+                            'image' => $image,
+                            'application_id' => $resource->id,
+                        ]);
+                    } elseif ($existingDb->image !== $image) {
+                        $existingDb->image = $image;
+                        $existingDb->save();
+                    }
+                }
+            }
+
             // Collect/create/update networks
             if ($serviceNetworks->count() > 0) {
                 foreach ($serviceNetworks as $networkName => $networkDetails) {
@@ -2808,6 +2837,21 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
             'configs' => $topLevelConfigs->toArray(),
             'secrets' => $topLevelSecrets->toArray(),
         ];
+
+        // Clean up ServiceDatabase records for services no longer in the compose file
+        if ($pull_request_id === 0) {
+            $currentDatabaseServiceNames = $resource->composeDatabases()->pluck('name')->toArray();
+            $composeServiceNames = collect(data_get($yaml, 'services', []))->keys()->toArray();
+            $staleNames = array_diff($currentDatabaseServiceNames, $composeServiceNames);
+            if (! empty($staleNames)) {
+                ServiceDatabase::where('application_id', $resource->id)
+                    ->whereIn('name', $staleNames)
+                    ->each(function ($db) {
+                        $db->delete();
+                    });
+            }
+        }
+
         $resource->docker_compose_raw = Yaml::dump($yaml, 10, 2);
         $resource->docker_compose = Yaml::dump($finalServices, 10, 2);
         data_forget($resource, 'environment_variables');

--- a/database/migrations/2026_02_08_000001_add_application_id_to_service_databases_table.php
+++ b/database/migrations/2026_02_08_000001_add_application_id_to_service_databases_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->foreignId('application_id')->nullable()->constrained()->onDelete('cascade');
+            $table->foreignId('service_id')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->dropForeign(['application_id']);
+            $table->dropColumn('application_id');
+            $table->foreignId('service_id')->nullable(false)->change();
+        });
+    }
+};

--- a/resources/views/livewire/project/application/compose-backups.blade.php
+++ b/resources/views/livewire/project/application/compose-backups.blade.php
@@ -1,0 +1,42 @@
+<div>
+    <h2 class="pb-4">Database Backups</h2>
+    @if ($composeDatabases->isEmpty())
+        <div class="text-neutral-500">
+            No database services detected in this Docker Compose file. Database services are automatically detected based on their image (PostgreSQL, MySQL, MariaDB, MongoDB).
+        </div>
+    @else
+        <div class="flex flex-col gap-4 sm:flex-row">
+            <div class="flex flex-col gap-2 min-w-[200px]">
+                <h3 class="pb-2">Databases</h3>
+                @foreach ($composeDatabases as $db)
+                    <button wire:click="selectDatabase({{ $db->id }})"
+                        @class([
+                            'text-left px-4 py-2 rounded text-sm',
+                            'dark:bg-coolgray-200 bg-neutral-200 font-bold' => $selectedDatabase && $selectedDatabase->id === $db->id,
+                            'dark:bg-coolgray-100 bg-white hover:dark:bg-coolgray-200 hover:bg-neutral-100' => !$selectedDatabase || $selectedDatabase->id !== $db->id,
+                        ])>
+                        {{ $db->name }}
+                        <span class="text-xs opacity-60">({{ $db->image }})</span>
+                    </button>
+                @endforeach
+            </div>
+            <div class="flex-1">
+                @if ($selectedDatabase)
+                    <div class="flex gap-2 items-center pb-4">
+                        <h3>Scheduled Backups for {{ $selectedDatabase->name }}</h3>
+                        @can('update', $application)
+                            <x-modal-input buttonTitle="+ Add" title="New Scheduled Backup">
+                                <livewire:project.database.create-scheduled-backup :database="$selectedDatabase"
+                                    wire:key="create-backup-{{ $selectedDatabase->id }}" />
+                            </x-modal-input>
+                        @endcan
+                    </div>
+                    <livewire:project.database.scheduled-backups :database="$selectedDatabase"
+                        wire:key="backups-{{ $selectedDatabase->id }}" />
+                @else
+                    <div class="text-neutral-500">Select a database to manage its backups.</div>
+                @endif
+            </div>
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/project/application/configuration.blade.php
+++ b/resources/views/livewire/project/application/configuration.blade.php
@@ -54,6 +54,10 @@
                 <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
                     href="{{ route('project.application.healthcheck', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Healthcheck</span></a>
             @endif
+            @if ($application->build_pack === 'dockercompose')
+                <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                    href="{{ route('project.application.backups', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Backups</span></a>
+            @endif
             <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
                 href="{{ route('project.application.rollback', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Rollback</span></a>
             <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
@@ -100,6 +104,8 @@
                 <livewire:project.shared.metrics :resource="$application" />
             @elseif ($currentRoute === 'project.application.tags')
                 <livewire:project.shared.tags :resource="$application" />
+            @elseif ($currentRoute === 'project.application.backups' && $application->build_pack === 'dockercompose')
+                <livewire:project.application.compose-backups :application="$application" />
             @elseif ($currentRoute === 'project.application.danger')
                 <livewire:project.shared.danger :resource="$application" />
             @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -208,6 +208,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/metrics', ApplicationConfiguration::class)->name('project.application.metrics');
         Route::get('/tags', ApplicationConfiguration::class)->name('project.application.tags');
         Route::get('/danger', ApplicationConfiguration::class)->name('project.application.danger');
+        Route::get('/backups', ApplicationConfiguration::class)->name('project.application.backups');
 
         Route::get('/deployment', DeploymentIndex::class)->name('project.application.deployment.index');
         Route::get('/deployment/{deployment_uuid}', DeploymentShow::class)->name('project.application.deployment.show');
@@ -328,7 +329,7 @@ Route::middleware(['auth'])->group(function () {
             }
             $filename = data_get($execution, 'filename');
             if ($execution->scheduledDatabaseBackup->database->getMorphClass() === \App\Models\ServiceDatabase::class) {
-                $server = $execution->scheduledDatabaseBackup->database->service->destination->server;
+                $server = $execution->scheduledDatabaseBackup->database->getServer();
             } else {
                 $server = $execution->scheduledDatabaseBackup->database->destination->server;
             }


### PR DESCRIPTION
## Summary

- Fixes Docker Compose deployments via GitHub App (`dockercompose` buildpack) not detecting database services and not creating `ServiceDatabase` records, which prevented automated backups
- Adds nullable `application_id` FK to `service_databases` table so a `ServiceDatabase` can belong to either a `Service` (existing behavior) or a docker-compose `Application`
- Creates `ServiceDatabase` records during Application model parsing in `parseDockerComposeFile()` when database images are detected via `isDatabaseImage()`
- Adds a **Backups** tab to the Application configuration page for `dockercompose` build pack applications
- Updates all code paths (backup execution, download, proxy start/stop, container status checking, file storage operations) to resolve server/network through either Service or Application ownership

## Issue

Resolves https://github.com/coollabsio/coolify/issues/7528

/claim #7528

## Category

- [x] Bug fix
- [x] New Feature

## Technical Details

### Database Changes
- **Migration**: Adds nullable `application_id` (FK to `applications`) to `service_databases` table, makes `service_id` nullable
- Cascade delete ensures Application-owned ServiceDatabase records are cleaned up when the Application is deleted

### Model Changes
- **ServiceDatabase**: Added `application()` relationship, `getOwner()`, `getOwnerUuid()`, `getServer()`, `getNetwork()` helper methods. Updated `team()`, `workdir()`, `restart()`, `getServiceDatabaseUrl()`, `ownedByCurrentTeam()`, `ownedByCurrentTeamAPI()` to handle both ownership types
- **Application**: Added `composeDatabases()` relationship. Cleanup of compose databases when switching away from `dockercompose` build pack

### Parser Changes (shared.php)
- In the Application model path of `parseDockerComposeFile()`, after `isDatabaseImage()` detection, creates/updates `ServiceDatabase` records with `application_id` (skips preview deployments)
- Cleans up stale `ServiceDatabase` records when services are removed from the compose file

### Updated Code Paths
- `DatabaseBackupJob`: Server resolution, container naming, network for S3 upload
- `StartDatabaseProxy` / `StopDatabaseProxy`: Network, server, container name resolution
- `GetContainersStatus`: Owner UUID resolution for TCP proxy detection
- `ScheduledDatabaseBackup`: Server resolution
- `BackupExecutions`, `BackupEdit`, `Import`: Server resolution, redirect handling
- `LocalFileVolume`: Server resolution for file storage operations
- `databases.php` helper: Server resolution for backup cleanup
- `web.php` download route: Server resolution for backup downloads
- `getResourceByUuid`: Team ownership check for Application-owned ServiceDatabases

### UI Changes
- Added "Backups" tab to Application configuration sidebar (only for `dockercompose` build pack)
- Created `ComposeBackups` Livewire component with database selector and backup management

## Steps to Test

1. Create a new Application using the `dockercompose` buildpack via the GitHub App flow
2. Use a repo with a `docker-compose.yml` containing a database service (e.g., `postgres:16-alpine`) and at least one non-database service
3. Deploy the Application
4. Navigate to **Project > Environment > Application > Configuration > Backups**
5. Verify the database service is listed and you can create a scheduled backup
6. Run a backup and confirm a new execution entry is created

## AI Usage

- [x] AI is used in the process of creating this PR

## Contributor Agreement

> [!IMPORTANT]
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them