### PR TITLE
feat(templates): add Docker Mailserver service template

### DIFF
--- a/templates/compose/docker-mailserver.yaml
+++ b/templates/compose/docker-mailserver.yaml
@@ -1,0 +1,44 @@
+# documentation: https://docker-mailserver.github.io/docker-mailserver/latest/
+# slogan: A full-featured, production-ready mail server in a Docker container.
+# category: email
+# tags: email, mail, smtp, imap, postfix, dovecot, self-hosted
+# logo: svgs/docker-mailserver.svg
+# port: 443
+
+services:
+  mailserver:
+    image: ghcr.io/docker-mailserver/docker-mailserver:latest
+    hostname: mail.example.com
+    ports:
+      - "25:25"
+      - "465:465"
+      - "587:587"
+      - "993:993"
+    volumes:
+      - mail-data:/var/mail
+      - mail-state:/var/mail-state
+      - mail-logs:/var/log/mail
+      - mail-config:/tmp/docker-mailserver
+    environment:
+      - OVERRIDE_HOSTNAME=mail.example.com
+      - ENABLE_RSPAMD=1
+      - ENABLE_CLAMAV=0
+      - ENABLE_FAIL2BAN=1
+      - SSL_TYPE=manual
+      - SSL_CERT_PATH=/etc/letsencrypt/live/mail.example.com/fullchain.pem
+      - SSL_KEY_PATH=/etc/letsencrypt/live/mail.example.com/privkey.pem
+      - POSTMASTER_ADDRESS=postmaster@example.com
+      - PERMIT_DOCKER=network
+      - ONE_DIR=1
+      - ENABLE_POP3=0
+      - ENABLE_IMAP=1
+      - ENABLE_POSTGREY=0
+      - SPOOF_PROTECTION=1
+    cap_add:
+      - NET_ADMIN
+    healthcheck:
+      test: ["CMD-SHELL", "ss --listening --tcp | grep -P 'LISTEN.+:smtp' || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+      start_period: 30s


### PR DESCRIPTION
Adds a one-click service template for self-hosted email using Docker Mailserver.

/claim #8266

## What this adds

A new template at `templates/compose/docker-mailserver.yaml` that deploys a production-ready mail server with:

- **Postfix** for SMTP (ports 25, 465, 587)
- **Dovecot** for IMAP (port 993)
- **Rspamd** for spam filtering
- **Fail2ban** for brute-force protection

Persistent volumes for mail data, server state, logs, and configuration.

## Notes

- Users will need to update `hostname` and SSL paths to match their domain
- DNS records (MX, SPF, DKIM, DMARC) need to be configured separately
- ClamAV is disabled by default to reduce memory usage but can be enabled via env var

Based on the official docker-mailserver project which is actively maintained and widely used.

Fixes #8266