### PR TITLE
fix: use custom SSH port for deploy_key in fetch/submodule/lfs

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -1093,6 +1093,14 @@ class Application extends BaseModel
         $escapedBaseDir = escapeshellarg($baseDir);
         $isShallowCloneEnabled = $this->settings?->is_git_shallow_clone_enabled ?? false;
 
+        // For deploy_key (e.g. Gitea with custom port), fetch/submodule/lfs must use same SSH port as clone
+        if ($this->deploymentType() === 'deploy_key') {
+            ['port' => $customPort] = $this->customRepository();
+            $git_ssh_followup = "ssh -p {$customPort} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null";
+        } else {
+            $git_ssh_followup = 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null';
+        }
+
         // Use the explicitly passed commit (e.g. from rollback), falling back to the application's git_commit_sha.
         // Invalid refs will cause the git checkout/fetch command to fail on the remote server.
         $commitToUse = $commit ?? $this->git_commit_sha;
@@ -1102,9 +1110,9 @@ class Application extends BaseModel
             // If shallow clone is enabled and we need a specific commit,
             // we need to fetch that specific commit with depth=1
             if ($isShallowCloneEnabled) {
-                $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null\" git fetch --depth=1 origin {$escapedCommit} && git -c advice.detachedHead=false checkout {$escapedCommit} >/dev/null 2>&1";
+                $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"{$git_ssh_followup}\" git fetch --depth=1 origin {$escapedCommit} && git -c advice.detachedHead=false checkout {$escapedCommit} >/dev/null 2>&1";
             } else {
-                $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null\" git -c advice.detachedHead=false checkout {$escapedCommit} >/dev/null 2>&1";
+                $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"{$git_ssh_followup}\" git -c advice.detachedHead=false checkout {$escapedCommit} >/dev/null 2>&1";
             }
         }
         if ($this->settings->is_git_submodules_enabled) {
@@ -1115,10 +1123,10 @@ class Application extends BaseModel
             }
             // Add shallow submodules flag if shallow clone is enabled
             $submoduleFlags = $isShallowCloneEnabled ? '--depth=1' : '';
-            $git_clone_command = "{$git_clone_command} git submodule sync && GIT_SSH_COMMAND=\"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null\" git submodule update --init --recursive {$submoduleFlags}; fi";
+            $git_clone_command = "{$git_clone_command} git submodule sync && GIT_SSH_COMMAND=\"{$git_ssh_followup}\" git submodule update --init --recursive {$submoduleFlags}; fi";
         }
         if ($this->settings->is_git_lfs_enabled) {
-            $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null\" git lfs pull";
+            $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"{$git_ssh_followup}\" git lfs pull";
         }
 
         return $git_clone_command;


### PR DESCRIPTION
## Changes

When an application uses a deploy key with a custom SSH port (e.g. Gitea on 222), the initial `git clone` gets the correct `GIT_SSH_COMMAND` with `-p`, but the follow-up commands added by `setGitImportSettings()` — `git fetch`, checkout, submodule update, and `git lfs pull` — used a minimal `GIT_SSH_COMMAND` with no port. SSH then connected to port 22 and the deployment failed (e.g. "connect to host ... port 22: Operation timed out" or "Permission denied").

This change fixes that by using the same custom port for those follow-up git commands when the deployment type is `deploy_key`. Inside `setGitImportSettings()`, we only need the port in that case, so the port is read from `customRepository()` inside the `deploy_key` branch and used to build a `$git_ssh_followup` string that includes `-p {$customPort}`. Fetch, checkout, submodule, and lfs now use that string instead of the minimal one, so they connect to the same port as the clone.

## Issues

- Fixes #7139

## Category

- [x] Bug fix

## Preview

N/A — backend-only change; no UI changes. Deployment logs show the same clone/fetch/submodule/lfs sequence, but fetch/submodule/lfs now succeed when the Git server uses a custom SSH port.

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Cursor / AI assistant for code changes and commit message.
- How extensively: Patch and structure were written with AI; the fix was validated by testing deployments on a self-hosted Coolify instance with Gitea on a custom port (222), and by reverting the change to confirm the failure without it.

## Testing

Tested on a self-hosted Coolify instance (v4.0.0-beta.464) with:

- Git source: private Gitea repo, deploy key, custom SSH port 222.
- Deployment flow: clone, fetch to a specific commit SHA, submodule update, and git LFS pull.

Without the patch, deployment failed when `git fetch` (and/or submodule/lfs) ran with the minimal `GIT_SSH_COMMAND` (no port). With the patch, the full sequence completes successfully. Also confirmed that moving the port lookup inside the `deploy_key` branch and using only `-p` (no redundant `-o Port=`, no `ConnectTimeout`/`LogLevel`) behaves correctly.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.

