### PR TITLE
feat: pgBackRest support for PostgreSQL incremental backups

### DIFF
--- a/app/Actions/Database/PgBackrestRestore.php
+++ b/app/Actions/Database/PgBackrestRestore.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Actions\Database;
+
+use App\Models\ScheduledDatabaseBackup;
+use App\Models\StandalonePostgresql;
+use App\Services\Backup\PgBackrestService;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class PgBackrestRestore
+{
+    use AsAction;
+
+    public function handle(
+        StandalonePostgresql $database,
+        ScheduledDatabaseBackup $backup,
+        ?string $targetTime = null,
+        ?string $backupLabel = null,
+    ) {
+        $server = $database->destination->server;
+        $containerName = $database->uuid;
+
+        $service = new PgBackrestService($database, $backup);
+
+        $commands = [];
+
+        // Write pgbackrest config into the container
+        foreach ($service->getSetupCommands() as $cmd) {
+            $commands[] = executeInDocker($containerName, $cmd);
+        }
+
+        // Stop the PostgreSQL process inside the container
+        $commands[] = executeInDocker($containerName, 'pg_ctl stop -D /var/lib/postgresql/data -m fast 2>/dev/null || true');
+
+        // Run the delta restore
+        $restoreCommands = $service->getRestoreDatabaseCommand($targetTime, $backupLabel);
+        foreach ($restoreCommands as $cmd) {
+            // Skip the pg_ctl stop/start since we handle it ourselves
+            if (str_contains($cmd, 'pg_ctl stop') || str_contains($cmd, 'pg_ctl start')) {
+                continue;
+            }
+            $commands[] = executeInDocker($containerName, $cmd);
+        }
+
+        // Restart the container to bring PostgreSQL back cleanly
+        $commands[] = "docker restart {$containerName}";
+        $commands[] = "echo 'pgBackRest restore completed.'";
+
+        return remote_process($commands, $server, callEventOnFinish: 'DatabaseStatusChanged');
+    }
+}

--- a/app/Actions/Database/StartPostgresql.php
+++ b/app/Actions/Database/StartPostgresql.php
@@ -3,8 +3,10 @@
 namespace App\Actions\Database;
 
 use App\Helpers\SslHelper;
+use App\Models\ScheduledDatabaseBackup;
 use App\Models\SslCertificate;
 use App\Models\StandalonePostgresql;
+use App\Services\Backup\PgBackrestService;
 use Lorisleiva\Actions\Concerns\AsAction;
 use Symfony\Component\Yaml\Yaml;
 
@@ -98,6 +100,27 @@ class StartPostgresql
         $environment_variables = $this->generate_environment_variables();
         $this->generate_init_scripts();
         $this->add_custom_conf();
+
+        // Check if any pgBackRest backup schedules exist for WAL archiving setup
+        $pgbackrestBackup = $this->database->isPgBackrestEnabled()
+            ? ScheduledDatabaseBackup::where('database_id', $this->database->id)
+                ->where('database_type', $this->database->getMorphClass())
+                ->where('backup_engine', 'pgbackrest')
+                ->first()
+            : null;
+
+        $pgbackrestService = null;
+        if ($pgbackrestBackup) {
+            $pgbackrestService = new PgBackrestService($this->database, $pgbackrestBackup);
+
+            // Add pgBackRest repo volumes
+            foreach ($pgbackrestService->getDockerVolumes() as $vol) {
+                $persistent_storages[] = $vol;
+            }
+            foreach ($pgbackrestService->getDockerVolumeDefinitions() as $name => $def) {
+                $volume_names[$name] = $def;
+            }
+        }
 
         $docker_compose = [
             'services' => [
@@ -208,6 +231,11 @@ class StartPostgresql
             ]);
         }
 
+        // Add WAL archiving config for pgBackRest
+        if ($pgbackrestService) {
+            $command = array_merge($command, $pgbackrestService->getWalArchivingParams());
+        }
+
         // Add custom docker run options
         $docker_run_options = convertDockerRunToCompose($this->database->custom_docker_run_options);
         $docker_compose = generateCustomDockerRunOptionsForDatabases($docker_run_options, $docker_compose, $container_name, $this->database->destination->network);
@@ -229,6 +257,22 @@ class StartPostgresql
         if ($this->database->enable_ssl) {
             $this->commands[] = executeInDocker($this->database->uuid, "chown {$this->database->postgres_user}:{$this->database->postgres_user} /var/lib/postgresql/certs/server.key /var/lib/postgresql/certs/server.crt");
         }
+
+        // Install and configure pgBackRest inside the container after startup
+        if ($pgbackrestService) {
+            $this->commands[] = "echo 'Installing pgBackRest...'";
+            foreach ($pgbackrestService->getInstallCommands() as $cmd) {
+                $this->commands[] = executeInDocker($this->database->uuid, $cmd);
+            }
+            $this->commands[] = "echo 'Configuring pgBackRest...'";
+            foreach ($pgbackrestService->getSetupCommands() as $cmd) {
+                $this->commands[] = executeInDocker($this->database->uuid, $cmd);
+            }
+            $this->commands[] = "echo 'Creating pgBackRest stanza...'";
+            $this->commands[] = executeInDocker($this->database->uuid, $pgbackrestService->getStanzaCreateCommand());
+            $this->commands[] = "echo 'pgBackRest setup completed.'";
+        }
+
         $this->commands[] = "echo 'Database started.'";
 
         return remote_process($this->commands, $database->destination->server, callEventOnFinish: 'DatabaseStatusChanged');

