### PR TITLE
fix(ssh): validate key file content and invalidate stale mux connections on key change

### DIFF
--- a/app/Helpers/SshMultiplexingHelper.php
+++ b/app/Helpers/SshMultiplexingHelper.php
@@ -44,9 +44,19 @@ class SshMultiplexingHelper
             return self::establishNewMultiplexedConnection($server);
         }
 
+        // Connection exists — verify the key hasn't changed since the mux was opened.
+        // A cached fingerprint mismatch means the server was re-keyed; the existing
+        // mux socket is authenticated with the old key and must be replaced.
+        if (self::isKeyStaleForConnection($server)) {
+            Log::info('SSH key fingerprint changed since mux was established, refreshing', [
+                'server_uuid' => $server->uuid,
+            ]);
+
+            return self::refreshMultiplexedConnection($server);
+        }
+
         // Connection exists, ensure we have metadata for age tracking
         if (self::getConnectionAge($server) === null) {
-            // Existing connection but no metadata, store current time as fallback
             self::storeConnectionMetadata($server);
         }
 
@@ -201,14 +211,92 @@ class SshMultiplexingHelper
         return config('constants.ssh.mux_enabled') && ! config('constants.coolify.is_windows_docker_desktop');
     }
 
+    /**
+     * Validate that the SSH key file exists on disk with correct content and permissions.
+     *
+     * The previous implementation only checked file existence (`ls`). This caused
+     * sporadic "Permission denied (publickey)" errors when:
+     * - The key was rotated in the database but the old file remained on disk
+     * - A container restart or volume remount left stale key files
+     * - File permissions drifted from the required 0600
+     *
+     * When a mismatch is detected the key is re-written, permissions are enforced,
+     * and all multiplexed connections using this key are torn down so the next
+     * SSH command authenticates with the current key.
+     *
+     * @see https://github.com/coollabsio/coolify/issues/7724
+     */
     private static function validateSshKey(PrivateKey $privateKey): void
     {
-        $keyLocation = $privateKey->getKeyLocation();
-        $checkKeyCommand = "ls $keyLocation 2>/dev/null";
-        $keyCheckProcess = Process::run($checkKeyCommand);
+        // Refresh from database to bypass Eloquent's in-memory/relationship cache
+        // that may hold a stale key from earlier in the same request lifecycle.
+        $freshKey = PrivateKey::find($privateKey->id);
+        if (! $freshKey) {
+            Log::error('SSH private key no longer exists in database', [
+                'key_id' => $privateKey->id,
+            ]);
 
-        if ($keyCheckProcess->exitCode() !== 0) {
-            $privateKey->storeInFileSystem();
+            return;
+        }
+
+        $keyLocation = $freshKey->getKeyLocation();
+        $needsRewrite = false;
+
+        if (! file_exists($keyLocation)) {
+            Log::debug('SSH key file missing from disk, writing key', [
+                'key_uuid' => $freshKey->uuid,
+            ]);
+            $needsRewrite = true;
+        } else {
+            // Verify file content matches database — detects stale keys after rotation
+            $diskContent = file_get_contents($keyLocation);
+            if ($diskContent !== $freshKey->private_key) {
+                Log::warning('SSH key file content does not match database, refreshing', [
+                    'key_uuid' => $freshKey->uuid,
+                ]);
+                $needsRewrite = true;
+            }
+        }
+
+        if ($needsRewrite) {
+            $freshKey->storeInFileSystem();
+
+            // Invalidate multiplexed connections that authenticated with the old key
+            foreach ($freshKey->servers as $server) {
+                try {
+                    self::removeMuxFile($server);
+                    Log::debug('Invalidated mux connection due to SSH key change', [
+                        'server_uuid' => $server->uuid,
+                        'key_uuid' => $freshKey->uuid,
+                    ]);
+                } catch (\Exception $e) {
+                    Log::warning('Failed to invalidate mux connection during key refresh', [
+                        'server_uuid' => $server->uuid,
+                        'error' => $e->getMessage(),
+                    ]);
+                }
+            }
+        }
+
+        // Enforce correct permissions — SSH refuses keys that are group/world-readable
+        self::ensureKeyPermissions($keyLocation);
+    }
+
+    /**
+     * Ensure the SSH key file has 0600 permissions.
+     *
+     * SSH clients reject private keys with overly permissive file modes.
+     * Laravel's Storage driver does not guarantee 0600 on every write.
+     */
+    private static function ensureKeyPermissions(string $keyLocation): void
+    {
+        if (! file_exists($keyLocation)) {
+            return;
+        }
+
+        $currentPerms = fileperms($keyLocation) & 0777;
+        if ($currentPerms !== 0600) {
+            chmod($keyLocation, 0600);
         }
     }
 
@@ -292,12 +380,40 @@ class SshMultiplexingHelper
     }
 
     /**
-     * Store connection metadata when a new connection is established
+     * Check if the SSH key used to establish the mux connection differs from the
+     * server's current key. Returns false when no cached fingerprint exists
+     * (pre-upgrade connections) to avoid unnecessary churn.
+     */
+    private static function isKeyStaleForConnection(Server $server): bool
+    {
+        $cached = Cache::get("ssh_mux_key_fingerprint_{$server->uuid}");
+        if ($cached === null) {
+            return false;
+        }
+
+        $privateKey = PrivateKey::find($server->private_key_id);
+        if (! $privateKey) {
+            return true; // Key deleted — force refresh to surface a clear error
+        }
+
+        return $cached !== $privateKey->fingerprint;
+    }
+
+    /**
+     * Store connection metadata (timestamp + key fingerprint) when a new
+     * connection is established.
      */
     private static function storeConnectionMetadata(Server $server): void
     {
-        $cacheKey = "ssh_mux_connection_time_{$server->uuid}";
-        Cache::put($cacheKey, time(), config('constants.ssh.mux_persist_time') + 300); // Cache slightly longer than persist time
+        $ttl = config('constants.ssh.mux_persist_time') + 300;
+
+        Cache::put("ssh_mux_connection_time_{$server->uuid}", time(), $ttl);
+
+        // Record which key authenticated this connection for later staleness checks.
+        $privateKey = PrivateKey::find($server->private_key_id);
+        if ($privateKey && $privateKey->fingerprint) {
+            Cache::put("ssh_mux_key_fingerprint_{$server->uuid}", $privateKey->fingerprint, $ttl);
+        }
     }
 
     /**
@@ -305,7 +421,7 @@ class SshMultiplexingHelper
      */
     private static function clearConnectionMetadata(Server $server): void
     {
-        $cacheKey = "ssh_mux_connection_time_{$server->uuid}";
-        Cache::forget($cacheKey);
+        Cache::forget("ssh_mux_connection_time_{$server->uuid}");
+        Cache::forget("ssh_mux_key_fingerprint_{$server->uuid}");
     }
 }

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -9,6 +9,7 @@ use App\Actions\Server\StartSentinel;
 use App\Actions\Server\ValidatePrerequisites;
 use App\Enums\ProxyTypes;
 use App\Events\ServerReachabilityChanged;
