### PR TITLE
Add server-level environment variables for deployed apps

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -1181,6 +1181,13 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         $coolify_envs->each(function ($item, $key) use ($envs) {
             $envs->push($key.'='.$item);
         });
+
+        // Inject server-level environment variables (between system defaults and app-level vars)
+        $serverEnvVars = $this->mainServer->environmentVariables()->get();
+        foreach ($serverEnvVars as $serverEnv) {
+            $envs->push($serverEnv->key.'='.$serverEnv->real_value);
+        }
+
         if ($this->pull_request_id === 0) {
             // Generate SERVICE_ variables first for dockercompose
             if ($this->build_pack === 'dockercompose') {
@@ -1463,6 +1470,15 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         $coolify_envs = $this->generate_coolify_env_variables(forBuildTime: true);
         foreach ($coolify_envs as $key => $item) {
             $envs_dict[$key] = escapeBashEnvValue($item);
+        }
+
+        // 2.5. Add server-level environment variables (between system defaults and app-level vars)
+        $serverEnvVars = $this->mainServer->environmentVariables()->get();
+        foreach ($serverEnvVars as $serverEnv) {
+            $value = $serverEnv->value;
+            if ($value !== null) {
+                $envs_dict[$serverEnv->key] = escapeBashEnvValue($value);
+            }
         }
 
         // 3. Add SERVICE_NAME, SERVICE_FQDN, SERVICE_URL variables for Docker Compose builds
@@ -2340,6 +2356,11 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
     private function generate_coolify_env_variables(bool $forBuildTime = false): Collection
     {
         $coolify_envs = collect([]);
+
+        // Always inject server identification variables
+        $coolify_envs->put('COOLIFY_SERVER_NAME', $this->mainServer->name);
+        $coolify_envs->put('COOLIFY_SERVER_UUID', $this->mainServer->uuid);
+
         $local_branch = $this->branch;
         if ($this->pull_request_id !== 0) {
             // Only add SOURCE_COMMIT for runtime OR when explicitly enabled for build-time

--- a/app/Livewire/Server/EnvironmentVariable/Add.php
+++ b/app/Livewire/Server/EnvironmentVariable/Add.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Livewire\Server\EnvironmentVariable;
+
+use Livewire\Component;
+
+class Add extends Component
+{
+    public string $key = '';
+
+    public ?string $value = null;
+
+    public bool $is_multiline = false;
+
+    public bool $is_literal = false;
+
+    public bool $is_shown_once = false;
+
+    protected $listeners = ['clearAddEnv' => 'clear'];
+
+    protected $rules = [
+        'key' => 'required|string',
+        'value' => 'nullable',
+        'is_multiline' => 'required|boolean',
+        'is_literal' => 'required|boolean',
+        'is_shown_once' => 'required|boolean',
+    ];
+
+    public function submit()
+    {
+        $this->validate();
+        $this->dispatch('saveKey', [
+            'key' => $this->key,
+            'value' => $this->value,
+            'is_multiline' => $this->is_multiline,
+            'is_literal' => $this->is_literal,
+            'is_shown_once' => $this->is_shown_once,
+        ]);
+        $this->clear();
+    }
+
+    public function clear()
+    {
+        $this->key = '';
+        $this->value = '';
+        $this->is_multiline = false;
+        $this->is_literal = false;
+        $this->is_shown_once = false;
+    }
+
+    public function render()
+    {
+        return view('livewire.server.environment-variable.add');
+    }
+}

--- a/app/Livewire/Server/EnvironmentVariable/All.php
+++ b/app/Livewire/Server/EnvironmentVariable/All.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace App\Livewire\Server\EnvironmentVariable;
+
+use App\Models\Server;
+use App\Models\ServerEnvironmentVariable;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Component;
+
+class All extends Component
+{
+    use AuthorizesRequests;
+
+    public Server $server;
+
+    public string $view = 'normal';
+
+    public ?string $variables = null;
+
+    protected $listeners = [
+        'saveKey' => 'submit',
+        'refreshEnvs',
+        'environmentVariableDeleted' => 'refreshEnvs',
+    ];
+
+    public function mount(string $server_uuid)
+    {
+        $this->server = Server::ownedByCurrentTeam()->whereUuid($server_uuid)->firstOrFail();
+        $this->getDevView();
+    }
+
+    public function getEnvironmentVariablesProperty()
+    {
+        return $this->server->environmentVariables()->orderBy('key')->get();
+    }
+
+    public function getDevView()
+    {
+        $this->variables = $this->environmentVariables->map(function ($item) {
+            if ($item->is_shown_once) {
+                return "$item->key=(Locked Secret, delete and add again to change)";
+            }
+            if ($item->is_multiline) {
+                return "$item->key=(Multiline environment variable, edit in normal view)";
+            }
+
+            return "$item->key=$item->value";
+        })->join("\n");
+    }
+
+    public function switch()
+    {
+        $this->view = $this->view === 'normal' ? 'dev' : 'normal';
+        $this->getDevView();
+    }
+
+    public function submit($data = null)
+    {
+        try {
+            $this->authorize('update', $this->server);
+            if ($data === null) {
+                $this->handleBulkSubmit();
+            } else {
+                $this->handleSingleSubmit($data);
+            }
+            $this->getDevView();
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        } finally {
+            $this->refreshEnvs();
+        }
+    }
+
+    private function handleBulkSubmit()
+    {
+        $variables = parseEnvFormatToArray($this->variables);
+        $changesMade = false;
+
+        // Delete removed variables
+        $variablesToDelete = $this->server->environmentVariables()
+            ->whereNotIn('key', array_keys($variables))
+            ->get();
+
+        if ($variablesToDelete->isNotEmpty()) {
+            $this->server->environmentVariables()
+                ->whereNotIn('key', array_keys($variables))
+                ->delete();
+            $changesMade = true;
+        }
+
+        // Update or create variables
+        foreach ($variables as $key => $value) {
+            $found = $this->server->environmentVariables()->where('key', $key)->first();
+            if ($found) {
+                if (! $found->is_shown_once && ! $found->is_multiline) {
+                    if ($found->value !== $value) {
+                        $found->value = $value;
+                        $found->save();
+                        $changesMade = true;
+                    }
+                }
+            } else {
+                ServerEnvironmentVariable::create([
+                    'key' => $key,
+                    'value' => $value,
+                    'server_id' => $this->server->id,
+                ]);
+                $changesMade = true;
+            }
+        }
+
+        if ($changesMade) {
+            $this->dispatch('success', 'Environment variables updated.');
+        }
+    }
+
+    private function handleSingleSubmit($data)
+    {
+        $found = $this->server->environmentVariables()->where('key', $data['key'])->first();
+        if ($found) {
+            $this->dispatch('error', 'Environment variable already exists.');
+
+            return;
+        }
+
+        ServerEnvironmentVariable::create([
+            'key' => $data['key'],
+            'value' => $data['value'],
+            'is_multiline' => $data['is_multiline'] ?? false,
+            'is_literal' => $data['is_literal'] ?? false,
+            'is_shown_once' => $data['is_shown_once'] ?? false,
+            'server_id' => $this->server->id,
+        ]);
+
+        $this->dispatch('success', 'Environment variable added.');
+    }
+
+    public function refreshEnvs()
+    {
+        $this->server->refresh();
+        unset($this->environmentVariables);
+        $this->getDevView();
+    }
+
+    public function render()
+    {
+        return view('livewire.server.environment-variable.all');
+    }
+}

--- a/app/Livewire/Server/EnvironmentVariable/Show.php
+++ b/app/Livewire/Server/EnvironmentVariable/Show.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Livewire\Server\EnvironmentVariable;
+
+use App\Models\ServerEnvironmentVariable;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Component;
+
+class Show extends Component
+{
+    use AuthorizesRequests;
+
+    public ServerEnvironmentVariable $env;
+
+    public ?string $value = null;
+
+    public bool $is_multiline = false;
+
+    public bool $is_literal = false;
+
+    protected $rules = [
+        'env.key' => 'required|string',
+        'env.value' => 'nullable',
+        'env.is_multiline' => 'required|boolean',
+        'env.is_literal' => 'required|boolean',
+        'env.is_shown_once' => 'required|boolean',
+    ];
+
+    public function mount(ServerEnvironmentVariable $env)
+    {
+        $this->env = $env;
+        $this->is_multiline = $env->is_multiline;
+        $this->is_literal = $env->is_literal;
+    }
+
+    public function submit()
+    {
+        try {
+            $this->authorize('update', $this->env->server);
+            $this->validate();
+            $this->env->save();
+            $this->dispatch('success', 'Environment variable updated.');
+            $this->dispatch('refreshEnvs');
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function delete()
+    {
+        try {
+            $this->authorize('update', $this->env->server);
+            $this->env->delete();
+            $this->dispatch('success', 'Environment variable deleted.');
+            $this->dispatch('environmentVariableDeleted');
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function render()
+    {
+        return view('livewire.server.environment-variable.show');
+    }
+}

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -191,6 +191,7 @@ class Server extends BaseModel
             });
             $server->settings()->delete();
             $server->sslCertificates()->delete();
+            $server->environmentVariables()->delete();
         });
 
         static::updated(function () {
@@ -313,6 +314,11 @@ class Server extends BaseModel
     public function settings()
     {
         return $this->hasOne(ServerSetting::class);
+    }
+
+    public function environmentVariables()
+    {
+        return $this->hasMany(ServerEnvironmentVariable::class);
     }
 
     public function dockerCleanupExecutions()

--- a/app/Models/ServerEnvironmentVariable.php
+++ b/app/Models/ServerEnvironmentVariable.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Casts\Attribute;
+
+class ServerEnvironmentVariable extends BaseModel
+{
+    protected $guarded = [];
+
+    protected $casts = [
+        'key' => 'string',
+        'value' => 'encrypted',
+        'is_multiline' => 'boolean',
+        'is_literal' => 'boolean',
+        'is_shown_once' => 'boolean',
+    ];
+
+    public function server()
+    {
+        return $this->belongsTo(Server::class);
+    }
+
+    protected function key(): Attribute
+    {
+        return Attribute::make(
+            set: fn (string $value) => str($value)->trim()->replace(' ', '_')->value,
+        );
+    }
+
+    protected function value(): Attribute
+    {
+        return Attribute::make(
+            get: fn (?string $value = null) => $value ? trim(decrypt($value)) : null,
+            set: fn (?string $value = null) => is_null($value) || $value === '' ? null : encrypt(trim($value)),
+        );
+    }
+
+    public function realValue(): Attribute
+    {
+        return Attribute::make(
+            get: function () {
+                $real_value = $this->value;
+
+                if (is_null($real_value)) {
+                    return null;
+                }
+
+                if ($this->is_literal || $this->is_multiline) {
+                    return '\'' . $real_value . '\'';
+                }
+
+                return escapeEnvVariables($real_value);
+            }
+        );
+    }
+}

--- a/bootstrap/helpers/parsers.php
+++ b/bootstrap/helpers/parsers.php
@@ -1184,6 +1184,22 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
             $coolifyEnvironments->put('COOLIFY_FQDN', $urls->implode(','));
         }
         add_coolify_default_environment_variables($resource, $coolifyEnvironments, $resource->environment_variables);
+
+        // Inject server-level environment variables
+        $serverForEnvVars = null;
+        if ($resource instanceof \App\Models\Application) {
+            $serverForEnvVars = $resource->destination->server ?? null;
+        } elseif ($resource instanceof \App\Models\Service) {
+            $serverForEnvVars = $resource->server ?? null;
+        }
+        if ($serverForEnvVars) {
+            foreach ($serverForEnvVars->environmentVariables as $serverEnv) {
+                if ($serverEnv->value !== null) {
+                    $coolifyEnvironments->put($serverEnv->key, $serverEnv->value);
+                }
+            }
+        }
+
         if ($environment->count() > 0) {
             $environment = $environment->filter(function ($value, $key) {
                 return ! str($key)->startsWith('SERVICE_FQDN_');
@@ -2286,6 +2302,22 @@ function serviceParser(Service $resource): Collection
             $coolifyEnvironments->put('COOLIFY_URL', $urls->implode(','));
         }
         add_coolify_default_environment_variables($resource, $coolifyEnvironments, $resource->environment_variables);
+
+        // Inject server-level environment variables
+        $serverForEnvVars = null;
+        if ($resource instanceof \App\Models\Application) {
+            $serverForEnvVars = $resource->destination->server ?? null;
+        } elseif ($resource instanceof \App\Models\Service) {
+            $serverForEnvVars = $resource->server ?? null;
+        }
+        if ($serverForEnvVars) {
+            foreach ($serverForEnvVars->environmentVariables as $serverEnv) {
+                if ($serverEnv->value !== null) {
+                    $coolifyEnvironments->put($serverEnv->key, $serverEnv->value);
+                }
+            }
+        }
+
         if ($environment->count() > 0) {
             $environment = $environment->filter(function ($value, $key) {
                 return ! str($key)->startsWith('SERVICE_FQDN_');

--- a/database/migrations/2026_02_18_000001_create_server_environment_variables_table.php
+++ b/database/migrations/2026_02_18_000001_create_server_environment_variables_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('server_environment_variables', function (Blueprint $table) {
+            $table->id();
+            $table->string('uuid')->unique();
+            $table->string('key');
+            $table->text('value')->nullable();
+            $table->boolean('is_multiline')->default(false);
+            $table->boolean('is_literal')->default(false);
+            $table->boolean('is_shown_once')->default(false);
+            $table->foreignId('server_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->unique(['key', 'server_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('server_environment_variables');
+    }
+};

--- a/resources/views/livewire/server/environment-variable/add.blade.php
+++ b/resources/views/livewire/server/environment-variable/add.blade.php
@@ -1,0 +1,19 @@
+<form class="flex flex-col w-full gap-2 rounded-sm" wire:submit="submit">
+    <x-forms.input placeholder="NODE_ENV" id="key" label="Name" required />
+    @if ($is_multiline)
+        <x-forms.textarea id="value" label="Value" />
+    @else
+        <x-forms.input placeholder="production" id="value" label="Value" />
+    @endif
+
+    <x-forms.checkbox id="is_literal"
+        helper="When enabled, dollar signs ($) in the value will be treated literally instead of as variable references."
+        label="Is Literal?" />
+    <x-forms.checkbox id="is_multiline" label="Is Multiline?" />
+    <x-forms.checkbox id="is_shown_once"
+        helper="Once saved, the value will be hidden and cannot be viewed again. You can only delete and re-add."
+        label="Lock Value (One-time view)" />
+    <x-forms.button type="submit" @click="slideOverOpen=false">
+        Save
+    </x-forms.button>
+</form>

--- a/resources/views/livewire/server/environment-variable/all.blade.php
+++ b/resources/views/livewire/server/environment-variable/all.blade.php
@@ -1,0 +1,41 @@
+<div>
+    <x-slot:title>
+        {{ data_get_str($server, 'name')->limit(10) }} > Environment Variables | Coolify
+    </x-slot>
+    <livewire:server.navbar :server="$server" />
+    <div class="flex items-center gap-2">
+        <h2>Environment Variables</h2>
+        <x-slide-over>
+            <x-slot:title>New Environment Variable</x-slot:title>
+            <x-slot:content>
+                <livewire:server.environment-variable.add />
+            </x-slot:content>
+            <x-slot:button-title>
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 24 24" stroke-width="1.5"
+                    stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                    <path d="M12 5l0 14" />
+                    <path d="M5 12l14 0" />
+                </svg>
+                Add
+            </x-slot:button-title>
+        </x-slide-over>
+    </div>
+    <div class="mb-4 text-sm text-neutral-500 dark:text-neutral-400">
+        These environment variables will be injected into every application deployed on this server.
+        Application-level variables with the same key will take precedence.
+    </div>
+    <div class="mb-2 text-sm text-neutral-500 dark:text-neutral-400">
+        Additionally, <code class="text-xs">COOLIFY_SERVER_NAME</code> and <code class="text-xs">COOLIFY_SERVER_UUID</code>
+        are automatically available in all deployments.
+    </div>
+    <div class="flex flex-col gap-2">
+        @forelse ($this->environmentVariables as $env)
+            <livewire:server.environment-variable.show :env="$env" :key="$env->id" />
+        @empty
+            <div class="text-neutral-500 dark:text-neutral-400">
+                No environment variables defined for this server.
+            </div>
+        @endforelse
+    </div>
+</div>

--- a/resources/views/livewire/server/environment-variable/show.blade.php
+++ b/resources/views/livewire/server/environment-variable/show.blade.php
@@ -1,0 +1,54 @@
+<div>
+    <form wire:submit="submit"
+        class="flex flex-col items-center gap-4 p-4 bg-white border lg:items-start dark:bg-base dark:border-coolgray-300 border-neutral-200">
+        <div class="flex flex-col w-full gap-2 lg:flex-row">
+            @if ($env->is_shown_once)
+                <x-forms.input disabled id="env.key" label="Name" />
+                <svg class="icon my-1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                    <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"
+                        stroke-width="2">
+                        <path d="M5 13a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2v-6z" />
+                        <path d="M11 16a1 1 0 1 0 2 0a1 1 0 0 0-2 0m-3-5V7a4 4 0 1 1 8 0v4" />
+                    </g>
+                </svg>
+                <x-modal-confirmation title="Confirm Environment Variable Deletion?" isErrorButton
+                    buttonTitle="Delete" submitAction="delete"
+                    :actions="['The selected environment variable will be permanently deleted.']"
+                    confirmationText="{{ $env->key }}"
+                    confirmationLabel="Please confirm the execution of the actions by entering the Environment Variable Name below"
+                    shortConfirmationLabel="Environment Variable Name" :confirmWithPassword="false"
+                    step2ButtonText="Permanently Delete" />
+            @else
+                @if ($env->is_multiline)
+                    <x-forms.input id="env.key" label="Name" />
+                    <x-forms.textarea type="password" id="env.value" label="Value" />
+                @else
+                    <x-forms.input id="env.key" label="Name" />
+                    <x-forms.input type="password" id="env.value" label="Value" />
+                @endif
+            @endif
+        </div>
+        @if (!$env->is_shown_once)
+            <div class="flex flex-col w-full gap-3">
+                <div class="flex flex-wrap w-full items-center gap-4">
+                    <x-forms.checkbox instantSave id="env.is_multiline" label="Is Multiline?" />
+                    @if (!$env->is_multiline)
+                        <x-forms.checkbox instantSave id="env.is_literal"
+                            helper="When enabled, dollar signs ($) in the value will be treated literally instead of as variable references."
+                            label="Is Literal?" />
+                    @endif
+                </div>
+                <div class="flex w-full justify-end gap-2">
+                    <x-forms.button type="submit">Update</x-forms.button>
+                    <x-modal-confirmation title="Confirm Environment Variable Deletion?" isErrorButton
+                        buttonTitle="Delete" submitAction="delete"
+                        :actions="['The selected environment variable will be permanently deleted.']"
+                        confirmationText="{{ $env->key }}"
+                        confirmationLabel="Please confirm the execution of the actions by entering the Environment Variable Name below"
+                        shortConfirmationLabel="Environment Variable Name" :confirmWithPassword="false"
+                        step2ButtonText="Permanently Delete" />
+                </div>
+            </div>
+        @endif
+    </form>
+</div>

--- a/resources/views/livewire/server/navbar.blade.php
+++ b/resources/views/livewire/server/navbar.blade.php
@@ -87,6 +87,11 @@
 ]) }}" {{ wireNavigate() }}>
                 Resources
             </a>
+            <a class="{{ request()->routeIs('server.environment-variables') ? 'dark:text-white' : '' }}" href="{{ route('server.environment-variables', [
+    'server_uuid' => data_get($server, 'uuid'),
+]) }}" {{ wireNavigate() }}>
+                Environment
+            </a>
             @can('canAccessTerminal')
                         <a class="{{ request()->routeIs('server.command') ? 'dark:text-white' : '' }}" href="{{ route('server.command', [
                     'server_uuid' => data_get($server, 'uuid'),

--- a/routes/web.php
+++ b/routes/web.php
@@ -60,6 +60,7 @@ use App\Livewire\Server\Security\TerminalAccess;
 use App\Livewire\Server\Sentinel as ServerSentinel;
 use App\Livewire\Server\Show as ServerShow;
 use App\Livewire\Server\Swarm as ServerSwarm;
+use App\Livewire\Server\EnvironmentVariable\All as ServerEnvironmentVariables;
 use App\Livewire\Settings\Advanced as SettingsAdvanced;
 use App\Livewire\Settings\Index as SettingsIndex;
 use App\Livewire\Settings\Updates as SettingsUpdates;
@@ -265,6 +266,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/cloudflare-tunnel', CloudflareTunnel::class)->name('server.cloudflare-tunnel');
         Route::get('/destinations', ServerDestinations::class)->name('server.destinations');
         Route::get('/log-drains', LogDrains::class)->name('server.log-drains');
+        Route::get('/environment-variables', ServerEnvironmentVariables::class)->name('server.environment-variables');
         Route::get('/metrics', ServerCharts::class)->name('server.charts');
         Route::get('/danger', DeleteServer::class)->name('server.delete');
         Route::get('/proxy', ProxyShow::class)->name('server.proxy');


### PR DESCRIPTION
Fixes #7738

/claim #7738

## What this does

Adds the ability to set environment variables on a per-server basis. These get injected into every application deployed on that server, so apps can tell which server they're running on in multi-server deployments.

The priority order is: system defaults -> server env vars -> app env vars, meaning app-level vars can override server-level ones.

Also auto-injects `COOLIFY_SERVER_NAME` and `COOLIFY_SERVER_UUID` into all deployments by default (no config needed).

## Changes

- New `server_environment_variables` table + `ServerEnvironmentVariable` model
- `environmentVariables()` relationship on the `Server` model
- "Environment" tab in the server navbar with full CRUD UI
- Injection into both runtime and buildtime env var generation in `ApplicationDeploymentJob`
- Injection in `parsers.php` for service/compose-based deployments
- Cleanup on server deletion

## How to test

1. Go to any server page, click "Environment" tab
2. Add a variable like `MY_SERVER=server-1`
3. Deploy any app on that server
4. Check that `MY_SERVER` and `COOLIFY_SERVER_NAME` / `COOLIFY_SERVER_UUID` are available inside the container
5. If the app also defines `MY_SERVER`, the app-level value should win