### PR TITLE
fix(upgrade): suppress Livewire error dialogs during server restart

### DIFF
--- a/resources/views/livewire/upgrade.blade.php
+++ b/resources/views/livewire/upgrade.blade.php
@@ -1,5 +1,5 @@
 <div @if ($isUpgradeAvailable) title="New version available" @else title="No upgrade available" @endif
-    x-init="$wire.checkUpdate" x-data="upgradeModal({
+    x-data="upgradeModal({
         currentVersion: @js($currentVersion),
         latestVersion: @js($latestVersion),
         devMode: @js($devMode)
@@ -239,6 +239,25 @@
                 this.currentStep = 1;
                 this.currentStatus = 'Starting upgrade...';
                 this.startTimer();
+
+                // Suppress Livewire's internal error dialog during upgrade.
+                // When the server restarts, Livewire requests fail and its JS
+                // tries to call showModal() on a <dialog>, throwing InvalidStateError.
+                // This hook intercepts failed requests so the error doesn't block
+                // the polling catch block from switching to health-check mode.
+                this._upgradeInProgress = true;
+                if (!this._livewireHookRegistered) {
+                    this._livewireHookRegistered = true;
+                    const self = this;
+                    Livewire.hook('request', ({ fail }) => {
+                        if (self._upgradeInProgress) {
+                            fail((response, failCallback) => {
+                                console.log('Livewire request failed during upgrade (suppressed)');
+                            });
+                        }
+                    });
+                }
+
                 // Trigger server-side upgrade script via Livewire
                 this.$wire.$call('upgrade');
                 // Start client-side status polling
@@ -330,6 +349,7 @@
                     this.beforeUnloadHandler = null;
                 }
 
+                this._upgradeInProgress = false;
                 this.upgradeComplete = true;
                 this.currentStep = 5;
                 this.currentStatus = `Successfully upgraded to ${this.latestVersion}`;
@@ -368,11 +388,13 @@
                     this.beforeUnloadHandler = null;
                 }
 
+                this._upgradeInProgress = false;
                 this.upgradeError = true;
                 this.currentStatus = `Error: ${message}`;
             },
 
             closeErrorModal() {
+                this._upgradeInProgress = false;
                 this.modalOpen = false;
                 this.showProgress = false;
                 this.upgradeError = false;

--- a/resources/views/livewire/upgrade.blade.php
+++ b/resources/views/livewire/upgrade.blade.php
@@ -419,6 +419,19 @@
                             this.showSuccess();
                         } else if (data.status === 'error') {
                             this.showError(data.message);
+                        } else if (data.status === 'none' && this.showProgress) {
+                            // Status file cleared after server restart —
+                            // fall back to health check to detect when server is back
+                            if (!this.serviceDown) {
+                                this.serviceDown = true;
+                                this.currentStep = 4;
+                                this.currentStatus = 'Coolify is restarting with the new version...';
+                                if (this.checkUpgradeStatusInterval) {
+                                    clearInterval(this.checkUpgradeStatusInterval);
+                                    this.checkUpgradeStatusInterval = null;
+                                }
+                                this.revive();
+                            }
                         }
                     } catch (error) {
                         // Service is down - switch to health check mode


### PR DESCRIPTION
## Summary

- Fixes upgrade wizard spinner that persists even though the server updates successfully
- Suppresses Livewire's error dialog that throws `InvalidStateError` during server restart
- Allows polling mechanism to properly detect server recovery and complete the upgrade

## Problem

When upgrading, the server restarts and Livewire requests fail. Livewire's JS tries to show an error dialog via `showModal()`, but the dialog is already open in non-modal mode, throwing:
```
InvalidStateError: Failed to execute 'showModal' on 'HTMLDialogElement'
```

This uncaught error blocks the polling catch block from switching to health-check mode, causing the spinner to infinitely loop even though the upgrade completes successfully on the server.

## Solution

Registers a Livewire request hook during the upgrade process that suppresses error dialogs by consuming the fail callback. This prevents the modal error from blocking the polling mechanism. The `_upgradeInProgress` flag ensures errors are only suppressed during the actual upgrade operation.

## Fixes

Closes #8241

---

Fixes #8241