### PR TITLE
Add Debian 13 + Alpine support in server OS detection/install flow

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -80,6 +80,8 @@ class InstallDocker
                 $command = $command->merge([$this->getSuseDockerInstallCommand()]);
             } elseif ($supported_os_type->contains('arch')) {
                 $command = $command->merge([$this->getArchDockerInstallCommand()]);
+            } elseif ($supported_os_type->contains('alpine')) {
+                $command = $command->merge([$this->getAlpineDockerInstallCommand()]);
             } else {
                 $command = $command->merge([$this->getGenericDockerInstallCommand()]);
             }
@@ -118,10 +120,13 @@ class InstallDocker
     {
         return "curl --max-time 300 --retry 3 https://releases.rancher.com/install-docker/{$this->dockerVersion}.sh | sh || curl --max-time 300 --retry 3 https://get.docker.com | sh -s -- --version {$this->dockerVersion} || (".
             '. /etc/os-release && '.
+            'CODENAME="${VERSION_CODENAME:-}" && '.
+            'if [ -z "$CODENAME" ] || [ "$CODENAME" = "${VERSION_ID:-}" ]; then CODENAME=bookworm; fi && '.
+            'if [ "$ID" = "debian" ] && [ "$CODENAME" = "trixie" ]; then CODENAME=bookworm; fi && '.
             'install -m 0755 -d /etc/apt/keyrings && '.
             'curl -fsSL https://download.docker.com/linux/${ID}/gpg -o /etc/apt/keyrings/docker.asc && '.
             'chmod a+r /etc/apt/keyrings/docker.asc && '.
-            'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${ID} ${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list && '.
+            'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${ID} ${CODENAME} stable" > /etc/apt/sources.list.d/docker.list && '.
             'apt-get update && '.
             'apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin'.
             ')';
@@ -157,6 +162,14 @@ class InstallDocker
         return 'pacman -Syu --noconfirm --needed docker docker-compose && '.
             'systemctl enable docker.service && '.
             'systemctl start docker.service';
+    }
+
+    private function getAlpineDockerInstallCommand(): string
+    {
+        return 'apk update && '.
+            'apk add --no-cache docker docker-cli docker-cli-compose && '.
+            '(rc-update add docker boot >/dev/null 2>&1 || true) && '.
+            '(service docker start >/dev/null 2>&1 || rc-service docker start >/dev/null 2>&1 || true)';
     }
 
     private function getGenericDockerInstallCommand(): string

--- a/app/Actions/Server/InstallPrerequisites.php
+++ b/app/Actions/Server/InstallPrerequisites.php
@@ -53,6 +53,12 @@ class InstallPrerequisites
                 "echo 'Installing Prerequisites for Arch Linux...'",
                 'pacman -Syu --noconfirm --needed curl wget git jq',
             ]);
