### PR TITLE
fix: validate SSH key content, not just file existence (#7724)

### DIFF
--- a/app/Helpers/SshMultiplexingHelper.php
+++ b/app/Helpers/SshMultiplexingHelper.php
@@ -204,11 +204,27 @@ class SshMultiplexingHelper
     private static function validateSshKey(PrivateKey $privateKey): void
     {
         $keyLocation = $privateKey->getKeyLocation();
-        $checkKeyCommand = "ls $keyLocation 2>/dev/null";
-        $keyCheckProcess = Process::run($checkKeyCommand);
 
-        if ($keyCheckProcess->exitCode() !== 0) {
+        // Check if file exists
+        if (! file_exists($keyLocation)) {
             $privateKey->storeInFileSystem();
+
+            return;
+        }
+
+        // Check if file content matches the database value
+        // This catches the case where the key was rotated in the DB
+        // but the old file still exists on disk
+        $fileContent = file_get_contents($keyLocation);
+        if ($fileContent !== $privateKey->private_key) {
+            ray('SSH key content mismatch detected, re-storing key for: '.$privateKey->uuid);
+            $privateKey->storeInFileSystem();
+
+            // Invalidate any multiplexed connections using the old key
+            // since they'd be caching the stale credentials
+            foreach ($privateKey->servers as $server) {
+                self::removeMuxFile($server);
+            }
         }
     }
 


### PR DESCRIPTION
## Fix: Sporadic Permission denied (publickey,password)

Fixes #7724

### Root Cause

`validateSshKey()` in `SshMultiplexingHelper.php` only checked if the SSH key **file existed** on disk (`ls`). It never verified the file **content** matched the database.

When a key is rotated/updated in the database:
1. Old key file still exists on disk ✅
2. `validateSshKey()` says 'file exists, we're good' ❌
3. SSH connection uses the **stale** key from the old file
4. → `Permission denied (publickey)`

Additionally, multiplexed SSH connections cache credentials, so even if the file is eventually updated, existing mux connections continue using the old key.

### Fix

- **Content validation:** Compare file content against the database value, not just file existence
- **Auto-repair:** When content mismatches, re-store the correct key from DB to filesystem
- **Mux invalidation:** Remove multiplexed connection sockets for affected servers when a key change is detected, forcing new connections with the correct key

### Changes

```
app/Helpers/SshMultiplexingHelper.php | 1 file, +19 -3 lines
```

### Why the existing PR (#7727) isn't enough

PR #7727 focuses on key content format validation (whitespace/newlines). While helpful, it doesn't address the core issue: the **file vs database content desync**. A key can have valid formatting but still be the wrong key if it was rotated.