### PR TITLE
fix: preserve docker label values with equals

### DIFF
--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -96,21 +96,33 @@ function format_docker_labels_to_json(string|array $rawOutput): Collection
     if (is_array($rawOutput)) {
         return collect($rawOutput);
     }
-    $outputLines = explode(PHP_EOL, $rawOutput);
+    $outputLines = collect(explode(PHP_EOL, $rawOutput))
+        ->reject(fn ($line) => empty($line));
 
-    return collect($outputLines)
-        ->reject(fn ($line) => empty($line))
+    if ($outputLines->isEmpty()) {
+        return collect([]);
+    }
+
+    return $outputLines
         ->map(function ($outputLine) {
             $outputArray = explode(',', $outputLine);
 
             return collect($outputArray)
                 ->map(function ($outputLine) {
-                    return explode('=', $outputLine);
+                    return explode('=', $outputLine, 2);
                 })
                 ->mapWithKeys(function ($outputLine) {
-                    return [$outputLine[0] => $outputLine[1]];
+                    $key = $outputLine[0] ?? null;
+                    $value = $outputLine[1] ?? '';
+
+                    if (empty($key)) {
+                        return [];
+                    }
+
+                    return [$key => $value];
                 });
-        })[0];
+        })
+        ->first() ?? collect([]);
 }
 
 function format_docker_envs_to_json($rawOutput)

--- a/tests/Feature/DockerLabelsToJsonTest.php
+++ b/tests/Feature/DockerLabelsToJsonTest.php
@@ -1,0 +1,16 @@
+<?php
+
+test('format_docker_labels_to_json preserves equals in values', function () {
+    $rawLabels = 'coolify.config=foo=bar,com.docker.compose.project=coolify';
+
+    $labels = format_docker_labels_to_json($rawLabels);
+
+    expect($labels->get('coolify.config'))->toBe('foo=bar')
+        ->and($labels->get('com.docker.compose.project'))->toBe('coolify');
+});
+
+test('format_docker_labels_to_json returns empty collection for empty input', function () {
+    $labels = format_docker_labels_to_json('');
+
+    expect($labels->isEmpty())->toBeTrue();
+});


### PR DESCRIPTION
### Changes
- Preserve docker label values containing `=`.
- Return empty collection for empty label input.
- Add tests for docker label parsing edge cases.

### Issues
- fixes: n/a

### Category
- [x] Bug fix

### Screenshots or Video (if applicable)
- n/a

### AI Usage
- [x] AI is used in the process of creating this PR

### Steps to Test
- Step 1 – `composer install`
- Step 2 – `vendor/bin/pint --dirty --format agent`
- Step 3 – `php artisan test --compact tests/Feature/DockerLabelsToJsonTest.php`

### Contributor Agreement
> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have tested the changes thoroughly and am confident that they will work as expected without issues when the maintainer tests them
