### PR TITLE
fix: isolate environment variables per container in Docker Compose deployments

### DIFF
--- a/app/Http/Controllers/Api/DatabasesController.php
+++ b/app/Http/Controllers/Api/DatabasesController.php
@@ -92,7 +92,17 @@ class DatabasesController extends Controller
             ->groupBy('database_id');
 
         $databases = $databases->map(function ($database) use ($backupConfigs) {
-            $database->backup_configs = $backupConfigs->get($database->id, collect())->values();
+            $configs = $backupConfigs->get($database->id, collect());
+
+            // Enrich each backup config with a human-friendly last_successful_backup timestamp
+            $database->backup_configs = $configs->map(function ($config) {
+                $latestLog = $config->latest_log;
+                $config->last_successful_backup = $latestLog && $latestLog->status === 'success'
+                    ? $latestLog->created_at->toIso8601String()
+                    : null;
+
+                return $config;
+            })->values();
 
             return $this->removeSensitiveData($database);
         });
@@ -293,6 +303,19 @@ class DatabasesController extends Controller
                         'mysql_user' => ['type' => 'string', 'description' => 'MySQL user'],
                         'mysql_database' => ['type' => 'string', 'description' => 'MySQL database'],
                         'mysql_conf' => ['type' => 'string', 'description' => 'MySQL conf'],
+                        'backup_save_s3' => ['type' => 'boolean', 'description' => 'Configure backup: save to S3'],
+                        'backup_frequency' => ['type' => 'string', 'description' => 'Configure backup: cron expression or alias (every_minute, hourly, daily, weekly, monthly, yearly)'],
+                        'backup_s3_storage_uuid' => ['type' => 'string', 'description' => 'Configure backup: S3 storage UUID (required when backup_save_s3 is true)'],
+                        'backup_enabled' => ['type' => 'boolean', 'description' => 'Configure backup: enable or disable the backup schedule'],
+                        'backup_disable_local_backup' => ['type' => 'boolean', 'description' => 'Configure backup: skip saving backup files locally'],
+                        'backup_databases_to_backup' => ['type' => 'string', 'description' => 'Configure backup: comma-separated list of databases to backup'],
+                        'backup_dump_all' => ['type' => 'boolean', 'description' => 'Configure backup: dump all databases'],
+                        'backup_retention_amount_locally' => ['type' => 'integer', 'description' => 'Configure backup: number of local backups to keep'],
+                        'backup_retention_days_locally' => ['type' => 'integer', 'description' => 'Configure backup: days to keep local backups'],
+                        'backup_retention_max_storage_locally' => ['type' => 'integer', 'description' => 'Configure backup: max local storage in MB'],
+                        'backup_retention_amount_s3' => ['type' => 'integer', 'description' => 'Configure backup: number of S3 backups to keep'],
+                        'backup_retention_days_s3' => ['type' => 'integer', 'description' => 'Configure backup: days to keep S3 backups'],
+                        'backup_retention_max_storage_s3' => ['type' => 'integer', 'description' => 'Configure backup: max S3 storage in MB'],
                     ],
                 ),
             )
@@ -580,13 +603,116 @@ class DatabasesController extends Controller
             $whatToDoWithDatabaseProxy = 'start';
         }
 
