### PR TITLE
feat: integrated backup support for Docker Compose applications

### DIFF
--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -93,7 +93,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $this->database = data_get($this->backup, 'database');
-                $this->server = $this->database->service->server;
+                $this->server = $this->database->server();
                 $this->s3 = $this->backup->s3;
             } else {
                 $this->database = data_get($this->backup, 'database');
@@ -121,11 +121,16 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $databaseType = $this->database->databaseType();
-                $serviceUuid = $this->database->service->uuid;
-                $serviceName = str($this->database->service->name)->slug();
+                if ($this->database->application_id) {
+                    $parentUuid = $this->database->application->uuid;
+                    $parentName = str($this->database->application->name)->slug();
+                } else {
+                    $parentUuid = $this->database->service->uuid;
+                    $parentName = str($this->database->service->name)->slug();
+                }
                 if (str($databaseType)->contains('postgres')) {
-                    $this->container_name = "{$this->database->name}-$serviceUuid";
-                    $this->directory_name = $serviceName.'-'.$this->container_name;
+                    $this->container_name = "{$this->database->name}-$parentUuid";
+                    $this->directory_name = $parentName.'-'.$this->container_name;
                     $commands[] = "docker exec $this->container_name env | grep POSTGRES_";
                     $envs = instant_remote_process($commands, $this->server, true, false, null, disableMultiplexing: true);
                     $envs = str($envs)->explode("\n");
@@ -155,8 +160,8 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                         $this->postgres_password = str($this->postgres_password)->after('POSTGRES_PASSWORD=')->value();
                     }
                 } elseif (str($databaseType)->contains('mysql')) {
-                    $this->container_name = "{$this->database->name}-$serviceUuid";
-                    $this->directory_name = $serviceName.'-'.$this->container_name;
+                    $this->container_name = "{$this->database->name}-$parentUuid";
+                    $this->directory_name = $parentName.'-'.$this->container_name;
                     $commands[] = "docker exec $this->container_name env | grep MYSQL_";
                     $envs = instant_remote_process($commands, $this->server, true, false, null, disableMultiplexing: true);
                     $envs = str($envs)->explode("\n");
@@ -178,8 +183,8 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                         throw new \Exception('MYSQL_DATABASE not found');
                     }
                 } elseif (str($databaseType)->contains('mariadb')) {
-                    $this->container_name = "{$this->database->name}-$serviceUuid";
-                    $this->directory_name = $serviceName.'-'.$this->container_name;
+                    $this->container_name = "{$this->database->name}-$parentUuid";
+                    $this->directory_name = $parentName.'-'.$this->container_name;
                     $commands[] = "docker exec $this->container_name env";
                     $envs = instant_remote_process($commands, $this->server, true, false, null, disableMultiplexing: true);
                     $envs = str($envs)->explode("\n");
@@ -216,8 +221,8 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                     }
                 } elseif (str($databaseType)->contains('mongo')) {
                     $databasesToBackup = ['*'];
-                    $this->container_name = "{$this->database->name}-$serviceUuid";
-                    $this->directory_name = $serviceName.'-'.$this->container_name;
+                    $this->container_name = "{$this->database->name}-$parentUuid";
+                    $this->directory_name = $parentName.'-'.$this->container_name;
 
                     // Try to extract MongoDB credentials from environment variables
                     try {

--- a/app/Livewire/Project/Application/DatabaseBackups.php
+++ b/app/Livewire/Project/Application/DatabaseBackups.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Livewire\Project\Application;
+
+use App\Models\Application;
+use App\Models\ServiceDatabase;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Component;
+
+class DatabaseBackups extends Component
+{
+    use AuthorizesRequests;
+
+    public ?Application $application = null;
+
+    public ?ServiceDatabase $serviceDatabase = null;
+
+    public array $parameters;
+
+    protected $listeners = ['refreshScheduledBackups' => '$refresh'];
+
+    public function mount(): void
+    {
+        try {
+            $this->parameters = get_route_parameters();
+            $this->application = Application::whereUuid($this->parameters['application_uuid'])->first();
+            if (! $this->application) {
+                redirect()->route('dashboard');
+
+                return;
+            }
+            $this->authorize('view', $this->application);
+
+            if ($this->application->build_pack !== 'dockercompose') {
+                redirect()->route('project.application.configuration', $this->parameters);
+
+                return;
+            }
+
+            $this->serviceDatabase = $this->application->databases()
+                ->whereUuid($this->parameters['database_uuid'])
+                ->first();
+
+            if (! $this->serviceDatabase || ! $this->serviceDatabase->isBackupSolutionAvailable()) {
+                redirect()->route('project.application.configuration', $this->parameters);
+
+                return;
+            }
+        } catch (\Throwable $e) {
+            handleError($e, $this);
+        }
+    }
+
+    public function render()
+    {
+        return view('livewire.project.application.database-backups');
+    }
+}

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -136,6 +136,11 @@ class Application extends BaseModel
                 'additional_networks',
             ]);
         });
