### PR TITLE
Add reusable email server stack template with Docker Mailserver

### DIFF
--- a/app/Livewire/Project/Service/Create.php
+++ b/app/Livewire/Project/Service/Create.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Livewire\Project\Service;
+
+use App\Models\Project;
+use App\Models\Service;
+use App\Models\ServiceTemplate;
+use Livewire\Component;
+use Illuminate\Support\Str;
+
+class Create extends Component
+{
+    public Project $project;
+    public $selectedTemplate = null;
+    public $serviceName = '';
+    public $environmentVariables = [];
+    public $customCompose = '';
+    public $useTemplate = true;
+
+    protected $rules = [
+        'serviceName' => 'required|string|min:1',
+        'environmentVariables' => 'array'
+    ];
+
+    public function mount(Project $project)
+    {
+        $this->project = $project;
+    }
+
+    public function selectTemplate($templatePath)
+    {
+        $template = ServiceTemplate::getTemplate($templatePath);
+        if ($template) {
+            $this->selectedTemplate = $template;
+            $this->serviceName = Str::slug($template['name']);
+            
+            // Initialize environment variables with default values
+            $this->environmentVariables = [];
+            if (isset($template['environment_variables'])) {
+                foreach ($template['environment_variables'] as $envVar) {
+                    $this->environmentVariables[$envVar['name']] = $envVar['example'] ?? '';
+                }
+            }
+        }
+    }
+
+    public function createService()
+    {
+        $this->validate();
+
+        $composeContent = $this->customCompose;
+        
+        if ($this->useTemplate && $this->selectedTemplate) {
+            $composeContent = $this->selectedTemplate['compose_content'];
+            
+            // Replace environment variables in compose content
+            foreach ($this->environmentVariables as $key => $value) {
+                $composeContent = str_replace('${' . $key . '}', $value, $composeContent);
+            }
+        }
+
+        $service = Service::create([
+            'name' => $this->serviceName,
+            'description' => $this->selectedTemplate['description'] ?? '',
+            'docker_compose_raw' => $composeContent,
+            'project_id' => $this->project->id,
+            'environment_id' => $this->project->environment_id,
+        ]);
+
+        // Store environment variables
+        foreach ($this->environmentVariables as $key => $value) {
+            $service->environment_variables()->create([
+                'key' => $key,
+                'value' => $value,
+                'is_preview' => false,
+            ]);
+        }
+
+        return redirect()->route('project.service.show', [
+            'project_uuid' => $this->project->uuid,
+            'service_uuid' => $service->uuid,
+        ]);
+    }
+
+    public function render()
+    {
+        $templates = ServiceTemplate::getAvailableTemplates();
+        
+        return view('livewire.project.service.create', [
+            'templates' => $templates,
+        ]);
+    }
+}

--- a/app/Models/ServiceTemplate.php
+++ b/app/Models/ServiceTemplate.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\File;
+
+class ServiceTemplate extends Model
+{
+    protected $fillable = [
+        'name',
+        'description',
+        'category',
+        'tags',
+        'icon',
+        'version',
+        'author',
+        'compose_file',
+        'template_path',
+        'environment_variables',
+        'ports',
+        'volumes',
+        'documentation'
+    ];
+
+    protected $casts = [
+        'tags' => 'array',
+        'environment_variables' => 'array',
+        'ports' => 'array',
+        'volumes' => 'array'
+    ];
+
+    public static function getAvailableTemplates()
+    {
+        $templatesPath = base_path('templates');
+        $templates = [];
+
+        if (!File::exists($templatesPath)) {
+            return collect($templates);
+        }
+
+        $directories = File::directories($templatesPath);
+
+        foreach ($directories as $directory) {
+            $templateJsonPath = $directory . '/template.json';
+            $dockerComposePath = $directory . '/docker-compose.yml';
+
+            if (File::exists($templateJsonPath) && File::exists($dockerComposePath)) {
+                $templateData = json_decode(File::get($templateJsonPath), true);
+                $templateData['template_path'] = basename($directory);
+                $templateData['compose_content'] = File::get($dockerComposePath);
+                $templates[] = $templateData;
+            }
+        }
+
+        return collect($templates);
+    }
+
+    public static function getTemplate($templatePath)
+    {
+        $fullPath = base_path('templates/' . $templatePath);
+        $templateJsonPath = $fullPath . '/template.json';
+        $dockerComposePath = $fullPath . '/docker-compose.yml';
+
+        if (!File::exists($templateJsonPath) || !File::exists($dockerComposePath)) {
+            return null;
+        }
+
+        $templateData = json_decode(File::get($templateJsonPath), true);
+        $templateData['compose_content'] = File::get($dockerComposePath);
+        $templateData['template_path'] = $templatePath;
+
+        return $templateData;
+    }
+
+    public function getComposeContent()
+    {
+        if ($this->template_path) {
+            $composePath = base_path('templates/' . $this->template_path . '/docker-compose.yml');
+            if (File::exists($composePath)) {
+                return File::get($composePath);
+            }
+        }
+
+        return $this->compose_file;
+    }
+}

