### PR TITLE
feat(templates): add SurrealDB templates (RocksDB + TiKV)

### DIFF
--- a/templates/compose/surrealdb-with-tikv.yaml
+++ b/templates/compose/surrealdb-with-tikv.yaml
@@ -1,0 +1,48 @@
+# documentation: https://surrealdb.com/docs/surrealdb/installation/running/tikv
+# slogan: SurrealDB with TiKV backend for distributed storage.
+# category: database
+# tags: database, surrealdb, tikv, distributed
+# logo: svgs/default.webp
+# port: 8000
+
+services:
+  pd:
+    image: pingcap/pd:latest
+    command: --name=pd --data-dir=/data --client-urls=http://0.0.0.0:2379 --peer-urls=http://0.0.0.0:2380 --advertise-client-urls=http://pd:2379 --advertise-peer-urls=http://pd:2380 --initial-cluster=pd=http://pd:2380
+    volumes:
+      - pd-data:/data
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:2379/pd/api/v1/health"]
+      interval: 10s
+      timeout: 20s
+      retries: 20
+
+  tikv:
+    image: pingcap/tikv:latest
+    command: --addr=0.0.0.0:20160 --advertise-addr=tikv:20160 --data-dir=/data --pd=pd:2379
+    depends_on:
+      pd:
+        condition: service_healthy
+    volumes:
+      - tikv-data:/data
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:20180/status"]
+      interval: 10s
+      timeout: 20s
+      retries: 20
+
+  surrealdb:
+    image: surrealdb/surrealdb:latest
+    command: start --user ${SERVICE_USER_SURREALDB} --pass ${SERVICE_PASSWORD_SURREALDB} --log ${SURREALDB_LOG_LEVEL:-info} tikv://pd:2379
+    environment:
+      - SERVICE_URL_SURREALDB_8000
+    depends_on:
+      pd:
+        condition: service_healthy
+      tikv:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/health"]
+      interval: 5s
+      timeout: 20s
+      retries: 20

--- a/templates/compose/surrealdb.yaml
+++ b/templates/compose/surrealdb.yaml
@@ -1,0 +1,20 @@
+# documentation: https://surrealdb.com/docs/surrealdb/installation/running/docker
+# slogan: Multi-model database for the cloud, edge, and everything in between.
+# category: database
+# tags: database, surrealdb, kv, nosql, sql
+# logo: svgs/default.webp
+# port: 8000
+
+services:
+  surrealdb:
+    image: surrealdb/surrealdb:latest
+    command: start --user ${SERVICE_USER_SURREALDB} --pass ${SERVICE_PASSWORD_SURREALDB} --log ${SURREALDB_LOG_LEVEL:-info} rocksdb:/mydata/surreal.db
+    environment:
+      - SERVICE_URL_SURREALDB_8000
+    volumes:
+      - surrealdb-data:/mydata
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/health"]
+      interval: 5s
+      timeout: 20s
+      retries: 20

--- a/templates/service-templates-latest.json
+++ b/templates/service-templates-latest.json
@@ -5284,5 +5284,36 @@
         "logo": "svgs/marimo.svg",
         "minversion": "0.0.0",
         "port": "8080"
