### PR TITLE
fix(livewire): add error handling and selectedActions to delete methods

### DIFF
--- a/app/Livewire/NavbarDeleteTeam.php
+++ b/app/Livewire/NavbarDeleteTeam.php
@@ -15,10 +15,10 @@ class NavbarDeleteTeam extends Component
         $this->team = currentTeam()->name;
     }
 
-    public function delete($password)
+    public function delete($password, $selectedActions = [])
     {
         if (! verifyPasswordConfirmation($password, $this)) {
-            return;
+            return 'The provided password is incorrect.';
         }
 
         $currentTeam = currentTeam();

--- a/app/Livewire/Project/Database/BackupEdit.php
+++ b/app/Livewire/Project/Database/BackupEdit.php
@@ -146,12 +146,12 @@ class BackupEdit extends Component
         }
     }
 
-    public function delete($password)
+    public function delete($password, $selectedActions = [])
     {
         $this->authorize('manageBackups', $this->backup->database);
 
         if (! verifyPasswordConfirmation($password, $this)) {
-            return;
+            return 'The provided password is incorrect.';
         }
 
         try {

--- a/app/Livewire/Project/Database/BackupExecutions.php
+++ b/app/Livewire/Project/Database/BackupExecutions.php
@@ -65,10 +65,10 @@ class BackupExecutions extends Component
         }
     }
 
-    public function deleteBackup($executionId, $password)
+    public function deleteBackup($executionId, $password, $selectedActions = [])
     {
         if (! verifyPasswordConfirmation($password, $this)) {
-            return;
+            return 'The provided password is incorrect.';
         }
 
         $execution = $this->backup->executions()->where('id', $executionId)->first();
@@ -96,7 +96,11 @@ class BackupExecutions extends Component
             $this->refreshBackupExecutions();
         } catch (\Exception $e) {
             $this->dispatch('error', 'Failed to delete backup: '.$e->getMessage());
+
+            return true;
         }
+
+        return true;
     }
 
     public function download_file($exeuctionId)

--- a/app/Livewire/Project/Service/FileStorage.php
+++ b/app/Livewire/Project/Service/FileStorage.php
@@ -134,12 +134,12 @@ class FileStorage extends Component
         }
     }
 
-    public function delete($password)
+    public function delete($password, $selectedActions = [])
     {
         $this->authorize('update', $this->resource);
 
         if (! verifyPasswordConfirmation($password, $this)) {
-            return;
+            return 'The provided password is incorrect.';
         }
 
         try {
@@ -158,6 +158,8 @@ class FileStorage extends Component
         } finally {
             $this->dispatch('refreshStorages');
         }
+
+        return true;
     }
 
     public function submit()

--- a/app/Livewire/Project/Service/Index.php
+++ b/app/Livewire/Project/Service/Index.php
@@ -194,13 +194,13 @@ class Index extends Component
         }
     }
 
-    public function deleteDatabase($password)
+    public function deleteDatabase($password, $selectedActions = [])
     {
         try {
             $this->authorize('delete', $this->serviceDatabase);
 
             if (! verifyPasswordConfirmation($password, $this)) {
-                return;
+                return 'The provided password is incorrect.';
             }
 
             $this->serviceDatabase->delete();
@@ -398,13 +398,13 @@ class Index extends Component
         }
     }
 
-    public function deleteApplication($password)
+    public function deleteApplication($password, $selectedActions = [])
     {
         try {
             $this->authorize('delete', $this->serviceApplication);
 
             if (! verifyPasswordConfirmation($password, $this)) {
-                return;
+                return 'The provided password is incorrect.';
             }
 
             $this->serviceApplication->delete();

--- a/app/Livewire/Project/Shared/Danger.php
+++ b/app/Livewire/Project/Shared/Danger.php
@@ -88,16 +88,21 @@ class Danger extends Component
         }
     }
 
