### PR TITLE
feat(env): inject COOLIFY_SERVER_NAME/UUID at runtime

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -2382,6 +2382,11 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                     }
                 }
             }
+            $this->add_server_metadata_env_variables(
+                $coolify_envs,
+                $this->application->environment_variables_preview,
+                $forBuildTime
+            );
 
             add_coolify_default_environment_variables($this->application, $coolify_envs, $this->application->environment_variables_preview);
 
@@ -2426,12 +2431,32 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                     }
                 }
             }
+            $this->add_server_metadata_env_variables(
+                $coolify_envs,
+                $this->application->environment_variables,
+                $forBuildTime
+            );
 
             add_coolify_default_environment_variables($this->application, $coolify_envs, $this->application->environment_variables);
 
         }
 
         return $coolify_envs;
+    }
+
+    private function add_server_metadata_env_variables(Collection $coolify_envs, Collection $resourceEnvironmentVariables, bool $forBuildTime): void
+    {
+        if ($forBuildTime) {
+            return;
+        }
+
+        if ($resourceEnvironmentVariables->where('key', 'COOLIFY_SERVER_NAME')->isEmpty() && filled($this->server->name)) {
+            $coolify_envs->put('COOLIFY_SERVER_NAME', $this->server->name);
+        }
+
+        if ($resourceEnvironmentVariables->where('key', 'COOLIFY_SERVER_UUID')->isEmpty() && filled($this->server->uuid)) {
+            $coolify_envs->put('COOLIFY_SERVER_UUID', $this->server->uuid);
+        }
     }
 
     private function generate_env_variables()

