### PR TITLE
fix(security): sanitize newlines in health check commands to prevent RCE

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -2777,9 +2777,10 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
     {
         // Handle CMD type healthcheck
         if ($this->application->health_check_type === 'cmd' && ! empty($this->application->health_check_command)) {
-            $this->full_healthcheck_url = $this->application->health_check_command;
+            $command = str_replace(["\r\n", "\r", "\n"], ' ', $this->application->health_check_command);
+            $this->full_healthcheck_url = $command;
 
-            return $this->application->health_check_command;
+            return $command;
         }
 
         // HTTP type healthcheck (default)


### PR DESCRIPTION
## Summary

- Sanitize CMD type health check commands by removing and normalizing newline characters
- Prevents command injection attacks through newline-based command chaining in health check configuration
- Fixes OS Command Injection vulnerability allowing remote code execution in deployed containers

## Details

Addresses security advisory **GHSA-4fhp-xqqp-w7vv**: OS Command Injection in Health Check Configuration.

The vulnerability allowed authenticated users to inject arbitrary shell commands via the health check configuration, leading to remote code execution inside deployment containers. This fix sanitizes the health check command input by replacing all newline variants (`\r\n`, `\r`, `\n`) with spaces, preventing attackers from breaking out of the intended command via newline injection.

## Breaking Changes

None - this is a security hardening fix that sanitizes user input.