### PR TITLE
feat(deploy): detect embedded HEALTHCHECK in Docker images

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -557,6 +557,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         $this->application_deployment_queue->addLogEntry("Starting deployment of {$displayName} to {$this->server->name}.");
         $this->generate_image_names();
         $this->prepare_builder_image();
+        $this->detect_image_healthcheck();
         $this->generate_compose_file();
 
         // Save runtime environment variables (including empty .env file if no variables defined)
@@ -1171,6 +1172,43 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                 'hidden' => true,
                 'save' => 'local_image_found',
             ]);
+        }
+    }
+
+    private function detect_image_healthcheck()
+    {
+        $this->execute_remote_command(
+            [
+                "docker pull {$this->production_image_name} 2>/dev/null",
+                'hidden' => true,
+                'ignore_errors' => true,
+            ],
+            [
+                "docker inspect --format='{{json .Config.Healthcheck}}' {$this->production_image_name} 2>/dev/null",
+                'hidden' => true,
+                'save' => 'image_healthcheck',
+                'ignore_errors' => true,
+            ],
+        );
+
+        $output = trim($this->saved_outputs->get('image_healthcheck') ?? '');
+        $has_healthcheck = false;
+
+        if (! empty($output) && $output !== 'null' && $output !== '<no value>') {
+            $healthcheck = json_decode($output, true);
+            if (is_array($healthcheck) && isset($healthcheck['Test'])) {
+                $test = $healthcheck['Test'];
+                // HEALTHCHECK NONE → {"Test":["NONE"]}
+                $has_healthcheck = ! (is_array($test) && count($test) === 1 && strtoupper($test[0]) === 'NONE');
+            }
+        }
+
+        if ($has_healthcheck !== $this->application->custom_healthcheck_found) {
+            $this->application->custom_healthcheck_found = $has_healthcheck;
+            $this->application->save();
+            if ($has_healthcheck) {
+                $this->application_deployment_queue->addLogEntry('Custom healthcheck detected in Docker image.');
+            }
         }
     }
 
