### PR TITLE
feat(api): add POST /move endpoints to relocate resources between environments

### DIFF
--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -3828,6 +3828,99 @@ class ApplicationsController extends Controller
         );
     }
 
+    #[OA\Post(
+        summary: 'Move',
+        description: 'Move application to another project/environment. This is a purely organizational change — running containers are not affected. Note: after moving, the application will pick up shared environment variables from the new environment on the next deployment.',
+        path: '/applications/{uuid}/move',
+        operationId: 'move-application-by-uuid',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Applications'],
+        parameters: [
+            new OA\Parameter(
+                name: 'uuid',
+                in: 'path',
+                description: 'UUID of the application.',
+                required: true,
+                schema: new OA\Schema(
+                    type: 'string',
+                )
+            ),
+        ],
+        requestBody: new OA\RequestBody(
+            description: 'Target environment to move the application to.',
+            required: true,
+            content: [
+                new OA\MediaType(
+                    mediaType: 'application/json',
+                    schema: new OA\Schema(
+                        type: 'object',
+                        properties: [
+                            'environment_uuid' => ['type' => 'string', 'description' => 'UUID of the target environment.'],
+                        ],
+                        required: ['environment_uuid'],
+                    )
+                ),
+            ]
+        ),
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Application moved successfully.',
+                content: [
+                    new OA\MediaType(
+                        mediaType: 'application/json',
+                        schema: new OA\Schema(
+                            type: 'object',
+                            properties: [
+                                'message' => ['type' => 'string', 'example' => 'Application moved successfully.'],
+                                'uuid' => ['type' => 'string'],
+                                'project_uuid' => ['type' => 'string'],
+                                'environment_uuid' => ['type' => 'string'],
+                            ]
+                        )
+                    ),
+                ]
+            ),
+            new OA\Response(
+                response: 401,
+                ref: '#/components/responses/401',
+            ),
+            new OA\Response(
+                response: 400,
+                ref: '#/components/responses/400',
+            ),
+            new OA\Response(
+                response: 404,
+                ref: '#/components/responses/404',
+            ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
+            ),
+        ]
+    )]
+    public function move_by_uuid(Request $request): \Illuminate\Http\JsonResponse
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+        $uuid = $request->route('uuid');
+        if (! $uuid) {
+            return response()->json(['message' => 'UUID is required.'], 400);
+        }
+        $application = Application::ownedByCurrentTeamAPI($teamId)->where('uuid', $request->uuid)->first();
+        if (! $application) {
+            return response()->json(['message' => 'Application not found.'], 404);
+        }
+
+        $this->authorize('update', $application);
+
+        return moveResourceToEnvironment($request, $application, 'Application', $teamId);
+    }
+
     private function validateDataApplications(Request $request, Server $server)
     {
         $teamId = getTeamIdFromToken();

--- a/app/Http/Controllers/Api/DatabasesController.php
+++ b/app/Http/Controllers/Api/DatabasesController.php
@@ -2503,6 +2503,99 @@ class DatabasesController extends Controller
         ]);
     }
 
