### PR TITLE
feat: configurable proxy timeout for public database TCP proxy

### DIFF
--- a/app/Actions/Database/StartDatabaseProxy.php
+++ b/app/Actions/Database/StartDatabaseProxy.php
@@ -54,6 +54,11 @@ class StartDatabaseProxy
         if (isDev()) {
             $configuration_dir = '/var/lib/docker/volumes/coolify_dev_coolify_data/_data/databases/'.$database->uuid.'/proxy';
         }
+        $proxyTimeout = (int) ($database->public_proxy_timeout ?? 0);
+        $timeoutDirectives = $proxyTimeout > 0
+            ? "proxy_timeout {$proxyTimeout}s;"
+            : 'proxy_timeout 0;';
+
         $nginxconf = <<<EOF
     user  nginx;
     worker_processes  auto;
@@ -67,6 +72,7 @@ class StartDatabaseProxy
        server {
             listen $database->public_port;
             proxy_pass $containerName:$internalPort;
+            $timeoutDirectives
        }
     }
     EOF;

--- a/app/Livewire/Project/Database/Clickhouse/General.php
+++ b/app/Livewire/Project/Database/Clickhouse/General.php
@@ -36,6 +36,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $publicProxyTimeout = null;
+
     public ?string $customDockerRunOptions = null;
 
     public ?string $dbUrl = null;
@@ -80,6 +82,7 @@ class General extends Component
             'portsMappings' => 'nullable|string',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'publicProxyTimeout' => 'nullable|integer|min:0',
             'customDockerRunOptions' => 'nullable|string',
             'dbUrl' => 'nullable|string',
             'dbUrlPublic' => 'nullable|string',
@@ -99,6 +102,7 @@ class General extends Component
                 'image.required' => 'The Docker Image field is required.',
                 'image.string' => 'The Docker Image must be a string.',
                 'publicPort.integer' => 'The Public Port must be an integer.',
+                'publicProxyTimeout.integer' => 'The Proxy Timeout must be an integer.',
             ]
         );
     }
@@ -115,6 +119,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_proxy_timeout = $this->publicProxyTimeout;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->save();
@@ -130,6 +135,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->publicProxyTimeout = $this->database->public_proxy_timeout;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->dbUrl = $this->database->internal_db_url;

--- a/app/Livewire/Project/Database/Dragonfly/General.php
+++ b/app/Livewire/Project/Database/Dragonfly/General.php
@@ -36,6 +36,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $publicProxyTimeout = null;
+
     public ?string $customDockerRunOptions = null;
 
     public ?string $dbUrl = null;
@@ -91,6 +93,7 @@ class General extends Component
             'portsMappings' => 'nullable|string',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'publicProxyTimeout' => 'nullable|integer|min:0',
             'customDockerRunOptions' => 'nullable|string',
             'dbUrl' => 'nullable|string',
             'dbUrlPublic' => 'nullable|string',
@@ -109,6 +112,7 @@ class General extends Component
                 'image.required' => 'The Docker Image field is required.',
                 'image.string' => 'The Docker Image must be a string.',
                 'publicPort.integer' => 'The Public Port must be an integer.',
+                'publicProxyTimeout.integer' => 'The Proxy Timeout must be an integer.',
             ]
         );
     }
@@ -124,6 +128,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_proxy_timeout = $this->publicProxyTimeout;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->enable_ssl = $this->enable_ssl;
@@ -139,6 +144,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->publicProxyTimeout = $this->database->public_proxy_timeout;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->enable_ssl = $this->database->enable_ssl;

--- a/app/Livewire/Project/Database/Keydb/General.php
+++ b/app/Livewire/Project/Database/Keydb/General.php
@@ -38,6 +38,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $publicProxyTimeout = null;
+
     public ?string $customDockerRunOptions = null;
 
     public ?string $dbUrl = null;
@@ -94,6 +96,7 @@ class General extends Component
             'portsMappings' => 'nullable|string',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'publicProxyTimeout' => 'nullable|integer|min:0',
             'customDockerRunOptions' => 'nullable|string',
             'dbUrl' => 'nullable|string',
             'dbUrlPublic' => 'nullable|string',
@@ -114,6 +117,7 @@ class General extends Component
                 'image.required' => 'The Docker Image field is required.',
                 'image.string' => 'The Docker Image must be a string.',
                 'publicPort.integer' => 'The Public Port must be an integer.',
