### PR TITLE
fix: add fallback for Debian 13 VERSION_CODENAME

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -121,7 +121,8 @@ class InstallDocker
             'install -m 0755 -d /etc/apt/keyrings && '.
             'curl -fsSL https://download.docker.com/linux/${ID}/gpg -o /etc/apt/keyrings/docker.asc && '.
             'chmod a+r /etc/apt/keyrings/docker.asc && '.
-            'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${ID} ${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list && '.
+            'CODENAME=${VERSION_CODENAME:-stable} && '.
+            'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${ID} ${CODENAME} stable" > /etc/apt/sources.list.d/docker.list && '.
             'apt-get update && '.
             'apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin'.
             ')';


### PR DESCRIPTION
## Problem
Debian 13 (Trixie) may have a VERSION_CODENAME that is not yet available in the Docker repository, causing Docker installation to fail on Debian 13 servers.

## Solution
Add a fallback to use 'stable' if VERSION_CODENAME is not set or not recognized.

```diff
-CODENAME=${VERSION_CODENAME}
+CODENAME=${VERSION_CODENAME:-stable}
```

## Testing
- Test with Debian 13 (Trixie) server

Fixes #8154