### PR TITLE
feat: make database proxy timeout configurable

### DIFF
--- a/app/Actions/Database/StartDatabaseProxy.php
+++ b/app/Actions/Database/StartDatabaseProxy.php
@@ -51,6 +51,7 @@ class StartDatabaseProxy
         }
 
         $configuration_dir = database_proxy_dir($database->uuid);
+        $proxyTimeout = data_get($database, 'proxy_timeout', 300);
         if (isDev()) {
             $configuration_dir = '/var/lib/docker/volumes/coolify_dev_coolify_data/_data/databases/'.$database->uuid.'/proxy';
         }
@@ -66,6 +67,9 @@ class StartDatabaseProxy
     stream {
        server {
             listen $database->public_port;
+            proxy_connect_timeout 60s;
+            proxy_timeout {$proxyTimeout}s;
+            proxy_buffer_size 16k;
             proxy_pass $containerName:$internalPort;
        }
     }

--- a/app/Livewire/Project/Database/Mysql/General.php
+++ b/app/Livewire/Project/Database/Mysql/General.php
@@ -46,6 +46,8 @@ class General extends Component
 
     public bool $isLogDrainEnabled = false;
 
+    public ?int $proxyTimeout = null;
+
     public ?string $customDockerRunOptions = null;
 
     public bool $enableSsl = false;
@@ -82,6 +84,7 @@ class General extends Component
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
             'isLogDrainEnabled' => 'nullable|boolean',
+            'proxyTimeout' => 'nullable|integer|min:0',
             'customDockerRunOptions' => 'nullable',
             'enableSsl' => 'boolean',
             'sslMode' => 'nullable|string|in:PREFERRED,REQUIRED,VERIFY_CA,VERIFY_IDENTITY',
@@ -160,6 +163,7 @@ class General extends Component
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
+            $this->database->proxy_timeout = $this->proxyTimeout;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->enable_ssl = $this->enableSsl;
             $this->database->ssl_mode = $this->sslMode;
@@ -180,6 +184,7 @@ class General extends Component
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
+            $this->proxyTimeout = $this->database->proxy_timeout;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->enableSsl = $this->database->enable_ssl;
             $this->sslMode = $this->database->ssl_mode;

--- a/app/Livewire/Project/Database/Postgresql/General.php
+++ b/app/Livewire/Project/Database/Postgresql/General.php
@@ -66,6 +66,8 @@ class General extends Component
 
     public ?Carbon $certificateValidUntil = null;
 
+    public ?int $proxyTimeout = null;
+
     public function getListeners()
     {
         $userId = Auth::id();
@@ -97,6 +99,7 @@ class General extends Component
             'customDockerRunOptions' => 'nullable',
             'enableSsl' => 'boolean',
             'sslMode' => 'nullable|string|in:allow,prefer,require,verify-ca,verify-full',
+            'proxyTimeout' => 'nullable|integer|min:0',
         ];
     }
 
@@ -133,6 +136,7 @@ class General extends Component
         'customDockerRunOptions' => 'Custom Docker Run Options',
         'enableSsl' => 'Enable SSL',
         'sslMode' => 'SSL Mode',
+        'proxyTimeout' => 'Proxy Timeout',
     ];
 
     public function mount()
@@ -178,6 +182,7 @@ class General extends Component
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->enable_ssl = $this->enableSsl;
             $this->database->ssl_mode = $this->sslMode;
+            $this->database->proxy_timeout = $this->proxyTimeout;
             $this->database->save();
 
             $this->db_url = $this->database->internal_db_url;
@@ -200,6 +205,7 @@ class General extends Component
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->enableSsl = $this->database->enable_ssl;
             $this->sslMode = $this->database->ssl_mode;
+            $this->proxyTimeout = $this->database->proxy_timeout;
             $this->db_url = $this->database->internal_db_url;
             $this->db_url_public = $this->database->external_db_url;
         }

--- a/app/Livewire/Project/Database/Redis/General.php
+++ b/app/Livewire/Project/Database/Redis/General.php
@@ -38,6 +38,8 @@ class General extends Component
 
     public bool $isLogDrainEnabled = false;
 
+    public ?int $proxyTimeout = null;
+
     public ?string $customDockerRunOptions = null;
 
     public string $redisUsername;
@@ -75,6 +77,7 @@ class General extends Component
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
             'isLogDrainEnabled' => 'nullable|boolean',
+            'proxyTimeout' => 'nullable|integer|min:0',
             'customDockerRunOptions' => 'nullable',
             'redisUsername' => 'required',
             'redisPassword' => 'required',
@@ -144,6 +147,7 @@ class General extends Component
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
+            $this->database->proxy_timeout = $this->proxyTimeout;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->enable_ssl = $this->enableSsl;
             $this->database->save();
