### PR TITLE
fix(logs): handle missing clipboard API in non-HTTPS contexts

### DIFF
--- a/resources/views/livewire/project/application/deployment/show.blade.php
+++ b/resources/views/livewire/project/application/deployment/show.blade.php
@@ -212,8 +212,15 @@
                                 <button
                                     x-on:click="
                                     $wire.copyLogs().then(logs => {
-                                        navigator.clipboard.writeText(logs);
-                                        Livewire.dispatch('success', ['Logs copied to clipboard.']);
+                                        if (!navigator.clipboard) {
+                                            Livewire.dispatch('error', ['Clipboard is not available. Please use HTTPS.']);
+                                            return;
+                                        }
+                                        navigator.clipboard.writeText(logs).then(() => {
+                                            Livewire.dispatch('success', ['Logs copied to clipboard.']);
+                                        }).catch(() => {
+                                            Livewire.dispatch('error', ['Failed to copy logs to clipboard.']);
+                                        });
                                     });
                                 "
                                 title="Copy Logs"

--- a/resources/views/livewire/project/shared/get-logs.blade.php
+++ b/resources/views/livewire/project/shared/get-logs.blade.php
@@ -314,8 +314,15 @@
                         <button
                             x-on:click="
                                 $wire.copyLogs().then(logs => {
-                                    navigator.clipboard.writeText(logs);
-                                    Livewire.dispatch('success', ['Logs copied to clipboard.']);
+                                    if (!navigator.clipboard) {
+                                        Livewire.dispatch('error', ['Clipboard is not available. Please use HTTPS.']);
+                                        return;
+                                    }
+                                    navigator.clipboard.writeText(logs).then(() => {
+                                        Livewire.dispatch('success', ['Logs copied to clipboard.']);
+                                    }).catch(() => {
+                                        Livewire.dispatch('error', ['Failed to copy logs to clipboard.']);
+                                    });
                                 });
                             "
                             title="Copy Logs"


### PR DESCRIPTION
## Changes

The copy-logs clipboard button was silently failing when Coolify is accessed over HTTP (non-HTTPS). The `navigator.clipboard` API is only available in [secure contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) (HTTPS or localhost). Calling `.writeText()` on `undefined` threw a `TypeError` that Alpine.js caught and logged, but no feedback was shown to the user — the button appeared to do nothing.

Two issues were fixed:
- Added a `navigator.clipboard` existence check before attempting the write
- Chained `.then()/.catch()` on the `writeText()` Promise so success/failure both surface as user-visible toast notifications instead of silent errors

Affected files:
- `resources/views/livewire/project/application/deployment/show.blade.php`
- `resources/views/livewire/project/shared/get-logs.blade.php`

## Issues

- Fixes clipboard button silently failing on HTTP deployments

## Category

- [x] Bug fix

## Preview

**Before:** Clicking "Copy Logs" on an HTTP instance threw `Alpine Expression Error: Cannot read properties of undefined (reading 'writeText')` in the console with no user feedback.

**After:**
- HTTPS: clipboard works as expected, success toast shown
- HTTP: error toast shown — `"Clipboard is not available. Please use HTTPS."`
- HTTPS but permission denied: error toast shown — `"Failed to copy logs to clipboard."`

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (claude-sonnet-4-6)
- How extensively: AI identified the root cause (missing secure context check and unhandled Promise), suggested the fix, and applied it to both affected blade files. The fix was reviewed and confirmed by the human contributor before submitting.

## Testing

Reproduced the error by accessing a local Coolify dev instance over HTTP and clicking the copy logs button — confirmed `TypeError` in the browser console with no user feedback. After the fix, the error toast appeared correctly. On HTTPS the copy succeeds and the success toast fires as expected.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.