### PR TITLE
Fix formatting in CleanupDocker.php for docker command

### DIFF
--- a/app/Actions/Server/CleanupDocker.php
+++ b/app/Actions/Server/CleanupDocker.php
@@ -127,7 +127,7 @@ class CleanupDocker
 
         $commands[] = "docker images --format '{{.Repository}}:{{.Tag}}' | ".
             $grepCommands.' | '.
-            "xargs -r -I {} sh -c 'docker inspect --format \"{{{{index .Config.Labels \\\"coolify.managed\\\"}}}}\" \"{}\" 2>/dev/null | grep -q true || docker rmi \"{}\" 2>/dev/null' || true";
+            "xargs -r -I {} sh -c 'docker inspect --format \"{{index .Config.Labels \\\"coolify.managed\\\"}}\" \"{}\" 2>/dev/null | grep -q true || docker rmi \"{}\" 2>/dev/null' || true";
 
         return implode(' && ', $commands);
     }


### PR DESCRIPTION
# Changes
Fix the Docker image prune command to correctly check the coolify.managed=true label by replacing four braces ({{{{…}}}}) with two braces ({{…}}) in CleanupDocker.php. This prevents accidental deletion of managed images.

# Category
Fixing or updating existing functionality

# AI Assistance
- [X] AI was NOT used to create this PR


# Fixes
#8822 

# Testing

- Built a test image with the label coolify.managed=true and confirmed it was preserved during cleanup.
- Ran the full cleanup process and confirmed that all essential images (helper, realtime, and application images) were not deleted.

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [X] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [X] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [X] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
