### PR TITLE
feat: OAuth independent registration

### DIFF
--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -22,13 +22,15 @@ class OauthController extends Controller
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                // Allow OAuth registration if either general registration OR OAuth-specific registration is enabled
+                if (! $settings->is_registration_enabled && ! $settings->oauth_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 
                 $user = User::create([
                     'name' => $oauthUser->name,
                     'email' => $oauthUser->email,
+                    'oauth_only' => $settings->oauth_only,
                 ]);
             }
             Auth::login($user);

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -15,6 +15,12 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $oauth_registration_enabled;
+
+    #[Validate('boolean')]
+    public bool $oauth_only;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -41,6 +47,8 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'oauth_registration_enabled' => 'boolean',
+            'oauth_only' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => 'nullable|string',
@@ -62,6 +70,8 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->oauth_registration_enabled = $this->settings->oauth_registration_enabled ?? false;
+        $this->oauth_only = $this->settings->oauth_only ?? false;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -142,6 +152,8 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->oauth_registration_enabled = $this->oauth_registration_enabled;
+            $this->settings->oauth_only = $this->oauth_only;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -55,6 +55,7 @@ class User extends Authenticatable implements SendsEmail
         'force_password_reset' => 'boolean',
         'show_boarding' => 'boolean',
         'email_change_code_expires_at' => 'datetime',
+        'oauth_only' => 'boolean',
     ];
 
     /**

--- a/database/migrations/2025_03_10_080000_add_oauth_registration_settings.php
+++ b/database/migrations/2025_03_10_080000_add_oauth_registration_settings.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('oauth_registration_enabled')->default(false)->after('is_registration_enabled');
+            $table->boolean('oauth_only')->default(false)->after('oauth_registration_enabled');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn(['oauth_registration_enabled', 'oauth_only']);
+        });
+    }
+};

--- a/database/migrations/2025_03_10_080001_add_oauth_only_to_users.php
+++ b/database/migrations/2025_03_10_080001_add_oauth_only_to_users.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('oauth_only')->default(false)->after('password');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('oauth_only');
+        });
+    }
+};

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -21,6 +21,17 @@
                             helper="Allow users to self-register. If disabled, only administrators can create accounts."
                             label="Registration Allowed" />
                     </div>
+                    <h4 class="pt-4">OAuth Settings</h4>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="oauth_registration_enabled"
+                            helper="Allow users to self-register via OAuth providers even when general registration is disabled."
+                            label="OAuth Registration" />
+                    </div>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="oauth_only"
+                            helper="Restrict users to OAuth-only authentication. OAuth users cannot create or use passwords. This allows centralized access control via your OAuth provider."
+                            label="OAuth Only" />
+                    </div>
                     <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"
                             helper="Opt out of reporting this instance to coolify.io's installation count. No other data is collected."


### PR DESCRIPTION
## Summary

Implements #8042 - OAuth independent registration functionality.

## Changes

### New Features

1. **OAuth Registration Setting** (`oauth_registration_enabled`)
   - Allows users to self-register via OAuth providers even when general registration is disabled
   - Gives admins fine-grained control over registration methods

2. **OAuth-Only Mode** (`oauth_only`)
   - Restricts users to OAuth-only authentication
   - OAuth users cannot create or use passwords
   - Enables centralized access control via OAuth provider (e.g., Authentik)

### Technical Implementation

- Added `oauth_registration_enabled` and `oauth_only` columns to `instance_settings` table
- Added `oauth_only` column to `users` table to track OAuth-only users
- Updated `OauthController` to respect new settings during OAuth callback
- Added UI controls in Advanced settings page for admin configuration

## Use Cases

This PR addresses the following needs from #8042:

1. **Control who can access Coolify via external identity provider**
   - Admins can disable general registration but keep OAuth registration enabled
   - Access control is delegated to the OAuth provider (e.g., only allow users from specific organization)

2. **Centralized user suspension**
   - With OAuth-only mode, disabling a user in the OAuth provider immediately blocks access
   - No need to manage passwords or local user accounts

## Testing

1. Disable general registration, enable OAuth registration → OAuth users can still register
2. Enable OAuth-only mode → OAuth users are marked as oauth_only and cannot set passwords
3. Admin UI shows new toggles in Advanced settings

Closes #8042