@@ -1805,13 +1843,13 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             if ($this->server->isSwarm()) {
                 // Implement healthcheck for swarm
             } else {
-                if ($this->application->isHealthcheckDisabled() && $this->application->custom_healthcheck_found === false) {
+                if ($this->application->isHealthcheckDisabled()) {
                     $this->newVersionIsHealthy = true;
 
                     return;
                 }
                 if ($this->application->custom_healthcheck_found) {
-                    $this->application_deployment_queue->addLogEntry('Custom healthcheck found in Dockerfile.');
+                    $this->application_deployment_queue->addLogEntry('Using custom healthcheck from image.');
                 }
                 if ($this->container_name) {
                     $counter = 1;
@@ -2573,9 +2611,11 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         // Always use .env file
         $docker_compose['services'][$this->container_name]['env_file'] = ['.env'];
 
-        // Only add Coolify healthcheck if no custom HEALTHCHECK found in Dockerfile
-        // If custom_healthcheck_found is true, the Dockerfile's HEALTHCHECK will be used
-        // If healthcheck is disabled, no healthcheck will be added
+        // Healthcheck logic:
+        // - HC enabled + no image HC → inject Coolify's curl/wget check
+        // - HC enabled + image has HC → let Docker use image's own HEALTHCHECK
+        // - HC disabled + image has HC → explicitly disable it in compose
+        // - HC disabled + no image HC → no healthcheck at all
         if (! $this->application->custom_healthcheck_found && ! $this->application->isHealthcheckDisabled()) {
             $docker_compose['services'][$this->container_name]['healthcheck'] = [
                 'test' => [
@@ -2586,6 +2626,10 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                 'timeout' => $this->application->health_check_timeout.'s',
                 'retries' => $this->application->health_check_retries,
                 'start_period' => $this->application->health_check_start_period.'s',
+            ];
+        } elseif ($this->application->isHealthcheckDisabled() && $this->application->custom_healthcheck_found) {
+            $docker_compose['services'][$this->container_name]['healthcheck'] = [
+                'disable' => true,
             ];
         }
 
@@ -3267,7 +3311,7 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
                     });
                 }
             } else {
-                if ($this->application->dockerfile || $this->application->build_pack === 'dockerfile' || $this->application->build_pack === 'dockerimage') {
+                if (($this->application->dockerfile || $this->application->build_pack === 'dockerfile' || $this->application->build_pack === 'dockerimage') && ! $this->application->custom_healthcheck_found) {
                     $this->application_deployment_queue->addLogEntry('----------------------------------------');
                     $this->application_deployment_queue->addLogEntry("WARNING: Dockerfile or Docker Image based deployment detected. The healthcheck needs a curl or wget command to check the health of the application. Please make sure that it is available in the image or turn off healthcheck on Coolify's UI.");
                     $this->application_deployment_queue->addLogEntry('----------------------------------------');

--- a/resources/views/livewire/project/shared/health-checks.blade.php
+++ b/resources/views/livewire/project/shared/health-checks.blade.php
@@ -15,9 +15,13 @@
     </div>
     <div class="mt-1 pb-4">Define how your resource's health should be checked.</div>
     <div class="flex flex-col gap-4">
-        @if ($customHealthcheckFound)
-            <x-callout type="warning" title="Caution">
-                <p>A custom health check has been detected. If you enable this health check, it will disable the custom one and use this instead.</p>
+        @if ($customHealthcheckFound && $healthCheckEnabled)
+            <x-callout type="info" title="Custom Healthcheck Active">
+                <p>A custom health check was detected in the Docker image and is being used. The settings below are not applied. To use Coolify's health check instead, disable the healthcheck and re-enable it after removing the custom one from the image.</p>
+            </x-callout>
+        @elseif ($customHealthcheckFound && !$healthCheckEnabled)
+            <x-callout type="warning" title="Custom Healthcheck Disabled">
+                <p>A custom health check was detected in the Docker image, but healthcheck is disabled. The image's health check will not run. Enable healthcheck to use the image's custom health check.</p>
             </x-callout>
         @endif
 


### PR DESCRIPTION
### Changes

Currently Coolify only detects custom healthchecks from Dockerfile source (`build_pack=dockerfile`), but not from pulled Docker images (`build_pack=dockerimage`). This means images that ship with their own `HEALTHCHECK` directive (distroless, minimal images, or anything without curl/wget) fail deployment because Coolify injects a `curl || wget` check that doesn't exist in the container.

This PR adds `detect_image_healthcheck()` which runs `docker inspect` on the pulled image to check for an embedded HEALTHCHECK. If found, Coolify uses Docker's native health monitoring instead of injecting curl/wget.

For example, an image built with `HEALTHCHECK CMD ["myapp", "health"]` will now work without needing curl or wget installed. Coolify detects it, skips the curl/wget injection, and monitors the container's health via `docker inspect .State.Health.Status` as usual.

The healthcheck toggle in the UI gives users full control:
- **Enabled** (with image HC): uses the image's own healthcheck, monitors it during deploy
- **Enabled** (no image HC): injects Coolify's curl/wget check as before
- **Disabled** (with image HC): explicitly disables the image's HC in compose, skips monitoring
- **Disabled** (no image HC): no healthcheck at all, same as before

Also handles edge cases like `HEALTHCHECK NONE` and image replacement (HC present → HC absent resets the flag).

### Issues

- fixes: N/A (no existing issue)

### Category

- [x] New feature

### AI Usage

- [x] AI is used in the process of creating this PR

### Steps to Test

- Step 1 – Create a Docker image with a `HEALTHCHECK` directive and no curl/wget (e.g. `FROM debian:bookworm-slim` with `HEALTHCHECK CMD ["some-binary", "health"]`)
- Step 2 – Push to a registry, deploy in Coolify as a Docker Image (`build_pack=dockerimage`)
- Step 3 – Check deployment logs: should show "Custom healthcheck detected in Docker image." and "Using custom healthcheck from image.", then "New container is healthy."
- Step 4 – Go to Healthcheck page: should show info callout about custom healthcheck being active
- Step 5 – Disable healthcheck in UI and redeploy: should skip health monitoring entirely, deploy succeeds instantly
- Step 6 – Test with an image that has NO healthcheck: should behave exactly as before (curl/wget injected if HC enabled)

### Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them