### PR TITLE
fix: stop auto-injecting env_file .env into Docker Compose services

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -637,14 +637,12 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             }
         } else {
             $composeFile = $this->application->parse(pull_request_id: $this->pull_request_id, preview_id: data_get($this->preview, 'id'), commit: $this->commit);
-            // Always add .env file to services
-            $services = collect(data_get($composeFile, 'services', []));
-            $services = $services->map(function ($service, $name) {
-                $service['env_file'] = ['.env'];
-
-                return $service;
-            });
-            $composeFile['services'] = $services->toArray();
+            // Do NOT auto-inject env_file: ['.env'] into services.
+            // Per Docker Compose semantics, .env is used for variable interpolation only
+            // (i.e. ${VAR} substitution in the compose file). Runtime environment variables
+            // should be explicitly declared by the user via environment: or env_file: in
+            // their compose file. Auto-injecting .env as env_file causes all variables to
+            // leak into every container, which is a security issue (#7655).
             if (empty($composeFile)) {
                 $this->application_deployment_queue->addLogEntry('Failed to parse docker-compose file.');
                 $this->fail('Failed to parse docker-compose file.');

--- a/bootstrap/helpers/parsers.php
+++ b/bootstrap/helpers/parsers.php
@@ -1317,15 +1317,20 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
         if ($depends_on->count() > 0) {
             $payload['depends_on'] = $depends_on;
         }
-        // Auto-inject .env file so Coolify environment variables are available inside containers
-        // This makes Applications behave consistently with manual .env file usage
+        // Do NOT auto-inject .env as env_file. Per Docker Compose semantics, .env is for
+        // variable interpolation only (${VAR} substitution). Injecting it via env_file
+        // leaks all variables into every container as runtime env vars (#7655).
+        // Preserve any env_file entries the user explicitly defined in their compose file.
         $existingEnvFiles = data_get($service, 'env_file');
-        $envFiles = collect(is_null($existingEnvFiles) ? [] : (is_array($existingEnvFiles) ? $existingEnvFiles : [$existingEnvFiles]))
-            ->push('.env')
-            ->unique()
-            ->values();
-
-        $payload['env_file'] = $envFiles;
+        if (! is_null($existingEnvFiles)) {
+            $envFiles = collect(is_array($existingEnvFiles) ? $existingEnvFiles : [$existingEnvFiles])
+                ->reject(fn ($f) => $f === '.env')
+                ->unique()
+                ->values();
+            if ($envFiles->isNotEmpty()) {
+                $payload['env_file'] = $envFiles;
+            }
+        }
 
         // Inject commit-based image tag for services with build directive (for rollback support)
         // Only inject if service has build but no explicit image defined
@@ -2416,15 +2421,20 @@ function serviceParser(Service $resource): Collection
         if ($depends_on->count() > 0) {
             $payload['depends_on'] = $depends_on;
         }
-        // Auto-inject .env file so Coolify environment variables are available inside containers
-        // This makes Services behave consistently with Applications
+        // Do NOT auto-inject .env as env_file. Per Docker Compose semantics, .env is for
+        // variable interpolation only (${VAR} substitution). Injecting it via env_file
+        // leaks all variables into every container as runtime env vars (#7655).
+        // Preserve any env_file entries the user explicitly defined in their compose file.
         $existingEnvFiles = data_get($service, 'env_file');
-        $envFiles = collect(is_null($existingEnvFiles) ? [] : (is_array($existingEnvFiles) ? $existingEnvFiles : [$existingEnvFiles]))
-            ->push('.env')
-            ->unique()
-            ->values();
-
-        $payload['env_file'] = $envFiles;
+        if (! is_null($existingEnvFiles)) {
+            $envFiles = collect(is_array($existingEnvFiles) ? $existingEnvFiles : [$existingEnvFiles])
+                ->reject(fn ($f) => $f === '.env')
+                ->unique()
+                ->values();
+            if ($envFiles->isNotEmpty()) {
+                $payload['env_file'] = $envFiles;
+            }
+        }
 
         $parsedServices->put($serviceName, $payload);
     }


### PR DESCRIPTION
/claim #7655

## Problem

Coolify auto-injects `env_file: ['.env']` into every service in a Docker Compose project. This means all environment variables defined via the Coolify UI end up as runtime env vars in every container, regardless of which service they were intended for.

This is a security issue (container A can read secrets meant for container B) and it breaks Docker Compose semantics — the `.env` file is supposed to be used for variable interpolation only (`${VAR}` substitution in the compose file), not for runtime injection.

As @nuxwin correctly pointed out in the issue discussion, the previous PRs went in the wrong direction by splitting `.env` into per-service files or adding database columns. The root cause is simpler: Coolify should not be injecting `.env` via `env_file` at all.

## Fix

Removed the auto-injection of `env_file: ['.env']` from three places:

1. `ApplicationDeploymentJob::deploy_docker_compose_buildpack()` — was overwriting env_file for all services after parsing
2. `applicationParser()` in `parsers.php` — was appending `.env` to env_file for compose v3+ parsing
3. `serviceParser()` in `parsers.php` — same issue for one-click services

The `.env` file is still created and written with all the environment variables. Docker Compose will still read it automatically for `${VAR}` interpolation in the compose file — that's standard behavior and doesn't require `env_file`.

Any user-defined `env_file` entries in the compose file are preserved (minus `.env` itself, to clean up any previously injected references).

Single-container deployments (dockerimage, dockerfile, nixpacks) are not affected since they only have one service.

## Backward compatibility

Existing users who rely on Coolify env vars being available as runtime vars inside their containers will need to add `environment:` or `env_file:` to their compose file explicitly. This is standard Docker Compose usage.

For example, if they had a var `DB_PASSWORD` set in Coolify UI and used it in their app container, they'd add to their compose file:

```yaml
services:
  app:
    environment:
      - DB_PASSWORD=${DB_PASSWORD}
```

This is how Docker Compose is supposed to work — interpolation from `.env`, explicit declaration for runtime.

## What I did NOT change

- No database migrations
- No new UI fields
- No new columns or models
- The `.env` file generation is untouched — it still gets created for interpolation
- Single-container deployments still work exactly as before