### PR TITLE
fix: add static build pack support in preview deployments

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -1882,6 +1882,11 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
 
             return;
         }
+        if ($this->application->build_pack === 'static') {
+            $this->deploy_static_buildpack();
+
+            return;
+        }
         if ($this->use_build_server) {
             $this->server = $this->build_server;
         }


### PR DESCRIPTION
## Description

Fix #8238 - Preview Deployments Fail for Static Sites

This PR adds support for the 'static' build pack in preview deployments (pull request deployments). Previously, preview deployments for static sites would fail with the error:

```
ERROR: failed to build: failed to solve: failed to read dockerfile: open Dockerfile: no such file or directory
```

## Changes

- Added a check for `static` build pack in the `deploy_pull_request()` method in `app/Jobs/ApplicationDeploymentJob.php`
- When build pack is 'static', it now calls `deploy_static_buildpack()` instead of trying to build a Dockerfile

## How it works

The fix mirrors the existing handling for `dockercompose` build pack. Now:
1. If build pack is 'dockercompose' → call `deploy_docker_compose_buildpack()`
2. **NEW**: If build pack is 'static' → call `deploy_static_buildpack()`
3. Otherwise → continue with the default build logic

## Testing

This follows the existing pattern that already works for regular (non-preview) deployments of static sites.