### PR TITLE
feat: add OpenReplay service template

### DIFF
--- a/templates/compose/openreplay.yaml
+++ b/templates/compose/openreplay.yaml
@@ -1,0 +1,133 @@
+# documentation: https://docs.openreplay.com/
+# slogan: Session replay, co-browsing and product analytics you can self-host
+# tags: analytics,session-replay,monitoring,user-tracking
+# logo: svgs/openreplay.svg
+# port: 8080
+
+services:
+  postgres:
+    image: postgres:15-alpine
+    environment:
+      - POSTGRES_DB=${POSTGRES_DB:-openreplay}
+      - POSTGRES_USER=${SERVICE_USER_POSTGRES}
+      - POSTGRES_PASSWORD=${SERVICE_PASSWORD_POSTGRES}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${SERVICE_USER_POSTGRES}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    command: redis-server --requirepass ${SERVICE_PASSWORD_REDIS}
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  clickhouse:
+    image: clickhouse/clickhouse-server:23-alpine
+    environment:
+      - CLICKHOUSE_DB=${CLICKHOUSE_DB:-openreplay}
+      - CLICKHOUSE_USER=${SERVICE_USER_CLICKHOUSE}
+      - CLICKHOUSE_PASSWORD=${SERVICE_PASSWORD_CLICKHOUSE}
+    volumes:
+      - clickhouse-data:/var/lib/clickhouse
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+
+  minio:
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    environment:
+      - MINIO_ROOT_USER=${SERVICE_USER_MINIO}
+      - MINIO_ROOT_PASSWORD=${SERVICE_PASSWORD_MINIO}
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+
+  frontend:
+    image: public.ecr.aws/p1t3u8a3/frontend:latest
+    environment:
+      - SERVICE_FQDN_FRONTEND_8080
+      - API_URL=http://http:8080
+    depends_on:
+      http:
+        condition: service_started
+
+  http:
+    image: public.ecr.aws/p1t3u8a3/http:latest
+    environment:
+      - POSTGRES_HOST=postgres
+      - POSTGRES_PORT=5432
+      - POSTGRES_DB=${POSTGRES_DB:-openreplay}
+      - POSTGRES_USER=${SERVICE_USER_POSTGRES}
+      - POSTGRES_PASSWORD=${SERVICE_PASSWORD_POSTGRES}
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+      - REDIS_PASSWORD=${SERVICE_PASSWORD_REDIS}
+      - JWT_SECRET=${SERVICE_PASSWORD_64_JWT}
+      - DOMAIN_NAME=${SERVICE_FQDN_FRONTEND}
+    volumes:
+      - shared-volume:/mnt/efs
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  sink:
+    image: public.ecr.aws/p1t3u8a3/sink:latest
+    environment:
+      - CLICKHOUSE_HOST=clickhouse
+      - CLICKHOUSE_PORT=9000
+      - CLICKHOUSE_DB=${CLICKHOUSE_DB:-openreplay}
+      - CLICKHOUSE_USER=${SERVICE_USER_CLICKHOUSE}
+      - CLICKHOUSE_PASSWORD=${SERVICE_PASSWORD_CLICKHOUSE}
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+      - REDIS_PASSWORD=${SERVICE_PASSWORD_REDIS}
+    volumes:
+      - shared-volume:/mnt/efs
+    depends_on:
+      - clickhouse
+      - redis
+
+  assets:
+    image: public.ecr.aws/p1t3u8a3/assets:latest
+    environment:
+      - POSTGRES_HOST=postgres
+      - POSTGRES_PORT=5432
+      - POSTGRES_DB=${POSTGRES_DB:-openreplay}
+      - POSTGRES_USER=${SERVICE_USER_POSTGRES}
+      - POSTGRES_PASSWORD=${SERVICE_PASSWORD_POSTGRES}
+    volumes:
+      - shared-volume:/mnt/efs
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  storage:
+    image: public.ecr.aws/p1t3u8a3/storage:latest
+    environment:
+      - MINIO_HOST=minio
+      - MINIO_PORT=9000
+      - MINIO_ACCESS_KEY=${SERVICE_USER_MINIO}
+      - MINIO_SECRET_KEY=${SERVICE_PASSWORD_MINIO}
+      - S3_BUCKET=${S3_BUCKET:-openreplay}
+    volumes:
+      - shared-volume:/mnt/efs
+    depends_on:
+      minio:
+        condition: service_healthy


### PR DESCRIPTION
Adds OpenReplay session replay as a service template.

Includes PostgreSQL, Redis, ClickHouse, MinIO, and all OpenReplay services.

Fixes #8232