### PR TITLE
feat: Environment variables for each server

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -1181,6 +1181,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         $coolify_envs->each(function ($item, $key) use ($envs) {
             $envs->push($key.'='.$item);
         });
+
         if ($this->pull_request_id === 0) {
             // Generate SERVICE_ variables first for dockercompose
             if ($this->build_pack === 'dockercompose') {
@@ -1304,6 +1305,18 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             // Add HOST if not exists
             if ($this->application->environment_variables_preview->where('key', 'HOST')->isEmpty()) {
                 $envs->push('HOST=0.0.0.0');
+            }
+        }
+
+        // Inject server-level runtime environment variables (app vars take precedence)
+        $existingKeys = $envs->map(function ($item) {
+            return str($item)->before('=')->value();
+        })->toArray();
+
+        $serverEnvVars = $this->mainServer->environmentVariables()->get();
+        foreach ($serverEnvVars as $env) {
+            if (! in_array($env->key, $existingKeys)) {
+                $envs->push($env->key.'='.$env->real_value);
             }
         }
 
@@ -1516,6 +1529,14 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                     }
                 }
             }
+        }
+
+        // 3.5. Add server-level build-time environment variables (app vars override these)
+        $serverBuildEnvVars = $this->mainServer->environmentVariables()
+            ->where('is_buildtime', true)
+            ->get();
+        foreach ($serverBuildEnvVars as $env) {
+            $envs_dict[$env->key] = escapeBashEnvValue($env->value);
         }
 
         // 4. Add user-defined build-time variables LAST (highest priority - can override everything)

