### PR TITLE
Fix: Add traefik.docker.network label to prevent routing to wrong network

### DIFF
--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -406,10 +406,15 @@ function fqdnLabelsForCaddy(string $network, string $uuid, Collection $domains, 
     return $labels->sort();
 }
 
-function fqdnLabelsForTraefik(string $uuid, Collection $domains, bool $is_force_https_enabled = false, $onlyPort = null, ?Collection $serviceLabels = null, ?bool $is_gzip_enabled = true, ?bool $is_stripprefix_enabled = true, ?string $service_name = null, bool $generate_unique_uuid = false, ?string $image = null, string $redirect_direction = 'both', bool $is_http_basic_auth_enabled = false, ?string $http_basic_auth_username = null, ?string $http_basic_auth_password = null)
+function fqdnLabelsForTraefik(string $uuid, Collection $domains, bool $is_force_https_enabled = false, $onlyPort = null, ?Collection $serviceLabels = null, ?bool $is_gzip_enabled = true, ?bool $is_stripprefix_enabled = true, ?string $service_name = null, bool $generate_unique_uuid = false, ?string $image = null, string $redirect_direction = 'both', bool $is_http_basic_auth_enabled = false, ?string $http_basic_auth_username = null, ?string $http_basic_auth_password = null, ?string $network = null)
 {
     $labels = collect([]);
     $labels->push('traefik.enable=true');
+    if ($serviceLabels) {
+        $labels->push("traefik.docker.network={$uuid}");
+    } elseif ($network) {
+        $labels->push("traefik.docker.network={$network}");
+    }
     if ($is_gzip_enabled) {
         $labels->push('traefik.http.middlewares.gzip.compress=true');
     }

--- a/bootstrap/helpers/parsers.php
+++ b/bootstrap/helpers/parsers.php
@@ -1334,7 +1334,8 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
                             is_gzip_enabled: $originalResource->isGzipEnabled(),
                             is_stripprefix_enabled: $originalResource->isStripprefixEnabled(),
                             service_name: $serviceName,
-                            image: $image
+                            image: $image,
+                            network: $network,
                         ));
                         break;
                     case ProxyTypes::CADDY->value:
@@ -1361,7 +1362,8 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
                     is_gzip_enabled: $originalResource->isGzipEnabled(),
                     is_stripprefix_enabled: $originalResource->isStripprefixEnabled(),
                     service_name: $serviceName,
-                    image: $image
+                    image: $image,
+                    network: $network,
                 ));
                 $serviceLabels = $serviceLabels->merge(fqdnLabelsForCaddy(
                     network: $network,
@@ -2599,7 +2601,8 @@ function serviceParser(Service $resource): Collection
                             is_gzip_enabled: $originalResource->isGzipEnabled(),
                             is_stripprefix_enabled: $originalResource->isStripprefixEnabled(),
                             service_name: $serviceName,
-                            image: $image
+                            image: $image,
+                            network: $network,
                         ));
                         break;
                     case ProxyTypes::CADDY->value:
@@ -2626,7 +2629,8 @@ function serviceParser(Service $resource): Collection
                     is_gzip_enabled: $originalResource->isGzipEnabled(),
                     is_stripprefix_enabled: $originalResource->isStripprefixEnabled(),
                     service_name: $serviceName,
-                    image: $image
+                    image: $image,
+                    network: $network,
                 ));
                 $serviceLabels = $serviceLabels->merge(fqdnLabelsForCaddy(
                     network: $network,

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -2333,7 +2333,8 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                                         is_gzip_enabled: $savedService->isGzipEnabled(),
                                         is_stripprefix_enabled: $savedService->isStripprefixEnabled(),
                                         service_name: $serviceName,
-                                        image: data_get($service, 'image')
+                                        image: data_get($service, 'image'),
+                                        network: $resource->destination->network,
                                     ));
                                     break;
                                 case ProxyTypes::CADDY->value:
@@ -2359,7 +2360,8 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                                 is_gzip_enabled: $savedService->isGzipEnabled(),
                                 is_stripprefix_enabled: $savedService->isStripprefixEnabled(),
                                 service_name: $serviceName,
-                                image: data_get($service, 'image')
+                                image: data_get($service, 'image'),
+                                network: $resource->destination->network,
                             ));
                             $serviceLabels = $serviceLabels->merge(fqdnLabelsForCaddy(
                                 network: $resource->destination->network,
@@ -3109,6 +3111,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                                             is_force_https_enabled: $resource->isForceHttpsEnabled(),
                                             is_gzip_enabled: $resource->isGzipEnabled(),
                                             is_stripprefix_enabled: $resource->isStripprefixEnabled(),
+                                            network: $resource->destination->network,
                                         )
                                     );
                                     break;
@@ -3138,6 +3141,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                                     is_force_https_enabled: $resource->isForceHttpsEnabled(),
                                     is_gzip_enabled: $resource->isGzipEnabled(),
                                     is_stripprefix_enabled: $resource->isStripprefixEnabled(),
+                                    network: $resource->destination->network,
                                 )
                             );
                             $serviceLabels = $serviceLabels->merge(


### PR DESCRIPTION
## Changes

When a Docker Compose app has multiple networks (e.g., an `internal: true` 
network for service isolation), Traefik randomly picks which network IP to 
route to because Go map iteration is non-deterministic. If it picks an 
unreachable network, requests hang.

`fqdnLabelsForCaddy()` already handles this by emitting `caddy_ingress_network`, 
but `fqdnLabelsForTraefik()` never emitted the equivalent `traefik.docker.network` 
label. This PR adds it, following the same pattern: use `$uuid` for Docker 
Compose deployments (where `$serviceLabels` is set), and `$network` for 
single-container apps.

Three files changed:
- `bootstrap/helpers/docker.php` — added `?string $network = null` parameter 
  and label emission to `fqdnLabelsForTraefik()`
- `bootstrap/helpers/parsers.php` — pass `$network` to all 4 call sites
- `bootstrap/helpers/shared.php` — pass `$resource->destination->network` to 
  all 4 call sites

## Issues

- Fixes #6215

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A — label-only change with no UI impact.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: AI identified the relevant code paths and generated the 
  initial diff. All changes were reviewed and verified by a human against 
  the existing Caddy implementation to ensure correctness.

## Testing

- Reproduced the issue on a Coolify v4.0.0-beta.468 instance with a Docker 
  Compose app using an `internal: true` sandbox network alongside the 
  Coolify-managed network
- Confirmed Traefik non-deterministically routes to the internal network IP, 
  causing request hangs
- Verified the fix mirrors the existing `fqdnLabelsForCaddy()` logic exactly
- The new parameter defaults to `null` and the label is only emitted when a 
  network value is provided, so existing single-network deployments are unaffected

## Contributor Agreement

- [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
- [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
- [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.