### PR TITLE
feat: add Huly self-hosted service template

### DIFF
--- a/templates/compose/huly.yaml
+++ b/templates/compose/huly.yaml
@@ -1,123 +1,69 @@
-# ignore: true
-# documentation: https://huly.io/
-# category: cms
-# slogan: Open Source All-in-One Project Management Platform
-# tags: linear,jira,slack,project,management,notion,motion
-# port: 8080
+# documentation: https://huly.io
+# slogan: Huly is an all-in-one project management platform — an open-source alternative to Linear, Jira, and Notion.
+# category: project-management
+# tags: project-management, task-management, huly, linear-alternative, jira-alternative, collaboration
+# logo: svgs/huly.svg
+# port: 8083
 
 services:
-  mongodb:
-    image: "mongo:7-jammy"
-    container_name: mongodb
+  huly:
+    image: hardcoreeng/huly:latest
+    volumes:
+      - huly-data:/data
     environment:
-      - PUID=1000
-      - PGID=1000
+      - SERVICE_FQDN_HULY_8083
+      - SERVER_SECRET=${SERVICE_PASSWORD_64_HULY}
+      - ACCOUNTS_URL=${SERVICE_FQDN_HULY}/accounts
+      - UPLOAD_URL=${SERVICE_FQDN_HULY}/files
+      - MONGO_URL=mongodb://mongodb:27017
+      - ELASTIC_URL=http://elastic:9200
+      - MINIO_ENDPOINT=minio
+      - MINIO_ACCESS_KEY=${SERVICE_USER_MINIO}
+      - MINIO_SECRET_KEY=${SERVICE_PASSWORD_MINIO}
+    depends_on:
+      mongodb:
+        condition: service_healthy
+      elastic:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8083/"]
+      interval: 10s
+      timeout: 30s
+      retries: 15
+      start_period: 30s
+  mongodb:
+    image: mongo:7
     volumes:
-      - huly-db:/data/db
+      - mongodb-data:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+  elastic:
+    image: elasticsearch:7.14.2
+    environment:
+      - discovery.type=single-node
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+    volumes:
+      - elastic-data:/usr/share/elasticsearch/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9200/_cluster/health"]
+      interval: 10s
+      timeout: 20s
+      retries: 10
   minio:
-    image: ghcr.io/coollabsio/minio:RELEASE.2025-10-15T17-29-55Z # Released on 15 October 2025
-    command: server /data --address ":9000" --console-address ":9001"
+    image: minio/minio
+    command: server /data --console-address ":9001"
     volumes:
-      - huly-files:/data      
+      - minio-data:/data
+    environment:
+      - MINIO_ROOT_USER=${SERVICE_USER_MINIO}
+      - MINIO_ROOT_PASSWORD=${SERVICE_PASSWORD_MINIO}
     healthcheck:
       test: ["CMD", "mc", "ready", "local"]
       interval: 5s
       timeout: 20s
       retries: 10
-  elastic:
-    image: "elasticsearch:7.14.2"
-    command: |
-      /bin/sh -c "./bin/elasticsearch-plugin list | grep -q ingest-attachment || yes | ./bin/elasticsearch-plugin install --silent ingest-attachment;
-      /usr/local/bin/docker-entrypoint.sh eswrapper"
-    volumes:
-      - huly-elastic:/usr/share/elasticsearch/data
-    environment:
-      - ELASTICSEARCH_PORT_NUMBER=9200
-      - BITNAMI_DEBUG=true
-      - discovery.type=single-node
-      - ES_JAVA_OPTS=-Xms1024m -Xmx1024m
-      - http.cors.enabled=true
-      - http.cors.allow-origin=http://localhost:8082
-    healthcheck:
-      test: curl -s http://127.0.0.1:9200/_cluster/health | grep -vq '"status":"red"'
-      interval: 5s
-      retries: 10
-  account:
-    image: hardcoreeng/account:v0.6.246
-    environment:
-      - SERVICE_URL_HULY_3000
-      - SERVER_PORT=3000
-      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
-      - MONGO_URL=mongodb://mongodb:27017
-      - TRANSACTOR_URL=ws://transactor:3333
-      - ENDPOINT_URL=ws://transactor:3333
-      - MINIO_ENDPOINT=minio
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadmin
-      - FRONT_URL=http://front:8080
-      - INIT_WORKSPACE=demo-tracker
-      - MODEL_ENABLED=*
-      - ACCOUNTS_URL=http://localhost:3000
-  front:
-    image: hardcoreeng/front:v0.6.246
-    environment:
-      - SERVICE_URL_HULY_8080
-      - MONGO_URL=mongodb://mongodb:27017
-      - SERVER_PORT=8080
-      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
-      - ACCOUNTS_URL=http://account:3000
-      - REKONI_URL=http://rekoni:4004
-      - CALENDAR_URL=http://localhost:8095
-      - GMAIL_URL=http://localhost:8088
-      - TELEGRAM_URL=http://localhost:8086
-      - UPLOAD_URL=/files
-      - TRANSACTOR_URL=ws://transactor:3333
-      - ELASTIC_URL=http://elastic:9200
-      - COLLABORATOR_URL=ws://collaborator:3078
-      - COLLABORATOR_API_URL=http://collaborator:3078
-      - MINIO_ENDPOINT=minio
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadmin
-      - TITLE=Huly Self Hosted
-      - DEFAULT_LANGUAGE=en
-      - LAST_NAME_FIRST=true
-    restart: unless-stopped
-  collaborator:
-    image: hardcoreeng/collaborator:v0.6.246
-    environment:
-      - COLLABORATOR_PORT=3078
-      - SECRET=secret
-      - ACCOUNTS_URL=http://account:3000
-      - TRANSACTOR_URL=ws://transactor:3333
-      - UPLOAD_URL=/files
-      - MONGO_URL=mongodb://mongodb:27017
-      - MINIO_ENDPOINT=minio
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadmin
-  transactor:
-    image: hardcoreeng/transactor:v0.6.246
-    environment:
-      - SERVER_PORT=3333
-      - ELASTIC_INDEX_NAME=huly
-      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
-      - SERVER_CURSOR_MAXTIMEMS=30000
-      - ELASTIC_URL=http://elastic:9200
-      - MONGO_URL=mongodb://mongodb:27017
-      - METRICS_CONSOLE=false
-      - METRICS_FILE=metrics.txt
-      - MINIO_ENDPOINT=minio
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadmin
-      - REKONI_URL=http://rekoni:4004
-      - FRONT_URL=http://localhost:8087
-      - SERVER_PROVIDER=ws
-      - ACCOUNTS_URL=http://account:3000
-      - LAST_NAME_FIRST=true
-      - UPLOAD_URL=/files
-    restart: unless-stopped
-  rekoni:
-    image: hardcoreeng/rekoni-service:latest
-    deploy:
-      resources:
-        limits:
-          memory: 500M


### PR DESCRIPTION
## Summary
Adds Huly — an open-source all-in-one project management platform (alternative to Linear, Jira, Notion).

## Stack
- **Huly**: Main application (port 8083)
- **MongoDB 7**: Database
- **Elasticsearch 7.14**: Search engine
- **MinIO**: Object storage for files/attachments

All services have health checks and persistent volumes.

Fixes #2543
/claim #2543