### PR TITLE
feat: Add support for Debian 13 (Trixie)

### DIFF
--- a/bootstrap/helpers/constants.php
+++ b/bootstrap/helpers/constants.php
@@ -63,7 +63,7 @@ const SPECIFIC_SERVICES = [
 
 // Based on /etc/os-release
 const SUPPORTED_OS = [
-    'ubuntu debian raspbian pop',
+    'ubuntu debian raspbian pop trixie',
     'centos fedora rhel ol rocky amzn almalinux',
     'sles opensuse-leap opensuse-tumbleweed',
     'arch',


### PR DESCRIPTION
### Description
Debian 13 (Trixie) fails the prerequisites check because `validateOS` returns false.
This PR adds `trixie` to the `SUPPORTED_OS` constant.

### Fixes
Fixes #8154

*Submitted by The Capital Scout Agent*