### PR TITLE
feat: scripts/provisioning — clean Ubuntu VPS → hardened Coolify + Tailscale + Cloudflare Tunnel in ~15 min

### DIFF
--- a/scripts/provisioning/bootstrap_hardening.sh
+++ b/scripts/provisioning/bootstrap_hardening.sh
@@ -377,9 +377,9 @@ check_disk_space() {
     return 0
   fi
 
-  # If a stale swapfile exists and will be removed, we can reclaim that space
+  # If a stale swapfile exists and will be removed, we can reclaim that space.
   local swapfile_mb=0
-  if [[ -f /swapfile && ! swapon --show --noheadings | grep -q /swapfile ]]; then
+  if [[ -f /swapfile ]] && ! swapon --show --noheadings 2>/dev/null | grep -q '/swapfile'; then
     swapfile_mb="$(du -m /swapfile 2>/dev/null | cut -f1)" || swapfile_mb=0
   fi
 
@@ -477,6 +477,16 @@ retry_apt_update() {
 
 verify_tailscale_iface() {
   ip link show "${TAILSCALE_IFACE}" >/dev/null 2>&1 || die "Interface ${TAILSCALE_IFACE} not found. Refusing Tailscale-only SSH hardening."
+}
+
+warn_on_state_version_mismatch() {
+  [[ -f "${STATE_FILE}" ]] || return 0
+
+  local existing_version
+  existing_version="$(grep -m1 '^script_version=' "${STATE_FILE}" | cut -d= -f2- || true)"
+  if [[ -n "${existing_version}" && "${existing_version}" != "${SCRIPT_VERSION}" ]]; then
+    warn "Existing hardening state found (v${existing_version}), re-running v${SCRIPT_VERSION}."
+  fi
 }
 
 # Store detected Tailscale IP for split-horizon binding
@@ -651,20 +661,23 @@ configure_coolify_binding() {
 
   if command -v ufw >/dev/null 2>&1; then
     # Idempotent — ufw silently skips duplicate rules
-    local ufw_result
+    local ufw_result ufw_ok=true
     ufw_result="$(ufw allow in on "${TAILSCALE_IFACE}" proto tcp to any port 8000 \
       comment "coolify-hardening-dashboard-tailscale" 2>&1)" || {
       warn "UFW rule for port 8000 on ${TAILSCALE_IFACE} failed: ${ufw_result}"
+      ufw_ok=false
     }
     ufw_result="$(ufw allow in on "${TAILSCALE_IFACE}" proto tcp to any port 6001 \
       comment "coolify-hardening-soketi-tailscale" 2>&1)" || {
       warn "UFW rule for port 6001 on ${TAILSCALE_IFACE} failed: ${ufw_result}"
+      ufw_ok=false
     }
     ufw_result="$(ufw allow in on "${TAILSCALE_IFACE}" proto tcp to any port 6002 \
       comment "coolify-hardening-terminal-tailscale" 2>&1)" || {
       warn "UFW rule for port 6002 on ${TAILSCALE_IFACE} failed: ${ufw_result}"
+      ufw_ok=false
     }
-    log "UFW rules verified for ports 8000, 6001, and 6002 on ${TAILSCALE_IFACE}."
+    is_true "${ufw_ok}" && log "UFW rules verified for ports 8000, 6001, and 6002 on ${TAILSCALE_IFACE}."
   else
     warn "ufw not found — skipping UFW rule verification."
   fi
@@ -1750,6 +1763,7 @@ main() {
   setup_logging
 
   log "Starting ${SCRIPT_NAME} v${SCRIPT_VERSION}"
+  warn_on_state_version_mismatch
   validate_inputs
   detect_os
   check_disk_space

--- a/scripts/provisioning/bootstrap_hardening.sh
+++ b/scripts/provisioning/bootstrap_hardening.sh
@@ -1,0 +1,1854 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_VERSION="1.2.1"
+SCRIPT_NAME="$(basename "$0")"
+
+LOG_FILE="/var/log/bootstrap-hardening.log"
+REPORT_FILE="/var/log/bootstrap-hardening-report.json"
+STATE_DIR="/var/lib/bootstrap-hardening"
+STATE_FILE="${STATE_DIR}/state"
+
+SSH_DROPIN_FILE="/etc/ssh/sshd_config.d/00-coolify-hardening.conf"
+JOURNALD_DROPIN_FILE="/etc/systemd/journald.conf.d/60-persistent.conf"
+AUDIT_RULES_FILE="/etc/audit/rules.d/60-coolify-baseline.rules"
+DOCKER_USER_SCRIPT="/usr/local/sbin/docker-user-hardening.sh"
+DOCKER_USER_ENV_FILE="/etc/default/docker-user-hardening"
+DOCKER_USER_UNIT_FILE="/etc/systemd/system/docker-user-hardening.service"
+APT_AUTO_FILE="/etc/apt/apt.conf.d/20auto-upgrades"
+APT_LOCAL_FILE="/etc/apt/apt.conf.d/52unattended-upgrades-local"
+SYSCTL_DROPIN_FILE="/etc/sysctl.d/60-coolify-hardening.conf"
+FAIL2BAN_JAIL_FILE="/etc/fail2ban/jail.d/coolify-hardening.local"
+COOLIFY_BINDING_GUARD_SCRIPT="/usr/local/sbin/coolify-binding-guard.sh"
+COOLIFY_BINDING_GUARD_SERVICE="/etc/systemd/system/coolify-binding-guard.service"
+COOLIFY_BINDING_GUARD_TIMER="/etc/systemd/system/coolify-binding-guard.timer"
+
+TAILSCALE_IFACE="tailscale0"
+COOLIFY_ENV_FILE="/data/coolify/source/.env"
+
+ADMIN_USER="${ADMIN_USER:-}"
+ADMIN_PUBKEY="${ADMIN_PUBKEY:-}"
+TAILSCALE_CIDR="${TAILSCALE_CIDR:-100.64.0.0/10}"
+SSH_PORT="${SSH_PORT:-22}"
+WAN_IFACE="${WAN_IFACE:-}"
+ENABLE_AUTO_REBOOT="${ENABLE_AUTO_REBOOT:-true}"
+AUTO_REBOOT_TIME="${AUTO_REBOOT_TIME:-03:30}"
+JOURNAL_RETENTION="${JOURNAL_RETENTION:-3month}"
+JOURNAL_MAX_USE="${JOURNAL_MAX_USE:-1G}"
+TUNNEL_MODE="${TUNNEL_MODE:-false}"
+SWAP_SIZE="${SWAP_SIZE:-2G}"
+DRY_RUN="${DRY_RUN:-false}"
+FORCE="${FORCE:-false}"
+UPGRADE_MAIL="${UPGRADE_MAIL:-}"
+BIND_DASHBOARD_TO_TAILSCALE="${BIND_DASHBOARD_TO_TAILSCALE:-false}"
+INSTALL_TAILSCALE="${INSTALL_TAILSCALE:-false}"
+TAILSCALE_AUTH_KEY="${TAILSCALE_AUTH_KEY:-}"
+
+OS_VERSION=""
+DOCKER_PRESENT="false"
+DOCKER_RULES_APPLIED="false"
+DOCKER_DAEMON_NEEDS_RESTART="false"
+
+log() {
+  printf '[%s] %s\n' "$(date -Iseconds)" "$*"
+}
+
+warn() {
+  log "WARN: $*"
+}
+
+die() {
+  log "ERROR: $*"
+  exit 1
+}
+
+on_err() {
+  local line_no="$1"
+  local cmd="$2"
+  log "ERROR: command failed at line ${line_no}: ${cmd}"
+}
+
+trap 'on_err "${LINENO}" "${BASH_COMMAND}"' ERR
+
+is_true() {
+  case "${1,,}" in
+    1|true|yes|y|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+require_value() {
+  local opt="$1"
+  local val="${2:-}"
+  [[ -n "${val}" ]] || die "Option ${opt} requires a value."
+}
+
+usage() {
+  cat <<'EOF'
+Ubuntu Coolify bootstrap hardening script.
+
+Usage:
+  bootstrap_hardening.sh --admin-user <name> --admin-pubkey "<ssh key>" [options]
+
+Required:
+  --admin-user <name>           Admin user to create/ensure and allow via SSH
+  --admin-pubkey "<ssh key>"    SSH public key to add for admin user
+
+Optional:
+  --tailscale-cidr <cidr>       Tailscale CIDR hint (default: 100.64.0.0/10)
+  --ssh-port <port>             SSH port (default: 22)
+  --wan-iface <iface>           WAN interface (default: auto-detected)
+  --tunnel-mode                 Skip WAN 80/443 rules (Cloudflare Tunnel / outbound-only)
+  --swap-size <size>            Swap file size (default: 2G; format: <N>G or <N>M; 0 to skip)
+  --enable-auto-reboot <bool>   Enable unattended-upgrades reboot (default: true)
+  --auto-reboot-time <HH:MM>    Reboot time for unattended-upgrades (default: 03:30)
+  --journal-retention <span>   Journal retention period (default: 3month)
+  --bind-dashboard-to-tailscale Bind Coolify dashboard to Tailscale IP only (split-horizon)
+  --install-tailscale           Install Tailscale if not present (requires --tailscale-auth-key or interactive)
+  --tailscale-auth-key <key>    Tailscale auth key for non-interactive setup (use with --install-tailscale)
+  --upgrade-mail <address>      Email for unattended-upgrade failure reports (optional)
+  --env-file <path>             Source variables from file before parsing flags
+  --dry-run                     Print actions without changing system
+  --force                       Override non-Tailscale SSH-session safety gate
+  -h, --help                    Show this help
+
+Environment variables are also supported for all options above.
+Env-file uses the same variable names (ADMIN_USER, SSH_PORT, TUNNEL_MODE, etc.).
+CLI flags override env-file values.
+
+Dashboard Tailscale Restriction (--bind-dashboard-to-tailscale):
+  Verifies and re-applies UFW rules restricting Coolify dashboard (port 8000), Soketi
+  (port 6001), and terminal (port 6002) to the tailscale0 interface only, then installs
+  a watchdog timer that periodically re-applies them if removed. UFW rules on tailscale0
+  are always configured by the hardening step; this flag adds a periodic verification
+  layer on top.
+EOF
+}
+
+run() {
+  if is_true "${DRY_RUN}"; then
+    log "DRY-RUN: $*"
+    return 0
+  fi
+  "$@"
+}
+
+write_file() {
+  local path="$1"
+  local mode="$2"
+  local owner="$3"
+  local group="$4"
+  local tmp
+
+  tmp="$(mktemp)"
+  cat > "${tmp}"
+
+  if is_true "${DRY_RUN}"; then
+    log "DRY-RUN: write ${path}"
+    rm -f "${tmp}"
+    return 0
+  fi
+
+  install -d -m 0755 "$(dirname "${path}")"
+  install -m "${mode}" -o "${owner}" -g "${group}" "${tmp}" "${path}"
+  rm -f "${tmp}"
+}
+
+parse_args() {
+  # Pre-scan for --env-file to source it before parsing other args
+  local env_file=""
+  local arg
+  for arg in "$@"; do
+    if [[ "${arg}" == --env-file=* ]]; then
+      env_file="${arg#--env-file=}"
+    fi
+  done
+  if [[ -z "${env_file}" ]]; then
+    local prev=""
+    for arg in "$@"; do
+      if [[ "${prev}" == "--env-file" ]]; then
+        env_file="${arg}"
+        break
+      fi
+      prev="${arg}"
+    done
+  fi
+  if [[ -n "${env_file}" ]]; then
+    [[ -f "${env_file}" ]] || die "Env file not found: ${env_file}"
+    local file_perms
+    file_perms="$(stat -c '%a' "${env_file}" 2>/dev/null || stat -f '%Lp' "${env_file}" 2>/dev/null || echo "unknown")"
+    if [[ "${file_perms}" != "unknown" && "${file_perms}" != "600" && "${file_perms}" != "400" ]]; then
+      warn "Env file ${env_file} has permissions ${file_perms}; recommend 0600 or stricter."
+    fi
+    # shellcheck disable=SC1090
+    source "${env_file}"
+  fi
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --env-file)
+        # Already processed in pre-scan; consume and skip
+        require_value "$1" "${2:-}"
+        shift 2
+        ;;
+      --env-file=*)
+        # Already processed in pre-scan; skip
+        shift
+        ;;
+      --admin-user)
+        require_value "$1" "${2:-}"
+        ADMIN_USER="$2"
+        shift 2
+        ;;
+      --admin-pubkey)
+        require_value "$1" "${2:-}"
+        ADMIN_PUBKEY="$2"
+        shift 2
+        ;;
+      --tailscale-cidr)
+        require_value "$1" "${2:-}"
+        TAILSCALE_CIDR="$2"
+        shift 2
+        ;;
+      --ssh-port)
+        require_value "$1" "${2:-}"
+        SSH_PORT="$2"
+        shift 2
+        ;;
+      --wan-iface)
+        require_value "$1" "${2:-}"
+        WAN_IFACE="$2"
+        shift 2
+        ;;
+      --enable-auto-reboot)
+        require_value "$1" "${2:-}"
+        ENABLE_AUTO_REBOOT="$2"
+        shift 2
+        ;;
+      --auto-reboot-time)
+        require_value "$1" "${2:-}"
+        AUTO_REBOOT_TIME="$2"
+        shift 2
+        ;;
+      --journal-retention)
+        require_value "$1" "${2:-}"
+        JOURNAL_RETENTION="$2"
+        shift 2
+        ;;
+      --swap-size)
+        require_value "$1" "${2:-}"
+        SWAP_SIZE="$2"
+        shift 2
+        ;;
+      --tunnel-mode)
+        TUNNEL_MODE="true"
+        shift
+        ;;
+      --bind-dashboard-to-tailscale)
+        BIND_DASHBOARD_TO_TAILSCALE="true"
+        shift
+        ;;
+      --install-tailscale)
+        INSTALL_TAILSCALE="true"
+        shift
+        ;;
+      --tailscale-auth-key)
+        require_value "$1" "${2:-}"
+        TAILSCALE_AUTH_KEY="$2"
+        shift 2
+        ;;
+      --dry-run)
+        DRY_RUN="true"
+        shift
+        ;;
+      --force)
+        FORCE="true"
+        shift
+        ;;
+      --upgrade-mail)
+        require_value "$1" "${2:-}"
+        UPGRADE_MAIL="$2"
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        die "Unknown option: $1 (use --help)"
+        ;;
+    esac
+  done
+}
+
+setup_logging() {
+  if is_true "${DRY_RUN}"; then
+    log "Dry-run enabled; no host changes will be applied."
+    return 0
+  fi
+
+  install -d -m 0750 /var/log
+  touch "${LOG_FILE}"
+  chmod 0600 "${LOG_FILE}"
+  exec > >(tee -a "${LOG_FILE}") 2>&1
+}
+
+require_root() {
+  [[ "$(id -u)" -eq 0 ]] || die "Run as root."
+}
+
+validate_pubkey() {
+  printf '%s\n' "${ADMIN_PUBKEY}" | awk '
+    $1 ~ /^(ssh-ed25519|ssh-rsa|ecdsa-sha2-nistp(256|384|521)|sk-ssh-ed25519@openssh.com|sk-ecdsa-sha2-nistp256@openssh.com)$/ && NF >= 2 { ok=1 }
+    END { exit(ok ? 0 : 1) }
+  ' || die "ADMIN_PUBKEY does not look like a valid SSH public key."
+}
+
+validate_inputs() {
+  [[ -n "${ADMIN_USER}" ]] || die "Missing ADMIN_USER / --admin-user."
+  [[ -n "${ADMIN_PUBKEY}" ]] || die "Missing ADMIN_PUBKEY / --admin-pubkey."
+  [[ "${ADMIN_USER}" != "root" ]] || die "ADMIN_USER must not be root."
+  [[ "${ADMIN_USER}" =~ ^[a-z_][a-z0-9_-]*[$]?$ ]] || die "ADMIN_USER is not a valid Linux username."
+  [[ "${SSH_PORT}" =~ ^[0-9]+$ ]] || die "SSH_PORT must be numeric."
+  (( SSH_PORT >= 1 && SSH_PORT <= 65535 )) || die "SSH_PORT must be in range 1..65535."
+  [[ "${AUTO_REBOOT_TIME}" =~ ^([01][0-9]|2[0-3]):[0-5][0-9]$ ]] || die "AUTO_REBOOT_TIME must be HH:MM (24h)."
+
+  # Validate ENABLE_AUTO_REBOOT is either true or false (or recognized variant)
+  local reboot_lower="${ENABLE_AUTO_REBOOT,,}"
+  if [[ "${reboot_lower}" != "true" && "${reboot_lower}" != "false" && "${reboot_lower}" != "1" && "${reboot_lower}" != "0" && "${reboot_lower}" != "yes" && "${reboot_lower}" != "no" ]]; then
+    die "ENABLE_AUTO_REBOOT must be true/false (got: ${ENABLE_AUTO_REBOOT})."
+  fi
+
+  [[ "${JOURNAL_RETENTION}" =~ ^[0-9]+(us(ec)?|ms(ec)?|s(ec(ond)?s?)?|m(in(ute)?s?)?|h(our)?s?|d(ay)?s?|w(eek)?s?|month?s?|y(ear)?s?)$ ]] \
+    || die "JOURNAL_RETENTION must be a valid systemd time span (e.g. 3month, 4w, 90d)."
+
+  if [[ "${SWAP_SIZE}" != "0" ]]; then
+    [[ "${SWAP_SIZE}" =~ ^[0-9]+[GgMm]$ ]] || die "SWAP_SIZE must be <N>G or <N>M (e.g. 2G, 512M), or 0 to skip."
+  fi
+
+  # Validate split-horizon binding options
+  if is_true "${BIND_DASHBOARD_TO_TAILSCALE}" && ! is_true "${DRY_RUN}"; then
+    [[ -f "${COOLIFY_ENV_FILE}" ]] \
+      || die "Coolify .env not found at ${COOLIFY_ENV_FILE}. Is Coolify installed?"
+    command -v docker >/dev/null 2>&1 \
+      || die "--bind-dashboard-to-tailscale requires Docker."
+    docker compose version >/dev/null 2>&1 \
+      || die "--bind-dashboard-to-tailscale requires the Docker Compose plugin."
+    [[ -d "/data/coolify/source" ]] \
+      || die "--bind-dashboard-to-tailscale requires /data/coolify/source to exist."
+  fi
+
+  # Validate Tailscale install options
+  if is_true "${INSTALL_TAILSCALE}"; then
+    # If Tailscale is not already installed and no auth key provided, warn about interactive mode
+    if ! command -v tailscale >/dev/null 2>&1 && [[ -z "${TAILSCALE_AUTH_KEY}" ]]; then
+      warn "INSTALL_TAILSCALE is set but TAILSCALE_AUTH_KEY not provided. Interactive auth required."
+    fi
+  fi
+
+  validate_pubkey
+}
+
+detect_os() {
+  [[ -f /etc/os-release ]] || die "/etc/os-release not found."
+  # shellcheck disable=SC1091
+  source /etc/os-release
+  [[ "${ID:-}" == "ubuntu" ]] || die "Only Ubuntu is supported."
+  OS_VERSION="${VERSION_ID:-unknown}"
+
+  if [[ "${OS_VERSION}" != "24.04" ]] && ! is_true "${FORCE}"; then
+    die "Expected Ubuntu 24.04.x (found ${OS_VERSION}). Use --force to override."
+  fi
+}
+
+check_disk_space() {
+  local swap_size="${SWAP_SIZE:-2G}"
+  local required_mb=512
+  if [[ "${swap_size}" != "0" ]]; then
+    local swap_num="${swap_size%[GgMm]}"
+    local swap_unit="${swap_size: -1}"
+    case "${swap_unit,,}" in
+      g) required_mb=$(( required_mb + swap_num * 1024 )) ;;
+      m) required_mb=$(( required_mb + swap_num )) ;;
+    esac
+  fi
+  if is_true "${DRY_RUN}"; then
+    log "DRY-RUN: would check disk space (required: ${required_mb}M)."
+    return 0
+  fi
+
+  # If a stale swapfile exists and will be removed, we can reclaim that space
+  local swapfile_mb=0
+  if [[ -f /swapfile && ! swapon --show --noheadings | grep -q /swapfile ]]; then
+    swapfile_mb="$(du -m /swapfile 2>/dev/null | cut -f1)" || swapfile_mb=0
+  fi
+
+  local avail_mb
+  avail_mb="$(df -m / 2>/dev/null | awk 'NR==2 {print $4}')"
+  if [[ -z "${avail_mb}" || ! "${avail_mb}" =~ ^[0-9]+$ ]]; then
+    warn "Cannot determine available disk space; skipping pre-flight check."
+    return 0
+  fi
+
+  # Add reclaimed swapfile space to available
+  local effective_avail=$(( avail_mb + swapfile_mb ))
+
+  if (( effective_avail < required_mb )); then
+    die "Insufficient disk space: ${avail_mb}M available (+${swapfile_mb}M from stale swap), ${required_mb}M required (swap: ${swap_size} + 512M base)."
+  fi
+  log "Disk pre-flight: ${avail_mb}M available, ${required_mb}M required. OK."
+}
+
+detect_wan_iface() {
+  if [[ -n "${WAN_IFACE}" ]]; then
+    return 0
+  fi
+
+  WAN_IFACE="$(ip -o route get 1.1.1.1 2>/dev/null | awk '{for (i = 1; i <= NF; i++) if ($i == "dev") { print $(i+1); exit }}')"
+  [[ -n "${WAN_IFACE}" ]] || die "Unable to auto-detect WAN interface. Set --wan-iface."
+}
+
+ssh_session_safety_gate() {
+  if [[ -z "${SSH_CONNECTION:-}" ]]; then
+    return 0
+  fi
+
+  local src_ip
+  src_ip="${SSH_CONNECTION%% *}"
+  if [[ "${src_ip}" != 100.* && "${src_ip}" != fd7a:* ]] && ! is_true "${FORCE}"; then
+    die "Current SSH source (${src_ip}) is not Tailscale-like; refusing to continue without --force."
+  fi
+}
+
+ensure_packages() {
+  local packages
+  local missing=()
+  packages=(
+    curl
+    ufw
+    auditd
+    audispd-plugins
+    unattended-upgrades
+    apt-listchanges
+    openssh-server
+    iptables
+    fail2ban
+  )
+
+  for pkg in "${packages[@]}"; do
+    if ! dpkg-query -W -f='${Status}' "${pkg}" 2>/dev/null | grep -q "install ok installed"; then
+      missing+=("${pkg}")
+    fi
+  done
+
+  if ((${#missing[@]} > 0)); then
+    log "Installing required packages: ${missing[*]}"
+    retry_apt_update
+    run env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "${missing[@]}"
+  fi
+}
+
+require_commands() {
+  local commands=()
+  commands+=(ip awk grep sed)
+
+  if ! is_true "${DRY_RUN}"; then
+    commands+=(sshd ufw iptables journalctl systemctl augenrules auditctl fail2ban-client)
+  fi
+
+  for cmd in "${commands[@]}"; do
+    command -v "${cmd}" >/dev/null 2>&1 || die "Missing command: ${cmd}"
+  done
+}
+
+retry_apt_update() {
+  local attempts=3 delay=5 i
+  for (( i = 1; i <= attempts; i++ )); do
+    if run apt-get update; then
+      return 0
+    fi
+    if (( i < attempts )); then
+      log "apt-get update failed (attempt ${i}/${attempts}); retrying in ${delay}s..."
+      sleep "${delay}"
+    fi
+  done
+  die "apt-get update failed after ${attempts} attempts."
+}
+
+verify_tailscale_iface() {
+  ip link show "${TAILSCALE_IFACE}" >/dev/null 2>&1 || die "Interface ${TAILSCALE_IFACE} not found. Refusing Tailscale-only SSH hardening."
+}
+
+# Store detected Tailscale IP for split-horizon binding
+DETECTED_TAILSCALE_IP=""
+
+get_tailscale_ip() {
+  if [[ -n "${DETECTED_TAILSCALE_IP}" ]]; then
+    echo "${DETECTED_TAILSCALE_IP}"
+    return 0
+  fi
+
+  command -v tailscale >/dev/null 2>&1 || return 1
+  DETECTED_TAILSCALE_IP="$(tailscale ip -4 2>/dev/null)" || return 1
+  echo "${DETECTED_TAILSCALE_IP}"
+}
+
+install_tailscale() {
+  if command -v tailscale >/dev/null 2>&1; then
+    log "Tailscale already installed."
+    return 0
+  fi
+
+  if is_true "${DRY_RUN}"; then
+    log "DRY-RUN: would install Tailscale via official install script."
+    return 0
+  fi
+
+  log "Installing Tailscale..."
+  run curl -fsSL https://tailscale.com/install.sh | sh
+
+  # Authenticate Tailscale
+  if [[ -n "${TAILSCALE_AUTH_KEY}" ]]; then
+    log "Authenticating Tailscale with provided auth key..."
+    run tailscale up --ssh --authkey="${TAILSCALE_AUTH_KEY}"
+  else
+    log "Interactive Tailscale authentication required."
+    log "Run: tailscale up --ssh"
+    log "Waiting for Tailscale connection (timeout: 120s)..."
+
+    local timeout=120
+    local elapsed=0
+    while ! ip link show "${TAILSCALE_IFACE}" >/dev/null 2>&1; do
+      if (( elapsed >= timeout )); then
+        die "Timeout waiting for Tailscale interface. Run 'tailscale up --ssh' manually and retry."
+      fi
+      sleep 2
+      elapsed=$((elapsed + 2))
+      log "Waiting for ${TAILSCALE_IFACE}... (${elapsed}s/${timeout}s)"
+    done
+  fi
+
+  log "Tailscale installed and configured."
+}
+
+configure_coolify_binding_watchdog() {
+  if ! is_true "${BIND_DASHBOARD_TO_TAILSCALE}"; then
+    return 0
+  fi
+
+  write_file "${COOLIFY_BINDING_GUARD_SCRIPT}" "0750" "root" "root" <<'GUARD_EOF'
+#!/usr/bin/env bash
+# Coolify dashboard UFW binding guard.
+# Verifies that UFW rules restricting the Coolify dashboard (port 8000), Soketi
+# (port 6001), and terminal (port 6002) to the tailscale0 interface exist, and
+# re-applies them if missing.
+# Does NOT modify Coolify's .env — security is enforced entirely by UFW.
+set -Euo pipefail
+
+TAILSCALE_IFACE="tailscale0"
+LOG_TAG="coolify-binding-guard"
+
+log() { logger -t "${LOG_TAG}" -- "$*"; }
+
+command -v ufw >/dev/null 2>&1 || { log "ufw not found; skipping."; exit 0; }
+
+ufw_status="$(ufw status 2>/dev/null | head -1)" || true
+[[ "${ufw_status}" == "Status: active" ]] || { log "UFW not active; skipping."; exit 0; }
+
+changed=false
+
+# Check and re-apply UFW rule for port 8000 on tailscale0
+if ! ufw status | grep -q "8000.*on ${TAILSCALE_IFACE}"; then
+  log "UFW rule for port 8000 on ${TAILSCALE_IFACE} missing — re-applying."
+  ufw allow in on "${TAILSCALE_IFACE}" proto tcp to any port 8000 \
+    comment "coolify-hardening-dashboard-tailscale" 2>/dev/null || true
+  changed=true
+fi
+
+# Check and re-apply UFW rule for port 6001 on tailscale0
+if ! ufw status | grep -q "6001.*on ${TAILSCALE_IFACE}"; then
+  log "UFW rule for port 6001 on ${TAILSCALE_IFACE} missing — re-applying."
+  ufw allow in on "${TAILSCALE_IFACE}" proto tcp to any port 6001 \
+    comment "coolify-hardening-soketi-tailscale" 2>/dev/null || true
+  changed=true
+fi
+
+# Check and re-apply UFW rule for port 6002 on tailscale0
+if ! ufw status | grep -q "6002.*on ${TAILSCALE_IFACE}"; then
+  log "UFW rule for port 6002 on ${TAILSCALE_IFACE} missing — re-applying."
+  ufw allow in on "${TAILSCALE_IFACE}" proto tcp to any port 6002 \
+    comment "coolify-hardening-terminal-tailscale" 2>/dev/null || true
+  changed=true
+fi
+
+if "${changed}"; then
+  log "UFW rules re-applied for ports 8000, 6001, and 6002 on ${TAILSCALE_IFACE}."
+else
+  log "UFW rules for ports 8000, 6001, and 6002 on ${TAILSCALE_IFACE} are present — no action needed."
+fi
+
+# Verify public IP is NOT serving the dashboard
+if command -v nc >/dev/null 2>&1; then
+  public_ip="$(ip -o route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="src") print $(i+1)}')" || true
+  tailscale_ip="$(tailscale ip -4 2>/dev/null)" || true
+  if [[ -n "${public_ip}" && "${public_ip}" != "${tailscale_ip}" ]]; then
+    if nc -z -w2 "${public_ip}" 8000 2>/dev/null; then
+      log "WARN: Port 8000 still reachable on public IP ${public_ip} — check UFW rules."
+    fi
+  fi
+fi
+GUARD_EOF
+
+  write_file "${COOLIFY_BINDING_GUARD_SERVICE}" "0644" "root" "root" <<'UNIT_EOF'
+[Unit]
+Description=Verify Coolify dashboard UFW rules on tailscale0 are present
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/coolify-binding-guard.sh
+UNIT_EOF
+
+  write_file "${COOLIFY_BINDING_GUARD_TIMER}" "0644" "root" "root" <<'TIMER_EOF'
+[Unit]
+Description=Periodically verify Coolify dashboard UFW rules on tailscale0
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+AccuracySec=30s
+
+[Install]
+WantedBy=timers.target
+TIMER_EOF
+
+  run systemctl daemon-reload
+  run systemctl enable --now coolify-binding-guard.timer
+  log "Coolify binding watchdog enabled (checks every 5 minutes)."
+}
+
+configure_coolify_binding() {
+  if ! is_true "${BIND_DASHBOARD_TO_TAILSCALE}"; then
+    return 0
+  fi
+
+  # Dashboard Tailscale restriction is enforced via UFW, not APP_PORT socket binding.
+  # Coolify's docker-compose.prod.yml uses APP_PORT in both ports: and expose: directives;
+  # expose: requires a plain port number, so IP:port format is incompatible and breaks
+  # Coolify container startup. UFW default-deny + explicit allow on tailscale0 provides
+  # equivalent defense-in-depth without touching Coolify's configuration.
+  #
+  # UFW rules for 8000/6001 on tailscale0 are already applied by configure_ufw(); this
+  # function verifies they exist and re-applies them idempotently.
+
+  log "Verifying Coolify dashboard UFW rules on ${TAILSCALE_IFACE}..."
+
+  if is_true "${DRY_RUN}"; then
+    log "DRY-RUN: would verify UFW rules for ports 8000, 6001, and 6002 on ${TAILSCALE_IFACE}"
+    log "DRY-RUN: would verify port 8000 is listening and not reachable on public IP"
+    return 0
+  fi
+
+  if command -v ufw >/dev/null 2>&1; then
+    # Idempotent — ufw silently skips duplicate rules
+    local ufw_result
+    ufw_result="$(ufw allow in on "${TAILSCALE_IFACE}" proto tcp to any port 8000 \
+      comment "coolify-hardening-dashboard-tailscale" 2>&1)" || {
+      warn "UFW rule for port 8000 on ${TAILSCALE_IFACE} failed: ${ufw_result}"
+    }
+    ufw_result="$(ufw allow in on "${TAILSCALE_IFACE}" proto tcp to any port 6001 \
+      comment "coolify-hardening-soketi-tailscale" 2>&1)" || {
+      warn "UFW rule for port 6001 on ${TAILSCALE_IFACE} failed: ${ufw_result}"
+    }
+    ufw_result="$(ufw allow in on "${TAILSCALE_IFACE}" proto tcp to any port 6002 \
+      comment "coolify-hardening-terminal-tailscale" 2>&1)" || {
+      warn "UFW rule for port 6002 on ${TAILSCALE_IFACE} failed: ${ufw_result}"
+    }
+    log "UFW rules verified for ports 8000, 6001, and 6002 on ${TAILSCALE_IFACE}."
+  else
+    warn "ufw not found — skipping UFW rule verification."
+  fi
+
+  # Wait for Coolify to bind port 8000 (up to 30s)
+  log "Waiting for Coolify to bind port 8000 (up to 30s)..."
+  local i
+  for (( i = 1; i <= 6; i++ )); do
+    if ss -tlnp 2>/dev/null | grep -q ':8000 '; then
+      break
+    fi
+    sleep 5
+  done
+
+  # Verify port 8000 is listening
+  local bound_8000
+  bound_8000="$(ss -tlnp 2>/dev/null | grep ':8000 ' || true)"
+  if [[ -n "${bound_8000}" ]]; then
+    log "PASS: Port 8000 is listening"
+  else
+    warn "Port 8000 not yet listening. Check: ss -tlnp | grep 8000"
+  fi
+
+  # Verify public IP is NOT serving the dashboard (UFW should block it)
+  if command -v nc >/dev/null 2>&1; then
+    local public_ip
+    public_ip="$(ip -o route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="src") print $(i+1)}')"
+    local tailscale_ip
+    tailscale_ip="$(get_tailscale_ip)" || true
+    if [[ -n "${public_ip}" && "${public_ip}" != "${tailscale_ip}" ]]; then
+      if nc -z -w2 "${public_ip}" 8000 2>/dev/null; then
+        warn "Port 8000 still appears reachable on public IP ${public_ip}. Check UFW rules."
+      else
+        log "PASS: Port 8000 not reachable on public IP ${public_ip}"
+      fi
+    fi
+  fi
+
+  log "Coolify dashboard UFW restriction verified."
+}
+
+ensure_timesync() {
+  if ! is_true "${DRY_RUN}"; then
+    local ntp_active
+    ntp_active="$(timedatectl show --property=NTP --value 2>/dev/null || echo "n/a")"
+    if [[ "${ntp_active}" != "yes" ]]; then
+      if run timedatectl set-ntp true; then
+        log "NTP synchronization enabled."
+      else
+        warn "Could not enable NTP (timedatectl set-ntp failed). Verify manually."
+      fi
+    else
+      log "NTP synchronization already active."
+    fi
+    local i
+    for (( i = 1; i <= 6; i++ )); do
+      local synced
+      synced="$(timedatectl show --property=NTPSynchronized --value 2>/dev/null || echo "n/a")"
+      if [[ "${synced}" == "yes" ]]; then
+        log "NTP synchronized."
+        return 0
+      fi
+      log "Waiting for NTP synchronization (${i}/6)..."
+      sleep 5
+    done
+    warn "NTP not synchronized after 30s; continuing. Verify with: timedatectl status"
+  else
+    log "DRY-RUN: would verify NTP synchronization."
+  fi
+}
+
+configure_swap() {
+  local swap_size="${SWAP_SIZE:-2G}"
+  [[ "${swap_size}" == "0" ]] && { log "Swap creation disabled (--swap-size 0)."; return 0; }
+
+  if is_true "${DRY_RUN}"; then
+    log "DRY-RUN: would configure ${swap_size} swap file at /swapfile."
+    return 0
+  fi
+
+  if swapon --show --noheadings | grep -q .; then
+    log "Swap already active. Skipping."
+    return 0
+  fi
+
+  local swap_file="/swapfile"
+  if [[ -f "${swap_file}" ]]; then
+    log "Stale ${swap_file} found (not active in swapon); removing."
+    run rm -f "${swap_file}"
+  fi
+  run fallocate -l "${swap_size}" "${swap_file}"
+  run chmod 600 "${swap_file}"
+  run mkswap "${swap_file}"
+  run swapon "${swap_file}"
+
+  if ! grep -qxF "${swap_file} none swap sw 0 0" /etc/fstab; then
+    echo "${swap_file} none swap sw 0 0" >> /etc/fstab
+  fi
+
+  log "Swap configured: ${swap_size} at ${swap_file}."
+}
+
+disable_unused_services() {
+  local services=(rpcbind avahi-daemon cups cups-browsed)
+  local unit
+  for svc in "${services[@]}"; do
+    for unit in "${svc}.service" "${svc}.socket"; do
+      if systemctl list-unit-files --no-legend "${unit}" 2>/dev/null | grep -q "${unit}"; then
+        log "Disabling and masking ${unit}"
+        run systemctl disable --now "${unit}" 2>/dev/null || true
+        run systemctl mask "${unit}" 2>/dev/null || true
+      fi
+    done
+  done
+}
+
+configure_sysctl() {
+  # Check if BBR kernel module is available
+  local bbr_available="false"
+  if modinfo tcp_bbr &>/dev/null; then
+    bbr_available="true"
+  fi
+
+  {
+    cat <<'SYSCTL_BASE'
+# Managed by bootstrap hardening — Coolify/Docker safe
+net.ipv4.ip_forward = 1
+net.ipv4.tcp_syncookies = 1
+net.ipv4.conf.all.accept_redirects = 0
+net.ipv4.conf.default.accept_redirects = 0
+net.ipv6.conf.all.accept_redirects = 0
+net.ipv6.conf.default.accept_redirects = 0
+net.ipv4.conf.all.send_redirects = 0
+net.ipv4.conf.default.send_redirects = 0
+net.ipv4.conf.all.accept_source_route = 0
+net.ipv4.conf.default.accept_source_route = 0
+net.ipv6.conf.all.accept_source_route = 0
+net.ipv6.conf.default.accept_source_route = 0
+net.ipv4.conf.all.log_martians = 1
+net.ipv4.conf.default.log_martians = 1
+net.ipv4.icmp_echo_ignore_broadcasts = 1
+net.ipv4.icmp_ignore_bogus_error_responses = 1
+net.ipv4.conf.all.rp_filter = 2
+net.ipv4.conf.default.rp_filter = 2
+# SYN flood hardening
+net.ipv4.tcp_max_syn_backlog = 2048
+net.ipv4.tcp_synack_retries = 2
+fs.protected_hardlinks = 1
+fs.protected_symlinks = 1
+fs.suid_dumpable = 0
+kernel.unprivileged_bpf_disabled = 1
+kernel.kexec_load_disabled = 1
+kernel.sysrq = 4
+kernel.randomize_va_space = 2
+kernel.kptr_restrict = 2
+kernel.dmesg_restrict = 1
+kernel.yama.ptrace_scope = 1
+kernel.perf_event_paranoid = 3
+SYSCTL_BASE
+
+    if [[ "${bbr_available}" == "true" ]]; then
+      cat <<'SYSCTL_BBR'
+# TCP performance: BBR congestion control
+net.core.default_qdisc = fq
+net.ipv4.tcp_congestion_control = bbr
+SYSCTL_BBR
+    fi
+
+    if [[ "${SWAP_SIZE:-2G}" != "0" ]]; then
+      cat <<'SYSCTL_SWAP'
+# Swap tuning: prefer RAM, use swap only under pressure
+vm.swappiness = 10
+SYSCTL_SWAP
+    fi
+  } | write_file "${SYSCTL_DROPIN_FILE}" "0644" "root" "root"
+
+  if [[ "${bbr_available}" == "false" ]]; then
+    warn "BBR not available: kernel module tcp_bbr not found. Using default congestion control."
+  fi
+
+  run sysctl --system
+
+  if ! is_true "${DRY_RUN}"; then
+    local syncookies ip_forward
+    syncookies="$(sysctl -n net.ipv4.tcp_syncookies 2>/dev/null || echo "?")"
+    ip_forward="$(sysctl -n net.ipv4.ip_forward 2>/dev/null || echo "?")"
+    [[ "${syncookies}" == "1" ]] || die "Post-sysctl check failed: tcp_syncookies is ${syncookies}, expected 1."
+    [[ "${ip_forward}" == "1" ]] || die "Post-sysctl check failed: ip_forward is ${ip_forward}, expected 1 (Docker requires this)."
+
+    if [[ "${bbr_available}" == "true" ]]; then
+      local bbr
+      bbr="$(sysctl -n net.ipv4.tcp_congestion_control 2>/dev/null || echo "?")"
+      [[ "${bbr}" == "bbr" ]] || warn "BBR not active: ${bbr} (kernel module tcp_bbr may be unavailable)."
+    fi
+  fi
+}
+
+configure_fail2ban() {
+  write_file "${FAIL2BAN_JAIL_FILE}" "0644" "root" "root" <<EOF
+# Managed by bootstrap hardening
+[DEFAULT]
+bantime = 1h
+findtime = 10m
+maxretry = 5
+banaction = ufw
+ignoreip = 127.0.0.1/8 ::1 ${TAILSCALE_CIDR}
+
+[sshd]
+enabled = true
+port = ${SSH_PORT}
+backend = systemd
+maxretry = 3
+bantime = 1h
+EOF
+
+  run systemctl enable --now fail2ban
+  if ! is_true "${DRY_RUN}"; then
+    run systemctl restart fail2ban
+  fi
+}
+
+configure_banner() {
+  write_file "/etc/issue.net" "0644" "root" "root" <<'EOF'
+***************************************************************************
+                   AUTHORIZED ACCESS ONLY
+This system is for authorized use only. All activity may be monitored
+and reported. Unauthorized access is prohibited and may be subject to
+criminal and civil penalties.
+***************************************************************************
+EOF
+}
+
+ensure_admin_access() {
+  local home_dir
+  local ssh_dir
+  local auth_file
+  local user_exists="false"
+
+  if id "${ADMIN_USER}" >/dev/null 2>&1; then
+    user_exists="true"
+    log "Admin user exists: ${ADMIN_USER}"
+  else
+    run useradd -m -s /bin/bash -G sudo "${ADMIN_USER}"
+  fi
+
+  if [[ "${user_exists}" == "true" ]] && ! id -nG "${ADMIN_USER}" | tr ' ' '\n' | grep -qx "sudo"; then
+    run usermod -aG sudo "${ADMIN_USER}"
+  fi
+
+  # Configure passwordless sudo for admin user
+  # This is required because the admin user has no password set,
+  # but sudo requires password by default, blocking all admin operations.
+  local sudoers_file="/etc/sudoers.d/${ADMIN_USER}"
+  if is_true "${DRY_RUN}"; then
+    log "DRY-RUN: would create ${sudoers_file} with passwordless sudo for ${ADMIN_USER}"
+  else
+    echo "${ADMIN_USER} ALL=(ALL) NOPASSWD: ALL" > "${sudoers_file}"
+    chmod 440 "${sudoers_file}"
+    # Validate sudoers syntax before committing
+    if ! visudo -c -f "${sudoers_file}" >/dev/null 2>&1; then
+      rm -f "${sudoers_file}"
+      die "Failed to create valid sudoers file for ${ADMIN_USER}"
+    fi
+    log "Configured passwordless sudo for ${ADMIN_USER}"
+  fi
+
+  if is_true "${DRY_RUN}" && [[ "${user_exists}" == "false" ]]; then
+    log "DRY-RUN: would create /home/${ADMIN_USER}/.ssh/authorized_keys with provided key."
+    return 0
+  fi
+
+  home_dir="$(getent passwd "${ADMIN_USER}" | cut -d: -f6)"
+  [[ -n "${home_dir}" ]] || die "Unable to resolve home directory for ${ADMIN_USER}."
+  ssh_dir="${home_dir}/.ssh"
+  auth_file="${ssh_dir}/authorized_keys"
+
+  if is_true "${DRY_RUN}"; then
+    log "DRY-RUN: ensure ${auth_file} contains provided key."
+    return 0
+  fi
+
+  install -d -m 0700 -o "${ADMIN_USER}" -g "${ADMIN_USER}" "${ssh_dir}"
+  touch "${auth_file}"
+  chown "${ADMIN_USER}:${ADMIN_USER}" "${auth_file}"
+  chmod 0600 "${auth_file}"
+
+  if ! grep -qxF "${ADMIN_PUBKEY}" "${auth_file}"; then
+    printf '%s\n' "${ADMIN_PUBKEY}" >> "${auth_file}"
+  fi
+}
+
+restore_ssh_dropin() {
+  local backup="$1"
+  if is_true "${DRY_RUN}"; then
+    return 0
+  fi
+  if [[ -n "${backup}" && -f "${backup}" ]]; then
+    cp -a "${backup}" "${SSH_DROPIN_FILE}"
+  else
+    rm -f "${SSH_DROPIN_FILE}"
+  fi
+}
+
+assert_sshd_effective() {
+  local effective="$1"
+
+  grep -qE "^port ${SSH_PORT}$" <<< "${effective}" || return 1
+  grep -q "^permitrootlogin no$" <<< "${effective}" || return 1
+  grep -q "^passwordauthentication no$" <<< "${effective}" || return 1
+  grep -q "^kbdinteractiveauthentication no$" <<< "${effective}" || return 1
+  grep -q "^pubkeyauthentication yes$" <<< "${effective}" || return 1
+  grep -q "^authenticationmethods publickey$" <<< "${effective}" || return 1
+  grep -qE "^allowusers .*\\b${ADMIN_USER}\\b" <<< "${effective}" || return 1
+  grep -q "^permitemptypasswords no$" <<< "${effective}" || return 1
+  grep -q "^compression no$" <<< "${effective}" || return 1
+  grep -q "chacha20-poly1305@openssh.com" <<< "${effective}" || return 1
+  grep -q "hmac-sha2-512-etm@openssh.com" <<< "${effective}" || return 1
+  grep -q "sntrup761x25519-sha512@openssh.com" <<< "${effective}" || return 1
+  grep -q "hostkeyalgorithms .*ssh-ed25519" <<< "${effective}" || return 1
+}
+
+assert_sshd_match_localhost() {
+  local effective="$1"
+
+  # OpenSSH outputs "prohibit-password" or its legacy synonym "without-password"
+  grep -qE "^permitrootlogin (prohibit-password|without-password)$" <<< "${effective}" || return 1
+  grep -qE "^allowusers .*\\broot\\b" <<< "${effective}" || return 1
+  grep -qE "^allowusers .*\\b${ADMIN_USER}\\b" <<< "${effective}" || return 1
+}
+
+reload_ssh_service() {
+  local units
+  local has_ssh="false"
+  local has_sshd="false"
+
+  if ! systemctl list-unit-files --type=service --no-legend >/dev/null 2>&1; then
+    return 1
+  fi
+
+  units="$(systemctl list-unit-files --type=service --no-legend 2>/dev/null | awk '{print $1}')"
+  grep -qx "ssh.service" <<< "${units}" && has_ssh="true" || true
+  grep -qx "sshd.service" <<< "${units}" && has_sshd="true" || true
+
+  if [[ "${has_ssh}" == "true" ]]; then
+    if ! systemctl is-active --quiet ssh; then
+      systemctl start ssh || return 1
+    fi
+    systemctl reload ssh || systemctl restart ssh || return 1
+    return 0
+  fi
+
+  if [[ "${has_sshd}" == "true" ]]; then
+    if ! systemctl is-active --quiet sshd; then
+      systemctl start sshd || return 1
+    fi
+    systemctl reload sshd || systemctl restart sshd || return 1
+    return 0
+  fi
+
+  return 1
+}
+
+configure_ssh() {
+  local backup=""
+  local effective=""
+
+  if ! is_true "${DRY_RUN}" && [[ ! -d /run/sshd ]]; then
+    install -d -m 0755 /run/sshd
+  fi
+
+  if [[ -f "${SSH_DROPIN_FILE}" ]] && ! is_true "${DRY_RUN}"; then
+    backup="${SSH_DROPIN_FILE}.bak.$(date +%s)"
+    cp -a "${SSH_DROPIN_FILE}" "${backup}"
+  fi
+
+  write_file "${SSH_DROPIN_FILE}" "0644" "root" "root" <<EOF
+# Managed by ${SCRIPT_NAME}
+Port ${SSH_PORT}
+PermitRootLogin no
+PasswordAuthentication no
+PermitEmptyPasswords no
+KbdInteractiveAuthentication no
+PubkeyAuthentication yes
+AuthenticationMethods publickey
+AllowUsers ${ADMIN_USER}
+X11Forwarding no
+AllowAgentForwarding no
+AllowTcpForwarding no
+Compression no
+MaxAuthTries 3
+LoginGraceTime 30
+ClientAliveInterval 300
+ClientAliveCountMax 2
+Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com
+MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com
+KexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org
+HostKeyAlgorithms ssh-ed25519,rsa-sha2-512,rsa-sha2-256
+Banner /etc/issue.net
+
+# Coolify connects to its own host as root via localhost / Docker bridge.
+# Allow key-only root login from loopback and Docker address pool (10.0.0.0/8
+# configured in daemon.json) and RFC 1918 172.16/12 bridges.
+Match Address 127.0.0.1,::1,172.16.0.0/12,10.0.0.0/8
+    PermitRootLogin prohibit-password
+    AllowUsers ${ADMIN_USER} root
+EOF
+
+  if is_true "${DRY_RUN}"; then
+    return 0
+  fi
+
+  if ! sshd -t; then
+    restore_ssh_dropin "${backup}"
+    die "sshd -t failed after writing SSH hardening drop-in."
+  fi
+
+  effective="$(sshd -T 2>/dev/null || true)"
+  if ! assert_sshd_effective "${effective}"; then
+    restore_ssh_dropin "${backup}"
+    die "sshd -T did not match expected hardened values."
+  fi
+
+  local match_effective
+  match_effective="$(sshd -T -C addr=127.0.0.1,user=root,host=localhost,laddr=127.0.0.1 2>/dev/null || true)"
+  if ! assert_sshd_match_localhost "${match_effective}"; then
+    restore_ssh_dropin "${backup}"
+    die "sshd -T -C (localhost Match block) did not match expected values."
+  fi
+
+  if ! reload_ssh_service; then
+    restore_ssh_dropin "${backup}"
+    die "Failed to reload SSH service."
+  fi
+}
+
+configure_ufw() {
+  run ufw --force reset
+  run ufw default deny incoming
+  run ufw default allow outgoing
+  run ufw default deny routed
+
+  run ufw allow in on "${TAILSCALE_IFACE}" proto tcp to any port "${SSH_PORT}" comment "coolify-hardening-ssh-tailscale"
+
+  # Allow Coolify to SSH to the host from inside its Docker container.
+  # Docker uses 10.0.0.0/8 as address pool (set in daemon.json). The container
+  # connects to host.docker.internal (= Docker bridge gateway) on port 22 to manage
+  # "This Machine". Key-only auth; the sshd Match block above restricts login to root.
+  run ufw allow in from 10.0.0.0/8 to any port "${SSH_PORT}" comment "coolify-hardening-ssh-docker-bridge"
+
+  # Allow Coolify dashboard, Soketi, and terminal on Tailscale interface only.
+  # UFW default deny blocks external access; these rules make them reachable via VPN.
+  # 8000 = dashboard, 6001 = Soketi real-time, 6002 = terminal (required since beta.336)
+  run ufw allow in on "${TAILSCALE_IFACE}" proto tcp to any port 8000 comment "coolify-hardening-dashboard-tailscale"
+  run ufw allow in on "${TAILSCALE_IFACE}" proto tcp to any port 6001 comment "coolify-hardening-soketi-tailscale"
+  run ufw allow in on "${TAILSCALE_IFACE}" proto tcp to any port 6002 comment "coolify-hardening-terminal-tailscale"
+
+  if is_true "${TUNNEL_MODE}"; then
+    log "Tunnel mode: skipping WAN 80/443 UFW rules (traffic arrives via outbound tunnel)."
+  else
+    run ufw allow in on "${WAN_IFACE}" proto tcp to any port 80 comment "coolify-hardening-http"
+    run ufw allow in on "${WAN_IFACE}" proto tcp to any port 443 comment "coolify-hardening-https"
+  fi
+
+  run ufw allow in on "${WAN_IFACE}" proto udp to any port 41641 comment "coolify-hardening-tailscale-direct"
+
+  # ICMP is allowed via UFW's default before.rules (ufw allow proto icmp is not supported)
+
+  run ufw --force enable
+}
+
+install_docker_user_assets() {
+  write_file "${DOCKER_USER_SCRIPT}" "0750" "root" "root" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+WAN_IFACE="${WAN_IFACE:-${1:-}}"
+TAILSCALE_IFACE="${TAILSCALE_IFACE:-tailscale0}"
+TUNNEL_MODE="${TUNNEL_MODE:-false}"
+
+if [[ -z "${WAN_IFACE}" ]]; then
+  echo "WAN_IFACE is required." >&2
+  exit 1
+fi
+
+if ! command -v iptables >/dev/null 2>&1; then
+  echo "iptables is required." >&2
+  exit 1
+fi
+
+is_true() {
+  case "${1,,}" in
+    1|true|yes|y|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+ipt() {
+  iptables -w "$@"
+}
+
+# --- IPv4 ---
+
+ipt -t filter -N DOCKER-USER 2>/dev/null || true
+if ! ipt -t filter -C FORWARD -j DOCKER-USER >/dev/null 2>&1; then
+  ipt -t filter -I FORWARD 1 -j DOCKER-USER
+fi
+
+while true; do
+  line_no="$(ipt -t filter -L DOCKER-USER --line-numbers -n | awk '/coolify-hardening-/ { print $1; exit }')"
+  [[ -n "${line_no}" ]] || break
+  ipt -t filter -D DOCKER-USER "${line_no}" || true
+done
+
+ipt -t filter -A DOCKER-USER -m conntrack --ctstate RELATED,ESTABLISHED -m comment --comment "coolify-hardening-estab" -j RETURN
+ipt -t filter -A DOCKER-USER -i "${TAILSCALE_IFACE}" -m comment --comment "coolify-hardening-tailscale" -j ACCEPT
+ipt -t filter -A DOCKER-USER -i docker0 -m comment --comment "coolify-hardening-bridge-docker0" -j RETURN
+ipt -t filter -A DOCKER-USER -i "br+" -m comment --comment "coolify-hardening-bridge-user" -j RETURN
+if ! is_true "${TUNNEL_MODE}"; then
+  ipt -t filter -A DOCKER-USER -i "${WAN_IFACE}" -p tcp -m multiport --dports 80,443 -m comment --comment "coolify-hardening-wan-web" -j ACCEPT
+fi
+ipt -t filter -A DOCKER-USER -i "${WAN_IFACE}" -m comment --comment "coolify-hardening-wan-drop" -j DROP
+ipt -t filter -A DOCKER-USER -m comment --comment "coolify-hardening-return" -j RETURN
+
+# --- IPv6 ---
+
+if command -v ip6tables >/dev/null 2>&1; then
+  ipt6() {
+    ip6tables -w "$@"
+  }
+
+  ipt6 -t filter -N DOCKER-USER 2>/dev/null || true
+  if ! ipt6 -t filter -C FORWARD -j DOCKER-USER >/dev/null 2>&1; then
+    ipt6 -t filter -I FORWARD 1 -j DOCKER-USER
+  fi
+
+  while true; do
+    line_no="$(ipt6 -t filter -L DOCKER-USER --line-numbers -n | awk '/coolify-hardening-/ { print $1; exit }')"
+    [[ -n "${line_no}" ]] || break
+    ipt6 -t filter -D DOCKER-USER "${line_no}" || true
+  done
+
+  ipt6 -t filter -A DOCKER-USER -m conntrack --ctstate RELATED,ESTABLISHED -m comment --comment "coolify-hardening-estab6" -j RETURN
+  ipt6 -t filter -A DOCKER-USER -i "${TAILSCALE_IFACE}" -m comment --comment "coolify-hardening-tailscale6" -j ACCEPT
+  if ! is_true "${TUNNEL_MODE}"; then
+    ipt6 -t filter -A DOCKER-USER -i "${WAN_IFACE}" -p tcp -m multiport --dports 80,443 -m comment --comment "coolify-hardening-wan-web6" -j ACCEPT
+  fi
+  ipt6 -t filter -A DOCKER-USER -i "${WAN_IFACE}" -m comment --comment "coolify-hardening-wan-drop6" -j DROP
+  ipt6 -t filter -A DOCKER-USER -m comment --comment "coolify-hardening-return6" -j RETURN
+else
+  echo "ip6tables not available; skipping IPv6 DOCKER-USER rules." >&2
+fi
+EOF
+
+  write_file "${DOCKER_USER_ENV_FILE}" "0644" "root" "root" <<EOF
+WAN_IFACE=${WAN_IFACE}
+TAILSCALE_IFACE=${TAILSCALE_IFACE}
+TUNNEL_MODE=${TUNNEL_MODE}
+EOF
+
+  write_file "${DOCKER_USER_UNIT_FILE}" "0644" "root" "root" <<EOF
+[Unit]
+Description=Apply managed DOCKER-USER hardening rules
+After=docker.service
+Requires=docker.service
+PartOf=docker.service
+
+[Service]
+Type=oneshot
+EnvironmentFile=${DOCKER_USER_ENV_FILE}
+ExecStart=${DOCKER_USER_SCRIPT}
+RemainAfterExit=yes
+
+[Install]
+WantedBy=docker.service
+EOF
+}
+
+detect_docker() {
+  if command -v docker >/dev/null 2>&1; then
+    DOCKER_PRESENT="true"
+    log "Docker detected."
+  else
+    log "Docker not detected."
+  fi
+}
+
+configure_docker_user() {
+  install_docker_user_assets
+
+  # Remove stale WantedBy=multi-user.target symlinks from prior script versions
+  if ! is_true "${DRY_RUN}"; then
+    systemctl disable docker-user-hardening.service 2>/dev/null || true
+  fi
+  run systemctl daemon-reload
+  run systemctl enable docker-user-hardening.service
+
+  if [[ "${DOCKER_PRESENT}" == "true" ]]; then
+    # Docker CLI may exist while docker.service is not yet installed/available.
+    if systemctl list-unit-files --type=service 2>/dev/null | awk '{print $1}' | grep -qx 'docker.service'; then
+      run systemctl start docker-user-hardening.service || warn "docker-user-hardening.service could not be started; start after Docker is ready."
+      if systemctl is-active --quiet docker-user-hardening.service 2>/dev/null; then
+        DOCKER_RULES_APPLIED="true"
+      fi
+    else
+      warn "Docker CLI detected but docker.service is not present; DOCKER-USER start is deferred."
+    fi
+  else
+    warn "Docker not detected; DOCKER-USER unit installed and enabled, but start is deferred."
+  fi
+}
+
+DOCKER_DAEMON_JSON="/etc/docker/daemon.json"
+
+configure_docker_daemon() {
+  # Required settings for hardening
+  # Note: log-driver uses json-file (same as Coolify) for compatibility.
+  # Hardening owns: log-driver, log-opts, live-restore. Coolify may add: default-address-pools.
+  local required_settings='{"log-driver":"json-file","log-opts":{"max-size":"10m","max-file":"3"},"live-restore":true}'
+
+  if [[ "${DOCKER_PRESENT}" != "true" ]]; then
+    log "Docker not present; skipping daemon.json creation (will be needed post-install)."
+    return 0
+  fi
+
+  if [[ -f "${DOCKER_DAEMON_JSON}" ]]; then
+    # File exists - merge our required settings with existing config
+    log "Merging hardening settings into existing ${DOCKER_DAEMON_JSON}"
+
+    if is_true "${DRY_RUN}"; then
+      log "DRY-RUN: would merge hardening settings into ${DOCKER_DAEMON_JSON}"
+      return 0
+    fi
+
+    # Check if jq is available for proper JSON merging
+    if ! command -v jq >/dev/null 2>&1; then
+      warn "jq not installed; installing for JSON merge..."
+      retry_apt_update
+      run env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends jq
+    fi
+
+    # Backup existing config
+    local backup="${DOCKER_DAEMON_JSON}.bak.$(date +%s)"
+    cp -a "${DOCKER_DAEMON_JSON}" "${backup}"
+    log "Backed up ${DOCKER_DAEMON_JSON} to ${backup}"
+
+    # Merge: our settings take precedence but preserve other existing settings
+    local merged required_tmp
+    required_tmp="$(mktemp)"
+    echo "${required_settings}" > "${required_tmp}"
+    merged="$(jq -s '.[0] * .[1]' "${DOCKER_DAEMON_JSON}" "${required_tmp}" 2>/dev/null)"
+    rm -f "${required_tmp}"
+
+    if [[ -z "${merged}" ]]; then
+      die "Failed to merge ${DOCKER_DAEMON_JSON} with jq; cannot safely apply hardening settings."
+    else
+      echo "${merged}" > "${DOCKER_DAEMON_JSON}"
+      chmod 0644 "${DOCKER_DAEMON_JSON}"
+    fi
+
+    if systemctl is-active --quiet docker; then
+      DOCKER_DAEMON_NEEDS_RESTART="true"
+      log "Docker daemon.json updated; restart deferred until after DOCKER-USER rules are applied."
+    fi
+
+    log "Docker daemon.json updated with hardening settings."
+    return 0
+  fi
+
+  # File doesn't exist - create it
+  # Note: log-driver uses json-file (same as Coolify) for compatibility.
+  # Hardening owns: log-driver, log-opts, live-restore. Coolify may add: default-address-pools.
+  write_file "${DOCKER_DAEMON_JSON}" "0644" "root" "root" <<'EOF'
+{
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "10m",
+    "max-file": "3"
+  },
+  "live-restore": true
+}
+EOF
+
+  log "Docker daemon.json written with log rotation (json-file driver, 10m x 3) and live-restore."
+}
+
+configure_journald() {
+  write_file "${JOURNALD_DROPIN_FILE}" "0644" "root" "root" <<EOF
+[Journal]
+Storage=persistent
+Compress=yes
+SystemMaxUse=${JOURNAL_MAX_USE}
+MaxRetentionSec=${JOURNAL_RETENTION}
+EOF
+  run systemctl restart systemd-journald
+}
+
+build_audit_rules() {
+  cat <<'EOF'
+# Managed by bootstrap hardening
+-w /etc/passwd -p wa -k identity
+-w /etc/shadow -p wa -k identity
+-w /etc/group -p wa -k identity
+-w /etc/gshadow -p wa -k identity
+-w /etc/ssh/sshd_config -p wa -k sshd-config
+-w /etc/ssh/sshd_config.d/ -p wa -k sshd-config
+-w /etc/localtime -p wa -k time-change
+-a always,exit -F arch=b64 -S adjtimex,settimeofday,clock_settime -k time-change
+-a always,exit -F arch=b32 -S adjtimex,settimeofday,clock_settime -k time-change
+-a always,exit -F arch=b64 -S sethostname,setdomainname -k system-locale
+-a always,exit -F arch=b32 -S sethostname,setdomainname -k system-locale
+-w /etc/sudoers -p wa -k sudoers-change
+-w /etc/sudoers.d/ -p wa -k sudoers-change
+EOF
+
+  local bin
+  for bin in /usr/bin/docker /usr/bin/dockerd /usr/bin/containerd; do
+    if [[ -e "${bin}" ]]; then
+      printf -- "-w %s -p x -k container-runtime\n" "${bin}"
+    fi
+  done
+
+  local path
+  for path in /var/run/docker.sock /etc/docker/; do
+    if [[ -e "${path}" ]]; then
+      printf -- "-w %s -p wa -k docker-config\n" "${path}"
+    fi
+  done
+}
+
+configure_auditd() {
+  local tmp
+  tmp="$(mktemp)"
+  build_audit_rules > "${tmp}"
+
+  if is_true "${DRY_RUN}"; then
+    log "DRY-RUN: write ${AUDIT_RULES_FILE}"
+    rm -f "${tmp}"
+  else
+    install -d -m 0755 "$(dirname "${AUDIT_RULES_FILE}")"
+    install -m 0640 -o root -g root "${tmp}" "${AUDIT_RULES_FILE}"
+    rm -f "${tmp}"
+  fi
+
+  run systemctl enable --now auditd || warn "auditd could not be started (container/kernel limitation); rules file written."
+  run augenrules --load
+}
+
+configure_unattended_upgrades() {
+  local reboot_bool
+  reboot_bool="false"
+  if is_true "${ENABLE_AUTO_REBOOT}"; then
+    reboot_bool="true"
+  fi
+
+  write_file "${APT_AUTO_FILE}" "0644" "root" "root" <<'EOF'
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Download-Upgradeable-Packages "1";
+APT::Periodic::Unattended-Upgrade "1";
+APT::Periodic::AutocleanInterval "7";
+EOF
+
+  write_file "${APT_LOCAL_FILE}" "0644" "root" "root" <<EOF
+Unattended-Upgrade::Origins-Pattern {
+    "origin=Ubuntu,codename=\${distro_codename}-security,label=Ubuntu";
+    "origin=Ubuntu,codename=\${distro_codename}-updates,label=Ubuntu";
+    "origin=Docker,label=Docker CE";
+};
+Unattended-Upgrade::MinimalSteps "true";
+Unattended-Upgrade::Automatic-Reboot "${reboot_bool}";
+Unattended-Upgrade::Automatic-Reboot-Time "${AUTO_REBOOT_TIME}";
+Unattended-Upgrade::Remove-Unused-Dependencies "true";
+Unattended-Upgrade::Remove-New-Unused-Dependencies "true";
+$(if [[ -n "${UPGRADE_MAIL}" ]]; then
+  printf 'Unattended-Upgrade::Mail "%s";\n' "${UPGRADE_MAIL}"
+  printf 'Unattended-Upgrade::MailReport "only-on-error";\n'
+fi)
+EOF
+
+  run systemctl enable --now apt-daily.timer apt-daily-upgrade.timer
+  if ! is_true "${DRY_RUN}"; then
+    unattended-upgrade --dry-run --debug >/tmp/unattended-upgrade-dryrun.log 2>&1 || warn "unattended-upgrade dry-run returned non-zero; see /tmp/unattended-upgrade-dryrun.log"
+  fi
+}
+
+bool_cmd() {
+  if "$@" >/dev/null 2>&1; then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+
+run_post_checks() {
+  if is_true "${DRY_RUN}"; then
+    log "Dry-run complete; post-apply checks skipped."
+    return 0
+  fi
+
+  local ssh_effective
+  ssh_effective="$(sshd -T 2>/dev/null || true)"
+  assert_sshd_effective "${ssh_effective}" || die "Post-check failed: sshd effective settings do not match expected hardening."
+
+  local ssh_match_local
+  ssh_match_local="$(sshd -T -C addr=127.0.0.1,user=root,host=localhost,laddr=127.0.0.1 2>/dev/null || true)"
+  assert_sshd_match_localhost "${ssh_match_local}" || die "Post-check failed: SSH Match block for localhost/Docker root access not effective."
+
+  local ssh_match_external
+  ssh_match_external="$(sshd -T -C addr=203.0.113.1,user=root,host=example.com,laddr=0.0.0.0 2>/dev/null || true)"
+  if grep -qE "^permitrootlogin (prohibit-password|without-password|yes)$" <<< "${ssh_match_external}"; then
+    die "Post-check failed: root login permitted from external address (Match block leak)."
+  fi
+
+  ufw status | grep -q "^Status: active$" || die "Post-check failed: UFW is not active."
+  ufw status verbose | grep -qE "${SSH_PORT}/tcp.*on ${TAILSCALE_IFACE}.*ALLOW IN" || die "Post-check failed: SSH allow rule on ${TAILSCALE_IFACE} missing."
+  if ufw status verbose | grep -qE "${SSH_PORT}/tcp.*on ${WAN_IFACE}.*ALLOW IN"; then
+    die "Post-check failed: SSH appears allowed on WAN interface ${WAN_IFACE}."
+  fi
+
+  if is_true "${TUNNEL_MODE}"; then
+    if ufw status verbose | grep -qE "80/tcp.*on ${WAN_IFACE}.*ALLOW IN"; then
+      die "Post-check failed: tunnel-mode is active but WAN port 80 UFW rule exists."
+    fi
+    if ufw status verbose | grep -qE "443/tcp.*on ${WAN_IFACE}.*ALLOW IN"; then
+      die "Post-check failed: tunnel-mode is active but WAN port 443 UFW rule exists."
+    fi
+  fi
+
+  if [[ "${DOCKER_PRESENT}" == "true" ]]; then
+    iptables -t filter -S DOCKER-USER | grep -q "coolify-hardening-wan-drop" || die "Post-check failed: DOCKER-USER IPv4 drop rule missing."
+    iptables -t filter -S DOCKER-USER | grep -q "coolify-hardening-bridge-docker0" || die "Post-check failed: DOCKER-USER bridge-docker0 rule missing."
+    if is_true "${TUNNEL_MODE}"; then
+      if iptables -t filter -S DOCKER-USER | grep -q "coolify-hardening-wan-web"; then
+        die "Post-check failed: tunnel-mode is active but DOCKER-USER wan-web ACCEPT rule exists."
+      fi
+    fi
+    if command -v ip6tables >/dev/null 2>&1; then
+      ip6tables -t filter -S DOCKER-USER 2>/dev/null | grep -q "coolify-hardening-wan-drop6" || die "Post-check failed: DOCKER-USER IPv6 drop rule missing."
+    fi
+  fi
+
+  if [[ "${DOCKER_PRESENT}" == "true" && -f "${DOCKER_DAEMON_JSON}" ]]; then
+    grep -q '"log-driver"' "${DOCKER_DAEMON_JSON}" || warn "Post-check: Docker daemon.json exists but log-driver not configured."
+    grep -q '"live-restore"' "${DOCKER_DAEMON_JSON}" || warn "Post-check: Docker daemon.json exists but live-restore not configured."
+  fi
+
+  grep -q "^Storage=persistent$" "${JOURNALD_DROPIN_FILE}" || die "Post-check failed: journald persistence drop-in missing."
+  { auditctl -l 2>/dev/null || cat "${AUDIT_RULES_FILE}"; } | grep -q "identity" \
+    || die "Post-check failed: audit rules not loaded."
+  { auditctl -l 2>/dev/null || cat "${AUDIT_RULES_FILE}"; } | grep -q "sudoers-change" \
+    || die "Post-check failed: sudoers audit rules not loaded."
+  grep -q 'APT::Periodic::Unattended-Upgrade "1";' "${APT_AUTO_FILE}" || die "Post-check failed: unattended-upgrades periodic config missing."
+
+  local syncookies ip_forward
+  syncookies="$(sysctl -n net.ipv4.tcp_syncookies 2>/dev/null || echo "?")"
+  ip_forward="$(sysctl -n net.ipv4.ip_forward 2>/dev/null || echo "?")"
+  [[ "${syncookies}" == "1" ]] || die "Post-check failed: tcp_syncookies is ${syncookies}, expected 1."
+  [[ "${ip_forward}" == "1" ]] || die "Post-check failed: ip_forward is ${ip_forward}, expected 1."
+
+  systemctl is-active --quiet fail2ban || die "Post-check failed: fail2ban is not active."
+
+  [[ -f /etc/issue.net ]] || die "Post-check failed: /etc/issue.net missing."
+
+  journalctl --disk-usage || true
+
+  if command -v aa-status >/dev/null 2>&1; then
+    if ! aa-status --enabled 2>/dev/null; then
+      warn "AppArmor is installed but not enabled. Ubuntu 24.04 should have it active by default."
+    fi
+  else
+    warn "aa-status not found; cannot verify AppArmor status."
+  fi
+
+  # Dashboard UFW restriction verification (UFW-based; does not check socket binding)
+  if is_true "${BIND_DASHBOARD_TO_TAILSCALE}"; then
+    log "Verifying Coolify dashboard UFW rules on ${TAILSCALE_IFACE}..."
+    if command -v ufw >/dev/null 2>&1; then
+      if ufw status | grep -q "8000.*on ${TAILSCALE_IFACE}"; then
+        log "PASS: UFW rule for port 8000 on ${TAILSCALE_IFACE} is present"
+      else
+        warn "UFW rule for port 8000 on ${TAILSCALE_IFACE} not found. Check: ufw status"
+      fi
+      if ufw status | grep -q "6001.*on ${TAILSCALE_IFACE}"; then
+        log "PASS: UFW rule for port 6001 on ${TAILSCALE_IFACE} is present"
+      else
+        warn "UFW rule for port 6001 on ${TAILSCALE_IFACE} not found. Check: ufw status"
+      fi
+      if ufw status | grep -q "6002.*on ${TAILSCALE_IFACE}"; then
+        log "PASS: UFW rule for port 6002 on ${TAILSCALE_IFACE} is present"
+      else
+        warn "UFW rule for port 6002 on ${TAILSCALE_IFACE} not found. Check: ufw status"
+      fi
+    fi
+
+    # Verify public IP is NOT serving the dashboard
+    if command -v nc >/dev/null 2>&1 && [[ -n "${DETECTED_TAILSCALE_IP}" ]]; then
+      local public_ip
+      public_ip="$(ip -o route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="src") print $(i+1)}')"
+      if [[ -n "${public_ip}" && "${public_ip}" != "${DETECTED_TAILSCALE_IP}" ]]; then
+        if nc -z -w2 "${public_ip}" 8000 2>/dev/null; then
+          warn "Port 8000 still appears reachable on public IP ${public_ip}. Check UFW rules."
+        else
+          log "PASS: Port 8000 not reachable on public IP ${public_ip}"
+        fi
+      fi
+    fi
+  fi
+}
+
+write_state() {
+  if is_true "${DRY_RUN}"; then
+    log "DRY-RUN: write ${STATE_FILE}"
+    return 0
+  fi
+
+  install -d -m 0750 "${STATE_DIR}"
+  cat > "${STATE_FILE}" <<EOF
+script_version=${SCRIPT_VERSION}
+applied_at=$(date -Iseconds)
+admin_user=${ADMIN_USER}
+wan_iface=${WAN_IFACE}
+ssh_port=${SSH_PORT}
+tailscale_cidr=${TAILSCALE_CIDR}
+tunnel_mode=${TUNNEL_MODE}
+swap_size=${SWAP_SIZE}
+journal_retention=${JOURNAL_RETENTION}
+bind_dashboard_to_tailscale=${BIND_DASHBOARD_TO_TAILSCALE}
+install_tailscale=${INSTALL_TAILSCALE}
+EOF
+
+  # Add detected Tailscale IP if binding was configured
+  if is_true "${BIND_DASHBOARD_TO_TAILSCALE}" && [[ -n "${DETECTED_TAILSCALE_IP}" ]]; then
+    echo "tailscale_ip=${DETECTED_TAILSCALE_IP}" >> "${STATE_FILE}"
+  fi
+
+  chmod 0640 "${STATE_FILE}"
+}
+
+generate_report() {
+  if is_true "${DRY_RUN}"; then
+    log "DRY-RUN: write ${REPORT_FILE}"
+    return 0
+  fi
+
+  local tailscale_iface_present
+  local ufw_active
+  local ssh_root_disabled
+  local ssh_password_disabled
+  local journald_persistent
+  local auditd_enabled
+  local audit_rules_loaded
+  local docker_drop_rule
+  local docker_drop_rule_v6
+  local sysctl_syncookies
+  local fail2ban_active
+  local banner_present
+
+  tailscale_iface_present="$(bool_cmd ip link show "${TAILSCALE_IFACE}")"
+  ufw_active="$(ufw status | grep -q "^Status: active$" && echo "true" || echo "false")"
+  local ssh_root_local_only
+  ssh_root_disabled="$(sshd -T 2>/dev/null | grep -q "^permitrootlogin no$" && echo "true" || echo "false")"
+  ssh_root_local_only="$(sshd -T -C addr=127.0.0.1,user=root,host=localhost,laddr=127.0.0.1 2>/dev/null | grep -qE "^permitrootlogin (prohibit-password|without-password)$" && echo "true" || echo "false")"
+  ssh_password_disabled="$(sshd -T 2>/dev/null | grep -q "^passwordauthentication no$" && echo "true" || echo "false")"
+  journald_persistent="$(grep -q "^Storage=persistent$" "${JOURNALD_DROPIN_FILE}" && echo "true" || echo "false")"
+  auditd_enabled="$(systemctl is-enabled auditd >/dev/null 2>&1 && echo "true" || echo "false")"
+  audit_rules_loaded="$(auditctl -l | grep -q "identity" && echo "true" || echo "false")"
+  docker_drop_rule="$(iptables -t filter -S DOCKER-USER 2>/dev/null | grep -q "coolify-hardening-wan-drop" && echo "true" || echo "false")"
+  docker_drop_rule_v6="$(ip6tables -t filter -S DOCKER-USER 2>/dev/null | grep -q "coolify-hardening-wan-drop6" && echo "true" || echo "false")"
+  sysctl_syncookies="$([[ "$(sysctl -n net.ipv4.tcp_syncookies 2>/dev/null)" == "1" ]] && echo "true" || echo "false")"
+  local sysctl_bbr
+  sysctl_bbr="$([[ "$(sysctl -n net.ipv4.tcp_congestion_control 2>/dev/null)" == "bbr" ]] && echo "true" || echo "false")"
+  local timesync_ntp
+  timesync_ntp="$([[ "$(timedatectl show --property=NTP --value 2>/dev/null)" == "yes" ]] && echo "true" || echo "false")"
+  local swap_active
+  swap_active="$(swapon --show --noheadings 2>/dev/null | grep -q . && echo "true" || echo "false")"
+  fail2ban_active="$(systemctl is-active --quiet fail2ban && echo "true" || echo "false")"
+  banner_present="$([[ -f /etc/issue.net ]] && echo "true" || echo "false")"
+
+  # Dashboard UFW restriction check (UFW-based; security enforced by UFW not socket binding)
+  local coolify_dashboard_bound="false"
+  local coolify_dashboard_ip=""
+  if is_true "${BIND_DASHBOARD_TO_TAILSCALE}"; then
+    coolify_dashboard_ip="${DETECTED_TAILSCALE_IP:-}"
+    # Check if UFW rule for port 8000 on tailscale0 is present
+    if command -v ufw >/dev/null 2>&1 && ufw status | grep -q "8000.*on ${TAILSCALE_IFACE}"; then
+      coolify_dashboard_bound="true"
+    fi
+  fi
+
+  cat > "${REPORT_FILE}" <<EOF
+{
+  "generated_at": "$(date -Iseconds)",
+  "script_version": "${SCRIPT_VERSION}",
+  "os_version": "${OS_VERSION}",
+  "admin_user": "${ADMIN_USER}",
+  "wan_iface": "${WAN_IFACE}",
+  "tailscale_iface": "${TAILSCALE_IFACE}",
+  "tailscale_cidr_hint": "${TAILSCALE_CIDR}",
+  "ssh_port": ${SSH_PORT},
+  "tunnel_mode": $(is_true "${TUNNEL_MODE}" && echo true || echo false),
+  "swap_size": "${SWAP_SIZE:-2G}",
+  "journal_retention": "${JOURNAL_RETENTION}",
+  "auto_reboot_requested": $(is_true "${ENABLE_AUTO_REBOOT}" && echo true || echo false),
+  "auto_reboot_time": "${AUTO_REBOOT_TIME}",
+  "bind_dashboard_to_tailscale": $(is_true "${BIND_DASHBOARD_TO_TAILSCALE}" && echo true || echo false),
+  "install_tailscale": $(is_true "${INSTALL_TAILSCALE}" && echo true || echo false),
+  "tailscale_ip": "${DETECTED_TAILSCALE_IP:-}",
+  "dry_run": $(is_true "${DRY_RUN}" && echo true || echo false),
+  "checks": {
+    "tailscale_iface_present": ${tailscale_iface_present},
+    "ufw_active": ${ufw_active},
+    "ssh_root_login_disabled": ${ssh_root_disabled},
+    "ssh_root_local_only_key_auth": ${ssh_root_local_only},
+    "ssh_password_auth_disabled": ${ssh_password_disabled},
+    "journald_persistent": ${journald_persistent},
+    "auditd_enabled": ${auditd_enabled},
+    "audit_rules_loaded": ${audit_rules_loaded},
+    "docker_user_drop_rule_v4": ${docker_drop_rule},
+    "docker_user_drop_rule_v6": ${docker_drop_rule_v6},
+    "sysctl_syncookies": ${sysctl_syncookies},
+    "sysctl_bbr": ${sysctl_bbr},
+    "timesync_ntp": ${timesync_ntp},
+    "swap_active": ${swap_active},
+    "fail2ban_active": ${fail2ban_active},
+    "banner_present": ${banner_present},
+    "coolify_dashboard_bound_to_tailscale": ${coolify_dashboard_bound}
+  }
+}
+EOF
+
+  chmod 0600 "${REPORT_FILE}"
+}
+
+configure_hardening_validation_timer() {
+  if is_true "${DRY_RUN}"; then
+    log "DRY-RUN: would install hardening-validate.timer (daily validate_hardening.sh run)."
+    return 0
+  fi
+
+  # Locate validate_hardening.sh relative to this script, with realpath fallback
+  local script_dir validate_src validate_dest
+  script_dir="$(cd "${BASH_SOURCE[0]%/*}" 2>/dev/null && pwd)" || script_dir="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+  validate_src="${script_dir}/validate_hardening.sh"
+  validate_dest="/usr/local/sbin/validate-hardening"
+
+  if [[ -f "${validate_src}" ]]; then
+    install -m 0750 -o root -g root "${validate_src}" "${validate_dest}"
+    log "Installed ${validate_src} → ${validate_dest}"
+  else
+    warn "validate_hardening.sh not found at ${validate_src}; skipping timer install."
+    return 0
+  fi
+
+  cat > /etc/systemd/system/hardening-validate.service <<'SVCEOF'
+[Unit]
+Description=Run hardening validation checks
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/validate-hardening
+SVCEOF
+
+  cat > /etc/systemd/system/hardening-validate.timer <<'TIMEREOF'
+[Unit]
+Description=Daily hardening validation
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+TIMEREOF
+
+  run systemctl daemon-reload
+  run systemctl enable --now hardening-validate.timer
+  log "hardening-validate.timer enabled (runs validate_hardening.sh daily)."
+}
+
+main() {
+  parse_args "$@"
+  require_root
+  setup_logging
+
+  log "Starting ${SCRIPT_NAME} v${SCRIPT_VERSION}"
+  validate_inputs
+  detect_os
+  check_disk_space
+
+  log "Verifying NTP time synchronization."
+  ensure_timesync
+
+  detect_wan_iface
+  ssh_session_safety_gate
+  ensure_packages
+
+  # Install Tailscale if requested (before verify_tailscale_iface)
+  if is_true "${INSTALL_TAILSCALE}"; then
+    log "Installing Tailscale."
+    install_tailscale
+  fi
+
+  require_commands
+  verify_tailscale_iface
+  detect_docker
+
+  log "Configuring swap."
+  configure_swap
+
+  log "Disabling unused network services."
+  disable_unused_services
+
+  log "Applying login banner."
+  configure_banner
+
+  log "Applying account and SSH hardening."
+  ensure_admin_access
+  configure_ssh
+
+  log "Applying auditd baseline."
+  configure_auditd
+
+  log "Applying sysctl kernel hardening."
+  configure_sysctl
+
+  log "Applying UFW baseline."
+  configure_ufw
+
+  log "Applying Docker daemon log rotation."
+  configure_docker_daemon
+
+  log "Applying DOCKER-USER hardening assets."
+  configure_docker_user
+
+  if is_true "${DOCKER_DAEMON_NEEDS_RESTART}"; then
+    log "Restarting Docker (deferred from daemon.json update, DOCKER-USER rules already applied)."
+    run systemctl restart docker
+    if [[ "${DOCKER_PRESENT}" == "true" ]]; then
+      run systemctl start docker-user-hardening.service
+    fi
+  fi
+
+  log "Applying fail2ban."
+  configure_fail2ban
+
+  log "Applying journald persistence."
+  configure_journald
+
+  log "Applying unattended-upgrades policy."
+  configure_unattended_upgrades
+  log "Installing hardening validation timer."
+  configure_hardening_validation_timer
+
+  # Configure Coolify split-horizon binding if requested
+  if is_true "${BIND_DASHBOARD_TO_TAILSCALE}"; then
+    log "Configuring Coolify split-horizon binding."
+    configure_coolify_binding
+    log "Installing Coolify binding watchdog."
+    configure_coolify_binding_watchdog
+  fi
+
+  write_state
+
+  log "Running post-apply checks."
+  run_post_checks
+
+  # Ensure DETECTED_TAILSCALE_IP is populated for generate_report() regardless of
+  # --bind-dashboard-to-tailscale (get_tailscale_ip only runs inside configure_coolify_binding
+  # which is skipped when binding is not requested). Do this BEFORE generate_report.
+  if [[ -z "${DETECTED_TAILSCALE_IP}" ]]; then
+    get_tailscale_ip >/dev/null 2>&1 || true
+  fi
+
+  generate_report
+  log "Completed hardening bootstrap successfully."
+
+  # Print Tailscale IP on stdout for orchestrators (deploy.sh) to capture.
+  # Post-hardening, UFW blocks all SSH on the public IP (tailscale0 only), so
+  # the orchestrator cannot run 'tailscale ip -4' via a new root SSH session.
+  local _ts_ip_final
+  _ts_ip_final="$(tailscale ip -4 2>/dev/null)" || true
+  [[ -n "${_ts_ip_final}" ]] && printf 'HARDEN_RESULT_TAILSCALE_IP=%s\n' "${_ts_ip_final}"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/scripts/provisioning/configure_coolify_binding.sh
+++ b/scripts/provisioning/configure_coolify_binding.sh
@@ -115,22 +115,23 @@ unset _i
 # Verify security posture
 log "Verifying bindings..."
 
-BOUND_8000="$(ss -tlnp 2>/dev/null | grep ':8000 ' || true)"
-if [[ -n "${BOUND_8000}" ]]; then
+local bound_8000 bound_6001 bound_6002 public_ip
+bound_8000="$(ss -tlnp 2>/dev/null | grep ':8000 ' || true)"
+if [[ -n "${bound_8000}" ]]; then
   log "PASS: Port 8000 is listening"
 else
   warn "Port 8000 not yet listening. Check: ss -tlnp | grep 8000"
 fi
 
-BOUND_6001="$(ss -tlnp 2>/dev/null | grep ':6001 ' || true)"
-if [[ -n "${BOUND_6001}" ]]; then
+bound_6001="$(ss -tlnp 2>/dev/null | grep ':6001 ' || true)"
+if [[ -n "${bound_6001}" ]]; then
   log "PASS: Port 6001 is listening"
 else
   warn "Port 6001 not yet listening (may start later). Check: ss -tlnp | grep 6001"
 fi
 
-BOUND_6002="$(ss -tlnp 2>/dev/null | grep ':6002 ' || true)"
-if [[ -n "${BOUND_6002}" ]]; then
+bound_6002="$(ss -tlnp 2>/dev/null | grep ':6002 ' || true)"
+if [[ -n "${bound_6002}" ]]; then
   log "PASS: Port 6002 is listening"
 else
   warn "Port 6002 not yet listening (may start later). Check: ss -tlnp | grep 6002"
@@ -138,12 +139,12 @@ fi
 
 # Test that public IP is NOT serving the dashboard (UFW should block it)
 if command -v nc >/dev/null 2>&1; then
-  PUBLIC_IP="$(ip -o route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="src") print $(i+1)}')"
-  if [[ -n "${PUBLIC_IP}" && "${PUBLIC_IP}" != "${TAILSCALE_IP}" ]]; then
-    if nc -z -w2 "${PUBLIC_IP}" 8000 2>/dev/null; then
-      warn "Port 8000 still appears reachable on public IP ${PUBLIC_IP}. Check UFW rules."
+  public_ip="$(ip -o route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="src") print $(i+1)}')"
+  if [[ -n "${public_ip}" && "${public_ip}" != "${TAILSCALE_IP}" ]]; then
+    if nc -z -w2 "${public_ip}" 8000 2>/dev/null; then
+      warn "Port 8000 still appears reachable on public IP ${public_ip}. Check UFW rules."
     else
-      log "PASS: Port 8000 not reachable on public IP ${PUBLIC_IP}"
+      log "PASS: Port 8000 not reachable on public IP ${public_ip}"
     fi
   fi
 fi

--- a/scripts/provisioning/configure_coolify_binding.sh
+++ b/scripts/provisioning/configure_coolify_binding.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# configure_coolify_binding.sh — Bind Coolify dashboard to Tailscale IP only
+# Companion script for bootstrap_hardening.sh
+#
+# Usage:
+#   sudo ./configure_coolify_binding.sh [--tailscale-ip <ip>] [--dry-run]
+
+SCRIPT_NAME="$(basename "$0")"
+COOLIFY_ENV="/data/coolify/source/.env"
+TAILSCALE_IP=""
+DRY_RUN="false"
+
+log() {
+  printf '[%s] %s\n' "$(date -Iseconds)" "$*"
+}
+
+warn() {
+  log "WARN: $*"
+}
+
+die() {
+  log "ERROR: $*"
+  exit 1
+}
+
+usage() {
+  cat <<'EOF'
+Bind Coolify dashboard and Soketi to Tailscale IP only.
+
+Usage:
+  configure_coolify_binding.sh [options]
+
+Options:
+  --tailscale-ip <ip>   Override auto-detected Tailscale IPv4 address
+  --dry-run             Print actions without changing system
+  -h, --help            Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tailscale-ip)
+      [[ -n "${2:-}" ]] || die "Option $1 requires a value."
+      TAILSCALE_IP="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown option: $1 (use --help)"
+      ;;
+  esac
+done
+
+# Require root
+[[ "$(id -u)" -eq 0 ]] || die "Run as root."
+
+# Auto-detect Tailscale IP if not provided
+if [[ -z "${TAILSCALE_IP}" ]]; then
+  command -v tailscale >/dev/null 2>&1 || die "tailscale command not found. Install Tailscale or use --tailscale-ip."
+  TAILSCALE_IP="$(tailscale ip -4 2>/dev/null)" || die "Failed to detect Tailscale IPv4 address. Is Tailscale running?"
+  [[ -n "${TAILSCALE_IP}" ]] || die "Tailscale returned empty IPv4 address."
+fi
+
+# Validate IP format
+[[ "${TAILSCALE_IP}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "Invalid IP address format: ${TAILSCALE_IP}"
+
+log "Using Tailscale IP: ${TAILSCALE_IP}"
+
+# Check Coolify env file exists
+[[ -f "${COOLIFY_ENV}" ]] || die "Coolify .env file not found at ${COOLIFY_ENV}. Is Coolify installed?"
+
+if [[ "${DRY_RUN}" == "true" ]]; then
+  log "DRY-RUN: would add UFW rules for ports 8000, 6001, and 6002 on tailscale0"
+  log "DRY-RUN: would verify Coolify is listening on port 8000"
+  log "DRY-RUN: would verify port 8000 is not reachable on public IP"
+  exit 0
+fi
+
+# Dashboard security is enforced via UFW, not APP_PORT socket binding.
+# Coolify's docker-compose.prod.yml uses APP_PORT in both ports: and expose: directives;
+# expose: requires a plain port number, so IP:port format is incompatible.
+# UFW default-deny incoming + explicit allow rules on tailscale0 provides the same
+# defense-in-depth: dashboard reachable via Tailscale, blocked from public interfaces.
+
+log "Ensuring UFW rules allow dashboard on Tailscale interface..."
+if command -v ufw >/dev/null 2>&1; then
+  # Idempotent — ufw silently skips duplicate rules
+  ufw allow in on tailscale0 proto tcp to any port 8000 comment "coolify-hardening-dashboard-tailscale" 2>/dev/null || true
+  ufw allow in on tailscale0 proto tcp to any port 6001 comment "coolify-hardening-soketi-tailscale" 2>/dev/null || true
+  ufw allow in on tailscale0 proto tcp to any port 6002 comment "coolify-hardening-terminal-tailscale" 2>/dev/null || true
+  log "UFW rules applied for ports 8000, 6001, and 6002 on tailscale0."
+else
+  warn "ufw not found — skipping UFW rule check."
+fi
+
+# Wait for Coolify to start (up to 60s)
+log "Waiting for Coolify to bind port 8000 (up to 60s)..."
+for (( _i = 1; _i <= 12; _i++ )); do
+  if ss -tlnp 2>/dev/null | grep -q ':8000 '; then
+    break
+  fi
+  sleep 5
+done
+unset _i
+
+# Verify security posture
+log "Verifying bindings..."
+
+BOUND_8000="$(ss -tlnp 2>/dev/null | grep ':8000 ' || true)"
+if [[ -n "${BOUND_8000}" ]]; then
+  log "PASS: Port 8000 is listening"
+else
+  warn "Port 8000 not yet listening. Check: ss -tlnp | grep 8000"
+fi
+
+BOUND_6001="$(ss -tlnp 2>/dev/null | grep ':6001 ' || true)"
+if [[ -n "${BOUND_6001}" ]]; then
+  log "PASS: Port 6001 is listening"
+else
+  warn "Port 6001 not yet listening (may start later). Check: ss -tlnp | grep 6001"
+fi
+
+BOUND_6002="$(ss -tlnp 2>/dev/null | grep ':6002 ' || true)"
+if [[ -n "${BOUND_6002}" ]]; then
+  log "PASS: Port 6002 is listening"
+else
+  warn "Port 6002 not yet listening (may start later). Check: ss -tlnp | grep 6002"
+fi
+
+# Test that public IP is NOT serving the dashboard (UFW should block it)
+if command -v nc >/dev/null 2>&1; then
+  PUBLIC_IP="$(ip -o route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="src") print $(i+1)}')"
+  if [[ -n "${PUBLIC_IP}" && "${PUBLIC_IP}" != "${TAILSCALE_IP}" ]]; then
+    if nc -z -w2 "${PUBLIC_IP}" 8000 2>/dev/null; then
+      warn "Port 8000 still appears reachable on public IP ${PUBLIC_IP}. Check UFW rules."
+    else
+      log "PASS: Port 8000 not reachable on public IP ${PUBLIC_IP}"
+    fi
+  fi
+fi
+
+log "Coolify binding configuration complete."
+log "Dashboard accessible at: http://${TAILSCALE_IP}:8000 (via Tailscale)"

--- a/scripts/provisioning/deploy.sh
+++ b/scripts/provisioning/deploy.sh
@@ -657,8 +657,9 @@ PUSHER_EOF
 
     # Write tunnel config — always include both wildcard levels so manually set app domains
     # at either scope (vps or apex) are routed correctly.
-    # ws. and terminal. hostnames route Soketi WebSocket and terminal services through the
-    # tunnel so the browser can reach them over HTTPS without exposing extra ports.
+    # ws.DOMAIN routes Soketi WebSocket traffic.
+    # Terminal WebSocket uses path /terminal/ws on the dashboard hostname, so this
+    # rule must come before the dashboard catch-all (cloudflared is first-match).
     local extra_apex_ingress=""
     if [[ "${APP_DOMAIN}" != "${CF_ZONE_NAME}" ]]; then
       extra_apex_ingress="  - hostname: \"*.${CF_ZONE_NAME}\"
@@ -671,11 +672,12 @@ credentials-file: /etc/cloudflared/${TUNNEL_ID}.json
 
 ingress:
   - hostname: ${DOMAIN}
+    path: /terminal/ws
+    service: http://localhost:6002
+  - hostname: ${DOMAIN}
     service: http://localhost:8000
   - hostname: ws.${DOMAIN}
     service: http://localhost:6001
-  - hostname: terminal.${DOMAIN}
-    service: http://localhost:6002
   - hostname: "*.${APP_DOMAIN}"
     service: http://localhost:80
 ${extra_apex_ingress}  - service: http_status:404

--- a/scripts/provisioning/deploy.sh
+++ b/scripts/provisioning/deploy.sh
@@ -1,0 +1,817 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# deploy.sh — Laptop-side orchestrator for secure Coolify deployment
+# Runs on the operator's machine; SSHes into the remote server.
+#
+# Interactive mode:  ./deploy.sh
+# Non-interactive:   ./deploy.sh --server-ip 1.2.3.4 --root-pass ... --yes
+# Mixed:             ./deploy.sh --server-ip 1.2.3.4  (prompted for the rest)
+
+SCRIPT_NAME="$(basename "$0")"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# shellcheck source=lib/coolify-common.sh
+source "${SCRIPT_DIR}/lib/coolify-common.sh"
+
+# ── Inputs (populated by flags or prompts) ──────────────────────────────────
+
+SERVER_IP="${SERVER_IP:-}"
+ROOT_PASS="${ROOT_PASS:-}"
+ADMIN_USER="${ADMIN_USER:-}"
+PUBKEY_FILE="${PUBKEY_FILE:-}"
+TAILSCALE_AUTH_KEY="${TAILSCALE_AUTH_KEY:-}"
+DEPLOY_MODE="${DEPLOY_MODE:-}"
+DOMAIN="${DOMAIN:-}"
+CF_API_TOKEN="${CF_API_TOKEN:-}"
+CF_ZONE="${CF_ZONE:-}"
+APP_DOMAIN_MODE="${APP_DOMAIN_MODE:-}"
+SWAP_SIZE="${SWAP_SIZE:-}"
+AUTO_YES="${AUTO_YES:-false}"
+SKIP_HARDEN="${SKIP_HARDEN:-false}"  # set via --ts-ip to resume after partial harden
+
+# ── Derived at runtime ──────────────────────────────────────────────────────
+
+ADMIN_PUBKEY=""
+PRIVATE_KEY=""
+TS_IP=""
+CF_ZONE_ID=""
+CF_ZONE_NAME=""
+APP_DOMAIN=""
+CF_ACCOUNT_ID=""
+TUNNEL_ID=""
+TUNNEL_SECRET=""
+
+# ── SSH options ─────────────────────────────────────────────────────────────
+
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -o LogLevel=ERROR"
+# Root SSH uses password auth; PreferredAuthentications ensures sshpass works even when server
+# advertises publickey first (macOS OpenSSH skips password challenge otherwise).
+ROOT_SSH_OPTS="${SSH_OPTS} -o PreferredAuthentications=keyboard-interactive,password"
+
+# ── Usage ───────────────────────────────────────────────────────────────────
+
+usage() {
+  cat <<'EOF'
+deploy.sh — Laptop-side orchestrator for secure Coolify deployment
+Run this on your LOCAL MACHINE (laptop/workstation), not on the server.
+
+Usage:
+  deploy.sh [options]
+
+If all required flags are provided, runs non-interactively.
+If any are missing, prompts for them (mixed mode supported).
+
+Required:
+  --server-ip <ip>              Server public IPv4 address
+  --root-pass <pass>            Root password for initial SSH
+  --tailscale-auth-key <key>    Tailscale auth key (tskey-auth-...)
+  --domain <fqdn>               Domain name for Coolify
+  --cf-api-token <token>        Cloudflare API token
+
+Optional:
+  --admin-user <name>           Admin username (default: coolifyadmin)
+  --pubkey-file <path>          SSH public key file (default: ~/.ssh/id_ed25519.pub)
+  --mode <tunnel|standard>       Deployment mode (default: tunnel)
+  --app-domain-mode <vps|apex>  App subdomain scope: vps=appname.DOMAIN, apex=appname.ZONE (default: apex)
+  --cf-zone <zone>              Cloudflare zone (default: derived from domain)
+  --swap-size <size>            Swap size (default: 2G)
+  --yes                         Skip confirmation prompts (for automation)
+  --ts-ip <ip>                  Skip phase 1 (hardening already done); set Tailscale IP directly
+  -h, --help                    Show this help
+EOF
+}
+
+# ── Argument parsing ────────────────────────────────────────────────────────
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --server-ip)       SERVER_IP="${2:?--server-ip requires a value}"; shift 2 ;;
+      --root-pass)       ROOT_PASS="${2:?--root-pass requires a value}"; shift 2 ;;
+      --admin-user)      ADMIN_USER="${2:?--admin-user requires a value}"; shift 2 ;;
+      --pubkey-file)     PUBKEY_FILE="${2:?--pubkey-file requires a value}"; shift 2 ;;
+      --tailscale-auth-key) TAILSCALE_AUTH_KEY="${2:?--tailscale-auth-key requires a value}"; shift 2 ;;
+      --mode)            DEPLOY_MODE="${2:?--mode requires a value}"; shift 2 ;;
+      --domain)          DOMAIN="${2:?--domain requires a value}"; shift 2 ;;
+      --cf-api-token)    CF_API_TOKEN="${2:?--cf-api-token requires a value}"; shift 2 ;;
+      --cf-zone)         CF_ZONE="${2:?--cf-zone requires a value}"; shift 2 ;;
+      --app-domain-mode) APP_DOMAIN_MODE="${2:?--app-domain-mode requires a value}"; shift 2 ;;
+      --swap-size)       SWAP_SIZE="${2:?--swap-size requires a value}"; shift 2 ;;
+      --yes)             AUTO_YES="true"; shift ;;
+      --ts-ip)           TS_IP="${2:?--ts-ip requires a value}"; SKIP_HARDEN="true"; shift 2 ;;
+      -h|--help)         usage; exit 0 ;;
+      *)                 die "Unknown option: $1 (use --help)" ;;
+    esac
+  done
+}
+
+# ── Input collection (flag → prompt fallback) ──────────────────────────────
+
+collect_inputs() {
+  # When hardening is being skipped (--ts-ip), tailscale auth key is not needed.
+  # Pre-populate to bypass the interactive prompt in collect_common_inputs so that
+  # automated --yes --ts-ip runs don't block on read waiting for a key.
+  if is_true "${SKIP_HARDEN}" && [[ -z "${TAILSCALE_AUTH_KEY}" ]]; then
+    TAILSCALE_AUTH_KEY="(not-needed)"
+  fi
+  collect_common_inputs
+  # ROOT_PASS not needed when --ts-ip is supplied (hardening already done)
+  if ! is_true "${SKIP_HARDEN}"; then
+    [[ -n "${ROOT_PASS}" ]] || prompt_secret ROOT_PASS "Root password"
+  fi
+}
+
+# ── Input validation ───────────────────────────────────────────────────────
+
+validate_inputs() {
+  [[ "${SERVER_IP}" =~ ${IPV4_RE} ]]      || die "Invalid server IP: ${SERVER_IP}"
+  # ROOT_PASS not required when --ts-ip is supplied (hardening already done)
+  if ! is_true "${SKIP_HARDEN}"; then
+    [[ -n "${ROOT_PASS}" ]]               || die "Root password is required."
+  fi
+  [[ "${ADMIN_USER}" =~ ${LINUX_USER_RE} ]] || die "Invalid admin username: ${ADMIN_USER}"
+  [[ "${ADMIN_USER}" != "root" ]]          || die "Admin user must not be root."
+
+  [[ -f "${PUBKEY_FILE}" ]]                || die "Public key file not found: ${PUBKEY_FILE}"
+  ssh-keygen -l -f "${PUBKEY_FILE}" >/dev/null 2>&1 \
+    || die "Invalid SSH public key: ${PUBKEY_FILE}"
+  ADMIN_PUBKEY="$(cat "${PUBKEY_FILE}")"
+  PRIVATE_KEY="${PUBKEY_FILE%.pub}"
+  [[ -f "${PRIVATE_KEY}" ]] || die "Private key not found: ${PRIVATE_KEY} (expected alongside ${PUBKEY_FILE})"
+
+  # Auth key only required when hardening will run; --ts-ip skips hardening.
+  if ! is_true "${SKIP_HARDEN}"; then
+    [[ "${TAILSCALE_AUTH_KEY}" == tskey-auth-* ]] \
+      || die "Tailscale auth key must start with 'tskey-auth-' (got: ${TAILSCALE_AUTH_KEY:0:12}...)"
+  fi
+
+  # When resuming via --ts-ip, validate the supplied IP is a valid IPv4 address.
+  if is_true "${SKIP_HARDEN}"; then
+    [[ "${TS_IP}" =~ ${IPV4_RE} ]] \
+      || die "Invalid Tailscale IP supplied via --ts-ip: '${TS_IP}'"
+  fi
+
+  [[ "${DEPLOY_MODE}" == "standard" || "${DEPLOY_MODE}" == "tunnel" ]] \
+    || die "Mode must be 'standard' or 'tunnel' (got: ${DEPLOY_MODE})"
+
+  [[ "${APP_DOMAIN_MODE}" == "vps" || "${APP_DOMAIN_MODE}" == "apex" ]] \
+    || die "App domain mode must be 'vps' or 'apex' (got: ${APP_DOMAIN_MODE})"
+
+  [[ "${DOMAIN}" =~ ${FQDN_RE} ]]         || die "Invalid domain: ${DOMAIN}"
+  [[ -n "${CF_API_TOKEN}" ]]               || die "Cloudflare API token is required."
+  [[ "${SWAP_SIZE}" =~ ${SWAP_RE} ]]       || die "Invalid swap size: ${SWAP_SIZE} (expected e.g. 2G, 512M)"
+
+  # Verify companion scripts exist before prompting to proceed
+  local scripts=(bootstrap_hardening.sh validate_hardening.sh configure_coolify_binding.sh)
+  for script in "${scripts[@]}"; do
+    [[ -f "${SCRIPT_DIR}/${script}" ]] || die "Required script not found: ${SCRIPT_DIR}/${script}"
+  done
+}
+
+# ── SSH wrappers ────────────────────────────────────────────────────────────
+
+ssh_root() {
+  SSHPASS="${ROOT_PASS}" sshpass -e ssh ${ROOT_SSH_OPTS} "root@${SERVER_IP}" "$@"
+}
+
+scp_root() {
+  SSHPASS="${ROOT_PASS}" sshpass -e scp ${ROOT_SSH_OPTS} "$@"
+}
+
+scp_admin() {
+  scp ${SSH_OPTS} -i "${PRIVATE_KEY}" "$@"
+}
+
+ssh_admin() {
+  ssh ${SSH_OPTS} -i "${PRIVATE_KEY}" "${ADMIN_USER}@${TS_IP}" "$@"
+}
+
+ssh_admin_sudo() {
+  ssh ${SSH_OPTS} -i "${PRIVATE_KEY}" "${ADMIN_USER}@${TS_IP}" "sudo $*"
+}
+
+# Upload companion scripts to /root/ on the server using admin key + sudo.
+# Called at start of phase 2 so all phases always use the latest local scripts,
+# even when phase 1 (root SCP upload) was skipped via --ts-ip.
+sync_companion_scripts() {
+  local scripts=(bootstrap_hardening.sh validate_hardening.sh configure_coolify_binding.sh)
+  log "Syncing companion scripts to server /root/..."
+  for script in "${scripts[@]}"; do
+    local path="${SCRIPT_DIR}/${script}"
+    [[ -f "${path}" ]] || die "Script not found: ${path}"
+    scp_admin "${path}" "${ADMIN_USER}@${TS_IP}:/tmp/${script}" \
+      || die "Failed to upload ${script}"
+    # Use bash -c so both mv and chmod run under sudo (&&-chain only elevates the first command)
+    ssh_admin_sudo "bash -c 'mv /tmp/${script} /root/${script} && chmod 755 /root/${script}'" \
+      || die "Failed to install ${script} to /root/"
+  done
+  pass "Companion scripts synced to server"
+}
+
+verify_docker_user_gate_remote() {
+  local gate_label="$1"
+  local gate_d_inactive_msg="Gate D failed: docker-user-hardening.service is not active."
+
+  if ssh_admin_sudo 'systemctl is-active --quiet docker-user-hardening.service'; then
+    pass "${gate_label}: docker-user-hardening.service is active"
+  else
+    fail "${gate_label}: docker-user-hardening.service is not active"
+    die "${gate_d_inactive_msg}"
+  fi
+
+  local iptables_out
+  iptables_out="$(ssh_admin_sudo 'iptables -S DOCKER-USER' 2>/dev/null)" || true
+  if printf '%s' "${iptables_out}" | grep -q "coolify-hardening"; then
+    pass "${gate_label}: DOCKER-USER hardening rules active"
+  else
+    fail "${gate_label}: DOCKER-USER hardening rules not found"
+    die "${gate_label} failed. Check: sudo systemctl status docker-user-hardening.service"
+  fi
+}
+
+reconcile_docker_daemon_remote() {
+  log "Reconciling Docker daemon settings after Coolify install..."
+  # Hardening owns: log-driver, log-opts, live-restore. Coolify may add: default-address-pools.
+  # Using json-file driver to match Coolify's expectation for compatibility.
+  ssh_admin 'sudo bash -s' <<'EOF'
+set -Eeuo pipefail
+daemon_json="/etc/docker/daemon.json"
+tmp="$(mktemp)"
+
+# Drift detection: warn if hardening keys were changed (e.g., by Coolify update)
+if [[ -f "${daemon_json}" ]]; then
+  current_driver="$(jq -r '.["log-driver"] // ""' "${daemon_json}" 2>/dev/null || true)"
+  if [[ "${current_driver}" != "" && "${current_driver}" != "json-file" ]]; then
+    echo "WARNING: Docker log-driver drift detected (was '${current_driver}', expected 'json-file'). Reconciling..." >&2
+  fi
+  current_live_restore="$(jq -r '.["live-restore"] // ""' "${daemon_json}" 2>/dev/null || true)"
+  if [[ "${current_live_restore}" != "" && "${current_live_restore}" != "true" ]]; then
+    echo "WARNING: Docker live-restore drift detected (was '${current_live_restore}', expected 'true'). Reconciling..." >&2
+  fi
+fi
+
+if [[ -f "${daemon_json}" ]]; then
+  jq '. + {"log-driver":"json-file","log-opts":((.["log-opts"] // {}) + {"max-size":"10m","max-file":"3"}),"live-restore":true}' "${daemon_json}" > "${tmp}"
+else
+  jq -n '{"log-driver":"json-file","log-opts":{"max-size":"10m","max-file":"3"},"live-restore":true}' > "${tmp}"
+fi
+
+if [[ -f "${daemon_json}" ]] && cmp -s "${tmp}" "${daemon_json}"; then
+  rm -f "${tmp}"
+  exit 0
+fi
+
+if [[ -f "${daemon_json}" ]]; then
+  cp -a "${daemon_json}" "${daemon_json}.bak.$(date +%s)"
+fi
+
+cat "${tmp}" > "${daemon_json}"
+chmod 0644 "${daemon_json}"
+rm -f "${tmp}"
+systemctl restart docker
+EOF
+  pass "Docker daemon hardening reconciled (json-file log rotation + live-restore)"
+}
+
+# ── Pre-flight ──────────────────────────────────────────────────────────────
+
+preflight() {
+  step "0/5" "Pre-flight checks"
+
+  # Check local tools
+  local required_cmds=(ssh scp curl jq sshpass ssh-keygen openssl)
+  for cmd in "${required_cmds[@]}"; do
+    command -v "${cmd}" >/dev/null 2>&1 || die "Required command not found: ${cmd}. Install it first."
+  done
+  pass "Local tools present: ${required_cmds[*]}"
+
+  # Validate pubkey
+  ssh-keygen -l -f "${PUBKEY_FILE}" >/dev/null 2>&1 || die "Invalid SSH public key file: ${PUBKEY_FILE}"
+  pass "SSH public key valid: ${PUBKEY_FILE}"
+
+  # Verify Cloudflare token
+  cf_verify_token
+  cf_get_zone_id
+  cf_get_account_id  # always fetch — needed for tunnel (default mode)
+  resolve_app_domain
+  pass "Cloudflare API verified (zone: ${CF_ZONE_ID})"
+
+  # Test SSH connectivity (skipped when --ts-ip is used; root SSH is disabled post-harden)
+  if is_true "${SKIP_HARDEN}"; then
+    log "Skipping root SSH check (--ts-ip mode; hardening already applied)."
+  else
+    log "Testing SSH to root@${SERVER_IP}..."
+    if ssh_root 'echo ok' >/dev/null 2>&1; then
+      pass "SSH root@${SERVER_IP} reachable"
+    else
+      die "Cannot SSH to root@${SERVER_IP}. Check IP and root password."
+    fi
+  fi
+}
+
+# ── Phase 1: Upload + Harden ───────────────────────────────────────────────
+
+phase1_upload_harden() {
+  step "1/5" "Upload scripts & harden server"
+
+  # Upload scripts
+  local scripts=(bootstrap_hardening.sh validate_hardening.sh configure_coolify_binding.sh)
+  for script in "${scripts[@]}"; do
+    local path="${SCRIPT_DIR}/${script}"
+    [[ -f "${path}" ]] || die "Script not found: ${path}"
+    scp_root "${path}" "root@${SERVER_IP}:/root/${script}"
+    ssh_root "chmod +x /root/${script}"
+  done
+  pass "Scripts uploaded"
+
+  # Write env file on server (avoids quoting issues with SSH pubkey)
+  local tunnel_flag="false"
+  [[ "${DEPLOY_MODE}" == "tunnel" ]] && tunnel_flag="true"
+
+  ssh_root "cat > /root/deploy.env" <<EOF
+ADMIN_USER=${ADMIN_USER}
+ADMIN_PUBKEY="${ADMIN_PUBKEY}"
+TAILSCALE_CIDR=100.64.0.0/10
+SSH_PORT=22
+TUNNEL_MODE=${tunnel_flag}
+SWAP_SIZE=${SWAP_SIZE}
+INSTALL_TAILSCALE=true
+TAILSCALE_AUTH_KEY=${TAILSCALE_AUTH_KEY}
+BIND_DASHBOARD_TO_TAILSCALE=false
+EOF
+  ssh_root "chmod 600 /root/deploy.env"
+  pass "Environment file written"
+
+  # Run hardening, streaming output to terminal while capturing it for TS_IP extraction.
+  # After hardening, UFW blocks all SSH on the public IP (only tailscale0 allowed), so
+  # we cannot open a new root SSH session to run 'tailscale ip -4'. Instead, bootstrap
+  # prints 'HARDEN_RESULT_TAILSCALE_IP=<ip>' as the last stdout line; we parse that.
+  log "Running bootstrap_hardening.sh (this may take a few minutes)..."
+  local harden_tmp harden_exit_code
+  harden_tmp="$(mktemp)"
+
+  # Capture both stdout and stderr, preserving exit code.
+  # Using a subshell to properly handle pipeline exit status with set -Eeuo pipefail.
+  set +e
+  ssh_root "/root/bootstrap_hardening.sh --env-file /root/deploy.env --install-tailscale --force" \
+    2>&1 | tee "${harden_tmp}"
+  harden_exit_code="${PIPESTATUS[0]}"
+  set -E
+
+  if [[ "${harden_exit_code}" -ne 0 ]]; then
+    rm -f "${harden_tmp}"
+    die "bootstrap_hardening.sh failed (exit code ${harden_exit_code}). Check server logs: /var/log/bootstrap-hardening.log"
+  fi
+  pass "Hardening completed"
+
+  # Extract Tailscale IP from captured bootstrap output (sentinel line)
+  TS_IP="$(grep '^HARDEN_RESULT_TAILSCALE_IP=' "${harden_tmp}" | cut -d= -f2 | tr -d '[:space:]')"
+  rm -f "${harden_tmp}"
+  [[ -n "${TS_IP}" ]] || die "Failed to get Tailscale IP from bootstrap output."
+  pass "Server Tailscale IP: ${TS_IP}"
+
+  # Note: deploy.env cleanup is deferred to phase2_gates (ssh_admin_sudo after Gate B),
+  # because root SSH via public IP is now blocked by UFW.
+}
+
+# ── Phase 2: Gate checks ───────────────────────────────────────────────────
+
+phase2_gates() {
+  step "2/5" "Gate checks (SSH transition to admin@tailscale)"
+
+  # Gate A: SSH as admin via Tailscale IP using key auth
+  log "Gate A: Testing SSH admin@${TS_IP} via key auth..."
+  # (Gate A runs first so we know SSH works before syncing scripts)
+  local attempt max_attempts=6 delay=10
+  for (( attempt=1; attempt<=max_attempts; attempt++ )); do
+    if ssh_admin 'echo ok' >/dev/null 2>&1; then
+      pass "Gate A: SSH ${ADMIN_USER}@${TS_IP} works"
+      break
+    fi
+    if (( attempt == max_attempts )); then
+      fail "Gate A: Cannot SSH to ${ADMIN_USER}@${TS_IP} after ${max_attempts} attempts"
+      die "Gate A failed. Tailscale peering may not be established. Check 'tailscale status' on both machines."
+    fi
+    log "  Attempt ${attempt}/${max_attempts} failed, retrying in ${delay}s (Tailscale peering may need time)..."
+    sleep "${delay}"
+  done
+
+  # Gate B: Verify admin identity
+  local whoami_result
+  whoami_result="$(ssh_admin 'whoami' 2>/dev/null | tr -d '[:space:]')"
+  if [[ "${whoami_result}" == "${ADMIN_USER}" ]]; then
+    pass "Gate B: whoami=${ADMIN_USER}"
+  else
+    fail "Gate B: Expected ${ADMIN_USER}, got '${whoami_result}'"
+    die "Gate B failed."
+  fi
+
+  # Clean up sensitive deploy.env left on server by phase 1.
+  # Done here (not in phase 1) because post-hardening UFW blocks root SSH on the public IP.
+  ssh_admin_sudo "rm -f /root/deploy.env" 2>/dev/null || true
+
+  # Always re-sync companion scripts via admin SCP after Gate A/B confirm SSH works.
+  # This ensures the latest versions are used even when phase 1 (root upload) was skipped.
+  sync_companion_scripts
+
+  # Gate C: Validation passes
+  log "Gate C: Running validate_hardening.sh..."
+  local validate_json
+  validate_json="$(ssh_admin_sudo '/root/validate_hardening.sh --json' 2>/dev/null)" || true
+  report_validation_result "Gate C" "${validate_json}" \
+    "Gate C failed. Fix validation failures before continuing."
+}
+
+# ── Phase 3: Docker + Coolify ──────────────────────────────────────────────
+
+phase3_docker_coolify() {
+  step "3/5" "Install Docker & Coolify"
+
+  # Install Docker (skip if already present — the install script is not idempotent on network errors)
+  if ssh_admin_sudo 'docker version >/dev/null 2>&1'; then
+    log "Docker already installed — skipping install."
+  else
+    log "Installing Docker..."
+    # Use bash -c under sudo so the entire pipeline runs as root
+    ssh_admin_sudo 'bash -c "curl -fsSL https://get.docker.com | sh"' \
+      || die "Docker installation failed."
+    pass "Docker installed"
+  fi
+  pass "Docker present"
+
+  # Start DOCKER-USER hardening service
+  ssh_admin_sudo 'systemctl start docker-user-hardening.service' \
+    || die "Failed to start docker-user-hardening.service"
+
+  # Gate D: Verify DOCKER-USER rules
+  verify_docker_user_gate_remote "Gate D"
+
+  # Install Coolify (skip if already running)
+  if ssh_admin_sudo 'test -f /data/coolify/source/.env' >/dev/null 2>&1; then
+    log "Coolify .env found — skipping install (already installed)."
+    pass "Coolify already installed"
+  else
+    log "Installing Coolify (this may take a few minutes)..."
+    # Use bash -c under sudo so the entire pipeline runs as root
+    ssh_admin_sudo 'bash -c "curl -fsSL https://cdn.coollabs.io/coolify/install.sh | bash"' \
+      || die "Coolify installation failed."
+    pass "Coolify installed"
+  fi
+
+  # Coolify installer manages daemon.json; re-apply hardening settings while preserving its keys.
+  reconcile_docker_daemon_remote
+
+  # Docker restart can flush DOCKER-USER runtime rules; re-apply and verify.
+  ssh_admin_sudo 'systemctl restart docker-user-hardening.service' \
+    || die "Failed to restart docker-user-hardening.service after Docker daemon reconciliation."
+  verify_docker_user_gate_remote "Gate D (post-Coolify)"
+
+  # Add Coolify's generated SSH public key to root's authorized_keys.
+  # Required for the Coolify "This Machine" onboarding: Coolify SSHes to localhost as root
+  # using its own key. The hardening Match block allows key-only root login from
+  # localhost (127.0.0.1), 172.16.0.0/12, and 10.0.0.0/8 (Docker pool); key must be present.
+  log "Adding Coolify SSH key to root authorized_keys..."
+  ssh_admin_sudo 'bash -s' <<'SSHEOF'
+set -Eeuo pipefail
+keyfile=$(ls /data/coolify/ssh/keys/ssh_key@* 2>/dev/null | head -1 || true)
+[[ -n "${keyfile}" ]] || { echo "No Coolify SSH key found — skipping"; exit 0; }
+pubkey=$(ssh-keygen -y -f "${keyfile}")
+auth=/root/.ssh/authorized_keys
+mkdir -p /root/.ssh && chmod 700 /root/.ssh
+touch "${auth}" && chmod 600 "${auth}"
+if grep -qxF "${pubkey}" "${auth}" 2>/dev/null; then
+  echo "Coolify key already in root authorized_keys"
+else
+  # Ensure file ends with newline before appending to avoid key concatenation
+  [[ -s "${auth}" ]] && [[ "$(tail -c1 "${auth}" | od -An -tx1 | tr -d ' \n')" != "0a" ]] \
+    && printf '\n' >> "${auth}"
+  printf '%s\n' "${pubkey}" >> "${auth}"
+  echo "Coolify key added to root authorized_keys"
+fi
+SSHEOF
+  pass "Coolify SSH key in root authorized_keys"
+
+  # Fix host.docker.internal resolution on Linux Docker.
+  # Docker on Linux doesn't resolve host-gateway to a real IP in all versions/configurations.
+  # Patch Coolify's docker-compose.yml to use the actual coolify network gateway IP,
+  # then recreate the container so the fix takes effect.
+  log "Fixing host.docker.internal for Linux Docker..."
+  ssh_admin_sudo 'bash -s' <<'SSHEOF'
+set -Eeuo pipefail
+compose_yml="/data/coolify/source/docker-compose.yml"
+[[ -f "${compose_yml}" ]] || { echo "docker-compose.yml not found — skipping"; exit 0; }
+
+# Get the IPv4 gateway of the coolify Docker network
+gateway=$(docker network inspect coolify --format '{{range .IPAM.Config}}{{.Subnet}} {{.Gateway}} {{end}}' 2>/dev/null \
+  | tr ' ' '\n' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' | grep -v '/[0-9]' | head -1 || true)
+
+if [[ -z "${gateway}" ]]; then
+  echo "Cannot determine coolify network gateway — skipping host.docker.internal fix"
+  exit 0
+fi
+echo "Coolify network gateway: ${gateway}"
+
+# Only patch if the current value is host-gateway or invalid IP (not an already-correct IP)
+current=$(grep -m1 'host\.docker\.internal:' "${compose_yml}" | awk -F: '{print $NF}' | tr -d ' ' || true)
+if [[ "${current}" == "${gateway}" ]]; then
+  echo "host.docker.internal already set to ${gateway}"
+  exit 0
+fi
+
+sed -i "s|host\.docker\.internal:.*|host.docker.internal:${gateway}|g" "${compose_yml}"
+echo "Patched host.docker.internal → ${gateway}"
+
+# Recreate affected containers (coolify, soketi) to apply the new extra_hosts
+docker compose -f /data/coolify/source/docker-compose.yml \
+               -f /data/coolify/source/docker-compose.prod.yml \
+               up -d --force-recreate coolify soketi 2>&1 | tail -5
+SSHEOF
+  pass "host.docker.internal patched in Coolify docker-compose"
+}
+
+# ── Phase 4: Binding + DNS ─────────────────────────────────────────────────
+
+phase4_binding_dns() {
+  step "4/5" "Configure dashboard binding & DNS"
+
+  # Wait for Coolify to write its .env file before binding (installer is async)
+  log "Waiting for Coolify to initialize /data/coolify/source/.env..."
+  local coolify_wait=0 coolify_max=120
+  until ssh_admin_sudo 'test -f /data/coolify/source/.env' >/dev/null 2>&1; do
+    (( coolify_wait += 5 ))
+    if (( coolify_wait >= coolify_max )); then
+      warn "Coolify .env not found after ${coolify_max}s — binding may fail; continuing."
+      break
+    fi
+    sleep 5
+  done
+
+  # Run configure_coolify_binding.sh on server
+  log "Binding Coolify dashboard to Tailscale IP..."
+  ssh_admin_sudo "/root/configure_coolify_binding.sh --tailscale-ip ${TS_IP}" \
+    || warn "configure_coolify_binding.sh returned non-zero (may be ok if Coolify is still starting)"
+  pass "Dashboard binding configured"
+
+  # Set Coolify wildcard domain directly in the database.
+  # configure_coolify_binding.sh already waited up to 60s for port 8000 to bind,
+  # which guarantees the s6 startup sequence (migrate→seed→init) has completed and
+  # the server_settings row (server_id=0, the hardcoded Localhost server) exists.
+  # The API PATCH /servers/{uuid} does not expose wildcard_domain, so we write
+  # directly to PostgreSQL via docker exec on the coolify-db container.
+  log "Setting Coolify wildcard domain to http://${APP_DOMAIN}..."
+  ssh_admin_sudo 'bash -s' <<WILDCARD_EOF
+set -Eeuo pipefail
+coolify_env="/data/coolify/source/.env"
+db_user="\$(grep '^DB_USERNAME=' "\${coolify_env}" | cut -d= -f2 || echo 'coolify')"
+db_name="\$(grep '^DB_DATABASE=' "\${coolify_env}" | cut -d= -f2 || echo 'coolify')"
+db_pass="\$(grep '^DB_PASSWORD=' "\${coolify_env}" | cut -d= -f2)"
+docker exec -e PGPASSWORD="\${db_pass}" coolify-db \
+  psql -U "\${db_user}" -d "\${db_name}" -c \
+  "UPDATE server_settings SET wildcard_domain = 'http://${APP_DOMAIN}' WHERE server_id = 0;" \
+  2>/dev/null || echo "WARN: psql update failed — set Wildcard Domain manually in Coolify UI"
+WILDCARD_EOF
+  pass "Coolify wildcard domain: http://${APP_DOMAIN}"
+
+  # In tunnel mode, set PUSHER_* env vars so the browser connects to Soketi via the
+  # tunnel (wss://ws.DOMAIN) instead of trying to reach localhost:6001 directly.
+  # Standard mode does not need this — browser connects to the Tailscale IP on port 6001.
+  if [[ "${DEPLOY_MODE}" == "tunnel" ]]; then
+    log "Setting PUSHER env vars for tunnel-mode WebSocket routing..."
+    ssh_admin_sudo 'bash -s' <<PUSHER_EOF
+set -Eeuo pipefail
+coolify_env="/data/coolify/source/.env"
+# Idempotent: remove existing PUSHER_HOST/PORT/SCHEME lines, then append
+sed -i '/^PUSHER_HOST=/d; /^PUSHER_PORT=/d; /^PUSHER_SCHEME=/d' "\${coolify_env}"
+cat >> "\${coolify_env}" <<'INNER'
+PUSHER_HOST=ws.${DOMAIN}
+PUSHER_PORT=443
+PUSHER_SCHEME=https
+INNER
+echo "PUSHER env vars written to \${coolify_env}"
+# Recreate coolify + soketi to pick up the new env (fast — ~10s, no DB/redis restart)
+docker compose -f /data/coolify/source/docker-compose.yml \
+               -f /data/coolify/source/docker-compose.prod.yml \
+               up -d --force-recreate coolify soketi 2>&1 | tail -5
+PUSHER_EOF
+    pass "PUSHER env vars configured: ws.${DOMAIN}:443 (wss)"
+  fi
+
+  if [[ "${DEPLOY_MODE}" == "standard" ]]; then
+    # Standard mode: A records pointing to server public IP (proxied)
+    log "Configuring DNS: A record ${DOMAIN} → ${SERVER_IP} (proxied)..."
+    cf_upsert_a_record "${DOMAIN}" "${SERVER_IP}" "true"
+    pass "DNS A record configured: ${DOMAIN} → ${SERVER_IP}"
+
+    # Wildcard A records — always create both scopes so manually set domains at either level work
+    local wildcard_name="*.${APP_DOMAIN}"
+    log "Configuring DNS: wildcard A record ${wildcard_name} → ${SERVER_IP} (proxied)..."
+    cf_upsert_a_record "${wildcard_name}" "${SERVER_IP}" "true"
+    pass "DNS wildcard A record configured: ${wildcard_name} → ${SERVER_IP}"
+    if [[ "${APP_DOMAIN}" != "${CF_ZONE_NAME}" ]]; then
+      local apex_wildcard="*.${CF_ZONE_NAME}"
+      cf_upsert_a_record "${apex_wildcard}" "${SERVER_IP}" "true"
+      pass "DNS wildcard A record configured: ${apex_wildcard} → ${SERVER_IP}"
+    fi
+
+  elif [[ "${DEPLOY_MODE}" == "tunnel" ]]; then
+    # Tunnel mode: create tunnel, install cloudflared, CNAME
+    log "Creating Cloudflare Tunnel..."
+    _stop_cloudflared() { ssh_admin_sudo 'systemctl stop cloudflared 2>/dev/null || true'; }
+    cf_create_tunnel "_stop_cloudflared"
+    pass "Tunnel created: ${TUNNEL_ID}"
+
+    # Install cloudflared on server
+    log "Installing cloudflared on server..."
+    # Use bash -c under sudo so the entire && chain runs as root (sudo only elevates the first
+    # command when chaining with &&; bash -c ensures all commands inherit root privileges)
+    ssh_admin_sudo 'bash -c "apt-get update -qq && apt-get install -y -qq cloudflared"' 2>/dev/null \
+      || {
+        # Fallback: add Cloudflare repo and install
+        log "Trying Cloudflare repository..."
+        ssh_admin_sudo 'bash -c "curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg | tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null"' \
+          || die "Failed to add Cloudflare GPG key"
+        ssh_admin_sudo 'bash -c "echo \"deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared \$(lsb_release -cs) main\" | tee /etc/apt/sources.list.d/cloudflared.list"' \
+          || die "Failed to add Cloudflare repository"
+        ssh_admin_sudo 'bash -c "apt-get update -qq && apt-get install -y -qq cloudflared"' \
+          || die "Failed to install cloudflared"
+      }
+    pass "cloudflared installed"
+
+    # Write tunnel credentials
+    local creds_json
+    creds_json="$(jq -n --arg id "${TUNNEL_ID}" --arg secret "${TUNNEL_SECRET}" --arg account "${CF_ACCOUNT_ID}" \
+      '{AccountTag:$account,TunnelID:$id,TunnelSecret:$secret}')"
+    ssh_admin_sudo "mkdir -p /etc/cloudflared"
+    printf '%s' "${creds_json}" | ssh_admin_sudo "tee /etc/cloudflared/${TUNNEL_ID}.json >/dev/null"
+    ssh_admin_sudo "chmod 600 /etc/cloudflared/${TUNNEL_ID}.json"
+
+    # Write tunnel config — always include both wildcard levels so manually set app domains
+    # at either scope (vps or apex) are routed correctly.
+    # ws. and terminal. hostnames route Soketi WebSocket and terminal services through the
+    # tunnel so the browser can reach them over HTTPS without exposing extra ports.
+    local extra_apex_ingress=""
+    if [[ "${APP_DOMAIN}" != "${CF_ZONE_NAME}" ]]; then
+      extra_apex_ingress="  - hostname: \"*.${CF_ZONE_NAME}\"
+    service: http://localhost:80
+"
+    fi
+    ssh_admin_sudo "tee /etc/cloudflared/config.yml >/dev/null" <<EOF
+tunnel: ${TUNNEL_ID}
+credentials-file: /etc/cloudflared/${TUNNEL_ID}.json
+
+ingress:
+  - hostname: ${DOMAIN}
+    service: http://localhost:8000
+  - hostname: ws.${DOMAIN}
+    service: http://localhost:6001
+  - hostname: terminal.${DOMAIN}
+    service: http://localhost:6002
+  - hostname: "*.${APP_DOMAIN}"
+    service: http://localhost:80
+${extra_apex_ingress}  - service: http_status:404
+EOF
+    local wc_summary="*.${APP_DOMAIN}"
+    [[ "${APP_DOMAIN}" != "${CF_ZONE_NAME}" ]] && wc_summary+=" and *.${CF_ZONE_NAME}"
+    pass "Tunnel credentials and config written (wildcards: ${wc_summary})"
+
+    # Start cloudflared service
+    ssh_admin_sudo 'cloudflared service install 2>/dev/null || true'
+    ssh_admin_sudo 'systemctl enable --now cloudflared' \
+      || die "Failed to start cloudflared service"
+    pass "cloudflared service running"
+
+    # Create CNAME records: exact domain + wildcard for subdomains
+    local tunnel_target="${TUNNEL_ID}.cfargotunnel.com"
+    cf_upsert_cname "${DOMAIN}" "${tunnel_target}"
+    pass "DNS CNAME configured: ${DOMAIN} → ${tunnel_target}"
+
+    # Always create both wildcard CNAME levels for full routing coverage
+    cf_upsert_cname "*.${APP_DOMAIN}" "${tunnel_target}"
+    pass "DNS wildcard CNAME configured: *.${APP_DOMAIN} → ${tunnel_target}"
+    if [[ "${APP_DOMAIN}" != "${CF_ZONE_NAME}" ]]; then
+      cf_upsert_cname "*.${CF_ZONE_NAME}" "${tunnel_target}"
+      pass "DNS wildcard CNAME configured: *.${CF_ZONE_NAME} → ${tunnel_target}"
+    fi
+  fi
+}
+
+# ── Phase 5: Verification ─────────────────────────────────────────────────
+
+phase5_verify() {
+  step "5/5" "Final verification"
+
+  # Gate E: Dashboard reachable on Tailscale, not on public IP
+  log "Gate E: Checking dashboard accessibility..."
+  sleep 5  # Give Coolify a moment
+
+  local ts_code
+  local pub_code
+  local attempts=12
+  local attempt
+  local delay=10
+  local gate_e_passed=false
+  for (( attempt=1; attempt<=attempts; attempt++ )); do
+    # curl -w '%{http_code}' writes "000" to stdout on connection errors and exits non-zero.
+    # On complete failure, output may be empty; default to "000".
+    ts_code="$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 10 "http://${TS_IP}:8000" 2>/dev/null)" || ts_code=""
+    pub_code="$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 "http://${SERVER_IP}:8000" 2>/dev/null)" || pub_code=""
+    # Ensure we have a 3-char code; default to "000" on empty output
+    ts_code="${ts_code:-000}"
+    pub_code="${pub_code:-000}"
+    ts_code="${ts_code:0:3}"
+    pub_code="${pub_code:0:3}"
+    if [[ "${ts_code}" != "000" && "${pub_code}" == "000" ]]; then
+      gate_e_passed=true
+      break
+    fi
+    if (( attempt < attempts )); then
+      log "  Gate E not ready (tailscale=${ts_code}, public=${pub_code}); retrying in ${delay}s (${attempt}/${attempts})..."
+      sleep "${delay}"
+    fi
+  done
+
+  if [[ "${gate_e_passed}" != "true" ]]; then
+    if [[ "${ts_code}" == "000" ]]; then
+      fail "Gate E: dashboard not reachable on ${TS_IP}:8000"
+      die "Gate E failed: dashboard not reachable via Tailscale."
+    fi
+    fail "Gate E: dashboard reachable on public IP ${SERVER_IP}:8000 (HTTP ${pub_code})"
+    die "Gate E failed: dashboard reachable on public IP."
+  fi
+
+  pass "Gate E: Dashboard reachable on Tailscale IP (HTTP ${ts_code})"
+  pass "Gate E: Dashboard NOT reachable on public IP (good)"
+
+  # Gate F: External HTTPS endpoint reachable (validates tunnel/DNS/TLS end-to-end)
+  # This is the external vantage point test that the server-side validate_hardening.sh
+  # cannot perform — it proves the domain resolves, Cloudflare proxies it, and Coolify responds.
+  log "Gate F: Checking external HTTPS endpoint..."
+  local https_code attempts=12 attempt delay=10
+  local gate_f_passed=false
+  for (( attempt=1; attempt<=attempts; attempt++ )); do
+    https_code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 -L "https://${DOMAIN}" 2>/dev/null)" || https_code=""
+    # Ensure we have a 3-char code; default to "000" on empty output
+    https_code="${https_code:-000}"
+    https_code="${https_code:0:3}"
+    # Accept any non-zero HTTP response — even a 302/401 proves the tunnel and DNS work
+    if [[ "${https_code}" != "000" && -n "${https_code}" ]]; then
+      gate_f_passed=true
+      break
+    fi
+    if (( attempt < attempts )); then
+      log "  Gate F not ready (https_code=${https_code}); retrying in ${delay}s (${attempt}/${attempts})..."
+      sleep "${delay}"
+    fi
+  done
+
+  if [[ "${gate_f_passed}" == "true" ]]; then
+    pass "Gate F: https://${DOMAIN} reachable (HTTP ${https_code})"
+  else
+    warn "Gate F: https://${DOMAIN} not reachable after $((attempts * delay))s — DNS propagation may still be in progress"
+  fi
+
+  # Final validation run
+  log "Running final validate_hardening.sh..."
+  local final_validate_json
+  final_validate_json="$(ssh_admin_sudo '/root/validate_hardening.sh --json' 2>/dev/null)" || true
+  report_validation_result "Final validation" "${final_validate_json}" \
+    "Final validation failed. Resolve validation failures before considering deployment complete."
+
+  # Print summary
+  print_deployment_summary
+}
+
+# ── Main ────────────────────────────────────────────────────────────────────
+
+main() {
+  parse_args "$@"
+  collect_inputs
+  validate_inputs
+
+  # Show summary before proceeding
+  printf '\n'
+  log "Deployment configuration:"
+  log "  Server:    ${SERVER_IP}"
+  log "  Admin:     ${ADMIN_USER}"
+  log "  Pubkey:    ${PUBKEY_FILE}"
+  log "  Mode:      ${DEPLOY_MODE}"
+  log "  Domain:    ${DOMAIN}"
+  log "  App scope: ${APP_DOMAIN_MODE}"
+  log "  Swap:      ${SWAP_SIZE}"
+  is_true "${SKIP_HARDEN}" && log "  TS IP:     ${TS_IP} (--ts-ip; skipping phase 1)"
+  confirm "Proceed with deployment?"
+
+  preflight
+  if is_true "${SKIP_HARDEN}"; then
+    log "Skipping phase 1 (--ts-ip supplied; hardening already complete on ${TS_IP})"
+  else
+    phase1_upload_harden
+  fi
+  phase2_gates
+  phase3_docker_coolify
+  phase4_binding_dns
+  phase5_verify
+}
+
+main "$@"

--- a/scripts/provisioning/deploy.sh
+++ b/scripts/provisioning/deploy.sh
@@ -348,20 +348,14 @@ EOF
   # we cannot open a new root SSH session to run 'tailscale ip -4'. Instead, bootstrap
   # prints 'HARDEN_RESULT_TAILSCALE_IP=<ip>' as the last stdout line; we parse that.
   log "Running bootstrap_hardening.sh (this may take a few minutes)..."
-  local harden_tmp harden_exit_code
+  local harden_tmp
   harden_tmp="$(mktemp)"
 
-  # Capture both stdout and stderr, preserving exit code.
-  # Using a subshell to properly handle pipeline exit status with set -Eeuo pipefail.
-  set +e
-  ssh_root "/root/bootstrap_hardening.sh --env-file /root/deploy.env --install-tailscale --force" \
-    2>&1 | tee "${harden_tmp}"
-  harden_exit_code="${PIPESTATUS[0]}"
-  set -E
-
-  if [[ "${harden_exit_code}" -ne 0 ]]; then
+  # Capture stdout/stderr while preserving failure semantics from the SSH command.
+  if ! ssh_root "/root/bootstrap_hardening.sh --env-file /root/deploy.env --install-tailscale --force" \
+    2>&1 | tee "${harden_tmp}"; then
     rm -f "${harden_tmp}"
-    die "bootstrap_hardening.sh failed (exit code ${harden_exit_code}). Check server logs: /var/log/bootstrap-hardening.log"
+    die "bootstrap_hardening.sh failed. Check server logs: /var/log/bootstrap-hardening.log"
   fi
   pass "Hardening completed"
 
@@ -433,8 +427,8 @@ phase3_docker_coolify() {
     log "Docker already installed — skipping install."
   else
     log "Installing Docker..."
-    # Use bash -c under sudo so the entire pipeline runs as root
-    ssh_admin_sudo 'bash -c "curl -fsSL https://get.docker.com | sh"' \
+    # Use pipefail so curl/network failures are not masked by the shell pipeline.
+    ssh_admin_sudo "bash -o pipefail -c 'curl -fsSL https://get.docker.com | sh'" \
       || die "Docker installation failed."
     pass "Docker installed"
   fi
@@ -453,8 +447,8 @@ phase3_docker_coolify() {
     pass "Coolify already installed"
   else
     log "Installing Coolify (this may take a few minutes)..."
-    # Use bash -c under sudo so the entire pipeline runs as root
-    ssh_admin_sudo 'bash -c "curl -fsSL https://cdn.coollabs.io/coolify/install.sh | bash"' \
+    # Use pipefail so curl/network failures are not masked by the shell pipeline.
+    ssh_admin_sudo "bash -o pipefail -c 'curl -fsSL https://cdn.coollabs.io/coolify/install.sh | bash'" \
       || die "Coolify installation failed."
     pass "Coolify installed"
   fi

--- a/scripts/provisioning/lib/coolify-common.sh
+++ b/scripts/provisioning/lib/coolify-common.sh
@@ -49,7 +49,8 @@ prompt_value() {
   local val
   # When --yes is set and a default exists, accept it without prompting
   if is_true "${AUTO_YES}" && [[ -n "${default}" ]]; then
-    eval "${var_name}=\${default}"
+    # Use declare -g for safer variable assignment (bash 4.2+)
+    declare -g "${var_name}=${default}"
     return 0
   fi
   printf '%s' "${prompt}"
@@ -60,7 +61,7 @@ prompt_value() {
   if [[ -n "${regex}" ]] && ! [[ "${val}" =~ ${regex} ]]; then
     die "Invalid input for ${var_name}: '${val}' does not match ${regex}"
   fi
-  eval "${var_name}=\${val}"
+  declare -g "${var_name}=${val}"
 }
 
 prompt_secret() {
@@ -70,7 +71,7 @@ prompt_secret() {
   read -rs val
   printf '\n'
   [[ -n "${val}" ]] || die "${var_name} cannot be empty."
-  eval "${var_name}=\${val}"
+  declare -g "${var_name}=${val}"
 }
 
 prompt_choice() {
@@ -79,7 +80,7 @@ prompt_choice() {
   local options=("$@")
   # When --yes is set, accept the default without prompting
   if is_true "${AUTO_YES}"; then
-    eval "${var_name}=\${default}"
+    declare -g "${var_name}=${default}"
     return 0
   fi
   printf '%s [%s] (%s): ' "${prompt}" "${default}" "$(IFS=/; echo "${options[*]}")"
@@ -90,7 +91,7 @@ prompt_choice() {
     [[ "${val}" == "${opt}" ]] && valid=true
   done
   ${valid} || die "Invalid choice for ${var_name}: '${val}'. Options: ${options[*]}"
-  eval "${var_name}=\${val}"
+  declare -g "${var_name}=${val}"
 }
 
 # ── Cloudflare API ─────────────────────────────────────────────────────────
@@ -323,7 +324,7 @@ print_deployment_summary() {
       && printf '│                   + CNAME *.%-32s│\n' "${CF_ZONE_NAME}"
     printf '│  Tunnel ID        : %-40s│\n' "${TUNNEL_ID}"
     printf '│  WebSocket (Soketi): ws.%-36s│\n' "${DOMAIN} → tunnel"
-    printf '│  Terminal         : terminal.%-31s│\n' "${DOMAIN} → tunnel"
+    printf '│  Terminal         : %-40s│\n' "${DOMAIN}/terminal/ws → tunnel"
   fi
   printf '└─────────────────────────────────────────────────────────────┘\n'
   printf '\n'

--- a/scripts/provisioning/lib/coolify-common.sh
+++ b/scripts/provisioning/lib/coolify-common.sh
@@ -1,0 +1,331 @@
+#!/usr/bin/env bash
+# lib/coolify-common.sh — Shared utilities for deploy.sh and setup.sh.
+# Source this file; do not execute it directly.
+# Requires: set -Eeuo pipefail in the caller.
+
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] \
+  || { printf 'Source this file, do not execute it.\n' >&2; exit 1; }
+[[ -z "${_COOLIFY_COMMON_LOADED:-}" ]] || return 0
+_COOLIFY_COMMON_LOADED=1
+
+# ── Regex patterns ──────────────────────────────────────────────────────────
+
+IPV4_RE='^([0-9]{1,3}\.){3}[0-9]{1,3}$'
+LINUX_USER_RE='^[a-z_][a-z0-9_-]*$'
+FQDN_RE='^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\.[a-zA-Z]{2,}$'
+SWAP_RE='^[0-9]+[GM]$'
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+log()  { printf '[%s] %s\n' "$(date -Iseconds)" "$*"; }
+warn() { log "WARN: $*"; }
+die()  { log "FATAL: $*" >&2; exit 1; }
+step() { printf '\n\033[1;36m[%s] %s\033[0m\n' "$1" "$2"; }
+pass() { printf '  \033[1;32mPASS\033[0m %s\n' "$*"; }
+fail() { printf '  \033[1;31mFAIL\033[0m %s\n' "$*"; }
+
+is_true() {
+  case "${1,,}" in
+    1|true|yes|y|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+confirm() {
+  if is_true "${AUTO_YES}"; then return 0; fi
+  local msg="${1:-Continue?}"
+  printf '\n%s [y/N] ' "${msg}"
+  read -r ans
+  case "${ans,,}" in
+    y|yes) return 0 ;;
+    *) die "Aborted by user." ;;
+  esac
+}
+
+# ── Input helpers ───────────────────────────────────────────────────────────
+
+prompt_value() {
+  local var_name="$1" prompt="$2" default="${3:-}" regex="${4:-}"
+  local val
+  # When --yes is set and a default exists, accept it without prompting
+  if is_true "${AUTO_YES}" && [[ -n "${default}" ]]; then
+    eval "${var_name}=\${default}"
+    return 0
+  fi
+  printf '%s' "${prompt}"
+  [[ -n "${default}" ]] && printf ' [%s]' "${default}"
+  printf ': '
+  read -r val
+  val="${val:-$default}"
+  if [[ -n "${regex}" ]] && ! [[ "${val}" =~ ${regex} ]]; then
+    die "Invalid input for ${var_name}: '${val}' does not match ${regex}"
+  fi
+  eval "${var_name}=\${val}"
+}
+
+prompt_secret() {
+  local var_name="$1" prompt="$2"
+  local val
+  printf '%s: ' "${prompt}"
+  read -rs val
+  printf '\n'
+  [[ -n "${val}" ]] || die "${var_name} cannot be empty."
+  eval "${var_name}=\${val}"
+}
+
+prompt_choice() {
+  local var_name="$1" prompt="$2" default="$3"
+  shift 3
+  local options=("$@")
+  # When --yes is set, accept the default without prompting
+  if is_true "${AUTO_YES}"; then
+    eval "${var_name}=\${default}"
+    return 0
+  fi
+  printf '%s [%s] (%s): ' "${prompt}" "${default}" "$(IFS=/; echo "${options[*]}")"
+  read -r val
+  val="${val:-$default}"
+  local valid=false
+  for opt in "${options[@]}"; do
+    [[ "${val}" == "${opt}" ]] && valid=true
+  done
+  ${valid} || die "Invalid choice for ${var_name}: '${val}'. Options: ${options[*]}"
+  eval "${var_name}=\${val}"
+}
+
+# ── Cloudflare API ─────────────────────────────────────────────────────────
+
+cf_api() {
+  local method="$1" endpoint="$2" body="${3:-}"
+  local url="https://api.cloudflare.com/client/v4${endpoint}"
+  local args=(-s -X "${method}" -H "Authorization: Bearer ${CF_API_TOKEN}" -H "Content-Type: application/json")
+  [[ -n "${body}" ]] && args+=(-d "${body}")
+  curl "${args[@]}" "${url}"
+}
+
+cf_verify_token() {
+  # Use zones endpoint rather than /user/tokens/verify — the latter requires
+  # User:User Tokens:Read which is not part of our required token permissions.
+  local resp
+  resp="$(cf_api GET /zones?per_page=1)"
+  local status
+  status="$(printf '%s' "${resp}" | jq -r '.success // false')"
+  [[ "${status}" == "true" ]] || die "Cloudflare API token verification failed: $(printf '%s' "${resp}" | jq -r '.errors[0].message // "unknown"')"
+  log "Cloudflare API token verified."
+}
+
+cf_get_zone_id() {
+  # If --cf-zone was specified, use it directly
+  if [[ -n "${CF_ZONE}" ]]; then
+    local resp
+    resp="$(cf_api GET "/zones?name=${CF_ZONE}&status=active")"
+    CF_ZONE_ID="$(printf '%s' "${resp}" | jq -r '.result[0].id // empty')"
+    [[ -n "${CF_ZONE_ID}" ]] || die "Cloudflare zone not found for '${CF_ZONE}'. Check --cf-zone value."
+    CF_ZONE_NAME="${CF_ZONE}"
+    log "Cloudflare zone ID: ${CF_ZONE_ID} (${CF_ZONE_NAME})"
+    return 0
+  fi
+
+  # Auto-detect zone by trying progressively shorter suffixes of DOMAIN.
+  # This correctly handles multi-part TLDs (e.g. .com.au, .co.uk) where
+  # stripping only the first label would give a non-existent zone.
+  local candidate="${DOMAIN}"
+  while [[ "${candidate}" == *.* ]]; do
+    local resp
+    resp="$(cf_api GET "/zones?name=${candidate}&status=active")"
+    CF_ZONE_ID="$(printf '%s' "${resp}" | jq -r '.result[0].id // empty')"
+    if [[ -n "${CF_ZONE_ID}" ]]; then
+      CF_ZONE_NAME="${candidate}"
+      log "Cloudflare zone ID: ${CF_ZONE_ID} (${CF_ZONE_NAME})"
+      return 0
+    fi
+    candidate="${candidate#*.}"  # strip leftmost label and retry
+  done
+  die "Cloudflare zone not found for any suffix of '${DOMAIN}'. Check domain or use --cf-zone."
+}
+
+cf_get_account_id() {
+  local resp
+  resp="$(cf_api GET /accounts)"
+  CF_ACCOUNT_ID="$(printf '%s' "${resp}" | jq -r '.result[0].id // empty')"
+  [[ -n "${CF_ACCOUNT_ID}" ]] || die "No Cloudflare account found."
+  log "Cloudflare account ID: ${CF_ACCOUNT_ID}"
+}
+
+cf_upsert_a_record() {
+  local name="$1" ip="$2" proxied="${3:-true}"
+  local existing
+  existing="$(cf_api GET "/zones/${CF_ZONE_ID}/dns_records?type=A&name=${name}")"
+  local record_id
+  record_id="$(printf '%s' "${existing}" | jq -r '.result[0].id // empty')"
+  local body
+  body="$(jq -n --arg name "${name}" --arg ip "${ip}" --argjson proxied "${proxied}" \
+    '{type:"A",name:$name,content:$ip,proxied:$proxied,ttl:1}')"
+
+  if [[ -n "${record_id}" ]]; then
+    cf_api PUT "/zones/${CF_ZONE_ID}/dns_records/${record_id}" "${body}" >/dev/null
+    log "Updated A record: ${name} → ${ip} (proxied=${proxied})"
+  else
+    cf_api POST "/zones/${CF_ZONE_ID}/dns_records" "${body}" >/dev/null
+    log "Created A record: ${name} → ${ip} (proxied=${proxied})"
+  fi
+}
+
+cf_create_tunnel() {
+  local stop_fn="${1:-}"   # optional: name of function to call to stop cloudflared
+  local tunnel_name="${DOMAIN%%.*}-coolify"
+
+  # Delete any existing tunnel with the same name (idempotent re-run support).
+  # Stop cloudflared first so it releases active connections — the CF API rejects DELETE for
+  # tunnels with active connections, and the name stays reserved even after a failed delete.
+  local existing_id
+  existing_id="$(cf_api GET "/accounts/${CF_ACCOUNT_ID}/cfd_tunnel?name=${tunnel_name}&is_deleted=false" \
+    | jq -r '.result[0].id // empty')"
+  if [[ -n "${existing_id}" ]]; then
+    log "Stopping cloudflared on server to release tunnel connections before delete..."
+    [[ -n "${stop_fn}" ]] && "${stop_fn}"
+    sleep 3  # Allow connections to close
+    log "Deleting stale tunnel ${tunnel_name} (${existing_id}) before recreating..."
+    cf_api DELETE "/accounts/${CF_ACCOUNT_ID}/cfd_tunnel/${existing_id}" >/dev/null \
+      || warn "Could not delete stale tunnel ${existing_id}; proceeding anyway."
+    sleep 2  # Allow CF to release the name
+  fi
+
+  TUNNEL_SECRET="$(openssl rand -base64 32)"
+  local body
+  body="$(jq -n --arg name "${tunnel_name}" --arg secret "${TUNNEL_SECRET}" \
+    '{name:$name,tunnel_secret:$secret,config_src:"local"}')"
+  local resp
+  resp="$(cf_api POST "/accounts/${CF_ACCOUNT_ID}/cfd_tunnel" "${body}")"
+  TUNNEL_ID="$(printf '%s' "${resp}" | jq -r '.result.id // empty')"
+  [[ -n "${TUNNEL_ID}" ]] || die "Failed to create Cloudflare Tunnel: $(printf '%s' "${resp}" | jq -r '.errors[0].message // "unknown"')"
+  log "Created tunnel: ${tunnel_name} (${TUNNEL_ID})"
+}
+
+cf_upsert_cname() {
+  local name="$1" target="$2"
+  local existing
+  existing="$(cf_api GET "/zones/${CF_ZONE_ID}/dns_records?type=CNAME&name=${name}")"
+  local record_id
+  record_id="$(printf '%s' "${existing}" | jq -r '.result[0].id // empty')"
+  local body
+  body="$(jq -n --arg name "${name}" --arg target "${target}" \
+    '{type:"CNAME",name:$name,content:$target,proxied:true,ttl:1}')"
+
+  if [[ -n "${record_id}" ]]; then
+    cf_api PUT "/zones/${CF_ZONE_ID}/dns_records/${record_id}" "${body}" >/dev/null
+    log "Updated CNAME: ${name} → ${target}"
+  else
+    cf_api POST "/zones/${CF_ZONE_ID}/dns_records" "${body}" >/dev/null
+    log "Created CNAME: ${name} → ${target}"
+  fi
+}
+
+# ── Shared deployment helpers ────────────────────────────────────────────────
+
+# report_validation_result — Parse and report validate_hardening.sh JSON output.
+# Caller captures JSON (via SSH or locally) and passes it in as the second argument.
+# Usage: report_validation_result "Gate C" "${validate_json}" "Gate C failed. ..."
+report_validation_result() {
+  local label="$1" validate_json="$2" die_msg="$3"
+  local fail_count
+  fail_count="$(printf '%s' "${validate_json}" | jq -r '.fail // -1' 2>/dev/null || echo "-1")"
+  if [[ "${fail_count}" == "0" ]]; then
+    pass "${label}: validate_hardening.sh — 0 failures"
+  else
+    fail "${label}: validate_hardening.sh reported ${fail_count} failures"
+    printf '%s\n' "${validate_json}" | jq '.checks[] | select(.status=="FAIL")' 2>/dev/null || true
+    die "${die_msg}"
+  fi
+}
+
+# collect_common_inputs — Prompt for inputs shared by both deploy.sh and setup.sh.
+# Each script calls this then adds its own script-specific prompts.
+collect_common_inputs() {
+  [[ -n "${SERVER_IP}" ]]   || prompt_value  SERVER_IP "Server public IP" "" "${IPV4_RE}"
+  [[ -n "${ADMIN_USER}" ]]  || prompt_value  ADMIN_USER "Admin username" "coolifyadmin" "${LINUX_USER_RE}"
+  [[ -n "${PUBKEY_FILE}" ]] || prompt_value  PUBKEY_FILE "SSH public key file" "${HOME}/.ssh/id_ed25519.pub"
+  [[ -n "${TAILSCALE_AUTH_KEY}" ]] || prompt_value TAILSCALE_AUTH_KEY "Tailscale auth key (tskey-auth-...)" ""
+  [[ -n "${DEPLOY_MODE}" ]] || prompt_choice DEPLOY_MODE "Deployment mode" "tunnel" "tunnel" "standard"
+  [[ -n "${DOMAIN}" ]]      || prompt_value  DOMAIN "Domain name (FQDN)" "" "${FQDN_RE}"
+  [[ -n "${CF_API_TOKEN}" ]] || prompt_secret CF_API_TOKEN "Cloudflare API token"
+  # CF_ZONE intentionally left as-is (derived from domain when empty; --cf-zone overrides)
+  [[ -n "${SWAP_SIZE}" ]]   || SWAP_SIZE="2G"
+  # App subdomain scope: where Coolify auto-assigns app URLs.
+  #   apex → appname.CF_ZONE     e.g. appname.example.com      (default — Free Universal SSL)
+  #   vps  → appname.DOMAIN      e.g. appname.vps.example.com  (server-scoped; needs ACM/Enterprise for proxied SSL)
+  if [[ -z "${APP_DOMAIN_MODE}" ]]; then
+    printf '  App subdomain scope:\n'
+    printf '    apex → appname.ZONE_APEX                (default — works with Cloudflare Free SSL)\n'
+    printf '    vps  → appname.%s  (scoped to this server; requires paid ACM or Enterprise for proxied SSL)\n' "${DOMAIN:-DOMAIN}"
+    prompt_choice APP_DOMAIN_MODE "App subdomain scope" "apex" "apex" "vps"
+  fi
+}
+
+# resolve_app_domain — Set APP_DOMAIN from APP_DOMAIN_MODE after CF_ZONE_NAME is known.
+# Call this after cf_get_zone_id.
+resolve_app_domain() {
+  if [[ "${APP_DOMAIN_MODE}" == "apex" ]]; then
+    APP_DOMAIN="${CF_ZONE_NAME}"
+  else
+    APP_DOMAIN="${DOMAIN}"
+    if [[ "${DOMAIN}" != "${CF_ZONE_NAME}" ]]; then
+      warn "vps mode: DOMAIN (${DOMAIN}) is a subdomain of zone ${CF_ZONE_NAME}."
+      warn "Apps at appname.${DOMAIN} are two levels deep and NOT covered by Cloudflare Free Universal SSL."
+      warn "Use --app-domain-mode apex for free proxied SSL, or provision ACM / CF for SaaS manually."
+    fi
+  fi
+  log "App subdomain scope: ${APP_DOMAIN_MODE} — new apps at appname.${APP_DOMAIN}"
+}
+
+# print_deployment_summary — Print completion banner and next-steps block.
+# Uses globals: SERVER_IP, TS_IP, ADMIN_USER, DEPLOY_MODE, DOMAIN, CF_ZONE_NAME, APP_DOMAIN, TUNNEL_ID
+print_deployment_summary() {
+  printf '\n'
+  printf '┌─────────────────────────────────────────────────────────────┐\n'
+  printf '│                    DEPLOYMENT COMPLETE                      │\n'
+  printf '├─────────────────────────────────────────────────────────────┤\n'
+  printf '│  Server Public IP : %-40s│\n' "${SERVER_IP}"
+  printf '│  Tailscale IP     : %-40s│\n' "${TS_IP}"
+  printf '│  Admin User       : %-40s│\n' "${ADMIN_USER}"
+  printf '│  Deploy Mode      : %-40s│\n' "${DEPLOY_MODE}"
+  printf '│  Domain           : %-40s│\n' "${DOMAIN}"
+  printf '│  Dashboard URL    : %-40s│\n' "http://${TS_IP}:8000"
+  printf '│  SSH Access       : ssh %-36s│\n' "${ADMIN_USER}@${TS_IP}"
+  printf '├─────────────────────────────────────────────────────────────┤\n'
+  if [[ "${DEPLOY_MODE}" == "standard" ]]; then
+    printf '│  DNS              : A %-38s│\n' "${DOMAIN} → ${SERVER_IP}"
+    printf '│  Wildcard DNS     : A *.%-36s│\n' "${APP_DOMAIN}"
+    [[ "${APP_DOMAIN}" != "${CF_ZONE_NAME}" ]] \
+      && printf '│                   + A *.%-36s│\n' "${CF_ZONE_NAME}"
+  else
+    printf '│  DNS              : CNAME %-34s│\n' "${DOMAIN}"
+    printf '│  Wildcard DNS     : CNAME *.%-32s│\n' "${APP_DOMAIN}"
+    [[ "${APP_DOMAIN}" != "${CF_ZONE_NAME}" ]] \
+      && printf '│                   + CNAME *.%-32s│\n' "${CF_ZONE_NAME}"
+    printf '│  Tunnel ID        : %-40s│\n' "${TUNNEL_ID}"
+    printf '│  WebSocket (Soketi): ws.%-36s│\n' "${DOMAIN} → tunnel"
+    printf '│  Terminal         : terminal.%-31s│\n' "${DOMAIN} → tunnel"
+  fi
+  printf '└─────────────────────────────────────────────────────────────┘\n'
+  printf '\n'
+  log "Next steps:"
+  log "  1. Open http://${TS_IP}:8000 and create your Coolify admin account."
+  log ""
+  log "  2. Cloudflare SSL mode (one-time):"
+  log "       Cloudflare dashboard > your zone > SSL/TLS > Overview > set to 'Full'"
+  log "       (not Full Strict — Coolify uses self-signed certs internally)"
+  log ""
+  log "  3. Start the proxy: Coolify UI > Servers > localhost > Proxy > Start Proxy"
+  log "       (required for app subdomains to route through Traefik)"
+  log ""
+  log "  4. Wildcard Domain is already set to http://${APP_DOMAIN} (done automatically)."
+  log "       New apps will get  http://appname.${APP_DOMAIN}"
+  log "       If an app already has a sslip.io URL: App > Settings > Domains > update it."
+  log ""
+  log "  5. For each app deployment in Coolify:"
+  log "       Use http:// domain (not https://) — Cloudflare proxy adds TLS."
+  log "       Example:  http://myapp.${APP_DOMAIN}"
+  log ""
+  log "  6. Deploy your first app — it gets a subdomain + Cloudflare SSL automatically."
+}

--- a/scripts/provisioning/setup.sh
+++ b/scripts/provisioning/setup.sh
@@ -515,8 +515,9 @@ PUSHER_INNER
 
     # Write tunnel config — always include both wildcard levels so manually set app domains
     # at either scope (vps or apex) are routed correctly.
-    # ws. and terminal. hostnames route Soketi WebSocket and terminal services through the
-    # tunnel so the browser can reach them over HTTPS without exposing extra ports.
+    # ws.DOMAIN routes Soketi WebSocket traffic.
+    # Terminal WebSocket uses path /terminal/ws on the dashboard hostname, so this
+    # rule must come before the dashboard catch-all (cloudflared is first-match).
     local extra_apex_ingress=""
     if [[ "${APP_DOMAIN}" != "${CF_ZONE_NAME}" ]]; then
       extra_apex_ingress="  - hostname: \"*.${CF_ZONE_NAME}\"
@@ -529,11 +530,12 @@ credentials-file: /etc/cloudflared/${TUNNEL_ID}.json
 
 ingress:
   - hostname: ${DOMAIN}
+    path: /terminal/ws
+    service: http://localhost:6002
+  - hostname: ${DOMAIN}
     service: http://localhost:8000
   - hostname: ws.${DOMAIN}
     service: http://localhost:6001
-  - hostname: terminal.${DOMAIN}
-    service: http://localhost:6002
   - hostname: "*.${APP_DOMAIN}"
     service: http://localhost:80
 ${extra_apex_ingress}  - service: http_status:404

--- a/scripts/provisioning/setup.sh
+++ b/scripts/provisioning/setup.sh
@@ -301,7 +301,7 @@ phase3_docker_coolify() {
     log "Docker already installed — skipping install."
   else
     log "Installing Docker..."
-    curl -fsSL https://get.docker.com | sh \
+    bash -o pipefail -c 'curl -fsSL https://get.docker.com | sh' \
       || die "Docker installation failed."
     pass "Docker installed"
   fi
@@ -320,7 +320,7 @@ phase3_docker_coolify() {
     pass "Coolify already installed"
   else
     log "Installing Coolify (this may take a few minutes)..."
-    curl -fsSL https://cdn.coollabs.io/coolify/install.sh | bash \
+    bash -o pipefail -c 'curl -fsSL https://cdn.coollabs.io/coolify/install.sh | bash' \
       || die "Coolify installation failed."
     pass "Coolify installed"
   fi

--- a/scripts/provisioning/setup.sh
+++ b/scripts/provisioning/setup.sh
@@ -1,0 +1,598 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# setup.sh — Server-side orchestrator for secure Coolify deployment
+# Run directly on the server (after SSH'ing in manually).
+#
+# Interactive mode:  sudo ./setup.sh
+# Non-interactive:   sudo ./setup.sh --server-ip 1.2.3.4 --admin-user ... --yes
+# Mixed:             sudo ./setup.sh --server-ip 1.2.3.4  (prompted for the rest)
+
+SCRIPT_NAME="$(basename "$0")"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# shellcheck source=lib/coolify-common.sh
+source "${SCRIPT_DIR}/lib/coolify-common.sh"
+
+# ── Inputs (populated by flags or prompts) ──────────────────────────────────
+
+SERVER_IP="${SERVER_IP:-}"
+ADMIN_USER="${ADMIN_USER:-}"
+PUBKEY_FILE="${PUBKEY_FILE:-}"
+TAILSCALE_AUTH_KEY="${TAILSCALE_AUTH_KEY:-}"
+DEPLOY_MODE="${DEPLOY_MODE:-}"
+DOMAIN="${DOMAIN:-}"
+CF_API_TOKEN="${CF_API_TOKEN:-}"
+CF_ZONE="${CF_ZONE:-}"
+APP_DOMAIN_MODE="${APP_DOMAIN_MODE:-}"
+SWAP_SIZE="${SWAP_SIZE:-}"
+AUTO_YES="${AUTO_YES:-false}"
+
+# ── Derived at runtime ──────────────────────────────────────────────────────
+
+ADMIN_PUBKEY=""
+TS_IP=""
+CF_ZONE_ID=""
+CF_ZONE_NAME=""
+APP_DOMAIN=""
+CF_ACCOUNT_ID=""
+TUNNEL_ID=""
+TUNNEL_SECRET=""
+
+pause_for_operator() {
+  if is_true "${AUTO_YES}"; then return 0; fi
+  local msg="$1"
+  printf '\n  \033[1;33m⏸  %s\033[0m\n' "${msg}"
+  printf '  Press Enter when ready...'
+  read -r
+}
+
+# ── Usage ───────────────────────────────────────────────────────────────────
+
+usage() {
+  cat <<'EOF'
+setup.sh — Server-side orchestrator for secure Coolify deployment
+
+Usage:
+  sudo setup.sh [options]
+
+Run this directly on the server. If all required flags are provided,
+runs non-interactively. If any are missing, prompts for them.
+
+Required:
+  --server-ip <ip>              Server public IPv4 address
+  --admin-user <name>           Admin username
+  --pubkey-file <path>          SSH public key file (on this server)
+  --tailscale-auth-key <key>    Tailscale auth key (tskey-auth-...)
+  --domain <fqdn>               Domain name for Coolify
+  --cf-api-token <token>        Cloudflare API token
+
+Optional:
+  --mode <tunnel|standard>       Deployment mode (default: tunnel)
+  --app-domain-mode <vps|apex>  App subdomain scope: vps=appname.DOMAIN, apex=appname.ZONE (default: apex)
+  --cf-zone <zone>              Cloudflare zone (default: derived from domain)
+  --swap-size <size>            Swap size (default: 2G)
+  --yes                         Skip confirmation prompts (for automation)
+  -h, --help                    Show this help
+EOF
+}
+
+# ── Argument parsing ────────────────────────────────────────────────────────
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --server-ip)       SERVER_IP="${2:?--server-ip requires a value}"; shift 2 ;;
+      --admin-user)      ADMIN_USER="${2:?--admin-user requires a value}"; shift 2 ;;
+      --pubkey-file)     PUBKEY_FILE="${2:?--pubkey-file requires a value}"; shift 2 ;;
+      --tailscale-auth-key) TAILSCALE_AUTH_KEY="${2:?--tailscale-auth-key requires a value}"; shift 2 ;;
+      --mode)            DEPLOY_MODE="${2:?--mode requires a value}"; shift 2 ;;
+      --domain)          DOMAIN="${2:?--domain requires a value}"; shift 2 ;;
+      --cf-api-token)    CF_API_TOKEN="${2:?--cf-api-token requires a value}"; shift 2 ;;
+      --cf-zone)         CF_ZONE="${2:?--cf-zone requires a value}"; shift 2 ;;
+      --app-domain-mode) APP_DOMAIN_MODE="${2:?--app-domain-mode requires a value}"; shift 2 ;;
+      --swap-size)       SWAP_SIZE="${2:?--swap-size requires a value}"; shift 2 ;;
+      --yes)             AUTO_YES="true"; shift ;;
+      -h|--help)         usage; exit 0 ;;
+      *)                 die "Unknown option: $1 (use --help)" ;;
+    esac
+  done
+}
+
+# ── Input collection (flag → prompt fallback) ──────────────────────────────
+
+collect_inputs() {
+  collect_common_inputs
+}
+
+# ── Input validation ───────────────────────────────────────────────────────
+
+validate_inputs() {
+  [[ "$(id -u)" -eq 0 ]] || die "This script must be run as root (use sudo)."
+  [[ "${SERVER_IP}" =~ ${IPV4_RE} ]]      || die "Invalid server IP: ${SERVER_IP}"
+  [[ "${ADMIN_USER}" =~ ${LINUX_USER_RE} ]] || die "Invalid admin username: ${ADMIN_USER}"
+  [[ "${ADMIN_USER}" != "root" ]]          || die "Admin user must not be root."
+
+  [[ -f "${PUBKEY_FILE}" ]]                || die "Public key file not found: ${PUBKEY_FILE}"
+  ssh-keygen -l -f "${PUBKEY_FILE}" >/dev/null 2>&1 \
+    || die "Invalid SSH public key: ${PUBKEY_FILE}"
+  ADMIN_PUBKEY="$(cat "${PUBKEY_FILE}")"
+
+  [[ "${TAILSCALE_AUTH_KEY}" == tskey-auth-* ]] \
+    || die "Tailscale auth key must start with 'tskey-auth-' (got: ${TAILSCALE_AUTH_KEY:0:12}...)"
+
+  [[ "${DEPLOY_MODE}" == "standard" || "${DEPLOY_MODE}" == "tunnel" ]] \
+    || die "Mode must be 'standard' or 'tunnel' (got: ${DEPLOY_MODE})"
+
+  [[ "${APP_DOMAIN_MODE}" == "vps" || "${APP_DOMAIN_MODE}" == "apex" ]] \
+    || die "App domain mode must be 'vps' or 'apex' (got: ${APP_DOMAIN_MODE})"
+
+  [[ "${DOMAIN}" =~ ${FQDN_RE} ]]         || die "Invalid domain: ${DOMAIN}"
+  [[ -n "${CF_API_TOKEN}" ]]               || die "Cloudflare API token is required."
+  [[ "${SWAP_SIZE}" =~ ${SWAP_RE} ]]       || die "Invalid swap size: ${SWAP_SIZE} (expected e.g. 2G, 512M)"
+
+  # Verify scripts are present in current directory
+  local scripts=(bootstrap_hardening.sh validate_hardening.sh configure_coolify_binding.sh)
+  for script in "${scripts[@]}"; do
+    [[ -f "${SCRIPT_DIR}/${script}" ]] || die "Required script not found: ${SCRIPT_DIR}/${script}"
+  done
+}
+
+verify_docker_user_gate_local() {
+  local gate_label="$1"
+  local gate_d_inactive_msg="Gate D failed: docker-user-hardening.service is not active."
+
+  if systemctl is-active --quiet docker-user-hardening.service; then
+    pass "${gate_label}: docker-user-hardening.service is active"
+  else
+    fail "${gate_label}: docker-user-hardening.service is not active"
+    die "${gate_d_inactive_msg}"
+  fi
+
+  local iptables_out
+  iptables_out="$(iptables -S DOCKER-USER 2>/dev/null)" || true
+  if printf '%s' "${iptables_out}" | grep -q "coolify-hardening"; then
+    pass "${gate_label}: DOCKER-USER hardening rules active"
+  else
+    fail "${gate_label}: DOCKER-USER hardening rules not found"
+    die "${gate_label} failed. Check: systemctl status docker-user-hardening.service"
+  fi
+}
+
+reconcile_docker_daemon_local() {
+  log "Reconciling Docker daemon settings after Coolify install..."
+  # Hardening owns: log-driver, log-opts, live-restore. Coolify may add: default-address-pools.
+  # Using json-file driver to match Coolify's expectation for compatibility.
+  local daemon_json="/etc/docker/daemon.json"
+  local tmp
+  tmp="$(mktemp)"
+
+  # Drift detection: warn if hardening keys were changed (e.g., by Coolify update)
+  if [[ -f "${daemon_json}" ]]; then
+    local current_driver current_live_restore
+    current_driver="$(jq -r '.["log-driver"] // ""' "${daemon_json}" 2>/dev/null || true)"
+    if [[ "${current_driver}" != "" && "${current_driver}" != "json-file" ]]; then
+      warn "Docker log-driver drift detected (was '${current_driver}', expected 'json-file'). Reconciling..."
+    fi
+    current_live_restore="$(jq -r '.["live-restore"] // ""' "${daemon_json}" 2>/dev/null || true)"
+    if [[ "${current_live_restore}" != "" && "${current_live_restore}" != "true" ]]; then
+      warn "Docker live-restore drift detected (was '${current_live_restore}', expected 'true'). Reconciling..."
+    fi
+  fi
+
+  if [[ -f "${daemon_json}" ]]; then
+    jq '. + {"log-driver":"json-file","log-opts":((.["log-opts"] // {}) + {"max-size":"10m","max-file":"3"}),"live-restore":true}' "${daemon_json}" > "${tmp}"
+  else
+    jq -n '{"log-driver":"json-file","log-opts":{"max-size":"10m","max-file":"3"},"live-restore":true}' > "${tmp}"
+  fi
+
+  if [[ -f "${daemon_json}" ]] && cmp -s "${tmp}" "${daemon_json}"; then
+    rm -f "${tmp}"
+    pass "Docker daemon settings already match hardening policy"
+    return 0
+  fi
+
+  if [[ -f "${daemon_json}" ]]; then
+    cp -a "${daemon_json}" "${daemon_json}.bak.$(date +%s)"
+  fi
+
+  cat "${tmp}" > "${daemon_json}"
+  chmod 0644 "${daemon_json}"
+  rm -f "${tmp}"
+  systemctl restart docker
+  pass "Docker daemon hardening reconciled (json-file log rotation + live-restore)"
+}
+
+# ── Pre-flight ──────────────────────────────────────────────────────────────
+
+preflight() {
+  step "0/5" "Pre-flight checks"
+
+  # Check local tools
+  local required_cmds=(curl jq ssh-keygen openssl)
+  for cmd in "${required_cmds[@]}"; do
+    command -v "${cmd}" >/dev/null 2>&1 || die "Required command not found: ${cmd}. Install it first."
+  done
+  pass "Required tools present"
+
+  # Validate pubkey
+  ssh-keygen -l -f "${PUBKEY_FILE}" >/dev/null 2>&1 || die "Invalid SSH public key file: ${PUBKEY_FILE}"
+  pass "SSH public key valid: ${PUBKEY_FILE}"
+
+  # Verify Cloudflare token
+  cf_verify_token
+  cf_get_zone_id
+  cf_get_account_id  # always fetch — needed for tunnel (default mode)
+  resolve_app_domain
+  pass "Cloudflare API verified (zone: ${CF_ZONE_ID})"
+}
+
+# ── Phase 1: Harden ────────────────────────────────────────────────────────
+
+phase1_harden() {
+  step "1/5" "Harden server"
+
+  local tunnel_flag="false"
+  [[ "${DEPLOY_MODE}" == "tunnel" ]] && tunnel_flag="true"
+
+  # Write env file (avoids quoting issues with pubkey)
+  cat > /root/deploy.env <<EOF
+ADMIN_USER=${ADMIN_USER}
+ADMIN_PUBKEY="${ADMIN_PUBKEY}"
+TAILSCALE_CIDR=100.64.0.0/10
+SSH_PORT=22
+TUNNEL_MODE=${tunnel_flag}
+SWAP_SIZE=${SWAP_SIZE}
+INSTALL_TAILSCALE=true
+TAILSCALE_AUTH_KEY=${TAILSCALE_AUTH_KEY}
+BIND_DASHBOARD_TO_TAILSCALE=false
+EOF
+  chmod 600 /root/deploy.env
+  pass "Environment file written"
+
+  # Run hardening
+  log "Running bootstrap_hardening.sh (this may take a few minutes)..."
+  "${SCRIPT_DIR}/bootstrap_hardening.sh" --env-file /root/deploy.env --install-tailscale --force \
+    || die "bootstrap_hardening.sh failed. Check: /var/log/bootstrap-hardening.log"
+  pass "Hardening completed"
+
+  # Capture Tailscale IP
+  TS_IP="$(tailscale ip -4 2>/dev/null | tr -d '[:space:]')"
+  [[ -n "${TS_IP}" ]] || die "Failed to get Tailscale IP."
+  pass "Server Tailscale IP: ${TS_IP}"
+
+  # Clean up sensitive env file
+  rm -f /root/deploy.env
+}
+
+# ── Phase 2: Gate checks ───────────────────────────────────────────────────
+
+phase2_gates() {
+  step "2/5" "Gate checks"
+
+  # Gate A: Operator verifies SSH from laptop
+  pause_for_operator "From your LAPTOP, verify SSH: ssh ${ADMIN_USER}@${TS_IP} (Tailscale IP)"
+
+  # Gate B: Verify admin user is functional locally
+  local admin_home
+  admin_home="$(getent passwd "${ADMIN_USER}" | cut -d: -f6 2>/dev/null)" || true
+  if [[ -n "${admin_home}" ]] && [[ -d "${admin_home}/.ssh" ]]; then
+    pass "Gate B: Admin user ${ADMIN_USER} exists with SSH dir"
+  else
+    fail "Gate B: Admin user ${ADMIN_USER} home or .ssh not found"
+    die "Gate B failed."
+  fi
+
+  # Gate C: Validation passes
+  log "Gate C: Running validate_hardening.sh..."
+  local validate_json
+  validate_json="$("${SCRIPT_DIR}/validate_hardening.sh" --json 2>/dev/null)" || true
+  report_validation_result "Gate C" "${validate_json}" \
+    "Gate C failed. Fix validation failures before continuing."
+}
+
+# ── Phase 3: Docker + Coolify ──────────────────────────────────────────────
+
+phase3_docker_coolify() {
+  step "3/5" "Install Docker & Coolify"
+
+  # Install Docker (skip if already present — the install script is not idempotent on network errors)
+  if docker version >/dev/null 2>&1; then
+    log "Docker already installed — skipping install."
+  else
+    log "Installing Docker..."
+    curl -fsSL https://get.docker.com | sh \
+      || die "Docker installation failed."
+    pass "Docker installed"
+  fi
+  pass "Docker present"
+
+  # Start DOCKER-USER hardening service
+  systemctl start docker-user-hardening.service \
+    || die "Failed to start docker-user-hardening.service"
+
+  # Gate D: Verify DOCKER-USER rules
+  verify_docker_user_gate_local "Gate D"
+
+  # Install Coolify (skip if already installed)
+  if [[ -f /data/coolify/source/.env ]]; then
+    log "Coolify .env found — skipping install (already installed)."
+    pass "Coolify already installed"
+  else
+    log "Installing Coolify (this may take a few minutes)..."
+    curl -fsSL https://cdn.coollabs.io/coolify/install.sh | bash \
+      || die "Coolify installation failed."
+    pass "Coolify installed"
+  fi
+
+  # Coolify installer manages daemon.json; re-apply hardening settings while preserving its keys.
+  reconcile_docker_daemon_local
+
+  # Docker restart can flush DOCKER-USER runtime rules; re-apply and verify.
+  systemctl restart docker-user-hardening.service \
+    || die "Failed to restart docker-user-hardening.service after Docker daemon reconciliation."
+  verify_docker_user_gate_local "Gate D (post-Coolify)"
+
+  # Add Coolify's generated SSH public key to root's authorized_keys.
+  # Required for the Coolify "This Machine" onboarding: Coolify SSHes to localhost as root
+  # using its own key. The hardening Match block allows key-only root login from
+  # localhost (127.0.0.1), 172.16.0.0/12, and 10.0.0.0/8 (Docker pool); key must be present.
+  log "Adding Coolify SSH key to root authorized_keys..."
+  local keyfile auth pubkey
+  keyfile=$(ls /data/coolify/ssh/keys/ssh_key@* 2>/dev/null | head -1 || true)
+  if [[ -z "${keyfile}" ]]; then
+    warn "No Coolify SSH key found — skipping root authorized_keys update"
+  else
+    pubkey=$(ssh-keygen -y -f "${keyfile}")
+    auth=/root/.ssh/authorized_keys
+    mkdir -p /root/.ssh && chmod 700 /root/.ssh
+    touch "${auth}" && chmod 600 "${auth}"
+    if grep -qxF "${pubkey}" "${auth}" 2>/dev/null; then
+      log "Coolify key already in root authorized_keys"
+    else
+      # Ensure file ends with newline before appending to avoid key concatenation
+      [[ -s "${auth}" ]] && [[ "$(tail -c1 "${auth}" | od -An -tx1 | tr -d ' \n')" != "0a" ]] \
+        && printf '\n' >> "${auth}"
+      printf '%s\n' "${pubkey}" >> "${auth}"
+    fi
+    pass "Coolify SSH key in root authorized_keys"
+  fi
+
+  # Fix host.docker.internal resolution on Linux Docker.
+  # Docker on Linux doesn't resolve host-gateway to a real IP in all versions/configurations.
+  # Patch Coolify's docker-compose.yml to use the actual coolify network gateway IP,
+  # then recreate the container so the fix takes effect.
+  log "Fixing host.docker.internal for Linux Docker..."
+  local compose_yml="/data/coolify/source/docker-compose.yml"
+  if [[ -f "${compose_yml}" ]]; then
+    local gateway
+    gateway=$(docker network inspect coolify --format '{{range .IPAM.Config}}{{.Subnet}} {{.Gateway}} {{end}}' 2>/dev/null \
+      | tr ' ' '\n' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' | grep -v '/[0-9]' | head -1 || true)
+
+    if [[ -z "${gateway}" ]]; then
+      warn "Cannot determine coolify network gateway — skipping host.docker.internal fix"
+    else
+      local current
+      current=$(grep -m1 'host\.docker\.internal:' "${compose_yml}" | awk -F: '{print $NF}' | tr -d ' ' || true)
+      if [[ "${current}" == "${gateway}" ]]; then
+        log "host.docker.internal already set to ${gateway}"
+      else
+        sed -i "s|host\.docker\.internal:.*|host.docker.internal:${gateway}|g" "${compose_yml}"
+        log "Patched host.docker.internal → ${gateway}"
+        docker compose -f /data/coolify/source/docker-compose.yml \
+                       -f /data/coolify/source/docker-compose.prod.yml \
+                       up -d --force-recreate coolify soketi 2>&1 | tail -5
+      fi
+      pass "host.docker.internal patched in Coolify docker-compose"
+    fi
+  else
+    warn "docker-compose.yml not found — skipping host.docker.internal fix"
+  fi
+}
+
+# ── Phase 4: Binding + DNS ─────────────────────────────────────────────────
+
+phase4_binding_dns() {
+  step "4/5" "Configure dashboard binding & DNS"
+
+  # Wait for Coolify to write its .env file before binding (installer is async)
+  log "Waiting for Coolify to initialize /data/coolify/source/.env..."
+  local coolify_wait=0 coolify_max=120
+  until [[ -f /data/coolify/source/.env ]]; do
+    (( coolify_wait += 5 ))
+    if (( coolify_wait >= coolify_max )); then
+      warn "Coolify .env not found after ${coolify_max}s — binding may fail; continuing."
+      break
+    fi
+    sleep 5
+  done
+
+  # Run configure_coolify_binding.sh directly
+  log "Binding Coolify dashboard to Tailscale IP..."
+  "${SCRIPT_DIR}/configure_coolify_binding.sh" --tailscale-ip "${TS_IP}" \
+    || warn "configure_coolify_binding.sh returned non-zero (may be ok if Coolify is still starting)"
+  pass "Dashboard binding configured"
+
+  # Set Coolify wildcard domain directly in the database.
+  # configure_coolify_binding.sh already waited up to 60s for port 8000 to bind,
+  # which guarantees the s6 startup sequence (migrate→seed→init) has completed and
+  # the server_settings row (server_id=0, the hardcoded Localhost server) exists.
+  # The API PATCH /servers/{uuid} does not expose wildcard_domain, so we write
+  # directly to PostgreSQL via docker exec on the coolify-db container.
+  log "Setting Coolify wildcard domain to http://${APP_DOMAIN}..."
+  local coolify_env="/data/coolify/source/.env"
+  local db_user db_name db_pass
+  db_user="$(grep '^DB_USERNAME=' "${coolify_env}" | cut -d= -f2 || echo 'coolify')"
+  db_name="$(grep '^DB_DATABASE=' "${coolify_env}" | cut -d= -f2 || echo 'coolify')"
+  db_pass="$(grep '^DB_PASSWORD=' "${coolify_env}" | cut -d= -f2)"
+  docker exec -e PGPASSWORD="${db_pass}" coolify-db \
+    psql -U "${db_user}" -d "${db_name}" -c \
+    "UPDATE server_settings SET wildcard_domain = 'http://${APP_DOMAIN}' WHERE server_id = 0;" \
+    2>/dev/null \
+    || warn "psql update failed — set Wildcard Domain manually in Coolify UI > Servers > localhost"
+  pass "Coolify wildcard domain: http://${APP_DOMAIN}"
+
+  # In tunnel mode, set PUSHER_* env vars so the browser connects to Soketi via the
+  # tunnel (wss://ws.DOMAIN) instead of trying to reach localhost:6001 directly.
+  # Standard mode does not need this — browser connects to the Tailscale IP on port 6001.
+  if [[ "${DEPLOY_MODE}" == "tunnel" ]]; then
+    log "Setting PUSHER env vars for tunnel-mode WebSocket routing..."
+    local coolify_env="/data/coolify/source/.env"
+    # Idempotent: remove existing PUSHER_HOST/PORT/SCHEME lines, then append
+    sed -i '/^PUSHER_HOST=/d; /^PUSHER_PORT=/d; /^PUSHER_SCHEME=/d' "${coolify_env}"
+    cat >> "${coolify_env}" <<PUSHER_INNER
+PUSHER_HOST=ws.${DOMAIN}
+PUSHER_PORT=443
+PUSHER_SCHEME=https
+PUSHER_INNER
+    log "PUSHER env vars written to ${coolify_env}"
+    # Recreate coolify + soketi to pick up the new env (fast — ~10s, no DB/redis restart)
+    docker compose -f /data/coolify/source/docker-compose.yml \
+                   -f /data/coolify/source/docker-compose.prod.yml \
+                   up -d --force-recreate coolify soketi 2>&1 | tail -5
+    pass "PUSHER env vars configured: ws.${DOMAIN}:443 (wss)"
+  fi
+
+  if [[ "${DEPLOY_MODE}" == "standard" ]]; then
+    # Standard mode: A records pointing to server public IP (proxied)
+    log "Configuring DNS: A record ${DOMAIN} → ${SERVER_IP} (proxied)..."
+    cf_upsert_a_record "${DOMAIN}" "${SERVER_IP}" "true"
+    pass "DNS A record configured: ${DOMAIN} → ${SERVER_IP}"
+
+    # Wildcard A records — always create both scopes so manually set domains at either level work
+    local wildcard_name="*.${APP_DOMAIN}"
+    log "Configuring DNS: wildcard A record ${wildcard_name} → ${SERVER_IP} (proxied)..."
+    cf_upsert_a_record "${wildcard_name}" "${SERVER_IP}" "true"
+    pass "DNS wildcard A record configured: ${wildcard_name} → ${SERVER_IP}"
+    if [[ "${APP_DOMAIN}" != "${CF_ZONE_NAME}" ]]; then
+      local apex_wildcard="*.${CF_ZONE_NAME}"
+      cf_upsert_a_record "${apex_wildcard}" "${SERVER_IP}" "true"
+      pass "DNS wildcard A record configured: ${apex_wildcard} → ${SERVER_IP}"
+    fi
+
+  elif [[ "${DEPLOY_MODE}" == "tunnel" ]]; then
+    # Tunnel mode: create tunnel, install cloudflared, CNAME
+    log "Creating Cloudflare Tunnel..."
+    _stop_cloudflared() { systemctl stop cloudflared 2>/dev/null || true; }
+    cf_create_tunnel "_stop_cloudflared"
+    pass "Tunnel created: ${TUNNEL_ID}"
+
+    # Install cloudflared
+    log "Installing cloudflared..."
+    apt-get update -qq && apt-get install -y -qq cloudflared 2>/dev/null \
+      || {
+        log "Trying Cloudflare repository..."
+        curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg \
+          | tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null
+        echo "deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared $(lsb_release -cs) main" \
+          | tee /etc/apt/sources.list.d/cloudflared.list
+        apt-get update -qq && apt-get install -y -qq cloudflared \
+          || die "Failed to install cloudflared"
+      }
+    pass "cloudflared installed"
+
+    # Write tunnel credentials
+    local creds_json
+    creds_json="$(jq -n --arg id "${TUNNEL_ID}" --arg secret "${TUNNEL_SECRET}" --arg account "${CF_ACCOUNT_ID}" \
+      '{AccountTag:$account,TunnelID:$id,TunnelSecret:$secret}')"
+    mkdir -p /etc/cloudflared
+    printf '%s' "${creds_json}" > "/etc/cloudflared/${TUNNEL_ID}.json"
+    chmod 600 "/etc/cloudflared/${TUNNEL_ID}.json"
+
+    # Write tunnel config — always include both wildcard levels so manually set app domains
+    # at either scope (vps or apex) are routed correctly.
+    # ws. and terminal. hostnames route Soketi WebSocket and terminal services through the
+    # tunnel so the browser can reach them over HTTPS without exposing extra ports.
+    local extra_apex_ingress=""
+    if [[ "${APP_DOMAIN}" != "${CF_ZONE_NAME}" ]]; then
+      extra_apex_ingress="  - hostname: \"*.${CF_ZONE_NAME}\"
+    service: http://localhost:80
+"
+    fi
+    cat > /etc/cloudflared/config.yml <<EOF
+tunnel: ${TUNNEL_ID}
+credentials-file: /etc/cloudflared/${TUNNEL_ID}.json
+
+ingress:
+  - hostname: ${DOMAIN}
+    service: http://localhost:8000
+  - hostname: ws.${DOMAIN}
+    service: http://localhost:6001
+  - hostname: terminal.${DOMAIN}
+    service: http://localhost:6002
+  - hostname: "*.${APP_DOMAIN}"
+    service: http://localhost:80
+${extra_apex_ingress}  - service: http_status:404
+EOF
+    local wc_summary="*.${APP_DOMAIN}"
+    [[ "${APP_DOMAIN}" != "${CF_ZONE_NAME}" ]] && wc_summary+=" and *.${CF_ZONE_NAME}"
+    pass "Tunnel credentials and config written (wildcards: ${wc_summary})"
+
+    # Start cloudflared service
+    cloudflared service install 2>/dev/null || true
+    systemctl enable --now cloudflared \
+      || die "Failed to start cloudflared service"
+    pass "cloudflared service running"
+
+    # Create CNAME records: exact domain + wildcard for subdomains
+    local tunnel_target="${TUNNEL_ID}.cfargotunnel.com"
+    cf_upsert_cname "${DOMAIN}" "${tunnel_target}"
+    pass "DNS CNAME configured: ${DOMAIN} → ${tunnel_target}"
+
+    # Always create both wildcard CNAME levels for full routing coverage
+    cf_upsert_cname "*.${APP_DOMAIN}" "${tunnel_target}"
+    pass "DNS wildcard CNAME configured: *.${APP_DOMAIN} → ${tunnel_target}"
+    if [[ "${APP_DOMAIN}" != "${CF_ZONE_NAME}" ]]; then
+      cf_upsert_cname "*.${CF_ZONE_NAME}" "${tunnel_target}"
+      pass "DNS wildcard CNAME configured: *.${CF_ZONE_NAME} → ${tunnel_target}"
+    fi
+  fi
+}
+
+# ── Phase 5: Verification ─────────────────────────────────────────────────
+
+phase5_verify() {
+  step "5/5" "Final verification"
+
+  # Gate E: Operator verifies from laptop
+  pause_for_operator "From your LAPTOP, verify: curl http://${TS_IP}:8000 should work; curl http://${SERVER_IP}:8000 should NOT"
+
+  # Final validation run
+  log "Running final validate_hardening.sh..."
+  local final_validate_json
+  final_validate_json="$("${SCRIPT_DIR}/validate_hardening.sh" --json 2>/dev/null)" || true
+  report_validation_result "Final validation" "${final_validate_json}" \
+    "Final validation failed. Resolve validation failures before considering deployment complete."
+
+  # Print summary
+  print_deployment_summary
+}
+
+# ── Main ────────────────────────────────────────────────────────────────────
+
+main() {
+  parse_args "$@"
+  collect_inputs
+  validate_inputs
+
+  # Show summary before proceeding
+  printf '\n'
+  log "Deployment configuration:"
+  log "  Server:    ${SERVER_IP}"
+  log "  Admin:     ${ADMIN_USER}"
+  log "  Pubkey:    ${PUBKEY_FILE}"
+  log "  Mode:      ${DEPLOY_MODE}"
+  log "  Domain:    ${DOMAIN}"
+  log "  App scope: ${APP_DOMAIN_MODE}"
+  log "  Swap:      ${SWAP_SIZE}"
+  confirm "Proceed with deployment?"
+
+  preflight
+  phase1_harden
+  phase2_gates
+  phase3_docker_coolify
+  phase4_binding_dns
+  phase5_verify
+}
+
+main "$@"

--- a/scripts/provisioning/tests/unit/test_deploy_workflow_contract.bats
+++ b/scripts/provisioning/tests/unit/test_deploy_workflow_contract.bats
@@ -56,6 +56,12 @@ DEPLOY_MATRIX="${PROJECT_ROOT}/docs/deploy_setup_functionality_test_matrix.md"
   ! grep -Fq "<<'INNER'" "${DEPLOY_SCRIPT}"
 }
 
+@test "deploy: tunnel terminal ingress uses dashboard path (not terminal subdomain)" {
+  grep -Fq 'path: /terminal/ws' "${DEPLOY_SCRIPT}"
+  grep -Fq 'service: http://localhost:6002' "${DEPLOY_SCRIPT}"
+  ! grep -Fq 'hostname: terminal.${DOMAIN}' "${DEPLOY_SCRIPT}"
+}
+
 @test "deploy: gate E fails when exposure checks do not pass" {
   grep -Fq "Gate E: Checking dashboard accessibility..." "${DEPLOY_SCRIPT}"
   grep -Fq "Gate E failed: dashboard not reachable via Tailscale" "${DEPLOY_SCRIPT}"

--- a/scripts/provisioning/tests/unit/test_deploy_workflow_contract.bats
+++ b/scripts/provisioning/tests/unit/test_deploy_workflow_contract.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+# Tier 0: Contract tests for deploy.sh workflow structure
+
+load '../helpers'
+
+DEPLOY_SCRIPT="${PROJECT_ROOT}/deploy.sh"
+DEPLOY_MATRIX="${PROJECT_ROOT}/docs/deploy_setup_functionality_test_matrix.md"
+
+@test "deploy: preflight phase marker exists" {
+  grep -Fq 'step "0/5" "Pre-flight checks"' "${DEPLOY_SCRIPT}"
+}
+
+@test "deploy: phase1 upload+harden marker exists" {
+  grep -Fq 'phase1_upload_harden()' "${DEPLOY_SCRIPT}"
+  grep -Fq 'step "1/5" "Upload scripts & harden server"' "${DEPLOY_SCRIPT}"
+}
+
+@test "deploy: hardening invocation uses env-file and tailscale install" {
+  grep -Fq '/root/bootstrap_hardening.sh --env-file /root/deploy.env --install-tailscale --force' "${DEPLOY_SCRIPT}"
+}
+
+@test "deploy: gate A checks admin SSH on tailscale" {
+  grep -Fq 'Gate A: Testing SSH admin@' "${DEPLOY_SCRIPT}"
+}
+
+@test "deploy: gate B verifies admin identity" {
+  grep -Fq 'Gate B: whoami=' "${DEPLOY_SCRIPT}"
+}
+
+@test "deploy: gate C runs validate_hardening.sh json" {
+  grep -Fq "Gate C: Running validate_hardening.sh..." "${DEPLOY_SCRIPT}"
+  grep -Fq "validate_hardening.sh --json" "${DEPLOY_SCRIPT}"
+}
+
+@test "deploy: gate D validates service active and managed rules" {
+  grep -Fq "verify_docker_user_gate_remote()" "${DEPLOY_SCRIPT}"
+  grep -Fq "systemctl is-active --quiet docker-user-hardening.service" "${DEPLOY_SCRIPT}"
+  grep -Fq 'verify_docker_user_gate_remote "Gate D"' "${DEPLOY_SCRIPT}"
+  grep -Fq "coolify-hardening" "${DEPLOY_SCRIPT}"
+}
+
+@test "deploy: phase4 binding+dns marker exists" {
+  grep -Fq 'phase4_binding_dns()' "${DEPLOY_SCRIPT}"
+  grep -Fq 'step "4/5" "Configure dashboard binding & DNS"' "${DEPLOY_SCRIPT}"
+}
+
+@test "deploy: binding failure is fatal" {
+  grep -Fq 'configure_coolify_binding.sh --tailscale-ip' "${DEPLOY_SCRIPT}"
+  grep -Fq 'die "configure_coolify_binding.sh failed. Fix binding errors before continuing."' "${DEPLOY_SCRIPT}"
+}
+
+@test "deploy: PUSHER env supports mode switch and expanded domain" {
+  grep -Fq 'mode="${DEPLOY_MODE}"' "${DEPLOY_SCRIPT}"
+  grep -Fq 'PUSHER_HOST=ws.${DOMAIN}' "${DEPLOY_SCRIPT}"
+  grep -Fq 'PUSHER env vars cleared for standard mode' "${DEPLOY_SCRIPT}"
+  ! grep -Fq "<<'INNER'" "${DEPLOY_SCRIPT}"
+}
+
+@test "deploy: gate E fails when exposure checks do not pass" {
+  grep -Fq "Gate E: Checking dashboard accessibility..." "${DEPLOY_SCRIPT}"
+  grep -Fq "Gate E failed: dashboard not reachable via Tailscale" "${DEPLOY_SCRIPT}"
+  grep -Fq "Gate E failed: dashboard reachable on public IP" "${DEPLOY_SCRIPT}"
+}
+
+@test "deploy: final validation is executed" {
+  grep -Fq "Running final validate_hardening.sh..." "${DEPLOY_SCRIPT}"
+}
+
+@test "deploy: matrix includes all DEP contract ids" {
+  grep -Fq "DEP-01" "${DEPLOY_MATRIX}"
+  grep -Fq "DEP-10" "${DEPLOY_MATRIX}"
+}

--- a/scripts/provisioning/tests/unit/test_setup_workflow_contract.bats
+++ b/scripts/provisioning/tests/unit/test_setup_workflow_contract.bats
@@ -52,6 +52,12 @@ DEPLOY_MATRIX="${PROJECT_ROOT}/docs/deploy_setup_functionality_test_matrix.md"
   grep -Fq "sed '/^PUSHER_HOST=/d; /^PUSHER_PORT=/d; /^PUSHER_SCHEME=/d'" "${SETUP_SCRIPT}"
 }
 
+@test "setup: tunnel terminal ingress uses dashboard path (not terminal subdomain)" {
+  grep -Fq 'path: /terminal/ws' "${SETUP_SCRIPT}"
+  grep -Fq 'service: http://localhost:6002' "${SETUP_SCRIPT}"
+  ! grep -Fq 'hostname: terminal.${DOMAIN}' "${SETUP_SCRIPT}"
+}
+
 @test "setup: gate E requires operator laptop verification" {
   grep -Fq 'Gate E: Operator verifies from laptop' "${SETUP_SCRIPT}"
 }

--- a/scripts/provisioning/tests/unit/test_setup_workflow_contract.bats
+++ b/scripts/provisioning/tests/unit/test_setup_workflow_contract.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+# Tier 0: Contract tests for setup.sh workflow structure
+
+load '../helpers'
+
+SETUP_SCRIPT="${PROJECT_ROOT}/setup.sh"
+DEPLOY_MATRIX="${PROJECT_ROOT}/docs/deploy_setup_functionality_test_matrix.md"
+
+@test "setup: preflight phase marker exists" {
+  grep -Fq 'step "0/5" "Pre-flight checks"' "${SETUP_SCRIPT}"
+}
+
+@test "setup: phase1 harden marker exists" {
+  grep -Fq 'phase1_harden()' "${SETUP_SCRIPT}"
+  grep -Fq 'step "1/5" "Harden server"' "${SETUP_SCRIPT}"
+}
+
+@test "setup: gate A requires operator laptop verification" {
+  grep -Fq 'Gate A: Operator verifies SSH from laptop' "${SETUP_SCRIPT}"
+}
+
+@test "setup: gate B verifies admin user home and ssh directory" {
+  grep -Fq 'Gate B: Admin user' "${SETUP_SCRIPT}"
+  grep -Fq '.ssh not found' "${SETUP_SCRIPT}"
+}
+
+@test "setup: gate C runs validate_hardening.sh json" {
+  grep -Fq "Gate C: Running validate_hardening.sh..." "${SETUP_SCRIPT}"
+  grep -Fq 'validate_hardening.sh" --json' "${SETUP_SCRIPT}"
+}
+
+@test "setup: gate D validates service active and managed rules" {
+  grep -Fq "verify_docker_user_gate_local()" "${SETUP_SCRIPT}"
+  grep -Fq "systemctl is-active --quiet docker-user-hardening.service" "${SETUP_SCRIPT}"
+  grep -Fq 'verify_docker_user_gate_local "Gate D"' "${SETUP_SCRIPT}"
+  grep -Fq "coolify-hardening" "${SETUP_SCRIPT}"
+}
+
+@test "setup: phase4 binding+dns marker exists" {
+  grep -Fq 'phase4_binding_dns()' "${SETUP_SCRIPT}"
+  grep -Fq 'step "4/5" "Configure dashboard binding & DNS"' "${SETUP_SCRIPT}"
+}
+
+@test "setup: binding failure is fatal" {
+  grep -Fq 'configure_coolify_binding.sh" --tailscale-ip' "${SETUP_SCRIPT}"
+  grep -Fq 'die "configure_coolify_binding.sh failed. Fix binding errors before continuing."' "${SETUP_SCRIPT}"
+}
+
+@test "setup: PUSHER env supports mode switch and expanded domain" {
+  grep -Fq 'PUSHER_HOST=ws.${DOMAIN}' "${SETUP_SCRIPT}"
+  grep -Fq 'PUSHER env vars cleared for standard mode' "${SETUP_SCRIPT}"
+  grep -Fq "sed '/^PUSHER_HOST=/d; /^PUSHER_PORT=/d; /^PUSHER_SCHEME=/d'" "${SETUP_SCRIPT}"
+}
+
+@test "setup: gate E requires operator laptop verification" {
+  grep -Fq 'Gate E: Operator verifies from laptop' "${SETUP_SCRIPT}"
+}
+
+@test "setup: final validation is executed" {
+  grep -Fq "Running final validate_hardening.sh..." "${SETUP_SCRIPT}"
+}
+
+@test "setup: matrix includes all SET contract ids" {
+  grep -Fq "SET-01" "${DEPLOY_MATRIX}"
+  grep -Fq "SET-09" "${DEPLOY_MATRIX}"
+}

--- a/scripts/provisioning/tests/unit/test_validate_functions.bats
+++ b/scripts/provisioning/tests/unit/test_validate_functions.bats
@@ -1,0 +1,430 @@
+#!/usr/bin/env bats
+# Tier 0: Unit tests for pure functions in validate_hardening.sh
+# No Docker, no root, no system access required.
+#
+# Note: validate_hardening.sh has a root check that runs at source time.
+# These tests extract and test the functions using grep/sed to avoid
+# triggering the root check.
+
+load '../helpers'
+
+VALIDATE_SCRIPT="${PROJECT_ROOT}/validate_hardening.sh"
+
+# ── is_true() (extracted from validate_hardening.sh) ───────────────────────────
+# We define our own is_true here to match the one in validate_hardening.sh
+
+is_true() {
+  case "${1,,}" in
+    1|true|yes|y|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# ── record() (extracted for unit testing) ─────────────────────────────────────
+
+record() {
+  local status="$1"
+  local name="$2"
+  local detail="${3:-}"
+
+  case "${status}" in
+    PASS) ((++PASS_COUNT)) ;;
+    FAIL) ((++FAIL_COUNT)) ;;
+    INFO) ((++INFO_COUNT)) ;;
+  esac
+
+  if [[ "${JSON_MODE}" == "true" ]]; then
+    RESULTS+=("{\"check\":\"${name}\",\"status\":\"${status}\",\"detail\":\"${detail}\"}")
+  else
+    printf '%-6s %-45s %s\n' "[${status}]" "${name}" "${detail}"
+  fi
+}
+
+# ── check() (extracted for unit testing) ──────────────────────────────────────
+
+check() {
+  local name="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    record "PASS" "${name}"
+  else
+    record "FAIL" "${name}" "$*"
+  fi
+}
+
+setup() {
+  PASS_COUNT=0
+  FAIL_COUNT=0
+  INFO_COUNT=0
+  JSON_MODE="false"
+  RESULTS=()
+}
+
+# ── is_true() tests ────────────────────────────────────────────────────────────
+
+@test "validate is_true: '1' returns 0" {
+  run is_true "1"
+  assert_success
+}
+
+@test "validate is_true: 'true' returns 0" {
+  run is_true "true"
+  assert_success
+}
+
+@test "validate is_true: 'false' returns 1" {
+  run is_true "false"
+  assert_failure
+}
+
+@test "validate is_true: empty returns 1" {
+  run is_true ""
+  assert_failure
+}
+
+@test "validate is_true: 'yes' returns 0" {
+  run is_true "yes"
+  assert_success
+}
+
+@test "validate is_true: 'on' returns 0" {
+  run is_true "on"
+  assert_success
+}
+
+@test "validate is_true: 'no' returns 1" {
+  run is_true "no"
+  assert_failure
+}
+
+# ── record() tests ────────────────────────────────────────────────────────────
+
+@test "record: increments PASS_COUNT on PASS" {
+  record "PASS" "test-check" "detail"
+  [ "${PASS_COUNT}" -eq 1 ]
+}
+
+@test "record: increments FAIL_COUNT on FAIL" {
+  record "FAIL" "test-check" "detail"
+  [ "${FAIL_COUNT}" -eq 1 ]
+}
+
+@test "record: increments INFO_COUNT on INFO" {
+  record "INFO" "test-check" "detail"
+  [ "${INFO_COUNT}" -eq 1 ]
+}
+
+@test "record: outputs formatted line in non-JSON mode" {
+  run record "PASS" "my-check" "my-detail"
+  assert_output --partial "[PASS]"
+  assert_output --partial "my-check"
+  assert_output --partial "my-detail"
+}
+
+@test "record: adds to RESULTS array in JSON mode" {
+  JSON_MODE="true"
+  record "PASS" "json-check" "json-detail"
+  [ "${#RESULTS[@]}" -eq 1 ]
+  [[ "${RESULTS[0]}" == *"json-check"* ]]
+}
+
+@test "record: formats JSON entry correctly" {
+  JSON_MODE="true"
+  record "FAIL" "some-check" "error detail"
+  [[ "${RESULTS[0]}" == *'"status":"FAIL"'* ]]
+  [[ "${RESULTS[0]}" == *'"check":"some-check"'* ]]
+}
+
+# ── check() tests ─────────────────────────────────────────────────────────────
+
+@test "check: records PASS when command succeeds" {
+  check "test-check" true
+  [ "${PASS_COUNT}" -eq 1 ]
+  [ "${FAIL_COUNT}" -eq 0 ]
+}
+
+@test "check: records FAIL when command fails" {
+  check "test-check" false
+  [ "${PASS_COUNT}" -eq 0 ]
+  [ "${FAIL_COUNT}" -eq 1 ]
+}
+
+@test "check: records multiple passes correctly" {
+  check "check1" true
+  check "check2" true
+  check "check3" true
+  [ "${PASS_COUNT}" -eq 3 ]
+}
+
+@test "check: records mixed results correctly" {
+  check "passing" true
+  check "failing" false
+  check "another-pass" true
+  [ "${PASS_COUNT}" -eq 2 ]
+  [ "${FAIL_COUNT}" -eq 1 ]
+}
+
+# ── validate_hardening.sh function existence tests ─────────────────────────────
+# These verify the functions exist in the script without sourcing it
+
+@test "validate script contains is_true function" {
+  grep -q "^is_true()" "${VALIDATE_SCRIPT}"
+}
+
+@test "validate script contains record function" {
+  grep -q "^record()" "${VALIDATE_SCRIPT}"
+}
+
+@test "validate script contains check function" {
+  grep -q "^check()" "${VALIDATE_SCRIPT}"
+}
+
+@test "validate script contains ssh_check function" {
+  grep -q "^ssh_check()" "${VALIDATE_SCRIPT}"
+}
+
+@test "validate script contains ufw_check function" {
+  grep -q "^ufw_check()" "${VALIDATE_SCRIPT}"
+}
+
+@test "validate script contains docker_user_check function" {
+  grep -q "^docker_user_check()" "${VALIDATE_SCRIPT}"
+}
+
+@test "validate script contains sysctl_check function" {
+  grep -q "^sysctl_check()" "${VALIDATE_SCRIPT}"
+}
+
+@test "validate script contains fail2ban_check function" {
+  grep -q "^fail2ban_check()" "${VALIDATE_SCRIPT}"
+}
+
+@test "validate script contains auditd_check function" {
+  grep -q "^auditd_check()" "${VALIDATE_SCRIPT}"
+}
+
+@test "validate script contains journald_check function" {
+  grep -q "^journald_check()" "${VALIDATE_SCRIPT}"
+}
+
+@test "validate script contains banner_check function" {
+  grep -q "^banner_check()" "${VALIDATE_SCRIPT}"
+}
+
+@test "validate script contains docker_daemon_check function" {
+  grep -q "^docker_daemon_check()" "${VALIDATE_SCRIPT}"
+}
+
+@test "validate script contains apparmor_check function" {
+  grep -q "^apparmor_check()" "${VALIDATE_SCRIPT}"
+}
+
+@test "validate script contains disabled_services_check function" {
+  grep -q "^disabled_services_check()" "${VALIDATE_SCRIPT}"
+}
+
+@test "validate script contains tailscale_check function" {
+  grep -q "^tailscale_check()" "${VALIDATE_SCRIPT}"
+}
+
+# ── validate_hardening.sh SSH check expectations ───────────────────────────────
+
+@test "ssh_check expects permitrootlogin no" {
+  grep -q '\[permitrootlogin\]="no"' "${VALIDATE_SCRIPT}"
+}
+
+@test "ssh_check expects passwordauthentication no" {
+  grep -q '\[passwordauthentication\]="no"' "${VALIDATE_SCRIPT}"
+}
+
+@test "ssh_check expects pubkeyauthentication yes" {
+  grep -q '\[pubkeyauthentication\]="yes"' "${VALIDATE_SCRIPT}"
+}
+
+# ── validate_hardening.sh sysctl check expectations ────────────────────────────
+
+@test "sysctl_check expects tcp_syncookies=1" {
+  grep -q '\[net.ipv4.tcp_syncookies\]="1"' "${VALIDATE_SCRIPT}"
+}
+
+@test "sysctl_check expects ip_forward=1" {
+  grep -q '\[net.ipv4.ip_forward\]="1"' "${VALIDATE_SCRIPT}"
+}
+
+@test "sysctl_check expects protected_hardlinks=1" {
+  grep -q '\[fs.protected_hardlinks\]="1"' "${VALIDATE_SCRIPT}"
+}
+
+# ── JSON output format tests ──────────────────────────────────────────────────
+
+@test "JSON_MODE flag is respected" {
+  JSON_MODE="true"
+  [ "${JSON_MODE}" == "true" ]
+}
+
+@test "IS_CONTAINER can be set for container tests" {
+  IS_CONTAINER="true"
+  [ "${IS_CONTAINER}" == "true" ]
+}
+
+# ── State file defaults verification ───────────────────────────────────────────
+
+@test "validate script sets default SSH_PORT=22" {
+  grep -q 'SSH_PORT="22"' "${VALIDATE_SCRIPT}" || grep -q 'SSH_PORT=\${ssh_port:-22}' "${VALIDATE_SCRIPT}"
+}
+
+@test "validate script sets default TUNNEL_MODE=false" {
+  grep -q 'TUNNEL_MODE="false"' "${VALIDATE_SCRIPT}" || grep -q 'TUNNEL_MODE=\${tunnel_mode:-false}' "${VALIDATE_SCRIPT}"
+}
+
+@test "validate script sets default TAILSCALE_IFACE=tailscale0" {
+  grep -q 'TAILSCALE_IFACE="tailscale0"' "${VALIDATE_SCRIPT}"
+}
+
+# ── validate_hardening.sh journald check ──────────────────────────────────────
+
+@test "journald_check looks for Storage=persistent" {
+  grep -q 'Storage=persistent' "${VALIDATE_SCRIPT}"
+}
+
+# ── validate_hardening.sh banner check ────────────────────────────────────────
+
+@test "banner_check looks for AUTHORIZED in /etc/issue.net" {
+  grep -q 'AUTHORIZED' "${VALIDATE_SCRIPT}"
+}
+
+# ── validate_hardening.sh disabled services check ─────────────────────────────
+
+@test "disabled_services_check checks rpcbind" {
+  grep -q 'rpcbind' "${VALIDATE_SCRIPT}"
+}
+
+@test "disabled_services_check checks avahi-daemon" {
+  grep -q 'avahi-daemon' "${VALIDATE_SCRIPT}"
+}
+
+@test "disabled_services_check checks cups" {
+  grep -q 'cups' "${VALIDATE_SCRIPT}"
+}
+
+# ── validate_hardening.sh docker checks ───────────────────────────────────────
+
+@test "docker_user_check looks for wan-drop rule" {
+  grep -q 'coolify-hardening-wan-drop' "${VALIDATE_SCRIPT}"
+}
+
+@test "docker_daemon_check looks for log-driver" {
+  grep -q 'log-driver' "${VALIDATE_SCRIPT}"
+}
+
+@test "docker_daemon_check expects json-file driver (matches Coolify)" {
+  grep -q 'json-file' "${VALIDATE_SCRIPT}"
+}
+
+@test "docker_daemon_check looks for live-restore" {
+  grep -q 'live-restore' "${VALIDATE_SCRIPT}"
+}
+
+# ── New kernel parameter checks (Priority 3.1) ───────────────────────────────────
+
+@test "sysctl_check expects kernel.dmesg_restrict=1" {
+  grep -q '\[kernel.dmesg_restrict\]="1"' "${VALIDATE_SCRIPT}"
+}
+
+@test "sysctl_check expects kernel.perf_event_paranoid=3" {
+  grep -q '\[kernel.perf_event_paranoid\]="3"' "${VALIDATE_SCRIPT}"
+}
+
+@test "sysctl_check expects kernel.yama.ptrace_scope=1" {
+  grep -q '\[kernel.yama.ptrace_scope\]="1"' "${VALIDATE_SCRIPT}"
+}
+
+# ── Swappiness check (Priority 3.2) ─────────────────────────────────────────────
+
+@test "sysctl_check expects vm.swappiness=10" {
+  grep -q '\[vm.swappiness\]="10"' "${VALIDATE_SCRIPT}"
+}
+
+# ── Admin sudo check function (Priority 3.4) ────────────────────────────────────
+
+@test "validate script contains admin_sudo_check function" {
+  grep -q "^admin_sudo_check()" "${VALIDATE_SCRIPT}"
+}
+
+@test "admin_sudo_check looks for NOPASSWD" {
+  grep -q 'NOPASSWD' "${VALIDATE_SCRIPT}"
+}
+
+@test "admin_sudo_check checks for sudoers.d file" {
+  grep -q 'sudoers.d' "${VALIDATE_SCRIPT}"
+}
+
+# ── Docker detection before DOCKER-USER check (Priority 3.3) ───────────────────
+
+@test "docker_user_check checks if docker command exists" {
+  grep -q 'command -v docker' "${VALIDATE_SCRIPT}"
+}
+
+# ── docker_user_lifecycle_check ──────────────────────────────────────────────
+
+@test "validate script contains docker_user_lifecycle_check function" {
+  grep -q "^docker_user_lifecycle_check()" "${VALIDATE_SCRIPT}"
+}
+
+@test "docker_user_lifecycle_check checks PartOf=docker.service" {
+  grep -q "PartOf=docker.service" "${VALIDATE_SCRIPT}"
+}
+
+@test "docker_user_lifecycle_check checks WantedBy=docker.service" {
+  grep -q "WantedBy=docker.service" "${VALIDATE_SCRIPT}"
+}
+
+# ── unattended_upgrades_check ─────────────────────────────────────────────────
+
+@test "validate script contains unattended_upgrades_check function" {
+  grep -q "^unattended_upgrades_check()" "${VALIDATE_SCRIPT}"
+}
+
+@test "unattended_upgrades_check verifies Docker CE origin" {
+  grep -q '"Docker"' "${VALIDATE_SCRIPT}"
+}
+
+# ── coolify binding guard timer check ────────────────────────────────────────
+
+@test "coolify_binding_check verifies binding-guard timer is active" {
+  grep -q "coolify-binding-guard.timer" "${VALIDATE_SCRIPT}"
+}
+
+# ── fail2ban ignoreip ─────────────────────────────────────────────────────────
+
+@test "fail2ban_check: checks for Tailscale CIDR in ignoreip" {
+  grep -q "TAILSCALE_CIDR" "${VALIDATE_SCRIPT}"
+  grep -q "tailscale_cidr" "${VALIDATE_SCRIPT}"
+}
+
+@test "admin_sudo_check: allows option-prefixed authorized_keys lines" {
+  grep -Fq "ssh-[^[:space:]]+" "${VALIDATE_SCRIPT}"
+  grep -Fq "ecdsa-sha2-[^[:space:]]+" "${VALIDATE_SCRIPT}"
+}
+
+# ── timesync NTPSynchronized ──────────────────────────────────────────────────
+
+@test "timesync_check: checks NTPSynchronized property" {
+  grep -q "NTPSynchronized" "${VALIDATE_SCRIPT}"
+}
+
+# ── validate timer check ──────────────────────────────────────────────────────
+
+@test "validate script contains validate_timer_check function" {
+  grep -q "^validate_timer_check()" "${VALIDATE_SCRIPT}"
+}
+
+@test "validate_timer_check: checks hardening-validate.timer" {
+  grep -q "hardening-validate.timer" "${VALIDATE_SCRIPT}"
+}
+
+# ── coolify binding public exposure rationale ─────────────────────────────────
+
+@test "coolify_binding_check: documents why self-connect cannot validate public exposure" {
+  grep -q "cannot validate public exposure" "${VALIDATE_SCRIPT}"
+}

--- a/scripts/provisioning/validate_hardening.sh
+++ b/scripts/provisioning/validate_hardening.sh
@@ -1,0 +1,1206 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# validate_hardening.sh — Standalone health-check companion for bootstrap_hardening.sh
+# Re-runnable: prints PASS/FAIL per check, exits 0 if all pass, 1 if any fail.
+# Usage: sudo ./validate_hardening.sh [--json]
+
+STATE_FILE="/var/lib/bootstrap-hardening/state"
+JOURNALD_DROPIN="/etc/systemd/journald.conf.d/60-persistent.conf"
+JSON_MODE="false"
+IS_CONTAINER="false"
+
+if [[ "${1:-}" == "--json" ]]; then
+  JSON_MODE="true"
+fi
+
+if [[ -f /.dockerenv || "${container:-}" == "docker" ]]; then
+  IS_CONTAINER="true"
+fi
+
+PASS_COUNT=0
+FAIL_COUNT=0
+INFO_COUNT=0
+declare -a RESULTS=()
+
+record() {
+  local status="$1"
+  local name="$2"
+  local detail="${3:-}"
+
+  case "${status}" in
+    PASS) ((++PASS_COUNT)) ;;
+    FAIL) ((++FAIL_COUNT)) ;;
+    INFO) ((++INFO_COUNT)) ;;
+  esac
+
+  if [[ "${JSON_MODE}" == "true" ]]; then
+    # Escape special characters for valid JSON output
+    local escaped_name escaped_detail
+    escaped_name="$(printf '%s' "${name}" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr '\n' ' ')"
+    escaped_detail="$(printf '%s' "${detail}" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr '\n' ' ')"
+    RESULTS+=("{\"check\":\"${escaped_name}\",\"status\":\"${status}\",\"detail\":\"${escaped_detail}\"}")
+  else
+    printf '%-6s %-45s %s\n' "[${status}]" "${name}" "${detail}"
+  fi
+}
+
+check() {
+  local name="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    record "PASS" "${name}"
+  else
+    record "FAIL" "${name}" "$*"
+  fi
+}
+
+# Load state file for context (non-fatal if missing)
+ADMIN_USER=""
+SSH_PORT="22"
+TUNNEL_MODE="false"
+WAN_IFACE=""
+TAILSCALE_IFACE="tailscale0"
+BIND_DASHBOARD_TO_TAILSCALE="false"
+TAILSCALE_IP=""
+COOLIFY_ENV_FILE="/data/coolify/source/.env"
+
+if [[ -f "${STATE_FILE}" ]]; then
+  # shellcheck disable=SC1090
+  source "${STATE_FILE}"
+  ADMIN_USER="${admin_user:-}"
+  SSH_PORT="${ssh_port:-22}"
+  TUNNEL_MODE="${tunnel_mode:-false}"
+  WAN_IFACE="${wan_iface:-}"
+  swap_size="${swap_size:-2G}"
+  BIND_DASHBOARD_TO_TAILSCALE="${bind_dashboard_to_tailscale:-false}"
+  TAILSCALE_IP="${tailscale_ip:-}"
+fi
+
+is_true() {
+  case "${1,,}" in
+    1|true|yes|y|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# ── SSH effective config ──
+
+ssh_check() {
+  local effective
+  effective="$(sshd -T 2>/dev/null)" || { record "FAIL" "ssh: sshd -T" "cannot query"; return; }
+
+  local field val expected
+  declare -A ssh_expects=(
+    [permitrootlogin]="no"
+    [passwordauthentication]="no"
+    [pubkeyauthentication]="yes"
+    [permitemptypasswords]="no"
+    [compression]="no"
+  )
+
+  for field in "${!ssh_expects[@]}"; do
+    expected="${ssh_expects[${field}]}"
+    val="$(grep -m1 "^${field} " <<< "${effective}" | awk '{print $2}')"
+    if [[ "${val}" == "${expected}" ]]; then
+      record "PASS" "ssh: ${field}=${val}"
+    else
+      record "FAIL" "ssh: ${field}" "expected ${expected}, got ${val:-<empty>}"
+    fi
+  done
+
+  if grep -q "chacha20-poly1305@openssh.com" <<< "${effective}"; then
+    record "PASS" "ssh: cipher restrictions present"
+  else
+    record "FAIL" "ssh: cipher restrictions" "chacha20-poly1305 not in ciphers"
+  fi
+
+  if [[ -n "${ADMIN_USER}" ]]; then
+    if grep -qE "^allowusers .*\\b${ADMIN_USER}\\b" <<< "${effective}"; then
+      record "PASS" "ssh: AllowUsers includes ${ADMIN_USER}"
+    else
+      record "FAIL" "ssh: AllowUsers" "${ADMIN_USER} not listed"
+    fi
+  fi
+
+  # Verify Match Address block: root key-only login from localhost/Docker bridge (10.0.0.0/8)
+  local match_local
+  match_local="$(sshd -T -C addr=127.0.0.1,user=root,host=localhost,laddr=127.0.0.1 2>/dev/null)" || true
+  if [[ -n "${match_local}" ]]; then
+    local match_root_val
+    match_root_val="$(grep -m1 "^permitrootlogin " <<< "${match_local}" | awk '{print $2}')"
+    if grep -qE "^permitrootlogin (prohibit-password|without-password)$" <<< "${match_local}"; then
+      record "PASS" "ssh: Match localhost root=prohibit-password"
+    else
+      record "FAIL" "ssh: Match localhost root" "expected prohibit-password/without-password, got ${match_root_val:-<empty>}"
+    fi
+
+    if grep -qE "^allowusers .*\\broot\\b" <<< "${match_local}"; then
+      record "PASS" "ssh: Match localhost AllowUsers includes root"
+    else
+      record "FAIL" "ssh: Match localhost AllowUsers" "root not listed"
+    fi
+  fi
+
+  # Verify Docker bridge address (10.0.0.0/8) also gets the Match block
+  local match_docker
+  match_docker="$(sshd -T -C addr=10.0.1.5,user=root,host=10.0.1.5,laddr=10.0.1.1 2>/dev/null)" || true
+  if [[ -n "${match_docker}" ]]; then
+    if grep -qE "^permitrootlogin (prohibit-password|without-password)$" <<< "${match_docker}"; then
+      record "PASS" "ssh: Match Docker bridge root=prohibit-password"
+    else
+      local docker_root_val
+      docker_root_val="$(grep -m1 "^permitrootlogin " <<< "${match_docker}" | awk '{print $2}')"
+      record "FAIL" "ssh: Match Docker bridge root" \
+        "expected prohibit-password, got ${docker_root_val:-<empty>} — Coolify SSH will be denied"
+    fi
+  fi
+
+  # Verify external addresses still deny root
+  local match_external
+  match_external="$(sshd -T -C addr=203.0.113.1,user=root,host=example.com,laddr=0.0.0.0 2>/dev/null)" || true
+  if [[ -n "${match_external}" ]]; then
+    local ext_root_val
+    ext_root_val="$(grep -m1 "^permitrootlogin " <<< "${match_external}" | awk '{print $2}')"
+    if [[ "${ext_root_val}" == "no" ]]; then
+      record "PASS" "ssh: external root login denied"
+    else
+      record "FAIL" "ssh: external root login" "expected no, got ${ext_root_val:-<empty>}"
+    fi
+  fi
+}
+
+# ── UFW ──
+
+ufw_check() {
+  local ufw_out
+  ufw_out="$(ufw status verbose 2>/dev/null)" || { record "FAIL" "ufw: status query" "cannot run ufw"; return; }
+
+  if grep -q "^Status: active$" <<< "${ufw_out}"; then
+    record "PASS" "ufw: active"
+  else
+    record "FAIL" "ufw: active" "UFW is not active"
+    return
+  fi
+
+  if grep -qE "${SSH_PORT}/tcp.*on ${TAILSCALE_IFACE}.*ALLOW IN" <<< "${ufw_out}"; then
+    record "PASS" "ufw: SSH on ${TAILSCALE_IFACE}"
+  else
+    record "FAIL" "ufw: SSH on ${TAILSCALE_IFACE}" "rule missing"
+  fi
+
+  # Coolify SSHes from its Docker container (10.0.0.0/8) to the host.
+  if grep -qE "${SSH_PORT}.*ALLOW.*10\.0\.0\.0/8" <<< "${ufw_out}"; then
+    record "PASS" "ufw: SSH from Docker bridge (10.0.0.0/8)"
+  else
+    record "FAIL" "ufw: SSH from Docker bridge" "10.0.0.0/8 → port ${SSH_PORT} rule missing — Coolify cannot reach host"
+  fi
+
+  # Coolify dashboard (8000), Soketi (6001), terminal (6002) on Tailscale only.
+  for port_label in "8000:dashboard" "6001:soketi" "6002:terminal"; do
+    local port="${port_label%%:*}" label="${port_label##*:}"
+    if grep -qE "${port}/tcp.*on ${TAILSCALE_IFACE}.*ALLOW IN" <<< "${ufw_out}"; then
+      record "PASS" "ufw: Coolify ${label} (${port}) on ${TAILSCALE_IFACE}"
+    else
+      record "FAIL" "ufw: Coolify ${label} (${port})" "port ${port} not allowed on ${TAILSCALE_IFACE}"
+    fi
+  done
+
+  if [[ -n "${WAN_IFACE}" ]]; then
+    # SSH must not be on WAN
+    if grep -qE "${SSH_PORT}/tcp.*on ${WAN_IFACE}.*ALLOW IN" <<< "${ufw_out}"; then
+      record "FAIL" "ufw: SSH NOT on WAN" "SSH allowed on ${WAN_IFACE}"
+    else
+      record "PASS" "ufw: SSH NOT on WAN"
+    fi
+
+    # Coolify ports must not be on WAN (must only be on tailscale0)
+    for port_label in "8000:dashboard" "6001:soketi" "6002:terminal"; do
+      local port="${port_label%%:*}" label="${port_label##*:}"
+      if grep -qE "${port}/tcp.*on ${WAN_IFACE}.*ALLOW IN" <<< "${ufw_out}" \
+         || grep -qE "${port}/tcp\s+ALLOW IN\s+Anywhere" <<< "${ufw_out}"; then
+        record "FAIL" "ufw: ${label} (${port}) NOT on WAN" \
+          "port ${port} allowed on WAN — must be tailscale0-only"
+      else
+        record "PASS" "ufw: ${label} (${port}) NOT on WAN"
+      fi
+    done
+
+    if is_true "${TUNNEL_MODE}"; then
+      if grep -qE "80/tcp.*on ${WAN_IFACE}.*ALLOW IN" <<< "${ufw_out}"; then
+        record "FAIL" "ufw: tunnel-mode no port 80" "WAN 80 rule exists"
+      else
+        record "PASS" "ufw: tunnel-mode no port 80"
+      fi
+      if grep -qE "443/tcp.*on ${WAN_IFACE}.*ALLOW IN" <<< "${ufw_out}"; then
+        record "FAIL" "ufw: tunnel-mode no port 443" "WAN 443 rule exists"
+      else
+        record "PASS" "ufw: tunnel-mode no port 443"
+      fi
+    fi
+  fi
+}
+
+# ── DOCKER-USER iptables (IPv4 + IPv6) ──
+
+docker_user_check() {
+  if ! command -v iptables >/dev/null 2>&1; then
+    record "FAIL" "docker-user: iptables" "iptables not found"
+    return
+  fi
+
+  # Check if Docker is installed first
+  if ! command -v docker >/dev/null 2>&1; then
+    record "INFO" "docker-user: Docker" "Docker not installed; skipping DOCKER-USER checks"
+    return
+  fi
+
+  local rules
+  rules="$(iptables -t filter -S DOCKER-USER 2>/dev/null)" || { record "FAIL" "docker-user: IPv4" "DOCKER-USER chain absent (Docker may need restart)"; return; }
+
+  if grep -q "coolify-hardening-wan-drop" <<< "${rules}"; then
+    record "PASS" "docker-user: IPv4 wan-drop"
+  else
+    record "FAIL" "docker-user: IPv4 wan-drop" "rule missing"
+  fi
+
+  if grep -q "coolify-hardening-bridge-docker0" <<< "${rules}"; then
+    record "PASS" "docker-user: IPv4 bridge-docker0"
+  else
+    record "FAIL" "docker-user: IPv4 bridge-docker0" "rule missing"
+  fi
+
+  if is_true "${TUNNEL_MODE}" && grep -q "coolify-hardening-wan-web" <<< "${rules}"; then
+    record "FAIL" "docker-user: tunnel-mode no wan-web" "wan-web ACCEPT present"
+  elif is_true "${TUNNEL_MODE}"; then
+    record "PASS" "docker-user: tunnel-mode no wan-web"
+  fi
+
+  if command -v ip6tables >/dev/null 2>&1; then
+    local rules6
+    rules6="$(ip6tables -t filter -S DOCKER-USER 2>/dev/null)" || { record "INFO" "docker-user: IPv6" "DOCKER-USER chain absent"; return; }
+
+    if grep -q "coolify-hardening-wan-drop6" <<< "${rules6}"; then
+      record "PASS" "docker-user: IPv6 wan-drop6"
+    else
+      record "FAIL" "docker-user: IPv6 wan-drop6" "rule missing"
+    fi
+  else
+    record "INFO" "docker-user: IPv6" "ip6tables not available"
+  fi
+}
+
+# ── docker-user-hardening service lifecycle ──
+
+docker_user_lifecycle_check() {
+  local unit_file="/etc/systemd/system/docker-user-hardening.service"
+  if [[ ! -f "${unit_file}" ]]; then
+    if command -v docker >/dev/null 2>&1; then
+      record "FAIL" "docker-user: unit file" "not found at ${unit_file}"
+    else
+      record "INFO" "docker-user: unit file" "Docker not installed; skipped"
+    fi
+    return
+  fi
+
+  if grep -q "PartOf=docker.service" "${unit_file}"; then
+    record "PASS" "docker-user: PartOf=docker.service"
+  else
+    record "FAIL" "docker-user: PartOf=docker.service" "missing — rules lost on Docker daemon restart"
+  fi
+
+  if grep -q "WantedBy=docker.service" "${unit_file}"; then
+    record "PASS" "docker-user: WantedBy=docker.service"
+  else
+    record "FAIL" "docker-user: WantedBy=docker.service" "missing — rules may not re-apply after Docker start"
+  fi
+
+  # Functional: service must have run at least once since boot (rules are only in iptables if it did).
+  local active_state
+  active_state="$(systemctl show docker-user-hardening.service --property=ActiveState --value 2>/dev/null || echo "unknown")"
+  if [[ "${active_state}" == "active" || "${active_state}" == "activating" ]]; then
+    record "PASS" "docker-user: service has run (${active_state})"
+  else
+    # For a oneshot service, "inactive" is normal after a successful run.
+    local result
+    result="$(systemctl show docker-user-hardening.service --property=Result --value 2>/dev/null || echo "unknown")"
+    if [[ "${result}" == "success" ]]; then
+      record "PASS" "docker-user: service completed successfully"
+    else
+      record "FAIL" "docker-user: service result" "result=${result} — rules may not have been applied"
+    fi
+  fi
+}
+
+# ── Sysctl ──
+
+sysctl_check() {
+  local key expected val
+  declare -A sysctl_expects=(
+    [net.ipv4.tcp_syncookies]="1"
+    [net.ipv4.ip_forward]="1"
+    [net.ipv4.conf.all.rp_filter]="2"
+    [net.ipv4.tcp_max_syn_backlog]="2048"
+    [net.ipv4.tcp_synack_retries]="2"
+    [fs.protected_hardlinks]="1"
+    [fs.protected_symlinks]="1"
+    [fs.suid_dumpable]="0"
+    [kernel.unprivileged_bpf_disabled]="1"
+    [kernel.kexec_load_disabled]="1"
+    [kernel.sysrq]="4"
+    [kernel.randomize_va_space]="2"
+    [kernel.dmesg_restrict]="1"
+    [kernel.perf_event_paranoid]="3"
+    [kernel.yama.ptrace_scope]="1"
+    [kernel.kptr_restrict]="2"
+    [vm.swappiness]="10"
+  )
+
+  for key in "${!sysctl_expects[@]}"; do
+    expected="${sysctl_expects[${key}]}"
+    val="$(sysctl -n "${key}" 2>/dev/null || echo "?")"
+    if [[ "${val}" == "${expected}" ]]; then
+      record "PASS" "sysctl: ${key}=${val}"
+    elif [[ "${val}" == "?" && "${IS_CONTAINER}" == "true" ]]; then
+      record "INFO" "sysctl: ${key}" "unavailable in container namespace"
+    else
+      record "FAIL" "sysctl: ${key}" "expected ${expected}, got ${val}"
+    fi
+  done
+
+  # BBR congestion control (informational — depends on kernel module availability)
+  local bbr_val
+  bbr_val="$(sysctl -n net.ipv4.tcp_congestion_control 2>/dev/null || echo "?")"
+  if [[ "${bbr_val}" == "bbr" ]]; then
+    record "PASS" "sysctl: tcp_congestion_control=bbr"
+  elif [[ "${bbr_val}" == "?" && "${IS_CONTAINER}" == "true" ]]; then
+    record "INFO" "sysctl: tcp_congestion_control" "unavailable in container namespace"
+  else
+    record "INFO" "sysctl: tcp_congestion_control=${bbr_val}" "BBR not active (kernel module may be unavailable)"
+  fi
+
+  local qdisc_val
+  qdisc_val="$(sysctl -n net.core.default_qdisc 2>/dev/null || echo "?")"
+  if [[ "${qdisc_val}" == "fq" ]]; then
+    record "PASS" "sysctl: default_qdisc=fq"
+  elif [[ "${qdisc_val}" == "?" && "${IS_CONTAINER}" == "true" ]]; then
+    record "INFO" "sysctl: default_qdisc" "unavailable in container namespace"
+  else
+    record "INFO" "sysctl: default_qdisc=${qdisc_val}" "fq not active (BBR may be unavailable)"
+  fi
+}
+
+# ── fail2ban ──
+
+fail2ban_check() {
+  if systemctl is-active --quiet fail2ban 2>/dev/null; then
+    record "PASS" "fail2ban: active"
+  else
+    record "FAIL" "fail2ban: active" "service not running"
+    return
+  fi
+
+  if fail2ban-client status sshd >/dev/null 2>&1; then
+    record "PASS" "fail2ban: sshd jail enabled"
+  else
+    record "FAIL" "fail2ban: sshd jail" "jail not active"
+  fi
+
+  local _jail_file="/etc/fail2ban/jail.d/coolify-hardening.local"
+  if [[ -f "${_jail_file}" ]] && grep -q "100.64.0.0/10" "${_jail_file}"; then
+    record "PASS" "fail2ban: ignoreip includes Tailscale CIDR"
+  elif [[ ! -f "${_jail_file}" ]]; then
+    record "FAIL" "fail2ban: ignoreip" "jail file missing"
+  else
+    record "FAIL" "fail2ban: ignoreip" "100.64.0.0/10 not in ignoreip"
+  fi
+
+  # Functional check: verify fail2ban's ban backend is operational.
+  # When banaction=ufw, fail2ban delegates to UFW instead of creating iptables chains directly.
+  # When banaction=iptables-multiport (default), it creates f2b-* chains.
+  local banaction
+  banaction="$(grep -m1 '^banaction' /etc/fail2ban/jail.d/coolify-hardening.local 2>/dev/null \
+    | awk '{print $3}' || true)"
+  banaction="${banaction:-iptables-multiport}"
+
+  if [[ "${banaction}" == "ufw" ]]; then
+    if command -v ufw >/dev/null 2>&1 && ufw status 2>/dev/null | grep -q "^Status: active"; then
+      record "PASS" "fail2ban: banaction=ufw and UFW active"
+    else
+      record "FAIL" "fail2ban: banaction=ufw" "UFW not active — fail2ban bans will silently fail"
+    fi
+  else
+    if iptables -L f2b-sshd >/dev/null 2>&1; then
+      record "PASS" "fail2ban: f2b-sshd iptables chain present"
+    else
+      record "FAIL" "fail2ban: f2b-sshd iptables chain" "chain missing — fail2ban may not have hooked into iptables"
+    fi
+  fi
+}
+
+# ── auditd ──
+
+auditd_check() {
+  if systemctl is-active --quiet auditd 2>/dev/null; then
+    record "PASS" "auditd: active"
+  elif [[ "${IS_CONTAINER}" == "true" ]]; then
+    record "INFO" "auditd: active" "not active in container test environment"
+  else
+    record "FAIL" "auditd: active" "service not running"
+    return
+  fi
+
+  local rules
+  rules="$(auditctl -l 2>/dev/null)" || { record "FAIL" "auditd: rules" "cannot list"; return; }
+
+  if grep -q "identity" <<< "${rules}"; then
+    record "PASS" "auditd: identity rules loaded"
+  else
+    record "FAIL" "auditd: identity rules" "not loaded"
+  fi
+
+  if grep -q "sudoers-change" <<< "${rules}"; then
+    record "PASS" "auditd: sudoers rules loaded"
+  else
+    record "FAIL" "auditd: sudoers rules" "not loaded"
+  fi
+}
+
+# ── journald ──
+
+journald_check() {
+  if [[ -f "${JOURNALD_DROPIN}" ]] && grep -q "^Storage=persistent$" "${JOURNALD_DROPIN}"; then
+    record "PASS" "journald: persistent storage"
+  else
+    record "FAIL" "journald: persistent storage" "drop-in missing or not persistent"
+  fi
+
+  local usage
+  usage="$(journalctl --disk-usage 2>/dev/null | head -1)" || true
+  if [[ -n "${usage}" ]]; then
+    record "INFO" "journald: disk usage" "${usage}"
+  fi
+}
+
+# ── NTP / Timesync ──
+
+timesync_check() {
+  local ntp_val
+  ntp_val="$(timedatectl show --property=NTP --value 2>/dev/null || echo "?")"
+  if [[ "${ntp_val}" == "yes" ]]; then
+    record "PASS" "timesync: NTP active"
+  elif [[ "${IS_CONTAINER}" == "true" ]]; then
+    record "INFO" "timesync: NTP" "unavailable in container"
+  else
+    record "FAIL" "timesync: NTP" "not active"
+  fi
+
+  local synced_val
+  synced_val="$(timedatectl show --property=NTPSynchronized --value 2>/dev/null || echo "?")"
+  if [[ "${synced_val}" == "yes" ]]; then
+    record "PASS" "timesync: NTPSynchronized"
+  elif [[ "${IS_CONTAINER}" == "true" || "${ntp_val}" != "yes" ]]; then
+    record "INFO" "timesync: NTPSynchronized" "skipped (NTP not active or container)"
+  else
+    record "FAIL" "timesync: NTPSynchronized" "not yet synchronized"
+  fi
+}
+
+# ── Swap ──
+
+swap_check() {
+  local swap_size="${swap_size:-2G}"
+  if [[ "${swap_size}" == "0" ]]; then
+    record "INFO" "swap: disabled" "swap creation was skipped (--swap-size 0)"
+    return
+  fi
+
+  if swapon --show --noheadings 2>/dev/null | grep -q .; then
+    local swap_total swap_output
+    # swapon --show output format: NAME TYPE SIZE USED PRIO
+    # SIZE column position varies; use --bytes and sum the SIZE column (3rd field)
+    swap_output="$(swapon --show --noheadings --bytes 2>/dev/null)" || true
+    if [[ -n "${swap_output}" ]]; then
+      swap_total="$(awk '{sum+=$3} END {printf "%.0fM", sum/1048576}' <<< "${swap_output}")"
+      record "PASS" "swap: active (${swap_total})"
+    else
+      record "PASS" "swap: active"
+    fi
+  elif [[ "${IS_CONTAINER}" == "true" ]]; then
+    record "INFO" "swap: status" "unavailable in container"
+  else
+    record "FAIL" "swap: active" "no swap detected"
+  fi
+
+  if [[ -f /swapfile ]]; then
+    local perms
+    perms="$(stat -c '%a' /swapfile 2>/dev/null || echo "?")"
+    if [[ "${perms}" == "600" ]]; then
+      record "PASS" "swap: /swapfile permissions 0600"
+    else
+      record "FAIL" "swap: /swapfile permissions" "expected 600, got ${perms}"
+    fi
+  fi
+
+  local fstab_count
+  # Match any /swapfile fstab entry regardless of options format.
+  # Old Ubuntu: "/swapfile none swap sw 0 0"
+  # Modern Ubuntu: "/swapfile swap swap defaults 0 0"
+  fstab_count="$(grep -cE '^/swapfile[[:space:]]' /etc/fstab 2>/dev/null || true)"
+  fstab_count="${fstab_count:-0}"
+  if [[ "${fstab_count}" == "1" ]]; then
+    record "PASS" "swap: single fstab entry"
+  elif [[ "${fstab_count}" == "0" && "${IS_CONTAINER}" == "true" ]]; then
+    record "INFO" "swap: fstab" "not applicable in container"
+  elif (( fstab_count > 1 )); then
+    record "FAIL" "swap: fstab" "duplicate entries (${fstab_count})"
+  else
+    record "FAIL" "swap: fstab" "entry not found in /etc/fstab — swap will not persist on reboot"
+  fi
+}
+
+# ── Banner ──
+
+banner_check() {
+  if [[ -f /etc/issue.net ]] && grep -q "AUTHORIZED" /etc/issue.net; then
+    record "PASS" "banner: /etc/issue.net present"
+  else
+    record "FAIL" "banner: /etc/issue.net" "missing or no AUTHORIZED text"
+  fi
+}
+
+# ── Admin sudo access ──
+
+admin_sudo_check() {
+  # Skip if no admin user configured
+  if [[ -z "${ADMIN_USER}" ]]; then
+    record "INFO" "admin: sudo" "no admin user in state file"
+    return 0
+  fi
+
+  # Check if admin user exists
+  if ! id "${ADMIN_USER}" >/dev/null 2>&1; then
+    record "FAIL" "admin: user" "${ADMIN_USER} does not exist"
+    return 0
+  fi
+
+  # Check if admin user is in sudo group
+  if id -nG "${ADMIN_USER}" | tr ' ' '\n' | grep -qx "sudo"; then
+    record "PASS" "admin: in sudo group"
+  else
+    record "FAIL" "admin: sudo group" "${ADMIN_USER} not in sudo group"
+    return 0
+  fi
+
+  # Check if passwordless sudo is configured.
+  # Passwordless sudo is required: ssh_admin_sudo in the orchestrator runs non-interactively
+  # and will hang waiting for a password prompt if NOPASSWD is absent.
+  local sudoers_file="/etc/sudoers.d/${ADMIN_USER}"
+  if [[ -f "${sudoers_file}" ]]; then
+    if grep -q "NOPASSWD" "${sudoers_file}" 2>/dev/null; then
+      record "PASS" "admin: passwordless sudo"
+    else
+      record "FAIL" "admin: sudo" "sudoers file exists but NOPASSWD not set — ssh_admin_sudo will hang"
+    fi
+  else
+    # Check if sudo -l shows NOPASSWD for this user
+    if sudo -l -U "${ADMIN_USER}" 2>/dev/null | grep -q "NOPASSWD"; then
+      record "PASS" "admin: passwordless sudo (via other config)"
+    else
+      record "FAIL" "admin: sudo" "NOPASSWD not configured — ssh_admin_sudo will hang"
+    fi
+  fi
+
+  # Check admin authorized_keys: file must exist, be non-empty, and each key must be
+  # on its own line. The concatenation bug (missing trailing newline on a prior key)
+  # would still allow sudo to work while silently breaking SSH login.
+  local home_dir auth_file
+  home_dir="$(getent passwd "${ADMIN_USER}" | cut -d: -f6 2>/dev/null)" || true
+  auth_file="${home_dir}/.ssh/authorized_keys"
+  if [[ ! -f "${auth_file}" ]]; then
+    record "FAIL" "admin: authorized_keys exists" "${auth_file} not found"
+  elif [[ ! -s "${auth_file}" ]]; then
+    record "FAIL" "admin: authorized_keys non-empty" "${auth_file} is empty"
+  else
+    # Every non-comment, non-blank line must start with a recognised key type.
+    # A line starting with anything else (e.g. two keys fused together) will fail this check.
+    local bad_lines auth_content
+    # Check each line for valid key format. grep -v exits 1 when it finds no
+    # non-matching lines (the success case). Capture output first, then count.
+    auth_content=$(grep -vE '^(#|[[:space:]]*$|ssh-[a-z0-9-]+[[:space:]]|ecdsa-sha2-[a-z0-9-]+[[:space:]]|sk-[a-z0-9@.-]+[[:space:]])' \
+      "${auth_file}" 2>/dev/null) || auth_content=""
+    bad_lines=$(wc -l <<< "${auth_content}" 2>/dev/null || echo "0")
+    if [[ "${bad_lines}" -eq 0 ]]; then
+      record "PASS" "admin: authorized_keys format"
+    else
+      record "FAIL" "admin: authorized_keys format" \
+        "${bad_lines} line(s) do not start with a valid key type (possible concatenation bug)"
+    fi
+  fi
+}
+
+# ── Docker daemon.json ──
+# Hardening owns: log-driver, log-opts, live-restore. Coolify may add: default-address-pools.
+# Using json-file driver to match Coolify's expectation for compatibility.
+
+docker_daemon_check() {
+  local daemon_json="/etc/docker/daemon.json"
+  if [[ ! -f "${daemon_json}" ]]; then
+    if command -v docker >/dev/null 2>&1; then
+      record "FAIL" "docker-daemon: daemon.json" "file missing (no log rotation)"
+    else
+      record "INFO" "docker-daemon: daemon.json" "Docker not installed; skipped"
+    fi
+    return
+  fi
+
+  # Check log-driver is json-file (matches Coolify's expectation)
+  local log_driver
+  log_driver="$(jq -r '.["log-driver"] // ""' "${daemon_json}" 2>/dev/null || true)"
+  if [[ "${log_driver}" == "json-file" ]]; then
+    record "PASS" "docker-daemon: log-driver is json-file"
+  elif [[ "${log_driver}" == "" ]]; then
+    record "FAIL" "docker-daemon: log-driver" "not set in daemon.json"
+  else
+    record "FAIL" "docker-daemon: log-driver" "expected 'json-file', got '${log_driver}'"
+  fi
+
+  # Check log-opts have rotation configured
+  if jq -e '.["log-opts"]["max-size"]' "${daemon_json}" >/dev/null 2>&1; then
+    record "PASS" "docker-daemon: log-opts.max-size configured"
+  else
+    record "FAIL" "docker-daemon: log-opts.max-size" "not set in daemon.json"
+  fi
+
+  if grep -q '"live-restore"' "${daemon_json}"; then
+    record "PASS" "docker-daemon: live-restore configured"
+  else
+    record "FAIL" "docker-daemon: live-restore" "not set in daemon.json"
+  fi
+
+  # Verify the RUNNING daemon matches the config file — daemon.json changes only take
+  # effect after a restart, so file and live state can diverge silently.
+  if docker info >/dev/null 2>&1; then
+    local live_driver
+    live_driver="$(docker info --format '{{.LoggingDriver}}' 2>/dev/null || true)"
+    if [[ "${live_driver}" == "json-file" ]]; then
+      record "PASS" "docker-daemon: live log-driver is json-file"
+    elif [[ -n "${live_driver}" ]]; then
+      record "FAIL" "docker-daemon: live log-driver" \
+        "daemon reports '${live_driver}' — restart Docker to apply daemon.json"
+    fi
+  else
+    record "INFO" "docker-daemon: live config" "docker daemon not responding; skipping live check"
+  fi
+}
+
+# ── AppArmor ──
+
+apparmor_check() {
+  if command -v aa-status >/dev/null 2>&1; then
+    if aa-status --enabled 2>/dev/null; then
+      record "PASS" "apparmor: enabled"
+    elif [[ "${IS_CONTAINER}" == "true" ]]; then
+      record "INFO" "apparmor: status" "cannot verify in container"
+    else
+      record "FAIL" "apparmor: enabled" "AppArmor not enabled"
+    fi
+  elif [[ "${IS_CONTAINER}" == "true" ]]; then
+    record "INFO" "apparmor: status" "cannot check in container"
+  else
+    record "FAIL" "apparmor: aa-status" "command not found"
+  fi
+}
+
+# ── Disabled services ──
+
+disabled_services_check() {
+  local svc
+  for svc in rpcbind avahi-daemon cups; do
+    local state="not-found"
+    state="$(systemctl is-enabled "${svc}.service" 2>/dev/null || true)"
+    state="${state%%$'\n'*}"
+    [[ -n "${state}" ]] || state="not-found"
+
+    if [[ "${state}" == masked* || "${state}" == "not-found" ]]; then
+      record "PASS" "disabled: ${svc} (${state})"
+    else
+      record "FAIL" "disabled: ${svc}" "state is ${state}, expected masked"
+    fi
+  done
+}
+
+# ── Tailscale interface ──
+
+tailscale_check() {
+  if ip link show "${TAILSCALE_IFACE}" >/dev/null 2>&1; then
+    record "PASS" "tailscale: ${TAILSCALE_IFACE} present"
+  else
+    record "FAIL" "tailscale: ${TAILSCALE_IFACE}" "interface not found"
+    return
+  fi
+
+  # Check actual connection state via tailscale CLI (not just interface presence).
+  # Interface can exist while the daemon is in a broken/logged-out state.
+  if command -v tailscale >/dev/null 2>&1; then
+    local ts_state
+    ts_state="$(tailscale status --json 2>/dev/null \
+      | python3 -c "import sys,json; print(json.load(sys.stdin).get('BackendState','unknown'))" \
+      2>/dev/null || echo "unknown")"
+    if [[ "${ts_state}" == "Running" ]]; then
+      record "PASS" "tailscale: BackendState=Running"
+    else
+      record "FAIL" "tailscale: BackendState" "expected Running, got ${ts_state}"
+    fi
+
+    # Check that a Tailscale IPv4 (100.x) has actually been assigned
+    local ts_ip
+    ts_ip="$(tailscale ip -4 2>/dev/null || true)"
+    if [[ -n "${ts_ip}" ]]; then
+      record "PASS" "tailscale: IPv4 assigned (${ts_ip})"
+    else
+      record "FAIL" "tailscale: IPv4 address" "no Tailscale IPv4 — check auth key and login state"
+    fi
+  else
+    record "INFO" "tailscale: CLI" "tailscale binary not found; skipping state/IP checks"
+  fi
+}
+
+# ── Coolify split-horizon binding ──
+
+coolify_binding_check() {
+  # Skip if binding restriction was not configured
+  if ! is_true "${BIND_DASHBOARD_TO_TAILSCALE}"; then
+    record "INFO" "coolify: dashboard UFW restriction" "not configured (use --bind-dashboard-to-tailscale)"
+    return 0
+  fi
+
+  # Dashboard Tailscale restriction is enforced via UFW rules on tailscale0, not by
+  # socket binding (APP_PORT=IP:port breaks Coolify's expose: directive). Check UFW rules.
+
+  if ! command -v ufw >/dev/null 2>&1; then
+    record "FAIL" "coolify: ufw" "ufw command not found"
+    return 0
+  fi
+
+  local ufw_out
+  ufw_out="$(ufw status 2>/dev/null)" || true
+
+  # Check UFW rule for port 8000 on tailscale0
+  if echo "${ufw_out}" | grep -q "8000.*on ${TAILSCALE_IFACE}"; then
+    record "PASS" "coolify: UFW rule port 8000 on ${TAILSCALE_IFACE}"
+  else
+    record "FAIL" "coolify: UFW rule port 8000" "rule for port 8000 on ${TAILSCALE_IFACE} missing"
+  fi
+
+  # Check UFW rule for port 6001 on tailscale0
+  if echo "${ufw_out}" | grep -q "6001.*on ${TAILSCALE_IFACE}"; then
+    record "PASS" "coolify: UFW rule port 6001 on ${TAILSCALE_IFACE}"
+  else
+    record "INFO" "coolify: UFW rule port 6001" "rule for port 6001 on ${TAILSCALE_IFACE} missing (Soketi may not be in use)"
+  fi
+
+  # Check UFW rule for port 6002 on tailscale0
+  if echo "${ufw_out}" | grep -q "6002.*on ${TAILSCALE_IFACE}"; then
+    record "PASS" "coolify: UFW rule port 6002 on ${TAILSCALE_IFACE}"
+  else
+    record "INFO" "coolify: UFW rule port 6002" "rule for port 6002 on ${TAILSCALE_IFACE} missing (terminal may not be in use)"
+  fi
+
+  # Check port 8000 is listening (any address — UFW restricts which interfaces can reach it)
+  local bound_8000
+  bound_8000="$(ss -tlnp 2>/dev/null | grep ':8000 ' || true)"
+  if [[ -n "${bound_8000}" ]]; then
+    record "PASS" "coolify: port 8000 listening"
+  else
+    record "INFO" "coolify: port 8000" "not yet listening (Coolify may still be starting)"
+  fi
+
+  # Note: nc-based self-connect tests cannot validate public exposure — the kernel
+  # routes server→own-public-IP locally, bypassing UFW INPUT rules entirely.
+  # Public port exposure is validated via UFW rule inspection in ufw_check() instead.
+  # External connectivity tests (Gate E/F in deploy.sh) verify from the operator machine.
+
+  # Verify UFW binding-guard timer is active (periodically re-applies UFW rules if removed)
+  if systemctl is-active --quiet coolify-binding-guard.timer 2>/dev/null; then
+    record "PASS" "coolify: UFW binding-guard timer active"
+  else
+    record "FAIL" "coolify: UFW binding-guard timer" "not active — UFW rule drift may go undetected"
+  fi
+}
+
+# ── unattended-upgrades coverage ──
+
+unattended_upgrades_check() {
+  local apt_local="/etc/apt/apt.conf.d/52unattended-upgrades-local"
+  if [[ ! -f "${apt_local}" ]]; then
+    record "FAIL" "auto-updates: local config" "not found at ${apt_local}"
+    return
+  fi
+
+  if grep -q "Ubuntu" "${apt_local}"; then
+    record "PASS" "auto-updates: Ubuntu origin covered"
+  else
+    record "FAIL" "auto-updates: Ubuntu origin" "not in origins pattern"
+  fi
+
+  if grep -q "Docker" "${apt_local}"; then
+    record "PASS" "auto-updates: Docker CE origin covered"
+  else
+    record "FAIL" "auto-updates: Docker CE origin" "missing — Docker packages not auto-updated"
+  fi
+
+  if grep -q 'Unattended-Upgrade::Automatic-Reboot' "${apt_local}"; then
+    record "PASS" "auto-updates: reboot policy configured"
+  else
+    record "FAIL" "auto-updates: reboot policy" "not configured"
+  fi
+
+  # Functional: verify apt timers are actually running (config alone doesn't prove execution).
+  for timer in apt-daily.timer apt-daily-upgrade.timer; do
+    if systemctl is-active --quiet "${timer}" 2>/dev/null; then
+      record "PASS" "auto-updates: ${timer} active"
+    else
+      record "FAIL" "auto-updates: ${timer}" "timer not active — unattended-upgrades will not run"
+    fi
+  done
+}
+
+# ── Listening ports (informational) ──
+
+listening_ports_info() {
+  local ports
+  ports="$(ss -tlnp 2>/dev/null | tail -n +2 | awk '{print $4}' | sort -u)" || true
+  if [[ -n "${ports}" ]]; then
+    record "INFO" "listening: TCP ports" "$(echo "${ports}" | tr '\n' ' ')"
+  fi
+}
+
+# ── Coolify SSH access to localhost ──
+# Gate-C safe: all checks are skipped if Coolify is not yet installed.
+
+coolify_ssh_check() {
+  local ssh_dir="/data/coolify/ssh/keys"
+
+  # Skip entirely if Coolify hasn't been installed yet (Gate C runs before install)
+  if [[ ! -d "${ssh_dir}" ]]; then
+    return 0
+  fi
+
+  local keyfile
+  keyfile=$(ls "${ssh_dir}"/ssh_key@* 2>/dev/null | head -1 || true)
+  if [[ -z "${keyfile}" ]]; then
+    record "FAIL" "coolify: ssh key exists" "no ssh_key@* found in ${ssh_dir}"
+    return 0
+  fi
+  record "PASS" "coolify: ssh key exists"
+
+  # Derive the public key from the private key
+  local pubkey
+  pubkey=$(ssh-keygen -y -f "${keyfile}" 2>/dev/null || true)
+  if [[ -z "${pubkey}" ]]; then
+    record "FAIL" "coolify: ssh key readable" "ssh-keygen -y failed on ${keyfile}"
+    return 0
+  fi
+
+  # Check authorized_keys exists and contains the key on its own line.
+  # Match on key data (field 2) only — sshd ignores comment field 3+, and ssh-keygen -y
+  # may output a different comment than what was written. A bare substring grep would
+  # still match a concatenated line, so we compare against per-line field 2 extractions.
+  local auth="/root/.ssh/authorized_keys"
+  if [[ ! -f "${auth}" ]]; then
+    record "FAIL" "coolify: key in root authorized_keys" "${auth} does not exist"
+    return 0
+  fi
+
+  local key_data
+  key_data=$(awk '{print $2}' <<< "${pubkey}")
+
+  if awk '{print $2}' "${auth}" 2>/dev/null | grep -qxF "${key_data}"; then
+    record "PASS" "coolify: key in root authorized_keys"
+  else
+    # Check for concatenation: key data appears but not as a standalone field
+    if grep -qF "${key_data}" "${auth}" 2>/dev/null; then
+      record "FAIL" "coolify: key in root authorized_keys" \
+        "key present but not on its own line (concatenation bug) — rewrite ${auth}"
+    else
+      record "FAIL" "coolify: key in root authorized_keys" \
+        "Coolify public key not found in ${auth}"
+    fi
+    return 0
+  fi
+
+  # Functional test 1: SSH as root to 127.0.0.1 using Coolify's key (host-side).
+  # Tests key + sshd Match block from the host loopback perspective.
+  if ssh \
+      -o StrictHostKeyChecking=no \
+      -o UserKnownHostsFile=/dev/null \
+      -o ConnectTimeout=5 \
+      -o BatchMode=yes \
+      -o LogLevel=ERROR \
+      -i "${keyfile}" \
+      root@127.0.0.1 'exit 0' 2>/dev/null; then
+    record "PASS" "coolify: root@127.0.0.1 SSH functional"
+  else
+    record "FAIL" "coolify: root@127.0.0.1 SSH functional" \
+      "key auth failed — check sshd Match block and authorized_keys"
+  fi
+
+  # Functional test 2: SSH from INSIDE the coolify container to host.docker.internal.
+  # This is the exact path Coolify uses for 'This Machine'. Catches:
+  #   - host.docker.internal not resolving (host-gateway bug on Linux Docker)
+  #   - UFW blocking port 22 from Docker bridge subnet (10.0.0.0/8)
+  #   - sshd Match block not covering the Docker bridge address range
+  if command -v docker >/dev/null 2>&1 && docker inspect coolify >/dev/null 2>&1; then
+    local container_keyfile
+    container_keyfile="/var/www/html/storage/app/ssh/keys/$(basename "${keyfile}")"
+    if docker exec coolify \
+        sh -c "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+               -o ConnectTimeout=5 -o BatchMode=yes -o LogLevel=ERROR \
+               -i '${container_keyfile}' root@host.docker.internal 'exit 0'" \
+        2>/dev/null; then
+      record "PASS" "coolify: container→host SSH via host.docker.internal"
+    else
+      record "FAIL" "coolify: container→host SSH via host.docker.internal" \
+        "SSH from coolify container failed — check host.docker.internal in /etc/hosts, UFW 10.0.0.0/8 rule, and sshd Match block"
+    fi
+  else
+    record "INFO" "coolify: container→host SSH" "coolify container not running; skipped"
+  fi
+}
+
+# ── cloudflared ──
+
+cloudflared_check() {
+  # Not installed at all — that is fine before Coolify deploy
+  if ! systemctl list-unit-files --no-legend cloudflared.service 2>/dev/null | grep -q cloudflared \
+      && ! command -v cloudflared >/dev/null 2>&1; then
+    record "INFO" "cloudflared: not installed"
+    return
+  fi
+
+  # Installed — now it must be active
+  if systemctl is-active --quiet cloudflared 2>/dev/null; then
+    record "PASS" "cloudflared: service active"
+  else
+    local svc_state
+    svc_state="$(systemctl is-active cloudflared 2>/dev/null || echo "unknown")"
+    record "FAIL" "cloudflared: service active" "state is ${svc_state}"
+    return
+  fi
+
+  # Config file checks
+  local config_file="/etc/cloudflared/config.yml"
+  if [[ ! -f "${config_file}" ]]; then
+    record "FAIL" "cloudflared: config file" "${config_file} not found"
+    return
+  fi
+
+  local tunnel_id
+  tunnel_id="$(grep -m1 '^tunnel:' "${config_file}" | awk '{print $2}' || true)"
+  if [[ -n "${tunnel_id}" ]]; then
+    record "PASS" "cloudflared: tunnel ID configured"
+  else
+    record "FAIL" "cloudflared: tunnel ID" "not found in ${config_file}"
+  fi
+
+  # Dashboard hostname must route to Coolify on port 8000
+  if grep -qE 'localhost:8000|127\.0\.0\.1:8000' "${config_file}"; then
+    record "PASS" "cloudflared: ingress routes dashboard (port 8000)"
+  else
+    local ingress_svc
+    ingress_svc="$(grep -m1 '^\s*service:' "${config_file}" | awk '{print $2}' || true)"
+    record "FAIL" "cloudflared: ingress dashboard" \
+      "expected localhost:8000 for dashboard, got '${ingress_svc:-unknown}' — re-run deploy to fix"
+  fi
+
+  # Wildcard app domains must route to Traefik (coolify-proxy) on port 80, not port 8000.
+  # Port 8000 is the Coolify dashboard — routing wildcards there causes all app domains
+  # to show the dashboard instead of the actual app.
+  if grep -qE 'localhost:80$|localhost:80[^0-9]|127\.0\.0\.1:80$|127\.0\.0\.1:80[^0-9]' "${config_file}"; then
+    record "PASS" "cloudflared: ingress routes apps via Traefik (port 80)"
+  else
+    record "FAIL" "cloudflared: ingress app routing" \
+      "no localhost:80 route — app domains will show dashboard instead of apps"
+  fi
+
+  # Soketi WebSocket route (ws.DOMAIN → localhost:6001)
+  if grep -qE 'localhost:6001|127\.0\.0\.1:6001' "${config_file}"; then
+    record "PASS" "cloudflared: ingress routes Soketi (port 6001)"
+  else
+    record "FAIL" "cloudflared: ingress Soketi" \
+      "no localhost:6001 route — WebSocket real-time service unreachable via tunnel"
+  fi
+
+  # Terminal route (DOMAIN/terminal/ws → localhost:6002, path-based on dashboard hostname).
+  # Must use path-based routing on the dashboard hostname, NOT a separate terminal.DOMAIN hostname.
+  # Coolify's terminal WebSocket connects to /terminal/ws on the same origin as the dashboard.
+  if grep -qE 'localhost:6002|127\.0\.0\.1:6002' "${config_file}"; then
+    if grep -q '/terminal/ws' "${config_file}"; then
+      record "PASS" "cloudflared: ingress routes terminal (port 6002 via /terminal/ws path)"
+    else
+      record "FAIL" "cloudflared: ingress terminal path" \
+        "localhost:6002 route exists but missing 'path: /terminal/ws' — terminal uses path-based routing on dashboard hostname, not a separate hostname"
+    fi
+  else
+    record "FAIL" "cloudflared: ingress terminal" \
+      "no localhost:6002 route — terminal service unreachable via tunnel"
+  fi
+
+  # Ingress order: terminal path rule must appear BEFORE the dashboard catch-all.
+  # cloudflared matches first-match — if DOMAIN→:8000 comes before DOMAIN+path→:6002,
+  # the path rule never fires and the terminal WebSocket breaks.
+  local terminal_line dashboard_line
+  terminal_line="$(grep -nE 'localhost:6002|127\.0\.0\.1:6002' "${config_file}" | head -1 | cut -d: -f1 || true)"
+  dashboard_line="$(grep -nE 'localhost:8000|127\.0\.0\.1:8000' "${config_file}" | head -1 | cut -d: -f1 || true)"
+  if [[ -n "${terminal_line}" && -n "${dashboard_line}" ]]; then
+    if (( terminal_line < dashboard_line )); then
+      record "PASS" "cloudflared: terminal rule before dashboard (correct ingress order)"
+    else
+      record "FAIL" "cloudflared: ingress order" \
+        "terminal (line ${terminal_line}) must appear before dashboard (line ${dashboard_line}) — cloudflared is first-match"
+    fi
+  fi
+
+  # Functional connectivity: probe cloudflared's /ready endpoint.
+  # The metrics port is not always 2000; newer cloudflared picks an ephemeral port or
+  # uses a management socket. Discover the port dynamically from ss/procfs, then probe it.
+  local cf_pid cf_port
+  cf_pid="$(pgrep -x cloudflared | head -1 || true)"
+  if [[ -n "${cf_pid}" ]]; then
+    cf_port="$(ss -tlnp 2>/dev/null \
+      | awk -v pid="${cf_pid}" 'index($0,"pid="pid",") && /127\.0\.0\.1:/{print $4}' \
+      | awk -F: '{print $NF}' | head -1 || true)"
+  fi
+
+  if [[ -n "${cf_port:-}" ]] && curl -sf --max-time 3 "http://127.0.0.1:${cf_port}/ready" >/dev/null 2>&1; then
+    local ready_json conn_count
+    ready_json="$(curl -sf --max-time 3 "http://127.0.0.1:${cf_port}/ready" 2>/dev/null || true)"
+    conn_count="$(printf '%s' "${ready_json}" | python3 -c \
+      "import sys,json; print(json.load(sys.stdin).get('readyConnections',0))" 2>/dev/null || echo "?")"
+    record "PASS" "cloudflared: tunnel /ready OK (${conn_count} connections)"
+  elif [[ -n "${cf_port:-}" ]]; then
+    record "FAIL" "cloudflared: tunnel /ready" \
+      "port ${cf_port} not responding — tunnel may be disconnected"
+  else
+    record "INFO" "cloudflared: tunnel /ready" \
+      "could not determine cloudflared metrics port — manual check needed"
+  fi
+}
+
+# ── Coolify container health ──
+# Gate-C safe: skips entirely if /data/coolify does not exist.
+
+coolify_container_check() {
+  if ! command -v docker >/dev/null 2>&1; then
+    record "INFO" "coolify-containers: docker" "Docker not installed; skipped"
+    return
+  fi
+
+  if [[ ! -d "/data/coolify" ]]; then
+    return 0
+  fi
+
+  local containers=("coolify" "coolify-db" "coolify-redis" "coolify-proxy")
+  for ctr in "${containers[@]}"; do
+    local state health
+    state="$(docker inspect --format '{{.State.Status}}' "${ctr}" 2>/dev/null || echo "not-found")"
+    if [[ "${state}" == "not-found" ]]; then
+      # proxy may genuinely be absent if no apps deployed yet — info not fail
+      if [[ "${ctr}" == "coolify-proxy" ]]; then
+        record "INFO" "coolify-containers: ${ctr}" "not found (normal before first app deploy)"
+      else
+        record "FAIL" "coolify-containers: ${ctr}" "container not found"
+      fi
+      continue
+    fi
+
+    if [[ "${state}" != "running" ]]; then
+      record "FAIL" "coolify-containers: ${ctr} running" "state is ${state}"
+      continue
+    fi
+
+    # Check healthcheck status if configured (some containers have none)
+    health="$(docker inspect \
+      --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}no-healthcheck{{end}}' \
+      "${ctr}" 2>/dev/null || echo "unknown")"
+
+    case "${health}" in
+      healthy|no-healthcheck)
+        record "PASS" "coolify-containers: ${ctr} running (${health})" ;;
+      starting)
+        record "INFO" "coolify-containers: ${ctr}" "healthcheck still starting — re-run in a minute" ;;
+      *)
+        record "FAIL" "coolify-containers: ${ctr} health" "${health}" ;;
+    esac
+  done
+}
+
+# ── Hardening validation timer ──
+
+validate_timer_check() {
+  if systemctl is-active --quiet hardening-validate.timer 2>/dev/null; then
+    record "PASS" "validate-timer: active"
+  elif systemctl list-unit-files --no-legend hardening-validate.timer 2>/dev/null | grep -q hardening-validate; then
+    record "FAIL" "validate-timer: active" "timer installed but not active"
+  else
+    record "INFO" "validate-timer: not installed" "run bootstrap to install"
+  fi
+}
+
+# ── Run all checks ──
+
+[[ "$(id -u)" -eq 0 ]] || { echo "Run as root." >&2; exit 1; }
+
+if [[ "${JSON_MODE}" == "false" ]]; then
+  printf '%-6s %-45s %s\n' "STATUS" "CHECK" "DETAIL"
+  printf '%s\n' "--------------------------------------------------------------"
+fi
+
+ssh_check
+ufw_check
+docker_user_check
+docker_user_lifecycle_check
+docker_daemon_check
+sysctl_check
+fail2ban_check
+auditd_check
+unattended_upgrades_check
+journald_check
+timesync_check
+swap_check
+banner_check
+admin_sudo_check
+apparmor_check
+disabled_services_check
+tailscale_check
+coolify_binding_check
+coolify_ssh_check
+coolify_container_check
+validate_timer_check
+listening_ports_info
+cloudflared_check
+
+# ── Summary ──
+
+if [[ "${JSON_MODE}" == "true" ]]; then
+  printf '{"pass":%d,"fail":%d,"info":%d,"checks":[' "${PASS_COUNT}" "${FAIL_COUNT}" "${INFO_COUNT}"
+  first="true"
+  for r in "${RESULTS[@]}"; do
+    if [[ "${first}" == "true" ]]; then
+      first="false"
+    else
+      printf ','
+    fi
+    printf '%s' "${r}"
+  done
+  printf ']}\n'
+else
+  printf '%s\n' "--------------------------------------------------------------"
+  printf 'Summary: %d PASS, %d FAIL, %d INFO\n' "${PASS_COUNT}" "${FAIL_COUNT}" "${INFO_COUNT}"
+fi
+
+if ((FAIL_COUNT > 0)); then
+  exit 1
+fi
+exit 0

--- a/scripts/provisioning/validate_hardening.sh
+++ b/scripts/provisioning/validate_hardening.sh
@@ -3,15 +3,24 @@ set -Eeuo pipefail
 
 # validate_hardening.sh — Standalone health-check companion for bootstrap_hardening.sh
 # Re-runnable: prints PASS/FAIL per check, exits 0 if all pass, 1 if any fail.
-# Usage: sudo ./validate_hardening.sh [--json]
+# Usage: sudo ./validate_hardening.sh [--json|--health-check]
 
 STATE_FILE="/var/lib/bootstrap-hardening/state"
 JOURNALD_DROPIN="/etc/systemd/journald.conf.d/60-persistent.conf"
 JSON_MODE="false"
+HEALTH_CHECK_MODE="false"
 IS_CONTAINER="false"
 
-if [[ "${1:-}" == "--json" ]]; then
-  JSON_MODE="true"
+for arg in "$@"; do
+  case "${arg}" in
+    --json) JSON_MODE="true" ;;
+    --health-check) HEALTH_CHECK_MODE="true" ;;
+  esac
+done
+
+if [[ "${JSON_MODE}" == "true" && "${HEALTH_CHECK_MODE}" == "true" ]]; then
+  printf 'Error: --json and --health-check are mutually exclusive.\n' >&2
+  exit 1
 fi
 
 if [[ -f /.dockerenv || "${container:-}" == "docker" ]]; then
@@ -40,8 +49,10 @@ record() {
     escaped_name="$(printf '%s' "${name}" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr '\n' ' ')"
     escaped_detail="$(printf '%s' "${detail}" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr '\n' ' ')"
     RESULTS+=("{\"check\":\"${escaped_name}\",\"status\":\"${status}\",\"detail\":\"${escaped_detail}\"}")
-  else
+  elif [[ "${HEALTH_CHECK_MODE}" != "true" ]]; then
     printf '%-6s %-45s %s\n' "[${status}]" "${name}" "${detail}"
+  else
+    :
   fi
 }
 
@@ -175,6 +186,14 @@ ssh_check() {
 ufw_check() {
   local ufw_out
   ufw_out="$(ufw status verbose 2>/dev/null)" || { record "FAIL" "ufw: status query" "cannot run ufw"; return; }
+  ufw_has_port_on_iface() {
+    local port="$1" iface="$2"
+    grep -qE "${port}/tcp.*(on[[:space:]]+${iface}.*ALLOW IN|ALLOW IN.*on[[:space:]]+${iface})" <<< "${ufw_out}"
+  }
+  ufw_has_port_anywhere_unscoped() {
+    local port="$1"
+    grep -qE "${port}/tcp[[:space:]]+ALLOW IN[[:space:]]+Anywhere([[:space:]]+\\(v6\\))?$" <<< "${ufw_out}"
+  }
 
   if grep -q "^Status: active$" <<< "${ufw_out}"; then
     record "PASS" "ufw: active"
@@ -183,7 +202,7 @@ ufw_check() {
     return
   fi
 
-  if grep -qE "${SSH_PORT}/tcp.*on ${TAILSCALE_IFACE}.*ALLOW IN" <<< "${ufw_out}"; then
+  if ufw_has_port_on_iface "${SSH_PORT}" "${TAILSCALE_IFACE}"; then
     record "PASS" "ufw: SSH on ${TAILSCALE_IFACE}"
   else
     record "FAIL" "ufw: SSH on ${TAILSCALE_IFACE}" "rule missing"
@@ -199,7 +218,7 @@ ufw_check() {
   # Coolify dashboard (8000), Soketi (6001), terminal (6002) on Tailscale only.
   for port_label in "8000:dashboard" "6001:soketi" "6002:terminal"; do
     local port="${port_label%%:*}" label="${port_label##*:}"
-    if grep -qE "${port}/tcp.*on ${TAILSCALE_IFACE}.*ALLOW IN" <<< "${ufw_out}"; then
+    if ufw_has_port_on_iface "${port}" "${TAILSCALE_IFACE}"; then
       record "PASS" "ufw: Coolify ${label} (${port}) on ${TAILSCALE_IFACE}"
     else
       record "FAIL" "ufw: Coolify ${label} (${port})" "port ${port} not allowed on ${TAILSCALE_IFACE}"
@@ -208,7 +227,8 @@ ufw_check() {
 
   if [[ -n "${WAN_IFACE}" ]]; then
     # SSH must not be on WAN
-    if grep -qE "${SSH_PORT}/tcp.*on ${WAN_IFACE}.*ALLOW IN" <<< "${ufw_out}"; then
+    if ufw_has_port_on_iface "${SSH_PORT}" "${WAN_IFACE}" \
+      || ufw_has_port_anywhere_unscoped "${SSH_PORT}"; then
       record "FAIL" "ufw: SSH NOT on WAN" "SSH allowed on ${WAN_IFACE}"
     else
       record "PASS" "ufw: SSH NOT on WAN"
@@ -217,8 +237,8 @@ ufw_check() {
     # Coolify ports must not be on WAN (must only be on tailscale0)
     for port_label in "8000:dashboard" "6001:soketi" "6002:terminal"; do
       local port="${port_label%%:*}" label="${port_label##*:}"
-      if grep -qE "${port}/tcp.*on ${WAN_IFACE}.*ALLOW IN" <<< "${ufw_out}" \
-         || grep -qE "${port}/tcp\s+ALLOW IN\s+Anywhere" <<< "${ufw_out}"; then
+      if ufw_has_port_on_iface "${port}" "${WAN_IFACE}" \
+         || ufw_has_port_anywhere_unscoped "${port}"; then
         record "FAIL" "ufw: ${label} (${port}) NOT on WAN" \
           "port ${port} allowed on WAN — must be tailscale0-only"
       else
@@ -227,12 +247,14 @@ ufw_check() {
     done
 
     if is_true "${TUNNEL_MODE}"; then
-      if grep -qE "80/tcp.*on ${WAN_IFACE}.*ALLOW IN" <<< "${ufw_out}"; then
+      if ufw_has_port_on_iface "80" "${WAN_IFACE}" \
+        || ufw_has_port_anywhere_unscoped "80"; then
         record "FAIL" "ufw: tunnel-mode no port 80" "WAN 80 rule exists"
       else
         record "PASS" "ufw: tunnel-mode no port 80"
       fi
-      if grep -qE "443/tcp.*on ${WAN_IFACE}.*ALLOW IN" <<< "${ufw_out}"; then
+      if ufw_has_port_on_iface "443" "${WAN_IFACE}" \
+        || ufw_has_port_anywhere_unscoped "443"; then
         record "FAIL" "ufw: tunnel-mode no port 443" "WAN 443 rule exists"
       else
         record "PASS" "ufw: tunnel-mode no port 443"
@@ -629,7 +651,8 @@ admin_sudo_check() {
     # non-matching lines (the success case). Capture output first, then count.
     auth_content=$(grep -vE '^(#|[[:space:]]*$|ssh-[a-z0-9-]+[[:space:]]|ecdsa-sha2-[a-z0-9-]+[[:space:]]|sk-[a-z0-9@.-]+[[:space:]])' \
       "${auth_file}" 2>/dev/null) || auth_content=""
-    bad_lines=$(wc -l <<< "${auth_content}" 2>/dev/null || echo "0")
+    # Avoid here-string counting an empty input as one line.
+    bad_lines="$(printf '%s' "${auth_content}" | awk 'END {print NR+0}' 2>/dev/null || echo "0")"
     if [[ "${bad_lines}" -eq 0 ]]; then
       record "PASS" "admin: authorized_keys format"
     else
@@ -1152,7 +1175,7 @@ validate_timer_check() {
 
 [[ "$(id -u)" -eq 0 ]] || { echo "Run as root." >&2; exit 1; }
 
-if [[ "${JSON_MODE}" == "false" ]]; then
+if [[ "${JSON_MODE}" == "false" && "${HEALTH_CHECK_MODE}" != "true" ]]; then
   printf '%-6s %-45s %s\n' "STATUS" "CHECK" "DETAIL"
   printf '%s\n' "--------------------------------------------------------------"
 fi
@@ -1183,7 +1206,14 @@ cloudflared_check
 
 # ── Summary ──
 
-if [[ "${JSON_MODE}" == "true" ]]; then
+if [[ "${HEALTH_CHECK_MODE}" == "true" ]]; then
+  if ((FAIL_COUNT > 0)); then
+    echo "UNHEALTHY"
+    exit 1
+  fi
+  echo "HEALTHY"
+  exit 0
+elif [[ "${JSON_MODE}" == "true" ]]; then
   printf '{"pass":%d,"fail":%d,"info":%d,"checks":[' "${PASS_COUNT}" "${FAIL_COUNT}" "${INFO_COUNT}"
   first="true"
   for r in "${RESULTS[@]}"; do


### PR DESCRIPTION
### Why this PR exists

Most Coolify guides end at `curl -fsSL https://get.coolify.io | bash`. That gets Coolify running — but it leaves the server in a state most people would not accept in production:

- Root SSH open with password authentication
- No firewall (all ports reachable from the internet)
- Coolify dashboard on port 8000, publicly accessible
- **Docker bypasses UFW by default** — containers can open ports to the internet regardless of firewall rules
- No audit logging, no intrusion detection, no automatic security patches

Closing all of these gaps manually requires knowing UFW, iptables DOCKER-USER chains, sshd_config hardening, auditd, fail2ban, sysctl kernel parameters, Tailscale, and Cloudflare Tunnel — then correctly wiring them together. This PR automates it.

### Security architecture

```
                         Internet
                            │
                    ┌───────┴───────┐
                    │  Cloudflare   │  ← Universal SSL (*.example.com)
                    │     Edge      │
                    └───────┬───────┘
                            │
         ┌──────────────────┼──────────────────┐
         │ Tunnel (default) │   Standard       │
         │  Outbound-only   │   Ports 80/443   │
         └──────────────────┼──────────────────┘
                            │
                    ┌───────┴───────┐
                    │    Server     │
                    │  ┌─────────┐  │
                    │  │ Traefik │  │  ← Host-header routing
                    │  └─────────┘  │
                    │  Tailscale ◄──┼── Admin SSH + Dashboard (100.x.x.x)
                    └───────────────┘
                  No public SSH. No public dashboard.
```

### Before and after

| | Before | After |
|---|---|---|
| SSH | Root + password, public IP | Key-only, admin user, Tailscale VPN only |
| Coolify dashboard | Port 8000, public internet | Tailscale IP only (`100.x.x.x:8000`) |
| App traffic | — | Cloudflare edge SSL → tunnel → Traefik → containers |
| Docker ports | Bypass UFW by default | DOCKER-USER chain blocks WAN ingress |
| Firewall | None | UFW default-deny |
| Audit logging | None | Auditd: identity changes, sudo, Docker socket |
| Security patches | Manual | Unattended-upgrades with scheduled reboots |
| Public attack surface | SSH + 8000 + Docker bypass | Zero management surface on public IP |

Every new app deployed in Coolify automatically gets: auto-assigned subdomain → wildcard DNS → Cloudflare edge SSL → tunnel → Traefik → container. No per-app DNS or TLS configuration needed.

### Threat model

| Threat | Mitigation |
|--------|------------|
| SSH brute-force | fail2ban + key-only auth + Tailscale-only access |
| Docker bypasses UFW | DOCKER-USER iptables chain with explicit DROP |
| Root compromise via SSH | Root login disabled globally; localhost-only exception for Coolify container→host |
| Kernel exploits | ASLR full, ptrace restricted, BPF/kexec disabled |
| Unpatched vulnerabilities | Unattended-upgrades with auto-reboot for kernel updates |
| Dashboard exposure | UFW restricts port 8000 to `tailscale0` only; binding-guard timer re-applies on reboot |
| Direct IP bypass (tunnel mode) | Cloudflare Tunnel is outbound-only; origin IP never exposed |

### Changes

Adds `scripts/provisioning/` alongside the existing `scripts/` install and upgrade scripts. No PHP, Laravel, Livewire, or database changes. Purely additive.

**Scripts added:**

- `deploy.sh` — run from your laptop; SSHes into the VPS with the root password and orchestrates all phases remotely (~15 min, fully automated)
- `setup.sh` — same orchestration, run directly on the server
- `bootstrap_hardening.sh` — 15 security controls: UFW default-deny, DOCKER-USER iptables chain (closes Docker's UFW bypass), SSH key-only auth + admin user + root login disabled, auditd, kernel hardening (BBR, ASLR, SYN cookies, ptrace restrict, BPF/kexec disabled), fail2ban, swap, service cleanup, unattended-upgrades. Warns on state version mismatch when re-running against an already-hardened server.
- `validate_hardening.sh` — post-hardening gate check with three output modes:
  - default: human-readable `[PASS]/[FAIL]` per check
  - `--json`: machine-readable `{"pass":N,"fail":N,"checks":[...]}` for CI/automation
  - `--health-check`: prints `HEALTHY`/`UNHEALTHY`, exits 0/1 — suitable for monitoring scripts and systemd `ExecCondition`
- `configure_coolify_binding.sh` — splits Coolify's listener from `0.0.0.0` to Tailscale IP so the dashboard is unreachable on the public internet
- `lib/coolify-common.sh` — shared helpers: Cloudflare API wrappers with explicit success validation (CF API errors surface immediately), logging, prompts

Scripts are also designed to work with an AI assistant — `AGENTS_DEPLOY.md` provides a structured spec that an LLM can follow to run the deployment autonomously, with machine-readable validation output at each gate.

<details>
<summary><strong>Hardening checklist — what validate_hardening.sh checks (94 checks, 0 failures on live deployment)</strong></summary>

**Time sync**
- [ ] NTP service active
- [ ] NTPSynchronized=yes

**Swap**
- [ ] Swap active at configured size
- [ ] `/swapfile` permissions 0600
- [ ] Single fstab entry

**Service cleanup**
- [ ] `rpcbind`, `avahi-daemon`, `cups` disabled and stopped

**Login banner**
- [ ] `/etc/issue.net` present

**SSH hardening**
- [ ] Key-only auth (`PasswordAuthentication no`)
- [ ] Root login disabled globally (`PermitRootLogin no`)
- [ ] Admin user in `AllowUsers`
- [ ] Modern cipher/MAC/Kex restrictions
- [ ] `Match Address` block: root login from localhost + Docker bridge only (required for Coolify container→host SSH)
- [ ] `Match Address` block: `AllowUsers root` scoped to localhost

**Auditd**
- [ ] Service active
- [ ] Identity-change rules loaded (`su`, `useradd`, `groupadd`, `passwd`, `usermod`)
- [ ] Sudoers rules loaded

**Kernel hardening (sysctl)**
- [ ] `net.ipv4.tcp_syncookies=1` — SYN flood protection
- [ ] `net.ipv4.tcp_max_syn_backlog=2048`
- [ ] `net.ipv4.tcp_synack_retries=2`
- [ ] `net.ipv4.conf.all.rp_filter=2` — reverse path filtering
- [ ] `net.ipv4.ip_forward=1`
- [ ] `fs.protected_hardlinks=1`, `fs.protected_symlinks=1`, `fs.suid_dumpable=0`
- [ ] `kernel.randomize_va_space=2` — ASLR full
- [ ] `kernel.yama.ptrace_scope=1` — ptrace restricted
- [ ] `kernel.kptr_restrict=2`, `kernel.dmesg_restrict=1`, `kernel.perf_event_paranoid=3`
- [ ] `kernel.unprivileged_bpf_disabled=1`, `kernel.kexec_load_disabled=1`
- [ ] `net.ipv4.tcp_congestion_control=bbr`, `net.core.default_qdisc=fq`

**UFW firewall**
- [ ] Active, default-deny incoming
- [ ] SSH blocked on WAN; allowed on Tailscale interface and Docker bridge
- [ ] Dashboard (8000), Soketi (6001), terminal (6002) only on Tailscale interface
- [ ] Tunnel mode: ports 80 and 443 not open on WAN

**Docker daemon**
- [ ] `log-driver=json-file` with `max-size` rotation; `live-restore=true`

**DOCKER-USER iptables chain** (prevents Docker bypassing UFW)
- [ ] Systemd unit file present, `PartOf=docker.service`
- [ ] IPv4 and IPv6 WAN drop rules active; bridge-docker0 return rule active
- [ ] Tunnel mode: no WAN web traffic bypass

**Fail2ban**
- [ ] Active; SSH jail enabled; `banaction=ufw`
- [ ] Tailscale CIDR (`100.64.0.0/10`) in `ignoreip`; `f2b-sshd` chain present

**Journald** — persistent storage configured

**Unattended-upgrades** — Ubuntu + Docker CE origins covered, reboot policy set, timer active

**Tailscale VPN** — CLI installed, `tailscale0` present, `BackendState=Running`, IPv4 assigned

**Admin user** — exists, in `sudo`, passwordless sudo, valid `authorized_keys`

**Coolify dashboard binding**
- [ ] Port 8000 listening; UFW restricts to Tailscale interface
- [ ] Binding-guard timer active (re-applies on reboot)
- [ ] `root@127.0.0.1` SSH functional; container→host SSH via `host.docker.internal`

**Cloudflare Tunnel** (if installed)
- [ ] Config, tunnel ID, service active, `/ready` responding
- [ ] Ingress: wildcard → Traefik (80), dashboard → Coolify (8000), Soketi (6001), terminal (6002 via `/terminal/ws`)
- [ ] Terminal rule before catch-all (correct order)

**AppArmor** — enabled, `aa-status` reachable

</details>

### Code review requests

I would particularly appreciate eyes on:

1. **SSH `Match Address` block** (`bootstrap_hardening.sh`) — allows root login from localhost and Docker bridge only, which Coolify requires for container→host SSH. Too strict breaks Coolify deployments; too loose re-opens root SSH.
2. **DOCKER-USER iptables chain** (`bootstrap_hardening.sh`) — core of the Docker UFW bypass fix. Rules must survive `docker restart` and server reboots via `PartOf=docker.service`.
3. **UFW Tailscale rules** (`bootstrap_hardening.sh`) — management interfaces (8000, 6001, 6002) pinned to `tailscale0`. Relies on interface name stability.
4. **`validate_hardening.sh` accuracy** — 94 checks should catch all real misconfigurations without false positives. If a check fails on a correctly configured server, it is a bug in the validator, not the server.

### Issues

- Implements: https://github.com/coollabsio/coolify/discussions/8547

### Category

- [x] New feature

### Inputs

Five things you need before running the script:

| Input | Example | Where to get it |
|-------|---------|-----------------|
| VPS public IP | `203.0.113.1` | VPS provider control panel |
| Root password | | VPS provider control panel |
| Tailscale auth key | `tskey-auth-xxx...` | [tailscale.com/admin/settings/keys](https://login.tailscale.com/admin/settings/keys) — Reusable, Ephemeral |
| Domain on Cloudflare | `coolify.example.com` | Any domain managed in Cloudflare DNS |
| Cloudflare API token | | [dash.cloudflare.com/profile/api-tokens](https://dash.cloudflare.com/profile/api-tokens) — needs `Zone:DNS:Edit` + `Account:Cloudflare Tunnel:Edit` |

Your SSH public key is read automatically. All other options (admin username, swap size, deployment mode) have sensible defaults.

### Screenshots or Video

**Phase progress** (`deploy.sh`, abridged):
```
[1/5] Upload scripts and harden server
  PASS Hardening completed
  PASS Server Tailscale IP: 100.64.1.42

[2/5] Gate checks
  PASS Gate A: SSH reachable via Tailscale
  PASS Gate C: validate_hardening.sh — 0 failures

[3/5] Install Docker and Coolify
  PASS Docker installed
  PASS Coolify installed

[4/5] Configure Cloudflare DNS and Tunnel
  PASS Cloudflare token verified
  PASS CNAME: coolify.example.com → tunnel
  PASS CNAME: *.example.com → tunnel
  PASS Cloudflare Tunnel created

[5/5] Final verification
  PASS Gate E: dashboard reachable on Tailscale (HTTP 302)
  PASS Gate F: https://coolify.example.com responds (HTTP 302)
  PASS Gate G: validate_hardening.sh — 0 failures
```

**Completion summary:**
```
┌─────────────────────────────────────────────────────────────┐
│                    DEPLOYMENT COMPLETE                      │
├─────────────────────────────────────────────────────────────┤
│  Server Public IP : 203.0.113.1                            │
│  Tailscale IP     : 100.64.1.42                            │
│  Admin User       : coolifyadmin                           │
│  Deploy Mode      : tunnel                                 │
│  Domain           : coolify.example.com                    │
│  Dashboard URL    : http://100.64.1.42:8000                │
│  SSH Access       : ssh coolifyadmin@100.64.1.42           │
├─────────────────────────────────────────────────────────────┤
│  DNS              : CNAME coolify.example.com              │
│  Wildcard DNS     : CNAME *.example.com                    │
│  Tunnel ID        : xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx   │
│  WebSocket (Soketi): ws.coolify.example.com → tunnel       │
│  Terminal         : terminal.coolify.example.com → tunnel  │
└─────────────────────────────────────────────────────────────┘
```

**Validation output** (`validate_hardening.sh`):
```
[PASS] ssh: PermitRootLogin=no
[PASS] ssh: PasswordAuthentication=no
[PASS] ssh: external root login denied
[PASS] ufw: active
[PASS] ufw: SSH NOT on WAN
[PASS] ufw: SSH on tailscale0
[PASS] ufw: Coolify dashboard (8000) on tailscale0
[PASS] docker-user: IPv4 wan-drop
[PASS] docker-user: IPv6 wan-drop6
[PASS] sysctl: kernel.randomize_va_space=2
[PASS] sysctl: net.ipv4.tcp_syncookies=1
[PASS] sysctl: kernel.yama.ptrace_scope=1
[PASS] fail2ban: active
[PASS] fail2ban: ignoreip includes Tailscale CIDR
[PASS] auditd: identity rules loaded
[PASS] cloudflared: tunnel /ready OK (4 connections)
[PASS] cloudflared: ingress routes apps via Traefik (port 80)
... 77 more checks ...
{"pass":94,"fail":0,"info":3}
```

### AI Usage

- [x] AI is used in the process of creating this PR

### Steps to Test

**Requirements:** Ubuntu 24.04 VPS (2GB+ RAM, 40GB+ disk), domain on Cloudflare, Tailscale account + auth key, Cloudflare API token with `Zone:DNS:Edit` + `Account:Cloudflare Tunnel:Edit`.

- Step 1 — Clone the branch:
  `git clone -b feat/provisioning-scripts https://github.com/jroth1111/coolify && cd coolify/scripts/provisioning`

- Step 2 — Dry-run (no system changes, safe to run anywhere):
  `sudo bash bootstrap_hardening.sh --admin-user testadmin --admin-pubkey "$(cat ~/.ssh/id_ed12345.pub)" --dry-run`
  Expected: each control printed as would-apply, exits 0, no changes made.

- Step 3 — Unit tests (requires [bats-core](https://github.com/bats-core/bats-core)):
  `make setup-bats && make test-unit-local`
  Expected: all tests pass.

- Step 4 — Full deployment against a clean VPS:
  `bash deploy.sh --server-ip <ip> --root-pass <pass> --tailscale-auth-key tskey-auth-... --domain coolify.example.com --cf-api-token <token> --yes`
  Expected: completes all phases, Coolify reachable at `https://coolify.example.com`.

- Step 5 — Post-deploy gate check (SSH to server via Tailscale):
  `sudo validate_hardening.sh --json`
  Expected: `{"pass":94,"fail":0,...}`

- Step 6 — Health-check mode (suitable for monitoring/cron):
  `sudo validate_hardening.sh --health-check; echo $?`
  Expected: prints `HEALTHY`, exits 0.

- Step 7 — Verify public attack surface is closed:
  `curl -v http://<public-vps-ip>:8000` → connection refused or timeout
  `ssh root@<public-vps-ip>` → connection refused
  Expected: no response on management interfaces from the public IP.

### Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them