### PR TITLE
feat: deploy on GitHub release

### DIFF
--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -161,6 +161,7 @@ class ApplicationsController extends Controller
                             'is_static' => ['type' => 'boolean', 'description' => 'The flag to indicate if the application is static.'],
                             'is_spa' => ['type' => 'boolean', 'description' => 'The flag to indicate if the application is a single-page application (SPA). Only relevant when is_static is true.'],
                             'is_auto_deploy_enabled' => ['type' => 'boolean', 'description' => 'The flag to indicate if auto-deploy is enabled on git push. Defaults to true.'],
+                            'is_deploy_on_release_enabled' => ['type' => 'boolean', 'description' => 'The flag to indicate if deploy on GitHub release is enabled. Defaults to false.'],
                             'is_force_https_enabled' => ['type' => 'boolean', 'description' => 'The flag to indicate if HTTPS is forced. Defaults to true.'],
                             'static_image' => ['type' => 'string', 'enum' => ['nginx:alpine'], 'description' => 'The static image.'],
                             'install_command' => ['type' => 'string', 'description' => 'The install command.'],
@@ -327,6 +328,7 @@ class ApplicationsController extends Controller
                             'is_static' => ['type' => 'boolean', 'description' => 'The flag to indicate if the application is static.'],
                             'is_spa' => ['type' => 'boolean', 'description' => 'The flag to indicate if the application is a single-page application (SPA). Only relevant when is_static is true.'],
                             'is_auto_deploy_enabled' => ['type' => 'boolean', 'description' => 'The flag to indicate if auto-deploy is enabled on git push. Defaults to true.'],
+                            'is_deploy_on_release_enabled' => ['type' => 'boolean', 'description' => 'The flag to indicate if deploy on GitHub release is enabled. Defaults to false.'],
                             'is_force_https_enabled' => ['type' => 'boolean', 'description' => 'The flag to indicate if HTTPS is forced. Defaults to true.'],
                             'static_image' => ['type' => 'string', 'enum' => ['nginx:alpine'], 'description' => 'The static image.'],
                             'install_command' => ['type' => 'string', 'description' => 'The install command.'],
@@ -492,6 +494,7 @@ class ApplicationsController extends Controller
                             'is_static' => ['type' => 'boolean', 'description' => 'The flag to indicate if the application is static.'],
                             'is_spa' => ['type' => 'boolean', 'description' => 'The flag to indicate if the application is a single-page application (SPA). Only relevant when is_static is true.'],
                             'is_auto_deploy_enabled' => ['type' => 'boolean', 'description' => 'The flag to indicate if auto-deploy is enabled on git push. Defaults to true.'],
+                            'is_deploy_on_release_enabled' => ['type' => 'boolean', 'description' => 'The flag to indicate if deploy on GitHub release is enabled. Defaults to false.'],
                             'is_force_https_enabled' => ['type' => 'boolean', 'description' => 'The flag to indicate if HTTPS is forced. Defaults to true.'],
                             'static_image' => ['type' => 'string', 'enum' => ['nginx:alpine'], 'description' => 'The static image.'],
                             'install_command' => ['type' => 'string', 'description' => 'The install command.'],
@@ -1002,7 +1005,7 @@ class ApplicationsController extends Controller
         if ($return instanceof \Illuminate\Http\JsonResponse) {
             return $return;
         }
