### PR TITLE
fix(logs): handle missing clipboard API in non-HTTPS contexts

### DIFF
--- a/resources/views/livewire/project/application/deployment/show.blade.php
+++ b/resources/views/livewire/project/application/deployment/show.blade.php
@@ -212,8 +212,15 @@
                                 <button
                                     x-on:click="
                                     $wire.copyLogs().then(logs => {
-                                        navigator.clipboard.writeText(logs);
-                                        Livewire.dispatch('success', ['Logs copied to clipboard.']);
+                                        if (!navigator.clipboard) {
+                                            Livewire.dispatch('error', ['Clipboard is not available. Please use HTTPS.']);
+                                            return;
+                                        }
+                                        navigator.clipboard.writeText(logs).then(() => {
+                                            Livewire.dispatch('success', ['Logs copied to clipboard.']);
+                                        }).catch(() => {
+                                            Livewire.dispatch('error', ['Failed to copy logs to clipboard.']);
+                                        });
                                     });
                                 "
                                 title="Copy Logs"

--- a/resources/views/livewire/project/shared/get-logs.blade.php
+++ b/resources/views/livewire/project/shared/get-logs.blade.php
@@ -314,8 +314,15 @@
                         <button
                             x-on:click="
                                 $wire.copyLogs().then(logs => {
-                                    navigator.clipboard.writeText(logs);
-                                    Livewire.dispatch('success', ['Logs copied to clipboard.']);
+                                    if (!navigator.clipboard) {
+                                        Livewire.dispatch('error', ['Clipboard is not available. Please use HTTPS.']);
+                                        return;
+                                    }
+                                    navigator.clipboard.writeText(logs).then(() => {
+                                        Livewire.dispatch('success', ['Logs copied to clipboard.']);
+                                    }).catch(() => {
+                                        Livewire.dispatch('error', ['Failed to copy logs to clipboard.']);
+                                    });
                                 });
                             "
                             title="Copy Logs"


### PR DESCRIPTION
## Changes

The copy-logs clipboard button was silently failing on HTTP (non-HTTPS) instances. `navigator.clipboard` is only available in [secure contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts); calling `.writeText()` on `undefined` threw a `TypeError` that Alpine.js swallowed — the button appeared to do nothing with no feedback.

Two issues fixed:
- Added `navigator.clipboard` existence check before attempting the write
- Properly chained `.then()/.catch()` on the `writeText()` Promise so both success and failure surface as toast notifications

Affected: `deployment/show.blade.php` and `project/shared/get-logs.blade.php`

## Issues

- Fixes

## Category

- [x] Bug fix

## Preview

**Before:** Silent fail, `Alpine Expression Error: Cannot read properties of undefined (reading 'writeText')` in console.

**After:**
- HTTPS → success toast as expected
- HTTP → `"Clipboard is not available. Please use HTTPS."`
- Permission denied → `"Failed to copy logs to clipboard."`

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (claude-sonnet-4-6)
- How extensively: AI identified the root cause and applied the fix to both blade files. Fix was reviewed by the human contributor before submitting.

## Testing

Reproduced on a local HTTP dev instance — confirmed `TypeError` in console with no user feedback. After the fix, the error toast appeared correctly. On HTTPS the copy succeeds with the success toast.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.