### PR TITLE
fix(api): correct permission requirements for POST endpoints

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -55,7 +55,7 @@ Route::group([
     Route::post('/projects/{uuid}/environments', [ProjectController::class, 'create_environment'])->middleware(['api.ability:write']);
     Route::delete('/projects/{uuid}/environments/{environment_name_or_uuid}', [ProjectController::class, 'delete_environment'])->middleware(['api.ability:write']);
 
-    Route::post('/projects', [ProjectController::class, 'create_project'])->middleware(['api.ability:read']);
+    Route::post('/projects', [ProjectController::class, 'create_project'])->middleware(['api.ability:write']);
     Route::patch('/projects/{uuid}', [ProjectController::class, 'update_project'])->middleware(['api.ability:write']);
     Route::delete('/projects/{uuid}', [ProjectController::class, 'delete_project'])->middleware(['api.ability:write']);
 
@@ -86,7 +86,7 @@ Route::group([
 
     Route::get('/servers/{uuid}/validate', [ServersController::class, 'validate_server'])->middleware(['api.ability:read']);
 
-    Route::post('/servers', [ServersController::class, 'create_server'])->middleware(['api.ability:read']);
+    Route::post('/servers', [ServersController::class, 'create_server'])->middleware(['api.ability:write']);
     Route::patch('/servers/{uuid}', [ServersController::class, 'update_server'])->middleware(['api.ability:write']);
     Route::delete('/servers/{uuid}', [ServersController::class, 'delete_server'])->middleware(['api.ability:write']);
 

--- a/tests/Feature/ApiTokenPermissionTest.php
+++ b/tests/Feature/ApiTokenPermissionTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+
+    session(['currentTeam' => $this->team]);
+});
+
+describe('POST /api/v1/projects', function () {
+    test('read-only token cannot create a project', function () {
+        $token = $this->user->createToken('read-only', ['read']);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token->plainTextToken,
+            'Content-Type' => 'application/json',
+        ])->postJson('/api/v1/projects', [
+            'name' => 'Test Project',
+        ]);
+
+        $response->assertStatus(403);
+    });
+
+    test('write token can create a project', function () {
+        $token = $this->user->createToken('write-token', ['write']);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token->plainTextToken,
+            'Content-Type' => 'application/json',
+        ])->postJson('/api/v1/projects', [
+            'name' => 'Test Project',
+        ]);
+
+        $response->assertStatus(201);
+        $response->assertJsonStructure(['uuid']);
+    });
+
+    test('root token can create a project', function () {
+        $token = $this->user->createToken('root-token', ['root']);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token->plainTextToken,
+            'Content-Type' => 'application/json',
+        ])->postJson('/api/v1/projects', [
+            'name' => 'Test Project',
+        ]);
+
+        $response->assertStatus(201);
+        $response->assertJsonStructure(['uuid']);
+    });
+});
+
+describe('POST /api/v1/servers', function () {
+    test('read-only token cannot create a server', function () {
+        $token = $this->user->createToken('read-only', ['read']);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token->plainTextToken,
+            'Content-Type' => 'application/json',
+        ])->postJson('/api/v1/servers', [
+            'name' => 'Test Server',
+            'ip' => '1.2.3.4',
+            'private_key_uuid' => 'fake-uuid',
+        ]);
+
+        $response->assertStatus(403);
+    });
+});


### PR DESCRIPTION
## Summary

- Fixed incorrect permission middleware on POST /api/v1/projects (create_project) - changed from `api.ability:read` to `api.ability:write`
- Fixed incorrect permission middleware on POST /api/v1/servers (create_server) - changed from `api.ability:read` to `api.ability:write`
- Added comprehensive test coverage to verify permission checks work correctly for read-only, write, and root tokens

## Details

The create project and create server endpoints are write operations that modify data, but were incorrectly configured to accept read-only API tokens. This has been corrected to require write permissions, preventing read-only token holders from performing these operations.

New tests verify that:
- Read-only tokens are rejected with 403 status
- Write and root tokens are accepted with 201 status