### PR TITLE
feat: add server-level shared environment variables

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -1181,6 +1181,11 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         $coolify_envs->each(function ($item, $key) use ($envs) {
             $envs->push($key.'='.$item);
         });
+
+        // Inject server-level shared environment variables
+        // These are added before application variables so apps can override them
+        $this->inject_server_environment_variables($envs);
+
         if ($this->pull_request_id === 0) {
             // Generate SERVICE_ variables first for dockercompose
             if ($this->build_pack === 'dockercompose') {
@@ -1465,6 +1470,12 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             $envs_dict[$key] = escapeBashEnvValue($item);
         }
 
+        // 2.5 Add server-level shared environment variables (can be overridden by user vars)
+        $serverEnvVars = $this->mainServer->environment_variables()->get();
+        foreach ($serverEnvVars as $env) {
+            $envs_dict[$env->key] = escapeBashEnvValue($env->value);
+        }
+
         // 3. Add SERVICE_NAME, SERVICE_FQDN, SERVICE_URL variables for Docker Compose builds
         if ($this->build_pack === 'dockercompose') {
             if ($this->pull_request_id === 0) {
@@ -1637,6 +1648,21 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         }
 
         return $envs;
+    }
+
+    private function inject_server_environment_variables(Collection $envs): void
+    {
+        $server = $this->mainServer;
+        $serverEnvVars = $server->environment_variables()->get();
+        foreach ($serverEnvVars as $env) {
+            $value = $env->value;
+            if ($env->is_literal || $env->is_multiline) {
+                $value = '\''.$value.'\'';
+            } else {
+                $value = escapeEnvVariables($value);
+            }
+            $envs->push($env->key.'='.$value);
+        }
     }
 
     private function save_buildtime_environment_variables()

--- a/app/Livewire/Project/Shared/EnvironmentVariable/Add.php
+++ b/app/Livewire/Project/Shared/EnvironmentVariable/Add.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Project\Shared\EnvironmentVariable;
 
 use App\Models\Environment;
 use App\Models\Project;
+use App\Models\Server;
 use App\Traits\EnvironmentVariableAnalyzer;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Livewire\Attributes\Computed;
@@ -67,6 +68,7 @@ class Add extends Component
             'team' => [],
             'project' => [],
             'environment' => [],
+            'server' => [],
         ];
 
         // Early return if no team
@@ -120,6 +122,21 @@ class Add extends Component
                     // User not authorized to view project variables
                 }
             }
+        }
+
+        // Get server variables from all servers owned by the current team
+        try {
+            $servers = Server::ownedByCurrentTeam()->get();
+            $serverVars = [];
+            foreach ($servers as $server) {
+                $vars = $server->environment_variables()
+                    ->pluck('key')
+                    ->toArray();
+                $serverVars = array_merge($serverVars, $vars);
+            }
+            $result['server'] = array_unique($serverVars);
+        } catch (\Illuminate\Auth\Access\AuthorizationException $e) {
+            // User not authorized to view server variables
         }
 
         return $result;

--- a/app/Livewire/Project/Shared/EnvironmentVariable/Show.php
+++ b/app/Livewire/Project/Shared/EnvironmentVariable/Show.php
@@ -5,6 +5,7 @@ namespace App\Livewire\Project\Shared\EnvironmentVariable;
 use App\Models\Environment;
 use App\Models\EnvironmentVariable as ModelsEnvironmentVariable;
 use App\Models\Project;
+use App\Models\Server;
 use App\Models\SharedEnvironmentVariable;
 use App\Traits\EnvironmentVariableAnalyzer;
 use App\Traits\EnvironmentVariableProtection;
@@ -204,6 +205,7 @@ class Show extends Component
             'team' => [],
             'project' => [],
             'environment' => [],
+            'server' => [],
         ];
 
         // Early return if no team
@@ -257,6 +259,21 @@ class Show extends Component
                     // User not authorized to view project variables
                 }
             }
+        }
+
+        // Get server variables from all servers owned by the current team
+        try {
+            $servers = Server::ownedByCurrentTeam()->get();
+            $serverVars = [];
+            foreach ($servers as $server) {
+                $vars = $server->environment_variables()
+                    ->pluck('key')
+                    ->toArray();
+                $serverVars = array_merge($serverVars, $vars);
+            }
+            $result['server'] = array_unique($serverVars);
+        } catch (\Illuminate\Auth\Access\AuthorizationException $e) {
+            // User not authorized to view server variables
         }
 
         return $result;

