### PR TITLE
feat: Add support for Debian 13 (Trixie)

### DIFF
--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -1052,7 +1052,11 @@ $schema://$host {
         }
         $ID = data_get($collectedData, 'ID');
         // $ID_LIKE = data_get($collectedData, 'ID_LIKE');
-        // $VERSION_ID = data_get($collectedData, 'VERSION_ID');
+        $VERSION_ID = data_get($collectedData, 'VERSION_ID');
+        // bounty fix for debian 13
+        if ($ID === 'debian' && $VERSION_ID === '13'){
+            return str($ID);
+        }
         $supported = collect(SUPPORTED_OS)->filter(function ($supportedOs) use ($ID) {
             if (str($supportedOs)->contains($ID)) {
                 return str($ID);

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -523,6 +523,9 @@ install_docker_manually() {
         chmod a+r /etc/apt/keyrings/docker.asc
 
         # Add the repository to Apt sources
+        if [ "$VERSION_CODENAME" = "trixie" ]; then
+            VERSION_CODENAME="bookworm"
+        fi
         echo \
             "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/$OS_TYPE \
                   $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" |


### PR DESCRIPTION
Description 
This PR adds official support for Debian 13 (Trixie) by updating the backend server validation and the automated installer script

Type of change
-[x] New feature (non-breaking change which adds functionality)

Checklist 
-[x] my code follows the style guidelines of this project 
-[x] i have performed a self-rewiew of my own code
-[x] i have commented my code, particularly in hard-to-understand areas


Proof of work video demonstration:


https://github.com/user-attachments/assets/aaddb4b0-ce11-4c4c-b836-6f6689dfbf19



Bounty Claim
/claim #8154