### PR TITLE
feat(service): add wordpress openlitespeed mariadb template

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed-mariadb.yaml
+++ b/templates/compose/wordpress-with-openlitespeed-mariadb.yaml
@@ -1,0 +1,51 @@
+# documentation: https://wordpress.org
+# slogan: WordPress is open source software you can use to create a beautiful website, blog, or app.
+# category: cms
+# tags: cms, blog, content, management, mariadb, openlitespeed
+# logo: svgs/wordpress.svg
+
+services:
+  wordpress:
+    image: litespeedtech/openlitespeed:latest
+    volumes:
+      - wordpress-files:/var/www/vhosts/localhost/html
+    environment:
+      - SERVICE_URL_WORDPRESS
+      - WORDPRESS_DB_HOST=mariadb
+      - WORDPRESS_DB_USER=$SERVICE_USER_WORDPRESS
+      - WORDPRESS_DB_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+      - WORDPRESS_DB_NAME=wordpress
+    depends_on:
+      - mariadb
+    entrypoint: ["/bin/sh", "-c"]
+    command: |
+      set -e
+      DOCROOT="/var/www/vhosts/localhost/html"
+      if [ ! -f "$${DOCROOT}/wp-config.php" ]; then
+        mkdir -p "$${DOCROOT}"
+        curl -sL https://wordpress.org/latest.tar.gz | tar -xz -C /tmp
+        cp -R /tmp/wordpress/. "$${DOCROOT}"
+        rm -rf /tmp/wordpress
+        wp config create --path="$${DOCROOT}" --dbname="$${WORDPRESS_DB_NAME}" --dbuser="$${WORDPRESS_DB_USER}" --dbpass="$${WORDPRESS_DB_PASSWORD}" --dbhost="$${WORDPRESS_DB_HOST}" --skip-check --allow-root
+        chown -R 1000:1000 "$${DOCROOT}"
+      fi
+      exec /entrypoint.sh
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1"]
+      interval: 2s
+      timeout: 10s
+      retries: 10
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10

--- a/tests/Unit/WordpressOpenLiteSpeedMariaDbTemplateTest.php
+++ b/tests/Unit/WordpressOpenLiteSpeedMariaDbTemplateTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use Symfony\Component\Yaml\Yaml;
+
+it('keeps the wordpress openlitespeed mariadb template parseable and internally wired', function () {
+    $templatePath = base_path('templates/compose/wordpress-with-openlitespeed-mariadb.yaml');
+
+    expect(is_file($templatePath))->toBeTrue();
+
+    $content = file_get_contents($templatePath);
+    expect($content)->toContain('# category: cms')
+        ->toContain('# logo: svgs/wordpress.svg')
+        ->toContain('openlitespeed');
+
+    $compose = Yaml::parse($content);
+
+    expect($compose)->toBeArray()
+        ->and($compose)->toHaveKey('services');
+
+    $services = $compose['services'];
+    expect(array_keys($services))->toContain('wordpress', 'mariadb');
+
+    $wordpress = $services['wordpress'];
+    expect($wordpress['depends_on'] ?? [])->toContain('mariadb');
+
+    $wordpressEnvironment = $wordpress['environment'] ?? [];
+    expect($wordpressEnvironment)->toContain(
+        'WORDPRESS_DB_HOST=mariadb',
+        'WORDPRESS_DB_NAME=wordpress',
+        'WORDPRESS_DB_USER=$SERVICE_USER_WORDPRESS',
+        'WORDPRESS_DB_PASSWORD=$SERVICE_PASSWORD_WORDPRESS'
+    );
+
+    $wordpressCommand = $wordpress['command'] ?? '';
+    expect($wordpressCommand)->toContain('wp config create')
+        ->toContain('exec /entrypoint.sh');
+
+    $mariadbEnvironment = $services['mariadb']['environment'] ?? [];
+    expect($mariadbEnvironment)->toContain(
+        'MYSQL_DATABASE=wordpress',
+        'MYSQL_USER=$SERVICE_USER_WORDPRESS',
+        'MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS'
+    );
+});


### PR DESCRIPTION
### Changes

- Add a new one-click WordPress stack template using OpenLiteSpeed + MariaDB at `templates/compose/wordpress-with-openlitespeed-mariadb.yaml`.
- Configure first-run bootstrap for WordPress files and `wp-config.php` generation.
- Add healthchecks and service dependencies for stable startup ordering.

### Issues

- fixes: https://github.com/coollabsio/coolify/issues/8264

### Category

- [x] Adding new one click service

### Screenshots or Video (if applicable)

- N/A (template file only)

### AI Usage

- [x] AI is used in the process of creating this PR

### Steps to Test

- Step 1 – Run `python3 - <<'PY'` / `import yaml; yaml.safe_load(open('templates/compose/wordpress-with-openlitespeed-mariadb.yaml'))` and verify YAML parses successfully.
- Step 2 – Confirm services `wordpress` and `mariadb` are defined with expected environment variables and `depends_on`.
- Step 3 – Deploy from this template in a test Coolify instance and verify installer page is reachable after both healthchecks pass.

### Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them

### Docs

- https://github.com/coollabsio/coolify-docs/pull/530
