### PR TITLE
feat: add configurable proxy timeout for public database connections

### DIFF
--- a/app/Actions/Database/StartDatabaseProxy.php
+++ b/app/Actions/Database/StartDatabaseProxy.php
@@ -50,6 +50,13 @@ class StartDatabaseProxy
             };
         }
 
+        $proxyTimeout = $database->public_proxy_timeout ?? 0;
+        if ($proxyTimeout <= 0) {
+            $timeoutValue = '365d';
+        } else {
+            $timeoutValue = "{$proxyTimeout}s";
+        }
+
         $configuration_dir = database_proxy_dir($database->uuid);
         if (isDev()) {
             $configuration_dir = '/var/lib/docker/volumes/coolify_dev_coolify_data/_data/databases/'.$database->uuid.'/proxy';
@@ -67,6 +74,8 @@ class StartDatabaseProxy
        server {
             listen $database->public_port;
             proxy_pass $containerName:$internalPort;
+            proxy_timeout $timeoutValue;
+            proxy_connect_timeout 60s;
        }
     }
     EOF;

--- a/app/Livewire/Project/Database/Clickhouse/General.php
+++ b/app/Livewire/Project/Database/Clickhouse/General.php
@@ -36,6 +36,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $publicProxyTimeout = null;
+
     public ?string $customDockerRunOptions = null;
 
     public ?string $dbUrl = null;
@@ -80,6 +82,7 @@ class General extends Component
             'portsMappings' => 'nullable|string',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'publicProxyTimeout' => 'nullable|integer|min:0',
             'customDockerRunOptions' => 'nullable|string',
             'dbUrl' => 'nullable|string',
             'dbUrlPublic' => 'nullable|string',
@@ -115,6 +118,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_proxy_timeout = $this->publicProxyTimeout;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->save();
@@ -130,6 +134,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->publicProxyTimeout = $this->database->public_proxy_timeout;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->dbUrl = $this->database->internal_db_url;

--- a/app/Livewire/Project/Database/Dragonfly/General.php
+++ b/app/Livewire/Project/Database/Dragonfly/General.php
@@ -36,6 +36,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $publicProxyTimeout = null;
+
     public ?string $customDockerRunOptions = null;
 
     public ?string $dbUrl = null;
@@ -91,6 +93,7 @@ class General extends Component
             'portsMappings' => 'nullable|string',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'publicProxyTimeout' => 'nullable|integer|min:0',
             'customDockerRunOptions' => 'nullable|string',
             'dbUrl' => 'nullable|string',
             'dbUrlPublic' => 'nullable|string',
@@ -124,6 +127,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_proxy_timeout = $this->publicProxyTimeout;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->enable_ssl = $this->enable_ssl;
@@ -139,6 +143,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->publicProxyTimeout = $this->database->public_proxy_timeout;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->enable_ssl = $this->database->enable_ssl;

--- a/app/Livewire/Project/Database/Keydb/General.php
+++ b/app/Livewire/Project/Database/Keydb/General.php
@@ -38,6 +38,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $publicProxyTimeout = null;
+
     public ?string $customDockerRunOptions = null;
 
     public ?string $dbUrl = null;
@@ -94,6 +96,7 @@ class General extends Component
             'portsMappings' => 'nullable|string',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'publicProxyTimeout' => 'nullable|integer|min:0',
             'customDockerRunOptions' => 'nullable|string',
             'dbUrl' => 'nullable|string',
             'dbUrlPublic' => 'nullable|string',
@@ -130,6 +133,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_proxy_timeout = $this->publicProxyTimeout;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->enable_ssl = $this->enable_ssl;
@@ -146,6 +150,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->publicProxyTimeout = $this->database->public_proxy_timeout;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->enable_ssl = $this->database->enable_ssl;

--- a/app/Livewire/Project/Database/Mariadb/General.php
+++ b/app/Livewire/Project/Database/Mariadb/General.php
@@ -44,6 +44,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $publicProxyTimeout = null;
+
     public bool $isLogDrainEnabled = false;
 
     public ?string $customDockerRunOptions = null;
@@ -79,6 +81,7 @@ class General extends Component
             'portsMappings' => 'nullable',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'publicProxyTimeout' => 'nullable|integer|min:0',
             'isLogDrainEnabled' => 'nullable|boolean',
             'customDockerRunOptions' => 'nullable',
             'enableSsl' => 'boolean',