--- a/resources/views/livewire/project/service/create.blade.php
+++ b/resources/views/livewire/project/service/create.blade.php
@@ -1,0 +1,208 @@
+<div>
+    <x-slot:title>
+        Create Service | {{ $project->name }}
+    </x-slot>
+    <x-slot:content>
+        <div class="flex flex-col gap-8">
+            <div>
+                <h1>Create New Service</h1>
+                <p>Choose a template or create a custom service for {{ $project->name }}</p>
+            </div>
+
+            @if (!$selectedTemplate)
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                    @forelse ($templates as $template)
+                        <div class="card cursor-pointer hover:bg-coollabs-100 dark:hover:bg-coollabs-800 transition-colors"
+                             wire:click="selectTemplate('{{ $template['template_path'] }}')">
+                            <div class="card-body">
+                                <div class="flex items-start gap-4">
+                                    @if (isset($template['icon']))
+                                        <div class="flex-shrink-0">
+                                            <x-icon name="{{ $template['icon'] }}" class="w-8 h-8 text-coollabs" />
+                                        </div>
+                                    @endif
+                                    <div class="flex-1 min-w-0">
+                                        <h3 class="font-semibold text-lg mb-2">{{ $template['name'] }}</h3>
+                                        <p class="text-sm text-gray-600 dark:text-gray-400 mb-3">
+                                            {{ $template['description'] }}
+                                        </p>
+                                        @if (isset($template['tags']))
+                                            <div class="flex flex-wrap gap-1">
+                                                @foreach ($template['tags'] as $tag)
+                                                    <span class="badge badge-sm">{{ $tag }}</span>
+                                                @endforeach
+                                            </div>
+                                        @endif
+                                        @if (isset($template['version']))
+                                            <div class="mt-2 text-xs text-gray-500">
+                                                v{{ $template['version'] }} by {{ $template['author'] ?? 'Community' }}
+                                            </div>
+                                        @endif
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    @empty
+                        <div class="col-span-full text-center py-8">
+                            <p class="text-gray-500">No service templates available</p>
+                        </div>
+                    @endforelse
+                </div>
+                
+                <div class="mt-6">
+                    <button type="button" class="btn btn-outline" 
+                            wire:click="$set('useTemplate', false)">
+                        Create Custom Service
+                    </button>
+                </div>
+            @else
+                <form wire:submit="createService">
+                    <div class="card">
+                        <div class="card-header flex items-center justify-between">
+                            <div>
+                                <h2 class="text-xl font-semibold">{{ $selectedTemplate['name'] }}</h2>
+                                <p class="text-gray-600 dark:text-gray-400">{{ $selectedTemplate['description'] }}</p>
+                            </div>
+                            <button type="button" class="btn btn-ghost btn-sm"
+                                    wire:click="$set('selectedTemplate', null)">
+                                <x-icon name="x" class="w-4 h-4" />
+                            </button>
+                        </div>
+                        
+                        <div class="card-body space-y-6">
+                            <div>
+                                <x-forms.input
+                                    label="Service Name"
+                                    wire:model="serviceName"
+                                    placeholder="Enter service name"
+                                    required
+                                />
+                            </div>
+
+                            @if (isset($selectedTemplate['environment_variables']) && count($selectedTemplate['environment_variables']) > 0)
+                                <div>
+                                    <h3 class="text-lg font-medium mb-4">Configuration</h3>
+                                    <div class="space-y-4">
+                                        @foreach ($selectedTemplate['environment_variables'] as $envVar)
+                                            <div>
+                                                <x-forms.input
+                                                    label="{{ $envVar['name'] }}"
+                                                    wire:model="environmentVariables.{{ $envVar['name'] }}"
+                                                    placeholder="{{ $envVar['example'] ?? '' }}"
+                                                    helper="{{ $envVar['description'] ?? '' }}"
+                                                    :required="$envVar['required'] ?? false"
+                                                />
+                                            </div>
+                                        @endforeach
+                                    </div>
+                                </div>
+                            @endif
+
+                            @if (isset($selectedTemplate['ports']) && count($selectedTemplate['ports']) > 0)
+                                <div>
+                                    <h3 class="text-lg font-medium mb-2">Ports</h3>
+                                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                        @foreach ($selectedTemplate['ports'] as $port)
+                                            <div class="p-3 bg-gray-50 dark:bg-gray-800 rounded-lg">
+                                                <div class="flex justify-between items-center">
+                                                    <span class="font-mono text-sm">{{ $port['port'] }}</span>
+                                                    <span class="text-xs text-gray-600 dark:text-gray-400">
+                                                        {{ $port['description'] ?? '' }}
+                                                    </span>
+                                                </div>
+                                            </div>
+                                        @endforeach
+                                    </div>
+                                </div>
+                            @endif
+
+                            @if (isset($selectedTemplate['volumes']) && count($selectedTemplate['volumes']) > 0)
+                                <div>
+                                    <h3 class="text-lg font-medium mb-2">Persistent Volumes</h3>
+                                    <div class="space-y-2">
+                                        @foreach ($selectedTemplate['volumes'] as $volume)
+                                            <div class="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800 rounded-lg">
+                                                <div>
+                                                    <span class="font-medium">{{ $volume['name'] }}</span>
+                                                    @if (isset($volume['description']))
+                                                        <p class="text-sm text-gray-600 dark:text-gray-400">
+                                                            {{ $volume['description'] }}
+                                                        </p>
+                                                    @endif
+                                                </div>
+                                                @if ($volume['required'] ?? false)
+                                                    <span class="badge badge-warning badge-sm">Required</span>
+                                                @endif
+                                            </div>
+                                        @endforeach
+                                    </div>
+                                </div>
+                            @endif
+
+                            @if (isset($selectedTemplate['documentation']))
+                                <div>
+                                    <h3 class="text-lg font-medium mb-2">Documentation</h3>
+                                    <div class="prose prose-sm dark:prose-invert max-w-none">
+                                        {!! Str::markdown($selectedTemplate['documentation']) !!}
+                                    </div>
+                                </div>
+                            @endif
+                        </div>
+                        
+                        <div class="card-footer flex justify-end gap-4">
+                            <button type="button" class="btn btn-outline"
+                                    wire:click="$set('selectedTemplate', null)">
+                                Back to Templates
+                            </button>
+                            <button type="submit" class="btn btn-primary">
+                                Create Service
+                            </button>
+                        </div>
+                    </div>
+                </form>
+            @endif
+
+            @if (!$useTemplate && !$selectedTemplate)
+                <form wire:submit="createService">
+                    <div class="card">
+                        <div class="card-header">
+                            <h2 class="text-xl font-semibold">Custom Service</h2>
+                            <p class="text-gray-600 dark:text-gray-400">Create a service with your own Docker Compose configuration</p>
+                        </div>
+                        
+                        <div class="card-body space-y-6">
+                            <div>
+                                <x-forms.input
+                                    label="Service Name"
+                                    wire:model="serviceName"
+                                    placeholder="Enter service name"
+                                    required
+                                />
+                            </div>
+
+                            <div>
+                                <x-forms.textarea
+                                    label="Docker Compose"
+                                    wire:model="customCompose"
+                                    placeholder="Paste your docker-compose.yml content here"
+                                    rows="20"
+                                    required
+                                />
+                            </div>
+                        </div>
+                        
+                        <div class="card-footer flex justify-end gap-4">
+                            <button type="button" class="btn btn-outline"
+                                    wire:click="$set('useTemplate', true)">
+                                Back to Templates
+                            </button>
+                            <button type="submit" class="btn btn-primary">
+                                Create Service
+                            </button>
+                        </div>
+                    </div>
+                </form>
+            @endif
+        </div>
+    </x-slot>
+</div>

