### PR TITLE
fix: increase database proxy timeout from 10m to 24h

### DIFF
--- a/app/Actions/Database/StartDatabaseProxy.php
+++ b/app/Actions/Database/StartDatabaseProxy.php
@@ -67,6 +67,8 @@ class StartDatabaseProxy
        server {
             listen $database->public_port;
             proxy_pass $containerName:$internalPort;
+            proxy_timeout 24h;
+            proxy_connect_timeout 60s;
        }
     }
     EOF;


### PR DESCRIPTION
## Summary
Fixes #7743

The nginx TCP proxy for public database connections was using the default `proxy_timeout` of 10 minutes, causing long-running queries to be terminated unexpectedly.

## Changes
- Set `proxy_timeout` to 24h to support long-running queries (e.g., large SELECT exports that take 30+ minutes)
- Set `proxy_connect_timeout` to 60s for reasonable connection establishment timeout

## Technical Details
The database proxy uses nginx's stream module. The default `proxy_timeout` is 10 minutes, which defines the timeout between two successive read or write operations. For long-running database queries, this timeout would fire between result chunks being sent.

Setting it to 24h allows for extremely long queries while still eventually cleaning up abandoned connections.

## Testing
- Deploy a database with "Expose publicly" enabled
- Run a long-running query (30+ minutes)
- Verify the connection stays alive

## Related
This bounty was funded by [Hack Club](https://hackclub.com) 🎉