### PR TITLE
fix: storage volume modal closing and uuid naming ui #8620

### DIFF
--- a/app/Livewire/Project/Shared/Storages/Show.php
+++ b/app/Livewire/Project/Shared/Storages/Show.php
@@ -51,14 +51,22 @@ class Show extends Component
      */
     private function syncData(bool $toModel = false): void
     {
+        $uuidPrefix = $this->resource->uuid . '-';
         if ($toModel) {
             // Sync TO model (before save)
-            $this->storage->name = $this->name;
+            $nameToSave = $this->name;
+            if (!str_starts_with($nameToSave, $uuidPrefix)) {
+                $nameToSave = $uuidPrefix . $nameToSave;
+            }
+            $this->storage->name = $nameToSave;
             $this->storage->mount_path = $this->mountPath;
             $this->storage->host_path = $this->hostPath;
         } else {
             // Sync FROM model (on load/refresh)
             $this->name = $this->storage->name;
+            if (str_starts_with($this->name, $uuidPrefix)) {
+                $this->name = substr($this->name, strlen($uuidPrefix));
+            }
             $this->mountPath = $this->storage->mount_path;
             $this->hostPath = $this->storage->host_path;
         }

--- a/resources/views/livewire/project/service/storage.blade.php
+++ b/resources/views/livewire/project/service/storage.blade.php
@@ -25,9 +25,9 @@
                             directoryModalOpen: false
                         }"
                             @close-storage-modal.window="
-                            if ($event.detail === 'volume') volumeModalOpen = false;
-                            if ($event.detail === 'file') fileModalOpen = false;
-                            if ($event.detail === 'directory') directoryModalOpen = false;
+                            if ($event.detail[0] === 'volume') volumeModalOpen = false;
+                            if ($event.detail[0] === 'file') fileModalOpen = false;
+                            if ($event.detail[0] === 'directory') directoryModalOpen = false;
                         ">
                             <div class="relative" @click.outside="dropdownOpen = false">
                                 <x-forms.button @click="dropdownOpen = !dropdownOpen">


### PR DESCRIPTION
Fixes #8620

This PR addresses two bugs with the persistent storage UI:
1. Strips the container UUID prefix from the volume name when displaying it in the UI and automatically prepends it before saving (preventing users from accidentally deleting the prefix and breaking volume mounts).
2. Fixes the "Add" volume/file/directory modal so it closes automatically after creation (by using `$event.detail[0]` to match Livewire 3 event parameter arrays).