### PR TITLE
feat: add WordPress + OpenLiteSpeed stack template

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed-mariadb.yaml
+++ b/templates/compose/wordpress-with-openlitespeed-mariadb.yaml
@@ -1,0 +1,38 @@
+# documentation: https://wordpress.org
+# slogan: WordPress running on OpenLiteSpeed web server with MariaDB database.
+# category: cms
+# tags: cms, blog, content, management, openlitespeed, mariadb
+# logo: svgs/wordpress.svg
+
+services:
+  wordpress:
+    image: litespeedtech/openlitespeed-wordpress:latest
+    volumes:
+      - wordpress-files:/var/www/vhosts/localhost
+    environment:
+      - SERVICE_URL_WORDPRESS
+      - WORDPRESS_DB_HOST=mariadb
+      - WORDPRESS_DB_USER=$SERVICE_USER_WORDPRESS
+      - WORDPRESS_DB_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+      - WORDPRESS_DB_NAME=wordpress
+    depends_on:
+      - mariadb
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1"]
+      interval: 2s
+      timeout: 10s
+      retries: 10
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
/claim #8255

### Changes
- Added a new **WordPress + OpenLiteSpeed** one-click service template
- The stack follows existing WordPress service patterns used in Coolify
- Uses environment-based configuration with persistent volumes
- Works behind Coolify’s proxy without exposing ports
- No changes to existing services or core architecture

### Issues
- fixes: #8255

### Category
- [ ] Bug fix
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

### Steps to Test
- Step 1 – Open the Coolify dashboard and create a new application
- Step 2 – Select the **WordPress + OpenLiteSpeed** one-click service
- Step 3 – Configure the required environment variables (domain and database credentials)
- Step 4 – Deploy the service and wait until all containers are healthy
- Step 5 – Open the configured domain and verify that the WordPress installer or dashboard loads correctly

### Contributor Agreement
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them