### PR TITLE
fix: bind Soketi to dual-stack (::) to support IPv6 connections

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -76,6 +76,7 @@ services:
       SOKETI_DEFAULT_APP_ID: "${PUSHER_APP_ID:-coolify}"
       SOKETI_DEFAULT_APP_KEY: "${PUSHER_APP_KEY:-coolify}"
       SOKETI_DEFAULT_APP_SECRET: "${PUSHER_APP_SECRET:-coolify}"
+      SOKETI_HOST: "::"
     healthcheck:
       test: [ "CMD-SHELL", "curl -fsS http://127.0.0.1:6001/ready && curl -fsS http://127.0.0.1:6002/ready || exit 1" ]
       interval: 5s

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -72,6 +72,7 @@ services:
       SOKETI_DEFAULT_APP_ID: "${PUSHER_APP_ID}"
       SOKETI_DEFAULT_APP_KEY: "${PUSHER_APP_KEY}"
       SOKETI_DEFAULT_APP_SECRET: "${PUSHER_APP_SECRET}"
+      SOKETI_HOST: "::"
     healthcheck:
       test: [ "CMD-SHELL", "wget -qO- http://127.0.0.1:6001/ready && wget -qO- http://127.0.0.1:6002/ready || exit 1" ]
       interval: 5s

--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -113,6 +113,7 @@ services:
       SOKETI_DEFAULT_APP_ID: "${PUSHER_APP_ID}"
       SOKETI_DEFAULT_APP_KEY: "${PUSHER_APP_KEY}"
       SOKETI_DEFAULT_APP_SECRET: "${PUSHER_APP_SECRET}"
+      SOKETI_HOST: "::"
     healthcheck:
       test: [ "CMD-SHELL", "wget -qO- http://127.0.0.1:6001/ready && wget -qO- http://127.0.0.1:6002/ready || exit 1" ]
       interval: 5s

--- a/other/nightly/docker-compose.prod.yml
+++ b/other/nightly/docker-compose.prod.yml
@@ -72,6 +72,7 @@ services:
       SOKETI_DEFAULT_APP_ID: "${PUSHER_APP_ID}"
       SOKETI_DEFAULT_APP_KEY: "${PUSHER_APP_KEY}"
       SOKETI_DEFAULT_APP_SECRET: "${PUSHER_APP_SECRET}"
+      SOKETI_HOST: "::"
     healthcheck:
       test: [ "CMD-SHELL", "wget -qO- http://127.0.0.1:6001/ready && wget -qO- http://127.0.0.1:6002/ready || exit 1" ]
       interval: 5s

--- a/other/nightly/docker-compose.windows.yml
+++ b/other/nightly/docker-compose.windows.yml
@@ -113,6 +113,7 @@ services:
       SOKETI_DEFAULT_APP_ID: "${PUSHER_APP_ID}"
       SOKETI_DEFAULT_APP_KEY: "${PUSHER_APP_KEY}"
       SOKETI_DEFAULT_APP_SECRET: "${PUSHER_APP_SECRET}"
+      SOKETI_HOST: "::"
     healthcheck:
       test: [ "CMD-SHELL", "wget -qO- http://127.0.0.1:6001/ready && wget -qO- http://127.0.0.1:6002/ready || exit 1" ]
       interval: 5s


### PR DESCRIPTION
## Summary
- Adds `SOKETI_HOST: "::"` to the soketi service environment in all docker-compose files (prod, dev, windows, nightly) so Soketi binds dual-stack instead of IPv4-only.
- This fixes WebSocket connection failures when `localhost` resolves to `[::1]` (IPv6), which is standard behavior on most modern Linux distros and Go-based resolvers (e.g., Cloudflare Tunnel).
- Brings Soketi (port 6001) in line with the terminal server (port 6002), which already listens on `::` via Node.js defaults.

## Problem
Soketi defaults its `host` option to `0.0.0.0`, binding IPv4-only on port 6001. Any client or reverse proxy that resolves `localhost` to `[::1]` gets a connection reset. The terminal server on port 6002 works fine because Node.js `server.listen()` defaults to `::` (dual-stack).

## Fix
One-line env var addition per compose file:
```yaml
SOKETI_HOST: "::"
```

## Files Changed
- `docker-compose.prod.yml`
- `docker-compose.dev.yml`
- `docker-compose.windows.yml`
- `other/nightly/docker-compose.prod.yml`
- `other/nightly/docker-compose.windows.yml`

## Verification
Tested on Debian 13 with Cloudflare Tunnel — after the change, `netstat -tlnp` inside the container shows `:::6001` (dual-stack) instead of `0.0.0.0:6001` (IPv4-only), and WebSocket connections succeed over both IPv4 and IPv6.

Closes #8584