### PR TITLE
Add container-level file browser

### DIFF
--- a/app/Livewire/Project/Shared/FileBrowser.php
+++ b/app/Livewire/Project/Shared/FileBrowser.php
@@ -1,0 +1,548 @@
+<?php
+
+namespace App\Livewire\Project\Shared;
+
+use App\Models\Application;
+use App\Models\Server;
+use App\Models\Service;
+use Illuminate\Support\Collection;
+use Livewire\Component;
+use Livewire\WithFileUploads;
+
+class FileBrowser extends Component
+{
+    use WithFileUploads;
+
+    public ?string $type = null;
+
+    public $resource;
+
+    public Collection $servers;
+
+    public Collection $containers;
+
+    public string $selectedContainer = '';
+
+    public string $currentPath = '/';
+
+    public array $files = [];
+
+    public bool $loading = false;
+
+    public bool $connected = false;
+
+    public $parameters;
+
+    public $uploadFile;
+
+    public string $newFolderName = '';
+
+    public string $sortBy = 'name';
+
+    public string $sortDirection = 'asc';
+
+    public function mount()
+    {
+        $this->parameters = get_route_parameters();
+        $this->containers = collect();
+        $this->servers = collect();
+
+        if (data_get($this->parameters, 'application_uuid')) {
+            $this->type = 'application';
+            $this->resource = Application::where('uuid', $this->parameters['application_uuid'])->firstOrFail();
+            if ($this->resource->destination->server->isFunctional()) {
+                $this->servers = $this->servers->push($this->resource->destination->server);
+            }
+            foreach ($this->resource->additional_servers as $server) {
+                if ($server->isFunctional()) {
+                    $this->servers = $this->servers->push($server);
+                }
+            }
+        } elseif (data_get($this->parameters, 'database_uuid')) {
+            $this->type = 'database';
+            $resource = getResourceByUuid($this->parameters['database_uuid'], data_get(auth()->user()->currentTeam(), 'id'));
+            if (is_null($resource)) {
+                abort(404);
+            }
+            $this->resource = $resource;
+            if ($this->resource->destination->server->isFunctional()) {
+                $this->servers = $this->servers->push($this->resource->destination->server);
+            }
+        } elseif (data_get($this->parameters, 'service_uuid')) {
+            $this->type = 'service';
+            $this->resource = Service::where('uuid', $this->parameters['service_uuid'])->firstOrFail();
+            if ($this->resource->server->isFunctional()) {
+                $this->servers = $this->servers->push($this->resource->server);
+            }
+        }
+
+        $this->loadContainers();
+
+        if ($this->containers->count() === 1) {
+            $this->selectedContainer = data_get($this->containers->first(), 'container.Names');
+            $this->connect();
+        }
+    }
+
+    public function loadContainers()
+    {
+        foreach ($this->servers as $server) {
+            if (data_get($this->parameters, 'application_uuid')) {
+                if ($server->isSwarm()) {
+                    continue;
+                }
+                $containers = getCurrentApplicationContainerStatus($server, $this->resource->id, includePullrequests: true);
+                foreach ($containers as $container) {
+                    if (data_get($container, 'State') === 'running') {
+                        $this->containers = $this->containers->push([
+                            'server' => $server,
+                            'container' => $container,
+                        ]);
+                    }
+                }
+            } elseif (data_get($this->parameters, 'database_uuid')) {
+                if ($this->resource->isRunning()) {
+                    $this->containers = $this->containers->push([
+                        'server' => $server,
+                        'container' => ['Names' => $this->resource->uuid],
+                    ]);
+                }
+            } elseif (data_get($this->parameters, 'service_uuid')) {
+                $this->resource->applications()->get()->each(function ($application) {
+                    if ($application->isRunning()) {
+                        $this->containers->push([
+                            'server' => $this->resource->server,
+                            'container' => [
+                                'Names' => data_get($application, 'name') . '-' . data_get($this->resource, 'uuid'),
+                            ],
+                        ]);
+                    }
+                });
+                $this->resource->databases()->get()->each(function ($database) {
+                    if ($database->isRunning()) {
+                        $this->containers->push([
+                            'server' => $this->resource->server,
+                            'container' => [
+                                'Names' => data_get($database, 'name') . '-' . data_get($this->resource, 'uuid'),
+                            ],
+                        ]);
+                    }
+                });
+            }
+        }
+
+        $this->containers = $this->containers->sortBy(fn ($c) => data_get($c, 'container.Names'));
+    }
+
+    public function connect()
+    {
+        if (empty($this->selectedContainer)) {
+            $this->dispatch('error', 'Please select a container.');
+
+            return;
+        }
+
+        if (! preg_match('/^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/', $this->selectedContainer)) {
+            $this->dispatch('error', 'Invalid container name.');
+
+            return;
+        }
+
+        $container = $this->containers->firstWhere('container.Names', $this->selectedContainer);
+        if (is_null($container)) {
+            $this->dispatch('error', 'Container not found.');
+
+            return;
+        }
+
+        $server = data_get($container, 'server');
+        if (! $server || $server->isForceDisabled()) {
+            $this->dispatch('error', 'Server is not available.');
+
+            return;
+        }
+
+        $this->connected = true;
+        $this->currentPath = '/';
+        $this->listFiles();
+    }
+
+    public function updatedSelectedContainer()
+    {
+        if (! empty($this->selectedContainer)) {
+            $this->connect();
+        }
+    }
+
+    private function getServer(): ?Server
+    {
+        $container = $this->containers->firstWhere('container.Names', $this->selectedContainer);
+
+        return data_get($container, 'server');
+    }
+
+    private function sanitizePath(string $path): string
+    {
+        $path = str_replace('\\', '/', $path);
+        $parts = explode('/', $path);
+        $resolved = [];
+        foreach ($parts as $part) {
+            if ($part === '' || $part === '.') {
+                continue;
+            }
+            if ($part === '..') {
+                array_pop($resolved);
+            } else {
+                $resolved[] = $part;
+            }
+        }
+
+        return '/'.implode('/', $resolved);
+    }
+
+    public function listFiles()
+    {
+        $server = $this->getServer();
+        if (! $server) {
+            return;
+        }
+
+        $path = $this->sanitizePath($this->currentPath);
+        $this->currentPath = $path;
+        $escapedContainer = escapeshellarg($this->selectedContainer);
+        $escapedPath = escapeshellarg($path);
+
+        try {
+            $command = "docker exec {$escapedContainer} ls -la --time-style=long-iso {$escapedPath} 2>/dev/null || docker exec {$escapedContainer} ls -la {$escapedPath}";
+            if ($server->isNonRoot()) {
+                $command = "sudo {$command}";
+            }
+            $output = instant_remote_process([$command], $server, throwError: false);
+
+            $this->files = [];
+            if ($output) {
+                $lines = explode("\n", trim($output));
+                foreach ($lines as $line) {
+                    $line = trim($line);
+                    if (empty($line) || str_starts_with($line, 'total')) {
+                        continue;
+                    }
+
+                    $parsed = $this->parseLsLine($line);
+                    if ($parsed && $parsed['name'] !== '.') {
+                        $this->files[] = $parsed;
+                    }
+                }
+            }
+
+            $this->sortFiles();
+        } catch (\Throwable $e) {
+            $this->dispatch('error', 'Failed to list files: '.$e->getMessage());
+        }
+    }
+
+    private function parseLsLine(string $line): ?array
+    {
+        $parts = preg_split('/\s+/', $line, 9);
+        if (count($parts) < 9) {
+            $parts = preg_split('/\s+/', $line, 8);
+            if (count($parts) < 8) {
+                return null;
+            }
+            $permissions = $parts[0];
+            $owner = $parts[2] ?? '-';
+            $group = $parts[3] ?? '-';
+            $size = $parts[4] ?? '0';
+            $name = end($parts);
+        } else {
+            $permissions = $parts[0];
+            $owner = $parts[2];
+            $group = $parts[3];
+            $size = $parts[4];
+            $name = $parts[8];
+        }
+
+        if (empty($name)) {
+            return null;
+        }
+
+        $isDirectory = str_starts_with($permissions, 'd');
+        $isLink = str_starts_with($permissions, 'l');
+
+        $displayName = $name;
+        $linkTarget = null;
+        if ($isLink && str_contains($name, ' -> ')) {
+            [$displayName, $linkTarget] = explode(' -> ', $name, 2);
+        }
+
+        return [
+            'name' => $displayName,
+            'permissions' => $permissions,
+            'owner' => $owner,
+            'group' => $group,
+            'size' => $this->formatSize((int) $size),
+            'rawSize' => (int) $size,
+            'isDirectory' => $isDirectory,
+            'isLink' => $isLink,
+            'linkTarget' => $linkTarget,
+        ];
+    }
+
+    private function formatSize(int $bytes): string
+    {
+        if ($bytes === 0) {
+            return '0 B';
+        }
+        $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+        $i = floor(log($bytes, 1024));
+        $i = min($i, count($units) - 1);
+
+        return round($bytes / pow(1024, $i), 1).' '.$units[$i];
+    }
+
+    public function navigateTo(string $name)
+    {
+        if ($name === '..') {
+            $this->currentPath = dirname($this->currentPath);
+            if ($this->currentPath === '.') {
+                $this->currentPath = '/';
+            }
+        } else {
+            $this->currentPath = rtrim($this->currentPath, '/').'/'.$name;
+        }
+        $this->currentPath = $this->sanitizePath($this->currentPath);
+        $this->listFiles();
+    }
+
+    public function navigateToPath(string $path)
+    {
+        $this->currentPath = $this->sanitizePath($path);
+        $this->listFiles();
+    }
+
+    public function downloadFile(string $filename)
+    {
+        $server = $this->getServer();
+        if (! $server) {
+            return;
+        }
+
+        if (! preg_match('/^[^\/\0]+$/', $filename)) {
+            $this->dispatch('error', 'Invalid filename.');
+
+            return;
+        }
+
+        $filePath = rtrim($this->currentPath, '/').'/'.$filename;
+        $filePath = $this->sanitizePath($filePath);
+        $escapedContainer = escapeshellarg($this->selectedContainer);
+        $escapedPath = escapeshellarg($filePath);
+
+        try {
+            $tmpFile = '/tmp/coolify-download-'.md5($filePath.time());
+            $escapedTmp = escapeshellarg($tmpFile);
+
+            $commands = [
+                "docker cp {$escapedContainer}:{$escapedPath} {$escapedTmp}",
+                "base64 {$escapedTmp}",
+                "rm -f {$escapedTmp}",
+            ];
+
+            if ($server->isNonRoot()) {
+                $commands = array_map(fn ($cmd) => "sudo {$cmd}", $commands);
+            }
+
+            $output = instant_remote_process($commands, $server);
+
+            if ($output) {
+                $content = base64_decode($output);
+
+                return response()->streamDownload(function () use ($content) {
+                    echo $content;
+                }, $filename);
+            }
+        } catch (\Throwable $e) {
+            $this->dispatch('error', 'Download failed: '.$e->getMessage());
+        }
+    }
+
+    public function uploadToContainer()
+    {
+        $server = $this->getServer();
+        if (! $server) {
+            return;
+        }
+
+        if (! $this->uploadFile) {
+            $this->dispatch('error', 'No file selected.');
+
+            return;
+        }
+
+        $this->validate([
+            'uploadFile' => 'required|file|max:102400',
+        ]);
+
+        $escapedContainer = escapeshellarg($this->selectedContainer);
+        $originalName = $this->uploadFile->getClientOriginalName();
+
+        if (! preg_match('/^[a-zA-Z0-9._\-\s()]+$/', $originalName)) {
+            $this->dispatch('error', 'Invalid filename. Use only alphanumeric characters, dots, dashes, underscores, and spaces.');
+
+            return;
+        }
+
+        $targetPath = rtrim($this->currentPath, '/').'/'.$originalName;
+        $targetPath = $this->sanitizePath($targetPath);
+        $escapedTarget = escapeshellarg($targetPath);
+
+        try {
+            $content = base64_encode(file_get_contents($this->uploadFile->getRealPath()));
+            $tmpFile = '/tmp/coolify-upload-'.md5($targetPath.time());
+            $escapedTmp = escapeshellarg($tmpFile);
+
+            $commands = [
+                "echo '{$content}' | base64 -d > {$escapedTmp}",
+                "docker cp {$escapedTmp} {$escapedContainer}:{$escapedTarget}",
+                "rm -f {$escapedTmp}",
+            ];
+
+            if ($server->isNonRoot()) {
+                $commands = array_map(fn ($cmd) => "sudo {$cmd}", $commands);
+            }
+
+            instant_remote_process($commands, $server);
+
+            $this->uploadFile = null;
+            $this->dispatch('success', "File '{$originalName}' uploaded successfully.");
+            $this->listFiles();
+        } catch (\Throwable $e) {
+            $this->dispatch('error', 'Upload failed: '.$e->getMessage());
+        }
+    }
+
+    public function createFolder()
+    {
+        $server = $this->getServer();
+        if (! $server) {
+            return;
+        }
+
+        if (empty($this->newFolderName)) {
+            $this->dispatch('error', 'Please enter a folder name.');
+
+            return;
+        }
+
+        if (! preg_match('/^[a-zA-Z0-9._\-\s]+$/', $this->newFolderName)) {
+            $this->dispatch('error', 'Invalid folder name. Use only alphanumeric characters, dots, dashes, underscores, and spaces.');
+
+            return;
+        }
+
+        $escapedContainer = escapeshellarg($this->selectedContainer);
+        $folderPath = rtrim($this->currentPath, '/').'/'.$this->newFolderName;
+        $folderPath = $this->sanitizePath($folderPath);
+        $escapedPath = escapeshellarg($folderPath);
+
+        try {
+            $command = "docker exec {$escapedContainer} mkdir -p {$escapedPath}";
+            if ($server->isNonRoot()) {
+                $command = "sudo {$command}";
+            }
+
+            instant_remote_process([$command], $server);
+            $this->newFolderName = '';
+            $this->dispatch('success', 'Folder created successfully.');
+            $this->listFiles();
+        } catch (\Throwable $e) {
+            $this->dispatch('error', 'Failed to create folder: '.$e->getMessage());
+        }
+    }
+
+    public function deleteItem(string $name, bool $isDirectory = false)
+    {
+        $server = $this->getServer();
+        if (! $server) {
+            return;
+        }
+
+        if (! preg_match('/^[^\/\0]+$/', $name)) {
+            $this->dispatch('error', 'Invalid name.');
+
+            return;
+        }
+
+        $escapedContainer = escapeshellarg($this->selectedContainer);
+        $itemPath = rtrim($this->currentPath, '/').'/'.$name;
+        $itemPath = $this->sanitizePath($itemPath);
+        $escapedPath = escapeshellarg($itemPath);
+
+        try {
+            $flag = $isDirectory ? '-rf' : '';
+            $command = "docker exec {$escapedContainer} rm {$flag} {$escapedPath}";
+            if ($server->isNonRoot()) {
+                $command = "sudo {$command}";
+            }
+
+            instant_remote_process([$command], $server);
+            $this->dispatch('success', "'{$name}' deleted successfully.");
+            $this->listFiles();
+        } catch (\Throwable $e) {
+            $this->dispatch('error', 'Failed to delete: '.$e->getMessage());
+        }
+    }
+
+    public function sort(string $column)
+    {
+        if ($this->sortBy === $column) {
+            $this->sortDirection = $this->sortDirection === 'asc' ? 'desc' : 'asc';
+        } else {
+            $this->sortBy = $column;
+            $this->sortDirection = 'asc';
+        }
+        $this->sortFiles();
+    }
+
+    private function sortFiles()
+    {
+        usort($this->files, function ($a, $b) {
+            if ($a['name'] === '..') {
+                return -1;
+            }
+            if ($b['name'] === '..') {
+                return 1;
+            }
+
+            if ($a['isDirectory'] !== $b['isDirectory']) {
+                return $a['isDirectory'] ? -1 : 1;
+            }
+
+            $result = match ($this->sortBy) {
+                'size' => $a['rawSize'] <=> $b['rawSize'],
+                'permissions' => strcmp($a['permissions'], $b['permissions']),
+                default => strcasecmp($a['name'], $b['name']),
+            };
+
+            return $this->sortDirection === 'asc' ? $result : -$result;
+        });
+    }
+
+    public function getBreadcrumbs(): array
+    {
+        $parts = array_filter(explode('/', $this->currentPath));
+        $breadcrumbs = [['name' => '/', 'path' => '/']];
+        $current = '';
+        foreach ($parts as $part) {
+            $current .= '/'.$part;
+            $breadcrumbs[] = ['name' => $part, 'path' => $current];
+        }
+
+        return $breadcrumbs;
+    }
+
+    public function render()
+    {
+        return view('livewire.project.shared.file-browser');
+    }
+}

