### PR TITLE
Fix IPv6 gateway CIDR suffix causing Traefik ParseAddr error

### DIFF
--- a/bootstrap/helpers/proxy.php
+++ b/bootstrap/helpers/proxy.php
@@ -155,7 +155,42 @@ function ensureProxyNetworksExist(Server $server)
         });
     }
 
+    // Fix IPv6 gateway CIDR issue: Docker may store the gateway with a CIDR
+    // suffix (e.g. ::1/64) which causes ParseAddr errors in Traefik.
+    $commands->push(fixIpv6GatewayCidrCommand('coolify'));
+
     return $commands->flatten();
+}
+
+/**
+ * Returns a shell command that detects and fixes an IPv6 gateway stored with
+ * a CIDR suffix (e.g. "::1/64") on the given Docker network. The CIDR notation
+ * belongs only on the Subnet field; when present on the Gateway it causes
+ * Go's netip.ParseAddr to fail with "unexpected character, want colon".
+ */
+function fixIpv6GatewayCidrCommand(string $network): string
+{
+    return <<<BASH
+if command -v jq >/dev/null 2>&1; then
+  IPV6_GW=\$(docker network inspect {$network} 2>/dev/null | jq -r '.[0].IPAM.Config[] | select(.Gateway | test(":")) | .Gateway' 2>/dev/null)
+  if echo "\$IPV6_GW" | grep -q '/'; then
+    echo "Fixing IPv6 gateway CIDR on network {$network}..."
+    IPV4_SUBNET=\$(docker network inspect {$network} 2>/dev/null | jq -r '.[0].IPAM.Config[] | select(.Gateway | test(":") | not) | .Subnet')
+    IPV4_GW=\$(docker network inspect {$network} 2>/dev/null | jq -r '.[0].IPAM.Config[] | select(.Gateway | test(":") | not) | .Gateway')
+    IPV6_SUBNET=\$(docker network inspect {$network} 2>/dev/null | jq -r '.[0].IPAM.Config[] | select(.Gateway | test(":")) | .Subnet')
+    IPV6_GW_FIXED=\$(echo "\$IPV6_GW" | sed 's|/.*||')
+    for C in \$(docker network inspect {$network} --format '{{range .Containers}}{{.Name}} {{end}}'); do
+      docker network disconnect {$network} "\$C" 2>/dev/null || true
+    done
+    docker network rm {$network} 2>/dev/null || true
+    docker network create --attachable --ipv6 --subnet "\$IPV4_SUBNET" --gateway "\$IPV4_GW" --subnet "\$IPV6_SUBNET" --gateway "\$IPV6_GW_FIXED" {$network} 2>/dev/null
+    for C in \$(docker ps --format '{{.Names}}' | grep '^coolify'); do
+      docker network connect {$network} "\$C" 2>/dev/null || true
+    done
+    echo "IPv6 gateway fixed on network {$network}"
+  fi
+fi
+BASH;
 }
 
 function extractCustomProxyCommands(Server $server, string $existing_config): array

--- a/other/nightly/upgrade.sh
+++ b/other/nightly/upgrade.sh
@@ -139,6 +139,31 @@ if ! docker network inspect coolify >/dev/null 2>&1; then
     fi
 else
     log "Network 'coolify' already exists"
+    # Fix IPv6 gateway CIDR issue: Docker may store the gateway with a CIDR
+    # suffix (e.g. ::1/64) which causes ParseAddr errors in Traefik.
+    # The CIDR notation belongs only on the Subnet field, not the Gateway.
+    if command -v jq >/dev/null 2>&1; then
+        IPV6_GW=$(docker network inspect coolify 2>/dev/null | jq -r '.[0].IPAM.Config[] | select(.Gateway | test(":")) | .Gateway' 2>/dev/null)
+        if echo "$IPV6_GW" | grep -q '/'; then
+            log "Found IPv6 gateway with CIDR notation ($IPV6_GW), recreating network to fix..."
+            IPV4_SUBNET=$(docker network inspect coolify 2>/dev/null | jq -r '.[0].IPAM.Config[] | select(.Gateway | test(":") | not) | .Subnet')
+            IPV4_GW=$(docker network inspect coolify 2>/dev/null | jq -r '.[0].IPAM.Config[] | select(.Gateway | test(":") | not) | .Gateway')
+            IPV6_SUBNET=$(docker network inspect coolify 2>/dev/null | jq -r '.[0].IPAM.Config[] | select(.Gateway | test(":")) | .Subnet')
+            IPV6_GW_FIXED=$(echo "$IPV6_GW" | sed 's|/.*||')
+            for CONTAINER in $(docker network inspect coolify --format '{{range .Containers}}{{.Name}} {{end}}'); do
+                docker network disconnect coolify "$CONTAINER" 2>/dev/null || true
+            done
+            docker network rm coolify 2>/dev/null || true
+            docker network create --attachable --ipv6 \
+                --subnet "$IPV4_SUBNET" --gateway "$IPV4_GW" \
+                --subnet "$IPV6_SUBNET" --gateway "$IPV6_GW_FIXED" \
+                coolify 2>/dev/null
+            for CONTAINER in $(docker ps --format '{{.Names}}' | grep '^coolify'); do
+                docker network connect coolify "$CONTAINER" 2>/dev/null || true
+            done
+            log "Network 'coolify' recreated with fixed IPv6 gateway ($IPV6_GW_FIXED)"
+        fi
+    fi
 fi
 
 # Check if Docker config file exists

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -139,6 +139,31 @@ if ! docker network inspect coolify >/dev/null 2>&1; then
     fi
 else
     log "Network 'coolify' already exists"
