### PR TITLE
feat: add deploy on GitHub release support

### DIFF
--- a/app/Http/Controllers/Webhook/Github.php
+++ b/app/Http/Controllers/Webhook/Github.php
@@ -55,6 +55,19 @@ class Github extends Controller
                 $after_sha = data_get($payload, 'after', data_get($payload, 'pull_request.head.sha'));
                 $author_association = data_get($payload, 'pull_request.author_association');
             }
+            if ($x_github_event === 'release') {
+                $action = data_get($payload, 'action');
+                $full_name = data_get($payload, 'repository.full_name');
+                $release_tag = data_get($payload, 'release.tag_name');
+                $release_name = data_get($payload, 'release.name');
+                $target_commitish = data_get($payload, 'release.target_commitish');
+                $branch = $target_commitish; // Use target branch for release
+                
+                // Only deploy on 'published' action (new release created and published)
+                if ($action !== 'published') {
+                    return response("Release event received but action is '$action', not 'published'. Ignoring.");
+                }
+            }
             if (! $branch) {
                 return response('Nothing to do. No branch found in the request.');
             }
@@ -69,6 +82,12 @@ class Github extends Controller
                 $applications = $applications->where('git_branch', $base_branch)->get();
                 if ($applications->isEmpty()) {
                     return response("Nothing to do. No applications found for repo $full_name and branch '$base_branch'.");
+                }
+            }
+            if ($x_github_event === 'release') {
+                $applications = $applications->where('git_branch', $branch)->get();
+                if ($applications->isEmpty()) {
+                    return response("Nothing to do. No applications found for repo $full_name and branch '$branch'.");
                 }
             }
             $applicationsByServer = $applications->groupBy(function ($app) {
@@ -181,6 +200,45 @@ class Github extends Controller
                             'message' => 'PR webhook received, processing queued.',
                         ]);
                     }
+                    if ($x_github_event === 'release') {
+                        if ($application->isReleaseDeployable()) {
+                            $deployment_uuid = new Cuid2;
+                            $result = queue_application_deployment(
+                                application: $application,
+                                deployment_uuid: $deployment_uuid,
+                                force_rebuild: false,
+                                commit: $target_commitish ?? 'HEAD',
+                                is_webhook: true,
+                            );
+                            if ($result['status'] === 'queue_full') {
+                                return response($result['message'], 429)->header('Retry-After', 60);
+                            } elseif ($result['status'] === 'skipped') {
+                                $return_payloads->push([
+                                    'application' => $application->name,
+                                    'status' => 'skipped',
+                                    'message' => $result['message'],
+                                ]);
+                            } else {
+                                $return_payloads->push([
+                                    'application' => $application->name,
+                                    'status' => 'success',
+                                    'message' => "Release '$release_tag' deployment queued.",
+                                    'application_uuid' => $application->uuid,
+                                    'application_name' => $application->name,
+                                    'deployment_uuid' => $result['deployment_uuid'],
+                                    'release_tag' => $release_tag,
+                                    'release_name' => $release_name,
+                                ]);
+                            }
+                        } else {
+                            $return_payloads->push([
+                                'status' => 'failed',
+                                'message' => 'Deploy on release is disabled for this application.',
+                                'application_uuid' => $application->uuid,
+                                'application_name' => $application->name,
+                            ]);
+                        }
+                    }
                 }
             }
 
@@ -246,6 +304,18 @@ class Github extends Controller
                 $after_sha = data_get($payload, 'after', data_get($payload, 'pull_request.head.sha'));
                 $author_association = data_get($payload, 'pull_request.author_association');
             }
+            if ($x_github_event === 'release') {
+                $action = data_get($payload, 'action');
+                $id = data_get($payload, 'repository.id');
+                $release_tag = data_get($payload, 'release.tag_name');
+                $release_name = data_get($payload, 'release.name');
+                $target_commitish = data_get($payload, 'release.target_commitish');
+                $branch = $target_commitish;
+                
+                if ($action !== 'published') {
+                    return response("Release event received but action is '$action', not 'published'. Ignoring.");
+                }
+            }
             if (! $id || ! $branch) {
                 return response('Nothing to do. No id or branch found.');
             }
@@ -262,6 +332,12 @@ class Github extends Controller
                 $applications = $applications->where('git_branch', $base_branch)->get();
                 if ($applications->isEmpty()) {
                     return response("Nothing to do. No applications found with branch '$base_branch'.");
+                }
+            }
+            if ($x_github_event === 'release') {
+                $applications = $applications->where('git_branch', $branch)->get();
+                if ($applications->isEmpty()) {
+                    return response("Nothing to do. No applications found with branch '$branch'.");
                 }
             }
             $applicationsByServer = $applications->groupBy(function ($app) {
@@ -357,6 +433,37 @@ class Github extends Controller
                             'status' => 'queued',
                             'message' => 'PR webhook received, processing queued.',
                         ]);
+                    }
+                    if ($x_github_event === 'release') {
+                        if ($application->isReleaseDeployable()) {
+                            $deployment_uuid = new Cuid2;
+                            $result = queue_application_deployment(
+                                application: $application,
+                                deployment_uuid: $deployment_uuid,
+                                force_rebuild: false,
+                                commit: $target_commitish ?? 'HEAD',
+                                is_webhook: true,
+                            );
+                            if ($result['status'] === 'queue_full') {
+                                return response($result['message'], 429)->header('Retry-After', 60);
+                            }
+                            $return_payloads->push([
+                                'status' => $result['status'],
+                                'message' => "Release '$release_tag' deployment queued.",
+                                'application_uuid' => $application->uuid,
+                                'application_name' => $application->name,
+                                'deployment_uuid' => $result['deployment_uuid'] ?? null,
+                                'release_tag' => $release_tag,
+                                'release_name' => $release_name,
+                            ]);
+                        } else {
+                            $return_payloads->push([
+                                'status' => 'failed',
+                                'message' => 'Deploy on release is disabled for this application.',
+                                'application_uuid' => $application->uuid,
+                                'application_name' => $application->name,
+                            ]);
+                        }
                     }
                 }
             }

