### PR TITLE
fix: add x-cloak to eye-off icon to prevent flash (#8592)

### DIFF
--- a/resources/views/components/forms/input.blade.php
+++ b/resources/views/components/forms/input.blade.php
@@ -25,7 +25,7 @@
                         <path d="M21 12c-2.4 4 -5.4 6 -9 6c-3.6 0 -6.6 -2 -9 -6c2.4 -4 5.4 -6 9 -6c3.6 0 6.6 2 9 6" />
                     </svg>
                     {{-- Eye-off icon (shown when password is visible) --}}
-                    <svg x-show="type === 'text'" xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" viewBox="0 0 24 24" stroke-width="1.5"
+                    <svg x-show="type === 'text'" x-cloak xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" viewBox="0 0 24 24" stroke-width="1.5"
                         stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
                         <path stroke="none" d="M0 0h24v24H0z" fill="none" />
                         <path d="M10.585 10.587a2 2 0 0 0 2.829 2.828" />


### PR DESCRIPTION
## Description

Fixed issue #8592: Double eye icon flash on password fields before Alpine.js initializes

## Root Cause
The eye-off SVG was missing the x-cloak attribute. The CSS rule [x-cloak] { display: none !important; } exists in layouts/base.blade.php but was not applied to this element.

## Fix
Added x-cloak attribute to the eye-off SVG element. This ensures the element is hidden via CSS before Alpine.js processes the x-show directive, preventing the visual flash on page load.

## Changes
- resources/views/components/forms/input.blade.php: Added x-cloak to the eye-off icon SVG

## Testing
- Navigate to /register, /login, or any page with password input
- Reload the page and observe the password field eye icon area
- The flash should no longer occur