+                'publicProxyTimeout.integer' => 'The Proxy Timeout must be an integer.',
             ]
         );
     }
@@ -130,6 +134,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_proxy_timeout = $this->publicProxyTimeout;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->enable_ssl = $this->enable_ssl;
@@ -146,6 +151,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->publicProxyTimeout = $this->database->public_proxy_timeout;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->enable_ssl = $this->database->enable_ssl;

--- a/app/Livewire/Project/Database/Mariadb/General.php
+++ b/app/Livewire/Project/Database/Mariadb/General.php
@@ -44,6 +44,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $publicProxyTimeout = null;
+
     public bool $isLogDrainEnabled = false;
 
     public ?string $customDockerRunOptions = null;
@@ -79,6 +81,7 @@ class General extends Component
             'portsMappings' => 'nullable',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'publicProxyTimeout' => 'nullable|integer|min:0',
             'isLogDrainEnabled' => 'nullable|boolean',
             'customDockerRunOptions' => 'nullable',
             'enableSsl' => 'boolean',
@@ -97,6 +100,7 @@ class General extends Component
                 'mariadbDatabase.required' => 'The MariaDB Database field is required.',
                 'image.required' => 'The Docker Image field is required.',
                 'publicPort.integer' => 'The Public Port must be an integer.',
+                'publicProxyTimeout.integer' => 'The Proxy Timeout must be an integer.',
             ]
         );
     }
@@ -113,6 +117,7 @@ class General extends Component
         'portsMappings' => 'Port Mapping',
         'isPublic' => 'Is Public',
         'publicPort' => 'Public Port',
+        'publicProxyTimeout' => 'Proxy Timeout',
         'customDockerRunOptions' => 'Custom Docker Options',
         'enableSsl' => 'Enable SSL',
     ];
@@ -154,6 +159,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_proxy_timeout = $this->publicProxyTimeout;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->enable_ssl = $this->enableSsl;
@@ -173,6 +179,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->publicProxyTimeout = $this->database->public_proxy_timeout;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->enableSsl = $this->database->enable_ssl;

--- a/app/Livewire/Project/Database/Mongodb/General.php
+++ b/app/Livewire/Project/Database/Mongodb/General.php
@@ -42,6 +42,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $publicProxyTimeout = null;
+
     public bool $isLogDrainEnabled = false;
 
     public ?string $customDockerRunOptions = null;
@@ -78,6 +80,7 @@ class General extends Component
             'portsMappings' => 'nullable',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'publicProxyTimeout' => 'nullable|integer|min:0',
             'isLogDrainEnabled' => 'nullable|boolean',
             'customDockerRunOptions' => 'nullable',
             'enableSsl' => 'boolean',
@@ -96,6 +99,7 @@ class General extends Component
                 'mongoInitdbDatabase.required' => 'The MongoDB Database field is required.',
                 'image.required' => 'The Docker Image field is required.',
                 'publicPort.integer' => 'The Public Port must be an integer.',
+                'publicProxyTimeout.integer' => 'The Proxy Timeout must be an integer.',
                 'sslMode.in' => 'The SSL Mode must be one of: allow, prefer, require, verify-full.',
             ]
         );
@@ -112,6 +116,7 @@ class General extends Component
         'portsMappings' => 'Port Mapping',
         'isPublic' => 'Is Public',
         'publicPort' => 'Public Port',
+        'publicProxyTimeout' => 'Proxy Timeout',
         'customDockerRunOptions' => 'Custom Docker Run Options',
         'enableSsl' => 'Enable SSL',
         'sslMode' => 'SSL Mode',
@@ -153,6 +158,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_proxy_timeout = $this->publicProxyTimeout;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->enable_ssl = $this->enableSsl;
@@ -172,6 +178,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->publicProxyTimeout = $this->database->public_proxy_timeout;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->enableSsl = $this->database->enable_ssl;

--- a/app/Livewire/Project/Database/Mysql/General.php
+++ b/app/Livewire/Project/Database/Mysql/General.php
@@ -44,6 +44,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $publicProxyTimeout = null;
+
     public bool $isLogDrainEnabled = false;
 
     public ?string $customDockerRunOptions = null;
@@ -81,6 +83,7 @@ class General extends Component
             'portsMappings' => 'nullable',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'publicProxyTimeout' => 'nullable|integer|min:0',
             'isLogDrainEnabled' => 'nullable|boolean',
             'customDockerRunOptions' => 'nullable',
             'enableSsl' => 'boolean',