--- a/app/Http/Controllers/Api/DatabasesController.php
+++ b/app/Http/Controllers/Api/DatabasesController.php
@@ -672,7 +672,7 @@ class DatabasesController extends Controller
     )]
     public function create_backup(Request $request)
     {
-        $backupConfigFields = ['save_s3', 'enabled', 'dump_all', 'frequency', 'databases_to_backup', 'database_backup_retention_amount_locally', 'database_backup_retention_days_locally', 'database_backup_retention_max_storage_locally', 'database_backup_retention_amount_s3', 'database_backup_retention_days_s3', 'database_backup_retention_max_storage_s3', 's3_storage_uuid'];
+        $backupConfigFields = ['save_s3', 'enabled', 'dump_all', 'frequency', 'databases_to_backup', 'database_backup_retention_amount_locally', 'database_backup_retention_days_locally', 'database_backup_retention_max_storage_locally', 'database_backup_retention_amount_s3', 'database_backup_retention_days_s3', 'database_backup_retention_max_storage_s3', 's3_storage_uuid', 'backup_engine', 'pgbackrest_stanza', 'pgbackrest_backup_type', 'pgbackrest_repo_type', 'pgbackrest_s3_bucket', 'pgbackrest_s3_endpoint', 'pgbackrest_s3_region', 'pgbackrest_s3_key', 'pgbackrest_s3_secret', 'pgbackrest_compress_type', 'pgbackrest_compress_level', 'pgbackrest_retention_full', 'pgbackrest_retention_diff', 'pgbackrest_log_level_console', 'pgbackrest_log_level_file'];
 
         $teamId = getTeamIdFromToken();
         if (is_null($teamId)) {
@@ -699,6 +699,21 @@ class DatabasesController extends Controller
             'database_backup_retention_amount_s3' => 'integer|min:0',
             'database_backup_retention_days_s3' => 'integer|min:0',
             'database_backup_retention_max_storage_s3' => 'integer|min:0',
+            'backup_engine' => 'string|in:dump,pgbackrest',
+            'pgbackrest_stanza' => 'string|nullable',
+            'pgbackrest_backup_type' => 'string|in:full,incr,diff|nullable',
+            'pgbackrest_repo_type' => 'string|in:posix,s3|nullable',
+            'pgbackrest_s3_bucket' => 'string|nullable',
+            'pgbackrest_s3_endpoint' => 'string|nullable',
+            'pgbackrest_s3_region' => 'string|nullable',
+            'pgbackrest_s3_key' => 'string|nullable',
+            'pgbackrest_s3_secret' => 'string|nullable',
+            'pgbackrest_compress_type' => 'string|in:gz,lz4,zst,none|nullable',
+            'pgbackrest_compress_level' => 'integer|min:0|max:9|nullable',
+            'pgbackrest_retention_full' => 'integer|min:1|nullable',
+            'pgbackrest_retention_diff' => 'integer|min:1|nullable',
+            'pgbackrest_log_level_console' => 'string|in:off,error,warn,info,detail,debug,trace|nullable',
+            'pgbackrest_log_level_file' => 'string|in:off,error,warn,info,detail,debug,trace|nullable',
         ]);
 
         if ($validator->fails()) {
@@ -890,7 +905,7 @@ class DatabasesController extends Controller
     )]
     public function update_backup(Request $request)
     {
-        $backupConfigFields = ['save_s3', 'enabled', 'dump_all', 'frequency', 'databases_to_backup', 'database_backup_retention_amount_locally', 'database_backup_retention_days_locally', 'database_backup_retention_max_storage_locally', 'database_backup_retention_amount_s3', 'database_backup_retention_days_s3', 'database_backup_retention_max_storage_s3', 's3_storage_uuid'];
+        $backupConfigFields = ['save_s3', 'enabled', 'dump_all', 'frequency', 'databases_to_backup', 'database_backup_retention_amount_locally', 'database_backup_retention_days_locally', 'database_backup_retention_max_storage_locally', 'database_backup_retention_amount_s3', 'database_backup_retention_days_s3', 'database_backup_retention_max_storage_s3', 's3_storage_uuid', 'backup_engine', 'pgbackrest_stanza', 'pgbackrest_backup_type', 'pgbackrest_repo_type', 'pgbackrest_s3_bucket', 'pgbackrest_s3_endpoint', 'pgbackrest_s3_region', 'pgbackrest_s3_key', 'pgbackrest_s3_secret', 'pgbackrest_compress_type', 'pgbackrest_compress_level', 'pgbackrest_retention_full', 'pgbackrest_retention_diff', 'pgbackrest_log_level_console', 'pgbackrest_log_level_file'];
 
         $teamId = getTeamIdFromToken();
         if (is_null($teamId)) {
@@ -915,6 +930,21 @@ class DatabasesController extends Controller
             'database_backup_retention_amount_s3' => 'integer|min:0',
             'database_backup_retention_days_s3' => 'integer|min:0',
             'database_backup_retention_max_storage_s3' => 'integer|min:0',
+            'backup_engine' => 'string|in:dump,pgbackrest',
+            'pgbackrest_stanza' => 'string|nullable',
+            'pgbackrest_backup_type' => 'string|in:full,incr,diff|nullable',
+            'pgbackrest_repo_type' => 'string|in:posix,s3|nullable',
+            'pgbackrest_s3_bucket' => 'string|nullable',
+            'pgbackrest_s3_endpoint' => 'string|nullable',
+            'pgbackrest_s3_region' => 'string|nullable',
+            'pgbackrest_s3_key' => 'string|nullable',
+            'pgbackrest_s3_secret' => 'string|nullable',
+            'pgbackrest_compress_type' => 'string|in:gz,lz4,zst,none|nullable',
+            'pgbackrest_compress_level' => 'integer|min:0|max:9|nullable',
+            'pgbackrest_retention_full' => 'integer|min:1|nullable',
+            'pgbackrest_retention_diff' => 'integer|min:1|nullable',
+            'pgbackrest_log_level_console' => 'string|in:off,error,warn,info,detail,debug,trace|nullable',
+            'pgbackrest_log_level_file' => 'string|in:off,error,warn,info,detail,debug,trace|nullable',
         ]);
         if ($validator->fails()) {
             return response()->json([
@@ -2501,6 +2531,97 @@ class DatabasesController extends Controller
         return response()->json([
             'executions' => $executions,
         ]);
+    }
+
+    #[OA\Get(
+        summary: 'pgBackRest Info',
+        description: 'Get pgBackRest backup information for a PostgreSQL database.',
+        path: '/databases/{uuid}/pgbackrest/info',
+        operationId: 'get-database-pgbackrest-info',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Databases'],
+        parameters: [
+            new OA\Parameter(
+                name: 'uuid',
+                in: 'path',
+                description: 'UUID of the database.',
+                required: true,
+                schema: new OA\Schema(
+                    type: 'string',
+                )
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'pgBackRest backup information.',
+            ),
+            new OA\Response(
+                response: 401,
+                ref: '#/components/responses/401',
+            ),
+            new OA\Response(
+                response: 400,
+                ref: '#/components/responses/400',
+            ),
+            new OA\Response(
+                response: 404,
+                ref: '#/components/responses/404',
+            ),
+        ]
+    )]
+    public function pgbackrest_info(Request $request)
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+
+        $uuid = $request->route('uuid');
+        if (! $uuid) {
+            return response()->json(['message' => 'UUID is required.'], 400);
+        }
+
+        $database = queryDatabaseByUuidWithinTeam($uuid, $teamId);
+        if (! $database) {
+            return response()->json(['message' => 'Database not found.'], 404);
+        }
+
+        if (! ($database instanceof StandalonePostgresql)) {
+            return response()->json(['message' => 'pgBackRest is only supported for PostgreSQL databases.'], 400);
+        }
+
+        if (! $database->isPgBackrestEnabled()) {
+            return response()->json(['message' => 'pgBackRest is not enabled for this database.'], 400);
+        }
+
+        $backup = ScheduledDatabaseBackup::where('database_id', $database->id)
+            ->where('database_type', $database->getMorphClass())
+            ->where('backup_engine', 'pgbackrest')
+            ->first();
+
+        if (! $backup) {
+            return response()->json(['message' => 'No pgBackRest backup configuration found.'], 404);
+        }
+
+        $service = new \App\Services\Backup\PgBackrestService($database, $backup);
+        $server = $database->destination->server;
+        $containerName = $database->uuid;
+
+        try {
+            $infoCmd = executeInDocker($containerName, $service->getInfoCommand('json'));
+            $infoOutput = instant_remote_process([$infoCmd], $server, true, false, 60, disableMultiplexing: true);
+            $backups = $service->parseBackupInfo($infoOutput);
+
+            return response()->json([
+                'stanza' => $service->getStanza(),
+                'backups' => $backups,
+            ]);
+        } catch (\Throwable $e) {
+            return response()->json(['message' => 'Failed to retrieve pgBackRest info: '.$e->getMessage()], 500);
+        }
     }
 
     #[OA\Get(