+    },
+    "surrealdb": {
+        "documentation": "https://surrealdb.com/docs/surrealdb/installation/running/docker?utm_source=coolify.io",
+        "slogan": "Multi-model database for the cloud, edge, and everything in between.",
+        "compose": "IyBkb2N1bWVudGF0aW9uOiBodHRwczovL3N1cnJlYWxkYi5jb20vZG9jcy9zdXJyZWFsZGIvaW5zdGFsbGF0aW9uL3J1bm5pbmcvZG9ja2VyCiMgc2xvZ2FuOiBNdWx0aS1tb2RlbCBkYXRhYmFzZSBmb3IgdGhlIGNsb3VkLCBlZGdlLCBhbmQgZXZlcnl0aGluZyBpbiBiZXR3ZWVuLgojIGNhdGVnb3J5OiBkYXRhYmFzZQojIHRhZ3M6IGRhdGFiYXNlLCBzdXJyZWFsZGIsIGt2LCBub3NxbCwgc3FsCiMgbG9nbzogc3Zncy9kZWZhdWx0LndlYnAKIyBwb3J0OiA4MDAwCgpzZXJ2aWNlczoKICBzdXJyZWFsZGI6CiAgICBpbWFnZTogc3VycmVhbGRiL3N1cnJlYWxkYjpsYXRlc3QKICAgIGNvbW1hbmQ6IHN0YXJ0IC0tdXNlciAke1NFUlZJQ0VfVVNFUl9TVVJSRUFMREJ9IC0tcGFzcyAke1NFUlZJQ0VfUEFTU1dPUkRfU1VSUkVBTERCfSAtLWxvZyAke1NVUlJFQUxEQl9MT0dfTEVWRUw6LWluZm99IHJvY2tzZGI6L215ZGF0YS9zdXJyZWFsLmRiCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX1VSTF9TVVJSRUFMREJfODAwMAogICAgdm9sdW1lczoKICAgICAgLSBzdXJyZWFsZGItZGF0YTovbXlkYXRhCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDogWyJDTUQiLCAiY3VybCIsICItZiIsICJodHRwOi8vMTI3LjAuMC4xOjgwMDAvaGVhbHRoIl0KICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAyMAo=",
+        "tags": [
+            "database",
+            "surrealdb",
+            "kv",
+            "nosql",
+            "sql"
+        ],
+        "category": "database",
+        "logo": "svgs/default.webp",
+        "minversion": "0.0.0",
+        "port": "8000"
+    },
+    "surrealdb-with-tikv": {
+        "documentation": "https://surrealdb.com/docs/surrealdb/installation/running/tikv?utm_source=coolify.io",
+        "slogan": "SurrealDB with TiKV backend for distributed storage.",
+        "compose": "IyBkb2N1bWVudGF0aW9uOiBodHRwczovL3N1cnJlYWxkYi5jb20vZG9jcy9zdXJyZWFsZGIvaW5zdGFsbGF0aW9uL3J1bm5pbmcvdGlrdgojIHNsb2dhbjogU3VycmVhbERCIHdpdGggVGlLViBiYWNrZW5kIGZvciBkaXN0cmlidXRlZCBzdG9yYWdlLgojIGNhdGVnb3J5OiBkYXRhYmFzZQojIHRhZ3M6IGRhdGFiYXNlLCBzdXJyZWFsZGIsIHRpa3YsIGRpc3RyaWJ1dGVkCiMgbG9nbzogc3Zncy9kZWZhdWx0LndlYnAKIyBwb3J0OiA4MDAwCgpzZXJ2aWNlczoKICBwZDoKICAgIGltYWdlOiBwaW5nY2FwL3BkOmxhdGVzdAogICAgY29tbWFuZDogLS1uYW1lPXBkIC0tZGF0YS1kaXI9L2RhdGEgLS1jbGllbnQtdXJscz1odHRwOi8vMC4wLjAuMDoyMzc5IC0tcGVlci11cmxzPWh0dHA6Ly8wLjAuMC4wOjIzODAgLS1hZHZlcnRpc2UtY2xpZW50LXVybHM9aHR0cDovL3BkOjIzNzkgLS1hZHZlcnRpc2UtcGVlci11cmxzPWh0dHA6Ly9wZDoyMzgwIC0taW5pdGlhbC1jbHVzdGVyPXBkPWh0dHA6Ly9wZDoyMzgwCiAgICB2b2x1bWVzOgogICAgICAtIHBkLWRhdGE6L2RhdGEKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OiBbIkNNRCIsICJ3Z2V0IiwgIi0tc3BpZGVyIiwgIi1xIiwgImh0dHA6Ly8xMjcuMC4wLjE6MjM3OS9wZC9hcGkvdjEvaGVhbHRoIl0KICAgICAgaW50ZXJ2YWw6IDEwcwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMjAKCiAgdGlrdjoKICAgIGltYWdlOiBwaW5nY2FwL3Rpa3Y6bGF0ZXN0CiAgICBjb21tYW5kOiAtLWFkZHI9MC4wLjAuMDoyMDE2MCAtLWFkdmVydGlzZS1hZGRyPXRpa3Y6MjAxNjAgLS1kYXRhLWRpcj0vZGF0YSAtLXBkPXBkOjIzNzkKICAgIGRlcGVuZHNfb246CiAgICAgIHBkOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5CiAgICB2b2x1bWVzOgogICAgICAtIHRpa3YtZGF0YTovZGF0YQogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6IFsiQ01EIiwgIndnZXQiLCAiLS1zcGlkZXIiLCAiLXEiLCAiaHR0cDovLzEyNy4wLjAuMToyMDE4MC9zdGF0dXMiXQogICAgICBpbnRlcnZhbDogMTBzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAyMAoKICBzdXJyZWFsZGI6CiAgICBpbWFnZTogc3VycmVhbGRiL3N1cnJlYWxkYjpsYXRlc3QKICAgIGNvbW1hbmQ6IHN0YXJ0IC0tdXNlciAke1NFUlZJQ0VfVVNFUl9TVVJSRUFMREJ9IC0tcGFzcyAke1NFUlZJQ0VfUEFTU1dPUkRfU1VSUkVBTERCfSAtLWxvZyAke1NVUlJFQUxEQl9MT0dfTEVWRUw6LWluZm99IHRpa3Y6Ly9wZDoyMzc5CiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX1VSTF9TVVJSRUFMREJfODAwMAogICAgZGVwZW5kc19vbjoKICAgICAgcGQ6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICAgICAgdGlrdjoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfaGVhbHRoeQogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6IFsiQ01EIiwgImN1cmwiLCAiLWYiLCAiaHR0cDovLzEyNy4wLjAuMTo4MDAwL2hlYWx0aCJdCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMjAK",
+        "tags": [
+            "database",
+            "surrealdb",
+            "tikv",
+            "distributed"
+        ],
+        "category": "database",
+        "logo": "svgs/default.webp",
+        "minversion": "0.0.0",
+        "port": "8000"
     }
 }

