### PR TITLE
fix(soketi): make host binding configurable for IPv6 support

### DIFF
--- a/docker-compose-maxio.dev.yml
+++ b/docker-compose-maxio.dev.yml
@@ -78,6 +78,7 @@ services:
       SOKETI_DEFAULT_APP_ID: "${PUSHER_APP_ID:-coolify}"
       SOKETI_DEFAULT_APP_KEY: "${PUSHER_APP_KEY:-coolify}"
       SOKETI_DEFAULT_APP_SECRET: "${PUSHER_APP_SECRET:-coolify}"
+      SOKETI_HOST: "${SOKETI_HOST:-0.0.0.0}"
     healthcheck:
       test: [ "CMD-SHELL", "curl -fsS http://127.0.0.1:6001/ready && curl -fsS http://127.0.0.1:6002/ready || exit 1" ]
       interval: 5s

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -78,6 +78,7 @@ services:
       SOKETI_DEFAULT_APP_ID: "${PUSHER_APP_ID:-coolify}"
       SOKETI_DEFAULT_APP_KEY: "${PUSHER_APP_KEY:-coolify}"
       SOKETI_DEFAULT_APP_SECRET: "${PUSHER_APP_SECRET:-coolify}"
+      SOKETI_HOST: "${SOKETI_HOST:-0.0.0.0}"
     healthcheck:
       test: [ "CMD-SHELL", "curl -fsS http://127.0.0.1:6001/ready && curl -fsS http://127.0.0.1:6002/ready || exit 1" ]
       interval: 5s

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -72,6 +72,7 @@ services:
       SOKETI_DEFAULT_APP_ID: "${PUSHER_APP_ID}"
       SOKETI_DEFAULT_APP_KEY: "${PUSHER_APP_KEY}"
       SOKETI_DEFAULT_APP_SECRET: "${PUSHER_APP_SECRET}"
+      SOKETI_HOST: "${SOKETI_HOST:-0.0.0.0}"
     healthcheck:
       test: [ "CMD-SHELL", "wget -qO- http://127.0.0.1:6001/ready && wget -qO- http://127.0.0.1:6002/ready || exit 1" ]
       interval: 5s

--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -113,6 +113,7 @@ services:
       SOKETI_DEFAULT_APP_ID: "${PUSHER_APP_ID}"
       SOKETI_DEFAULT_APP_KEY: "${PUSHER_APP_KEY}"
       SOKETI_DEFAULT_APP_SECRET: "${PUSHER_APP_SECRET}"
+      SOKETI_HOST: "${SOKETI_HOST:-0.0.0.0}"
     healthcheck:
       test: [ "CMD-SHELL", "wget -qO- http://127.0.0.1:6001/ready && wget -qO- http://127.0.0.1:6002/ready || exit 1" ]
       interval: 5s

--- a/other/nightly/docker-compose.prod.yml
+++ b/other/nightly/docker-compose.prod.yml
@@ -72,6 +72,7 @@ services:
       SOKETI_DEFAULT_APP_ID: "${PUSHER_APP_ID}"
       SOKETI_DEFAULT_APP_KEY: "${PUSHER_APP_KEY}"
       SOKETI_DEFAULT_APP_SECRET: "${PUSHER_APP_SECRET}"
+      SOKETI_HOST: "${SOKETI_HOST:-0.0.0.0}"
     healthcheck:
       test: [ "CMD-SHELL", "wget -qO- http://127.0.0.1:6001/ready && wget -qO- http://127.0.0.1:6002/ready || exit 1" ]
       interval: 5s

--- a/other/nightly/docker-compose.windows.yml
+++ b/other/nightly/docker-compose.windows.yml
@@ -113,6 +113,7 @@ services:
       SOKETI_DEFAULT_APP_ID: "${PUSHER_APP_ID}"
       SOKETI_DEFAULT_APP_KEY: "${PUSHER_APP_KEY}"
       SOKETI_DEFAULT_APP_SECRET: "${PUSHER_APP_SECRET}"
+      SOKETI_HOST: "${SOKETI_HOST:-0.0.0.0}"
     healthcheck:
       test: [ "CMD-SHELL", "wget -qO- http://127.0.0.1:6001/ready && wget -qO- http://127.0.0.1:6002/ready || exit 1" ]
       interval: 5s


### PR DESCRIPTION
## Summary

Soketi binds to `0.0.0.0:6001` (IPv4 only) by default. When a reverse proxy or tunnel (e.g. Cloudflare Tunnel / `cloudflared`) resolves `localhost` to `[::1]` (IPv6), WebSocket connections to Soketi are refused — while the terminal server on port 6002 works fine because Node.js defaults to dual-stack (`::`) binding.

Hardcoding `SOKETI_HOST="::"` would fix IPv6 but **breaks Soketi on hosts with IPv6 disabled** (`ipv6.disable=1` kernel param or Docker without IPv6 support), causing an `EAFNOSUPPORT` error and preventing startup.

## Solution

Add a configurable `SOKETI_HOST` env var with a safe default:

```yaml
SOKETI_HOST: "${SOKETI_HOST:-0.0.0.0}"
```

- **Default behavior unchanged** — Soketi binds `0.0.0.0:6001` (IPv4), works everywhere
- **Opt-in dual-stack** — users add `SOKETI_HOST=::` to `.env` to enable IPv6 support
- **Zero risk** of breaking existing installations

## Files changed

Added `SOKETI_HOST: "${SOKETI_HOST:-0.0.0.0}"` to the soketi service environment in all 6 docker-compose files:
- `docker-compose.prod.yml`
- `docker-compose.dev.yml`
- `docker-compose.windows.yml`
- `docker-compose-maxio.dev.yml`
- `other/nightly/docker-compose.prod.yml`
- `other/nightly/docker-compose.windows.yml`

## Test plan

- [ ] Default (no `.env` change): `netstat -tlnp` inside container shows `0.0.0.0:6001` — unchanged behavior
- [ ] With `SOKETI_HOST=::` in `.env`: shows `:::6001` — dual-stack, IPv6 connections succeed
- [ ] Healthchecks (`127.0.0.1:6001`) pass in both modes

Closes #8584