### PR TITLE
fix(ssh): prevent RCE via SSH command injection

### DIFF
--- a/app/Helpers/SshMultiplexingHelper.php
+++ b/app/Helpers/SshMultiplexingHelper.php
@@ -37,7 +37,7 @@ class SshMultiplexingHelper
         if (data_get($server, 'settings.is_cloudflare_tunnel')) {
             $checkCommand .= '-o ProxyCommand="cloudflared access ssh --hostname %h" ';
         }
-        $checkCommand .= "{$server->user}@{$server->ip}";
+        $checkCommand .= self::escapedUserAtHost($server);
         $process = Process::run($checkCommand);
 
         if ($process->exitCode() !== 0) {
@@ -80,7 +80,7 @@ class SshMultiplexingHelper
             $establishCommand .= ' -o ProxyCommand="cloudflared access ssh --hostname %h" ';
         }
         $establishCommand .= self::getCommonSshOptions($server, $sshKeyLocation, $connectionTimeout, $serverInterval);
-        $establishCommand .= "{$server->user}@{$server->ip}";
+        $establishCommand .= self::escapedUserAtHost($server);
         $establishProcess = Process::run($establishCommand);
         if ($establishProcess->exitCode() !== 0) {
             return false;
@@ -101,7 +101,7 @@ class SshMultiplexingHelper
         if (data_get($server, 'settings.is_cloudflare_tunnel')) {
             $closeCommand .= '-o ProxyCommand="cloudflared access ssh --hostname %h" ';
         }
-        $closeCommand .= "{$server->user}@{$server->ip}";
+        $closeCommand .= self::escapedUserAtHost($server);
         Process::run($closeCommand);
 
         // Clear connection metadata from cache
@@ -141,9 +141,9 @@ class SshMultiplexingHelper
 
         $scp_command .= self::getCommonSshOptions($server, $sshKeyLocation, config('constants.ssh.connection_timeout'), config('constants.ssh.server_interval'), isScp: true);
         if ($server->isIpv6()) {
-            $scp_command .= "{$source} {$server->user}@[{$server->ip}]:{$dest}";
+            $scp_command .= "{$source} ".escapeshellarg($server->user).'@['.escapeshellarg($server->ip)."]:{$dest}";
         } else {
-            $scp_command .= "{$source} {$server->user}@{$server->ip}:{$dest}";
+            $scp_command .= "{$source} ".self::escapedUserAtHost($server).":{$dest}";
         }
 
         return $scp_command;
@@ -189,11 +189,16 @@ class SshMultiplexingHelper
         $delimiter = base64_encode($delimiter);
         $command = str_replace($delimiter, '', $command);
 
-        $ssh_command .= "{$server->user}@{$server->ip} 'bash -se' << \\$delimiter".PHP_EOL
+        $ssh_command .= self::escapedUserAtHost($server)." 'bash -se' << \\$delimiter".PHP_EOL
             .$command.PHP_EOL
             .$delimiter;
 
         return $ssh_command;
+    }
+
+    private static function escapedUserAtHost(Server $server): string
+    {
+        return escapeshellarg($server->user).'@'.escapeshellarg($server->ip);
     }
 
     private static function isMultiplexingEnabled(): bool
@@ -224,9 +229,9 @@ class SshMultiplexingHelper
 
         // Bruh
         if ($isScp) {
-            $options .= "-P {$server->port} ";
+            $options .= '-P '.escapeshellarg((string) $server->port).' ';
         } else {
-            $options .= "-p {$server->port} ";
+            $options .= '-p '.escapeshellarg((string) $server->port).' ';
         }
 
         return $options;
@@ -245,7 +250,7 @@ class SshMultiplexingHelper
         if (data_get($server, 'settings.is_cloudflare_tunnel')) {
             $healthCommand .= '-o ProxyCommand="cloudflared access ssh --hostname %h" ';
         }
