### PR TITLE
fix(ssh): sync stale key files via fingerprint before SSH exec

### DIFF
--- a/app/Helpers/SshMultiplexingHelper.php
+++ b/app/Helpers/SshMultiplexingHelper.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Facades\Storage;
 
 class SshMultiplexingHelper
 {
@@ -158,7 +159,7 @@ class SshMultiplexingHelper
         $sshConfig = self::serverSshConfiguration($server);
         $sshKeyLocation = $sshConfig['sshKeyLocation'];
 
-        self::validateSshKey($server->privateKey);
+        self::validateSshKey($server->privateKey, $server);
 
         $muxSocket = $sshConfig['muxFilename'];
 
@@ -206,14 +207,28 @@ class SshMultiplexingHelper
         return config('constants.ssh.mux_enabled') && ! config('constants.coolify.is_windows_docker_desktop');
     }
 
-    private static function validateSshKey(PrivateKey $privateKey): void
+    private static function validateSshKey(PrivateKey $privateKey, ?Server $server = null): void
     {
-        $keyLocation = $privateKey->getKeyLocation();
-        $checkKeyCommand = "ls $keyLocation 2>/dev/null";
-        $keyCheckProcess = Process::run($checkKeyCommand);
+        $disk = Storage::disk('ssh-keys');
+        $filename = "ssh_key@{$privateKey->uuid}";
 
-        if ($keyCheckProcess->exitCode() !== 0) {
+        $shouldSyncToDisk = ! $disk->exists($filename);
+        if (! $shouldSyncToDisk) {
+            $storedContent = $disk->get($filename);
+            $storedFingerprint = PrivateKey::generateFingerprint($storedContent);
+            $expectedFingerprint = $privateKey->fingerprint ?? PrivateKey::generateFingerprint($privateKey->private_key);
+
+            // Fingerprint mismatch means key file is stale/corrupted on this node.
+            $shouldSyncToDisk = is_null($storedFingerprint) || is_null($expectedFingerprint) || ! hash_equals($expectedFingerprint, $storedFingerprint);
+        }
+
+        if ($shouldSyncToDisk) {
             $privateKey->storeInFileSystem();
+
+            // Any existing mux session can still reference the stale key in memory.
+            if (! is_null($server) && self::isMultiplexingEnabled()) {
+                self::removeMuxFile($server);
+            }
         }
     }
 

--- a/tests/Unit/SshKeyFileSyncTest.php
+++ b/tests/Unit/SshKeyFileSyncTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use App\Helpers\SshMultiplexingHelper;
+use App\Models\PrivateKey;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class SshKeyFileSyncTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->actingAs(\App\Models\User::factory()->create());
+    }
+
+    protected function getValidPrivateKey(): string
+    {
+        return '-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACBbhpqHhqv6aI67Mj9abM3DVbmcfYhZAhC7ca4d9UCevAAAAJi/QySHv0Mk
+hwAAAAtzc2gtZWQyNTUxOQAAACBbhpqHhqv6aI67Mj9abM3DVbmcfYhZAhC7ca4d9UCevA
+AAAECBQw4jg1WRT2IGHMncCiZhURCts2s24HoDS0thHnnRKVuGmoeGq/pojrsyP1pszcNV
+uZx9iFkCELtxrh31QJ68AAAAEXNhaWxANzZmZjY2ZDJlMmRkAQIDBA==
+-----END OPENSSH PRIVATE KEY-----';
+    }
+
+    protected function invokeValidate(PrivateKey $privateKey): void
+    {
+        $method = new ReflectionMethod(SshMultiplexingHelper::class, 'validateSshKey');
+        $method->setAccessible(true);
+        $method->invoke(null, $privateKey, null);
+    }
+
+    /** @test */
+    public function it_recreates_missing_ssh_key_file_before_ssh_command_generation()
+    {
+        Storage::fake('ssh-keys');
+
+        $privateKey = PrivateKey::createAndStore([
+            'name' => 'Test Key',
+            'description' => 'Test Description',
+            'private_key' => $this->getValidPrivateKey(),
+            'team_id' => currentTeam()->id,
+        ]);
+
+        $filename = "ssh_key@{$privateKey->uuid}";
+        Storage::disk('ssh-keys')->delete($filename);
+        Storage::disk('ssh-keys')->assertMissing($filename);
+
+        $this->invokeValidate($privateKey);
+
+        Storage::disk('ssh-keys')->assertExists($filename);
+        expect(Storage::disk('ssh-keys')->get($filename))->toBe($privateKey->private_key);
+    }
+
+    /** @test */
+    public function it_rewrites_stale_or_corrupted_ssh_key_file()
+    {
+        Storage::fake('ssh-keys');
+
+        $privateKey = PrivateKey::createAndStore([
+            'name' => 'Test Key',
+            'description' => 'Test Description',
+            'private_key' => $this->getValidPrivateKey(),
+            'team_id' => currentTeam()->id,
+        ]);
+
+        $filename = "ssh_key@{$privateKey->uuid}";
+        Storage::disk('ssh-keys')->put($filename, 'corrupted-key-content');
+
+        $this->invokeValidate($privateKey);
+
+        expect(Storage::disk('ssh-keys')->get($filename))->toBe($privateKey->private_key);
+    }
+}


### PR DESCRIPTION
/claim #7724

## Summary
Re-submit of the stale SSH key synchronization fix for intermittent `Permission denied (publickey,password)` failures.

This patch makes `validateSshKey()` actively repair missing/stale key files before command execution by comparing key fingerprints (DB vs disk), then resets the current server mux file if a re-sync occurs.

## Why this is targeted
- Existing logic only ensured key file existence.
- Sporadic auth failures are consistent with stale/corrupted per-node key material and stale mux sessions.
- Fingerprint comparison avoids brittle raw-content assumptions and keeps blast radius local to the active server context.

## Changes
- `app/Helpers/SshMultiplexingHelper.php`
  - `validateSshKey(PrivateKey $privateKey, ?Server $server = null)`
  - detect stale/missing key file using fingerprint mismatch
  - re-store DB key material to disk when mismatch found
  - invalidate current server mux file when sync happens
- `tests/Unit/SshKeyFileSyncTest.php`
  - missing key file is recreated
  - corrupted key file is repaired

## Verification
- Unit test coverage added for both missing-file and corrupted-file repair paths.
- Local CI-style PHP test execution is environment-constrained in this workspace, but patch is scoped, deterministic, and covered by focused unit tests for maintainer CI.
