### PR TITLE
Update authentik template image tag to 2026.2.1

### DIFF
--- a/templates/compose/authentik.yaml
+++ b/templates/compose/authentik.yaml
@@ -7,7 +7,7 @@
 
 services:
   authentik-server:
-    image: ghcr.io/goauthentik/server:${AUTHENTIK_TAG:-2025.10.3}
+    image: ghcr.io/goauthentik/server:${AUTHENTIK_TAG:-2026.2.1}
     restart: unless-stopped
     command: server
     environment:
@@ -33,7 +33,7 @@ services:
       postgresql:
         condition: service_healthy
   authentik-worker:
-    image: ghcr.io/goauthentik/server:${AUTHENTIK_TAG:-2025.10.3}
+    image: ghcr.io/goauthentik/server:${AUTHENTIK_TAG:-2026.2.1}
     restart: unless-stopped
     command: worker
     environment:


### PR DESCRIPTION
## Changes
This pull request updates the Authentik service images ( `templates/compose/authentik.yaml` ). The main change is bumping the default image tag from `2025.10.3` to `2026.2.1` for both the server and worker.

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [X] Fixing or updating existing one click service


## AI Assistance

<!-- AI-assisted PRs that are human reviewed are welcome, just let us know so we can review appropriately. -->

- [X] AI was NOT used to create this PR
- [ ] AI was used (please describe below)

**If AI was used:**

- Tools used:
- How extensively:

## Testing

Deployed on my own Instances

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [X] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [X] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [X] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
