### PR TITLE
feat: allow OAuth2 self-registration independent of general registration

### DIFF
--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -20,15 +20,16 @@ class OauthController extends Controller
         try {
             $oauthUser = get_socialite_provider($provider)->user();
             $user = User::whereEmail($oauthUser->email)->first();
-            if (! $user) {
+            if (!$user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (!$settings->is_registration_enabled && !$settings->is_oauth_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 
                 $user = User::create([
                     'name' => $oauthUser->name,
                     'email' => $oauthUser->email,
+                    'oauth_only' => true,
                 ]);
             }
             Auth::login($user);

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -15,6 +15,9 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $is_oauth_registration_enabled;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -41,6 +44,7 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_registration_enabled' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => 'nullable|string',
@@ -54,7 +58,7 @@ class Advanced extends Component
 
     public function mount()
     {
-        if (! isInstanceAdmin()) {
+        if (!isInstanceAdmin()) {
             return redirect()->route('dashboard');
         }
         $this->settings = instanceSettings();
@@ -62,6 +66,7 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -83,7 +88,7 @@ class Advanced extends Component
             $this->allowed_ips = str($this->allowed_ips)->replaceEnd(',', '')->trim();
 
             // Only validate and clean up if we have IPs and it's not 0.0.0.0 (allow all)
-            if (! empty($this->allowed_ips) && ! in_array('0.0.0.0', array_map('trim', explode(',', $this->allowed_ips)))) {
+            if (!empty($this->allowed_ips) && !in_array('0.0.0.0', array_map('trim', explode(',', $this->allowed_ips)))) {
                 $invalidEntries = [];
                 $validEntries = str($this->allowed_ips)->trim()->explode(',')->map(function ($entry) use (&$invalidEntries) {
                     $entry = str($entry)->trim()->toString();
@@ -113,8 +118,8 @@ class Advanced extends Component
                     return null;
                 })->filter()->unique();
 
-                if (! empty($invalidEntries)) {
-                    $this->dispatch('error', 'Invalid IP addresses or subnets: '.implode(', ', $invalidEntries));
+                if (!empty($invalidEntries)) {
+                    $this->dispatch('error', 'Invalid IP addresses or subnets: ' . implode(', ', $invalidEntries));
 
                     return;
                 }
@@ -138,6 +143,7 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;
@@ -155,7 +161,7 @@ class Advanced extends Component
 
     public function toggleTwoStepConfirmation($password): bool
     {
-        if (! verifyPasswordConfirmation($password, $this)) {
+        if (!verifyPasswordConfirmation($password, $this)) {
             return false;
         }
 

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -31,6 +31,7 @@ class InstanceSettings extends Model
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',
         'is_wire_navigate_enabled' => 'boolean',
+        'is_oauth_registration_enabled' => 'boolean',
     ];
 
     protected static function booted(): void
@@ -54,7 +55,7 @@ class InstanceSettings extends Model
                     $url = Url::fromString($value);
                     $host = $url->getHost();
 
-                    return $url->getScheme().'://'.$host;
+                    return $url->getScheme() . '://' . $host;
                 }
             }
         );
@@ -86,7 +87,7 @@ class InstanceSettings extends Model
 
     public static function get()
     {
-        return once(fn () => InstanceSettings::findOrFail(0));
+        return once(fn() => InstanceSettings::findOrFail(0));
     }
 
     // public function getRecipients($notification)
@@ -102,7 +103,7 @@ class InstanceSettings extends Model
     public function getTitleDisplayName(): string
     {
         $instanceName = $this->instance_name;
-        if (! $instanceName) {
+        if (!$instanceName) {
             return '';
         }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -55,6 +55,7 @@ class User extends Authenticatable implements SendsEmail
         'force_password_reset' => 'boolean',
         'show_boarding' => 'boolean',
         'email_change_code_expires_at' => 'datetime',
+        'oauth_only' => 'boolean',
     ];
 
     /**
@@ -79,7 +80,7 @@ class User extends Authenticatable implements SendsEmail
 
         static::created(function (User $user) {
             $team = [
-                'name' => $user->name."'s Team",
+                'name' => $user->name . "'s Team",
                 'personal_team' => true,
                 'show_boarding' => true,
             ];
@@ -182,7 +183,7 @@ class User extends Authenticatable implements SendsEmail
     public function recreate_personal_team()
     {
         $team = [
-            'name' => $this->name."'s Team",
+            'name' => $this->name . "'s Team",
             'personal_team' => true,
             'show_boarding' => true,
         ];
@@ -213,7 +214,7 @@ class User extends Authenticatable implements SendsEmail
             'team_id' => session('currentTeam')->id,
         ]);
 
-        return new NewAccessToken($token, $token->getKey().'|'.$plainTextToken);
+        return new NewAccessToken($token, $token->getKey() . '|' . $plainTextToken);
     }
 
     public function teams()
@@ -321,14 +322,14 @@ class User extends Authenticatable implements SendsEmail
         }
 
         // Check if user actually belongs to this team
-        if (! $this->teams->contains('id', $sessionTeamId)) {
+        if (!$this->teams->contains('id', $sessionTeamId)) {
             session()->forget('currentTeam');
-            Cache::forget('user:'.$this->id.':team:'.$sessionTeamId);
+            Cache::forget('user:' . $this->id . ':team:' . $sessionTeamId);
 
             return null;
         }
 
-        return Cache::remember('user:'.$this->id.':team:'.$sessionTeamId, 3600, function () use ($sessionTeamId) {
+        return Cache::remember('user:' . $this->id . ':team:' . $sessionTeamId, 3600, function () use ($sessionTeamId) {
             return Team::find($sessionTeamId);
         });
     }
@@ -366,7 +367,7 @@ class User extends Authenticatable implements SendsEmail
     {
         $team = $this->teams->where('id', $teamId)->first();
 
-        if (! $team) {
+        if (!$team) {
             return false;
         }
 
@@ -384,7 +385,7 @@ class User extends Authenticatable implements SendsEmail
         // Check if user is member of root team
         $rootTeam = $this->teams->where('id', 0)->first();
 
-        if (! $rootTeam) {
+        if (!$rootTeam) {
             return false;
         }
 
@@ -420,7 +421,7 @@ class User extends Authenticatable implements SendsEmail
 
     public function confirmEmailChange(string $code): bool
     {
-        if (! $this->isEmailChangeCodeValid($code)) {
+        if (!$this->isEmailChangeCodeValid($code)) {
             return false;
         }
 
@@ -460,8 +461,8 @@ class User extends Authenticatable implements SendsEmail
 
     public function hasEmailChangeRequest(): bool
     {
-        return ! is_null($this->pending_email)
-            && ! is_null($this->email_change_code)
+        return !is_null($this->pending_email)
+            && !is_null($this->email_change_code)
             && $this->email_change_code_expires_at
             && Carbon::now()->lessThan($this->email_change_code_expires_at);
     }
@@ -472,6 +473,6 @@ class User extends Authenticatable implements SendsEmail
      */
     public function hasPassword(): bool
     {
-        return ! empty($this->password);
+        return !empty($this->password);
     }
 }

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -13,6 +13,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\RegisterResponse;
 use Laravel\Fortify\Fortify;
 
@@ -23,8 +24,7 @@ class FortifyServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        $this->app->instance(RegisterResponse::class, new class implements RegisterResponse
-        {
+        $this->app->instance(RegisterResponse::class, new class implements RegisterResponse {
             public function toResponse($request)
             {
                 // First user (root) will be redirected to /settings instead of / on registration.
@@ -47,7 +47,7 @@ class FortifyServiceProvider extends ServiceProvider
             $isFirstUser = User::count() === 0;
 
             $settings = instanceSettings();
-            if (! $settings->is_registration_enabled) {
+            if (!$settings->is_registration_enabled) {
                 return redirect()->route('login');
             }
 
@@ -78,6 +78,13 @@ class FortifyServiceProvider extends ServiceProvider
                 $user &&
                 Hash::check($request->password, $user->password)
             ) {
+                // Block password login for OAuth-only users
+                if ($user->oauth_only) {
+                    throw ValidationException::withMessages([
+                        'email' => [__('auth.oauth_only')],
+                    ]);
+                }
+
                 $user->updated_at = now();
                 $user->save();
 
@@ -86,7 +93,7 @@ class FortifyServiceProvider extends ServiceProvider
                 if ($invitation && $invitation->isValid()) {
                     // User is logging in for the first time after being invited
                     // Attach them to the invited team if not already attached
-                    if (! $user->teams()->where('team_id', $invitation->team->id)->exists()) {
+                    if (!$user->teams()->where('team_id', $invitation->team->id)->exists()) {
                         $user->teams()->attach($invitation->team->id, ['role' => $invitation->role]);
                     }
                     $user->currentTeam = $invitation->team;
@@ -94,7 +101,7 @@ class FortifyServiceProvider extends ServiceProvider
                 } else {
                     // Normal login - use personal team
                     $user->currentTeam = $user->teams->firstWhere('personal_team', true);
-                    if (! $user->currentTeam) {
+                    if (!$user->currentTeam) {
                         $user->currentTeam = $user->recreate_personal_team();
                     }
                 }
@@ -139,7 +146,7 @@ class FortifyServiceProvider extends ServiceProvider
             // server('REMOTE_ADDR') gives the actual connecting IP before proxy headers
             $realIp = $request->server('REMOTE_ADDR') ?? $request->ip();
 
-            return Limit::perMinute(5)->by($email.'|'.$realIp);
+            return Limit::perMinute(5)->by($email . '|' . $realIp);
         });
 
         RateLimiter::for('two-factor', function (Request $request) {

--- a/database/migrations/2026_02_10_000001_add_oauth_registration_settings.php
+++ b/database/migrations/2026_02_10_000001_add_oauth_registration_settings.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_registration_enabled')->default(false)->after('is_registration_enabled');
+        });
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('oauth_only')->default(false)->after('password');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn('is_oauth_registration_enabled');
+        });
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('oauth_only');
+        });
+    }
+};

--- a/lang/en.json
+++ b/lang/en.json
@@ -25,6 +25,7 @@
     "auth.failed.password": "The provided password is incorrect.",
     "auth.failed.email": "If an account exists with this email address, you will receive a password reset link shortly.",
     "auth.throttle": "Too many login attempts. Please try again in :seconds seconds.",
+    "auth.oauth_only": "This account is restricted to OAuth login only. Please use an OAuth provider to sign in.",
     "input.name": "Name",
     "input.email": "Email",
     "input.password": "Password",

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -22,6 +22,11 @@
                             label="Registration Allowed" />
                     </div>
                     <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_registration_enabled"
+                            helper="Allow new users to self-register through OAuth2 providers even when general registration is disabled. Useful for controlling access via external identity providers like Authentik or Azure AD."
+                            label="OAuth Registration Allowed" />
+                    </div>
+                    <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"
                             helper="Opt out of reporting this instance to coolify.io's installation count. No other data is collected."
                             label="Do Not Track" />

--- a/tests/Feature/OauthRegistrationTest.php
+++ b/tests/Feature/OauthRegistrationTest.php
@@ -1,0 +1,129 @@
+<?php
+
+use App\Models\InstanceSettings;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+
+beforeEach(function () {
+    // Ensure instance settings exist for tests
+    if (!InstanceSettings::find(0)) {
+        InstanceSettings::create(['id' => 0]);
+    }
+});
+
+it('allows oauth user creation when only is_oauth_registration_enabled is true', function () {
+    $settings = InstanceSettings::find(0);
+    $settings->is_registration_enabled = false;
+    $settings->is_oauth_registration_enabled = true;
+    $settings->save();
+
+    // Simulate what OauthController::callback does when creating a new user
+    $user = User::create([
+        'name' => 'OAuth Test User',
+        'email' => 'oauthtest@example.com',
+        'oauth_only' => true,
+    ]);
+
+    expect($user)->toBeInstanceOf(User::class);
+    expect($user->oauth_only)->toBeTrue();
+    expect($user->hasPassword())->toBeFalse();
+});
+
+it('blocks oauth user creation when both registration flags are false', function () {
+    $settings = InstanceSettings::find(0);
+    $settings->is_registration_enabled = false;
+    $settings->is_oauth_registration_enabled = false;
+    $settings->save();
+
+    // Simulate the check in OauthController::callback
+    $canRegister = $settings->is_registration_enabled || $settings->is_oauth_registration_enabled;
+
+    expect($canRegister)->toBeFalse();
+});
+
+it('allows oauth user creation when is_registration_enabled is true regardless of oauth flag', function () {
+    $settings = InstanceSettings::find(0);
+    $settings->is_registration_enabled = true;
+    $settings->is_oauth_registration_enabled = false;
+    $settings->save();
+
+    $canRegister = $settings->is_registration_enabled || $settings->is_oauth_registration_enabled;
+
+    expect($canRegister)->toBeTrue();
+});
+
+it('marks oauth-created users as oauth_only', function () {
+    $user = User::create([
+        'name' => 'OAuth Only User',
+        'email' => 'oauthonly@example.com',
+        'oauth_only' => true,
+    ]);
+
+    expect($user->oauth_only)->toBeTrue();
+    expect($user->password)->toBeNull();
+    expect($user->hasPassword())->toBeFalse();
+});
+
+it('does not mark regular users as oauth_only', function () {
+    $user = User::create([
+        'name' => 'Regular User',
+        'email' => 'regular@example.com',
+        'password' => Hash::make('password123'),
+    ]);
+
+    expect($user->oauth_only)->toBeFalse();
+    expect($user->hasPassword())->toBeTrue();
+});
+
+it('rejects password login for oauth_only users', function () {
+    $settings = InstanceSettings::find(0);
+    $settings->is_registration_enabled = true;
+    $settings->save();
+
+    // Create an oauth_only user with a password (edge case: admin sets password manually)
+    $user = User::create([
+        'name' => 'OAuth Blocked User',
+        'email' => 'oauthblocked@example.com',
+        'password' => Hash::make('password123'),
+        'oauth_only' => true,
+    ]);
+
+    // Attempt password login - should be rejected
+    $response = $this->post('/login', [
+        'email' => 'oauthblocked@example.com',
+        'password' => 'password123',
+    ]);
+
+    // Should redirect back with errors (not successfully authenticated)
+    $response->assertStatus(302);
+    $this->assertGuest();
+});
+
+it('allows password login for normal users', function () {
+    $settings = InstanceSettings::find(0);
+    $settings->is_registration_enabled = true;
+    $settings->save();
+
+    $user = User::create([
+        'name' => 'Normal User',
+        'email' => 'normallogin@example.com',
+        'password' => Hash::make('password123'),
+        'oauth_only' => false,
+    ]);
+    $user->markEmailAsVerified();
+
+    $response = $this->post('/login', [
+        'email' => 'normallogin@example.com',
+        'password' => 'password123',
+    ]);
+
+    $response->assertStatus(302);
+    $this->assertAuthenticated();
+});
+
+it('has is_oauth_registration_enabled setting default to false', function () {
+    $settings = InstanceSettings::find(0);
+
+    // Default should be false (set by migration)
+    expect($settings->is_oauth_registration_enabled)->toBeFalse();
+});


### PR DESCRIPTION
This PR improves Coolify’s authentication model by decoupling OAuth2 self-registration from password-based registration and enforcing OAuth-only authentication for OAuth-origin users.

It enables administrators to fully delegate access control to an external Identity Provider (e.g. Authentik, Azure AD, Okta), making it possible to instantly revoke access across multiple Coolify instances by disabling a user in the IdP.

---

### Changes

- Added a new instance-level setting `is_oauth_registration_enabled` (Settings → Advanced)
  - Allows OAuth2 users to self-register even when general registration (`is_registration_enabled`) is disabled
- Introduced an `oauth_only` flag on users
  - Users created via OAuth are automatically marked as `oauth_only`
  - `oauth_only` users are blocked from logging in via email/password
- Enforced OAuth-only behavior at the authentication layer
  - Password login attempts for `oauth_only` users throw a validation error
- UI updates to expose the new toggle in the admin panel
- Added comprehensive feature tests covering:
  - Registration flag combinations
  - OAuth user creation and marking
  - Password login blocking for OAuth-only users

---

### Issues

- fixes: #8042  
- /claim #8042

---

### Category

- [x] New feature

---

### Screenshots or Video (if applicable)

📹 **Demo video included in this PR**  


https://github.com/user-attachments/assets/3df607fe-24f1-42aa-bcf5-1d6acbd05298


Shows:
- OAuth self-registration while general registration is disabled
- Automatic `oauth_only` user creation
- Password login being blocked for OAuth-only users

---

### AI Usage

- [x] AI is NOT used in the process of creating this PR

---

### Steps to Test

1. Go to **Settings → Advanced**
2. Disable **General Registration**
3. Enable **OAuth Registration**
4. Log out
5. Sign in using an OAuth2 provider (e.g. Authentik)
   - Verify the user is created successfully
6. Attempt to log in with the same user via email/password
   - Login should be blocked
7. Disable the user in the OAuth provider
8. Attempt OAuth login again
   - Access should be denied

### Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the contributor guidelines. If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them