--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -16,6 +16,7 @@ use App\Models\Team;
 use App\Notifications\Database\BackupFailed;
 use App\Notifications\Database\BackupSuccess;
 use App\Notifications\Database\BackupSuccessWithS3Warning;
+use App\Services\Backup\PgBackrestService;
 use Carbon\Carbon;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeEncrypted;
@@ -289,6 +290,17 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                 $ip = Str::slug($this->server->ip);
                 $this->backup_dir = backup_dir().'/coolify'."/coolify-db-$ip";
             }
+
+            // pgBackRest flow: handle separately from the traditional per-database dump loop
+            if ($this->backup->isPgBackrest() && str($databaseType)->contains('postgres') && $this->database instanceof StandalonePostgresql) {
+                $this->run_pgbackrest_backup($databaseType);
+                if ($this->backup_log && $this->backup_log->status === 'success') {
+                    removeOldBackups($this->backup);
+                }
+
+                return;
+            }
+
             foreach ($databasesToBackup as $database) {
                 // Generate unique UUID for each database backup execution
                 $attempts = 0;
@@ -680,6 +692,94 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
         $latestVersion = getHelperVersion();
 
         return "{$helperImage}:{$latestVersion}";
+    }
+
+    private function run_pgbackrest_backup(string $databaseType): void
+    {
+        try {
+            $service = new PgBackrestService($this->database, $this->backup);
+
+            // Generate unique UUID for the backup execution
+            $attempts = 0;
+            do {
+                $this->backup_log_uuid = (string) new Cuid2;
+                $exists = ScheduledDatabaseBackupExecution::where('uuid', $this->backup_log_uuid)->exists();
+                $attempts++;
+                if ($attempts >= 3 && $exists) {
+                    throw new \Exception('Unable to generate unique UUID for backup execution after 3 attempts');
+                }
+            } while ($exists);
+
+            $this->backup_log = ScheduledDatabaseBackupExecution::create([
+                'uuid' => $this->backup_log_uuid,
+                'database_name' => $this->database->postgres_db,
+                'filename' => 'pgbackrest://'.$service->getStanza(),
+                'scheduled_database_backup_id' => $this->backup->id,
+                'backup_engine' => 'pgbackrest',
+                'pgbackrest_backup_type' => $this->backup->pgbackrest_backup_type ?? 'full',
+                'local_storage_deleted' => false,
+            ]);
+
+            $containerName = $this->database->uuid;
+
+            // Write pgbackrest.conf into the container
+            $setupCommands = [];
+            foreach ($service->getSetupCommands() as $cmd) {
+                $setupCommands[] = executeInDocker($containerName, $cmd);
+            }
+            instant_remote_process($setupCommands, $this->server, true, false, $this->timeout, disableMultiplexing: true);
+
+            // Create stanza if it doesn't exist
+            $stanzaCheck = executeInDocker($containerName, $service->getStanzaCheckCommand());
+            try {
+                instant_remote_process([$stanzaCheck], $this->server, true, false, 60, disableMultiplexing: true);
+            } catch (\Throwable) {
+                $stanzaCreate = executeInDocker($containerName, $service->getStanzaCreateCommand());
+                instant_remote_process([$stanzaCreate], $this->server, true, false, 120, disableMultiplexing: true);
+            }
+
+            // Run the backup
+            $backupCmd = executeInDocker($containerName, $service->getBackupCommand());
+            $this->backup_output = instant_remote_process([$backupCmd], $this->server, true, false, $this->timeout, disableMultiplexing: true);
+
+            // Run expire to enforce retention
+            $expireCmd = executeInDocker($containerName, $service->getExpireCommand());
+            instant_remote_process([$expireCmd], $this->server, false, false, 120, disableMultiplexing: true);
+
+            // Get backup info for label and size
+            $infoCmd = executeInDocker($containerName, $service->getInfoCommand('json'));
+            $infoOutput = instant_remote_process([$infoCmd], $this->server, true, false, 60, disableMultiplexing: true);
+
+            $backups = $service->parseBackupInfo($infoOutput);
+            $latestBackup = ! empty($backups) ? end($backups) : null;
+
+            $this->backup_log->update([
+                'status' => 'success',
+                'message' => $this->backup_output,
+                'size' => $latestBackup['repository_size'] ?? 0,
+                'pgbackrest_backup_label' => $latestBackup['label'] ?? null,
+                's3_uploaded' => $this->backup->pgbackrest_repo_type === 's3' ? true : null,
+            ]);
+
+            $this->team->notify(new BackupSuccess($this->backup, $this->database, $this->database->postgres_db));
+        } catch (\Throwable $e) {
+            $this->add_to_error_output($e->getMessage());
+
+            if ($this->backup_log) {
+                $this->backup_log->update([
+                    'status' => 'failed',
+                    'message' => $this->error_output ?? $this->backup_output ?? $e->getMessage(),
+                    'size' => 0,
+                ]);
+            }
+
+            $this->team?->notify(new BackupFailed(
+                $this->backup,
+                $this->database,
+                $this->error_output ?? $this->backup_output ?? $e->getMessage(),
+                $this->database->postgres_db
+            ));
+        }
     }
 
     public function failed(?Throwable $exception): void