+use App\Helpers\SshMultiplexingHelper;
 use App\Helpers\SslHelper;
 use App\Jobs\CheckAndStartSentinelJob;
 use App\Jobs\RegenerateSslCertJob;
@@ -25,6 +26,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Stringable;
 use OpenApi\Attributes as OA;
@@ -136,6 +138,20 @@ class Server extends BaseModel
         static::saved(function ($server) {
             if ($server->privateKey?->isDirty()) {
                 refresh_server_connection($server->privateKey);
+            }
+
+            // When the server is switched to a different SSH key, tear down the
+            // multiplexed connection so it re-authenticates with the new key.
+            // @see https://github.com/coollabsio/coolify/issues/7724
+            if ($server->wasChanged('private_key_id')) {
+                try {
+                    SshMultiplexingHelper::removeMuxFile($server);
+                } catch (\Exception $e) {
+                    Log::warning('Failed to invalidate mux after SSH key change', [
+                        'server_uuid' => $server->uuid,
+                        'error' => $e->getMessage(),
+                    ]);
+                }
             }
         });
         static::created(function ($server) {


### PR DESCRIPTION
/claim #7724

## Problem

Sporadic `Permission denied (publickey,password)` errors occur because the SSH subsystem can silently use a **stale private key** to authenticate. Three independent failure modes combine to cause this:

### 1. Key file validation only checks existence, not content
`validateSshKey()` runs `ls` to confirm the file exists on disk, but never verifies its **content** matches the database. When a user rotates their SSH key (updates `private_key` in the DB), the old key file remains on disk and SSH happily authenticates with it — until it doesn't.

### 2. Multiplexed connections survive key rotation
Even if the key file is eventually refreshed, an existing **mux socket** stays open and continues authenticating with the key that was active when the connection was first established. There is no mechanism to detect that the underlying key has changed.

### 3. No file permission enforcement
SSH clients refuse private keys that are group- or world-readable (`0644`). Laravel's local Storage driver's `put()` does not guarantee `0600` permissions on every write, especially after container restarts or volume remounts.

## Root Cause

```php
// Before: only checks file existence
private static function validateSshKey(PrivateKey $privateKey): void
{
    $keyLocation = $privateKey->getKeyLocation();
    $checkKeyCommand = "ls $keyLocation 2>/dev/null";
    $keyCheckProcess = Process::run($checkKeyCommand);

    if ($keyCheckProcess->exitCode() !== 0) {
        $privateKey->storeInFileSystem();
    }
}
```

This passes as long as *any* file exists at that path — even if it contains a completely different (old) key.

## Solution

### `SshMultiplexingHelper::validateSshKey()` — content-aware validation
- **Refreshes** the `PrivateKey` model from the database (`PrivateKey::find()`) to bypass Eloquent's in-memory relationship cache that may hold a stale version from earlier in the request
- **Compares** file content against the DB value; re-writes the file on mismatch
- **Invalidates** all multiplexed connections for servers using that key when a mismatch is detected
- **Enforces** `0600` permissions on every invocation via `ensureKeyPermissions()`

### `SshMultiplexingHelper::ensureMultiplexedConnection()` — fingerprint tracking
- `storeConnectionMetadata()` now caches the SSH key **fingerprint** alongside the connection timestamp
- `isKeyStaleForConnection()` compares the cached fingerprint against the current key; triggers `refreshMultiplexedConnection()` on mismatch
- `clearConnectionMetadata()` cleans up both cache entries
- Gracefully handles pre-upgrade connections (no cached fingerprint → no forced refresh)

### `Server::saved()` — immediate mux teardown on key reassignment
- Detects `wasChanged('private_key_id')` in the `saved` hook
- Calls `SshMultiplexingHelper::removeMuxFile()` so the next SSH command establishes a fresh connection with the new key

## Files Changed

| File | Change |
|------|--------|
| `app/Helpers/SshMultiplexingHelper.php` | Content validation, permission enforcement, fingerprint tracking, mux invalidation |
| `app/Models/Server.php` | Mux teardown on `private_key_id` change |

## Defense in Depth

The fix operates at **three layers** to ensure no stale key can be used:

1. **File layer** — every `generateSshCommand()` call validates the key file content and permissions
2. **Mux layer** — every `ensureMultiplexedConnection()` call checks the key fingerprint against the one used when the mux was established
3. **Model layer** — changing a server's SSH key immediately tears down the mux socket

## Backward Compatibility

- All changes are additive; no config keys, database migrations, or API changes
- Pre-upgrade mux connections without cached fingerprints are left alone (no unnecessary churn)
- The existing retry mechanism (`SshRetryable` trait) continues to work as a complementary safety net