+        static::deleting(function ($application) {
+            $application->databases()->each(function ($database) {
+                $database->delete();
+            });
+        });
         static::saving(function ($application) {
             $payload = [];
             if ($application->isDirty('fqdn')) {
@@ -842,6 +847,11 @@ class Application extends BaseModel
         }
 
         return null;
+    }
+
+    public function databases()
+    {
+        return $this->hasMany(ServiceDatabase::class);
     }
 
     public function environment_variables()

--- a/app/Models/ScheduledDatabaseBackup.php
+++ b/app/Models/ScheduledDatabaseBackup.php
@@ -63,12 +63,11 @@ class ScheduledDatabaseBackup extends BaseModel
         ];
     }
 
-    public function server()
+    public function server(): ?Server
     {
         if ($this->database) {
             if ($this->database instanceof ServiceDatabase) {
-                $destination = data_get($this->database->service, 'destination');
-                $server = data_get($destination, 'server');
+                return $this->database->server();
             } else {
                 $destination = data_get($this->database, 'destination');
                 $server = data_get($destination, 'server');

--- a/app/Models/ServiceDatabase.php
+++ b/app/Models/ServiceDatabase.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class ServiceDatabase extends BaseModel
@@ -27,7 +28,10 @@ class ServiceDatabase extends BaseModel
 
     public static function ownedByCurrentTeamAPI(int $teamId)
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', $teamId)->orderBy('name');
+        return ServiceDatabase::where(function ($query) use ($teamId) {
+            $query->whereRelation('service.environment.project.team', 'id', $teamId)
+                ->orWhereRelation('application.environment.project.team', 'id', $teamId);
+        })->orderBy('name');
     }
 
     /**
@@ -36,7 +40,12 @@ class ServiceDatabase extends BaseModel
      */
     public static function ownedByCurrentTeam()
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', currentTeam()->id)->orderBy('name');
+        $teamId = currentTeam()->id;
+
+        return ServiceDatabase::where(function ($query) use ($teamId) {
+            $query->whereRelation('service.environment.project.team', 'id', $teamId)
+                ->orWhereRelation('application.environment.project.team', 'id', $teamId);
+        })->orderBy('name');
     }
 
     /**
@@ -49,10 +58,23 @@ class ServiceDatabase extends BaseModel
         });
     }
 
-    public function restart()
+    public function restart(): void
     {
-        $container_id = $this->name.'-'.$this->service->uuid;
-        remote_process(["docker restart {$container_id}"], $this->service->server);
+        $parentUuid = $this->application ? $this->application->uuid : $this->service->uuid;
+        $container_id = $this->name.'-'.$parentUuid;
+        remote_process(["docker restart {$container_id}"], $this->server());
+    }
+
+    /**
+     * Resolve the server this database container runs on.
+     */
+    public function server(): ?Server
+    {
+        if ($this->application_id) {
+            return data_get($this->application, 'destination.server');
+        }
+
+        return data_get($this->service, 'destination.server');
     }
 
     public function isRunning()
@@ -111,11 +133,15 @@ class ServiceDatabase extends BaseModel
         return "standalone-$finalImage";
     }
 
