### PR TITLE
feat(templates): add WordPress + OpenLiteSpeed service template

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -1,0 +1,39 @@
+# documentation: https://openlitespeed.org
+# slogan: WordPress powered by OpenLiteSpeed - a high-performance, lightweight web server with built-in caching.
+# category: cms
+# tags: cms, blog, wordpress, openlitespeed, litespeed, mariadb, high-performance
+# logo: svgs/wordpress.svg
+
+services:
+  wordpress:
+    image: litespeedtech/openlitespeed-wordpress:latest
+    volumes:
+      - wordpress-files:/var/www/vhosts/localhost
+      - lsws-config:/usr/local/lsws/conf
+    environment:
+      - SERVICE_URL_WORDPRESS
+      - WORDPRESS_DB_HOST=mariadb
+      - WORDPRESS_DB_NAME=wordpress
+      - WORDPRESS_DB_USER=$SERVICE_USER_WORDPRESS
+      - WORDPRESS_DB_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    depends_on:
+      - mariadb
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:80"]
+      interval: 5s
+      timeout: 10s
+      retries: 10
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
Adds a one-click service template for deploying WordPress on OpenLiteSpeed with MariaDB.

/claim #8264

## What this adds

A new template at `templates/compose/wordpress-with-openlitespeed.yaml` that deploys:
- **WordPress** via the official `litespeedtech/openlitespeed-wordpress` image
- **MariaDB 11** for the database

Features:
- Persistent volumes for WordPress files, LiteSpeed config, and DB data
- Auto-generated credentials via Coolify service variables
- Health checks on both containers
- Follows the same patterns as existing WordPress templates

## Why OpenLiteSpeed

OpenLiteSpeed provides built-in page caching and generally better performance than Apache for WordPress workloads. The `litespeedtech/openlitespeed-wordpress` image is officially maintained and includes the LiteSpeed Cache plugin pre-configured.

Fixes #8264