### PR TITLE
feat(service): Add librespeed

### DIFF
--- a/templates/compose/librespeed.yaml
+++ b/templates/compose/librespeed.yaml
@@ -1,0 +1,23 @@
+# documentation: https://github.com/librespeed/speedtest
+# slogan: Self-hosted lightweight Speed Test.
+# category: devtools
+# tags: speedtest, internet-speed
+# logo: svgs/librespeed.png
+# port: 80
+
+services:
+  librespeed:
+    image: adolfintel/speedtest:latest
+    container_name: librespeed
+    restart: always
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=UTC
+      - PASSWORD=password
+    network_mode: bridge
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost"]
+      interval: 30s
+      timeout: 10s
+      retries: 3


### PR DESCRIPTION
Adds a reusable one-click service template for Librespeed, a lightweight self-hosted speed test. Note: Logo librespeed.png is referenced from PR #8626 files.