### PR TITLE
fix(deployment): ensure team ID comparison is type-safe

### DIFF
--- a/app/Http/Controllers/Api/DeployController.php
+++ b/app/Http/Controllers/Api/DeployController.php
@@ -128,7 +128,7 @@ class DeployController extends Controller
             return response()->json(['message' => 'Deployment not found.'], 404);
         }
         $application = $deployment->application;
-        if (! $application || data_get($application->team(), 'id') !== $teamId) {
+        if (! $application || (string) data_get($application->team(), 'id') !== (string) $teamId) {
             return response()->json(['message' => 'Deployment not found.'], 404);
         }
 

--- a/tests/Feature/DeploymentByUuidApiTest.php
+++ b/tests/Feature/DeploymentByUuidApiTest.php
@@ -1,0 +1,124 @@
+<?php
+
+use App\Enums\ApplicationDeploymentStatus;
+use App\Models\Application;
+use App\Models\ApplicationDeploymentQueue;
+use App\Models\InstanceSettings;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Visus\Cuid2\Cuid2;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::create(['id' => 0, 'is_api_enabled' => true]);
+
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+
+    session(['currentTeam' => $this->team]);
+
+    $this->token = $this->user->createToken('test-token', ['*']);
+    $this->bearerToken = $this->token->plainTextToken;
+
+    $this->server = Server::factory()->create(['team_id' => $this->team->id]);
+
+    StandaloneDocker::withoutEvents(function () {
+        $this->destination = StandaloneDocker::firstOrCreate(
+            ['server_id' => $this->server->id, 'network' => 'coolify'],
+            ['uuid' => (string) new Cuid2, 'name' => 'test-docker']
+        );
+    });
+
+    $this->project = Project::create([
+        'uuid' => (string) new Cuid2,
+        'name' => 'test-project',
+        'team_id' => $this->team->id,
+    ]);
+
+    $this->environment = $this->project->environments()->first();
+
+    $this->application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => $this->destination->getMorphClass(),
+    ]);
+});
+
+function deploymentAuthHeaders(string $bearerToken): array
+{
+    return [
+        'Authorization' => 'Bearer '.$bearerToken,
+        'Content-Type' => 'application/json',
+    ];
+}
+
+describe('GET /api/v1/deployments/{uuid}', function () {
+    test('returns 401 when not authenticated', function () {
+        $response = $this->getJson('/api/v1/deployments/some-uuid');
+
+        $response->assertUnauthorized();
+    });
+
+    test('returns 404 when deployment not found', function () {
+        $response = $this->withHeaders(deploymentAuthHeaders($this->bearerToken))
+            ->getJson('/api/v1/deployments/non-existent-uuid');
+
+        $response->assertNotFound();
+        $response->assertJson(['message' => 'Deployment not found.']);
+    });
+
+    test('returns 404 when deployment belongs to another team', function () {
+        $otherTeam = Team::factory()->create();
+        $otherProject = Project::create([
+            'uuid' => (string) new Cuid2,
+            'name' => 'other-project',
+            'team_id' => $otherTeam->id,
+        ]);
+        $otherEnvironment = $otherProject->environments()->first();
+        $otherServer = Server::factory()->create(['team_id' => $otherTeam->id]);
+
+        $otherDestination = StandaloneDocker::firstOrCreate(
+            ['server_id' => $otherServer->id, 'network' => 'coolify'],
+            ['uuid' => (string) new Cuid2, 'name' => 'other-docker']
+        );
+        $otherApplication = Application::factory()->create([
+            'environment_id' => $otherEnvironment->id,
+            'destination_id' => $otherDestination->id,
+            'destination_type' => $otherDestination->getMorphClass(),
+        ]);
+
+        $deployment = ApplicationDeploymentQueue::create([
+            'deployment_uuid' => 'other-team-deployment-uuid',
+            'application_id' => $otherApplication->id,
+            'server_id' => $otherServer->id,
+            'status' => ApplicationDeploymentStatus::IN_PROGRESS->value,
+        ]);
+
+        $response = $this->withHeaders(deploymentAuthHeaders($this->bearerToken))
+            ->getJson("/api/v1/deployments/{$deployment->deployment_uuid}");
+
+        $response->assertNotFound();
+        $response->assertJson(['message' => 'Deployment not found.']);
+    });
+
+    test('returns deployment when it belongs to the token team', function () {
+        $deployment = ApplicationDeploymentQueue::create([
+            'deployment_uuid' => 'own-team-deployment-uuid',
+            'application_id' => $this->application->id,
+            'server_id' => $this->server->id,
+            'status' => ApplicationDeploymentStatus::IN_PROGRESS->value,
+        ]);
+
+        $response = $this->withHeaders(deploymentAuthHeaders($this->bearerToken))
+            ->getJson("/api/v1/deployments/{$deployment->deployment_uuid}");
+
+        $response->assertOk();
+        $response->assertJsonFragment(['deployment_uuid' => 'own-team-deployment-uuid']);
+    });
+});


### PR DESCRIPTION
## Changes

Fixes regression in the deployment api added in https://github.com/coollabsio/coolify/commit/ba3994bc5c34a1e8d5900460ff95dccad7a8f01f. After upgrading, our deploy pipeline started throwing 404 errors from the deployment API.

## Issues
Likely fixes #8917.

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Cursor
- How extensively: To aid in test generation

## Testing

Verified a failing test without the fix.

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
