### PR TITLE
feat: server-level environment variables for all deployments

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -1181,6 +1181,19 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         $coolify_envs->each(function ($item, $key) use ($envs) {
             $envs->push($key.'='.$item);
         });
+
+        // Inject server-level environment variables (lowest precedence — app vars override these)
+        $server = data_get($this->application, 'destination.server');
+        if ($server) {
+            $envs->push('COOLIFY_SERVER_UUID='.$server->uuid);
+            $envs->push('COOLIFY_SERVER_IP='.$server->ip);
+            $envs->push('COOLIFY_SERVER_NAME='.$server->name);
+
+            foreach ($server->environment_variables ?? collect() as $serverEnv) {
+                $envs->push($serverEnv->key.'='.$serverEnv->real_value);
+            }
+        }
+
         if ($this->pull_request_id === 0) {
             // Generate SERVICE_ variables first for dockercompose
             if ($this->build_pack === 'dockercompose') {

--- a/app/Livewire/Server/EnvironmentVariableItem.php
+++ b/app/Livewire/Server/EnvironmentVariableItem.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Livewire\Server;
+
+use App\Models\EnvironmentVariable;
+use App\Models\Server;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Component;
+
+class EnvironmentVariableItem extends Component
+{
+    use AuthorizesRequests;
+
+    public EnvironmentVariable $env;
+
+    public Server $server;
+
+    public string $key;
+
+    public ?string $value = null;
+
+    public bool $isLocked = false;
+
+    protected $rules = [
+        'key' => 'required|string',
+        'value' => 'nullable',
+    ];
+
+    public function mount()
+    {
+        $this->key = $this->env->key;
+        $this->value = $this->env->value;
+        $this->isLocked = $this->env->is_shown_once;
+    }
+
+    public function submit()
+    {
+        try {
+            $this->authorize('update', $this->server);
+            $this->validate();
+
+            $this->env->key = $this->key;
+            if (! $this->isLocked) {
+                $this->env->value = $this->value;
+            }
+            $this->env->save();
+
+            $this->dispatch('success', 'Environment variable updated.');
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function lock()
+    {
+        try {
+            $this->authorize('update', $this->server);
+
+            $this->env->is_shown_once = true;
+            $this->env->save();
+            $this->isLocked = true;
+
+            $this->dispatch('success', 'Environment variable locked.');
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function delete()
+    {
+        try {
+            $this->authorize('update', $this->server);
+
+            $this->env->delete();
+            $this->dispatch('success', 'Environment variable deleted.');
+            $this->dispatch('refreshServerEnvs');
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function render()
+    {
+        return view('livewire.server.environment-variable-item');
+    }
+}

--- a/app/Livewire/Server/EnvironmentVariables.php
+++ b/app/Livewire/Server/EnvironmentVariables.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Livewire\Server;
+
+use App\Models\EnvironmentVariable;
+use App\Models\Server;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Component;
+
+class EnvironmentVariables extends Component
+{
+    use AuthorizesRequests;
+
+    public Server $server;
+
+    public array $parameters = [];
+
+    public string $newKey = '';
+
+    public ?string $newValue = '';
+
+    protected $listeners = [
+        'refreshServerEnvs' => '$refresh',
+        'environmentVariableDeleted' => '$refresh',
+    ];
+
+    public function mount(string $server_uuid)
+    {
+        try {
+            $this->server = Server::ownedByCurrentTeam()->whereUuid($server_uuid)->firstOrFail();
+            $this->parameters = get_route_parameters();
+        } catch (\Throwable) {
+            return redirect()->route('server.index');
+        }
+    }
+
+    public function getEnvironmentVariablesProperty()
+    {
+        return $this->server->environment_variables()->orderBy('key')->get();
+    }
+
+    public function submit()
+    {
+        try {
+            $this->authorize('update', $this->server);
+
+            $this->validate([
+                'newKey' => 'required|string',
+                'newValue' => 'nullable',
+            ]);
+
+            $existing = $this->server->environment_variables()->where('key', $this->newKey)->first();
+            if ($existing) {
+                $this->dispatch('error', "Environment variable '{$this->newKey}' already exists.");
+
+                return;
+            }
+
+            $env = new EnvironmentVariable;
+            $env->key = $this->newKey;
+            $env->value = $this->newValue;
+            $env->is_runtime = true;
+            $env->is_buildtime = false;
+            $env->is_preview = false;
+            $env->resourceable_id = $this->server->id;
+            $env->resourceable_type = $this->server->getMorphClass();
+            $env->save();
+
+            $this->newKey = '';
+            $this->newValue = '';
+            $this->dispatch('success', 'Environment variable added.');
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function delete(int $id)
+    {
+        try {
+            $this->authorize('update', $this->server);
+
+            $env = $this->server->environment_variables()->findOrFail($id);
+            $env->delete();
+
+            $this->dispatch('success', 'Environment variable deleted.');
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function render()
+    {
+        return view('livewire.server.environment-variables');
+    }
+}

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -315,6 +315,11 @@ class Server extends BaseModel
         return $this->hasOne(ServerSetting::class);
     }
 
+    public function environment_variables()
+    {
+        return $this->morphMany(EnvironmentVariable::class, 'resourceable');
+    }
+
     public function dockerCleanupExecutions()
     {
         return $this->hasMany(DockerCleanupExecution::class);

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -1562,6 +1562,18 @@ class Service extends BaseModel
             }
         }
 
+        // Inject server-level environment variables (lowest precedence — service vars override these)
+        $server = $this->server;
+        if ($server) {
+            $envs->push('COOLIFY_SERVER_UUID='.$server->uuid);
+            $envs->push('COOLIFY_SERVER_IP='.$server->ip);
+            $envs->push('COOLIFY_SERVER_NAME='.$server->name);
+
+            foreach ($server->environment_variables ?? collect() as $serverEnv) {
+                $envs->push("{$serverEnv->key}={$serverEnv->real_value}");
+            }
+        }
+
         $envs_from_coolify = $this->environment_variables()->get();
         $sorted = $envs_from_coolify->sortBy(function ($env) {
             if (str($env->key)->startsWith('SERVICE_')) {

--- a/resources/views/components/server/sidebar.blade.php
+++ b/resources/views/components/server/sidebar.blade.php
@@ -28,6 +28,9 @@
             href="{{ route('server.cloudflare-tunnel', ['server_uuid' => $server->uuid]) }}"><span class="menu-item-label">Cloudflare Tunnel</span></a>
     @endif
     @if ($server->isFunctional())
+        <a class="sub-menu-item {{ $activeMenu === 'environment-variables' ? 'menu-item-active' : '' }}" {{ wireNavigate() }}
+            href="{{ route('server.environment-variables', ['server_uuid' => $server->uuid]) }}"><span class="menu-item-label">Environment Variables</span>
+        </a>
         <a class="sub-menu-item {{ $activeMenu === 'docker-cleanup' ? 'menu-item-active' : '' }}" {{ wireNavigate() }}
             href="{{ route('server.docker-cleanup', ['server_uuid' => $server->uuid]) }}"><span class="menu-item-label">Docker Cleanup</span>
         </a>

--- a/resources/views/livewire/server/environment-variable-item.blade.php
+++ b/resources/views/livewire/server/environment-variable-item.blade.php
@@ -1,0 +1,24 @@
+<form wire:submit='submit' class="flex flex-col gap-2 p-4 rounded dark:bg-coolgray-100">
+    <div class="flex flex-wrap gap-2 sm:flex-nowrap items-end">
+        <x-forms.input id="key" label="Key" required canGate="update" :canResource="$server" />
+        @if ($isLocked)
+            <x-forms.input id="value" label="Value" type="password" disabled
+                placeholder="(Locked — delete and re-add to change)" />
+        @else
+            <x-forms.input id="value" label="Value" type="password" canGate="update" :canResource="$server" />
+        @endif
+    </div>
+    <div class="flex gap-2">
+        @can('update', $server)
+            <x-forms.button type="submit">Save</x-forms.button>
+            @if (! $isLocked)
+                <x-forms.button wire:click='lock' isWarning>Lock</x-forms.button>
+            @endif
+            <x-modal-confirmation title="Confirm Deletion?"
+                buttonTitle="Delete"
+                isErrorButton
+                action="delete"
+                :content="'Are you sure you want to delete the environment variable <strong>' . e($key) . '</strong>?'" />
+        @endcan
+    </div>
+</form>

--- a/resources/views/livewire/server/environment-variables.blade.php
+++ b/resources/views/livewire/server/environment-variables.blade.php
@@ -1,0 +1,59 @@
+<div>
+    <x-slot:title>
+        {{ data_get_str($server, 'name')->limit(10) }} > Environment Variables | Coolify
+    </x-slot>
+    <livewire:server.navbar :server="$server" />
+    <div x-data class="flex flex-col h-full gap-8 sm:flex-row">
+        <x-server.sidebar :server="$server" activeMenu="environment-variables" />
+        <div class="w-full">
+            <div>
+                <div class="flex items-center gap-2">
+                    <h2>Environment Variables</h2>
+                </div>
+                <div class="mb-4">
+                    Environment variables that are automatically injected into all applications and services deployed on this server.
+                    Application-level variables take precedence over server-level variables.
+                </div>
+            </div>
+
+            <div class="flex flex-col gap-4">
+                <div class="mb-4 p-4 rounded dark:bg-coolgray-100">
+                    <h4 class="mb-2">Auto-injected Variables</h4>
+                    <div class="text-sm dark:text-neutral-400">
+                        The following variables are automatically available in every container on this server:
+                    </div>
+                    <div class="mt-2 font-mono text-sm">
+                        <div><span class="dark:text-warning">COOLIFY_SERVER_UUID</span>={{ $server->uuid }}</div>
+                        <div><span class="dark:text-warning">COOLIFY_SERVER_IP</span>={{ $server->ip }}</div>
+                        <div><span class="dark:text-warning">COOLIFY_SERVER_NAME</span>={{ $server->name }}</div>
+                    </div>
+                </div>
+
+                @can('update', $server)
+                    <form wire:submit='submit' class="flex flex-col gap-2">
+                        <h3>Add New Variable</h3>
+                        <div class="flex flex-wrap gap-2 sm:flex-nowrap">
+                            <x-forms.input id="newKey" label="Key" placeholder="VARIABLE_NAME" required />
+                            <x-forms.input id="newValue" label="Value" placeholder="value" type="password" />
+                        </div>
+                        <div>
+                            <x-forms.button type="submit">Add</x-forms.button>
+                        </div>
+                    </form>
+                @endcan
+
+                <div class="flex flex-col gap-2">
+                    <h3>Current Variables</h3>
+                    @forelse ($this->environmentVariables as $env)
+                        <livewire:server.environment-variable-item
+                            wire:key="server-env-{{ $env->id }}"
+                            :env="$env"
+                            :server="$server" />
+                    @empty
+                        <div class="dark:text-neutral-400">No custom environment variables configured.</div>
+                    @endforelse
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -47,6 +47,7 @@ use App\Livewire\Server\CloudflareTunnel;
 use App\Livewire\Server\CloudProviderToken\Show as CloudProviderTokenShow;
 use App\Livewire\Server\Delete as DeleteServer;
 use App\Livewire\Server\Destinations as ServerDestinations;
+use App\Livewire\Server\EnvironmentVariables as ServerEnvironmentVariables;
 use App\Livewire\Server\DockerCleanup;
 use App\Livewire\Server\Index as ServerIndex;
 use App\Livewire\Server\LogDrains;
@@ -256,6 +257,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::prefix('server/{server_uuid}')->group(function () {
         Route::get('/', ServerShow::class)->name('server.show');
         Route::get('/advanced', ServerAdvanced::class)->name('server.advanced');
+        Route::get('/environment-variables', ServerEnvironmentVariables::class)->name('server.environment-variables');
         Route::get('/swarm', ServerSwarm::class)->name('server.swarm');
         Route::get('/sentinel', ServerSentinel::class)->name('server.sentinel');
         Route::get('/private-key', PrivateKeyShow::class)->name('server.private-key');


### PR DESCRIPTION
## Fixes
- https://github.com/coollabsio/coolify/issues/7738

## Summary
Adds the ability to define **environment variables per server** that are automatically injected into every application and service deployed on that server. This solves the problem of distinguishing between servers in multi-server deployments and enables server-specific configuration.

**Key design decisions:**
- Uses the existing `EnvironmentVariable` polymorphic model — no new tables needed
- Server vars have **lowest precedence** (app-level vars override them)
- Auto-injected vars: `COOLIFY_SERVER_UUID`, `COOLIFY_SERVER_IP`, `COOLIFY_SERVER_NAME`
- Full CRUD UI under Server > Environment Variables tab

## Changes
- Server model: added `environment_variables()` morphMany relationship
- New Livewire page: Server > Environment Variables (CRUD management)
- `ApplicationDeploymentJob`: injects server env vars before app-level vars
- `Service::saveComposeConfigs`: injects server env vars into `.env` file
- Server sidebar: added Environment Variables navigation item
- New route: `/server/{uuid}/environment-variables`

## Test plan
- [ ] Navigate to Server > Environment Variables and add a variable
- [ ] Deploy an application and verify the server variable is injected
- [ ] Override the server variable at app level, verify app-level takes precedence
- [ ] Verify auto-injected vars (COOLIFY_SERVER_UUID, etc.) are present
- [ ] Test with services (docker compose) — verify vars appear in .env