### PR TITLE
fix(scheduled-tasks): capture output on failure to prevent empty logs

### DIFF
--- a/app/Jobs/ScheduledTaskJob.php
+++ b/app/Jobs/ScheduledTaskJob.php
@@ -27,7 +27,7 @@ class ScheduledTaskJob implements ShouldQueue
     /**
      * The number of times the job may be attempted.
      */
-    public $tries = 3;
+    public $tries = 1;
 
     /**
      * The maximum number of unhandled exceptions to allow before failing.
@@ -51,8 +51,9 @@ class ScheduledTaskJob implements ShouldQueue
 
     /**
      * Store execution ID to survive job serialization for timeout handling.
+     * Public so it is included in the queue payload and available in failed().
      */
-    protected ?int $executionId = null;
+    public ?int $executionId = null;
 
     public string $task_status = 'failed';
 
@@ -100,10 +101,9 @@ class ScheduledTaskJob implements ShouldQueue
             $this->task_log = ScheduledTaskExecution::create([
                 'scheduled_task_id' => $this->task->id,
                 'started_at' => $startTime,
-                'retry_count' => $this->attempts() - 1,
             ]);
 
-            // Store execution ID for timeout handling
+            // Store execution ID for timeout handling (public so it survives serialization)
             $this->executionId = $this->task_log->id;
 
             $this->server = $this->resource->destination->server;
@@ -139,9 +139,32 @@ class ScheduledTaskJob implements ShouldQueue
                 if (count($this->containers) == 1 || str_starts_with($containerName, $this->task->container.'-'.$this->resource->uuid)) {
                     $cmd = "sh -c '".str_replace("'", "'\''", $this->task->command)."'";
                     $exec = "docker exec {$containerName} {$cmd}";
+
+                    // Run the command with throwError=false and redirect stderr to stdout
+                    // so we always capture all output even when the command fails.
+                    // Append a unique exit code marker so we can determine success/failure.
                     // Disable SSH multiplexing to prevent race conditions when multiple tasks run concurrently
                     // See: https://github.com/coollabsio/coolify/issues/6736
-                    $this->task_output = instant_remote_process([$exec], $this->server, true, false, $this->timeout, disableMultiplexing: true);
+                    $wrappedExec = '('.$exec.') 2>&1; echo "COOLIFY_EXIT_CODE:$?"';
+                    $rawOutput = instant_remote_process([$wrappedExec], $this->server, false, false, $this->timeout, disableMultiplexing: true);
+
+                    // Parse exit code and clean output
+                    $exitCode = $this->parseExitCode($rawOutput);
+                    $this->task_output = $this->stripExitCodeLine($rawOutput);
+
+                    if ($exitCode !== 0) {
+                        $failureMessage = $this->task_output ?: "Task failed with exit code {$exitCode} (no output)";
+
+                        $this->task_log->update([
+                            'status' => 'failed',
+                            'message' => $failureMessage,
+                        ]);
+
+                        $this->team?->notify(new TaskFailed($this->task, $failureMessage));
+
+                        return;
+                    }
+
                     $this->task_log->update([
                         'status' => 'success',
                         'message' => $this->task_output,
@@ -156,10 +179,19 @@ class ScheduledTaskJob implements ShouldQueue
             // No valid container was found.
             throw new NonReportableException('ScheduledTaskJob failed: No valid container was found. Is the container name correct?');
         } catch (\Throwable $e) {
+            // Build a meaningful error message that includes any captured output
+            $errorMessage = $e->getMessage();
+            if ($this->task_output) {
+                $errorMessage = $this->task_output."\n\n".$errorMessage;
+            }
+            if (empty($errorMessage)) {
+                $errorMessage = 'Task failed with unknown error (no output captured)';
+            }
+
             if ($this->task_log) {
                 $this->task_log->update([
                     'status' => 'failed',
-                    'message' => $this->task_output ?? $e->getMessage(),
+                    'message' => $errorMessage,
                 ]);
             }
 
@@ -169,14 +201,16 @@ class ScheduledTaskJob implements ShouldQueue
                 'task_id' => $this->task->uuid,
                 'task_name' => $this->task->name,
                 'server' => $this->server?->name ?? 'unknown',
-                'attempt' => $this->attempts(),
                 'error' => $e->getMessage(),
             ]);
 
-            // Only notify and throw on final failure
+            // Notify team about the failure
+            $this->team?->notify(new TaskFailed($this->task, $errorMessage));
 
-            // Re-throw to trigger Laravel's retry mechanism with backoff
-            throw $e;
+            // Do not re-throw: the execution log already records the failure status
+            // and message. Re-throwing would cause Laravel to invoke failed() in a
+            // potentially separate process (e.g., on timeout) where the execution
+            // record may not be reliably found, leading to missing logs.
         } finally {
             ScheduledTaskDone::dispatch($this->team->id);
             if ($this->task_log) {
@@ -192,15 +226,44 @@ class ScheduledTaskJob implements ShouldQueue
     }
 
     /**
-     * Calculate the number of seconds to wait before retrying the job.
+     * Parse the exit code from the wrapped command output.
+     * The output ends with "COOLIFY_EXIT_CODE:<code>" appended by the wrapper.
      */
-    public function backoff(): array
+    private function parseExitCode(?string $output): int
     {
-        return [30, 60, 120]; // 30s, 60s, 120s between retries
+        if ($output === null || $output === '') {
+            return 1;
+        }
+
+        if (preg_match('/COOLIFY_EXIT_CODE:(\d+)\s*$/', $output, $matches)) {
+            return (int) $matches[1];
+        }
+
+        // If we can't find the exit code marker, assume failure
+        return 1;
     }
 
     /**
-     * Handle a job failure.
+     * Strip the COOLIFY_EXIT_CODE marker line from the command output.
+     */
+    private function stripExitCodeLine(?string $output): ?string
+    {
+        if ($output === null || $output === '') {
+            return $output;
+        }
+
+        $cleaned = preg_replace('/\nCOOLIFY_EXIT_CODE:\d+\s*$/', '', $output);
+        // Handle case where the marker is the only output
+        $cleaned = preg_replace('/^COOLIFY_EXIT_CODE:\d+\s*$/', '', $cleaned);
+
+        $cleaned = trim($cleaned);
+
+        return $cleaned !== '' ? $cleaned : null;
+    }
+
+    /**
+     * Handle a job failure (e.g., timeout kills the worker process).
+     * This runs in a fresh process when a timeout occurs.
      */
     public function failed(?\Throwable $exception): void
     {
@@ -209,22 +272,16 @@ class ScheduledTaskJob implements ShouldQueue
             'task_id' => $this->task->uuid,
             'task_name' => $this->task->name,
             'server' => $this->server?->name ?? 'unknown',
-            'total_attempts' => $this->attempts(),
             'error' => $exception?->getMessage(),
-            'trace' => $exception?->getTraceAsString(),
         ]);
 
