### PR TITLE
feat: Update Huly service template to v0.7.x architecture

### DIFF
--- a/templates/compose/huly.yaml
+++ b/templates/compose/huly.yaml
@@ -1,36 +1,217 @@
-# ignore: true
 # documentation: https://huly.io/
-# category: cms
-# slogan: Open Source All-in-One Project Management Platform
-# tags: linear,jira,slack,project,management,notion,motion
+# slogan: Open-source All-in-One Project Management Platform
+# category: productivity
+# tags: linear,jira,slack,project,management,notion,motion,collaboration,workspace
+# logo: svgs/huly.svg
 # port: 8080
 
 services:
-  mongodb:
-    image: "mongo:7-jammy"
-    container_name: mongodb
+  front:
+    image: hardcoreeng/front:${HULY_VERSION:-v0.7.310}
     environment:
-      - PUID=1000
-      - PGID=1000
+      - SERVICE_URL_HULY_8080
+      - SERVER_PORT=8080
+      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
+      - LOVE_ENDPOINT=http${SECURE:+s}://${SERVICE_FQDN_HULY_8080}/_love
+      - ACCOUNTS_URL=http${SECURE:+s}://${SERVICE_FQDN_HULY_8080}/_accounts
+      - ACCOUNTS_URL_INTERNAL=http://account:3000
+      - REKONI_URL=http${SECURE:+s}://${SERVICE_FQDN_HULY_8080}/_rekoni
+      - CALENDAR_URL=http${SECURE:+s}://${SERVICE_FQDN_HULY_8080}/_calendar
+      - GMAIL_URL=http${SECURE:+s}://${SERVICE_FQDN_HULY_8080}/_gmail
+      - TELEGRAM_URL=http${SECURE:+s}://${SERVICE_FQDN_HULY_8080}/_telegram
+      - STATS_URL=http${SECURE:+s}://${SERVICE_FQDN_HULY_8080}/_stats
+      - UPLOAD_URL=/files
+      - ELASTIC_URL=http://elastic:9200
+      - COLLABORATOR_URL=ws${SECURE:+s}://${SERVICE_FQDN_HULY_8080}/_collaborator
+      - STORAGE_CONFIG=minio|minio?accessKey=minioadmin&secretKey=minioadmin
+      - TITLE=${TITLE:-Huly Self Host}
+      - DEFAULT_LANGUAGE=${DEFAULT_LANGUAGE:-en}
+      - LAST_NAME_FIRST=${LAST_NAME_FIRST:-true}
+    depends_on:
+      - transactor
+      - account
+      - collaborator
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+  
+  transactor:
+    image: hardcoreeng/transactor:${HULY_VERSION:-v0.7.310}
+    environment:
+      - SERVER_PORT=3333
+      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
+      - DB_URL=postgresql://${SERVICE_USER_COCKROACHDB}:${SERVICE_PASSWORD_COCKROACHDB}@cockroach:26257/defaultdb?sslmode=disable
+      - STORAGE_CONFIG=minio|minio?accessKey=minioadmin&secretKey=minioadmin
+      - FRONT_URL=http${SECURE:+s}://${SERVICE_FQDN_HULY_8080}
+      - ACCOUNTS_URL=http://account:3000
+      - FULLTEXT_URL=http://fulltext:4700
+      - STATS_URL=http://stats:4900
+      - LAST_NAME_FIRST=${LAST_NAME_FIRST:-true}
+      - QUEUE_CONFIG=redpanda:9092
+    depends_on:
+      - cockroach
+      - redpanda
+      - minio
+      - elastic
+    restart: unless-stopped
+
+  collaborator:
+    image: hardcoreeng/collaborator:${HULY_VERSION:-v0.7.310}
+    environment:
+      - COLLABORATOR_PORT=3078
+      - SECRET=$SERVICE_PASSWORD_SECRET
+      - ACCOUNTS_URL=http://account:3000
+      - STATS_URL=http://stats:4900
+      - STORAGE_CONFIG=minio|minio?accessKey=minioadmin&secretKey=minioadmin
+    restart: unless-stopped
+
+  account:
+    image: hardcoreeng/account:${HULY_VERSION:-v0.7.310}
+    environment:
+      - SERVER_PORT=3000
+      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
+      - DB_URL=postgresql://${SERVICE_USER_COCKROACHDB}:${SERVICE_PASSWORD_COCKROACHDB}@cockroach:26257/defaultdb?sslmode=disable
+      - TRANSACTOR_URL=ws://transactor:3333;ws${SECURE:+s}://${SERVICE_FQDN_HULY_8080}/_transactor
+      - STORAGE_CONFIG=minio|minio?accessKey=minioadmin&secretKey=minioadmin
+      - FRONT_URL=http${SECURE:+s}://${SERVICE_FQDN_HULY_8080}
+      - STATS_URL=http${SECURE:+s}://${SERVICE_FQDN_HULY_8080}/_stats
+      - MODEL_ENABLED=*
+      - ACCOUNTS_URL=http${SECURE:+s}://${SERVICE_FQDN_HULY_8080}/_accounts
+      - ACCOUNT_PORT=3000
+      - QUEUE_CONFIG=redpanda:9092
+    depends_on:
+      - cockroach
+      - redpanda
+    restart: unless-stopped
+
+  workspace:
+    image: hardcoreeng/workspace:${HULY_VERSION:-v0.7.310}
+    environment:
+      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
+      - DB_URL=postgresql://${SERVICE_USER_COCKROACHDB}:${SERVICE_PASSWORD_COCKROACHDB}@cockroach:26257/defaultdb?sslmode=disable
+      - TRANSACTOR_URL=ws://transactor:3333;ws${SECURE:+s}://${SERVICE_FQDN_HULY_8080}/_transactor
+      - STORAGE_CONFIG=minio|minio?accessKey=minioadmin&secretKey=minioadmin
+      - MODEL_ENABLED=*
+      - ACCOUNTS_URL=http://account:3000
+      - STATS_URL=http://stats:4900
+      - QUEUE_CONFIG=redpanda:9092
+      - ACCOUNTS_DB_URL=postgresql://${SERVICE_USER_COCKROACHDB}:${SERVICE_PASSWORD_COCKROACHDB}@cockroach:26257/defaultdb?sslmode=disable
+    depends_on:
+      - cockroach
+      - redpanda
+    restart: unless-stopped
+
+  fulltext:
+    image: hardcoreeng/fulltext:${HULY_VERSION:-v0.7.310}
+    environment:
+      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
+      - DB_URL=postgresql://${SERVICE_USER_COCKROACHDB}:${SERVICE_PASSWORD_COCKROACHDB}@cockroach:26257/defaultdb?sslmode=disable
+      - FULLTEXT_DB_URL=http://elastic:9200
+      - ELASTIC_INDEX_NAME=huly_storage_index
+      - STORAGE_CONFIG=minio|minio?accessKey=minioadmin&secretKey=minioadmin
+      - REKONI_URL=http://rekoni:4004
+      - ACCOUNTS_URL=http://account:3000
+      - STATS_URL=http://stats:4900
+      - QUEUE_CONFIG=redpanda:9092
+    depends_on:
+      - cockroach
+      - elastic
+      - redpanda
+    restart: unless-stopped
+
+  rekoni:
+    image: hardcoreeng/rekoni-service:${HULY_VERSION:-v0.7.310}
+    environment:
+      - SECRET=$SERVICE_PASSWORD_SECRET
+    deploy:
+      resources:
+        limits:
+          memory: 500M
+    restart: unless-stopped
+
+  stats:
+    image: hardcoreeng/stats:${HULY_VERSION:-v0.7.310}
+    environment:
+      - PORT=4900
+      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
+    restart: unless-stopped
+
+  kvs:
+    image: hardcoreeng/hulykvs:${HULY_VERSION:-v0.7.310}
+    environment:
+      - HULY_DB_CONNECTION=postgresql://${SERVICE_USER_COCKROACHDB}:${SERVICE_PASSWORD_COCKROACHDB}@cockroach:26257/defaultdb?sslmode=disable
+      - HULY_TOKEN_SECRET=$SERVICE_PASSWORD_SECRET
+    depends_on:
+      - cockroach
+    restart: unless-stopped
+
+  cockroach:
+    image: cockroachdb/cockroach:latest-v24.2
+    command: start-single-node --accept-sql-without-tls
+    environment:
+      - COCKROACH_USER=${SERVICE_USER_COCKROACHDB}
+      - COCKROACH_PASSWORD=${SERVICE_PASSWORD_COCKROACHDB}
+      - COCKROACH_DATABASE=defaultdb
     volumes:
