### PR TITLE
fix(team): include webhook notifications in enabled check

### DIFF
--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -191,7 +191,8 @@ class Team extends Model implements SendsDiscord, SendsEmail, SendsPushover, Sen
             $this->getNotificationSettings('discord')?->isEnabled() ||
             $this->getNotificationSettings('slack')?->isEnabled() ||
             $this->getNotificationSettings('telegram')?->isEnabled() ||
-            $this->getNotificationSettings('pushover')?->isEnabled();
+            $this->getNotificationSettings('pushover')?->isEnabled() ||
+            $this->getNotificationSettings('webhook')?->isEnabled();
     }
 
     public function subscriptionEnded()

--- a/tests/Feature/TeamNotificationCheckTest.php
+++ b/tests/Feature/TeamNotificationCheckTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->team = Team::factory()->create();
+});
+
+describe('isAnyNotificationEnabled', function () {
+    test('returns false when no notifications are enabled', function () {
+        expect($this->team->isAnyNotificationEnabled())->toBeFalse();
+    });
+
+    test('returns true when email notifications are enabled', function () {
+        $this->team->emailNotificationSettings->update(['smtp_enabled' => true]);
+
+        expect($this->team->isAnyNotificationEnabled())->toBeTrue();
+    });
+
+    test('returns true when discord notifications are enabled', function () {
+        $this->team->discordNotificationSettings->update(['discord_enabled' => true]);
+
+        expect($this->team->isAnyNotificationEnabled())->toBeTrue();
+    });
+
+    test('returns true when slack notifications are enabled', function () {
+        $this->team->slackNotificationSettings->update(['slack_enabled' => true]);
+
+        expect($this->team->isAnyNotificationEnabled())->toBeTrue();
+    });
+
+    test('returns true when telegram notifications are enabled', function () {
+        $this->team->telegramNotificationSettings->update(['telegram_enabled' => true]);
+
+        expect($this->team->isAnyNotificationEnabled())->toBeTrue();
+    });
+
+    test('returns true when pushover notifications are enabled', function () {
+        $this->team->pushoverNotificationSettings->update(['pushover_enabled' => true]);
+
+        expect($this->team->isAnyNotificationEnabled())->toBeTrue();
+    });
+
+    test('returns true when webhook notifications are enabled', function () {
+        $this->team->webhookNotificationSettings->update(['webhook_enabled' => true]);
+
+        expect($this->team->isAnyNotificationEnabled())->toBeTrue();
+    });
+});


### PR DESCRIPTION
## Summary
- include webhook notification settings in `Team::isAnyNotificationEnabled`
- add feature coverage for each notification channel, including webhook

## Breaking Changes
- none

fix #8448 