### PR TITLE
feat: add IPv6 CIDR support to API allowed IPs

### DIFF
--- a/app/Rules/ValidIpOrCidr.php
+++ b/app/Rules/ValidIpOrCidr.php
@@ -44,8 +44,18 @@ class ValidIpOrCidr implements ValidationRule
                 }
 
                 [$ip, $mask] = $parts;
+                $mask = (int) $mask;
 
-                if (! filter_var($ip, FILTER_VALIDATE_IP) || ! is_numeric($mask) || $mask < 0 || $mask > 32) {
+                if (! filter_var($ip, FILTER_VALIDATE_IP) || ! is_numeric($mask)) {
+                    $invalidEntries[] = $entry;
+
+                    continue;
+                }
+
+                // IPv4: mask 0-32, IPv6: mask 0-128
+                $isIpv6 = filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6);
+                $validMask = $isIpv6 ? ($mask >= 0 && $mask <= 128) : ($mask >= 0 && $mask <= 32);
+                if (! $validMask) {
                     $invalidEntries[] = $entry;
                 }
             } else {

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -1146,23 +1146,29 @@ function checkIPAgainstAllowlist($ip, $allowlist)
 
             $mask = (int) $mask;
 
-            // Validate mask
-            if ($mask < 0 || $mask > 32) {
-                continue;
+            // IPv4 CIDR (mask 0-32)
+            if ($mask >= 0 && $mask <= 32) {
+                $ip_long = ip2long($ip);
+                $subnet_long = ip2long($subnet);
+
+                if ($ip_long !== false && $subnet_long !== false) {
+                    $mask_long = ~((1 << (32 - $mask)) - 1);
+                    if (($ip_long & $mask_long) == ($subnet_long & $mask_long)) {
+                        return true;
+                    }
+                }
             }
+            // IPv6 CIDR (mask 0-128)
+            elseif ($mask > 32 && $mask <= 128) {
+                $ip_bin = @inet_pton($ip);
+                $subnet_bin = @inet_pton($subnet);
 
-            // Calculate network addresses
-            $ip_long = ip2long($ip);
-            $subnet_long = ip2long($subnet);
-
-            if ($ip_long === false || $subnet_long === false) {
-                continue;
-            }
-
-            $mask_long = ~((1 << (32 - $mask)) - 1);
-
-            if (($ip_long & $mask_long) == ($subnet_long & $mask_long)) {
-                return true;
+                if ($ip_bin !== false && $subnet_bin !== false && strlen($ip_bin) === 16 && strlen($subnet_bin) === 16) {
+                    $bytes_to_compare = (int) ceil($mask / 8);
+                    if (substr_compare($ip_bin, $subnet_bin, 0, $bytes_to_compare) === 0) {
+                        return true;
+                    }
+                }
             }
         } else {
             // Special case: 0.0.0.0 means allow all

--- a/tests/Feature/IpAllowlistTest.php
+++ b/tests/Feature/IpAllowlistTest.php
@@ -106,6 +106,31 @@ test('IP allowlist with various subnet sizes', function () {
     expect(checkIPAgainstAllowlist('255.255.255.255', ['0.0.0.0/0']))->toBeTrue();
 });
 
+test('IP allowlist with IPv6 CIDR notation', function () {
+    $testCases = [
+        ['ip' => '2a02:a457:7181:1:2d1f:d36b:ea09:f05', 'allowlist' => ['2a02:a457:7181::/48'], 'expected' => true],
+        ['ip' => '2a02:a457:7181:ffff:ffff:ffff:ffff:ffff', 'allowlist' => ['2a02:a457:7181::/48'], 'expected' => true],
+        ['ip' => '2a02:a457:7182::1', 'allowlist' => ['2a02:a457:7181::/48'], 'expected' => false],
+        ['ip' => '2001:db8::1', 'allowlist' => ['2001:db8::/32'], 'expected' => true],
+        ['ip' => '2001:db8:ffff:ffff:ffff:ffff:ffff:ffff', 'allowlist' => ['2001:db8::/32'], 'expected' => true],
+        ['ip' => '2001:db9::1', 'allowlist' => ['2001:db8::/32'], 'expected' => false],
+    ];
+
+    foreach ($testCases as $case) {
+        $result = checkIPAgainstAllowlist($case['ip'], $case['allowlist']);
+        expect($result)->toBe($case['expected']);
+    }
+});
+
+test('IP allowlist with mixed IPv4 and IPv6', function () {
+    $allowlist = ['84.85.134.157', '2a02:a457:7181::/48'];
+
+    expect(checkIPAgainstAllowlist('84.85.134.157', $allowlist))->toBeTrue();
+    expect(checkIPAgainstAllowlist('2a02:a457:7181:1:2d1f:d36b:ea09:f05', $allowlist))->toBeTrue();
+    expect(checkIPAgainstAllowlist('8.8.8.8', $allowlist))->toBeFalse();
+    expect(checkIPAgainstAllowlist('2001:db8::1', $allowlist))->toBeFalse();
+});
+
 test('IP allowlist comma-separated string input', function () {
     // Test with comma-separated string (as it would come from the settings)
     $allowlistString = '192.168.1.100,10.0.0.0/8,172.16.0.0/16';
@@ -139,6 +164,8 @@ test('ValidIpOrCidr validation rule', function () {
     expect($validate('10.0.0.0/8'))->toBeTrue(); // Valid CIDR
     expect($validate('192.168.1.1,10.0.0.1'))->toBeTrue(); // Multiple valid IPs
     expect($validate('192.168.1.0/24,10.0.0.0/8'))->toBeTrue(); // Multiple CIDRs
+    expect($validate('2a02:a457:7181::/48'))->toBeTrue(); // IPv6 CIDR
+    expect($validate('2001:db8::1'))->toBeTrue(); // IPv6 single address
     expect($validate('0.0.0.0/0'))->toBeTrue(); // 0.0.0.0 with subnet
     expect($validate('0.0.0.0/24'))->toBeTrue(); // 0.0.0.0 with any subnet
     expect($validate(' 192.168.1.1 '))->toBeTrue(); // With spaces
@@ -147,7 +174,8 @@ test('ValidIpOrCidr validation rule', function () {
     expect($validate('1'))->toBeFalse(); // Single digit
     expect($validate('abc'))->toBeFalse(); // Invalid text
     expect($validate('192.168.1.256'))->toBeFalse(); // Invalid IP (256)
-    expect($validate('192.168.1.0/33'))->toBeFalse(); // Invalid CIDR mask (>32)
+    expect($validate('192.168.1.0/33'))->toBeFalse(); // Invalid IPv4 CIDR mask (>32)
+    expect($validate('2a02:a457:7181::/129'))->toBeFalse(); // Invalid IPv6 CIDR mask (>128)
     expect($validate('192.168.1.0/-1'))->toBeFalse(); // Invalid CIDR mask (<0)
     expect($validate('192.168.1.1,abc'))->toBeFalse(); // Mix of valid and invalid
     expect($validate('192.168.1.1,192.168.1.256'))->toBeFalse(); // Mix with invalid IP


### PR DESCRIPTION
## Summary

Adds IPv6 CIDR support to Coolify's API allowed IPs feature. Users with rotating IPv6 addresses (e.g. `2001:db8::/48`) can now restrict API access by subnet instead of single addresses.

## Changes

- **bootstrap/helpers/shared.php**: Extended `checkIPAgainstAllowlist()` to support IPv6 CIDR notation (mask 33-128) using `inet_pton()` and byte comparison
- **app/Rules/ValidIpOrCidr.php**: Updated validation to accept IPv6 addresses and CIDR notation (mask 0-128 for IPv6)
- **tests/Feature/IpAllowlistTest.php**: Added comprehensive tests for IPv6 CIDR and mixed IPv4/IPv6 allowlists

## Example

```
Allowed IPs: 192.0.2.1,2001:db8::/48
```

This allows API access from:
- IPv4: 192.0.2.1
- IPv6: Any address in the 2001:db8::/48 subnet (e.g. rotating residential IPv6)

## Testing

- All existing IPv4 tests pass
- New IPv6 CIDR tests added
- ValidIpOrCidr validation updated for IPv6