### PR TITLE
fix: stop auto-injecting .env as env_file into Docker Compose services

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -634,14 +634,9 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             }
         } else {
             $composeFile = $this->application->parse(pull_request_id: $this->pull_request_id, preview_id: data_get($this->preview, 'id'), commit: $this->commit);
-            // Always add .env file to services
-            $services = collect(data_get($composeFile, 'services', []));
-            $services = $services->map(function ($service, $name) {
-                $service['env_file'] = ['.env'];
-
-                return $service;
-            });
-            $composeFile['services'] = $services->toArray();
+            // The .env file is kept in the compose directory for YAML variable interpolation,
+            // but is NOT injected as env_file into services. Each service receives only its own
+            // environment variables via the 'environment' section, preventing cross-container leakage.
             if (empty($composeFile)) {
                 $this->application_deployment_queue->addLogEntry('Failed to parse docker-compose file.');
                 $this->fail('Failed to parse docker-compose file.');

--- a/bootstrap/helpers/parsers.php
+++ b/bootstrap/helpers/parsers.php
@@ -1317,15 +1317,21 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
         if ($depends_on->count() > 0) {
             $payload['depends_on'] = $depends_on;
         }
-        // Auto-inject .env file so Coolify environment variables are available inside containers
-        // This makes Applications behave consistently with manual .env file usage
+        // Preserve user-defined env_file entries from the compose file, but do NOT auto-inject .env
+        // The .env file in the compose directory is used for Docker Compose YAML variable interpolation only.
+        // Runtime environment variables are passed via the per-service 'environment' section above.
+        // Auto-injecting .env as env_file leaks ALL environment variables into EVERY container,
+        // which is a security issue (e.g., POSTGRES_PASSWORD visible in the app container).
         $existingEnvFiles = data_get($service, 'env_file');
-        $envFiles = collect(is_null($existingEnvFiles) ? [] : (is_array($existingEnvFiles) ? $existingEnvFiles : [$existingEnvFiles]))
-            ->push('.env')
-            ->unique()
-            ->values();
-
-        $payload['env_file'] = $envFiles;
+        if (! is_null($existingEnvFiles)) {
+            $envFiles = collect(is_array($existingEnvFiles) ? $existingEnvFiles : [$existingEnvFiles])
+                ->reject(fn ($f) => $f === '.env')
+                ->unique()
+                ->values();
+            if ($envFiles->isNotEmpty()) {
+                $payload['env_file'] = $envFiles;
+            }
+        }
 
         // Inject commit-based image tag for services with build directive (for rollback support)
         // Only inject if service has build but no explicit image defined
@@ -2416,15 +2422,19 @@ function serviceParser(Service $resource): Collection
         if ($depends_on->count() > 0) {
             $payload['depends_on'] = $depends_on;
         }
-        // Auto-inject .env file so Coolify environment variables are available inside containers
-        // This makes Services behave consistently with Applications
+        // Preserve user-defined env_file entries from the compose file, but do NOT auto-inject .env
+        // The .env file is used for Docker Compose YAML variable interpolation only.
+        // Runtime environment variables are passed via the per-service 'environment' section above.
         $existingEnvFiles = data_get($service, 'env_file');
-        $envFiles = collect(is_null($existingEnvFiles) ? [] : (is_array($existingEnvFiles) ? $existingEnvFiles : [$existingEnvFiles]))
-            ->push('.env')
-            ->unique()
-            ->values();
-
-        $payload['env_file'] = $envFiles;
+        if (! is_null($existingEnvFiles)) {
+            $envFiles = collect(is_array($existingEnvFiles) ? $existingEnvFiles : [$existingEnvFiles])
+                ->reject(fn ($f) => $f === '.env')
+                ->unique()
+                ->values();
+            if ($envFiles->isNotEmpty()) {
+                $payload['env_file'] = $envFiles;
+            }
+        }
 
         $parsedServices->put($serviceName, $payload);
     }


### PR DESCRIPTION
## Fixes
- https://github.com/coollabsio/coolify/issues/7655
- /claim #7655

## Summary

Coolify was auto-injecting `env_file: [".env"]` into every service in Docker Compose deployments, causing ALL environment variables to leak into EVERY container regardless of which service they were defined for.

**Example of the security issue:** In a Next.js + PostgreSQL + Redis stack, the Redis container has access to `POSTGRES_PASSWORD` and the PostgreSQL container can see `OPENAI_API_KEY` meant only for the app.

Per [Docker Compose documentation](https://docs.docker.com/compose/how-tos/environment-variables/variable-interpolation/), the `.env` file is used for **YAML variable interpolation only** (`${VAR}` substitution in the compose file), not for runtime environment injection into containers.

## Root Cause

Three locations auto-injected `.env` into every service's `env_file`:
1. `bootstrap/helpers/parsers.php` — Application parser flow (line ~1322)
2. `bootstrap/helpers/parsers.php` — Service parser flow (line ~2421)
3. `app/Jobs/ApplicationDeploymentJob.php` — Compose deployment (line ~640)

## Changes

- **Remove** auto-injection of `.env` into `env_file` for all Compose services
- **Preserve** any user-defined `env_file` entries (if users explicitly add `env_file: [my-custom.env]` in their compose, it is preserved)
- **Keep** `.env` file generation for Docker Compose YAML variable interpolation (unchanged)
- **Keep** single-container deployments unaffected (non-compose still uses `.env`)

Each service now only receives environment variables from its own `environment:` section, which is already populated per-service by the parsers with the correct variables.

## How to Test

1. Create a Docker Compose service with multiple containers (e.g., app + postgres + redis)
2. Set environment variables on each service (e.g., `POSTGRES_PASSWORD` for postgres, `API_KEY` for app)
3. Deploy and `docker exec` into each container
4. Verify: `env | grep POSTGRES_PASSWORD` in the app container should return nothing
5. Verify: `env | grep API_KEY` in the postgres container should return nothing
6. Verify: Each container only has its own environment variables
7. Verify: `${SERVICE_*}` variable interpolation in compose YAML still works
8. Verify: User-defined `env_file:` entries in compose are preserved

## Breaking Change Note

Users who relied on the implicit behavior of all env vars being shared across all containers will need to explicitly add variables to each service's `environment:` section or use `env_file:` in their compose file. This is the correct Docker Compose behavior.