--- a/tests/Unit/ApplicationDeploymentServerEnvVariablesTest.php
+++ b/tests/Unit/ApplicationDeploymentServerEnvVariablesTest.php
@@ -1,0 +1,104 @@
+<?php
+
+use App\Jobs\ApplicationDeploymentJob;
+use App\Models\Application;
+use App\Models\Server;
+use Illuminate\Support\Collection;
+
+function applicationDeploymentServerEnvKeysCollection(array $keys): Collection
+{
+    return collect($keys)->map(fn (string $key) => (object) ['key' => $key]);
+}
+
+function buildApplicationDeploymentJobForServerEnvVariablesTest(Collection $environmentVariables, int $pullRequestId = 0): ApplicationDeploymentJob
+{
+    $settings = (object) ['include_source_commit_in_build' => false];
+
+    $application = Mockery::mock(Application::class);
+    $application->shouldReceive('getAttribute')->andReturnUsing(function (string $key) use ($environmentVariables, $settings) {
+        return match ($key) {
+            'environment_variables' => $environmentVariables,
+            'environment_variables_preview' => $environmentVariables,
+            'compose_parsing_version' => '2',
+            'build_pack' => 'dockerfile',
+            'fqdn' => 'https://app.example.com',
+            'uuid' => 'app-uuid',
+            'settings' => $settings,
+            default => null,
+        };
+    });
+
+    $server = new Server;
+    $server->forceFill([
+        'id' => 42,
+        'name' => 'server-chi',
+        'uuid' => 'srv-uuid-42',
+    ]);
+
+    $job = Mockery::mock(ApplicationDeploymentJob::class)->makePartial();
+    $job->shouldAllowMockingProtectedMethods();
+
+    $reflection = new ReflectionClass(ApplicationDeploymentJob::class);
+
+    $applicationProperty = $reflection->getProperty('application');
+    $applicationProperty->setAccessible(true);
+    $applicationProperty->setValue($job, $application);
+
+    $pullRequestProperty = $reflection->getProperty('pull_request_id');
+    $pullRequestProperty->setAccessible(true);
+    $pullRequestProperty->setValue($job, $pullRequestId);
+
+    $branchProperty = $reflection->getProperty('branch');
+    $branchProperty->setAccessible(true);
+    $branchProperty->setValue($job, 'main');
+
+    $commitProperty = $reflection->getProperty('commit');
+    $commitProperty->setAccessible(true);
+    $commitProperty->setValue($job, 'abc123');
+
+    $containerNameProperty = $reflection->getProperty('container_name');
+    $containerNameProperty->setAccessible(true);
+    $containerNameProperty->setValue($job, 'coolify-test-container');
+
+    $serverProperty = $reflection->getProperty('server');
+    $serverProperty->setAccessible(true);
+    $serverProperty->setValue($job, $server);
+
+    return $job;
+}
+
+function callGenerateCoolifyEnvVariablesForServerEnvTest(ApplicationDeploymentJob $job, bool $forBuildTime): Collection
+{
+    $reflection = new ReflectionClass(ApplicationDeploymentJob::class);
+    $method = $reflection->getMethod('generate_coolify_env_variables');
+    $method->setAccessible(true);
+
+    return $method->invoke($job, $forBuildTime);
+}
+
+it('injects server metadata environment variables at runtime when keys are not overridden', function () {
+    $job = buildApplicationDeploymentJobForServerEnvVariablesTest(applicationDeploymentServerEnvKeysCollection([]));
+    $coolifyEnvs = callGenerateCoolifyEnvVariablesForServerEnvTest($job, false);
+
+    expect($coolifyEnvs->get('COOLIFY_SERVER_NAME'))->toBe('server-chi');
+    expect($coolifyEnvs->get('COOLIFY_SERVER_UUID'))->toBe('srv-uuid-42');
+});
+
+it('does not inject server metadata environment variables when application overrides keys', function () {
+    $job = buildApplicationDeploymentJobForServerEnvVariablesTest(applicationDeploymentServerEnvKeysCollection([
+        'COOLIFY_SERVER_NAME',
+        'COOLIFY_SERVER_UUID',
+    ]));
+    $coolifyEnvs = callGenerateCoolifyEnvVariablesForServerEnvTest($job, false);
+
+    expect($coolifyEnvs->has('COOLIFY_SERVER_NAME'))->toBeFalse();
+    expect($coolifyEnvs->has('COOLIFY_SERVER_UUID'))->toBeFalse();
+});
+
+it('does not inject server metadata environment variables into build-time env generation', function () {
+    $job = buildApplicationDeploymentJobForServerEnvVariablesTest(applicationDeploymentServerEnvKeysCollection([]));
+    $coolifyEnvs = callGenerateCoolifyEnvVariablesForServerEnvTest($job, true);
+
+    expect($coolifyEnvs->has('COOLIFY_SERVER_NAME'))->toBeFalse();
+    expect($coolifyEnvs->has('COOLIFY_SERVER_UUID'))->toBeFalse();
+});


### PR DESCRIPTION
## Summary
This PR adds two predefined server metadata environment variables for application deployments:
- `COOLIFY_SERVER_NAME`
- `COOLIFY_SERVER_UUID`

The injection is intentionally minimal and runtime-only, implemented in the existing `ApplicationDeploymentJob::generate_coolify_env_variables()` path.

## Why
Issue #7738 asks for predefined server variables so an app can identify where it runs in multi-server deployments.

## Behavior
- Adds `COOLIFY_SERVER_NAME` and `COOLIFY_SERVER_UUID` for runtime env generation.
- Keeps application-level precedence: if the app already defines either key, Coolify does not override it.
- Does **not** inject these variables for build-time env generation (keeps build cache behavior stable and avoids build-server/runtime-server mismatch).

## Scope
- No schema changes
- No UI changes
- No API changes
- No server-level custom variable CRUD

## Tests
Added `tests/Unit/ApplicationDeploymentServerEnvVariablesTest.php` with coverage for:
1. Runtime injection when keys are not overridden
2. No injection when app env already defines those keys
3. No injection in build-time env generation

### Verification command used
```bash
docker run --rm -t --user root \
  -v /var/www/html:/var/www/html \
  -w /var/www/html docker.io/serversideup/php:8.4-fpm-nginx \
  sh -lc "install-php-extensions sockets >/tmp/install-sockets.log 2>&1 && php artisan test --compact tests/Unit/ApplicationDeploymentServerEnvVariablesTest.php"
```

/claim #7738