--- a/app/Livewire/SharedVariables/Server/Index.php
+++ b/app/Livewire/SharedVariables/Server/Index.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Livewire\SharedVariables\Server;
+
+use App\Models\Server;
+use Illuminate\Support\Collection;
+use Livewire\Component;
+
+class Index extends Component
+{
+    public Collection $servers;
+
+    public function mount()
+    {
+        $this->servers = Server::ownedByCurrentTeam()->get();
+    }
+
+    public function render()
+    {
+        return view('livewire.shared-variables.server.index');
+    }
+}

--- a/app/Livewire/SharedVariables/Server/Show.php
+++ b/app/Livewire/SharedVariables/Server/Show.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace App\Livewire\SharedVariables\Server;
+
+use App\Models\Server;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Facades\DB;
+use Livewire\Component;
+
+class Show extends Component
+{
+    use AuthorizesRequests;
+
+    public Server $server;
+
+    public string $view = 'normal';
+
+    public ?string $variables = null;
+
+    protected $listeners = ['refreshEnvs' => 'refreshEnvs', 'saveKey' => 'saveKey', 'environmentVariableDeleted' => 'refreshEnvs'];
+
+    public function saveKey($data)
+    {
+        try {
+            $this->authorize('update', $this->server);
+
+            $found = $this->server->environment_variables()->where('key', $data['key'])->first();
+            if ($found) {
+                throw new \Exception('Variable already exists.');
+            }
+            $this->server->environment_variables()->create([
+                'key' => $data['key'],
+                'value' => $data['value'],
+                'is_multiline' => $data['is_multiline'],
+                'is_literal' => $data['is_literal'],
+                'type' => 'server',
+                'team_id' => currentTeam()->id,
+            ]);
+            $this->server->refresh();
+            $this->getDevView();
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function mount()
+    {
+        $serverUuid = request()->route('server_uuid');
+        $teamId = currentTeam()->id;
+        $server = Server::where('team_id', $teamId)->where('uuid', $serverUuid)->first();
+        if (! $server) {
+            return redirect()->route('dashboard');
+        }
+        $this->server = $server;
+        $this->getDevView();
+    }
+
+    public function switch()
+    {
+        $this->authorize('view', $this->server);
+        $this->view = $this->view === 'normal' ? 'dev' : 'normal';
+        $this->getDevView();
+    }
+
+    public function getDevView()
+    {
+        $this->variables = $this->formatEnvironmentVariables($this->server->environment_variables->sortBy('key'));
+    }
+
+    private function formatEnvironmentVariables($variables)
+    {
+        return $variables->map(function ($item) {
+            if ($item->is_shown_once) {
+                return "$item->key=(Locked Secret, delete and add again to change)";
+            }
+            if ($item->is_multiline) {
+                return "$item->key=(Multiline environment variable, edit in normal view)";
+            }
+
+            return "$item->key=$item->value";
+        })->join("\n");
+    }
+
+    public function submit()
+    {
+        try {
+            $this->authorize('update', $this->server);
+            $this->handleBulkSubmit();
+            $this->getDevView();
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        } finally {
+            $this->refreshEnvs();
+        }
+    }
+
+    private function handleBulkSubmit()
+    {
+        $variables = parseEnvFormatToArray($this->variables);
+
+        $changesMade = DB::transaction(function () use ($variables) {
+            // Delete removed variables
+            $deletedCount = $this->deleteRemovedVariables($variables);
+
+            // Update or create variables
+            $updatedCount = $this->updateOrCreateVariables($variables);
+
+            return $deletedCount > 0 || $updatedCount > 0;
+        });
+
+        if ($changesMade) {
+            $this->dispatch('success', 'Environment variables updated.');
+        }
+    }
+
+    private function deleteRemovedVariables($variables)
+    {
+        $variablesToDelete = $this->server->environment_variables()->whereNotIn('key', array_keys($variables))->get();
+
+        if ($variablesToDelete->isEmpty()) {
+            return 0;
+        }
+
+        $this->server->environment_variables()->whereNotIn('key', array_keys($variables))->delete();
+
+        return $variablesToDelete->count();
+    }
+
+    private function updateOrCreateVariables($variables)
+    {
+        $count = 0;
+        foreach ($variables as $key => $value) {
+            $found = $this->server->environment_variables()->where('key', $key)->first();
+
+            if ($found) {
+                if (! $found->is_shown_once && ! $found->is_multiline) {
+                    if ($found->value !== $value) {
+                        $found->value = $value;
+                        $found->save();
+                        $count++;
+                    }
+                }
+            } else {
+                $this->server->environment_variables()->create([
+                    'key' => $key,
+                    'value' => $value,
+                    'is_multiline' => false,
+                    'is_literal' => false,
+                    'type' => 'server',
+                    'team_id' => currentTeam()->id,
+                ]);
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    public function refreshEnvs()
+    {
+        $this->server->refresh();
+        $this->getDevView();
+    }
+
+    public function render()
+    {
+        return view('livewire.shared-variables.server.show');
+    }
+}

--- a/app/Models/EnvironmentVariable.php
+++ b/app/Models/EnvironmentVariable.php
@@ -209,6 +209,12 @@ class EnvironmentVariable extends BaseModel
                 $id = $resource->environment->project->id;
             } elseif ($type->value() === 'team') {
                 $id = $resource->team()->id;
+            } elseif ($type->value() === 'server') {
+                $server = null;
+                if (method_exists($resource, 'destination') && $resource->destination) {
+                    $server = $resource->destination->server;
+                }
+                $id = $server?->id;
             }
             if (is_null($id)) {
                 continue;

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -315,6 +315,11 @@ class Server extends BaseModel
         return $this->hasOne(ServerSetting::class);
     }
 
+    public function environment_variables()
+    {
+        return $this->hasMany(SharedEnvironmentVariable::class);
+    }
+
     public function dockerCleanupExecutions()
     {
         return $this->hasMany(DockerCleanupExecution::class);

--- a/app/Models/SharedEnvironmentVariable.php
+++ b/app/Models/SharedEnvironmentVariable.php
@@ -27,4 +27,9 @@ class SharedEnvironmentVariable extends Model
     {
         return $this->belongsTo(Environment::class);
     }
+
+    public function server()
+    {
+        return $this->belongsTo(Server::class);
+    }
 }

--- a/app/View/Components/Forms/EnvVarInput.php
+++ b/app/View/Components/Forms/EnvVarInput.php
@@ -86,6 +86,7 @@ class EnvVarInput extends Component
                     'environment_uuid' => $this->environmentUuid,
                 ])
                 : route('shared-variables.environment.index'),
+            'server' => route('shared-variables.server.index'),
             'default' => route('shared-variables.index'),
         ];
 

--- a/bootstrap/helpers/constants.php
+++ b/bootstrap/helpers/constants.php
@@ -81,4 +81,4 @@ const NEEDS_TO_DISABLE_GZIP = [
 const NEEDS_TO_DISABLE_STRIPPREFIX = [
     'appwrite' => ['appwrite', 'appwrite-console', 'appwrite-realtime'],
 ];
-const SHARED_VARIABLE_TYPES = ['team', 'project', 'environment'];
+const SHARED_VARIABLE_TYPES = ['team', 'project', 'environment', 'server'];

--- a/database/migrations/2025_12_24_000001_add_server_to_shared_environment_variables_table.php
+++ b/database/migrations/2025_12_24_000001_add_server_to_shared_environment_variables_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('shared_environment_variables', function (Blueprint $table) {
+            $table->foreignId('server_id')->nullable()->after('environment_id')->constrained()->onDelete('cascade');
+        });
+
+        // Update the type CHECK constraint to include 'server'
+        DB::statement('ALTER TABLE shared_environment_variables DROP CONSTRAINT shared_environment_variables_type_check');
+        DB::statement("ALTER TABLE shared_environment_variables ADD CONSTRAINT shared_environment_variables_type_check CHECK (type::text = ANY (ARRAY['team'::text, 'project'::text, 'environment'::text, 'server'::text]))");
+
+        Schema::table('shared_environment_variables', function (Blueprint $table) {
+            $table->unique(['key', 'server_id', 'team_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        // Delete all server-type variables first
+        DB::table('shared_environment_variables')->where('type', 'server')->delete();
+
+        Schema::table('shared_environment_variables', function (Blueprint $table) {
+            $table->dropUnique(['key', 'server_id', 'team_id']);
+            $table->dropForeign(['server_id']);
+            $table->dropColumn('server_id');
+        });
+
+        // Restore original type CHECK constraint
+        DB::statement('ALTER TABLE shared_environment_variables DROP CONSTRAINT shared_environment_variables_type_check');
+        DB::statement("ALTER TABLE shared_environment_variables ADD CONSTRAINT shared_environment_variables_type_check CHECK (type::text = ANY (ARRAY['team'::text, 'project'::text, 'environment'::text]))");
+    }
+};

--- a/resources/views/components/forms/env-var-input.blade.php
+++ b/resources/views/components/forms/env-var-input.blade.php
@@ -17,7 +17,7 @@
             selectedIndex: 0,
             cursorPosition: 0,
             currentScope: null,
-            availableScopes: ['team', 'project', 'environment'],
+            availableScopes: ['team', 'project', 'environment', 'server'],
             availableVars: @js($availableVars),
             scopeUrls: @js($scopeUrls),
 

--- a/resources/views/livewire/shared-variables/index.blade.php
+++ b/resources/views/livewire/shared-variables/index.blade.php
@@ -5,7 +5,7 @@
     <div class="flex items-start gap-2">
         <h1>Shared Variables</h1>
     </div>
-    <div class="subtitle">Set Team / Project / Environment wide variables.</div>
+    <div class="subtitle">Set Team / Project / Environment / Server wide variables.</div>
 
     <div class="flex flex-col gap-2 -mt-1">
         <a class="coolbox group" href="{{ route('shared-variables.team.index') }}" {{ wireNavigate() }}>
@@ -24,6 +24,12 @@
             <div class="flex flex-col justify-center mx-6">
                 <div class="box-title">Environment wide</div>
                 <div class="box-description">Usable for all resources in an environment.</div>
+            </div>
+        </a>
+        <a class="coolbox group" href="{{ route('shared-variables.server.index') }}" {{ wireNavigate() }}>
+            <div class="flex flex-col justify-center mx-6">
+                <div class="box-title">Server wide</div>
+                <div class="box-description">Usable for all resources deployed on a server.</div>
             </div>
         </a>
 

--- a/resources/views/livewire/shared-variables/server/index.blade.php
+++ b/resources/views/livewire/shared-variables/server/index.blade.php
@@ -1,0 +1,25 @@
+<div>
+    <x-slot:title>
+        Server Variables | Coolify
+    </x-slot>
+    <div class="flex gap-2">
+        <h1>Servers</h1>
+    </div>
+    <div class="subtitle">Select a server to manage its shared variables.</div>
+    <div class="flex flex-col gap-2">
+        @forelse ($servers as $server)
+            <a class="coolbox group"
+                href="{{ route('shared-variables.server.show', ['server_uuid' => data_get($server, 'uuid')]) }}" {{ wireNavigate() }}>
+                <div class="flex flex-col justify-center mx-6 ">
+                    <div class="box-title">{{ $server->name }}</div>
+                    <div class="box-description ">
+                        {{ $server->description }}</div>
+                </div>
+            </a>
+        @empty
+            <div>
+                <div>No server found.</div>
+            </div>
+        @endforelse
+    </div>
+</div>

--- a/resources/views/livewire/shared-variables/server/show.blade.php
+++ b/resources/views/livewire/shared-variables/server/show.blade.php
@@ -1,0 +1,36 @@
+<div>
+    <x-slot:title>
+        Server Variable | Coolify
+    </x-slot>
+    <div class="flex gap-2 items-center">
+        <h1>Shared Variables for {{ data_get($server, 'name') }}</h1>
+        @can('update', $server)
+            <x-modal-input buttonTitle="+ Add" title="New Shared Variable">
+                <livewire:project.shared.environment-variable.add :shared="true" />
+            </x-modal-input>
+        @endcan
+        <x-forms.button canGate="update" :canResource="$server" wire:click='switch'>{{ $view === 'normal' ? 'Developer view' : 'Normal view' }}</x-forms.button>
+    </div>
+    <div class="flex flex-wrap gap-1 subtitle">
+        <div>You can use these variables anywhere with</div>
+        <div class="dark:text-warning text-coollabs">@{{ server.VARIABLENAME }} </div>
+        <x-helper
+            helper="More info <a class='underline dark:text-white' href='https://coolify.io/docs/knowledge-base/environment-variables#shared-variables' target='_blank'>here</a>."></x-helper>
+    </div>
+    @if ($view === 'normal')
+        <div class="flex flex-col gap-2">
+            @forelse ($server->environment_variables->sort()->sortBy('key') as $env)
+                <livewire:project.shared.environment-variable.show wire:key="environment-{{ $env->id }}"
+                    :env="$env" type="server" />
+            @empty
+                <div>No environment variables found.</div>
+            @endforelse
+        </div>
+    @else
+        <form wire:submit='submit' class="flex flex-col gap-2">
+            <x-forms.textarea canGate="update" :canResource="$server" rows="20" class="whitespace-pre-wrap" id="variables" wire:model="variables"
+                label="Server Shared Variables"></x-forms.textarea>
+            <x-forms.button canGate="update" :canResource="$server" type="submit" class="btn btn-primary">Save All Environment Variables</x-forms.button>
+        </form>
+    @endif
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -71,6 +71,8 @@ use App\Livewire\SharedVariables\Environment\Show as EnvironmentSharedVariablesS
 use App\Livewire\SharedVariables\Index as SharedVariablesIndex;
 use App\Livewire\SharedVariables\Project\Index as ProjectSharedVariablesIndex;
 use App\Livewire\SharedVariables\Project\Show as ProjectSharedVariablesShow;
+use App\Livewire\SharedVariables\Server\Index as ServerSharedVariablesIndex;
+use App\Livewire\SharedVariables\Server\Show as ServerSharedVariablesShow;
 use App\Livewire\SharedVariables\Team\Index as TeamSharedVariablesIndex;
 use App\Livewire\Source\Github\Change as GitHubChange;
 use App\Livewire\Storage\Index as StorageIndex;
@@ -146,6 +148,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/project/{project_uuid}', ProjectSharedVariablesShow::class)->name('shared-variables.project.show');
         Route::get('/environments', EnvironmentSharedVariablesIndex::class)->name('shared-variables.environment.index');
         Route::get('/environments/project/{project_uuid}/environment/{environment_uuid}', EnvironmentSharedVariablesShow::class)->name('shared-variables.environment.show');
+        Route::get('/servers', ServerSharedVariablesIndex::class)->name('shared-variables.server.index');
+        Route::get('/server/{server_uuid}', ServerSharedVariablesShow::class)->name('shared-variables.server.show');
     });
 
     Route::prefix('team')->group(function () {


### PR DESCRIPTION
## Summary

Adds server-scoped shared environment variables, allowing users to define variables per server that are automatically available to all applications deployed on that server.

This addresses the limitation described in #7738 where multi-server deployments have no way to distinguish between servers from within the application. Server-level environment variables enable per-server configuration (e.g., server identifiers, region-specific settings) without duplicating variables across individual resources.

## Changes

### Database
- New migration adding `server_id` foreign key to `shared_environment_variables` table
- Updated CHECK constraint to include `'server'` type
- Added unique constraint on `(key, server_id, team_id)`

### Models
- **SharedEnvironmentVariable**: Added `server()` relationship
- **Server**: Added `environment_variables()` relationship
- **EnvironmentVariable**: Added `'server'` type resolution in shared variable lookup — resolves the server through `resource → destination → server`

### Shared Variable Management UI
- New `SharedVariables\Server\Index` Livewire component — lists all team servers for selection
- New `SharedVariables\Server\Show` Livewire component — full CRUD with normal/developer (bulk edit) views
- New blade views for server variable listing and management
- Updated shared variables index page to include "Server wide" navigation link
- Variables use the `{{ server.VARIABLE_NAME }}` syntax consistent with existing scopes

### Autocomplete Support
- Updated `EnvVarInput` component to include `'server'` scope in autocomplete dropdown
- Updated `Add.php` and `Show.php` environment variable components to fetch server-scoped variables for autocomplete suggestions

### Deployment Integration
- **Runtime**: Server environment variables injected after Coolify system variables but before user-defined variables (user vars take precedence)
- **Buildtime**: Server environment variables injected at the same priority level (step 2.5 — after COOLIFY_ vars, before SERVICE_ and user vars)
- New `inject_server_environment_variables()` method handles runtime injection with proper escaping for literal/multiline values

### Routes
- `GET /shared-variables/servers` — Server list for variable management
- `GET /shared-variables/server/{server_uuid}` — Server variable management page

### Constants
- Updated `SHARED_VARIABLE_TYPES` to include `'server'`

## How It Works

1. Navigate to **Shared Variables → Server wide** and select a server
2. Add environment variables scoped to that server
3. Any application deployed on that server automatically receives those variables at both build and runtime
4. Variables can also be referenced from other resources using the `{{ server.VARIABLE_NAME }}` syntax
5. Application-level variables override server-level variables when names conflict

## Security Note

Server IP addresses and other sensitive server metadata are NOT automatically exposed as environment variables, per maintainer guidance in #7738.

/claim #7738