### PR TITLE
feat: add IPv6 CIDR support to API allowed IPs

### DIFF
--- a/app/Rules/ValidIpOrCidr.php
+++ b/app/Rules/ValidIpOrCidr.php
@@ -45,7 +45,17 @@ class ValidIpOrCidr implements ValidationRule
 
                 [$ip, $mask] = $parts;
 
-                if (! filter_var($ip, FILTER_VALIDATE_IP) || ! is_numeric($mask) || $mask < 0 || $mask > 32) {
+                if (! filter_var($ip, FILTER_VALIDATE_IP) || ! is_numeric($mask)) {
+                    $invalidEntries[] = $entry;
+
+                    continue;
+                }
+
+                $mask = (int) $mask;
+
+                $isIpv6 = filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6);
+                $validMask = $isIpv6 ? ($mask >= 0 && $mask <= 128) : ($mask >= 0 && $mask <= 32);
+                if (! $validMask) {
                     $invalidEntries[] = $entry;
                 }
             } else {

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -1146,23 +1146,27 @@ function checkIPAgainstAllowlist($ip, $allowlist)
 
             $mask = (int) $mask;
 
-            // Validate mask
-            if ($mask < 0 || $mask > 32) {
-                continue;
+            if ($mask >= 0 && $mask <= 32) {
+                $ip_long = ip2long($ip);
+                $subnet_long = ip2long($subnet);
+
+                if ($ip_long !== false && $subnet_long !== false) {
+                    $mask_long = ~((1 << (32 - $mask)) - 1);
+                    if (($ip_long & $mask_long) == ($subnet_long & $mask_long)) {
+                        return true;
+                    }
+                }
             }
+            elseif ($mask > 32 && $mask <= 128) {
+                $ip_bin = @inet_pton($ip);
+                $subnet_bin = @inet_pton($subnet);
 
-            // Calculate network addresses
-            $ip_long = ip2long($ip);
-            $subnet_long = ip2long($subnet);
-
-            if ($ip_long === false || $subnet_long === false) {
-                continue;
-            }
-
-            $mask_long = ~((1 << (32 - $mask)) - 1);
-
-            if (($ip_long & $mask_long) == ($subnet_long & $mask_long)) {
-                return true;
+                if ($ip_bin !== false && $subnet_bin !== false && strlen($ip_bin) === 16 && strlen($subnet_bin) === 16) {
+                    $bytes_to_compare = (int) ceil($mask / 8);
+                    if (substr_compare($ip_bin, $subnet_bin, 0, $bytes_to_compare) === 0) {
+                        return true;
+                    }
+                }
             }
         } else {
             // Special case: 0.0.0.0 means allow all

--- a/tests/Feature/IpAllowlistTest.php
+++ b/tests/Feature/IpAllowlistTest.php
@@ -106,6 +106,31 @@ test('IP allowlist with various subnet sizes', function () {
     expect(checkIPAgainstAllowlist('255.255.255.255', ['0.0.0.0/0']))->toBeTrue();
 });
 
+test('IP allowlist with IPv6 CIDR notation', function () {
+    $testCases = [
+        ['ip' => '2001:db8::1', 'allowlist' => ['2001:db8::/32'], 'expected' => true],
+        ['ip' => '2001:db8:ffff:ffff:ffff:ffff:ffff:ffff', 'allowlist' => ['2001:db8::/32'], 'expected' => true],
+        ['ip' => '2001:db9::1', 'allowlist' => ['2001:db8::/32'], 'expected' => false],
+        ['ip' => 'fd00::1', 'allowlist' => ['fd00::/8'], 'expected' => true],
+        ['ip' => 'fd00:ffff:ffff:ffff:ffff:ffff:ffff:ffff', 'allowlist' => ['fd00::/8'], 'expected' => true],
+        ['ip' => 'fe80::1', 'allowlist' => ['fd00::/8'], 'expected' => false],
+    ];
+
+    foreach ($testCases as $case) {
+        $result = checkIPAgainstAllowlist($case['ip'], $case['allowlist']);
+        expect($result)->toBe($case['expected']);
+    }
+});
+
+test('IP allowlist with mixed IPv4 and IPv6', function () {
+    $allowlist = ['192.0.2.1', '2001:db8::/32'];
+
+    expect(checkIPAgainstAllowlist('192.0.2.1', $allowlist))->toBeTrue();
+    expect(checkIPAgainstAllowlist('2001:db8::1', $allowlist))->toBeTrue();
+    expect(checkIPAgainstAllowlist('198.51.100.1', $allowlist))->toBeFalse();
+    expect(checkIPAgainstAllowlist('2001:db9::1', $allowlist))->toBeFalse();
+});
+
 test('IP allowlist comma-separated string input', function () {
     // Test with comma-separated string (as it would come from the settings)
     $allowlistString = '192.168.1.100,10.0.0.0/8,172.16.0.0/16';


### PR DESCRIPTION
# feat: add IPv6 CIDR support to API allowed IPs

## Summary

Adds **IPv6 CIDR** (mask 33–128) support to the API allowed IPs feature. **IPv4 behavior is unchanged** — existing single IPs and IPv4 CIDR (mask 0–32) work exactly as before.

## Motivation

Users with rotating IPv6 addresses (e.g. residential ISPs) cannot rely on single-IP allowlisting. This change lets them allow entire IPv6 subnets, e.g. `2001:db8::/48`, so the API stays accessible as their IPv6 prefix changes.

## Changes

- **`bootstrap/helpers/shared.php`** – Adds IPv6 CIDR handling in `checkIPAgainstAllowlist()` via `inet_pton()` and byte comparison. IPv4 logic is left as-is.
- **`app/Rules/ValidIpOrCidr.php`** – Extends validation to accept IPv6 CIDR masks 0–128.
- **`tests/Feature/IpAllowlistTest.php`** – New tests for IPv6 CIDR and mixed IPv4/IPv6 allowlists (using anonymous IPs only).

## IPv6 only

- IPv4 single IPs and IPv4 CIDR (0–32) — **no changes**
- IPv6 CIDR (33–128) — **new support**

## Examples (anonymous IPs)

| Allowlist Entry | Accepts |
|-----------------|---------|
| `192.0.2.1` | Single IPv4 (unchanged) |
| `10.0.0.0/8` | IPv4 subnet (unchanged) |
| `2001:db8::/48` | Any IPv6 in that subnet (new) |

## Testing

- Existing IPv4 tests pass unchanged.
- New tests cover IPv6 CIDR and mixed allowlists.