--- a/app/Livewire/Project/Database/BackupEdit.php
+++ b/app/Livewire/Project/Database/BackupEdit.php
@@ -78,6 +78,51 @@ class BackupEdit extends Component
     #[Validate(['required', 'int', 'min:60', 'max:36000'])]
     public int $timeout = 3600;
 
+    #[Validate(['required', 'string', 'in:dump,pgbackrest'])]
+    public string $backupEngine = 'dump';
+
+    #[Validate(['nullable', 'string'])]
+    public ?string $pgbackrestStanza = null;
+
+    #[Validate(['required', 'string', 'in:full,incr,diff'])]
+    public string $pgbackrestBackupType = 'full';
+
+    #[Validate(['required', 'string', 'in:posix,s3'])]
+    public string $pgbackrestRepoType = 'posix';
+
+    #[Validate(['nullable', 'string'])]
+    public ?string $pgbackrestS3Bucket = null;
+
+    #[Validate(['nullable', 'string'])]
+    public ?string $pgbackrestS3Endpoint = null;
+
+    #[Validate(['nullable', 'string'])]
+    public ?string $pgbackrestS3Region = 'us-east-1';
+
+    #[Validate(['nullable', 'string'])]
+    public ?string $pgbackrestS3Key = null;
+
+    #[Validate(['nullable', 'string'])]
+    public ?string $pgbackrestS3Secret = null;
+
+    #[Validate(['required', 'string', 'in:gz,lz4,zst,none'])]
+    public string $pgbackrestCompressType = 'gz';
+
+    #[Validate(['required', 'integer', 'min:0', 'max:9'])]
+    public int $pgbackrestCompressLevel = 6;
+
+    #[Validate(['required', 'integer', 'min:1'])]
+    public int $pgbackrestRetentionFull = 2;
+
+    #[Validate(['required', 'integer', 'min:1'])]
+    public int $pgbackrestRetentionDiff = 7;
+
+    #[Validate(['required', 'string', 'in:off,error,warn,info,detail,debug,trace'])]
+    public string $pgbackrestLogLevelConsole = 'warn';
+
+    #[Validate(['required', 'string', 'in:off,error,warn,info,detail,debug,trace'])]
+    public string $pgbackrestLogLevelFile = 'info';
+
     public function mount()
     {
         try {
@@ -125,6 +170,31 @@ class BackupEdit extends Component
             $this->backup->databases_to_backup = $this->databasesToBackup;
             $this->backup->dump_all = $this->dumpAll;
             $this->backup->timeout = $this->timeout;
+            $this->backup->backup_engine = $this->backupEngine;
+            $this->backup->pgbackrest_stanza = $this->pgbackrestStanza;
+            $this->backup->pgbackrest_backup_type = $this->pgbackrestBackupType;
+            $this->backup->pgbackrest_repo_type = $this->pgbackrestRepoType;
+            $this->backup->pgbackrest_s3_bucket = $this->pgbackrestS3Bucket;
+            $this->backup->pgbackrest_s3_endpoint = $this->pgbackrestS3Endpoint;
+            $this->backup->pgbackrest_s3_region = $this->pgbackrestS3Region;
+            $this->backup->pgbackrest_s3_key = $this->pgbackrestS3Key;
+            $this->backup->pgbackrest_s3_secret = $this->pgbackrestS3Secret;
+            $this->backup->pgbackrest_compress_type = $this->pgbackrestCompressType;
+            $this->backup->pgbackrest_compress_level = $this->pgbackrestCompressLevel;
+            $this->backup->pgbackrest_retention_full = $this->pgbackrestRetentionFull;
+            $this->backup->pgbackrest_retention_diff = $this->pgbackrestRetentionDiff;
+            $this->backup->pgbackrest_log_level_console = $this->pgbackrestLogLevelConsole;
+            $this->backup->pgbackrest_log_level_file = $this->pgbackrestLogLevelFile;
+
+            // Enable pgbackrest on the database model when engine is pgbackrest
+            if ($this->backupEngine === 'pgbackrest' && $this->backup->database_type === 'App\Models\StandalonePostgresql') {
+                $db = $this->backup->database;
+                if ($db && ! $db->pgbackrest_enabled) {
+                    $db->pgbackrest_enabled = true;
+                    $db->save();
+                }
+            }
+
             $this->customValidate();
             $this->backup->save();
         } else {
@@ -143,6 +213,21 @@ class BackupEdit extends Component
             $this->databasesToBackup = $this->backup->databases_to_backup;
             $this->dumpAll = $this->backup->dump_all;
             $this->timeout = $this->backup->timeout;
+            $this->backupEngine = $this->backup->backup_engine ?? 'dump';
+            $this->pgbackrestStanza = $this->backup->pgbackrest_stanza;
+            $this->pgbackrestBackupType = $this->backup->pgbackrest_backup_type ?? 'full';
+            $this->pgbackrestRepoType = $this->backup->pgbackrest_repo_type ?? 'posix';
+            $this->pgbackrestS3Bucket = $this->backup->pgbackrest_s3_bucket;
+            $this->pgbackrestS3Endpoint = $this->backup->pgbackrest_s3_endpoint;
+            $this->pgbackrestS3Region = $this->backup->pgbackrest_s3_region ?? 'us-east-1';
+            $this->pgbackrestS3Key = $this->backup->pgbackrest_s3_key;
+            $this->pgbackrestS3Secret = $this->backup->pgbackrest_s3_secret;
+            $this->pgbackrestCompressType = $this->backup->pgbackrest_compress_type ?? 'gz';
+            $this->pgbackrestCompressLevel = $this->backup->pgbackrest_compress_level ?? 6;
+            $this->pgbackrestRetentionFull = $this->backup->pgbackrest_retention_full ?? 2;
+            $this->pgbackrestRetentionDiff = $this->backup->pgbackrest_retention_diff ?? 7;
+            $this->pgbackrestLogLevelConsole = $this->backup->pgbackrest_log_level_console ?? 'warn';
+            $this->pgbackrestLogLevelFile = $this->backup->pgbackrest_log_level_file ?? 'info';
         }
     }
 

