### PR TITLE
fix: prevent scheduled task input fields from losing focus

### DIFF
--- a/app/Livewire/Project/Shared/ScheduledTask/Show.php
+++ b/app/Livewire/Project/Shared/ScheduledTask/Show.php
@@ -52,15 +52,6 @@ class Show extends Component
     #[Locked]
     public string $task_uuid;
 
-    public function getListeners()
-    {
-        $teamId = auth()->user()->currentTeam()->id;
-
-        return [
-            "echo-private:team.{$teamId},ServiceChecked" => '$refresh',
-        ];
-    }
-
     public function mount(string $task_uuid, string $project_uuid, string $environment_uuid, ?string $application_uuid = null, ?string $service_uuid = null)
     {
         try {


### PR DESCRIPTION
Removed redundant polling listener to prevent form re-renders and focus loss. Fixes #8654.