### PR TITLE
fix: fallback Debian docker repo when codename missing

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -118,10 +118,14 @@ class InstallDocker
     {
         return "curl --max-time 300 --retry 3 https://releases.rancher.com/install-docker/{$this->dockerVersion}.sh | sh || curl --max-time 300 --retry 3 https://get.docker.com | sh -s -- --version {$this->dockerVersion} || (".
             '. /etc/os-release && '.
+            'DOCKER_CODENAME=${VERSION_CODENAME} && '.
+            'if ! curl -fsSL "https://download.docker.com/linux/${ID}/dists/${VERSION_CODENAME}/Release" >/dev/null 2>&1; then '.
+            'DOCKER_CODENAME=bookworm; '.
+            'fi && '.
             'install -m 0755 -d /etc/apt/keyrings && '.
             'curl -fsSL https://download.docker.com/linux/${ID}/gpg -o /etc/apt/keyrings/docker.asc && '.
             'chmod a+r /etc/apt/keyrings/docker.asc && '.
-            'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${ID} ${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list && '.
+            'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${ID} ${DOCKER_CODENAME} stable" > /etc/apt/sources.list.d/docker.list && '.
             'apt-get update && '.
             'apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin'.
             ')';

--- a/tests/Unit/InstallDockerDebianFallbackTest.php
+++ b/tests/Unit/InstallDockerDebianFallbackTest.php
@@ -1,0 +1,14 @@
+<?php
+
+use App\Actions\Server\InstallDocker;
+
+it('uses a dynamic Debian codename fallback for Docker repo setup', function () {
+    $reflection = new ReflectionClass(InstallDocker::class);
+    $source = file_get_contents($reflection->getFileName());
+
+    expect($source)
+        ->toContain('DOCKER_CODENAME=${VERSION_CODENAME}')
+        ->toContain('https://download.docker.com/linux/${ID}/dists/${VERSION_CODENAME}/Release')
+        ->toContain('DOCKER_CODENAME=bookworm')
+        ->toContain('https://download.docker.com/linux/${ID} ${DOCKER_CODENAME} stable');
+})->note('Debian Docker install falls back to bookworm when the repo codename is missing');


### PR DESCRIPTION
## Summary
- Add a dynamic Debian Docker repo fallback that uses `${VERSION_CODENAME}` when available and falls back to `bookworm` if the repo isn’t present.
- Add a focused unit test covering the fallback logic.

## Why
Debian 13 (`trixie`) passes OS detection, but Docker’s APT repo may not publish `trixie` yet. The fallback install step fails, which blocks “Validate & Install” for additional servers. This change makes Debian 13 work now and auto‑switches to `trixie` once Docker supports it.

## Demo
https://youtu.be/FuCyfkg11Xg

## Testing
- php artisan test --compact --filter=InstallDockerDebianFallbackTest
- vendor/bin/pint --dirty --format agent

/claim #8154
