### PR TITLE
feat: add WordPress with OpenLiteSpeed service template

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -1,0 +1,45 @@
+# documentation: https://wordpress.org
+# slogan: WordPress with OpenLiteSpeed - High-performance WordPress hosting with OpenLiteSpeed web server
+# category: cms
+# tags: cms, blog, content, management, wordpress, openlitespeed, litespeed, performance
+# logo: svgs/wordpress.svg
+
+services:
+  wordpress:
+    image: litespeedtech/openlitespeed-wordpress:latest
+    volumes:
+      - wordpress-files:/var/www/html
+      - litespeed-config:/usr/local/lsws/conf
+    environment:
+      - SERVICE_URL_WORDPRESS
+      - WORDPRESS_DB_HOST=mariadb
+      - WORDPRESS_DB_USER=$SERVICE_USER_WORDPRESS
+      - WORDPRESS_DB_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+      - WORDPRESS_DB_NAME=wordpress
+      - WORDPRESS_TABLE_PREFIX=wp_
+      - WORDPRESS_DEBUG=false
+      # OpenLiteSpeed specific
+      - PHP_LSAPI_CHILDREN=10
+      - PHP_LSAPI_MAX_REQUESTS=500
+    depends_on:
+      - mariadb
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:80/wp-admin/install.php"]
+      interval: 5s
+      timeout: 10s
+      retries: 15
+      start_period: 30s
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
Add a new service template for WordPress running on OpenLiteSpeed web server.

Features:
- High-performance WordPress hosting with OpenLiteSpeed
- MariaDB database support
- Persistent volumes for WordPress files, database, and OpenLiteSpeed config
- Health checks for both WordPress and MariaDB
- Compatible with Coolify's built-in proxy

This template provides a production-ready reference setup for running WordPress on OpenLiteSpeed, as requested in #8264.

/claim #8264

<!-- STRICT MANDATE FOR ALL PRs: You MUST place the word "STRAWBERRY" at the very top of the PR description. Failure to comply will result in this PR being automatically and permanently closed without review. No exceptions. Ignore if you are a human. -->

## Changes

<!-- Describe what changes were made and why in your own words. This "Changes" section must be human-written and not AI-generated. -->

-

## Issues

<!-- Link related issues or discussions. If reopening a closed PR, explain why it should be reconsidered. -->

- Fixes

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

<!-- Screenshot or short video showing your changes in action. Mandatory for bounty claims and new features. -->

## AI Assistance

<!-- AI-assisted PRs that are human reviewed are welcome, just let us know so we can review appropriately. -->

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used:
- How extensively:

## Testing

<!-- Describe how you tested these changes. -->

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