-      - huly-db:/data/db
+      - cockroach-data:/cockroach/cockroach-data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health?ready=1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  redpanda:
+    image: docker.redpanda.com/redpandadata/redpanda:v24.3.6
+    command:
+      - redpanda
+      - start
+      - --kafka-addr internal://0.0.0.0:9092,external://0.0.0.0:19092
+      - --advertise-kafka-addr internal://redpanda:9092,external://localhost:19092
+      - --pandaproxy-addr internal://0.0.0.0:8082,external://0.0.0.0:18082
+      - --advertise-pandaproxy-addr internal://redpanda:8082,external://localhost:18082
+      - --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:18081
+      - --rpc-addr redpanda:33145
+      - --advertise-rpc-addr redpanda:33145
+      - --mode dev-container
+      - --smp 1
+      - --default-log-level=info
+    volumes:
+      - redpanda-data:/var/lib/redpanda/data
+    environment:
+      - REDPANDA_SUPERUSER_USERNAME=${SERVICE_USER_REDPANDA:-admin}
+      - REDPANDA_SUPERUSER_PASSWORD=${SERVICE_PASSWORD_REDPANDA:-admin}
+    healthcheck:
+      test: ['CMD', 'rpk', 'cluster', 'info', '-X', 'user=${SERVICE_USER_REDPANDA:-admin}', '-X', 'pass=${SERVICE_PASSWORD_REDPANDA:-admin}']
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
   minio:
