### PR TITLE
feat(service): add docker mailserver one-click template

### DIFF
--- a/public/svgs/docker-mailserver.svg
+++ b/public/svgs/docker-mailserver.svg
@@ -1,0 +1,19 @@
+<svg width="500" height="500" viewBox="0 0 500 500" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <defs/>
+  <!-- Mail envelope background -->
+  <rect x="50" y="150" width="400" height="250" rx="20" ry="20" fill="#2563eb" stroke="#1e40af" stroke-width="2"/>
+  <!-- Envelope flap -->
+  <path d="M50 150 L250 280 L450 150" fill="#3b82f6" stroke="#1e40af" stroke-width="2"/>
+  <!-- Mail lines inside envelope -->
+  <rect x="100" y="220" width="300" height="8" rx="4" fill="#ffffff" opacity="0.3"/>
+  <rect x="100" y="250" width="250" height="8" rx="4" fill="#ffffff" opacity="0.3"/>
+  <rect x="100" y="280" width="200" height="8" rx="4" fill="#ffffff" opacity="0.3"/>
+  <!-- Docker container elements -->
+  <rect x="180" y="80" width="140" height="20" rx="10" fill="#0ea5e9" stroke="#0284c7" stroke-width="2"/>
+  <rect x="180" y="110" width="140" height="20" rx="10" fill="#06b6d4" stroke="#0891b2" stroke-width="2"/>
+  <!-- Server icon -->
+  <circle cx="100" cy="450" r="15" fill="#10b981"/>
+  <circle cx="150" cy="450" r="15" fill="#10b981"/>
+  <circle cx="200" cy="450" r="15" fill="#10b981"/>
+  <rect x="70" y="420" width="160" height="10" rx="5" fill="#059669"/>
+</svg>

--- a/templates/compose/docker-mailserver.yaml
+++ b/templates/compose/docker-mailserver.yaml
@@ -1,0 +1,85 @@
+# documentation: https://docker-mailserver.github.io/docker-mailserver/latest/
+# slogan: Production-ready fullstack mail server (SMTP, IMAP, LDAP, Antispam, Antivirus, etc.)
+# category: email
+# tags: docker-mailserver,email,smtp,imap,postfix,dovecot,mail
+# logo: svgs/docker-mailserver.svg
+# port: 80
+
+services:
+  mailserver:
+    image: ghcr.io/docker-mailserver/docker-mailserver:latest
+    hostname: ${MAILSERVER_HOSTNAME:-mail.example.com}
+    environment:
+      - SERVICE_URL_MAILSERVER_80
+      - OVERRIDE_HOSTNAME=${MAILSERVER_HOSTNAME:-mail.example.com}
+      - LOG_LEVEL=${LOG_LEVEL:-info}
+      - ACCOUNT_PROVISIONER=${ACCOUNT_PROVISIONER:-FILE}
+      - POSTMASTER_ADDRESS=${POSTMASTER_ADDRESS}
+      - PERMIT_DOCKER=${PERMIT_DOCKER:-none}
+      - TZ=${TZ:-UTC}
+      - TLS_LEVEL=${TLS_LEVEL:-modern}
+      - ENABLE_OPENDKIM=${ENABLE_OPENDKIM:-1}
+      - ENABLE_OPENDMARC=${ENABLE_OPENDMARC:-1}
+      - ENABLE_POLICYD_SPF=${ENABLE_POLICYD_SPF:-1}
+      - ENABLE_IMAP=${ENABLE_IMAP:-1}
+      - ENABLE_POP3=${ENABLE_POP3:-0}
+      - ENABLE_CLAMAV=${ENABLE_CLAMAV:-0}
+      - ENABLE_RSPAMD=${ENABLE_RSPAMD:-0}
+      - ENABLE_SPAMASSASSIN=${ENABLE_SPAMASSASSIN:-0}
+      - ENABLE_AMAVIS=${ENABLE_AMAVIS:-1}
+      - ENABLE_FAIL2BAN=${ENABLE_FAIL2BAN:-0}
+      - ENABLE_MANAGESIEVE=${ENABLE_MANAGESIEVE:-1}
+      - ENABLE_QUOTAS=${ENABLE_QUOTAS:-1}
+      - SSL_TYPE=${SSL_TYPE:-letsencrypt}
+      - POSTFIX_MESSAGE_SIZE_LIMIT=${POSTFIX_MESSAGE_SIZE_LIMIT:-10240000}
+      - POSTFIX_MAILBOX_SIZE_LIMIT=${POSTFIX_MAILBOX_SIZE_LIMIT:-0}
+      - PFLOGSUMM_TRIGGER=${PFLOGSUMM_TRIGGER:-daily_cron}
+      - PFLOGSUMM_RECIPIENT=${PFLOGSUMM_RECIPIENT}
+      - LOGROTATE_INTERVAL=${LOGROTATE_INTERVAL:-weekly}
+      - ENABLE_UPDATE_CHECK=${ENABLE_UPDATE_CHECK:-1}
+    ports:
+      - "25:25"
+      - "143:143"
+      - "465:465"
+      - "587:587"
+      - "993:993"
+      - "4190:4190"
+    volumes:
+      - mailserver-mail-data:/var/mail/
+      - mailserver-mail-state:/var/mail-state/
+      - mailserver-mail-logs:/var/log/mail/
+      - mailserver-config:/tmp/docker-mailserver/
+      - /etc/localtime:/etc/localtime:ro
+      - type: bind
+        source: ./postfix-main.cf
+        target: /tmp/docker-mailserver/postfix-main.cf
+        isDirectory: false
+        content: ""
+      - type: bind
+        source: ./postfix-master.cf
+        target: /tmp/docker-mailserver/postfix-master.cf
+        isDirectory: false
+        content: ""
+      - type: bind
+        source: ./postfix-accounts.cf
+        target: /tmp/docker-mailserver/postfix-accounts.cf
+        isDirectory: false
+        content: ""
+      - type: bind
+        source: ./postfix-virtual.cf
+        target: /tmp/docker-mailserver/postfix-virtual.cf
+        isDirectory: false
+        content: ""
+      - type: bind
+        source: ./dovecot.cf
+        target: /tmp/docker-mailserver/dovecot.cf
+        isDirectory: false
+        content: ""
+    restart: always
+    stop_grace_period: 1m
+    healthcheck:
+      test: "ss --listening --ipv4 --tcp | grep --silent ':smtp' || exit 1"
+      timeout: 3s
+      retries: 10
+      interval: 30s
+      start_period: 120s