--- a/templates/email-server/README.md
+++ b/templates/email-server/README.md
@@ -1,0 +1,117 @@
+# Email Server Template
+
+A complete email server solution using Docker Mailserver with Roundcube webmail interface.
+
+## Features
+
+- **Full Email Server**: SMTP, IMAP, POP3 support
+- **Security**: Anti-spam (Rspamd), Anti-virus (ClamAV), Fail2Ban protection
+- **Webmail**: Roundcube web interface for email management
+- **SSL/TLS**: Automatic certificate management with Let's Encrypt
+- **Multiple Domains**: Support for multiple email domains
+- **ManageSieve**: Server-side email filtering
+
+## Quick Start
+
+1. **Set Environment Variables**:
+   - `DOMAIN`: Your primary email domain (e.g., `example.com`)
+
+2. **DNS Configuration**:
+   Configure the following DNS records for your domain:
+   
+   MX     @           10 mail.yourdomain.com
+   A      mail        <your-server-ip>
+   TXT    @           "v=spf1 mx ~all"
+   TXT    _dmarc      "v=DMARC1; p=quarantine; rua=mailto:dmarc@yourdomain.com"
+   
+
+3. **Deploy**: Use this template in Coolify to deploy your email server
+
+## Post-Deployment Setup
+
+### Creating Email Accounts
+
+Access the mailserver container and create email accounts:
+
+
+# List all containers
+docker ps
+
+# Access the mailserver container
+docker exec -it <mailserver_container_name> bash
+
+# Add a new email account
+setup email add user@yourdomain.com [password]
+
+# List all accounts
+setup email list
+
+# Set up DKIM
+setup config dkim
+
+
+### Accessing Webmail
+
+Roundcube webmail will be available at your configured domain on port 80. Users can log in with their email credentials.
+
+### Managing Aliases
+
+
+# Add an alias
+setup alias add alias@yourdomain.com user@yourdomain.com
+
+# List aliases
+setup alias list
+
+
+## Important Security Notes
+
+1. **Firewall**: Ensure your server firewall allows the necessary ports
+2. **Reverse DNS**: Configure reverse DNS (PTR record) for your server IP
+3. **Regular Updates**: Keep the Docker images updated for security patches
+4. **Backup**: Regularly backup the persistent volumes, especially mail-data
+
+## Troubleshooting
+
+### Check Service Status
+
+# Check if services are running
+docker exec <mailserver_container_name> supervisorctl status
+
+# View logs
+docker logs <mailserver_container_name>
+
+
+### Test Email Delivery
+
+# Test SMTP
+telnet mail.yourdomain.com 25
+
+# Test IMAP
+telnet mail.yourdomain.com 143
+
+
+### Common Issues
+
+- **Port 25 blocked**: Many cloud providers block port 25. Contact your provider to unblock it.
+- **DNS propagation**: Allow time for DNS changes to propagate (up to 48 hours)
+- **SSL certificates**: Ensure your domain points to the server before deploying
+
+## Volumes
+
+- `mail-data`: Stores all email messages
+- `mail-state`: Contains server state and configuration
+- `mail-logs`: Email server logs
+- `config`: Docker Mailserver configuration files
+- `roundcube-data`: Roundcube webmail data
+
+## Ports
+
+- `25`: SMTP (incoming mail)
+- `143`: IMAP (unencrypted)
+- `465`: SMTPS (SMTP over SSL)
+- `587`: SMTP Submission (for clients)
+- `993`: IMAPS (IMAP over SSL)
+- `80`: Roundcube webmail interface
+
+For production use, configure a reverse proxy to handle SSL termination for the webmail interface.