@@ -154,6 +157,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_proxy_timeout = $this->publicProxyTimeout;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->enable_ssl = $this->enableSsl;
@@ -173,6 +177,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->publicProxyTimeout = $this->database->public_proxy_timeout;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->enableSsl = $this->database->enable_ssl;

--- a/app/Livewire/Project/Database/Mongodb/General.php
+++ b/app/Livewire/Project/Database/Mongodb/General.php
@@ -42,6 +42,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $publicProxyTimeout = null;
+
     public bool $isLogDrainEnabled = false;
 
     public ?string $customDockerRunOptions = null;
@@ -78,6 +80,7 @@ class General extends Component
             'portsMappings' => 'nullable',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'publicProxyTimeout' => 'nullable|integer|min:0',
             'isLogDrainEnabled' => 'nullable|boolean',
             'customDockerRunOptions' => 'nullable',
             'enableSsl' => 'boolean',
@@ -153,6 +156,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_proxy_timeout = $this->publicProxyTimeout;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->enable_ssl = $this->enableSsl;
@@ -172,6 +176,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->publicProxyTimeout = $this->database->public_proxy_timeout;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->enableSsl = $this->database->enable_ssl;

--- a/app/Livewire/Project/Database/Mysql/General.php
+++ b/app/Livewire/Project/Database/Mysql/General.php
@@ -44,6 +44,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $publicProxyTimeout = null;
+
     public bool $isLogDrainEnabled = false;
 
     public ?string $customDockerRunOptions = null;
@@ -81,6 +83,7 @@ class General extends Component
             'portsMappings' => 'nullable',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'publicProxyTimeout' => 'nullable|integer|min:0',
             'isLogDrainEnabled' => 'nullable|boolean',
             'customDockerRunOptions' => 'nullable',
             'enableSsl' => 'boolean',
@@ -159,6 +162,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_proxy_timeout = $this->publicProxyTimeout;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->enable_ssl = $this->enableSsl;
@@ -179,6 +183,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->publicProxyTimeout = $this->database->public_proxy_timeout;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->enableSsl = $this->database->enable_ssl;

--- a/app/Livewire/Project/Database/Postgresql/General.php
+++ b/app/Livewire/Project/Database/Postgresql/General.php
@@ -48,6 +48,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $publicProxyTimeout = null;
+
     public bool $isLogDrainEnabled = false;
 
     public ?string $customDockerRunOptions = null;
@@ -93,6 +95,7 @@ class General extends Component
             'portsMappings' => 'nullable',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'publicProxyTimeout' => 'nullable|integer|min:0',
             'isLogDrainEnabled' => 'nullable|boolean',
             'customDockerRunOptions' => 'nullable',
             'enableSsl' => 'boolean',
@@ -174,6 +177,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_proxy_timeout = $this->publicProxyTimeout;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->enable_ssl = $this->enableSsl;
@@ -196,6 +200,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->publicProxyTimeout = $this->database->public_proxy_timeout;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->enableSsl = $this->database->enable_ssl;

--- a/app/Livewire/Project/Database/Redis/General.php
+++ b/app/Livewire/Project/Database/Redis/General.php
@@ -36,6 +36,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $publicProxyTimeout = null;
+
     public bool $isLogDrainEnabled = false;
 
     public ?string $customDockerRunOptions = null;
@@ -74,6 +76,7 @@ class General extends Component
             'portsMappings' => 'nullable',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'publicProxyTimeout' => 'nullable|integer|min:0',
             'isLogDrainEnabled' => 'nullable|boolean',
             'customDockerRunOptions' => 'nullable',
             'redisUsername' => 'required',
@@ -143,6 +146,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_proxy_timeout = $this->publicProxyTimeout;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->enable_ssl = $this->enableSsl;
@@ -158,6 +162,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->publicProxyTimeout = $this->database->public_proxy_timeout;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->enableSsl = $this->database->enable_ssl;

