### PR TITLE
fix: fallback Debian 13 Docker repo codename when unavailable

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -118,10 +118,12 @@ class InstallDocker
     {
         return "curl --max-time 300 --retry 3 https://releases.rancher.com/install-docker/{$this->dockerVersion}.sh | sh || curl --max-time 300 --retry 3 https://get.docker.com | sh -s -- --version {$this->dockerVersion} || (".
             '. /etc/os-release && '.
+            'DOCKER_CODENAME=${VERSION_CODENAME} && '.
+            'if ! curl -fsSL https://download.docker.com/linux/${ID}/dists/${VERSION_CODENAME}/Release >/dev/null 2>&1; then DOCKER_CODENAME=bookworm; fi && '.
             'install -m 0755 -d /etc/apt/keyrings && '.
             'curl -fsSL https://download.docker.com/linux/${ID}/gpg -o /etc/apt/keyrings/docker.asc && '.
             'chmod a+r /etc/apt/keyrings/docker.asc && '.
-            'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${ID} ${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list && '.
+            'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${ID} ${DOCKER_CODENAME} stable" > /etc/apt/sources.list.d/docker.list && '.
             'apt-get update && '.
             'apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin'.
             ')';

--- a/tests/Unit/Actions/Server/InstallDockerCommandTest.php
+++ b/tests/Unit/Actions/Server/InstallDockerCommandTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Actions\Server\InstallDocker;
+
+it('uses debian codename fallback for docker apt repo', function () {
+    $action = new InstallDocker;
+
+    $reflection = new ReflectionClass($action);
+
+    $dockerVersionProperty = $reflection->getProperty('dockerVersion');
+    $dockerVersionProperty->setAccessible(true);
+    $dockerVersionProperty->setValue($action, '24.0');
+
+    $method = $reflection->getMethod('getDebianDockerInstallCommand');
+    $method->setAccessible(true);
+    $command = $method->invoke($action);
+
+    expect($command)
+        ->toContain('DOCKER_CODENAME=${VERSION_CODENAME}')
+        ->toContain('/dists/${VERSION_CODENAME}/Release')
+        ->toContain('DOCKER_CODENAME=bookworm')
+        ->toContain('${DOCKER_CODENAME} stable');
+});


### PR DESCRIPTION
## Summary
- add a minimal Debian apt repo codename fallback in Docker install path
- when Docker repo for VERSION_CODENAME is unavailable, fallback to bookworm
- keep all existing behavior unchanged for supported codename paths
- add a focused unit test for command generation

## Why
Debian 13 (trixie) servers can fail on the final apt fallback when Docker does not publish that codename yet. This keeps the change scoped to the fallback path only.

## Files changed
- app/Actions/Server/InstallDocker.php
- tests/Unit/Actions/Server/InstallDockerCommandTest.php

## Notes
- Local test execution not run in this environment because PHP binary is unavailable (php: command not found).

/claim #8154
