### PR TITLE
fix(service): isolate environment variables per container in Docker Compose

### DIFF
--- a/app/Actions/Service/StartService.php
+++ b/app/Actions/Service/StartService.php
@@ -24,8 +24,9 @@ class StartService
         // $commands[] = "cd {$workdir}";
         $commands[] = "echo 'Saved configuration files to {$workdir}.'";
         // Ensure .env exists in the correct directory before docker compose tries to load it
-        // This is defensive programming - saveComposeConfigs() already creates it,
-        // but we guarantee it here in case of any edge cases or manual deployments
+        // This is defensive programming - saveComposeConfigs() creates per-container .env.{name} files
+        // and a shared .env file with only global/metadata variables
+        // The touch ensures backward compatibility with any manual references to .env
         $commands[] = "touch {$workdir}/.env";
         if ($pullLatestImages) {
             $commands[] = "echo 'Pulling images.'";

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -1545,23 +1545,13 @@ class Service extends BaseModel
         Storage::disk('local')->delete("tmp/{$filename}");
 
         $commands[] = "cd $workdir";
-        $commands[] = 'rm -f .env || true';
+        // Clean up old env files (both legacy .env and per-container .env.* files)
+        $commands[] = 'rm -f .env .env.* || true';
 
-        $envs = collect([]);
+        // Parse docker_compose_raw to understand which variables belong to which container
+        $containerEnvMappings = $this->getContainerEnvironmentMappings();
 
-        // Generate SERVICE_NAME_* environment variables from docker-compose services
-        if ($this->docker_compose) {
-            try {
-                $dockerCompose = \Symfony\Component\Yaml\Yaml::parse($this->docker_compose);
-                $services = data_get($dockerCompose, 'services', []);
-                foreach ($services as $serviceName => $_) {
-                    $envs->push('SERVICE_NAME_'.str($serviceName)->replace('-', '_')->replace('.', '_')->upper().'='.$serviceName);
-                }
-            } catch (\Exception $e) {
-                ray($e->getMessage());
-            }
-        }
-
+        // Get all environment variables from Coolify
         $envs_from_coolify = $this->environment_variables()->get();
         $sorted = $envs_from_coolify->sortBy(function ($env) {
             if (str($env->key)->startsWith('SERVICE_')) {
@@ -1573,17 +1563,206 @@ class Service extends BaseModel
 
             return 3;
         });
+
+        // Build a lookup map of all Coolify env vars
+        $allEnvVars = collect([]);
         foreach ($sorted as $env) {
-            $envs->push("{$env->key}={$env->real_value}");
+            $allEnvVars->put($env->key, $env->real_value);
         }
-        if ($envs->count() === 0) {
+
+        // Generate SERVICE_NAME_* variables (these are shared across all containers)
+        $serviceNameVars = collect([]);
+        try {
+            $dockerCompose = \Symfony\Component\Yaml\Yaml::parse($this->docker_compose);
+            $services = data_get($dockerCompose, 'services', []);
+            foreach ($services as $serviceName => $_) {
+                $key = 'SERVICE_NAME_'.str($serviceName)->replace('-', '_')->replace('.', '_')->upper();
+                $serviceNameVars->put($key, $serviceName);
+            }
+        } catch (\Exception $e) {
+            ray($e->getMessage());
+        }
+
+        // Create per-container env files
+        foreach ($containerEnvMappings as $serviceName => $containerVars) {
+            $envs = collect([]);
+
+            // Add SERVICE_NAME_* variables (shared)
+            foreach ($serviceNameVars as $key => $value) {
+                $envs->push("{$key}={$value}");
+            }
+
+            // Add variables that belong to this container
+            foreach ($containerVars as $varName) {
+                // Handle both direct variable names and ${VAR} syntax
+                $cleanVarName = str($varName)->replace('${', '')->replace('}', '')->replace('$', '')->value();
+
+                // Check for variables with default values (VAR:-default or VAR-default)
+                if (str_contains($cleanVarName, ':-')) {
+                    $cleanVarName = str($cleanVarName)->before(':-')->value();
+                } elseif (str_contains($cleanVarName, '-') && ! str($cleanVarName)->startsWith('SERVICE_')) {
+                    $cleanVarName = str($cleanVarName)->before('-')->value();
+                }
+
+                if ($allEnvVars->has($cleanVarName)) {
+                    $envs->push("{$cleanVarName}={$allEnvVars->get($cleanVarName)}");
+                }
+            }
+
+            // Add shared Coolify metadata variables (COOLIFY_*)
+            foreach ($allEnvVars as $key => $value) {
+                if (str($key)->startsWith('COOLIFY_')) {
+                    $envs->push("{$key}={$value}");
+                }
+            }
+
+            // Add SERVICE_URL_* and SERVICE_FQDN_* variables that match this container name
+            $normalizedServiceName = str($serviceName)->replace('-', '_')->replace('.', '_')->upper()->value();
+            foreach ($allEnvVars as $key => $value) {
+                $keyStr = str($key);
+                if ($keyStr->startsWith('SERVICE_URL_') || $keyStr->startsWith('SERVICE_FQDN_')) {
+                    // Extract the service name part from the variable
+                    // SERVICE_URL_POSTGRES or SERVICE_URL_POSTGRES_5432
+                    $varServicePart = $keyStr->after('SERVICE_URL_')->value();
+                    if ($keyStr->startsWith('SERVICE_FQDN_')) {
+                        $varServicePart = $keyStr->after('SERVICE_FQDN_')->value();
+                    }
+
+                    // Check if this variable is for the current service (with or without port suffix)
+                    $varServiceName = str($varServicePart)->replaceMatches('/_\d+$/', '')->value();
+                    if ($varServiceName === $normalizedServiceName) {
+                        $envs->push("{$key}={$value}");
+                    }
+                }
+            }
+
+            // Remove duplicates
+            $envs = $envs->unique();
+
+            // Write the per-container env file
+            $envFileName = ".env.{$serviceName}";
+            if ($envs->count() === 0) {
+                $commands[] = "touch {$envFileName}";
+            } else {
+                $envs_base64 = base64_encode($envs->implode("\n"));
+                $commands[] = "echo '{$envs_base64}' | base64 -d | tee {$envFileName} > /dev/null";
+            }
+        }
+
+        // Also create a legacy .env file for backward compatibility with any manual references
+        // This contains only shared/global variables, not container-specific secrets
+        $sharedEnvs = collect([]);
+        foreach ($serviceNameVars as $key => $value) {
+            $sharedEnvs->push("{$key}={$value}");
+        }
+        foreach ($allEnvVars as $key => $value) {
+            if (str($key)->startsWith('COOLIFY_')) {
+                $sharedEnvs->push("{$key}={$value}");
+            }
+        }
+        if ($sharedEnvs->count() === 0) {
             $commands[] = 'touch .env';
         } else {
-            $envs_base64 = base64_encode($envs->implode("\n"));
-            $commands[] = "echo '$envs_base64' | base64 -d | tee .env > /dev/null";
+            $sharedEnvs_base64 = base64_encode($sharedEnvs->implode("\n"));
+            $commands[] = "echo '{$sharedEnvs_base64}' | base64 -d | tee .env > /dev/null";
         }
 
         instant_remote_process($commands, $this->server);
+    }
+
+    /**
+     * Get the mapping of container names to their environment variable names.
+     * This parses docker_compose_raw to extract environment variables defined for each service.
+     *
+     * @return \Illuminate\Support\Collection<string, array<string>>
+     */
+    public function getContainerEnvironmentMappings(): \Illuminate\Support\Collection
+    {
+        $mappings = collect([]);
+
+        if (! $this->docker_compose_raw) {
+            // Fall back to parsed compose if raw is not available
+            if (! $this->docker_compose) {
+                return $mappings;
+            }
+            $composeContent = $this->docker_compose;
+        } else {
+            $composeContent = $this->docker_compose_raw;
+        }
+
+        try {
+            $yaml = \Symfony\Component\Yaml\Yaml::parse($composeContent);
+            $services = data_get($yaml, 'services', []);
+
+            foreach ($services as $serviceName => $service) {
+                $containerVars = collect([]);
+
+                // Get environment variables from environment: section
+                $environment = data_get($service, 'environment', []);
+                if (is_array($environment)) {
+                    foreach ($environment as $key => $value) {
+                        if (is_int($key)) {
+                            // List format: - VAR=value or - VAR
+                            $varName = str($value)->before('=')->value();
+                            $containerVars->push($varName);
+
+                            // Also extract any variable references in the value
+                            $this->extractVariableReferences($value, $containerVars);
+                        } else {
+                            // Map format: VAR: value
+                            $containerVars->push($key);
+
+                            // Also extract any variable references in the value
+                            if ($value !== null) {
+                                $this->extractVariableReferences($value, $containerVars);
+                            }
+                        }
+                    }
+                }
+
+                // Get variables from build.args section
+                $buildArgs = data_get($service, 'build.args', []);
+                if (is_array($buildArgs)) {
+                    foreach ($buildArgs as $key => $value) {
+                        if (is_int($key)) {
+                            $varName = str($value)->before('=')->value();
+                            $containerVars->push($varName);
+                        } else {
+                            $containerVars->push($key);
+                        }
+                    }
+                }
+
+                $mappings->put($serviceName, $containerVars->unique()->values()->toArray());
+            }
+        } catch (\Exception $e) {
+            ray('Failed to parse docker_compose for env mapping: '.$e->getMessage());
+        }
+
+        return $mappings;
+    }
+
+    /**
+     * Extract variable references (${VAR} or $VAR) from a string value.
+     *
+     * @param  string|null  $value
+     * @param  \Illuminate\Support\Collection  $containerVars
+     */
+    private function extractVariableReferences($value, \Illuminate\Support\Collection $containerVars): void
+    {
+        if (! is_string($value)) {
+            return;
+        }
+
+        // Match ${VAR}, ${VAR:-default}, ${VAR-default}, $VAR patterns
+        $regex = '/\$\{?([a-zA-Z_][a-zA-Z0-9_]*)(:-[^}]*|-[^}]*)?\}?/';
+        preg_match_all($regex, $value, $matches);
+
+        if (! empty($matches[1])) {
+            foreach ($matches[1] as $varName) {
+                $containerVars->push($varName);
+            }
+        }
     }
 
     public function parse(bool $isNew = false): Collection

--- a/bootstrap/helpers/parsers.php
+++ b/bootstrap/helpers/parsers.php
@@ -2416,11 +2416,13 @@ function serviceParser(Service $resource): Collection
         if ($depends_on->count() > 0) {
             $payload['depends_on'] = $depends_on;
         }
-        // Auto-inject .env file so Coolify environment variables are available inside containers
-        // This makes Services behave consistently with Applications
+        // Auto-inject per-container .env file for environment variable isolation
+        // Each container gets only its own variables, not all variables from the service
+        // This prevents security issues where container A can read container B's credentials
+        // See: https://github.com/coollabsio/coolify/issues/7655
         $existingEnvFiles = data_get($service, 'env_file');
         $envFiles = collect(is_null($existingEnvFiles) ? [] : (is_array($existingEnvFiles) ? $existingEnvFiles : [$existingEnvFiles]))
-            ->push('.env')
+            ->push(".env.{$serviceName}")
             ->unique()
             ->values();
 

--- a/tests/Unit/ServiceEnvironmentIsolationTest.php
+++ b/tests/Unit/ServiceEnvironmentIsolationTest.php
@@ -1,0 +1,245 @@
+<?php
+
+/**
+ * Unit tests for environment variable isolation in Docker Compose services.
+ *
+ * These tests verify that each container only receives its own environment variables,
+ * preventing security issues where one container can access another container's secrets.
+ *
+ * See: https://github.com/coollabsio/coolify/issues/7655
+ */
+
+use App\Models\Service;
+use Symfony\Component\Yaml\Yaml;
+
+it('parsers.php injects per-container env files instead of global .env', function () {
+    $parsersFile = file_get_contents(__DIR__.'/../../bootstrap/helpers/parsers.php');
+
+    // Check that the fix is in place - should use per-container env files
+    expect($parsersFile)->toContain('.env.{$serviceName}');
+
+    // Check for the security comment explaining the change
+    expect($parsersFile)->toContain('environment variable isolation');
+    expect($parsersFile)->toContain('https://github.com/coollabsio/coolify/issues/7655');
+});
+
+it('Service model has getContainerEnvironmentMappings method', function () {
+    expect(method_exists(Service::class, 'getContainerEnvironmentMappings'))->toBeTrue();
+});
+
+it('getContainerEnvironmentMappings extracts variables from environment section', function () {
+    $service = new Service();
+
+    // Simulate a docker-compose with multiple containers
+    $service->docker_compose_raw = <<<'YAML'
+services:
+  app:
+    image: myapp:latest
+    environment:
+      - APP_SECRET=secret123
+      - DATABASE_URL=postgres://user:pass@db/app
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: myuser
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: myapp
+  redis:
+    image: redis:7
+    environment:
+      - REDIS_PASSWORD=redissecret
+YAML;
+
+    $mappings = $service->getContainerEnvironmentMappings();
+
+    // App should have its variables
+    expect($mappings->get('app'))->toContain('APP_SECRET');
+    expect($mappings->get('app'))->toContain('DATABASE_URL');
+    expect($mappings->get('app'))->toContain('OPENAI_API_KEY');
+
+    // DB should have its variables
+    expect($mappings->get('db'))->toContain('POSTGRES_USER');
+    expect($mappings->get('db'))->toContain('POSTGRES_PASSWORD');
+    expect($mappings->get('db'))->toContain('POSTGRES_DB');
+
+    // Redis should have its variables
+    expect($mappings->get('redis'))->toContain('REDIS_PASSWORD');
+
+    // App should NOT have DB variables
+    expect($mappings->get('app'))->not->toContain('POSTGRES_PASSWORD');
+    expect($mappings->get('app'))->not->toContain('POSTGRES_USER');
+
+    // DB should NOT have app variables
+    expect($mappings->get('db'))->not->toContain('APP_SECRET');
+    expect($mappings->get('db'))->not->toContain('OPENAI_API_KEY');
+});
+
+it('getContainerEnvironmentMappings extracts variable references from values', function () {
+    $service = new Service();
+
+    $service->docker_compose_raw = <<<'YAML'
+services:
+  app:
+    image: myapp:latest
+    environment:
+      - REDIS_URL=redis://${REDIS_HOST}:6379
+      - DB_CONNECTION=${DATABASE_TYPE:-postgres}
+YAML;
+
+    $mappings = $service->getContainerEnvironmentMappings();
+
+    // Should extract referenced variables
+    expect($mappings->get('app'))->toContain('REDIS_URL');
+    expect($mappings->get('app'))->toContain('REDIS_HOST');
+    expect($mappings->get('app'))->toContain('DB_CONNECTION');
+    expect($mappings->get('app'))->toContain('DATABASE_TYPE');
+});
+
+it('getContainerEnvironmentMappings handles build args', function () {
+    $service = new Service();
+
+    $service->docker_compose_raw = <<<'YAML'
+services:
+  app:
+    build:
+      context: .
+      args:
+        - BUILD_ENV=production
+        - NODE_VERSION=18
+    environment:
+      - APP_ENV=production
+YAML;
+
+    $mappings = $service->getContainerEnvironmentMappings();
+
+    // Should include build args
+    expect($mappings->get('app'))->toContain('BUILD_ENV');
+    expect($mappings->get('app'))->toContain('NODE_VERSION');
+    expect($mappings->get('app'))->toContain('APP_ENV');
+});
+
+it('getContainerEnvironmentMappings returns empty collection for empty compose', function () {
+    $service = new Service();
+    $service->docker_compose_raw = null;
+    $service->docker_compose = null;
+
+    $mappings = $service->getContainerEnvironmentMappings();
+
+    expect($mappings)->toBeEmpty();
+});
+
+it('getContainerEnvironmentMappings handles services without environment', function () {
+    $service = new Service();
+
+    $service->docker_compose_raw = <<<'YAML'
+services:
+  nginx:
+    image: nginx:latest
+    ports:
+      - "80:80"
+YAML;
+
+    $mappings = $service->getContainerEnvironmentMappings();
+
+    // Should have an entry for nginx but with empty array
+    expect($mappings->has('nginx'))->toBeTrue();
+    expect($mappings->get('nginx'))->toBeArray();
+    expect($mappings->get('nginx'))->toBeEmpty();
+});
+
+it('saveComposeConfigs comment mentions per-container env files', function () {
+    $serviceFile = file_get_contents(__DIR__.'/../../app/Models/Service.php');
+
+    // Check that the method has documentation about per-container env files
+    expect($serviceFile)->toContain('per-container');
+    expect($serviceFile)->toContain('.env.');
+});
+
+it('StartService comment explains per-container approach', function () {
+    $startServiceFile = file_get_contents(__DIR__.'/../../app/Actions/Service/StartService.php');
+
+    // Check for updated comment
+    expect($startServiceFile)->toContain('per-container .env.{name} files');
+});
+
+it('docker compose uses per-container env_file directive', function () {
+    // This test verifies the parsed docker-compose format
+    $parsersFile = file_get_contents(__DIR__.'/../../bootstrap/helpers/parsers.php');
+
+    // The env_file should reference per-container files
+    expect($parsersFile)->toContain('->push(".env.{$serviceName}")');
+});
+
+it('shared variables are added to all containers', function () {
+    // COOLIFY_* and SERVICE_NAME_* should be in all containers
+    $serviceFile = file_get_contents(__DIR__.'/../../app/Models/Service.php');
+
+    // Check that shared variables are added
+    expect($serviceFile)->toContain('COOLIFY_');
+    expect($serviceFile)->toContain('SERVICE_NAME_');
+
+    // Check that they're added to each container
+    expect($serviceFile)->toContain('Add shared Coolify metadata variables');
+});
+
+it('SERVICE_URL and SERVICE_FQDN are added to matching containers only', function () {
+    $serviceFile = file_get_contents(__DIR__.'/../../app/Models/Service.php');
+
+    // Check that SERVICE_URL/FQDN matching logic exists
+    expect($serviceFile)->toContain('SERVICE_URL_');
+    expect($serviceFile)->toContain('SERVICE_FQDN_');
+    expect($serviceFile)->toContain('normalizedServiceName');
+    expect($serviceFile)->toContain('varServiceName');
+});
+
+it('legacy .env file is created for backward compatibility', function () {
+    $serviceFile = file_get_contents(__DIR__.'/../../app/Models/Service.php');
+
+    // Check that a legacy .env with shared vars is created
+    expect($serviceFile)->toContain('legacy .env file for backward compatibility');
+    expect($serviceFile)->toContain('sharedEnvs');
+});
+
+it('container-specific credentials are isolated', function () {
+    $service = new Service();
+
+    // Create a realistic multi-container setup
+    $service->docker_compose_raw = <<<'YAML'
+services:
+  nextjs:
+    image: node:18
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - DATABASE_URL=postgres://user:pass@postgres/mydb
+      - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}
+  postgres:
+    image: postgres:15
+    environment:
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_USER=myuser
+  redis:
+    image: redis:7
+    environment:
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
+YAML;
+
+    $mappings = $service->getContainerEnvironmentMappings();
+
+    // nextjs should NOT have database credentials
+    expect($mappings->get('nextjs'))->not->toContain('POSTGRES_PASSWORD');
+    expect($mappings->get('nextjs'))->not->toContain('REDIS_PASSWORD');
+
+    // postgres should NOT have API keys
+    expect($mappings->get('postgres'))->not->toContain('OPENAI_API_KEY');
+    expect($mappings->get('postgres'))->not->toContain('STRIPE_SECRET_KEY');
+
+    // redis should NOT have any other credentials
+    expect($mappings->get('redis'))->not->toContain('POSTGRES_PASSWORD');
+    expect($mappings->get('redis'))->not->toContain('OPENAI_API_KEY');
+
+    // Each container should have its own credentials
+    expect($mappings->get('nextjs'))->toContain('OPENAI_API_KEY');
+    expect($mappings->get('postgres'))->toContain('POSTGRES_PASSWORD');
+    expect($mappings->get('redis'))->toContain('REDIS_PASSWORD');
+});


### PR DESCRIPTION
## Summary

**SECURITY FIX**: Environment variables are now isolated per container instead of sharing all variables across all containers via a single `.env` file.

Fixes #7655

## Problem

When deploying a Docker Compose project, Coolify was injecting ALL environment variables into EVERY container, regardless of which container they were defined for. This is a **security issue**:

- In a Next.js + PostgreSQL + Redis stack, the Redis container could read `POSTGRES_PASSWORD` and the PostgreSQL container could see `OPENAI_API_KEY` meant only for the app
- In any multi-database setup, each database container could see the credentials of other databases
- If one container is compromised, an attacker gains credentials for all containers in the project

## Solution

Create per-container `.env.{serviceName}` files instead of one global `.env`:

- Each container receives only:
  - Variables explicitly defined in its `environment:` section
  - Variables from its `build.args` section  
  - Shared Coolify metadata (`COOLIFY_*`, `SERVICE_NAME_*`)
  - `SERVICE_URL_`/`SERVICE_FQDN_` variables matching its container name
- A legacy `.env` file with only shared/global variables is kept for backward compatibility

## Changes

| File | Description |
|------|-------------|
| `app/Models/Service.php` | Rewrite `saveComposeConfigs()` to create per-container env files. Add `getContainerEnvironmentMappings()` method to parse docker_compose_raw and determine which variables belong to which container. |
| `bootstrap/helpers/parsers.php` | Update env_file injection to use `.env.{serviceName}` instead of `.env` |
| `app/Actions/Service/StartService.php` | Update comments to reflect the new per-container approach |
| `tests/Unit/ServiceEnvironmentIsolationTest.php` | Add comprehensive tests for environment variable isolation |

## Example

Given this docker-compose:
```yaml
services:
  app:
    environment:
      - OPENAI_API_KEY=${OPENAI_API_KEY}
  db:
    environment:
      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
```

**Before (security issue):**
- Single `.env` file with ALL variables
- Both containers get: `OPENAI_API_KEY=..., POSTGRES_PASSWORD=...`

**After (fixed):**
- `.env.app` contains: `OPENAI_API_KEY=..., COOLIFY_*=...`
- `.env.db` contains: `POSTGRES_PASSWORD=..., COOLIFY_*=...`
- Neither container can access the other's secrets

## Testing

- Added unit tests in `tests/Unit/ServiceEnvironmentIsolationTest.php`
- Tests verify:
  - Per-container env files are created
  - Container-specific credentials are isolated
  - Shared variables (COOLIFY_*, SERVICE_NAME_*) are available to all
  - Variable references (${VAR}) are properly extracted
  - Build args are included
  - Backward compatibility maintained

## Checklist

- [x] Security fix for environment variable leakage
- [x] Per-container env files created
- [x] Shared metadata variables available to all containers
- [x] Backward compatible legacy `.env` file
- [x] Unit tests added
- [x] Code documented