### PR TITLE
fix: only show redeploy banner for deployment-relevant settings

### DIFF
--- a/app/Livewire/Project/Application/Advanced.php
+++ b/app/Livewire/Project/Application/Advanced.php
@@ -178,6 +178,23 @@ class Advanced extends Component
                 $reset = true;
             }
 
+            // Check if a deployment-relevant setting changed before dispatching configurationChanged.
+            // Settings like preview deployments, auto deploy, and git clone options don't require redeployment.
+            $deploymentRelevantChanged = $reset
+                || $this->application->isLogDrainEnabled() !== $this->isLogDrainEnabled
+                || $this->application->settings->is_gpu_enabled !== $this->isGpuEnabled
+                || $this->application->settings->gpu_driver !== $this->gpuDriver
+                || $this->application->settings->gpu_count !== $this->gpuCount
+                || $this->application->settings->gpu_device_ids !== $this->gpuDeviceIds
+                || $this->application->settings->gpu_options !== $this->gpuOptions
+                || $this->application->settings->is_build_server_enabled !== $this->isBuildServerEnabled
+                || $this->application->settings->is_consistent_container_name_enabled !== $this->isConsistentContainerNameEnabled
+                || $this->application->settings->is_raw_compose_deployment_enabled !== $this->isRawComposeDeploymentEnabled
+                || $this->application->settings->connect_to_docker_network !== $this->isConnectToDockerNetworkEnabled
+                || $this->application->settings->disable_build_cache !== $this->disableBuildCache
+                || $this->application->settings->inject_build_args_to_dockerfile !== $this->injectBuildArgsToDockerfile
+                || $this->application->settings->include_source_commit_in_build !== $this->includeSourceCommitInBuild;
+
             if ($this->application->settings->is_raw_compose_deployment_enabled) {
                 $this->application->oldRawParser();
             } else {
@@ -190,7 +207,9 @@ class Advanced extends Component
             }
 
             $this->dispatch('success', 'Settings saved.');
-            $this->dispatch('configurationChanged');
+            if ($deploymentRelevantChanged) {
+                $this->dispatch('configurationChanged');
+            }
         } catch (\Throwable $e) {
             return handleError($e, $this);
         }


### PR DESCRIPTION
## What

Prevents the "Please redeploy" notification from appearing after saving non-deployment settings.

Closes #8357

## Why

`instantSave()` in `Advanced.php` unconditionally dispatched the `configurationChanged` event after saving ANY setting. This caused `ConfigurationChecker` to re-evaluate the config hash and show the "Please redeploy to apply the new configuration" banner — even when the changed setting has no effect on the running deployment.

For example, toggling "Preview Deployments" does not require redeployment, but it still triggered the banner because `configurationChanged` was always dispatched.

## How

### `app/Livewire/Project/Application/Advanced.php`

Added a `$deploymentRelevantChanged` check that compares the current model state against the form values **before** saving. The `configurationChanged` event is now only dispatched when a deployment-relevant setting actually changed.

**Deployment-relevant settings** (DO trigger the banner):
- Force HTTPS, Gzip, Stripprefix (proxy labels)
- Log Drain (container logging config)
- GPU settings (container runtime)
- Build Server, Consistent Container Name
- Docker Network, Raw Compose Deployment
- Build Cache, Build Args Injection, Source Commit

**Non-deployment settings** (do NOT trigger the banner):
- Preview Deployments
- Auto Deploy
- PR Deployments Public
- Git Submodules, Git LFS, Shallow Clone

## Testing

1. Deploy an application
2. Go to Settings → toggle "Preview Deployments" → Save
3. **Before fix:** "Please redeploy" banner appears
4. **After fix:** No banner — setting saved without redeploy notification
5. Toggle "Force HTTPS" → Save → Banner correctly appears (deployment-relevant change)
