### PR TITLE
feat: add Stalwart Mail Server and WordPress OpenLiteSpeed service templates

### DIFF
--- a/public/svgs/openlitespeed.svg
+++ b/public/svgs/openlitespeed.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="#1B3A4B"/>
+  <path d="M32 12L14 28v22h36V28L32 12z" fill="#3DA63A" stroke="#fff" stroke-width="1.5"/>
+  <path d="M26 34h12v16H26z" fill="#1B3A4B"/>
+  <circle cx="32" cy="24" r="5" fill="#fff"/>
+  <path d="M20 50h24" stroke="#fff" stroke-width="1.5"/>
+</svg>

--- a/public/svgs/stalwart.svg
+++ b/public/svgs/stalwart.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="#1A56DB"/>
+  <path d="M18 20h6v4h-6zM26 20h6v4h-6zM34 20h6v4h-6zM42 20h6v4h-6z" fill="#fff" opacity="0.5"/>
+  <path d="M16 30l16 12 16-12" stroke="#fff" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M16 30v14h32V30" stroke="#fff" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/templates/compose/stalwart-mail.yaml
+++ b/templates/compose/stalwart-mail.yaml
@@ -1,0 +1,24 @@
+# documentation: https://stalw.art/docs/get-started
+# slogan: All-in-one mail server with SMTP, IMAP, JMAP, and ManageSieve support.
+# category: email
+# tags: email, smtp, imap, jmap, mail, server, self-hosted, dkim, spf, dmarc
+# logo: svgs/stalwart.svg
+# port: 8080
+
+services:
+  stalwart:
+    image: stalwartlabs/mail-server:latest
+    ports:
+      - '25:25'
+      - '587:587'
+      - '993:993'
+      - '4190:4190'
+    volumes:
+      - stalwart-data:/opt/stalwart-mail
+    environment:
+      - SERVICE_URL_STALWART_8080
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8080/healthz"]
+      interval: 10s
+      timeout: 10s
+      retries: 5

--- a/templates/compose/wordpress-openlitespeed-with-mariadb.yaml
+++ b/templates/compose/wordpress-openlitespeed-with-mariadb.yaml
@@ -1,0 +1,40 @@
+# documentation: https://openlitespeed.org/kb/
+# slogan: High-performance WordPress on OpenLiteSpeed with MariaDB.
+# category: cms
+# tags: cms, wordpress, openlitespeed, litespeed, blog, content, management, mariadb, performance
+# logo: svgs/openlitespeed.svg
+
+services:
+  wordpress:
+    image: litespeedtech/openlitespeed:latest
+    volumes:
+      - wordpress-files:/var/www/vhosts/localhost
+      - lsws-conf:/usr/local/lsws/conf
+    environment:
+      - SERVICE_URL_WORDPRESS
+      - WORDPRESS_DB_HOST=mariadb
+      - WORDPRESS_DB_USER=$SERVICE_USER_WORDPRESS
+      - WORDPRESS_DB_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+      - WORDPRESS_DB_NAME=wordpress
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:80"]
+      interval: 5s
+      timeout: 10s
+      retries: 10
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10

--- a/templates/compose/wordpress-openlitespeed-with-mariadb.yaml
+++ b/templates/compose/wordpress-openlitespeed-with-mariadb.yaml
@@ -16,6 +16,24 @@ services:
       - WORDPRESS_DB_USER=$SERVICE_USER_WORDPRESS
       - WORDPRESS_DB_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
       - WORDPRESS_DB_NAME=wordpress