-    public function getServiceDatabaseUrl()
+    public function getServiceDatabaseUrl(): string
     {
         $port = $this->public_port;
-        $realIp = $this->service->server->ip;
-        if ($this->service->server->isLocalhost() || isDev()) {
+        $server = $this->server();
+        if (! $server) {
+            return '';
+        }
+        $realIp = $server->ip;
+        if ($server->isLocalhost() || isDev()) {
             $realIp = base_ip();
         }
 
@@ -124,17 +150,30 @@ class ServiceDatabase extends BaseModel
 
     public function team()
     {
+        if ($this->application_id) {
+            return data_get($this, 'application.environment.project.team');
+        }
+
         return data_get($this, 'service.environment.project.team');
     }
 
-    public function workdir()
+    public function workdir(): string
     {
+        if ($this->application_id) {
+            return base_configuration_dir().'/applications/'.$this->application->uuid;
+        }
+
         return service_configuration_dir()."/{$this->service->uuid}";
     }
 
-    public function service()
+    public function service(): BelongsTo
     {
         return $this->belongsTo(Service::class);
+    }
+
+    public function application(): BelongsTo
+    {
+        return $this->belongsTo(Application::class);
     }
 
     public function persistentStorages()

--- a/bootstrap/helpers/parsers.php
+++ b/bootstrap/helpers/parsers.php
@@ -681,6 +681,19 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
         $coolifyEnvironments = collect([]);
 
         $isDatabase = isDatabaseImage($image, $service);
+
+        // Track detected database containers for backup support
+        if ($isDatabase && ! $isPullRequest) {
+            $savedDatabase = ServiceDatabase::firstOrCreate([
+                'name' => $serviceName,
+                'application_id' => $resource->id,
+            ]);
+            if ($savedDatabase->image !== $image->value()) {
+                $savedDatabase->image = $image->value();
+                $savedDatabase->save();
+            }
+        }
+
         $volumesParsed = collect([]);
 
         $baseName = generateApplicationContainerName(

--- a/database/migrations/2026_01_05_000001_add_application_id_to_service_databases.php
+++ b/database/migrations/2026_01_05_000001_add_application_id_to_service_databases.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->foreignId('application_id')->nullable()->after('service_id');
+            $table->foreignId('service_id')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->dropColumn('application_id');
+            $table->foreignId('service_id')->nullable(false)->change();
+        });
+    }
+};

--- a/resources/views/livewire/project/application/database-backups.blade.php
+++ b/resources/views/livewire/project/application/database-backups.blade.php
@@ -1,0 +1,18 @@
+<div>
+    <livewire:project.application.heading :application="$application" />
+    <div class="w-full">
+        <x-slot:title>
+            {{ data_get_str($application, 'name')->limit(10) }} >
+            {{ data_get_str($serviceDatabase, 'name')->limit(10) }} > Backups | Coolify
+        </x-slot>
+        <div class="flex gap-2">
+            <h2 class="pb-4">Scheduled Backups for {{ $serviceDatabase->name }}</h2>
+            @can('update', $application)
+                <x-modal-input buttonTitle="+ Add" title="New Scheduled Backup">
+                    <livewire:project.database.create-scheduled-backup :database="$serviceDatabase" />
+                </x-modal-input>
+            @endcan
+        </div>
+        <livewire:project.database.scheduled-backups :database="$serviceDatabase" />
+    </div>
+</div>

--- a/resources/views/livewire/project/application/heading.blade.php
+++ b/resources/views/livewire/project/application/heading.blade.php
@@ -29,6 +29,23 @@
                     </a>
                 @endcan
             @endif
+            @if ($application->build_pack === 'dockercompose' && $application->databases->filter(fn($db) => $db->isBackupSolutionAvailable())->count() > 0)
+                <x-dropdown>
+                    <x-slot:title>
+                        <span class="{{ request()->routeIs('project.application.database.backups') ? 'dark:text-white' : '' }}">
+                            Backups
+                        </span>
+                    </x-slot:title>
+                    @foreach ($application->databases as $database)
+                        @if ($database->isBackupSolutionAvailable())
+                            <a class="flex items-center gap-2 px-3 py-1.5 text-sm hover:bg-coolgray-100 dark:hover:bg-coolgray-300"
+                                href="{{ route('project.application.database.backups', array_merge($parameters, ['database_uuid' => $database->uuid])) }}">
+                                {{ $database->name }}
+                            </a>
+                        @endif
+                    @endforeach
+                </x-dropdown>
+            @endif
             <x-applications.links :application="$application" />
         </nav>
         <div class="flex flex-wrap gap-2 items-center">

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,7 @@ use App\Livewire\Notifications\Telegram as NotificationTelegram;
 use App\Livewire\Notifications\Webhook as NotificationWebhook;
 use App\Livewire\Profile\Index as ProfileIndex;
 use App\Livewire\Project\Application\Configuration as ApplicationConfiguration;
