### PR TITLE
fix(logs): handle missing clipboard API in non-HTTPS contexts

### DIFF
--- a/resources/views/livewire/project/application/deployment/show.blade.php
+++ b/resources/views/livewire/project/application/deployment/show.blade.php
@@ -212,8 +212,15 @@
                                 <button
                                     x-on:click="
                                     $wire.copyLogs().then(logs => {
-                                        navigator.clipboard.writeText(logs);
-                                        Livewire.dispatch('success', ['Logs copied to clipboard.']);
+                                        if (!navigator.clipboard) {
+                                            Livewire.dispatch('error', ['Clipboard is not available. Please use HTTPS.']);
+                                            return;
+                                        }
+                                        navigator.clipboard.writeText(logs).then(() => {
+                                            Livewire.dispatch('success', ['Logs copied to clipboard.']);
+                                        }).catch(() => {
+                                            Livewire.dispatch('error', ['Failed to copy logs to clipboard.']);
+                                        });
                                     });
                                 "
                                 title="Copy Logs"

--- a/resources/views/livewire/project/shared/get-logs.blade.php
+++ b/resources/views/livewire/project/shared/get-logs.blade.php
@@ -314,8 +314,15 @@
                         <button
                             x-on:click="
                                 $wire.copyLogs().then(logs => {
-                                    navigator.clipboard.writeText(logs);
-                                    Livewire.dispatch('success', ['Logs copied to clipboard.']);
+                                    if (!navigator.clipboard) {
+                                        Livewire.dispatch('error', ['Clipboard is not available. Please use HTTPS.']);
+                                        return;
+                                    }
+                                    navigator.clipboard.writeText(logs).then(() => {
+                                        Livewire.dispatch('success', ['Logs copied to clipboard.']);
+                                    }).catch(() => {
+                                        Livewire.dispatch('error', ['Failed to copy logs to clipboard.']);
+                                    });
                                 });
                             "
                             title="Copy Logs"


### PR DESCRIPTION
## Changes

The copy-logs clipboard button was silently failing on HTTP instances. `navigator.clipboard` is only available in secure contexts (HTTPS or localhost). Calling `.writeText()` on `undefined` threw a `TypeError` that Alpine.js swallowed — the button appeared to do nothing with no user feedback.

Both `deployment/show.blade.php` and `project/shared/get-logs.blade.php` had the same issue.

- Added `navigator.clipboard` existence check before attempting the write
- Properly chained `.then()/.catch()` on the `writeText()` Promise so success and failure both surface as toast notifications instead of silent crashes

## Issues

- Fixes

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No visual changes — behavior fix. On HTTP the error toast now appears instead of silently failing.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Used to explore codebase and identify root cause. I reviewed and verified all changes.

## Testing

1. Access Coolify over HTTP
2. Start a deployment, open the deployment log screen
3. Click the copy logs button
4. Before: silent fail with TypeError in console
5. After: error toast — "Clipboard is not available. Please use HTTPS."
6. Same test on HTTPS: copy succeeds with success toast

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.