### PR TITLE
templates: add PayloadCMS service template

### DIFF
--- a/public/svgs/payloadcms.svg
+++ b/public/svgs/payloadcms.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="PayloadCMS">
+  <rect width="128" height="128" rx="24" fill="#111827"/>
+  <path d="M38 40h26c15 0 26 10 26 24s-11 24-26 24H54v20H38V40zm16 14v20h10c7 0 12-4 12-10s-5-10-12-10H54z" fill="#ffffff"/>
+</svg>

--- a/templates/compose/payloadcms.yaml
+++ b/templates/compose/payloadcms.yaml
@@ -1,0 +1,43 @@
+# documentation: https://payloadcms.com/docs
+# slogan: Developer-first headless CMS built with Node.js.
+# category: cms
+# tags: cms, headless, nodejs, mongodb
+# logo: svgs/payloadcms.svg
+# port: 3000
+
+services:
+  payload:
+    image: payloadcms/payload:latest
+    environment:
+      - SERVICE_URL_PAYLOAD_3000
+      - SERVICE_FQDN_PAYLOAD
+      - PAYLOAD_PUBLIC_SERVER_URL=$SERVICE_URL_PAYLOAD
+      - DATABASE_URI=mongodb://mongodb:27017/payload
+      - PAYLOAD_SECRET=$SERVICE_BASE64_64_SECRET
+      - NODE_ENV=production
+    depends_on:
+      mongodb:
+        condition: service_started
+    healthcheck:
+      test:
+        - CMD
+        - wget
+        - "-q"
+        - "--spider"
+        - "http://127.0.0.1:3000/"
+      interval: 5s
+      timeout: 20s
+      retries: 10
+
+  mongodb:
+    image: mongo:7-jammy
+    volumes:
+      - payload-mongodb-data:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.runCommand({ ping: 1 }).ok"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+
+volumes:
+  payload-mongodb-data:


### PR DESCRIPTION
Closes #2346

## What
- Add a new compose template: `templates/compose/payloadcms.yaml`
- Add an SVG logo: `public/svgs/payloadcms.svg`

## Bounty
- /claim #2346

## Notes
- Uses the `payloadcms/payload` image + MongoDB.
- Includes `SERVICE_URL_*` / `SERVICE_FQDN_*` placeholders consistent with existing templates.