### PR TITLE
templates: enable Huly self-host template

### DIFF
--- a/templates/compose/huly.yaml
+++ b/templates/compose/huly.yaml
@@ -1,6 +1,5 @@
-# ignore: true
-# documentation: https://huly.io/
-# category: cms
+# documentation: https://github.com/hcengineering/huly-selfhost
+# category: productivity
 # slogan: Open Source All-in-One Project Management Platform
 # tags: linear,jira,slack,project,management,notion,motion
 # port: 8080


### PR DESCRIPTION
Closes #2543

## What
- Enable the existing `huly.yaml` compose template (remove `# ignore: true`).
- Update metadata to point to the official self-host docs repo.

## Bounty
- /claim #2543

## Notes
- Template already existed in `templates/compose/huly.yaml` but was ignored by the generator.
- This change makes it available in generated service templates.