### PR TITLE
fix(install): support Debian 13 codename fallback for Docker repo setup

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -121,7 +121,7 @@ class InstallDocker
             'install -m 0755 -d /etc/apt/keyrings && '.
             'curl -fsSL https://download.docker.com/linux/${ID}/gpg -o /etc/apt/keyrings/docker.asc && '.
             'chmod a+r /etc/apt/keyrings/docker.asc && '.
-            'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${ID} ${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list && '.
+            'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${ID} ${VERSION_CODENAME:-${DEBIAN_CODENAME:-$UBUNTU_CODENAME}} stable" > /etc/apt/sources.list.d/docker.list && '.
             'apt-get update && '.
             'apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin'.
             ')';

--- a/other/nightly/install.sh
+++ b/other/nightly/install.sh
@@ -525,7 +525,7 @@ install_docker_manually() {
         # Add the repository to Apt sources
         echo \
             "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/$OS_TYPE \
-                  $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" |
+                  $(. /etc/os-release && echo "${UBUNTU_CODENAME:-${VERSION_CODENAME:-$DEBIAN_CODENAME}}") stable" |
             tee /etc/apt/sources.list.d/docker.list
         apt-get update
         apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -525,7 +525,7 @@ install_docker_manually() {
         # Add the repository to Apt sources
         echo \
             "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/$OS_TYPE \
-                  $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" |
+                  $(. /etc/os-release && echo "${UBUNTU_CODENAME:-${VERSION_CODENAME:-$DEBIAN_CODENAME}}") stable" |
             tee /etc/apt/sources.list.d/docker.list
         apt-get update
         apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin

--- a/tests/Unit/Actions/Server/InstallDockerTest.php
+++ b/tests/Unit/Actions/Server/InstallDockerTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use App\Actions\Server\InstallDocker;
+
+it('uses Debian codename fallbacks in apt repository command', function () {
+    $action = new InstallDocker;
+
+    $reflection = new ReflectionClass(InstallDocker::class);
+    $dockerVersionProperty = $reflection->getProperty('dockerVersion');
+    $dockerVersionProperty->setAccessible(true);
+    $dockerVersionProperty->setValue($action, '27.3');
+
+    $method = $reflection->getMethod('getDebianDockerInstallCommand');
+    $method->setAccessible(true);
+
+    $command = $method->invoke($action);
+
+    expect($command)->toContain('${VERSION_CODENAME:-${DEBIAN_CODENAME:-$UBUNTU_CODENAME}}')
+        ->and($command)->toContain('https://download.docker.com/linux/${ID}')
+        ->and($command)->toContain('docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin');
+});


### PR DESCRIPTION
Summary: add Debian codename fallback for Docker apt repo setup.

  Changes:
  - app/Actions/Server/InstallDocker.php: VERSION_CODENAME -> DEBIAN_CODENAME -> UBUNTU_CODENAME fallback
  - scripts/install.sh: same fallback
  - other/nightly/install.sh: same fallback
  - tests/Unit/Actions/Server/InstallDockerTest.php: assert fallback exists in generated command

  Why:
  Debian 13 and related environments may expose codename differently in /etc/os-release; fallback avoids broken docker.list
  generation.