### PR TITLE
fix: scheduled task input fields losing focus every 10s #8647

### DIFF
--- a/app/Livewire/Project/Shared/ScheduledTask/Show.php
+++ b/app/Livewire/Project/Shared/ScheduledTask/Show.php
@@ -52,14 +52,7 @@ class Show extends Component
     #[Locked]
     public string $task_uuid;
 
-    public function getListeners()
-    {
-        $teamId = auth()->user()->currentTeam()->id;
 
-        return [
-            "echo-private:team.{$teamId},ServiceChecked" => '$refresh',
-        ];
-    }
 
     public function mount(string $task_uuid, string $project_uuid, string $environment_uuid, ?string $application_uuid = null, ?string $service_uuid = null)
     {


### PR DESCRIPTION
Fixes #8647

The Scheduled Task configuration inputs were losing focus every 10 seconds because `ScheduledTask/Show.php` needlessly listened to the background daemon's `ServiceChecked` event. 

Every 10 seconds, this triggered a `$refresh` that forced a complete DOM re-render. Since Coolify's basic input components use a dynamically generated `Cuid2` for their HTML IDs on every render (to ensure uniqueness), Livewire's morphdom saw these changing IDs and completely replaced the input elements, destroying user focus and text selection.

By removing this listener, the page remains static while the user fills out the form, completely matching the intended behavior of all other settings pages.