+    command: >
+      /bin/sh -c "
+      if [ ! -f /var/www/vhosts/localhost/html/wp-config.php ]; then
+        echo 'Provisioning WordPress...';
+        if [ -z \"\$(ls -A /var/www/vhosts/localhost/html)\" ]; then
+          curl -Lo /tmp/wp.tar.gz https://wordpress.org/latest.tar.gz;
+          tar -xzf /tmp/wp.tar.gz -C /var/www/vhosts/localhost/html --strip-components=1;
+          rm /tmp/wp.tar.gz;
+        fi;
+        cp /var/www/vhosts/localhost/html/wp-config-sample.php /var/www/vhosts/localhost/html/wp-config.php;
+        sed -i \"s|put your unique phrase here|\$(head -c 64 /dev/urandom | base64)|g\" /var/www/vhosts/localhost/html/wp-config.php;
+        sed -i \"s/database_name_here/\$WORDPRESS_DB_NAME/\" /var/www/vhosts/localhost/html/wp-config.php;
+        sed -i \"s/username_here/\$WORDPRESS_DB_USER/\" /var/www/vhosts/localhost/html/wp-config.php;
+        sed -i \"s/password_here/\$WORDPRESS_DB_PASSWORD/\" /var/www/vhosts/localhost/html/wp-config.php;
+        sed -i \"s/localhost/\$WORDPRESS_DB_HOST/\" /var/www/vhosts/localhost/html/wp-config.php;
+        chown -R 1000:1000 /var/www/vhosts/localhost/html;
+      fi;
+      exec /entrypoint.sh"
     depends_on:
       mariadb:
         condition: service_healthy

--- a/templates/compose/wordpress-openlitespeed-without-database.yaml
+++ b/templates/compose/wordpress-openlitespeed-without-database.yaml
@@ -1,0 +1,19 @@
+# documentation: https://openlitespeed.org/kb/
+# slogan: High-performance WordPress on OpenLiteSpeed, bring your own database.
+# category: cms
+# tags: cms, wordpress, openlitespeed, litespeed, blog, content, management, performance
+# logo: svgs/openlitespeed.svg
+
+services:
+  wordpress:
+    image: litespeedtech/openlitespeed:latest
+    volumes:
+      - wordpress-files:/var/www/vhosts/localhost
+      - lsws-conf:/usr/local/lsws/conf
+    environment:
+      - SERVICE_URL_WORDPRESS
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:80"]
+      interval: 5s
+      timeout: 10s
+      retries: 10

--- a/templates/compose/wordpress-openlitespeed-without-database.yaml
+++ b/templates/compose/wordpress-openlitespeed-without-database.yaml
@@ -12,6 +12,15 @@ services:
       - lsws-conf:/usr/local/lsws/conf
     environment:
       - SERVICE_URL_WORDPRESS
+    command: >
+      /bin/sh -c "
+      if [ -z \"\$(ls -A /var/www/vhosts/localhost/html)\" ]; then
+        curl -Lo /tmp/wp.tar.gz https://wordpress.org/latest.tar.gz;
+        tar -xzf /tmp/wp.tar.gz -C /var/www/vhosts/localhost/html --strip-components=1;
+        rm /tmp/wp.tar.gz;
+        chown -R 1000:1000 /var/www/vhosts/localhost/html;
+      fi;
+      exec /entrypoint.sh"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:80"]
       interval: 5s


### PR DESCRIPTION
/claim #8255

This PR adds agency-focused one-click service templates to support real-world hosting workflows, particularly for managing client email domains and high-performance WordPress sites.

### Changes
- Added `stalwart-mail.yaml`: a modern, single-container mail server written in Rust supporting SMTP, IMAP, and JMAP
- Added `wordpress-openlitespeed-with-mariadb.yaml`: WordPress on OpenLiteSpeed with a bundled MariaDB database
- Added `wordpress-openlitespeed-without-database.yaml`: WordPress on OpenLiteSpeed configured for external databases (BYODB)
- Added SVG logos for Stalwart Mail Server and OpenLiteSpeed

All templates include required metadata, validated YAML syntax, and verified Docker images.

### Issues
- fixes: #8255

### Category
- [x] Adding new one click service

### Screenshots or Video

https://github.com/user-attachments/assets/53fef45e-5531-4a49-8ba3-67803d464fa5


A short demo video is attached showing:
- The newly added service templates
- Template metadata and configuration
- Successful registration inside Coolify

### AI Usage
- [x] AI is NOT used in the process of creating this PR

### Steps to Test
1. Checkout the `next` branch and pull this PR
2. Navigate to **Services → Create New**
3. Verify the presence of:
   - Stalwart Mail Server
   - WordPress OpenLiteSpeed (with MariaDB)
   - WordPress OpenLiteSpeed (without database)
4. Deploy each service using default values
5. Confirm containers start successfully and expected ports/services are available

### Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the contributor guidelines. If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them