### PR TITLE
fix: handle missing upgrade status after server restart

### DIFF
--- a/resources/views/livewire/upgrade.blade.php
+++ b/resources/views/livewire/upgrade.blade.php
@@ -397,6 +397,19 @@
                             this.showSuccess();
                         } else if (data.status === 'error') {
                             this.showError(data.message);
+                        } else if (data.status === 'none' && this.showProgress) {
+                            // Status file missing/cleared after server restart —
+                            // fall back to health check to detect when server is back
+                            if (!this.serviceDown) {
+                                this.serviceDown = true;
+                                this.currentStep = 4;
+                                this.currentStatus = 'Coolify is restarting with the new version...';
+                                if (this.checkUpgradeStatusInterval) {
+                                    clearInterval(this.checkUpgradeStatusInterval);
+                                    this.checkUpgradeStatusInterval = null;
+                                }
+                                this.revive();
+                            }
                         }
                     } catch (error) {
                         // Service is down - switch to health check mode


### PR DESCRIPTION
## What

Fixes the upgrade wizard spinner running forever even though the server updates successfully.

Closes #8241

## Why

When the Coolify container restarts during upgrade, the `.upgrade-status` file can be cleared or become stale. The PHP `getUpgradeStatus()` method correctly returns `{status: 'none'}` in this case, but the JavaScript polling loop only handles `in_progress`, `complete`, and `error` — **silently ignoring** `none`. This leaves the spinner stuck with no state transition.

## How

Added a handler for `status === 'none'` in the upgrade polling loop (guarded by `this.showProgress` to avoid false positives before upgrade starts). When the status file is missing after an upgrade has been initiated:

1. Clears the Livewire status-polling interval
2. Switches to health-check polling via `revive()`
3. `revive()` hits `/api/health` every 2 seconds until the server responds
4. Shows the success state with auto-reload countdown

This mirrors the existing `catch` block behavior (lines 401-413) which handles the case when Livewire itself is unreachable. The new handler covers the case when **Livewire reconnects but the status file is gone**.

## Testing

1. On a Coolify instance, trigger an upgrade
2. During upgrade, the status file may be cleared when the container restarts
3. **Before fix:** spinner keeps spinning forever
4. **After fix:** falls back to health check, detects server is back, shows "Upgrade Complete!" with countdown

## Breaking changes

None — this only adds a fallback path that previously resulted in an infinite spinner.
