### PR TITLE
feat: add WordPress + OpenLiteSpeed service template

### DIFF
--- a/templates/compose/wordpress-openlitespeed.yaml
+++ b/templates/compose/wordpress-openlitespeed.yaml
@@ -1,0 +1,46 @@
+# documentation: https://docs.litespeedtech.com/cloud/docker/
+# slogan: WordPress with OpenLiteSpeed - High-performance HTTP/3 web server
+# category: cms
+# tags: wordpress, openlitespeed, litespeed, cms, blog, http3, performance
+# logo: svgs/wordpress.svg
+# port: 80
+
+services:
+  litespeed:
+    image: litespeedtech/openlitespeed:latest
+    volumes:
+      - wordpress-data:/var/www/vhosts/localhost/html
+      - lsws-conf:/usr/local/lsws/conf
+      - lsws-logs:/usr/local/lsws/logs
+    environment:
+      - SERVICE_FQDN_LITESPEED_80
+      - MYSQL_HOST=mariadb
+      - MYSQL_DATABASE=${MYSQL_DATABASE:-wordpress}
+      - MYSQL_USER=${SERVICE_USER_MYSQL}
+      - MYSQL_PASSWORD=${SERVICE_PASSWORD_MYSQL}
+    ports:
+      - "7080:7080"
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:80"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=${SERVICE_PASSWORD_MYSQLROOT}
+      - MYSQL_DATABASE=${MYSQL_DATABASE:-wordpress}
+      - MYSQL_USER=${SERVICE_USER_MYSQL}
+      - MYSQL_PASSWORD=${SERVICE_PASSWORD_MYSQL}
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
## Summary
Adds a high-performance WordPress template using OpenLiteSpeed web server.

Closes #8264

## Features
- **OpenLiteSpeed** with HTTP/3 support for better performance
- **MariaDB 11** for the database
- **Admin panel** access on port 7080
- Proper health checks for both services

## Why OpenLiteSpeed?
OpenLiteSpeed provides significantly better performance than Apache/Nginx for WordPress:
- Native LiteSpeed Cache support
- HTTP/3 (QUIC) support
- Lower memory footprint
- Better concurrent connection handling

## Template Details
- Uses Coolify's standard variable format (${SERVICE_*})
- Follows existing template patterns (similar to ghost.yaml)
- Includes volume persistence for WordPress data and server config

---
**Bounty:** $7 via Algora