### PR TITLE
Fix TCP DB proxy timeouts for public databases

### DIFF
--- a/app/Actions/Database/StartDatabaseProxy.php
+++ b/app/Actions/Database/StartDatabaseProxy.php
@@ -66,6 +66,11 @@ class StartDatabaseProxy
     stream {
        server {
             listen $database->public_port;
+            # Keep TCP connections open for long-running downloads/queries.
+            # Without this, some environments can see connections dropped around ~10 minutes.
+            # Nginx stream proxy timeouts are independent from Postgres query timeouts.
+            proxy_connect_timeout 60s;
+            proxy_timeout 12h;
             proxy_pass $containerName:$internalPort;
        }
     }


### PR DESCRIPTION
Fixes #7743

/claim #7743

### What
Public database exposure uses an nginx `stream` proxy generated in `StartDatabaseProxy`. Some users observe the TCP connection dropping around ~10 minutes.

This PR increases stream proxy timeouts so long-running downloads/queries can complete.

### Changes
- Add `proxy_connect_timeout 60s;`
- Add `proxy_timeout 12h;`

### Notes
- These are stream proxy timeouts, independent from Postgres statement timeouts.
- Follow-up could make this configurable in the UI if maintainers prefer.

### Demo
(Will add a short demo video link here once I can capture it.)
