### PR TITLE
fix(auth): prevent CSRF redirect loop during 2FA challenge

### DIFF
--- a/app/Http/Middleware/CheckForcePasswordReset.php
+++ b/app/Http/Middleware/CheckForcePasswordReset.php
@@ -25,7 +25,7 @@ class CheckForcePasswordReset
             }
             $force_password_reset = auth()->user()->force_password_reset;
             if ($force_password_reset) {
-                if ($request->routeIs('auth.force-password-reset') || $request->path() === 'force-password-reset' || $request->path() === 'livewire/update' || $request->path() === 'logout') {
+                if ($request->routeIs('auth.force-password-reset') || $request->path() === 'force-password-reset' || $request->path() === 'two-factor-challenge' || $request->path() === 'livewire/update' || $request->path() === 'logout') {
                     return $next($request);
                 }
 

--- a/bootstrap/helpers/subscriptions.php
+++ b/bootstrap/helpers/subscriptions.php
@@ -77,6 +77,7 @@ function allowedPathsForUnsubscribedAccounts()
         'login',
         'logout',
         'force-password-reset',
+        'two-factor-challenge',
         'livewire/update',
         'admin',
     ];
@@ -95,6 +96,7 @@ function allowedPathsForInvalidAccounts()
         'logout',
         'verify',
         'force-password-reset',
+        'two-factor-challenge',
         'livewire/update',
     ];
 }

--- a/resources/views/errors/419.blade.php
+++ b/resources/views/errors/419.blade.php
@@ -3,15 +3,11 @@
     <div>
         <p class="font-mono font-semibold text-7xl dark:text-warning">419</p>
         <h1 class="mt-4 font-bold tracking-tight dark:text-white">This page is definitely old, not like you!</h1>
-        <p class="text-base leading-7 dark:text-neutral-300 text-black">Sorry, we couldn't find the page you're looking
-            for.
+        <p class="text-base leading-7 dark:text-neutral-300 text-black">Your session has expired. Please log in again to continue.
         </p>
         <div class="flex items-center mt-10 gap-x-2">
-            <a href="{{ url()->previous() }}">
-                <x-forms.button>Go back</x-forms.button>
-            </a>
-            <a href="{{ route('dashboard') }}" {{ wireNavigate() }}>
-                <x-forms.button>Dashboard</x-forms.button>
+            <a href="/login">
+                <x-forms.button>Back to Login</x-forms.button>
             </a>
             <a target="_blank" class="text-xs" href="{{ config('constants.urls.contact') }}">Contact
                 support

--- a/tests/Feature/TwoFactorChallengeAccessTest.php
+++ b/tests/Feature/TwoFactorChallengeAccessTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->team = Team::factory()->personal()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+    session(['currentTeam' => $this->team]);
+});
+
+it('allows unauthenticated access to two-factor-challenge page', function () {
+    $response = $this->get('/two-factor-challenge');
+
+    // Fortify returns a redirect to /login if there's no login.id in session,
+    // but the important thing is it does NOT return a 419 or 500
+    expect($response->status())->toBeIn([200, 302]);
+});
+
+it('includes two-factor-challenge in allowed paths for unsubscribed accounts', function () {
+    $paths = allowedPathsForUnsubscribedAccounts();
+
+    expect($paths)->toContain('two-factor-challenge');
+});
+
+it('includes two-factor-challenge in allowed paths for invalid accounts', function () {
+    $paths = allowedPathsForInvalidAccounts();
+
+    expect($paths)->toContain('two-factor-challenge');
+});
+
+it('includes two-factor-challenge in allowed paths for boarding accounts', function () {
+    $paths = allowedPathsForBoardingAccounts();
+
+    expect($paths)->toContain('two-factor-challenge');
+});
+
+it('does not redirect authenticated user with force_password_reset from two-factor-challenge', function () {
+    $this->user->update(['force_password_reset' => true]);
+
+    $response = $this->actingAs($this->user)->get('/two-factor-challenge');
+
+    // Should NOT redirect to force-password-reset page
+    if ($response->isRedirect()) {
+        expect($response->headers->get('Location'))->not->toContain('force-password-reset');
+    }
+});
+
+it('renders 419 error page with login link instead of previous url', function () {
+    $response = $this->get('/two-factor-challenge', [
+        'X-CSRF-TOKEN' => 'invalid-token',
+    ]);
+
+    // The 419 page should exist and contain a link to /login
+    $view = view('errors.419')->render();
+
+    expect($view)->toContain('/login');
+    expect($view)->toContain('Back to Login');
+    expect($view)->toContain('This page is definitely old, not like you!');
+    expect($view)->not->toContain('url()->previous()');
+});


### PR DESCRIPTION
## Summary

Fixes a redirect loop that occurs when users with force password reset enabled or in unsubscribed/invalid account states attempt to complete 2FA authentication.

- Added `two-factor-challenge` path to force password reset middleware allowlist to prevent premature redirects
- Added `two-factor-challenge` to allowed paths for unsubscribed and invalid accounts
- Improved 419 CSRF error page to clarify session expiration and redirect to login instead of `url()->previous()` (which could cause loops)
- Added comprehensive test suite to prevent regression in 2FA challenge access across different account states