### PR TITLE
fix: prevent scheduled task input fields from losing focus

### DIFF
--- a/app/Livewire/Project/Shared/ScheduledTask/Show.php
+++ b/app/Livewire/Project/Shared/ScheduledTask/Show.php
@@ -52,15 +52,6 @@ class Show extends Component
     #[Locked]
     public string $task_uuid;
 
-    public function getListeners()
-    {
-        $teamId = auth()->user()->currentTeam()->id;
-
-        return [
-            "echo-private:team.{$teamId},ServiceChecked" => '$refresh',
-        ];
-    }
-
     public function mount(string $task_uuid, string $project_uuid, string $environment_uuid, ?string $application_uuid = null, ?string $service_uuid = null)
     {
         try {


### PR DESCRIPTION
## Summary

- Fixes input fields on the Scheduled Tasks page losing focus every 10 seconds while editing
- Root cause: the `Show` component listened for the `ServiceChecked` Echo event with `$refresh`, causing a full re-render every time the heading component's `wire:poll.10000ms` triggered a status check
- The heading component (`project.service.heading` / `project.application.heading`) already handles status display independently as a separate Livewire component, so the task edit form does not need to re-render on status checks

Fixes #8647

## Changes

| File | Change |
|------|--------|
| `app/Livewire/Project/Shared/ScheduledTask/Show.php` | Remove `getListeners()` method that bound `ServiceChecked` → `$refresh` |

## Test plan

- [ ] Navigate to a service's Scheduled Tasks page
- [ ] Create or edit a scheduled task
- [ ] Click into any input field (Name, Command, Frequency, etc.)
- [ ] Type continuously for 30+ seconds — verify focus is **never** lost
- [ ] Verify the heading component still updates service status independently
- [ ] Verify the "Execute Now" button still appears when the resource is running