--- a/app/Models/ScheduledDatabaseBackup.php
+++ b/app/Models/ScheduledDatabaseBackup.php
@@ -10,6 +10,19 @@ class ScheduledDatabaseBackup extends BaseModel
 {
     protected $guarded = [];
 
+    protected function casts(): array
+    {
+        return [
+            'pgbackrest_s3_key' => 'encrypted',
+            'pgbackrest_s3_secret' => 'encrypted',
+        ];
+    }
+
+    public function isPgBackrest(): bool
+    {
+        return $this->backup_engine === 'pgbackrest';
+    }
+
     public static function ownedByCurrentTeam()
     {
         return ScheduledDatabaseBackup::whereRelation('team', 'id', currentTeam()->id)->orderBy('created_at', 'desc');

--- a/app/Models/ScheduledDatabaseBackupExecution.php
+++ b/app/Models/ScheduledDatabaseBackupExecution.php
@@ -14,7 +14,13 @@ class ScheduledDatabaseBackupExecution extends BaseModel
             's3_uploaded' => 'boolean',
             'local_storage_deleted' => 'boolean',
             's3_storage_deleted' => 'boolean',
+            'finished_at' => 'datetime',
         ];
+    }
+
+    public function isPgBackrest(): bool
+    {
+        return $this->backup_engine === 'pgbackrest';
     }
 
     public function scheduledDatabaseBackup(): BelongsTo

--- a/app/Models/StandalonePostgresql.php
+++ b/app/Models/StandalonePostgresql.php
@@ -20,6 +20,7 @@ class StandalonePostgresql extends BaseModel
     protected $casts = [
         'init_scripts' => 'array',
         'postgres_password' => 'encrypted',
+        'pgbackrest_enabled' => 'boolean',
         'restart_count' => 'integer',
         'last_restart_at' => 'datetime',
         'last_restart_type' => 'string',
@@ -343,5 +344,15 @@ class StandalonePostgresql extends BaseModel
     public function isBackupSolutionAvailable()
     {
         return true;
+    }
+
+    public function isPgBackrestEnabled(): bool
+    {
+        return (bool) $this->pgbackrest_enabled;
+    }
+
+    public function pgbackrestVolumeName(): string
+    {
+        return 'pgbackrest-'.$this->uuid;
     }
 }

