### PR TITLE
feat: OAuth-only self registration option

### DIFF
--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -20,9 +20,9 @@ class OauthController extends Controller
         try {
             $oauthUser = get_socialite_provider($provider)->user();
             $user = User::whereEmail($oauthUser->email)->first();
+            $settings = instanceSettings();
             if (! $user) {
-                $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! $settings->is_oauth_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 
@@ -30,6 +30,8 @@ class OauthController extends Controller
                     'name' => $oauthUser->name,
                     'email' => $oauthUser->email,
                 ]);
+            } elseif ($settings->is_oauth_only_allowed) {
+                // User exists but OAuth-only mode is enabled — allow login via OAuth
             }
             Auth::login($user);
 

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -15,6 +15,12 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $is_oauth_registration_enabled;
+
+    #[Validate('boolean')]
+    public bool $is_oauth_only_allowed;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -41,6 +47,8 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_registration_enabled' => 'boolean',
+            'is_oauth_only_allowed' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => 'nullable|string',
@@ -62,6 +70,8 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled ?? false;
+        $this->is_oauth_only_allowed = $this->settings->is_oauth_only_allowed ?? false;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -138,6 +148,8 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
+            $this->settings->is_oauth_only_allowed = $this->is_oauth_only_allowed;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -31,6 +31,8 @@ class InstanceSettings extends Model
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',
         'is_wire_navigate_enabled' => 'boolean',
+        'is_oauth_registration_enabled' => 'boolean',
+        'is_oauth_only_allowed' => 'boolean',
     ];
 
     protected static function booted(): void

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -73,6 +73,10 @@ class FortifyServiceProvider extends ServiceProvider
 
         Fortify::authenticateUsing(function (Request $request) {
             $email = strtolower($request->email);
+            $settings = instanceSettings();
+            if ($settings->is_oauth_only_allowed) {
+                return null;
+            }
             $user = User::where('email', $email)->with('teams')->first();
             if (
                 $user &&

--- a/database/migrations/2026_01_01_000001_add_oauth_registration_settings_to_instance_settings_table.php
+++ b/database/migrations/2026_01_01_000001_add_oauth_registration_settings_to_instance_settings_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_registration_enabled')->default(false)->after('is_registration_enabled');
+            $table->boolean('is_oauth_only_allowed')->default(false)->after('is_oauth_registration_enabled');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn(['is_oauth_registration_enabled', 'is_oauth_only_allowed']);
+        });
+    }
+};

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -29,6 +29,7 @@
                         </div>
                     @endif
 
+                    @if (!($is_oauth_only_allowed ?? false))
                     <form action="/login" method="POST" class="flex flex-col gap-4">
                         @csrf
                         @env('local')
@@ -54,8 +55,9 @@
                             {{ __('auth.login') }}
                         </x-forms.button>
                     </form>
+                    @endif
 
-                    @if ($is_registration_enabled)
+                    @if ($is_registration_enabled || ($is_oauth_registration_enabled ?? false))
                         <div class="relative my-6">
                             <div class="absolute inset-0 flex items-center">
                                 <div class="w-full border-t border-neutral-300 dark:border-coolgray-400"></div>

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -22,6 +22,16 @@
                             label="Registration Allowed" />
                     </div>
                     <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_registration_enabled"
+                            helper="Allow users to self-register via OAuth providers even when general registration is disabled."
+                            label="Allow OAuth Self-Registration" />
+                    </div>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_only_allowed"
+                            helper="Restrict authentication to OAuth providers only. Password-based login will be disabled for all users."
+                            label="OAuth Only Mode" />
+                    </div>
+                    <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"
                             helper="Opt out of reporting this instance to coolify.io's installation count. No other data is collected."
                             label="Do Not Track" />


### PR DESCRIPTION
## Summary

Adds OAuth-only self-registration support as requested in #8042.

## Changes

- **New setting: Allow OAuth Self-Registration** — lets OAuth users self-register even when general registration is disabled
- **New setting: OAuth Only Mode** — restricts all authentication to OAuth providers, disabling password-based login
- Added database migration for new `instance_settings` columns
- Updated Advanced settings UI with the two new checkboxes
- Hidden password login form on the login page when OAuth-only mode is enabled

## How it works

- `is_oauth_registration_enabled`: In `OauthController::callback()`, registration is now allowed if either `is_registration_enabled` OR `is_oauth_registration_enabled` is true
- `is_oauth_only_allowed`: In `FortifyServiceProvider`, password authentication returns `null` (fails) when this flag is set; the login form is also hidden in the UI

## Testing

- OAuth users can register when general registration is disabled but `Allow OAuth Self-Registration` is enabled
- Password login is blocked (returns auth error) when `OAuth Only Mode` is enabled
- OAuth login still works normally in OAuth-only mode

Fixes coollabsio/coolify#8042