### PR TITLE
feat: add WordPress + OpenLiteSpeed service template (#8264)

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -1,0 +1,44 @@
+# documentation: https://openlitespeed.org/kb/
+# slogan: WordPress powered by OpenLiteSpeed — a high-performance, lightweight web server with built-in caching.
+# category: cms
+# tags: cms, blog, wordpress, openlitespeed, litespeed, cache, performance, mariadb
+# logo: svgs/wordpress.svg
+# port: 80
+
+services:
+  openlitespeed:
+    image: litespeedtech/openlitespeed-wordpress:latest
+    volumes:
+      - wordpress-files:/var/www/vhosts/localhost/html
+      - lsws-config:/usr/local/lsws/conf
+      - lsws-logs:/usr/local/lsws/logs
+    environment:
+      - SERVICE_URL_WORDPRESS_80
+      - WORDPRESS_DB_HOST=mariadb
+      - WORDPRESS_DB_USER=$SERVICE_USER_WORDPRESS
+      - WORDPRESS_DB_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+      - WORDPRESS_DB_NAME=wordpress
+      - DOMAIN=$SERVICE_URL_WORDPRESS
+      - ADMIN_PASS=$SERVICE_PASSWORD_LSWS
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1"]
+      interval: 5s
+      timeout: 10s
+      retries: 10
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
## Summary

Adds a one-click service template for WordPress powered by OpenLiteSpeed, as requested in #8264.

## Why OpenLiteSpeed?

| Feature | Apache/Nginx (existing WP templates) | OpenLiteSpeed |
|---------|-------------------------------------|---------------|
| Built-in page cache | ❌ Requires plugin | ✅ LSCache module |
| Event-driven | ❌ Apache: prefork/worker | ✅ Non-blocking I/O |
| .htaccess support | ✅ Apache only | ✅ Native support |
| HTTP/3 (QUIC) | ⚠️ Nginx only, compile flag | ✅ Built-in |
| Memory usage | Higher | ~50% less |

## Template Details

### Services

**openlitespeed** — `litespeedtech/openlitespeed-wordpress:latest`
- Official LiteSpeed Technologies image with WordPress pre-configured
- Persistent volumes for WordPress files, LSWS config, and logs
- Environment variables for DB connection, domain, and admin password
- Health check via HTTP

**mariadb** — `mariadb:11`
- Same proven database setup as existing WordPress templates
- Health check via `healthcheck.sh --connect --innodb_initialized`

### Volumes
- `wordpress-files` → `/var/www/vhosts/localhost/html`
- `lsws-config` → `/usr/local/lsws/conf` (server configuration persistence)
- `lsws-logs` → `/usr/local/lsws/logs`
- `mariadb-data` → `/var/lib/mysql`

## Follows Existing Patterns

Modeled after `wordpress-with-mariadb.yaml` — same Coolify variable conventions (`SERVICE_URL_*`, `SERVICE_USER_*`, `SERVICE_PASSWORD_*`), same MariaDB configuration, same health check patterns.

Closes #8264