-    public function delete($password)
+    public function delete($password, $selectedActions = [])
     {
         if (! verifyPasswordConfirmation($password, $this)) {
-            return;
+            return 'The provided password is incorrect.';
         }
 
         if (! $this->resource) {
-            $this->addError('resource', 'Resource not found.');
+            return 'Resource not found.';
+        }
 
-            return;
+        if (! empty($selectedActions)) {
+            $this->delete_volumes = in_array('delete_volumes', $selectedActions);
+            $this->delete_connected_networks = in_array('delete_connected_networks', $selectedActions);
+            $this->delete_configurations = in_array('delete_configurations', $selectedActions);
+            $this->docker_cleanup = in_array('docker_cleanup', $selectedActions);
         }
 
         try {

--- a/app/Livewire/Project/Shared/Destination.php
+++ b/app/Livewire/Project/Shared/Destination.php
@@ -134,11 +134,11 @@ class Destination extends Component
         $this->dispatch('refresh');
     }
 
-    public function removeServer(int $network_id, int $server_id, $password)
+    public function removeServer(int $network_id, int $server_id, $password, $selectedActions = [])
     {
         try {
             if (! verifyPasswordConfirmation($password, $this)) {
-                return;
+                return 'The provided password is incorrect.';
             }
 
             if ($this->resource->destination->server->id == $server_id && $this->resource->destination->id == $network_id) {
@@ -152,6 +152,8 @@ class Destination extends Component
             $this->loadData();
             $this->dispatch('refresh');
             ApplicationStatusChanged::dispatch(data_get($this->resource, 'environment.project.team.id'));
+
+            return true;
         } catch (\Exception $e) {
             return handleError($e, $this);
         }

--- a/app/Livewire/Project/Shared/Storages/Show.php
+++ b/app/Livewire/Project/Shared/Storages/Show.php
@@ -77,15 +77,17 @@ class Show extends Component
         $this->dispatch('success', 'Storage updated successfully');
     }
 
-    public function delete($password)
+    public function delete($password, $selectedActions = [])
     {
         $this->authorize('update', $this->resource);
 
         if (! verifyPasswordConfirmation($password, $this)) {
-            return;
+            return 'The provided password is incorrect.';
         }
 
         $this->storage->delete();
         $this->dispatch('refreshStorages');
+
+        return true;
     }
 }

--- a/app/Livewire/Server/Delete.php
+++ b/app/Livewire/Server/Delete.php
@@ -24,10 +24,14 @@ class Delete extends Component
         }
     }
 
-    public function delete($password)
+    public function delete($password, $selectedActions = [])
     {
         if (! verifyPasswordConfirmation($password, $this)) {
-            return;
+            return 'The provided password is incorrect.';
+        }
+
+        if (! empty($selectedActions)) {
+            $this->delete_from_hetzner = in_array('delete_from_hetzner', $selectedActions);
         }
         try {
             $this->authorize('delete', $this->server);

--- a/app/Livewire/Server/Security/TerminalAccess.php
+++ b/app/Livewire/Server/Security/TerminalAccess.php
@@ -31,7 +31,7 @@ class TerminalAccess extends Component
         }
     }
 
-    public function toggleTerminal($password)
+    public function toggleTerminal($password, $selectedActions = [])
     {
         try {
             $this->authorize('update', $this->server);
@@ -43,7 +43,7 @@ class TerminalAccess extends Component
 
             // Verify password
             if (! verifyPasswordConfirmation($password, $this)) {
-                return;
+                return 'The provided password is incorrect.';
             }
 
             // Toggle the terminal setting
@@ -55,6 +55,8 @@ class TerminalAccess extends Component
 
             $status = $this->isTerminalEnabled ? 'enabled' : 'disabled';
             $this->dispatch('success', "Terminal access has been {$status}.");
+
+            return true;
         } catch (\Throwable $e) {
             return handleError($e, $this);
         }

--- a/app/Livewire/Team/AdminView.php
+++ b/app/Livewire/Team/AdminView.php
@@ -49,14 +49,14 @@ class AdminView extends Component
         }
     }
 
