### PR TITLE
feat: Integrated backups for Git-based Docker Compose databases

### DIFF
--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -93,7 +93,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $this->database = data_get($this->backup, 'database');
-                $this->server = $this->database->service->server;
+                $this->server = $this->database->getServer();
                 $this->s3 = $this->backup->s3;
             } else {
                 $this->database = data_get($this->backup, 'database');
@@ -109,17 +109,34 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
 
             BackupCreated::dispatch($this->team->id);
 
+            // Skip backup if the parent application is being deployed (prevents corrupted backups)
+            if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class
+                && $this->database->isApplicationOwned()
+                && $this->database->application->isDeploymentInprogress()) {
+                Log::info('Skipping backup: deployment in progress for application', [
+                    'application' => $this->database->application->name,
+                    'database' => $this->database->name,
+                ]);
+
+                return;
+            }
+
             $status = str(data_get($this->database, 'status'));
             if (! $status->startsWith('running') && $this->database->id !== 0) {
                 return;
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $databaseType = $this->database->databaseType();
-                $serviceUuid = $this->database->service->uuid;
-                $serviceName = str($this->database->service->name)->slug();
+                if ($this->database->isApplicationOwned()) {
+                    $containerName = $this->database->containerName();
+                    $parentName = str($this->database->application->name)->slug();
+                } else {
+                    $containerName = "{$this->database->name}-{$this->database->service->uuid}";
+                    $parentName = str($this->database->service->name)->slug();
+                }
                 if (str($databaseType)->contains('postgres')) {
-                    $this->container_name = "{$this->database->name}-$serviceUuid";
-                    $this->directory_name = $serviceName.'-'.$this->container_name;
+                    $this->container_name = $containerName;
+                    $this->directory_name = $parentName.'-'.$this->container_name;
                     $commands[] = "docker exec $this->container_name env | grep POSTGRES_";
                     $envs = instant_remote_process($commands, $this->server, true, false, null, disableMultiplexing: true);
                     $envs = str($envs)->explode("\n");
@@ -149,8 +166,8 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                         $this->postgres_password = str($this->postgres_password)->after('POSTGRES_PASSWORD=')->value();
                     }
                 } elseif (str($databaseType)->contains('mysql')) {
-                    $this->container_name = "{$this->database->name}-$serviceUuid";
-                    $this->directory_name = $serviceName.'-'.$this->container_name;
+                    $this->container_name = $containerName;
+                    $this->directory_name = $parentName.'-'.$this->container_name;
                     $commands[] = "docker exec $this->container_name env | grep MYSQL_";
                     $envs = instant_remote_process($commands, $this->server, true, false, null, disableMultiplexing: true);
                     $envs = str($envs)->explode("\n");
@@ -172,8 +189,8 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                         throw new \Exception('MYSQL_DATABASE not found');
                     }
                 } elseif (str($databaseType)->contains('mariadb')) {
-                    $this->container_name = "{$this->database->name}-$serviceUuid";
-                    $this->directory_name = $serviceName.'-'.$this->container_name;
+                    $this->container_name = $containerName;
+                    $this->directory_name = $parentName.'-'.$this->container_name;
                     $commands[] = "docker exec $this->container_name env";
                     $envs = instant_remote_process($commands, $this->server, true, false, null, disableMultiplexing: true);
                     $envs = str($envs)->explode("\n");
@@ -210,8 +227,8 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                     }
                 } elseif (str($databaseType)->contains('mongo')) {
                     $databasesToBackup = ['*'];
-                    $this->container_name = "{$this->database->name}-$serviceUuid";
-                    $this->directory_name = $serviceName.'-'.$this->container_name;
+                    $this->container_name = $containerName;
+                    $this->directory_name = $parentName.'-'.$this->container_name;
 
                     // Try to extract MongoDB credentials from environment variables
                     try {
@@ -630,7 +647,8 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             $endpoint = $this->s3->endpoint;
             $this->s3->testConnection(shouldSave: true);
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
-                $network = $this->database->service->destination->network;
+                $parent = $this->database->parentResource();
+                $network = $parent->destination->network;
             } else {
                 $network = $this->database->destination->network;
             }

--- a/app/Livewire/Project/Application/ComposeDatabaseBackups.php
+++ b/app/Livewire/Project/Application/ComposeDatabaseBackups.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Livewire\Project\Application;
+
+use App\Models\Application;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Component;
+
+class ComposeDatabaseBackups extends Component
+{
+    use AuthorizesRequests;
+
+    public Application $application;
+
+    protected $listeners = ['refreshScheduledBackups' => '$refresh'];
+
+    public function mount()
+    {
+        $this->authorize('view', $this->application);
+    }
+
+    public function render()
+    {
+        $databases = $this->application->composeDatabases()
+            ->get()
+            ->filter(fn ($db) => $db->isBackupSolutionAvailable());
+
+        return view('livewire.project.application.compose-database-backups', [
+            'databases' => $databases,
+        ]);
+    }
+}

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -134,6 +134,12 @@ class Application extends BaseModel
                 'additional_networks',
             ]);
         });
