### PR TITLE
fix: robust OS validation and support for Debian 13 & Alpine

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -80,6 +80,8 @@ class InstallDocker
                 $command = $command->merge([$this->getSuseDockerInstallCommand()]);
             } elseif ($supported_os_type->contains('arch')) {
                 $command = $command->merge([$this->getArchDockerInstallCommand()]);
+            } elseif ($supported_os_type->contains('alpine')) {
+                $command = $command->merge([$this->getAlpineDockerInstallCommand()]);
             } else {
                 $command = $command->merge([$this->getGenericDockerInstallCommand()]);
             }
@@ -118,13 +120,22 @@ class InstallDocker
     {
         return "curl --max-time 300 --retry 3 https://releases.rancher.com/install-docker/{$this->dockerVersion}.sh | sh || curl --max-time 300 --retry 3 https://get.docker.com | sh -s -- --version {$this->dockerVersion} || (".
             '. /etc/os-release && '.
+            'DOCKER_CODENAME=${VERSION_CODENAME} && '.
+            'if ! curl -fsSL https://download.docker.com/linux/${ID}/dists/${VERSION_CODENAME}/Release >/dev/null 2>&1; then DOCKER_CODENAME=bookworm; fi && '.
             'install -m 0755 -d /etc/apt/keyrings && '.
             'curl -fsSL https://download.docker.com/linux/${ID}/gpg -o /etc/apt/keyrings/docker.asc && '.
             'chmod a+r /etc/apt/keyrings/docker.asc && '.
-            'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${ID} ${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list && '.
+            'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${ID} ${DOCKER_CODENAME} stable" > /etc/apt/sources.list.d/docker.list && '.
             'apt-get update && '.
             'apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin'.
             ')';
+    }
+
+    private function getAlpineDockerInstallCommand(): string
+    {
+        return 'apk update && apk add --no-cache docker docker-cli-compose && '.
+            'rc-update add docker default && '.
+            'service docker start';
     }
 
     private function getRhelDockerInstallCommand(): string

--- a/app/Actions/Server/InstallPrerequisites.php
+++ b/app/Actions/Server/InstallPrerequisites.php
@@ -53,8 +53,14 @@ class InstallPrerequisites
                 "echo 'Installing Prerequisites for Arch Linux...'",
                 'pacman -Syu --noconfirm --needed curl wget git jq',
             ]);
+        } elseif ($supported_os_type->contains('alpine')) {
+            $command = $command->merge([
+                "echo 'Installing Prerequisites for Alpine Linux...'",
+                'apk update',
+                'apk add --no-cache curl wget git jq',
+            ]);
         } else {
-            throw new \Exception('Unsupported OS type for prerequisites installation');
+            throw new \Exception('Unsupported OS type for prerequisites installation: ' . $supported_os_type);
         }
 
         $command->push("echo 'Prerequisites installed successfully.'");

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -1048,17 +1048,29 @@ $schema://$host {
         $collectedData = collect([]);
         foreach ($releaseLines as $line) {
             $item = str($line)->trim();
-            $collectedData->put($item->before('=')->value(), $item->after('=')->lower()->replace('"', '')->value());
+            if ($item->contains('=')) {
+                $collectedData->put($item->before('=')->value(), $item->after('=')->lower()->replace('"', '')->value());
+            }
         }
         $ID = data_get($collectedData, 'ID');
-        // $ID_LIKE = data_get($collectedData, 'ID_LIKE');
-        // $VERSION_ID = data_get($collectedData, 'VERSION_ID');
-        $supported = collect(SUPPORTED_OS)->filter(function ($supportedOs) use ($ID) {
-            if (str($supportedOs)->contains($ID)) {
-                return str($ID);
+        $ID_LIKE = data_get($collectedData, 'ID_LIKE');
+
+        $supported = collect(SUPPORTED_OS)->filter(function ($supportedOs) use ($ID, $ID_LIKE) {
+            if ($ID && str($supportedOs)->contains($ID)) {
+                return true;
             }
+            if ($ID_LIKE) {
+                $likes = str($ID_LIKE)->explode(' ');
+                foreach ($likes as $like) {
+                    if (str($supportedOs)->contains(trim($like))) {
+                        return true;
+                    }
+                }
+            }
+            return false;
         });
-        if ($supported->count() === 1) {
+
+        if ($supported->count() >= 1) {
             return str($supported->first());
         } else {
             return false;


### PR DESCRIPTION
## Problem
Debian 13 (Trixie) and Alpine Linux servers often fail validation or prerequisites installation. 
1. Debian 13's codename (`trixie`) is not yet supported in official Docker APT repos, causing fallback installation failures.
2. Alpine Linux is in the supported list but lacks implementation handlers in prerequisites and Docker installation actions.
3. OS validation strictly relies on `ID`, failing for many derivatives that have `ID_LIKE=debian`.

## Solution
1. **Robust OS Detection**: `validateOS` now utilizes `ID_LIKE` as a fallback if the primary `ID` doesn't yield a match.
2. **Dynamic Debian Fallback**: In the APT fallback path, the script now dynamically checks if the official Docker repo has a release file for the current codename. If not (common for testing releases like trixie), it falls back to `bookworm` to ensure a working Docker engine is installed.
3. **Alpine Handlers**: Implemented complete handlers for Alpine Linux using `apk` and OpenRC (`rc-update` / `service`).

YO COOLIFY SO FAT THAT IT NEEDS 5 CONTAINERS TO OPERATE

Fixes #8154