### PR TITLE
fix(jobs): initialize status variable in checkHetznerStatus

### DIFF
--- a/app/Jobs/ServerConnectionCheckJob.php
+++ b/app/Jobs/ServerConnectionCheckJob.php
@@ -107,6 +107,8 @@ class ServerConnectionCheckJob implements ShouldBeEncrypted, ShouldQueue
 
     private function checkHetznerStatus(): void
     {
+        $status = null;
+
         try {
             $hetznerService = new \App\Services\HetznerService($this->server->cloudProviderToken->token);
             $serverData = $hetznerService->getServer($this->server->hetzner_server_id);


### PR DESCRIPTION
## Summary
- Initialize `$status` variable to `null` at the start of `checkHetznerStatus()` method
- Prevents undefined variable warning/error when the variable is used later in the method

## Breaking Changes
None