### PR TITLE
fix: prevent 10-minute timeout on public database proxies

### DIFF
--- a/app/Actions/Database/StartDatabaseProxy.php
+++ b/app/Actions/Database/StartDatabaseProxy.php
@@ -20,6 +20,27 @@ class StartDatabaseProxy
 
     public string $jobQueue = 'high';
 
+    public static function generateNginxStreamConfig(int $publicPort, string $containerName, int $internalPort): string
+    {
+        return <<<EOF
+    user  nginx;
+    worker_processes  auto;
+
+    error_log  /var/log/nginx/error.log;
+
+    events {
+        worker_connections  1024;
+    }
+    stream {
+       server {
+            listen {$publicPort};
+            proxy_pass {$containerName}:{$internalPort};
+            proxy_timeout 0;
+       }
+    }
+    EOF;
+    }
+
     public function handle(StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse|ServiceDatabase $database)
     {
         $databaseType = $database->database_type;
@@ -54,22 +75,7 @@ class StartDatabaseProxy
         if (isDev()) {
             $configuration_dir = '/var/lib/docker/volumes/coolify_dev_coolify_data/_data/databases/'.$database->uuid.'/proxy';
         }
-        $nginxconf = <<<EOF
-    user  nginx;
-    worker_processes  auto;
-
-    error_log  /var/log/nginx/error.log;
-
-    events {
-        worker_connections  1024;
-    }
-    stream {
-       server {
-            listen $database->public_port;
-            proxy_pass $containerName:$internalPort;
-       }
-    }
-    EOF;
+        $nginxconf = self::generateNginxStreamConfig($database->public_port, $containerName, $internalPort);
         $docker_compose = [
             'services' => [
                 $proxyContainerName => [

--- a/tests/Unit/Actions/Database/StartDatabaseProxyTest.php
+++ b/tests/Unit/Actions/Database/StartDatabaseProxyTest.php
@@ -1,0 +1,11 @@
+<?php
+
+use App\Actions\Database\StartDatabaseProxy;
+
+it('disables stream proxy timeout for public database proxy connections', function () {
+    $config = StartDatabaseProxy::generateNginxStreamConfig(54320, 'test-db', 5432);
+
+    expect($config)->toContain('listen 54320;');
+    expect($config)->toContain('proxy_pass test-db:5432;');
+    expect($config)->toContain('proxy_timeout 0;');
+});


### PR DESCRIPTION
## Summary
- disable the nginx stream idle timeout for public DB proxy connections by setting `proxy_timeout 0`
- extract stream config generation into `StartDatabaseProxy::generateNginxStreamConfig()` for easier verification
- add a unit test ensuring generated config includes `proxy_timeout 0` and expected listen/proxy directives

## Why
Nginx stream proxy defaults to a 10 minute timeout, which cuts long-running query result streams (`SELECT *` / large exports). This change aligns with issue #7743 by removing the timeout entirely.

## Testing
- Added: `tests/Unit/Actions/Database/StartDatabaseProxyTest.php`
- Could not run PHP test suite in this environment because `php`/`composer` are unavailable on the runner host.

Fixes #7743
