### PR TITLE
Add separate OAuth registration toggle

### DIFF
--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -22,7 +22,7 @@ class OauthController extends Controller
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! $settings->is_oauth_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -15,6 +15,9 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $is_oauth_registration_enabled;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -41,6 +44,7 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_registration_enabled' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => 'nullable|string',
@@ -62,6 +66,7 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -138,6 +143,7 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/database/migrations/2026_02_13_000001_add_is_oauth_registration_enabled_to_instance_settings_table.php
+++ b/database/migrations/2026_02_13_000001_add_is_oauth_registration_enabled_to_instance_settings_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_registration_enabled')->default(false)->after('is_registration_enabled');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn('is_oauth_registration_enabled');
+        });
+    }
+};

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -22,6 +22,11 @@
                             label="Registration Allowed" />
                     </div>
                     <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_registration_enabled"
+                            helper="Allow new users to register through OAuth providers (GitHub, Google, etc.) even when general registration is disabled."
+                            label="OAuth Registration Allowed" />
+                    </div>
+                    <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"
                             helper="Opt out of reporting this instance to coolify.io's installation count. No other data is collected."
                             label="Do Not Track" />


### PR DESCRIPTION
### Changes

- Added `is_oauth_registration_enabled` boolean column to `instance_settings` table (defaults to `false`, preserving current behavior)
- Modified `OauthController::callback()` to allow new user creation when either `is_registration_enabled` OR `is_oauth_registration_enabled` is true
- Added the toggle to the Advanced Settings page in the Livewire component and Blade view, placed directly below the existing "Registration Allowed" checkbox

This lets admins disable password-based self-registration while still allowing users to register through configured OAuth providers (GitHub, Google, etc.). Before this change, disabling registration blocked OAuth signups too, which forced admins to choose between open registration for everyone or manually creating accounts for OAuth users.

### Issues

- fixes: #8042

### Category

- [x] New feature

### Screenshots or Video (if applicable)

Will provide screen recording on request. The UI change is a single checkbox added below "Registration Allowed" in Settings > Advanced.

### AI Usage

- [x] AI is used in the process of creating this PR

### Steps to Test

- Step 1 – Run `php artisan migrate` to add the new `is_oauth_registration_enabled` column
- Step 2 – Go to Settings > Advanced. Confirm the new "OAuth Registration Allowed" checkbox appears below "Registration Allowed"
- Step 3 – Disable both "Registration Allowed" and "OAuth Registration Allowed". Configure an OAuth provider (e.g. GitHub) in Settings > Auth. Open an incognito window, click the OAuth login button, and authenticate with a new account (not already in the database). Confirm you get a 403 "Registration is disabled" error.
- Step 4 – Go back to Settings > Advanced and enable "OAuth Registration Allowed" (keep "Registration Allowed" disabled). Repeat the OAuth login flow with a new account. Confirm the user is created and logged in.
- Step 5 – Verify that the Fortify registration form at /register still shows "Registration disabled" (password-based registration remains off)

### Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them