### PR TITLE
feat: add WordPress + OpenLiteSpeed service template (#8264)

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -1,0 +1,38 @@
+# documentation: https://wordpress.org
+# slogan: WordPress + OpenLiteSpeed service template for high-performance hosting.
+# category: cms
+# tags: cms, blog, content, management, openlitespeed, mariadb
+# logo: svgs/wordpress.svg
+
+services:
+  wordpress:
+    image: litespeedtech/openlitespeed:latest
+    volumes:
+      - wordpress-files:/var/www/html
+    environment:
+      - SERVICE_FQDN_WORDPRESS
+      - WORDPRESS_DB_HOST=mariadb
+      - WORDPRESS_DB_USER=$SERVICE_USER_WORDPRESS
+      - WORDPRESS_DB_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+      - WORDPRESS_DB_NAME=wordpress
+    depends_on:
+      - mariadb
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1"]
+      interval: 2s
+      timeout: 10s
+      retries: 10
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
This PR adds the WordPress + OpenLiteSpeed service template as requested in #8264.

### Changes
- Added `wordpress-with-openlitespeed.yaml` to `templates/compose/`.
- Uses official `litespeedtech/openlitespeed` image.
- Includes MariaDB 11 with healthchecks.
- Persistent volumes for WordPress files and database.

### Validation
- Template structure follows existing WordPress templates.
- Target branch is `next` as per new PR quality requirements.

Closes #8264