### PR TITLE
fix: Add Debian 13 support and Alpine Linux handlers

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -80,6 +80,8 @@ class InstallDocker
                 $command = $command->merge([$this->getSuseDockerInstallCommand()]);
             } elseif ($supported_os_type->contains('arch')) {
                 $command = $command->merge([$this->getArchDockerInstallCommand()]);
+            } elseif ($supported_os_type->contains('alpine')) {
+                $command = $command->merge([$this->getAlpineDockerInstallCommand()]);
             } else {
                 $command = $command->merge([$this->getGenericDockerInstallCommand()]);
             }
@@ -94,8 +96,8 @@ class InstallDocker
                 "jq -s '.[0] * .[1]' /etc/docker/daemon.json.coolify /etc/docker/daemon.json | tee /etc/docker/daemon.json.appended > /dev/null",
                 'mv /etc/docker/daemon.json.appended /etc/docker/daemon.json',
                 "echo 'Restarting Docker Engine...'",
-                'systemctl enable docker >/dev/null 2>&1 || true',
-                'systemctl restart docker',
+                'systemctl enable docker >/dev/null 2>&1 || rc-update add docker >/dev/null 2>&1 || true',
+                'systemctl restart docker >/dev/null 2>&1 || service docker restart >/dev/null 2>&1 || true',
             ]);
             if ($server->isSwarm()) {
                 $command = $command->merge([
@@ -121,7 +123,9 @@ class InstallDocker
             'install -m 0755 -d /etc/apt/keyrings && '.
             'curl -fsSL https://download.docker.com/linux/${ID}/gpg -o /etc/apt/keyrings/docker.asc && '.
             'chmod a+r /etc/apt/keyrings/docker.asc && '.
-            'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${ID} ${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list && '.
+            'DOCKER_CODENAME=${VERSION_CODENAME} && '.
+            'if ! curl -fsSL --head https://download.docker.com/linux/${ID}/dists/${VERSION_CODENAME}/Release >/dev/null 2>&1; then DOCKER_CODENAME=bookworm; fi && '.
+            'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${ID} ${DOCKER_CODENAME} stable" > /etc/apt/sources.list.d/docker.list && '.
             'apt-get update && '.
             'apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin'.
             ')';
@@ -157,6 +161,13 @@ class InstallDocker
         return 'pacman -Syu --noconfirm --needed docker docker-compose && '.
             'systemctl enable docker.service && '.
             'systemctl start docker.service';
+    }
+
+    private function getAlpineDockerInstallCommand(): string
+    {
+        return 'apk update && apk add --no-cache docker docker-cli-compose && '.
+            'rc-update add docker && '.
+            'service docker start';
     }
 
     private function getGenericDockerInstallCommand(): string

--- a/app/Actions/Server/InstallPrerequisites.php
+++ b/app/Actions/Server/InstallPrerequisites.php
@@ -53,6 +53,12 @@ class InstallPrerequisites
                 "echo 'Installing Prerequisites for Arch Linux...'",
                 'pacman -Syu --noconfirm --needed curl wget git jq',
             ]);
+        } elseif ($supported_os_type->contains('alpine')) {
+            $command = $command->merge([
+                "echo 'Installing Prerequisites for Alpine Linux...'",
+                'apk update',
+                'apk add --no-cache curl wget git jq',
+            ]);
         } else {
             throw new \Exception('Unsupported OS type for prerequisites installation');
         }


### PR DESCRIPTION
Fixes #8154

/claim #8154

## Changes
- Add dynamic Docker APT repo codename fallback in `InstallDocker.php`: when `VERSION_CODENAME` (e.g. `trixie` for Debian 13) doesn't exist in Docker's APT repo, automatically fall back to `bookworm`. This is future-proof — once Docker adds `trixie` support, the fallback stops being used.
- Add Alpine Linux prerequisite handler in `InstallPrerequisites.php` using `apk` — Alpine was listed in `SUPPORTED_OS` but had no handler, causing the "Unsupported OS type" error.
- Add Alpine Linux Docker install handler using `apk` and OpenRC service management.
- Make Docker enable/restart commands compatible with both systemd and OpenRC init systems.

## Testing
- Verified PHP syntax of both modified files
- Confirmed Debian 13 (`ID=debian`) already matches existing `SUPPORTED_OS` constant — no changes needed there
- Verified the dynamic repo check approach works: `curl --head` against Docker's repo returns 404 for missing codenames, triggering the `bookworm` fallback
- All changes follow existing code patterns for other OS handlers (RHEL, SLES, Arch)