--- a/templates/service-templates.json
+++ b/templates/service-templates.json
@@ -5284,5 +5284,36 @@
         "logo": "svgs/marimo.svg",
         "minversion": "0.0.0",
         "port": "8080"
+    },
+    "surrealdb": {
+        "documentation": "https://surrealdb.com/docs/surrealdb/installation/running/docker?utm_source=coolify.io",
+        "slogan": "Multi-model database for the cloud, edge, and everything in between.",
+        "compose": "IyBkb2N1bWVudGF0aW9uOiBodHRwczovL3N1cnJlYWxkYi5jb20vZG9jcy9zdXJyZWFsZGIvaW5zdGFsbGF0aW9uL3J1bm5pbmcvZG9ja2VyCiMgc2xvZ2FuOiBNdWx0aS1tb2RlbCBkYXRhYmFzZSBmb3IgdGhlIGNsb3VkLCBlZGdlLCBhbmQgZXZlcnl0aGluZyBpbiBiZXR3ZWVuLgojIGNhdGVnb3J5OiBkYXRhYmFzZQojIHRhZ3M6IGRhdGFiYXNlLCBzdXJyZWFsZGIsIGt2LCBub3NxbCwgc3FsCiMgbG9nbzogc3Zncy9kZWZhdWx0LndlYnAKIyBwb3J0OiA4MDAwCgpzZXJ2aWNlczoKICBzdXJyZWFsZGI6CiAgICBpbWFnZTogc3VycmVhbGRiL3N1cnJlYWxkYjpsYXRlc3QKICAgIGNvbW1hbmQ6IHN0YXJ0IC0tdXNlciAke1NFUlZJQ0VfVVNFUl9TVVJSRUFMREJ9IC0tcGFzcyAke1NFUlZJQ0VfUEFTU1dPUkRfU1VSUkVBTERCfSAtLWxvZyAke1NVUlJFQUxEQl9MT0dfTEVWRUw6LWluZm99IHJvY2tzZGI6L215ZGF0YS9zdXJyZWFsLmRiCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fU1VSUkVBTERCXzgwMDAKICAgIHZvbHVtZXM6CiAgICAgIC0gc3VycmVhbGRiLWRhdGE6L215ZGF0YQogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6IFsiQ01EIiwgImN1cmwiLCAiLWYiLCAiaHR0cDovLzEyNy4wLjAuMTo4MDAwL2hlYWx0aCJdCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMjAK",
+        "tags": [
+            "database",
+            "surrealdb",
+            "kv",
+            "nosql",
+            "sql"
+        ],
+        "category": "database",
+        "logo": "svgs/default.webp",
+        "minversion": "0.0.0",
+        "port": "8000"
+    },
+    "surrealdb-with-tikv": {
+        "documentation": "https://surrealdb.com/docs/surrealdb/installation/running/tikv?utm_source=coolify.io",
+        "slogan": "SurrealDB with TiKV backend for distributed storage.",
+        "compose": "IyBkb2N1bWVudGF0aW9uOiBodHRwczovL3N1cnJlYWxkYi5jb20vZG9jcy9zdXJyZWFsZGIvaW5zdGFsbGF0aW9uL3J1bm5pbmcvdGlrdgojIHNsb2dhbjogU3VycmVhbERCIHdpdGggVGlLViBiYWNrZW5kIGZvciBkaXN0cmlidXRlZCBzdG9yYWdlLgojIGNhdGVnb3J5OiBkYXRhYmFzZQojIHRhZ3M6IGRhdGFiYXNlLCBzdXJyZWFsZGIsIHRpa3YsIGRpc3RyaWJ1dGVkCiMgbG9nbzogc3Zncy9kZWZhdWx0LndlYnAKIyBwb3J0OiA4MDAwCgpzZXJ2aWNlczoKICBwZDoKICAgIGltYWdlOiBwaW5nY2FwL3BkOmxhdGVzdAogICAgY29tbWFuZDogLS1uYW1lPXBkIC0tZGF0YS1kaXI9L2RhdGEgLS1jbGllbnQtdXJscz1odHRwOi8vMC4wLjAuMDoyMzc5IC0tcGVlci11cmxzPWh0dHA6Ly8wLjAuMC4wOjIzODAgLS1hZHZlcnRpc2UtY2xpZW50LXVybHM9aHR0cDovL3BkOjIzNzkgLS1hZHZlcnRpc2UtcGVlci11cmxzPWh0dHA6Ly9wZDoyMzgwIC0taW5pdGlhbC1jbHVzdGVyPXBkPWh0dHA6Ly9wZDoyMzgwCiAgICB2b2x1bWVzOgogICAgICAtIHBkLWRhdGE6L2RhdGEKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OiBbIkNNRCIsICJ3Z2V0IiwgIi0tc3BpZGVyIiwgIi1xIiwgImh0dHA6Ly8xMjcuMC4wLjE6MjM3OS9wZC9hcGkvdjEvaGVhbHRoIl0KICAgICAgaW50ZXJ2YWw6IDEwcwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMjAKCiAgdGlrdjoKICAgIGltYWdlOiBwaW5nY2FwL3Rpa3Y6bGF0ZXN0CiAgICBjb21tYW5kOiAtLWFkZHI9MC4wLjAuMDoyMDE2MCAtLWFkdmVydGlzZS1hZGRyPXRpa3Y6MjAxNjAgLS1kYXRhLWRpcj0vZGF0YSAtLXBkPXBkOjIzNzkKICAgIGRlcGVuZHNfb246CiAgICAgIHBkOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5CiAgICB2b2x1bWVzOgogICAgICAtIHRpa3YtZGF0YTovZGF0YQogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6IFsiQ01EIiwgIndnZXQiLCAiLS1zcGlkZXIiLCAiLXEiLCAiaHR0cDovLzEyNy4wLjAuMToyMDE4MC9zdGF0dXMiXQogICAgICBpbnRlcnZhbDogMTBzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAyMAoKICBzdXJyZWFsZGI6CiAgICBpbWFnZTogc3VycmVhbGRiL3N1cnJlYWxkYjpsYXRlc3QKICAgIGNvbW1hbmQ6IHN0YXJ0IC0tdXNlciAke1NFUlZJQ0VfVVNFUl9TVVJSRUFMREJ9IC0tcGFzcyAke1NFUlZJQ0VfUEFTU1dPUkRfU1VSUkVBTERCfSAtLWxvZyAke1NVUlJFQUxEQl9MT0dfTEVWRUw6LWluZm99IHRpa3Y6Ly9wZDoyMzc5CiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fU1VSUkVBTERCXzgwMDAKICAgIGRlcGVuZHNfb246CiAgICAgIHBkOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5CiAgICAgIHRpa3Y6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OiBbIkNNRCIsICJjdXJsIiwgIi1mIiwgImh0dHA6Ly8xMjcuMC4wLjE6ODAwMC9oZWFsdGgiXQogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDIwCg==",
+        "tags": [
+            "database",
+            "surrealdb",
+            "tikv",
+            "distributed"
+        ],
+        "category": "database",
+        "logo": "svgs/default.webp",
+        "minversion": "0.0.0",
+        "port": "8000"
     }
 }


### PR DESCRIPTION
## Summary
Adds two new one-click service templates for SurrealDB:
- `surrealdb` (single-node with RocksDB persistence)
- `surrealdb-with-tikv` (distributed backend with PD + TiKV)

## What changed
- Added `templates/compose/surrealdb.yaml`
- Added `templates/compose/surrealdb-with-tikv.yaml`
- Updated template manifests:
  - `templates/service-templates.json`
  - `templates/service-templates-latest.json`

Both templates include:
- Auth defaults using `SERVICE_USER_SURREALDB` / `SERVICE_PASSWORD_SURREALDB`
- Healthchecks
- Metadata (docs, category, tags, exposed port)

## Notes
- This follows the issue request to support SurrealDB with and without TiKV.
- `surrealdb` uses RocksDB persistence via mounted volume.

/claim #7642