### PR TITLE
fix: prevent public database proxies from timing out (#7743)

### DIFF
--- a/app/Actions/Database/StartDatabaseProxy.php
+++ b/app/Actions/Database/StartDatabaseProxy.php
@@ -67,6 +67,7 @@ class StartDatabaseProxy
        server {
             listen $database->public_port;
             proxy_pass $containerName:$internalPort;
+            proxy_timeout 0;
        }
     }
     EOF;


### PR DESCRIPTION
This PR fixes issue #7743 by adding `proxy_timeout 0;` to the Nginx stream server configuration for database proxies. This prevents the default 10-minute timeout for public database connections.

Payment info:
USDC/SOL: `GKqwBPH4m6bkZj35j3WVvyJHHdUxddtmETH6ZA8W1aZH`