+    # Fix IPv6 gateway CIDR issue: Docker may store the gateway with a CIDR
+    # suffix (e.g. ::1/64) which causes ParseAddr errors in Traefik.
+    # The CIDR notation belongs only on the Subnet field, not the Gateway.
+    if command -v jq >/dev/null 2>&1; then
+        IPV6_GW=$(docker network inspect coolify 2>/dev/null | jq -r '.[0].IPAM.Config[] | select(.Gateway | test(":")) | .Gateway' 2>/dev/null)
+        if echo "$IPV6_GW" | grep -q '/'; then
+            log "Found IPv6 gateway with CIDR notation ($IPV6_GW), recreating network to fix..."
+            IPV4_SUBNET=$(docker network inspect coolify 2>/dev/null | jq -r '.[0].IPAM.Config[] | select(.Gateway | test(":") | not) | .Subnet')
+            IPV4_GW=$(docker network inspect coolify 2>/dev/null | jq -r '.[0].IPAM.Config[] | select(.Gateway | test(":") | not) | .Gateway')
+            IPV6_SUBNET=$(docker network inspect coolify 2>/dev/null | jq -r '.[0].IPAM.Config[] | select(.Gateway | test(":")) | .Subnet')
+            IPV6_GW_FIXED=$(echo "$IPV6_GW" | sed 's|/.*||')
+            for CONTAINER in $(docker network inspect coolify --format '{{range .Containers}}{{.Name}} {{end}}'); do
+                docker network disconnect coolify "$CONTAINER" 2>/dev/null || true
+            done
+            docker network rm coolify 2>/dev/null || true
+            docker network create --attachable --ipv6 \
+                --subnet "$IPV4_SUBNET" --gateway "$IPV4_GW" \
+                --subnet "$IPV6_SUBNET" --gateway "$IPV6_GW_FIXED" \
+                coolify 2>/dev/null
+            for CONTAINER in $(docker ps --format '{{.Names}}' | grep '^coolify'); do
+                docker network connect coolify "$CONTAINER" 2>/dev/null || true
+            done
+            log "Network 'coolify' recreated with fixed IPv6 gateway ($IPV6_GW_FIXED)"
+        fi
+    fi
 fi
 
 # Fix SSH directory ownership if not owned by container user UID 9999 (fixes #6621)


### PR DESCRIPTION
## Changes

When Docker creates an IPv6-enabled bridge network (via `docker network create --attachable --ipv6 coolify`), certain Docker versions store the gateway address with a CIDR suffix (e.g. `fdee:22bc:552b::1/64`). The CIDR notation should only appear on the Subnet field, not the Gateway.

This causes Traefik (coolify-proxy) to fail on startup with:

```
ParseAddr("fdee:22bc:552b::1/64"): unexpected character, want colon (at "/64")
```

This is because Go's `netip.ParseAddr` (used by Traefik) does not accept CIDR notation — it expects a bare IP address.

**The fix** adds detection and auto-repair logic in three places:

1. **`scripts/upgrade.sh`** — After confirming the coolify network exists, checks if the IPv6 gateway has a CIDR suffix. If so, recreates the network with the corrected gateway while preserving all subnet/gateway configuration.

2. **`other/nightly/upgrade.sh`** — Same fix for the nightly upgrade path.

3. **`bootstrap/helpers/proxy.php`** (`ensureProxyNetworksExist`) — Adds a gateway CIDR check that runs before each proxy startup, via a new `fixIpv6GatewayCidrCommand()` helper. This ensures the issue is caught even outside of upgrades (e.g. after a Docker daemon restart that re-introduces the bug).

The fix uses `jq` (already a dependency on Coolify servers) to parse the network inspect JSON and extract IPv6 vs IPv4 IPAM config reliably.

## Issues

- Fixes proxy startup failure: `ParseAddr("...::1/64"): unexpected character, want colon`
- Affects servers with IPv6-enabled Docker networks where Docker stores gateway with CIDR suffix

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

**Before fix** — Proxy fails to start:
```
Starting coolify-proxy.
ParseAddr("fdee:22bc:552b::1/64"): unexpected character, want colon (at "/64")
```

**After fix** — Gateway CIDR is detected and corrected automatically:
```
Found IPv6 gateway with CIDR notation (fdee:22bc:552b::1/64), recreating network to fix...
Network 'coolify' recreated with fixed IPv6 gateway (fdee:22bc:552b::1)
```

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Claude Opus 4.6)
- How extensively: AI identified the root cause (Docker storing IPv6 gateway with CIDR suffix vs Go's netip.ParseAddr expectation), wrote the fix across all three files, and verified it works on a live Coolify instance. All changes were reviewed and tested manually.

## Testing

1. On a Coolify server with IPv6 enabled, confirmed the `coolify` Docker network had gateway `fdee:22bc:552b::1/64` (with CIDR suffix)
2. Verified proxy failed to start with `ParseAddr` error
3. Applied the fix — network was recreated with gateway `fdee:22bc:552b::1` (no CIDR)
4. Proxy started successfully and reported healthy
5. Verified all Coolify services (coolify, coolify-db, coolify-redis, coolify-realtime, coolify-proxy, coolify-sentinel) reconnected and are healthy
6. Tested the detection logic with both affected (gateway has `/64`) and clean (gateway without CIDR) networks — fix only triggers when needed

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.