### PR TITLE
feat: Add support for Debian 13 (Trixie)

### DIFF
--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -1052,7 +1052,11 @@ $schema://$host {
         }
         $ID = data_get($collectedData, 'ID');
         // $ID_LIKE = data_get($collectedData, 'ID_LIKE');
-        // $VERSION_ID = data_get($collectedData, 'VERSION_ID');
+        $VERSION_ID = data_get($collectedData, 'VERSION_ID');
+        // bounty fix for debian 13
+        if ($ID === 'debian' && $VERSION_ID === '13'){
+            return str($ID);
+        }
         $supported = collect(SUPPORTED_OS)->filter(function ($supportedOs) use ($ID) {
             if (str($supportedOs)->contains($ID)) {
                 return str($ID);

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -523,6 +523,9 @@ install_docker_manually() {
         chmod a+r /etc/apt/keyrings/docker.asc
 
         # Add the repository to Apt sources
+        if [ "$VERSION_CODENAME" = "trixie" ]; then
+            VERSION_CODENAME="bookworm"
+        fi
         echo \
             "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/$OS_TYPE \
                   $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" |


### PR DESCRIPTION
this PR adds official official support Debian 13 Trixie 

technical fixes:
backend os validation: updated app/Models/Server.php to recognize Debian 13 by adding a version ID check that returns debian for version 13.
Docker Installer Bridge: Modified scripts/install.sh to map the trixie codename to bookworm for the docker repository setup.

https://github.com/user-attachments/assets/65b54a8f-f587-4817-86ff-d52e5b64a33c

/claim #8154 