+        static::deleting(function ($application) {
+            // Clean up compose database records and their scheduled backups
+            $application->composeDatabases()->each(function ($db) {
+                $db->delete();
+            });
+        });
         static::saving(function ($application) {
             $payload = [];
             if ($application->isDirty('fqdn')) {
@@ -908,6 +914,11 @@ class Application extends BaseModel
     public function previews()
     {
         return $this->hasMany(ApplicationPreview::class)->orderBy('pull_request_id', 'desc');
+    }
+
+    public function composeDatabases()
+    {
+        return $this->hasMany(ServiceDatabase::class);
     }
 
     public function deployment_queue()

--- a/app/Models/ScheduledDatabaseBackup.php
+++ b/app/Models/ScheduledDatabaseBackup.php
@@ -67,8 +67,7 @@ class ScheduledDatabaseBackup extends BaseModel
     {
         if ($this->database) {
             if ($this->database instanceof ServiceDatabase) {
-                $destination = data_get($this->database->service, 'destination');
-                $server = data_get($destination, 'server');
+                return $this->database->getServer();
             } else {
                 $destination = data_get($this->database, 'destination');
                 $server = data_get($destination, 'server');

--- a/app/Models/ServiceDatabase.php
+++ b/app/Models/ServiceDatabase.php
@@ -27,7 +27,10 @@ class ServiceDatabase extends BaseModel
 
     public static function ownedByCurrentTeamAPI(int $teamId)
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', $teamId)->orderBy('name');
+        return ServiceDatabase::where(function ($query) use ($teamId) {
+            $query->whereRelation('service.environment.project.team', 'id', $teamId)
+                ->orWhereRelation('application.environment.project.team', 'id', $teamId);
+        })->orderBy('name');
     }
 
     /**
@@ -36,7 +39,10 @@ class ServiceDatabase extends BaseModel
      */
     public static function ownedByCurrentTeam()
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', currentTeam()->id)->orderBy('name');
+        return ServiceDatabase::where(function ($query) {
+            $query->whereRelation('service.environment.project.team', 'id', currentTeam()->id)
+                ->orWhereRelation('application.environment.project.team', 'id', currentTeam()->id);
+        })->orderBy('name');
     }
 
     /**
@@ -49,10 +55,82 @@ class ServiceDatabase extends BaseModel
         });
     }
 
+    /**
+     * Check if this database is owned by an Application (Git-based Docker Compose).
+     */
+    public function isApplicationOwned(): bool
+    {
+        return filled($this->application_id);
+    }
+
+    /**
+     * Get the parent resource (Service or Application).
+     */
+    public function parentResource(): Service|Application|null
+    {
+        if ($this->isApplicationOwned()) {
+            return $this->application;
+        }
+
+        return $this->service;
+    }
+
+    /**
+     * Get the server this database runs on.
+     */
+    public function getServer(): ?Server
+    {
+        $parent = $this->parentResource();
+        if (! $parent) {
+            return null;
+        }
+
+        if ($parent instanceof Application) {
+            return $parent->destination?->server;
+        }
+
+        return $parent->destination?->server;
+    }
+
     public function restart()
     {
-        $container_id = $this->name.'-'.$this->service->uuid;
-        remote_process(["docker restart {$container_id}"], $this->service->server);
+        $server = $this->getServer();
+        $containerName = $this->containerName();
+        if ($server && $containerName) {
+            remote_process(["docker restart {$containerName}"], $server);
+        }
+    }
+
+    /**
+     * Get the container name for this database.
+     * For application-owned databases, resolves the running container via docker labels.
+     * Falls back to the expected name pattern if resolution fails.
+     */
+    public function containerName(): string
+    {
+        if ($this->isApplicationOwned()) {
+            // Try to find the running container by label
+            $server = $this->getServer();
+            if ($server) {
+                try {
+                    $output = instant_remote_process(
+                        ["docker ps --filter 'label=coolify.applicationId={$this->application->id}' --filter 'name={$this->name}-' --format '{{.Names}}' | head -1"],
+                        $server,
+                        throwError: false,
+                    );
+                    if (filled($output)) {
+                        return trim($output);
+                    }
+                } catch (\Throwable) {
+                    // Fall through to default
+                }
+            }
+
+            // Fallback: construct from uuid (consistent naming pattern)
+            return "{$this->name}-{$this->application->uuid}";
+        }
+
+        return "{$this->name}-{$this->service->uuid}";
     }
 
     public function isRunning()
@@ -114,8 +192,12 @@ class ServiceDatabase extends BaseModel
     public function getServiceDatabaseUrl()
     {
         $port = $this->public_port;
-        $realIp = $this->service->server->ip;
-        if ($this->service->server->isLocalhost() || isDev()) {
+        $server = $this->getServer();
+        if (! $server) {
+            return null;
+        }
+        $realIp = $server->ip;
+        if ($server->isLocalhost() || isDev()) {
             $realIp = base_ip();
         }
 
@@ -124,17 +206,30 @@ class ServiceDatabase extends BaseModel
 
     public function team()
     {
-        return data_get($this, 'environment.project.team');
+        if ($this->isApplicationOwned()) {
+            return data_get($this, 'application.environment.project.team');
+        }
+
+        return data_get($this, 'service.environment.project.team');
     }
 
     public function workdir()
     {
+        if ($this->isApplicationOwned()) {
+            return application_configuration_dir()."/{$this->application->uuid}";
+        }
+
         return service_configuration_dir()."/{$this->service->uuid}";
     }
 
     public function service()
     {
         return $this->belongsTo(Service::class);
+    }
+
+    public function application()
+    {
+        return $this->belongsTo(Application::class);
     }
 
     public function persistentStorages()

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -556,8 +556,12 @@ function getResourceByUuid(string $uuid, ?int $teamId = null)
     }
 
     // ServiceDatabase has a different relationship path: service->environment->project->team_id
+    // or application->environment->project->team_id (for Git-based Docker Compose)
     if ($resource instanceof \App\Models\ServiceDatabase) {
         if ($resource->service?->environment?->project?->team_id === $teamId) {
+            return $resource;
+        }
+        if ($resource->application?->environment?->project?->team_id === $teamId) {
             return $resource;
         }
 
@@ -2114,7 +2118,8 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
         if ($pull_request_id !== 0) {
             $definedNetwork = collect(["{$resource->uuid}-$pull_request_id"]);
         }
-        $services = collect($services)->map(function ($service, $serviceName) use ($topLevelVolumes, $topLevelNetworks, $definedNetwork, $isNew, $generatedServiceFQDNS, $resource, $server, $pull_request_id, $preview_id) {
+        $detectedDatabaseNames = collect();
+        $services = collect($services)->map(function ($service, $serviceName) use ($topLevelVolumes, $topLevelNetworks, $definedNetwork, $isNew, $generatedServiceFQDNS, $resource, $server, $pull_request_id, $preview_id, $detectedDatabaseNames) {
             $serviceVolumes = collect(data_get($service, 'volumes', []));
             $servicePorts = collect(data_get($service, 'ports', []));
             $serviceNetworks = collect(data_get($service, 'networks', []));
@@ -2417,6 +2422,25 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
             $image = data_get_str($service, 'image');
             $isDatabase = isDatabaseImage($image, $service);
             data_set($service, 'is_database', $isDatabase);
+
+            // Create/update ServiceDatabase records for detected databases (enables backups)
+            if ($isDatabase && $pull_request_id === 0) {
+                $detectedDatabaseNames->push($serviceName);
+                $existingDb = ServiceDatabase::where('name', $serviceName)
+                    ->where('application_id', $resource->id)
+                    ->first();
+                if (is_null($existingDb)) {
+                    ServiceDatabase::create([
+                        'name' => $serviceName,
+                        'image' => $image,
+                        'application_id' => $resource->id,
+                        'service_id' => null,
+                    ]);
+                } elseif ($existingDb->image !== $image) {
+                    $existingDb->image = $image;
+                    $existingDb->save();
+                }
+            }
 
             // Collect/create/update networks
             if ($serviceNetworks->count() > 0) {
@@ -2813,6 +2837,17 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
         data_forget($resource, 'environment_variables');
         data_forget($resource, 'environment_variables_preview');
         $resource->save();
+
+        // Clean up stale ServiceDatabase records for databases removed from compose
+        if ($pull_request_id === 0) {
+            $query = ServiceDatabase::where('application_id', $resource->id);
+            if ($detectedDatabaseNames->isNotEmpty()) {
+                $query->whereNotIn('name', $detectedDatabaseNames->toArray());
+            }
+            $query->each(function ($staleDb) {
+                $staleDb->delete();
+            });
+        }
 
         return collect($finalServices);
     }

--- a/database/migrations/2026_03_07_000001_add_application_id_to_service_databases.php
+++ b/database/migrations/2026_03_07_000001_add_application_id_to_service_databases.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->foreignId('application_id')->nullable()->after('service_id');
+        });
+
+        // Make service_id nullable so ServiceDatabase can belong to either Service or Application
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->unsignedBigInteger('service_id')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->dropColumn('application_id');
+        });
+
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->unsignedBigInteger('service_id')->nullable(false)->change();
+        });
+    }
+};

--- a/resources/views/livewire/project/application/compose-database-backups.blade.php
+++ b/resources/views/livewire/project/application/compose-database-backups.blade.php
@@ -1,0 +1,41 @@
+<div>
+    <h2 class="pb-4">Database Backups</h2>
+    <p class="pb-4 text-sm">Databases detected in your Docker Compose file. You can configure scheduled backups for each database.</p>
+
+    @if ($databases->count() === 0)
+        <div class="text-neutral-400">
+            No supported databases detected in your Docker Compose file.
+            <br>
+            Supported databases: PostgreSQL, MySQL, MariaDB, MongoDB.
+        </div>
+    @else
+        <div class="flex flex-col gap-4">
+            @foreach ($databases as $database)
+                <div class="box p-4">
+                    <div class="flex items-center justify-between pb-2">
+                        <div>
+                            <h3 class="font-bold">{{ $database->name }}</h3>
+                            <p class="text-sm text-neutral-400">{{ $database->image }} ({{ str($database->databaseType())->after('standalone-') }})</p>
+                        </div>
+                        <div class="flex items-center gap-2">
+                            <span class="badge {{ $database->isRunning() ? 'badge-success' : 'badge-warning' }}">
+                                {{ $database->isRunning() ? 'Running' : $database->status }}
+                            </span>
+                        </div>
+                    </div>
+                    <div class="pt-2 border-t border-coolgray-300">
+                        <div class="flex gap-2 pb-4">
+                            <h4>Scheduled Backups</h4>
+                            @can('update', $application)
+                                <x-modal-input buttonTitle="+ Add" title="New Scheduled Backup">
+                                    <livewire:project.database.create-scheduled-backup :database="$database" :wire:key="'create-backup-' . $database->id" />
+                                </x-modal-input>
+                            @endcan
+                        </div>
+                        <livewire:project.database.scheduled-backups :database="$database" :wire:key="'backups-' . $database->id" />
+                    </div>
+                </div>
+            @endforeach
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/project/application/configuration.blade.php
+++ b/resources/views/livewire/project/application/configuration.blade.php
@@ -44,6 +44,10 @@
             </a>
             <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
                 href="{{ route('project.application.scheduled-tasks.show', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Scheduled Tasks</span></a>
+            @if ($application->build_pack === 'dockercompose' && $application->composeDatabases()->count() > 0)
+                <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                    href="{{ route('project.application.database-backups', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Database Backups</span></a>
+            @endif
             <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
                 href="{{ route('project.application.webhooks', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Webhooks</span></a>
             @if ($application->deploymentType() !== 'deploy_key')
@@ -100,6 +104,8 @@
                 <livewire:project.shared.metrics :resource="$application" />
             @elseif ($currentRoute === 'project.application.tags')
                 <livewire:project.shared.tags :resource="$application" />
+            @elseif ($currentRoute === 'project.application.database-backups')
+                <livewire:project.application.compose-database-backups :application="$application" />
             @elseif ($currentRoute === 'project.application.danger')
                 <livewire:project.shared.danger :resource="$application" />
             @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -208,6 +208,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/metrics', ApplicationConfiguration::class)->name('project.application.metrics');
         Route::get('/tags', ApplicationConfiguration::class)->name('project.application.tags');
         Route::get('/danger', ApplicationConfiguration::class)->name('project.application.danger');
+        Route::get('/database-backups', ApplicationConfiguration::class)->name('project.application.database-backups');
 
         Route::get('/deployment', DeploymentIndex::class)->name('project.application.deployment.index');
         Route::get('/deployment/{deployment_uuid}', DeploymentShow::class)->name('project.application.deployment.show');


### PR DESCRIPTION
## Summary

Resolves #7528 — Enables automated database backups for Docker Compose applications deployed via GitHub App (dockercompose buildpack).

Currently, database detection and backup scheduling only work for **Empty Docker Compose** and **one-click services** (Service model path). Git-based Docker Compose deployments (Application model path) detect databases via `isDatabaseImage()` but never create `ServiceDatabase` records, so backups are unavailable.

This PR adds full backup support by:

### 1. Database Detection & Persistence (Backend)
- In `parseDockerComposeFile()`, the Application model path now creates `ServiceDatabase` records for detected database containers (PostgreSQL, MySQL, MariaDB, MongoDB)
- Records are linked via a new `application_id` column (nullable) on `service_databases`, with `service_id` made nullable to support dual ownership
- Database image changes in compose are automatically tracked and updated

### 2. Backup Configuration UI
- Adds a **Database Backups** menu item in the Application configuration sidebar (only shown for `dockercompose` build pack when databases are detected)
- Reuses the existing `CreateScheduledBackup` and `ScheduledBackups` Livewire components — no new backup logic needed
- Users can create, configure, and monitor scheduled backups for each detected database

### 3. Backup Execution
- `DatabaseBackupJob` updated to resolve server, container name, and network from application-owned `ServiceDatabase` records
- Container name resolution uses `docker ps` label filtering to find the actual running container (handles both consistent and non-consistent naming)
- S3 upload network resolution handles both Service and Application parents

### 4. Deployment Safety (Overlapping Re-deployments)
- Backup job checks `isDeploymentInprogress()` before executing for application-owned databases
- If a deployment is running, the backup is skipped and logged (prevents incomplete/corrupted backups)

### 5. Compose Changes Handling
- When `parseDockerComposeFile()` runs (on each deploy), stale `ServiceDatabase` records are automatically cleaned up if the database service was removed from the compose file
- `Application::deleting()` hook cleans up all compose database records and their scheduled backups when the application is deleted

### Files Changed

**New files (3):**
- `database/migrations/2026_03_07_000001_add_application_id_to_service_databases.php`
- `app/Livewire/Project/Application/ComposeDatabaseBackups.php`
- `resources/views/livewire/project/application/compose-database-backups.blade.php`

**Modified files (7):**
- `app/Models/ServiceDatabase.php` — Dual ownership (Service or Application), `getServer()`, `containerName()`, updated team queries
- `app/Models/Application.php` — `composeDatabases()` relationship, cleanup on deletion
- `app/Models/ScheduledDatabaseBackup.php` — Updated `server()` resolution
- `app/Jobs/DatabaseBackupJob.php` — Application-owned database support, deployment safety check
- `bootstrap/helpers/shared.php` — ServiceDatabase creation in Application path, stale record cleanup, team resolution
- `resources/views/livewire/project/application/configuration.blade.php` — Database Backups menu item
- `routes/web.php` — `project.application.database-backups` route

### Backward Compatibility
- `service_id` remains the primary FK for existing Service-owned databases (unchanged behavior)
- `application_id` is nullable, defaulting to null for all existing records
- No changes to existing Service model path or one-click service behavior

/claim #7528