### PR TITLE
Fix for missing curly braces on litellm compose file

### DIFF
--- a/templates/compose/litellm.yaml
+++ b/templates/compose/litellm.yaml
@@ -146,8 +146,8 @@ services:
     image: "postgres:16-alpine"
     environment:
       - POSTGRES_DB=${POSTGRES_DB:-litellm}
-      - POSTGRES_PASSWORD=$SERVICE_PASSWORD_POSTGRES
-      - POSTGRES_USER=$SERVICE_USER_POSTGRES
+      - POSTGRES_PASSWORD=${SERVICE_PASSWORD_POSTGRES}
+      - POSTGRES_USER=${SERVICE_USER_POSTGRES}
     volumes:
       - "pg-data:/var/lib/postgresql/data"
     healthcheck:


### PR DESCRIPTION
## Changes

I ran into an issue installing litellm, which was caused by missing curly braces around the postgres creds. This was causing this error on deploy:

```
Saved configuration files to /data/coolify/services/uav44yffi415e12euokc9ddz.
Pulling images.
failed to read /data/coolify/services/uav44yffi415e12euokc9ddz/.env: line 30: unexpected character "$" in variable name "$SERVICE_PASSWORD_POSTGRES="
```

Adding the missing curly braces (and if you already have the resource created, removing the bad env vars) fixes the deploy.


## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

<img width="914" height="535" alt="image" src="https://github.com/user-attachments/assets/7d7af23c-e096-48d8-8891-04a74dcdaf6a" />

## AI Assistance

<!-- AI-assisted PRs that are human reviewed are welcome, just let us know so we can review appropriately. -->

- [x] AI was NOT used to create this PR
- [ ] AI was used (please describe below)


## Testing

This was tested manually

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