-        // Reload execution log from database
-        // When a job times out, failed() is called in a fresh process with the original
-        // queue payload, so $executionId will be null. We need to query for the latest execution.
+        // Find the execution record to update
         $execution = null;
 
-        // Try to find execution using stored ID first (works for non-timeout failures)
         if ($this->executionId) {
             $execution = ScheduledTaskExecution::find($this->executionId);
         }
 
-        // If no stored ID or not found, query for the most recent execution log for this task
         if (! $execution) {
             $execution = ScheduledTaskExecution::query()
                 ->where('scheduled_task_id', $this->task->id)
@@ -232,31 +289,36 @@ class ScheduledTaskJob implements ShouldQueue
                 ->first();
         }
 
-        // Last resort: check task_log property
-        if (! $execution && $this->task_log) {
-            $execution = $this->task_log;
-        }
-
         if ($execution) {
-            $errorMessage = 'Job permanently failed after '.$this->attempts().' attempts';
-            if ($exception) {
-                $errorMessage .= ': '.$exception->getMessage();
-            }
+            $errorMessage = $exception?->getMessage() ?? 'Unknown error';
+
+            // Preserve any output that was already captured before the failure
+            $message = $execution->message
+                ? $execution->message."\n\n".$errorMessage
+                : $errorMessage;
 
             $execution->update([
                 'status' => 'failed',
-                'message' => $errorMessage,
-                'error_details' => $exception?->getTraceAsString(),
+                'message' => $message,
                 'finished_at' => Carbon::now()->toImmutable(),
             ]);
         } else {
-            Log::channel('scheduled-errors')->warning('Could not find execution log to update', [
+            // Create an execution record as a last resort so the failure is visible in the UI
+            ScheduledTaskExecution::create([
+                'scheduled_task_id' => $this->task->id,
+                'status' => 'failed',
+                'message' => $exception?->getMessage() ?? 'Unknown error (no execution record found)',
+                'started_at' => Carbon::now(),
+                'finished_at' => Carbon::now()->toImmutable(),
+            ]);
+
+            Log::channel('scheduled-errors')->warning('Created new execution record for failed task (original not found)', [
                 'execution_id' => $this->executionId,
                 'task_id' => $this->task->uuid,
             ]);
         }
 
-        // Notify team about permanent failure
+        // Notify team about the failure
         $this->team?->notify(new TaskFailed($this->task, $exception?->getMessage() ?? 'Unknown error'));
     }
 }