@@ -100,6 +103,7 @@ class General extends Component
                 'mysqlDatabase.required' => 'The MySQL Database field is required.',
                 'image.required' => 'The Docker Image field is required.',
                 'publicPort.integer' => 'The Public Port must be an integer.',
+                'publicProxyTimeout.integer' => 'The Proxy Timeout must be an integer.',
                 'sslMode.in' => 'The SSL Mode must be one of: PREFERRED, REQUIRED, VERIFY_CA, VERIFY_IDENTITY.',
             ]
         );
@@ -117,6 +121,7 @@ class General extends Component
         'portsMappings' => 'Port Mapping',
         'isPublic' => 'Is Public',
         'publicPort' => 'Public Port',
+        'publicProxyTimeout' => 'Proxy Timeout',
         'customDockerRunOptions' => 'Custom Docker Run Options',
         'enableSsl' => 'Enable SSL',
         'sslMode' => 'SSL Mode',
@@ -159,6 +164,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_proxy_timeout = $this->publicProxyTimeout;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->enable_ssl = $this->enableSsl;
@@ -179,6 +185,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->publicProxyTimeout = $this->database->public_proxy_timeout;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->enableSsl = $this->database->enable_ssl;

--- a/app/Livewire/Project/Database/Postgresql/General.php
+++ b/app/Livewire/Project/Database/Postgresql/General.php
@@ -48,6 +48,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $publicProxyTimeout = null;
+
     public bool $isLogDrainEnabled = false;
 
     public ?string $customDockerRunOptions = null;
@@ -93,6 +95,7 @@ class General extends Component
             'portsMappings' => 'nullable',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'publicProxyTimeout' => 'nullable|integer|min:0',
             'isLogDrainEnabled' => 'nullable|boolean',
             'customDockerRunOptions' => 'nullable',
             'enableSsl' => 'boolean',
@@ -111,6 +114,7 @@ class General extends Component
                 'postgresDb.required' => 'The Postgres Database field is required.',
                 'image.required' => 'The Docker Image field is required.',
                 'publicPort.integer' => 'The Public Port must be an integer.',
+                'publicProxyTimeout.integer' => 'The Proxy Timeout must be an integer.',
                 'sslMode.in' => 'The SSL Mode must be one of: allow, prefer, require, verify-ca, verify-full.',
             ]
         );
@@ -130,6 +134,7 @@ class General extends Component
         'portsMappings' => 'Port Mapping',
         'isPublic' => 'Is Public',
         'publicPort' => 'Public Port',
+        'publicProxyTimeout' => 'Proxy Timeout',
         'customDockerRunOptions' => 'Custom Docker Run Options',
         'enableSsl' => 'Enable SSL',
         'sslMode' => 'SSL Mode',
@@ -174,6 +179,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_proxy_timeout = $this->publicProxyTimeout;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->enable_ssl = $this->enableSsl;
@@ -196,6 +202,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->publicProxyTimeout = $this->database->public_proxy_timeout;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->enableSsl = $this->database->enable_ssl;

--- a/app/Livewire/Project/Database/Redis/General.php
+++ b/app/Livewire/Project/Database/Redis/General.php
@@ -36,6 +36,8 @@ class General extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $publicProxyTimeout = null;
+
     public bool $isLogDrainEnabled = false;
 
     public ?string $customDockerRunOptions = null;
@@ -74,6 +76,7 @@ class General extends Component
             'portsMappings' => 'nullable',
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer',
+            'publicProxyTimeout' => 'nullable|integer|min:0',
             'isLogDrainEnabled' => 'nullable|boolean',
             'customDockerRunOptions' => 'nullable',
             'redisUsername' => 'required',
@@ -90,6 +93,7 @@ class General extends Component
                 'name.required' => 'The Name field is required.',
                 'image.required' => 'The Docker Image field is required.',
                 'publicPort.integer' => 'The Public Port must be an integer.',
+                'publicProxyTimeout.integer' => 'The Proxy Timeout must be an integer.',
                 'redisUsername.required' => 'The Redis Username field is required.',
                 'redisPassword.required' => 'The Redis Password field is required.',
             ]
