### PR TITLE
feat: Docker Compose database detection and backup support

### DIFF
--- a/app/Actions/Database/StartDatabaseProxy.php
+++ b/app/Actions/Database/StartDatabaseProxy.php
@@ -31,9 +31,9 @@ class StartDatabaseProxy
 
         if ($database->getMorphClass() === \App\Models\ServiceDatabase::class) {
             $databaseType = $database->databaseType();
-            $network = $database->service->uuid;
-            $server = data_get($database, 'service.destination.server');
-            $containerName = "{$database->name}-{$database->service->uuid}";
+            $network = $database->getNetwork();
+            $server = $database->getServer();
+            $containerName = "{$database->name}-{$database->getOwnerUuid()}";
         }
         $internalPort = match ($databaseType) {
             'standalone-mariadb', 'standalone-mysql' => 3306,

--- a/app/Actions/Database/StopDatabaseProxy.php
+++ b/app/Actions/Database/StopDatabaseProxy.php
@@ -25,7 +25,7 @@ class StopDatabaseProxy
         $server = data_get($database, 'destination.server');
         $uuid = $database->uuid;
         if ($database->getMorphClass() === \App\Models\ServiceDatabase::class) {
-            $server = data_get($database, 'service.server');
+            $server = $database->getServer();
         }
         instant_remote_process(["docker rm -f {$uuid}-proxy"], $server);
 

--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -93,7 +93,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $this->database = data_get($this->backup, 'database');
-                $this->server = $this->database->service->server;
+                $this->server = $this->database->getServer();
                 $this->s3 = $this->backup->s3;
             } else {
                 $this->database = data_get($this->backup, 'database');
@@ -115,8 +115,8 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $databaseType = $this->database->databaseType();
-                $serviceUuid = $this->database->service->uuid;
-                $serviceName = str($this->database->service->name)->slug();
+                $serviceUuid = $this->database->getOwnerUuid();
+                $serviceName = str($this->database->getOwner()->name)->slug();
                 if (str($databaseType)->contains('postgres')) {
                     $this->container_name = "{$this->database->name}-$serviceUuid";
                     $this->directory_name = $serviceName.'-'.$this->container_name;
@@ -630,7 +630,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             $endpoint = $this->s3->endpoint;
             $this->s3->testConnection(shouldSave: true);
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
-                $network = $this->database->service->destination->network;
+                $network = $this->database->getNetwork();
             } else {
                 $network = $this->database->destination->network;
             }

--- a/app/Livewire/Project/Application/DatabaseBackups.php
+++ b/app/Livewire/Project/Application/DatabaseBackups.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Livewire\Project\Application;
+
+use App\Models\Application;
+use App\Models\ServiceDatabase;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Component;
+
+class DatabaseBackups extends Component
+{
+    use AuthorizesRequests;
+
+    public ?Application $application = null;
+
+    public ?ServiceDatabase $serviceDatabase = null;
+
+    public $project;
+
+    public $environment;
+
+    public array $parameters;
+
+    protected $listeners = ['refreshScheduledBackups' => '$refresh'];
+
+    public function mount()
+    {
+        try {
+            $this->parameters = get_route_parameters();
+
+            $project = currentTeam()
+                ->projects()
+                ->select('id', 'uuid', 'team_id')
+                ->where('uuid', request()->route('project_uuid'))
+                ->firstOrFail();
+            $environment = $project->environments()
+                ->select('id', 'uuid', 'name', 'project_id')
+                ->where('uuid', request()->route('environment_uuid'))
+                ->firstOrFail();
+            $this->application = $environment->applications()
+                ->where('uuid', request()->route('application_uuid'))
+                ->firstOrFail();
+
+            $this->project = $project;
+            $this->environment = $environment;
+
+            $this->authorize('view', $this->application);
+
+            $this->serviceDatabase = $this->application->composeDatabases()
+                ->whereUuid($this->parameters['stack_service_uuid'])
+                ->first();
+
+            if (! $this->serviceDatabase) {
+                return redirect()->route('project.application.configuration', [
+                    'project_uuid' => $this->parameters['project_uuid'],
+                    'environment_uuid' => $this->parameters['environment_uuid'],
+                    'application_uuid' => $this->parameters['application_uuid'],
+                ]);
+            }
+
+            if (! $this->serviceDatabase->isBackupSolutionAvailable()) {
+                return redirect()->route('project.application.configuration', [
+                    'project_uuid' => $this->parameters['project_uuid'],
+                    'environment_uuid' => $this->parameters['environment_uuid'],
+                    'application_uuid' => $this->parameters['application_uuid'],
+                ]);
+            }
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function render()
+    {
+        return view('livewire.project.application.database-backups');
+    }
+}

--- a/app/Livewire/Project/Database/BackupEdit.php
+++ b/app/Livewire/Project/Database/BackupEdit.php
@@ -157,7 +157,7 @@ class BackupEdit extends Component
         try {
             $server = null;
             if ($this->backup->database instanceof \App\Models\ServiceDatabase) {
-                $server = $this->backup->database->service->destination->server;
+                $server = $this->backup->database->getServer();
             } elseif ($this->backup->database->destination && $this->backup->database->destination->server) {
                 $server = $this->backup->database->destination->server;
             }
@@ -184,6 +184,15 @@ class BackupEdit extends Component
 
             if ($this->backup->database->getMorphClass() === \App\Models\ServiceDatabase::class) {
                 $serviceDatabase = $this->backup->database;
+
+                if ($serviceDatabase->application_id) {
+                    return redirect()->route('project.application.database.backups', [
+                        'project_uuid' => $this->parameters['project_uuid'],
+                        'environment_uuid' => $this->parameters['environment_uuid'],
+                        'application_uuid' => $serviceDatabase->application->uuid,
+                        'stack_service_uuid' => $serviceDatabase->uuid,
+                    ]);
+                }
 
                 return redirect()->route('project.service.database.backups', [
                     'project_uuid' => $this->parameters['project_uuid'],

--- a/app/Livewire/Project/Database/BackupExecutions.php
+++ b/app/Livewire/Project/Database/BackupExecutions.php
@@ -79,7 +79,7 @@ class BackupExecutions extends Component
         }
 
         $server = $execution->scheduledDatabaseBackup->database->getMorphClass() === \App\Models\ServiceDatabase::class
-            ? $execution->scheduledDatabaseBackup->database->service->destination->server
+            ? $execution->scheduledDatabaseBackup->database->getServer()
             : $execution->scheduledDatabaseBackup->database->destination->server;
 
         try {
@@ -182,7 +182,7 @@ class BackupExecutions extends Component
             $server = null;
 
             if ($this->database instanceof \App\Models\ServiceDatabase) {
-                $server = $this->database->service->destination->server;
+                $server = $this->database->getServer();
             } elseif ($this->database->destination && $this->database->destination->server) {
                 $server = $this->database->destination->server;
             }

--- a/app/Livewire/Project/Database/Import.php
+++ b/app/Livewire/Project/Database/Import.php
@@ -314,12 +314,12 @@ EOD;
 
         // Handle ServiceDatabase server access differently
         if ($resource->getMorphClass() === \App\Models\ServiceDatabase::class) {
-            $server = $resource->service?->server;
+            $server = $resource->getServer();
             if (! $server) {
                 abort(404, 'Server not found for this service database.');
             }
             $this->serverId = $server->id;
-            $this->container = $resource->name.'-'.$resource->service->uuid;
+            $this->container = $resource->name.'-'.$resource->getOwnerUuid();
             $this->resourceUuid = $resource->uuid; // Use ServiceDatabase's own UUID
 
             // Determine database type for ServiceDatabase
@@ -633,7 +633,7 @@ EOD;
 
             // Get the database destination network
             if ($this->resource->getMorphClass() === \App\Models\ServiceDatabase::class) {
-                $destinationNetwork = $this->resource->service->destination->network ?? 'coolify';
+                $destinationNetwork = $this->resource->getNetwork() ?? 'coolify';
             } else {
                 $destinationNetwork = $this->resource->destination->network ?? 'coolify';
             }

--- a/app/Livewire/Project/Service/Index.php
+++ b/app/Livewire/Project/Service/Index.php
@@ -137,7 +137,7 @@ class Index extends Component
 
     private function initializeDatabaseProperties(): void
     {
-        $this->server = $this->serviceDatabase->service->destination->server;
+        $this->server = $this->serviceDatabase->getServer();
         if ($this->serviceDatabase->is_public) {
             $this->db_url_public = $this->serviceDatabase->getServiceDatabaseUrl();
         }
@@ -221,7 +221,7 @@ class Index extends Component
     {
         try {
             $this->authorize('update', $this->serviceDatabase);
-            if (! $this->serviceDatabase->service->destination->server->isLogDrainEnabled()) {
+            if (! $this->serviceDatabase->getServer()->isLogDrainEnabled()) {
                 $this->isLogDrainEnabled = false;
                 $this->dispatch('error', 'Log drain is not enabled on the server. Please enable it first.');
 

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -200,6 +200,11 @@ class Application extends BaseModel
                                 ->orWhere('key', 'LIKE', 'SERVICE_URL_%');
                         })
                         ->delete();
+
+                    // Remove detected compose databases
+                    $application->composeDatabases()->each(function ($db) {
+                        $db->delete();
+                    });
                 }
 
                 // Clear Dockerfile specific data when switching away from dockerfile
@@ -247,6 +252,9 @@ class Application extends BaseModel
             foreach ($application->deployment_queue as $deployment) {
                 $deployment->delete();
             }
+            $application->composeDatabases()->each(function ($db) {
+                $db->delete();
+            });
         });
     }
 
@@ -913,6 +921,11 @@ class Application extends BaseModel
     public function deployment_queue()
     {
         return $this->hasMany(ApplicationDeploymentQueue::class);
+    }
+
+    public function composeDatabases(): HasMany
+    {
+        return $this->hasMany(ServiceDatabase::class);
     }
 
     public function destination()

--- a/app/Models/LocalFileVolume.php
+++ b/app/Models/LocalFileVolume.php
@@ -47,10 +47,10 @@ class LocalFileVolume extends BaseModel
     public function loadStorageOnServer()
     {
         $this->load(['service']);
-        $isService = data_get($this->resource, 'service');
+        $isService = data_get($this->resource, 'service') || data_get($this->resource, 'application_id');
         if ($isService) {
-            $workdir = $this->resource->service->workdir();
-            $server = $this->resource->service->server;
+            $workdir = $this->resource->workdir();
+            $server = $this->resource->getServer();
         } else {
             $workdir = $this->resource->workdir();
             $server = $this->resource->destination->server;
@@ -82,10 +82,10 @@ class LocalFileVolume extends BaseModel
     public function deleteStorageOnServer()
     {
         $this->load(['service']);
-        $isService = data_get($this->resource, 'service');
+        $isService = data_get($this->resource, 'service') || data_get($this->resource, 'application_id');
         if ($isService) {
-            $workdir = $this->resource->service->workdir();
-            $server = $this->resource->service->server;
+            $workdir = $this->resource->workdir();
+            $server = $this->resource->getServer();
         } else {
             $workdir = $this->resource->workdir();
             $server = $this->resource->destination->server;
@@ -119,10 +119,10 @@ class LocalFileVolume extends BaseModel
     public function saveStorageOnServer()
     {
         $this->load(['service']);
-        $isService = data_get($this->resource, 'service');
+        $isService = data_get($this->resource, 'service') || data_get($this->resource, 'application_id');
         if ($isService) {
-            $workdir = $this->resource->service->workdir();
-            $server = $this->resource->service->server;
+            $workdir = $this->resource->workdir();
+            $server = $this->resource->getServer();
         } else {
             $workdir = $this->resource->workdir();
             $server = $this->resource->destination->server;

--- a/app/Models/ScheduledDatabaseBackup.php
+++ b/app/Models/ScheduledDatabaseBackup.php
@@ -67,8 +67,7 @@ class ScheduledDatabaseBackup extends BaseModel
     {
         if ($this->database) {
             if ($this->database instanceof ServiceDatabase) {
-                $destination = data_get($this->database->service, 'destination');
-                $server = data_get($destination, 'server');
+                $server = $this->database->getServer();
             } else {
                 $destination = data_get($this->database, 'destination');
                 $server = data_get($destination, 'server');

--- a/app/Models/ServiceDatabase.php
+++ b/app/Models/ServiceDatabase.php
@@ -27,7 +27,10 @@ class ServiceDatabase extends BaseModel
 
     public static function ownedByCurrentTeamAPI(int $teamId)
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', $teamId)->orderBy('name');
+        return ServiceDatabase::where(function ($query) use ($teamId) {
+            $query->whereRelation('service.environment.project.team', 'id', $teamId)
+                ->orWhereRelation('application.environment.project.team', 'id', $teamId);
+        })->orderBy('name');
     }
 
     /**
@@ -36,7 +39,10 @@ class ServiceDatabase extends BaseModel
      */
     public static function ownedByCurrentTeam()
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', currentTeam()->id)->orderBy('name');
+        return ServiceDatabase::where(function ($query) {
+            $query->whereRelation('service.environment.project.team', 'id', currentTeam()->id)
+                ->orWhereRelation('application.environment.project.team', 'id', currentTeam()->id);
+        })->orderBy('name');
     }
 
     /**
@@ -49,10 +55,54 @@ class ServiceDatabase extends BaseModel
         });
     }
 
+    /**
+     * Get the owner of this database (either a Service or an Application).
+     */
+    public function getOwner()
+    {
+        return $this->service ?? $this->application;
+    }
+
+    /**
+     * Get the UUID of the owner (Service or Application).
+     */
+    public function getOwnerUuid(): ?string
+    {
+        $owner = $this->getOwner();
+
+        return $owner?->uuid;
+    }
+
+    /**
+     * Get the server this database runs on.
+     */
+    public function getServer()
+    {
+        if ($this->service_id) {
+            return $this->service?->server;
+        }
+
+        return $this->application?->destination?->server;
+    }
+
+    /**
+     * Get the network for this database.
+     */
+    public function getNetwork(): ?string
+    {
+        if ($this->service_id) {
+            return $this->service?->uuid;
+        }
+
+        return $this->application?->destination?->network;
+    }
+
     public function restart()
     {
-        $container_id = $this->name.'-'.$this->service->uuid;
-        remote_process(["docker restart {$container_id}"], $this->service->server);
+        $ownerUuid = $this->getOwnerUuid();
+        $server = $this->getServer();
+        $container_id = $this->name.'-'.$ownerUuid;
+        remote_process(["docker restart {$container_id}"], $server);
     }
 
     public function isRunning()
@@ -114,8 +164,9 @@ class ServiceDatabase extends BaseModel
     public function getServiceDatabaseUrl()
     {
         $port = $this->public_port;
-        $realIp = $this->service->server->ip;
-        if ($this->service->server->isLocalhost() || isDev()) {
+        $server = $this->getServer();
+        $realIp = $server->ip;
+        if ($server->isLocalhost() || isDev()) {
             $realIp = base_ip();
         }
 
@@ -124,17 +175,32 @@ class ServiceDatabase extends BaseModel
 
     public function team()
     {
-        return data_get($this, 'environment.project.team');
+        if ($this->service_id) {
+            return data_get($this, 'service.environment.project.team');
+        }
+
+        return data_get($this, 'application.environment.project.team');
     }
 
     public function workdir()
     {
-        return service_configuration_dir()."/{$this->service->uuid}";
+        $ownerUuid = $this->getOwnerUuid();
+
+        if ($this->application_id) {
+            return application_configuration_dir()."/{$ownerUuid}";
+        }
+
+        return service_configuration_dir()."/{$ownerUuid}";
     }
 
     public function service()
     {
         return $this->belongsTo(Service::class);
+    }
+
+    public function application()
+    {
+        return $this->belongsTo(Application::class);
     }
 
     public function persistentStorages()

--- a/bootstrap/helpers/databases.php
+++ b/bootstrap/helpers/databases.php
@@ -346,7 +346,7 @@ function deleteOldBackupsLocally($backup): Collection
 
     $server = null;
     if ($backup->database_type === \App\Models\ServiceDatabase::class) {
-        $server = $backup->database->service->server;
+        $server = $backup->database->getServer();
     } else {
         $server = $backup->database->destination->server;
     }

--- a/bootstrap/helpers/parsers.php
+++ b/bootstrap/helpers/parsers.php
@@ -641,6 +641,39 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
         }
     }
 
+    // Detect and register database services for backup support (skip for preview deployments)
+    if ($pull_request_id === 0) {
+        $detectedDatabaseNames = collect([]);
+        foreach ($services as $serviceName => $service) {
+            $serviceImage = data_get_str($service, 'image');
+            if (isDatabaseImage($serviceImage, $service)) {
+                $detectedDatabaseNames->push($serviceName);
+                $savedDb = ServiceDatabase::firstOrCreate([
+                    'name' => $serviceName,
+                    'application_id' => $resource->id,
+                ]);
+                if ($savedDb->image !== $serviceImage) {
+                    $savedDb->image = $serviceImage;
+                    $savedDb->save();
+                }
+            }
+        }
+        // Clean up stale ServiceDatabase records for services no longer in the compose file
+        if ($detectedDatabaseNames->isNotEmpty()) {
+            ServiceDatabase::where('application_id', $resource->id)
+                ->whereNotIn('name', $detectedDatabaseNames->toArray())
+                ->each(function ($db) {
+                    $db->delete();
+                });
+        } else {
+            // No databases detected, remove all application-owned service databases
+            ServiceDatabase::where('application_id', $resource->id)
+                ->each(function ($db) {
+                    $db->delete();
+                });
+        }
+    }
+
     // generate SERVICE_NAME variables for docker compose services
     $serviceNameEnvironments = collect([]);
     if ($resource->build_pack === 'dockercompose') {

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -555,9 +555,12 @@ function getResourceByUuid(string $uuid, ?int $teamId = null)
         return null;
     }
 
-    // ServiceDatabase has a different relationship path: service->environment->project->team_id
+    // ServiceDatabase has a different relationship path depending on ownership
     if ($resource instanceof \App\Models\ServiceDatabase) {
-        if ($resource->service?->environment?->project?->team_id === $teamId) {
+        if ($resource->service_id && $resource->service?->environment?->project?->team_id === $teamId) {
+            return $resource;
+        }
+        if ($resource->application_id && $resource->application?->environment?->project?->team_id === $teamId) {
             return $resource;
         }
 

--- a/database/migrations/2026_02_14_000001_add_application_id_to_service_databases.php
+++ b/database/migrations/2026_02_14_000001_add_application_id_to_service_databases.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->foreignId('application_id')->nullable()->after('service_id')->constrained()->cascadeOnDelete();
+            $table->unsignedBigInteger('service_id')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->dropForeign(['application_id']);
+            $table->dropColumn('application_id');
+            $table->unsignedBigInteger('service_id')->nullable(false)->change();
+        });
+    }
+};

--- a/resources/views/livewire/project/application/configuration.blade.php
+++ b/resources/views/livewire/project/application/configuration.blade.php
@@ -54,6 +54,14 @@
                 <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
                     href="{{ route('project.application.healthcheck', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Healthcheck</span></a>
             @endif
+            @if ($application->build_pack === 'dockercompose')
+                @foreach ($application->composeDatabases as $composeDb)
+                    @if ($composeDb->isBackupSolutionAvailable())
+                        <a class="sub-menu-item" {{ wireNavigate() }}
+                            href="{{ route('project.application.database.backups', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid, 'stack_service_uuid' => $composeDb->uuid]) }}"><span class="menu-item-label">Backups: {{ $composeDb->name }}</span></a>
+                    @endif
+                @endforeach
+            @endif
             <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
                 href="{{ route('project.application.rollback', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Rollback</span></a>
             <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"

--- a/resources/views/livewire/project/application/database-backups.blade.php
+++ b/resources/views/livewire/project/application/database-backups.blade.php
@@ -1,0 +1,24 @@
+<div>
+    <x-slot:title>
+        {{ data_get_str($application, 'name')->limit(10) }} >
+        {{ data_get_str($serviceDatabase, 'name')->limit(10) }} > Backups | Coolify
+    </x-slot>
+    <livewire:project.application.heading :application="$application" />
+    <div class="flex flex-col h-full gap-8 sm:flex-row">
+        <div class="sub-menu-wrapper">
+            <a class='sub-menu-item' {{ wireNavigate() }}
+                href="{{ route('project.application.configuration', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Back to Configuration</span></a>
+        </div>
+        <div class="w-full">
+            <div class="flex gap-2">
+                <h2 class="pb-4">Scheduled Backups for {{ $serviceDatabase->name }}</h2>
+                @can('update', $application)
+                    <x-modal-input buttonTitle="+ Add" title="New Scheduled Backup">
+                        <livewire:project.database.create-scheduled-backup :database="$serviceDatabase" />
+                    </x-modal-input>
+                @endcan
+            </div>
+            <livewire:project.database.scheduled-backups :database="$serviceDatabase" />
+        </div>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,7 @@ use App\Livewire\Notifications\Telegram as NotificationTelegram;
 use App\Livewire\Notifications\Webhook as NotificationWebhook;
 use App\Livewire\Profile\Index as ProfileIndex;
 use App\Livewire\Project\Application\Configuration as ApplicationConfiguration;
+use App\Livewire\Project\Application\DatabaseBackups as ApplicationDatabaseBackups;
 use App\Livewire\Project\Application\Deployment\Index as DeploymentIndex;
 use App\Livewire\Project\Application\Deployment\Show as DeploymentShow;
 use App\Livewire\Project\CloneMe as ProjectCloneMe;
@@ -214,6 +215,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/logs', Logs::class)->name('project.application.logs');
         Route::get('/terminal', ExecuteContainerCommand::class)->name('project.application.command')->middleware('can.access.terminal');
         Route::get('/tasks/{task_uuid}', ScheduledTaskShow::class)->name('project.application.scheduled-tasks');
+        Route::get('/{stack_service_uuid}/backups', ApplicationDatabaseBackups::class)->name('project.application.database.backups');
     });
     Route::prefix('project/{project_uuid}/environment/{environment_uuid}/database/{database_uuid}')->group(function () {
         Route::get('/', DatabaseConfiguration::class)->name('project.database.configuration');
@@ -328,7 +330,7 @@ Route::middleware(['auth'])->group(function () {
             }
             $filename = data_get($execution, 'filename');
             if ($execution->scheduledDatabaseBackup->database->getMorphClass() === \App\Models\ServiceDatabase::class) {
-                $server = $execution->scheduledDatabaseBackup->database->service->destination->server;
+                $server = $execution->scheduledDatabaseBackup->database->getServer();
             } else {
                 $server = $execution->scheduledDatabaseBackup->database->destination->server;
             }


### PR DESCRIPTION
### Changes

Add automatic detection of database services in Docker Compose applications deployed via the `dockercompose` build pack, and enable backup support for detected databases. Fixes a long-standing gap where Compose-deployed databases had no backup path in Coolify.

- **Database schema**: Add nullable `application_id` FK to `service_databases` table; make `service_id` nullable so a `ServiceDatabase` record can be owned by either a `Service` or an `Application`.
- **Model layer**: `ServiceDatabase` gains `application()` relationship and helper methods (`getOwner()`, `getOwnerUuid()`, `getServer()`, `getNetwork()`) that abstract over both ownership types. `Application` gains `composeDatabases()` hasMany relationship with cleanup on build pack switch and force delete.
- **Parser**: In `applicationParser()` (`bootstrap/helpers/parsers.php`), after the magic environments loop, a new pre-pass detects database images via `isDatabaseImage()` and creates/updates `ServiceDatabase` records with `application_id`. Skips preview deployments. Cleans up stale records when services are removed from compose.
- **Downstream fixes**: All 14 files that previously hardcoded `$database->service->...` chains are updated to use the new helper methods, so application-owned `ServiceDatabase` records work correctly for backups, proxy management, imports, and file storage.
- **UI**: Adds "Backups: {db_name}" sidebar links to the Application configuration page for `dockercompose` apps with detected databases. New `ApplicationDatabaseBackups` Livewire component, view, and route.

### Issues

- fixes: #7528

### Category

- [ ] Bug fix
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

### Screenshots or Video (if applicable)

N/A - backend logic and existing UI components; no new visual elements beyond sidebar links that follow existing patterns.

### AI Usage

- [ ] AI is used in the process of creating this PR
- [x] AI is NOT used in the process of creating this PR

### Steps to Test

- Step 1 – Create a Docker Compose application in Coolify with a database service (e.g., `postgres:16`, `mysql:8`, `mariadb:11`, or `mongo:7`) defined in the compose file alongside an app service.
- Step 2 – Deploy the application. After deployment completes, navigate to the Application configuration page in the sidebar.
- Step 3 – Verify that a new "Backups: {db_service_name}" link appears in the sidebar under the application.
- Step 4 – Click the backup link. Create a scheduled backup for the detected database and verify the backup form loads correctly.
- Step 5 – Trigger a manual backup execution and confirm it completes successfully. Download the backup file and verify it is valid.
- Step 6 – Edit the compose file to remove the database service, then redeploy. Verify the corresponding `ServiceDatabase` record and sidebar link are cleaned up.
- Step 7 – Switch the application build pack away from `dockercompose` (e.g., to `dockerfile`). Verify all compose database records are removed.
- Step 8 – Deploy an existing Service-owned database (not via Compose) and verify its backups still work as before (no regression).
- Step 9 – Create a pull request preview deployment for a Compose app with a database service. Verify that NO `ServiceDatabase` records are created for preview deployments.

### Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them