+    #[OA\Post(
+        summary: 'Move',
+        description: 'Move database to another project/environment. This is a purely organizational change — running containers are not affected. Note: after moving, the database will pick up shared environment variables from the new environment on the next deployment.',
+        path: '/databases/{uuid}/move',
+        operationId: 'move-database-by-uuid',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Databases'],
+        parameters: [
+            new OA\Parameter(
+                name: 'uuid',
+                in: 'path',
+                description: 'UUID of the database.',
+                required: true,
+                schema: new OA\Schema(
+                    type: 'string',
+                )
+            ),
+        ],
+        requestBody: new OA\RequestBody(
+            description: 'Target environment to move the database to.',
+            required: true,
+            content: [
+                new OA\MediaType(
+                    mediaType: 'application/json',
+                    schema: new OA\Schema(
+                        type: 'object',
+                        properties: [
+                            'environment_uuid' => ['type' => 'string', 'description' => 'UUID of the target environment.'],
+                        ],
+                        required: ['environment_uuid'],
+                    )
+                ),
+            ]
+        ),
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Database moved successfully.',
+                content: [
+                    new OA\MediaType(
+                        mediaType: 'application/json',
+                        schema: new OA\Schema(
+                            type: 'object',
+                            properties: [
+                                'message' => ['type' => 'string', 'example' => 'Database moved successfully.'],
+                                'uuid' => ['type' => 'string'],
+                                'project_uuid' => ['type' => 'string'],
+                                'environment_uuid' => ['type' => 'string'],
+                            ]
+                        )
+                    ),
+                ]
+            ),
+            new OA\Response(
+                response: 401,
+                ref: '#/components/responses/401',
+            ),
+            new OA\Response(
+                response: 400,
+                ref: '#/components/responses/400',
+            ),
+            new OA\Response(
+                response: 404,
+                ref: '#/components/responses/404',
+            ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
+            ),
+        ]
+    )]
+    public function move_by_uuid(Request $request): \Illuminate\Http\JsonResponse
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+        $uuid = $request->route('uuid');
+        if (! $uuid) {
+            return response()->json(['message' => 'UUID is required.'], 400);
+        }
+        $database = queryDatabaseByUuidWithinTeam($request->uuid, $teamId);
+        if (! $database) {
+            return response()->json(['message' => 'Database not found.'], 404);
+        }
+
+        $this->authorize('update', $database);
+
+        return moveResourceToEnvironment($request, $database, 'Database', $teamId);
+    }
+
     #[OA\Get(
         summary: 'Start',
         description: 'Start database. `Post` request is also accepted.',

--- a/app/Http/Controllers/Api/ServicesController.php
+++ b/app/Http/Controllers/Api/ServicesController.php
@@ -1591,6 +1591,99 @@ class ServicesController extends Controller
         return response()->json(['message' => 'Environment variable deleted.']);
     }
 
+    #[OA\Post(
+        summary: 'Move',
+        description: 'Move service to another project/environment. This is a purely organizational change — running containers are not affected. Note: after moving, the service will pick up shared environment variables from the new environment on the next deployment.',
+        path: '/services/{uuid}/move',
+        operationId: 'move-service-by-uuid',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Services'],
+        parameters: [
+            new OA\Parameter(
+                name: 'uuid',
+                in: 'path',
+                description: 'UUID of the service.',
+                required: true,
+                schema: new OA\Schema(
+                    type: 'string',
+                )
+            ),
+        ],
+        requestBody: new OA\RequestBody(
+            description: 'Target environment to move the service to.',
+            required: true,
+            content: [
+                new OA\MediaType(
+                    mediaType: 'application/json',
+                    schema: new OA\Schema(
+                        type: 'object',
+                        properties: [
+                            'environment_uuid' => ['type' => 'string', 'description' => 'UUID of the target environment.'],
+                        ],
+                        required: ['environment_uuid'],
+                    )
+                ),
+            ]
+        ),
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Service moved successfully.',
+                content: [
+                    new OA\MediaType(
+                        mediaType: 'application/json',
+                        schema: new OA\Schema(
+                            type: 'object',
+                            properties: [
+                                'message' => ['type' => 'string', 'example' => 'Service moved successfully.'],
+                                'uuid' => ['type' => 'string'],
+                                'project_uuid' => ['type' => 'string'],
+                                'environment_uuid' => ['type' => 'string'],
+                            ]
+                        )
+                    ),
+                ]
+            ),
+            new OA\Response(
+                response: 401,
+                ref: '#/components/responses/401',
+            ),
+            new OA\Response(
+                response: 400,
+                ref: '#/components/responses/400',
+            ),
+            new OA\Response(
+                response: 404,
+                ref: '#/components/responses/404',
+            ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
+            ),
+        ]
+    )]
+    public function move_by_uuid(Request $request): \Illuminate\Http\JsonResponse
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+        $uuid = $request->route('uuid');
+        if (! $uuid) {
+            return response()->json(['message' => 'UUID is required.'], 400);
+        }
+        $service = Service::whereRelation('environment.project.team', 'id', $teamId)->whereUuid($request->uuid)->first();
+        if (! $service) {
+            return response()->json(['message' => 'Service not found.'], 404);
+        }
+
+        $this->authorize('update', $service);
+
+        return moveResourceToEnvironment($request, $service, 'Service', $teamId);
+    }
+
     #[OA\Get(
         summary: 'Start',
         description: 'Start service. `Post` request is also accepted.',