-    image: ghcr.io/coollabsio/minio:RELEASE.2025-10-15T17-29-55Z # Released on 15 October 2025
+    image: ghcr.io/coollabsio/minio:RELEASE.2025-10-15T17-29-55Z
     command: server /data --address ":9000" --console-address ":9001"
     volumes:
-      - huly-files:/data      
+      - minio-data:/data
+    environment:
+      - MINIO_ROOT_USER=minioadmin
+      - MINIO_ROOT_PASSWORD=minioadmin
     healthcheck:
-      test: ["CMD", "mc", "ready", "local"]
+      test: ['CMD', 'mc', 'ready', 'local']
       interval: 5s
       timeout: 20s
       retries: 10
+    restart: unless-stopped
+
   elastic:
-    image: "elasticsearch:7.14.2"
+    image: elasticsearch:7.14.2
     command: |
       /bin/sh -c "./bin/elasticsearch-plugin list | grep -q ingest-attachment || yes | ./bin/elasticsearch-plugin install --silent ingest-attachment;
       /usr/local/bin/docker-entrypoint.sh eswrapper"
     volumes:
-      - huly-elastic:/usr/share/elasticsearch/data
+      - elastic-data:/usr/share/elasticsearch/data
     environment:
       - ELASTICSEARCH_PORT_NUMBER=9200
       - BITNAMI_DEBUG=true
@@ -39,85 +220,8 @@ services:
       - http.cors.enabled=true
       - http.cors.allow-origin=http://localhost:8082
     healthcheck:
-      test: curl -s http://127.0.0.1:9200/_cluster/health | grep -vq '"status":"red"'
-      interval: 5s
+      test: curl -s http://localhost:9200/_cluster/health | grep -vq '"status":"red"'
+      interval: 20s
+      timeout: 5s
       retries: 10