+        } elseif ($supported_os_type->contains('alpine')) {
+            $command = $command->merge([
+                "echo 'Installing Prerequisites for Alpine Linux...'",
+                'apk update',
+                'apk add --no-cache curl wget git jq',
+            ]);
         } else {
             throw new \Exception('Unsupported OS type for prerequisites installation');
         }

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -1044,25 +1044,63 @@ $schema://$host {
     public function validateOS(): bool|Stringable
     {
         $os_release = instant_remote_process(['cat /etc/os-release'], $this);
-        $releaseLines = collect(explode("\n", $os_release));
+        $collectedData = self::parseOsRelease($os_release);
+
+        return self::detectSupportedOsType($collectedData);
+    }
+
+    public static function parseOsRelease(string $osRelease): \Illuminate\Support\Collection
+    {
+        $releaseLines = collect(explode("\n", $osRelease));
         $collectedData = collect([]);
         foreach ($releaseLines as $line) {
             $item = str($line)->trim();
-            $collectedData->put($item->before('=')->value(), $item->after('=')->lower()->replace('"', '')->value());
-        }
-        $ID = data_get($collectedData, 'ID');
-        // $ID_LIKE = data_get($collectedData, 'ID_LIKE');
-        // $VERSION_ID = data_get($collectedData, 'VERSION_ID');
-        $supported = collect(SUPPORTED_OS)->filter(function ($supportedOs) use ($ID) {
-            if (str($supportedOs)->contains($ID)) {
-                return str($ID);
+            if ($item->isEmpty() || ! $item->contains('=')) {
+                continue;
             }
+
+            $key = $item->before('=');
+            $value = $item->after('=');
+            $collectedData->put($key->value(), $value->lower()->replace('"', '')->value());
+        }
+
+        return $collectedData;
+    }
+
+    public static function detectSupportedOsType(\Illuminate\Support\Collection $osRelease): bool|Stringable
+    {
+        $id = str((string) data_get($osRelease, 'ID', ''))->trim()->value();
+        $idLike = str((string) data_get($osRelease, 'ID_LIKE', ''))->trim()->value();
+
+        $supported = collect(SUPPORTED_OS)->first(function ($supportedOs) use ($id, $idLike) {
+            $supportedIds = collect(explode(' ', $supportedOs))
+                ->filter()
+                ->map(fn ($value) => str($value)->lower()->value())
+                ->values();
+
+            if ($id !== '' && $supportedIds->contains($id)) {
+                return true;
+            }
+
+            if ($idLike !== '') {
+                $idLikeValues = collect(explode(' ', $idLike))
+                    ->filter()
+                    ->map(fn ($value) => str($value)->lower()->value())
+                    ->values();
+
+                if ($idLikeValues->intersect($supportedIds)->isNotEmpty()) {
+                    return true;
+                }
+            }
+
+            return false;
         });
-        if ($supported->count() === 1) {
-            return str($supported->first());
-        } else {
+
+        if (! $supported) {
             return false;
         }
+
+        return str($supported);
     }
 
     public function isTerminalEnabled()

--- a/tests/Unit/ServerOsDetectionTest.php
+++ b/tests/Unit/ServerOsDetectionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use App\Actions\Server\InstallDocker;
+use App\Models\Server;
+
+it('detects supported OS using ID', function () {
+    $parsed = Server::parseOsRelease("ID=debian\nVERSION_ID=13\nVERSION_CODENAME=trixie\n");
+    $detected = Server::detectSupportedOsType($parsed);
+
+    expect((string) $detected)->toContain('debian');
+});
+
+it('detects supported OS using ID_LIKE fallback', function () {
+    $parsed = Server::parseOsRelease("ID=customlinux\nID_LIKE=debian\nVERSION_ID=1\n");
+    $detected = Server::detectSupportedOsType($parsed);
+
+    expect((string) $detected)->toContain('debian');
+});
+
+it('returns false for unsupported OS', function () {
+    $parsed = Server::parseOsRelease("ID=myos\nID_LIKE=unknown\n");
+
+    expect(Server::detectSupportedOsType($parsed))->toBeFalse();
+});
+
+it('uses codename fallback logic in debian docker install command', function () {
+    $action = new InstallDocker;
+    $reflection = new ReflectionClass($action);
+    $method = $reflection->getMethod('getDebianDockerInstallCommand');
+    $method->setAccessible(true);
+    $command = $method->invoke($action);
+
+    expect($command)
+        ->toContain('CODENAME="${VERSION_CODENAME:-}"')
+        ->toContain('if [ "$ID" = "debian" ] && [ "$CODENAME" = "trixie" ]; then CODENAME=bookworm; fi')
+        ->toContain('${CODENAME}');
+});
+
+it('contains alpine docker install command', function () {
+    $action = new InstallDocker;
+    $reflection = new ReflectionClass($action);
+    $method = $reflection->getMethod('getAlpineDockerInstallCommand');
+    $method->setAccessible(true);
+    $command = $method->invoke($action);
+
+    expect($command)
+        ->toContain('apk add --no-cache docker docker-cli docker-cli-compose')
+        ->toContain('service docker start');
+});


### PR DESCRIPTION
/claim #8154

## Summary
- improve OS family detection by using both `ID` and `ID_LIKE` from `/etc/os-release`
- keep Debian 13 compatible by falling back Docker apt repo codename to `bookworm` when codename is missing/numeric or equals `trixie`
- add explicit Alpine prerequisites + Docker install path

## Changes
- `app/Models/Server.php`
  - extracted `parseOsRelease()`
  - added `detectSupportedOsType()` with `ID_LIKE` fallback support
- `app/Actions/Server/InstallPrerequisites.php`
  - added Alpine branch (`apk update && apk add --no-cache curl wget git jq`)
- `app/Actions/Server/InstallDocker.php`
  - added Alpine Docker install command
  - added Debian codename normalization fallback for Docker apt repo setup
- `tests/Unit/ServerOsDetectionTest.php`
  - OS detection tests for `ID`, `ID_LIKE`, unsupported OS
  - command-generation checks for Debian codename fallback and Alpine install command

Closes #8154