--- a/app/Models/Environment.php
+++ b/app/Models/Environment.php
@@ -42,6 +42,11 @@ class Environment extends BaseModel
         return Environment::whereRelation('project.team', 'id', currentTeam()->id)->orderBy('name');
     }
 
+    public static function ownedByCurrentTeamAPI(int $teamId)
+    {
+        return Environment::whereRelation('project.team', 'id', $teamId)->orderBy('name');
+    }
+
     public function isEmpty()
     {
         return $this->applications()->count() == 0 &&

--- a/bootstrap/helpers/api.php
+++ b/bootstrap/helpers/api.php
@@ -144,6 +144,50 @@ function sharedDataApplications()
     ];
 }
 
+function moveResourceToEnvironment(Request $request, $resource, string $resourceType, int $teamId): \Illuminate\Http\JsonResponse
+{
+
+    $validator = \Illuminate\Support\Facades\Validator::make($request->all(), [
+        'environment_uuid' => 'required|string',
+    ]);
+
+    if ($validator->fails()) {
+        return response()->json([
+            'message' => 'Validation failed.',
+            'errors' => $validator->errors(),
+        ], 422);
+    }
+
+    $extraFields = array_diff(array_keys($request->all()), ['environment_uuid']);
+    if (! empty($extraFields)) {
+        return response()->json([
+            'message' => 'Validation failed.',
+            'errors' => collect($extraFields)->mapWithKeys(fn ($field) => [$field => 'This field is not allowed.'])->toArray(),
+        ], 422);
+    }
+
+    $newEnvironment = \App\Models\Environment::ownedByCurrentTeamAPI($teamId)
+        ->whereUuid($request->environment_uuid)
+        ->first();
+
+    if (! $newEnvironment) {
+        return response()->json(['message' => 'Target environment not found or not owned by your team.'], 404);
+    }
+
+    if ($resource->environment_id === $newEnvironment->id) {
+        return response()->json(['message' => "$resourceType is already in this environment."], 400);
+    }
+
+    $resource->update(['environment_id' => $newEnvironment->id]);
+
+    return response()->json([
+        'message' => "$resourceType moved successfully.",
+        'uuid' => $resource->uuid,
+        'project_uuid' => $newEnvironment->project->uuid,
+        'environment_uuid' => $newEnvironment->uuid,
+    ]);
+}
+
 function validateIncomingRequest(Request $request)
 {
     // check if request is json

--- a/routes/api.php
+++ b/routes/api.php
@@ -121,6 +121,7 @@ Route::group([
     Route::delete('/applications/{uuid}/envs/{env_uuid}', [ApplicationsController::class, 'delete_env_by_uuid'])->middleware(['api.ability:write']);
     Route::get('/applications/{uuid}/logs', [ApplicationsController::class, 'logs_by_uuid'])->middleware(['api.ability:read']);
 
+    Route::post('/applications/{uuid}/move', [ApplicationsController::class, 'move_by_uuid'])->middleware(['api.ability:write']);
     Route::match(['get', 'post'], '/applications/{uuid}/start', [ApplicationsController::class, 'action_deploy'])->middleware(['api.ability:deploy']);
     Route::match(['get', 'post'], '/applications/{uuid}/restart', [ApplicationsController::class, 'action_restart'])->middleware(['api.ability:deploy']);
     Route::match(['get', 'post'], '/applications/{uuid}/stop', [ApplicationsController::class, 'action_stop'])->middleware(['api.ability:deploy']);
@@ -152,6 +153,7 @@ Route::group([
     Route::delete('/databases/{uuid}/backups/{scheduled_backup_uuid}', [DatabasesController::class, 'delete_backup_by_uuid'])->middleware(['api.ability:write']);
     Route::delete('/databases/{uuid}/backups/{scheduled_backup_uuid}/executions/{execution_uuid}', [DatabasesController::class, 'delete_execution_by_uuid'])->middleware(['api.ability:write']);
 
+    Route::post('/databases/{uuid}/move', [DatabasesController::class, 'move_by_uuid'])->middleware(['api.ability:write']);
     Route::match(['get', 'post'], '/databases/{uuid}/start', [DatabasesController::class, 'action_deploy'])->middleware(['api.ability:deploy']);
     Route::match(['get', 'post'], '/databases/{uuid}/restart', [DatabasesController::class, 'action_restart'])->middleware(['api.ability:deploy']);
     Route::match(['get', 'post'], '/databases/{uuid}/stop', [DatabasesController::class, 'action_stop'])->middleware(['api.ability:deploy']);
@@ -169,6 +171,7 @@ Route::group([
     Route::patch('/services/{uuid}/envs', [ServicesController::class, 'update_env_by_uuid'])->middleware(['api.ability:write']);
     Route::delete('/services/{uuid}/envs/{env_uuid}', [ServicesController::class, 'delete_env_by_uuid'])->middleware(['api.ability:write']);
 
+    Route::post('/services/{uuid}/move', [ServicesController::class, 'move_by_uuid'])->middleware(['api.ability:write']);
     Route::match(['get', 'post'], '/services/{uuid}/start', [ServicesController::class, 'action_deploy'])->middleware(['api.ability:deploy']);
     Route::match(['get', 'post'], '/services/{uuid}/restart', [ServicesController::class, 'action_restart'])->middleware(['api.ability:deploy']);
     Route::match(['get', 'post'], '/services/{uuid}/stop', [ServicesController::class, 'action_stop'])->middleware(['api.ability:deploy']);

--- a/tests/Feature/MoveResourceApiTest.php
+++ b/tests/Feature/MoveResourceApiTest.php
@@ -1,0 +1,238 @@
+<?php
+
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\Service;
+use App\Models\StandaloneDocker;
+use App\Models\StandalonePostgresql;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+
+    session(['currentTeam' => $this->team]);
+
+    $this->token = $this->user->createToken('test-token', ['*']);
+    $this->bearerToken = $this->token->plainTextToken;
+
+    $this->server = Server::factory()->create(['team_id' => $this->team->id]);
+    $this->destination = StandaloneDocker::factory()->create(['server_id' => $this->server->id]);
+    $this->project = Project::factory()->create(['team_id' => $this->team->id]);
+    $this->environment = Environment::factory()->create(['project_id' => $this->project->id]);
+
+    $this->targetProject = Project::factory()->create(['team_id' => $this->team->id]);
+    $this->targetEnvironment = Environment::factory()->create(['project_id' => $this->targetProject->id]);
+});
+
+describe('POST /api/v1/applications/{uuid}/move', function () {
+    test('moves application to another environment', function () {
+        $application = Application::factory()->create([
+            'environment_id' => $this->environment->id,
+            'destination_id' => $this->destination->id,
+            'destination_type' => $this->destination->getMorphClass(),
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->postJson("/api/v1/applications/{$application->uuid}/move", [
+            'environment_uuid' => $this->targetEnvironment->uuid,
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['message' => 'Application moved successfully.']);
+        $response->assertJsonStructure(['message', 'uuid', 'project_uuid', 'environment_uuid']);
+
+        $application->refresh();
+        expect($application->environment_id)->toBe($this->targetEnvironment->id);
+    });
+
+    test('returns 404 when application not found', function () {
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->postJson('/api/v1/applications/non-existent-uuid/move', [
+            'environment_uuid' => $this->targetEnvironment->uuid,
+        ]);
+
+        $response->assertStatus(404);
+    });
+
+    test('returns 422 when environment_uuid is missing', function () {
+        $application = Application::factory()->create([
+            'environment_id' => $this->environment->id,
+            'destination_id' => $this->destination->id,
+            'destination_type' => $this->destination->getMorphClass(),
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->postJson("/api/v1/applications/{$application->uuid}/move", []);
+
+        $response->assertStatus(422);
+    });
+
+    test('returns 422 when extra fields are provided', function () {
+        $application = Application::factory()->create([
+            'environment_id' => $this->environment->id,
+            'destination_id' => $this->destination->id,
+            'destination_type' => $this->destination->getMorphClass(),
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->postJson("/api/v1/applications/{$application->uuid}/move", [
+            'environment_uuid' => $this->targetEnvironment->uuid,
+            'bogus_field' => 'value',
+        ]);
+
+        $response->assertStatus(422);
+    });
+
+    test('returns 404 when target environment belongs to another team', function () {
+        $otherTeam = Team::factory()->create();
+        $otherProject = Project::factory()->create(['team_id' => $otherTeam->id]);
+        $otherEnvironment = Environment::factory()->create(['project_id' => $otherProject->id]);
+
+        $application = Application::factory()->create([
+            'environment_id' => $this->environment->id,
+            'destination_id' => $this->destination->id,
+            'destination_type' => $this->destination->getMorphClass(),
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->postJson("/api/v1/applications/{$application->uuid}/move", [
+            'environment_uuid' => $otherEnvironment->uuid,
+        ]);
+
+        $response->assertStatus(404);
+    });
+
+    test('returns 400 when application is already in the target environment', function () {
+        $application = Application::factory()->create([
+            'environment_id' => $this->environment->id,
+            'destination_id' => $this->destination->id,
+            'destination_type' => $this->destination->getMorphClass(),
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->postJson("/api/v1/applications/{$application->uuid}/move", [
+            'environment_uuid' => $this->environment->uuid,
+        ]);
+
+        $response->assertStatus(400);
+    });
+
+    test('preserves resource-level environment variables after move', function () {
+        $application = Application::factory()->create([
+            'environment_id' => $this->environment->id,
+            'destination_id' => $this->destination->id,
+            'destination_type' => $this->destination->getMorphClass(),
+        ]);
+
+        \App\Models\EnvironmentVariable::create([
+            'key' => 'TEST_VAR',
+            'value' => 'test-value',
+            'resourceable_type' => Application::class,
+            'resourceable_id' => $application->id,
+            'is_preview' => false,
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->postJson("/api/v1/applications/{$application->uuid}/move", [
+            'environment_uuid' => $this->targetEnvironment->uuid,
+        ]);
+
+        $response->assertStatus(200);
+
+        $application->refresh();
+        $envVar = $application->environment_variables->where('key', 'TEST_VAR')->first();
+        expect($envVar)->not->toBeNull();
+        expect($envVar->value)->toBe('test-value');
+    });
+});
+
+describe('POST /api/v1/databases/{uuid}/move', function () {
+    test('moves database to another environment', function () {
+        $database = StandalonePostgresql::factory()->create([
+            'environment_id' => $this->environment->id,
+            'destination_id' => $this->destination->id,
+            'destination_type' => $this->destination->getMorphClass(),
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->postJson("/api/v1/databases/{$database->uuid}/move", [
+            'environment_uuid' => $this->targetEnvironment->uuid,
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['message' => 'Database moved successfully.']);
+
+        $database->refresh();
+        expect($database->environment_id)->toBe($this->targetEnvironment->id);
+    });
+
+    test('returns 404 when database not found', function () {
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->postJson('/api/v1/databases/non-existent-uuid/move', [
+            'environment_uuid' => $this->targetEnvironment->uuid,
+        ]);
+
+        $response->assertStatus(404);
+    });
+});
+
+describe('POST /api/v1/services/{uuid}/move', function () {
+    test('moves service to another environment', function () {
+        $service = Service::factory()->create([
+            'server_id' => $this->server->id,
+            'destination_id' => $this->destination->id,
+            'destination_type' => $this->destination->getMorphClass(),
+            'environment_id' => $this->environment->id,
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->postJson("/api/v1/services/{$service->uuid}/move", [
+            'environment_uuid' => $this->targetEnvironment->uuid,
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['message' => 'Service moved successfully.']);
+
+        $service->refresh();
+        expect($service->environment_id)->toBe($this->targetEnvironment->id);
+    });
+
+    test('returns 404 when service not found', function () {
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->postJson('/api/v1/services/non-existent-uuid/move', [
+            'environment_uuid' => $this->targetEnvironment->uuid,
+        ]);
+
+        $response->assertStatus(404);
+    });
+});

--- a/tests/Feature/MoveResourceApiTest.php
+++ b/tests/Feature/MoveResourceApiTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\Application;
 use App\Models\Environment;
+use App\Models\InstanceSettings;
 use App\Models\Project;
 use App\Models\Server;
 use App\Models\Service;
@@ -14,6 +15,8 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 uses(RefreshDatabase::class);
 
 beforeEach(function () {
+    InstanceSettings::create(['id' => 0, 'is_api_enabled' => true]);
+
     $this->team = Team::factory()->create();
     $this->user = User::factory()->create();
     $this->team->members()->attach($this->user->id, ['role' => 'owner']);
@@ -24,12 +27,12 @@ beforeEach(function () {
     $this->bearerToken = $this->token->plainTextToken;
 
     $this->server = Server::factory()->create(['team_id' => $this->team->id]);
-    $this->destination = StandaloneDocker::factory()->create(['server_id' => $this->server->id]);
+    $this->destination = StandaloneDocker::where('server_id', $this->server->id)->first();
     $this->project = Project::factory()->create(['team_id' => $this->team->id]);
-    $this->environment = Environment::factory()->create(['project_id' => $this->project->id]);
+    $this->environment = $this->project->environments()->first();
 
     $this->targetProject = Project::factory()->create(['team_id' => $this->team->id]);
-    $this->targetEnvironment = Environment::factory()->create(['project_id' => $this->targetProject->id]);
+    $this->targetEnvironment = $this->targetProject->environments()->first();
 });
 
 describe('POST /api/v1/applications/{uuid}/move', function () {
@@ -170,7 +173,11 @@ describe('POST /api/v1/applications/{uuid}/move', function () {
 
 describe('POST /api/v1/databases/{uuid}/move', function () {
     test('moves database to another environment', function () {
-        $database = StandalonePostgresql::factory()->create([
+        $database = StandalonePostgresql::create([
+            'name' => 'test-pg',
+            'postgres_user' => 'postgres',
+            'postgres_password' => 'secret',
+            'postgres_db' => 'testdb',
             'environment_id' => $this->environment->id,
             'destination_id' => $this->destination->id,
             'destination_type' => $this->destination->getMorphClass(),


### PR DESCRIPTION
## Changes

- Add `POST /api/v1/applications/{uuid}/move` endpoint
- Add `POST /api/v1/databases/{uuid}/move` endpoint
- Add `POST /api/v1/services/{uuid}/move` endpoint
- Add shared `moveResourceToEnvironment()` helper to avoid code duplication across the three controllers
- Add `ownedByCurrentTeamAPI` scope to Environment model for team-scoped lookups

Accepts `environment_uuid` in the request body and moves the resource to the target environment within the same team. This is a purely organizational change — running containers are not affected. After moving, the resource will pick up shared environment variables from the new environment on the next deployment.

## Issues

- Discussed in https://github.com/coollabsio/coolify/discussions/8960

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No UI changes — API-only enhancement.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Partially used for boilerplate generation (OpenAPI annotations, repetitive controller methods) and test setup. Core logic, architecture decisions, and review done manually.

## Testing

- 11 Pest feature tests in `tests/Feature/MoveResourceApiTest.php`
- Covers: successful move (application, database, service), 404 not found, 422 validation errors, 400 already-in-environment, cross-team rejection, environment variable preservation after move
- All tests pass locally with `php artisan test --compact tests/Feature/MoveResourceApiTest.php`

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.