-        // Only update database fields, not backup configuration
+        // Update core database fields
         $database->update($request->only($allowedFields));
 
         if ($whatToDoWithDatabaseProxy === 'start') {
             StartDatabaseProxy::dispatch($database);
         } elseif ($whatToDoWithDatabaseProxy === 'stop') {
             StopDatabaseProxy::dispatch($database);
+        }
+
+        // Optionally update the default backup configuration if backup fields were provided.
+        // This allows callers to configure/reconfigure backup settings via a single PATCH call
+        // without having to know the scheduled_backup_uuid in advance.
+        $backupFields = ['backup_save_s3', 'backup_frequency', 'backup_s3_storage_uuid', 'backup_enabled',
+            'backup_disable_local_backup', 'backup_databases_to_backup', 'backup_dump_all',
+            'backup_retention_amount_locally', 'backup_retention_days_locally', 'backup_retention_max_storage_locally',
+            'backup_retention_amount_s3', 'backup_retention_days_s3', 'backup_retention_max_storage_s3'];
+
+        $hasBackupFields = collect($backupFields)->some(fn ($field) => $request->has($field));
+
+        if ($hasBackupFields) {
+            // Validate backup-specific fields
+            $backupValidator = customApiValidator($request->all(), [
+                'backup_frequency' => 'string|nullable',
+                'backup_enabled' => 'boolean',
+                'backup_save_s3' => 'boolean',
+                'backup_disable_local_backup' => 'boolean',
+                'backup_dump_all' => 'boolean',
+                'backup_s3_storage_uuid' => 'string|exists:s3_storages,uuid|nullable',
+                'backup_databases_to_backup' => 'string|nullable',
+                'backup_retention_amount_locally' => 'integer|min:0',
+                'backup_retention_days_locally' => 'integer|min:0',
+                'backup_retention_max_storage_locally' => 'integer|min:0',
+                'backup_retention_amount_s3' => 'integer|min:0',
+                'backup_retention_days_s3' => 'integer|min:0',
+                'backup_retention_max_storage_s3' => 'integer|min:0',
+            ]);
+
+            if ($backupValidator->fails()) {
+                return response()->json([
+                    'message' => 'Validation failed.',
+                    'errors' => $backupValidator->errors(),
+                ], 422);
+            }
+
+            if ($request->filled('backup_frequency') && ! validate_cron_expression($request->backup_frequency)) {
+                return response()->json([
+                    'message' => 'Validation failed.',
+                    'errors' => ['backup_frequency' => ['Invalid cron expression or frequency format.']],
+                ], 422);
+            }
+
+            if ($request->boolean('backup_save_s3') && ! $request->filled('backup_s3_storage_uuid')) {
+                return response()->json([
+                    'message' => 'Validation failed.',
+                    'errors' => ['backup_s3_storage_uuid' => ['The backup_s3_storage_uuid field is required when backup_save_s3 is true.']],
+                ], 422);
+            }
+
+            // Build the backup data mapping (strip the backup_ prefix)
+            $backupData = [];
+            $fieldMap = [
+                'backup_save_s3' => 'save_s3',
+                'backup_frequency' => 'frequency',
+                'backup_enabled' => 'enabled',
+                'backup_disable_local_backup' => 'disable_local_backup',
+                'backup_dump_all' => 'dump_all',
+                'backup_databases_to_backup' => 'databases_to_backup',
+                'backup_retention_amount_locally' => 'database_backup_retention_amount_locally',
+                'backup_retention_days_locally' => 'database_backup_retention_days_locally',
+                'backup_retention_max_storage_locally' => 'database_backup_retention_max_storage_locally',
+                'backup_retention_amount_s3' => 'database_backup_retention_amount_s3',
+                'backup_retention_days_s3' => 'database_backup_retention_days_s3',
+                'backup_retention_max_storage_s3' => 'database_backup_retention_max_storage_s3',
+            ];
+
+            foreach ($fieldMap as $requestKey => $dbKey) {
+                if ($request->has($requestKey)) {
+                    $backupData[$dbKey] = $request->input($requestKey);
+                }
+            }
+
+            // Resolve S3 storage UUID → ID
+            if ($request->filled('backup_s3_storage_uuid')) {
+                $s3 = S3Storage::ownedByCurrentTeam()->where('uuid', $request->backup_s3_storage_uuid)->first();
+                if (! $s3) {
+                    return response()->json([
+                        'message' => 'Validation failed.',
+                        'errors' => ['backup_s3_storage_uuid' => ['The selected S3 storage is invalid for this team.']],
+                    ], 422);
+                }
+                $backupData['s3_storage_id'] = $s3->id;
+            }
+
+            // Find the first (most recently created) backup config for this database, or create one
+            $backupConfig = ScheduledDatabaseBackup::ownedByCurrentTeamAPI($teamId)
+                ->where('database_id', $database->id)
+                ->orderBy('created_at', 'asc')
+                ->first();
+
+            if ($backupConfig) {
+                $backupConfig->update($backupData);
+            } else {
+                // Auto-create with sensible defaults if none exists yet
+                $backupData['database_id'] = $database->id;
+                $backupData['database_type'] = $database->getMorphClass();
+                $backupData['team_id'] = $teamId;
+                $backupData['frequency'] ??= 'daily';
+                $backupData['enabled'] ??= true;
+                ScheduledDatabaseBackup::create($backupData);
+            }
         }
 
         return response()->json([
@@ -629,6 +755,7 @@ class DatabasesController extends Controller
                         's3_storage_uuid' => ['type' => 'string', 'description' => 'S3 storage UUID (required if save_s3 is true)'],
                         'databases_to_backup' => ['type' => 'string', 'description' => 'Comma separated list of databases to backup'],
                         'dump_all' => ['type' => 'boolean', 'description' => 'Whether to dump all databases', 'default' => false],
+                        'disable_local_backup' => ['type' => 'boolean', 'description' => 'Skip saving backup files locally (useful when only storing to S3)', 'default' => false],
                         'backup_now' => ['type' => 'boolean', 'description' => 'Whether to trigger backup immediately after creation'],
                         'database_backup_retention_amount_locally' => ['type' => 'integer', 'description' => 'Number of backups to retain locally'],
                         'database_backup_retention_days_locally' => ['type' => 'integer', 'description' => 'Number of days to retain backups locally'],
@@ -672,7 +799,7 @@ class DatabasesController extends Controller
     )]
     public function create_backup(Request $request)
     {
-        $backupConfigFields = ['save_s3', 'enabled', 'dump_all', 'frequency', 'databases_to_backup', 'database_backup_retention_amount_locally', 'database_backup_retention_days_locally', 'database_backup_retention_max_storage_locally', 'database_backup_retention_amount_s3', 'database_backup_retention_days_s3', 'database_backup_retention_max_storage_s3', 's3_storage_uuid'];
+        $backupConfigFields = ['save_s3', 'enabled', 'dump_all', 'disable_local_backup', 'frequency', 'databases_to_backup', 'database_backup_retention_amount_locally', 'database_backup_retention_days_locally', 'database_backup_retention_max_storage_locally', 'database_backup_retention_amount_s3', 'database_backup_retention_days_s3', 'database_backup_retention_max_storage_s3', 's3_storage_uuid'];
 
         $teamId = getTeamIdFromToken();
         if (is_null($teamId)) {
@@ -690,6 +817,7 @@ class DatabasesController extends Controller
             'enabled' => 'boolean',
             'save_s3' => 'boolean',
             'dump_all' => 'boolean',
+            'disable_local_backup' => 'boolean',
             'backup_now' => 'boolean|nullable',
             's3_storage_uuid' => 'string|exists:s3_storages,uuid|nullable',
             'databases_to_backup' => 'string|nullable',
@@ -854,7 +982,8 @@ class DatabasesController extends Controller
                         'enabled' => ['type' => 'boolean', 'description' => 'Whether the backup is enabled or not'],
                         'databases_to_backup' => ['type' => 'string', 'description' => 'Comma separated list of databases to backup'],
                         'dump_all' => ['type' => 'boolean', 'description' => 'Whether all databases are dumped or not'],
-                        'frequency' => ['type' => 'string', 'description' => 'Frequency of the backup'],
+                        'disable_local_backup' => ['type' => 'boolean', 'description' => 'Skip saving backup files locally'],
+                        'frequency' => ['type' => 'string', 'description' => 'Frequency of the backup (cron expression or: every_minute, hourly, daily, weekly, monthly, yearly)'],
                         'database_backup_retention_amount_locally' => ['type' => 'integer', 'description' => 'Retention amount of the backup locally'],
                         'database_backup_retention_days_locally' => ['type' => 'integer', 'description' => 'Retention days of the backup locally'],
                         'database_backup_retention_max_storage_locally' => ['type' => 'integer', 'description' => 'Max storage of the backup locally'],
@@ -890,7 +1019,7 @@ class DatabasesController extends Controller
     )]
     public function update_backup(Request $request)
     {
-        $backupConfigFields = ['save_s3', 'enabled', 'dump_all', 'frequency', 'databases_to_backup', 'database_backup_retention_amount_locally', 'database_backup_retention_days_locally', 'database_backup_retention_max_storage_locally', 'database_backup_retention_amount_s3', 'database_backup_retention_days_s3', 'database_backup_retention_max_storage_s3', 's3_storage_uuid'];
+        $backupConfigFields = ['save_s3', 'enabled', 'dump_all', 'disable_local_backup', 'frequency', 'databases_to_backup', 'database_backup_retention_amount_locally', 'database_backup_retention_days_locally', 'database_backup_retention_max_storage_locally', 'database_backup_retention_amount_s3', 'database_backup_retention_days_s3', 'database_backup_retention_max_storage_s3', 's3_storage_uuid'];
 
         $teamId = getTeamIdFromToken();
         if (is_null($teamId)) {
@@ -906,9 +1035,10 @@ class DatabasesController extends Controller
             'backup_now' => 'boolean|nullable',
             'enabled' => 'boolean',
             'dump_all' => 'boolean',
+            'disable_local_backup' => 'boolean',
             's3_storage_uuid' => 'string|exists:s3_storages,uuid|nullable',
             'databases_to_backup' => 'string|nullable',
-            'frequency' => 'string|in:every_minute,hourly,daily,weekly,monthly,yearly',
+            'frequency' => 'string',  // validated via validate_cron_expression() below
             'database_backup_retention_amount_locally' => 'integer|min:0',
             'database_backup_retention_days_locally' => 'integer|min:0',
             'database_backup_retention_max_storage_locally' => 'integer|min:0',
@@ -953,6 +1083,16 @@ class DatabasesController extends Controller
                 return response()->json([
                     'message' => 'Validation failed.',
                     'errors' => ['s3_storage_uuid' => ['The selected S3 storage is invalid for this team.']],
+                ], 422);
+            }
+        }
+
+        // Validate frequency as a cron expression when provided
+        if ($request->filled('frequency')) {
+            if (! validate_cron_expression($request->frequency)) {
+                return response()->json([
+                    'message' => 'Validation failed.',
+                    'errors' => ['frequency' => ['Invalid cron expression or frequency format.']],
                 ], 422);
             }
         }

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -125,6 +125,15 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
 
     private $docker_compose_base64;
 
