### PR TITLE
Fix: Add traefik.docker.network label to prevent routing to wrong network

### DIFF
--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -406,10 +406,15 @@ function fqdnLabelsForCaddy(string $network, string $uuid, Collection $domains, 
     return $labels->sort();
 }
 
-function fqdnLabelsForTraefik(string $uuid, Collection $domains, bool $is_force_https_enabled = false, $onlyPort = null, ?Collection $serviceLabels = null, ?bool $is_gzip_enabled = true, ?bool $is_stripprefix_enabled = true, ?string $service_name = null, bool $generate_unique_uuid = false, ?string $image = null, string $redirect_direction = 'both', bool $is_http_basic_auth_enabled = false, ?string $http_basic_auth_username = null, ?string $http_basic_auth_password = null)
+function fqdnLabelsForTraefik(string $uuid, Collection $domains, bool $is_force_https_enabled = false, $onlyPort = null, ?Collection $serviceLabels = null, ?bool $is_gzip_enabled = true, ?bool $is_stripprefix_enabled = true, ?string $service_name = null, bool $generate_unique_uuid = false, ?string $image = null, string $redirect_direction = 'both', bool $is_http_basic_auth_enabled = false, ?string $http_basic_auth_username = null, ?string $http_basic_auth_password = null, ?string $network = null)
 {
     $labels = collect([]);
     $labels->push('traefik.enable=true');
+    if ($serviceLabels) {
+        $labels->push("traefik.docker.network={$uuid}");
+    } elseif ($network) {
+        $labels->push("traefik.docker.network={$network}");
+    }
     if ($is_gzip_enabled) {
         $labels->push('traefik.http.middlewares.gzip.compress=true');
     }

--- a/bootstrap/helpers/parsers.php
+++ b/bootstrap/helpers/parsers.php
@@ -1334,7 +1334,8 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
                             is_gzip_enabled: $originalResource->isGzipEnabled(),
                             is_stripprefix_enabled: $originalResource->isStripprefixEnabled(),
                             service_name: $serviceName,
-                            image: $image
+                            image: $image,
+                            network: $network,
                         ));
                         break;
                     case ProxyTypes::CADDY->value:
@@ -1361,7 +1362,8 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
                     is_gzip_enabled: $originalResource->isGzipEnabled(),
                     is_stripprefix_enabled: $originalResource->isStripprefixEnabled(),
                     service_name: $serviceName,
-                    image: $image
+                    image: $image,
+                    network: $network,
                 ));
                 $serviceLabels = $serviceLabels->merge(fqdnLabelsForCaddy(
                     network: $network,
@@ -2599,7 +2601,8 @@ function serviceParser(Service $resource): Collection
                             is_gzip_enabled: $originalResource->isGzipEnabled(),
                             is_stripprefix_enabled: $originalResource->isStripprefixEnabled(),
                             service_name: $serviceName,
-                            image: $image
+                            image: $image,
+                            network: $network,
                         ));
                         break;
                     case ProxyTypes::CADDY->value:
@@ -2626,7 +2629,8 @@ function serviceParser(Service $resource): Collection
                     is_gzip_enabled: $originalResource->isGzipEnabled(),
                     is_stripprefix_enabled: $originalResource->isStripprefixEnabled(),
                     service_name: $serviceName,
-                    image: $image
+                    image: $image,
+                    network: $network,
                 ));
                 $serviceLabels = $serviceLabels->merge(fqdnLabelsForCaddy(
                     network: $network,

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -2333,7 +2333,8 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                                         is_gzip_enabled: $savedService->isGzipEnabled(),
                                         is_stripprefix_enabled: $savedService->isStripprefixEnabled(),
                                         service_name: $serviceName,
-                                        image: data_get($service, 'image')
+                                        image: data_get($service, 'image'),
+                                        network: $resource->destination->network,
                                     ));
                                     break;
                                 case ProxyTypes::CADDY->value:
@@ -2359,7 +2360,8 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                                 is_gzip_enabled: $savedService->isGzipEnabled(),
                                 is_stripprefix_enabled: $savedService->isStripprefixEnabled(),
                                 service_name: $serviceName,
-                                image: data_get($service, 'image')
+                                image: data_get($service, 'image'),
+                                network: $resource->destination->network,
                             ));
                             $serviceLabels = $serviceLabels->merge(fqdnLabelsForCaddy(
                                 network: $resource->destination->network,
@@ -3109,6 +3111,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                                             is_force_https_enabled: $resource->isForceHttpsEnabled(),
                                             is_gzip_enabled: $resource->isGzipEnabled(),
                                             is_stripprefix_enabled: $resource->isStripprefixEnabled(),
+                                            network: $resource->destination->network,
                                         )
                                     );
                                     break;
@@ -3138,6 +3141,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                                     is_force_https_enabled: $resource->isForceHttpsEnabled(),
                                     is_gzip_enabled: $resource->isGzipEnabled(),
                                     is_stripprefix_enabled: $resource->isStripprefixEnabled(),
+                                    network: $resource->destination->network,
                                 )
                             );
                             $serviceLabels = $serviceLabels->merge(


### PR DESCRIPTION
## Summary

Fixes #6215

When a container is on multiple Docker networks, Traefik non-deterministically
picks which network IP to route to. If it picks an internal or unreachable
network, requests hang or timeout.

The `traefik.docker.network` label tells Traefik which network to use for
backend connections. `fqdnLabelsForCaddy()` already handles this correctly
by emitting `caddy_ingress_network`, but `fqdnLabelsForTraefik()` never
emitted the equivalent `traefik.docker.network` label.

## Changes

- **`bootstrap/helpers/docker.php`**: Added `?string $network = null` parameter
  to `fqdnLabelsForTraefik()` and emit `traefik.docker.network` label, mirroring
  the existing Caddy logic (use `$uuid` for Docker Compose deployments,
  `$network` for single-container apps).
- **`bootstrap/helpers/parsers.php`**: Pass `$network` to all
  `fqdnLabelsForTraefik()` call sites.
- **`bootstrap/helpers/shared.php`**: Pass `$resource->destination->network`
  to all `fqdnLabelsForTraefik()` call sites.

## Test plan

- [ ] Deploy a Docker Compose app with multiple networks (including an `internal: true` network) behind Traefik
- [ ] Verify `traefik.docker.network` label appears on the container with the correct network name
- [ ] Confirm Traefik consistently routes to the correct network
- [ ] Verify single-container (non-compose) apps also get the correct label
- [ ] Verify no regression for Caddy deployments
- [ ] Verify no regression for single-network containers (label still emitted, just one network to choose from)

🤖 Generated with [Claude Code](https://claude.com/claude-code)