### PR TITLE
feat(openreplay): add OpenReplay service template

### DIFF
--- a/public/svgs/openreplay.svg
+++ b/public/svgs/openreplay.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="48" fill="#E7313B"/>
+  <path d="M38 28 L72 50 L38 72 Z" fill="#ffffff"/>
+</svg>

--- a/templates/compose/openreplay.yaml
+++ b/templates/compose/openreplay.yaml
@@ -1,0 +1,933 @@
+# documentation: https://openreplay.com/docs
+# slogan: OpenReplay is a self-hosted, open-source session replay suite you can deploy on your own infrastructure to fully control your data.
+# tags: openreplay, session-replay, analytics, monitoring, debugging, self-hosted, privacy
+# logo: svgs/openreplay.svg
+# port: 80
+# minversion: 0.0.0
+# category: analytics
+
+x-common-env: &common-env
+  COMMON_DOMAIN_NAME: ${SERVICE_FQDN_NGINXOPENREPLAY}
+  COMMON_PROTOCOL: "https"
+  COMMON_VERSION: ${OPENREPLAY_VERSION:-v1.25.0}
+  COMMON_PG_PASSWORD: ${SERVICE_PASSWORD_POSTGRES}
+  COMMON_S3_KEY: ${SERVICE_USER_MINIO}
+  COMMON_S3_SECRET: ${SERVICE_PASSWORD_MINIO}
+  COMMON_JWT_SECRET: ${SERVICE_PASSWORD_JWTSECRET}
+  COMMON_JWT_SPOT_SECRET: ${SERVICE_PASSWORD_JWTSECRET}
+  COMMON_JWT_REFRESH_SECRET: ${SERVICE_PASSWORD_JWTREFRESH}
+  COMMON_JWT_SPOT_REFRESH_SECRET: ${SERVICE_PASSWORD_JWTSPOTREFRESH}
+  COMMON_ASSIST_JWT_SECRET: ${SERVICE_PASSWORD_ASSISTJWT}
+  COMMON_ASSIST_KEY: ${SERVICE_PASSWORD_ASSISTKEY}
+
+x-app-common-env: &app-common-env
+  <<: *common-env
+  LICENSE_KEY: ""
+  KAFKA_SERVERS: ""
+  KAFKA_USE_SSL: "false"
+
+services:
+  postgresql:
+    image: ghcr.io/openreplay/postgres:17
+    volumes:
+      - pgdata:/bitnami/postgresql
+    networks:
+      openreplay-net:
+        aliases:
+          - postgresql.db.svc.cluster.local
+    environment:
+      POSTGRES_PASSWORD: ${SERVICE_PASSWORD_POSTGRES}
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - pg_isready -U postgres
+      interval: 5s
+      timeout: 10s
+      retries: 20
+    restart: unless-stopped
+
+  clickhouse:
+    image: clickhouse/clickhouse-server:25.11-alpine
+    volumes:
+      - clickhouse:/var/lib/clickhouse
+    networks:
+      openreplay-net:
+        aliases:
+          - clickhouse-openreplay-clickhouse.db.svc.cluster.local
+    environment:
+      CLICKHOUSE_USER: "default"
+      CLICKHOUSE_PASSWORD: ""
+      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: "1"
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - clickhouse-client --query "SELECT 1" || exit 1
+      interval: 5s
+      timeout: 10s
+      retries: 20
+    restart: unless-stopped
+
+  redis:
+    image: ghcr.io/openreplay/valkey:8
+    volumes:
+      - redisdata:/bitnami/redis/data
+    networks:
+      openreplay-net:
+        aliases:
+          - redis-master.db.svc.cluster.local
+    environment:
+      ALLOW_EMPTY_PASSWORD: "yes"
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - redis-cli ping | grep PONG
+      interval: 5s
+      timeout: 10s
+      retries: 20
+    restart: unless-stopped
+
+  minio:
+    image: ghcr.io/openreplay/minio:2025
+    volumes:
+      - miniodata:/bitnami/minio/data
+    networks:
+      openreplay-net:
+        aliases:
+          - minio.db.svc.cluster.local
+    environment:
+      MINIO_ROOT_USER: ${SERVICE_USER_MINIO}
+      MINIO_ROOT_PASSWORD: ${SERVICE_PASSWORD_MINIO}
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - curl -f http://localhost:9000/minio/health/live || exit 1
+      interval: 5s
+      timeout: 10s
+      retries: 20
+    restart: unless-stopped
+
+  fs-permission:
+    image: debian:stable-slim
+    volumes:
+      - shared-volume:/mnt/efs
+      - miniodata:/mnt/minio
+      - pgdata:/mnt/postgres
+    networks:
+      - openreplay-net
+    entrypoint:
+      - /bin/bash
+      - -c
+      - chown -R 1001:1001 /mnt/efs /mnt/minio /mnt/postgres
+    restart: "no"
+
+  minio-migration:
+    image: minio/mc:latest
+    depends_on:
+      minio:
+        condition: service_healthy
+      fs-permission:
+        condition: service_completed_successfully
+    networks:
+      - openreplay-net
+    environment:
+      MINIO_HOST: http://minio.db.svc.cluster.local:9000
+      MINIO_ACCESS_KEY: ${SERVICE_USER_MINIO}
+      MINIO_SECRET_KEY: ${SERVICE_PASSWORD_MINIO}
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        mc alias set minio $${MINIO_HOST} $${MINIO_ACCESS_KEY} $${MINIO_SECRET_KEY}
+        for bucket in mobs sessions-assets static sourcemaps sessions-mobile-assets quickwit vault-data records spots; do
+          mc mb --ignore-existing minio/$${bucket} || true
+        done
+        echo "MinIO buckets initialized."
+    restart: "no"
+
+  db-migration:
+    image: postgres:17-alpine
+    depends_on:
+      postgresql:
+        condition: service_healthy
+      minio-migration:
+        condition: service_completed_successfully
+    networks:
+      - openreplay-net
+    environment:
+      PGHOST: postgresql.db.svc.cluster.local
+      PGPORT: "5432"
+      PGDATABASE: postgres
+      PGUSER: postgres
+      PGPASSWORD: ${SERVICE_PASSWORD_POSTGRES}
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        apk add --no-cache wget
+        until pg_isready -h postgresql.db.svc.cluster.local; do
+          echo "Waiting for PostgreSQL..."
+          sleep 2
+        done
+        echo "Downloading PostgreSQL schema..."
+        wget -qO /tmp/init_schema.sql \
+          "https://raw.githubusercontent.com/openreplay/openreplay/${OPENREPLAY_VERSION:-v1.25.0}/scripts/schema/db/init_dbs/postgresql/init_schema.sql"
+        echo "Running PostgreSQL schema..."
+        psql -v ON_ERROR_STOP=0 -f /tmp/init_schema.sql || true
+        echo "PostgreSQL migration complete."
+    restart: "no"
+
+  clickhouse-migration:
+    image: clickhouse/clickhouse-server:25.11-alpine
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+      minio-migration:
+        condition: service_completed_successfully
+    networks:
+      - openreplay-net
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        echo "Downloading ClickHouse schema..."
+        wget -qO /tmp/init_schema.sql \
+          "https://raw.githubusercontent.com/openreplay/openreplay/${OPENREPLAY_VERSION:-v1.25.0}/scripts/schema/db/init_dbs/clickhouse/create/init_schema.sql"
+        echo "Running ClickHouse schema..."
+        clickhouse-client \
+          -h clickhouse-openreplay-clickhouse.db.svc.cluster.local \
+          --user default \
+          --port 9000 \
+          --multiquery < /tmp/init_schema.sql || true
+        echo "ClickHouse migration complete."
+    restart: "no"
+
+  alerts-openreplay:
+    image: public.ecr.aws/p1t3u8a3/alerts:${OPENREPLAY_VERSION:-v1.25.0}
+    domainname: app.svc.cluster.local
+    depends_on:
+      db-migration:
+        condition: service_completed_successfully
+      clickhouse-migration:
+        condition: service_completed_successfully
+    volumes:
+      - shared-volume:/mnt/efs
+    networks:
+      openreplay-net:
+        aliases:
+          - alerts-openreplay
+          - alerts-openreplay.app.svc.cluster.local
+    environment:
+      <<: *app-common-env
+      version_number: ${OPENREPLAY_VERSION:-v1.25.0}
+      pg_host: postgresql.db.svc.cluster.local
+      pg_port: "5432"
+      pg_dbname: postgres
+      pg_user: postgres
+      pg_password: ${SERVICE_PASSWORD_POSTGRES}
+      ch_host: clickhouse-openreplay-clickhouse.db.svc.cluster.local
+      ch_port: "9000"
+      ch_port_http: "8123"
+      ch_username: default
+      ch_password: ""
+      SITE_URL: https://${SERVICE_FQDN_NGINXOPENREPLAY}
+      S3_HOST: https://${SERVICE_FQDN_NGINXOPENREPLAY}
+      S3_KEY: ${SERVICE_USER_MINIO}
+      S3_SECRET: ${SERVICE_PASSWORD_MINIO}
+      AWS_DEFAULT_REGION: us-east-1
+      EMAIL_HOST: ""
+      EMAIL_PORT: "587"
+      EMAIL_USER: ""
+      EMAIL_PASSWORD: ""
+      EMAIL_USE_TLS: "true"
+      EMAIL_USE_SSL: "false"
+      EMAIL_SSL_KEY: ""
+      EMAIL_SSL_CERT: ""
+      EMAIL_FROM: "OpenReplay "
+      LOGLEVEL: INFO
+      PYTHONUNBUFFERED: "0"
+    restart: unless-stopped
+
+  api-openreplay:
+    image: public.ecr.aws/p1t3u8a3/api:${OPENREPLAY_VERSION:-v1.25.0}
+    domainname: app.svc.cluster.local
+    depends_on:
+      db-migration:
+        condition: service_completed_successfully
+      clickhouse-migration:
+        condition: service_completed_successfully
+    volumes:
+      - shared-volume:/mnt/efs
+    networks:
+      openreplay-net:
+        aliases:
+          - api-openreplay
+          - api-openreplay.app.svc.cluster.local
+    environment:
+      <<: *app-common-env
+      TOKEN_SECRET: ${SERVICE_PASSWORD_TOKEN}
+      ch_db: default
+      JWT_SECRET: ${SERVICE_PASSWORD_JWTSECRET}
+      ASSIST_JWT_SECRET: ${SERVICE_PASSWORD_ASSISTJWT}
+      AWS_ACCESS_KEY_ID: ${SERVICE_USER_MINIO}
+      AWS_SECRET_ACCESS_KEY: ${SERVICE_PASSWORD_MINIO}
+      AWS_ENDPOINT: https://${SERVICE_FQDN_NGINXOPENREPLAY}
+      AWS_REGION: us-east-1
+      BUCKET_NAME: mobs
+      CH_USERNAME: default
+      CH_PASSWORD: ""
+      CLICKHOUSE_STRING: clickhouse-openreplay-clickhouse.db.svc.cluster.local:9000/default
+      CLICKHOUSE_HTTP_STRING: clickhouse-openreplay-clickhouse.db.svc.cluster.local:8123/default
+      pg_password: ${SERVICE_PASSWORD_POSTGRES}
+      POSTGRES_STRING: postgres://postgres:${SERVICE_PASSWORD_POSTGRES}@postgresql.db.svc.cluster.local:5432/postgres?sslmode=disable
+      ASSIST_URL: http://assist-openreplay.app.svc.cluster.local:9001/assist/%s
+      ASSIST_KEY: ${SERVICE_PASSWORD_ASSISTKEY}
+      REDIS_STRING: redis://redis-master.db.svc.cluster.local:6379
+    restart: unless-stopped
+
+  http-openreplay:
+    image: public.ecr.aws/p1t3u8a3/http:${OPENREPLAY_VERSION:-v1.25.0}
+    domainname: app.svc.cluster.local
+    depends_on:
+      db-migration:
+        condition: service_completed_successfully
+    volumes:
+      - shared-volume:/mnt/efs
+    networks:
+      openreplay-net:
+        aliases:
+          - http-openreplay
+          - http-openreplay.app.svc.cluster.local
+    environment:
+      <<: *app-common-env
+      BUCKET_NAME: uxtesting-records
+      CACHE_ASSETS: "true"
+      AWS_ACCESS_KEY_ID: ${SERVICE_USER_MINIO}
+      AWS_SECRET_ACCESS_KEY: ${SERVICE_PASSWORD_MINIO}
+      AWS_REGION: us-east-1
+      AWS_ENDPOINT: https://${SERVICE_FQDN_NGINXOPENREPLAY}
+      JWT_SECRET: ${SERVICE_PASSWORD_JWTSECRET}
+      JWT_SPOT_SECRET: ${SERVICE_PASSWORD_JWTSECRET}
+      TOKEN_SECRET: ${SERVICE_PASSWORD_TOKEN}
+      pg_password: ${SERVICE_PASSWORD_POSTGRES}
+      POSTGRES_STRING: postgres://postgres:${SERVICE_PASSWORD_POSTGRES}@postgresql.db.svc.cluster.local:5432/postgres?sslmode=disable
+      REDIS_STRING: redis://redis-master.db.svc.cluster.local:6379
+    restart: unless-stopped
+
+  images-openreplay:
+    image: public.ecr.aws/p1t3u8a3/images:${OPENREPLAY_VERSION:-v1.25.0}
+    domainname: app.svc.cluster.local
+    depends_on:
+      db-migration:
+        condition: service_completed_successfully
+    volumes:
+      - shared-volume:/mnt/efs
+    networks:
+      openreplay-net:
+        aliases:
+          - images-openreplay
+          - images-openreplay.app.svc.cluster.local
+    environment:
+      <<: *app-common-env
+      AWS_ACCESS_KEY_ID: ${SERVICE_USER_MINIO}
+      AWS_SECRET_ACCESS_KEY: ${SERVICE_PASSWORD_MINIO}
+      AWS_ENDPOINT: https://${SERVICE_FQDN_NGINXOPENREPLAY}
+      AWS_REGION: us-east-1
+      BUCKET_NAME: mobs
+      FS_CLEAN_HRS: "24"
+      REDIS_STRING: redis://redis-master.db.svc.cluster.local:6379
+    restart: unless-stopped
+
+  integrations-openreplay:
+    image: public.ecr.aws/p1t3u8a3/integrations:${OPENREPLAY_VERSION:-v1.25.0}
+    domainname: app.svc.cluster.local
+    depends_on:
+      db-migration:
+        condition: service_completed_successfully
+    volumes:
+      - shared-volume:/mnt/efs
+    networks:
+      openreplay-net:
+        aliases:
+          - integrations-openreplay
+          - integrations-openreplay.app.svc.cluster.local
+    environment:
+      <<: *app-common-env
+      AWS_ACCESS_KEY_ID: ${SERVICE_USER_MINIO}
+      AWS_SECRET_ACCESS_KEY: ${SERVICE_PASSWORD_MINIO}
+      AWS_ENDPOINT: https://${SERVICE_FQDN_NGINXOPENREPLAY}
+      AWS_REGION: us-east-1
+      BUCKET_NAME: mobs
+      JWT_SECRET: ${SERVICE_PASSWORD_JWTSECRET}
+      TOKEN_SECRET: ${SERVICE_PASSWORD_TOKEN}
+      pg_password: ${SERVICE_PASSWORD_POSTGRES}
+      POSTGRES_STRING: postgres://postgres:${SERVICE_PASSWORD_POSTGRES}@postgresql.db.svc.cluster.local:5432/postgres?sslmode=disable
+      REDIS_STRING: redis://redis-master.db.svc.cluster.local:6379
+    restart: unless-stopped
+
+  sink-openreplay:
+    image: public.ecr.aws/p1t3u8a3/sink:${OPENREPLAY_VERSION:-v1.25.0}
+    domainname: app.svc.cluster.local
+    depends_on:
+      db-migration:
+        condition: service_completed_successfully
+    volumes:
+      - shared-volume:/mnt/efs
+    networks:
+      openreplay-net:
+        aliases:
+          - sink-openreplay
+          - sink-openreplay.app.svc.cluster.local
+    environment:
+      <<: *app-common-env
+      ASSETS_ORIGIN: https://${SERVICE_FQDN_NGINXOPENREPLAY}/sessions-assets
+      REDIS_STRING: redis://redis-master.db.svc.cluster.local:6379
+    restart: unless-stopped
+
+  sourcemapreader-openreplay:
+    image: public.ecr.aws/p1t3u8a3/sourcemapreader:${OPENREPLAY_VERSION:-v1.25.0}
+    domainname: app.svc.cluster.local
+    depends_on:
+      db-migration:
+        condition: service_completed_successfully
+    volumes:
+      - shared-volume:/mnt/efs
+    networks:
+      openreplay-net:
+        aliases:
+          - sourcemapreader-openreplay
+          - sourcemapreader-openreplay.app.svc.cluster.local
+    environment:
+      <<: *app-common-env
+      SMR_HOST: "0.0.0.0"
+      S3_HOST: http://minio.db.svc.cluster.local:9000
+      S3_KEY: ${SERVICE_USER_MINIO}
+      S3_SECRET: ${SERVICE_PASSWORD_MINIO}
+      AWS_REGION: us-east-1
+      ASSETS_ORIGIN: https://${SERVICE_FQDN_NGINXOPENREPLAY}/sessions-assets
+    restart: unless-stopped
+
+  spot-openreplay:
+    image: public.ecr.aws/p1t3u8a3/spot:${OPENREPLAY_VERSION:-v1.25.0}
+    domainname: app.svc.cluster.local
+    depends_on:
+      db-migration:
+        condition: service_completed_successfully
+    volumes:
+      - shared-volume:/mnt/efs
+    networks:
+      openreplay-net:
+        aliases:
+          - spot-openreplay
+          - spot-openreplay.app.svc.cluster.local
+    environment:
+      <<: *app-common-env
+      CACHE_ASSETS: "true"
+      FS_CLEAN_HRS: "24"
+      TOKEN_SECRET: ${SERVICE_PASSWORD_TOKEN}
+      AWS_ACCESS_KEY_ID: ${SERVICE_USER_MINIO}
+      AWS_SECRET_ACCESS_KEY: ${SERVICE_PASSWORD_MINIO}
+      BUCKET_NAME: spots
+      AWS_REGION: us-east-1
+      AWS_ENDPOINT: https://${SERVICE_FQDN_NGINXOPENREPLAY}
+      JWT_SECRET: ${SERVICE_PASSWORD_JWTSECRET}
+      JWT_SPOT_SECRET: ${SERVICE_PASSWORD_JWTSECRET}
+      pg_password: ${SERVICE_PASSWORD_POSTGRES}
+      POSTGRES_STRING: postgres://postgres:${SERVICE_PASSWORD_POSTGRES}@postgresql.db.svc.cluster.local:5432/postgres?sslmode=disable
+      REDIS_STRING: redis://redis-master.db.svc.cluster.local:6379
+    restart: unless-stopped
+
+  storage-openreplay:
+    image: public.ecr.aws/p1t3u8a3/storage:${OPENREPLAY_VERSION:-v1.25.0}
+    domainname: app.svc.cluster.local
+    depends_on:
+      db-migration:
+        condition: service_completed_successfully
+    volumes:
+      - shared-volume:/mnt/efs
+    networks:
+      openreplay-net:
+        aliases:
+          - storage-openreplay
+          - storage-openreplay.app.svc.cluster.local
+    environment:
+      <<: *app-common-env
+      AWS_ACCESS_KEY_ID: ${SERVICE_USER_MINIO}
+      AWS_SECRET_ACCESS_KEY: ${SERVICE_PASSWORD_MINIO}
+      AWS_ENDPOINT: https://${SERVICE_FQDN_NGINXOPENREPLAY}
+      AWS_REGION: us-east-1
+      BUCKET_NAME: mobs
+      FS_CLEAN_HRS: "24"
+      REDIS_STRING: redis://redis-master.db.svc.cluster.local:6379
+    restart: unless-stopped
+
+  assets-openreplay:
+    image: public.ecr.aws/p1t3u8a3/assets:${OPENREPLAY_VERSION:-v1.25.0}
+    domainname: app.svc.cluster.local
+    depends_on:
+      db-migration:
+        condition: service_completed_successfully
+    volumes:
+      - shared-volume:/mnt/efs
+    networks:
+      openreplay-net:
+        aliases:
+          - assets-openreplay
+          - assets-openreplay.app.svc.cluster.local
+    environment:
+      <<: *app-common-env
+      AWS_ACCESS_KEY_ID: ${SERVICE_USER_MINIO}
+      AWS_SECRET_ACCESS_KEY: ${SERVICE_PASSWORD_MINIO}
+      BUCKET_NAME: sessions-assets
+      AWS_ENDPOINT: https://${SERVICE_FQDN_NGINXOPENREPLAY}
+      AWS_REGION: us-east-1
+      ASSETS_ORIGIN: https://${SERVICE_FQDN_NGINXOPENREPLAY}/sessions-assets
+      REDIS_STRING: redis://redis-master.db.svc.cluster.local:6379
+    restart: unless-stopped
+
+  assist-openreplay:
+    image: public.ecr.aws/p1t3u8a3/assist:${OPENREPLAY_VERSION:-v1.25.0}
+    domainname: app.svc.cluster.local
+    depends_on:
+      db-migration:
+        condition: service_completed_successfully
+    volumes:
+      - shared-volume:/mnt/efs
+    networks:
+      openreplay-net:
+        aliases:
+          - assist-openreplay
+          - assist-openreplay.app.svc.cluster.local
+    environment:
+      <<: *app-common-env
+      ASSIST_JWT_SECRET: ${SERVICE_PASSWORD_ASSISTJWT}
+      ASSIST_KEY: ${SERVICE_PASSWORD_ASSISTKEY}
+      AWS_DEFAULT_REGION: us-east-1
+      REDIS_URL: redis://redis-master.db.svc.cluster.local:6379
+      CLEAR_SOCKET_TIME: "720"
+      debug: "0"
+      redis: "false"
+    restart: unless-stopped
+
+  canvases-openreplay:
+    image: public.ecr.aws/p1t3u8a3/canvases:${OPENREPLAY_VERSION:-v1.25.0}
+    domainname: app.svc.cluster.local
+    depends_on:
+      db-migration:
+        condition: service_completed_successfully
+    volumes:
+      - shared-volume:/mnt/efs
+    networks:
+      openreplay-net:
+        aliases:
+          - canvases-openreplay
+          - canvases-openreplay.app.svc.cluster.local
+    environment:
+      <<: *app-common-env
+      AWS_ACCESS_KEY_ID: ${SERVICE_USER_MINIO}
+      AWS_SECRET_ACCESS_KEY: ${SERVICE_PASSWORD_MINIO}
+      AWS_ENDPOINT: https://${SERVICE_FQDN_NGINXOPENREPLAY}
+      AWS_REGION: us-east-1
+      BUCKET_NAME: mobs
+      FS_CLEAN_HRS: "24"
+      REDIS_STRING: redis://redis-master.db.svc.cluster.local:6379
+    restart: unless-stopped
+
+  chalice-openreplay:
+    image: public.ecr.aws/p1t3u8a3/chalice:${OPENREPLAY_VERSION:-v1.25.0}
+    domainname: app.svc.cluster.local
+    depends_on:
+      db-migration:
+        condition: service_completed_successfully
+      clickhouse-migration:
+        condition: service_completed_successfully
+    volumes:
+      - shared-volume:/mnt/efs
+    networks:
+      openreplay-net:
+        aliases:
+          - chalice-openreplay
+          - chalice-openreplay.app.svc.cluster.local
+    environment:
+      <<: *app-common-env
+      REDIS_STRING: redis://redis-master.db.svc.cluster.local:6379
+      ch_username: default
+      ch_password: ""
+      ch_host: clickhouse-openreplay-clickhouse.db.svc.cluster.local
+      ch_port: "9000"
+      ch_port_http: "8123"
+      sourcemaps_reader: http://sourcemapreader-openreplay.app.svc.cluster.local:9000/{}/sourcemaps
+      ASSIST_URL: http://assist-openreplay.app.svc.cluster.local:9001/assist/%s
+      JWT_REFRESH_SECRET: ${SERVICE_PASSWORD_JWTREFRESH}
+      JWT_SPOT_REFRESH_SECRET: ${SERVICE_PASSWORD_JWTSPOTREFRESH}
+      ASSIST_JWT_SECRET: ${SERVICE_PASSWORD_ASSISTJWT}
+      JWT_SECRET: ${SERVICE_PASSWORD_JWTSECRET}
+      ASSIST_KEY: ${SERVICE_PASSWORD_ASSISTKEY}
+      JWT_SPOT_SECRET: ${SERVICE_PASSWORD_JWTSECRET}
+      version_number: ${OPENREPLAY_VERSION:-v1.25.0}
+      pg_host: postgresql.db.svc.cluster.local
+      pg_port: "5432"
+      pg_dbname: postgres
+      pg_user: postgres
+      pg_password: ${SERVICE_PASSWORD_POSTGRES}
+      SITE_URL: https://${SERVICE_FQDN_NGINXOPENREPLAY}
+      S3_HOST: https://${SERVICE_FQDN_NGINXOPENREPLAY}
+      S3_KEY: ${SERVICE_USER_MINIO}
+      S3_SECRET: ${SERVICE_PASSWORD_MINIO}
+      AWS_DEFAULT_REGION: us-east-1
+      sessions_region: us-east-1
+      ASSIST_RECORDS_BUCKET: records
+      sessions_bucket: mobs
+      IOS_VIDEO_BUCKET: mobs
+      sourcemaps_bucket: sourcemaps
+      js_cache_bucket: sessions-assets
+      EMAIL_HOST: ""
+      EMAIL_PORT: "587"
+      EMAIL_USER: ""
+      EMAIL_PASSWORD: ""
+      EMAIL_USE_TLS: "true"
+      EMAIL_USE_SSL: "false"
+      EMAIL_SSL_KEY: ""
+      EMAIL_SSL_CERT: ""
+      EMAIL_FROM: "OpenReplay "
+      CH_COMPRESSION: "false"
+      CLUSTER_URL: svc.cluster.local
+      JWT_EXPIRATION: "86400"
+      LOGLEVEL: INFO
+      PYTHONUNBUFFERED: "0"
+      SAML2_MD_URL: ""
+      root_path: /api
+    restart: unless-stopped
+
+  db-openreplay:
+    image: public.ecr.aws/p1t3u8a3/db:${OPENREPLAY_VERSION:-v1.25.0}
+    domainname: app.svc.cluster.local
+    depends_on:
+      db-migration:
+        condition: service_completed_successfully
+      clickhouse-migration:
+        condition: service_completed_successfully
+    volumes:
+      - shared-volume:/mnt/efs
+    networks:
+      openreplay-net:
+        aliases:
+          - db-openreplay
+          - db-openreplay.app.svc.cluster.local
+    environment:
+      <<: *app-common-env
+      CH_USERNAME: default
+      CH_PASSWORD: ""
+      CLICKHOUSE_STRING: clickhouse-openreplay-clickhouse.db.svc.cluster.local:9000/default
+      ch_db: default
+      pg_password: ${SERVICE_PASSWORD_POSTGRES}
+      POSTGRES_STRING: postgres://postgres:${SERVICE_PASSWORD_POSTGRES}@postgresql.db.svc.cluster.local:5432/postgres?sslmode=disable
+      REDIS_STRING: redis://redis-master.db.svc.cluster.local:6379
+    restart: unless-stopped
+
+  ender-openreplay:
+    image: public.ecr.aws/p1t3u8a3/ender:${OPENREPLAY_VERSION:-v1.25.0}
+    domainname: app.svc.cluster.local
+    depends_on:
+      db-migration:
+        condition: service_completed_successfully
+    volumes:
+      - shared-volume:/mnt/efs
+    networks:
+      openreplay-net:
+        aliases:
+          - ender-openreplay
+          - ender-openreplay.app.svc.cluster.local
+    environment:
+      <<: *app-common-env
+      pg_password: ${SERVICE_PASSWORD_POSTGRES}
+      POSTGRES_STRING: postgres://postgres:${SERVICE_PASSWORD_POSTGRES}@postgresql.db.svc.cluster.local:5432/postgres?sslmode=disable
+      REDIS_STRING: redis://redis-master.db.svc.cluster.local:6379
+    restart: unless-stopped
+
+  frontend-openreplay:
+    image: public.ecr.aws/p1t3u8a3/frontend:${OPENREPLAY_VERSION:-v1.25.0}
+    domainname: app.svc.cluster.local
+    depends_on:
+      db-migration:
+        condition: service_completed_successfully
+    volumes:
+      - shared-volume:/mnt/efs
+    networks:
+      openreplay-net:
+        aliases:
+          - frontend-openreplay
+          - frontend-openreplay.app.svc.cluster.local
+    environment:
+      <<: *app-common-env
+    restart: unless-stopped
+
+  heuristics-openreplay:
+    image: public.ecr.aws/p1t3u8a3/heuristics:${OPENREPLAY_VERSION:-v1.25.0}
+    domainname: app.svc.cluster.local
+    depends_on:
+      db-migration:
+        condition: service_completed_successfully
+    volumes:
+      - shared-volume:/mnt/efs
+    networks:
+      openreplay-net:
+        aliases:
+          - heuristics-openreplay
+          - heuristics-openreplay.app.svc.cluster.local
+    environment:
+      <<: *app-common-env
+      REDIS_STRING: redis://redis-master.db.svc.cluster.local:6379
+    restart: unless-stopped
+
+  nginx-openreplay:
+    image: nginx:latest
+    depends_on:
+      - frontend-openreplay
+      - chalice-openreplay
+      - api-openreplay
+    environment:
+      - SERVICE_URL_NGINXOPENREPLAY
+    volumes:
+      - type: bind
+        source: ./nginx/openreplay.conf
+        target: /etc/nginx/conf.d/default.conf
+        read_only: true
+        content: |
+          map $arg_peerId $sessionid {
+            default "";
+            "~.*-(\d+)(?:-.*|$)" $1;
+          }
+          map $http_x_forwarded_for $real_ip {
+            ~^(\d+\.\d+\.\d+\.\d+) $1;
+            default $remote_addr;
+          }
+          map $http_upgrade $connection_upgrade {
+            default upgrade;
+            '' close;
+          }
+          map $http_x_forwarded_proto $origin_proto {
+            default $http_x_forwarded_proto;
+            '' $scheme;
+          }
+          server {
+            listen 80;
+            client_body_buffer_size 512k;
+            client_max_body_size 10m;
+            proxy_buffer_size 64k;
+            proxy_buffers 32 64k;
+            proxy_busy_buffers_size 128k;
+            proxy_max_temp_file_size 2048m;
+            proxy_buffering on;
+            proxy_connect_timeout 120s;
+            proxy_read_timeout 300s;
+            proxy_send_timeout 300s;
+            real_ip_header X-Forwarded-For;
+            set_real_ip_from 0.0.0.0/0;
+            real_ip_recursive on;
+            add_header X-XSS-Protection "1; mode=block" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header Referrer-Policy "same-origin" always;
+            server_tokens off;
+            location ~ ^/(mobs|sessions-assets|frontend|static|sourcemaps|ios-images|uxtesting-records|records|spots)/ {
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header X-Forwarded-Proto $scheme;
+              proxy_set_header Host $http_host;
+              proxy_connect_timeout 300;
+              proxy_http_version 1.1;
+              proxy_set_header Connection "";
+              chunked_transfer_encoding off;
+              proxy_pass http://minio.db.svc.cluster.local:9000;
+            }
+            location /minio/ {
+              proxy_http_version 1.1;
+              proxy_set_header Upgrade $http_upgrade;
+              proxy_set_header Connection "Upgrade";
+              proxy_set_header Host $host;
+              proxy_pass http://minio.db.svc.cluster.local:9000;
+            }
+            location /ingest/ {
+              rewrite ^/ingest/(.*) /$1 break;
+              proxy_http_version 1.1;
+              proxy_set_header Upgrade $http_upgrade;
+              proxy_set_header Connection "Upgrade";
+              proxy_set_header X-Forwarded-For $real_ip;
+              proxy_set_header X-Forwarded-Host $host;
+              proxy_set_header X-Real-IP $real_ip;
+              proxy_set_header Host $host;
+              proxy_pass http://http-openreplay.app.svc.cluster.local:8080;
+              proxy_read_timeout 300s;
+              proxy_connect_timeout 120s;
+              proxy_send_timeout 300s;
+              add_header 'Access-Control-Allow-Origin' '*' always;
+              add_header 'Access-Control-Allow-Methods' 'POST' always;
+              add_header 'Access-Control-Allow-Headers' 'Content-Type,Authorization,Content-Encoding' always;
+              add_header 'Access-Control-Expose-Headers' 'Content-Length' always;
+            }
+            location /integrations/ {
+              rewrite ^/integrations/(.*) /$1 break;
+              proxy_http_version 1.1;
+              proxy_set_header Upgrade $http_upgrade;
+              proxy_set_header Connection "Upgrade";
+              proxy_set_header X-Forwarded-For $real_ip;
+              proxy_set_header X-Forwarded-Host $host;
+              proxy_set_header X-Real-IP $real_ip;
+              proxy_set_header Host $host;
+              proxy_pass http://integrations-openreplay.app.svc.cluster.local:8080;
+              proxy_read_timeout 300s;
+              proxy_connect_timeout 120s;
+              proxy_send_timeout 300s;
+              add_header 'Access-Control-Allow-Origin' '*' always;
+              add_header 'Access-Control-Allow-Methods' 'POST,PATCH,OPTIONS,DELETE' always;
+              add_header 'Access-Control-Allow-Headers' 'Content-Type,Authorization,Content-Encoding,X-Openreplay-Batch' always;
+              add_header 'Access-Control-Expose-Headers' 'Content-Length' always;
+            }
+            location /v2/api/ {
+              rewrite ^/v2/api/(.*) /$1 break;
+              proxy_http_version 1.1;
+              proxy_set_header Upgrade $http_upgrade;
+              proxy_set_header Connection "Upgrade";
+              proxy_set_header Host $host;
+              proxy_set_header X-Forwarded-Proto $origin_proto;
+              proxy_set_header X-Forwarded-For $real_ip;
+              proxy_set_header X-Real-IP $real_ip;
+              proxy_pass http://api-openreplay.app.svc.cluster.local:8080;
+              proxy_read_timeout 300s;
+              proxy_connect_timeout 120s;
+              proxy_send_timeout 300s;
+              add_header 'Access-Control-Allow-Origin' '$http_origin' always;
+              add_header 'Access-Control-Allow-Methods' 'POST, GET, PATCH, DELETE, OPTIONS, PUT' always;
+              add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization, Content-Encoding, X-Openreplay-Batch' always;
+              add_header 'Access-Control-Expose-Headers' 'Content-Length' always;
+              add_header 'Access-Control-Max-Age' '3600' always;
+              add_header 'Access-Control-Allow-Credentials' 'true' always;
+              if ($request_method = 'OPTIONS') {
+                add_header 'Access-Control-Allow-Origin' '$http_origin' always;
+                add_header 'Access-Control-Allow-Methods' 'POST, GET, PATCH, DELETE, OPTIONS, PUT' always;
+                add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization, Content-Encoding, X-Openreplay-Batch' always;
+                add_header 'Access-Control-Max-Age' '3600' always;
+                add_header 'Content-Length' '0';
+                add_header 'Content-Type' 'text/plain';
+                return 204;
+              }
+            }
+            location /api/ {
+              rewrite ^/api/(.*) /$1 break;
+              proxy_http_version 1.1;
+              proxy_set_header Upgrade $http_upgrade;
+              proxy_set_header Connection "Upgrade";
+              proxy_set_header Host $host;
+              proxy_set_header X-Forwarded-Proto $origin_proto;
+              proxy_set_header X-Forwarded-For $real_ip;
+              proxy_pass http://chalice-openreplay.app.svc.cluster.local:8000;
+              add_header Cache-Control "no-store,no-cache" always;
+              add_header Pragma "no-cache" always;
+            }
+            location /spot/ {
+              rewrite ^/spot/(.*) /$1 break;
+              proxy_http_version 1.1;
+              proxy_set_header Upgrade $http_upgrade;
+              proxy_set_header Connection "Upgrade";
+              proxy_set_header Host $host;
+              proxy_set_header X-Forwarded-Proto $origin_proto;
+              proxy_set_header X-Forwarded-For $real_ip;
+              proxy_set_header X-Real-IP $real_ip;
+              proxy_pass http://spot-openreplay.app.svc.cluster.local:8080;
+              proxy_read_timeout 300s;
+              proxy_connect_timeout 120s;
+              proxy_send_timeout 300s;
+              add_header 'Access-Control-Allow-Origin' '*' always;
+              add_header 'Access-Control-Allow-Methods' 'POST, PATCH, DELETE, OPTIONS' always;
+              add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization, Content-Encoding, X-Openreplay-Batch' always;
+              add_header 'Access-Control-Expose-Headers' 'Content-Length' always;
+              if ($request_method = 'OPTIONS') {
+                add_header 'Access-Control-Allow-Origin' '*' always;
+                add_header 'Access-Control-Allow-Methods' 'POST, PATCH, DELETE, OPTIONS' always;
+                add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization, Content-Encoding, X-Openreplay-Batch' always;
+                add_header 'Access-Control-Max-Age' '3600';
+                add_header 'Content-Type' 'text/plain charset=UTF-8';
+                add_header 'Content-Length' 0;
+                return 204;
+              }
+            }
+            location /assist/ {
+              rewrite ^/assist/(.*) /$1 break;
+              proxy_http_version 1.1;
+              proxy_set_header Upgrade $http_upgrade;
+              proxy_set_header Connection $connection_upgrade;
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $real_ip;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header X-Forwarded-Proto $origin_proto;
+              proxy_read_timeout 3600s;
+              proxy_send_timeout 3600s;
+              proxy_connect_timeout 75s;
+              proxy_buffering off;
+              proxy_pass http://assist-openreplay.app.svc.cluster.local:9001;
+            }
+            location /ws-assist/ {
+              rewrite ^/ws-assist/(.*) /$1 break;
+              proxy_http_version 1.1;
+              proxy_set_header Upgrade $http_upgrade;
+              proxy_set_header Connection $connection_upgrade;
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $real_ip;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header X-Forwarded-Proto $origin_proto;
+              proxy_read_timeout 3600s;
+              proxy_send_timeout 3600s;
+              proxy_connect_timeout 120s;
+              proxy_buffering off;
+              add_header 'Access-Control-Allow-Origin' '$http_origin' always;
+              add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;
+              add_header 'Access-Control-Allow-Headers' 'sessionid, Content-Type, Authorization' always;
+              add_header 'Access-Control-Max-Age' '1728000' always;
+              add_header 'X-Debug-Session-ID' $sessionid always;
+              proxy_pass http://assist-openreplay.app.svc.cluster.local:9001;
+            }
+            location /script/ {
+              rewrite ^/script/(.*)/openreplay(.*).js$ /$1/openreplay$2.js break;
+              proxy_http_version 1.1;
+              proxy_ssl_protocols TLSv1.2 TLSv1.3;
+              proxy_ssl_server_name on;
+              proxy_set_header Host static.openreplay.com;
+              proxy_pass https://static.openreplay.com;
+              proxy_read_timeout 300s;
+              proxy_connect_timeout 120s;
+              proxy_send_timeout 300s;
+              proxy_buffering on;
+              client_max_body_size 8m;
+            }
+            location / {
+              index /index.html;
+              rewrite ^((?!.(js|css|png|svg|jpg|woff|woff2)).)*$ /index.html break;
+              proxy_set_header Host $http_host;
+              proxy_set_header X-Forwarded-For $real_ip;
+              proxy_set_header X-Forwarded-Proto $origin_proto;
+              proxy_pass http://frontend-openreplay.app.svc.cluster.local:8080;
+              proxy_intercept_errors on;
+              error_page 404 =200 /index.html;
+            }
+          }
+    networks:
+      - openreplay-net
+    healthcheck:
+      test:
+        - CMD
+        - nginx
+        - -t
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    restart: unless-stopped
+
+volumes:
+  pgdata:
+  clickhouse:
+  redisdata:
+  miniodata:
+  shared-volume:
+
+networks:
+  openreplay-net:


### PR DESCRIPTION
/claim #8232

### Changes

- Added `templates/compose/openreplay.yaml` — full Docker Compose template covering all OpenReplay services (PostgreSQL 17, ClickHouse 25.11, Valkey 8, MinIO 2025, migration init containers, application services, and Nginx reverse proxy)
- Added `public/svgs/openreplay.svg` — OpenReplay logo

### Issues

- fixes: #8232

### Category

- [x] Adding new one click service

### Screenshots or Video (if applicable)

N/A

### AI Usage

- [x] AI is used in the process of creating this PR

### Steps to Test

- Step 1 – In your Coolify instance, go to a project environment and click **New Service**
- Step 2 – Search for **OpenReplay** and select it
- Step 3 – Set a domain, then click **Deploy**
- Step 4 – Wait for the migration init containers (`fs-permission`, `minio-migration`, `db-migration`, `clickhouse-migration`) to complete successfully
- Step 5 – Wait for all application containers to reach a healthy/running state (approx. 2–5 minutes)
- Step 6 – Visit the configured domain and confirm the OpenReplay login page loads
- Step 7 – Register an admin account and verify the dashboard is accessible

### Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them
