### PR TITLE
fix: detect and register ServiceDatabase records for GitHub App Docker Compose deployments

### DIFF
--- a/app/Actions/Database/StartDatabaseProxy.php
+++ b/app/Actions/Database/StartDatabaseProxy.php
@@ -31,9 +31,10 @@ class StartDatabaseProxy
 
         if ($database->getMorphClass() === \App\Models\ServiceDatabase::class) {
             $databaseType = $database->databaseType();
-            $network = $database->service->uuid;
-            $server = data_get($database, 'service.destination.server');
-            $containerName = "{$database->name}-{$database->service->uuid}";
+            // Use parent UUID as network name — works for both Service and Application parents
+            $network = $database->getParentUuid();
+            $server = $database->getServer();
+            $containerName = $database->getContainerName();
         }
         $internalPort = match ($databaseType) {
             'standalone-mariadb', 'standalone-mysql' => 3306,

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -10,6 +10,8 @@ use App\Events\ServiceStatusChanged;
 use App\Exceptions\DeploymentException;
 use App\Models\Application;
 use App\Models\ApplicationDeploymentQueue;
+use App\Models\ScheduledDatabaseBackupExecution;
+use App\Models\ServiceDatabase;
 use App\Models\ApplicationPreview;
 use App\Models\EnvironmentVariable;
 use App\Models\GithubApp;
@@ -265,6 +267,27 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             $this->application_deployment_queue->addLogEntry('Deployment was cancelled before starting.');
 
             return;
+        }
+
+        // For dockercompose buildpack: guard against deploying while a database backup is in progress.
+        // An active backup could be interrupted mid-stream by a container restart, producing a corrupt dump.
+        if ($this->application->build_pack === 'dockercompose') {
+            $activeBackup = ScheduledDatabaseBackupExecution::where('status', 'running')
+                ->whereHas('scheduledDatabaseBackup.database', function ($query) {
+                    $query->where('application_id', $this->application->id);
+                })
+                ->first();
+            if ($activeBackup) {
+                $this->application_deployment_queue->addLogEntry(
+                    'A database backup is currently in progress for a service in this Compose deployment. '.
+                    'The deployment has been cancelled to prevent a corrupt backup. Please retry after the backup completes.'
+                );
+                $this->application_deployment_queue->update([
+                    'status' => ApplicationDeploymentStatus::CANCELLED_BY_USER->value,
+                ]);
+
+                return;
+            }
         }
 
         $this->application_deployment_queue->update([

--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -2,7 +2,9 @@
 
 namespace App\Jobs;
 
+use App\Enums\ApplicationDeploymentStatus;
 use App\Events\BackupCreated;
+use App\Models\ApplicationDeploymentQueue;
 use App\Models\S3Storage;
 use App\Models\ScheduledDatabaseBackup;
 use App\Models\ScheduledDatabaseBackupExecution;
@@ -93,7 +95,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $this->database = data_get($this->backup, 'database');
-                $this->server = $this->database->service->server;
+                $this->server = $this->database->getServer();
                 $this->s3 = $this->backup->s3;
             } else {
                 $this->database = data_get($this->backup, 'database');
@@ -113,10 +115,32 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             if (! $status->startsWith('running') && $this->database->id !== 0) {
                 return;
             }
+
+            // For Application-owned compose databases: skip if a redeployment is in progress
+            // to prevent backing up a database container that is about to be recreated.
+            if (
+                data_get($this->backup, 'database_type') === ServiceDatabase::class &&
+                $this->database instanceof ServiceDatabase &&
+                $this->database->application_id
+            ) {
+                $activeDeployment = ApplicationDeploymentQueue::where('application_id', $this->database->application_id)
+                    ->whereIn('status', [
+                        ApplicationDeploymentStatus::IN_PROGRESS->value,
+                        ApplicationDeploymentStatus::QUEUED->value,
+                    ])
+                    ->exists();
+                if ($activeDeployment) {
+                    \Illuminate\Support\Facades\Log::info("Skipping backup [{$this->backup->id}]: deployment in progress for application [{$this->database->application_id}].");
+
+                    return;
+                }
+            }
+
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $databaseType = $this->database->databaseType();
-                $serviceUuid = $this->database->service->uuid;
-                $serviceName = str($this->database->service->name)->slug();
+                $parentResource = $this->database->getParentResource();
+                $serviceUuid = $this->database->getParentUuid();
+                $serviceName = str($parentResource?->name ?? $this->database->name)->slug();
                 if (str($databaseType)->contains('postgres')) {
                     $this->container_name = "{$this->database->name}-$serviceUuid";
                     $this->directory_name = $serviceName.'-'.$this->container_name;
@@ -630,7 +654,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             $endpoint = $this->s3->endpoint;
             $this->s3->testConnection(shouldSave: true);
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
-                $network = $this->database->service->destination->network;
+                $network = $this->database->getDestinationNetwork();
             } else {
                 $network = $this->database->destination->network;
             }

--- a/app/Livewire/Project/Application/ComposeServiceBackups.php
+++ b/app/Livewire/Project/Application/ComposeServiceBackups.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Livewire\Project\Application;
+
+use App\Models\Application;
+use App\Models\ServiceDatabase;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Component;
+
+/**
+ * Manages scheduled backup configuration for database services within
+ * a Docker Compose (GitHub App / dockercompose buildpack) Application deployment.
+ *
+ * This component mirrors the functionality of the Service-based DatabaseBackups
+ * component but targets Application-owned ServiceDatabase records.
+ */
+class ComposeServiceBackups extends Component
+{
+    use AuthorizesRequests;
+
+    public ?Application $application = null;
+
+    public ?ServiceDatabase $serviceDatabase = null;
+
+    public array $parameters;
+
+    public array $query;
+
+    public bool $isImportSupported = false;
+
+    protected $listeners = ['refreshScheduledBackups' => '$refresh'];
+
+    public function mount()
+    {
+        try {
+            $this->parameters = get_route_parameters();
+            $this->query = request()->query();
+
+            $this->application = Application::whereUuid($this->parameters['application_uuid'])->first();
+            if (! $this->application || $this->application->build_pack !== 'dockercompose') {
+                return redirect()->route('dashboard');
+            }
+            $this->authorize('view', $this->application);
+
+            $serviceName = $this->parameters['service_name'];
+            $this->serviceDatabase = ServiceDatabase::where([
+                'name' => $serviceName,
+                'application_id' => $this->application->id,
+            ])->first();
+
+            if (! $this->serviceDatabase) {
+                return redirect()->route('project.application.configuration', [
+                    'project_uuid' => $this->parameters['project_uuid'],
+                    'environment_uuid' => $this->parameters['environment_uuid'],
+                    'application_uuid' => $this->parameters['application_uuid'],
+                ]);
+            }
+
+            if (! $this->serviceDatabase->isBackupSolutionAvailable()) {
+                return redirect()->route('project.application.configuration', $this->parameters);
+            }
+
+            // Check if import/restore is supported for this database type
+            $dbType = $this->serviceDatabase->databaseType();
+            $supportedTypes = ['mysql', 'mariadb', 'postgres', 'mongo'];
+            $this->isImportSupported = collect($supportedTypes)->contains(fn ($type) => str_contains($dbType, $type));
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function render()
+    {
+        return view('livewire.project.application.compose-service-backups');
+    }
+}

--- a/app/Livewire/Project/Database/BackupEdit.php
+++ b/app/Livewire/Project/Database/BackupEdit.php
@@ -157,7 +157,7 @@ class BackupEdit extends Component
         try {
             $server = null;
             if ($this->backup->database instanceof \App\Models\ServiceDatabase) {
-                $server = $this->backup->database->service->destination->server;
+                $server = $this->backup->database->getServer();
             } elseif ($this->backup->database->destination && $this->backup->database->destination->server) {
                 $server = $this->backup->database->destination->server;
             }
@@ -184,6 +184,16 @@ class BackupEdit extends Component
 
             if ($this->backup->database->getMorphClass() === \App\Models\ServiceDatabase::class) {
                 $serviceDatabase = $this->backup->database;
+
+                // Application-owned compose database → redirect to compose database backups page
+                if ($serviceDatabase->application_id) {
+                    return redirect()->route('project.application.compose.database.backups', [
+                        'project_uuid' => $this->parameters['project_uuid'],
+                        'environment_uuid' => $this->parameters['environment_uuid'],
+                        'application_uuid' => $serviceDatabase->application->uuid,
+                        'service_name' => $serviceDatabase->name,
+                    ]);
+                }
 
                 return redirect()->route('project.service.database.backups', [
                     'project_uuid' => $this->parameters['project_uuid'],

--- a/app/Livewire/Project/Database/BackupExecutions.php
+++ b/app/Livewire/Project/Database/BackupExecutions.php
@@ -78,9 +78,10 @@ class BackupExecutions extends Component
             return;
         }
 
-        $server = $execution->scheduledDatabaseBackup->database->getMorphClass() === \App\Models\ServiceDatabase::class
-            ? $execution->scheduledDatabaseBackup->database->service->destination->server
-            : $execution->scheduledDatabaseBackup->database->destination->server;
+        $database = $execution->scheduledDatabaseBackup->database;
+        $server = $database->getMorphClass() === \App\Models\ServiceDatabase::class
+            ? $database->getServer()
+            : $database->destination->server;
 
         try {
             if ($execution->filename) {
@@ -182,7 +183,7 @@ class BackupExecutions extends Component
             $server = null;
 
             if ($this->database instanceof \App\Models\ServiceDatabase) {
-                $server = $this->database->service->destination->server;
+                $server = $this->database->getServer();
             } elseif ($this->database->destination && $this->database->destination->server) {
                 $server = $this->database->destination->server;
             }

--- a/app/Models/ScheduledDatabaseBackup.php
+++ b/app/Models/ScheduledDatabaseBackup.php
@@ -67,8 +67,7 @@ class ScheduledDatabaseBackup extends BaseModel
     {
         if ($this->database) {
             if ($this->database instanceof ServiceDatabase) {
-                $destination = data_get($this->database->service, 'destination');
-                $server = data_get($destination, 'server');
+                $server = $this->database->getServer();
             } else {
                 $destination = data_get($this->database, 'destination');
                 $server = data_get($destination, 'server');

--- a/app/Models/ServiceDatabase.php
+++ b/app/Models/ServiceDatabase.php
@@ -27,7 +27,10 @@ class ServiceDatabase extends BaseModel
 
     public static function ownedByCurrentTeamAPI(int $teamId)
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', $teamId)->orderBy('name');
+        return ServiceDatabase::where(function ($query) use ($teamId) {
+            $query->whereHas('service.environment.project.team', fn ($q) => $q->where('id', $teamId))
+                ->orWhereHas('application.environment.project.team', fn ($q) => $q->where('id', $teamId));
+        })->orderBy('name');
     }
 
     /**
@@ -36,7 +39,12 @@ class ServiceDatabase extends BaseModel
      */
     public static function ownedByCurrentTeam()
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', currentTeam()->id)->orderBy('name');
+        $teamId = currentTeam()->id;
+
+        return ServiceDatabase::where(function ($query) use ($teamId) {
+            $query->whereHas('service.environment.project.team', fn ($q) => $q->where('id', $teamId))
+                ->orWhereHas('application.environment.project.team', fn ($q) => $q->where('id', $teamId));
+        })->orderBy('name');
     }
 
     /**
@@ -49,10 +57,71 @@ class ServiceDatabase extends BaseModel
         });
     }
 
+    /**
+     * Get the parent resource — either a Service or Application.
+     */
+    public function getParentResource(): Service|Application|null
+    {
+        if ($this->application_id) {
+            return $this->application;
+        }
+
+        return $this->service;
+    }
+
+    /**
+     * Get the server for this database (works for both Service and Application parents).
+     */
+    public function getServer(): ?Server
+    {
+        if ($this->application_id) {
+            return $this->application?->destination?->server;
+        }
+
+        return $this->service?->destination?->server;
+    }
+
+    /**
+     * Get the Docker network for this database.
+     */
+    public function getDestinationNetwork(): ?string
+    {
+        if ($this->application_id) {
+            return $this->application?->destination?->network;
+        }
+
+        return $this->service?->destination?->network;
+    }
+
+    /**
+     * Get the container name for this database.
+     */
+    public function getContainerName(): string
+    {
+        $parentUuid = $this->application_id
+            ? $this->application?->uuid
+            : $this->service?->uuid;
+
+        return "{$this->name}-{$parentUuid}";
+    }
+
+    /**
+     * Get the parent UUID (service or application).
+     */
+    public function getParentUuid(): ?string
+    {
+        if ($this->application_id) {
+            return $this->application?->uuid;
+        }
+
+        return $this->service?->uuid;
+    }
+
     public function restart()
     {
-        $container_id = $this->name.'-'.$this->service->uuid;
-        remote_process(["docker restart {$container_id}"], $this->service->server);
+        $containerName = $this->getContainerName();
+        $server = $this->getServer();
+        remote_process(["docker restart {$containerName}"], $server);
     }
 
     public function isRunning()
@@ -114,8 +183,9 @@ class ServiceDatabase extends BaseModel
     public function getServiceDatabaseUrl()
     {
         $port = $this->public_port;
-        $realIp = $this->service->server->ip;
-        if ($this->service->server->isLocalhost() || isDev()) {
+        $server = $this->getServer();
+        $realIp = $server?->ip;
+        if ($server?->isLocalhost() || isDev()) {
             $realIp = base_ip();
         }
 
@@ -124,17 +194,30 @@ class ServiceDatabase extends BaseModel
 
     public function team()
     {
-        return data_get($this, 'environment.project.team');
+        if ($this->application_id) {
+            return data_get($this->application, 'environment.project.team');
+        }
+
+        return data_get($this->service, 'environment.project.team');
     }
 
     public function workdir()
     {
+        if ($this->application_id) {
+            return service_configuration_dir()."/{$this->application->uuid}";
+        }
+
         return service_configuration_dir()."/{$this->service->uuid}";
     }
 
     public function service()
     {
         return $this->belongsTo(Service::class);
+    }
+
+    public function application()
+    {
+        return $this->belongsTo(Application::class);
     }
 
     public function persistentStorages()

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -2418,6 +2418,28 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
             $isDatabase = isDatabaseImage($image, $service);
             data_set($service, 'is_database', $isDatabase);
 
+            // Create or update ServiceDatabase record for Application-based Docker Compose deployments.
+            // This enables backup scheduling for databases defined in GitHub App (dockercompose buildpack) deploys,
+            // mirroring the same logic used in the Service model path above.
+            if ($isDatabase && $pull_request_id === 0) {
+                $existingServiceDb = \App\Models\ServiceDatabase::where([
+                    'name' => $serviceName,
+                    'application_id' => $resource->id,
+                ])->first();
+                if (is_null($existingServiceDb)) {
+                    \App\Models\ServiceDatabase::create([
+                        'name' => $serviceName,
+                        'image' => $image->value(),
+                        'application_id' => $resource->id,
+                    ]);
+                } else {
+                    if ($existingServiceDb->image !== $image->value()) {
+                        $existingServiceDb->image = $image->value();
+                        $existingServiceDb->save();
+                    }
+                }
+            }
+
             // Collect/create/update networks
             if ($serviceNetworks->count() > 0) {
                 foreach ($serviceNetworks as $networkName => $networkDetails) {
@@ -2813,6 +2835,19 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
         data_forget($resource, 'environment_variables');
         data_forget($resource, 'environment_variables_preview');
         $resource->save();
+
+        // Cleanup stale ServiceDatabase records for compose services that no longer exist.
+        // If a database service is removed or renamed in the compose file, its ServiceDatabase record
+        // (and any associated scheduled backups) should be removed to avoid orphaned backup jobs.
+        if ($pull_request_id === 0) {
+            $currentServiceNames = collect(data_get($yaml, 'services', []))->keys()->toArray();
+            \App\Models\ServiceDatabase::where('application_id', $resource->id)
+                ->whereNotIn('name', $currentServiceNames)
+                ->each(function ($staleServiceDb) {
+                    $staleServiceDb->scheduledBackups()->delete();
+                    $staleServiceDb->delete();
+                });
+        }
 
         return collect($finalServices);
     }

--- a/database/migrations/2026_02_25_100000_add_application_id_to_service_databases.php
+++ b/database/migrations/2026_02_25_100000_add_application_id_to_service_databases.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            // Make service_id nullable to support Application-owned compose databases
+            $table->unsignedBigInteger('service_id')->nullable()->change();
+
+            // Add application_id for Docker Compose (GitHub App buildpack) deployments
+            $table->unsignedBigInteger('application_id')->nullable()->after('service_id');
+            $table->foreign('application_id')->references('id')->on('applications')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->dropForeign(['application_id']);
+            $table->dropColumn('application_id');
+
+            // Restore service_id to non-nullable
+            $table->unsignedBigInteger('service_id')->nullable(false)->change();
+        });
+    }
+};

--- a/resources/views/livewire/project/application/compose-service-backups.blade.php
+++ b/resources/views/livewire/project/application/compose-service-backups.blade.php
@@ -1,0 +1,44 @@
+<div>
+    <x-slot:title>
+        {{ data_get_str($application, 'name')->limit(10) }} >
+        {{ data_get_str($serviceDatabase, 'name')->limit(10) }} > Backups | Coolify
+    </x-slot>
+    <livewire:project.application.heading :application="$application" />
+    <div class="flex flex-col h-full gap-8 sm:flex-row">
+        <div class="sub-menu-wrapper">
+            <a class="sub-menu-item"
+                {{ wireNavigate() }}
+                href="{{ route('project.application.configuration', $parameters) }}">
+                <svg xmlns="http://www.w3.org/2000/svg" class="sub-menu-item-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+                </svg>
+                <span class="menu-item-label">Back to Application</span>
+            </a>
+            <div class="px-4 py-2 text-xs font-semibold uppercase text-neutral-500 dark:text-neutral-400">
+                {{ $serviceDatabase->name }}
+            </div>
+            <a class="sub-menu-item menu-item-active">
+                <span class="menu-item-label">Backups</span>
+            </a>
+        </div>
+        <div class="w-full">
+            <div class="flex gap-2">
+                <h2 class="pb-4">Scheduled Backups</h2>
+                @can('update', $application)
+                    <x-modal-input buttonTitle="+ Add" title="New Scheduled Backup">
+                        <livewire:project.database.create-scheduled-backup :database="$serviceDatabase" />
+                    </x-modal-input>
+                @endcan
+            </div>
+            <div class="pb-4">
+                <p class="text-sm text-neutral-500 dark:text-neutral-400">
+                    Backing up the <strong>{{ $serviceDatabase->name }}</strong> database service
+                    from the <strong>{{ $application->name }}</strong> Docker Compose deployment.
+                    <br>
+                    <span class="text-warning">Note:</span> Backups will pause automatically if a redeployment is in progress.
+                </p>
+            </div>
+            <livewire:project.database.scheduled-backups :database="$serviceDatabase" />
+        </div>
+    </div>
+</div>

--- a/resources/views/livewire/project/application/configuration.blade.php
+++ b/resources/views/livewire/project/application/configuration.blade.php
@@ -54,6 +54,22 @@
                 <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
                     href="{{ route('project.application.healthcheck', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Healthcheck</span></a>
             @endif
+            @if ($application->build_pack === 'dockercompose')
+                @php
+                    $composeDbCount = \App\Models\ServiceDatabase::where('application_id', $application->id)->count();
+                @endphp
+                @if ($composeDbCount > 0)
+                    <div class="px-4 py-1 text-xs font-semibold uppercase text-neutral-500 dark:text-neutral-400">Database Backups</div>
+                    @foreach (\App\Models\ServiceDatabase::where('application_id', $application->id)->get() as $composeDb)
+                        @if ($composeDb->isBackupSolutionAvailable())
+                            <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                                href="{{ route('project.application.compose.database.backups', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid, 'service_name' => $composeDb->name]) }}">
+                                <span class="menu-item-label">{{ $composeDb->name }}</span>
+                            </a>
+                        @endif
+                    @endforeach
+                @endif
+            @endif
             <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
                 href="{{ route('project.application.rollback', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Rollback</span></a>
             <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,6 +16,7 @@ use App\Livewire\Notifications\Slack as NotificationSlack;
 use App\Livewire\Notifications\Telegram as NotificationTelegram;
 use App\Livewire\Notifications\Webhook as NotificationWebhook;
 use App\Livewire\Profile\Index as ProfileIndex;
+use App\Livewire\Project\Application\ComposeServiceBackups;
 use App\Livewire\Project\Application\Configuration as ApplicationConfiguration;
 use App\Livewire\Project\Application\Deployment\Index as DeploymentIndex;
 use App\Livewire\Project\Application\Deployment\Show as DeploymentShow;
@@ -209,6 +210,10 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/tags', ApplicationConfiguration::class)->name('project.application.tags');
         Route::get('/danger', ApplicationConfiguration::class)->name('project.application.danger');
 
+        // Database backups for compose services (dockercompose buildpack)
+        Route::get('/compose-databases/{service_name}/backups', ComposeServiceBackups::class)
+            ->name('project.application.compose.database.backups');
+
         Route::get('/deployment', DeploymentIndex::class)->name('project.application.deployment.index');
         Route::get('/deployment/{deployment_uuid}', DeploymentShow::class)->name('project.application.deployment.show');
         Route::get('/logs', Logs::class)->name('project.application.logs');
@@ -328,7 +333,7 @@ Route::middleware(['auth'])->group(function () {
             }
             $filename = data_get($execution, 'filename');
             if ($execution->scheduledDatabaseBackup->database->getMorphClass() === \App\Models\ServiceDatabase::class) {
-                $server = $execution->scheduledDatabaseBackup->database->service->destination->server;
+                $server = $execution->scheduledDatabaseBackup->database->getServer();
             } else {
                 $server = $execution->scheduledDatabaseBackup->database->destination->server;
             }


### PR DESCRIPTION
## What does this PR do?

Fixes #7528 — database services in Docker Compose files deployed via GitHub App (dockercompose buildpack) are now detected, registered as `ServiceDatabase` records, and fully available for backup scheduling — including the UI, deployment conflict protection, and automatic cleanup on compose changes.

/claim #7528

---

## Problem

When deploying via GitHub App (`dockercompose` buildpack), database services in the compose file were **not** being detected and `ServiceDatabase` records were **not** being created. This meant automated backups were impossible for databases defined in GitHub App Docker Compose deployments.

The `Empty Docker Compose` / one-click Services path already worked correctly.

### Root Cause

`parseDockerComposeFile()` has two separate code paths:

| Path | Calls `isDatabaseImage()`? | Creates `ServiceDatabase`? |
|---|---|---|
| Service model path (lines ~1400) | ✅ Yes | ✅ Yes |
| Application model path (lines ~2416) | ✅ Yes | ❌ **No** — only set a flag |

The `service_databases` table had a non-nullable `service_id` FK, making it structurally impossible to associate a `ServiceDatabase` with an `Application` resource.

---

## Solution

This PR addresses **all three** requirements raised in the pinned comment:

### 1. Database schema + backend (ServiceDatabase creation)

- **Migration**: Makes `service_id` nullable; adds nullable `application_id` FK → `applications`
- **`parseDockerComposeFile()` Application path**: After `isDatabaseImage()` detection, creates/updates `ServiceDatabase` records linked via `application_id` (PR deployments excluded, mirrors Service path logic exactly)
- **`ServiceDatabase` model**: Added `application()` relationship (`belongsTo Application`); helper methods `getParentResource()`, `getServer()`, `getContainerName()`, `getDestinationNetwork()`, `getParentUuid()`; updated `ownedByCurrentTeam()` to include application-owned databases

### 2. Scheduled Backup config & UI

- **New route**: `GET /compose-databases/{service_name}/backups` → `project.application.compose.database.backups`
- **New Livewire component**: `App\Livewire\Project\Application\ComposeServiceBackups`
- **New Blade view**: `livewire/project/application/compose-service-backups.blade.php` — reuses existing `livewire:project.database.scheduled-backups` and `livewire:project.database.create-scheduled-backup` components, no duplication
- **Application config sidebar**: Shows a **Database Backups** section with a link per backup-capable database service when `build_pack === 'dockercompose'`

### 3. Overlapping Re-deployments protection

- **`ApplicationDeploymentJob`**: Before starting a deployment, checks for any `running` `ScheduledDatabaseBackupExecution` linked to this application's compose databases. If found, cancels the deployment with a clear log message — user retries after backup completes.
- **`DatabaseBackupJob`**: Before running a backup, checks if a deployment is `queued` or `in_progress` for the parent application. If so, skips the backup run (logged). Both guards are symmetric.

### 4. Compose Changes cleanup

After `parseDockerComposeFile()` finishes processing the Application path, any `ServiceDatabase` records whose `name` is no longer present in the current compose services list are deleted along with their associated `ScheduledDatabaseBackup` records. This prevents orphaned backup jobs running against containers that no longer exist.

### 5. Downstream fixes

All code that previously assumed `serviceDatabase->service->` now uses the new helper methods, so both Service-owned and Application-owned databases work transparently:

- `DatabaseBackupJob` — server, container name, network resolution
- `BackupExecutions` — server resolution
- `BackupEdit` — server resolution + post-delete redirect
- `ScheduledDatabaseBackup.server()`
- `StartDatabaseProxy`
- `routes/web.php` download.backup handler

---

## Files Changed

| File | Change |
|---|---|
| `database/migrations/2026_02_25_100000_add_application_id_to_service_databases.php` | New migration |
| `app/Models/ServiceDatabase.php` | Application relationship + helper methods |
| `bootstrap/helpers/shared.php` | DB creation + stale cleanup in Application path |
| `app/Jobs/ApplicationDeploymentJob.php` | Backup conflict guard |
| `app/Jobs/DatabaseBackupJob.php` | Deployment conflict guard + helper usage |
| `app/Livewire/Project/Application/ComposeServiceBackups.php` | New Livewire component |
| `resources/views/livewire/project/application/compose-service-backups.blade.php` | New Blade view |
| `resources/views/livewire/project/application/configuration.blade.php` | DB Backups sidebar section |
| `routes/web.php` | New route + server helper fix |
| `app/Livewire/Project/Database/BackupEdit.php` | Helper usage + redirect fix |
| `app/Livewire/Project/Database/BackupExecutions.php` | Helper usage |
| `app/Models/ScheduledDatabaseBackup.php` | Helper usage in server() |
| `app/Actions/Database/StartDatabaseProxy.php` | Helper usage |

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Before / After

| Deployment Method | Creates ServiceDatabase | Backup UI | Re-deploy lock | Compose cleanup |
|---|---|---|---|---|
| Empty Docker Compose (Service) | ✅ unchanged | ✅ unchanged | n/a | ✅ unchanged |
| GitHub App dockercompose (Application) | ❌ → **✅** | ❌ → **✅** | ❌ → **✅** | ❌ → **✅** |
| One-click Services | ✅ unchanged | ✅ unchanged | n/a | ✅ unchanged |