### PR TITLE
fix: resolve intermittent SSH Permission denied (publickey) race condition

### DIFF
--- a/app/Helpers/SshMultiplexingHelper.php
+++ b/app/Helpers/SshMultiplexingHelper.php
@@ -13,11 +13,14 @@ class SshMultiplexingHelper
 {
     public static function serverSshConfiguration(Server $server)
     {
+        // Always do a fresh DB lookup so we never use a stale in-memory key
+        // reference when the private_key_id has been changed or the key rotated.
         $privateKey = PrivateKey::findOrFail($server->private_key_id);
         $sshKeyLocation = $privateKey->getKeyLocation();
         $muxFilename = '/var/www/html/storage/app/ssh/mux/mux_'.$server->uuid;
 
         return [
+            'privateKey' => $privateKey,      // expose resolved key so callers use the same instance
             'sshKeyLocation' => $sshKeyLocation,
             'muxFilename' => $muxFilename,
         ];
@@ -158,7 +161,12 @@ class SshMultiplexingHelper
         $sshConfig = self::serverSshConfiguration($server);
         $sshKeyLocation = $sshConfig['sshKeyLocation'];
 
-        self::validateSshKey($server->privateKey);
+        // Use the same PrivateKey instance resolved by serverSshConfiguration to
+        // guarantee that validateSshKey operates on the exact key whose path is
+        // embedded in $sshKeyLocation.  Previously $server->privateKey was used
+        // here, which is a cached Eloquent relation and could point to a
+        // different (stale) key object after a key rotation or update.
+        self::validateSshKey($sshConfig['privateKey']);
 
         $muxSocket = $sshConfig['muxFilename'];
 
@@ -204,10 +212,31 @@ class SshMultiplexingHelper
     private static function validateSshKey(PrivateKey $privateKey): void
     {
         $keyLocation = $privateKey->getKeyLocation();
-        $checkKeyCommand = "ls $keyLocation 2>/dev/null";
-        $keyCheckProcess = Process::run($checkKeyCommand);
 
-        if ($keyCheckProcess->exitCode() !== 0) {
+        // Check existence AND content integrity.
+        //
+        // Previously only `ls` was used, which passes even when the file is
+        // empty or partially-written (a race window that causes SSH to send the
+        // wrong / corrupt key and get "Permission denied (publickey)").
+        $needsStore = false;
+
+        if (! file_exists($keyLocation)) {
+            $needsStore = true;
+        } else {
+            $onDisk = file_get_contents($keyLocation);
+            // Regenerate what the file should contain and compare.
+            // A mismatch means another process wrote a different key here
+            // (key rotation race) or the file is corrupt / truncated.
+            if ($onDisk === false || trim($onDisk) !== trim($privateKey->private_key)) {
+                $needsStore = true;
+            } elseif ((fileperms($keyLocation) & 0777) !== 0600) {
+                // Fix permissions without a full rewrite — SSH refuses keys
+                // that are readable by group/others.
+                chmod($keyLocation, 0600);
+            }
+        }
+
+        if ($needsStore) {
             $privateKey->storeInFileSystem();
         }
     }

--- a/app/Models/PrivateKey.php
+++ b/app/Models/PrivateKey.php
@@ -184,30 +184,41 @@ class PrivateKey extends BaseModel
     public function storeInFileSystem()
     {
         $filename = "ssh_key@{$this->uuid}";
-        $disk = Storage::disk('ssh-keys');
+        $finalPath = $this->getKeyLocation();
+        $tmpPath = $finalPath.'.tmp.'.getmypid();
 
         // Ensure the storage directory exists and is writable
         $this->ensureStorageDirectoryExists();
 
-        // Attempt to store the private key
-        $success = $disk->put($filename, $this->private_key);
+        // Atomic write: write to a temp file, then rename to final destination.
+        // This prevents other processes from reading a partially-written key file,
+        // which is a primary cause of intermittent "Permission denied (publickey)"
+        // errors in concurrent/cloud environments.
+        $written = file_put_contents($tmpPath, $this->private_key, LOCK_EX);
 
-        if (! $success) {
-            throw new \Exception("Failed to write SSH key to filesystem. Check disk space and permissions for: {$this->getKeyLocation()}");
+        if ($written === false) {
+            @unlink($tmpPath);
+            throw new \Exception("Failed to write SSH key to filesystem. Check disk space and permissions for: {$finalPath}");
         }
 
-        // Verify the file was actually created and has content
-        if (! $disk->exists($filename)) {
-            throw new \Exception("SSH key file was not created: {$this->getKeyLocation()}");
+        // Enforce strict permissions (SSH client refuses keys readable by others)
+        chmod($tmpPath, 0600);
+
+        // Verify content integrity before making it live
+        $storedContent = file_get_contents($tmpPath);
+        if ($storedContent === false || $storedContent !== $this->private_key) {
+            @unlink($tmpPath);
+            throw new \Exception("SSH key file content verification failed: {$finalPath}");
         }
 
-        $storedContent = $disk->get($filename);
-        if (empty($storedContent) || $storedContent !== $this->private_key) {
-            $disk->delete($filename); // Clean up the bad file
-            throw new \Exception("SSH key file content verification failed: {$this->getKeyLocation()}");
+        // Atomic rename — on POSIX systems this is guaranteed to be atomic,
+        // so readers always see either the old complete file or the new complete file.
+        if (! rename($tmpPath, $finalPath)) {
+            @unlink($tmpPath);
+            throw new \Exception("Failed to atomically install SSH key file: {$finalPath}");
         }
 
-        return $this->getKeyLocation();
+        return $finalPath;
     }
 
     public static function deleteFromStorage(self $privateKey)


### PR DESCRIPTION
### Changes

Fixed three interrelated race condition bugs in SSH key handling that caused Coolify Cloud users to intermittently receive `Permission denied (publickey,password)` errors. Regenerating the SSH key temporarily resolved it but the error recurred — a clear sign of a race condition.

**Bug 1 — TOCTOU race in `validateSshKey`**
The check used `ls $keyLocation` which only tests file *existence*. Under concurrent queue workers, Worker A could pass the check while Worker B simultaneously overwrites the key file via `storeInFileSystem()`, causing Worker A to authenticate with the replaced key content.

Fix: compare on-disk content against the decrypted database value. A mismatch triggers a fresh `storeInFileSystem()`; a permission mismatch is corrected with `chmod` only.

**Bug 2 — Stale Eloquent relation**
`generateSshCommand()` obtained the key path via `serverSshConfiguration()` (fresh `findOrFail()`) but then called `validateSshKey($server->privateKey)` (cached Eloquent relation, may point to a pre-rotation key object). The validated key could differ from the one embedded in the SSH command.

Fix: `serverSshConfiguration()` now returns the resolved `PrivateKey` instance; `generateSshCommand()` passes that same instance to `validateSshKey()`.

**Bug 3 — Non-atomic file write**
`Storage::disk()->put()` uses `file_put_contents()` internally, leaving a window where another process can read a partially-written or empty key file.

Fix: write to a per-process `.tmp` file, verify content, `chmod 0600`, then `rename()` (POSIX atomic operation).

### Issues

- fixes: #7724

### Category

- [x] Bug fix

### Screenshots or Video (if applicable)

No UI changes.

### AI Usage

- [x] AI is used in the process of creating this PR

### Steps to Test

1. Set up a Coolify instance with at least 2 queue workers running concurrently
2. Configure a server with an SSH private key
3. Trigger multiple simultaneous deployments (10+) to the same server while rotating/updating the SSH key mid-flight
4. Verify no `Permission denied (publickey)` errors appear in logs
5. Confirm `storeInFileSystem()` always produces a complete, readable key file even under concurrent writes

### Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them