### PR TITLE
feat(templates): add OpenReplay service compose

### DIFF
--- a/svgs/openreplay.svg
+++ b/svgs/openreplay.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="OpenReplay">
+  <rect width="256" height="256" rx="48" fill="#111827"/>
+  <path fill="#22C55E" d="M128 48c-44.2 0-80 35.8-80 80s35.8 80 80 80 80-35.8 80-80-35.8-80-80-80Zm0 24c30.9 0 56 25.1 56 56s-25.1 56-56 56-56-25.1-56-56 25.1-56 56-56Z"/>
+  <path fill="#E5E7EB" d="M118 104v48l44-24-44-24Z"/>
+</svg>

--- a/templates/compose/openreplay.yaml
+++ b/templates/compose/openreplay.yaml
@@ -1,0 +1,70 @@
+# documentation: https://docs.openreplay.com/
+# slogan: Session replay, co-browsing and product analytics you can self-host.
+# category: analytics
+# tags: analytics, session-replay, openreplay
+# logo: svgs/openreplay.svg
+
+services:
+  openreplay-postgresql:
+    image: ghcr.io/openreplay/postgres:${POSTGRES_VERSION:-16}
+    container_name: openreplay-postgres
+    volumes:
+      - openreplay-pgdata:/bitnami/postgresql
+    environment:
+      POSTGRES_PASSWORD: ${OPENREPLAY_COMMON_PG_PASSWORD:-$SERVICE_PASSWORD_64_OPENREPLAY}
+
+  openreplay-clickhouse:
+    image: clickhouse/clickhouse-server:${CLICKHOUSE_VERSION:-24.1}
+    container_name: openreplay-clickhouse
+    volumes:
+      - openreplay-clickhouse:/var/lib/clickhouse
+    environment:
+      CLICKHOUSE_USER: default
+      CLICKHOUSE_PASSWORD: ""
+      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: "1"
+
+  openreplay-redis:
+    image: ghcr.io/openreplay/valkey:${REDIS_VERSION:-7}
+    container_name: openreplay-redis
+    volumes:
+      - openreplay-redisdata:/bitnami/redis/data
+    environment:
+      ALLOW_EMPTY_PASSWORD: "yes"
+
+  openreplay-minio:
+    image: ghcr.io/openreplay/minio:${MINIO_VERSION:-2024-01-16}
+    container_name: openreplay-minio
+    volumes:
+      - openreplay-miniodata:/bitnami/minio/data
+    environment:
+      MINIO_ROOT_USER: ${OPENREPLAY_COMMON_S3_KEY:-$SERVICE_USER_OPENREPLAY}
+      MINIO_ROOT_PASSWORD: ${OPENREPLAY_COMMON_S3_SECRET:-$SERVICE_PASSWORD_OPENREPLAY}
+
+  openreplay-api:
+    image: public.ecr.aws/p1t3u8a3/api:${OPENREPLAY_VERSION:-latest}
+    container_name: openreplay-api
+    depends_on:
+      - openreplay-postgresql
+      - openreplay-clickhouse
+      - openreplay-redis
+      - openreplay-minio
+    env_file:
+      - docker-envs/api.env
+    environment: {}
+    restart: unless-stopped
+
+  openreplay-http:
+    image: public.ecr.aws/p1t3u8a3/http:${OPENREPLAY_VERSION:-latest}
+    container_name: openreplay-http
+    depends_on:
+      - openreplay-api
+    env_file:
+      - docker-envs/http.env
+    environment: {}
+    restart: unless-stopped
+
+volumes:
+  openreplay-pgdata:
+  openreplay-clickhouse:
+  openreplay-redisdata:
+  openreplay-miniodata:


### PR DESCRIPTION
### Changes
- Add an OpenReplay docker compose template at `templates/compose/openreplay.yaml`.
- Add a matching logo at `svgs/openreplay.svg`.

### Issues
- fixes: #8232

### Category
- [x] Adding new one click service

### Screenshots or Video (if applicable)
N/A (template + asset only). If you need a screen recording for claiming the bounty, tell me the preferred demo workflow in Coolify and I will provide it.

### AI Usage
- [x] AI is used in the process of creating this PR

### Steps to Test
1. Pull this branch.
2. Confirm the new files exist:
   - `templates/compose/openreplay.yaml`
   - `svgs/openreplay.svg`
3. (Maintainer) Register `openreplay` in `templates/service-templates-latest.json` to surface it in the UI.

### Contributor Agreement
> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them
