### PR TITLE
fix: respect destination_uuid in API for applications and services

### DIFF
--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -1095,6 +1095,17 @@ class ApplicationsController extends Controller
             return response()->json(['message' => 'Server has multiple destinations and you do not set destination_uuid.'], 400);
         }
         $destination = $destinations->first();
+        if ($destinations->count() > 1 && $request->has('destination_uuid')) {
+            $destination = $destinations->where('uuid', $request->destination_uuid)->first();
+            if (! $destination) {
+                return response()->json([
+                    'message' => 'Validation failed.',
+                    'errors' => [
+                        'destination_uuid' => 'Provided destination_uuid does not belong to the specified server.',
+                    ],
+                ], 422);
+            }
+        }
         if ($type === 'public') {
             $validationRules = [
                 'git_repository' => ['string', 'required', new ValidGitRepositoryUrl],

--- a/app/Http/Controllers/Api/ServicesController.php
+++ b/app/Http/Controllers/Api/ServicesController.php
@@ -377,6 +377,17 @@ class ServicesController extends Controller
             return response()->json(['message' => 'Server has multiple destinations and you do not set destination_uuid.'], 400);
         }
         $destination = $destinations->first();
+        if ($destinations->count() > 1 && $request->has('destination_uuid')) {
+            $destination = $destinations->where('uuid', $request->destination_uuid)->first();
+            if (! $destination) {
+                return response()->json([
+                    'message' => 'Validation failed.',
+                    'errors' => [
+                        'destination_uuid' => 'Provided destination_uuid does not belong to the specified server.',
+                    ],
+                ], 422);
+            }
+        }
         $services = get_service_templates();
         $serviceKeys = $services->keys();
         if ($serviceKeys->contains($request->type)) {
@@ -543,6 +554,17 @@ class ServicesController extends Controller
                 return response()->json(['message' => 'Server has multiple destinations and you do not set destination_uuid.'], 400);
             }
             $destination = $destinations->first();
+            if ($destinations->count() > 1 && $request->has('destination_uuid')) {
+                $destination = $destinations->where('uuid', $request->destination_uuid)->first();
+                if (! $destination) {
+                    return response()->json([
+                        'message' => 'Validation failed.',
+                        'errors' => [
+                            'destination_uuid' => 'Provided destination_uuid does not belong to the specified server.',
+                        ],
+                    ], 422);
+                }
+            }
             if (! isBase64Encoded($request->docker_compose_raw)) {
                 return response()->json([
                     'message' => 'Validation failed.',


### PR DESCRIPTION
## Summary

- Fixes the API ignoring the `destination_uuid` parameter when creating applications or services, always deploying to the first destination on the server
- Applies the same fix pattern from PR #7002 (which fixed this for databases) to `ApplicationsController` and `ServicesController`
- Adds proper validation that returns a 422 error if the provided `destination_uuid` doesn't belong to the specified server

Fixes #8645

## Changes

| File | Method | Description |
|------|--------|-------------|
| `ApplicationsController.php` | `create_application()` | Filter destinations by `destination_uuid` when provided |
| `ServicesController.php` | `create_service()` | Filter destinations by `destination_uuid` when provided |
| `ServicesController.php` | `update_by_uuid()` | Filter destinations by `destination_uuid` when provided |

## Test plan

- [ ] Create a server with 2+ Docker network destinations in the UI
- [ ] Call the API to create an application specifying the **second** destination's UUID → verify it deploys to the correct destination (not the first one)
- [ ] Call the API to create a service specifying the **second** destination's UUID → verify it deploys to the correct destination
- [ ] Call the API with an **invalid** `destination_uuid` → verify a 422 validation error is returned
- [ ] Call the API with a **single** destination on the server (no `destination_uuid`) → verify it still works as before (uses the only destination)