### PR TITLE
chore(scheduler): fix scheduled job duration metric

### DIFF
--- a/app/Jobs/ScheduledJobManager.php
+++ b/app/Jobs/ScheduledJobManager.php
@@ -104,7 +104,7 @@ class ScheduledJobManager implements ShouldQueue
 
         Log::channel('scheduled')->info('ScheduledJobManager completed', [
             'execution_time' => $this->executionTime->toIso8601String(),
-            'duration_ms' => Carbon::now()->diffInMilliseconds($this->executionTime),
+            'duration_ms' => $this->executionTime->diffInMilliseconds(Carbon::now()),
             'dispatched' => $this->dispatchedCount,
             'skipped' => $this->skippedCount,
         ]);


### PR DESCRIPTION
## Summary
- Correct scheduled job duration calculation to use execution start time as baseline
- Ensure logged duration reflects total runtime in milliseconds

## Breaking Changes
- None