### PR TITLE
feat(service): add WordPress OpenLiteSpeed service template

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed-mariadb.yaml
+++ b/templates/compose/wordpress-with-openlitespeed-mariadb.yaml
@@ -1,0 +1,51 @@
+# documentation: https://wordpress.org
+# slogan: WordPress is open source software you can use to create a beautiful website, blog, or app.
+# category: cms
+# tags: cms, blog, content, management, mariadb, openlitespeed
+# logo: svgs/wordpress.svg
+
+services:
+  wordpress:
+    image: litespeedtech/openlitespeed:latest
+    volumes:
+      - wordpress-files:/var/www/vhosts/localhost/html
+    environment:
+      - SERVICE_URL_WORDPRESS
+      - WORDPRESS_DB_HOST=mariadb
+      - WORDPRESS_DB_USER=$SERVICE_USER_WORDPRESS
+      - WORDPRESS_DB_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+      - WORDPRESS_DB_NAME=wordpress
+    depends_on:
+      - mariadb
+    entrypoint: ["/bin/sh", "-c"]
+    command: |
+      set -e
+      DOCROOT="/var/www/vhosts/localhost/html"
+      if [ ! -f "$${DOCROOT}/wp-config.php" ]; then
+        mkdir -p "$${DOCROOT}"
+        curl -sL https://wordpress.org/latest.tar.gz | tar -xz -C /tmp
+        cp -R /tmp/wordpress/. "$${DOCROOT}"
+        rm -rf /tmp/wordpress
+        wp config create --path="$${DOCROOT}" --dbname="$${WORDPRESS_DB_NAME}" --dbuser="$${WORDPRESS_DB_USER}" --dbpass="$${WORDPRESS_DB_PASSWORD}" --dbhost="$${WORDPRESS_DB_HOST}" --skip-check --allow-root
+        chown -R 1000:1000 "$${DOCROOT}"
+      fi
+      exec /entrypoint.sh
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1"]
+      interval: 2s
+      timeout: 10s
+      retries: 10
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
/claim #8264

### Changes

- Added a new reusable **WordPress + OpenLiteSpeed** one-click service template intended as a production-ready reference.
- The template automatically provisions WordPress core files and generates `wp-config.php` using inline, idempotent bootstrap logic inside the container.
- Uses persistent volumes for both WordPress files and MariaDB data to ensure data durability across restarts and redeployments.
- Designed to work with Coolify’s built-in proxy and follow existing service template conventions.
- Scope is intentionally limited to a single service template file, without introducing additional services or behavior.

### Issues

- fixes: #8264
- /claim #8264

### Category

- [ ] Bug fix  
- [ ] New feature  
- [x] Adding new one click service  
- [ ] Fixing or updating existing one click service  

### Screenshots or Video

**Note:**  
I am currently blocked from running a local Coolify instance due to issues installing and running the ServerSideUp Spin tool on macOS (Apple Silicon). This prevents me from recording a local demo at the moment.

The service template has been implemented following existing Coolify one-click service patterns and project guidelines.

A demo video will be uploaded as soon as I am able to complete a deployment on a working Coolify environment.

### AI Usage

- [x] AI is used in the process of creating this PR  
- [ ] AI is NOT used in the process of creating this PR  

> AI was used as an assistant. All changes were reviewed, fully understood, and manually validated before submission.

### Steps to Test

1. Checkout the `next` branch and pull this PR.
2. Open Coolify and add a new service.
3. Select **WordPress + OpenLiteSpeed** from the one-click services list.
4. Deploy the service with default settings.
5. Wait until both containers are healthy.
6. Open the generated service URL.
7. Verify:
   - WordPress installer loads correctly on first visit
   - Core files and configuration are already present
   - Restarting the service does not reinitialize WordPress files
   - Redeploying the service preserves existing data

### Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them