### PR TITLE
feat: add WordPress+OpenLiteSpeed and Docker Mailserver+Roundcube templates

### DIFF
--- a/templates/compose/docker-mailserver.yaml
+++ b/templates/compose/docker-mailserver.yaml
@@ -1,0 +1,105 @@
+# documentation: https://docker-mailserver.github.io/docker-mailserver/latest/
+# slogan: Docker Mailserver is a production-ready, self-hosted email server stack supporting SMTP, IMAP, DKIM, DMARC, SPF, and antispam.
+# category: email
+# tags: email, mail, smtp, imap, dkim, dmarc, spf, mailserver, postfix, dovecot
+# logo: svgs/docker-mailserver.svg
+# minMemory: 1024
+# port: 80
+
+# ⚠️  Before deploying, ensure your domain has correct DNS records:
+#     - MX  →  your server IP
+#     - A   →  mail.yourdomain.com → your server IP
+#     - PTR →  your server IP → mail.yourdomain.com  (set with your VPS provider)
+#     - SPF, DKIM, DMARC TXT records (DKIM key generated after first start)
+#
+# After deploy, add your first mail account:
+#   docker exec mailserver setup email add user@yourdomain.com <password>
+
+services:
+  mailserver:
+    image: ghcr.io/docker-mailserver/docker-mailserver:latest
+    container_name: mailserver
+    hostname: ${MAIL_HOSTNAME:-mail.example.com}
+    ports:
+      - "25:25"       # SMTP (receiving)
+      - "465:465"     # SMTPS (submission, TLS)
+      - "587:587"     # SMTP submission (STARTTLS)
+      - "143:143"     # IMAP
+      - "993:993"     # IMAPS (TLS)
+    volumes:
+      - mailserver-data:/var/mail
+      - mailserver-state:/var/mail-state
+      - mailserver-logs:/var/log/mail
+      - mailserver-config:/tmp/docker-mailserver
+      - /etc/localtime:/etc/localtime:ro
+    environment:
+      # General
+      - OVERRIDE_HOSTNAME=${MAIL_HOSTNAME:-mail.example.com}
+      - LOG_LEVEL=${LOG_LEVEL:-warn}
+      - SUPERVISOR_LOGLEVEL=${LOG_LEVEL:-warn}
+
+      # TLS — set to "letsencrypt" for automatic certs (requires ports 80/443 exposed),
+      # or "manual" and mount your own certs into /tmp/docker-mailserver/ssl/
+      - SSL_TYPE=${SSL_TYPE:-letsencrypt}
+
+      # DKIM
+      - ENABLE_OPENDKIM=1
+      - ENABLE_OPENDMARC=1
+      - ENABLE_POLICYD_SPF=1
+
+      # Antispam / antivirus
+      - ENABLE_SPAMASSASSIN=${ENABLE_SPAMASSASSIN:-1}
+      - ENABLE_CLAMAV=${ENABLE_CLAMAV:-0}
+      - SPAMASSASSIN_SPAM_TO_JUNK=${SPAMASSASSIN_SPAM_TO_JUNK:-1}
+
+      # Fail2ban
+      - ENABLE_FAIL2BAN=${ENABLE_FAIL2BAN:-1}
+
+      # SMTP
+      - ENABLE_POSTFIX_VIRTUAL_TRANSPORT=
+
+      # IMAP
+      - ENABLE_DOVECOT=1
+
+      # Postmaster
+      - POSTMASTER_ADDRESS=${POSTMASTER_ADDRESS:-postmaster@example.com}
+
+      # Relay (optional)
+      - RELAY_HOST=${RELAY_HOST:-}
+      - RELAY_PORT=${RELAY_PORT:-587}
+      - RELAY_USER=${RELAY_USER:-}
+      - RELAY_PASSWORD=${RELAY_PASSWORD:-}
+    cap_add:
+      - NET_ADMIN
+      - SYS_PTRACE
+    restart: unless-stopped
+    stop_grace_period: 1m
+    healthcheck:
+      test: ["CMD", "ss", "--listening", "--tcp", "|", "grep", "-P", "LISTEN.+:smtp"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 120s
+
+  roundcube:
+    image: roundcube/roundcubemail:latest
+    environment:
+      - SERVICE_FQDN_ROUNDCUBE_80
+      - ROUNDCUBEMAIL_DB_TYPE=sqlite
+      - ROUNDCUBEMAIL_DEFAULT_HOST=ssl://mailserver
+      - ROUNDCUBEMAIL_DEFAULT_PORT=993
+      - ROUNDCUBEMAIL_SMTP_SERVER=tls://mailserver
+      - ROUNDCUBEMAIL_SMTP_PORT=587
+      - ROUNDCUBEMAIL_SKIN=${ROUNDCUBE_SKIN:-elastic}
+      - ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE=${ROUNDCUBE_UPLOAD_MAX:-25M}
+    volumes:
+      - roundcube-data:/var/roundcube/db
+      - roundcube-temp:/tmp/roundcube-temp
+    depends_on:
+      - mailserver
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1/"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+      start_period: 30s

--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -1,0 +1,47 @@
+# documentation: https://openlitespeed.org/kb/wordpress/
+# slogan: WordPress running on OpenLiteSpeed — a high-performance, open-source HTTP server with built-in LiteSpeed Cache support.
+# category: cms
+# tags: cms, blog, wordpress, openlitespeed, ols, litespeed, performance, cache
+# logo: svgs/wordpress.svg
+# port: 8088
+
+services:
+  wordpress-ols:
+    image: litespeedtech/openlitespeed:latest
+    environment:
+      - SERVICE_FQDN_WORDPRESSOLS_8088
+      - OLS_ADMIN_USERNAME=${OLS_ADMIN_USERNAME:-admin}
+      - OLS_ADMIN_PASSWORD=${SERVICE_PASSWORD_OLS}
+      - WORDPRESS_DB_HOST=wordpress-ols-db
+      - WORDPRESS_DB_USER=${SERVICE_USER_MYSQL}
+      - WORDPRESS_DB_PASSWORD=${SERVICE_PASSWORD_MYSQL}
+      - WORDPRESS_DB_NAME=${MYSQL_DATABASE:-wordpress}
+      - WORDPRESS_TABLE_PREFIX=${WORDPRESS_TABLE_PREFIX:-wp_}
+      - WORDPRESS_DEBUG=${WORDPRESS_DEBUG:-false}
+    volumes:
+      - wordpress-ols-html:/var/www/vhosts/localhost/html
+      - wordpress-ols-conf:/usr/local/lsws/conf
+    depends_on:
+      wordpress-ols-db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8088"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
+
+  wordpress-ols-db:
+    image: mysql:8.0
+    environment:
+      - MYSQL_DATABASE=${MYSQL_DATABASE:-wordpress}
+      - MYSQL_USER=${SERVICE_USER_MYSQL}
+      - MYSQL_PASSWORD=${SERVICE_PASSWORD_MYSQL}
+      - MYSQL_ROOT_PASSWORD=${SERVICE_PASSWORD_ROOT}
+    volumes:
+      - wordpress-ols-mysql:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-u", "root", "-p${SERVICE_PASSWORD_ROOT}"]
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
### Changes

Two new one-click service templates:

**1. WordPress + OpenLiteSpeed + MySQL 8** (`wordpress-with-openlitespeed.yaml`)
- `litespeedtech/openlitespeed:latest` + `mysql:8.0`
- Built-in LiteSpeed Cache support
- Auto-generated passwords for OLS admin, MySQL user, root
- Persistent volumes + healthchecks

**2. Docker Mailserver + Roundcube** (`docker-mailserver.yaml`)
- Full stack: Postfix + Dovecot + OpenDKIM + OpenDMARC + SpamAssassin
- Ports: 25, 465, 587 (SMTP), 143, 993 (IMAP)
- Roundcube webmail via Coolify proxy
- Let's Encrypt TLS by default, optional relay + fail2ban
- DNS setup instructions in template comments

### Issues

- fixes: #8264
- fixes: #8266

### Category

- [x] Adding new one click service

### AI Usage

- [x] AI is used in the process of creating this PR

### Steps to Test

**WordPress + OpenLiteSpeed:**
1. Create new Service from template "WordPress with OpenLiteSpeed"
2. Verify OLS starts on port 8088 and MySQL connects
3. Access WordPress setup via the assigned domain

**Docker Mailserver:**
1. Create new Service from template "Docker Mailserver"
2. Set `MAIL_HOSTNAME` to your mail domain
3. Verify Roundcube is accessible via Coolify proxy
4. Run `docker exec mailserver setup email add user@domain.com password` to add first user

### Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them