### PR TITLE
feat: allow OAUTH2 registration even when general registration is disabled

### DIFF
--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -21,8 +21,8 @@ class OauthController extends Controller
             $oauthUser = get_socialite_provider($provider)->user();
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
-                $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                $oauth_setting = \App\Models\OauthSetting::where('provider', $provider)->where('enabled', true)->first();
+                if (! $oauth_setting) {
                     abort(403, 'Registration is disabled');
                 }
 


### PR DESCRIPTION
This PR decouples OAUTH2 registration from the general self-registration setting. Users can now sign up via OAUTH2 even if standard registration is disabled, as long as the OAUTH provider is enabled by the administrator. Resolves #8042