### PR TITLE
feat: Add WordPress + OpenLiteSpeed service template (closes #8264)

### DIFF
--- a/templates/compose/wordpress-openlitespeed.yaml
+++ b/templates/compose/wordpress-openlitespeed.yaml
@@ -1,0 +1,36 @@
+# documentation: https://openlitespeed.org/kb/wordpress-with-openlitespeed-docker/
+# slogan: WordPress with OpenLiteSpeed - high-performance web server with built-in caching for WordPress sites.
+# category: cms
+# tags: cms,wordpress,openlitespeed,performance,caching
+# logo: svgs/wordpress.svg
+
+services:
+  openlitespeed:
+    image: litespeedtech/openlitespeed:latest
+    environment:
+      - SERVICE_URL_WORDPRESS
+      - TZ=UTC
+    volumes:
+      - wordpress-files:/var/www/html
+      - openlitespeed-conf:/usr/local/lsws/conf
+    depends_on:
+      - mariadb
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:80"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
Adds a production-ready service template for WordPress with OpenLiteSpeed.

Features:
- OpenLiteSpeed web server for high-performance WordPress hosting
- Built-in LSCache caching capabilities
- MariaDB 11 database backend
- Persistent volumes for WordPress files, configuration, and database
- Health checks for both services

Closes #8264