### PR TITLE
Feat: add persistent storage endpoints for applications

### DIFF
--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -11,6 +11,7 @@ use App\Jobs\DeleteResourceJob;
 use App\Models\Application;
 use App\Models\EnvironmentVariable;
 use App\Models\GithubApp;
+use App\Models\LocalPersistentVolume;
 use App\Models\PrivateKey;
 use App\Models\Project;
 use App\Models\Server;
@@ -3516,6 +3517,602 @@ class ApplicationsController extends Controller
 
         return response()->json([
             'message' => 'Environment variable deleted.',
+        ]);
+    }
+
+    #[OA\Get(
+        summary: 'List Storages',
+        description: 'List all persistent storages by application UUID.',
+        path: '/applications/{uuid}/storages',
+        operationId: 'list-storages-by-application-uuid',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Applications'],
+        parameters: [
+            new OA\Parameter(
+                name: 'uuid',
+                in: 'path',
+                description: 'UUID of the application.',
+                required: true,
+                schema: new OA\Schema(
+                    type: 'string',
+                )
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'All persistent storages by application UUID.',
+                content: [
+                    new OA\MediaType(
+                        mediaType: 'application/json',
+                        schema: new OA\Schema(
+                            type: 'array',
+                            items: new OA\Items(
+                                type: 'object',
+                                properties: [
+                                    'id' => ['type' => 'integer'],
+                                    'name' => ['type' => 'string'],
+                                    'mount_path' => ['type' => 'string'],
+                                    'host_path' => ['type' => 'string', 'nullable' => true],
+                                    'created_at' => ['type' => 'string'],
+                                    'updated_at' => ['type' => 'string'],
+                                ],
+                            )
+                        )
+                    ),
+                ]
+            ),
+            new OA\Response(
+                response: 401,
+                ref: '#/components/responses/401',
+            ),
+            new OA\Response(
+                response: 400,
+                ref: '#/components/responses/400',
+            ),
+            new OA\Response(
+                response: 404,
+                ref: '#/components/responses/404',
+            ),
+        ]
+    )]
+    public function storages(Request $request)
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+        $application = Application::ownedByCurrentTeamAPI($teamId)->where('uuid', $request->uuid)->first();
+
+        if (! $application) {
+            return response()->json([
+                'message' => 'Application not found',
+            ], 404);
+        }
+
+        $this->authorize('view', $application);
+
+        $storages = $application->persistentStorages->sortBy('id')->values();
+
+        return response()->json($storages);
+    }
+
+    #[OA\Post(
+        summary: 'Create Storage',
+        description: 'Create persistent storage for an application by UUID.',
+        path: '/applications/{uuid}/storages',
+        operationId: 'create-storage-by-application-uuid',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Applications'],
+        parameters: [
+            new OA\Parameter(
+                name: 'uuid',
+                in: 'path',
+                description: 'UUID of the application.',
+                required: true,
+                schema: new OA\Schema(
+                    type: 'string',
+                )
+            ),
+        ],
+        requestBody: new OA\RequestBody(
+            required: true,
+            description: 'Storage created.',
+            content: new OA\MediaType(
+                mediaType: 'application/json',
+                schema: new OA\Schema(
+                    type: 'object',
+                    required: ['name', 'mount_path'],
+                    properties: [
+                        'name' => ['type' => 'string', 'description' => 'The name of the storage volume (will be prefixed with app UUID).'],
+                        'mount_path' => ['type' => 'string', 'description' => 'The mount path inside the container.'],
+                        'host_path' => ['type' => 'string', 'nullable' => true, 'description' => 'The host path on the server. If not set, a Docker named volume is used.'],
+                    ],
+                ),
+            ),
+        ),
+        responses: [
+            new OA\Response(
+                response: 201,
+                description: 'Persistent storage created.',
+                content: [
+                    new OA\MediaType(
+                        mediaType: 'application/json',
+                        schema: new OA\Schema(
+                            type: 'object',
+                            properties: [
+                                'id' => ['type' => 'integer'],
+                                'name' => ['type' => 'string'],
+                                'mount_path' => ['type' => 'string'],
+                                'host_path' => ['type' => 'string', 'nullable' => true],
+                            ]
+                        )
+                    ),
+                ]
+            ),
+            new OA\Response(
+                response: 401,
+                ref: '#/components/responses/401',
+            ),
+            new OA\Response(
+                response: 400,
+                ref: '#/components/responses/400',
+            ),
+            new OA\Response(
+                response: 404,
+                ref: '#/components/responses/404',
+            ),
+            new OA\Response(
+                response: 409,
+                description: 'Storage with this name already exists.',
+                content: [
+                    new OA\MediaType(
+                        mediaType: 'application/json',
+                        schema: new OA\Schema(
+                            type: 'object',
+                            properties: [
+                                'message' => ['type' => 'string', 'example' => 'Storage with this name already exists.'],
+                            ]
+                        )
+                    ),
+                ]
+            ),
+        ]
+    )]
+    public function create_storage(Request $request)
+    {
+        $allowedFields = ['name', 'mount_path', 'host_path'];
+        $teamId = getTeamIdFromToken();
+
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+        $application = Application::ownedByCurrentTeamAPI($teamId)->where('uuid', $request->uuid)->first();
+
+        if (! $application) {
+            return response()->json([
+                'message' => 'Application not found',
+            ], 404);
+        }
+
+        $this->authorize('update', $application);
+
+        $validator = customApiValidator($request->all(), [
+            'name' => 'string|required',
+            'mount_path' => 'string|required',
+            'host_path' => 'string|nullable',
+        ]);
+
+        $extraFields = array_diff(array_keys($request->all()), $allowedFields);
+        if ($validator->fails() || ! empty($extraFields)) {
+            $errors = $validator->errors();
+            if (! empty($extraFields)) {
+                foreach ($extraFields as $field) {
+                    $errors->add($field, 'This field is not allowed.');
+                }
+            }
+
+            return response()->json([
+                'message' => 'Validation failed.',
+                'errors' => $errors,
+            ], 422);
+        }
+
+        $name = $application->uuid.'-'.str($request->name)->trim()->value;
+
+        $existing = LocalPersistentVolume::where('name', $name)
+            ->where('resource_id', $application->id)
+            ->where('resource_type', $application->getMorphClass())
+            ->first();
+
+        if ($existing) {
+            return response()->json([
+                'message' => 'Storage with this name already exists.',
+            ], 409);
+        }
+
+        $storage = LocalPersistentVolume::create([
+            'name' => $name,
+            'mount_path' => $request->mount_path,
+            'host_path' => $request->host_path,
+            'resource_id' => $application->id,
+            'resource_type' => $application->getMorphClass(),
+        ]);
+
+        return response()->json([
+            'id' => $storage->id,
+            'name' => $storage->name,
+            'mount_path' => $storage->mount_path,
+            'host_path' => $storage->host_path,
+        ])->setStatusCode(201);
+    }
+
+    #[OA\Get(
+        summary: 'Get Storage',
+        description: 'Get persistent storage by ID for an application.',
+        path: '/applications/{uuid}/storages/{storage_id}',
+        operationId: 'get-storage-by-application-uuid',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Applications'],
+        parameters: [
+            new OA\Parameter(
+                name: 'uuid',
+                in: 'path',
+                description: 'UUID of the application.',
+                required: true,
+                schema: new OA\Schema(
+                    type: 'string',
+                )
+            ),
+            new OA\Parameter(
+                name: 'storage_id',
+                in: 'path',
+                description: 'ID of the persistent storage.',
+                required: true,
+                schema: new OA\Schema(
+                    type: 'integer',
+                )
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Persistent storage details.',
+                content: [
+                    new OA\MediaType(
+                        mediaType: 'application/json',
+                        schema: new OA\Schema(
+                            type: 'object',
+                            properties: [
+                                'id' => ['type' => 'integer'],
+                                'name' => ['type' => 'string'],
+                                'mount_path' => ['type' => 'string'],
+                                'host_path' => ['type' => 'string', 'nullable' => true],
+                                'created_at' => ['type' => 'string'],
+                                'updated_at' => ['type' => 'string'],
+                            ]
+                        )
+                    ),
+                ]
+            ),
+            new OA\Response(
+                response: 401,
+                ref: '#/components/responses/401',
+            ),
+            new OA\Response(
+                response: 400,
+                ref: '#/components/responses/400',
+            ),
+            new OA\Response(
+                response: 404,
+                ref: '#/components/responses/404',
+            ),
+        ]
+    )]
+    public function storage_by_id(Request $request)
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+        $application = Application::ownedByCurrentTeamAPI($teamId)->where('uuid', $request->uuid)->first();
+
+        if (! $application) {
+            return response()->json([
+                'message' => 'Application not found',
+            ], 404);
+        }
+
+        $this->authorize('view', $application);
+
+        $storage = LocalPersistentVolume::where('id', $request->storage_id)
+            ->where('resource_id', $application->id)
+            ->where('resource_type', $application->getMorphClass())
+            ->first();
+
+        if (! $storage) {
+            return response()->json([
+                'message' => 'Storage not found.',
+            ], 404);
+        }
+
+        return response()->json($storage);
+    }
+
+    #[OA\Patch(
+        summary: 'Update Storage',
+        description: 'Update persistent storage by ID for an application.',
+        path: '/applications/{uuid}/storages/{storage_id}',
+        operationId: 'update-storage-by-application-uuid',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Applications'],
+        parameters: [
+            new OA\Parameter(
+                name: 'uuid',
+                in: 'path',
+                description: 'UUID of the application.',
+                required: true,
+                schema: new OA\Schema(
+                    type: 'string',
+                )
+            ),
+            new OA\Parameter(
+                name: 'storage_id',
+                in: 'path',
+                description: 'ID of the persistent storage.',
+                required: true,
+                schema: new OA\Schema(
+                    type: 'integer',
+                )
+            ),
+        ],
+        requestBody: new OA\RequestBody(
+            required: true,
+            description: 'Storage updated.',
+            content: new OA\MediaType(
+                mediaType: 'application/json',
+                schema: new OA\Schema(
+                    type: 'object',
+                    properties: [
+                        'name' => ['type' => 'string', 'description' => 'The name of the storage volume (will be prefixed with app UUID).'],
+                        'mount_path' => ['type' => 'string', 'description' => 'The mount path inside the container.'],
+                        'host_path' => ['type' => 'string', 'nullable' => true, 'description' => 'The host path on the server. If not set, a Docker named volume is used.'],
+                    ],
+                ),
+            ),
+        ),
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Persistent storage updated.',
+                content: [
+                    new OA\MediaType(
+                        mediaType: 'application/json',
+                        schema: new OA\Schema(
+                            type: 'object',
+                            properties: [
+                                'id' => ['type' => 'integer'],
+                                'name' => ['type' => 'string'],
+                                'mount_path' => ['type' => 'string'],
+                                'host_path' => ['type' => 'string', 'nullable' => true],
+                            ]
+                        )
+                    ),
+                ]
+            ),
+            new OA\Response(
+                response: 401,
+                ref: '#/components/responses/401',
+            ),
+            new OA\Response(
+                response: 400,
+                ref: '#/components/responses/400',
+            ),
+            new OA\Response(
+                response: 404,
+                ref: '#/components/responses/404',
+            ),
+            new OA\Response(
+                response: 409,
+                description: 'Storage with this name already exists.',
+                content: [
+                    new OA\MediaType(
+                        mediaType: 'application/json',
+                        schema: new OA\Schema(
+                            type: 'object',
+                            properties: [
+                                'message' => ['type' => 'string', 'example' => 'Storage with this name already exists.'],
+                            ]
+                        )
+                    ),
+                ]
+            ),
+        ]
+    )]
+    public function update_storage(Request $request)
+    {
+        $allowedFields = ['name', 'mount_path', 'host_path'];
+        $teamId = getTeamIdFromToken();
+
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+        $application = Application::ownedByCurrentTeamAPI($teamId)->where('uuid', $request->uuid)->first();
+
+        if (! $application) {
+            return response()->json([
+                'message' => 'Application not found',
+            ], 404);
+        }
+
+        $this->authorize('update', $application);
+
+        $storage = LocalPersistentVolume::where('id', $request->storage_id)
+            ->where('resource_id', $application->id)
+            ->where('resource_type', $application->getMorphClass())
+            ->first();
+
+        if (! $storage) {
+            return response()->json([
+                'message' => 'Storage not found.',
+            ], 404);
+        }
+
+        $validator = customApiValidator($request->all(), [
+            'name' => 'string',
+            'mount_path' => 'string',
+            'host_path' => 'string|nullable',
+        ]);
+
+        $extraFields = array_diff(array_keys($request->all()), $allowedFields);
+        if ($validator->fails() || ! empty($extraFields)) {
+            $errors = $validator->errors();
+            if (! empty($extraFields)) {
+                foreach ($extraFields as $field) {
+                    $errors->add($field, 'This field is not allowed.');
+                }
+            }
+
+            return response()->json([
+                'message' => 'Validation failed.',
+                'errors' => $errors,
+            ], 422);
+        }
+
+        if ($request->has('name')) {
+            $newName = $application->uuid.'-'.str($request->name)->trim()->value;
+
+            $existing = LocalPersistentVolume::where('name', $newName)
+                ->where('resource_id', $application->id)
+                ->where('resource_type', $application->getMorphClass())
+                ->where('id', '!=', $storage->id)
+                ->first();
+
+            if ($existing) {
+                return response()->json([
+                    'message' => 'Storage with this name already exists.',
+                ], 409);
+            }
+
+            $storage->name = $newName;
+        }
+
+        if ($request->has('mount_path')) {
+            $storage->mount_path = $request->mount_path;
+        }
+
+        if ($request->has('host_path')) {
+            $storage->host_path = $request->host_path;
+        }
+
+        $storage->save();
+
+        return response()->json([
+            'id' => $storage->id,
+            'name' => $storage->name,
+            'mount_path' => $storage->mount_path,
+            'host_path' => $storage->host_path,
+        ]);
+    }
+
+    #[OA\Delete(
+        summary: 'Delete Storage',
+        description: 'Delete persistent storage by ID for an application.',
+        path: '/applications/{uuid}/storages/{storage_id}',
+        operationId: 'delete-storage-by-application-uuid',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Applications'],
+        parameters: [
+            new OA\Parameter(
+                name: 'uuid',
+                in: 'path',
+                description: 'UUID of the application.',
+                required: true,
+                schema: new OA\Schema(
+                    type: 'string',
+                )
+            ),
+            new OA\Parameter(
+                name: 'storage_id',
+                in: 'path',
+                description: 'ID of the persistent storage.',
+                required: true,
+                schema: new OA\Schema(
+                    type: 'integer',
+                )
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Persistent storage deleted.',
+                content: [
+                    new OA\MediaType(
+                        mediaType: 'application/json',
+                        schema: new OA\Schema(
+                            type: 'object',
+                            properties: [
+                                'message' => ['type' => 'string', 'example' => 'Storage deleted.'],
+                            ]
+                        )
+                    ),
+                ]
+            ),
+            new OA\Response(
+                response: 401,
+                ref: '#/components/responses/401',
+            ),
+            new OA\Response(
+                response: 400,
+                ref: '#/components/responses/400',
+            ),
+            new OA\Response(
+                response: 404,
+                ref: '#/components/responses/404',
+            ),
+        ]
+    )]
+    public function delete_storage(Request $request)
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+        $application = Application::ownedByCurrentTeamAPI($teamId)->where('uuid', $request->uuid)->first();
+
+        if (! $application) {
+            return response()->json([
+                'message' => 'Application not found.',
+            ], 404);
+        }
+
+        $this->authorize('update', $application);
+
+        $storage = LocalPersistentVolume::where('id', $request->storage_id)
+            ->where('resource_id', $application->id)
+            ->where('resource_type', $application->getMorphClass())
+            ->first();
+
+        if (! $storage) {
+            return response()->json([
+                'message' => 'Storage not found.',
+            ], 404);
+        }
+
+        $storage->delete();
+
+        return response()->json([
+            'message' => 'Storage deleted.',
         ]);
     }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -118,6 +118,13 @@ Route::group([
     Route::patch('/applications/{uuid}/envs/bulk', [ApplicationsController::class, 'create_bulk_envs'])->middleware(['api.ability:write']);
     Route::patch('/applications/{uuid}/envs', [ApplicationsController::class, 'update_env_by_uuid'])->middleware(['api.ability:write']);
     Route::delete('/applications/{uuid}/envs/{env_uuid}', [ApplicationsController::class, 'delete_env_by_uuid'])->middleware(['api.ability:write']);
+
+    Route::get('/applications/{uuid}/storages', [ApplicationsController::class, 'storages'])->middleware(['api.ability:read']);
+    Route::post('/applications/{uuid}/storages', [ApplicationsController::class, 'create_storage'])->middleware(['api.ability:write']);
+    Route::get('/applications/{uuid}/storages/{storage_id}', [ApplicationsController::class, 'storage_by_id'])->middleware(['api.ability:read']);
+    Route::patch('/applications/{uuid}/storages/{storage_id}', [ApplicationsController::class, 'update_storage'])->middleware(['api.ability:write']);
+    Route::delete('/applications/{uuid}/storages/{storage_id}', [ApplicationsController::class, 'delete_storage'])->middleware(['api.ability:write']);
+
     Route::get('/applications/{uuid}/logs', [ApplicationsController::class, 'logs_by_uuid'])->middleware(['api.ability:read']);
 
     Route::match(['get', 'post'], '/applications/{uuid}/start', [ApplicationsController::class, 'action_deploy'])->middleware(['api.ability:write']);


### PR DESCRIPTION
Closes #8397

## Summary

Add 5 new REST API endpoints for managing persistent storage (volumes) on applications, closing the gap where the Livewire UI could manage storage but the API had no surface for programmatic access.

### New Endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | `/applications/{uuid}/storages` | List all persistent storages |
| POST | `/applications/{uuid}/storages` | Create a new persistent storage |
| GET | `/applications/{uuid}/storages/{storage_id}` | Get a single storage by ID |
| PATCH | `/applications/{uuid}/storages/{storage_id}` | Update a storage |
| DELETE | `/applications/{uuid}/storages/{storage_id}` | Delete a storage |

### Implementation Details

- Follows the exact same patterns as the existing env variable endpoints (auth flow, validation, OpenAPI annotations, extra-field rejection)
- Volume name generation uses `$application->uuid . '-' . $request->name` (same as `submitPersistentVolume()` in `app/Livewire/Project/Service/Storage.php`)
- Handles duplicate names gracefully (409 Conflict via unique constraint check)
- Authorization: `authorize('view', $application)` for reads, `authorize('update', $application)` for writes
- Full `#[OA\...]` PHP attribute annotations for auto-generated OpenAPI documentation

### Motivation

The `LocalPersistentVolume` model, the `Application->persistentStorages()` relationship, and the deployment job that mounts volumes all exist. The only missing piece is the API surface. Additionally, `custom_docker_run_options` with `--volume` is silently ignored by `convertDockerRunToCompose()` (not in the supported options whitelist), so there is currently no API workaround at all.

### Files Changed

- `routes/api.php` — 5 new routes (7 lines)
- `app/Http/Controllers/Api/ApplicationsController.php` — 5 new methods + 1 import (597 lines)

## AI Disclosure

This PR was authored with the assistance of Claude Code (AI). All generated code has been reviewed, verified against the existing codebase patterns (env endpoints, Livewire storage component), and the implementation logic is fully understood by the submitter. The code follows the exact conventions found in the existing `envs()`, `create_env()`, `update_env_by_uuid()`, and `delete_env_by_uuid()` methods.

## Test plan

- [ ] Verify PHP syntax passes (`php -l` on both modified files)
- [ ] Run existing test suite to ensure no regressions
- [ ] Create an application via API, then test all 5 storage endpoints:
  - `GET /api/v1/applications/{uuid}/storages` → 200 with empty array
  - `POST /api/v1/applications/{uuid}/storages` with `{ "name": "data", "mount_path": "/data" }` → 201
  - `GET /api/v1/applications/{uuid}/storages/{id}` → 200 with storage details
  - `PATCH /api/v1/applications/{uuid}/storages/{id}` with `{ "mount_path": "/new-data" }` → 200
  - `DELETE /api/v1/applications/{uuid}/storages/{id}` → 200
- [ ] Verify 409 is returned when creating a storage with a duplicate name
- [ ] Verify 404 is returned when accessing a storage that doesn't belong to the application
- [ ] Verify that after creating a storage via API + redeploying, the volume is mounted in the container