--- a/tests/Unit/DockerMailserverTemplateTest.php
+++ b/tests/Unit/DockerMailserverTemplateTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use Symfony\Component\Yaml\Yaml;
+
+it('keeps the docker mailserver compose template parseable with required defaults', function () {
+    $templatePath = base_path('templates/compose/docker-mailserver.yaml');
+
+    expect(is_file($templatePath))->toBeTrue();
+
+    $content = file_get_contents($templatePath);
+    expect($content)->toContain('# category: email')
+        ->toContain('# logo: svgs/docker-mailserver.svg')
+        ->toContain('docker-mailserver');
+
+    $compose = Yaml::parse($content);
+
+    expect($compose)->toBeArray()
+        ->and($compose)->toHaveKey('services.mailserver');
+
+    $mailserver = $compose['services']['mailserver'];
+
+    expect($mailserver['ports'] ?? [])->toContain('25:25', '143:143', '465:465', '587:587', '993:993');
+
+    $environment = $mailserver['environment'] ?? [];
+    expect($environment)->toContain(
+        'SERVICE_URL_MAILSERVER_80',
+        'ENABLE_IMAP=${ENABLE_IMAP:-1}',
+        'SSL_TYPE=${SSL_TYPE:-letsencrypt}',
+        'POSTMASTER_ADDRESS=${POSTMASTER_ADDRESS}'
+    );
+
+    $volumeSources = [];
+    foreach ($mailserver['volumes'] ?? [] as $volume) {
+        if (is_array($volume) && ($volume['type'] ?? null) === 'bind') {
+            $volumeSources[] = $volume['source'] ?? null;
+            expect($volume['content'] ?? null)->toBe('');
+        }
+    }
+
+    expect($volumeSources)->toContain(
+        './postfix-main.cf',
+        './postfix-master.cf',
+        './postfix-accounts.cf',
+        './postfix-virtual.cf',
+        './dovecot.cf'
+    );
+});
+
+it('keeps the docker mailserver svg valid xml', function () {
+    $svgPath = base_path('public/svgs/docker-mailserver.svg');
+
+    expect(is_file($svgPath))->toBeTrue();
+
+    libxml_use_internal_errors(true);
+    $svg = simplexml_load_string(file_get_contents($svgPath));
+
+    expect($svg)->not->toBeFalse()
+        ->and($svg->getName())->toBe('svg');
+
+    libxml_clear_errors();
+});


### PR DESCRIPTION
### Changes

- Add a new Docker Mailserver one-click template at `templates/compose/docker-mailserver.yaml`.
- Include required service configuration, default env settings, mail protocol ports, persistent volumes, and healthcheck.
- Add matching icon asset at `public/svgs/docker-mailserver.svg`.

### Issues

- fixes: https://github.com/coollabsio/coolify/issues/8266

### Category

- [x] Adding new one click service

### Screenshots or Video (if applicable)

- N/A (template and icon only)

### AI Usage

- [x] AI is used in the process of creating this PR

### Steps to Test

- Step 1 – Run `python3 - <<'PY'` / `import yaml; yaml.safe_load(open('templates/compose/docker-mailserver.yaml'))` and verify YAML parses successfully.
- Step 2 – Confirm mail protocol ports (25, 143, 465, 587, 993, 4190) and required mail volumes are defined.
- Step 3 – Verify `public/svgs/docker-mailserver.svg` exists and is referenced by `# logo: svgs/docker-mailserver.svg`.

### Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them

### Docs

- https://github.com/coollabsio/coolify-docs/pull/531