@@ -159,6 +163,7 @@ class General extends Component
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
+            $this->proxyTimeout = $this->database->proxy_timeout;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->enableSsl = $this->database->enable_ssl;
             $this->dbUrl = $this->database->internal_db_url;

--- a/database/migrations/2026_02_12_000000_add_proxy_timeout_to_databases.php
+++ b/database/migrations/2026_02_12_000000_add_proxy_timeout_to_databases.php
@@ -1,0 +1,58 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $tables = [
+            'standalone_postgresqls',
+            'standalone_mysqls',
+            'standalone_mariadbs',
+            'standalone_mongodbs',
+            'standalone_redises',
+            'standalone_keydbs',
+            'standalone_dragonflies',
+            'standalone_clickhouses',
+            'service_databases',
+        ];
+
+        foreach ($tables as $table) {
+            if (Schema::hasTable($table)) {
+                Schema::table($table, function (Blueprint $table) {
+                    if (!Schema::hasColumn($table->getTable(), 'proxy_timeout')) {
+                        $table->integer('proxy_timeout')->default(300);
+                    }
+                });
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        $tables = [
+            'standalone_postgresqls',
+            'standalone_mysqls',
+            'standalone_mariadbs',
+            'standalone_mongodbs',
+            'standalone_redises',
+            'standalone_keydbs',
+            'standalone_dragonflies',
+            'standalone_clickhouses',
+            'service_databases',
+        ];
+
+        foreach ($tables as $table) {
+            if (Schema::hasTable($table)) {
+                Schema::table($table, function (Blueprint $table) {
+                    if (Schema::hasColumn($table->getTable(), 'proxy_timeout')) {
+                        $table->dropColumn('proxy_timeout');
+                    }
+                });
+            }
+        }
+    }
+};

--- a/resources/views/livewire/project/database/mysql/general.blade.php
+++ b/resources/views/livewire/project/database/mysql/general.blade.php
@@ -155,6 +155,11 @@
             </div>
             <x-forms.input placeholder="5432" disabled="{{ $isPublic }}"
                 id="publicPort" label="Public Port" canGate="update" :canResource="$database" />
+            @if ($isPublic)
+                <x-forms.input placeholder="300" id="proxyTimeout" label="Proxy Timeout (seconds)"
+                    helper="Timeout for the public proxy. Set to 0 to disable timeout." canGate="update"
+                    :canResource="$database" />
+            @endif
         </div>
         <x-forms.textarea label="Custom Mysql Configuration" rows="10" id="mysqlConf" canGate="update" :canResource="$database" />
         <h3 class="pt-4">Advanced</h3>

--- a/resources/views/livewire/project/database/postgresql/general.blade.php
+++ b/resources/views/livewire/project/database/postgresql/general.blade.php
@@ -165,6 +165,11 @@
                     </div>
                     <x-forms.input placeholder="5432" disabled="{{ $isPublic }}" id="publicPort"
                         label="Public Port" canGate="update" :canResource="$database" />
+                    @if ($isPublic)
+                        <x-forms.input placeholder="300" id="proxyTimeout" label="Proxy Timeout (seconds)"
+                            helper="Timeout for the public proxy. Set to 0 to disable timeout." canGate="update"
+                            :canResource="$database" />
+                    @endif
                 </div>
 
                 <div class="flex flex-col gap-2">

--- a/resources/views/livewire/project/database/redis/general.blade.php
+++ b/resources/views/livewire/project/database/redis/general.blade.php
@@ -134,6 +134,11 @@
             </div>
             <x-forms.input placeholder="5432" disabled="{{ $isPublic }}"
                 id="publicPort" label="Public Port" canGate="update" :canResource="$database" />
+            @if ($isPublic)
+                <x-forms.input placeholder="300" id="proxyTimeout" label="Proxy Timeout (seconds)"
+                    helper="Timeout for the public proxy. Set to 0 to disable timeout." canGate="update"
+                    :canResource="$database" />
+            @endif
         </div>
         <x-forms.textarea placeholder="# maxmemory 256mb
 # maxmemory-policy allkeys-lru


### PR DESCRIPTION
## Description
Currently, the public database proxy (using Nginx) has a default timeout that can interrupt long-running queries or data transfers. This PR adds a configurable timeout setting for public database proxies, allowing users to increase the timeout (defaulting to 300 seconds, and setting it to 0 for no timeout).

## Changes
- Added `proxy_timeout` field to database models via a new migration.
- Updated `StartDatabaseProxy` action to include `proxy_connect_timeout`, `proxy_timeout`, and `proxy_buffer_size` in the Nginx configuration.
- Updated the database General settings UI (PostgreSQL, MySQL, Redis) to include a 'Proxy Timeout' field.
- Updated Livewire components to handle saving the new setting.

Fixes #7743