### PR TITLE
fix: prevent service domain FQDN corruption when ports are present

### DIFF
--- a/bootstrap/helpers/parsers.php
+++ b/bootstrap/helpers/parsers.php
@@ -1263,7 +1263,7 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
         // Add COOLIFY_FQDN & COOLIFY_URL to environment
         if (! $isDatabase && $fqdns instanceof Collection && $fqdns->count() > 0) {
             $fqdnsWithoutPort = $fqdns->map(function ($fqdn) {
-                return str($fqdn)->after('://')->before(':')->prepend(str($fqdn)->before('://')->append('://'));
+                return getFqdnWithoutPort($fqdn);
             });
             $coolifyEnvironments->put('COOLIFY_URL', $fqdnsWithoutPort->implode(','));
 
@@ -1755,8 +1755,8 @@ function serviceParser(Service $resource): Collection
                     $fqdn = generateFqdn(server: $server, random: "$fqdnFor-$uuid", parserVersion: $resource->compose_parsing_version);
                     $url = generateUrl($server, "$fqdnFor-$uuid");
                 } elseif ($isServiceApplication) {
-                    $fqdn = str($savedService->fqdn)->after('://')->before(':')->prepend(str($savedService->fqdn)->before('://')->append('://'))->value();
-                    $url = str($savedService->fqdn)->after('://')->before(':')->prepend(str($savedService->fqdn)->before('://')->append('://'))->value();
+                    $fqdn = getFqdnWithoutPort($savedService->fqdn);
+                    $url = $fqdn;
                 } else {
                     // For ServiceDatabase, generate fqdn/url without saving to the model
                     $fqdn = generateFqdn(server: $server, random: "$fqdnFor-$uuid", parserVersion: $resource->compose_parsing_version);
@@ -2538,8 +2538,8 @@ function serviceParser(Service $resource): Collection
                 return str($fqdn)->replace('http://', '')->replace('https://', '')->before(':');
             });
             $coolifyEnvironments->put('COOLIFY_FQDN', $fqdnsWithoutPort->implode(','));
-            $urls = $fqdns->map(function ($fqdn): Stringable {
-                return str($fqdn)->after('://')->before(':')->prepend(str($fqdn)->before('://')->append('://'));
+            $urls = $fqdns->map(function ($fqdn) {
+                return getFqdnWithoutPort($fqdn);
             });
             $coolifyEnvironments->put('COOLIFY_URL', $urls->implode(','));
         }

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -2155,7 +2155,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                             if ($env) {
                                 $env_url = Url::fromString($savedService->fqdn);
                                 $env_port = $env_url->getPort();
-                                if ($env_port !== $predefinedPort) {
+                                if ((int) $env_port !== (int) $predefinedPort) {
                                     $env_url = $env_url->withPort($predefinedPort);
                                     $savedService->fqdn = $env_url->__toString();
                                     $savedService->save();
@@ -2240,7 +2240,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                                             if ($env) {
                                                 $env_url = Url::fromString($env->value);
                                                 $env_port = $env_url->getPort();
-                                                if ($env_port !== $predefinedPort) {
+                                                if ((int) $env_port !== (int) $predefinedPort) {
                                                     $env_url = $env_url->withPort($predefinedPort);
                                                     $savedService->fqdn = $env_url->__toString();
                                                     $savedService->save();


### PR DESCRIPTION
## Summary

Fixes #8798 — Service domain URLs with predefined ports (e.g., GitLab with port 80) get corrupted from `http://git.example.com:80` to `//:80git.example.com`.

**Root cause:** Three places in `parsers.php` use fragile string manipulation (`str()->after('://')->before(':')`) to strip ports from FQDNs. This breaks when the URL has no `://` delimiter or is already malformed, producing cascading corruption.

**Fix:**
- Replace all 3 instances with calls to the existing `getFqdnWithoutPort()` helper (defined in `shared.php:378`) which properly uses `Spatie\Url` for URL parsing with error handling
- Fix strict type comparison (`!==`) between `int` (from `getPort()`) and `string` (from template YAML) in the old parser's port matching — `80 !== "80"` is always true in PHP, causing unnecessary FQDN rewrites on every parse cycle

## Changes
- `bootstrap/helpers/parsers.php`: Replace 3 inline string manipulations with `getFqdnWithoutPort()` calls
- `bootstrap/helpers/shared.php`: Cast both sides of port comparison to `int`

## Test plan
- [ ] Deploy a one-click service with a predefined port (e.g., GitLab template with port 80)
- [ ] Change the domain FQDN and save
- [ ] Verify the URL is not corrupted (should remain `http://yourdomain.com:80`)
- [ ] Verify COOLIFY_URL and COOLIFY_FQDN environment variables are correctly set