--- a/app/Livewire/Server/EnvironmentVariable/All.php
+++ b/app/Livewire/Server/EnvironmentVariable/All.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace App\Livewire\Server\EnvironmentVariable;
+
+use App\Models\Server;
+use App\Models\ServerEnvironmentVariable;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Attributes\Locked;
+use Livewire\Component;
+
+class All extends Component
+{
+    use AuthorizesRequests;
+
+    public Server $server;
+
+    public string $view = 'normal';
+
+    public ?string $variables = null;
+
+    public string $newKey = '';
+
+    public string $newValue = '';
+
+    public bool $newIsMultiline = false;
+
+    public bool $newIsLiteral = false;
+
+    public bool $newIsBuildtime = false;
+
+    protected $listeners = [
+        'saveKey' => 'submit',
+        'refreshEnvs',
+        'environmentVariableDeleted' => 'refreshEnvs',
+    ];
+
+    public function mount(string $server_uuid)
+    {
+        $this->server = Server::ownedByCurrentTeam()->whereUuid($server_uuid)->firstOrFail();
+        $this->getDevView();
+    }
+
+    public function getEnvironmentVariablesProperty()
+    {
+        return $this->server->environmentVariables()->orderBy('key')->get();
+    }
+
+    public function getDevView()
+    {
+        $this->variables = $this->environmentVariables->map(function ($item) {
+            if ($item->is_shown_once) {
+                return "$item->key=(Locked Secret, delete and add again to change)";
+            }
+            if ($item->is_multiline) {
+                return "$item->key=(Multiline environment variable, edit in normal view)";
+            }
+
+            return "$item->key=$item->value";
+        })->join("\n");
+    }
+
+    public function switch()
+    {
+        $this->view = $this->view === 'normal' ? 'dev' : 'normal';
+        $this->getDevView();
+    }
+
+    public function addVariable()
+    {
+        try {
+            $this->authorize('update', $this->server);
+
+            $this->validate([
+                'newKey' => 'required|string',
+                'newValue' => 'required|string',
+            ]);
+
+            $found = $this->server->environmentVariables()->where('key', $this->newKey)->first();
+            if ($found) {
+                $this->dispatch('error', 'Environment variable already exists.');
+
+                return;
+            }
+
+            $env = new ServerEnvironmentVariable;
+            $env->key = $this->newKey;
+            $env->value = $this->newValue;
+            $env->is_multiline = $this->newIsMultiline;
+            $env->is_literal = $this->newIsLiteral;
+            $env->is_buildtime = $this->newIsBuildtime;
+            $env->server_id = $this->server->id;
+            $env->save();
+
+            $this->newKey = '';
+            $this->newValue = '';
+            $this->newIsMultiline = false;
+            $this->newIsLiteral = false;
+            $this->newIsBuildtime = false;
+
+            $this->dispatch('success', 'Environment variable added.');
+            $this->refreshEnvs();
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function submit($data = null)
+    {
+        try {
+            $this->authorize('update', $this->server);
+
+            $this->handleBulkSubmit();
+
+            $this->getDevView();
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        } finally {
+            $this->refreshEnvs();
+        }
+    }
+
+    private function handleBulkSubmit()
+    {
+        $variables = parseEnvFormatToArray($this->variables);
+        $changesMade = false;
+
+        // Delete removed variables
+        $deleted = $this->server->environmentVariables()->whereNotIn('key', array_keys($variables))->delete();
+        if ($deleted > 0) {
+            $changesMade = true;
+        }
+
+        // Update or create variables
+        foreach ($variables as $key => $value) {
+            $found = $this->server->environmentVariables()->where('key', $key)->first();
+            if ($found) {
+                if (! $found->is_shown_once && ! $found->is_multiline && $found->value !== $value) {
+                    $found->value = $value;
+                    $found->save();
+                    $changesMade = true;
+                }
+            } else {
+                $env = new ServerEnvironmentVariable;
+                $env->key = $key;
+                $env->value = $value;
+                $env->server_id = $this->server->id;
+                $env->save();
+                $changesMade = true;
+            }
+        }
+
+        if ($changesMade) {
+            $this->dispatch('success', 'Environment variables updated.');
+        }
+    }
+
+    private function handleSingleSubmit($data)
+    {
+        $found = $this->server->environmentVariables()->where('key', $data['key'])->first();
+        if ($found) {
+            $this->dispatch('error', 'Environment variable already exists.');
+
+            return;
+        }
+
+        $env = new ServerEnvironmentVariable;
+        $env->key = $data['key'];
+        $env->value = $data['value'];
+        $env->is_multiline = $data['is_multiline'] ?? false;
+        $env->is_literal = $data['is_literal'] ?? false;
+        $env->is_buildtime = $data['is_buildtime'] ?? false;
+        $env->is_shown_once = $data['is_shown_once'] ?? false;
+        $env->server_id = $this->server->id;
+        $env->save();
+
+        $this->dispatch('success', 'Environment variable added.');
+    }
+
+    public function deleteEnvironmentVariable($uuid)
+    {
+        try {
+            $this->authorize('update', $this->server);
+            $env = $this->server->environmentVariables()->where('uuid', $uuid)->firstOrFail();
+            $env->delete();
+            $this->dispatch('success', 'Environment variable deleted.');
+            $this->refreshEnvs();
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function refreshEnvs()
+    {
+        $this->server->refresh();
+        unset($this->environmentVariables);
+        $this->getDevView();
+    }
+
+    public function render()
+    {
+        return view('livewire.server.environment-variable.all');
+    }
+}

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -1003,6 +1003,11 @@ $schema://$host {
         return $this->belongsTo(Team::class);
     }
 
+    public function environmentVariables()
+    {
+        return $this->hasMany(ServerEnvironmentVariable::class);
+    }
+
     public function isProxyShouldRun()
     {
         // TODO: Do we need "|| $this->proxy->force_stop" here?

--- a/app/Models/ServerEnvironmentVariable.php
+++ b/app/Models/ServerEnvironmentVariable.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Casts\Attribute;
+
+class ServerEnvironmentVariable extends BaseModel
+{
+    protected $guarded = [];
+
+    protected $casts = [
+        'key' => 'string',
+        'value' => 'encrypted',
+        'is_shown_once' => 'boolean',
+        'is_literal' => 'boolean',
+        'is_multiline' => 'boolean',
+        'is_buildtime' => 'boolean',
+    ];
+
+    public function server()
+    {
+        return $this->belongsTo(Server::class);
+    }
+
+    protected function value(): Attribute
+    {
+        return Attribute::make(
+            get: fn (?string $value = null) => $this->getEnvironmentVariable($value),
+            set: fn (?string $value = null) => $this->setEnvironmentVariable($value),
+        );
+    }
+
+    protected function realValue(): Attribute
+    {
+        return Attribute::make(
+            get: function () {
+                $real_value = $this->value;
+
+                if (is_null($real_value)) {
+                    return null;
+                }
+
+                if ($this->is_literal || $this->is_multiline) {
+                    $real_value = '\'' . $real_value . '\'';
+                } else {
+                    $real_value = escapeEnvVariables($real_value);
+                }
+
+                return $real_value;
+            }
+        );
+    }
+
+    protected function key(): Attribute
+    {
+        return Attribute::make(
+            set: fn (string $value) => str($value)->trim()->replace(' ', '_')->value,
+        );
+    }
+
+    private function getEnvironmentVariable(?string $value = null): ?string
+    {
+        if (! $value) {
+            return null;
+        }
+
+        return trim(decrypt($value));
+    }
+
+    private function setEnvironmentVariable(?string $value = null): ?string
+    {
+        if (is_null($value) && $value === '') {
+            return null;
+        }
+
+        return encrypt(trim($value));
+    }
+}

--- a/database/migrations/2026_03_01_000001_create_server_environment_variables_table.php
+++ b/database/migrations/2026_03_01_000001_create_server_environment_variables_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('server_environment_variables', function (Blueprint $table) {
+            $table->id();
+            $table->string('uuid')->unique();
+            $table->string('key');
+            $table->text('value')->nullable();
+            $table->boolean('is_shown_once')->default(false);
+            $table->boolean('is_literal')->default(false);
+            $table->boolean('is_multiline')->default(false);
+            $table->boolean('is_buildtime')->default(false);
+            $table->foreignId('server_id')->constrained()->onDelete('cascade');
+            $table->unique(['key', 'server_id']);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('server_environment_variables');
+    }
+};

--- a/resources/views/livewire/server/environment-variable/all.blade.php
+++ b/resources/views/livewire/server/environment-variable/all.blade.php
@@ -1,0 +1,78 @@
+<div>
+    <x-slot:title>
+        Server Environment Variables | Coolify
+    </x-slot:title>
+    <x-server.navbar :server="$server" />
+    <div class="flex flex-col gap-4">
+        <div>
+            <div class="flex items-center gap-2">
+                <h2>Server Environment Variables</h2>
+                @can('update', $server)
+                    <x-forms.button
+                        wire:click='switch'>{{ $view === 'normal' ? 'Developer view' : 'Normal view' }}</x-forms.button>
+                @endcan
+            </div>
+            <div>Environment variables defined here will be available to all applications deployed on this server. Application-level variables take precedence over server-level variables.</div>
+        </div>
+
+        @if ($view === 'normal')
+            @can('update', $server)
+                <form wire:submit='addVariable' class="flex flex-col gap-2 p-4 bg-white border dark:bg-base dark:border-coolgray-300 border-neutral-200">
+                    <h3>Add New Variable</h3>
+                    <div class="flex flex-col w-full gap-2 lg:flex-row">
+                        <x-forms.input required id="newKey" label="Key" placeholder="VARIABLE_NAME" />
+                        <x-forms.input required id="newValue" label="Value" type="password" placeholder="value" />
+                    </div>
+                    <div class="flex items-center gap-4">
+                        <x-forms.checkbox id="newIsBuildtime" label="Available at Buildtime"
+                            helper="Make this variable available during Docker build process." />
+                        <x-forms.checkbox id="newIsMultiline" label="Is Multiline?" />
+                        <x-forms.checkbox id="newIsLiteral" label="Is Literal?"
+                            helper="Prevents variable interpolation. Use when value contains $ characters." />
+                    </div>
+                    <x-forms.button type="submit">Add</x-forms.button>
+                </form>
+            @endcan
+
+            @forelse ($this->environmentVariables as $env)
+                <div class="flex flex-col items-center gap-4 p-4 bg-white border lg:items-start dark:bg-base dark:border-coolgray-300 border-neutral-200">
+                    <div class="flex flex-col w-full gap-2 lg:flex-row">
+                        <x-forms.input value="{{ $env->key }}" disabled label="Key" />
+                        <x-forms.input value="{{ $env->is_shown_once ? '(Locked)' : $env->value }}" disabled type="password" label="Value" />
+                    </div>
+                    <div class="flex w-full items-center justify-between">
+                        <div class="flex items-center gap-4">
+                            <span class="text-xs {{ $env->is_buildtime ? 'dark:text-warning' : 'text-neutral-400' }}">
+                                {{ $env->is_buildtime ? 'Available at buildtime' : 'Runtime only' }}
+                            </span>
+                            @if ($env->is_literal)
+                                <span class="text-xs text-neutral-400">Literal</span>
+                            @endif
+                            @if ($env->is_multiline)
+                                <span class="text-xs text-neutral-400">Multiline</span>
+                            @endif
+                        </div>
+                        @can('update', $server)
+                            <x-modal-confirmation title="Confirm Environment Variable Deletion?" isErrorButton
+                                buttonTitle="Delete" submitAction="deleteEnvironmentVariable('{{ $env->uuid }}')"
+                                :actions="['The selected environment variable will be permanently deleted.']"
+                                confirmationText="{{ $env->key }}"
+                                confirmationLabel="Please confirm by entering the variable name"
+                                shortConfirmationLabel="Variable Name" :confirmWithPassword="false"
+                                step2ButtonText="Permanently Delete" />
+                        @endcan
+                    </div>
+                </div>
+            @empty
+                <div>No environment variables found.</div>
+            @endforelse
+        @else
+            <form wire:submit.prevent='submit' class="flex flex-col gap-2">
+                <x-forms.textarea rows="10" id="variables" label="Environment Variables (KEY=VALUE format)" />
+                @can('update', $server)
+                    <x-forms.button type="submit">Save</x-forms.button>
+                @endcan
+            </form>
+        @endif
+    </div>
+</div>

--- a/resources/views/livewire/server/navbar.blade.php
+++ b/resources/views/livewire/server/navbar.blade.php
@@ -87,6 +87,11 @@
 ]) }}" {{ wireNavigate() }}>
                 Resources
             </a>