--- a/app/Services/Backup/PgBackrestService.php
+++ b/app/Services/Backup/PgBackrestService.php
@@ -1,0 +1,249 @@
+<?php
+
+namespace App\Services\Backup;
+
+use App\Models\ScheduledDatabaseBackup;
+use App\Models\StandalonePostgresql;
+
+class PgBackrestService
+{
+    private string $pgDataPath;
+
+    private string $stanza;
+
+    public function __construct(
+        private StandalonePostgresql $database,
+        private ScheduledDatabaseBackup $backup
+    ) {
+        $this->pgDataPath = $this->detectPgDataPath();
+        $this->stanza = $this->backup->pgbackrest_stanza ?? ('db-'.$this->database->uuid);
+    }
+
+    public function generatePgBackrestConf(): string
+    {
+        $conf = [];
+        $conf[] = "[{$this->stanza}]";
+        $conf[] = "pg1-path={$this->pgDataPath}";
+        $conf[] = '';
+
+        $conf[] = '[global]';
+
+        if ($this->backup->pgbackrest_repo_type === 's3') {
+            $conf[] = 'repo1-type=s3';
+            $conf[] = "repo1-s3-bucket={$this->backup->pgbackrest_s3_bucket}";
+            $conf[] = "repo1-s3-endpoint={$this->backup->pgbackrest_s3_endpoint}";
+            $conf[] = "repo1-s3-region={$this->backup->pgbackrest_s3_region}";
+            $conf[] = "repo1-s3-key={$this->backup->pgbackrest_s3_key}";
+            $conf[] = "repo1-s3-key-secret={$this->backup->pgbackrest_s3_secret}";
+            $conf[] = "repo1-path=/pgbackrest/{$this->database->uuid}";
+
+            // Non-AWS S3 endpoints (MinIO, etc.) need path-style URIs and may need TLS off
+            if ($this->isNonAwsEndpoint($this->backup->pgbackrest_s3_endpoint)) {
+                $conf[] = 'repo1-s3-uri-style=path';
+                if (str_starts_with($this->backup->pgbackrest_s3_endpoint, 'http://')) {
+                    $conf[] = 'repo1-storage-verify-tls=n';
+                }
+            }
+        } else {
+            $conf[] = 'repo1-type=posix';
+            $conf[] = "repo1-path=/var/lib/pgbackrest";
+        }
+
+        $conf[] = "repo1-retention-full={$this->backup->pgbackrest_retention_full}";
+        $conf[] = "repo1-retention-diff={$this->backup->pgbackrest_retention_diff}";
+
+        $compressType = $this->backup->pgbackrest_compress_type ?? 'gz';
+        $compressLevel = $this->backup->pgbackrest_compress_level ?? 6;
+        $conf[] = "compress-type={$compressType}";
+        $conf[] = "compress-level={$compressLevel}";
+
+        $conf[] = "log-level-console={$this->backup->pgbackrest_log_level_console}";
+        $conf[] = "log-level-file={$this->backup->pgbackrest_log_level_file}";
+
+        // Start output to /dev/null since pgBackRest manages its own log files
+        $conf[] = 'log-path=/var/log/pgbackrest';
+
+        $conf[] = '';
+
+        return implode("\n", $conf);
+    }
+
+    public function getInstallCommands(): array
+    {
+        return [
+            // Try apt-get first (Debian-based), then apk (Alpine)
+            '(command -v pgbackrest > /dev/null 2>&1 && echo "pgBackRest already installed") || '.
+            '(apt-get update -qq && apt-get install -y -qq pgbackrest > /dev/null 2>&1) || '.
+            '(apk add --no-cache pgbackrest > /dev/null 2>&1)',
+            'mkdir -p /var/log/pgbackrest',
+            'mkdir -p /etc/pgbackrest',
+            'mkdir -p /var/lib/pgbackrest',
+            'chown -R postgres:postgres /var/log/pgbackrest /etc/pgbackrest /var/lib/pgbackrest',
+        ];
+    }
+
+    public function getSetupCommands(): array
+    {
+        $confContent = $this->generatePgBackrestConf();
+        $confBase64 = base64_encode($confContent);
+
+        return [
+            "echo '{$confBase64}' | base64 -d > /etc/pgbackrest/pgbackrest.conf",
+            'chown postgres:postgres /etc/pgbackrest/pgbackrest.conf',
+            'chmod 640 /etc/pgbackrest/pgbackrest.conf',
+        ];
+    }
+
+    public function getStanzaCreateCommand(): string
+    {
+        return "su - postgres -c 'pgbackrest --stanza={$this->stanza} stanza-create' 2>&1 || true";
+    }
+
+    public function getStanzaCheckCommand(): string
+    {
+        return "su - postgres -c 'pgbackrest --stanza={$this->stanza} check' 2>&1";
+    }
+
+    public function getBackupCommand(): string
+    {
+        $type = $this->backup->pgbackrest_backup_type ?? 'full';
+
+        return "su - postgres -c 'pgbackrest --stanza={$this->stanza} --type={$type} backup' 2>&1";
+    }
+
+    public function getInfoCommand(?string $outputFormat = 'json'): string
+    {
+        $formatArg = $outputFormat ? " --output={$outputFormat}" : '';
+
+        return "su - postgres -c 'pgbackrest --stanza={$this->stanza}{$formatArg} info' 2>&1";
+    }
+
+    public function getExpireCommand(): string
+    {
+        return "su - postgres -c 'pgbackrest --stanza={$this->stanza} expire' 2>&1";
+    }
+
+    public function getRestoreDatabaseCommand(?string $targetTime = null, ?string $backupLabel = null): array
+    {
+        $commands = [];
+
+        // Stop PostgreSQL
+        $commands[] = 'pg_ctl stop -D '.$this->pgDataPath.' -m fast 2>/dev/null || true';
+
+        // Build restore command
+        $restore = "pgbackrest --stanza={$this->stanza} --delta";
+
+        if ($backupLabel) {
+            $restore .= " --set={$backupLabel}";
+        }
+
+        if ($targetTime) {
+            $restore .= " --type=time --target=\"{$targetTime}\"";
+        }
+
+        $restore .= ' restore';
+
+        $commands[] = "su - postgres -c '{$restore}' 2>&1";
+
+        // Start PostgreSQL
+        $commands[] = 'pg_ctl start -D '.$this->pgDataPath.' 2>&1';
+
+        return $commands;
+    }
+
+    public function getWalArchivingParams(): array
+    {
+        return [
+            '-c', 'archive_mode=on',
+            '-c', "archive_command='pgbackrest --stanza={$this->stanza} archive-push %p'",
+            '-c', 'wal_level=replica',
+            '-c', 'max_wal_senders=3',
+        ];
+    }
+
+    public function getDockerVolumes(): array
+    {
+        $volumes = [];
+
+        if ($this->backup->pgbackrest_repo_type === 'posix') {
+            $volumeName = $this->database->pgbackrestVolumeName();
+            $volumes[] = "{$volumeName}:/var/lib/pgbackrest";
+        }
+
+        return $volumes;
+    }
+
+    public function getDockerVolumeDefinitions(): array
+    {
+        $definitions = [];
+
+        if ($this->backup->pgbackrest_repo_type === 'posix') {
+            $volumeName = $this->database->pgbackrestVolumeName();
+            $definitions[$volumeName] = [
+                'name' => $volumeName,
+                'external' => false,
+            ];
+        }
+
+        return $definitions;
+    }
+
+    public function parseBackupInfo(string $jsonOutput): array
+    {
+        $info = json_decode($jsonOutput, true);
+        if (! $info || ! is_array($info)) {
+            return [];
+        }
+
+        $result = [];
+        foreach ($info as $stanzaInfo) {
+            if (($stanzaInfo['name'] ?? '') !== $this->stanza) {
+                continue;
+            }
+            foreach ($stanzaInfo['backup'] ?? [] as $backup) {
+                $result[] = [
+                    'label' => $backup['label'] ?? '',
+                    'type' => $backup['type'] ?? '',
+                    'timestamp_start' => $backup['timestamp']['start'] ?? null,
+                    'timestamp_stop' => $backup['timestamp']['stop'] ?? null,
+                    'database_size' => $backup['info']['size'] ?? 0,
+                    'backup_size' => $backup['info']['delta'] ?? 0,
+                    'repository_size' => $backup['info']['repository']['size'] ?? 0,
+                    'repository_delta' => $backup['info']['repository']['delta'] ?? 0,
+                    'wal_start' => $backup['lsn']['start'] ?? null,
+                    'wal_stop' => $backup['lsn']['stop'] ?? null,
+                ];
+            }
+        }
+
+        return $result;
+    }
+
+    public function getStanza(): string
+    {
+        return $this->stanza;
+    }
+
+    private function detectPgDataPath(): string
+    {
+        $image = $this->database->image ?? '';
+        $majorVersion = 0;
+
+        if (preg_match('/:(?:pg)?(\d+)/i', $image, $matches)) {
+            $majorVersion = (int) $matches[1];
+        }
+
+        return $majorVersion >= 18
+            ? '/var/lib/postgresql'
+            : '/var/lib/postgresql/data';
+    }
+
+    private function isNonAwsEndpoint(?string $endpoint): bool
+    {
+        if (blank($endpoint)) {
+            return false;
+        }
+
+        return ! str_contains($endpoint, 'amazonaws.com');
+    }
+}

