### PR TITLE
fix: add --volume support to custom_docker_run_options

### DIFF
--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -995,6 +995,7 @@ function convertDockerRunToCompose(?string $custom_docker_run_options = null)
         '--ulimit',
         '--device',
         '--shm-size',
+        '--volume',
     ]);
     $mapping = collect([
         '--cap-add' => 'cap_add',
@@ -1011,6 +1012,7 @@ function convertDockerRunToCompose(?string $custom_docker_run_options = null)
         '--gpus' => 'gpus',
         '--hostname' => 'hostname',
         '--entrypoint' => 'entrypoint',
+        '--volume' => 'volumes',
     ]);
     foreach ($matches as $match) {
         $option = $match[1];
@@ -1108,6 +1110,10 @@ function convertDockerRunToCompose(?string $custom_docker_run_options = null)
                 // Docker compose accepts entrypoint as either a string or an array
                 // Keep it as a string for simplicity - docker compose will handle it
                 $compose_options->put($mapping[$option], $value[0]);
+            }
+        } elseif ($option === '--volume') {
+            if (! is_null($value) && is_array($value) && count($value) > 0) {
+                $compose_options->put($mapping[$option], array_values($value));
             }
         } elseif ($option === '--gpus') {
             $payload = [


### PR DESCRIPTION
## Problem

The `convertDockerRunToCompose()` function in `bootstrap/helpers/docker.php` maps `docker run` flags to their docker-compose equivalents. However, `--volume` is missing from both the `$list_options` and `$mapping` collections.

This means that setting `--volume /host/path:/container/path` in **Custom Docker Run Options** (for Docker Image applications) is silently ignored — containers are created without the specified volume mounts.

## Root Cause

The function supports `--cap-add`, `--device`, `--gpus`, `--hostname`, `--entrypoint`, `--shm-size`, etc., but `--volume` was never added to the mapping. The option gets parsed by the regex but is skipped because `data_get($mapping, '--volume')` returns null.

## Fix

Three additions:

1. **`$list_options`**: Add `'--volume'` (allows multiple `--volume` flags)
2. **`$mapping`**: Add `'--volume' => 'volumes'` (maps to docker-compose key)
3. **Handler**: Add a dedicated `elseif` block that puts the parsed volume paths as an array, matching docker-compose `volumes:` format

## Example

**Custom Docker Run Options:**
```
--volume /opt/data/logs:/app/logs --volume /opt/data/tracking:/app/tracking
```

**Before (generated compose):** No `volumes:` key — mounts silently missing.

**After (generated compose):**
```yaml
volumes:
  - '/opt/data/logs:/app/logs'
  - '/opt/data/tracking:/app/tracking'
```

## Testing

Verified with `convertDockerRunToCompose()` directly:

```php
$result = convertDockerRunToCompose('--volume /opt/data/logs:/app/logs --volume /opt/data/tracking:/app/tracking');
// Result: ['volumes' => ['/opt/data/logs:/app/logs', '/opt/data/tracking:/app/tracking']]
```

Confirmed end-to-end: deployed a Docker Image application with `--volume` in Custom Docker Run Options → `docker inspect` shows bind mounts applied correctly.