### PR TITLE
fix(docker-compose): respect preserveRepository setting when executing start command

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -805,9 +805,15 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                 );
 
                 $this->write_deployment_configurations();
-                $this->execute_remote_command(
-                    [executeInDocker($this->deployment_uuid, "cd {$this->basedir} && {$start_command}"), 'hidden' => true],
-                );
+                if ($this->preserveRepository) {
+                    $this->execute_remote_command(
+                        ['command' => "cd {$server_workdir} && {$start_command}", 'hidden' => true],
+                    );
+                } else {
+                    $this->execute_remote_command(
+                        [executeInDocker($this->deployment_uuid, "cd {$this->basedir} && {$start_command}"), 'hidden' => true],
+                    );
+                }
             } else {
                 $command = "{$this->coolify_variables} docker compose";
                 if ($this->preserveRepository) {

--- a/tests/Unit/DockerComposePreserveRepositoryStartCommandTest.php
+++ b/tests/Unit/DockerComposePreserveRepositoryStartCommandTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * Test to verify that docker-compose custom start commands use the correct
+ * execution context based on the preserveRepository setting.
+ *
+ * When preserveRepository is enabled, the compose file and .env file are
+ * written to the host at /data/coolify/applications/{uuid}/. The start
+ * command must run on the host (not inside the helper container) so it
+ * can access these files.
+ *
+ * When preserveRepository is disabled, the files are inside the helper
+ * container at /artifacts/{uuid}/, so the command must run inside the
+ * container via executeInDocker().
+ *
+ * @see https://github.com/coollabsio/coolify/issues/8417
+ */
+it('generates host command (not executeInDocker) when preserveRepository is true', function () {
+    $deploymentUuid = 'test-deployment-uuid';
+    $serverWorkdir = '/data/coolify/applications/app-uuid';
+    $basedir = '/artifacts/test-deployment-uuid';
+    $preserveRepository = true;
+
+    $startCommand = 'docker compose -f /data/coolify/applications/app-uuid/compose.yml --env-file /data/coolify/applications/app-uuid/.env --profile all up -d';
+
+    // Simulate the logic from ApplicationDeploymentJob::deploy_docker_compose_buildpack()
+    if ($preserveRepository) {
+        $command = "cd {$serverWorkdir} && {$startCommand}";
+    } else {
+        $command = executeInDocker($deploymentUuid, "cd {$basedir} && {$startCommand}");
+    }
+
+    // When preserveRepository is true, the command should NOT be wrapped in executeInDocker
+    expect($command)->not->toContain('docker exec');
+    expect($command)->toStartWith("cd {$serverWorkdir}");
+    expect($command)->toContain($startCommand);
+});
+
+it('generates executeInDocker command when preserveRepository is false', function () {
+    $deploymentUuid = 'test-deployment-uuid';
+    $serverWorkdir = '/data/coolify/applications/app-uuid';
+    $basedir = '/artifacts/test-deployment-uuid';
+    $workdir = '/artifacts/test-deployment-uuid/backend';
+    $preserveRepository = false;
+
+    $startCommand = 'docker compose -f /artifacts/test-deployment-uuid/backend/compose.yml --env-file /artifacts/test-deployment-uuid/backend/.env --profile all up -d';
+
+    // Simulate the logic from ApplicationDeploymentJob::deploy_docker_compose_buildpack()
+    if ($preserveRepository) {
+        $command = "cd {$serverWorkdir} && {$startCommand}";
+    } else {
+        $command = executeInDocker($deploymentUuid, "cd {$basedir} && {$startCommand}");
+    }
+
+    // When preserveRepository is false, the command SHOULD be wrapped in executeInDocker
+    expect($command)->toContain('docker exec');
+    expect($command)->toContain($deploymentUuid);
+    expect($command)->toContain("cd {$basedir}");
+});
+
+it('uses host paths for env-file when preserveRepository is true', function () {
+    $serverWorkdir = '/data/coolify/applications/app-uuid';
+    $composeLocation = '/compose.yml';
+    $preserveRepository = true;
+
+    $workdirPath = $preserveRepository ? $serverWorkdir : '/artifacts/deployment-uuid/backend';
+    $startCommand = injectDockerComposeFlags(
+        'docker compose --profile all up -d',
+        "{$workdirPath}{$composeLocation}",
+        "{$workdirPath}/.env"
+    );
+
+    // Verify the injected paths point to the host filesystem
+    expect($startCommand)->toContain("--env-file {$serverWorkdir}/.env");
+    expect($startCommand)->toContain("-f {$serverWorkdir}{$composeLocation}");
+});
+
+it('uses container paths for env-file when preserveRepository is false', function () {
+    $workdir = '/artifacts/deployment-uuid/backend';
+    $composeLocation = '/compose.yml';
+    $preserveRepository = false;
+    $serverWorkdir = '/data/coolify/applications/app-uuid';
+
+    $workdirPath = $preserveRepository ? $serverWorkdir : $workdir;
+    $startCommand = injectDockerComposeFlags(
+        'docker compose --profile all up -d',
+        "{$workdirPath}{$composeLocation}",
+        "{$workdirPath}/.env"
+    );
+
+    // Verify the injected paths point to the container filesystem
+    expect($startCommand)->toContain("--env-file {$workdir}/.env");
+    expect($startCommand)->toContain("-f {$workdir}{$composeLocation}");
+    expect($startCommand)->not->toContain('/data/coolify/applications/');
+});


### PR DESCRIPTION
## Summary

- Fixed docker-compose deployment failure when using custom start commands with `preserveRepository` enabled
- When `preserveRepository` is true, the compose file and `.env` are written to the host at `/data/coolify/applications/{uuid}/`, so the start command must run on the host (not inside the helper container)
- Added conditional logic to execute the command directly on the host when `preserveRepository` is enabled, instead of always wrapping it with `executeInDocker()`
- Added unit tests to verify correct execution context based on `preserveRepository` setting

## Details

The issue occurred because docker-compose custom start commands were always executed inside the helper container via `executeInDocker()`, even when the required files (compose.yml and .env) were located on the host filesystem. This caused the error: "couldn't find env file: /data/coolify/applications/.../\.env"

The fix adds a check before executing the start command:
- If `preserveRepository` is true: run the command directly on the host
- If `preserveRepository` is false: wrap the command with `executeInDocker()` as before

Fixes #8417

---

Fixes #8417