### PR TITLE
fix(ssh): automatically fix SSH directory permissions during upgrade

### DIFF
--- a/app/Models/PrivateKey.php
+++ b/app/Models/PrivateKey.php
@@ -237,7 +237,7 @@ class PrivateKey extends BaseModel
         $testSuccess = $disk->put($testFilename, 'test');
 
         if (! $testSuccess) {
-            throw new \Exception('SSH keys storage directory is not writable');
+            throw new \Exception('SSH keys storage directory is not writable. Run on the host: sudo chown -R 9999 /data/coolify/ssh && sudo chmod -R 700 /data/coolify/ssh && docker restart coolify');
         }
 
         // Clean up test file

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -141,6 +141,15 @@ else
     log "Network 'coolify' already exists"
 fi
 
+# Fix SSH directory ownership if not owned by container user UID 9999 (fixes #6621)
+# Only changes owner — preserves existing group to respect custom setups
+SSH_OWNER=$(stat -c '%u' /data/coolify/ssh 2>/dev/null || echo "unknown")
+if [ "$SSH_OWNER" != "9999" ]; then
+    log "Fixing SSH directory ownership (was owned by UID $SSH_OWNER)"
+    chown -R 9999 /data/coolify/ssh
+    chmod -R 700 /data/coolify/ssh
+fi
+
 # Check if Docker config file exists
 DOCKER_CONFIG_MOUNT=""
 if [ -f /root/.docker/config.json ]; then

--- a/tests/Unit/PrivateKeyStorageTest.php
+++ b/tests/Unit/PrivateKeyStorageTest.php
@@ -112,7 +112,7 @@ uZx9iFkCELtxrh31QJ68AAAAEXNhaWxANzZmZjY2ZDJlMmRkAQIDBA==
             );
 
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('SSH keys storage directory is not writable');
+        $this->expectExceptionMessage('SSH keys storage directory is not writable. Run on the host: sudo chown -R 9999 /data/coolify/ssh && sudo chmod -R 700 /data/coolify/ssh && docker restart coolify');
 
         PrivateKey::createAndStore([
             'name' => 'Test Key',


### PR DESCRIPTION
## Summary

- Automatically fix SSH directory ownership and permissions during upgrade to prevent the "SSH keys storage directory is not writable" error
- Add helpful instructions to the error message if the issue still occurs
- Update tests to match the new error message

## Detailed Changes

- **scripts/upgrade.sh**: Added automatic ownership fixing for `/data/coolify/ssh` if not owned by UID 9999 (container user)
- **app/Models/PrivateKey.php**: Enhanced error message with troubleshooting instructions
- **tests/Unit/PrivateKeyStorageTest.php**: Updated test assertion to match new error message

## Fixes

Resolves #6621 - Prevents deployment failures due to incorrect SSH directory permissions after upgrade

---

Fixes #6621