+            <a class="{{ request()->routeIs('server.environment-variables') ? 'dark:text-white' : '' }}" href="{{ route('server.environment-variables', [
+    'server_uuid' => data_get($server, 'uuid'),
+]) }}" {{ wireNavigate() }}>
+                Environment
+            </a>
             @can('canAccessTerminal')
                         <a class="{{ request()->routeIs('server.command') ? 'dark:text-white' : '' }}" href="{{ route('server.command', [
                     'server_uuid' => data_get($server, 'uuid'),

--- a/routes/web.php
+++ b/routes/web.php
@@ -59,6 +59,7 @@ use App\Livewire\Server\Security\Patches;
 use App\Livewire\Server\Security\TerminalAccess;
 use App\Livewire\Server\Sentinel as ServerSentinel;
 use App\Livewire\Server\Show as ServerShow;
+use App\Livewire\Server\EnvironmentVariable\All as ServerEnvironmentVariables;
 use App\Livewire\Server\Swarm as ServerSwarm;
 use App\Livewire\Settings\Advanced as SettingsAdvanced;
 use App\Livewire\Settings\Index as SettingsIndex;
@@ -262,6 +263,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/cloud-provider-token', CloudProviderTokenShow::class)->name('server.cloud-provider-token');
         Route::get('/ca-certificate', CaCertificateShow::class)->name('server.ca-certificate');
         Route::get('/resources', ResourcesShow::class)->name('server.resources');
