### PR TITLE
fix: use container labels instead of env vars for log drain

### DIFF
--- a/app/Actions/Server/StartLogDrain.php
+++ b/app/Actions/Server/StartLogDrain.php
@@ -53,10 +53,9 @@ class StartLogDrain
     Name                modify
     Match               *
     Set                 coolify.server_name {$server->name}
-    Rename              COOLIFY_APP_NAME coolify.app_name
-    Rename              COOLIFY_PROJECT_NAME coolify.project_name
-    Rename              COOLIFY_SERVER_IP coolify.server_ip
-    Rename              COOLIFY_ENVIRONMENT_NAME coolify.environment_name
+    Rename              coolify.serviceName coolify.service_name
+    Rename              coolify.projectName coolify.project_name
+    Rename              coolify.environmentName coolify.environment_name
 [OUTPUT]
     Name nrlogs
     Match *
@@ -108,10 +107,9 @@ class StartLogDrain
     Name                modify
     Match               *
     Set                 coolify.server_name {$server->name}
-    Rename              COOLIFY_APP_NAME coolify.app_name
-    Rename              COOLIFY_PROJECT_NAME coolify.project_name
-    Rename              COOLIFY_SERVER_IP coolify.server_ip
-    Rename              COOLIFY_ENVIRONMENT_NAME coolify.environment_name
+    Rename              coolify.serviceName coolify.service_name
+    Rename              coolify.projectName coolify.project_name
+    Rename              coolify.environmentName coolify.environment_name
 [OUTPUT]
     Name            http
     Match           *

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -2830,8 +2830,8 @@ function generate_fluentd_configuration(): array
             'fluentd-address' => 'tcp://127.0.0.1:24224',
             'fluentd-async' => 'true',
             'fluentd-sub-second-precision' => 'true',
-            // env vars are used in the LogDrain configurations
-            'env' => 'COOLIFY_APP_NAME,COOLIFY_PROJECT_NAME,COOLIFY_SERVER_IP,COOLIFY_ENVIRONMENT_NAME',
+            // labels are used in the LogDrain configurations
+            'labels' => 'coolify.serviceName,coolify.projectName,coolify.environmentName',
         ],
     ];
 }


### PR DESCRIPTION
## What

Fixes log drain using `env` instead of `labels` for Docker Compose services.

Closes #8415

## Why

`generate_fluentd_configuration()` configured the Docker fluentd logging driver with:

```
'env' => 'COOLIFY_APP_NAME,COOLIFY_PROJECT_NAME,COOLIFY_SERVER_IP,COOLIFY_ENVIRONMENT_NAME'
```

However, the function responsible for injecting these environment variables (`add_coolify_default_environment_variables()`) has been **disabled** — it contains an early `return;` at the top. This means these env vars never exist in containers, so the fluentd driver has nothing to forward.

Meanwhile, `defaultLabels()` and `defaultDatabaseLabels()` DO set container labels: `coolify.serviceName`, `coolify.projectName`, `coolify.environmentName`. The Docker fluentd driver supports forwarding both env vars and labels — but we need to use the right option key.

## How

### `bootstrap/helpers/shared.php`
Changed `generate_fluentd_configuration()` to use `labels` instead of `env`, referencing the actual container labels:

```diff
-'env' => 'COOLIFY_APP_NAME,COOLIFY_PROJECT_NAME,COOLIFY_SERVER_IP,COOLIFY_ENVIRONMENT_NAME',
+'labels' => 'coolify.serviceName,coolify.projectName,coolify.environmentName',
```

### `app/Actions/Server/StartLogDrain.php`
Updated Fluent Bit `Rename` filters for both New Relic and Axiom configs to match the incoming label key names:

```diff
-Rename              COOLIFY_APP_NAME coolify.app_name
-Rename              COOLIFY_PROJECT_NAME coolify.project_name
-Rename              COOLIFY_SERVER_IP coolify.server_ip
-Rename              COOLIFY_ENVIRONMENT_NAME coolify.environment_name
+Rename              coolify.serviceName coolify.service_name
+Rename              coolify.projectName coolify.project_name
+Rename              coolify.environmentName coolify.environment_name
```

## Testing

1. Deploy a Docker Compose service with log drain enabled
2. Inspect container: `docker inspect <container> --format '{{json .HostConfig.LogConfig}}' | jq`
3. **Before fix:** config shows `"env": "COOLIFY_APP_NAME,..."` — env vars don't exist
4. **After fix:** config shows `"labels": "coolify.serviceName,..."` — labels exist and are forwarded

## Breaking changes

Users with custom Fluent Bit configs that depend on `COOLIFY_APP_NAME`, `COOLIFY_PROJECT_NAME`, or `COOLIFY_SERVER_IP` field names will need to update their configs. However, these fields were never actually populated due to the disabled env injection, so in practice no working configs are affected.