--- a/database/migrations/2025_12_26_000001_add_pgbackrest_fields_to_scheduled_database_backups.php
+++ b/database/migrations/2025_12_26_000001_add_pgbackrest_fields_to_scheduled_database_backups.php
@@ -1,0 +1,74 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('scheduled_database_backups', function (Blueprint $table) {
+            $table->string('backup_engine')->default('dump')->after('team_id');
+            $table->string('pgbackrest_stanza')->nullable()->after('backup_engine');
+            $table->string('pgbackrest_backup_type')->default('full')->after('pgbackrest_stanza');
+            $table->string('pgbackrest_repo_type')->default('posix')->after('pgbackrest_backup_type');
+            $table->string('pgbackrest_s3_bucket')->nullable()->after('pgbackrest_repo_type');
+            $table->string('pgbackrest_s3_endpoint')->nullable()->after('pgbackrest_s3_bucket');
+            $table->string('pgbackrest_s3_region')->default('us-east-1')->after('pgbackrest_s3_endpoint');
+            $table->text('pgbackrest_s3_key')->nullable()->after('pgbackrest_s3_region');
+            $table->text('pgbackrest_s3_secret')->nullable()->after('pgbackrest_s3_key');
+            $table->string('pgbackrest_compress_type')->default('gz')->after('pgbackrest_s3_secret');
+            $table->integer('pgbackrest_compress_level')->default(6)->after('pgbackrest_compress_type');
+            $table->integer('pgbackrest_retention_full')->default(2)->after('pgbackrest_compress_level');
+            $table->integer('pgbackrest_retention_diff')->default(7)->after('pgbackrest_retention_full');
+            $table->string('pgbackrest_log_level_console')->default('warn')->after('pgbackrest_retention_diff');
+            $table->string('pgbackrest_log_level_file')->default('info')->after('pgbackrest_log_level_console');
+        });
+
+        Schema::table('scheduled_database_backup_executions', function (Blueprint $table) {
+            $table->string('backup_engine')->default('dump')->after('scheduled_database_backup_id');
+            $table->string('pgbackrest_backup_type')->nullable()->after('backup_engine');
+            $table->string('pgbackrest_backup_label')->nullable()->after('pgbackrest_backup_type');
+        });
+
+        Schema::table('standalone_postgresqls', function (Blueprint $table) {
+            $table->boolean('pgbackrest_enabled')->default(false)->after('custom_docker_run_options');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('scheduled_database_backups', function (Blueprint $table) {
+            $table->dropColumn([
+                'backup_engine',
+                'pgbackrest_stanza',
+                'pgbackrest_backup_type',
+                'pgbackrest_repo_type',
+                'pgbackrest_s3_bucket',
+                'pgbackrest_s3_endpoint',
+                'pgbackrest_s3_region',
+                'pgbackrest_s3_key',
+                'pgbackrest_s3_secret',
+                'pgbackrest_compress_type',
+                'pgbackrest_compress_level',
+                'pgbackrest_retention_full',
+                'pgbackrest_retention_diff',
+                'pgbackrest_log_level_console',
+                'pgbackrest_log_level_file',
+            ]);
+        });
+
+        Schema::table('scheduled_database_backup_executions', function (Blueprint $table) {
+            $table->dropColumn([
+                'backup_engine',
+                'pgbackrest_backup_type',
+                'pgbackrest_backup_label',
+            ]);
+        });
+
+        Schema::table('standalone_postgresqls', function (Blueprint $table) {
+            $table->dropColumn('pgbackrest_enabled');
+        });
+    }
+};

--- a/resources/views/livewire/project/database/backup-edit.blade.php
+++ b/resources/views/livewire/project/database/backup-edit.blade.php
@@ -44,6 +44,96 @@
             </x-forms.select>
         </div>
     @endif
+    @if ($backup->database_type === 'App\Models\StandalonePostgresql' && $backup->database_id !== 0)
+        <div class="pb-4">
+            <x-forms.select id="backupEngine" label="Backup Engine"
+                helper="Choose the backup engine. 'pg_dump' uses traditional dump/restore. 'pgBackRest' enables WAL-based incremental backups with point-in-time recovery.">
+                <option value="dump">pg_dump (Traditional)</option>
+                <option value="pgbackrest">pgBackRest (Incremental / PITR)</option>
+            </x-forms.select>
+        </div>
+
+        @if ($backupEngine === 'pgbackrest')
+            <div class="pb-4 border-l-2 border-blue-500/50 pl-4">
+                <h3 class="mb-3">pgBackRest Configuration</h3>
+                <div class="flex flex-col gap-3">
+                    <div class="flex gap-2">
+                        <x-forms.select id="pgbackrestBackupType" label="Backup Type"
+                            helper="Full: complete backup every time. Differential: changes since last full backup. Incremental: changes since last backup of any type.">
+                            <option value="full">Full</option>
+                            <option value="diff">Differential</option>
+                            <option value="incr">Incremental</option>
+                        </x-forms.select>
+                        <x-forms.input label="Stanza Name" id="pgbackrestStanza"
+                            helper="Custom stanza name. Leave empty to use the auto-generated name based on the database UUID."
+                            placeholder="Auto-generated" />
+                    </div>
+                    <div class="flex gap-2">
+                        <x-forms.select id="pgbackrestRepoType" label="Repository Type"
+                            helper="Posix: store backups on local disk. S3: store backups in an S3-compatible bucket.">
+                            <option value="posix">Local Disk (posix)</option>
+                            <option value="s3">S3 Storage</option>
+                        </x-forms.select>
+                        <x-forms.select id="pgbackrestCompressType" label="Compression">
+                            <option value="gz">gzip</option>
+                            <option value="lz4">LZ4</option>
+                            <option value="zst">Zstandard</option>
+                            <option value="none">None</option>
+                        </x-forms.select>
+                        <x-forms.input label="Compression Level" id="pgbackrestCompressLevel" type="number" min="0"
+                            max="9" />
+                    </div>
+
+                    @if ($pgbackrestRepoType === 's3')
+                        <h4 class="mt-2 font-medium">S3 Repository Settings</h4>
+                        <div class="flex gap-2">
+                            <x-forms.input label="S3 Bucket" id="pgbackrestS3Bucket" required />
+                            <x-forms.input label="S3 Endpoint" id="pgbackrestS3Endpoint" required
+                                placeholder="s3.amazonaws.com" />
+                            <x-forms.input label="S3 Region" id="pgbackrestS3Region" placeholder="us-east-1" />
+                        </div>
+                        <div class="flex gap-2">
+                            <x-forms.input label="S3 Access Key" id="pgbackrestS3Key" type="password" />
+                            <x-forms.input label="S3 Secret Key" id="pgbackrestS3Secret" type="password" />
+                        </div>
+                    @endif
+
+                    <h4 class="mt-2 font-medium">Retention</h4>
+                    <div class="flex gap-2">
+                        <x-forms.input label="Full Backup Retention" id="pgbackrestRetentionFull" type="number"
+                            min="1"
+                            helper="Number of full backups to retain. Older full backups and their dependent incremental/differential backups will be expired." />
+                        <x-forms.input label="Differential Backup Retention" id="pgbackrestRetentionDiff" type="number"
+                            min="1"
+                            helper="Number of differential backups to retain. Only applies when using differential backup type." />
+                    </div>
+
+                    <h4 class="mt-2 font-medium">Logging</h4>
+                    <div class="flex gap-2">
+                        <x-forms.select id="pgbackrestLogLevelConsole" label="Console Log Level">
+                            <option value="off">Off</option>
+                            <option value="error">Error</option>
+                            <option value="warn">Warn</option>
+                            <option value="info">Info</option>
+                            <option value="detail">Detail</option>
+                            <option value="debug">Debug</option>
+                            <option value="trace">Trace</option>
+                        </x-forms.select>
+                        <x-forms.select id="pgbackrestLogLevelFile" label="File Log Level">
+                            <option value="off">Off</option>
+                            <option value="error">Error</option>
+                            <option value="warn">Warn</option>
+                            <option value="info">Info</option>
+                            <option value="detail">Detail</option>
+                            <option value="debug">Debug</option>
+                            <option value="trace">Trace</option>
+                        </x-forms.select>
+                    </div>
+                </div>
+            </div>
+        @endif
+    @endif
+
     <div class="flex flex-col gap-2">
         <h3>Settings</h3>
         <div class="flex gap-2 flex-col ">