-        $allowedFields = ['project_uuid', 'environment_name', 'environment_uuid', 'server_uuid', 'destination_uuid', 'type', 'name', 'description', 'is_static', 'is_spa', 'is_auto_deploy_enabled', 'is_force_https_enabled', 'domains', 'git_repository', 'git_branch', 'git_commit_sha', 'private_key_uuid', 'docker_registry_image_name', 'docker_registry_image_tag', 'build_pack', 'install_command', 'build_command', 'start_command', 'ports_exposes', 'ports_mappings', 'custom_network_aliases', 'base_directory', 'publish_directory', 'health_check_enabled', 'health_check_path', 'health_check_port', 'health_check_host', 'health_check_method', 'health_check_return_code', 'health_check_scheme', 'health_check_response_text', 'health_check_interval', 'health_check_timeout', 'health_check_retries', 'health_check_start_period', 'limits_memory', 'limits_memory_swap', 'limits_memory_swappiness', 'limits_memory_reservation', 'limits_cpus', 'limits_cpuset', 'limits_cpu_shares', 'custom_labels', 'custom_docker_run_options', 'post_deployment_command', 'post_deployment_command_container', 'pre_deployment_command', 'pre_deployment_command_container',  'manual_webhook_secret_github', 'manual_webhook_secret_gitlab', 'manual_webhook_secret_bitbucket', 'manual_webhook_secret_gitea', 'redirect', 'github_app_uuid', 'instant_deploy', 'dockerfile', 'dockerfile_location', 'docker_compose_location', 'docker_compose_raw', 'docker_compose_custom_start_command', 'docker_compose_custom_build_command', 'docker_compose_domains', 'watch_paths', 'use_build_server', 'static_image', 'custom_nginx_configuration', 'is_http_basic_auth_enabled', 'http_basic_auth_username', 'http_basic_auth_password', 'connect_to_docker_network', 'force_domain_override', 'autogenerate_domain', 'is_container_label_escape_enabled'];
+        $allowedFields = ['project_uuid', 'environment_name', 'environment_uuid', 'server_uuid', 'destination_uuid', 'type', 'name', 'description', 'is_static', 'is_spa', 'is_auto_deploy_enabled', 'is_deploy_on_release_enabled', 'is_force_https_enabled', 'domains', 'git_repository', 'git_branch', 'git_commit_sha', 'private_key_uuid', 'docker_registry_image_name', 'docker_registry_image_tag', 'build_pack', 'install_command', 'build_command', 'start_command', 'ports_exposes', 'ports_mappings', 'custom_network_aliases', 'base_directory', 'publish_directory', 'health_check_enabled', 'health_check_path', 'health_check_port', 'health_check_host', 'health_check_method', 'health_check_return_code', 'health_check_scheme', 'health_check_response_text', 'health_check_interval', 'health_check_timeout', 'health_check_retries', 'health_check_start_period', 'limits_memory', 'limits_memory_swap', 'limits_memory_swappiness', 'limits_memory_reservation', 'limits_cpus', 'limits_cpuset', 'limits_cpu_shares', 'custom_labels', 'custom_docker_run_options', 'post_deployment_command', 'post_deployment_command_container', 'pre_deployment_command', 'pre_deployment_command_container',  'manual_webhook_secret_github', 'manual_webhook_secret_gitlab', 'manual_webhook_secret_bitbucket', 'manual_webhook_secret_gitea', 'redirect', 'github_app_uuid', 'instant_deploy', 'dockerfile', 'dockerfile_location', 'docker_compose_location', 'docker_compose_raw', 'docker_compose_custom_start_command', 'docker_compose_custom_build_command', 'docker_compose_domains', 'watch_paths', 'use_build_server', 'static_image', 'custom_nginx_configuration', 'is_http_basic_auth_enabled', 'http_basic_auth_username', 'http_basic_auth_password', 'connect_to_docker_network', 'force_domain_override', 'autogenerate_domain', 'is_container_label_escape_enabled'];
 
         $validator = customApiValidator($request->all(), [
             'name' => 'string|max:255',
@@ -1047,6 +1050,7 @@ class ApplicationsController extends Controller
         $isStatic = $request->is_static;
         $isSpa = $request->is_spa;
         $isAutoDeployEnabled = $request->is_auto_deploy_enabled;
+        $isDeployOnReleaseEnabled = $request->is_deploy_on_release_enabled;
         $isForceHttpsEnabled = $request->is_force_https_enabled;
         $connectToDockerNetwork = $request->connect_to_docker_network;
         $customNginxConfiguration = $request->custom_nginx_configuration;
@@ -1235,6 +1239,10 @@ class ApplicationsController extends Controller
             }
             if (isset($isAutoDeployEnabled)) {
                 $application->settings->is_auto_deploy_enabled = $isAutoDeployEnabled;
+                $application->settings->save();
+            }
+            if (isset($isDeployOnReleaseEnabled)) {
+                $application->settings->is_deploy_on_release_enabled = $isDeployOnReleaseEnabled;
                 $application->settings->save();
             }
             if (isset($isForceHttpsEnabled)) {
@@ -1470,6 +1478,10 @@ class ApplicationsController extends Controller
                 $application->settings->is_auto_deploy_enabled = $isAutoDeployEnabled;
                 $application->settings->save();
             }
+            if (isset($isDeployOnReleaseEnabled)) {
+                $application->settings->is_deploy_on_release_enabled = $isDeployOnReleaseEnabled;
+                $application->settings->save();
+            }
             if (isset($isForceHttpsEnabled)) {
                 $application->settings->is_force_https_enabled = $isForceHttpsEnabled;
                 $application->settings->save();
@@ -1665,6 +1677,10 @@ class ApplicationsController extends Controller
             }
             if (isset($isAutoDeployEnabled)) {
                 $application->settings->is_auto_deploy_enabled = $isAutoDeployEnabled;
+                $application->settings->save();
+            }
+            if (isset($isDeployOnReleaseEnabled)) {
+                $application->settings->is_deploy_on_release_enabled = $isDeployOnReleaseEnabled;
                 $application->settings->save();
             }
             if (isset($isForceHttpsEnabled)) {
@@ -2319,6 +2335,7 @@ class ApplicationsController extends Controller
                             'is_static' => ['type' => 'boolean', 'description' => 'The flag to indicate if the application is static.'],
                             'is_spa' => ['type' => 'boolean', 'description' => 'The flag to indicate if the application is a single-page application (SPA). Only relevant when is_static is true.'],
                             'is_auto_deploy_enabled' => ['type' => 'boolean', 'description' => 'The flag to indicate if auto-deploy is enabled on git push. Defaults to true.'],
+                            'is_deploy_on_release_enabled' => ['type' => 'boolean', 'description' => 'The flag to indicate if deploy on GitHub release is enabled. Defaults to false.'],
                             'is_force_https_enabled' => ['type' => 'boolean', 'description' => 'The flag to indicate if HTTPS is forced. Defaults to true.'],
                             'install_command' => ['type' => 'string', 'description' => 'The install command.'],
                             'build_command' => ['type' => 'string', 'description' => 'The build command.'],
@@ -2463,7 +2480,7 @@ class ApplicationsController extends Controller
         $this->authorize('update', $application);
 
         $server = $application->destination->server;
-        $allowedFields = ['name', 'description', 'is_static', 'is_spa', 'is_auto_deploy_enabled', 'is_force_https_enabled', 'domains', 'git_repository', 'git_branch', 'git_commit_sha', 'docker_registry_image_name', 'docker_registry_image_tag', 'build_pack', 'static_image', 'install_command', 'build_command', 'start_command', 'ports_exposes', 'ports_mappings', 'custom_network_aliases', 'base_directory', 'publish_directory', 'health_check_enabled', 'health_check_path', 'health_check_port', 'health_check_host', 'health_check_method', 'health_check_return_code', 'health_check_scheme', 'health_check_response_text', 'health_check_interval', 'health_check_timeout', 'health_check_retries', 'health_check_start_period', 'limits_memory', 'limits_memory_swap', 'limits_memory_swappiness', 'limits_memory_reservation', 'limits_cpus', 'limits_cpuset', 'limits_cpu_shares', 'custom_labels', 'custom_docker_run_options', 'post_deployment_command', 'post_deployment_command_container', 'pre_deployment_command', 'pre_deployment_command_container', 'watch_paths', 'manual_webhook_secret_github', 'manual_webhook_secret_gitlab', 'manual_webhook_secret_bitbucket', 'manual_webhook_secret_gitea', 'dockerfile_location', 'docker_compose_location', 'docker_compose_custom_start_command', 'docker_compose_custom_build_command', 'docker_compose_domains', 'redirect', 'instant_deploy', 'use_build_server', 'custom_nginx_configuration', 'is_http_basic_auth_enabled', 'http_basic_auth_username', 'http_basic_auth_password', 'connect_to_docker_network', 'force_domain_override', 'is_container_label_escape_enabled'];
+        $allowedFields = ['name', 'description', 'is_static', 'is_spa', 'is_auto_deploy_enabled', 'is_deploy_on_release_enabled', 'is_force_https_enabled', 'domains', 'git_repository', 'git_branch', 'git_commit_sha', 'docker_registry_image_name', 'docker_registry_image_tag', 'build_pack', 'static_image', 'install_command', 'build_command', 'start_command', 'ports_exposes', 'ports_mappings', 'custom_network_aliases', 'base_directory', 'publish_directory', 'health_check_enabled', 'health_check_path', 'health_check_port', 'health_check_host', 'health_check_method', 'health_check_return_code', 'health_check_scheme', 'health_check_response_text', 'health_check_interval', 'health_check_timeout', 'health_check_retries', 'health_check_start_period', 'limits_memory', 'limits_memory_swap', 'limits_memory_swappiness', 'limits_memory_reservation', 'limits_cpus', 'limits_cpuset', 'limits_cpu_shares', 'custom_labels', 'custom_docker_run_options', 'post_deployment_command', 'post_deployment_command_container', 'pre_deployment_command', 'pre_deployment_command_container', 'watch_paths', 'manual_webhook_secret_github', 'manual_webhook_secret_gitlab', 'manual_webhook_secret_bitbucket', 'manual_webhook_secret_gitea', 'dockerfile_location', 'docker_compose_location', 'docker_compose_custom_start_command', 'docker_compose_custom_build_command', 'docker_compose_domains', 'redirect', 'instant_deploy', 'use_build_server', 'custom_nginx_configuration', 'is_http_basic_auth_enabled', 'http_basic_auth_username', 'http_basic_auth_password', 'connect_to_docker_network', 'force_domain_override', 'is_container_label_escape_enabled'];
 
         $validationRules = [
             'name' => 'string|max:255',
@@ -2709,6 +2726,7 @@ class ApplicationsController extends Controller
         $isStatic = $request->is_static;
         $isSpa = $request->is_spa;
         $isAutoDeployEnabled = $request->is_auto_deploy_enabled;
+        $isDeployOnReleaseEnabled = $request->is_deploy_on_release_enabled;
         $isForceHttpsEnabled = $request->is_force_https_enabled;
         $connectToDockerNetwork = $request->connect_to_docker_network;
         $useBuildServer = $request->use_build_server;
@@ -2731,6 +2749,10 @@ class ApplicationsController extends Controller
 
         if (isset($isAutoDeployEnabled)) {
             $application->settings->is_auto_deploy_enabled = $isAutoDeployEnabled;
+            $application->settings->save();
+        }
+        if (isset($isDeployOnReleaseEnabled)) {
+            $application->settings->is_deploy_on_release_enabled = $isDeployOnReleaseEnabled;
             $application->settings->save();
         }
 

--- a/app/Http/Controllers/Webhook/Github.php
+++ b/app/Http/Controllers/Webhook/Github.php
@@ -55,6 +55,12 @@ class Github extends Controller
                 $after_sha = data_get($payload, 'after', data_get($payload, 'pull_request.head.sha'));
                 $author_association = data_get($payload, 'pull_request.author_association');
             }
+            if ($x_github_event === 'release') {
+                $action = data_get($payload, 'action');
+                $full_name = data_get($payload, 'repository.full_name');
+                $tag = data_get($payload, 'release.tag_name');
+                $branch = data_get($payload, 'release.target_commitish');
+            }
             if (! $branch) {
                 return response('Nothing to do. No branch found in the request.');
             }
@@ -69,6 +75,12 @@ class Github extends Controller
                 $applications = $applications->where('git_branch', $base_branch)->get();
                 if ($applications->isEmpty()) {
                     return response("Nothing to do. No applications found for repo $full_name and branch '$base_branch'.");
+                }
+            }
+            if ($x_github_event === 'release') {
+                $applications = $applications->where('git_branch', $branch)->get();
+                if ($applications->isEmpty()) {
+                    return response("Nothing to do. No applications found with deploy key set, branch is '$branch' and Git Repository name has $full_name.");
                 }
             }
             $applicationsByServer = $applications->groupBy(function ($app) {
@@ -181,6 +193,43 @@ class Github extends Controller
                             'message' => 'PR webhook received, processing queued.',
                         ]);
                     }
