### PR TITLE
fix(database): disable proxy on port allocation failure

### DIFF
--- a/app/Actions/Database/StartDatabaseProxy.php
+++ b/app/Actions/Database/StartDatabaseProxy.php
@@ -112,12 +112,52 @@ class StartDatabaseProxy
         $dockercompose_base64 = base64_encode(Yaml::dump($docker_compose, 4, 2));
         $nginxconf_base64 = base64_encode($nginxconf);
         instant_remote_process(["docker rm -f $proxyContainerName"], $server, false);
-        instant_remote_process([
-            "mkdir -p $configuration_dir",
-            "echo '{$nginxconf_base64}' | base64 -d | tee $configuration_dir/nginx.conf > /dev/null",
-            "echo '{$dockercompose_base64}' | base64 -d | tee $configuration_dir/docker-compose.yaml > /dev/null",
-            "docker compose --project-directory {$configuration_dir} pull",
-            "docker compose --project-directory {$configuration_dir} up -d",
-        ], $server);
+
+        try {
+            instant_remote_process([
+                "mkdir -p $configuration_dir",
+                "echo '{$nginxconf_base64}' | base64 -d | tee $configuration_dir/nginx.conf > /dev/null",
+                "echo '{$dockercompose_base64}' | base64 -d | tee $configuration_dir/docker-compose.yaml > /dev/null",
+                "docker compose --project-directory {$configuration_dir} pull",
+                "docker compose --project-directory {$configuration_dir} up -d",
+            ], $server);
+        } catch (\RuntimeException $e) {
+            if ($this->isNonTransientError($e->getMessage())) {
+                $database->update(['is_public' => false]);
+
+                $team = data_get($database, 'environment.project.team')
+                    ?? data_get($database, 'service.environment.project.team');
+
+                $team?->notify(
+                    new \App\Notifications\Container\ContainerRestarted(
+                        "TCP Proxy for {$database->name} database has been disabled due to error: {$e->getMessage()}",
+                        $server,
+                    )
+                );
+
+                ray("Database proxy for {$database->name} disabled due to non-transient error: {$e->getMessage()}");
+
+                return;
+            }
+
+            throw $e;
+        }
+    }
+
+    private function isNonTransientError(string $message): bool
+    {
+        $nonTransientPatterns = [
+            'port is already allocated',
+            'address already in use',
+            'Bind for',
+        ];
+
+        foreach ($nonTransientPatterns as $pattern) {
+            if (str_contains($message, $pattern)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/Feature/StartDatabaseProxyTest.php
+++ b/tests/Feature/StartDatabaseProxyTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Actions\Database\StartDatabaseProxy;
+use App\Models\StandalonePostgresql;
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Notification::fake();
+});
+
+test('database proxy is disabled on port already allocated error', function () {
+    $team = Team::factory()->create();
+
+    $database = StandalonePostgresql::factory()->create([
+        'team_id' => $team->id,
+        'is_public' => true,
+        'public_port' => 5432,
+    ]);
+
+    expect($database->is_public)->toBeTrue();
+
+    $action = new StartDatabaseProxy;
+
+    // Use reflection to test the private method directly
+    $method = new ReflectionMethod($action, 'isNonTransientError');
+
+    expect($method->invoke($action, 'Bind for 0.0.0.0:5432 failed: port is already allocated'))->toBeTrue();
+    expect($method->invoke($action, 'address already in use'))->toBeTrue();
+    expect($method->invoke($action, 'some other error'))->toBeFalse();
+});
+
+test('isNonTransientError detects port conflict patterns', function () {
+    $action = new StartDatabaseProxy;
+    $method = new ReflectionMethod($action, 'isNonTransientError');
+
+    expect($method->invoke($action, 'Bind for 0.0.0.0:5432 failed: port is already allocated'))->toBeTrue()
+        ->and($method->invoke($action, 'address already in use'))->toBeTrue()
+        ->and($method->invoke($action, 'Bind for 0.0.0.0:3306 failed: port is already allocated'))->toBeTrue()
+        ->and($method->invoke($action, 'network timeout'))->toBeFalse()
+        ->and($method->invoke($action, 'connection refused'))->toBeFalse();
+});


### PR DESCRIPTION
## Summary

- Adds error handling to `StartDatabaseProxy` to detect and handle port allocation failures gracefully
- Disables the database proxy (`is_public = false`) when a non-transient error occurs (port already in use, bind failures)
- Notifies the team of the proxy disable via notification
- Introduces `isNonTransientError()` helper to identify port conflicts vs transient failures
- Adds feature tests to verify error detection patterns

## Breaking Changes

None