### PR TITLE
feat: add Debian 13 (Trixie) support

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -118,10 +118,11 @@ class InstallDocker
     {
         return "curl --max-time 300 --retry 3 https://releases.rancher.com/install-docker/{$this->dockerVersion}.sh | sh || curl --max-time 300 --retry 3 https://get.docker.com | sh -s -- --version {$this->dockerVersion} || (".
             '. /etc/os-release && '.
+            'if [ "${VERSION_ID}" = "13" ]; then DOCKER_VERSION_CODENAME="bookworm"; else DOCKER_VERSION_CODENAME="${VERSION_CODENAME}"; fi && '.
             'install -m 0755 -d /etc/apt/keyrings && '.
             'curl -fsSL https://download.docker.com/linux/${ID}/gpg -o /etc/apt/keyrings/docker.asc && '.
             'chmod a+r /etc/apt/keyrings/docker.asc && '.
-            'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${ID} ${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list && '.
+            'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${ID} ${DOCKER_VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list && '.
             'apt-get update && '.
             'apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin'.
             ')';

--- a/bootstrap/helpers/constants.php
+++ b/bootstrap/helpers/constants.php
@@ -63,7 +63,7 @@ const SPECIFIC_SERVICES = [
 
 // Based on /etc/os-release
 const SUPPORTED_OS = [
-    'ubuntu debian raspbian pop',
+    'ubuntu debian raspbian pop trixie',
     'centos fedora rhel ol rocky amzn almalinux',
     'sles opensuse-leap opensuse-tumbleweed',
     'arch',

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -522,10 +522,17 @@ install_docker_manually() {
         curl -fsSL https://download.docker.com/linux/$OS_TYPE/gpg -o /etc/apt/keyrings/docker.asc
         chmod a+r /etc/apt/keyrings/docker.asc
 
+# Check if the OS is Debian 13 (Trixie), if so, use bookworm for Docker repo until Trixie is officially supported by Docker
+if [ "$OS_TYPE" = "debian" ] && [ "$OS_VERSION" = "13" ]; then
+    DOCKER_CODENAME="bookworm"
+else
+    DOCKER_CODENAME=$(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")
+fi
+
         # Add the repository to Apt sources
         echo \
             "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/$OS_TYPE \
-                  $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" |
+                  $DOCKER_CODENAME stable" |
             tee /etc/apt/sources.list.d/docker.list
         apt-get update
         apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin


### PR DESCRIPTION
/claim #8154

This PR adds support for Debian 13 (Trixie) by implementing a fallback to the `bookworm` Docker repository when official Trixie repositories are not yet available.

### Changes:
- **scripts/install.sh**: Added logic to detect Debian 13 and use `bookworm` codename for Docker repository installation.
- **app/Actions/Server/InstallDocker.php**: Implemented the same fallback logic for remote server Docker installation.
- **bootstrap/helpers/constants.php**: Added `trixie` to the `SUPPORTED_OS` constant list.

Verified in a `debian:trixie-slim` container.