### PR TITLE
feat: OAuth self-registration independent of general registration + OAuth-force-only mode

### DIFF
--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -20,9 +20,17 @@ class OauthController extends Controller
         try {
             $oauthUser = get_socialite_provider($provider)->user();
             $user = User::whereEmail($oauthUser->email)->first();
+            $settings = instanceSettings();
+
             if (! $user) {
-                $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                // New user: allow registration if either the general registration
+                // switch OR the dedicated OAuth registration switch is on.
+                // This lets admins disable password-based self-registration while
+                // still allowing trusted OAuth providers to onboard users.
+                $oauthRegistrationAllowed = $settings->is_oauth_registration_enabled ?? true;
+                $generalRegistrationAllowed = $settings->is_registration_enabled;
+
+                if (! $oauthRegistrationAllowed && ! $generalRegistrationAllowed) {
                     abort(403, 'Registration is disabled');
                 }
 
@@ -31,6 +39,14 @@ class OauthController extends Controller
                     'email' => $oauthUser->email,
                 ]);
             }
+
+            // If oauth_force_only is enabled, mark the user so they cannot use
+            // a local password.  The flag is stored on the user record and
+            // enforced by the Fortify authentication pipeline.
+            if ($settings->oauth_force_only ?? false) {
+                $user->forceFill(['oauth_force_only' => true])->save();
+            }
+
             Auth::login($user);
 
             return redirect('/');

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -37,6 +37,12 @@ class Advanced extends Component
     #[Validate('boolean')]
     public bool $is_wire_navigate_enabled;
 
+    #[Validate('boolean')]
+    public bool $is_oauth_registration_enabled;
+
+    #[Validate('boolean')]
+    public bool $oauth_force_only;
+
     public function rules()
     {
         return [
@@ -49,6 +55,8 @@ class Advanced extends Component
             'is_sponsorship_popup_enabled' => 'boolean',
             'disable_two_step_confirmation' => 'boolean',
             'is_wire_navigate_enabled' => 'boolean',
+            'is_oauth_registration_enabled' => 'boolean',
+            'oauth_force_only' => 'boolean',
         ];
     }
 
@@ -67,6 +75,8 @@ class Advanced extends Component
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
         $this->is_sponsorship_popup_enabled = $this->settings->is_sponsorship_popup_enabled;
         $this->is_wire_navigate_enabled = $this->settings->is_wire_navigate_enabled ?? true;
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled ?? true;
+        $this->oauth_force_only = $this->settings->oauth_force_only ?? false;
     }
 
     public function submit()
@@ -146,6 +156,8 @@ class Advanced extends Component
             $this->settings->is_sponsorship_popup_enabled = $this->is_sponsorship_popup_enabled;
             $this->settings->disable_two_step_confirmation = $this->disable_two_step_confirmation;
             $this->settings->is_wire_navigate_enabled = $this->is_wire_navigate_enabled;
+            $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
+            $this->settings->oauth_force_only = $this->oauth_force_only;
             $this->settings->save();
             $this->dispatch('success', 'Settings updated!');
         } catch (\Exception $e) {

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -31,6 +31,8 @@ class InstanceSettings extends Model
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',
         'is_wire_navigate_enabled' => 'boolean',
+        'is_oauth_registration_enabled' => 'boolean',
+        'oauth_force_only' => 'boolean',
     ];
 
     protected static function booted(): void

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -55,6 +55,7 @@ class User extends Authenticatable implements SendsEmail
         'force_password_reset' => 'boolean',
         'show_boarding' => 'boolean',
         'email_change_code_expires_at' => 'datetime',
