### PR TITLE
feat: allow OAuth self-registration when general registration is disabled

### DIFF
--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -22,7 +22,7 @@ class OauthController extends Controller
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! $settings->is_oauth_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -15,6 +15,9 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $is_oauth_registration_enabled;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -41,6 +44,7 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_registration_enabled' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => 'nullable|string',
@@ -62,6 +66,7 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -138,6 +143,7 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -67,6 +67,7 @@ class FortifyServiceProvider extends ServiceProvider
 
             return view('auth.login', [
                 'is_registration_enabled' => $settings->is_registration_enabled,
+                'is_oauth_registration_enabled' => $settings->is_oauth_registration_enabled,
                 'enabled_oauth_providers' => $enabled_oauth_providers,
             ]);
         });

--- a/database/migrations/2026_02_11_000001_add_is_oauth_registration_enabled_to_instance_settings_table.php
+++ b/database/migrations/2026_02_11_000001_add_is_oauth_registration_enabled_to_instance_settings_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_registration_enabled')->default(false)->after('is_registration_enabled');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn('is_oauth_registration_enabled');
+        });
+    }
+};

--- a/lang/en.json
+++ b/lang/en.json
@@ -19,6 +19,7 @@
     "auth.logout": "Logout",
     "auth.register": "Register",
     "auth.registration_disabled": "Registration is disabled. Please contact the administrator.",
+    "auth.oauth_registration_hint": "You can still register using an OAuth provider below.",
     "auth.reset_password": "Reset password",
     "auth.failed": "These credentials do not match our records.",
     "auth.failed.callback": "Failed to process callback from login provider.",

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -70,6 +70,10 @@
                             class="block w-full text-center py-3 px-4 rounded-lg border border-neutral-300 dark:border-coolgray-400 font-medium hover:border-coollabs dark:hover:border-warning transition-colors">
                             {{ __('auth.register_now') }}
                         </a>
+                    @elseif ($is_oauth_registration_enabled && $enabled_oauth_providers->isNotEmpty())
+                        <div class="mt-6 text-center text-sm text-neutral-500 dark:text-neutral-400">
+                            {{ __('auth.registration_disabled') }} {{ __('auth.oauth_registration_hint') }}
+                        </div>
                     @else
                         <div class="mt-6 text-center text-sm text-neutral-500 dark:text-neutral-400">
                             {{ __('auth.registration_disabled') }}

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -22,6 +22,11 @@
                             label="Registration Allowed" />
                     </div>
                     <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_registration_enabled"
+                            helper="Allow new users to register via OAuth providers even when general registration is disabled. Existing OAuth users can always log in."
+                            label="OAuth Registration Allowed" />
+                    </div>
+                    <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"
                             helper="Opt out of reporting this instance to coolify.io's installation count. No other data is collected."
                             label="Do Not Track" />


### PR DESCRIPTION
### Changes

Add a new "OAuth Registration Allowed" toggle in Settings > Advanced that allows new users to register via OAuth providers even when general (password-based) registration is disabled.

This addresses the use case where admins want to control access via an identity provider (e.g., Authentik) without opening up password-based self-registration.

Files changed:
- `database/migrations/...` — adds `is_oauth_registration_enabled` boolean column to `instance_settings` (default: `false`)
- `app/Http/Controllers/OauthController.php` — checks the new setting in the OAuth callback; allows user creation if either `is_registration_enabled` or `is_oauth_registration_enabled` is true
- `app/Livewire/Settings/Advanced.php` — wires up the new setting in the Advanced settings component
- `resources/views/livewire/settings/advanced.blade.php` — adds the checkbox toggle in the UI
- `app/Providers/FortifyServiceProvider.php` — passes the new flag to the login view
- `resources/views/auth/login.blade.php` — shows a hint when OAuth registration is available but general registration is disabled
- `lang/en.json` — adds the `auth.oauth_registration_hint` translation string

### Issues

- fixes: #8042

### Category

- [x] New feature

### Screenshots or Video (if applicable)

I do not have a running Coolify dev environment to record a screen recording at this time. Happy to provide one if needed before merge.

### AI Usage

- [x] AI is used in the process of creating this PR

### Steps to Test

- Step 1 – Run `php artisan migrate` to add the new `is_oauth_registration_enabled` column
- Step 2 – Go to Settings > Advanced. Verify the new "OAuth Registration Allowed" checkbox appears below "Registration Allowed"
- Step 3 – Disable "Registration Allowed" and enable "OAuth Registration Allowed". Save
- Step 4 – Open the login page in an incognito window. Verify the message says registration is disabled but you can register via OAuth
- Step 5 – Click an OAuth provider button (e.g., GitHub). Complete the OAuth flow with a new email not yet in the system. Verify the user is created and logged in
- Step 6 – Visit `/register` directly. Verify it redirects to login (password registration is still blocked)
- Step 7 – Disable both toggles. Repeat step 5 with another new OAuth email. Verify it returns a 403

### Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them

/claim #8042