### PR TITLE
fix(database): close confirmation modal after import/restore actions

### DIFF
--- a/app/Livewire/Project/Database/Import.php
+++ b/app/Livewire/Project/Database/Import.php
@@ -401,20 +401,24 @@ EOD;
         }
     }
 
-    public function runImport()
+    public function runImport(string $password = ''): bool|string
     {
+        if (! verifyPasswordConfirmation($password, $this)) {
+            return 'The provided password is incorrect.';
+        }
+
         $this->authorize('update', $this->resource);
 
         if ($this->filename === '') {
             $this->dispatch('error', 'Please select a file to import.');
 
-            return;
+            return true;
         }
 
         if (! $this->server) {
             $this->dispatch('error', 'Server not found. Please refresh the page.');
 
-            return;
+            return true;
         }
 
         try {
@@ -434,7 +438,7 @@ EOD;
                 if (! $this->validateServerPath($this->customLocation)) {
                     $this->dispatch('error', 'Invalid file path. Path must be absolute and contain only safe characters.');
 
-                    return;
+                    return true;
                 }
                 $tmpPath = '/tmp/restore_'.$this->resourceUuid;
                 $escapedCustomLocation = escapeshellarg($this->customLocation);
@@ -442,7 +446,7 @@ EOD;
             } else {
                 $this->dispatch('error', 'The file does not exist or has been deleted.');
 
-                return;
+                return true;
             }
 
             // Copy the restore command to a script file
@@ -474,11 +478,15 @@ EOD;
                 $this->dispatch('databaserestore');
             }
         } catch (\Throwable $e) {
-            return handleError($e, $this);
+            handleError($e, $this);
+
+            return true;
         } finally {
             $this->filename = null;
             $this->importCommands = [];
         }
+
+        return true;
     }
 
     public function loadAvailableS3Storages()
@@ -577,26 +585,30 @@ EOD;
         }
     }
 
-    public function restoreFromS3()
+    public function restoreFromS3(string $password = ''): bool|string
     {
+        if (! verifyPasswordConfirmation($password, $this)) {
+            return 'The provided password is incorrect.';
+        }
+
         $this->authorize('update', $this->resource);
 
         if (! $this->s3StorageId || blank($this->s3Path)) {
             $this->dispatch('error', 'Please select S3 storage and provide a path first.');
 
-            return;
+            return true;
         }
 
         if (is_null($this->s3FileSize)) {
             $this->dispatch('error', 'Please check the file first by clicking "Check File".');
 
-            return;
+            return true;
         }
 
         if (! $this->server) {
             $this->dispatch('error', 'Server not found. Please refresh the page.');
 
-            return;
+            return true;
         }
 
         try {
@@ -613,7 +625,7 @@ EOD;
             if (! $this->validateBucketName($bucket)) {
                 $this->dispatch('error', 'Invalid S3 bucket name. Bucket name must contain only alphanumerics, dots, dashes, and underscores.');
 
-                return;
+                return true;
             }
 
             // Clean the S3 path
@@ -623,7 +635,7 @@ EOD;
             if (! $this->validateS3Path($cleanPath)) {
                 $this->dispatch('error', 'Invalid S3 path. Path must contain only safe characters (alphanumerics, dots, dashes, underscores, slashes).');
 
-                return;
+                return true;
             }
 
             // Get helper image
@@ -711,9 +723,12 @@ EOD;
             $this->dispatch('info', 'Restoring database from S3. Progress will be shown in the activity monitor...');
         } catch (\Throwable $e) {
             $this->importRunning = false;
+            handleError($e, $this);
 
-            return handleError($e, $this);
+            return true;
         }
+
+        return true;
     }
 
     public function buildRestoreCommand(string $tmpPath): string


### PR DESCRIPTION
## Description

The password confirmation modal stays open after successful password verification when performing database import (both file-based and S3 restore). The restore process starts correctly and the activity monitor slide-over opens, but the modal remains visible on screen, blocking user interaction.

## Root Cause

The `modal-confirmation` component's JavaScript (`submitForm()`) calls the Livewire method and checks the return value:
- `true` → closes the modal
- `string` → displays it as a password error message
- `undefined/null` → modal stays open (the bug)

Both `runImport()` and `restoreFromS3()` in `Import.php` had three issues:

1. **Missing `$password` parameter** — The modal passes the user's password to the Livewire method, but neither method accepted it as a parameter
2. **No password verification** — Neither method called `verifyPasswordConfirmation()` to validate the password, meaning any password (even incorrect ones) would trigger the action
3. **No return value** — Neither method returned `true` on success, so the modal's JavaScript never received the signal to close

## Changes

**File:** `app/Livewire/Project/Database/Import.php`

- Added `string $password = ''` parameter to both `runImport()` and `restoreFromS3()`
- Added `verifyPasswordConfirmation($password, $this)` check at the start of both methods, returning `'The provided password is incorrect.'` on failure (displayed in modal)
- Added `bool|string` return type to both methods
- Changed all early `return;` statements to `return true;` so the modal always closes after the action is dispatched
- Changed `return handleError()` to `handleError(); return true;` so the modal closes even on errors (errors are shown via toast notifications)

## How to Test

1. Go to a running database resource → Import Backup
2. Select "Restore from S3" and check a valid S3 file
3. Click "Restore from S3" button
4. Enter confirmation text → Continue
5. Enter your password → Confirm
6. **Expected:** Modal closes, activity monitor slide-over opens on the right
7. **Before fix:** Modal stays open on top of the slide-over

Same test applies for "Restore from File" flow.

### Additional test cases:
- Enter wrong password → modal should show "The provided password is incorrect." and stay open
- Enter correct password → modal should close immediately

## Screenshots / Videos

N/A — UI behavior bug, no visual changes to components.