+        'oauth_force_only' => 'boolean',
     ];
 
     /**

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -47,6 +47,8 @@ class FortifyServiceProvider extends ServiceProvider
             $isFirstUser = User::count() === 0;
 
             $settings = instanceSettings();
+            // Block the password-based register page when registration is disabled.
+            // OAuth-only registration bypasses this page entirely via OauthController.
             if (! $settings->is_registration_enabled) {
                 return redirect()->route('login');
             }
@@ -74,6 +76,15 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::authenticateUsing(function (Request $request) {
             $email = strtolower($request->email);
             $user = User::where('email', $email)->with('teams')->first();
+
+            // Block password-based login for users who are marked as OAuth-only.
+            // Return null here so Fortify treats it as an authentication failure —
+            // the user will see a generic "credentials do not match" message and
+            // must use their OAuth provider to sign in.
+            if ($user && ($user->oauth_force_only ?? false)) {
+                return null;
+            }
+
             if (
                 $user &&
                 Hash::check($request->password, $user->password)

--- a/database/migrations/2026_02_20_000001_add_oauth_registration_settings_to_instance_settings.php
+++ b/database/migrations/2026_02_20_000001_add_oauth_registration_settings_to_instance_settings.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            // When true, users can create accounts via OAuth even if general
+            // self-registration (is_registration_enabled) is disabled.
+            $table->boolean('is_oauth_registration_enabled')->default(true)->after('is_registration_enabled');
+
+            // When true, users who sign in via OAuth are prevented from setting
+            // or using a local password (forces OAuth-only access, useful with
+            // identity providers like Authentik to centralise access control).
+            $table->boolean('oauth_force_only')->default(false)->after('is_oauth_registration_enabled');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn(['is_oauth_registration_enabled', 'oauth_force_only']);
+        });
+    }
+};

--- a/database/migrations/2026_02_20_000002_add_oauth_force_only_to_users_table.php
+++ b/database/migrations/2026_02_20_000002_add_oauth_force_only_to_users_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            // Per-user flag set when the instance has oauth_force_only enabled.
+            // When true, this user may only authenticate via OAuth — password
+            // authentication is blocked in the Fortify login pipeline.
+            $table->boolean('oauth_force_only')->default(false)->after('two_factor_confirmed_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('oauth_force_only');
+        });
+    }
+};

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -18,8 +18,18 @@
                 <div class="flex flex-col gap-1">
                     <div class="md:w-96">
                         <x-forms.checkbox instantSave id="is_registration_enabled"
-                            helper="Allow users to self-register. If disabled, only administrators can create accounts."
+                            helper="Allow users to self-register with a password. If disabled, only administrators can create accounts (unless OAuth registration is enabled)."
                             label="Registration Allowed" />
+                    </div>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_registration_enabled"
+                            helper="Allow new users to create accounts by signing in with an OAuth provider (e.g. GitHub, Google, Authentik), even when general registration is disabled. Useful for restricting signup to trusted identity providers only."
+                            label="OAuth Self-Registration Allowed" />
+                    </div>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="oauth_force_only"
+                            helper="Prevent users from logging in with a local password if they have authenticated via OAuth. This allows you to suspend access by disabling the user in your identity provider (e.g. Authentik, GitHub org membership). Applies to users on their next OAuth login."
+                            label="Require OAuth Login (disable password auth)" />
                     </div>
                     <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"


### PR DESCRIPTION
### Changes

Two new admin settings (Settings → Advanced):

**1. OAuth Self-Registration Allowed** (`is_oauth_registration_enabled`, default `true`)
Allows new users to register via OAuth providers even when general password registration is disabled. Use case: restrict signup to users in your Authentik/GitHub org without disabling OAuth entirely.

Logic: new user allowed if `is_oauth_registration_enabled` OR `is_registration_enabled`.

**2. Require OAuth Login** (`oauth_force_only`, default `false`)
When enabled, users who sign in via OAuth are flagged `users.oauth_force_only = true`. Subsequent password login attempts for that user are rejected in Fortify's auth callback. Use case: suspend access by removing the user from your identity provider.

### Issues

- fixes: #8042

### Category

- [x] New feature

### AI Usage

- [x] AI is used in the process of creating this PR

### Steps to Test

1. Disable "Registration Allowed" in Settings → Advanced
2. Enable "OAuth Self-Registration Allowed"
3. Sign out, try to register with email/password → should fail
4. Sign in via GitHub OAuth → should succeed and create account
5. Enable "Require OAuth Login", sign in via OAuth, sign out
6. Try to log in with password → should fail with auth error

### Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them