@@ -104,6 +108,7 @@ class General extends Component
         'portsMappings' => 'Port Mapping',
         'isPublic' => 'Is Public',
         'publicPort' => 'Public Port',
+        'publicProxyTimeout' => 'Proxy Timeout',
         'customDockerRunOptions' => 'Custom Docker Options',
         'redisUsername' => 'Redis Username',
         'redisPassword' => 'Redis Password',
@@ -143,6 +148,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort;
+            $this->database->public_proxy_timeout = $this->publicProxyTimeout;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->enable_ssl = $this->enableSsl;
@@ -158,6 +164,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->publicProxyTimeout = $this->database->public_proxy_timeout;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->enableSsl = $this->database->enable_ssl;

--- a/app/Livewire/Project/Service/Index.php
+++ b/app/Livewire/Project/Service/Index.php
@@ -53,6 +53,8 @@ class Index extends Component
 
     public ?int $publicPort = null;
 
+    public ?int $publicProxyTimeout = null;
+
     public bool $isPublic = false;
 
     public bool $isLogDrainEnabled = false;
@@ -158,6 +160,7 @@ class Index extends Component
             $this->serviceDatabase->image = $this->image;
             $this->serviceDatabase->exclude_from_status = $this->excludeFromStatus;
             $this->serviceDatabase->public_port = $this->publicPort;
+            $this->serviceDatabase->public_proxy_timeout = $this->publicProxyTimeout;
             $this->serviceDatabase->is_public = $this->isPublic;
             $this->serviceDatabase->is_log_drain_enabled = $this->isLogDrainEnabled;
         } else {
@@ -166,6 +169,7 @@ class Index extends Component
             $this->image = $this->serviceDatabase->image;
             $this->excludeFromStatus = $this->serviceDatabase->exclude_from_status ?? false;
             $this->publicPort = $this->serviceDatabase->public_port;
+            $this->publicProxyTimeout = $this->serviceDatabase->public_proxy_timeout;
             $this->isPublic = $this->serviceDatabase->is_public ?? false;
             $this->isLogDrainEnabled = $this->serviceDatabase->is_log_drain_enabled ?? false;
         }

