### PR TITLE
fix(api): add team authorization to domains_by_server endpoint

### DIFF
--- a/app/Http/Controllers/Api/ServersController.php
+++ b/app/Http/Controllers/Api/ServersController.php
@@ -290,9 +290,12 @@ class ServersController extends Controller
         }
         $uuid = $request->get('uuid');
         if ($uuid) {
-            $domains = Application::getDomainsByUuid($uuid);
+            $application = Application::ownedByCurrentTeamAPI($teamId)->where('uuid', $uuid)->first();
+            if (! $application) {
+                return response()->json(['message' => 'Application not found.'], 404);
+            }
 
-            return response()->json(serializeApiResponse($domains));
+            return response()->json(serializeApiResponse($application->fqdns));
         }
         $projects = Project::where('team_id', $teamId)->get();
         $domains = collect();

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -1959,16 +1959,6 @@ class Application extends BaseModel
         }
     }
 
-    public static function getDomainsByUuid(string $uuid): array
-    {
-        $application = self::where('uuid', $uuid)->first();
-
-        if ($application) {
-            return $application->fqdns;
-        }
-
-        return [];
-    }
 
     public function getLimits(): array
     {

--- a/tests/Feature/DomainsByServerApiTest.php
+++ b/tests/Feature/DomainsByServerApiTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+
+    $this->token = $this->user->createToken('test-token', ['*'], $this->team->id);
+    $this->bearerToken = $this->token->plainTextToken;
+
+    $this->server = Server::factory()->create(['team_id' => $this->team->id]);
+    $this->destination = StandaloneDocker::factory()->create(['server_id' => $this->server->id]);
+    $this->project = Project::factory()->create(['team_id' => $this->team->id]);
+    $this->environment = Environment::factory()->create(['project_id' => $this->project->id]);
+});
+
+function authHeaders(): array
+{
+    return [
+        'Authorization' => 'Bearer '.test()->bearerToken,
+    ];
+}
+
+test('returns domains for own team application via uuid query param', function () {
+    $application = Application::factory()->create([
+        'fqdn' => 'https://my-app.example.com',
+        'environment_id' => $this->environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => $this->destination->getMorphClass(),
+    ]);
+
+    $response = $this->withHeaders(authHeaders())
+        ->getJson("/api/v1/servers/{$this->server->uuid}/domains?uuid={$application->uuid}");
+
+    $response->assertOk();
+    $response->assertJsonFragment(['my-app.example.com']);
+});
+
+test('returns 404 when application uuid belongs to another team', function () {
+    $otherTeam = Team::factory()->create();
+    $otherUser = User::factory()->create();
+    $otherTeam->members()->attach($otherUser->id, ['role' => 'owner']);
+
+    $otherServer = Server::factory()->create(['team_id' => $otherTeam->id]);
+    $otherDestination = StandaloneDocker::factory()->create(['server_id' => $otherServer->id]);
+    $otherProject = Project::factory()->create(['team_id' => $otherTeam->id]);
+    $otherEnvironment = Environment::factory()->create(['project_id' => $otherProject->id]);
+
+    $otherApplication = Application::factory()->create([
+        'fqdn' => 'https://secret-app.internal.company.com',
+        'environment_id' => $otherEnvironment->id,
+        'destination_id' => $otherDestination->id,
+        'destination_type' => $otherDestination->getMorphClass(),
+    ]);
+
+    $response = $this->withHeaders(authHeaders())
+        ->getJson("/api/v1/servers/{$this->server->uuid}/domains?uuid={$otherApplication->uuid}");
+
+    $response->assertNotFound();
+    $response->assertJson(['message' => 'Application not found.']);
+});
+
+test('returns 404 for nonexistent application uuid', function () {
+    $response = $this->withHeaders(authHeaders())
+        ->getJson("/api/v1/servers/{$this->server->uuid}/domains?uuid=nonexistent-uuid");
+
+    $response->assertNotFound();
+    $response->assertJson(['message' => 'Application not found.']);
+});


### PR DESCRIPTION
## Summary
- Add team-based authorization check to the `domains_by_server` endpoint to prevent cross-team domain enumeration
- Query application only from the current team's resources using `ownedByCurrentTeamAPI()`
- Return 404 when application is not found or does not belong to the requesting team
- Remove now-unused `getDomainsByUuid()` static method from Application model
- Add comprehensive test coverage for team authorization and edge cases

## Breaking Changes
The API now returns 404 for applications that don't belong to the current team (previously would return the domains). This is the intended security behavior.