### PR TITLE
fix(template): standardize environment variable syntax in sure.yaml

### DIFF
--- a/templates/compose/sure.yaml
+++ b/templates/compose/sure.yaml
@@ -10,17 +10,17 @@ services:
     image: ghcr.io/we-promise/sure:0.6.7
     environment:
       - SERVICE_URL_SURE_3000
-      - APP_DOMAIN=$SERVICE_FQDN_SURE
-      - SECRET_KEY_BASE=$SERVICE_BASE64_BASE
+      - APP_DOMAIN=${SERVICE_FQDN_SURE}
+      - SECRET_KEY_BASE=${SERVICE_BASE64_BASE}
       - POSTGRES_USER=${SERVICE_USER_POSTGRESQL}
       - POSTGRES_PASSWORD=${SERVICE_PASSWORD_POSTGRESQL}
       - POSTGRES_DB=${POSTGRESQL_DATABASE:-sure}
-      - 'REDIS_URL=redis://valkey:6379'
+      - "REDIS_URL=redis://valkey:6379"
       - DB_HOST=postgresql
       - DB_PORT=5432
-      - 'SELF_HOSTED=true'
-      - 'RAILS_FORCE_SSL=false'
-      - 'RAILS_ASSUME_SSL=false'
+      - "SELF_HOSTED=true"
+      - "RAILS_FORCE_SSL=false"
+      - "RAILS_ASSUME_SSL=false"
       - ONBOARDING_STATE=${ONBOARDING_STATE:-open}
     depends_on:
       postgresql:
@@ -34,22 +34,22 @@ services:
       interval: 15s
       timeout: 20s
       retries: 5
-      
+
   worker:
     image: ghcr.io/we-promise/sure:0.6.7
     command: bundle exec sidekiq
     environment:
-      - APP_DOMAIN=$SERVICE_FQDN_SURE
-      - SECRET_KEY_BASE=$SERVICE_BASE64_BASE
+      - APP_DOMAIN=${SERVICE_FQDN_SURE}
+      - SECRET_KEY_BASE=${SERVICE_BASE64_BASE}
       - POSTGRES_USER=${SERVICE_USER_POSTGRESQL}
       - POSTGRES_PASSWORD=${SERVICE_PASSWORD_POSTGRESQL}
       - POSTGRES_DB=${POSTGRESQL_DATABASE:-sure}
-      - 'REDIS_URL=redis://valkey:6379'
+      - "REDIS_URL=redis://valkey:6379"
       - DB_HOST=postgresql
       - DB_PORT=5432
-      - 'SELF_HOSTED=true'
-      - 'RAILS_FORCE_SSL=false'
-      - 'RAILS_ASSUME_SSL=false'
+      - "SELF_HOSTED=true"
+      - "RAILS_FORCE_SSL=false"
+      - "RAILS_ASSUME_SSL=false"
       - ONBOARDING_STATE=${ONBOARDING_STATE:-open}
     volumes:
       - sure-app-storage:/rails/storage
@@ -63,7 +63,7 @@ services:
       interval: 15s
       timeout: 20s
       retries: 5
-      
+
   postgresql:
     image: postgres:16-alpine
     volumes:
@@ -86,7 +86,7 @@ services:
     healthcheck:
       test:
         - CMD-SHELL
-        - 'valkey-cli ping | grep PONG'
+        - "valkey-cli ping | grep PONG"
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
This pull request makes minor improvements to the `templates/compose/sure.yaml` file, focusing on consistent environment variable syntax and formatting for Docker Compose services.

Configuration and formatting updates:

* Updated environment variable references to use the `${VAR}` syntax instead of the older `$VAR` style for better compatibility in Docker Compose files. [[1]](diffhunk://#diff-90ec3913921d32730cf5337084957bd5a0d0614668f288a25a77d8a86af3d2fdL13-R23) [[2]](diffhunk://#diff-90ec3913921d32730cf5337084957bd5a0d0614668f288a25a77d8a86af3d2fdL42-R52)
* Changed single quotes to double quotes for environment variable values and the `healthcheck` command, ensuring consistency and preventing potential parsing issues. [[1]](diffhunk://#diff-90ec3913921d32730cf5337084957bd5a0d0614668f288a25a77d8a86af3d2fdL13-R23) [[2]](diffhunk://#diff-90ec3913921d32730cf5337084957bd5a0d0614668f288a25a77d8a86af3d2fdL42-R52) [[3]](diffhunk://#diff-90ec3913921d32730cf5337084957bd5a0d0614668f288a25a77d8a86af3d2fdL89-R89)