### PR TITLE
fix: resync stale SSH key files before command execution

### DIFF
--- a/app/Helpers/SshMultiplexingHelper.php
+++ b/app/Helpers/SshMultiplexingHelper.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Facades\Storage;
 
 class SshMultiplexingHelper
 {
@@ -158,7 +159,7 @@ class SshMultiplexingHelper
         $sshConfig = self::serverSshConfiguration($server);
         $sshKeyLocation = $sshConfig['sshKeyLocation'];
 
-        self::validateSshKey($server->privateKey);
+        self::validateSshKey($server);
 
         $muxSocket = $sshConfig['muxFilename'];
 
@@ -201,14 +202,32 @@ class SshMultiplexingHelper
         return config('constants.ssh.mux_enabled') && ! config('constants.coolify.is_windows_docker_desktop');
     }
 
-    private static function validateSshKey(PrivateKey $privateKey): void
+    private static function validateSshKey(Server $server): void
     {
-        $keyLocation = $privateKey->getKeyLocation();
-        $checkKeyCommand = "ls $keyLocation 2>/dev/null";
-        $keyCheckProcess = Process::run($checkKeyCommand);
+        $privateKey = $server->privateKey;
+        if (! $privateKey instanceof PrivateKey) {
+            return;
+        }
 
-        if ($keyCheckProcess->exitCode() !== 0) {
+        $keyFile = "ssh_key@{$privateKey->uuid}";
+        $sshKeysDisk = Storage::disk('ssh-keys');
+
+        $missingKeyFile = ! $sshKeysDisk->exists($keyFile);
+        $mismatchedKeyFile = false;
+
+        if (! $missingKeyFile) {
+            $storedKey = (string) $sshKeysDisk->get($keyFile);
+            $expectedKey = (string) $privateKey->private_key;
+            $mismatchedKeyFile = ! hash_equals($expectedKey, $storedKey);
+        }
+
+        if ($missingKeyFile || $mismatchedKeyFile) {
             $privateKey->storeInFileSystem();
+
+            if ($mismatchedKeyFile) {
+                Storage::disk('ssh-mux')->delete($server->muxFilename());
+                self::clearConnectionMetadata($server);
+            }
         }
     }
 

--- a/tests/Unit/SshKeySyncValidationTest.php
+++ b/tests/Unit/SshKeySyncValidationTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Helpers\SshMultiplexingHelper;
+use App\Models\PrivateKey;
+use App\Models\Server;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class SshKeySyncValidationTest extends TestCase
+{
+    public function test_it_resyncs_out_of_sync_key_and_clears_mux_artifacts(): void
+    {
+        config(['app.key' => 'base64:'.base64_encode(random_bytes(32))]);
+        Storage::fake('ssh-keys');
+        Storage::fake('ssh-mux');
+
+        $privateKey = new PrivateKey;
+        $privateKey->uuid = 'private-key-uuid';
+        $privateKey->private_key = "correct-key\n";
+
+        $server = new Server;
+        $server->uuid = 'server-uuid';
+        $server->ip = '127.0.0.1';
+        $server->port = 22;
+        $server->user = 'root';
+        $server->setRelation('privateKey', $privateKey);
+
+        Storage::disk('ssh-keys')->put('ssh_key@private-key-uuid', "stale-key\n");
+        Storage::disk('ssh-mux')->put($server->muxFilename(), 'mux-socket-content');
+        Cache::put("ssh_mux_connection_time_{$server->uuid}", time(), 300);
+
+        $reflection = new \ReflectionMethod(SshMultiplexingHelper::class, 'validateSshKey');
+        $reflection->setAccessible(true);
+        $reflection->invoke(null, $server);
+
+        $this->assertSame("correct-key\n", Storage::disk('ssh-keys')->get('ssh_key@private-key-uuid'));
+        $this->assertFalse(Storage::disk('ssh-mux')->exists($server->muxFilename()));
+        $this->assertNull(Cache::get("ssh_mux_connection_time_{$server->uuid}"));
+    }
+}


### PR DESCRIPTION
/claim #7724

## Proposed changes
- Replace SSH key validation in `SshMultiplexingHelper` from shell `ls` existence-check to filesystem-backed sync validation.
- Compare the stored key file content with the encrypted DB key for the server private key.
- If the file is missing or out-of-sync, rewrite it via `storeInFileSystem()`.
- When out-of-sync content is detected, clear local mux artifacts (`ssh-mux` socket file + mux metadata cache) so the next command does not reuse stale connection state.

## Why this helps issue #7724
The sporadic auth failures are consistent with stale per-instance key files: some app instances can keep an older key file while DB has the latest key. This change forces each command path to reconcile key file content against DB before building the SSH command.

## Proof
- Added unit regression test: `tests/Unit/SshKeySyncValidationTest.php`
  - starts with stale key file content
  - invokes `validateSshKey`
  - asserts key file is rewritten to DB value
  - asserts mux socket + mux metadata are cleared
- Test run:
  - `php artisan test --compact tests/Unit/SshKeySyncValidationTest.php tests/Unit/SshMultiplexingDisableTest.php`

## Checklist
- [x] PR created against `v4.x`
- [x] Relevant unit tests executed for this change
- [x] Tests added to validate fix behavior
- [ ] Additional docs required