+use App\Livewire\Project\Application\DatabaseBackups as ApplicationDatabaseBackups;
 use App\Livewire\Project\Application\Deployment\Index as DeploymentIndex;
 use App\Livewire\Project\Application\Deployment\Show as DeploymentShow;
 use App\Livewire\Project\CloneMe as ProjectCloneMe;
@@ -216,6 +217,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/logs', Logs::class)->name('project.application.logs');
         Route::get('/terminal', ExecuteContainerCommand::class)->name('project.application.command')->middleware('can.access.terminal');
         Route::get('/tasks/{task_uuid}', ScheduledTaskShow::class)->name('project.application.scheduled-tasks');
+        Route::get('/database/{database_uuid}/backups', ApplicationDatabaseBackups::class)->name('project.application.database.backups');
     });
     Route::prefix('project/{project_uuid}/environment/{environment_uuid}/database/{database_uuid}')->group(function () {
         Route::get('/', DatabaseConfiguration::class)->name('project.database.configuration');

--- a/tests/Feature/ApplicationDatabaseBackupTest.php
+++ b/tests/Feature/ApplicationDatabaseBackupTest.php
@@ -1,0 +1,127 @@
+<?php
+
+use App\Models\Application;
+use App\Models\ApplicationSetting;
+use App\Models\Environment;
+use App\Models\Project;
+use App\Models\ScheduledDatabaseBackup;
+use App\Models\Server;
+use App\Models\ServiceDatabase;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function createApplicationWithDatabase(): array
+{
+    $team = Team::factory()->create();
+
+    $project = Project::create([
+        'uuid' => (string) Illuminate\Support\Str::uuid(),
+        'name' => 'Test Project',
+        'team_id' => $team->id,
+    ]);
+
+    $environment = Environment::create([
+        'name' => 'test-env-'.Illuminate\Support\Str::random(8),
+        'project_id' => $project->id,
+    ]);
+
+    $server = Server::factory()->create([
+        'team_id' => $team->id,
+    ]);
+
+    $destination = StandaloneDocker::create([
+        'uuid' => (string) Illuminate\Support\Str::uuid(),
+        'name' => 'test-docker',
+        'server_id' => $server->id,
+        'network' => 'coolify',
+    ]);
+
+    $application = Application::create([
+        'uuid' => (string) Illuminate\Support\Str::uuid(),
+        'name' => 'my-compose-app',
+        'environment_id' => $environment->id,
+        'destination_id' => $destination->id,
+        'destination_type' => StandaloneDocker::class,
+        'build_pack' => 'dockercompose',
+    ]);
+
+    ApplicationSetting::create([
+        'application_id' => $application->id,
+    ]);
+
+    $serviceDatabase = ServiceDatabase::create([
+        'uuid' => (string) Illuminate\Support\Str::uuid(),
+        'name' => 'postgres',
+        'application_id' => $application->id,
+        'image' => 'postgres:16',
+    ]);
+
+    return [$team, $application, $serviceDatabase, $server];
+}
+
+it('creates a ServiceDatabase owned by an Application', function () {
+    [$team, $application, $serviceDatabase] = createApplicationWithDatabase();
+
+    expect($serviceDatabase->application_id)->toBe($application->id)
+        ->and($serviceDatabase->service_id)->toBeNull()
+        ->and($serviceDatabase->application->id)->toBe($application->id);
+});
+
+it('resolves team through application relationship', function () {
+    [$team, $application, $serviceDatabase] = createApplicationWithDatabase();
+
+    expect($serviceDatabase->team())->not->toBeNull()
+        ->and($serviceDatabase->team()->id)->toBe($team->id);
+});
+
+it('resolves server through application destination', function () {
+    [$team, $application, $serviceDatabase, $server] = createApplicationWithDatabase();
+
+    expect($serviceDatabase->server())->not->toBeNull()
+        ->and($serviceDatabase->server()->id)->toBe($server->id);
+});
+
+it('lists application databases in the databases relationship', function () {
+    [$team, $application, $serviceDatabase] = createApplicationWithDatabase();
+
+    expect($application->databases)->toHaveCount(1)
+        ->and($application->databases->first()->id)->toBe($serviceDatabase->id);
+});
+
+it('detects backup availability for postgres image', function () {
+    [$team, $application, $serviceDatabase] = createApplicationWithDatabase();
+
+    expect($serviceDatabase->isBackupSolutionAvailable())->toBeTrue();
+});
+
+it('returns correct database type for postgres image', function () {
+    [$team, $application, $serviceDatabase] = createApplicationWithDatabase();
+
+    expect($serviceDatabase->databaseType())->toBe('standalone-postgresql');
+});
+
+it('returns correct workdir for application-owned database', function () {
+    [$team, $application, $serviceDatabase] = createApplicationWithDatabase();
+
+    $expected = base_configuration_dir().'/applications/'.$application->uuid;
+    expect($serviceDatabase->workdir())->toBe($expected);
+});
+
+it('creates scheduled backup for application-owned database', function () {
+    [$team, $application, $serviceDatabase] = createApplicationWithDatabase();
+
+    $backup = ScheduledDatabaseBackup::create([
+        'uuid' => (string) Illuminate\Support\Str::uuid(),
+        'database_id' => $serviceDatabase->id,
+        'database_type' => ServiceDatabase::class,
+        'frequency' => '0 0 * * *',
+        'team_id' => $team->id,
+    ]);
+
+    expect($backup->database)->toBeInstanceOf(ServiceDatabase::class)
+        ->and($backup->database->id)->toBe($serviceDatabase->id)
+        ->and($serviceDatabase->scheduledBackups)->toHaveCount(1);
+});


### PR DESCRIPTION
## Summary

Adds scheduled backup support for database containers detected in Docker Compose (git-based) applications. Previously, backups were only available for standalone databases and one-click service databases. This PR extends the existing backup infrastructure to also cover databases defined within `docker-compose.yml` files deployed as Applications.

**Changes:**

- **Migration**: Adds nullable `application_id` column to `service_databases` table, makes `service_id` nullable to support Application ownership
- **ServiceDatabase model**: New `application()` relationship, `server()` helper method; updated `team()`, `workdir()`, `restart()`, `getServiceDatabaseUrl()`, `ownedByCurrentTeam()` to support both Service and Application ownership
- **Application model**: New `databases()` relationship, cleanup on deletion
- **applicationParser**: Detects database images via `isDatabaseImage()` and creates `ServiceDatabase` records for Docker Compose applications
- **DatabaseBackupJob**: Updated container name resolution to use either Service or Application UUID as parent
- **ScheduledDatabaseBackup**: Delegates server resolution to `ServiceDatabase.server()`
- **UI**: New Livewire component (`Application\DatabaseBackups`), blade view, route, and "Backups" dropdown in Application heading navigation
- **Tests**: Feature tests for Application-owned ServiceDatabase relationships, team resolution, backup creation

## How it works

1. When a Docker Compose application is parsed, `applicationParser()` detects database images (postgres, mysql, mariadb, mongodb) using the existing `isDatabaseImage()` helper
2. For each detected database container, a `ServiceDatabase` record is created with `application_id` set (instead of `service_id`)
3. Users can configure scheduled backups via the new "Backups" dropdown in the Application navigation
4. The existing `DatabaseBackupJob` handles backup execution — it resolves the container name as `{service_name}-{application_uuid}`, matching the container naming convention used in Docker Compose deployments

## Test plan

- [ ] Deploy a Docker Compose application containing a PostgreSQL database
- [ ] Verify the "Backups" dropdown appears in the Application navigation
- [ ] Create a scheduled backup and verify it executes successfully
- [ ] Test with MySQL, MariaDB, and MongoDB images
- [ ] Verify existing Service-owned database backups still work correctly
- [ ] Run `php artisan test --filter=ApplicationDatabaseBackup`

Closes #7528