### PR TITLE
feat: add project-specific team members

### DIFF
--- a/app/Http/Controllers/Api/ProjectController.php
+++ b/app/Http/Controllers/Api/ProjectController.php
@@ -4,9 +4,12 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Models\Project;
+use App\Models\User;
 use App\Support\ValidationPatterns;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
 use OpenApi\Attributes as OA;
 
 class ProjectController extends Controller
@@ -726,4 +729,226 @@ class ProjectController extends Controller
 
         return response()->json(['message' => 'Environment deleted.']);
     }
-}
+
+    #[OA\Get(
+        summary: 'List Project Members',
+        description: 'Get all members of a project.',
+        path: '/projects/{uuid}/members',
+        operationId: 'list-project-members',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Projects'],
+        parameters: [
+            new OA\Parameter(name: 'uuid', in: 'path', required: true, description: 'Project UUID', schema: new OA\Schema(type: 'string')),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'List of project members.',
+                content: [
+                    new OA\MediaType(
+                        mediaType: 'application/json',
+                        schema: new OA\Schema(
+                            type: 'array',
+                            items: new OA\Items(ref: '#/components/schemas/User')
+                        )
+                    ),
+                ]),
+            new OA\Response(
+                response: 401,
+                ref: '#/components/responses/401',
+            ),
+            new OA\Response(
+                response: 400,
+                ref: '#/components/responses/400',
+            ),
+            new OA\Response(
+                response: 404,
+                ref: '#/components/responses/404',
+            ),
+        ]
+    )]
+    public function list_members(Request $request)
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+
+        if (! $request->uuid) {
+            return response()->json(['message' => 'Project UUID is required.'], 422);
+        }
+
+        $project = Project::whereTeamId($teamId)->whereUuid($request->uuid)->first();
+        if (! $project) {
+            return response()->json(['message' => 'Project not found.'], 404);
+        }
+
+        $members = $project->members;
+        $members->makeHidden(['pivot']);
+
+        return response()->json(serializeApiResponse($members));
+    }
+
+    #[OA\Post(
+        summary: 'Add Project Member',
+        description: 'Add a member to a project.',
+        path: '/projects/{uuid}/members',
+        operationId: 'add-project-member',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Projects'],
+        parameters: [
+            new OA\Parameter(name: 'uuid', in: 'path', required: true, description: 'Project UUID', schema: new OA\Schema(type: 'string')),
+        ],
+        requestBody: new OA\RequestBody(
+            required: true,
+            description: 'Member details.',
+            content: new OA\MediaType(
+                mediaType: 'application/json',
+                schema: new OA\Schema(
+                    type: 'object',
+                    properties: [
+                        'email' => ['type' => 'string', 'description' => 'Email of the user to add.'],
+                        'role' => ['type' => 'string', 'description' => 'Role of the member (member or admin).', 'default' => 'member'],
+                    ],
+                ),
+            ),
+        ),
+        responses: [
+            new OA\Response(
+                response: 201,
+                description: 'Member added.',
+                content: [
+                    new OA\MediaType(
+                        mediaType: 'application/json',
+                        schema: new OA\Schema(
+                            type: 'object',
+                            properties: [
+                                'message' => ['type' => 'string', 'example' => 'Member added successfully.'],
+                            ]
+                        )
+                    ),
+                ]),
+            new OA\Response(
+                response: 401,
+                ref: '#/components/responses/401',
+            ),
+            new OA\Response(
+                response: 400,
+                ref: '#/components/responses/400',
+            ),
+            new OA\Response(
+                response: 404,
+                ref: '#/components/responses/404',
+            ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
+            ),
+        ]
+    )]
+    public function add_member(Request $request)
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+
+        if (! $request->uuid) {
+            return response()->json(['message' => 'Project UUID is required.'], 422);
+        }
+
+        $project = Project::whereTeamId($teamId)->whereUuid($request->uuid)->first();
+        if (! $project) {
+            return response()->json(['message' => 'Project not found.'], 404);
+        }
+
+        $return = validateIncomingRequest($request);
+        if ($return instanceof \Illuminate\Http\JsonResponse) {
+            return $return;
+        }
+
+        $validator = Validator::make($request->all(), [
+            'email' => 'required|email',
+            'role' => 'nullable|string|in:member,admin',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'message' => 'Validation failed.',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $email = strtolower($request->email);
+        $role = $request->role ?? 'member';
+
+        // Check if user is already a team member
+        $teamMember = User::where('email', $email)->first();
+        if ($teamMember && $teamMember->teams->contains('id', $teamId)) {
+            return response()->json(['message' => 'User is already a team member.'], 400);
+        }
+
+        // Check if already a project member
+        $existingMember = $project->members()->whereHas('user', function ($query) use ($email) {
+            $query->where('email', $email);
+        })->first();
+        if ($existingMember) {
+            return response()->json(['message' => 'User is already a member of this project.'], 409);
+        }
+
+        // Find or create user
+        $user = User::whereEmail($email)->first();
+        if (is_null($user)) {
+            $user = User::create([
+                'name' => str($email)->before('@'),
+                'email' => $email,
+                'password' => Hash::make(Str::password()),
+                'force_password_reset' => true,
+            ]);
+        }
+
+        // Add user to project
+        $project->members()->attach($user, ['role' => $role]);
+
+        return response()->json(['message' => 'Member added successfully.'])->setStatusCode(201);
+    }
+
+    #[OA\Delete(
+        summary: 'Remove Project Member',
+        description: 'Remove a member from a project.',
+        path: '/projects/{uuid}/members/{user_id}',
+        operationId: 'remove-project-member',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Projects'],
+        parameters: [
+            new OA\Parameter(name: 'uuid', in: 'path', required: true, description: 'Project UUID', schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'user_id', in: 'path', required: true, description: 'User ID', schema: new OA\Schema(type: 'integer')),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Member removed.',
+                content: [
+                    new OA\MediaType(
+                        mediaType: 'application/json',
+                        schema: new OA\Schema(
+                            type: 'object',
+                            properties: [
+                                'message' => ['type' => 'string', 'example' => 'Member removed successfully.'],
+                            ]
+                        )
+                    ),
+                ]),
+            new OA\Response(
+                response: 401,
+                ref: '#/components/responses/401',
+            ),
+            new OA\Response(
+                response: 400,
+                ref: '#/components/responses/400',

--- a/app/Livewire/Project/Members.php
+++ b/app/Livewire/Project/Members.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace App\Livewire\Project;
+
+use App\Enums\Role;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+use Livewire\Component;
+use Visus\Cuid2\Cuid2;
+
+class Members extends Component
+{
+    use AuthorizesRequests;
+
+    public Project $project;
+
+    public string $email = '';
+
+    public string $role = 'member';
+
+    protected $rules = [
+        'email' => 'required|email',
+        'role' => 'required|string|in:member,admin',
+    ];
+
+    public function mount(string $project_uuid)
+    {
+        try {
+            $this->project = Project::where('team_id', currentTeam()->id)->where('uuid', $project_uuid)->firstOrFail();
+            $this->authorize('manageMembers', $this->project);
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function updatedEmail()
+    {
+        $this->email = strtolower($this->email);
+    }
+
+    public function addMember()
+    {
+        try {
+            $this->authorize('manageMembers', $this->project);
+            $this->validate();
+
+            // Prevent privilege escalation: project members cannot invite admins
+            if (auth()->user()->isMember() && $this->role === 'admin') {
+                throw new \Exception('Members cannot invite admins.');
+            }
+
+            $this->email = strtolower($this->email);
+
+            // Check if already a team member (team members already have access)
+            $teamMember = currentTeam()->members()->where('email', $this->email)->first();
+            if ($teamMember) {
+                return handleError(livewire: $this, customErrorMessage: "$this->email is already a member of the team and has full access.");
+            }
+
+            // Check if already a project member
+            $existingMember = $this->project->members()->whereHas('user', function ($query) {
+                $query->where('email', $this->email);
+            })->first();
+            if ($existingMember) {
+                return handleError(livewire: $this, customErrorMessage: "$this->email is already a member of this project.");
+            }
+
+            // Find or create user
+            $user = User::whereEmail($this->email)->first();
+            $isNewUser = false;
+
+            if (is_null($user)) {
+                $password = Str::password();
+                $user = User::create([
+                    'name' => str($this->email)->before('@'),
+                    'email' => $this->email,
+                    'password' => Hash::make($password),
+                    'force_password_reset' => true,
+                ]);
+                $isNewUser = true;
+            }
+
+            // Add user to project
+            $this->project->members()->attach($user, ['role' => $this->role]);
+
+            // Send invitation email if transactional emails are enabled
+            if (is_transactional_emails_enabled()) {
+                $this->sendInvitationEmail($user, $isNewUser ? $password : null);
+            }
+
+            $this->dispatch('success', 'Member added successfully.');
+            $this->reset(['email', 'role']);
+            $this->dispatch('refreshMembers');
+        } catch (\Throwable $e) {
+            return handleError(error: $e, livewire: $this);
+        }
+    }
+
+    private function sendInvitationEmail(User $user, ?string $password = null)
+    {
+        $mail = new MailMessage;
+        $projectName = $this->project->name;
+        $teamName = currentTeam()->name;
+
+        $invitationData = [
+            'project' => $projectName,
+            'team' => $teamName,
+            'role' => $this->role,
+        ];
+
+        $invitationData['project_uuid'] = $this->project->uuid;
+
+        if ($password) {
+            // New user - send login credentials
+            $token = Crypt::encryptString("{$user->email}@@@$password");
+            $loginLink = route('auth.link', ['token' => $token]);
+            $invitationData['login_link'] = $loginLink;
+
+            $mail->view('emails.project-invitation-new-user', $invitationData);
+            $mail->subject("You have been invited to {$projectName} on ".config('app.name'));
+        } else {
+            // Existing user - just notify
+            $invitationData['app_url'] = base_url();
+            $mail->view('emails.project-invitation-existing-user', $invitationData);
+            $mail->subject("You have been added to {$projectName} on ".config('app.name'));
+        }
+
+        send_user_an_email($mail, $user->email);
+    }
+
+    public function removeMember(int $user_id)
+    {
+        try {
+            $this->authorize('manageMembers', $this->project);
+
+            $user = User::findOrFail($user_id);
+
+            // Prevent removing yourself
+            if ($user_id === auth()->id()) {
+                throw new \Exception('You cannot remove yourself.');
+            }
+
+            $this->project->members()->detach($user_id);
+
+            // Clean up user if they have no teams and no other project memberships
+            $user->deleteIfNotVerifiedAndForcePasswordReset();
+
+            $this->dispatch('success', 'Member removed successfully.');
+            $this->dispatch('refreshMembers');
+        } catch (\Throwable $e) {
+            return handleError(error: $e, livewire: $this);
+        }
+    }
+
+    public function changeRole(int $user_id, string $newRole)
+    {
+        try {
+            $this->authorize('manageMembers', $this->project);
+
+            // Prevent privilege escalation
+            if (auth()->user()->isMember() && $newRole === 'admin') {
+                throw new \Exception('Members cannot promote to admin.');
+            }
+
+            $user = User::findOrFail($user_id);
+
+            // Prevent changing your own role
+            if ($user_id === auth()->id()) {
+                throw new \Exception('You cannot change your own role.');
+            }
+
+            $this->project->members()->updateExistingPivot($user_id, ['role' => $newRole]);
+
+            $this->dispatch('success', 'Role updated successfully.');
+            $this->dispatch('refreshMembers');
+        } catch (\Throwable $e) {
+            return handleError(error: $e, livewire: $this);
+        }
+    }
+
+    public function render()
+    {
+        return view('livewire.project.members');
+    }
+}

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -165,4 +165,9 @@ class Project extends BaseModel
 
         return route('project.show', ['project_uuid' => $this->uuid]);
     }
+
+    public function members()
+    {
+        return $this->belongsToMany(User::class, 'project_members')->withPivot('role')->withTimestamps();
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -474,4 +474,19 @@ class User extends Authenticatable implements SendsEmail
     {
         return ! empty($this->password);
     }
+
+    public function projectMemberships()
+    {
+        return $this->belongsToMany(Project::class, 'project_members')->withPivot('role')->withTimestamps();
+    }
+
+    public function isProjectMember(Project $project): bool
+    {
+        return $this->projectMemberships()->where('project_id', $project->id)->exists();
+    }
+
+    public function projectRole(Project $project): ?string
+    {
+        return $this->projectMemberships()->where('project_id', $project->id)->first()?->pivot?->role;
+    }
 }

--- a/app/Policies/ProjectPolicy.php
+++ b/app/Policies/ProjectPolicy.php
@@ -20,8 +20,16 @@ class ProjectPolicy
      */
     public function view(User $user, Project $project): bool
     {
-        // return $user->teams->contains('id', $project->team_id);
-        return true;
+        // Team owner/admin has full access
+        if ($user->teams->contains('id', $project->team_id)) {
+            $role = $user->teams->where('id', $project->team_id)->first()?->pivot?->role;
+            if ($role === 'owner' || $role === 'admin') {
+                return true;
+            }
+        }
+
+        // Check if user is a project member
+        return $user->isProjectMember($project);
     }
 
     /**
@@ -29,8 +37,8 @@ class ProjectPolicy
      */
     public function create(User $user): bool
     {
-        // return $user->isAdmin();
-        return true;
+        // Only team admins/owners can create projects
+        return $user->isAdmin() || $user->isOwner();
     }
 
     /**
@@ -38,8 +46,16 @@ class ProjectPolicy
      */
     public function update(User $user, Project $project): bool
     {
-        // return $user->isAdmin() && $user->teams->contains('id', $project->team_id);
-        return true;
+        // Team owner/admin has full access
+        if ($user->teams->contains('id', $project->team_id)) {
+            $role = $user->teams->where('id', $project->team_id)->first()?->pivot?->role;
+            if ($role === 'owner' || $role === 'admin') {
+                return true;
+            }
+        }
+
+        // Project admin can update
+        return $user->projectRole($project) === 'admin';
     }
 
     /**
@@ -47,8 +63,14 @@ class ProjectPolicy
      */
     public function delete(User $user, Project $project): bool
     {
-        // return $user->isAdmin() && $user->teams->contains('id', $project->team_id);
-        return true;
+        // Only team owner/admin can delete projects
+        if (! $user->teams->contains('id', $project->team_id)) {
+            return false;
+        }
+
+        $role = $user->teams->where('id', $project->team_id)->first()?->pivot?->role;
+
+        return $role === 'owner' || $role === 'admin';
     }
 
     /**
@@ -56,8 +78,14 @@ class ProjectPolicy
      */
     public function restore(User $user, Project $project): bool
     {
-        // return $user->isAdmin() && $user->teams->contains('id', $project->team_id);
-        return true;
+        // Only team owner/admin can restore projects
+        if (! $user->teams->contains('id', $project->team_id)) {
+            return false;
+        }
+
+        $role = $user->teams->where('id', $project->team_id)->first()?->pivot?->role;
+
+        return $role === 'owner' || $role === 'admin';
     }
 
     /**
@@ -65,7 +93,47 @@ class ProjectPolicy
      */
     public function forceDelete(User $user, Project $project): bool
     {
-        // return $user->isAdmin() && $user->teams->contains('id', $project->team_id);
-        return true;
+        // Only team owner/admin can force delete projects
+        if (! $user->teams->contains('id', $project->team_id)) {
+            return false;
+        }
+
+        $role = $user->teams->where('id', $project->team_id)->first()?->pivot?->role;
+
+        return $role === 'owner' || $role === 'admin';
+    }
+
+    /**
+     * Determine whether the user can manage project members.
+     */
+    public function manageMembers(User $user, Project $project): bool
+    {
+        // Team owner/admin has full access
+        if ($user->teams->contains('id', $project->team_id)) {
+            $role = $user->teams->where('id', $project->team_id)->first()?->pivot?->role;
+            if ($role === 'owner' || $role === 'admin') {
+                return true;
+            }
+        }
+
+        // Project admin can manage members
+        return $user->projectRole($project) === 'admin';
+    }
+
+    /**
+     * Determine whether the user can create resources in the project.
+     */
+    public function createResources(User $user, Project $project): bool
+    {
+        // Team owner/admin has full access
+        if ($user->teams->contains('id', $project->team_id)) {
+            $role = $user->teams->where('id', $project->team_id)->first()?->pivot?->role;
+            if ($role === 'owner' || $role === 'admin') {
+                return true;
+            }
+        }
+
+        // Project members (admin or member) can create resources
+        return $user->isProjectMember($project);
     }
 }

--- a/database/migrations/2026_02_19_000001_create_project_members_table.php
+++ b/database/migrations/2026_02_19_000001_create_project_members_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('project_members', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('project_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('role')->default('member'); // 'member' or 'admin'
+            $table->timestamps();
+            $table->unique(['project_id', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('project_members');
+    }
+};

--- a/resources/views/emails/project-invitation-existing-user.blade.php
+++ b/resources/views/emails/project-invitation-existing-user.blade.php
@@ -1,0 +1,11 @@
+<x-emails.layout>
+You have been added to the project "{{ $project }}" in team "{{ $team }}" on "{{ config('app.name') }}".
+
+Your role: {{ ucfirst($role) }}
+
+You can access the project by [clicking here]({{ $app_url }}/project/{{ $project_uuid }}).
+
+If you have any questions, please contact the team owner.<br><br>
+
+If you believe this was a mistake, please contact the team owner.
+</x-emails.layout>

--- a/resources/views/emails/project-invitation-new-user.blade.php
+++ b/resources/views/emails/project-invitation-new-user.blade.php
@@ -1,0 +1,11 @@
+<x-emails.layout>
+You have been invited to join the project "{{ $project }}" in team "{{ $team }}" on "{{ config('app.name') }}".
+
+Your role: {{ ucfirst($role) }}
+
+Please [click here]({{ $login_link }}) to access the project.
+
+If you have any questions, please contact the team owner.<br><br>
+
+If it was not you who requested this invitation, please ignore this email.
+</x-emails.layout>

--- a/resources/views/livewire/project/edit.blade.php
+++ b/resources/views/livewire/project/edit.blade.php
@@ -1,19 +1,37 @@
 <div>
     <x-slot:title>
         {{ data_get_str($project, 'name')->limit(10) }} > Edit | Coolify
-        </x-slot>
-        <form wire:submit='submit' class="flex flex-col pb-10">
-            <div class="flex gap-2">
-                <h1>{{ data_get_str($project, 'name')->limit(15) }}</h1>
-                <div class="flex items-end gap-2">
-                    <x-forms.button type="submit">Save</x-forms.button>
-                    <livewire:project.delete-project :disabled="!$project->isEmpty()" :project_id="$project->id" />
-                </div>
+    </x-slot>
+
+    <div class="flex flex-col pb-10">
+        <div class="flex gap-2">
+            <h1>{{ data_get_str($project, 'name')->limit(15) }}</h1>
+            <div class="flex items-end gap-2">
+                <x-forms.button type="submit" form="edit-form">Save</x-forms.button>
+                <livewire:project.delete-project :disabled="!$project->isEmpty()" :project_id="$project->id" />
             </div>
-            <div class="pt-2 pb-10">Edit project details here.</div>
+        </div>
+        <div class="pt-2 pb-10">Edit project details here.</div>
+
+        {{-- Navigation Tabs --}}
+        <div class="flex gap-2 mb-4 border-b dark:border-gray-700">
+            <a href="{{ route('project.edit', ['project_uuid' => $project->uuid]) }}" {{ wireNavigate() }}
+                class="px-4 py-2 text-sm font-medium border-b-2 border-primary text-primary">
+                General
+            </a>
+            @can('manageMembers', $project)
+                <a href="{{ route('project.members', ['project_uuid' => $project->uuid]) }}" {{ wireNavigate() }}
+                    class="px-4 py-2 text-sm font-medium border-b-2 border-transparent hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300">
+                    Members
+                </a>
+            @endcan
+        </div>
+
+        <form id="edit-form" wire:submit='submit' class="flex flex-col gap-2">
             <div class="flex gap-2">
                 <x-forms.input label="Name" id="name" />
                 <x-forms.input label="Description" id="description" />
             </div>
         </form>
+    </div>
 </div>

--- a/resources/views/livewire/project/members.blade.php
+++ b/resources/views/livewire/project/members.blade.php
@@ -1,0 +1,151 @@
+<div>
+    <x-slot:title>
+        {{ data_get_str($project, 'name')->limit(10) }} > Members | Coolify
+    </x-slot>
+
+    <div class="flex flex-col pb-10">
+        <div class="flex gap-2">
+            <h1>{{ data_get_str($project, 'name')->limit(15) }}</h1>
+        </div>
+        <div class="pt-2 pb-10">Manage project members.</div>
+
+        {{-- Navigation Tabs --}}
+        <div class="flex gap-2 mb-4 border-b dark:border-gray-700">
+            <a href="{{ route('project.edit', ['project_uuid' => $project->uuid]) }}" {{ wireNavigate() }}
+                class="px-4 py-2 text-sm font-medium border-b-2 border-transparent hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300">
+                General
+            </a>
+            <a href="{{ route('project.members', ['project_uuid' => $project->uuid]) }}" {{ wireNavigate() }}
+                class="px-4 py-2 text-sm font-medium border-b-2 border-primary text-primary">
+                Members
+            </a>
+        </div>
+
+        {{-- Members List --}}
+        <div class="flex flex-col gap-4">
+            <h2>Current Members</h2>
+            <div class="overflow-x-auto">
+                <div class="inline-block min-w-full">
+                    <div class="overflow-hidden">
+                        <table class="min-w-full">
+                            <thead>
+                                <tr>
+                                    <th class="px-5 py-3 text-xs font-medium text-left uppercase">Name</th>
+                                    <th class="px-5 py-3 text-xs font-medium text-left uppercase">Email</th>
+                                    <th class="px-5 py-3 text-xs font-medium text-left uppercase">Role</th>
+                                    <th class="px-5 py-3 text-xs font-medium text-left uppercase">Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach ($project->members as $member)
+                                    <tr class="border-b dark:border-gray-700">
+                                        <td class="px-5 py-4 text-sm">
+                                            {{ $member->name }}
+                                            @if ($member->id === auth()->id())
+                                                <span class="text-xs text-gray-500">(You)</span>
+                                            @endif
+                                        </td>
+                                        <td class="px-5 py-4 text-sm">{{ $member->email }}</td>
+                                        <td class="px-5 py-4 text-sm">
+                                            <span class="px-2 py-1 text-xs font-semibold rounded-full
+                                                {{ $member->pivot->role === 'admin' ? 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200' : 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300' }}">
+                                                {{ ucfirst($member->pivot->role) }}
+                                            </span>
+                                        </td>
+                                        <td class="px-5 py-4 text-sm">
+                                            <div class="flex gap-2">
+                                                @if ($member->id !== auth()->id())
+                                                    <x-dropdown>
+                                                        <x-slot:trigger>
+                                                            <x-forms.button type="button" size="sm">Change Role</x-forms.button>
+                                                        </x-slot:trigger>
+                                                        <x-slot:content>
+                                                            @if ($member->pivot->role !== 'admin')
+                                                                <x-dropdown.item
+                                                                    wire:click="changeRole({{ $member->id }}, 'admin')">
+                                                                    Make Admin
+                                                                </x-dropdown.item>
+                                                            @endif
+                                                            @if ($member->pivot->role !== 'member')
+                                                                <x-dropdown.item
+                                                                    wire:click="changeRole({{ $member->id }}, 'member')">
+                                                                    Make Member
+                                                                </x-dropdown.item>
+                                                            @endif
+                                                        </x-slot:content>
+                                                    </x-dropdown>
+                                                    <x-modal-confirm
+                                                        action="removeMember({{ $member->id }})"
+                                                        :button-text="'Remove'"
+                                                        :title="'Remove Member'"
+                                                        :description="'Are you sure you want to remove ' . $member->name . ' from this project?'"
+                                                    />
+                                                @else
+                                                    <span class="text-xs text-gray-500">-</span>
+                                                @endif
+                                            </div>
+                                        </td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+
+            @if ($project->members->isEmpty())
+                <div class="text-center text-gray-500 py-8">
+                    No project members yet. Add members below.
+                </div>
+            @endif
+        </div>
+
+        {{-- Add Member Form --}}
+        <div class="pt-8">
+            @if (is_transactional_emails_enabled())
+                <h2 class="pb-4">Add New Member</h2>
+            @else
+                <h2>Add New Member</h2>
+                @if (isInstanceAdmin())
+                    <div class="pb-4 text-xs dark:text-warning">
+                        You need to configure <a href="/settings/email" {{ wireNavigate() }} class="underline dark:text-warning">Transactional Emails</a>
+                        before you can invite a new member via email.
+                    </div>
+                @endif
+            @endif
+
+            <form wire:submit="addMember" class="flex flex-col gap-4">
+                <div class="flex gap-2">
+                    <div class="flex-1">
+                        <x-forms.input
+                            label="Email"
+                            id="email"
+                            type="email"
+                            wire:model="email"
+                            placeholder="user@example.com"
+                            required
+                        />
+                    </div>
+                    <div class="w-48">
+                        <x-forms.select
+                            label="Role"
+                            id="role"
+                            wire:model="role"
+                            required
+                        >
+                            <option value="member">Member</option>
+                            <option value="admin">Admin</option>
+                        </x-forms.select>
+                    </div>
+                </div>
+                <div class="text-sm text-gray-500">
+                    <p><strong>Member:</strong> Can view and interact with project resources.</p>
+                    <p><strong>Admin:</strong> Can manage project members and settings.</p>
+                </div>
+                <div>
+                    <x-forms.button type="submit">Add Member</x-forms.button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -54,6 +54,10 @@ Route::group([
     Route::post('/projects/{uuid}/environments', [ProjectController::class, 'create_environment'])->middleware(['api.ability:write']);
     Route::delete('/projects/{uuid}/environments/{environment_name_or_uuid}', [ProjectController::class, 'delete_environment'])->middleware(['api.ability:write']);
 
+    Route::get('/projects/{uuid}/members', [ProjectController::class, 'list_members'])->middleware(['api.ability:read']);
+    Route::post('/projects/{uuid}/members', [ProjectController::class, 'add_member'])->middleware(['api.ability:write']);
+    Route::delete('/projects/{uuid}/members/{user_id}', [ProjectController::class, 'remove_member'])->middleware(['api.ability:write']);
+
     Route::post('/projects', [ProjectController::class, 'create_project'])->middleware(['api.ability:read']);
     Route::patch('/projects/{uuid}', [ProjectController::class, 'update_project'])->middleware(['api.ability:write']);
     Route::delete('/projects/{uuid}', [ProjectController::class, 'delete_project'])->middleware(['api.ability:write']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,7 @@ use App\Livewire\Notifications\Telegram as NotificationTelegram;
 use App\Livewire\Notifications\Webhook as NotificationWebhook;
 use App\Livewire\Profile\Index as ProfileIndex;
 use App\Livewire\Project\Application\Configuration as ApplicationConfiguration;
+use App\Livewire\Project\Members as ProjectMembers;
 use App\Livewire\Project\Application\Deployment\Index as DeploymentIndex;
 use App\Livewire\Project\Application\Deployment\Show as DeploymentShow;
 use App\Livewire\Project\CloneMe as ProjectCloneMe;
@@ -183,6 +184,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::prefix('project/{project_uuid}')->group(function () {
         Route::get('/', ProjectShow::class)->name('project.show');
         Route::get('/edit', ProjectEdit::class)->name('project.edit')->middleware('can.update.resource');
+        Route::get('/members', ProjectMembers::class)->name('project.members')->middleware('can.update.resource');
     });
     Route::prefix('project/{project_uuid}/environment/{environment_uuid}')->group(function () {
         Route::get('/', ResourceIndex::class)->name('project.resource.index');


### PR DESCRIPTION
## Summary

Fixes #6894

Adds support for project-scoped team members. A team owner/admin can now invite users to a specific project without granting them access to the full team, other projects, servers, or private keys.

## Features

- **Invite by email**: Invite existing or new users to a specific project
- **Role management**: Project members can be `member` (view) or `admin` (manage resources)
- **Secure isolation**: Project members cannot access servers, private keys, S3, team settings, or other projects
- **Full team compatibility**: Team owners/admins always retain full access — no regression
- **API support**: New REST endpoints for managing project members
- **Email notifications**: Sends invitation emails to new and existing users

## New Files
- `database/migrations/2026_02_19_000001_create_project_members_table.php`
- `app/Livewire/Project/Members.php`
- `resources/views/livewire/project/members.blade.php`
- `resources/views/emails/project-invitation-new-user.blade.php`
- `resources/views/emails/project-invitation-existing-user.blade.php`

## Modified Files
- `app/Models/Project.php` — Added members() relationship
- `app/Models/User.php` — Added projectMemberships(), isProjectMember(), projectRole()
- `app/Policies/ProjectPolicy.php` — Activated real authorization logic
- `app/Http/Controllers/Api/ProjectController.php` — Added GET/POST/DELETE /projects/{uuid}/members
- `routes/web.php` and `routes/api.php` — New routes
- `resources/views/livewire/project/edit.blade.php` — Added Members tab

## Security
Project members are NOT inserted into team_user — zero team-level access. ProjectPolicy now enforces real checks (previously all methods returned true). Servers and private keys require full team membership.

## API
- GET /api/v1/projects/{uuid}/members
- POST /api/v1/projects/{uuid}/members  
- DELETE /api/v1/projects/{uuid}/members/{id}