-  account:
-    image: hardcoreeng/account:v0.6.246
-    environment:
-      - SERVICE_URL_HULY_3000
-      - SERVER_PORT=3000
-      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
-      - MONGO_URL=mongodb://mongodb:27017
-      - TRANSACTOR_URL=ws://transactor:3333
-      - ENDPOINT_URL=ws://transactor:3333
-      - MINIO_ENDPOINT=minio
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadmin
-      - FRONT_URL=http://front:8080
-      - INIT_WORKSPACE=demo-tracker
-      - MODEL_ENABLED=*
-      - ACCOUNTS_URL=http://localhost:3000
-  front:
-    image: hardcoreeng/front:v0.6.246
-    environment:
-      - SERVICE_URL_HULY_8080
-      - MONGO_URL=mongodb://mongodb:27017
-      - SERVER_PORT=8080
-      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
-      - ACCOUNTS_URL=http://account:3000
-      - REKONI_URL=http://rekoni:4004
-      - CALENDAR_URL=http://localhost:8095
-      - GMAIL_URL=http://localhost:8088
-      - TELEGRAM_URL=http://localhost:8086
-      - UPLOAD_URL=/files
-      - TRANSACTOR_URL=ws://transactor:3333
-      - ELASTIC_URL=http://elastic:9200
-      - COLLABORATOR_URL=ws://collaborator:3078
-      - COLLABORATOR_API_URL=http://collaborator:3078
-      - MINIO_ENDPOINT=minio
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadmin
-      - TITLE=Huly Self Hosted
-      - DEFAULT_LANGUAGE=en
-      - LAST_NAME_FIRST=true
     restart: unless-stopped
-  collaborator:
-    image: hardcoreeng/collaborator:v0.6.246
-    environment:
-      - COLLABORATOR_PORT=3078
-      - SECRET=secret
-      - ACCOUNTS_URL=http://account:3000
-      - TRANSACTOR_URL=ws://transactor:3333
-      - UPLOAD_URL=/files
-      - MONGO_URL=mongodb://mongodb:27017
-      - MINIO_ENDPOINT=minio
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadmin
-  transactor:
-    image: hardcoreeng/transactor:v0.6.246
-    environment:
-      - SERVER_PORT=3333
-      - ELASTIC_INDEX_NAME=huly
-      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
-      - SERVER_CURSOR_MAXTIMEMS=30000
-      - ELASTIC_URL=http://elastic:9200
-      - MONGO_URL=mongodb://mongodb:27017
-      - METRICS_CONSOLE=false
-      - METRICS_FILE=metrics.txt
-      - MINIO_ENDPOINT=minio
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadmin
-      - REKONI_URL=http://rekoni:4004
-      - FRONT_URL=http://localhost:8087
-      - SERVER_PROVIDER=ws
-      - ACCOUNTS_URL=http://account:3000
-      - LAST_NAME_FIRST=true
-      - UPLOAD_URL=/files
-    restart: unless-stopped
-  rekoni:
-    image: hardcoreeng/rekoni-service:latest
-    deploy:
-      resources:
-        limits:
-          memory: 500M


### PR DESCRIPTION
/claim #2543

## Description

This PR updates the Huly service template from the legacy v0.6.x architecture to the modern v0.7.x architecture, making it compatible with the latest Huly self-hosted deployment.

## Changes

- ✅ Updated to Huly v0.7.x architecture using CockroachDB and Redpanda
- ✅ Replaced MongoDB with CockroachDB for improved scalability and distributed SQL capabilities
- ✅ Added Redpanda as message queue for asynchronous processing
- ✅ Added new services: workspace, fulltext, stats, and kvs
- ✅ Updated all service configurations to use Coolify environment variables (`SERVICE_*`)
- ✅ Removed `ignore: true` flag to make template available to users
- ✅ Added proper healthchecks for service readiness
- ✅ Updated service dependencies and orchestration

## Testing

The template follows the official Huly self-host deployment guide:
- Based on https://github.com/hcengineering/huly-selfhost
- Compatible with Huly v0.7.310 and later versions
- Uses production-tested service images

## Documentation

Official documentation: https://huly.io/

Fixes #2543