--- a/database/migrations/2026_02_18_000001_add_public_proxy_timeout_to_database_tables.php
+++ b/database/migrations/2026_02_18_000001_add_public_proxy_timeout_to_database_tables.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $tables = [
+            'standalone_postgresqls',
+            'standalone_mysqls',
+            'standalone_mariadbs',
+            'standalone_redis',
+            'standalone_keydbs',
+            'standalone_dragonflies',
+            'standalone_mongodbs',
+            'standalone_clickhouses',
+            'service_databases',
+        ];
+
+        foreach ($tables as $table) {
+            Schema::table($table, function (Blueprint $table) {
+                $table->integer('public_proxy_timeout')->default(0)->after('public_port');
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $tables = [
+            'standalone_postgresqls',
+            'standalone_mysqls',
+            'standalone_mariadbs',
+            'standalone_redis',
+            'standalone_keydbs',
+            'standalone_dragonflies',
+            'standalone_mongodbs',
+            'standalone_clickhouses',
+            'service_databases',
+        ];
+
+        foreach ($tables as $table) {
+            Schema::table($table, function (Blueprint $table) {
+                $table->dropColumn('public_proxy_timeout');
+            });
+        }
+    }
+};

--- a/resources/views/livewire/project/database/clickhouse/general.blade.php
+++ b/resources/views/livewire/project/database/clickhouse/general.blade.php
@@ -78,6 +78,9 @@
             </div>
             <x-forms.input placeholder="5432" disabled="{{ $isPublic }}" id="publicPort" label="Public Port"
                 canGate="update" :canResource="$database" />
+            <x-forms.input placeholder="0" id="publicProxyTimeout" label="Proxy Timeout (seconds)"
+                helper="Timeout in seconds for idle proxy connections. Set to 0 for no timeout (default)."
+                canGate="update" :canResource="$database" />
         </div>
     </form>
     <h3 class="pt-4">Advanced</h3>

--- a/resources/views/livewire/project/database/dragonfly/general.blade.php
+++ b/resources/views/livewire/project/database/dragonfly/general.blade.php
@@ -115,6 +115,9 @@
             </div>
             <x-forms.input placeholder="5432" disabled="{{ $isPublic }}" id="publicPort" label="Public Port"
                 canGate="update" :canResource="$database" />
+            <x-forms.input placeholder="0" id="publicProxyTimeout" label="Proxy Timeout (seconds)"
+                helper="Timeout in seconds for idle proxy connections. Set to 0 for no timeout (default)."
+                canGate="update" :canResource="$database" />
         </div>
     </form>
     <h3 class="pt-4">Advanced</h3>

--- a/resources/views/livewire/project/database/keydb/general.blade.php
+++ b/resources/views/livewire/project/database/keydb/general.blade.php
@@ -115,6 +115,9 @@
             </div>
             <x-forms.input placeholder="5432" disabled="{{ $isPublic }}" id="publicPort" label="Public Port"
                 canGate="update" :canResource="$database" />
+            <x-forms.input placeholder="0" id="publicProxyTimeout" label="Proxy Timeout (seconds)"
+                helper="Timeout in seconds for idle proxy connections. Set to 0 for no timeout (default)."
+                canGate="update" :canResource="$database" />
         </div>
         <x-forms.textarea
             helper="<a target='_blank' class='underline dark:text-white' href='https://raw.githubusercontent.com/Snapchat/KeyDB/unstable/keydb.conf'>KeyDB Default Configuration</a>"

--- a/resources/views/livewire/project/database/mariadb/general.blade.php
+++ b/resources/views/livewire/project/database/mariadb/general.blade.php
@@ -139,6 +139,9 @@
             </div>
             <x-forms.input placeholder="5432" disabled="{{ $isPublic }}"
                 id="publicPort" label="Public Port" canGate="update" :canResource="$database" />
+            <x-forms.input placeholder="0" id="publicProxyTimeout" label="Proxy Timeout (seconds)"
+                helper="Timeout in seconds for idle proxy connections. Set to 0 for no timeout (default)."
+                canGate="update" :canResource="$database" />
         </div>
         <x-forms.textarea label="Custom MariaDB Configuration" rows="10" id="mariadbConf"
             canGate="update" :canResource="$database" />

--- a/resources/views/livewire/project/database/mongodb/general.blade.php
+++ b/resources/views/livewire/project/database/mongodb/general.blade.php
@@ -153,6 +153,9 @@
                 </div>
                 <x-forms.input placeholder="5432" disabled="{{ $isPublic }}"
                     id="publicPort" label="Public Port" canGate="update" :canResource="$database" />
+                <x-forms.input placeholder="0" id="publicProxyTimeout" label="Proxy Timeout (seconds)"
+                    helper="Timeout in seconds for idle proxy connections. Set to 0 for no timeout (default)."
+                    canGate="update" :canResource="$database" />
             </div>
             <x-forms.textarea label="Custom MongoDB Configuration" rows="10" id="mongoConf"
                 canGate="update" :canResource="$database" />

--- a/resources/views/livewire/project/database/mysql/general.blade.php
+++ b/resources/views/livewire/project/database/mysql/general.blade.php
@@ -155,6 +155,9 @@
             </div>
             <x-forms.input placeholder="5432" disabled="{{ $isPublic }}"
                 id="publicPort" label="Public Port" canGate="update" :canResource="$database" />
+            <x-forms.input placeholder="0" id="publicProxyTimeout" label="Proxy Timeout (seconds)"
+                helper="Timeout in seconds for idle proxy connections. Set to 0 for no timeout (default)."
+                canGate="update" :canResource="$database" />
         </div>
         <x-forms.textarea label="Custom Mysql Configuration" rows="10" id="mysqlConf" canGate="update" :canResource="$database" />
         <h3 class="pt-4">Advanced</h3>

--- a/resources/views/livewire/project/database/postgresql/general.blade.php
+++ b/resources/views/livewire/project/database/postgresql/general.blade.php
@@ -165,6 +165,9 @@
                     </div>
                     <x-forms.input placeholder="5432" disabled="{{ $isPublic }}" id="publicPort"
                         label="Public Port" canGate="update" :canResource="$database" />
+                    <x-forms.input placeholder="0" id="publicProxyTimeout" label="Proxy Timeout (seconds)"
+                        helper="Timeout in seconds for idle proxy connections. Set to 0 for no timeout (default)."
+                        canGate="update" :canResource="$database" />
                 </div>
 
                 <div class="flex flex-col gap-2">

--- a/resources/views/livewire/project/database/redis/general.blade.php
+++ b/resources/views/livewire/project/database/redis/general.blade.php
@@ -134,6 +134,9 @@
             </div>
             <x-forms.input placeholder="5432" disabled="{{ $isPublic }}"
                 id="publicPort" label="Public Port" canGate="update" :canResource="$database" />
+            <x-forms.input placeholder="0" id="publicProxyTimeout" label="Proxy Timeout (seconds)"
+                helper="Timeout in seconds for idle proxy connections. Set to 0 for no timeout (default)."
+                canGate="update" :canResource="$database" />
         </div>
         <x-forms.textarea placeholder="# maxmemory 256mb
 # maxmemory-policy allkeys-lru


### PR DESCRIPTION
/claim #7743

## Problem

The nginx TCP proxy for publicly exposed databases uses the default `proxy_timeout` of 10 minutes. This causes long-running queries and idle database connections to be dropped unexpectedly — a significant issue for production workloads.

## Solution

Added a dedicated **"Proxy Timeout (seconds)"** field to all 8 database types, as requested by @zachlatta in the issue discussion.

### How it works

- **Default: `0` (no timeout)** — maps to `proxy_timeout 365d` in nginx, effectively disabling the idle timeout
- **Custom value** — any positive integer sets the timeout in seconds (e.g., `3600` = 1 hour)
- Also adds `proxy_connect_timeout 60s` for connection establishment

### Changes

**New file:**
- `database/migrations/2026_02_18_000001_add_public_proxy_timeout_to_database_tables.php` — adds `public_proxy_timeout` (integer, default 0) to all 9 database tables

**Modified (17 files):**
- `app/Actions/Database/StartDatabaseProxy.php` — reads timeout value and sets `proxy_timeout` + `proxy_connect_timeout` in nginx stream config
- 8 Livewire components (Clickhouse, Dragonfly, KeyDB, MariaDB, MongoDB, MySQL, PostgreSQL, Redis) — adds property, validation rule, and model sync
- 8 Blade templates — adds the timeout input field in the Proxy section

### Design decisions

- **Simple integer field in seconds** — per @zachlatta's preference for a dedicated timeout field with a default
- **Consistent across all database types** — applied uniformly to all 8 standalone types + service databases
- **Backward compatible** — default of 0 (no timeout) means existing databases work better than before with no action needed
- **Minimal footprint** — 129 lines added, 0 removed, no new dependencies

### Testing

- All PHP files pass syntax validation
- Nginx config generation verified to produce valid stream block with timeout directives
- Migration includes proper rollback support

Closes #7743