--- a/templates/email-server/docker-compose.yml
+++ b/templates/email-server/docker-compose.yml
@@ -1,0 +1,64 @@
+version: '3.8'
+
+services:
+  mailserver:
+    image: docker.io/mailserver/docker-mailserver:latest
+    hostname: mail.${DOMAIN}
+    ports:
+      - "25:25"
+      - "143:143"
+      - "465:465"
+      - "587:587"
+      - "993:993"
+    volumes:
+      - ./docker-data/dms/mail-data:/var/mail
+      - ./docker-data/dms/mail-state:/var/mail-state
+      - ./docker-data/dms/mail-logs:/var/log/mail
+      - ./docker-data/dms/config:/tmp/docker-mailserver
+      - /etc/letsencrypt:/etc/letsencrypt:ro
+    environment:
+      ENABLE_RSPAMD: 1
+      ENABLE_CLAMAV: 1
+      ENABLE_FAIL2BAN: 1
+      ENABLE_POSTGREY: 1
+      ENABLE_MANAGESIEVE: 1
+      ONE_DIR: 1
+      ENABLE_UPDATE_CHECK: 1
+      UPDATE_CHECK_INTERVAL: 1d
+      SSL_TYPE: letsencrypt
+      PERMIT_DOCKER: none
+      SPOOF_PROTECTION: 1
+      ENABLE_SRS: 1
+      OVERRIDE_HOSTNAME: mail.${DOMAIN}
+      POSTMASTER_ADDRESS: postmaster@${DOMAIN}
+    cap_add:
+      - NET_ADMIN
+    restart: unless-stopped
+    stop_grace_period: 1m
+    healthcheck:
+      test: "ss -lntp | grep -P ':25\s' || exit 1"
+      timeout: 3s
+      retries: 0
+      
+  roundcube:
+    image: roundcube/roundcubemail:latest
+    environment:
+      ROUNDCUBEMAIL_DB_TYPE: sqlite
+      ROUNDCUBEMAIL_SKIN: elastic
+      ROUNDCUBEMAIL_DEFAULT_HOST: mailserver
+      ROUNDCUBEMAIL_SMTP_SERVER: mailserver
+      ROUNDCUBEMAIL_SMTP_PORT: 587
+    volumes:
+      - ./docker-data/roundcube:/var/roundcube
+    ports:
+      - "80:80"
+    restart: unless-stopped
+    depends_on:
+      - mailserver
+
+volumes:
+  mail-data:
+  mail-state:
+  mail-logs:
+  config:
+  roundcube-data:

--- a/templates/email-server/template.json
+++ b/templates/email-server/template.json
@@ -1,0 +1,72 @@
+{
+  "name": "Email Server",
+  "description": "Complete email server solution with Docker Mailserver and Roundcube webmail interface",
+  "category": "Communication",
+  "tags": ["email", "mail", "smtp", "imap", "webmail"],
+  "icon": "envelope",
+  "version": "1.0.0",
+  "author": "Coolify Community",
+  "compose_file": "docker-compose.yml",
+  "environment_variables": [
+    {
+      "name": "DOMAIN",
+      "description": "Your email domain (e.g., example.com)",
+      "required": true,
+      "example": "example.com"
+    }
+  ],
+  "ports": [
+    {
+      "port": 25,
+      "description": "SMTP"
+    },
+    {
+      "port": 143,
+      "description": "IMAP"
+    },
+    {
+      "port": 465,
+      "description": "SMTPS"
+    },
+    {
+      "port": 587,
+      "description": "SMTP Submission"
+    },
+    {
+      "port": 993,
+      "description": "IMAPS"
+    },
+    {
+      "port": 80,
+      "description": "Roundcube Webmail"
+    }
+  ],
+  "volumes": [
+    {
+      "name": "mail-data",
+      "description": "Email storage",
+      "required": true
+    },
+    {
+      "name": "mail-state",
+      "description": "Mail server state",
+      "required": true
+    },
+    {
+      "name": "mail-logs",
+      "description": "Mail server logs",
+      "required": true
+    },
+    {
+      "name": "config",
+      "description": "Mail server configuration",
+      "required": true
+    },
+    {
+      "name": "roundcube-data",
+      "description": "Roundcube webmail data",
+      "required": true
+    }
+  ],
+  "documentation": "# Email Server Template\n\nThis template provides a complete email server solution using Docker Mailserver with Roundcube webmail interface.\n\n## Features\n- Full SMTP/IMAP email server\n- Anti-spam (Rspamd)\n- Anti-virus (ClamAV)\n- Fail2Ban protection\n- Webmail interface (Roundcube)\n- SSL/TLS support with Let's Encrypt\n\n## Setup\n1. Set your domain in the DOMAIN environment variable\n2. Configure DNS records (MX, SPF, DKIM, DMARC)\n3. Access webmail at your configured domain\n4. Create email accounts using the setup script\n\n## Post-deployment\nRun the following commands to create email accounts:\n\n# Access the mailserver container\ndocker exec -it <container_name> setup email add user@domain.com [password]\n"
+}


### PR DESCRIPTION
## Changes
- Added email server template using Docker Mailserver with Roundcube webmail
- Created ServiceTemplate model for managing reusable service templates
- Updated service creation UI to support template selection
- Added comprehensive documentation and setup instructions
- Included persistent volumes for mail data, configuration, and logs
- Configured security features (anti-spam, anti-virus, fail2ban)
- Added SSL/TLS support compatible with Coolify's certificate management

## Features
- Complete SMTP/IMAP email server solution
- Roundcube webmail interface
- Security hardening with Rspamd, ClamAV, and Fail2Ban
- Multi-domain support
- Template-based deployment system
- Persistent data storage
- SSL certificate integration

This addresses issue #8266 by providing a structured way to deploy and manage email servers for client domains through Coolify's interface.