--- a/resources/views/livewire/project/application/heading.blade.php
+++ b/resources/views/livewire/project/application/heading.blade.php
@@ -27,6 +27,10 @@
                         href="{{ route('project.application.command', $parameters) }}">
                         Terminal
                     </a>
+                    <a class="{{ request()->routeIs('project.application.file-browser') ? 'dark:text-white' : '' }}"
+                        href="{{ route('project.application.file-browser', $parameters) }}">
+                        Files
+                    </a>
                 @endcan
             @endif
             <x-applications.links :application="$application" />

--- a/resources/views/livewire/project/database/heading.blade.php
+++ b/resources/views/livewire/project/database/heading.blade.php
@@ -25,6 +25,10 @@
                     href="{{ route('project.database.command', $parameters) }}">
                     Terminal
                 </a>
+                <a class="{{ request()->routeIs('project.database.file-browser') ? 'dark:text-white' : '' }}"
+                    href="{{ route('project.database.file-browser', $parameters) }}">
+                    Files
+                </a>
             @endcan
             @if (
                 $database->getMorphClass() === 'App\Models\StandalonePostgresql' ||

--- a/resources/views/livewire/project/service/heading.blade.php
+++ b/resources/views/livewire/project/service/heading.blade.php
@@ -23,6 +23,10 @@
                     href="{{ route('project.service.command', $parameters) }}">
                     <button>Terminal</button>
                 </a>
+                <a class="{{ request()->routeIs('project.service.file-browser') ? 'dark:text-white' : '' }}"
+                    href="{{ route('project.service.file-browser', $parameters) }}">
+                    <button>Files</button>
+                </a>
             @endcan
             <x-services.links :service="$service" />
         </nav>

--- a/resources/views/livewire/project/shared/file-browser.blade.php
+++ b/resources/views/livewire/project/shared/file-browser.blade.php
@@ -1,0 +1,229 @@
+<div>
+    <x-slot:title>
+        {{ data_get_str($resource, 'name')->limit(10) }} > File Browser | Coolify
+    </x-slot>
+    @if ($type === 'application')
+        <livewire:project.shared.configuration-checker :resource="$resource" />
+        <h1>File Browser</h1>
+        <livewire:project.application.heading :application="$resource" />
+    @elseif ($type === 'database')
+        <livewire:project.shared.configuration-checker :resource="$resource" />
+        <h1>File Browser</h1>
+        <livewire:project.database.heading :database="$resource" />
+    @elseif ($type === 'service')
+        <livewire:project.shared.configuration-checker :resource="$resource" />
+        <livewire:project.service.heading :service="$resource" :parameters="$parameters" title="File Browser" />
+    @endif
+
+    <div class="pt-4">
+        @if ($containers->count() === 0)
+            <div class="dark:text-neutral-400">No running containers found.</div>
+        @else
+            @if ($containers->count() > 1)
+                <div class="flex gap-2 items-end pb-4">
+                    <x-forms.select label="Container" wire:model.live="selectedContainer">
+                        <option value="">Select a container</option>
+                        @foreach ($containers as $container)
+                            <option value="{{ data_get($container, 'container.Names') }}">
+                                {{ data_get($container, 'container.Names') }}
+                                ({{ data_get($container, 'server.name') }})
+                            </option>
+                        @endforeach
+                    </x-forms.select>
+                </div>
+            @endif
+
+            @if ($connected)
+                <div class="flex items-center gap-1 pb-3 text-sm flex-wrap">
+                    <svg class="w-4 h-4 dark:text-neutral-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+                    </svg>
+                    @foreach ($this->getBreadcrumbs() as $crumb)
+                        @if (!$loop->first)
+                            <span class="dark:text-neutral-500">/</span>
+                        @endif
+                        <button
+                            class="dark:text-neutral-300 hover:dark:text-white hover:underline"
+                            wire:click="navigateToPath('{{ $crumb['path'] }}')"
+                        >
+                            {{ $crumb['name'] }}
+                        </button>
+                    @endforeach
+                </div>
+
+                <div class="flex flex-wrap gap-3 items-end pb-4">
+                    <div class="flex gap-2 items-end">
+                        <div>
+                            <label class="block text-sm font-medium dark:text-neutral-300 pb-1">Upload File</label>
+                            <input type="file" wire:model="uploadFile"
+                                class="text-sm dark:text-neutral-300 file:mr-2 file:py-1 file:px-3 file:rounded file:border-0 file:text-sm file:bg-coolgray-200 file:dark:text-white hover:file:bg-coolgray-300 cursor-pointer" />
+                        </div>
+                        <x-forms.button wire:click="uploadToContainer" wire:loading.attr="disabled">
+                            <div wire:loading wire:target="uploadFile" class="pr-1">
+                                <svg class="animate-spin h-4 w-4" viewBox="0 0 24 24">
+                                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" fill="none"></circle>
+                                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+                                </svg>
+                            </div>
+                            Upload
+                        </x-forms.button>
+                    </div>
+
+                    <div class="flex gap-2 items-end">
+                        <x-forms.input wire:model="newFolderName" placeholder="New folder name" label="Create Folder" />
+                        <x-forms.button wire:click="createFolder">
+                            Create
+                        </x-forms.button>
+                    </div>
+
+                    <x-forms.button wire:click="listFiles">
+                        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                        </svg>
+                        Refresh
+                    </x-forms.button>
+                </div>
+
+                <div class="rounded-sm border dark:border-coolgray-300 overflow-hidden">
+                    <table class="w-full text-sm">
+                        <thead class="dark:bg-coolgray-200">
+                            <tr class="border-b dark:border-coolgray-300">
+                                <th class="text-left p-2 cursor-pointer hover:dark:text-white dark:text-neutral-300" wire:click="sort('name')">
+                                    <div class="flex items-center gap-1">
+                                        Name
+                                        @if ($sortBy === 'name')
+                                            <svg class="w-3 h-3" viewBox="0 0 24 24" fill="currentColor">
+                                                @if ($sortDirection === 'asc')
+                                                    <path d="M7 14l5-5 5 5z"/>
+                                                @else
+                                                    <path d="M7 10l5 5 5-5z"/>
+                                                @endif
+                                            </svg>
+                                        @endif
+                                    </div>
+                                </th>
+                                <th class="text-left p-2 cursor-pointer hover:dark:text-white dark:text-neutral-300 w-28" wire:click="sort('size')">
+                                    <div class="flex items-center gap-1">
+                                        Size
+                                        @if ($sortBy === 'size')
+                                            <svg class="w-3 h-3" viewBox="0 0 24 24" fill="currentColor">
+                                                @if ($sortDirection === 'asc')
+                                                    <path d="M7 14l5-5 5 5z"/>
+                                                @else
+                                                    <path d="M7 10l5 5 5-5z"/>
+                                                @endif
+                                            </svg>
+                                        @endif
+                                    </div>
+                                </th>
+                                <th class="text-left p-2 cursor-pointer hover:dark:text-white dark:text-neutral-300 hidden md:table-cell" wire:click="sort('permissions')">
+                                    <div class="flex items-center gap-1">
+                                        Permissions
+                                        @if ($sortBy === 'permissions')
+                                            <svg class="w-3 h-3" viewBox="0 0 24 24" fill="currentColor">
+                                                @if ($sortDirection === 'asc')
+                                                    <path d="M7 14l5-5 5 5z"/>
+                                                @else
+                                                    <path d="M7 10l5 5 5-5z"/>
+                                                @endif
+                                            </svg>
+                                        @endif
+                                    </div>
+                                </th>
+                                <th class="text-left p-2 dark:text-neutral-300 hidden lg:table-cell">Owner</th>
+                                <th class="text-right p-2 dark:text-neutral-300 w-24">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse ($files as $file)
+                                <tr class="border-b dark:border-coolgray-300 hover:dark:bg-coolgray-100 transition-colors" wire:key="file-{{ $loop->index }}">
+                                    <td class="p-2">
+                                        <div class="flex items-center gap-2">
+                                            @if ($file['name'] === '..')
+                                                <svg class="w-4 h-4 dark:text-neutral-400 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                                    <path d="M15 19l-7-7 7-7" />
+                                                </svg>
+                                                <button class="hover:underline dark:text-neutral-300 hover:dark:text-white" wire:click="navigateTo('..')">
+                                                    ..
+                                                </button>
+                                            @elseif ($file['isDirectory'])
+                                                <svg class="w-4 h-4 text-yellow-500 shrink-0" viewBox="0 0 24 24" fill="currentColor">
+                                                    <path d="M10 4H4a2 2 0 00-2 2v12a2 2 0 002 2h16a2 2 0 002-2V8a2 2 0 00-2-2h-8l-2-2z"/>
+                                                </svg>
+                                                <button class="hover:underline dark:text-neutral-200 hover:dark:text-white truncate" wire:click="navigateTo('{{ $file['name'] }}')">
+                                                    {{ $file['name'] }}
+                                                </button>
+                                            @elseif ($file['isLink'])
+                                                <svg class="w-4 h-4 dark:text-blue-400 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                                    <path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"/>
+                                                    <path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"/>
+                                                </svg>
+                                                <span class="dark:text-neutral-200 truncate">
+                                                    {{ $file['name'] }}
+                                                    @if ($file['linkTarget'])
+                                                        <span class="dark:text-neutral-500">-> {{ $file['linkTarget'] }}</span>
+                                                    @endif
+                                                </span>
+                                            @else
+                                                <svg class="w-4 h-4 dark:text-neutral-400 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                                    <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/>
+                                                    <polyline points="14 2 14 8 20 8"/>
+                                                </svg>
+                                                <span class="dark:text-neutral-200 truncate">{{ $file['name'] }}</span>
+                                            @endif
+                                        </div>
+                                    </td>
+                                    <td class="p-2 dark:text-neutral-400 text-xs whitespace-nowrap">
+                                        {{ $file['name'] === '..' ? '' : $file['size'] }}
+                                    </td>
+                                    <td class="p-2 dark:text-neutral-400 font-mono text-xs hidden md:table-cell">
+                                        {{ $file['name'] === '..' ? '' : $file['permissions'] }}
+                                    </td>
+                                    <td class="p-2 dark:text-neutral-400 text-xs hidden lg:table-cell">
+                                        {{ $file['name'] === '..' ? '' : $file['owner'] . ':' . $file['group'] }}
+                                    </td>
+                                    <td class="p-2 text-right">
+                                        @if ($file['name'] !== '..')
+                                            <div class="flex gap-1 justify-end">
+                                                @if (!$file['isDirectory'])
+                                                    <button
+                                                        class="p-1 rounded hover:dark:bg-coolgray-300 dark:text-neutral-400 hover:dark:text-white"
+                                                        title="Download"
+                                                        wire:click="downloadFile('{{ $file['name'] }}')"
+                                                    >
+                                                        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                                            <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/>
+                                                            <polyline points="7 10 12 15 17 10"/>
+                                                            <line x1="12" y1="15" x2="12" y2="3"/>
+                                                        </svg>
+                                                    </button>
+                                                @endif
+                                                <button
+                                                    class="p-1 rounded hover:dark:bg-coolgray-300 dark:text-neutral-400 hover:text-red-500"
+                                                    title="Delete"
+                                                    wire:click="deleteItem('{{ $file['name'] }}', {{ $file['isDirectory'] ? 'true' : 'false' }})"
+                                                    wire:confirm="Are you sure you want to delete '{{ $file['name'] }}'{{ $file['isDirectory'] ? ' and all its contents' : '' }}?"
+                                                >
+                                                    <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                                        <polyline points="3 6 5 6 21 6"/>
+                                                        <path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/>
+                                                    </svg>
+                                                </button>
+                                            </div>
+                                        @endif
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="5" class="p-4 text-center dark:text-neutral-400">
+                                        This directory is empty.
+                                    </td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            @endif
+        @endif
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,6 +32,7 @@ use App\Livewire\Project\Service\Configuration as ServiceConfiguration;
 use App\Livewire\Project\Service\DatabaseBackups as ServiceDatabaseBackups;
 use App\Livewire\Project\Service\Index as ServiceIndex;
 use App\Livewire\Project\Shared\ExecuteContainerCommand;
+use App\Livewire\Project\Shared\FileBrowser;
 use App\Livewire\Project\Shared\Logs;
 use App\Livewire\Project\Shared\ScheduledTask\Show as ScheduledTaskShow;
 use App\Livewire\Project\Show as ProjectShow;
@@ -213,6 +214,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/deployment/{deployment_uuid}', DeploymentShow::class)->name('project.application.deployment.show');
         Route::get('/logs', Logs::class)->name('project.application.logs');
         Route::get('/terminal', ExecuteContainerCommand::class)->name('project.application.command')->middleware('can.access.terminal');
+        Route::get('/file-browser', FileBrowser::class)->name('project.application.file-browser')->middleware('can.access.terminal');
         Route::get('/tasks/{task_uuid}', ScheduledTaskShow::class)->name('project.application.scheduled-tasks');
     });
     Route::prefix('project/{project_uuid}/environment/{environment_uuid}/database/{database_uuid}')->group(function () {
@@ -230,6 +232,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
         Route::get('/logs', Logs::class)->name('project.database.logs');
         Route::get('/terminal', ExecuteContainerCommand::class)->name('project.database.command')->middleware('can.access.terminal');
+        Route::get('/file-browser', FileBrowser::class)->name('project.database.file-browser')->middleware('can.access.terminal');
         Route::get('/backups', DatabaseBackupIndex::class)->name('project.database.backup.index');
         Route::get('/backups/{backup_uuid}', DatabaseBackupExecution::class)->name('project.database.backup.execution');
     });
