### PR TITLE
fix: ignore no notification warning if webhooks are enabled #8448

### DIFF
--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -191,7 +191,8 @@ class Team extends Model implements SendsDiscord, SendsEmail, SendsPushover, Sen
             $this->getNotificationSettings('discord')?->isEnabled() ||
             $this->getNotificationSettings('slack')?->isEnabled() ||
             $this->getNotificationSettings('telegram')?->isEnabled() ||
-            $this->getNotificationSettings('pushover')?->isEnabled();
+            $this->getNotificationSettings('pushover')?->isEnabled() ||
+            $this->getNotificationSettings('webhook')?->isEnabled();
     }
 
     public function subscriptionEnded()


### PR DESCRIPTION
Fixes #8448

When a user relied solely on Webhook notifications, the dashboard would incorrectly display a red warning popup stating: `No notifications enabled. It is highly recommended to enable at least one notification channel...`. 

This is because the `isAnyNotificationEnabled()` method in `app/Models/Team.php` checked all other notification channels (email, discord, slack, telegram, pushover) to determine if the warning should be suppressed, but it completely omitted checking for webhook channels. This PR adds the missing webhook check.