### PR TITLE
fix: disable timeout on public database proxies

### DIFF
--- a/app/Actions/Database/StartDatabaseProxy.php
+++ b/app/Actions/Database/StartDatabaseProxy.php
@@ -67,6 +67,8 @@ class StartDatabaseProxy
        server {
             listen $database->public_port;
             proxy_pass $containerName:$internalPort;
+            proxy_timeout 0;
+            proxy_connect_timeout 60s;
        }
     }
     EOF;


### PR DESCRIPTION
## Summary

Fixes #7743 — public database proxies time out after 10 minutes due to nginx's default `proxy_timeout` of 10m in the stream module.

## Changes

In `app/Actions/Database/StartDatabaseProxy.php`, added two directives to the nginx stream server block:

- `proxy_timeout 0;` — disables the idle timeout so long-running queries (30m+) won't be disconnected
- `proxy_connect_timeout 60s;` — keeps a reasonable timeout for the initial TCP connection

## How it works

The database proxy uses nginx's `stream` module to TCP-proxy connections to the database container. Without an explicit `proxy_timeout`, nginx defaults to 10 minutes, disconnecting any idle or long-running connection. Setting it to `0` removes this limit entirely.

This is the minimal, targeted fix. Existing proxies will pick up the change when they are next restarted/recreated.