### PR TITLE
fix: include preview_fqdn in webhook for Docker Compose preview deployments

### DIFF
--- a/app/Models/ApplicationPreview.php
+++ b/app/Models/ApplicationPreview.php
@@ -168,4 +168,19 @@ class ApplicationPreview extends BaseModel
         $this->docker_compose_domains = json_encode($docker_compose_domains);
         $this->save();
     }
+
+    public function getComposeFqdn(): ?string
+    {
+        $domains = json_decode($this->docker_compose_domains, true);
+        if (empty($domains)) {
+            return null;
+        }
+        $firstService = collect($domains)->first();
+        $domain = data_get($firstService, 'domain');
+        if (empty($domain)) {
+            return null;
+        }
+
+        return str($domain)->before(',')->trim()->value() ?: null;
+    }
 }

--- a/app/Notifications/Application/DeploymentFailed.php
+++ b/app/Notifications/Application/DeploymentFailed.php
@@ -202,7 +202,7 @@ class DeploymentFailed extends CustomEmailNotification
 
         if ($this->preview) {
             $data['pull_request_id'] = $this->preview->pull_request_id;
-            $data['preview_fqdn'] = $this->preview->fqdn;
+            $data['preview_fqdn'] = $this->preview->fqdn ?? $this->preview->getComposeFqdn();
         }
 
         if ($this->fqdn) {

--- a/app/Notifications/Application/DeploymentSuccess.php
+++ b/app/Notifications/Application/DeploymentSuccess.php
@@ -222,7 +222,7 @@ class DeploymentSuccess extends CustomEmailNotification
 
         if ($this->preview) {
             $data['pull_request_id'] = $this->preview->pull_request_id;
-            $data['preview_fqdn'] = $this->preview->fqdn;
+            $data['preview_fqdn'] = $this->preview->fqdn ?? $this->preview->getComposeFqdn();
         }
 
         if ($this->fqdn) {


### PR DESCRIPTION
## Summary

Fixes #8958 — Docker Compose preview deployments send `null` `preview_fqdn` in webhook notifications.

**Root cause:** `generate_preview_fqdn_compose()` stores preview domains in the `docker_compose_domains` JSON column but never sets `fqdn`. The webhook notification in `DeploymentSuccess`/`DeploymentFailed` reads `$this->preview->fqdn`, which is always `null` for Compose apps.

**Fix:**
- Add `getComposeFqdn()` to `ApplicationPreview` model — extracts the first domain from `docker_compose_domains`
- In both `DeploymentSuccess` and `DeploymentFailed`, fall back to `getComposeFqdn()` when `fqdn` is null: `$this->preview->fqdn ?? $this->preview->getComposeFqdn()`

This ensures regular apps continue using `fqdn` (unchanged behavior) while Compose apps now correctly return their preview domain.

## Changes
- `app/Models/ApplicationPreview.php`: Add `getComposeFqdn()` method
- `app/Notifications/Application/DeploymentSuccess.php`: Null-coalesce fallback
- `app/Notifications/Application/DeploymentFailed.php`: Same fallback

## Test plan
- [ ] Deploy a Docker Compose app with preview deployments enabled
- [ ] Open a PR to trigger a preview deployment
- [ ] Check webhook payload — `preview_fqdn` should now contain the preview URL
- [ ] Verify regular (non-Compose) app webhooks still work unchanged