### PR TITLE
fix: avoid 10-minute timeout on public database proxies

### DIFF
--- a/app/Actions/Database/StartDatabaseProxy.php
+++ b/app/Actions/Database/StartDatabaseProxy.php
@@ -67,6 +67,8 @@ class StartDatabaseProxy
        server {
             listen $database->public_port;
             proxy_pass $containerName:$internalPort;
+            proxy_connect_timeout 30s;
+            proxy_timeout 24h;
        }
     }
     EOF;


### PR DESCRIPTION
## Summary
- Add explicit stream proxy timeouts to the database public proxy nginx config
- Keep a short connect timeout (proxy_connect_timeout 30s)
- Increase stream timeout (proxy_timeout 24h) to avoid the default ~10 minute cutoff

## Why
Public database proxies currently drop long-running sessions after about 10 minutes due to nginx stream default timeout behavior. This breaks long queries/downloads for publicly exposed Postgres and other database types.

## Scope
This change is in StartDatabaseProxy, so it applies to all DB engines that use the public database proxy path (Postgres, MySQL, MariaDB, MongoDB, Redis/KeyDB/Dragonfly, ClickHouse).

Fixes #7743
