### PR TITLE
fix(ssh): sync stale key files via fingerprint before SSH exec

### DIFF
--- a/app/Helpers/SshMultiplexingHelper.php
+++ b/app/Helpers/SshMultiplexingHelper.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Facades\Storage;
 
 class SshMultiplexingHelper
 {
@@ -158,7 +159,7 @@ class SshMultiplexingHelper
         $sshConfig = self::serverSshConfiguration($server);
         $sshKeyLocation = $sshConfig['sshKeyLocation'];
 
-        self::validateSshKey($server->privateKey);
+        self::validateSshKey($server->privateKey, $server);
 
         $muxSocket = $sshConfig['muxFilename'];
 
@@ -206,14 +207,28 @@ class SshMultiplexingHelper
         return config('constants.ssh.mux_enabled') && ! config('constants.coolify.is_windows_docker_desktop');
     }
 
-    private static function validateSshKey(PrivateKey $privateKey): void
+    private static function validateSshKey(PrivateKey $privateKey, ?Server $server = null): void
     {
-        $keyLocation = $privateKey->getKeyLocation();
-        $checkKeyCommand = "ls $keyLocation 2>/dev/null";
-        $keyCheckProcess = Process::run($checkKeyCommand);
+        $disk = Storage::disk('ssh-keys');
+        $filename = "ssh_key@{$privateKey->uuid}";
 
-        if ($keyCheckProcess->exitCode() !== 0) {
+        $shouldSyncToDisk = ! $disk->exists($filename);
+        if (! $shouldSyncToDisk) {
+            $storedContent = $disk->get($filename);
+            $storedFingerprint = PrivateKey::generateFingerprint($storedContent);
+            $expectedFingerprint = $privateKey->fingerprint ?? PrivateKey::generateFingerprint($privateKey->private_key);
+
+            // Fingerprint mismatch means key file is stale/corrupted on this node.
+            $shouldSyncToDisk = is_null($storedFingerprint) || is_null($expectedFingerprint) || ! hash_equals($expectedFingerprint, $storedFingerprint);
+        }
+
+        if ($shouldSyncToDisk) {
             $privateKey->storeInFileSystem();
+
+            // Any existing mux session can still reference the stale key in memory.
+            if (! is_null($server) && self::isMultiplexingEnabled()) {
+                self::removeMuxFile($server);
+            }
         }
     }
 

--- a/tests/Unit/SshKeyFileSyncTest.php
+++ b/tests/Unit/SshKeyFileSyncTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use App\Helpers\SshMultiplexingHelper;
+use App\Models\PrivateKey;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class SshKeyFileSyncTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->actingAs(\App\Models\User::factory()->create());
+    }
+
+    protected function getValidPrivateKey(): string
+    {
+        return '-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACBbhpqHhqv6aI67Mj9abM3DVbmcfYhZAhC7ca4d9UCevAAAAJi/QySHv0Mk
+hwAAAAtzc2gtZWQyNTUxOQAAACBbhpqHhqv6aI67Mj9abM3DVbmcfYhZAhC7ca4d9UCevA
+AAAECBQw4jg1WRT2IGHMncCiZhURCts2s24HoDS0thHnnRKVuGmoeGq/pojrsyP1pszcNV
+uZx9iFkCELtxrh31QJ68AAAAEXNhaWxANzZmZjY2ZDJlMmRkAQIDBA==
+-----END OPENSSH PRIVATE KEY-----';
+    }
+
+    protected function invokeValidate(PrivateKey $privateKey): void
+    {
+        $method = new ReflectionMethod(SshMultiplexingHelper::class, 'validateSshKey');
+        $method->setAccessible(true);
+        $method->invoke(null, $privateKey, null);
+    }
+
+    /** @test */
+    public function it_recreates_missing_ssh_key_file_before_ssh_command_generation()
+    {
+        Storage::fake('ssh-keys');
+
+        $privateKey = PrivateKey::createAndStore([
+            'name' => 'Test Key',
+            'description' => 'Test Description',
+            'private_key' => $this->getValidPrivateKey(),
+            'team_id' => currentTeam()->id,
+        ]);
+
+        $filename = "ssh_key@{$privateKey->uuid}";
+        Storage::disk('ssh-keys')->delete($filename);
+        Storage::disk('ssh-keys')->assertMissing($filename);
+
+        $this->invokeValidate($privateKey);
+
+        Storage::disk('ssh-keys')->assertExists($filename);
+        expect(Storage::disk('ssh-keys')->get($filename))->toBe($privateKey->private_key);
+    }
+
+    /** @test */
+    public function it_rewrites_stale_or_corrupted_ssh_key_file()
+    {
+        Storage::fake('ssh-keys');
+
+        $privateKey = PrivateKey::createAndStore([
+            'name' => 'Test Key',
+            'description' => 'Test Description',
+            'private_key' => $this->getValidPrivateKey(),
+            'team_id' => currentTeam()->id,
+        ]);
+
+        $filename = "ssh_key@{$privateKey->uuid}";
+        Storage::disk('ssh-keys')->put($filename, 'corrupted-key-content');
+
+        $this->invokeValidate($privateKey);
+
+        expect(Storage::disk('ssh-keys')->get($filename))->toBe($privateKey->private_key);
+    }
+}


### PR DESCRIPTION
/claim #7724

## Summary
This patch hardens `validateSshKey()` so Coolify re-syncs the key file when it is missing, stale, or corrupted on the executing node.

Instead of raw-content assumptions, it compares **public key fingerprints**:
- expected fingerprint from DB key (`PrivateKey::fingerprint` fallback to computed)
- fingerprint from on-disk key content

If mismatch is detected:
1. Re-store key from DB to disk
2. Invalidate current server mux session so subsequent SSH uses the refreshed key

## Why this approach
Issue #7724 reports sporadic `Permission denied (publickey,password)` symptoms consistent with stale per-node key files. This patch addresses that path directly while keeping scope small.

Compared to prior attempts, this version:
- avoids broad server iteration for mux invalidation
- refreshes only the current server context
- uses fingerprint comparison rather than plain content equality checks

## Changes
- `app/Helpers/SshMultiplexingHelper.php`
  - `validateSshKey(PrivateKey $privateKey, ?Server $server = null)`
  - fingerprint-based stale file detection
  - targeted mux reset for current server when sync occurs
- `tests/Unit/SshKeyFileSyncTest.php`
  - missing key file is recreated
  - corrupted key file is repaired

## Notes
I could not execute PHP tests in this environment because `php` is unavailable (`php: command not found`), but I added focused unit coverage for CI validation.
