### PR TITLE
fix: add missing curly braces on litellm compose file

### DIFF
--- a/templates/compose/litellm.yaml
+++ b/templates/compose/litellm.yaml
@@ -146,8 +146,8 @@ services:
     image: "postgres:16-alpine"
     environment:
       - POSTGRES_DB=${POSTGRES_DB:-litellm}
-      - POSTGRES_PASSWORD=$SERVICE_PASSWORD_POSTGRES
-      - POSTGRES_USER=$SERVICE_USER_POSTGRES
+      - POSTGRES_PASSWORD=${SERVICE_PASSWORD_POSTGRES}
+      - POSTGRES_USER=${SERVICE_USER_POSTGRES}
     volumes:
       - "pg-data:/var/lib/postgresql/data"
     healthcheck:


### PR DESCRIPTION
Wrapped POSTGRES_PASSWORD and POSTGRES_USER in curly braces for LiteLLM template. Fixes #8874.