### PR TITLE
fix(api): add docker_cleanup parameter to stop endpoints

### DIFF
--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -3250,6 +3250,15 @@ class ApplicationsController extends Controller
                     format: 'uuid',
                 )
             ),
+            new OA\Parameter(
+                name: 'docker_cleanup',
+                in: 'query',
+                description: 'Perform docker cleanup (prune networks, volumes, etc.).',
+                schema: new OA\Schema(
+                    type: 'boolean',
+                    default: true,
+                )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -3298,7 +3307,8 @@ class ApplicationsController extends Controller
 
         $this->authorize('deploy', $application);
 
-        StopApplication::dispatch($application);
+        $dockerCleanup = $request->boolean('docker_cleanup', true);
+        StopApplication::dispatch($application, false, $dockerCleanup);
 
         return response()->json(
             [

--- a/app/Http/Controllers/Api/DatabasesController.php
+++ b/app/Http/Controllers/Api/DatabasesController.php
@@ -2611,6 +2611,15 @@ class DatabasesController extends Controller
                     format: 'uuid',
                 )
             ),
+            new OA\Parameter(
+                name: 'docker_cleanup',
+                in: 'query',
+                description: 'Perform docker cleanup (prune networks, volumes, etc.).',
+                schema: new OA\Schema(
+                    type: 'boolean',
+                    default: true,
+                )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -2662,7 +2671,9 @@ class DatabasesController extends Controller
         if (str($database->status)->contains('stopped') || str($database->status)->contains('exited')) {
             return response()->json(['message' => 'Database is already stopped.'], 400);
         }
-        StopDatabase::dispatch($database);
+
+        $dockerCleanup = $request->boolean('docker_cleanup', true);
+        StopDatabase::dispatch($database, $dockerCleanup);
 
         return response()->json(
             [

--- a/app/Http/Controllers/Api/ServicesController.php
+++ b/app/Http/Controllers/Api/ServicesController.php
@@ -1488,6 +1488,15 @@ class ServicesController extends Controller
                     format: 'uuid',
                 )
             ),
+            new OA\Parameter(
+                name: 'docker_cleanup',
+                in: 'query',
+                description: 'Perform docker cleanup (prune networks, volumes, etc.).',
+                schema: new OA\Schema(
+                    type: 'boolean',
+                    default: true,
+                )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -1539,7 +1548,9 @@ class ServicesController extends Controller
         if (str($service->status)->contains('stopped') || str($service->status)->contains('exited')) {
             return response()->json(['message' => 'Service is already stopped.'], 400);
         }
-        StopService::dispatch($service);
+
+        $dockerCleanup = $request->boolean('docker_cleanup', true);
+        StopService::dispatch($service, false, $dockerCleanup);
 
         return response()->json(
             [


### PR DESCRIPTION
## Summary

- Add optional `docker_cleanup` query parameter to stop endpoints for Services, Applications, and Databases
- Allows API users to control whether docker cleanup is performed when stopping resources
- Defaults to `true` for backward compatibility

Fixes #7758

🤖 Generated with [Claude Code](https://claude.ai/code)