### PR TITLE
fix(ssh): remove undefined trackSshRetryEvent() method call

### DIFF
--- a/app/Traits/ExecuteRemoteCommand.php
+++ b/app/Traits/ExecuteRemoteCommand.php
@@ -111,13 +111,6 @@ trait ExecuteRemoteCommand
                         $attempt++;
                         $delay = $this->calculateRetryDelay($attempt - 1);
 
-                        // Track SSH retry event in Sentry
-                        $this->trackSshRetryEvent($attempt, $maxRetries, $delay, $errorMessage, [
-                            'server' => $this->server->name ?? $this->server->ip ?? 'unknown',
-                            'command' => $this->redact_sensitive_info($command),
-                            'trait' => 'ExecuteRemoteCommand',
-                        ]);
-
                         // Add log entry for the retry
                         if (isset($this->application_deployment_queue)) {
                             $this->addRetryLogEntry($attempt, $maxRetries, $delay, $errorMessage);


### PR DESCRIPTION
## Summary

- Remove call to undefined `trackSshRetryEvent()` method from SSH retry logic in `ExecuteRemoteCommand` trait
- Fixes deployment failures that occur when SSH connection retries are triggered
- Sentry error tracking code was attempted without the method being defined

## Problem

Deployments were failing with error:
```
Call to undefined method App\Jobs\ApplicationDeploymentJob::trackSshRetryEvent()
```

This occurred when:
- Deployment triggered via Gitea webhook
- Manual redeploy attempted from Coolify UI
- SSH connection errors triggered retry logic

The error happened because the `ExecuteRemoteCommand` trait was attempting to call `trackSshRetryEvent()` to log retry events to Sentry, but this method doesn't exist on the job class, causing immediate deployment failure.

## Solution

Removed the problematic `trackSshRetryEvent()` call and its associated logging logic from the SSH retry handler. The core retry functionality remains intact—deployments will continue to retry on transient SSH errors, just without the Sentry event tracking.

---

Fixes #8926