### PR TITLE
fix(db-proxy): disable stream proxy timeout for public database proxies

### DIFF
--- a/app/Actions/Database/StartDatabaseProxy.php
+++ b/app/Actions/Database/StartDatabaseProxy.php
@@ -67,6 +67,10 @@ class StartDatabaseProxy
        server {
             listen $database->public_port;
             proxy_pass $containerName:$internalPort;
+
+            # Default `proxy_timeout` for nginx stream is 10m, which can break long-running
+            # queries or large result transfers. 0 disables the timeout.
+            proxy_timeout 0;
        }
     }
     EOF;


### PR DESCRIPTION
Fixes #7743\n\nCoolify uses an nginx stream proxy for publicly exposed databases. Nginx stream defaults  to 10m, which can terminate long-running queries / large result transfers.\n\nThis change sets  in the generated stream server block to disable the timeout.