### PR TITLE
feat: enable automated backups for databases in Docker Compose (GitHub App) deployments

### DIFF
--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -93,7 +93,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $this->database = data_get($this->backup, 'database');
-                $this->server = $this->database->service->server;
+                $this->server = $this->database->getServer();
                 $this->s3 = $this->backup->s3;
             } else {
                 $this->database = data_get($this->backup, 'database');
@@ -115,8 +115,8 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $databaseType = $this->database->databaseType();
-                $serviceUuid = $this->database->service->uuid;
-                $serviceName = str($this->database->service->name)->slug();
+                $serviceUuid = $this->database->getParentUuid();
+                $serviceName = str($this->database->getParentName())->slug();
                 if (str($databaseType)->contains('postgres')) {
                     $this->container_name = "{$this->database->name}-$serviceUuid";
                     $this->directory_name = $serviceName.'-'.$this->container_name;
@@ -630,7 +630,11 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             $endpoint = $this->s3->endpoint;
             $this->s3->testConnection(shouldSave: true);
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
-                $network = $this->database->service->destination->network;
+                if ($this->database->isComposeApplication()) {
+                    $network = $this->database->application->destination->network;
+                } else {
+                    $network = $this->database->service->destination->network;
+                }
             } else {
                 $network = $this->database->destination->network;
             }

--- a/app/Jobs/DeleteResourceJob.php
+++ b/app/Jobs/DeleteResourceJob.php
@@ -96,6 +96,16 @@ class DeleteResourceJob implements ShouldBeEncrypted, ShouldQueue
             }
             $this->resource->environment_variables()->delete();
 
+            // Clean up ServiceDatabase records for dockercompose Applications
+            if ($this->resource instanceof Application && $this->resource->build_pack === 'dockercompose') {
+                foreach ($this->resource->databases as $db) {
+                    $db->scheduledBackups()->delete();
+                    $db->persistentStorages()->delete();
+                    $db->fileStorages()->delete();
+                    $db->delete();
+                }
+            }
+
             if ($this->deleteConnectedNetworks && $this->resource->type() === 'application') {
                 $this->resource->deleteConnectedNetworks();
             }