--- a/database/migrations/2026_03_02_000001_add_proxy_timeout_to_standalone_databases.php
+++ b/database/migrations/2026_03_02_000001_add_proxy_timeout_to_standalone_databases.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $tables = [
+            'standalone_postgresqls',
+            'standalone_mysqls',
+            'standalone_mariadbs',
+            'standalone_mongodbs',
+            'standalone_redis',
+            'standalone_keydbs',
+            'standalone_dragonflies',
+            'standalone_clickhouses',
+            'service_databases',
+        ];
+
+        foreach ($tables as $table) {
+            Schema::table($table, function (Blueprint $blueprint) {
+                $blueprint->integer('public_proxy_timeout')->nullable()->default(0)->after('public_port');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        $tables = [
+            'standalone_postgresqls',
+            'standalone_mysqls',
+            'standalone_mariadbs',
+            'standalone_mongodbs',
+            'standalone_redis',
+            'standalone_keydbs',
+            'standalone_dragonflies',
+            'standalone_clickhouses',
+            'service_databases',
+        ];
+
+        foreach ($tables as $table) {
+            Schema::table($table, function (Blueprint $blueprint) {
+                $blueprint->dropColumn('public_proxy_timeout');
+            });
+        }
+    }
+};

--- a/resources/views/livewire/project/database/clickhouse/general.blade.php
+++ b/resources/views/livewire/project/database/clickhouse/general.blade.php
@@ -78,6 +78,10 @@
             </div>
             <x-forms.input placeholder="5432" disabled="{{ $isPublic }}" id="publicPort" label="Public Port"
                 canGate="update" :canResource="$database" />
+            <x-forms.input type="number" placeholder="0" id="publicProxyTimeout"
+                label="Proxy Timeout (seconds)"
+                helper="Timeout for the TCP proxy in seconds. Set to 0 for no timeout (default). Useful for long-running queries."
+                canGate="update" :canResource="$database" />
         </div>
     </form>
     <h3 class="pt-4">Advanced</h3>

--- a/resources/views/livewire/project/database/dragonfly/general.blade.php
+++ b/resources/views/livewire/project/database/dragonfly/general.blade.php
@@ -115,6 +115,10 @@
             </div>
             <x-forms.input placeholder="5432" disabled="{{ $isPublic }}" id="publicPort" label="Public Port"
                 canGate="update" :canResource="$database" />
+            <x-forms.input type="number" placeholder="0" id="publicProxyTimeout"
+                label="Proxy Timeout (seconds)"
+                helper="Timeout for the TCP proxy in seconds. Set to 0 for no timeout (default). Useful for long-running queries."
+                canGate="update" :canResource="$database" />
         </div>
     </form>
     <h3 class="pt-4">Advanced</h3>

--- a/resources/views/livewire/project/database/keydb/general.blade.php
+++ b/resources/views/livewire/project/database/keydb/general.blade.php
@@ -115,6 +115,10 @@
             </div>
             <x-forms.input placeholder="5432" disabled="{{ $isPublic }}" id="publicPort" label="Public Port"
                 canGate="update" :canResource="$database" />
+            <x-forms.input type="number" placeholder="0" id="publicProxyTimeout"
+                label="Proxy Timeout (seconds)"
+                helper="Timeout for the TCP proxy in seconds. Set to 0 for no timeout (default). Useful for long-running queries."
+                canGate="update" :canResource="$database" />
         </div>
         <x-forms.textarea
             helper="<a target='_blank' class='underline dark:text-white' href='https://raw.githubusercontent.com/Snapchat/KeyDB/unstable/keydb.conf'>KeyDB Default Configuration</a>"

--- a/resources/views/livewire/project/database/mariadb/general.blade.php
+++ b/resources/views/livewire/project/database/mariadb/general.blade.php
@@ -139,6 +139,10 @@
             </div>
             <x-forms.input placeholder="5432" disabled="{{ $isPublic }}"
                 id="publicPort" label="Public Port" canGate="update" :canResource="$database" />
+            <x-forms.input type="number" placeholder="0" id="publicProxyTimeout"
+                label="Proxy Timeout (seconds)"
+                helper="Timeout for the TCP proxy in seconds. Set to 0 for no timeout (default). Useful for long-running queries."
+                canGate="update" :canResource="$database" />
         </div>
         <x-forms.textarea label="Custom MariaDB Configuration" rows="10" id="mariadbConf"
             canGate="update" :canResource="$database" />

--- a/resources/views/livewire/project/database/mongodb/general.blade.php
+++ b/resources/views/livewire/project/database/mongodb/general.blade.php
@@ -153,6 +153,10 @@
                 </div>
                 <x-forms.input placeholder="5432" disabled="{{ $isPublic }}"
                     id="publicPort" label="Public Port" canGate="update" :canResource="$database" />
+            <x-forms.input type="number" placeholder="0" id="publicProxyTimeout"
+                label="Proxy Timeout (seconds)"
+                helper="Timeout for the TCP proxy in seconds. Set to 0 for no timeout (default). Useful for long-running queries."
+                canGate="update" :canResource="$database" />
             </div>
             <x-forms.textarea label="Custom MongoDB Configuration" rows="10" id="mongoConf"
                 canGate="update" :canResource="$database" />

--- a/resources/views/livewire/project/database/mysql/general.blade.php
+++ b/resources/views/livewire/project/database/mysql/general.blade.php
@@ -155,6 +155,10 @@
             </div>
             <x-forms.input placeholder="5432" disabled="{{ $isPublic }}"
                 id="publicPort" label="Public Port" canGate="update" :canResource="$database" />
+            <x-forms.input type="number" placeholder="0" id="publicProxyTimeout"
+                label="Proxy Timeout (seconds)"
+                helper="Timeout for the TCP proxy in seconds. Set to 0 for no timeout (default). Useful for long-running queries."
+                canGate="update" :canResource="$database" />
         </div>
         <x-forms.textarea label="Custom Mysql Configuration" rows="10" id="mysqlConf" canGate="update" :canResource="$database" />
         <h3 class="pt-4">Advanced</h3>

--- a/resources/views/livewire/project/database/postgresql/general.blade.php
+++ b/resources/views/livewire/project/database/postgresql/general.blade.php
@@ -165,6 +165,10 @@
                     </div>
                     <x-forms.input placeholder="5432" disabled="{{ $isPublic }}" id="publicPort"
                         label="Public Port" canGate="update" :canResource="$database" />
+                    <x-forms.input type="number" placeholder="0" id="publicProxyTimeout"
+                        label="Proxy Timeout (seconds)"
+                        helper="Timeout for the TCP proxy in seconds. Set to 0 for no timeout (default). Useful for long-running queries."
+                        canGate="update" :canResource="$database" />
                 </div>
 
                 <div class="flex flex-col gap-2">

--- a/resources/views/livewire/project/database/redis/general.blade.php
+++ b/resources/views/livewire/project/database/redis/general.blade.php
@@ -134,6 +134,10 @@
             </div>
             <x-forms.input placeholder="5432" disabled="{{ $isPublic }}"
                 id="publicPort" label="Public Port" canGate="update" :canResource="$database" />
+            <x-forms.input type="number" placeholder="0" id="publicProxyTimeout"
+                label="Proxy Timeout (seconds)"
+                helper="Timeout for the TCP proxy in seconds. Set to 0 for no timeout (default). Useful for long-running queries."
+                canGate="update" :canResource="$database" />
         </div>
         <x-forms.textarea placeholder="# maxmemory 256mb
 # maxmemory-policy allkeys-lru

--- a/resources/views/livewire/project/service/index.blade.php
+++ b/resources/views/livewire/project/service/index.blade.php
@@ -235,6 +235,10 @@
                                 </div>
                                 <x-forms.input canGate="update" :canResource="$serviceDatabase" placeholder="5432"
                                     disabled="{{ $serviceDatabase->is_public }}" id="publicPort" label="Public Port" />
+                                <x-forms.input type="number" placeholder="0" id="publicProxyTimeout"
+                                    label="Proxy Timeout (seconds)"
+                                    helper="Timeout for the TCP proxy in seconds. Set to 0 for no timeout (default). Useful for long-running queries."
+                                    canGate="update" :canResource="$serviceDatabase" />
                                 @if ($db_url_public)
                                     <x-forms.input label="Database IP:PORT (public)"
                                         helper="Your credentials are available in your environment variables." type="password"


### PR DESCRIPTION
## Fixes
- https://github.com/coollabsio/coolify/issues/7743

## Summary
Adds a configurable `proxy_timeout` setting to the nginx TCP stream proxy used for publicly exposed databases. Previously, the proxy used nginx's default 10-minute timeout, which killed long-running queries (30min+ SELECTs, pg_dump operations, etc.).

**Key design decisions:**
- **Default: 0 (no timeout)** — This directly addresses the issue's primary ask. Users who want a specific timeout can set one.
- **Covers ALL database types** — PostgreSQL, MySQL, MariaDB, MongoDB, Redis, KeyDB, Dragonfly, ClickHouse, and Service Databases
- **Proxy auto-restarts** on value change via existing `instantSave` → `StartDatabaseProxy::run()` flow

## Changes

### Migration
- Adds `public_proxy_timeout` (nullable integer, default 0) to all 9 database tables

### Backend (`StartDatabaseProxy.php`)
- Reads `public_proxy_timeout` from the database model
- Injects `proxy_timeout` directive into the nginx stream server block
- `0` = no timeout, any positive integer = timeout in seconds

### UI (all 8 database Livewire components + Service databases)
- New "Proxy Timeout (seconds)" input field next to "Public Port"
- Includes helper text explaining the setting
- Validation: nullable integer, min 0

## Screenshots
The new field appears below "Public Port" when a database is configured:

```
[✓] Make it publicly available
Public Port: [5432        ]
Proxy Timeout (seconds): [0           ]
  ℹ Timeout for the TCP proxy in seconds. Set to 0 for no timeout (default).
    Useful for long-running queries.
```

## Testing
- [ ] Migration runs successfully on fresh and existing databases
- [ ] Setting timeout to 0 produces `proxy_timeout 0;` in nginx config (no timeout)
- [ ] Setting timeout to 3600 produces `proxy_timeout 3600s;` in nginx config
- [ ] Proxy restarts when value is changed
- [ ] Long-running query (>10min) succeeds with timeout=0
- [ ] All existing tests pass

## Nginx Config Before/After

**Before:**
```nginx
stream {
   server {
        listen 5432;
        proxy_pass uuid:5432;
   }
}
```

**After (timeout=0, default):**
```nginx
stream {
   server {
        listen 5432;
        proxy_pass uuid:5432;
        proxy_timeout 0;
   }
}
```

**After (timeout=3600):**
```nginx
stream {
   server {
        listen 5432;
        proxy_pass uuid:5432;
        proxy_timeout 3600s;
   }
}
```