--- a/tests/Unit/ScheduledTaskJobTimeoutTest.php
+++ b/tests/Unit/ScheduledTaskJobTimeoutTest.php
@@ -14,9 +14,9 @@ it('has executionId property for timeout handling', function () {
     // Verify executionId property exists
     expect($reflection->hasProperty('executionId'))->toBeTrue();
 
-    // Verify it's protected (will be serialized with the job)
+    // Verify it's public (so it survives job serialization for timeout handling)
     $property = $reflection->getProperty('executionId');
-    expect($property->isProtected())->toBeTrue();
+    expect($property->isPublic())->toBeTrue();
 });
 
 it('has failed method that handles job failures', function () {
@@ -59,8 +59,8 @@ it('failed method implementation reloads execution from database', function () {
         ->toContain('notify');
 });
 
-it('failed method updates execution with error_details field', function () {
-    // Read the failed() method source code to verify error_details is populated
+it('failed method creates execution record as last resort', function () {
+    // Read the failed() method source code to verify fallback execution creation
     $reflection = new ReflectionClass(ScheduledTaskJob::class);
     $method = $reflection->getMethod('failed');
 
@@ -72,12 +72,14 @@ it('failed method updates execution with error_details field', function () {
     $source = file($filename);
     $methodSource = implode('', array_slice($source, $startLine - 1, $endLine - $startLine + 1));
 
-    // Verify the implementation populates error_details field
-    expect($methodSource)->toContain('error_details');
+    // Verify the implementation creates an execution record when none is found
+    expect($methodSource)
+        ->toContain('ScheduledTaskExecution::create')
+        ->toContain('last resort');
 });
 
-it('failed method logs when execution cannot be found', function () {
-    // Read the failed() method source code to verify defensive logging
+it('failed method preserves existing output in execution message', function () {
+    // Read the failed() method source code to verify it preserves existing output
     $reflection = new ReflectionClass(ScheduledTaskJob::class);
     $method = $reflection->getMethod('failed');
 
@@ -89,8 +91,75 @@ it('failed method logs when execution cannot be found', function () {
     $source = file($filename);
     $methodSource = implode('', array_slice($source, $startLine - 1, $endLine - $startLine + 1));
 
-    // Verify the implementation logs a warning if execution is not found
+    // Verify the implementation preserves existing message content
     expect($methodSource)
-        ->toContain('Could not find execution log')
-        ->toContain('warning');
+        ->toContain('$execution->message');
+});
+
+it('has parseExitCode method for extracting exit codes', function () {
+    $reflection = new ReflectionClass(ScheduledTaskJob::class);
+
+    expect($reflection->hasMethod('parseExitCode'))->toBeTrue();
+
+    $method = $reflection->getMethod('parseExitCode');
+    expect($method->isPrivate())->toBeTrue();
+});
+
+it('has stripExitCodeLine method for cleaning output', function () {
+    $reflection = new ReflectionClass(ScheduledTaskJob::class);
+
+    expect($reflection->hasMethod('stripExitCodeLine'))->toBeTrue();
+
+    $method = $reflection->getMethod('stripExitCodeLine');
+    expect($method->isPrivate())->toBeTrue();
+});
+
+it('parseExitCode correctly extracts exit codes from output', function () {
+    $reflection = new ReflectionClass(ScheduledTaskJob::class);
+    $method = $reflection->getMethod('parseExitCode');
+    $method->setAccessible(true);
+
+    // Create an uninitialized instance to call the method on
+    $instance = $reflection->newInstanceWithoutConstructor();
+
+    // Test successful exit code
+    expect($method->invoke($instance, "some output\nCOOLIFY_EXIT_CODE:0"))->toBe(0);
+
+    // Test failed exit code
+    expect($method->invoke($instance, "error output\nCOOLIFY_EXIT_CODE:1"))->toBe(1);
+
+    // Test higher exit code
+    expect($method->invoke($instance, "output\nCOOLIFY_EXIT_CODE:127"))->toBe(127);
+
+    // Test null output
+    expect($method->invoke($instance, null))->toBe(1);
+
+    // Test empty output
+    expect($method->invoke($instance, ''))->toBe(1);
+
+    // Test output without marker
+    expect($method->invoke($instance, 'just some output'))->toBe(1);
+});
+
+it('stripExitCodeLine correctly removes the marker from output', function () {
+    $reflection = new ReflectionClass(ScheduledTaskJob::class);
+    $method = $reflection->getMethod('stripExitCodeLine');
+    $method->setAccessible(true);
+
+    $instance = $reflection->newInstanceWithoutConstructor();
+
+    // Test normal output with marker
+    expect($method->invoke($instance, "hello world\nCOOLIFY_EXIT_CODE:0"))->toBe('hello world');
+
+    // Test multiline output with marker
+    expect($method->invoke($instance, "line1\nline2\nCOOLIFY_EXIT_CODE:1"))->toBe("line1\nline2");
+
+    // Test marker-only output
+    expect($method->invoke($instance, 'COOLIFY_EXIT_CODE:0'))->toBeNull();
+
+    // Test null output
+    expect($method->invoke($instance, null))->toBeNull();
+
+    // Test empty output
+    expect($method->invoke($instance, ''))->toBe('');
 });


### PR DESCRIPTION
## Summary

Fixes #6566

Scheduled tasks that fail show "Waiting for task output..." with no logs. This happens because:

1. **`instant_remote_process` discards stdout on failure**: When called with `throwError=true`, if the command exits with non-zero, only stderr is captured in the exception message. For most container commands, stderr is empty while all useful output goes to stdout -- so the log message ends up empty.

2. **`$maxExceptions=1` makes retry logic dead code**: With `$maxExceptions=1` and `$tries=3`, the job permanently fails on the first exception. The `backoff()` method and retry logic never execute.

3. **`executionId` lost during timeout serialization**: The property was `protected`, so it wasn't included in the queue payload. When a timeout kills the worker and `failed()` runs in a new process, it couldn't find the execution record by ID.

## Changes

- **Wrap command to capture all output**: Run docker exec inside `(cmd) 2>&1; echo "COOLIFY_EXIT_CODE:$?"` to merge stderr into stdout and preserve the exit code. Call `instant_remote_process` with `throwError=false` so output is always returned, even on failure.
- **Parse exit code from marker**: New `parseExitCode()` and `stripExitCodeLine()` methods extract the real exit code and clean the output.
- **Fix `$tries` to match `$maxExceptions`**: Set `$tries=1` since `$maxExceptions=1` already prevents retries. Removed dead `backoff()` method.
- **Make `executionId` public**: Ensures it survives job serialization so `failed()` can always find the execution record.
- **Create fallback execution record in `failed()`**: If no execution record is found (edge case), create one as a last resort so the failure is always visible in the UI.
- **Send failure notifications immediately**: Notify in the catch block instead of relying on the re-throw + `failed()` chain, which is unreliable across process boundaries.

## Test plan

- [x] Updated unit tests for `parseExitCode` and `stripExitCodeLine` helper methods
- [x] Updated tests for `executionId` visibility (now public)
- [x] Updated tests for `failed()` method behavior (fallback execution creation)
- [ ] Manual test: create a scheduled task with a command that fails (e.g., `exit 1`) and verify the failure output is visible in the logs
- [ ] Manual test: create a scheduled task with a command that produces output before failing (e.g., `echo "hello" && exit 1`) and verify both the output and failure are logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)