### PR TITLE
chore: Remove timeout for public database proxies

### DIFF
--- a/app/Actions/Database/StartDatabaseProxy.php
+++ b/app/Actions/Database/StartDatabaseProxy.php
@@ -67,6 +67,8 @@ class StartDatabaseProxy
        server {
             listen $database->public_port;
             proxy_pass $containerName:$internalPort;
+            proxy_timeout 0;
+            proxy_connect_timeout 60s;
        }
     }
     EOF;


### PR DESCRIPTION
## Summary
This PR fixes issue #7743 by removing the 10-minute timeout limitation for public database proxies, allowing long-running queries (30m+) to complete successfully.

## Changes
- Added `proxy_timeout 0;` to Nginx stream configuration (infinite timeout)
- Added `proxy_connect_timeout 60s;` to maintain reasonable connection establishment timeout
- Applies to all database types (PostgreSQL, MySQL, MariaDB, MongoDB, Redis, etc.)

## Technical Details
Modified `app/Actions/Database/StartDatabaseProxy.php`:
- The Nginx stream proxy now uses `proxy_timeout 0` which disables the read/write timeout
- `proxy_connect_timeout 60s` prevents hanging connections during initial connection
- This allows SELECT statements with large result sets to download without interruption

## Testing
- Long-running queries (30+ minutes) should no longer timeout
- Normal database connections remain unaffected
- Connection establishment still times out after 60 seconds (prevents dead connections)

## Use Case
As mentioned in #7743, this enables queries like `SELECT *` that take 30+ minutes to download results, which previously failed due to the 10-minute proxy timeout.

Closes #7743