+    /**
+     * Per-service env key lists for dockercompose builds.
+     * Populated during compose file generation so that save_runtime_environment_variables()
+     * can write per-service .env files instead of a single shared one.
+     *
+     * @var array<string, list<string>>
+     */
+    private array $composeServiceEnvKeys = [];
+
     private ?string $nixpacks_plan = null;
 
     private Collection $nixpacks_plan_json;
@@ -637,10 +646,33 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             }
         } else {
             $composeFile = $this->application->parse(pull_request_id: $this->pull_request_id, preview_id: data_get($this->preview, 'id'), commit: $this->commit);
-            // Always add .env file to services
+            // Parse the raw compose to discover which environment variable keys are declared
+            // for each service, so we can generate per-service .env files instead of sharing
+            // one global .env across all containers (security isolation, issue #7655).
+            $rawComposeForEnvParsing = Yaml::parse($this->application->docker_compose_raw) ?? [];
+            $rawServices = data_get($rawComposeForEnvParsing, 'services', []);
+
             $services = collect(data_get($composeFile, 'services', []));
-            $services = $services->map(function ($service, $name) {
-                $service['env_file'] = ['.env'];
+            $services = $services->map(function ($service, $name) use ($rawServices) {
+                // Collect the env keys explicitly defined for this service in the raw compose.
+                $serviceEnvKeys = collect();
+                $rawEnv = data_get($rawServices, "$name.environment", []);
+                if (is_array($rawEnv)) {
+                    foreach ($rawEnv as $k => $v) {
+                        // Support both list form ("KEY=value") and map form (key: value)
+                        $serviceEnvKeys->push(is_int($k) ? str_before((string) $v, '=') : (string) $k);
+                    }
+                }
+                $this->composeServiceEnvKeys[$name] = $serviceEnvKeys->unique()->values()->all();
+
+                // Point each service at its own per-service env file; generated later in
+                // save_runtime_environment_variables() alongside the global .env file.
+                $envFileName = '.env.'.str($name)->slug('_');
+                $existing = collect(data_get($service, 'env_file', []));
+                if (! $existing->contains($envFileName)) {
+                    $existing->prepend($envFileName);
+                }
+                $service['env_file'] = $existing->values()->all();
 
                 return $service;
             });
@@ -1417,6 +1449,90 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                     "echo '$envs_base64' | base64 -d | tee $this->configuration_dir/.env > /dev/null",
                 ]
             );
+        }
+
+        // For dockercompose deployments generate per-service env files so that each
+        // container only receives the variables it declared in its own `environment:`
+        // section plus Coolify metadata (COOLIFY_*, SERVICE_URL_*, SERVICE_FQDN_*,
+        // SERVICE_NAME_*).  This prevents unintended credential sharing across
+        // containers in a Compose project (issue #7655).
+        if ($this->build_pack === 'dockercompose' && ! empty($this->composeServiceEnvKeys)) {
+            $this->write_per_service_env_files($environment_variables);
+        }
+    }
+
+    /**
+     * Generate per-service .env files for Docker Compose deployments.
+     *
+     * Each file contains only:
+     *  - Variables explicitly declared in that service's `environment:` block
+     *  - Coolify-injected metadata variables (COOLIFY_*, SERVICE_URL_*, SERVICE_FQDN_*,
+     *    SERVICE_NAME_*)
+     *
+     * This ensures containers cannot read secrets that belong to sibling services.
+     *
+     * @param  \Illuminate\Support\Collection<int, string>  $allEnvLines  Full KEY=VALUE list from generate_runtime_environment_variables()
+     */
+    private function write_per_service_env_files(Collection $allEnvLines): void
+    {
+        // Build a lookup map of KEY => "KEY=value" from the full env list
+        $envMap = collect([]);
+        foreach ($allEnvLines as $line) {
+            $eq = strpos($line, '=');
+            if ($eq === false) {
+                continue;
+            }
+            $key = substr($line, 0, $eq);
+            $envMap->put($key, $line);
+        }
+
+        // Coolify-owned metadata keys that should be available to every service
+        $metadataPrefix = ['COOLIFY_', 'SERVICE_URL_', 'SERVICE_FQDN_', 'SERVICE_NAME_'];
+
+        $metadataLines = $envMap->filter(function ($_, $key) use ($metadataPrefix) {
+            foreach ($metadataPrefix as $prefix) {
+                if (str_starts_with($key, $prefix)) {
+                    return true;
+                }
+            }
+
+            return false;
+        });
+
+        foreach ($this->composeServiceEnvKeys as $serviceName => $declaredKeys) {
+            $slug = str($serviceName)->slug('_');
+            $envFileName = ".env.$slug";
+
+            // Start with Coolify metadata variables (always available to every container)
+            $serviceLines = $metadataLines->values();
+
+            // Add variables the service explicitly declared
+            foreach ($declaredKeys as $key) {
+                if ($envMap->has($key) && ! $serviceLines->contains($envMap->get($key))) {
+                    $serviceLines->push($envMap->get($key));
+                }
+            }
+
+            if ($serviceLines->isEmpty()) {
+                // Write an empty file to satisfy the env_file directive
+                $this->execute_remote_command([
+                    executeInDocker($this->deployment_uuid, "touch $this->workdir/$envFileName"),
+                    'hidden' => true,
+                ]);
+
+                continue;
+            }
+
+            $serviceEnvsBase64 = base64_encode($serviceLines->implode("\n"));
+            $this->application_deployment_queue->addLogEntry(
+                "Creating $envFileName for service '$serviceName' (".count($declaredKeys).' declared + '.
+                $metadataLines->count().' metadata variables).',
+                hidden: true
+            );
+            $this->execute_remote_command([
+                executeInDocker($this->deployment_uuid, "echo '$serviceEnvsBase64' | base64 -d | tee $this->workdir/$envFileName > /dev/null"),
+                'hidden' => true,
+            ]);
         }
     }
 


### PR DESCRIPTION
### Changes

Coolify injected a single `.env` file containing ALL environment variables from every service into every container via an unconditional `$service['env_file'] = ['.env']`. In a `nextjs + postgres + redis` stack, Redis could read `POSTGRES_PASSWORD` and Next.js API keys — a lateral-movement risk.

Now generates a per-service `.env.<service_name>` file containing only:
1. Variables explicitly declared in that service's `environment:` block
2. Coolify metadata (`COOLIFY_*`, `SERVICE_URL_*`, `SERVICE_FQDN_*`, `SERVICE_NAME_*`)

The global `.env` is preserved for backward compatibility.

### Issues

- fixes: #7655

### Category

- [x] Bug fix

### AI Usage

- [x] AI is used in the process of creating this PR

### Steps to Test

1. Deploy a multi-service Docker Compose project (e.g. nextjs + postgres + redis)
2. SSH into the postgres container and verify it cannot read Next.js-specific env vars
3. SSH into the nextjs container and verify it cannot read `POSTGRES_PASSWORD`
4. Confirm all services start correctly with their own variables available

### Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them