### PR TITLE
Fix: API ignores destination_uuid when creating applications

### DIFF
--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -1094,7 +1094,14 @@ class ApplicationsController extends Controller
         if ($destinations->count() > 1 && ! $request->has('destination_uuid')) {
             return response()->json(['message' => 'Server has multiple destinations and you do not set destination_uuid.'], 400);
         }
-        $destination = $destinations->first();
+        if ($request->has('destination_uuid')) {
+            $destination = $destinations->where('uuid', $request->destination_uuid)->first();
+            if (! $destination) {
+                return response()->json(['message' => 'Destination not found.'], 404);
+            }
+        } else {
+            $destination = $destinations->first();
+        }
         if ($type === 'public') {
             $validationRules = [
                 'git_repository' => ['string', 'required', new ValidGitRepositoryUrl],


### PR DESCRIPTION
## Changes

The `create_application` API method validates that `destination_uuid` is provided when a server has multiple destinations, but then ignores the parameter and always uses the first destination. This fix looks up the destination by UUID when the parameter is provided, and returns a 404 if the UUID doesn't match any destination on the server. When `destination_uuid` is not provided (single-destination servers), the existing behavior is preserved.

## Issues

- Fixes: API ignores destination_uuid when creating applications on servers with multiple destinations

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Assisted with identifying the bug and drafting the fix

## Testing

- Create an application via API on a server with a single destination (no destination_uuid) -- works as before
- Create an application via API on a server with multiple destinations without destination_uuid -- returns 400
- Create an application via API on a server with multiple destinations with a valid destination_uuid -- uses the specified destination
- Create an application via API with an invalid destination_uuid -- returns 404

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.