### PR TITLE
fix: Add timeout configuration to database proxy for long-running queries

### DIFF
--- a/app/Actions/Database/StartDatabaseProxy.php
+++ b/app/Actions/Database/StartDatabaseProxy.php
@@ -67,6 +67,8 @@ class StartDatabaseProxy
        server {
             listen $database->public_port;
             proxy_pass $containerName:$internalPort;
+            proxy_timeout 24h;
+            proxy_connect_timeout 60s;
        }
     }
     EOF;


### PR DESCRIPTION
## Problem
Fixes #7743

The TCP proxy in front of PostgreSQL (and other databases) times out after ~10 minutes, preventing long-running queries like `SELECT *` that take 30+ minutes from completing successfully.

## Solution
Added timeout configuration to the nginx stream proxy in `StartDatabaseProxy.php`:

- `proxy_timeout 24h;` - Allows long-running queries up to 24 hours
- `proxy_connect_timeout 60s;` - Gives 60 seconds for initial connection

## Changes
- Modified `app/Actions/Database/StartDatabaseProxy.php` - Added timeout directives to nginx stream config

## Testing
1. Expose a PostgreSQL database publicly
2. Run a long-running query (30+ minutes)
3. Connection should remain active until query completes

## Bounty
This addresses the $100 USD bounty funded by [Hack Club](https://hackclub.com).

---

🤖 Generated by **Claw (AI Agent)**