+                    if ($x_github_event === 'release' && $action === 'published') {
+                        if ($application->isReleaseDeployable()) {
+                            $deployment_uuid = new Cuid2;
+                            $result = queue_application_deployment(
+                                application: $application,
+                                deployment_uuid: $deployment_uuid,
+                                force_rebuild: false,
+                                commit: $tag,
+                                is_webhook: true,
+                            );
+                            if ($result['status'] === 'queue_full') {
+                                return response($result['message'], 429)->header('Retry-After', 60);
+                            } elseif ($result['status'] === 'skipped') {
+                                $return_payloads->push([
+                                    'application' => $application->name,
+                                    'status' => 'skipped',
+                                    'message' => $result['message'],
+                                ]);
+                            } else {
+                                $return_payloads->push([
+                                    'application' => $application->name,
+                                    'status' => 'success',
+                                    'message' => 'Release deployment queued.',
+                                    'application_uuid' => $application->uuid,
+                                    'application_name' => $application->name,
+                                    'deployment_uuid' => $result['deployment_uuid'],
+                                ]);
+                            }
+                        } else {
+                            $return_payloads->push([
+                                'status' => 'failed',
+                                'message' => 'Release deployments disabled.',
+                                'application_uuid' => $application->uuid,
+                                'application_name' => $application->name,
+                            ]);
+                        }
+                    }
                 }
             }
 
