### PR TITLE
fix: respect SMTP encryption setting for email notifications

### DIFF
--- a/app/Notifications/Channels/EmailChannel.php
+++ b/app/Notifications/Channels/EmailChannel.php
@@ -80,8 +80,8 @@ class EmailChannel
             } elseif ($isSmtpEnabled) {
                 $encryption = match (strtolower($settings->smtp_encryption)) {
                     'starttls' => null,
-                    'tls' => 'tls',
-                    'none' => null,
+                    'tls' => true,
+                    'none' => false,
                     default => null,
                 };
 


### PR DESCRIPTION
Ensure 'tls' and 'none' encryption settings are correctly handled in EsmtpTransport. Fixes #8655.