### PR TITLE
feat: add integrated backup support for Git-based Docker Compose applications

### DIFF
--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -13,6 +13,8 @@ use App\Models\StandaloneMongodb;
 use App\Models\StandaloneMysql;
 use App\Models\StandalonePostgresql;
 use App\Models\Team;
+use App\Models\ApplicationDeploymentQueue;
+use App\Enums\ApplicationDeploymentStatus;
 use App\Notifications\Database\BackupFailed;
 use App\Notifications\Database\BackupSuccess;
 use App\Notifications\Database\BackupSuccessWithS3Warning;
@@ -86,14 +88,18 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             $databasesToBackup = null;
 
             $this->team = Team::find($this->backup->team_id);
-            if (! $this->team) {
+            if (!$this->team) {
                 $this->backup->delete();
 
                 return;
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $this->database = data_get($this->backup, 'database');
-                $this->server = $this->database->service->server;
+                if ($this->database->application_id) {
+                    $this->server = $this->database->application->destination->server;
+                } else {
+                    $this->server = $this->database->service->server;
+                }
                 $this->s3 = $this->backup->s3;
             } else {
                 $this->database = data_get($this->backup, 'database');
@@ -110,16 +116,37 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             BackupCreated::dispatch($this->team->id);
 
             $status = str(data_get($this->database, 'status'));
-            if (! $status->startsWith('running') && $this->database->id !== 0) {
+            if (!$status->startsWith('running') && $this->database->id !== 0) {
                 return;
+            }
+
+            if ($this->database instanceof ServiceDatabase && $this->database->application_id) {
+                $deploymentInProgress = ApplicationDeploymentQueue::where('application_id', $this->database->application_id)
+                    ->where('status', ApplicationDeploymentStatus::IN_PROGRESS->value)
+                    ->exists();
+
+                if ($deploymentInProgress) {
+                    // Cap deferred retries to prevent infinite loops if a deployment hangs
+                    if ($this->attempts() < 10) {
+                        $this->release(30);
+
+                        return;
+                    }
+                    // After 10 attempts (~5 min), proceed anyway to avoid permanent backup starvation
+                }
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $databaseType = $this->database->databaseType();
-                $serviceUuid = $this->database->service->uuid;
-                $serviceName = str($this->database->service->name)->slug();
+                if ($this->database->application_id) {
+                    $serviceUuid = $this->database->application->uuid;
+                    $serviceName = str($this->database->application->name)->slug();
+                } else {
+                    $serviceUuid = $this->database->service->uuid;
+                    $serviceName = str($this->database->service->name)->slug();
+                }
                 if (str($databaseType)->contains('postgres')) {
                     $this->container_name = "{$this->database->name}-$serviceUuid";
-                    $this->directory_name = $serviceName.'-'.$this->container_name;
+                    $this->directory_name = $serviceName . '-' . $this->container_name;
                     $commands[] = "docker exec $this->container_name env | grep POSTGRES_";
                     $envs = instant_remote_process($commands, $this->server, true, false, null, disableMultiplexing: true);
                     $envs = str($envs)->explode("\n");
@@ -150,7 +177,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                     }
                 } elseif (str($databaseType)->contains('mysql')) {
                     $this->container_name = "{$this->database->name}-$serviceUuid";
-                    $this->directory_name = $serviceName.'-'.$this->container_name;
+                    $this->directory_name = $serviceName . '-' . $this->container_name;
                     $commands[] = "docker exec $this->container_name env | grep MYSQL_";
                     $envs = instant_remote_process($commands, $this->server, true, false, null, disableMultiplexing: true);
                     $envs = str($envs)->explode("\n");
@@ -173,7 +200,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                     }
                 } elseif (str($databaseType)->contains('mariadb')) {
                     $this->container_name = "{$this->database->name}-$serviceUuid";
-                    $this->directory_name = $serviceName.'-'.$this->container_name;
+                    $this->directory_name = $serviceName . '-' . $this->container_name;
                     $commands[] = "docker exec $this->container_name env";
                     $envs = instant_remote_process($commands, $this->server, true, false, null, disableMultiplexing: true);
                     $envs = str($envs)->explode("\n");
@@ -211,7 +238,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                 } elseif (str($databaseType)->contains('mongo')) {
                     $databasesToBackup = ['*'];
                     $this->container_name = "{$this->database->name}-$serviceUuid";
-                    $this->directory_name = $serviceName.'-'.$this->container_name;
+                    $this->directory_name = $serviceName . '-' . $this->container_name;
 
                     // Try to extract MongoDB credentials from environment variables
                     try {
@@ -242,7 +269,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             } else {
                 $databaseName = str($this->database->name)->slug()->value();
                 $this->container_name = $this->database->uuid;
-                $this->directory_name = $databaseName.'-'.$this->container_name;
+                $this->directory_name = $databaseName . '-' . $this->container_name;
                 $databaseType = $this->database->type();
                 $databasesToBackup = data_get($this->backup, 'databases_to_backup');
             }
@@ -282,12 +309,12 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                     return;
                 }
             }
-            $this->backup_dir = backup_dir().'/databases/'.str($this->team->name)->slug().'-'.$this->team->id.'/'.$this->directory_name;
+            $this->backup_dir = backup_dir() . '/databases/' . str($this->team->name)->slug() . '-' . $this->team->id . '/' . $this->directory_name;
             if ($this->database->name === 'coolify-db') {
                 $databasesToBackup = ['coolify'];
                 $this->directory_name = $this->container_name = 'coolify-db';
                 $ip = Str::slug($this->server->ip);
-                $this->backup_dir = backup_dir().'/coolify'."/coolify-db-$ip";
+                $this->backup_dir = backup_dir() . '/coolify' . "/coolify-db-$ip";
             }
             foreach ($databasesToBackup as $database) {
                 // Generate unique UUID for each database backup execution
@@ -308,11 +335,11 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                 // Step 1: Create local backup
                 try {
                     if (str($databaseType)->contains('postgres')) {
-                        $this->backup_file = "/pg-dump-$database-".Carbon::now()->timestamp.'.dmp';
+                        $this->backup_file = "/pg-dump-$database-" . Carbon::now()->timestamp . '.dmp';
                         if ($this->backup->dump_all) {
-                            $this->backup_file = '/pg-dump-all-'.Carbon::now()->timestamp.'.gz';
+                            $this->backup_file = '/pg-dump-all-' . Carbon::now()->timestamp . '.gz';
                         }
-                        $this->backup_location = $this->backup_dir.$this->backup_file;
+                        $this->backup_location = $this->backup_dir . $this->backup_file;
                         $this->backup_log = ScheduledDatabaseBackupExecution::create([
                             'uuid' => $this->backup_log_uuid,
                             'database_name' => $database,
@@ -332,8 +359,8 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                                 $databaseName = $database;
                             }
                         }
-                        $this->backup_file = "/mongo-dump-$databaseName-".Carbon::now()->timestamp.'.tar.gz';
-                        $this->backup_location = $this->backup_dir.$this->backup_file;
+                        $this->backup_file = "/mongo-dump-$databaseName-" . Carbon::now()->timestamp . '.tar.gz';
+                        $this->backup_location = $this->backup_dir . $this->backup_file;
                         $this->backup_log = ScheduledDatabaseBackupExecution::create([
                             'uuid' => $this->backup_log_uuid,
                             'database_name' => $databaseName,
@@ -343,11 +370,11 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                         ]);
                         $this->backup_standalone_mongodb($database);
                     } elseif (str($databaseType)->contains('mysql')) {
-                        $this->backup_file = "/mysql-dump-$database-".Carbon::now()->timestamp.'.dmp';
+                        $this->backup_file = "/mysql-dump-$database-" . Carbon::now()->timestamp . '.dmp';
                         if ($this->backup->dump_all) {
-                            $this->backup_file = '/mysql-dump-all-'.Carbon::now()->timestamp.'.gz';
+                            $this->backup_file = '/mysql-dump-all-' . Carbon::now()->timestamp . '.gz';
                         }
-                        $this->backup_location = $this->backup_dir.$this->backup_file;
+                        $this->backup_location = $this->backup_dir . $this->backup_file;
                         $this->backup_log = ScheduledDatabaseBackupExecution::create([
                             'uuid' => $this->backup_log_uuid,
                             'database_name' => $database,
@@ -357,11 +384,11 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                         ]);
                         $this->backup_standalone_mysql($database);
                     } elseif (str($databaseType)->contains('mariadb')) {
-                        $this->backup_file = "/mariadb-dump-$database-".Carbon::now()->timestamp.'.dmp';
+                        $this->backup_file = "/mariadb-dump-$database-" . Carbon::now()->timestamp . '.dmp';
                         if ($this->backup->dump_all) {
-                            $this->backup_file = '/mariadb-dump-all-'.Carbon::now()->timestamp.'.gz';
+                            $this->backup_file = '/mariadb-dump-all-' . Carbon::now()->timestamp . '.gz';
                         }
-                        $this->backup_location = $this->backup_dir.$this->backup_file;
+                        $this->backup_location = $this->backup_dir . $this->backup_file;
                         $this->backup_log = ScheduledDatabaseBackupExecution::create([
                             'uuid' => $this->backup_log_uuid,
                             'database_name' => $database,
@@ -421,8 +448,8 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
 
                     if ($s3UploadError) {
                         $message = $message
-                            ? $message."\n\nWarning: S3 upload failed: ".$s3UploadError
-                            : 'Warning: S3 upload failed: '.$s3UploadError;
+                            ? $message . "\n\nWarning: S3 upload failed: " . $s3UploadError
+                            : 'Warning: S3 upload failed: ' . $s3UploadError;
                     }
 
                     $this->backup_log->update([
@@ -474,7 +501,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
             \Log::info('MongoDB backup URL configured', ['has_url' => filled($url), 'using_env_vars' => blank($this->database->internal_db_url)]);
             if ($databaseWithCollections === 'all') {
-                $commands[] = 'mkdir -p '.$this->backup_dir;
+                $commands[] = 'mkdir -p ' . $this->backup_dir;
                 if (str($this->database->image)->startsWith('mongo:4')) {
                     $commands[] = "docker exec $this->container_name mongodump --uri=\"$url\" --gzip --archive > $this->backup_location";
                 } else {
@@ -488,7 +515,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                     $databaseName = $databaseWithCollections;
                     $collectionsToExclude = collect();
                 }
-                $commands[] = 'mkdir -p '.$this->backup_dir;
+                $commands[] = 'mkdir -p ' . $this->backup_dir;
 
                 // Validate and escape database name to prevent command injection
                 validateShellSafePath($databaseName, 'database name');
@@ -502,9 +529,9 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                     }
                 } else {
                     if (str($this->database->image)->startsWith('mongo:4')) {
-                        $commands[] = "docker exec $this->container_name mongodump --uri=$url --gzip --excludeCollection ".$collectionsToExclude->implode(' --excludeCollection ')." --archive > $this->backup_location";
+                        $commands[] = "docker exec $this->container_name mongodump --uri=$url --gzip --excludeCollection " . $collectionsToExclude->implode(' --excludeCollection ') . " --archive > $this->backup_location";
                     } else {
-                        $commands[] = "docker exec $this->container_name mongodump --authenticationDatabase=admin --uri=\"$url\" --db $escapedDatabaseName --gzip --excludeCollection ".$collectionsToExclude->implode(' --excludeCollection ')." --archive > $this->backup_location";
+                        $commands[] = "docker exec $this->container_name mongodump --authenticationDatabase=admin --uri=\"$url\" --db $escapedDatabaseName --gzip --excludeCollection " . $collectionsToExclude->implode(' --excludeCollection ') . " --archive > $this->backup_location";
                     }
                 }
             }
@@ -522,7 +549,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
     private function backup_standalone_postgresql(string $database): void
     {
         try {
-            $commands[] = 'mkdir -p '.$this->backup_dir;
+            $commands[] = 'mkdir -p ' . $this->backup_dir;
             $backupCommand = 'docker exec';
             if ($this->postgres_password) {
                 $backupCommand .= " -e PGPASSWORD=\"{$this->postgres_password}\"";
@@ -551,7 +578,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
     private function backup_standalone_mysql(string $database): void
     {
         try {
-            $commands[] = 'mkdir -p '.$this->backup_dir;
+            $commands[] = 'mkdir -p ' . $this->backup_dir;
             if ($this->backup->dump_all) {
                 $commands[] = "docker exec $this->container_name mysqldump -u root -p\"{$this->database->mysql_root_password}\" --all-databases --single-transaction --quick --lock-tables=false --compress | gzip > $this->backup_location";
             } else {
@@ -574,7 +601,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
     private function backup_standalone_mariadb(string $database): void
     {
         try {
-            $commands[] = 'mkdir -p '.$this->backup_dir;
+            $commands[] = 'mkdir -p ' . $this->backup_dir;
             if ($this->backup->dump_all) {
                 $commands[] = "docker exec $this->container_name mariadb-dump -u root -p\"{$this->database->mariadb_root_password}\" --all-databases --single-transaction --quick --lock-tables=false --compress > $this->backup_location";
             } else {
@@ -597,7 +624,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
     private function add_to_backup_output($output): void
     {
         if ($this->backup_output) {
-            $this->backup_output = $this->backup_output."\n".$output;
+            $this->backup_output = $this->backup_output . "\n" . $output;
         } else {
             $this->backup_output = $output;
         }
@@ -606,7 +633,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
     private function add_to_error_output($output): void
     {
         if ($this->error_output) {
-            $this->error_output = $this->error_output."\n".$output;
+            $this->error_output = $this->error_output . "\n" . $output;
         } else {
             $this->error_output = $output;
         }
@@ -630,7 +657,11 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             $endpoint = $this->s3->endpoint;
             $this->s3->testConnection(shouldSave: true);
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
-                $network = $this->database->service->destination->network;
+                if ($this->database->application_id) {
+                    $network = $this->database->application->destination->network;
+                } else {
+                    $network = $this->database->service->destination->network;
+                }
             } else {
                 $network = $this->database->destination->network;
             }
@@ -644,10 +675,10 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
 
             if (isDev()) {
                 if ($this->database->name === 'coolify-db') {
-                    $backup_location_from = '/var/lib/docker/volumes/coolify_dev_backups_data/_data/coolify/coolify-db-'.$this->server->ip.$this->backup_file;
+                    $backup_location_from = '/var/lib/docker/volumes/coolify_dev_backups_data/_data/coolify/coolify-db-' . $this->server->ip . $this->backup_file;
                     $commands[] = "docker run -d --network {$network} --name backup-of-{$this->backup_log_uuid} --rm -v $backup_location_from:$this->backup_location:ro {$fullImageName}";
                 } else {
-                    $backup_location_from = '/var/lib/docker/volumes/coolify_dev_backups_data/_data/databases/'.str($this->team->name)->slug().'-'.$this->team->id.'/'.$this->directory_name.$this->backup_file;
+                    $backup_location_from = '/var/lib/docker/volumes/coolify_dev_backups_data/_data/databases/' . str($this->team->name)->slug() . '-' . $this->team->id . '/' . $this->directory_name . $this->backup_file;
                     $commands[] = "docker run -d --network {$network} --name backup-of-{$this->backup_log_uuid} --rm -v $backup_location_from:$this->backup_location:ro {$fullImageName}";
                 }
             } else {
@@ -700,7 +731,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
         if ($log) {
             $log->update([
                 'status' => 'failed',
-                'message' => 'Job permanently failed after '.$this->attempts().' attempts: '.($exception?->getMessage() ?? 'Unknown error'),
+                'message' => 'Job permanently failed after ' . $this->attempts() . ' attempts: ' . ($exception?->getMessage() ?? 'Unknown error'),
                 'size' => 0,
                 'filename' => null,
                 'finished_at' => Carbon::now(),

--- a/app/Livewire/Project/Application/Configuration.php
+++ b/app/Livewire/Project/Application/Configuration.php
@@ -43,7 +43,7 @@ class Configuration extends Component
             ->where('uuid', request()->route('environment_uuid'))
             ->firstOrFail();
         $application = $environment->applications()
-            ->with(['destination'])
+            ->with(['destination', 'serviceDatabases'])
             ->where('uuid', request()->route('application_uuid'))
             ->firstOrFail();
 
@@ -56,6 +56,10 @@ class Configuration extends Component
         }
 
         if ($this->application->build_pack === 'dockercompose' && $this->currentRoute === 'project.application.healthcheck') {
+            return redirect()->route('project.application.configuration', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]);
+        }
+
+        if ($this->application->build_pack !== 'dockercompose' && $this->currentRoute === 'project.application.backups') {
             return redirect()->route('project.application.configuration', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]);
         }
     }

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -69,7 +69,7 @@ use Visus\Cuid2\Cuid2;
         'limits_cpuset' => ['type' => 'string', 'nullable' => true, 'description' => 'CPU set.'],
         'limits_cpu_shares' => ['type' => 'integer', 'description' => 'CPU shares.'],
         'status' => ['type' => 'string', 'description' => 'Application status.'],
-        'preview_url_template' => ['type' => 'string',  'description' => 'Preview URL template.'],
+        'preview_url_template' => ['type' => 'string', 'description' => 'Preview URL template.'],
         'destination_type' => ['type' => 'string', 'description' => 'Destination type.'],
         'destination_id' => ['type' => 'integer', 'description' => 'Destination identifier.'],
         'source_id' => ['type' => 'integer', 'nullable' => true, 'description' => 'Source identifier.'],
@@ -264,7 +264,7 @@ class Application extends BaseModel
                 }
 
                 // If it's a string but not JSON, treat it as a comma-separated list
-                if (is_string($value) && ! is_array($value)) {
+                if (is_string($value) && !is_array($value)) {
                     $value = explode(',', $value);
                 }
 
@@ -326,7 +326,7 @@ class Application extends BaseModel
      */
     private function isJson($string)
     {
-        if (! is_string($string)) {
+        if (!is_string($string)) {
             return false;
         }
         json_decode($string);
@@ -372,7 +372,7 @@ class Application extends BaseModel
         $server = data_get($this, 'destination.server');
         $workdir = $this->workdir();
         if (str($workdir)->endsWith($this->uuid)) {
-            instant_remote_process(['rm -rf '.$this->workdir()], $server, false);
+            instant_remote_process(['rm -rf ' . $this->workdir()], $server, false);
         }
     }
 
@@ -500,6 +500,11 @@ class Application extends BaseModel
         return $this->morphMany(LocalFileVolume::class, 'resource');
     }
 
+    public function serviceDatabases()
+    {
+        return $this->hasMany(ServiceDatabase::class);
+    }
+
     public function type()
     {
         return 'application';
@@ -508,7 +513,7 @@ class Application extends BaseModel
     public function publishDirectory(): Attribute
     {
         return Attribute::make(
-            set: fn ($value) => $value ? '/'.ltrim($value, '/') : null,
+            set: fn($value) => $value ? '/' . ltrim($value, '/') : null,
         );
     }
 
@@ -517,7 +522,7 @@ class Application extends BaseModel
         return Attribute::make(
             get: function () {
                 $base_dir = $this->base_directory ?? '/';
-                if (! is_null($this->source?->html_url) && ! is_null($this->git_repository) && ! is_null($this->git_branch)) {
+                if (!is_null($this->source?->html_url) && !is_null($this->git_repository) && !is_null($this->git_branch)) {
                     if (str($this->git_repository)->contains('bitbucket')) {
                         return "{$this->source->html_url}/{$this->git_repository}/src/{$this->git_branch}{$base_dir}";
                     }
@@ -544,7 +549,7 @@ class Application extends BaseModel
     {
         return Attribute::make(
             get: function () {
-                if (! is_null($this->source?->html_url) && ! is_null($this->git_repository) && ! is_null($this->git_branch)) {
+                if (!is_null($this->source?->html_url) && !is_null($this->git_repository) && !is_null($this->git_branch)) {
                     return "{$this->source->html_url}/{$this->git_repository}/settings/hooks";
                 }
                 // Convert the SSH URL to HTTPS URL
@@ -563,7 +568,7 @@ class Application extends BaseModel
     {
         return Attribute::make(
             get: function () {
-                if (! is_null($this->source?->html_url) && ! is_null($this->git_repository) && ! is_null($this->git_branch)) {
+                if (!is_null($this->source?->html_url) && !is_null($this->git_repository) && !is_null($this->git_branch)) {
                     return "{$this->source->html_url}/{$this->git_repository}/commits/{$this->git_branch}";
                 }
                 // Convert the SSH URL to HTTPS URL
@@ -580,7 +585,7 @@ class Application extends BaseModel
 
     public function gitCommitLink($link): string
     {
-        if (! is_null(data_get($this, 'source.html_url')) && ! is_null(data_get($this, 'git_repository')) && ! is_null(data_get($this, 'git_branch'))) {
+        if (!is_null(data_get($this, 'source.html_url')) && !is_null(data_get($this, 'git_repository')) && !is_null(data_get($this, 'git_branch'))) {
             if (str($this->source->html_url)->contains('bitbucket')) {
                 return "{$this->source->html_url}/{$this->git_repository}/commits/{$link}";
             }
@@ -591,7 +596,7 @@ class Application extends BaseModel
             $git_repository = str_replace('.git', '', $this->git_repository);
             $url = Url::fromString($git_repository);
             $url = $url->withUserInfo('');
-            $url = $url->withPath($url->getPath().'/commits/'.$link);
+            $url = $url->withPath($url->getPath() . '/commits/' . $link);
 
             return $url->__toString();
         }
@@ -644,23 +649,23 @@ class Application extends BaseModel
     public function baseDirectory(): Attribute
     {
         return Attribute::make(
-            set: fn ($value) => '/'.ltrim($value, '/'),
+            set: fn($value) => '/' . ltrim($value, '/'),
         );
     }
 
     public function portsMappings(): Attribute
     {
         return Attribute::make(
-            set: fn ($value) => $value === '' ? null : $value,
+            set: fn($value) => $value === '' ? null : $value,
         );
     }
 
     public function portsMappingsArray(): Attribute
     {
         return Attribute::make(
-            get: fn () => is_null($this->ports_mappings)
-                ? []
-                : explode(',', $this->ports_mappings),
+            get: fn() => is_null($this->ports_mappings)
+            ? []
+            : explode(',', $this->ports_mappings),
 
         );
     }
@@ -687,14 +692,14 @@ class Application extends BaseModel
                 // Check main server infrastructure health
                 $main_server_functional = $this->destination?->server?->isFunctional() ?? false;
 
-                if (! $main_server_functional) {
+                if (!$main_server_functional) {
                     return false;
                 }
 
                 // Check additional servers infrastructure health (not container status!)
                 if ($this->relationLoaded('additional_servers') && $this->additional_servers->count() > 0) {
                     foreach ($this->additional_servers as $server) {
-                        if (! $server->isFunctional()) {
+                        if (!$server->isFunctional()) {
                             return false;  // Real server infrastructure problem
                         }
                     }
@@ -778,17 +783,17 @@ class Application extends BaseModel
     public function customNginxConfiguration(): Attribute
     {
         return Attribute::make(
-            set: fn ($value) => base64_encode($value),
-            get: fn ($value) => base64_decode($value),
+            set: fn($value) => base64_encode($value),
+            get: fn($value) => base64_decode($value),
         );
     }
 
     public function portsExposesArray(): Attribute
     {
         return Attribute::make(
-            get: fn () => is_null($this->ports_exposes)
-                ? []
-                : explode(',', $this->ports_exposes)
+            get: fn() => is_null($this->ports_exposes)
+            ? []
+            : explode(',', $this->ports_exposes)
         );
     }
 
@@ -1032,7 +1037,7 @@ class Application extends BaseModel
 
     public function workdir()
     {
-        return application_configuration_dir()."/{$this->uuid}";
+        return application_configuration_dir() . "/{$this->uuid}";
     }
 
     public function isLogDrainEnabled()
@@ -1042,11 +1047,11 @@ class Application extends BaseModel
 
     public function isConfigurationChanged(bool $save = false)
     {
-        $newConfigHash = base64_encode($this->fqdn.$this->git_repository.$this->git_branch.$this->git_commit_sha.$this->build_pack.$this->static_image.$this->install_command.$this->build_command.$this->start_command.$this->ports_exposes.$this->ports_mappings.$this->custom_network_aliases.$this->base_directory.$this->publish_directory.$this->dockerfile.$this->dockerfile_location.$this->custom_labels.$this->custom_docker_run_options.$this->dockerfile_target_build.$this->redirect.$this->custom_nginx_configuration.$this->settings->use_build_secrets.$this->settings->inject_build_args_to_dockerfile.$this->settings->include_source_commit_in_build);
+        $newConfigHash = base64_encode($this->fqdn . $this->git_repository . $this->git_branch . $this->git_commit_sha . $this->build_pack . $this->static_image . $this->install_command . $this->build_command . $this->start_command . $this->ports_exposes . $this->ports_mappings . $this->custom_network_aliases . $this->base_directory . $this->publish_directory . $this->dockerfile . $this->dockerfile_location . $this->custom_labels . $this->custom_docker_run_options . $this->dockerfile_target_build . $this->redirect . $this->custom_nginx_configuration . $this->settings->use_build_secrets . $this->settings->inject_build_args_to_dockerfile . $this->settings->include_source_commit_in_build);
         if ($this->pull_request_id === 0 || $this->pull_request_id === null) {
-            $newConfigHash .= json_encode($this->environment_variables()->get(['value',  'is_multiline', 'is_literal', 'is_buildtime', 'is_runtime'])->sort());
+            $newConfigHash .= json_encode($this->environment_variables()->get(['value', 'is_multiline', 'is_literal', 'is_buildtime', 'is_runtime'])->sort());
         } else {
-            $newConfigHash .= json_encode($this->environment_variables_preview->get(['value',  'is_multiline', 'is_literal', 'is_buildtime', 'is_runtime'])->sort());
+            $newConfigHash .= json_encode($this->environment_variables_preview->get(['value', 'is_multiline', 'is_literal', 'is_buildtime', 'is_runtime'])->sort());
         }
         $newConfigHash = md5($newConfigHash);
         $oldConfigHash = data_get($this, 'config_hash');
@@ -1082,7 +1087,7 @@ class Application extends BaseModel
 
     public function dirOnServer()
     {
-        return application_configuration_dir()."/{$this->uuid}";
+        return application_configuration_dir() . "/{$this->uuid}";
     }
 
     public function setGitImportSettings(string $deployment_uuid, string $git_clone_command, bool $public = false)
@@ -1284,7 +1289,7 @@ class Application extends BaseModel
                     $fullRepoUrl = "{$this->source->html_url}/{$customRepository}";
                     $escapedRepoUrl = escapeshellarg("{$this->source->html_url}/{$customRepository}");
                     $git_clone_command = "{$git_clone_command} {$escapedRepoUrl} {$escapedBaseDir}";
-                    if (! $only_checkout) {
+                    if (!$only_checkout) {
                         $git_clone_command = $this->setGitImportSettings($deployment_uuid, $git_clone_command, public: true);
                     }
                     if ($exec_in_docker) {
@@ -1305,7 +1310,7 @@ class Application extends BaseModel
                         $git_clone_command = "{$git_clone_command} {$escapedRepoUrl} {$escapedBaseDir}";
                         $fullRepoUrl = $repoUrl;
                     }
-                    if (! $only_checkout) {
+                    if (!$only_checkout) {
                         $git_clone_command = $this->setGitImportSettings($deployment_uuid, $git_clone_command, public: false);
                     }
                     if ($exec_in_docker) {
@@ -1368,7 +1373,7 @@ class Application extends BaseModel
                     } else {
                         $commands->push("echo 'Checking out $branch'");
                     }
-                    $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$customPort} -o Port={$customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /root/.ssh/id_rsa\" git fetch origin $branch && ".$this->buildGitCheckoutCommand($pr_branch_name);
+                    $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$customPort} -o Port={$customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /root/.ssh/id_rsa\" git fetch origin $branch && " . $this->buildGitCheckoutCommand($pr_branch_name);
                 } elseif ($git_type === 'github' || $git_type === 'gitea') {
                     $branch = "pull/{$pull_request_id}/head:$pr_branch_name";
                     if ($exec_in_docker) {
@@ -1376,14 +1381,14 @@ class Application extends BaseModel
                     } else {
                         $commands->push("echo 'Checking out $branch'");
                     }
-                    $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$customPort} -o Port={$customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /root/.ssh/id_rsa\" git fetch origin $branch && ".$this->buildGitCheckoutCommand($pr_branch_name);
+                    $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$customPort} -o Port={$customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /root/.ssh/id_rsa\" git fetch origin $branch && " . $this->buildGitCheckoutCommand($pr_branch_name);
                 } elseif ($git_type === 'bitbucket') {
                     if ($exec_in_docker) {
                         $commands->push(executeInDocker($deployment_uuid, "echo 'Checking out $branch'"));
                     } else {
                         $commands->push("echo 'Checking out $branch'");
                     }
-                    $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$customPort} -o Port={$customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /root/.ssh/id_rsa\" ".$this->buildGitCheckoutCommand($commit);
+                    $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$customPort} -o Port={$customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /root/.ssh/id_rsa\" " . $this->buildGitCheckoutCommand($commit);
                 }
             }
 
@@ -1413,7 +1418,7 @@ class Application extends BaseModel
                     } else {
                         $commands->push("echo 'Checking out $branch'");
                     }
-                    $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$customPort} -o Port={$customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /root/.ssh/id_rsa\" git fetch origin $branch && ".$this->buildGitCheckoutCommand($pr_branch_name);
+                    $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$customPort} -o Port={$customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /root/.ssh/id_rsa\" git fetch origin $branch && " . $this->buildGitCheckoutCommand($pr_branch_name);
                 } elseif ($git_type === 'github' || $git_type === 'gitea') {
                     $branch = "pull/{$pull_request_id}/head:$pr_branch_name";
                     if ($exec_in_docker) {
@@ -1421,14 +1426,14 @@ class Application extends BaseModel
                     } else {
                         $commands->push("echo 'Checking out $branch'");
                     }
-                    $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$customPort} -o Port={$customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /root/.ssh/id_rsa\" git fetch origin $branch && ".$this->buildGitCheckoutCommand($pr_branch_name);
+                    $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$customPort} -o Port={$customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /root/.ssh/id_rsa\" git fetch origin $branch && " . $this->buildGitCheckoutCommand($pr_branch_name);
                 } elseif ($git_type === 'bitbucket') {
                     if ($exec_in_docker) {
                         $commands->push(executeInDocker($deployment_uuid, "echo 'Checking out $branch'"));
                     } else {
                         $commands->push("echo 'Checking out $branch'");
                     }
-                    $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$customPort} -o Port={$customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /root/.ssh/id_rsa\" ".$this->buildGitCheckoutCommand($commit);
+                    $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$customPort} -o Port={$customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /root/.ssh/id_rsa\" " . $this->buildGitCheckoutCommand($commit);
                 }
             }
 
@@ -1481,20 +1486,20 @@ class Application extends BaseModel
                         }
                         if ($source->startsWith('.')) {
                             $source = $source->after('.');
-                            $source = $workdir.$source;
+                            $source = $workdir . $source;
                         }
                         $commands->push("mkdir -p $source > /dev/null 2>&1 || true");
                     }
                 }
             }
             $labels = collect(data_get($service, 'labels', []));
-            if (! $labels->contains('coolify.managed')) {
+            if (!$labels->contains('coolify.managed')) {
                 $labels->push('coolify.managed=true');
             }
-            if (! $labels->contains('coolify.applicationId')) {
-                $labels->push('coolify.applicationId='.$this->id);
+            if (!$labels->contains('coolify.applicationId')) {
+                $labels->push('coolify.applicationId=' . $this->id);
             }
-            if (! $labels->contains('coolify.type')) {
+            if (!$labels->contains('coolify.type')) {
                 $labels->push('coolify.type=application');
             }
             data_set($service, 'labels', $labels->toArray());
@@ -1532,7 +1537,7 @@ class Application extends BaseModel
         $composeFile = $this->docker_compose_location;
         $fileList = collect([".$workdir$composeFile"]);
         $gitRemoteStatus = $this->getGitRemoteStatus(deployment_uuid: $uuid);
-        if (! $gitRemoteStatus['is_accessible']) {
+        if (!$gitRemoteStatus['is_accessible']) {
             throw new \RuntimeException("Failed to read Git source:\n\n{$gitRemoteStatus['error']}");
         }
         $getGitVersion = instant_remote_process(['git --version'], $this->destination->server, false);
@@ -1544,7 +1549,7 @@ class Application extends BaseModel
                 $paths = collect();
                 $currentPath = '';
                 foreach ($parts as $part) {
-                    $currentPath .= ($currentPath ? '/' : '').$part;
+                    $currentPath .= ($currentPath ? '/' : '') . $part;
                     if (str($currentPath)->isNotEmpty()) {
                         $paths->push($currentPath);
                     }
@@ -1624,7 +1629,7 @@ class Application extends BaseModel
                 $jsonNames = $json->keys()->toArray();
                 $diff = array_diff($jsonNames, $names);
                 $json = $json->filter(function ($value, $key) use ($diff) {
-                    return ! in_array($key, $diff);
+                    return !in_array($key, $diff);
                 });
                 if ($json) {
                     $this->docker_compose_domains = json_encode($json);
@@ -1651,7 +1656,7 @@ class Application extends BaseModel
     public function parseContainerLabels(?ApplicationPreview $preview = null)
     {
         $customLabels = data_get($this, 'custom_labels');
-        if (! $customLabels) {
+        if (!$customLabels) {
             return;
         }
         if (base64_encode(base64_decode($customLabels, true)) !== $customLabels) {
@@ -1671,9 +1676,9 @@ class Application extends BaseModel
     public function fqdns(): Attribute
     {
         return Attribute::make(
-            get: fn () => is_null($this->fqdn)
-                ? []
-                : explode(',', $this->fqdn),
+            get: fn() => is_null($this->fqdn)
+            ? []
+            : explode(',', $this->fqdn),
         );
     }
 
@@ -1701,7 +1706,7 @@ class Application extends BaseModel
                         $pathWithoutNegation = substr($path, 1);
                         $pathWithoutNegation = ltrim(trim($pathWithoutNegation), '/');
 
-                        return $negation.$pathWithoutNegation;
+                        return $negation . $pathWithoutNegation;
                     }
 
                     return ltrim($path, '/');
@@ -1755,16 +1760,16 @@ class Application extends BaseModel
 
                 if (self::globMatch($matchPattern, $file)) {
                     // This pattern matches - it determines the current state
-                    $shouldInclude = ! $isExclusion;
+                    $shouldInclude = !$isExclusion;
                 }
             }
 
             // If no patterns matched and we only have exclusion patterns, include by default
             if ($shouldInclude === null) {
                 // Check if we only have exclusion patterns
-                $hasInclusionPatterns = $watch_paths->contains(fn ($p) => ! str_starts_with(trim($p), '!'));
+                $hasInclusionPatterns = $watch_paths->contains(fn($p) => !str_starts_with(trim($p), '!'));
 
-                return ! $hasInclusionPatterns;
+                return !$hasInclusionPatterns;
             }
 
             return $shouldInclude;
@@ -1848,7 +1853,7 @@ class Application extends BaseModel
                 case '|':
                 case '\\':
                     // Escape regex special characters
-                    $regex .= '\\'.$c;
+                    $regex .= '\\' . $c;
                     break;
 
                 default:
@@ -1858,7 +1863,7 @@ class Application extends BaseModel
         }
 
         // Wrap in delimiters and anchors
-        return '#^'.$regex.'$#';
+        return '#^' . $regex . '$#';
     }
 
     public function normalizeWatchPaths(): void
@@ -1903,7 +1908,7 @@ class Application extends BaseModel
         $hasHealthcheck = str($dockerfile)->contains('HEALTHCHECK');
 
         // Always check if healthcheck was removed, regardless of health_check_enabled setting
-        if (! $hasHealthcheck && $this->custom_healthcheck_found) {
+        if (!$hasHealthcheck && $this->custom_healthcheck_found) {
             // HEALTHCHECK was removed from Dockerfile, reset to defaults
             $this->custom_healthcheck_found = false;
             $this->health_check_interval = 5;
@@ -1926,10 +1931,10 @@ class Application extends BaseModel
                     continue;
                 }
                 if (isset($healthcheckCommand) && str_contains($trimmedLine, '\\')) {
-                    $healthcheckCommand .= ' '.trim($trimmedLine, '\\ ');
+                    $healthcheckCommand .= ' ' . trim($trimmedLine, '\\ ');
                 }
-                if (isset($healthcheckCommand) && ! str_contains($trimmedLine, '\\') && ! empty($healthcheckCommand)) {
-                    $healthcheckCommand .= ' '.$trimmedLine;
+                if (isset($healthcheckCommand) && !str_contains($trimmedLine, '\\') && !empty($healthcheckCommand)) {
+                    $healthcheckCommand .= ' ' . $trimmedLine;
                     break;
                 }
             }

--- a/app/Models/ScheduledDatabaseBackup.php
+++ b/app/Models/ScheduledDatabaseBackup.php
@@ -67,7 +67,11 @@ class ScheduledDatabaseBackup extends BaseModel
     {
         if ($this->database) {
             if ($this->database instanceof ServiceDatabase) {
-                $destination = data_get($this->database->service, 'destination');
+                if ($this->database->application_id) {
+                    $destination = data_get($this->database->application, 'destination');
+                } else {
+                    $destination = data_get($this->database->service, 'destination');
+                }
                 $server = data_get($destination, 'server');
             } else {
                 $destination = data_get($this->database, 'destination');

--- a/app/Models/ServiceDatabase.php
+++ b/app/Models/ServiceDatabase.php
@@ -27,7 +27,10 @@ class ServiceDatabase extends BaseModel
 
     public static function ownedByCurrentTeamAPI(int $teamId)
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', $teamId)->orderBy('name');
+        return ServiceDatabase::where(function ($query) use ($teamId) {
+            $query->whereRelation('service.environment.project.team', 'id', $teamId)
+                ->orWhereRelation('application.environment.project.team', 'id', $teamId);
+        })->orderBy('name');
     }
 
     /**
@@ -36,7 +39,12 @@ class ServiceDatabase extends BaseModel
      */
     public static function ownedByCurrentTeam()
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', currentTeam()->id)->orderBy('name');
+        $teamId = currentTeam()->id;
+
+        return ServiceDatabase::where(function ($query) use ($teamId) {
+            $query->whereRelation('service.environment.project.team', 'id', $teamId)
+                ->orWhereRelation('application.environment.project.team', 'id', $teamId);
+        })->orderBy('name');
     }
 
     /**
@@ -51,8 +59,8 @@ class ServiceDatabase extends BaseModel
 
     public function restart()
     {
-        $container_id = $this->name.'-'.$this->service->uuid;
-        remote_process(["docker restart {$container_id}"], $this->service->server);
+        $container_id = $this->name . '-' . $this->getParentUuid();
+        remote_process(["docker restart {$container_id}"], $this->server());
     }
 
     public function isRunning()
@@ -93,7 +101,7 @@ class ServiceDatabase extends BaseModel
     public function databaseType()
     {
         if (filled($this->custom_type)) {
-            return 'standalone-'.$this->custom_type;
+            return 'standalone-' . $this->custom_type;
         }
         $image = str($this->image)->before(':');
         if ($image->contains('supabase/postgres')) {
@@ -114,8 +122,12 @@ class ServiceDatabase extends BaseModel
     public function getServiceDatabaseUrl()
     {
         $port = $this->public_port;
-        $realIp = $this->service->server->ip;
-        if ($this->service->server->isLocalhost() || isDev()) {
+        $server = $this->server();
+        if (is_null($server)) {
+            return null;
+        }
+        $realIp = $server->ip;
+        if ($server->isLocalhost() || isDev()) {
             $realIp = base_ip();
         }
 
@@ -124,17 +136,44 @@ class ServiceDatabase extends BaseModel
 
     public function team()
     {
-        return data_get($this, 'environment.project.team');
+        if ($this->application_id) {
+            return data_get($this, 'application.environment.project.team');
+        }
+
+        return data_get($this, 'service.environment.project.team');
     }
 
     public function workdir()
     {
-        return service_configuration_dir()."/{$this->service->uuid}";
+        return service_configuration_dir() . "/{$this->getParentUuid()}";
     }
 
     public function service()
     {
         return $this->belongsTo(Service::class);
+    }
+
+    public function application()
+    {
+        return $this->belongsTo(Application::class);
+    }
+
+    public function server()
+    {
+        if ($this->application_id) {
+            return data_get($this->application, 'destination.server');
+        }
+
+        return data_get($this->service, 'server');
+    }
+
+    public function getParentUuid()
+    {
+        if ($this->application_id) {
+            return $this->application->uuid;
+        }
+
+        return $this->service->uuid;
     }
 
     public function persistentStorages()

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -62,27 +62,27 @@ function base_configuration_dir(): string
 }
 function application_configuration_dir(): string
 {
-    return base_configuration_dir().'/applications';
+    return base_configuration_dir() . '/applications';
 }
 function service_configuration_dir(): string
 {
-    return base_configuration_dir().'/services';
+    return base_configuration_dir() . '/services';
 }
 function database_configuration_dir(): string
 {
-    return base_configuration_dir().'/databases';
+    return base_configuration_dir() . '/databases';
 }
 function database_proxy_dir($uuid): string
 {
-    return base_configuration_dir()."/databases/$uuid/proxy";
+    return base_configuration_dir() . "/databases/$uuid/proxy";
 }
 function backup_dir(): string
 {
-    return base_configuration_dir().'/backups';
+    return base_configuration_dir() . '/backups';
 }
 function metrics_dir(): string
 {
-    return base_configuration_dir().'/metrics';
+    return base_configuration_dir() . '/metrics';
 }
 
 function sanitize_string(?string $input = null): ?string
@@ -138,7 +138,7 @@ function validateShellSafePath(string $input, string $context = 'path'): string
     foreach ($dangerousChars as $char => $description) {
         if (str_contains($input, $char)) {
             throw new \Exception(
-                "Invalid {$context}: contains forbidden character '{$char}' ({$description}). ".
+                "Invalid {$context}: contains forbidden character '{$char}' ({$description}). " .
                 'Shell metacharacters are not allowed for security reasons.'
             );
         }
@@ -175,7 +175,7 @@ function showBoarding(): bool
 }
 function refreshSession(?Team $team = null): void
 {
-    if (! $team) {
+    if (!$team) {
         if (Auth::user()->currentTeam()) {
             $team = Team::find(Auth::user()->currentTeam()->id);
         } else {
@@ -183,10 +183,10 @@ function refreshSession(?Team $team = null): void
         }
     }
     // Clear old cache key format for backwards compatibility
-    Cache::forget('team:'.Auth::id());
+    Cache::forget('team:' . Auth::id());
     // Use new cache key format that includes team ID
-    Cache::forget('user:'.Auth::id().':team:'.$team->id);
-    Cache::remember('user:'.Auth::id().':team:'.$team->id, 3600, function () use ($team) {
+    Cache::forget('user:' . Auth::id() . ':team:' . $team->id);
+    Cache::remember('user:' . Auth::id() . ':team:' . $team->id, 3600, function () use ($team) {
         return $team;
     });
     session(['currentTeam' => $team]);
@@ -218,7 +218,7 @@ function handleError(?Throwable $error = null, ?Livewire\Component $livewire = n
         $message = null;
     }
     if ($customErrorMessage) {
-        $message = $customErrorMessage.' '.$message;
+        $message = $customErrorMessage . ' ' . $message;
     }
 
     if (isset($livewire)) {
@@ -289,7 +289,7 @@ function generateSSHKey(string $type = 'rsa')
 function formatPrivateKey(string $privateKey)
 {
     $privateKey = trim($privateKey);
-    if (! str_ends_with($privateKey, "\n")) {
+    if (!str_ends_with($privateKey, "\n")) {
         $privateKey .= "\n";
     }
 
@@ -317,7 +317,7 @@ function sortBranchesByPriority(Collection $branches): Collection
         return match ($name) {
             'main' => '0_main',
             'master' => '1_master',
-            default => '2_'.$name,
+            default => '2_' . $name,
         };
     })->values();
 }
@@ -392,7 +392,7 @@ function isSubscribed()
 
 function isProduction(): bool
 {
-    return ! isDev();
+    return !isDev();
 }
 function isDev(): bool
 {
@@ -401,7 +401,7 @@ function isDev(): bool
 
 function isCloud(): bool
 {
-    return ! config('constants.coolify.self_hosted');
+    return !config('constants.coolify.self_hosted');
 }
 
 function translate_cron_expression($expression_to_validate): string
@@ -534,12 +534,12 @@ function get_service_templates(bool $force = false): Collection
 
             return collect($services);
         } catch (\Throwable) {
-            $services = File::get(base_path('templates/'.config('constants.services.file_name')));
+            $services = File::get(base_path('templates/' . config('constants.services.file_name')));
 
             return collect(json_decode($services))->sortKeys();
         }
     } else {
-        $services = File::get(base_path('templates/'.config('constants.services.file_name')));
+        $services = File::get(base_path('templates/' . config('constants.services.file_name')));
 
         return collect(json_decode($services))->sortKeys();
     }
@@ -663,29 +663,29 @@ function queryResourcesByUuid(string $uuid)
 function generateTagDeployWebhook($tag_name)
 {
     $baseUrl = base_url();
-    $api = Url::fromString($baseUrl).'/api/v1';
+    $api = Url::fromString($baseUrl) . '/api/v1';
     $endpoint = "/deploy?tag=$tag_name";
 
-    return $api.$endpoint;
+    return $api . $endpoint;
 }
 function generateDeployWebhook($resource)
 {
     $baseUrl = base_url();
-    $api = Url::fromString($baseUrl).'/api/v1';
+    $api = Url::fromString($baseUrl) . '/api/v1';
     $endpoint = '/deploy';
     $uuid = data_get($resource, 'uuid');
 
-    return $api.$endpoint."?uuid=$uuid&force=false";
+    return $api . $endpoint . "?uuid=$uuid&force=false";
 }
 function generateGitManualWebhook($resource, $type)
 {
-    if ($resource->source_id !== 0 && ! is_null($resource->source_id)) {
+    if ($resource->source_id !== 0 && !is_null($resource->source_id)) {
         return null;
     }
     if ($resource->getMorphClass() === \App\Models\Application::class) {
         $baseUrl = base_url();
 
-        return Url::fromString($baseUrl)."/webhooks/source/$type/events/manual";
+        return Url::fromString($baseUrl) . "/webhooks/source/$type/events/manual";
     }
 
     return null;
@@ -730,7 +730,7 @@ function getTopLevelNetworks(Service|Application $resource)
                     (is_string($networkMode) && (str_starts_with($networkMode, 'service:') || str_starts_with($networkMode, 'container:')));
 
                 // Only add 'networks' key if 'network_mode' is not 'host' or does not start with 'service:' or 'container:'
-                if (! $hasValidNetworkMode) {
+                if (!$hasValidNetworkMode) {
                     // Collect/create/update networks
                     if ($serviceNetworks->count() > 0) {
                         foreach ($serviceNetworks as $networkName => $networkDetails) {
@@ -744,7 +744,7 @@ function getTopLevelNetworks(Service|Application $resource)
                             $networkExists = $topLevelNetworks->contains(function ($value, $key) use ($networkName) {
                                 return $value == $networkName || $key == $networkName;
                             });
-                            if (! $networkExists) {
+                            if (!$networkExists) {
                                 if (is_string($networkDetails) || is_int($networkDetails)) {
                                     $topLevelNetworks->put($networkDetails, null);
                                 }
@@ -755,7 +755,7 @@ function getTopLevelNetworks(Service|Application $resource)
                     $definedNetworkExists = $topLevelNetworks->contains(function ($value, $_) use ($definedNetwork) {
                         return $value == $definedNetwork;
                     });
-                    if (! $definedNetworkExists) {
+                    if (!$definedNetworkExists) {
                         foreach ($definedNetwork as $network) {
                             $topLevelNetworks->put($network, [
                                 'name' => $network,
@@ -803,7 +803,7 @@ function getTopLevelNetworks(Service|Application $resource)
                     $networkExists = $topLevelNetworks->contains(function ($value, $key) use ($networkName) {
                         return $value == $networkName || $key == $networkName;
                     });
-                    if (! $networkExists) {
+                    if (!$networkExists) {
                         if (is_string($networkDetails) || is_int($networkDetails)) {
                             $topLevelNetworks->put($networkDetails, null);
                         }
@@ -813,7 +813,7 @@ function getTopLevelNetworks(Service|Application $resource)
             $definedNetworkExists = $topLevelNetworks->contains(function ($value, $_) use ($definedNetwork) {
                 return $value == $definedNetwork;
             });
-            if (! $definedNetworkExists) {
+            if (!$definedNetworkExists) {
                 foreach ($definedNetwork as $network) {
                     $topLevelNetworks->put($network, [
                         'name' => $network,
@@ -955,7 +955,7 @@ function generateEnvValue(string $command, Service|Application|null $service = n
         case 'PASSWORDWITHSYMBOLS_64':
             $generatedValue = Str::password(length: 64, symbols: true);
             break;
-            // This is not base64, it's just a random string
+        // This is not base64, it's just a random string
         case 'BASE64_64':
             $generatedValue = Str::random(64);
             break;
@@ -966,7 +966,7 @@ function generateEnvValue(string $command, Service|Application|null $service = n
         case 'BASE64_32':
             $generatedValue = Str::random(32);
             break;
-            // This is base64,
+        // This is base64,
         case 'REALBASE64_64':
             $generatedValue = base64_encode(Str::random(64));
             break;
@@ -1069,7 +1069,7 @@ function validateDNSEntry(string $fqdn, Server $server)
     }
     $settings = instanceSettings();
     $is_dns_validation_enabled = data_get($settings, 'is_dns_validation_enabled');
-    if (! $is_dns_validation_enabled) {
+    if (!$is_dns_validation_enabled) {
         return true;
     }
     $dns_servers = data_get($settings, 'custom_dns_servers');
@@ -1086,7 +1086,7 @@ function validateDNSEntry(string $fqdn, Server $server)
             $query = new DNSQuery($dns_server);
             $results = $query->query($host, $type);
             if ($results === false || $query->hasError()) {
-                ray('Error: '.$query->getLasterror());
+                ray('Error: ' . $query->getLasterror());
             } else {
                 foreach ($results as $result) {
                     if ($result->getType() == $type) {
@@ -1250,7 +1250,7 @@ function isAnyDeploymentInprogress()
                 // Construct the full deployment URL
                 if ($runningJob->deployment_url) {
                     $baseUrl = base_url();
-                    $deploymentUrl = $baseUrl.$runningJob->deployment_url;
+                    $deploymentUrl = $baseUrl . $runningJob->deployment_url;
                 }
             }
 
@@ -1273,22 +1273,22 @@ function isAnyDeploymentInprogress()
 
     // Display enhanced deployment information
     echo "\n=== Running Deployments ===\n";
-    echo 'Total active deployments: '.count($horizonJobIds)."\n\n";
+    echo 'Total active deployments: ' . count($horizonJobIds) . "\n\n";
 
     foreach ($deploymentDetails as $index => $deployment) {
-        echo 'Deployment #'.($index + 1).":\n";
-        echo '  Application: '.$deployment['application_name']."\n";
-        echo '  Server: '.$deployment['server_name']."\n";
-        echo '  Started: '.$deployment['created_at']."\n";
+        echo 'Deployment #' . ($index + 1) . ":\n";
+        echo '  Application: ' . $deployment['application_name'] . "\n";
+        echo '  Server: ' . $deployment['server_name'] . "\n";
+        echo '  Started: ' . $deployment['created_at'] . "\n";
         if ($deployment['deployment_url']) {
-            echo '  URL: '.$deployment['deployment_url']."\n";
+            echo '  URL: ' . $deployment['deployment_url'] . "\n";
         }
-        if (! empty($deployment['team_members'])) {
-            echo '  Team members: '.implode(', ', $deployment['team_members'])."\n";
+        if (!empty($deployment['team_members'])) {
+            echo '  Team members: ' . implode(', ', $deployment['team_members']) . "\n";
         } else {
             echo "  Team members: No team members found\n";
         }
-        echo '  Horizon Job ID: '.$deployment['horizon_job_id']."\n";
+        echo '  Horizon Job ID: ' . $deployment['horizon_job_id'] . "\n";
         echo "\n";
     }
 
@@ -1383,7 +1383,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
 
                             return false;
                         }
-                        if (! str($serviceLabel)->contains('=')) {
+                        if (!str($serviceLabel)->contains('=')) {
                             $removedLabels->put($serviceLabelName, $serviceLabel);
 
                             return false;
@@ -1486,7 +1486,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                         $networkExists = $topLevelNetworks->contains(function ($value, $key) use ($networkName) {
                             return $value == $networkName || $key == $networkName;
                         });
-                        if (! $networkExists) {
+                        if (!$networkExists) {
                             if (is_string($networkDetails) || is_int($networkDetails)) {
                                 $topLevelNetworks->put($networkDetails, null);
                             }
@@ -1512,12 +1512,12 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                 $savedService->ports = $collectedPorts->implode(',');
                 $savedService->save();
 
-                if (! $hasValidNetworkMode) {
+                if (!$hasValidNetworkMode) {
                     // Add Coolify specific networks
                     $definedNetworkExists = $topLevelNetworks->contains(function ($value, $_) use ($definedNetwork) {
                         return $value == $definedNetwork;
                     });
-                    if (! $definedNetworkExists) {
+                    if (!$definedNetworkExists) {
                         foreach ($definedNetwork as $network) {
                             $topLevelNetworks->put($network, [
                                 'name' => $network,
@@ -1729,9 +1729,9 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                                 $fqdn = "$fqdn$path";
                             }
 
-                            if (! $isDatabase) {
+                            if (!$isDatabase) {
                                 if ($savedService->fqdn) {
-                                    data_set($savedService, 'fqdn', $savedService->fqdn.','.$fqdn);
+                                    data_set($savedService, 'fqdn', $savedService->fqdn . ',' . $fqdn);
                                 } else {
                                     data_set($savedService, 'fqdn', $fqdn);
                                 }
@@ -1746,7 +1746,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                             ]);
                         }
                         // Caddy needs exact port in some cases.
-                        if ($predefinedPort && ! $key->endsWith("_{$predefinedPort}")) {
+                        if ($predefinedPort && !$key->endsWith("_{$predefinedPort}")) {
                             $fqdns_exploded = str($savedService->fqdn)->explode(',');
                             if ($fqdns_exploded->count() > 1) {
                                 continue;
@@ -1789,12 +1789,12 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                                 'resourceable_id' => $resource->id,
                             ])->first();
                             ['command' => $command, 'forService' => $forService, 'generatedValue' => $generatedValue, 'port' => $port] = parseEnvVariable($value);
-                            if (! is_null($command)) {
+                            if (!is_null($command)) {
                                 if ($command?->value() === 'FQDN' || $command?->value() === 'URL') {
                                     if (Str::lower($forService) === $serviceName) {
                                         $fqdn = generateFqdn($resource->server, $containerName);
                                     } else {
-                                        $fqdn = generateFqdn($resource->server, Str::lower($forService).'-'.$resource->uuid);
+                                        $fqdn = generateFqdn($resource->server, Str::lower($forService) . '-' . $resource->uuid);
                                     }
                                     if ($port) {
                                         $fqdn = "$fqdn:$port";
@@ -1824,13 +1824,13 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                                             'is_preview' => false,
                                         ]);
                                     }
-                                    if (! $isDatabase) {
-                                        if ($command->value() === 'FQDN' && is_null($savedService->fqdn) && ! $foundEnv) {
+                                    if (!$isDatabase) {
+                                        if ($command->value() === 'FQDN' && is_null($savedService->fqdn) && !$foundEnv) {
                                             $savedService->fqdn = $fqdn;
                                             $savedService->save();
                                         }
                                         // Caddy needs exact port in some cases.
-                                        if ($predefinedPort && ! $key->endsWith("_{$predefinedPort}") && $command?->value() === 'FQDN' && $resource->server->proxyType() === 'CADDY') {
+                                        if ($predefinedPort && !$key->endsWith("_{$predefinedPort}") && $command?->value() === 'FQDN' && $resource->server->proxyType() === 'CADDY') {
                                             $fqdns_exploded = str($savedService->fqdn)->explode(',');
                                             if ($fqdns_exploded->count() > 1) {
                                                 continue;
@@ -1853,7 +1853,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                                     }
                                 } else {
                                     $generatedValue = generateEnvValue($command, $resource);
-                                    if (! $foundEnv) {
+                                    if (!$foundEnv) {
                                         EnvironmentVariable::create([
                                             'key' => $key,
                                             'value' => $generatedValue,
@@ -1920,7 +1920,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                     environment: $resource->environment->name,
                 );
                 $serviceLabels = $serviceLabels->merge($defaultLabels);
-                if (! $isDatabase && $fqdns->count() > 0) {
+                if (!$isDatabase && $fqdns->count() > 0) {
                     if ($fqdns) {
                         $shouldGenerateLabelsExactly = $resource->server->settings->generate_exact_labels;
                         if ($shouldGenerateLabelsExactly) {
@@ -1988,7 +1988,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                 }
                 data_set($service, 'labels', $serviceLabels->toArray());
                 data_forget($service, 'is_database');
-                if (! data_get($service, 'restart')) {
+                if (!data_get($service, 'restart')) {
                     data_set($service, 'restart', RESTART_MODE);
                 }
                 if (data_get($service, 'restart') === 'no' || data_get($service, 'exclude_from_hc')) {
@@ -2028,21 +2028,21 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                 $parsedServiceVariables->put('COOLIFY_CONTAINER_NAME', "$serviceName-{$resource->uuid}");
 
                 // TODO: move this in a shared function
-                if (! $parsedServiceVariables->has('COOLIFY_APP_NAME')) {
+                if (!$parsedServiceVariables->has('COOLIFY_APP_NAME')) {
                     $parsedServiceVariables->put('COOLIFY_APP_NAME', "\"{$resource->name}\"");
                 }
-                if (! $parsedServiceVariables->has('COOLIFY_SERVER_IP')) {
+                if (!$parsedServiceVariables->has('COOLIFY_SERVER_IP')) {
                     $parsedServiceVariables->put('COOLIFY_SERVER_IP', "\"{$resource->destination->server->ip}\"");
                 }
-                if (! $parsedServiceVariables->has('COOLIFY_ENVIRONMENT_NAME')) {
+                if (!$parsedServiceVariables->has('COOLIFY_ENVIRONMENT_NAME')) {
                     $parsedServiceVariables->put('COOLIFY_ENVIRONMENT_NAME', "\"{$resource->environment->name}\"");
                 }
-                if (! $parsedServiceVariables->has('COOLIFY_PROJECT_NAME')) {
+                if (!$parsedServiceVariables->has('COOLIFY_PROJECT_NAME')) {
                     $parsedServiceVariables->put('COOLIFY_PROJECT_NAME', "\"{$resource->project()->name}\"");
                 }
 
                 $parsedServiceVariables = $parsedServiceVariables->map(function ($value, $key) use ($envs_from_coolify) {
-                    if (! str($value)->startsWith('$')) {
+                    if (!str($value)->startsWith('$')) {
                         $found_env = $envs_from_coolify->where('key', $key)->first();
                         if ($found_env) {
                             return $found_env->value;
@@ -2080,6 +2080,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
         } catch (\Exception) {
             return;
         }
+        $detectedApplicationDatabases = collect();
         $server = $resource->destination->server;
         $topLevelVolumes = collect(data_get($yaml, 'volumes', []));
         if ($pull_request_id !== 0) {
@@ -2114,7 +2115,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
         if ($pull_request_id !== 0) {
             $definedNetwork = collect(["{$resource->uuid}-$pull_request_id"]);
         }
-        $services = collect($services)->map(function ($service, $serviceName) use ($topLevelVolumes, $topLevelNetworks, $definedNetwork, $isNew, $generatedServiceFQDNS, $resource, $server, $pull_request_id, $preview_id) {
+        $services = collect($services)->map(function ($service, $serviceName) use ($topLevelVolumes, $topLevelNetworks, $definedNetwork, $isNew, $generatedServiceFQDNS, $resource, $server, $pull_request_id, $preview_id, &$detectedApplicationDatabases) {
             $serviceVolumes = collect(data_get($service, 'volumes', []));
             $servicePorts = collect(data_get($service, 'ports', []));
             $serviceNetworks = collect(data_get($service, 'networks', []));
@@ -2132,7 +2133,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
 
                         return false;
                     }
-                    if (! str($serviceLabel)->contains('=')) {
+                    if (!str($serviceLabel)->contains('=')) {
                         $removedLabels->put($serviceLabelName, $serviceLabel);
 
                         return false;
@@ -2156,11 +2157,11 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                     $serviceVolumes = $serviceVolumes->map(function ($volume) use ($resource, $topLevelVolumes, $pull_request_id) {
                         if (is_string($volume)) {
                             $volume = str($volume);
-                            if ($volume->contains(':') && ! $volume->startsWith('/')) {
+                            if ($volume->contains(':') && !$volume->startsWith('/')) {
                                 $name = $volume->before(':');
                                 $mount = $volume->after(':');
                                 if ($name->startsWith('.') || $name->startsWith('~')) {
-                                    $dir = base_configuration_dir().'/applications/'.$resource->uuid;
+                                    $dir = base_configuration_dir() . '/applications/' . $resource->uuid;
                                     if ($name->startsWith('.')) {
                                         $name = $name->replaceFirst('.', $dir);
                                     }
@@ -2223,7 +2224,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                             $read_only = data_get($volume, 'read_only');
                             if ($source && $target) {
                                 if ((str($source)->startsWith('.') || str($source)->startsWith('~'))) {
-                                    $dir = base_configuration_dir().'/applications/'.$resource->uuid;
+                                    $dir = base_configuration_dir() . '/applications/' . $resource->uuid;
                                     if (str($source, '.')) {
                                         $source = str($source)->replaceFirst('.', $dir);
                                     }
@@ -2234,20 +2235,20 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                                         $source = addPreviewDeploymentSuffix($source, $pull_request_id);
                                     }
                                     if ($read_only) {
-                                        data_set($volume, 'source', $source.':'.$target.':ro');
+                                        data_set($volume, 'source', $source . ':' . $target . ':ro');
                                     } else {
-                                        data_set($volume, 'source', $source.':'.$target);
+                                        data_set($volume, 'source', $source . ':' . $target);
                                     }
                                 } else {
                                     if ($pull_request_id !== 0) {
                                         $source = addPreviewDeploymentSuffix($source, $pull_request_id);
                                     }
                                     if ($read_only) {
-                                        data_set($volume, 'source', $source.':'.$target.':ro');
+                                        data_set($volume, 'source', $source . ':' . $target . ':ro');
                                     } else {
-                                        data_set($volume, 'source', $source.':'.$target);
+                                        data_set($volume, 'source', $source . ':' . $target);
                                     }
-                                    if (! str($source)->startsWith('/')) {
+                                    if (!str($source)->startsWith('/')) {
                                         if ($topLevelVolumes->has($source)) {
                                             $v = $topLevelVolumes->get($source);
                                             if (data_get($v, 'driver_opts.type') === 'cifs') {
@@ -2280,11 +2281,11 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                     $serviceVolumes = $serviceVolumes->map(function ($volume) use ($resource, $topLevelVolumes, $pull_request_id) {
                         if (is_string($volume)) {
                             $volume = str($volume);
-                            if ($volume->contains(':') && ! $volume->startsWith('/')) {
+                            if ($volume->contains(':') && !$volume->startsWith('/')) {
                                 $name = $volume->before(':');
                                 $mount = $volume->after(':');
                                 if ($name->startsWith('.') || $name->startsWith('~')) {
-                                    $dir = base_configuration_dir().'/applications/'.$resource->uuid;
+                                    $dir = base_configuration_dir() . '/applications/' . $resource->uuid;
                                     if ($name->startsWith('.')) {
                                         $name = $name->replaceFirst('.', $dir);
                                     }
@@ -2298,7 +2299,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                                 } else {
                                     if ($pull_request_id !== 0) {
                                         $uuid = $resource->uuid;
-                                        $name = $uuid.'-'.addPreviewDeploymentSuffix($name, $pull_request_id);
+                                        $name = $uuid . '-' . addPreviewDeploymentSuffix($name, $pull_request_id);
                                         $volume = str("$name:$mount");
                                         if ($topLevelVolumes->has($name)) {
                                             $v = $topLevelVolumes->get($name);
@@ -2317,7 +2318,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                                         }
                                     } else {
                                         $uuid = $resource->uuid;
-                                        $name = str($uuid."-$name");
+                                        $name = str($uuid . "-$name");
                                         $volume = str("$name:$mount");
                                         if ($topLevelVolumes->has($name->value())) {
                                             $v = $topLevelVolumes->get($name->value());
@@ -2352,7 +2353,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                             if ($source && $target) {
                                 $uuid = $resource->uuid;
                                 if ((str($source)->startsWith('.') || str($source)->startsWith('~') || str($source)->startsWith('/'))) {
-                                    $dir = base_configuration_dir().'/applications/'.$resource->uuid;
+                                    $dir = base_configuration_dir() . '/applications/' . $resource->uuid;
                                     if (str($source, '.')) {
                                         $source = str($source)->replaceFirst('.', $dir);
                                     }
@@ -2360,22 +2361,22 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                                         $source = str($source)->replaceFirst('~', $dir);
                                     }
                                     if ($read_only) {
-                                        data_set($volume, 'source', $source.':'.$target.':ro');
+                                        data_set($volume, 'source', $source . ':' . $target . ':ro');
                                     } else {
-                                        data_set($volume, 'source', $source.':'.$target);
+                                        data_set($volume, 'source', $source . ':' . $target);
                                     }
                                 } else {
                                     if ($pull_request_id === 0) {
-                                        $source = $uuid."-$source";
+                                        $source = $uuid . "-$source";
                                     } else {
-                                        $source = $uuid.'-'.addPreviewDeploymentSuffix($source, $pull_request_id);
+                                        $source = $uuid . '-' . addPreviewDeploymentSuffix($source, $pull_request_id);
                                     }
                                     if ($read_only) {
-                                        data_set($volume, 'source', $source.':'.$target.':ro');
+                                        data_set($volume, 'source', $source . ':' . $target . ':ro');
                                     } else {
-                                        data_set($volume, 'source', $source.':'.$target);
+                                        data_set($volume, 'source', $source . ':' . $target);
                                     }
-                                    if (! str($source)->startsWith('/')) {
+                                    if (!str($source)->startsWith('/')) {
                                         if ($topLevelVolumes->has($source)) {
                                             $v = $topLevelVolumes->get($source);
                                             if (data_get($v, 'driver_opts.type') === 'cifs') {
@@ -2418,6 +2419,30 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
             $isDatabase = isDatabaseImage($image, $service);
             data_set($service, 'is_database', $isDatabase);
 
+            if ($isDatabase && $pull_request_id === 0) {
+                // Build a temporary ServiceDatabase to check if backup is supported
+                $probe = new ServiceDatabase(['image' => $image]);
+                if ($probe->isBackupSolutionAvailable()) {
+                    $savedDb = ServiceDatabase::where([
+                        'name' => $serviceName,
+                        'application_id' => $resource->id,
+                    ])->first();
+
+                    if (is_null($savedDb)) {
+                        ServiceDatabase::create([
+                            'name' => $serviceName,
+                            'image' => $image,
+                            'application_id' => $resource->id,
+                        ]);
+                    } elseif ($savedDb->image !== $image) {
+                        $savedDb->image = $image;
+                        $savedDb->save();
+                    }
+
+                    $detectedApplicationDatabases->push($serviceName);
+                }
+            }
+
             // Collect/create/update networks
             if ($serviceNetworks->count() > 0) {
                 foreach ($serviceNetworks as $networkName => $networkDetails) {
@@ -2431,7 +2456,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                     $networkExists = $topLevelNetworks->contains(function ($value, $key) use ($networkName) {
                         return $value == $networkName || $key == $networkName;
                     });
-                    if (! $networkExists) {
+                    if (!$networkExists) {
                         if (is_string($networkDetails) || is_int($networkDetails)) {
                             $topLevelNetworks->put($networkDetails, null);
                         }
@@ -2456,7 +2481,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
             $definedNetworkExists = $topLevelNetworks->contains(function ($value, $_) use ($definedNetwork) {
                 return $value == $definedNetwork;
             });
-            if (! $definedNetworkExists) {
+            if (!$definedNetworkExists) {
                 foreach ($definedNetwork as $network) {
                     if ($pull_request_id !== 0) {
                         $topLevelNetworks->put($network, [
@@ -2576,12 +2601,12 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                             'resourceable_id' => $resource->id,
                         ])->first();
                         ['command' => $command, 'forService' => $forService, 'generatedValue' => $generatedValue, 'port' => $port] = parseEnvVariable($value);
-                        if (! is_null($command)) {
+                        if (!is_null($command)) {
                             if ($command?->value() === 'FQDN' || $command?->value() === 'URL') {
                                 if (Str::lower($forService) === $serviceName) {
                                     $fqdn = generateFqdn($server, $containerName);
                                 } else {
-                                    $fqdn = generateFqdn($server, Str::lower($forService).'-'.$resource->uuid);
+                                    $fqdn = generateFqdn($server, Str::lower($forService) . '-' . $resource->uuid);
                                 }
                                 if ($port) {
                                     $fqdn = "$fqdn:$port";
@@ -2602,7 +2627,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                                 }
                             } else {
                                 $generatedValue = generateEnvValue($command);
-                                if (! $foundEnv) {
+                                if (!$foundEnv) {
                                     EnvironmentVariable::create([
                                         'key' => $key,
                                         'value' => $generatedValue,
@@ -2783,7 +2808,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
             }
             data_set($service, 'labels', $serviceLabels->toArray());
             data_forget($service, 'is_database');
-            if (! data_get($service, 'restart')) {
+            if (!data_get($service, 'restart')) {
                 data_set($service, 'restart', RESTART_MODE);
             }
             data_set($service, 'container_name', $containerName);
@@ -2814,6 +2839,33 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
         data_forget($resource, 'environment_variables_preview');
         $resource->save();
 
+        // Clean up ServiceDatabase records for services no longer in the compose file.
+        // Uses $detectedApplicationDatabases (populated during service iteration above)
+        // instead of re-reading is_database from $services (which has been data_forget-ed).
+        if ($pull_request_id === 0 && $detectedApplicationDatabases->isNotEmpty()) {
+            $staleRecords = ServiceDatabase::where('application_id', $resource->id)
+                ->whereNotIn('name', $detectedApplicationDatabases->values())
+                ->get();
+
+            foreach ($staleRecords as $staleDb) {
+                $staleDb->scheduledBackups()->each(function ($backup) {
+                    $backup->executions()->delete();
+                    $backup->delete();
+                });
+                $staleDb->delete();
+            }
+        } elseif ($pull_request_id === 0) {
+            // No backupable databases detected — clean up all Application-owned records
+            $orphans = ServiceDatabase::where('application_id', $resource->id)->get();
+            foreach ($orphans as $orphan) {
+                $orphan->scheduledBackups()->each(function ($backup) {
+                    $backup->executions()->delete();
+                    $backup->delete();
+                });
+                $orphan->delete();
+            }
+        }
+
         return collect($finalServices);
     }
 }
@@ -2838,7 +2890,7 @@ function isAssociativeArray($array)
         $array = $array->toArray();
     }
 
-    if (! is_array($array)) {
+    if (!is_array($array)) {
         throw new \InvalidArgumentException('Input must be an array or a Collection.');
     }
 
@@ -2982,7 +3034,7 @@ function getHelperVersion(): string
     $settings = instanceSettings();
 
     // In development mode, use the dev_helper_version if set, otherwise fallback to config
-    if (isDev() && ! empty($settings->dev_helper_version)) {
+    if (isDev() && !empty($settings->dev_helper_version)) {
         return $settings->dev_helper_version;
     }
 
@@ -2992,7 +3044,7 @@ function getHelperVersion(): string
 function loadConfigFromGit(string $repository, string $branch, string $base_directory, int $server_id, int $team_id)
 {
     $server = Server::find($server_id)->where('team_id', $team_id)->first();
-    if (! $server) {
+    if (!$server) {
         return;
     }
     $uuid = new Cuid2;
@@ -3019,7 +3071,7 @@ function loadConfigFromGit(string $repository, string $branch, string $base_dire
 
 function loggy($message = null, array $context = [])
 {
-    if (! isDev()) {
+    if (!isDev()) {
         return;
     }
     if (function_exists('ray') && config('app.debug')) {
@@ -3054,7 +3106,7 @@ function isEmailRateLimited(string $limiterKey, int $decaySeconds = 3600, ?calla
         $limiterKey,
         $maxAttempts = 0,
         function () use (&$rateLimited, &$limiterKey, $callbackOnSuccess) {
-            isDev() && loggy('Rate limit not reached for '.$limiterKey);
+            isDev() && loggy('Rate limit not reached for ' . $limiterKey);
             $rateLimited = false;
 
             if ($callbackOnSuccess) {
@@ -3063,8 +3115,8 @@ function isEmailRateLimited(string $limiterKey, int $decaySeconds = 3600, ?calla
         },
         $decaySeconds,
     );
-    if (! $executed) {
-        isDev() && loggy('Rate limit reached for '.$limiterKey.'. Rate limiter will be disabled for '.$decaySeconds.' seconds.');
+    if (!$executed) {
+        isDev() && loggy('Rate limit reached for ' . $limiterKey . '. Rate limiter will be disabled for ' . $decaySeconds . ' seconds.');
         $rateLimited = true;
     }
 
@@ -3149,7 +3201,7 @@ function convertGitUrl(string $gitRepository, string $deploymentType, ?GithubApp
                 $providerInfo['user'] = $source->custom_user;
                 break;
         }
-        if (! empty($providerInfo['host'])) {
+        if (!empty($providerInfo['host'])) {
             // Until we do not support more providers with App (like GithubApp), this will be always true, port will be 22
             if ($providerInfo['port'] === 22) {
                 $repository = "{$providerInfo['user']}@{$providerInfo['host']}:{$providerInfo['repository']}";
@@ -3221,14 +3273,14 @@ function parseDockerfileInterval(string $something)
 
 function addPreviewDeploymentSuffix(string $name, int $pull_request_id = 0): string
 {
-    return ($pull_request_id === 0) ? $name : $name.'-pr-'.$pull_request_id;
+    return ($pull_request_id === 0) ? $name : $name . '-pr-' . $pull_request_id;
 }
 
 function generateDockerComposeServiceName(mixed $services, int $pullRequestId = 0): Collection
 {
     $collection = collect([]);
     foreach ($services as $serviceName => $_) {
-        $collection->put('SERVICE_NAME_'.str($serviceName)->replace('-', '_')->replace('.', '_')->upper(), addPreviewDeploymentSuffix($serviceName, $pullRequestId));
+        $collection->put('SERVICE_NAME_' . str($serviceName)->replace('-', '_')->replace('.', '_')->upper(), addPreviewDeploymentSuffix($serviceName, $pullRequestId));
     }
 
     return $collection;
@@ -3252,7 +3304,7 @@ function formatBytes(?int $bytes, int $precision = 2): string
 
     $value = $bytes / pow($base, $exponent);
 
-    return round($value, $precision).' '.$units[$exponent];
+    return round($value, $precision) . ' ' . $units[$exponent];
 }
 
 /**
@@ -3277,7 +3329,7 @@ function isSafeTmpPath(?string $path): bool
     }
 
     // Must start with /tmp/
-    if (! str($decodedPath)->startsWith('/tmp/')) {
+    if (!str($decodedPath)->startsWith('/tmp/')) {
         return false;
     }
 
@@ -3311,11 +3363,11 @@ function isSafeTmpPath(?string $path): bool
         }
     }
 
-    $resolvedPath = '/'.implode('/', $resolvedParts);
+    $resolvedPath = '/' . implode('/', $resolvedParts);
 
     // Final check: resolved path must start with /tmp/
     // And must have at least one component after /tmp/
-    if (! str($resolvedPath)->startsWith('/tmp/') || $resolvedPath === '/tmp') {
+    if (!str($resolvedPath)->startsWith('/tmp/') || $resolvedPath === '/tmp') {
         return false;
     }
 
@@ -3338,7 +3390,7 @@ function isSafeTmpPath(?string $path): bool
         }
 
         // Check if the real directory is within /tmp (or its canonical path)
-        if (! str($realDir)->startsWith('/tmp') && ! str($realDir)->startsWith($canonicalTmpPath)) {
+        if (!str($realDir)->startsWith('/tmp') && !str($realDir)->startsWith($canonicalTmpPath)) {
             return false;
         }
     }
@@ -3375,14 +3427,14 @@ function formatContainerStatus(string $status): string
     if ($isExcluded) {
         if (count($parts) === 3) {
             // Has health status: running:unhealthy:excluded → Running (unhealthy, excluded)
-            return str($parts[0])->headline().' ('.$parts[1].', excluded)';
+            return str($parts[0])->headline() . ' (' . $parts[1] . ', excluded)';
         } else {
             // No health status: exited:excluded → Exited (excluded)
-            return str($parts[0])->headline().' (excluded)';
+            return str($parts[0])->headline() . ' (excluded)';
         }
     } elseif (count($parts) >= 2) {
         // Regular colon format: running:healthy → Running (healthy)
-        return str($parts[0])->headline().' ('.$parts[1].')';
+        return str($parts[0])->headline() . ' (' . $parts[1] . ')';
     } else {
         // Simple status: running → Running
         return str($status)->headline()->value();
@@ -3407,7 +3459,7 @@ function shouldSkipPasswordConfirmation(): bool
     }
 
     // Skip if user has no password (OAuth users)
-    if (! Auth::user()?->hasPassword()) {
+    if (!Auth::user()?->hasPassword()) {
         return true;
     }
 
@@ -3432,7 +3484,7 @@ function verifyPasswordConfirmation(mixed $password, ?Livewire\Component $compon
     }
 
     // Verify the password
-    if (! Hash::check($password, Auth::user()->password)) {
+    if (!Hash::check($password, Auth::user()->password)) {
         if ($component) {
             $component->addError('password', 'The provided password is incorrect.');
         }

--- a/database/migrations/2026_03_05_000001_add_application_id_to_service_databases.php
+++ b/database/migrations/2026_03_05_000001_add_application_id_to_service_databases.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->foreignId('application_id')->nullable()->after('service_id')
+                  ->constrained()->cascadeOnDelete();
+        });
+
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->unsignedBigInteger('service_id')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->dropForeign(['application_id']);
+            $table->dropColumn('application_id');
+        });
+
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->unsignedBigInteger('service_id')->nullable(false)->change();
+        });
+    }
+};

--- a/resources/views/livewire/project/application/configuration.blade.php
+++ b/resources/views/livewire/project/application/configuration.blade.php
@@ -1,108 +1,151 @@
 <div>
     <x-slot:title>
         {{ data_get_str($application, 'name')->limit(10) }} > Configuration | Coolify
-    </x-slot>
-    <h1>Configuration</h1>
-    <livewire:project.shared.configuration-checker :resource="$application" />
-    <livewire:project.application.heading :application="$application" />
+        </x-slot>
+        <h1>Configuration</h1>
+        <livewire:project.shared.configuration-checker :resource="$application" />
+        <livewire:project.application.heading :application="$application" />
 
-    <div class="flex flex-col h-full gap-8 sm:flex-row">
-        <div class="sub-menu-wrapper">
-            <a class='sub-menu-item' {{ wireNavigate() }} wire:current.exact="menu-item-active"
-                href="{{ route('project.application.configuration', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">General</span></a>
-            <a class='sub-menu-item' {{ wireNavigate() }} wire:current.exact="menu-item-active"
-                href="{{ route('project.application.advanced', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Advanced</span></a>
-            @if ($application->destination->server->isSwarm())
-                <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
-                    href="{{ route('project.application.swarm', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Swarm Configuration</span></a>
-            @endif
-            <a class='sub-menu-item' {{ wireNavigate() }} wire:current.exact="menu-item-active"
-                href="{{ route('project.application.environment-variables', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Environment Variables</span></a>
-            <a class='sub-menu-item' {{ wireNavigate() }} wire:current.exact="menu-item-active"
-                href="{{ route('project.application.persistent-storage', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Persistent Storage</span></a>
-            @if ($application->git_based())
+        <div class="flex flex-col h-full gap-8 sm:flex-row">
+            <div class="sub-menu-wrapper">
                 <a class='sub-menu-item' {{ wireNavigate() }} wire:current.exact="menu-item-active"
-                    href="{{ route('project.application.source', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Git Source</span></a>
-            @endif
-            <a class="sub-menu-item flex items-center gap-2" {{ wireNavigate() }} wire:current.exact="menu-item-active"
-                href="{{ route('project.application.servers', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Servers</span>
-                @if ($application->server_status == false)
-                    <span title="One or more servers are unreachable or misconfigured.">
-                        <svg class="w-4 h-4 text-error" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
-                            <path fill="currentColor"
-                                d="M240.26 186.1L152.81 34.23a28.74 28.74 0 0 0-49.62 0L15.74 186.1a27.45 27.45 0 0 0 0 27.71A28.31 28.31 0 0 0 40.55 228h174.9a28.31 28.31 0 0 0 24.79-14.19a27.45 27.45 0 0 0 .02-27.71m-20.8 15.7a4.46 4.46 0 0 1-4 2.2H40.55a4.46 4.46 0 0 1-4-2.2a3.56 3.56 0 0 1 0-3.73L124 46.2a4.77 4.77 0 0 1 8 0l87.44 151.87a3.56 3.56 0 0 1 .02 3.73M116 136v-32a12 12 0 0 1 24 0v32a12 12 0 0 1-24 0m28 40a16 16 0 1 1-16-16a16 16 0 0 1 16 16" />
-                        </svg>
-                    </span>
-                @elseif ($application->additional_servers()->exists() && str($application->status)->contains('degraded'))
-                    <span title="Application is in degraded state across multiple servers.">
-                        <svg class="w-4 h-4 text-error" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
-                            <path fill="currentColor"
-                                d="M240.26 186.1L152.81 34.23a28.74 28.74 0 0 0-49.62 0L15.74 186.1a27.45 27.45 0 0 0 0 27.71A28.31 28.31 0 0 0 40.55 228h174.9a28.31 28.31 0 0 0 24.79-14.19a27.45 27.45 0 0 0 .02-27.71m-20.8 15.7a4.46 4.46 0 0 1-4 2.2H40.55a4.46 4.46 0 0 1-4-2.2a3.56 3.56 0 0 1 0-3.73L124 46.2a4.77 4.77 0 0 1 8 0l87.44 151.87a3.56 3.56 0 0 1 .02 3.73M116 136v-32a12 12 0 0 1 24 0v32a12 12 0 0 1-24 0m28 40a16 16 0 1 1-16-16a16 16 0 0 1 16 16" />
-                        </svg>
-                    </span>
+                    href="{{ route('project.application.configuration', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span
+                        class="menu-item-label">General</span></a>
+                <a class='sub-menu-item' {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                    href="{{ route('project.application.advanced', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span
+                        class="menu-item-label">Advanced</span></a>
+                @if ($application->destination->server->isSwarm())
+                    <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                        href="{{ route('project.application.swarm', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span
+                            class="menu-item-label">Swarm Configuration</span></a>
                 @endif
-            </a>
-            <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
-                href="{{ route('project.application.scheduled-tasks.show', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Scheduled Tasks</span></a>
-            <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
-                href="{{ route('project.application.webhooks', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Webhooks</span></a>
-            @if ($application->deploymentType() !== 'deploy_key')
+                <a class='sub-menu-item' {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                    href="{{ route('project.application.environment-variables', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span
+                        class="menu-item-label">Environment Variables</span></a>
+                <a class='sub-menu-item' {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                    href="{{ route('project.application.persistent-storage', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span
+                        class="menu-item-label">Persistent Storage</span></a>
+                @if ($application->git_based())
+                    <a class='sub-menu-item' {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                        href="{{ route('project.application.source', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span
+                            class="menu-item-label">Git Source</span></a>
+                @endif
+                <a class="sub-menu-item flex items-center gap-2" {{ wireNavigate() }}
+                    wire:current.exact="menu-item-active"
+                    href="{{ route('project.application.servers', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span
+                        class="menu-item-label">Servers</span>
+                    @if ($application->server_status == false)
+                        <span title="One or more servers are unreachable or misconfigured.">
+                            <svg class="w-4 h-4 text-error" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+                                <path fill="currentColor"
+                                    d="M240.26 186.1L152.81 34.23a28.74 28.74 0 0 0-49.62 0L15.74 186.1a27.45 27.45 0 0 0 0 27.71A28.31 28.31 0 0 0 40.55 228h174.9a28.31 28.31 0 0 0 24.79-14.19a27.45 27.45 0 0 0 .02-27.71m-20.8 15.7a4.46 4.46 0 0 1-4 2.2H40.55a4.46 4.46 0 0 1-4-2.2a3.56 3.56 0 0 1 0-3.73L124 46.2a4.77 4.77 0 0 1 8 0l87.44 151.87a3.56 3.56 0 0 1 .02 3.73M116 136v-32a12 12 0 0 1 24 0v32a12 12 0 0 1-24 0m28 40a16 16 0 1 1-16-16a16 16 0 0 1 16 16" />
+                            </svg>
+                        </span>
+                    @elseif ($application->additional_servers()->exists() && str($application->status)->contains('degraded'))
+                        <span title="Application is in degraded state across multiple servers.">
+                            <svg class="w-4 h-4 text-error" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+                                <path fill="currentColor"
+                                    d="M240.26 186.1L152.81 34.23a28.74 28.74 0 0 0-49.62 0L15.74 186.1a27.45 27.45 0 0 0 0 27.71A28.31 28.31 0 0 0 40.55 228h174.9a28.31 28.31 0 0 0 24.79-14.19a27.45 27.45 0 0 0 .02-27.71m-20.8 15.7a4.46 4.46 0 0 1-4 2.2H40.55a4.46 4.46 0 0 1-4-2.2a3.56 3.56 0 0 1 0-3.73L124 46.2a4.77 4.77 0 0 1 8 0l87.44 151.87a3.56 3.56 0 0 1 .02 3.73M116 136v-32a12 12 0 0 1 24 0v32a12 12 0 0 1-24 0m28 40a16 16 0 1 1-16-16a16 16 0 0 1 16 16" />
+                            </svg>
+                        </span>
+                    @endif
+                </a>
                 <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
-                    href="{{ route('project.application.preview-deployments', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Preview Deployments</span></a>
-            @endif
-            @if ($application->build_pack !== 'dockercompose')
+                    href="{{ route('project.application.scheduled-tasks.show', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span
+                        class="menu-item-label">Scheduled Tasks</span></a>
                 <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
-                    href="{{ route('project.application.healthcheck', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Healthcheck</span></a>
-            @endif
-            <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
-                href="{{ route('project.application.rollback', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Rollback</span></a>
-            <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
-                href="{{ route('project.application.resource-limits', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Resource Limits</span></a>
-            <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
-                href="{{ route('project.application.resource-operations', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Resource Operations</span></a>
-            <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
-                href="{{ route('project.application.metrics', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Metrics</span></a>
-            <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
-                href="{{ route('project.application.tags', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Tags</span></a>
-            <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
-                href="{{ route('project.application.danger', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Danger Zone</span></a>
+                    href="{{ route('project.application.webhooks', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span
+                        class="menu-item-label">Webhooks</span></a>
+                @if ($application->deploymentType() !== 'deploy_key')
+                    <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                        href="{{ route('project.application.preview-deployments', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span
+                            class="menu-item-label">Preview Deployments</span></a>
+                @endif
+                @if ($application->build_pack !== 'dockercompose')
+                    <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                        href="{{ route('project.application.healthcheck', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span
+                            class="menu-item-label">Healthcheck</span></a>
+                @endif
+                <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                    href="{{ route('project.application.rollback', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span
+                        class="menu-item-label">Rollback</span></a>
+                <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                    href="{{ route('project.application.resource-limits', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span
+                        class="menu-item-label">Resource Limits</span></a>
+                <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                    href="{{ route('project.application.resource-operations', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span
+                        class="menu-item-label">Resource Operations</span></a>
+                <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                    href="{{ route('project.application.metrics', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span
+                        class="menu-item-label">Metrics</span></a>
+                <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                    href="{{ route('project.application.tags', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span
+                        class="menu-item-label">Tags</span></a>
+                @if ($application->build_pack === 'dockercompose' && $application->serviceDatabases->count() > 0)
+                    <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                        href="{{ route('project.application.backups', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span
+                            class="menu-item-label">Backups</span></a>
+                @endif
+                <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                    href="{{ route('project.application.danger', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span
+                        class="menu-item-label">Danger Zone</span></a>
+            </div>
+            <div class="w-full sm:flex-grow">
+                @if ($currentRoute === 'project.application.configuration')
+                    <livewire:project.application.general :application="$application" />
+                @elseif ($currentRoute === 'project.application.swarm' && $application->destination->server->isSwarm())
+                    <livewire:project.application.swarm :application="$application" />
+                @elseif ($currentRoute === 'project.application.advanced')
+                    <livewire:project.application.advanced :application="$application" />
+                @elseif ($currentRoute === 'project.application.environment-variables')
+                    <livewire:project.shared.environment-variable.all :resource="$application" />
+                @elseif ($currentRoute === 'project.application.persistent-storage')
+                    <livewire:project.service.storage :resource="$application" />
+                @elseif ($currentRoute === 'project.application.source' && $application->git_based())
+                    <livewire:project.application.source :application="$application" />
+                @elseif ($currentRoute === 'project.application.servers')
+                    <livewire:project.shared.destination :resource="$application" />
+                @elseif ($currentRoute === 'project.application.scheduled-tasks.show')
+                    <livewire:project.shared.scheduled-task.all :resource="$application" />
+                @elseif ($currentRoute === 'project.application.webhooks')
+                    <livewire:project.shared.webhooks :resource="$application" />
+                @elseif ($currentRoute === 'project.application.preview-deployments')
+                    <livewire:project.application.previews :application="$application" />
+                @elseif ($currentRoute === 'project.application.healthcheck' && $application->build_pack !== 'dockercompose')
+                    <livewire:project.shared.health-checks :resource="$application" />
+                @elseif ($currentRoute === 'project.application.rollback')
+                    <livewire:project.application.rollback :application="$application" />
+                @elseif ($currentRoute === 'project.application.resource-limits')
+                    <livewire:project.shared.resource-limits :resource="$application" />
+                @elseif ($currentRoute === 'project.application.resource-operations')
+                    <livewire:project.shared.resource-operations :resource="$application" />
+                @elseif ($currentRoute === 'project.application.metrics')
+                    <livewire:project.shared.metrics :resource="$application" />
+                @elseif ($currentRoute === 'project.application.tags')
+                    <livewire:project.shared.tags :resource="$application" />
+                @elseif ($currentRoute === 'project.application.backups' && $application->build_pack === 'dockercompose')
+                    <div>
+                        @foreach ($application->serviceDatabases as $serviceDatabase)
+                            <div class="pb-6">
+                                <div class="flex gap-2 items-center">
+                                    <h2 class="pb-4">{{ $serviceDatabase->name }} — Scheduled Backups</h2>
+                                    @if (filled($serviceDatabase->custom_type) || !$serviceDatabase->is_migrated)
+                                        @can('update', $serviceDatabase)
+                                            <x-modal-input buttonTitle="+ Add" title="New Scheduled Backup">
+                                                <livewire:project.database.create-scheduled-backup :database="$serviceDatabase"
+                                                    wire:key="create-backup-{{ $serviceDatabase->id }}" />
+                                            </x-modal-input>
+                                        @endcan
+                                    @endif
+                                </div>
+                                <livewire:project.database.scheduled-backups :database="$serviceDatabase"
+                                    wire:key="backups-{{ $serviceDatabase->id }}" />
+                            </div>
+                        @endforeach
+                    </div>
+                @elseif ($currentRoute === 'project.application.danger')
+                    <livewire:project.shared.danger :resource="$application" />
+                @endif
+            </div>
         </div>
-        <div class="w-full sm:flex-grow">
-            @if ($currentRoute === 'project.application.configuration')
-                <livewire:project.application.general :application="$application" />
-            @elseif ($currentRoute === 'project.application.swarm' && $application->destination->server->isSwarm())
-                <livewire:project.application.swarm :application="$application" />
-            @elseif ($currentRoute === 'project.application.advanced')
-                <livewire:project.application.advanced :application="$application" />
-            @elseif ($currentRoute === 'project.application.environment-variables')
-                <livewire:project.shared.environment-variable.all :resource="$application" />
-            @elseif ($currentRoute === 'project.application.persistent-storage')
-                <livewire:project.service.storage :resource="$application" />
-            @elseif ($currentRoute === 'project.application.source' && $application->git_based())
-                <livewire:project.application.source :application="$application" />
-            @elseif ($currentRoute === 'project.application.servers')
-                <livewire:project.shared.destination :resource="$application" />
-            @elseif ($currentRoute === 'project.application.scheduled-tasks.show')
-                <livewire:project.shared.scheduled-task.all :resource="$application" />
-            @elseif ($currentRoute === 'project.application.webhooks')
-                <livewire:project.shared.webhooks :resource="$application" />
-            @elseif ($currentRoute === 'project.application.preview-deployments')
-                <livewire:project.application.previews :application="$application" />
-            @elseif ($currentRoute === 'project.application.healthcheck' && $application->build_pack !== 'dockercompose')
-                <livewire:project.shared.health-checks :resource="$application" />
-            @elseif ($currentRoute === 'project.application.rollback')
-                <livewire:project.application.rollback :application="$application" />
-            @elseif ($currentRoute === 'project.application.resource-limits')
-                <livewire:project.shared.resource-limits :resource="$application" />
-            @elseif ($currentRoute === 'project.application.resource-operations')
-                <livewire:project.shared.resource-operations :resource="$application" />
-            @elseif ($currentRoute === 'project.application.metrics')
-                <livewire:project.shared.metrics :resource="$application" />
-            @elseif ($currentRoute === 'project.application.tags')
-                <livewire:project.shared.tags :resource="$application" />
-            @elseif ($currentRoute === 'project.application.danger')
-                <livewire:project.shared.danger :resource="$application" />
-            @endif
-        </div>
-    </div>
 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -207,6 +207,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/resource-operations', ApplicationConfiguration::class)->name('project.application.resource-operations');
         Route::get('/metrics', ApplicationConfiguration::class)->name('project.application.metrics');
         Route::get('/tags', ApplicationConfiguration::class)->name('project.application.tags');
+        Route::get('/backups', ApplicationConfiguration::class)->name('project.application.backups');
         Route::get('/danger', ApplicationConfiguration::class)->name('project.application.danger');
 
         Route::get('/deployment', DeploymentIndex::class)->name('project.application.deployment.index');
@@ -272,7 +273,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/proxy/logs', ProxyLogs::class)->name('server.proxy.logs');
         Route::get('/terminal', ExecuteContainerCommand::class)->name('server.command')->middleware('can.access.terminal');
         Route::get('/docker-cleanup', DockerCleanup::class)->name('server.docker-cleanup');
-        Route::get('/security', fn () => redirect(route('dashboard')))->name('server.security')->middleware('can.update.resource');
+        Route::get('/security', fn() => redirect(route('dashboard')))->name('server.security')->middleware('can.update.resource');
         Route::get('/security/patches', Patches::class)->name('server.security.patches')->middleware('can.update.resource');
         Route::get('/security/terminal-access', TerminalAccess::class)->name('server.security.terminal-access')->middleware('can.update.resource');
     });
@@ -328,7 +329,11 @@ Route::middleware(['auth'])->group(function () {
             }
             $filename = data_get($execution, 'filename');
             if ($execution->scheduledDatabaseBackup->database->getMorphClass() === \App\Models\ServiceDatabase::class) {
-                $server = $execution->scheduledDatabaseBackup->database->service->destination->server;
+                if ($execution->scheduledDatabaseBackup->database->application_id) {
+                    $server = $execution->scheduledDatabaseBackup->database->application->destination->server;
+                } else {
+                    $server = $execution->scheduledDatabaseBackup->database->service->destination->server;
+                }
             } else {
                 $server = $execution->scheduledDatabaseBackup->database->destination->server;
             }
@@ -342,7 +347,7 @@ Route::middleware(['auth'])->group(function () {
                 'privateKey' => $privateKeyLocation,
                 'root' => '/',
             ]);
-            if (! $disk->exists($filename)) {
+            if (!$disk->exists($filename)) {
                 if ($execution->scheduledDatabaseBackup->disable_local_backup === true && $execution->scheduledDatabaseBackup->save_s3 === true) {
                     return response()->json(['message' => 'Backup not available locally, but available on S3.'], 404);
                 }
@@ -358,7 +363,7 @@ Route::middleware(['auth'])->group(function () {
                 if ($stream === false || is_null($stream)) {
                     abort(500, 'Failed to open stream for the requested file.');
                 }
-                while (! feof($stream)) {
+                while (!feof($stream)) {
                     echo fread($stream, 2048);
                     flush();
                 }
@@ -366,7 +371,7 @@ Route::middleware(['auth'])->group(function () {
                 fclose($stream);
             }, 200, [
                 'Content-Type' => 'application/octet-stream',
-                'Content-Disposition' => 'attachment; filename="'.basename($filename).'"',
+                'Content-Disposition' => 'attachment; filename="' . basename($filename) . '"',
             ]);
         } catch (\Throwable $e) {
             return response()->json(['message' => $e->getMessage()], 500);


### PR DESCRIPTION
Fixes #7528

When deploying a Docker Compose file via GitHub App (the `dockercompose` buildpack), database services like Postgres or MySQL weren't being detected — which meant users couldn't set up scheduled backups for them. This PR fixes that by adding database detection to the Application parsing path in [parseDockerComposeFile()](cci:1://file:///C:/Users/balav/Videos/coolify/bootstrap/helpers/shared.php:1311:0-2870:1), creating [ServiceDatabase](cci:2://file:///C:/Users/balav/Videos/coolify/app/Models/ServiceDatabase.php:7:0-207:1) records for any backupable databases found in the compose file.On the UI side, a new "Backups" tab now appears in the application configuration page whenever a dockercompose app has detected database services. It reuses the existing `scheduled-backups` and `create-scheduled-backup` Livewire components, so the experience is identical to what users already know from Service Stacks.
Since Git-based composes have automated redeployments, I've added deployment-lock protection in [DatabaseBackupJob](cci:2://file:///C:/Users/balav/Videos/coolify/app/Jobs/DatabaseBackupJob.php:32:0-747:1) — it checks for in-progress deployments before starting a backup, deferring the job for up to ~5 minutes to avoid corrupted backups. If the deployment is stuck beyond that, the backup proceeds anyway to prevent permanent starvation.When the compose file changes (e.g. a database service is removed or its image is changed), the parser automatically cleans up stale [ServiceDatabase](cci:2://file:///C:/Users/balav/Videos/coolify/app/Models/ServiceDatabase.php:7:0-207:1) records and cascades through their scheduled backups and executions, so nothing is left dangling.The [ServiceDatabase](cci:2://file:///C:/Users/balav/Videos/coolify/app/Models/ServiceDatabase.php:7:0-207:1) model now supports dual ownership — it can belong to either a [Service](cci:2://file:///C:/Users/balav/Videos/coolify/app/Models/ServiceDatabase.php:7:0-207:1) or an [Application](cci:2://file:///C:/Users/balav/Videos/coolify/app/Models/Application.php:24:0-2032:1) via a nullable `application_id` foreign key. All methods like [server()](cci:1://file:///C:/Users/balav/Videos/coolify/app/Models/ServiceDatabase.php:160:4-167:5), [team()](cci:1://file:///C:/Users/balav/Videos/coolify/app/Models/ServiceDatabase.php:136:4-143:5), [workdir()](cci:1://file:///C:/Users/balav/Videos/coolify/app/Models/ServiceDatabase.php:145:4-148:5), and [restart()](cci:1://file:///C:/Users/balav/Videos/coolify/app/Models/ServiceDatabase.php:59:4-63:5) branch accordingly.