@@ -246,6 +295,12 @@ class Github extends Controller
                 $after_sha = data_get($payload, 'after', data_get($payload, 'pull_request.head.sha'));
                 $author_association = data_get($payload, 'pull_request.author_association');
             }
+            if ($x_github_event === 'release') {
+                $action = data_get($payload, 'action');
+                $id = data_get($payload, 'repository.id');
+                $tag = data_get($payload, 'release.tag_name');
+                $branch = data_get($payload, 'release.target_commitish');
+            }
             if (! $id || ! $branch) {
                 return response('Nothing to do. No id or branch found.');
             }
@@ -262,6 +317,12 @@ class Github extends Controller
                 $applications = $applications->where('git_branch', $base_branch)->get();
                 if ($applications->isEmpty()) {
                     return response("Nothing to do. No applications found with branch '$base_branch'.");
+                }
+            }
+            if ($x_github_event === 'release') {
+                $applications = $applications->where('git_branch', $branch)->get();
+                if ($applications->isEmpty()) {
+                    return response("Nothing to do. No applications found with branch '$branch'.");
                 }
             }
             $applicationsByServer = $applications->groupBy(function ($app) {
@@ -357,6 +418,35 @@ class Github extends Controller
                             'status' => 'queued',
                             'message' => 'PR webhook received, processing queued.',
                         ]);
