### PR TITLE
fix(server): improve Debian-compatible OS detection robustness

### DIFF
--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -1048,21 +1048,38 @@ $schema://$host {
         $collectedData = collect([]);
         foreach ($releaseLines as $line) {
             $item = str($line)->trim();
+            if ($item->isEmpty() || ! $item->contains('=')) {
+                continue;
+            }
             $collectedData->put($item->before('=')->value(), $item->after('=')->lower()->replace('"', '')->value());
         }
-        $ID = data_get($collectedData, 'ID');
-        // $ID_LIKE = data_get($collectedData, 'ID_LIKE');
-        // $VERSION_ID = data_get($collectedData, 'VERSION_ID');
-        $supported = collect(SUPPORTED_OS)->filter(function ($supportedOs) use ($ID) {
-            if (str($supportedOs)->contains($ID)) {
-                return str($ID);
+
+        $ID = str((string) data_get($collectedData, 'ID'))->trim();
+        $ID_LIKE = str((string) data_get($collectedData, 'ID_LIKE'))->trim();
+
+        // Some distros/environments may return unexpected ID values while still being Debian-compatible.
+        // Use both ID and ID_LIKE tokens to improve matching stability (e.g. Debian 13 derivatives).
+        $osTokens = collect([])
+            ->merge($ID->isNotEmpty() ? [$ID->value()] : [])
+            ->merge($ID_LIKE->isNotEmpty() ? preg_split('/\s+/', $ID_LIKE->value()) : [])
+            ->filter(fn ($token) => ! empty($token))
+            ->unique();
+
+        $supported = collect(SUPPORTED_OS)->filter(function ($supportedOs) use ($osTokens) {
+            foreach ($osTokens as $token) {
+                if (str($supportedOs)->contains($token)) {
+                    return true;
+                }
             }
+
+            return false;
         });
+
         if ($supported->count() === 1) {
             return str($supported->first());
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     public function isTerminalEnabled()

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -1043,8 +1043,14 @@ $schema://$host {
 
     public function validateOS(): bool|Stringable
     {
-        $os_release = instant_remote_process(['cat /etc/os-release'], $this);
-        $releaseLines = collect(explode("\n", $os_release));
+        $osRelease = instant_remote_process(['cat /etc/os-release'], $this);
+
+        return self::detectSupportedOsFromRelease($osRelease);
+    }
+
+    public static function detectSupportedOsFromRelease(string $osRelease): bool|Stringable
+    {
+        $releaseLines = collect(explode("\n", $osRelease));
         $collectedData = collect([]);
         foreach ($releaseLines as $line) {
             $item = str($line)->trim();

--- a/tests/Unit/ServerValidateOsParsingTest.php
+++ b/tests/Unit/ServerValidateOsParsingTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use App\Models\Server;
+
+it('detects debian via id token', function () {
+    $osRelease = <<<'TXT'
+NAME="Debian GNU/Linux"
+VERSION_ID="13"
+ID=debian
+TXT;
+
+    $detected = Server::detectSupportedOsFromRelease($osRelease);
+
+    expect($detected)->toBe('ubuntu debian raspbian pop');
+});
+
+it('detects debian family via id_like token when id is custom', function () {
+    $osRelease = <<<'TXT'
+NAME="Custom Debian Derivative"
+ID=mycustomos
+ID_LIKE="debian ubuntu"
+VERSION_ID="13"
+TXT;
+
+    $detected = Server::detectSupportedOsFromRelease($osRelease);
+
+    expect($detected)->toBe('ubuntu debian raspbian pop');
+});
+
+it('detects rhel family via id_like token with multiple markers', function () {
+    $osRelease = <<<'TXT'
+NAME="Rocky Linux"
+ID=rocky-clone
+ID_LIKE="rhel centos fedora"
+VERSION_ID="9"
+TXT;
+
+    $detected = Server::detectSupportedOsFromRelease($osRelease);
+
+    expect($detected)->toBe('centos fedora rhel ol rocky amzn almalinux');
+});
+
+it('returns false when id and id_like are both empty or unsupported', function () {
+    $emptyTokens = <<<'TXT'
+NAME="Unknown Linux"
+ID=""
+ID_LIKE=""
+TXT;
+
+    $unsupported = <<<'TXT'
+NAME="Unknown Linux"
+ID=unknownos
+ID_LIKE="strangeos"
+TXT;
+
+    expect(Server::detectSupportedOsFromRelease($emptyTokens))->toBeFalse();
+    expect(Server::detectSupportedOsFromRelease($unsupported))->toBeFalse();
+});
+
+it('ignores malformed or non key-value lines in os-release payload', function () {
+    $osRelease = <<<'TXT'
+this is not key value
+
+ID=debian
+MALFORMED
+ID_LIKE="debian"
+TXT;
+
+    $detected = Server::detectSupportedOsFromRelease($osRelease);
+
+    expect($detected)->toBe('ubuntu debian raspbian pop');
+});


### PR DESCRIPTION
## Summary
Improve server OS detection robustness in `Server::validateOS()` by:
- Skipping empty/invalid lines from `/etc/os-release`
- Matching with both `ID` and `ID_LIKE` tokens
- Keeping existing `SUPPORTED_OS` mapping behavior

## Why
Some Debian-compatible environments can expose unexpected `ID` values while still being Debian-family. Relying on `ID` only may cause false negatives and lead to prerequisite-installation failures.

## Scope
- File changed: `app/Models/Server.php`
- Function: `validateOS()`
- Small, targeted change (no behavior changes outside OS detection)

## Risk
Low. The patch only broadens detection input (`ID_LIKE`) while still constrained by existing `SUPPORTED_OS` groups.