--- a/resources/views/livewire/project/database/backup-executions.blade.php
+++ b/resources/views/livewire/project/database/backup-executions.blade.php
@@ -83,6 +83,15 @@
                         @if(data_get($execution, 'size'))
                             • Size: {{ formatBytes(data_get($execution, 'size')) }}
                         @endif
+                        @if(data_get($execution, 'backup_engine') === 'pgbackrest')
+                            • Engine: pgBackRest
+                            @if(data_get($execution, 'pgbackrest_backup_type'))
+                                ({{ ucfirst(data_get($execution, 'pgbackrest_backup_type')) }})
+                            @endif
+                            @if(data_get($execution, 'pgbackrest_backup_label'))
+                                • Label: {{ data_get($execution, 'pgbackrest_backup_label') }}
+                            @endif
+                        @endif
                     </div>
                     <div class="text-gray-600 dark:text-gray-400 text-sm">
                         Location: {{ data_get($execution, 'filename', 'N/A') }}

--- a/routes/api.php
+++ b/routes/api.php
@@ -144,6 +144,7 @@ Route::group([
     Route::get('/databases/{uuid}', [DatabasesController::class, 'database_by_uuid'])->middleware(['api.ability:read']);
     Route::get('/databases/{uuid}/backups', [DatabasesController::class, 'database_backup_details_uuid'])->middleware(['api.ability:read']);
     Route::get('/databases/{uuid}/backups/{scheduled_backup_uuid}/executions', [DatabasesController::class, 'list_backup_executions'])->middleware(['api.ability:read']);
+    Route::get('/databases/{uuid}/pgbackrest/info', [DatabasesController::class, 'pgbackrest_info'])->middleware(['api.ability:read']);
     Route::patch('/databases/{uuid}', [DatabasesController::class, 'update_by_uuid'])->middleware(['api.ability:write']);
     Route::post('/databases/{uuid}/backups', [DatabasesController::class, 'create_backup'])->middleware(['api.ability:write']);
     Route::patch('/databases/{uuid}/backups/{scheduled_backup_uuid}', [DatabasesController::class, 'update_backup'])->middleware(['api.ability:write']);


### PR DESCRIPTION
## Summary

Implements pgBackRest as an alternative backup engine for PostgreSQL databases in Coolify, enabling WAL-based incremental and differential backups with point-in-time recovery capabilities.

/claim #7423

### What this PR does

- **Backup engine selection**: Users can choose between traditional `pg_dump` and `pgBackRest` per backup schedule
- **Incremental/differential backups**: Supports full, incremental, and differential backup types via WAL archiving
- **Point-in-time recovery**: Includes a restore action (`PgBackrestRestore`) that supports delta restore with optional PITR target time
- **Dual repository support**: Works with both local disk (posix) and S3-compatible storage (including MinIO with auto path-style URI detection)
- **Auto-provisioning**: pgBackRest is installed inside the PostgreSQL container on startup when enabled, with stanza creation and WAL archiving configuration handled automatically
- **Full UI integration**: Livewire backup editor includes engine selector, backup type, repository config, S3 settings, compression, retention, and log level controls
- **API support**: Extended `create_backup` and `update_backup` API endpoints with all pgBackRest fields, plus a new `GET /databases/{uuid}/pgbackrest/info` endpoint

### Files changed

**New files (3):**
- `app/Services/Backup/PgBackrestService.php` - Core service: config generation, command building, backup info parsing
- `app/Actions/Database/PgBackrestRestore.php` - Restore action with delta restore and PITR support
- `database/migrations/2025_12_26_000001_add_pgbackrest_fields_to_scheduled_database_backups.php` - Migration for new fields

**Modified files (10):**
- `app/Models/StandalonePostgresql.php` - Added `pgbackrest_enabled` cast and helper methods
- `app/Models/ScheduledDatabaseBackup.php` - Added encrypted S3 casts and `isPgBackrest()` method
- `app/Models/ScheduledDatabaseBackupExecution.php` - Added `isPgBackrest()` method and `finished_at` cast
- `app/Jobs/DatabaseBackupJob.php` - Added pgBackRest early-return flow and `run_pgbackrest_backup()` method
- `app/Actions/Database/StartPostgresql.php` - WAL archiving config, pgBackRest volumes, and post-start install/setup
- `app/Http/Controllers/Api/DatabasesController.php` - Extended backup CRUD with pgBackRest fields, added `pgbackrest_info` endpoint
- `app/Livewire/Project/Database/BackupEdit.php` - Added 14 pgBackRest properties and bidirectional syncData
- `resources/views/livewire/project/database/backup-edit.blade.php` - Backup engine selector and full pgBackRest config panel
- `resources/views/livewire/project/database/backup-executions.blade.php` - pgBackRest execution info display
- `routes/api.php` - Added pgBackRest info route

### Design decisions

- **In-container installation**: pgBackRest is installed inside the existing PostgreSQL container (via `apt-get` or `apk`) rather than requiring a custom image, keeping the existing workflow intact
- **Per-schedule engine**: The backup engine is selected per backup schedule, not globally, allowing mixed strategies
- **Auto-stanza management**: Stanza creation happens automatically on container startup and before each backup
- **S3 credentials encryption**: pgBackRest S3 keys are stored with Laravel's `encrypted` cast
- **Non-AWS detection**: Automatically enables path-style URIs and disables TLS verification for non-AWS S3 endpoints (MinIO, etc.)

## Test plan

- [ ] Create a PostgreSQL database in Coolify
- [ ] Create a backup schedule and select "pgBackRest" as the engine
- [ ] Verify pgBackRest is installed in the container after restart
- [ ] Run a full backup and verify it completes successfully
- [ ] Run an incremental backup and verify it references the full backup
- [ ] Verify the pgBackRest info API endpoint returns backup details
- [ ] Test with S3 repository type (MinIO or AWS)
- [ ] Verify traditional pg_dump backups still work unchanged
- [ ] Verify the backup execution list shows pgBackRest-specific info (engine, type, label)