@@ -244,6 +247,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/tags', ServiceConfiguration::class)->name('project.service.tags');
         Route::get('/danger', ServiceConfiguration::class)->name('project.service.danger');
         Route::get('/terminal', ExecuteContainerCommand::class)->name('project.service.command')->middleware('can.access.terminal');
+        Route::get('/file-browser', FileBrowser::class)->name('project.service.file-browser')->middleware('can.access.terminal');
         Route::get('/{stack_service_uuid}/backups', ServiceDatabaseBackups::class)->name('project.service.database.backups');
         Route::get('/{stack_service_uuid}/import', ServiceIndex::class)->name('project.service.database.import')->middleware('can.update.resource');
         Route::get('/{stack_service_uuid}', ServiceIndex::class)->name('project.service.index');


### PR DESCRIPTION
Adds a file browser UI for browsing files inside running containers. This addresses #6519.

## What it does

- New "Files" tab next to Terminal on applications, databases, and services
- Browse the container filesystem with directory navigation and breadcrumbs
- Upload files into the container (via `docker cp`)
- Download individual files from the container
- Create and delete folders/files
- Shows file size, permissions, and owner info
- Sortable columns (name, size, permissions)
- Supports non-root server users, symlinks, and multi-container resources

The implementation reuses the same container discovery logic from ExecuteContainerCommand and uses `docker exec` for listing + `docker cp` for transfers. Access is gated behind the same `can.access.terminal` middleware (admin/owner only).

/claim #6519