### PR TITLE
Fix Debian 13 OS detection fallback and Docker codename mapping

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -118,10 +118,12 @@ class InstallDocker
     {
         return "curl --max-time 300 --retry 3 https://releases.rancher.com/install-docker/{$this->dockerVersion}.sh | sh || curl --max-time 300 --retry 3 https://get.docker.com | sh -s -- --version {$this->dockerVersion} || (".
             '. /etc/os-release && '.
+            'DOCKER_VERSION_CODENAME=${VERSION_CODENAME:-${VERSION_ID}} && '.
+            'if [ "${DOCKER_VERSION_CODENAME}" = "13" ]; then DOCKER_VERSION_CODENAME=trixie; fi && '.
             'install -m 0755 -d /etc/apt/keyrings && '.
             'curl -fsSL https://download.docker.com/linux/${ID}/gpg -o /etc/apt/keyrings/docker.asc && '.
             'chmod a+r /etc/apt/keyrings/docker.asc && '.
-            'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${ID} ${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list && '.
+            'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${ID} ${DOCKER_VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list && '.
             'apt-get update && '.
             'apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin'.
             ')';

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -1043,26 +1043,62 @@ $schema://$host {
 
     public function validateOS(): bool|Stringable
     {
-        $os_release = instant_remote_process(['cat /etc/os-release'], $this);
-        $releaseLines = collect(explode("\n", $os_release));
-        $collectedData = collect([]);
-        foreach ($releaseLines as $line) {
-            $item = str($line)->trim();
-            $collectedData->put($item->before('=')->value(), $item->after('=')->lower()->replace('"', '')->value());
-        }
-        $ID = data_get($collectedData, 'ID');
-        // $ID_LIKE = data_get($collectedData, 'ID_LIKE');
-        // $VERSION_ID = data_get($collectedData, 'VERSION_ID');
-        $supported = collect(SUPPORTED_OS)->filter(function ($supportedOs) use ($ID) {
-            if (str($supportedOs)->contains($ID)) {
-                return str($ID);
+        $osRelease = instant_remote_process(['cat /etc/os-release'], $this);
+        $releaseData = self::parseOsReleaseContent($osRelease);
+
+        return self::resolveSupportedOsTypeFromReleaseData($releaseData);
+    }
+
+    public static function parseOsReleaseContent(string $osRelease): Collection
+    {
+        return collect(explode("\n", $osRelease))
+            ->map(fn ($line) => str($line)->trim())
+            ->filter(fn (Stringable $line) => $line->isNotEmpty() && $line->contains('='))
+            ->reduce(function (Collection $releaseData, Stringable $line) {
+                $key = $line->before('=');
+                if ($key->isEmpty()) {
+                    return $releaseData;
+                }
+
+                $value = $line->after('=')
+                    ->lower()
+                    ->replace('"', '')
+                    ->trim()
+                    ->value();
+                $releaseData->put($key->value(), $value);
+
+                return $releaseData;
+            }, collect([]));
+    }
+
+    public static function resolveSupportedOsTypeFromReleaseData(Collection $releaseData): bool|Stringable
+    {
+        $identifiers = collect([
+            data_get($releaseData, 'ID'),
+            data_get($releaseData, 'ID_LIKE'),
+        ])->filter();
+
+        $candidateIds = $identifiers
+            ->flatMap(function ($identifier) {
+                return preg_split('/\s+/', (string) $identifier) ?: [];
+            })
+            ->map(fn ($identifier) => str($identifier)->trim()->lower()->value())
+            ->filter();
+
+        foreach ($candidateIds as $candidateId) {
+            $supportedGroup = collect(SUPPORTED_OS)->first(function ($supportedOs) use ($candidateId) {
+                $supportedIds = collect(explode(' ', $supportedOs))
+                    ->map(fn ($id) => str($id)->trim()->lower()->value())
+                    ->filter();
+
+                return $supportedIds->contains($candidateId);
+            });
+            if ($supportedGroup) {
+                return str($supportedGroup);
             }
-        });
-        if ($supported->count() === 1) {
-            return str($supported->first());
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     public function isTerminalEnabled()

--- a/tests/Unit/Actions/Server/InstallDockerCommandTest.php
+++ b/tests/Unit/Actions/Server/InstallDockerCommandTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use App\Actions\Server\InstallDocker;
+
+it('maps Debian numeric codename 13 to trixie in APT fallback command', function () {
+    $action = new InstallDocker;
+
+    $dockerVersionProperty = new ReflectionProperty($action, 'dockerVersion');
+    $dockerVersionProperty->setAccessible(true);
+    $dockerVersionProperty->setValue($action, '27.3');
+
+    $method = new ReflectionMethod($action, 'getDebianDockerInstallCommand');
+    $method->setAccessible(true);
+    $command = $method->invoke($action);
+
+    expect($command)->toContain('DOCKER_VERSION_CODENAME=${VERSION_CODENAME:-${VERSION_ID}}')
+        ->and($command)->toContain('if [ "${DOCKER_VERSION_CODENAME}" = "13" ]; then DOCKER_VERSION_CODENAME=trixie; fi')
+        ->and($command)->toContain('https://download.docker.com/linux/${ID} ${DOCKER_VERSION_CODENAME} stable');
+});

--- a/tests/Unit/ServerOsDetectionTest.php
+++ b/tests/Unit/ServerOsDetectionTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use App\Models\Server;
+
+it('resolves Debian family when ID is debian', function () {
+    $releaseData = Server::parseOsReleaseContent(<<<'EOT'
+        PRETTY_NAME="Debian GNU/Linux 13 (trixie)"
+        ID=debian
+        VERSION_ID="13"
+        VERSION_CODENAME=trixie
+        EOT
+    );
+
+    $supportedOs = Server::resolveSupportedOsTypeFromReleaseData($releaseData);
+
+    expect($supportedOs)->not->toBeFalse()
+        ->and($supportedOs->value())->toBe('ubuntu debian raspbian pop');
+});
+
+it('resolves Debian family when ID_LIKE includes debian', function () {
+    $releaseData = Server::parseOsReleaseContent(<<<'EOT'
+        NAME="Kali GNU/Linux"
+        ID=kali
+        ID_LIKE=debian
+        VERSION_ID="2026.1"
+        EOT
+    );
+
+    $supportedOs = Server::resolveSupportedOsTypeFromReleaseData($releaseData);
+
+    expect($supportedOs)->not->toBeFalse()
+        ->and($supportedOs->value())->toBe('ubuntu debian raspbian pop');
+});
+
+it('supports numeric VERSION_CODENAME value for Debian 13 releases', function () {
+    $releaseData = Server::parseOsReleaseContent(<<<'EOT'
+        PRETTY_NAME="Debian GNU/Linux 13"
+        ID=debian
+        VERSION_ID="13"
+        VERSION_CODENAME="13"
+        EOT
+    );
+
+    $supportedOs = Server::resolveSupportedOsTypeFromReleaseData($releaseData);
+
+    expect($supportedOs)->not->toBeFalse()
+        ->and($supportedOs->value())->toBe('ubuntu debian raspbian pop')
+        ->and(data_get($releaseData, 'VERSION_CODENAME'))->toBe('13');
+});
+
+it('returns false for unsupported distributions', function () {
+    $releaseData = Server::parseOsReleaseContent(<<<'EOT'
+        NAME="NixOS"
+        ID=nixos
+        ID_LIKE=linux
+        VERSION_ID="25.05"
+        EOT
+    );
+
+    $supportedOs = Server::resolveSupportedOsTypeFromReleaseData($releaseData);
+
+    expect($supportedOs)->toBeFalse();
+});


### PR DESCRIPTION
## Summary

This PR improves Debian 13 compatibility in the additional-server validation + Docker installation path.

## Root cause

In some Debian 13 environments, OS detection can rely on `ID_LIKE` rather than only `ID`, and Docker repository setup may fail when `VERSION_CODENAME` is numeric (`13`) instead of `trixie`.

## What changed

- `app/Models/Server.php`
  - Refactored `/etc/os-release` parsing into testable helpers.
  - OS family resolution now checks `ID` first, then falls back to `ID_LIKE`.
  - Unsupported distributions are still rejected explicitly (no silent fallback).

- `app/Actions/Server/InstallDocker.php`
  - Debian APT fallback now normalizes codename:
    - `DOCKER_VERSION_CODENAME=${VERSION_CODENAME:-${VERSION_ID}}`
    - if codename is `13`, map to `trixie`
  - Docker apt source uses normalized codename.

- Tests
  - `tests/Unit/ServerOsDetectionTest.php`
  - `tests/Unit/Actions/Server/InstallDockerCommandTest.php`

## Repro / verification steps

### Unit tests

```bash
php artisan test --compact tests/Unit/ServerOsDetectionTest.php
php artisan test --compact tests/Unit/Actions/Server/InstallDockerCommandTest.php
```

Expected:
- Debian 13 (`ID=debian`, `VERSION_CODENAME=trixie`) resolves to Debian family.
- Debian-like distro (`ID_LIKE=debian`) resolves to Debian family.
- Numeric codename path (`VERSION_CODENAME=13`) is accepted and covered.
- Unsupported distro still returns `false`.
- Debian Docker command contains `13 -> trixie` normalization.

### Manual flow (UI)

1. Add an additional server running Debian 13.
2. Run server validation + prerequisites + Docker installation.

Expected:
- Validation no longer fails due to Debian-family detection edge cases.
- Docker APT fallback uses normalized codename (`trixie`) when codename is numeric.

## Demo checklist

- [ ] Attach short demo video (Debian 13 server validation + install flow)

/claim #8154
