### PR TITLE
feat: add database backup support for Docker Compose deployments

### DIFF
--- a/app/Actions/Database/StartDatabaseProxy.php
+++ b/app/Actions/Database/StartDatabaseProxy.php
@@ -31,9 +31,10 @@ class StartDatabaseProxy
 
         if ($database->getMorphClass() === \App\Models\ServiceDatabase::class) {
             $databaseType = $database->databaseType();
-            $network = $database->service->uuid;
-            $server = data_get($database, 'service.destination.server');
-            $containerName = "{$database->name}-{$database->service->uuid}";
+            $owner = $database->owner();
+            $network = $owner->uuid;
+            $server = $database->serverResource();
+            $containerName = "{$database->name}-{$owner->uuid}";
         }
         $internalPort = match ($databaseType) {
             'standalone-mariadb', 'standalone-mysql' => 3306,

--- a/app/Console/Commands/CleanupStuckedResources.php
+++ b/app/Console/Commands/CleanupStuckedResources.php
@@ -432,8 +432,8 @@ class CleanupStuckedResources extends Command
         try {
             $serviceDatabases = ServiceDatabase::all();
             foreach ($serviceDatabases as $service) {
-                if (! data_get($service, 'service')) {
-                    echo 'ServiceDatabase without service: '.$service->name.'\n';
+                if (! data_get($service, 'service') && ! data_get($service, 'application')) {
+                    echo 'ServiceDatabase without owner: '.$service->name.'\n';
                     $service->forceDelete();
 
                     continue;

--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -93,7 +93,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $this->database = data_get($this->backup, 'database');
-                $this->server = $this->database->service->server;
+                $this->server = $this->database->serverResource();
                 $this->s3 = $this->backup->s3;
             } else {
                 $this->database = data_get($this->backup, 'database');
@@ -115,8 +115,9 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $databaseType = $this->database->databaseType();
-                $serviceUuid = $this->database->service->uuid;
-                $serviceName = str($this->database->service->name)->slug();
+                $owner = $this->database->owner();
+                $serviceUuid = $owner->uuid;
+                $serviceName = str($owner->name)->slug();
                 if (str($databaseType)->contains('postgres')) {
                     $this->container_name = "{$this->database->name}-$serviceUuid";
                     $this->directory_name = $serviceName.'-'.$this->container_name;
@@ -630,7 +631,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             $endpoint = $this->s3->endpoint;
             $this->s3->testConnection(shouldSave: true);
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
-                $network = $this->database->service->destination->network;
+                $network = $this->database->owner()->destination->network;
             } else {
                 $network = $this->database->destination->network;
             }

--- a/app/Livewire/Project/Application/DatabaseBackups.php
+++ b/app/Livewire/Project/Application/DatabaseBackups.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Livewire\Project\Application;
+
+use App\Models\Application;
+use App\Models\ServiceDatabase;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Component;
+
+class DatabaseBackups extends Component
+{
+    use AuthorizesRequests;
+
+    public ?Application $application = null;
+
+    public array $parameters;
+
+    public $serviceDatabases = [];
+
+    public ?ServiceDatabase $selectedDatabase = null;
+
+    public bool $isImportSupported = false;
+
+    protected $listeners = ['refreshScheduledBackups' => '$refresh'];
+
+    public function mount()
+    {
+        try {
+            $this->parameters = get_route_parameters();
+            $this->application = Application::whereUuid($this->parameters['application_uuid'])->first();
+            if (! $this->application) {
+                return redirect()->route('dashboard');
+            }
+            $this->authorize('view', $this->application);
+
+            $this->serviceDatabases = $this->application->serviceDatabases()
+                ->where(function ($query) {
+                    $query->whereNull('deleted_at');
+                })
+                ->get();
+
+            if ($this->serviceDatabases->isEmpty()) {
+                return redirect()->route('project.application.configuration', $this->parameters);
+            }
+
+            $this->selectedDatabase = $this->serviceDatabases->first();
+            $this->updateImportSupport();
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function selectDatabase($databaseId): void
+    {
+        $this->selectedDatabase = $this->serviceDatabases->firstWhere('id', $databaseId);
+        $this->updateImportSupport();
+    }
+
+    private function updateImportSupport(): void
+    {
+        if ($this->selectedDatabase) {
+            $dbType = $this->selectedDatabase->databaseType();
+            $supportedTypes = ['mysql', 'mariadb', 'postgres', 'mongo'];
+            $this->isImportSupported = collect($supportedTypes)->contains(fn ($type) => str_contains($dbType, $type));
+        }
+    }
+
+    public function render()
+    {
+        return view('livewire.project.application.database-backups');
+    }
+}

--- a/app/Livewire/Project/Database/BackupEdit.php
+++ b/app/Livewire/Project/Database/BackupEdit.php
@@ -157,7 +157,7 @@ class BackupEdit extends Component
         try {
             $server = null;
             if ($this->backup->database instanceof \App\Models\ServiceDatabase) {
-                $server = $this->backup->database->service->destination->server;
+                $server = $this->backup->database->serverResource();
             } elseif ($this->backup->database->destination && $this->backup->database->destination->server) {
                 $server = $this->backup->database->destination->server;
             }
@@ -184,6 +184,14 @@ class BackupEdit extends Component
 
             if ($this->backup->database->getMorphClass() === \App\Models\ServiceDatabase::class) {
                 $serviceDatabase = $this->backup->database;
+
+                if ($serviceDatabase->isOwnedByApplication()) {
+                    return redirect()->route('project.application.configuration', [
+                        'project_uuid' => $this->parameters['project_uuid'],
+                        'environment_uuid' => $this->parameters['environment_uuid'],
+                        'application_uuid' => $serviceDatabase->application->uuid,
+                    ]);
+                }
 
                 return redirect()->route('project.service.database.backups', [
                     'project_uuid' => $this->parameters['project_uuid'],

--- a/app/Livewire/Project/Database/BackupExecutions.php
+++ b/app/Livewire/Project/Database/BackupExecutions.php
@@ -79,7 +79,7 @@ class BackupExecutions extends Component
         }
 
         $server = $execution->scheduledDatabaseBackup->database->getMorphClass() === \App\Models\ServiceDatabase::class
-            ? $execution->scheduledDatabaseBackup->database->service->destination->server
+            ? $execution->scheduledDatabaseBackup->database->serverResource()
             : $execution->scheduledDatabaseBackup->database->destination->server;
 
         try {
@@ -182,7 +182,7 @@ class BackupExecutions extends Component
             $server = null;
 
             if ($this->database instanceof \App\Models\ServiceDatabase) {
-                $server = $this->database->service->destination->server;
+                $server = $this->database->serverResource();
             } elseif ($this->database->destination && $this->database->destination->server) {
                 $server = $this->database->destination->server;
             }

--- a/app/Livewire/Project/Database/Import.php
+++ b/app/Livewire/Project/Database/Import.php
@@ -314,12 +314,12 @@ EOD;
 
         // Handle ServiceDatabase server access differently
         if ($resource->getMorphClass() === \App\Models\ServiceDatabase::class) {
-            $server = $resource->service?->server;
+            $server = $resource->serverResource();
             if (! $server) {
                 abort(404, 'Server not found for this service database.');
             }
             $this->serverId = $server->id;
-            $this->container = $resource->name.'-'.$resource->service->uuid;
+            $this->container = $resource->name.'-'.$resource->owner()->uuid;
             $this->resourceUuid = $resource->uuid; // Use ServiceDatabase's own UUID
 
             // Determine database type for ServiceDatabase
@@ -633,7 +633,7 @@ EOD;
 
             // Get the database destination network
             if ($this->resource->getMorphClass() === \App\Models\ServiceDatabase::class) {
-                $destinationNetwork = $this->resource->service->destination->network ?? 'coolify';
+                $destinationNetwork = $this->resource->owner()->destination->network ?? 'coolify';
             } else {
                 $destinationNetwork = $this->resource->destination->network ?? 'coolify';
             }

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -915,6 +915,11 @@ class Application extends BaseModel
         return $this->hasMany(ApplicationDeploymentQueue::class);
     }
 
+    public function serviceDatabases()
+    {
+        return $this->hasMany(ServiceDatabase::class);
+    }
+
     public function destination()
     {
         return $this->morphTo();

--- a/app/Models/ScheduledDatabaseBackup.php
+++ b/app/Models/ScheduledDatabaseBackup.php
@@ -67,8 +67,7 @@ class ScheduledDatabaseBackup extends BaseModel
     {
         if ($this->database) {
             if ($this->database instanceof ServiceDatabase) {
-                $destination = data_get($this->database->service, 'destination');
-                $server = data_get($destination, 'server');
+                $server = $this->database->serverResource();
             } else {
                 $destination = data_get($this->database, 'destination');
                 $server = data_get($destination, 'server');

--- a/app/Models/ServiceDatabase.php
+++ b/app/Models/ServiceDatabase.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class ServiceDatabase extends BaseModel
@@ -27,7 +28,10 @@ class ServiceDatabase extends BaseModel
 
     public static function ownedByCurrentTeamAPI(int $teamId)
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', $teamId)->orderBy('name');
+        return ServiceDatabase::where(function ($query) use ($teamId) {
+            $query->whereRelation('service.environment.project.team', 'id', $teamId)
+                ->orWhereRelation('application.environment.project.team', 'id', $teamId);
+        })->orderBy('name');
     }
 
     /**
@@ -36,7 +40,10 @@ class ServiceDatabase extends BaseModel
      */
     public static function ownedByCurrentTeam()
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', currentTeam()->id)->orderBy('name');
+        return ServiceDatabase::where(function ($query) {
+            $query->whereRelation('service.environment.project.team', 'id', currentTeam()->id)
+                ->orWhereRelation('application.environment.project.team', 'id', currentTeam()->id);
+        })->orderBy('name');
     }
 
     /**
@@ -49,10 +56,51 @@ class ServiceDatabase extends BaseModel
         });
     }
 
+    /**
+     * Check if this ServiceDatabase is owned by an Application (docker compose).
+     */
+    public function isOwnedByApplication(): bool
+    {
+        return filled($this->application_id);
+    }
+
+    /**
+     * Get the owner of this ServiceDatabase (either Service or Application).
+     */
+    public function owner(): Service|Application|null
+    {
+        if ($this->isOwnedByApplication()) {
+            return $this->application;
+        }
+
+        return $this->service;
+    }
+
+    /**
+     * Get the server for this ServiceDatabase regardless of owner type.
+     */
+    public function serverResource(): ?Server
+    {
+        $owner = $this->owner();
+        if (! $owner) {
+            return null;
+        }
+
+        return data_get($owner, 'destination.server');
+    }
+
     public function restart()
     {
-        $container_id = $this->name.'-'.$this->service->uuid;
-        remote_process(["docker restart {$container_id}"], $this->service->server);
+        $owner = $this->owner();
+        if (! $owner) {
+            return;
+        }
+
+        $container_id = $this->name.'-'.$owner->uuid;
+        $server = $this->serverResource();
+        if ($server) {
+            remote_process(["docker restart {$container_id}"], $server);
+        }
     }
 
     public function isRunning()
@@ -82,6 +130,10 @@ class ServiceDatabase extends BaseModel
 
     public function type()
     {
+        if ($this->isOwnedByApplication()) {
+            return 'application';
+        }
+
         return 'service';
     }
 
@@ -114,8 +166,12 @@ class ServiceDatabase extends BaseModel
     public function getServiceDatabaseUrl()
     {
         $port = $this->public_port;
-        $realIp = $this->service->server->ip;
-        if ($this->service->server->isLocalhost() || isDev()) {
+        $server = $this->serverResource();
+        if (! $server) {
+            return null;
+        }
+        $realIp = $server->ip;
+        if ($server->isLocalhost() || isDev()) {
             $realIp = base_ip();
         }
 
@@ -124,17 +180,31 @@ class ServiceDatabase extends BaseModel
 
     public function team()
     {
-        return data_get($this, 'environment.project.team');
+        if ($this->isOwnedByApplication()) {
+            return data_get($this, 'application.environment.project.team');
+        }
+
+        return data_get($this, 'service.environment.project.team');
     }
 
     public function workdir()
     {
-        return service_configuration_dir()."/{$this->service->uuid}";
+        $owner = $this->owner();
+        if ($owner instanceof Application) {
+            return application_configuration_dir()."/{$owner->uuid}";
+        }
+
+        return service_configuration_dir()."/{$owner->uuid}";
     }
 
-    public function service()
+    public function service(): BelongsTo
     {
         return $this->belongsTo(Service::class);
+    }
+
+    public function application(): BelongsTo
+    {
+        return $this->belongsTo(Application::class);
     }
 
     public function persistentStorages()

--- a/bootstrap/helpers/databases.php
+++ b/bootstrap/helpers/databases.php
@@ -346,7 +346,7 @@ function deleteOldBackupsLocally($backup): Collection
 
     $server = null;
     if ($backup->database_type === \App\Models\ServiceDatabase::class) {
-        $server = $backup->database->service->server;
+        $server = $backup->database->serverResource();
     } else {
         $server = $backup->database->destination->server;
     }

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -2418,6 +2418,24 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
             $isDatabase = isDatabaseImage($image, $service);
             data_set($service, 'is_database', $isDatabase);
 
+            // For Application-owned docker compose, create ServiceDatabase records for detected databases
+            if ($resource instanceof Application && $isDatabase && $pull_request_id === 0) {
+                $savedDb = ServiceDatabase::where([
+                    'name' => $serviceName,
+                    'application_id' => $resource->id,
+                ])->first();
+                if (is_null($savedDb)) {
+                    ServiceDatabase::create([
+                        'name' => $serviceName,
+                        'image' => $image,
+                        'application_id' => $resource->id,
+                    ]);
+                } elseif ($savedDb->image !== $image) {
+                    $savedDb->image = $image;
+                    $savedDb->save();
+                }
+            }
+
             // Collect/create/update networks
             if ($serviceNetworks->count() > 0) {
                 foreach ($serviceNetworks as $networkName => $networkDetails) {

--- a/database/migrations/2026_02_17_000001_add_application_id_to_service_databases_table.php
+++ b/database/migrations/2026_02_17_000001_add_application_id_to_service_databases_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->foreignId('application_id')->nullable()->after('service_id')->constrained('applications')->nullOnDelete();
+        });
+
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->foreignId('service_id')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->dropForeign(['application_id']);
+            $table->dropColumn('application_id');
+        });
+
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->foreignId('service_id')->nullable(false)->change();
+        });
+    }
+};

--- a/resources/views/livewire/project/application/configuration.blade.php
+++ b/resources/views/livewire/project/application/configuration.blade.php
@@ -62,6 +62,10 @@
                 href="{{ route('project.application.resource-operations', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Resource Operations</span></a>
             <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
                 href="{{ route('project.application.metrics', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Metrics</span></a>
+            @if ($application->build_pack === 'dockercompose' && $application->serviceDatabases()->exists())
+                <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                    href="{{ route('project.application.backups', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Backups</span></a>
+            @endif
             <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
                 href="{{ route('project.application.tags', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Tags</span></a>
             <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
@@ -98,6 +102,8 @@
                 <livewire:project.shared.resource-operations :resource="$application" />
             @elseif ($currentRoute === 'project.application.metrics')
                 <livewire:project.shared.metrics :resource="$application" />
+            @elseif ($currentRoute === 'project.application.backups' && $application->build_pack === 'dockercompose')
+                <livewire:project.application.database-backups :application="$application" />
             @elseif ($currentRoute === 'project.application.tags')
                 <livewire:project.shared.tags :resource="$application" />
             @elseif ($currentRoute === 'project.application.danger')

--- a/resources/views/livewire/project/application/database-backups.blade.php
+++ b/resources/views/livewire/project/application/database-backups.blade.php
@@ -1,0 +1,40 @@
+<div>
+    <x-slot:title>
+        {{ data_get_str($application, 'name')->limit(10) }} > Database Backups | Coolify
+    </x-slot>
+    <h2 class="pb-4">Database Backups</h2>
+    <p class="pb-4">Manage scheduled backups for databases detected in your Docker Compose deployment.</p>
+
+    @if ($serviceDatabases->count() > 1)
+        <div class="flex gap-2 pb-4">
+            @foreach ($serviceDatabases as $db)
+                <button wire:click="selectDatabase({{ $db->id }})"
+                    class="px-4 py-2 rounded {{ $selectedDatabase && $selectedDatabase->id === $db->id ? 'bg-coollabs text-white' : 'bg-coolgray-200 dark:bg-coolgray-100' }}">
+                    {{ $db->name }}
+                </button>
+            @endforeach
+        </div>
+    @endif
+
+    @if ($selectedDatabase)
+        @if ($selectedDatabase->isBackupSolutionAvailable())
+            <div class="flex gap-2 pb-4">
+                <h3>{{ $selectedDatabase->name }}</h3>
+                @can('update', $application)
+                    <x-modal-input buttonTitle="+ Add" title="New Scheduled Backup">
+                        <livewire:project.database.create-scheduled-backup :database="$selectedDatabase"
+                            :key="'create-backup-' . $selectedDatabase->id" />
+                    </x-modal-input>
+                @endcan
+            </div>
+            <livewire:project.database.scheduled-backups :database="$selectedDatabase"
+                :key="'backups-' . $selectedDatabase->id" />
+        @else
+            <div class="pb-4">
+                <p>Backup is not supported for this database type ({{ $selectedDatabase->databaseType() }}).</p>
+            </div>
+        @endif
+    @else
+        <p>No databases detected in this Docker Compose deployment.</p>
+    @endif
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -207,6 +207,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/resource-operations', ApplicationConfiguration::class)->name('project.application.resource-operations');
         Route::get('/metrics', ApplicationConfiguration::class)->name('project.application.metrics');
         Route::get('/tags', ApplicationConfiguration::class)->name('project.application.tags');
+        Route::get('/backups', ApplicationConfiguration::class)->name('project.application.backups');
         Route::get('/danger', ApplicationConfiguration::class)->name('project.application.danger');
 
         Route::get('/deployment', DeploymentIndex::class)->name('project.application.deployment.index');
@@ -328,7 +329,7 @@ Route::middleware(['auth'])->group(function () {
             }
             $filename = data_get($execution, 'filename');
             if ($execution->scheduledDatabaseBackup->database->getMorphClass() === \App\Models\ServiceDatabase::class) {
-                $server = $execution->scheduledDatabaseBackup->database->service->destination->server;
+                $server = $execution->scheduledDatabaseBackup->database->serverResource();
             } else {
                 $server = $execution->scheduledDatabaseBackup->database->destination->server;
             }


### PR DESCRIPTION
## Summary

Enables database detection and automated backup scheduling for applications deployed via Docker Compose (`dockercompose` buildpack). Previously, when deploying a Docker Compose file through a GitHub App source, database services (PostgreSQL, MySQL, MariaDB, MongoDB) were detected by `isDatabaseImage()` but no `ServiceDatabase` records were created, which meant automated backups were unavailable for these databases.

Fixes #7528

## Changes

### Database Schema
- Add nullable `application_id` foreign key to `service_databases` table
- Make `service_id` nullable to support application-owned service databases

### ServiceDatabase Model (`app/Models/ServiceDatabase.php`)
- Add `application()` BelongsTo relationship
- Add `isOwnedByApplication()` helper to check ownership type
- Add `owner()` helper that returns either Service or Application
- Add `serverResource()` helper for owner-agnostic server resolution
- Update `ownedByCurrentTeam()` and `ownedByCurrentTeamAPI()` to query both ownership paths
- Update `restart()`, `getServiceDatabaseUrl()`, `team()`, `workdir()`, `type()` for dual ownership

### Docker Compose Parsing (`bootstrap/helpers/shared.php`)
- In the Application model path of `parseDockerComposeFile()`, create `ServiceDatabase` records when `isDatabaseImage()` detects a database service (only for non-PR deployments)

### Backup System Updates
- `DatabaseBackupJob`: Use `serverResource()` and `owner()` instead of `->service->server` / `->service->uuid`
- `ScheduledDatabaseBackup`: Use `serverResource()` in `server()` method
- `BackupEdit`: Use `serverResource()` for server resolution; add redirect for application-owned databases
- `BackupExecutions`: Use `serverResource()` for server resolution
- `databases.php` helper: Use `serverResource()` for server resolution
- `StartDatabaseProxy`: Use `owner()` and `serverResource()` for network/server/container resolution
- `Import`: Use `serverResource()` and `owner()` for server/container/network resolution
- `routes/web.php`: Add backups route; use `serverResource()` in download handler

### UI
- New `DatabaseBackups` Livewire component for application database backups
- New `database-backups.blade.php` Blade view with database selector tabs
- Add "Backups" menu item in application configuration (only shown for `dockercompose` buildpack with detected databases)

### Cleanup
- Update `CleanupStuckedResources` to not delete application-owned `ServiceDatabase` records as orphans

## Test plan

- [ ] Deploy a Docker Compose application containing a PostgreSQL service
- [ ] Verify that the Backups tab appears in the application configuration
- [ ] Create a scheduled backup for the detected database
- [ ] Verify backup execution completes successfully
- [ ] Test backup download functionality
- [ ] Test backup deletion (both local and S3)
- [ ] Verify existing Service-owned ServiceDatabase backups continue to work
- [ ] Verify CleanupStuckedResources does not delete application-owned databases
- [ ] Test with multiple database services in a single Docker Compose file

Generated with [Claude Code](https://claude.com/claude-code)