### PR TITLE
fix(input): prevent eye icon flash on password fields before Alpine.js loads

### DIFF
--- a/resources/views/components/forms/input.blade.php
+++ b/resources/views/components/forms/input.blade.php
@@ -25,7 +25,7 @@
                         <path d="M21 12c-2.4 4 -5.4 6 -9 6c-3.6 0 -6.6 -2 -9 -6c2.4 -4 5.4 -6 9 -6c3.6 0 6.6 2 9 6" />
                     </svg>
                     {{-- Eye-off icon (shown when password is visible) --}}
-                    <svg x-show="type === 'text'" xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" viewBox="0 0 24 24" stroke-width="1.5"
+                    <svg x-cloak x-show="type === 'text'" xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" viewBox="0 0 24 24" stroke-width="1.5"
                         stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
                         <path stroke="none" d="M0 0h24v24H0z" fill="none" />
                         <path d="M10.585 10.587a2 2 0 0 0 2.829 2.828" />


### PR DESCRIPTION
## Summary

- Add `x-cloak` attribute to eye-off SVG icon in password input component
- Prevents visual flash where both eye icons appear simultaneously before Alpine.js initializes
- Leverages existing `[x-cloak] { display: none !important; }` CSS rule in base layout

## Changes

Modified `resources/views/components/forms/input.blade.php` to add `x-cloak` directive to the eye-off icon SVG. This ensures the icon is hidden via CSS before Alpine.js processes the `x-show` directive, eliminating the brief moment where both icons are visible on page load.

Closes #8592

---

Fixes #8592