### PR TITLE
feat(server): auto-fetch server metadata after validation

### DIFF
--- a/app/Jobs/ValidateAndInstallServerJob.php
+++ b/app/Jobs/ValidateAndInstallServerJob.php
@@ -179,6 +179,9 @@ class ValidateAndInstallServerJob implements ShouldBeEncrypted, ShouldQueue
             // Mark validation as complete
             $this->server->update(['is_validating' => false]);
 
+            // Auto-fetch server details now that validation passed
+            $this->server->gatherServerMetadata();
+
             // Refresh server to get latest state
             $this->server->refresh();
 

--- a/app/Livewire/Server/ValidateAndInstall.php
+++ b/app/Livewire/Server/ValidateAndInstall.php
@@ -198,6 +198,9 @@ class ValidateAndInstall extends Component
                 // Mark validation as complete
                 $this->server->update(['is_validating' => false]);
 
+                // Auto-fetch server details now that validation passed
+                $this->server->gatherServerMetadata();
+
                 $this->dispatch('refreshServerShow');
                 $this->dispatch('refreshBoardingIndex');
                 ServerValidated::dispatch($this->server->team_id, $this->server->uuid);

--- a/tests/Feature/ServerMetadataTest.php
+++ b/tests/Feature/ServerMetadataTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use App\Livewire\Server\ValidateAndInstall;
 use App\Models\Server;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
 
 uses(RefreshDatabase::class);
 
@@ -93,4 +95,25 @@ it('can overwrite server_metadata with new values', function () {
 
     expect($this->server->server_metadata['os'])->toBe('Ubuntu 22.04')
         ->and($this->server->server_metadata['cpus'])->toBe(4);
+});
+
+it('calls gatherServerMetadata during ValidateAndInstall when docker version is valid', function () {
+    $serverMock = Mockery::mock($this->server)->makePartial();
+    $serverMock->shouldReceive('isSwarm')->andReturn(false);
+    $serverMock->shouldReceive('validateDockerEngineVersion')->once()->andReturn('24.0.0');
+    $serverMock->shouldReceive('gatherServerMetadata')->once();
+    $serverMock->shouldReceive('isBuildServer')->andReturn(false);
+
+    Livewire::test(ValidateAndInstall::class, ['server' => $serverMock])
+        ->call('validateDockerVersion');
+});
+
+it('does not call gatherServerMetadata when docker version validation fails', function () {
+    $serverMock = Mockery::mock($this->server)->makePartial();
+    $serverMock->shouldReceive('isSwarm')->andReturn(false);
+    $serverMock->shouldReceive('validateDockerEngineVersion')->once()->andReturn(false);
+    $serverMock->shouldNotReceive('gatherServerMetadata');
+
+    Livewire::test(ValidateAndInstall::class, ['server' => $serverMock])
+        ->call('validateDockerVersion');
 });


### PR DESCRIPTION
## Summary

- Automatically fetch server metadata immediately after server validation completes
- Eliminates the need for a separate metadata refresh action post-validation
- Applied consistently across both async job queue and real-time Livewire validation flows
- Added tests to verify `gatherServerMetadata()` is called during validation when Docker validation succeeds

## Changes

- **ValidateAndInstallServerJob**: Call `gatherServerMetadata()` after marking validation complete
- **ValidateAndInstall Livewire component**: Call `gatherServerMetadata()` after Docker version validation passes
- **ServerMetadataTest**: Added tests to verify metadata is gathered on successful validation and skipped on failed validation