### PR TITLE
chore(ui): add container labels header

### DIFF
--- a/resources/views/livewire/project/application/general.blade.php
+++ b/resources/views/livewire/project/application/general.blade.php
@@ -527,6 +527,7 @@
                     @endif
                 </div>
 
+                <h3 class="pt-8">Labels</h3>
                 @if ($application->settings->is_container_label_readonly_enabled)
                     <x-forms.textarea readonly disabled label="Container Labels" rows="15" id="customLabels"
                         monacoEditorLanguage="ini" useMonacoEditor x-bind:disabled="!canUpdate"></x-forms.textarea>


### PR DESCRIPTION
Visually separating the container labels from the HTTP basic authentication section, as it regularly confuses users.

## Changes
- Added a h3 above the container labels textfield

## Issues
- N/A

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td>
<img width="889" height="665" alt="image" src="https://github.com/user-attachments/assets/7f92d7ea-a425-4197-89a9-0b2d845b7760" />
 <td>
<img width="889" height="665" alt="image" src="https://github.com/user-attachments/assets/bbf9e7fe-3ee5-4798-9ff1-e219e092c61d" />
</table>

## AI Assistance

<!-- AI-assisted PRs that are human reviewed are welcome, just let us know so we can review appropriately. -->

- [x] AI was NOT used to create this PR
- [ ] AI was used (please describe below)

## Testing
Open the general settings of a Application

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