--- a/app/Livewire/Project/Application/DatabaseBackups.php
+++ b/app/Livewire/Project/Application/DatabaseBackups.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Livewire\Project\Application;
+
+use App\Models\Application;
+use App\Models\ServiceDatabase;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Component;
+
+class DatabaseBackups extends Component
+{
+    use AuthorizesRequests;
+
+    public ?Application $application = null;
+
+    public ?ServiceDatabase $serviceDatabase = null;
+
+    public array $parameters;
+
+    public array $query;
+
+    public bool $isImportSupported = false;
+
+    protected $listeners = ['refreshScheduledBackups' => '$refresh'];
+
+    public function mount()
+    {
+        try {
+            $this->parameters = get_route_parameters();
+            $this->query = request()->query();
+            $this->application = Application::whereUuid($this->parameters['application_uuid'])->first();
+            if (! $this->application) {
+                return redirect()->route('dashboard');
+            }
+            $this->authorize('view', $this->application);
+
+            $this->serviceDatabase = $this->application->databases()->whereUuid($this->parameters['database_uuid'])->first();
+            if (! $this->serviceDatabase) {
+                return redirect()->route('project.application.configuration', [
+                    'project_uuid' => $this->parameters['project_uuid'],
+                    'environment_uuid' => $this->parameters['environment_uuid'],
+                    'application_uuid' => $this->parameters['application_uuid'],
+                ]);
+            }
+
+            // Check if backups are supported for this database
+            if (! $this->serviceDatabase->isBackupSolutionAvailable()) {
+                return redirect()->route('project.application.configuration', $this->parameters);
+            }
+
+            // Check if import is supported for this database type
+            $dbType = $this->serviceDatabase->databaseType();
+            $supportedTypes = ['mysql', 'mariadb', 'postgres', 'mongo'];
+            $this->isImportSupported = collect($supportedTypes)->contains(fn ($type) => str_contains($dbType, $type));
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function render()
+    {
+        return view('livewire.project.application.database-backups');
+    }
+}

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -500,6 +500,14 @@ class Application extends BaseModel
         return $this->morphMany(LocalFileVolume::class, 'resource');
     }
 
+    /**
+     * Get database services detected in dockercompose applications.
+     */
+    public function databases()
+    {
+        return $this->hasMany(ServiceDatabase::class);
+    }
+
     public function type()
     {
         return 'application';

--- a/app/Models/LocalFileVolume.php
+++ b/app/Models/LocalFileVolume.php
@@ -47,10 +47,10 @@ class LocalFileVolume extends BaseModel
     public function loadStorageOnServer()
     {
         $this->load(['service']);
-        $isService = data_get($this->resource, 'service');
+        $isService = data_get($this->resource, 'service') || ($this->resource instanceof ServiceDatabase && $this->resource->isComposeApplication());
         if ($isService) {
-            $workdir = $this->resource->service->workdir();
-            $server = $this->resource->service->server;
+            $workdir = $this->resource->workdir();
+            $server = $this->resource instanceof ServiceDatabase ? $this->resource->getServer() : $this->resource->service->server;
         } else {
             $workdir = $this->resource->workdir();
             $server = $this->resource->destination->server;
@@ -82,10 +82,10 @@ class LocalFileVolume extends BaseModel
     public function deleteStorageOnServer()
     {
         $this->load(['service']);
-        $isService = data_get($this->resource, 'service');
+        $isService = data_get($this->resource, 'service') || ($this->resource instanceof ServiceDatabase && $this->resource->isComposeApplication());
         if ($isService) {
-            $workdir = $this->resource->service->workdir();
-            $server = $this->resource->service->server;
+            $workdir = $this->resource->workdir();
+            $server = $this->resource instanceof ServiceDatabase ? $this->resource->getServer() : $this->resource->service->server;
         } else {
             $workdir = $this->resource->workdir();
             $server = $this->resource->destination->server;
@@ -119,10 +119,10 @@ class LocalFileVolume extends BaseModel
     public function saveStorageOnServer()
     {
         $this->load(['service']);
-        $isService = data_get($this->resource, 'service');
+        $isService = data_get($this->resource, 'service') || ($this->resource instanceof ServiceDatabase && $this->resource->isComposeApplication());
         if ($isService) {
-            $workdir = $this->resource->service->workdir();
-            $server = $this->resource->service->server;
+            $workdir = $this->resource->workdir();
+            $server = $this->resource instanceof ServiceDatabase ? $this->resource->getServer() : $this->resource->service->server;
         } else {
             $workdir = $this->resource->workdir();
             $server = $this->resource->destination->server;

--- a/app/Models/ScheduledDatabaseBackup.php
+++ b/app/Models/ScheduledDatabaseBackup.php
@@ -67,7 +67,11 @@ class ScheduledDatabaseBackup extends BaseModel
     {
         if ($this->database) {
             if ($this->database instanceof ServiceDatabase) {
-                $destination = data_get($this->database->service, 'destination');
+                if ($this->database->isComposeApplication()) {
+                    $destination = data_get($this->database->application, 'destination');
+                } else {
+                    $destination = data_get($this->database->service, 'destination');
+                }
                 $server = data_get($destination, 'server');
             } else {
                 $destination = data_get($this->database, 'destination');

--- a/app/Models/ServiceDatabase.php
+++ b/app/Models/ServiceDatabase.php
@@ -27,7 +27,10 @@ class ServiceDatabase extends BaseModel
 
     public static function ownedByCurrentTeamAPI(int $teamId)
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', $teamId)->orderBy('name');
+        return ServiceDatabase::where(function ($query) use ($teamId) {
+            $query->whereRelation('service.environment.project.team', 'id', $teamId)
+                ->orWhereRelation('application.environment.project.team', 'id', $teamId);
+        })->orderBy('name');
     }
 
     /**
@@ -36,7 +39,10 @@ class ServiceDatabase extends BaseModel
      */
     public static function ownedByCurrentTeam()
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', currentTeam()->id)->orderBy('name');
+        return ServiceDatabase::where(function ($query) {
+            $query->whereRelation('service.environment.project.team', 'id', currentTeam()->id)
+                ->orWhereRelation('application.environment.project.team', 'id', currentTeam()->id);
+        })->orderBy('name');
     }
 
     /**
@@ -49,10 +55,67 @@ class ServiceDatabase extends BaseModel
         });
     }
 
+    /**
+     * Check if this database belongs to a dockercompose Application.
+     */
+    public function isComposeApplication(): bool
+    {
+        return ! is_null($this->application_id);
+    }
+
+    /**
+     * Get the parent resource (Service or Application).
+     */
+    public function parentResource()
+    {
+        if ($this->isComposeApplication()) {
+            return $this->application;
+        }
+
+        return $this->service;
+    }
+
+    /**
+     * Get the server this database runs on.
+     */
+    public function getServer()
+    {
+        if ($this->isComposeApplication()) {
+            return $this->application->destination->server;
+        }
+
+        return $this->service->server;
+    }
+
+    /**
+     * Get the parent UUID (used for container naming).
+     */
+    public function getParentUuid(): string
+    {
+        if ($this->isComposeApplication()) {
+            return $this->application->uuid;
+        }
+
+        return $this->service->uuid;
+    }
+
+    /**
+     * Get the parent name (used for backup directory naming).
+     */
+    public function getParentName(): string
+    {
+        if ($this->isComposeApplication()) {
+            return $this->application->name;
+        }
+
+        return $this->service->name;
+    }
+
     public function restart()
     {
-        $container_id = $this->name.'-'.$this->service->uuid;
-        remote_process(["docker restart {$container_id}"], $this->service->server);
+        $parentUuid = $this->getParentUuid();
+        $container_id = $this->name.'-'.$parentUuid;
+        remote_process(["docker restart {$container_id}"], $this->getServer());
     }
 
     public function isRunning()
@@ -114,8 +177,9 @@ class ServiceDatabase extends BaseModel
     public function getServiceDatabaseUrl()
     {
         $port = $this->public_port;
-        $realIp = $this->service->server->ip;
-        if ($this->service->server->isLocalhost() || isDev()) {
+        $server = $this->getServer();
+        $realIp = $server->ip;
+        if ($server->isLocalhost() || isDev()) {
             $realIp = base_ip();
         }
 
@@ -124,17 +188,30 @@ class ServiceDatabase extends BaseModel
 
     public function team()
     {
+        if ($this->isComposeApplication()) {
+            return data_get($this->application, 'environment.project.team');
+        }
+
         return data_get($this, 'environment.project.team');
     }
 
     public function workdir()
     {
+        if ($this->isComposeApplication()) {
+            return application_configuration_dir()."/{$this->application->uuid}";
+        }
+
         return service_configuration_dir()."/{$this->service->uuid}";
     }
 
     public function service()
     {
         return $this->belongsTo(Service::class);
+    }
+
+    public function application()
+    {
+        return $this->belongsTo(Application::class);
     }
 
     public function persistentStorages()

--- a/bootstrap/helpers/parsers.php
+++ b/bootstrap/helpers/parsers.php
@@ -404,6 +404,35 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
 
     $parsedServices = collect([]);
 
+    // Presave: detect database services and create ServiceDatabase records
+    // This enables backups for databases in dockercompose Applications (GitHub App deployments)
+    if ($resource->build_pack === 'dockercompose') {
+        $existingDbNames = $resource->databases()->pluck('name')->toArray();
+        foreach ($services as $svcName => $svc) {
+            $svcImage = data_get_str($svc, 'image');
+            if ($svcImage && isDatabaseImage($svcImage, $svc)) {
+                if (! in_array($svcName, $existingDbNames)) {
+                    ServiceDatabase::firstOrCreate([
+                        'name' => $svcName,
+                        'application_id' => $resource->id,
+                    ], [
+                        'image' => $svcImage,
+                    ]);
+                } else {
+                    // Update image if changed
+                    $existingDb = $resource->databases()->where('name', $svcName)->first();
+                    if ($existingDb && $existingDb->image !== (string) $svcImage) {
+                        $existingDb->image = $svcImage;
+                        $existingDb->save();
+                    }
+                }
+            }
+        }
+        // Clean up ServiceDatabase records for services no longer in the compose file
+        $currentServiceNames = array_keys($services);
+        $resource->databases()->whereNotIn('name', $currentServiceNames)->delete();
+    }
+
     $allMagicEnvironments = collect([]);
     foreach ($services as $serviceName => $service) {
         // Validate service name for command injection

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -556,9 +556,16 @@ function getResourceByUuid(string $uuid, ?int $teamId = null)
     }
 
     // ServiceDatabase has a different relationship path: service->environment->project->team_id
+    // or application->environment->project->team_id for dockercompose Applications
     if ($resource instanceof \App\Models\ServiceDatabase) {
-        if ($resource->service?->environment?->project?->team_id === $teamId) {
-            return $resource;
+        if ($resource->isComposeApplication()) {
+            if ($resource->application?->environment?->project?->team_id === $teamId) {
+                return $resource;
+            }
+        } else {
+            if ($resource->service?->environment?->project?->team_id === $teamId) {
+                return $resource;
+            }
         }
 
         return null;

--- a/database/migrations/2025_12_18_000001_add_application_id_to_service_databases.php
+++ b/database/migrations/2025_12_18_000001_add_application_id_to_service_databases.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->foreignId('application_id')->nullable()->after('service_id');
+            // Make service_id nullable so we can have either service_id or application_id
+            $table->foreignId('service_id')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->dropColumn('application_id');
+            $table->foreignId('service_id')->nullable(false)->change();
+        });
+    }
+};

--- a/resources/views/livewire/project/application/configuration.blade.php
+++ b/resources/views/livewire/project/application/configuration.blade.php
@@ -50,6 +50,14 @@
                 <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
                     href="{{ route('project.application.preview-deployments', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Preview Deployments</span></a>
             @endif
+            @if ($application->build_pack === 'dockercompose' && $application->databases()->count() > 0)
+                @foreach ($application->databases as $database)
+                    @if ($database->isBackupSolutionAvailable())
+                        <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                            href="{{ route('project.application.database.backups', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid, 'database_uuid' => $database->uuid]) }}"><span class="menu-item-label">Backups: {{ $database->name }}</span></a>
+                    @endif
+                @endforeach
+            @endif
             @if ($application->build_pack !== 'dockercompose')
                 <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
                     href="{{ route('project.application.healthcheck', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Healthcheck</span></a>

--- a/resources/views/livewire/project/application/database-backups.blade.php
+++ b/resources/views/livewire/project/application/database-backups.blade.php
@@ -1,0 +1,24 @@
+<div>
+    <x-slot:title>
+        {{ data_get_str($application, 'name')->limit(10) }} > Database Backups | Coolify
+    </x-slot>
+    @if ($serviceDatabase)
+        <div class="flex flex-col gap-4">
+            <h2>Database Backups - {{ $serviceDatabase->name }}</h2>
+            <div class="flex flex-col gap-2">
+                <div class="flex items-center gap-2">
+                    <a href="{{ route('project.application.configuration', ['project_uuid' => $parameters['project_uuid'], 'environment_uuid' => $parameters['environment_uuid'], 'application_uuid' => $parameters['application_uuid']]) }}"
+                        class="button">← Back to Configuration</a>
+                </div>
+            </div>
+            <div class="flex flex-col gap-4">
+                <div>
+                    <livewire:project.database.create-scheduled-backup :database="$serviceDatabase" />
+                </div>
+                <div>
+                    <livewire:project.database.scheduled-backups :database="$serviceDatabase" />
+                </div>
+            </div>
+        </div>
+    @endif
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,7 @@ use App\Livewire\Notifications\Telegram as NotificationTelegram;
 use App\Livewire\Notifications\Webhook as NotificationWebhook;
 use App\Livewire\Profile\Index as ProfileIndex;
 use App\Livewire\Project\Application\Configuration as ApplicationConfiguration;
+use App\Livewire\Project\Application\DatabaseBackups as ApplicationDatabaseBackups;
 use App\Livewire\Project\Application\Deployment\Index as DeploymentIndex;
 use App\Livewire\Project\Application\Deployment\Show as DeploymentShow;
 use App\Livewire\Project\CloneMe as ProjectCloneMe;
@@ -208,6 +209,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/metrics', ApplicationConfiguration::class)->name('project.application.metrics');
         Route::get('/tags', ApplicationConfiguration::class)->name('project.application.tags');
         Route::get('/danger', ApplicationConfiguration::class)->name('project.application.danger');
+
+        Route::get('/database/{database_uuid}/backups', ApplicationDatabaseBackups::class)->name('project.application.database.backups');
 
         Route::get('/deployment', DeploymentIndex::class)->name('project.application.deployment.index');
         Route::get('/deployment/{deployment_uuid}', DeploymentShow::class)->name('project.application.deployment.show');


### PR DESCRIPTION
## Summary

Fixes #7528 — /claim #7528

When deploying a Docker Compose file via GitHub App (`dockercompose` buildpack), database services are not detected and `ServiceDatabase` records are not created — meaning automated backups are unavailable. This works correctly for "Empty Docker Compose" and one-click services.

## Root Cause

- **Empty Docker Compose** → `Service` model → `serviceParser()` → calls `isDatabaseImage()` → creates `ServiceDatabase` ✅
- **GitHub App dockercompose** → `Application` model → `applicationParser()` → calls `isDatabaseImage()` but **never** creates `ServiceDatabase` ❌

`ServiceDatabase` had a non-nullable `service_id` FK, making it impossible to associate with an `Application`.

## Changes

1. **Migration** — Add nullable `application_id` to `service_databases`, make `service_id` nullable
2. **ServiceDatabase model** — New `application()` relation + helper methods for polymorphic parent access
3. **Application model** — New `databases()` relation
4. **parsers.php / shared.php** — Detect DB images in `applicationParser()` and create `ServiceDatabase` records
5. **DatabaseBackupJob** — Use polymorphic getters instead of direct `service->` access
6. **ScheduledDatabaseBackup** — Handle both service and application paths
7. **DeleteResourceJob** — Clean up `ServiceDatabase` on Application deletion
8. **Routes + Livewire + Blade** — New backup management UI for Application resources

## Testing
- Database images are detected via `isDatabaseImage()` (same logic as service parser)
- Backup scheduling uses existing `DatabaseBackupJob` infrastructure
- Backward compatible: existing Service-based backups unaffected