-    public function delete($id, $password)
+    public function delete($id, $password, $selectedActions = [])
     {
         if (! isInstanceAdmin()) {
             return redirect()->route('dashboard');
         }
 
         if (! verifyPasswordConfirmation($password, $this)) {
-            return;
+            return 'The provided password is incorrect.';
         }
 
         if (! auth()->user()->isInstanceAdmin()) {
@@ -71,6 +71,8 @@ class AdminView extends Component
         try {
             $user->delete();
             $this->getUsers();
+
+            return true;
         } catch (\Exception $e) {
             return $this->dispatch('error', $e->getMessage());
         }

--- a/tests/v4/Feature/DangerDeleteResourceTest.php
+++ b/tests/v4/Feature/DangerDeleteResourceTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use App\Livewire\Project\Shared\Danger;
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\InstanceSettings;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Route;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::create(['id' => 0]);
+    Queue::fake();
+
+    $this->user = User::factory()->create([
+        'password' => Hash::make('test-password'),
+    ]);
+    $this->team = Team::factory()->create();
+    $this->user->teams()->attach($this->team, ['role' => 'owner']);
+
+    $this->server = Server::factory()->create(['team_id' => $this->team->id]);
+    $this->destination = StandaloneDocker::factory()->create([
+        'server_id' => $this->server->id,
+        'network' => 'test-network-'.fake()->unique()->word(),
+    ]);
+    $this->project = Project::factory()->create(['team_id' => $this->team->id]);
+    $this->environment = Environment::factory()->create(['project_id' => $this->project->id]);
+
+    $this->application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => $this->destination->getMorphClass(),
+    ]);
+
+    $this->actingAs($this->user);
+    session(['currentTeam' => $this->team]);
+
+    // Bind route parameters so get_route_parameters() works in the Danger component
+    $route = Route::get('/test/{project_uuid}/{environment_uuid}', fn () => '')->name('test.danger');
+    $request = Request::create("/test/{$this->project->uuid}/{$this->environment->uuid}");
+    $route->bind($request);
+    app('router')->setRoutes(app('router')->getRoutes());
+    Route::dispatch($request);
+});
+
+test('delete returns error string when password is incorrect', function () {
+    Livewire::test(Danger::class, ['resource' => $this->application])
+        ->call('delete', 'wrong-password')
+        ->assertReturned('The provided password is incorrect.');
+
+    // Resource should NOT be deleted
+    expect(Application::find($this->application->id))->not->toBeNull();
+});
+
+test('delete succeeds with correct password and redirects', function () {
+    Livewire::test(Danger::class, ['resource' => $this->application])
+        ->call('delete', 'test-password')
+        ->assertHasNoErrors();
+
+    // Resource should be soft-deleted
+    expect(Application::find($this->application->id))->toBeNull();
+});
+
+test('delete applies selectedActions from checkbox state', function () {
+    $component = Livewire::test(Danger::class, ['resource' => $this->application])
+        ->call('delete', 'test-password', ['delete_configurations', 'docker_cleanup']);
+
+    expect($component->get('delete_volumes'))->toBeFalse();
+    expect($component->get('delete_connected_networks'))->toBeFalse();
+    expect($component->get('delete_configurations'))->toBeTrue();
+    expect($component->get('docker_cleanup'))->toBeTrue();
+});


### PR DESCRIPTION
## Summary

Fixes issue #8836 where resource deletion fails silently in the danger zone without any error feedback.

- Added `$selectedActions` parameter to all delete methods to properly process deletion checkboxes (delete_volumes, delete_connected_networks, delete_configurations, docker_cleanup)
- Changed error handling to return descriptive error messages instead of silently returning (e.g., "The provided password is incorrect.")
- Added explicit `return true` statements to indicate successful completion, allowing frontend to properly respond
- Updated 12 Livewire delete methods across the codebase for consistency
- Added comprehensive tests to verify deletion behavior, error messages, and selectedActions processing

## Breaking Changes

None. The `$selectedActions` parameter has a default value of `[]`, maintaining backward compatibility.

---

Fixes #8836