+                    }
+                    if ($x_github_event === 'release' && $action === 'published') {
+                        if ($application->isReleaseDeployable()) {
+                            $deployment_uuid = new Cuid2;
+                            $result = queue_application_deployment(
+                                application: $application,
+                                deployment_uuid: $deployment_uuid,
+                                force_rebuild: false,
+                                commit: $tag,
+                                is_webhook: true,
+                            );
+                            if ($result['status'] === 'queue_full') {
+                                return response($result['message'], 429)->header('Retry-After', 60);
+                            }
+                            $return_payloads->push([
+                                'status' => $result['status'],
+                                'message' => $result['message'],
+                                'application_uuid' => $application->uuid,
+                                'application_name' => $application->name,
+                                'deployment_uuid' => $result['deployment_uuid'] ?? null,
+                            ]);
+                        } else {
+                            $return_payloads->push([
+                                'status' => 'failed',
+                                'message' => 'Release deployments disabled.',
+                                'application_uuid' => $application->uuid,
+                                'application_name' => $application->name,
+                            ]);
+                        }
                     }
                 }
             }

--- a/app/Livewire/Project/Application/Advanced.php
+++ b/app/Livewire/Project/Application/Advanced.php
@@ -35,6 +35,9 @@ class Advanced extends Component
     public bool $isAutoDeployEnabled = true;
 
     #[Validate(['boolean'])]
+    public bool $isDeployOnReleaseEnabled = false;
+
+    #[Validate(['boolean'])]
     public bool $disableBuildCache = false;
 
     #[Validate(['boolean'])]
@@ -102,6 +105,7 @@ class Advanced extends Component
             $this->application->settings->is_preview_deployments_enabled = $this->isPreviewDeploymentsEnabled;
             $this->application->settings->is_pr_deployments_public_enabled = $this->isPrDeploymentsPublicEnabled;
             $this->application->settings->is_auto_deploy_enabled = $this->isAutoDeployEnabled;
+            $this->application->settings->is_deploy_on_release_enabled = $this->isDeployOnReleaseEnabled;
             $this->application->settings->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->application->settings->is_gpu_enabled = $this->isGpuEnabled;
             $this->application->settings->gpu_driver = $this->gpuDriver;
@@ -131,6 +135,7 @@ class Advanced extends Component
             $this->isPreviewDeploymentsEnabled = $this->application->settings->is_preview_deployments_enabled;
             $this->isPrDeploymentsPublicEnabled = $this->application->settings->is_pr_deployments_public_enabled ?? false;
             $this->isAutoDeployEnabled = $this->application->settings->is_auto_deploy_enabled;
