### PR TITLE
feat: OAuth self-registration & force OAuth login

### DIFF
--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -22,7 +22,7 @@ class OauthController extends Controller
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! $settings->is_oauth_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -15,6 +15,12 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $is_oauth_registration_enabled;
+
+    #[Validate('boolean')]
+    public bool $force_oauth_login;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -41,6 +47,8 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_registration_enabled' => 'boolean',
+            'force_oauth_login' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => 'nullable|string',
@@ -62,6 +70,8 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled;
+        $this->force_oauth_login = $this->settings->force_oauth_login;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -138,6 +148,8 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
+            $this->settings->force_oauth_login = $this->force_oauth_login;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -31,6 +31,8 @@ class InstanceSettings extends Model
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',
         'is_wire_navigate_enabled' => 'boolean',
+        'is_oauth_registration_enabled' => 'boolean',
+        'force_oauth_login' => 'boolean',
     ];
 
     protected static function booted(): void

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -67,6 +67,8 @@ class FortifyServiceProvider extends ServiceProvider
 
             return view('auth.login', [
                 'is_registration_enabled' => $settings->is_registration_enabled,
+                'is_oauth_registration_enabled' => $settings->is_oauth_registration_enabled,
+                'force_oauth_login' => $settings->force_oauth_login,
                 'enabled_oauth_providers' => $enabled_oauth_providers,
             ]);
         });

--- a/database/migrations/2026_03_02_000002_add_oauth_registration_settings_to_instance_settings.php
+++ b/database/migrations/2026_03_02_000002_add_oauth_registration_settings_to_instance_settings.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_registration_enabled')->default(false)->after('is_registration_enabled');
+            $table->boolean('force_oauth_login')->default(false)->after('is_oauth_registration_enabled');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn(['is_oauth_registration_enabled', 'force_oauth_login']);
+        });
+    }
+};

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -29,6 +29,7 @@
                         </div>
                     @endif
 
+                    @if (empty($force_oauth_login))
                     <form action="/login" method="POST" class="flex flex-col gap-4">
                         @csrf
                         @env('local')
@@ -54,6 +55,7 @@
                             {{ __('auth.login') }}
                         </x-forms.button>
                     </form>
+                    @endif
 
                     @if ($is_registration_enabled)
                         <div class="relative my-6">

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -22,6 +22,16 @@
                             label="Registration Allowed" />
                     </div>
                     <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_registration_enabled"
+                            helper="Allow new users to register via OAuth providers (GitHub, Google, etc.) even when general registration is disabled. Existing users can always log in via OAuth."
+                            label="OAuth Registration Allowed" />
+                    </div>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="force_oauth_login"
+                            helper="Hide the password login form and only show OAuth login buttons. Users must authenticate through a configured OAuth provider."
+                            label="Force OAuth Login" />
+                    </div>
+                    <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"
                             helper="Opt out of reporting this instance to coolify.io's installation count. No other data is collected."
                             label="Do Not Track" />


### PR DESCRIPTION
## Summary

Resolves #8042

Adds two new instance-level settings to give admins granular control over OAuth registration and login:

- **OAuth Registration Allowed** (`is_oauth_registration_enabled`): When enabled, new users can register via configured OAuth providers (GitHub, Google, etc.) even when general registration is disabled. Existing users can always log in via OAuth regardless of this setting.
- **Force OAuth Login** (`force_oauth_login`): When enabled, the password login form is hidden and users must authenticate through a configured OAuth provider.

### Auth Matrix

| `is_registration_enabled` | `is_oauth_registration_enabled` | Password signup | OAuth new user |
|---|---|---|---|
| ✅ | any | ✅ | ✅ |
| ❌ | ✅ | ❌ | ✅ |
| ❌ | ❌ | ❌ | ❌ |

### Changes

- **Migration**: Adds `is_oauth_registration_enabled` and `force_oauth_login` boolean columns to `instance_settings`
- **OauthController**: Updated callback to allow OAuth registration when `is_oauth_registration_enabled` is true
- **Settings/Advanced**: Added toggles for both new settings in the admin panel
- **FortifyServiceProvider**: Passes `force_oauth_login` to the login view
- **login.blade.php**: Conditionally hides the password form when `force_oauth_login` is enabled
- **InstanceSettings model**: Added boolean casts for both new fields

## Test plan

- [ ] Enable OAuth registration with general registration disabled → new OAuth users can register
- [ ] Disable both registration settings → new OAuth users get 403
- [ ] Enable force OAuth login → password form hidden, only OAuth buttons shown
- [ ] Disable force OAuth login → password form visible as normal
- [ ] Existing users can always log in via OAuth regardless of registration settings
- [ ] Admin toggles persist correctly in Settings > Advanced

🤖 Generated with [Claude Code](https://claude.com/claude-code)