-        $healthCommand .= "{$server->user}@{$server->ip} 'echo \"health_check_ok\"'";
+        $healthCommand .= self::escapedUserAtHost($server)." 'echo \"health_check_ok\"'";
 
         $process = Process::run($healthCommand);
         $isHealthy = $process->exitCode() === 0 && str_contains($process->output(), 'health_check_ok');

--- a/app/Http/Controllers/Api/ServersController.php
+++ b/app/Http/Controllers/Api/ServersController.php
@@ -11,6 +11,7 @@ use App\Models\Application;
 use App\Models\PrivateKey;
 use App\Models\Project;
 use App\Models\Server as ModelsServer;
+use App\Rules\ValidServerIp;
 use Illuminate\Http\Request;
 use OpenApi\Attributes as OA;
 use Stringable;
@@ -472,10 +473,10 @@ class ServersController extends Controller
         $validator = customApiValidator($request->all(), [
             'name' => 'string|max:255',
             'description' => 'string|nullable',
-            'ip' => 'string|required',
-            'port' => 'integer|nullable',
+            'ip' => ['string', 'required', new ValidServerIp],
+            'port' => 'integer|nullable|between:1,65535',
             'private_key_uuid' => 'string|required',
-            'user' => 'string|nullable',
+            'user' => ['string', 'nullable', 'regex:/^[a-zA-Z0-9_-]+$/'],
             'is_build_server' => 'boolean|nullable',
             'instant_validate' => 'boolean|nullable',
             'proxy_type' => 'string|nullable',
@@ -637,10 +638,10 @@ class ServersController extends Controller
         $validator = customApiValidator($request->all(), [
             'name' => 'string|max:255|nullable',
             'description' => 'string|nullable',
-            'ip' => 'string|nullable',
-            'port' => 'integer|nullable',
+            'ip' => ['string', 'nullable', new ValidServerIp],
+            'port' => 'integer|nullable|between:1,65535',
             'private_key_uuid' => 'string|nullable',
-            'user' => 'string|nullable',
+            'user' => ['string', 'nullable', 'regex:/^[a-zA-Z0-9_-]+$/'],
             'is_build_server' => 'boolean|nullable',
             'instant_validate' => 'boolean|nullable',
             'proxy_type' => 'string|nullable',

--- a/app/Livewire/Server/New/ByIp.php
+++ b/app/Livewire/Server/New/ByIp.php
@@ -5,6 +5,7 @@ namespace App\Livewire\Server\New;
 use App\Enums\ProxyTypes;
 use App\Models\Server;
 use App\Models\Team;
+use App\Rules\ValidServerIp;
 use App\Support\ValidationPatterns;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Livewire\Attributes\Locked;
@@ -55,8 +56,8 @@ class ByIp extends Component
             'new_private_key_value' => 'nullable|string',
             'name' => ValidationPatterns::nameRules(),
             'description' => ValidationPatterns::descriptionRules(),
-            'ip' => 'required|string',
-            'user' => 'required|string',
+            'ip' => ['required', 'string', new ValidServerIp],
+            'user' => ['required', 'string', 'regex:/^[a-zA-Z0-9_-]+$/'],
             'port' => 'required|integer|between:1,65535',
             'is_build_server' => 'required|boolean',
         ];

--- a/app/Livewire/Server/Show.php
+++ b/app/Livewire/Server/Show.php
@@ -7,6 +7,7 @@ use App\Actions\Server\StopSentinel;
 use App\Events\ServerReachabilityChanged;
 use App\Models\CloudProviderToken;
 use App\Models\Server;
+use App\Rules\ValidServerIp;
 use App\Services\HetznerService;
 use App\Support\ValidationPatterns;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
@@ -106,9 +107,9 @@ class Show extends Component
         return [
             'name' => ValidationPatterns::nameRules(),
             'description' => ValidationPatterns::descriptionRules(),
-            'ip' => 'required',
-            'user' => 'required',
-            'port' => 'required',
+            'ip' => ['required', new ValidServerIp],
+            'user' => ['required', 'regex:/^[a-zA-Z0-9_-]+$/'],
+            'port' => 'required|integer|between:1,65535',
             'validationLogs' => 'nullable',
             'wildcardDomain' => 'nullable|url',
             'isReachable' => 'required',

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -913,6 +913,9 @@ $schema://$host {
         return Attribute::make(
             get: function ($value) {
                 return (int) preg_replace('/[^0-9]/', '', $value);
+            },
+            set: function ($value) {
+                return (int) preg_replace('/[^0-9]/', '', (string) $value);
             }
         );
     }
@@ -922,6 +925,9 @@ $schema://$host {
         return Attribute::make(
             get: function ($value) {
                 return preg_replace('/[^A-Za-z0-9\-_]/', '', $value);
+            },
+            set: function ($value) {
+                return preg_replace('/[^A-Za-z0-9\-_]/', '', $value);
             }
         );
     }
@@ -930,6 +936,9 @@ $schema://$host {
     {
         return Attribute::make(
             get: function ($value) {
+                return preg_replace('/[^0-9a-zA-Z.:%-]/', '', $value);
+            },
+            set: function ($value) {
                 return preg_replace('/[^0-9a-zA-Z.:%-]/', '', $value);
             }
         );

--- a/app/Rules/ValidServerIp.php
+++ b/app/Rules/ValidServerIp.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class ValidServerIp implements ValidationRule
+{
+    /**
+     * Accepts a valid IPv4 address, IPv6 address, or RFC 1123 hostname.
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (empty($value)) {
+            return;
+        }
+
+        $trimmed = trim($value);
+
+        if (filter_var($trimmed, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+            return;
+        }
+
+        if (filter_var($trimmed, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
+            return;
+        }
+
+        // Delegate hostname validation to ValidHostname
+        $hostnameRule = new ValidHostname;
+        $failed = false;
+        $hostnameRule->validate($attribute, $trimmed, function () use (&$failed) {
+            $failed = true;
+        });
+
+        if ($failed) {
+            $fail('The :attribute must be a valid IPv4 address, IPv6 address, or hostname.');
+        }
+    }
+}

--- a/tests/Unit/SshCommandInjectionTest.php
+++ b/tests/Unit/SshCommandInjectionTest.php
@@ -1,0 +1,125 @@
+<?php
+
+use App\Helpers\SshMultiplexingHelper;
+use App\Rules\ValidHostname;
+use App\Rules\ValidServerIp;
+
+// -------------------------------------------------------------------------
+// ValidServerIp rule
+// -------------------------------------------------------------------------
+
+it('accepts a valid IPv4 address', function () {
+    $rule = new ValidServerIp;
+    $failed = false;
+    $rule->validate('ip', '192.168.1.1', function () use (&$failed) {
+        $failed = true;
+    });
+    expect($failed)->toBeFalse();
+});
+
+it('accepts a valid IPv6 address', function () {
+    $rule = new ValidServerIp;
+    $failed = false;
+    $rule->validate('ip', '2001:db8::1', function () use (&$failed) {
+        $failed = true;
+    });
+    expect($failed)->toBeFalse();
+});
+
+it('accepts a valid hostname', function () {
+    $rule = new ValidServerIp;
+    $failed = false;
+    $rule->validate('ip', 'my-server.example.com', function () use (&$failed) {
+        $failed = true;
+    });
+    expect($failed)->toBeFalse();
+});
+
+it('rejects injection payloads in server ip', function (string $payload) {
+    $rule = new ValidServerIp;
+    $failed = false;
+    $rule->validate('ip', $payload, function () use (&$failed) {
+        $failed = true;
+    });
+    expect($failed)->toBeTrue("ValidServerIp should reject: $payload");
+})->with([
+    'semicolon' => ['192.168.1.1; rm -rf /'],
+    'pipe' => ['192.168.1.1 | cat /etc/passwd'],
+    'backtick' => ['192.168.1.1`id`'],
+    'dollar subshell' => ['192.168.1.1$(id)'],
+    'ampersand' => ['192.168.1.1 & id'],
+    'newline' => ["192.168.1.1\nid"],
+    'null byte' => ["192.168.1.1\0id"],
+]);
+
+// -------------------------------------------------------------------------
+// Server model setter casts
+// -------------------------------------------------------------------------
+
+it('strips dangerous characters from server ip on write', function () {
+    $server = new App\Models\Server;
+    $server->ip = '192.168.1.1;rm -rf /';
+    // Regex [^0-9a-zA-Z.:%-] removes ; space and /; hyphen is allowed
+    expect($server->ip)->toBe('192.168.1.1rm-rf');
+});
+
+it('strips dangerous characters from server user on write', function () {
+    $server = new App\Models\Server;
+    $server->user = 'root$(id)';
+    expect($server->user)->toBe('rootid');
+});
+
+it('strips non-numeric characters from server port on write', function () {
+    $server = new App\Models\Server;
+    $server->port = '22; evil';
+    expect($server->port)->toBe(22);
+});
+
+// -------------------------------------------------------------------------
+// escapeshellarg() in generated SSH commands (source-level verification)
+// -------------------------------------------------------------------------
+
+it('has escapedUserAtHost private static helper in SshMultiplexingHelper', function () {
+    $reflection = new ReflectionClass(SshMultiplexingHelper::class);
+    expect($reflection->hasMethod('escapedUserAtHost'))->toBeTrue();
+
+    $method = $reflection->getMethod('escapedUserAtHost');
+    expect($method->isPrivate())->toBeTrue();
+    expect($method->isStatic())->toBeTrue();
+});
+
+it('wraps port with escapeshellarg in getCommonSshOptions', function () {
+    $reflection = new ReflectionClass(SshMultiplexingHelper::class);
+    $source = file_get_contents($reflection->getFileName());
+
+    expect($source)->toContain('escapeshellarg((string) $server->port)');
+});
+
+it('has no raw user@ip string interpolation in SshMultiplexingHelper', function () {
+    $reflection = new ReflectionClass(SshMultiplexingHelper::class);
+    $source = file_get_contents($reflection->getFileName());
+
+    expect($source)->not->toContain('{$server->user}@{$server->ip}');
+});
+
+// -------------------------------------------------------------------------
+// ValidHostname rejects shell metacharacters
+// -------------------------------------------------------------------------
+
+it('rejects semicolon in hostname', function () {
+    $rule = new ValidHostname;
+    $failed = false;
+    $rule->validate('hostname', 'example.com;id', function () use (&$failed) {
+        $failed = true;
+    });
+    expect($failed)->toBeTrue();
+});
+
+it('rejects backtick in hostname', function () {
+    $rule = new ValidHostname;
+    $failed = false;
+    $rule->validate('hostname', 'example.com`id`', function () use (&$failed) {
+        $failed = true;
+    });
+    expect($failed)->toBeTrue();
+});


### PR DESCRIPTION
## Summary

This PR addresses a critical security vulnerability where unsanitized server IP, user, and port values could be injected into SSH commands, allowing remote code execution.

**Key Changes:**
- Added `ValidServerIp` rule to validate IPv4, IPv6 addresses and hostnames
- Introduced `escapedUserAtHost()` helper method in `SshMultiplexingHelper` using `escapeshellarg()`
- Added setter methods to Server model attributes to sanitize dangerous characters from IP, user, and port on write
- Added regex validation for user field to only allow alphanumeric, hyphen, and underscore characters
- Added port range validation (1-65535) in controllers and Livewire components
- Added comprehensive test suite covering injection payloads and proper escaping

## Breaking Changes

None. This is a security hardening fix that strengthens validation without changing the public API.