### PR TITLE
fix(vikunja): fix volume mount, add healthcheck, remove nginx proxy

### DIFF
--- a/templates/compose/vikunja-with-postgresql.yaml
+++ b/templates/compose/vikunja-with-postgresql.yaml
@@ -3,68 +3,9 @@
 # category: productivity
 # tags: productivity,todo
 # logo: svgs/vikunja.svg
-# port: 80
+# port: 3456
 
 services:
-  nginx:
-    image: nginx:alpine
-    volumes:
-      - nginx-config:/etc/nginx/conf.d:ro
-    depends_on:
-      - vikunja
-      - nginx-init
-
-  nginx-init:
-    image: busybox
-    restart: "no"
-    volumes:
-      - nginx-config:/etc/nginx/conf.d
-    command:
-      - sh
-      - -c
-      - |
-        cat > /etc/nginx/conf.d/default.conf << 'NGINX'
-        server {
-            listen 80;
-            server_name _;
-            client_max_body_size 20M;
-
-            location ~ ^/(api|dav|\.well-known)/ {
-                proxy_pass http://vikunja:3456;
-                proxy_http_version 1.1;
-                proxy_set_header Host $host;
-                proxy_set_header X-Real-IP $remote_addr;
-                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
-            }
-
-            location ~ \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|map|json|webmanifest)$ {
-                proxy_pass http://vikunja:3456;
-                proxy_http_version 1.1;
-                proxy_set_header Host $host;
-            }
-
-            location / {
-                proxy_pass http://vikunja:3456;
-                proxy_http_version 1.1;
-                proxy_set_header Host $host;
-                proxy_set_header X-Real-IP $remote_addr;
-                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
-                proxy_intercept_errors on;
-                error_page 404 = /index.html;
-            }
-
-            location = /index.html {
-                proxy_pass http://vikunja:3456;
-                proxy_http_version 1.1;
-                proxy_set_header Host $host;
-                internal;
-            }
-        }
-        NGINX
-        echo "Nginx config created"
-
   vikunja:
     image: vikunja/vikunja
     environment:
@@ -76,12 +17,18 @@ services:
       - VIKUNJA_DATABASE_HOST=postgresql
       - VIKUNJA_DATABASE_PASSWORD=${SERVICE_PASSWORD_POSTGRESQL}
       - VIKUNJA_DATABASE_USER=${SERVICE_USER_POSTGRESQL}
-      - VIKUNJA_DATABASE_DATABASE=${POSTGRESQL_DATABASE}
+      - VIKUNJA_DATABASE_DATABASE=${POSTGRESQL_DATABASE:-vikunja}
     volumes:
-      - vikunja-data:/app/vikunja/
+      - vikunja-files:/app/vikunja/files
     depends_on:
       postgresql:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "/app/vikunja/vikunja", "healthcheck"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
 
   postgresql:
     image: postgres:16-alpine
@@ -90,7 +37,7 @@ services:
     environment:
       - POSTGRES_USER=${SERVICE_USER_POSTGRESQL}
       - POSTGRES_PASSWORD=${SERVICE_PASSWORD_POSTGRESQL}
-      - POSTGRES_DB=${POSTGRESQL_DATABASE}
+      - POSTGRES_DB=${POSTGRESQL_DATABASE:-vikunja}
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
       interval: 5s

--- a/templates/compose/vikunja-with-postgresql.yaml
+++ b/templates/compose/vikunja-with-postgresql.yaml
@@ -3,9 +3,68 @@
 # category: productivity
 # tags: productivity,todo
 # logo: svgs/vikunja.svg
-# port: 3456
+# port: 80
 
 services:
+  nginx:
+    image: nginx:alpine
+    volumes:
+      - nginx-config:/etc/nginx/conf.d:ro
+    depends_on:
+      - vikunja
+      - nginx-init
+
+  nginx-init:
+    image: busybox
+    restart: "no"
+    volumes:
+      - nginx-config:/etc/nginx/conf.d
+    command:
+      - sh
+      - -c
+      - |
+        cat > /etc/nginx/conf.d/default.conf << 'NGINX'
+        server {
+            listen 80;
+            server_name _;
+            client_max_body_size 20M;
+
+            location ~ ^/(api|dav|\.well-known)/ {
+                proxy_pass http://vikunja:3456;
+                proxy_http_version 1.1;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+            }
+
+            location ~ \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|map|json|webmanifest)$ {
+                proxy_pass http://vikunja:3456;
+                proxy_http_version 1.1;
+                proxy_set_header Host $host;
+            }
+
+            location / {
+                proxy_pass http://vikunja:3456;
+                proxy_http_version 1.1;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_intercept_errors on;
+                error_page 404 = /index.html;
+            }
+
+            location = /index.html {
+                proxy_pass http://vikunja:3456;
+                proxy_http_version 1.1;
+                proxy_set_header Host $host;
+                internal;
+            }
+        }
+        NGINX
+        echo "Nginx config created"
+
   vikunja:
     image: vikunja/vikunja
     environment:
@@ -23,6 +82,7 @@ services:
     depends_on:
       postgresql:
         condition: service_healthy
+
   postgresql:
     image: postgres:16-alpine
     volumes:

--- a/templates/compose/vikunja.yaml
+++ b/templates/compose/vikunja.yaml
@@ -3,68 +3,9 @@
 # category: productivity
 # tags: productivity,todo
 # logo: svgs/vikunja.svg
-# port: 80
+# port: 3456
 
 services:
-  nginx:
-    image: nginx:alpine
-    volumes:
-      - nginx-config:/etc/nginx/conf.d:ro
-    depends_on:
-      - vikunja
-      - nginx-init
-
-  nginx-init:
-    image: busybox
-    restart: "no"
-    volumes:
-      - nginx-config:/etc/nginx/conf.d
-    command:
-      - sh
-      - -c
-      - |
-        cat > /etc/nginx/conf.d/default.conf << 'NGINX'
-        server {
-            listen 80;
-            server_name _;
-            client_max_body_size 20M;
-
-            location ~ ^/(api|dav|\.well-known)/ {
-                proxy_pass http://vikunja:3456;
-                proxy_http_version 1.1;
-                proxy_set_header Host $host;
-                proxy_set_header X-Real-IP $remote_addr;
-                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
-            }
-
-            location ~ \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|map|json|webmanifest)$ {
-                proxy_pass http://vikunja:3456;
-                proxy_http_version 1.1;
-                proxy_set_header Host $host;
-            }
-
-            location / {
-                proxy_pass http://vikunja:3456;
-                proxy_http_version 1.1;
-                proxy_set_header Host $host;
-                proxy_set_header X-Real-IP $remote_addr;
-                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
-                proxy_intercept_errors on;
-                error_page 404 = /index.html;
-            }
-
-            location = /index.html {
-                proxy_pass http://vikunja:3456;
-                proxy_http_version 1.1;
-                proxy_set_header Host $host;
-                internal;
-            }
-        }
-        NGINX
-        echo "Nginx config created"
-
   vikunja:
     image: vikunja/vikunja
     environment:
@@ -75,15 +16,22 @@ services:
       - VIKUNJA_DATABASE_PATH=/db/vikunja.db
       - VIKUNJA_DATABASE_TYPE=sqlite
     volumes:
-      - vikunja-data:/app/vikunja/
+      - vikunja-files:/app/vikunja/files
       - vikunja-sqlite-data:/db
     depends_on:
-      - init
+      init:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD", "/app/vikunja/vikunja", "healthcheck"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
 
   init:
     image: busybox
     restart: "no"
     volumes:
       - vikunja-sqlite-data:/db
-      - vikunja-data:/app/vikunja
-    command: ["sh", "-c", "mkdir -p /app/vikunja/files && touch /db/vikunja.db && chown -R 1000:1000 /db /app/vikunja"]
+      - vikunja-files:/app/vikunja/files
+    command: ["sh", "-c", "mkdir -p /app/vikunja/files && touch /db/vikunja.db && chown -R 1000:1000 /db /app/vikunja/files"]

--- a/templates/compose/vikunja.yaml
+++ b/templates/compose/vikunja.yaml
@@ -3,9 +3,68 @@
 # category: productivity
 # tags: productivity,todo
 # logo: svgs/vikunja.svg
-# port: 3456
+# port: 80
 
 services:
+  nginx:
+    image: nginx:alpine
+    volumes:
+      - nginx-config:/etc/nginx/conf.d:ro
+    depends_on:
+      - vikunja
+      - nginx-init
+
+  nginx-init:
+    image: busybox
+    restart: "no"
+    volumes:
+      - nginx-config:/etc/nginx/conf.d
+    command:
+      - sh
+      - -c
+      - |
+        cat > /etc/nginx/conf.d/default.conf << 'NGINX'
+        server {
+            listen 80;
+            server_name _;
+            client_max_body_size 20M;
+
+            location ~ ^/(api|dav|\.well-known)/ {
+                proxy_pass http://vikunja:3456;
+                proxy_http_version 1.1;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+            }
+
+            location ~ \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|map|json|webmanifest)$ {
+                proxy_pass http://vikunja:3456;
+                proxy_http_version 1.1;
+                proxy_set_header Host $host;
+            }
+
+            location / {
+                proxy_pass http://vikunja:3456;
+                proxy_http_version 1.1;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_intercept_errors on;
+                error_page 404 = /index.html;
+            }
+
+            location = /index.html {
+                proxy_pass http://vikunja:3456;
+                proxy_http_version 1.1;
+                proxy_set_header Host $host;
+                internal;
+            }
+        }
+        NGINX
+        echo "Nginx config created"
+
   vikunja:
     image: vikunja/vikunja
     environment:
@@ -20,9 +79,11 @@ services:
       - vikunja-sqlite-data:/db
     depends_on:
       - init
+
   init:
     image: busybox
-    restart: no
+    restart: "no"
     volumes:
       - vikunja-sqlite-data:/db
-    command: ["sh", "-c", "touch /db/vikunja.db && chown -R 1000 /db"]
+      - vikunja-data:/app/vikunja
+    command: ["sh", "-c", "mkdir -p /app/vikunja/files && touch /db/vikunja.db && chown -R 1000:1000 /db /app/vikunja"]


### PR DESCRIPTION
## Summary

This PR fixes several issues with the Vikunja service templates:

### Fixed: Volume mount prevents upgrades
- Changed volume mount from `/app/vikunja/` to `/app/vikunja/files`
- The old mount included the Vikunja binary, which got persisted in the volume
- This caused image upgrades to have no effect (old binary kept running)

### Added: Native healthcheck
- Added healthcheck using Vikunja's built-in `healthcheck` command
- Works with the distroless image (no curl/wget needed)

### Removed: Unnecessary nginx proxy
- Since Vikunja v0.22+, the frontend is served directly by the Vikunja binary
- Removed nginx and nginx-init containers (no longer needed)
- Updated exposed port from 80 to 3456

### Other improvements
- Use `service_completed_successfully` for init container dependency
- Applies to both SQLite and PostgreSQL templates

## Test plan

- [ ] Deploy fresh Vikunja instance using SQLite template
- [ ] Verify healthcheck shows healthy status
- [ ] Pull new image version and restart - verify version updates correctly
- [ ] Deploy fresh Vikunja instance using PostgreSQL template
- [ ] Verify same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)