### PR TITLE
feat: OAuth self-registration only

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -19,7 +19,8 @@ class CreateNewUser implements CreatesNewUsers
     public function create(array $input): User
     {
         $settings = instanceSettings();
-        if (! $settings->is_registration_enabled) {
+        $oauthEnabled = \App\Models\OauthSetting::where('enabled', true)->exists();
+        if (! $settings->is_registration_enabled || $oauthEnabled) {
             abort(403);
         }
         Validator::make($input, [

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -58,6 +58,11 @@ class Controller extends BaseController
                 return response()->json(['message' => 'Transactional emails are not active'], 400);
             }
             $request->validate([Fortify::email() => 'required|email']);
+            $oauthEnabled = \App\Models\OauthSetting::where('enabled', true)->exists();
+            $user = User::whereEmail($request->get(Fortify::email()))->first();
+            if ($oauthEnabled && $user && ! $user->hasPassword()) {
+                return response()->json(['message' => 'Password reset is disabled for OAuth users'], 403);
+            }
             $status = Password::broker(config('fortify.passwords'))->sendResetLink(
                 $request->only(Fortify::email())
             );

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -22,7 +22,8 @@ class OauthController extends Controller
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                $oauthEnabled = \App\Models\OauthSetting::where('enabled', true)->exists();
+                if (! $settings->is_registration_enabled && ! $oauthEnabled) {
                     abort(403, 'Registration is disabled');
                 }
 

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -47,7 +47,8 @@ class FortifyServiceProvider extends ServiceProvider
             $isFirstUser = User::count() === 0;
 
             $settings = instanceSettings();
-            if (! $settings->is_registration_enabled) {
+            $oauthEnabled = OauthSetting::where('enabled', true)->exists();
+            if (! $settings->is_registration_enabled || $oauthEnabled) {
                 return redirect()->route('login');
             }
 
@@ -59,14 +60,15 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::loginView(function () {
             $settings = instanceSettings();
             $enabled_oauth_providers = OauthSetting::where('enabled', true)->get();
+            $oauthEnabled = $enabled_oauth_providers->isNotEmpty();
             $users = User::count();
-            if ($users == 0) {
-                // If there are no users, redirect to registration
+            if ($users == 0 && ! $oauthEnabled) {
+                // If there are no users and no OAuth providers, redirect to registration
                 return redirect()->route('register');
             }
 
             return view('auth.login', [
-                'is_registration_enabled' => $settings->is_registration_enabled,
+                'is_registration_enabled' => $settings->is_registration_enabled && ! $oauthEnabled,
                 'enabled_oauth_providers' => $enabled_oauth_providers,
             ]);
         });


### PR DESCRIPTION
Fixes #8042

When any OAuth provider is enabled:
- Manual registration form is blocked
- OAuth self-registration works even if general registration is disabled
- Password reset is disabled for OAuth-only users
- Login page no longer redirects to register when no users exist (if OAuth enabled)