### PR TITLE
fix(applications): treat zero private_key_id as deploy key

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -990,7 +990,7 @@ class Application extends BaseModel
         if (isDev() && data_get($this, 'private_key_id') === 0) {
             return 'deploy_key';
         }
-        if (data_get($this, 'private_key_id')) {
+        if (! is_null(data_get($this, 'private_key_id'))) {
             return 'deploy_key';
         } elseif (data_get($this, 'source')) {
             return 'source';

--- a/tests/Unit/ApplicationDeploymentTypeTest.php
+++ b/tests/Unit/ApplicationDeploymentTypeTest.php
@@ -1,0 +1,11 @@
+<?php
+
+use App\Models\Application;
+
+it('treats zero private key id as deploy key', function () {
+    $application = new Application();
+    $application->private_key_id = 0;
+    $application->source = null;
+
+    expect($application->deploymentType())->toBe('deploy_key');
+});


### PR DESCRIPTION
## Summary
- fix deployment type detection to treat `private_key_id=0` as a valid deploy key
- add unit test covering zero private key id behavior

---

Fixes #8562