### PR TITLE
feat: add OAuth-only self-registration

### DIFF
--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -17,6 +17,13 @@ class ResetUserPassword implements ResetsUserPasswords
      */
     public function reset(User $user, array $input): void
     {
+        // Prevent OAuth-only users from setting a password
+        if ($user->oauth_only) {
+            throw \Illuminate\Validation\ValidationException::withMessages([
+                'email' => ['This account can only login via OAuth. Password reset is not available.'],
+            ]);
+        }
+
         Validator::make($input, [
             'password' => ['required', Password::defaults(), 'confirmed'],
         ])->validate();

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -22,13 +22,16 @@ class OauthController extends Controller
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                // Allow OAuth registration if either general registration is enabled
+                // OR OAuth-specific registration is enabled
+                if (! $settings->is_registration_enabled && ! $settings->is_oauth_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 
                 $user = User::create([
                     'name' => $oauthUser->name,
                     'email' => $oauthUser->email,
+                    'oauth_only' => $settings->is_oauth_registration_enabled && ! $settings->is_registration_enabled,
                 ]);
             }
             Auth::login($user);

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -15,6 +15,9 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $is_oauth_registration_enabled;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -41,6 +44,7 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_registration_enabled' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => 'nullable|string',
@@ -62,6 +66,7 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled ?? false;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -138,6 +143,7 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -27,6 +27,7 @@ class InstanceSettings extends Model
 
         'allowed_ip_ranges' => 'array',
         'is_auto_update_enabled' => 'boolean',
+        'is_oauth_registration_enabled' => 'boolean',
         'auto_update_frequency' => 'string',
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -53,6 +53,7 @@ class User extends Authenticatable implements SendsEmail
     protected $casts = [
         'email_verified_at' => 'datetime',
         'force_password_reset' => 'boolean',
+        'oauth_only' => 'boolean',
         'show_boarding' => 'boolean',
         'email_change_code_expires_at' => 'datetime',
     ];

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -67,6 +67,7 @@ class FortifyServiceProvider extends ServiceProvider
 
             return view('auth.login', [
                 'is_registration_enabled' => $settings->is_registration_enabled,
+                'is_oauth_registration_enabled' => $settings->is_oauth_registration_enabled,
                 'enabled_oauth_providers' => $enabled_oauth_providers,
             ]);
         });
@@ -74,6 +75,12 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::authenticateUsing(function (Request $request) {
             $email = strtolower($request->email);
             $user = User::where('email', $email)->with('teams')->first();
+
+            // Block OAuth-only users from password login
+            if ($user && $user->oauth_only) {
+                return null;
+            }
+
             if (
                 $user &&
                 Hash::check($request->password, $user->password)

--- a/database/migrations/2026_02_27_120000_add_oauth_registration_settings_to_instance_settings_table.php
+++ b/database/migrations/2026_02_27_120000_add_oauth_registration_settings_to_instance_settings_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_registration_enabled')->default(false)->after('is_registration_enabled');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn('is_oauth_registration_enabled');
+        });
+    }
+};

--- a/database/migrations/2026_02_27_120001_add_oauth_only_to_users_table.php
+++ b/database/migrations/2026_02_27_120001_add_oauth_only_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('oauth_only')->default(false)->after('force_password_reset');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('oauth_only');
+        });
+    }
+};

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -70,6 +70,10 @@
                             class="block w-full text-center py-3 px-4 rounded-lg border border-neutral-300 dark:border-coolgray-400 font-medium hover:border-coollabs dark:hover:border-warning transition-colors">
                             {{ __('auth.register_now') }}
                         </a>
+                    @elseif ($is_oauth_registration_enabled ?? false)
+                        <div class="mt-6 text-center text-sm text-neutral-500 dark:text-neutral-400">
+                            New users can register via OAuth providers below.
+                        </div>
                     @else
                         <div class="mt-6 text-center text-sm text-neutral-500 dark:text-neutral-400">
                             {{ __('auth.registration_disabled') }}

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -22,6 +22,11 @@
                             label="Registration Allowed" />
                     </div>
                     <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_registration_enabled"
+                            helper="Allow users to self-register via OAuth providers even when general registration is disabled. Users registered this way will only be able to login via OAuth (no password)."
+                            label="OAuth Registration Allowed" />
+                    </div>
+                    <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"
                             helper="Opt out of reporting this instance to coolify.io's installation count. No other data is collected."
                             label="Do Not Track" />


### PR DESCRIPTION
## Description

Implements OAuth-only self-registration feature as requested in #8042.

### What this PR does:

1. **New setting 'OAuth Registration Allowed'** in Settings > Advanced
   - When enabled, allows users to self-register via OAuth even when general registration is disabled
   - Users registered this way are marked as `oauth_only`

2. **OAuth-only users have restrictions:**
   - Cannot login with password (must use OAuth)
   - Cannot reset password
   - Must continue using the OAuth provider they registered with

3. **Database changes:**
   - Added `is_oauth_registration_enabled` boolean to `instance_settings` table
   - Added `oauth_only` boolean flag to `users` table

4. **UI updates:**
   - Login page shows helpful message when OAuth registration is enabled but general registration is disabled
   - New checkbox in Settings > Advanced for enabling OAuth Registration

### Use Case

This allows organizations to:
- Control who can access Coolify through identity providers like Authentik
- Disable general email/password registration while still allowing OAuth self-registration  
- Suspend access across multiple Coolify instances by deactivating users in the identity provider
- Prevent OAuth users from creating passwords (ensuring single point of access control)

### How to test

1. Run migrations to add the new database columns
2. Go to Settings > Advanced
3. Disable 'Registration Allowed' and enable 'OAuth Registration Allowed'
4. Configure an OAuth provider in Settings > OAuth
5. Log out and verify:
   - Regular registration is disabled
   - Login page shows OAuth providers with 'New users can register via OAuth' message
   - New users can register via OAuth and are marked as `oauth_only`
   - These users cannot reset password or login with email/password

### Related Issues

Closes #8042

/claim #8042