### PR TITLE
fix(db-proxy): disable timeout for public database proxies

### DIFF
--- a/app/Actions/Database/StartDatabaseProxy.php
+++ b/app/Actions/Database/StartDatabaseProxy.php
@@ -67,6 +67,10 @@ class StartDatabaseProxy
        server {
             listen $database->public_port;
             proxy_pass $containerName:$internalPort;
+
+            # Default `proxy_timeout` for nginx stream is 10m, which can break long-running
+            # queries or large result transfers. 0 disables the timeout.
+            proxy_timeout 0;
        }
     }
     EOF;


### PR DESCRIPTION
### Changes
- Disable the default 10 minute timeout for public database proxies (nginx stream) by setting proxy_timeout to 0 in the generated config.

### Issues
- fixes: #7743

### Category
- [x] Bug fix

### Screenshots or Video (if applicable)
N/A.

### AI Usage
- [x] AI is used in the process of creating this PR

### Steps to Test
1. Expose a PostgreSQL database publicly.
2. Run a query or transfer that takes longer than 10 minutes.
3. Connection should stay open beyond 10 minutes.

### Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the contributor guidelines. If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them
