### PR TITLE
feat(templates): Add agency-focused service templates (Email + WordPress on OpenLiteSpeed)

### DIFF
--- a/public/svgs/openlitespeed.svg
+++ b/public/svgs/openlitespeed.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="#1B3A4B"/>
+  <path d="M32 12L14 28v22h36V28L32 12z" fill="#3DA63A" stroke="#fff" stroke-width="1.5"/>
+  <path d="M26 34h12v16H26z" fill="#1B3A4B"/>
+  <circle cx="32" cy="24" r="5" fill="#fff"/>
+  <path d="M20 50h24" stroke="#fff" stroke-width="1.5"/>
+</svg>

--- a/public/svgs/stalwart.svg
+++ b/public/svgs/stalwart.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="#1A56DB"/>
+  <path d="M18 20h6v4h-6zM26 20h6v4h-6zM34 20h6v4h-6zM42 20h6v4h-6z" fill="#fff" opacity="0.5"/>
+  <path d="M16 30l16 12 16-12" stroke="#fff" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M16 30v14h32V30" stroke="#fff" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/templates/compose/stalwart-mail.yaml
+++ b/templates/compose/stalwart-mail.yaml
@@ -1,0 +1,24 @@
+# documentation: https://stalw.art/docs/get-started
+# slogan: All-in-one mail server with SMTP, IMAP, JMAP, and ManageSieve support.
+# category: email
+# tags: email, smtp, imap, jmap, mail, server, self-hosted, dkim, spf, dmarc
+# logo: svgs/stalwart.svg
+# port: 8080
+
+services:
+  stalwart:
+    image: stalwartlabs/mail-server:latest
+    ports:
+      - '25:25'
+      - '587:587'
+      - '993:993'
+      - '4190:4190'
+    volumes:
+      - stalwart-data:/opt/stalwart-mail
+    environment:
+      - SERVICE_URL_STALWART_8080
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8080/healthz"]
+      interval: 10s
+      timeout: 10s
+      retries: 5

--- a/templates/compose/wordpress-openlitespeed-with-mariadb.yaml
+++ b/templates/compose/wordpress-openlitespeed-with-mariadb.yaml
@@ -1,0 +1,40 @@
+# documentation: https://openlitespeed.org/kb/
+# slogan: High-performance WordPress on OpenLiteSpeed with MariaDB.
+# category: cms
+# tags: cms, wordpress, openlitespeed, litespeed, blog, content, management, mariadb, performance
+# logo: svgs/openlitespeed.svg
+
+services:
+  wordpress:
+    image: litespeedtech/openlitespeed:latest
+    volumes:
+      - wordpress-files:/var/www/vhosts/localhost
+      - lsws-conf:/usr/local/lsws/conf
+    environment:
+      - SERVICE_URL_WORDPRESS
+      - WORDPRESS_DB_HOST=mariadb
+      - WORDPRESS_DB_USER=$SERVICE_USER_WORDPRESS
+      - WORDPRESS_DB_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+      - WORDPRESS_DB_NAME=wordpress
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:80"]
+      interval: 5s
+      timeout: 10s
+      retries: 10
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10

--- a/templates/compose/wordpress-openlitespeed-without-database.yaml
+++ b/templates/compose/wordpress-openlitespeed-without-database.yaml
@@ -1,0 +1,19 @@
+# documentation: https://openlitespeed.org/kb/
+# slogan: High-performance WordPress on OpenLiteSpeed, bring your own database.
+# category: cms
+# tags: cms, wordpress, openlitespeed, litespeed, blog, content, management, performance
+# logo: svgs/openlitespeed.svg
+
+services:
+  wordpress:
+    image: litespeedtech/openlitespeed:latest
+    volumes:
+      - wordpress-files:/var/www/vhosts/localhost
+      - lsws-conf:/usr/local/lsws/conf
+    environment:
+      - SERVICE_URL_WORDPRESS
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:80"]
+      interval: 5s
+      timeout: 10s
+      retries: 10


### PR DESCRIPTION
/claim #8255

This PR adds agency-focused service templates aimed at real-world hosting workflows, particularly for teams managing multiple clients.

### What’s included

#### New service templates
- **stalwart-mail.yaml**
  - Stalwart Mail Server (SMTP / IMAP / JMAP)
  - Single-container, modern Rust-based mail server
  - Suitable for reusable, domain-based client email hosting

- **wordpress-openlitespeed-with-mariadb.yaml**
  - WordPress on OpenLiteSpeed with bundled MariaDB
  - Optimized for high-performance production usage

- **wordpress-openlitespeed-without-database.yaml**
  - WordPress on OpenLiteSpeed (BYODB)
  - Intended for setups using external or managed databases

#### Assets
- Added SVG logos:
  - `stalwart.svg`
  - `openlitespeed.svg`

### Validation
- YAML syntax validated
- Metadata headers validated
- SVG files validated
- Docker images verified and available

### Demo

https://github.com/user-attachments/assets/9781f545-25b8-4c15-8203-e29f80118fae

A short demo video is included showing:
- The new service templates
- Template metadata and configuration
- Overall integration into Coolify

### Notes
The only remaining step is regenerating `service-templates-latest.json` via:

```bash
php artisan generate:services
