### PR TITLE
fix(push-server-job): skip containers with empty service subId

### DIFF
--- a/app/Jobs/PushServerUpdateJob.php
+++ b/app/Jobs/PushServerUpdateJob.php
@@ -207,6 +207,9 @@ class PushServerUpdateJob implements ShouldBeEncrypted, ShouldQueue, Silenced
                 $serviceId = $labels->get('coolify.serviceId');
                 $subType = $labels->get('coolify.service.subType');
                 $subId = $labels->get('coolify.service.subId');
+                if (empty($subId)) {
+                    continue;
+                }
                 if ($subType === 'application') {
                     $this->foundServiceApplicationIds->push($subId);
                     // Store container status for aggregation

--- a/tests/Feature/PushServerUpdateJobTest.php
+++ b/tests/Feature/PushServerUpdateJobTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use App\Jobs\PushServerUpdateJob;
+use App\Models\Server;
+use App\Models\Service;
+use App\Models\ServiceApplication;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('containers with empty service subId are skipped', function () {
+    $server = Server::factory()->create();
+    $service = Service::factory()->create([
+        'server_id' => $server->id,
+    ]);
+    $serviceApp = ServiceApplication::factory()->create([
+        'service_id' => $service->id,
+    ]);
+
+    $data = [
+        'containers' => [
+            [
+                'name' => 'test-container',
+                'state' => 'running',
+                'health_status' => 'healthy',
+                'labels' => [
+                    'coolify.managed' => true,
+                    'coolify.serviceId' => (string) $service->id,
+                    'coolify.service.subType' => 'application',
+                    'coolify.service.subId' => '',
+                ],
+            ],
+        ],
+    ];
+
+    $job = new PushServerUpdateJob($server, $data);
+
+    // Run handle - should not throw a PDOException about empty bigint
+    $job->handle();
+
+    // The empty subId container should have been skipped
+    expect($job->foundServiceApplicationIds)->not->toContain('');
+    expect($job->serviceContainerStatuses)->toBeEmpty();
+});
+
+test('containers with valid service subId are processed', function () {
+    $server = Server::factory()->create();
+    $service = Service::factory()->create([
+        'server_id' => $server->id,
+    ]);
+    $serviceApp = ServiceApplication::factory()->create([
+        'service_id' => $service->id,
+    ]);
+
+    $data = [
+        'containers' => [
+            [
+                'name' => 'test-container',
+                'state' => 'running',
+                'health_status' => 'healthy',
+                'labels' => [
+                    'coolify.managed' => true,
+                    'coolify.serviceId' => (string) $service->id,
+                    'coolify.service.subType' => 'application',
+                    'coolify.service.subId' => (string) $serviceApp->id,
+                    'com.docker.compose.service' => 'myapp',
+                ],
+            ],
+        ],
+    ];
+
+    $job = new PushServerUpdateJob($server, $data);
+    $job->handle();
+
+    expect($job->foundServiceApplicationIds)->toContain((string) $serviceApp->id);
+});


### PR DESCRIPTION
## Summary

- Skip processing containers that have empty `coolify.service.subId` labels to prevent database query errors
- Added validation check before attempting to query services with empty subId values
- Added test coverage for both the empty subId error case and valid processing flow

## Changes

- **app/Jobs/PushServerUpdateJob.php**: Added early continue when subId is empty (lines 210-212)
- **tests/Feature/PushServerUpdateJobTest.php**: New test file with comprehensive coverage:
  - Test that containers with empty subId are skipped without throwing errors
  - Test that containers with valid subId are processed correctly

## Context

When containers have empty `coolify.service.subId` labels, the job would attempt to query the database with an empty value, resulting in a PDOException. This fix validates the subId before processing and safely skips invalid entries.