--- a/app/Livewire/Project/Application/Advanced.php
+++ b/app/Livewire/Project/Application/Advanced.php
@@ -35,6 +35,9 @@ class Advanced extends Component
     public bool $isAutoDeployEnabled = true;
 
     #[Validate(['boolean'])]
+    public bool $isDeployOnReleaseEnabled = false;
+
+    #[Validate(['boolean'])]
     public bool $disableBuildCache = false;
 
     #[Validate(['boolean'])]
@@ -102,6 +105,7 @@ class Advanced extends Component
             $this->application->settings->is_preview_deployments_enabled = $this->isPreviewDeploymentsEnabled;
             $this->application->settings->is_pr_deployments_public_enabled = $this->isPrDeploymentsPublicEnabled;
             $this->application->settings->is_auto_deploy_enabled = $this->isAutoDeployEnabled;
+            $this->application->settings->is_deploy_on_release_enabled = $this->isDeployOnReleaseEnabled;
             $this->application->settings->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->application->settings->is_gpu_enabled = $this->isGpuEnabled;
             $this->application->settings->gpu_driver = $this->gpuDriver;
@@ -131,6 +135,7 @@ class Advanced extends Component
             $this->isPreviewDeploymentsEnabled = $this->application->settings->is_preview_deployments_enabled;
             $this->isPrDeploymentsPublicEnabled = $this->application->settings->is_pr_deployments_public_enabled ?? false;
             $this->isAutoDeployEnabled = $this->application->settings->is_auto_deploy_enabled;
+            $this->isDeployOnReleaseEnabled = $this->application->settings->is_deploy_on_release_enabled ?? false;
             $this->isGpuEnabled = $this->application->settings->is_gpu_enabled;
             $this->gpuDriver = $this->application->settings->gpu_driver;
             $this->gpuCount = $this->application->settings->gpu_count;

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -985,6 +985,15 @@ class Application extends BaseModel
         return false;
     }
 
+    public function isReleaseDeployable(): bool
+    {
+        if ($this->settings->is_deploy_on_release_enabled) {
+            return true;
+        }
+
+        return false;
+    }
+
     public function deploymentType()
     {
         if (isDev() && data_get($this, 'private_key_id') === 0) {

--- a/app/Models/ApplicationSetting.php
+++ b/app/Models/ApplicationSetting.php
@@ -18,6 +18,7 @@ class ApplicationSetting extends Model
         'inject_build_args_to_dockerfile' => 'boolean',
         'include_source_commit_in_build' => 'boolean',
         'is_auto_deploy_enabled' => 'boolean',
+        'is_deploy_on_release_enabled' => 'boolean',
         'is_force_https_enabled' => 'boolean',
         'is_debug_enabled' => 'boolean',
         'is_preview_deployments_enabled' => 'boolean',

--- a/database/migrations/2026_02_16_000001_add_deploy_on_release_to_application_settings.php
+++ b/database/migrations/2026_02_16_000001_add_deploy_on_release_to_application_settings.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('application_settings', function (Blueprint $table) {
+            $table->boolean('is_deploy_on_release_enabled')->default(false)->after('is_auto_deploy_enabled');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('application_settings', function (Blueprint $table) {
+            $table->dropColumn('is_deploy_on_release_enabled');
+        });
+    }
+};

--- a/resources/views/livewire/project/application/advanced.blade.php
+++ b/resources/views/livewire/project/application/advanced.blade.php
@@ -9,6 +9,8 @@
             @if ($application->git_based())
                 <x-forms.checkbox helper="Automatically deploy new commits based on Git webhooks." instantSave
                     id="isAutoDeployEnabled" label="Auto Deploy" canGate="update" :canResource="$application" />
+                <x-forms.checkbox helper="Automatically deploy when a new GitHub release is published. Requires the 'release' webhook event to be enabled in your repository settings." instantSave
+                    id="isDeployOnReleaseEnabled" label="Deploy on Release" canGate="update" :canResource="$application" />
                 <x-forms.checkbox
                     helper="Allow to automatically deploy Preview Deployments for all opened PR's.<br><br>Closing a PR will delete Preview Deployments."
                     instantSave id="isPreviewDeploymentsEnabled" label="Preview Deployments" canGate="update"


### PR DESCRIPTION
## Summary
Adds the ability to trigger deployments when a new GitHub release is published.

Closes #4972

## Changes
- Add `is_deploy_on_release_enabled` setting to ApplicationSetting model
- Add database migration for the new column
- Add `isReleaseDeployable()` method to Application model  
- Update GitHub webhook controller (both `manual` and `normal` methods) to handle `release` events
- Add UI toggle "Deploy on Release" in Advanced settings
- Only triggers on `published` action (when a release is created and published)

## How it works
1. User enables "Deploy on Release" in application's Advanced settings
2. User adds `release` to their GitHub webhook events (in repo settings)
3. When a new release is published on GitHub, webhook fires
4. Coolify receives the `release` event with `action: published`
5. Deployment is queued for applications with `is_deploy_on_release_enabled = true`

## Screenshots
*Deploy on Release toggle added after Auto Deploy:*

![Deploy on Release Toggle](https://files.catbox.moe/aclmvs.png)

## Testing
- [x] Manual webhook endpoint handles release events
- [x] Normal webhook endpoint handles release events  
- [x] UI toggle syncs with database correctly
- [x] Migration adds column with default `false`

---
**Bounty:** $25 via Algora