+        Route::get('/environment-variables', ServerEnvironmentVariables::class)->name('server.environment-variables');
         Route::get('/cloudflare-tunnel', CloudflareTunnel::class)->name('server.cloudflare-tunnel');
         Route::get('/destinations', ServerDestinations::class)->name('server.destinations');
         Route::get('/log-drains', LogDrains::class)->name('server.log-drains');


### PR DESCRIPTION
## Summary

Adds the ability to define environment variables at the server level. These variables are automatically made available to all applications deployed on that server.

**Closes #7738**

## Changes

### Database
- New `server_environment_variables` table with encrypted values, supporting key/value pairs with `is_literal`, `is_multiline`, `is_buildtime`, and `is_shown_once` flags

### Models
- `ServerEnvironmentVariable` model with encrypted value storage (follows existing `EnvironmentVariable` patterns)
- `environmentVariables()` relationship added to `Server` model

### UI
- New **Environment** tab in server settings navbar
- Livewire component for managing server env vars
- Normal view: add/delete variables with key/value inputs and flag checkboxes
- Developer view: bulk edit in KEY=VALUE textarea format

### Deployment Integration
- **Runtime**: Server env vars are injected into application deployments, but only if not already defined by the application (app-level takes precedence)
- **Buildtime**: Server env vars marked as buildtime are injected before app-level build vars (app overrides server)

## How it works

1. Navigate to any server → **Environment** tab
2. Add environment variables (e.g., `SERVER_NAME=prod-1`, `REGION=us-east`)
3. Deploy any application to that server — server vars are automatically included
4. If the application defines the same variable, the application's value wins