### PR TITLE
fix: add --volume support to convertDockerRunToCompose

### DIFF
--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -995,6 +995,7 @@ function convertDockerRunToCompose(?string $custom_docker_run_options = null)
         '--ulimit',
         '--device',
         '--shm-size',
+        '--volume',
     ]);
     $mapping = collect([
         '--cap-add' => 'cap_add',
@@ -1011,6 +1012,7 @@ function convertDockerRunToCompose(?string $custom_docker_run_options = null)
         '--gpus' => 'gpus',
         '--hostname' => 'hostname',
         '--entrypoint' => 'entrypoint',
+        '--volume' => 'volumes',
     ]);
     foreach ($matches as $match) {
         $option = $match[1];
@@ -1108,6 +1110,10 @@ function convertDockerRunToCompose(?string $custom_docker_run_options = null)
                 // Docker compose accepts entrypoint as either a string or an array
                 // Keep it as a string for simplicity - docker compose will handle it
                 $compose_options->put($mapping[$option], $value[0]);
+            }
+        } elseif ($option === '--volume') {
+            if (! is_null($value) && is_array($value) && count($value) > 0) {
+                $compose_options->put($mapping[$option], array_values($value));
             }
         } elseif ($option === '--gpus') {
             $payload = [


### PR DESCRIPTION
## Changes

`--volume` flags in Custom Docker Run Options are silently ignored because `convertDockerRunToCompose()` has no mapping for them. This adds `--volume` to `$list_options`, `$mapping`, and a handler block so that volume bind mounts specified via Custom Docker Run Options are correctly included in the generated docker-compose config.

## Issues

- Related to volume mounts not being applied when using Docker Image build pack with Custom Docker Run Options

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude
- How extensively: Identified the missing mapping and wrote the 6-line fix

## Testing

Tested on a live Coolify v4.0.0-beta.460 instance:

1. Set Custom Docker Run Options to `--volume /opt/data/logs:/app/logs --volume /opt/data/tracking:/app/tracking`
2. Before fix: `docker inspect` shows `Mounts: []`
3. After fix: `docker inspect` shows both bind mounts applied
4. Also verified `convertDockerRunToCompose()` directly returns `['volumes' => ['/opt/data/logs:/app/logs', '/opt/data/tracking:/app/tracking']]`

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.