### PR TITLE
fix(database): close confirmation modal after database import/restore

### DIFF
--- a/app/Livewire/Project/Database/Import.php
+++ b/app/Livewire/Project/Database/Import.php
@@ -401,20 +401,24 @@ EOD;
         }
     }
 
-    public function runImport()
+    public function runImport(string $password = ''): bool|string
     {
+        if (! verifyPasswordConfirmation($password, $this)) {
+            return 'The provided password is incorrect.';
+        }
+
         $this->authorize('update', $this->resource);
 
         if ($this->filename === '') {
             $this->dispatch('error', 'Please select a file to import.');
 
-            return;
+            return true;
         }
 
         if (! $this->server) {
             $this->dispatch('error', 'Server not found. Please refresh the page.');
 
-            return;
+            return true;
         }
 
         try {
@@ -434,7 +438,7 @@ EOD;
                 if (! $this->validateServerPath($this->customLocation)) {
                     $this->dispatch('error', 'Invalid file path. Path must be absolute and contain only safe characters.');
 
-                    return;
+                    return true;
                 }
                 $tmpPath = '/tmp/restore_'.$this->resourceUuid;
                 $escapedCustomLocation = escapeshellarg($this->customLocation);
@@ -442,7 +446,7 @@ EOD;
             } else {
                 $this->dispatch('error', 'The file does not exist or has been deleted.');
 
-                return;
+                return true;
             }
 
             // Copy the restore command to a script file
@@ -474,11 +478,15 @@ EOD;
                 $this->dispatch('databaserestore');
             }
         } catch (\Throwable $e) {
-            return handleError($e, $this);
+            handleError($e, $this);
+
+            return true;
         } finally {
             $this->filename = null;
             $this->importCommands = [];
         }
+
+        return true;
     }
 
     public function loadAvailableS3Storages()
@@ -577,26 +585,30 @@ EOD;
         }
     }
 
-    public function restoreFromS3()
+    public function restoreFromS3(string $password = ''): bool|string
     {
+        if (! verifyPasswordConfirmation($password, $this)) {
+            return 'The provided password is incorrect.';
+        }
+
         $this->authorize('update', $this->resource);
 
         if (! $this->s3StorageId || blank($this->s3Path)) {
             $this->dispatch('error', 'Please select S3 storage and provide a path first.');
 
-            return;
+            return true;
         }
 
         if (is_null($this->s3FileSize)) {
             $this->dispatch('error', 'Please check the file first by clicking "Check File".');
 
-            return;
+            return true;
         }
 
         if (! $this->server) {
             $this->dispatch('error', 'Server not found. Please refresh the page.');
 
-            return;
+            return true;
         }
 
         try {
@@ -613,7 +625,7 @@ EOD;
             if (! $this->validateBucketName($bucket)) {
                 $this->dispatch('error', 'Invalid S3 bucket name. Bucket name must contain only alphanumerics, dots, dashes, and underscores.');
 
-                return;
+                return true;
             }
 
             // Clean the S3 path
@@ -623,7 +635,7 @@ EOD;
             if (! $this->validateS3Path($cleanPath)) {
                 $this->dispatch('error', 'Invalid S3 path. Path must contain only safe characters (alphanumerics, dots, dashes, underscores, slashes).');
 
-                return;
+                return true;
             }
 
             // Get helper image
@@ -711,9 +723,12 @@ EOD;
             $this->dispatch('info', 'Restoring database from S3. Progress will be shown in the activity monitor...');
         } catch (\Throwable $e) {
             $this->importRunning = false;
+            handleError($e, $this);
 
-            return handleError($e, $this);
+            return true;
         }
+
+        return true;
     }
 
     public function buildRestoreCommand(string $tmpPath): string


### PR DESCRIPTION
## Changes

The password confirmation modal was not closing after a successful password entry during database import (both file-based and S3 restore). The restore process would start and the activity monitor slide-over would open, but the modal stayed on screen blocking interaction.

The root cause was that `runImport()` and `restoreFromS3()` in `Import.php` did not accept the `$password` parameter from the modal, did not call `verifyPasswordConfirmation()`, and did not return `true` which the modal's JavaScript requires to close itself.

- Added `string $password` parameter and `verifyPasswordConfirmation()` call to both methods
- Added `return true` on all code paths so the modal closes after the action completes
- Returns error string on wrong password so the modal displays the error inline

## Issues

- Fixes #8689

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No visual component changes — this is a behavior fix for an existing modal interaction.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Claude Opus 4.6)
- How extensively: Used to explore the codebase, identify the root cause by tracing the modal-confirmation component's JavaScript flow, and apply the fix following the existing `verifyPasswordConfirmation()` pattern used across the codebase. I reviewed and verified all changes before committing.

## Testing

1. Go to a running database → Import Backup → Restore from S3
2. Configure an S3 source and click "Check File"
3. Click "Restore from S3" → enter confirmation text → Continue
4. Enter correct password → Confirm
5. Modal closes, activity monitor slide-over opens
6. Enter wrong password → modal stays open, shows "The provided password is incorrect."
7. Repeat steps 1-6 for "Restore from File" flow

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.