### PR TITLE
fix(modal): make confirmation modal close after dispatching Livewire actions

### DIFF
--- a/resources/views/components/modal-confirmation.blade.php
+++ b/resources/views/components/modal-confirmation.blade.php
@@ -94,7 +94,7 @@
         }
         if (this.dispatchAction) {
             $wire.dispatch(this.submitAction);
-            return true;
+            return Promise.resolve(true);
         }
 
         const methodName = this.submitAction.split('(')[0];


### PR DESCRIPTION
## Summary

- Changed `submitForm()` to return `Promise.resolve(true)` instead of `true` when dispatching Livewire actions
- Ensures the modal's promise chain completes properly, allowing the close handler to execute
- Fixes modal staying open after confirming package updates

## Breaking Changes

None

---

Fixes #8865