+            $this->isDeployOnReleaseEnabled = $this->application->settings->is_deploy_on_release_enabled ?? false;
             $this->isGpuEnabled = $this->application->settings->is_gpu_enabled;
             $this->gpuDriver = $this->application->settings->gpu_driver;
             $this->gpuCount = $this->application->settings->gpu_count;

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -985,6 +985,15 @@ class Application extends BaseModel
         return false;
     }
 
+    public function isReleaseDeployable(): bool
+    {
+        if ($this->settings->is_deploy_on_release_enabled) {
+            return true;
+        }
+
+        return false;
+    }
+
     public function deploymentType()
     {
         if (isDev() && data_get($this, 'private_key_id') === 0) {

--- a/app/Models/ApplicationSetting.php
+++ b/app/Models/ApplicationSetting.php
@@ -18,6 +18,7 @@ class ApplicationSetting extends Model
         'inject_build_args_to_dockerfile' => 'boolean',
         'include_source_commit_in_build' => 'boolean',
         'is_auto_deploy_enabled' => 'boolean',
+        'is_deploy_on_release_enabled' => 'boolean',
         'is_force_https_enabled' => 'boolean',
         'is_debug_enabled' => 'boolean',
         'is_preview_deployments_enabled' => 'boolean',

--- a/bootstrap/helpers/api.php
+++ b/bootstrap/helpers/api.php
@@ -88,6 +88,7 @@ function sharedDataApplications()
         'is_static' => 'boolean',
         'is_spa' => 'boolean',
         'is_auto_deploy_enabled' => 'boolean',
+        'is_deploy_on_release_enabled' => 'boolean',
         'is_force_https_enabled' => 'boolean',
         'static_image' => Rule::enum(StaticImageTypes::class),
         'domains' => 'string|nullable',
@@ -183,6 +184,7 @@ function removeUnnecessaryFieldsFromRequest(Request $request)
     $request->offsetUnset('is_static');
     $request->offsetUnset('is_spa');
     $request->offsetUnset('is_auto_deploy_enabled');
+    $request->offsetUnset('is_deploy_on_release_enabled');
     $request->offsetUnset('is_force_https_enabled');
     $request->offsetUnset('connect_to_docker_network');
     $request->offsetUnset('force_domain_override');

--- a/database/migrations/2026_02_18_000001_add_deploy_on_release_to_application_settings.php
+++ b/database/migrations/2026_02_18_000001_add_deploy_on_release_to_application_settings.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('application_settings', function (Blueprint $table) {
+            $table->boolean('is_deploy_on_release_enabled')->default(false)->after('is_auto_deploy_enabled');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('application_settings', function (Blueprint $table) {
+            $table->dropColumn('is_deploy_on_release_enabled');
+        });
+    }
+};

--- a/resources/views/livewire/project/application/advanced.blade.php
+++ b/resources/views/livewire/project/application/advanced.blade.php
@@ -10,6 +10,10 @@
                 <x-forms.checkbox helper="Automatically deploy new commits based on Git webhooks." instantSave
                     id="isAutoDeployEnabled" label="Auto Deploy" canGate="update" :canResource="$application" />
                 <x-forms.checkbox
+                    helper="Automatically deploy when a new release is published on GitHub. Your GitHub App or webhook must have the 'releases' event enabled."
+                    instantSave id="isDeployOnReleaseEnabled" label="Deploy on Release" canGate="update"
+                    :canResource="$application" />
+                <x-forms.checkbox
                     helper="Allow to automatically deploy Preview Deployments for all opened PR's.<br><br>Closing a PR will delete Preview Deployments."
                     instantSave id="isPreviewDeploymentsEnabled" label="Preview Deployments" canGate="update"
                     :canResource="$application" />


### PR DESCRIPTION
Closes #4972

/claim #4972

Adds support for triggering deployments when a GitHub release is published. This was requested in #4972 — the idea is that some users want a project to only deploy on new releases rather than on every push.

### What changed

- New `is_deploy_on_release_enabled` boolean in `application_settings` (defaults to false)
- GitHub webhook controller handles `release` events in both `manual()` and `normal()` endpoints
- Only triggers on the `published` action (ignores drafts, edits, etc.)
- New "Deploy on Release" checkbox in Advanced settings UI, right next to Auto Deploy
- API support for reading/setting the new flag
- Uses the release tag name as the commit reference for deployment

The GitHub App (or manual webhook) needs to have the `releases` event enabled for this to work — the helper text in the UI mentions this.

This is independent of the Auto Deploy toggle, so users can have push-based deploys off and release-based deploys on (or both, or neither).