### PR TITLE
feat: add SurrealDB service templates (standalone + TiKV)

### DIFF
--- a/templates/compose/surrealdb-with-tikv.yaml
+++ b/templates/compose/surrealdb-with-tikv.yaml
@@ -1,0 +1,46 @@
+# documentation: https://surrealdb.com/docs
+# slogan: SurrealDB with TiKV - Distributed multi-model database backed by TiKV for horizontal scaling.
+# category: database
+# tags: database, surrealdb, tikv, distributed, multi-model, graph, document, sql
+# logo: svgs/surrealdb.svg
+# port: 8000
+
+services:
+  surrealdb:
+    image: surrealdb/surrealdb:latest
+    command: start --user ${SERVICE_USER_SURREALDB} --pass ${SERVICE_PASSWORD_SURREALDB} tikv://pd:2379
+    environment:
+      - SERVICE_FQDN_SURREALDB_8000
+    depends_on:
+      pd:
+        condition: service_healthy
+      tikv:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+  pd:
+    image: pingcap/pd:latest
+    command: --name=pd --data-dir=/data/pd --client-urls=http://0.0.0.0:2379 --peer-urls=http://0.0.0.0:2380 --advertise-client-urls=http://pd:2379 --advertise-peer-urls=http://pd:2380
+    volumes:
+      - pd-data:/data/pd
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:2379/health"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+  tikv:
+    image: pingcap/tikv:latest
+    command: --addr=0.0.0.0:20160 --advertise-addr=tikv:20160 --data-dir=/data/tikv --pd=http://pd:2379
+    volumes:
+      - tikv-data:/data/tikv
+    depends_on:
+      pd:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:20180/status"]
+      interval: 5s
+      timeout: 20s
+      retries: 10

--- a/templates/compose/surrealdb.yaml
+++ b/templates/compose/surrealdb.yaml
@@ -1,0 +1,20 @@
+# documentation: https://surrealdb.com/docs
+# slogan: SurrealDB is a scalable, distributed, multi-model database for modern applications.
+# category: database
+# tags: database, surrealdb, multi-model, graph, document, sql, nosql
+# logo: svgs/surrealdb.svg
+# port: 8000
+
+services:
+  surrealdb:
+    image: surrealdb/surrealdb:latest
+    command: start --user ${SERVICE_USER_SURREALDB} --pass ${SERVICE_PASSWORD_SURREALDB} file:/data/database.db
+    volumes:
+      - surrealdb-data:/data
+    environment:
+      - SERVICE_FQDN_SURREALDB_8000
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
## Summary
Adds two SurrealDB service templates:

### 1. SurrealDB Standalone (`surrealdb.yaml`)
- File-based storage (RocksDB)
- Single container, simple deployment
- Auth via `SERVICE_USER`/`SERVICE_PASSWORD`

### 2. SurrealDB with TiKV (`surrealdb-with-tikv.yaml`)
- Distributed storage via TiKV + PD
- Horizontal scaling support
- 3 services: SurrealDB, PD (Placement Driver), TiKV

Both templates include health checks and persistent volumes.

Related discussions: #3587, #4013

Fixes #7642
/claim #7642