### PR TITLE
feat: Enable database detection and backup support for Docker Compose via GitHub App

### DIFF
--- a/app/Actions/Database/StartDatabaseProxy.php
+++ b/app/Actions/Database/StartDatabaseProxy.php
@@ -31,9 +31,9 @@ class StartDatabaseProxy
 
         if ($database->getMorphClass() === \App\Models\ServiceDatabase::class) {
             $databaseType = $database->databaseType();
-            $network = $database->service->uuid;
-            $server = data_get($database, 'service.destination.server');
-            $containerName = "{$database->name}-{$database->service->uuid}";
+            $network = $database->getNetwork();
+            $server = $database->getServer();
+            $containerName = "{$database->name}-{$database->getOwnerUuid()}";
         }
         $internalPort = match ($databaseType) {
             'standalone-mariadb', 'standalone-mysql' => 3306,

--- a/app/Actions/Database/StopDatabaseProxy.php
+++ b/app/Actions/Database/StopDatabaseProxy.php
@@ -25,7 +25,7 @@ class StopDatabaseProxy
         $server = data_get($database, 'destination.server');
         $uuid = $database->uuid;
         if ($database->getMorphClass() === \App\Models\ServiceDatabase::class) {
-            $server = data_get($database, 'service.server');
+            $server = $database->getServer();
         }
         instant_remote_process(["docker rm -f {$uuid}-proxy"], $server);
 

--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -93,7 +93,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $this->database = data_get($this->backup, 'database');
-                $this->server = $this->database->service->server;
+                $this->server = $this->database->getServer();
                 $this->s3 = $this->backup->s3;
             } else {
                 $this->database = data_get($this->backup, 'database');
@@ -115,8 +115,9 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $databaseType = $this->database->databaseType();
-                $serviceUuid = $this->database->service->uuid;
-                $serviceName = str($this->database->service->name)->slug();
+                $serviceUuid = $this->database->getOwnerUuid();
+                $owner = $this->database->getOwner();
+                $serviceName = str($owner->name)->slug();
                 if (str($databaseType)->contains('postgres')) {
                     $this->container_name = "{$this->database->name}-$serviceUuid";
                     $this->directory_name = $serviceName.'-'.$this->container_name;
@@ -630,7 +631,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             $endpoint = $this->s3->endpoint;
             $this->s3->testConnection(shouldSave: true);
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
-                $network = $this->database->service->destination->network;
+                $network = $this->database->getNetwork();
             } else {
                 $network = $this->database->destination->network;
             }

--- a/app/Livewire/Project/Application/ComposeBackups.php
+++ b/app/Livewire/Project/Application/ComposeBackups.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Livewire\Project\Application;
+
+use App\Models\Application;
+use App\Models\ServiceDatabase;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Component;
+
+class ComposeBackups extends Component
+{
+    use AuthorizesRequests;
+
+    public ?Application $application = null;
+
+    public ?ServiceDatabase $selectedDatabase = null;
+
+    public string $selectedDatabaseUuid = '';
+
+    public array $parameters;
+
+    public bool $isImportSupported = false;
+
+    protected $listeners = ['refreshScheduledBackups' => '$refresh'];
+
+    public function mount()
+    {
+        try {
+            $this->parameters = get_route_parameters();
+            $this->application = Application::whereUuid($this->parameters['application_uuid'])->first();
+            if (! $this->application || $this->application->build_pack !== 'dockercompose') {
+                return redirect()->route('dashboard');
+            }
+            $this->authorize('view', $this->application);
+
+            // Auto-select first database if available
+            $firstDb = $this->application->composeDatabases()->first();
+            if ($firstDb) {
+                $this->selectDatabase($firstDb->uuid);
+            }
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function selectDatabase(string $uuid)
+    {
+        $this->selectedDatabaseUuid = $uuid;
+        $this->selectedDatabase = $this->application->composeDatabases()->whereUuid($uuid)->first();
+
+        if ($this->selectedDatabase) {
+            $dbType = $this->selectedDatabase->databaseType();
+            $supportedTypes = ['mysql', 'mariadb', 'postgres', 'mongo'];
+            $this->isImportSupported = collect($supportedTypes)->contains(fn ($type) => str_contains($dbType, $type));
+        }
+    }
+
+    public function render()
+    {
+        return view('livewire.project.application.compose-backups', [
+            'composeDatabases' => $this->application->composeDatabases()->get(),
+        ]);
+    }
+}

--- a/app/Livewire/Project/Database/BackupEdit.php
+++ b/app/Livewire/Project/Database/BackupEdit.php
@@ -157,7 +157,7 @@ class BackupEdit extends Component
         try {
             $server = null;
             if ($this->backup->database instanceof \App\Models\ServiceDatabase) {
-                $server = $this->backup->database->service->destination->server;
+                $server = $this->backup->database->getServer();
             } elseif ($this->backup->database->destination && $this->backup->database->destination->server) {
                 $server = $this->backup->database->destination->server;
             }
@@ -184,6 +184,14 @@ class BackupEdit extends Component
 
             if ($this->backup->database->getMorphClass() === \App\Models\ServiceDatabase::class) {
                 $serviceDatabase = $this->backup->database;
+
+                if ($serviceDatabase->isApplicationOwned()) {
+                    return redirect()->route('project.application.compose-backups', [
+                        'project_uuid' => $this->parameters['project_uuid'],
+                        'environment_uuid' => $this->parameters['environment_uuid'],
+                        'application_uuid' => $serviceDatabase->application->uuid,
+                    ]);
+                }
 
                 return redirect()->route('project.service.database.backups', [
                     'project_uuid' => $this->parameters['project_uuid'],

--- a/app/Livewire/Project/Database/BackupExecutions.php
+++ b/app/Livewire/Project/Database/BackupExecutions.php
@@ -78,9 +78,10 @@ class BackupExecutions extends Component
             return;
         }
 
-        $server = $execution->scheduledDatabaseBackup->database->getMorphClass() === \App\Models\ServiceDatabase::class
-            ? $execution->scheduledDatabaseBackup->database->service->destination->server
-            : $execution->scheduledDatabaseBackup->database->destination->server;
+        $db = $execution->scheduledDatabaseBackup->database;
+        $server = $db->getMorphClass() === \App\Models\ServiceDatabase::class
+            ? $db->getServer()
+            : $db->destination->server;
 
         try {
             if ($execution->filename) {
@@ -182,7 +183,7 @@ class BackupExecutions extends Component
             $server = null;
 
             if ($this->database instanceof \App\Models\ServiceDatabase) {
-                $server = $this->database->service->destination->server;
+                $server = $this->database->getServer();
             } elseif ($this->database->destination && $this->database->destination->server) {
                 $server = $this->database->destination->server;
             }

--- a/app/Livewire/Project/Database/Import.php
+++ b/app/Livewire/Project/Database/Import.php
@@ -314,12 +314,12 @@ EOD;
 
         // Handle ServiceDatabase server access differently
         if ($resource->getMorphClass() === \App\Models\ServiceDatabase::class) {
-            $server = $resource->service?->server;
+            $server = $resource->getServer();
             if (! $server) {
                 abort(404, 'Server not found for this service database.');
             }
             $this->serverId = $server->id;
-            $this->container = $resource->name.'-'.$resource->service->uuid;
+            $this->container = $resource->name.'-'.$resource->getOwnerUuid();
             $this->resourceUuid = $resource->uuid; // Use ServiceDatabase's own UUID
 
             // Determine database type for ServiceDatabase
@@ -633,7 +633,7 @@ EOD;
 
             // Get the database destination network
             if ($this->resource->getMorphClass() === \App\Models\ServiceDatabase::class) {
-                $destinationNetwork = $this->resource->service->destination->network ?? 'coolify';
+                $destinationNetwork = $this->resource->getNetwork() ?? 'coolify';
             } else {
                 $destinationNetwork = $this->resource->destination->network ?? 'coolify';
             }

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -187,6 +187,11 @@ class Application extends BaseModel
                     $application->docker_compose_domains = null;
                     $application->docker_compose_raw = null;
 
+                    // Remove compose databases and their backups
+                    $application->composeDatabases()->each(function ($db) {
+                        $db->delete();
+                    });
+
                     // Remove SERVICE_FQDN_* and SERVICE_URL_* environment variables
                     $application->environment_variables()
                         ->where(function ($q) {
@@ -235,6 +240,9 @@ class Application extends BaseModel
         });
         static::forceDeleting(function ($application) {
             $application->update(['fqdn' => null]);
+            $application->composeDatabases()->each(function ($db) {
+                $db->delete();
+            });
             $application->settings()->delete();
             $application->persistentStorages()->delete();
             $application->environment_variables()->delete();
@@ -488,6 +496,11 @@ class Application extends BaseModel
     public function settings()
     {
         return $this->hasOne(ApplicationSetting::class);
+    }
+
+    public function composeDatabases()
+    {
+        return $this->hasMany(ServiceDatabase::class);
     }
 
     public function persistentStorages()

--- a/app/Models/LocalFileVolume.php
+++ b/app/Models/LocalFileVolume.php
@@ -51,6 +51,9 @@ class LocalFileVolume extends BaseModel
         if ($isService) {
             $workdir = $this->resource->service->workdir();
             $server = $this->resource->service->server;
+        } elseif ($this->resource instanceof \App\Models\ServiceDatabase && $this->resource->isApplicationOwned()) {
+            $workdir = $this->resource->workdir();
+            $server = $this->resource->getServer();
         } else {
             $workdir = $this->resource->workdir();
             $server = $this->resource->destination->server;
@@ -86,6 +89,9 @@ class LocalFileVolume extends BaseModel
         if ($isService) {
             $workdir = $this->resource->service->workdir();
             $server = $this->resource->service->server;
+        } elseif ($this->resource instanceof \App\Models\ServiceDatabase && $this->resource->isApplicationOwned()) {
+            $workdir = $this->resource->workdir();
+            $server = $this->resource->getServer();
         } else {
             $workdir = $this->resource->workdir();
             $server = $this->resource->destination->server;
@@ -123,6 +129,9 @@ class LocalFileVolume extends BaseModel
         if ($isService) {
             $workdir = $this->resource->service->workdir();
             $server = $this->resource->service->server;
+        } elseif ($this->resource instanceof \App\Models\ServiceDatabase && $this->resource->isApplicationOwned()) {
+            $workdir = $this->resource->workdir();
+            $server = $this->resource->getServer();
         } else {
             $workdir = $this->resource->workdir();
             $server = $this->resource->destination->server;

--- a/app/Models/ScheduledDatabaseBackup.php
+++ b/app/Models/ScheduledDatabaseBackup.php
@@ -67,8 +67,7 @@ class ScheduledDatabaseBackup extends BaseModel
     {
         if ($this->database) {
             if ($this->database instanceof ServiceDatabase) {
-                $destination = data_get($this->database->service, 'destination');
-                $server = data_get($destination, 'server');
+                $server = $this->database->getServer();
             } else {
                 $destination = data_get($this->database, 'destination');
                 $server = data_get($destination, 'server');
@@ -80,4 +79,5 @@ class ScheduledDatabaseBackup extends BaseModel
 
         return null;
     }
+
 }

--- a/app/Models/ServiceDatabase.php
+++ b/app/Models/ServiceDatabase.php
@@ -27,7 +27,10 @@ class ServiceDatabase extends BaseModel
 
     public static function ownedByCurrentTeamAPI(int $teamId)
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', $teamId)->orderBy('name');
+        return ServiceDatabase::where(function ($query) use ($teamId) {
+            $query->whereRelation('service.environment.project.team', 'id', $teamId)
+                ->orWhereRelation('application.environment.project.team', 'id', $teamId);
+        })->orderBy('name');
     }
 
     /**
@@ -36,7 +39,12 @@ class ServiceDatabase extends BaseModel
      */
     public static function ownedByCurrentTeam()
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', currentTeam()->id)->orderBy('name');
+        $teamId = currentTeam()->id;
+
+        return ServiceDatabase::where(function ($query) use ($teamId) {
+            $query->whereRelation('service.environment.project.team', 'id', $teamId)
+                ->orWhereRelation('application.environment.project.team', 'id', $teamId);
+        })->orderBy('name');
     }
 
     /**
@@ -49,10 +57,60 @@ class ServiceDatabase extends BaseModel
         });
     }
 
+    /**
+     * Check if this ServiceDatabase is owned by an Application (Docker Compose via GitHub App).
+     */
+    public function isApplicationOwned(): bool
+    {
+        return filled($this->application_id) && is_null($this->service_id);
+    }
+
+    /**
+     * Get the owning resource (Service or Application).
+     */
+    public function getOwner(): Service|Application|null
+    {
+        return $this->service ?? $this->application;
+    }
+
+    /**
+     * Get the UUID of the owning resource.
+     */
+    public function getOwnerUuid(): ?string
+    {
+        return $this->getOwner()?->uuid;
+    }
+
+    /**
+     * Get the server for this database, resolving through either Service or Application.
+     */
+    public function getServer(): ?Server
+    {
+        if ($this->service_id) {
+            return $this->service?->server;
+        }
+
+        return $this->application?->destination?->server;
+    }
+
+    /**
+     * Get the network for this database.
+     */
+    public function getNetwork(): ?string
+    {
+        if ($this->service_id) {
+            return $this->service?->uuid;
+        }
+
+        return $this->application?->uuid;
+    }
+
     public function restart()
     {
-        $container_id = $this->name.'-'.$this->service->uuid;
-        remote_process(["docker restart {$container_id}"], $this->service->server);
+        $ownerUuid = $this->getOwnerUuid();
+        $server = $this->getServer();
+        $container_id = $this->name.'-'.$ownerUuid;
+        remote_process(["docker restart {$container_id}"], $server);
     }
 
     public function isRunning()
@@ -114,8 +172,9 @@ class ServiceDatabase extends BaseModel
     public function getServiceDatabaseUrl()
     {
         $port = $this->public_port;
-        $realIp = $this->service->server->ip;
-        if ($this->service->server->isLocalhost() || isDev()) {
+        $server = $this->getServer();
+        $realIp = $server->ip;
+        if ($server->isLocalhost() || isDev()) {
             $realIp = base_ip();
         }
 
@@ -124,17 +183,28 @@ class ServiceDatabase extends BaseModel
 
     public function team()
     {
-        return data_get($this, 'environment.project.team');
+        if ($this->service_id) {
+            return data_get($this, 'service.environment.project.team');
+        }
+
+        return data_get($this, 'application.environment.project.team');
     }
 
     public function workdir()
     {
-        return service_configuration_dir()."/{$this->service->uuid}";
+        $ownerUuid = $this->getOwnerUuid();
+
+        return service_configuration_dir()."/{$ownerUuid}";
     }
 
     public function service()
     {
         return $this->belongsTo(Service::class);
+    }
+
+    public function application()
+    {
+        return $this->belongsTo(Application::class);
     }
 
     public function persistentStorages()

--- a/bootstrap/helpers/databases.php
+++ b/bootstrap/helpers/databases.php
@@ -346,7 +346,7 @@ function deleteOldBackupsLocally($backup): Collection
 
     $server = null;
     if ($backup->database_type === \App\Models\ServiceDatabase::class) {
-        $server = $backup->database->service->server;
+        $server = $backup->database->getServer();
     } else {
         $server = $backup->database->destination->server;
     }

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -555,9 +555,12 @@ function getResourceByUuid(string $uuid, ?int $teamId = null)
         return null;
     }
 
-    // ServiceDatabase has a different relationship path: service->environment->project->team_id
+    // ServiceDatabase has a different relationship path depending on ownership
     if ($resource instanceof \App\Models\ServiceDatabase) {
-        if ($resource->service?->environment?->project?->team_id === $teamId) {
+        if ($resource->service_id && $resource->service?->environment?->project?->team_id === $teamId) {
+            return $resource;
+        }
+        if ($resource->application_id && $resource->application?->environment?->project?->team_id === $teamId) {
             return $resource;
         }
 
@@ -2418,6 +2421,32 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
             $isDatabase = isDatabaseImage($image, $service);
             data_set($service, 'is_database', $isDatabase);
 
+            // Create/update ServiceDatabase records for detected databases (skip preview deployments)
+            if ($isDatabase && $pull_request_id === 0) {
+                if ($isNew) {
+                    ServiceDatabase::create([
+                        'name' => $serviceName,
+                        'image' => $image,
+                        'application_id' => $resource->id,
+                    ]);
+                } else {
+                    $existingDb = ServiceDatabase::where([
+                        'name' => $serviceName,
+                        'application_id' => $resource->id,
+                    ])->first();
+                    if (is_null($existingDb)) {
+                        ServiceDatabase::create([
+                            'name' => $serviceName,
+                            'image' => $image,
+                            'application_id' => $resource->id,
+                        ]);
+                    } elseif ($existingDb->image !== $image) {
+                        $existingDb->image = $image;
+                        $existingDb->save();
+                    }
+                }
+            }
+
             // Collect/create/update networks
             if ($serviceNetworks->count() > 0) {
                 foreach ($serviceNetworks as $networkName => $networkDetails) {
@@ -2795,6 +2824,16 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
 
             return $service;
         });
+        // Clean up stale ServiceDatabase records for services no longer in the compose file
+        if ($pull_request_id === 0) {
+            $currentServiceNames = $services->keys()->toArray();
+            ServiceDatabase::where('application_id', $resource->id)
+                ->whereNotIn('name', $currentServiceNames)
+                ->each(function ($staleDb) {
+                    $staleDb->delete();
+                });
+        }
+
         if ($pull_request_id !== 0) {
             $services->each(function ($service, $serviceName) use ($pull_request_id, $services) {
                 $services[addPreviewDeploymentSuffix($serviceName, $pull_request_id)] = $service;

--- a/database/migrations/2026_02_18_000000_add_application_id_to_service_databases_table.php
+++ b/database/migrations/2026_02_18_000000_add_application_id_to_service_databases_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->foreignId('application_id')->nullable()->after('service_id')->constrained()->cascadeOnDelete();
+        });
+
+        // Make service_id nullable so Application-owned databases don't need it
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->unsignedBigInteger('service_id')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->dropForeign(['application_id']);
+            $table->dropColumn('application_id');
+        });
+
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->unsignedBigInteger('service_id')->nullable(false)->change();
+        });
+    }
+};

--- a/resources/views/livewire/project/application/compose-backups.blade.php
+++ b/resources/views/livewire/project/application/compose-backups.blade.php
@@ -1,0 +1,51 @@
+<div>
+    <h2 class="pb-4">Docker Compose Database Backups</h2>
+
+    @if ($composeDatabases->isEmpty())
+        <div class="text-neutral-400">
+            No database services detected in your Docker Compose file.
+            <br>
+            Database images (PostgreSQL, MySQL, MariaDB, MongoDB, etc.) are automatically detected when deploying.
+        </div>
+    @else
+        <div class="flex flex-col gap-4">
+            {{-- Database selector --}}
+            <div class="flex flex-wrap gap-2">
+                @foreach ($composeDatabases as $db)
+                    <button
+                        wire:click="selectDatabase('{{ $db->uuid }}')"
+                        class="px-4 py-2 rounded text-sm font-medium transition-colors
+                            {{ $selectedDatabaseUuid === $db->uuid
+                                ? 'bg-coollabs text-white'
+                                : 'bg-coolgray-200 text-neutral-300 hover:bg-coolgray-300' }}"
+                    >
+                        {{ $db->name }} <span class="text-xs opacity-75">({{ str($db->image)->before(':') }})</span>
+                    </button>
+                @endforeach
+            </div>
+
+            {{-- Backup management for selected database --}}
+            @if ($selectedDatabase)
+                @if ($selectedDatabase->isBackupSolutionAvailable())
+                    <div class="w-full">
+                        <div class="flex gap-2 items-center">
+                            <h3 class="pb-2">Scheduled Backups for {{ $selectedDatabase->name }}</h3>
+                            @can('update', $selectedDatabase)
+                                <x-modal-input buttonTitle="+ Add" title="New Scheduled Backup">
+                                    <livewire:project.database.create-scheduled-backup :database="$selectedDatabase" :key="'create-backup-'.$selectedDatabase->uuid" />
+                                </x-modal-input>
+                            @endcan
+                        </div>
+                        <livewire:project.database.scheduled-backups :database="$selectedDatabase" :key="'backups-'.$selectedDatabase->uuid" />
+                    </div>
+                @else
+                    <div class="text-neutral-400">
+                        Backups are not available for this database type ({{ $selectedDatabase->databaseType() }}).
+                        <br>
+                        Supported database types: PostgreSQL, MySQL, MariaDB, MongoDB.
+                    </div>
+                @endif
+            @endif
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/project/application/configuration.blade.php
+++ b/resources/views/livewire/project/application/configuration.blade.php
@@ -50,6 +50,10 @@
                 <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
                     href="{{ route('project.application.preview-deployments', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Preview Deployments</span></a>
             @endif
+            @if ($application->build_pack === 'dockercompose' && $application->composeDatabases()->count() > 0)
+                <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                    href="{{ route('project.application.compose-backups', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Backups</span></a>
+            @endif
             @if ($application->build_pack !== 'dockercompose')
                 <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
                     href="{{ route('project.application.healthcheck', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Healthcheck</span></a>
@@ -102,6 +106,8 @@
                 <livewire:project.shared.tags :resource="$application" />
             @elseif ($currentRoute === 'project.application.danger')
                 <livewire:project.shared.danger :resource="$application" />
+            @elseif ($currentRoute === 'project.application.compose-backups')
+                <livewire:project.application.compose-backups />
             @endif
         </div>
     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -208,6 +208,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/metrics', ApplicationConfiguration::class)->name('project.application.metrics');
         Route::get('/tags', ApplicationConfiguration::class)->name('project.application.tags');
         Route::get('/danger', ApplicationConfiguration::class)->name('project.application.danger');
+        Route::get('/compose-backups', ApplicationConfiguration::class)->name('project.application.compose-backups');
 
         Route::get('/deployment', DeploymentIndex::class)->name('project.application.deployment.index');
         Route::get('/deployment/{deployment_uuid}', DeploymentShow::class)->name('project.application.deployment.show');
@@ -328,7 +329,7 @@ Route::middleware(['auth'])->group(function () {
             }
             $filename = data_get($execution, 'filename');
             if ($execution->scheduledDatabaseBackup->database->getMorphClass() === \App\Models\ServiceDatabase::class) {
-                $server = $execution->scheduledDatabaseBackup->database->service->destination->server;
+                $server = $execution->scheduledDatabaseBackup->database->getServer();
             } else {
                 $server = $execution->scheduledDatabaseBackup->database->destination->server;
             }


### PR DESCRIPTION
## Summary

Enables database detection and backup support for Docker Compose deployments via GitHub App (`dockercompose` buildpack). Previously, database services in these deployments were not detected and `ServiceDatabase` records were not created, meaning automated backups were unavailable.

## Issue

Resolves https://github.com/coollabsio/coolify/issues/7528

/claim #7528

## Category

- [x] Bug fix
- [x] New Feature

## Technical Details

### Root Cause

`parseDockerComposeFile()` in `bootstrap/helpers/shared.php` has two code paths:

| Path | Model | Calls `isDatabaseImage()` | Creates `ServiceDatabase` | Backups |
|---|---|---|---|---|
| Service model (lines ~1263-2025) | `Service` | ✅ | ✅ | ✅ |
| Application model (lines ~2026+) | `Application` | ✅ (already) | ❌ **missing** | ❌ |

The Application path already called `isDatabaseImage()` and set `is_database`, but never created `ServiceDatabase` records because the existing FK (`service_id`) only pointed to the `services` table.

### Database Changes

**New migration:** Adds nullable `application_id` FK (constrained to `applications`, cascade on delete) to `service_databases` table. Makes `service_id` nullable so Application-owned databases do not need it.

### Model Changes

**`ServiceDatabase`:**
- Added `application()` relationship (`belongsTo Application`)
- Added helper methods for owner-agnostic resolution:
  - `isApplicationOwned()` — checks if owned by Application vs Service
  - `getOwner()` — returns the owning Service or Application
  - `getOwnerUuid()` — UUID of the owner
  - `getServer()` — resolves server through either ownership path
  - `getNetwork()` — resolves network through either ownership path
- Updated `restart()`, `getServiceDatabaseUrl()`, `team()`, `workdir()` to use helpers
- Updated `ownedByCurrentTeam()` and `ownedByCurrentTeamAPI()` to query both ownership paths

**`Application`:**
- Added `composeDatabases()` HasMany relationship
- Cleanup of compose databases when switching away from `dockercompose` build pack
- Cleanup on `forceDeleting`

### Parser Changes (`shared.php`)

- In the Application model path of `parseDockerComposeFile()`, after `isDatabaseImage()` detection, creates/updates `ServiceDatabase` records with `application_id` (skips preview deployments)
- Cleans up stale `ServiceDatabase` records when services are removed from the compose file
- Updated `getResourceByUuid` team ownership check to handle Application-owned ServiceDatabases

### Updated Code Paths

All locations that previously used hardcoded `->service->server`, `->service->uuid`, `->service->destination->network` chains now use the new `getServer()`, `getOwnerUuid()`, `getNetwork()` helpers:

- `DatabaseBackupJob`: Server resolution, container naming, network for S3 upload
- `StartDatabaseProxy` / `StopDatabaseProxy`: Network, server, container name resolution
- `BackupExecutions`: Server resolution for backup deletion and download
- `BackupEdit`: Server resolution, redirect for Application-owned databases
- `ScheduledDatabaseBackup`: Server resolution
- `Import`: Server, container name, network resolution
- `LocalFileVolume`: Server/workdir resolution for file storage operations
- `databases.php` helper: Server resolution for backup cleanup
- `web.php` download route: Server resolution for backup file downloads

### UI Changes

- Added "Backups" tab to Application configuration sidebar (only for `dockercompose` build pack when databases are detected)
- Created `ComposeBackups` Livewire component with database selector and backup management
- Reuses existing `ScheduledBackups` and `CreateScheduledBackup` components

## Steps to Test

1. Create a new Application using the `dockercompose` buildpack via GitHub App
2. Use a repo with a `docker-compose.yml` containing a database service (e.g., `postgres:16-alpine`) and at least one non-database service
3. Deploy the Application
4. Navigate to **Project > Environment > Application > Configuration > Backups**
5. Verify the database service is listed and you can create a scheduled backup
6. Run a backup and confirm a new execution entry is created
7. Verify that removing the database from the compose file and redeploying cleans up the `ServiceDatabase` record

## AI Usage

- [x] AI is used in the process of creating this PR

## Contributor Agreement

> [!IMPORTANT]
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them