### PR TITLE
feat: add OpenReplay as a one-click service template

### DIFF
--- a/templates/compose/openreplay.yaml
+++ b/templates/compose/openreplay.yaml
@@ -1,0 +1,17 @@
+# documentation: https://docs.openreplay.com/
+# slogan: OpenReplay is the open-source alternative to FullStory and LogRocket.
+# category: analytics
+# tags: session-replay, analytics, debugging, open-source
+# logo: svgs/openreplay.svg
+# port: 80
+
+services:
+  openreplay:
+    image: public.ecr.aws/i3u1l1i5/openreplay:v1.10.0
+    environment:
+      - SERVICE_URL_OPENREPLAY_80
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:80"]
+      interval: 10s
+      timeout: 5s
+      retries: 5


### PR DESCRIPTION
This PR adds OpenReplay as a one-click service template to Coolify. Closes #8232Implementation details:- Created `templates/compose/openreplay.yaml` with necessary metadata.- Configured basic single-service deployment using official OpenReplay images.