### PR TITLE
feat: add OAuth-only self-registration setting

### DIFF
--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -22,7 +22,7 @@ class OauthController extends Controller
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! $settings->is_oauth_only_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -15,6 +15,9 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $is_oauth_only_registration_enabled;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -41,6 +44,7 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_only_registration_enabled' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => 'nullable|string',
@@ -62,6 +66,7 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_only_registration_enabled = $this->settings->is_oauth_only_registration_enabled;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -138,6 +143,7 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_only_registration_enabled = $this->is_oauth_only_registration_enabled;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -67,6 +67,7 @@ class FortifyServiceProvider extends ServiceProvider
 
             return view('auth.login', [
                 'is_registration_enabled' => $settings->is_registration_enabled,
+                'is_oauth_only_registration_enabled' => $settings->is_oauth_only_registration_enabled,
                 'enabled_oauth_providers' => $enabled_oauth_providers,
             ]);
         });

--- a/database/migrations/2026_03_01_000001_add_oauth_only_registration_to_instance_settings.php
+++ b/database/migrations/2026_03_01_000001_add_oauth_only_registration_to_instance_settings.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_only_registration_enabled')->default(false)->after('is_registration_enabled');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn('is_oauth_only_registration_enabled');
+        });
+    }
+};

--- a/lang/en.json
+++ b/lang/en.json
@@ -19,6 +19,7 @@
     "auth.logout": "Logout",
     "auth.register": "Register",
     "auth.registration_disabled": "Registration is disabled. Please contact the administrator.",
+    "auth.oauth_only_registration": "New accounts can only be created via OAuth. Use one of the providers below to sign up.",
     "auth.reset_password": "Reset password",
     "auth.failed": "These credentials do not match our records.",
     "auth.failed.callback": "Failed to process callback from login provider.",

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -70,6 +70,10 @@
                             class="block w-full text-center py-3 px-4 rounded-lg border border-neutral-300 dark:border-coolgray-400 font-medium hover:border-coollabs dark:hover:border-warning transition-colors">
                             {{ __('auth.register_now') }}
                         </a>
+                    @elseif ($is_oauth_only_registration_enabled && $enabled_oauth_providers->isNotEmpty())
+                        <div class="mt-6 text-center text-sm text-neutral-500 dark:text-neutral-400">
+                            {{ __('auth.oauth_only_registration') }}
+                        </div>
                     @else
                         <div class="mt-6 text-center text-sm text-neutral-500 dark:text-neutral-400">
                             {{ __('auth.registration_disabled') }}

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -18,8 +18,13 @@
                 <div class="flex flex-col gap-1">
                     <div class="md:w-96">
                         <x-forms.checkbox instantSave id="is_registration_enabled"
-                            helper="Allow users to self-register. If disabled, only administrators can create accounts."
+                            helper="Allow users to self-register via email/password. If disabled, only administrators can create accounts (unless OAuth-only registration is enabled)."
                             label="Registration Allowed" />
+                    </div>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_only_registration_enabled"
+                            helper="Allow new users to self-register only through configured OAuth2 providers (e.g., GitHub, Google, Authentik). Email/password registration remains disabled. This is useful for controlling access via an external identity provider."
+                            label="OAuth-Only Registration" />
                     </div>
                     <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"


### PR DESCRIPTION
## Summary

Adds a new instance setting **"OAuth-Only Registration"** that allows new users to self-register exclusively through configured OAuth2 providers (e.g., GitHub, Google, Authentik) while keeping general email/password registration disabled.

## Problem

Currently, OAuth2 user registration only works when general self-registration is enabled (`is_registration_enabled`). Admins who want to control access via an external identity provider (like Authentik) have no way to allow OAuth sign-ups while blocking email/password registration.

## Changes

- **Migration**: Added `is_oauth_only_registration_enabled` boolean column to `instance_settings`
- **OauthController**: Updated callback to allow new user creation when either general registration OR OAuth-only registration is enabled
- **Settings/Advanced**: Added new toggle with descriptive helper text in the Advanced Settings UI
- **FortifyServiceProvider**: Pass the new setting to the login view
- **Login view**: Show informative message when OAuth-only registration is active
- **Translations**: Added `auth.oauth_only_registration` string

## How it works

1. Admin enables "OAuth-Only Registration" in Settings → Advanced
2. General "Registration Allowed" can remain **disabled**
3. New users can sign up by clicking an OAuth provider on the login page
4. Email/password registration form remains hidden/disabled
5. Existing users can still log in with email/password

Closes #8042