### PR TITLE
fix: prevent idle timeout drops on public database proxies

### DIFF
--- a/app/Actions/Database/StartDatabaseProxy.php
+++ b/app/Actions/Database/StartDatabaseProxy.php
@@ -20,6 +20,27 @@ class StartDatabaseProxy
 
     public string $jobQueue = 'high';
 
+    public static function generateNginxStreamConfig(int $publicPort, string $containerName, int $internalPort): string
+    {
+        return <<<EOF
+    user  nginx;
+    worker_processes  auto;
+
+    error_log  /var/log/nginx/error.log;
+
+    events {
+        worker_connections  1024;
+    }
+    stream {
+       server {
+            listen {$publicPort};
+            proxy_pass {$containerName}:{$internalPort};
+            proxy_timeout 0;
+       }
+    }
+    EOF;
+    }
+
     public function handle(StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse|ServiceDatabase $database)
     {
         $databaseType = $database->database_type;
@@ -54,22 +75,7 @@ class StartDatabaseProxy
         if (isDev()) {
             $configuration_dir = '/var/lib/docker/volumes/coolify_dev_coolify_data/_data/databases/'.$database->uuid.'/proxy';
         }
-        $nginxconf = <<<EOF
-    user  nginx;
-    worker_processes  auto;
-
-    error_log  /var/log/nginx/error.log;
-
-    events {
-        worker_connections  1024;
-    }
-    stream {
-       server {
-            listen $database->public_port;
-            proxy_pass $containerName:$internalPort;
-       }
-    }
-    EOF;
+        $nginxconf = self::generateNginxStreamConfig($database->public_port, $containerName, $internalPort);
         $docker_compose = [
             'services' => [
                 $proxyContainerName => [

--- a/tests/Unit/Actions/Database/StartDatabaseProxyTest.php
+++ b/tests/Unit/Actions/Database/StartDatabaseProxyTest.php
@@ -1,0 +1,11 @@
+<?php
+
+use App\Actions\Database\StartDatabaseProxy;
+
+it('disables stream proxy timeout for public database proxy connections', function () {
+    $config = StartDatabaseProxy::generateNginxStreamConfig(54320, 'test-db', 5432);
+
+    expect($config)->toContain('listen 54320;');
+    expect($config)->toContain('proxy_pass test-db:5432;');
+    expect($config)->toContain('proxy_timeout 0;');
+});


### PR DESCRIPTION
## Summary
This fixes dropped long-running public database connections by removing the hardcoded 10-minute idle timeout from generated nginx stream proxy config.

## Changes
- Use `proxy_timeout 0;` for public database stream proxy config generation.
- Add a unit test for `StartDatabaseProxy` to verify the generated nginx config no longer applies a 10-minute idle timeout.

## Notes
- Base branch: `next`
- Commit author/PR author: `RyanD66`

/claim #7743
