### PR TITLE
feat(compose-preview): populate fqdn from docker_compose_domains

### DIFF
--- a/app/Models/ApplicationPreview.php
+++ b/app/Models/ApplicationPreview.php
@@ -166,6 +166,16 @@ class ApplicationPreview extends BaseModel
         }
 
         $this->docker_compose_domains = json_encode($docker_compose_domains);
+
+        // Populate fqdn from generated domains so webhook notifications can read it
+        $allDomains = collect($docker_compose_domains)
+            ->pluck('domain')
+            ->filter(fn ($d) => ! empty($d))
+            ->flatMap(fn ($d) => explode(',', $d))
+            ->implode(',');
+
+        $this->fqdn = ! empty($allDomains) ? $allDomains : null;
+
         $this->save();
     }
 }

--- a/tests/Feature/ComposePreviewFqdnTest.php
+++ b/tests/Feature/ComposePreviewFqdnTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use App\Models\Application;
+use App\Models\ApplicationPreview;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('populates fqdn from docker_compose_domains after generate_preview_fqdn_compose', function () {
+    $application = Application::factory()->create([
+        'build_pack' => 'dockercompose',
+        'docker_compose_domains' => json_encode([
+            'web' => ['domain' => 'https://example.com'],
+        ]),
+    ]);
+
+    $preview = ApplicationPreview::create([
+        'application_id' => $application->id,
+        'pull_request_id' => 42,
+        'docker_compose_domains' => $application->docker_compose_domains,
+    ]);
+
+    $preview->generate_preview_fqdn_compose();
+
+    $preview->refresh();
+
+    expect($preview->fqdn)->not->toBeNull();
+    expect($preview->fqdn)->toContain('42');
+    expect($preview->fqdn)->toContain('example.com');
+});
+
+it('populates fqdn with multiple domains from multiple services', function () {
+    $application = Application::factory()->create([
+        'build_pack' => 'dockercompose',
+        'docker_compose_domains' => json_encode([
+            'web' => ['domain' => 'https://web.example.com'],
+            'api' => ['domain' => 'https://api.example.com'],
+        ]),
+    ]);
+
+    $preview = ApplicationPreview::create([
+        'application_id' => $application->id,
+        'pull_request_id' => 7,
+        'docker_compose_domains' => $application->docker_compose_domains,
+    ]);
+
+    $preview->generate_preview_fqdn_compose();
+
+    $preview->refresh();
+
+    expect($preview->fqdn)->not->toBeNull();
+    $domains = explode(',', $preview->fqdn);
+    expect($domains)->toHaveCount(2);
+    expect($preview->fqdn)->toContain('web.example.com');
+    expect($preview->fqdn)->toContain('api.example.com');
+});
+
+it('sets fqdn to null when no domains are configured', function () {
+    $application = Application::factory()->create([
+        'build_pack' => 'dockercompose',
+        'docker_compose_domains' => json_encode([
+            'web' => ['domain' => ''],
+        ]),
+    ]);
+
+    $preview = ApplicationPreview::create([
+        'application_id' => $application->id,
+        'pull_request_id' => 99,
+        'docker_compose_domains' => $application->docker_compose_domains,
+    ]);
+
+    $preview->generate_preview_fqdn_compose();
+
+    $preview->refresh();
+
+    expect($preview->fqdn)->toBeNull();
+});


### PR DESCRIPTION
## Summary

- Populate `ApplicationPreview::fqdn` from `docker_compose_domains` in `generate_preview_fqdn_compose()` so webhook notifications include the correct `preview_fqdn`
- Fixes issue where Docker Compose preview deployments sent `null` for `preview_fqdn` in webhook payloads while regular apps (Nixpacks, Dockerfile, Static) worked correctly
- Collects all domains from all services and stores as comma-separated list in `fqdn` field, or `null` if no domains configured
- Added comprehensive test coverage for single domain, multiple services, and empty domain scenarios

## Related Issue

Fixes #8958

---

Fixes #8958