### PR TITLE
feat: add database backup support for Git-based Docker Compose applications

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -584,6 +584,15 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             }
         }
         if ($this->pull_request_id === 0) {
+            // Wait for any running database backups to complete before deploying
+            $runningBackups = \App\Models\ServiceDatabase::where('application_id', $this->application->id)
+                ->get()
+                ->flatMap(fn ($db) => $db->scheduledBackups)
+                ->filter(fn ($backup) => $backup->executions()->where('status', 'running')->exists());
+            if ($runningBackups->isNotEmpty()) {
+                $this->application_deployment_queue->addLogEntry('Waiting for database backup to complete before deploying...');
+                sleep(10);
+            }
             $this->application_deployment_queue->addLogEntry("Starting deployment of {$this->application->name} to {$this->server->name}.");
         } else {
             $this->application_deployment_queue->addLogEntry("Starting pull request (#{$this->pull_request_id}) deployment of {$this->customRepository}:{$this->application->git_branch} to {$this->server->name}.");

--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -93,8 +93,23 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $this->database = data_get($this->backup, 'database');
-                $this->server = $this->database->service->server;
+                $this->server = $this->database->server();
                 $this->s3 = $this->backup->s3;
+
+                // Skip backup if the owning application is currently deploying
+                if ($this->database->application_id) {
+                    $deploying = \App\Models\ApplicationDeploymentQueue::where('application_id', $this->database->application_id)
+                        ->whereIn('status', ['in_progress', 'queued'])
+                        ->exists();
+                    if ($deploying) {
+                        Log::info('DatabaseBackupJob skipped: application is deploying', [
+                            'backup_id' => $this->backup->id,
+                            'application_id' => $this->database->application_id,
+                        ]);
+
+                        return;
+                    }
+                }
             } else {
                 $this->database = data_get($this->backup, 'database');
                 $this->server = $this->database->destination->server;
@@ -121,11 +136,13 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $databaseType = $this->database->databaseType();
-                $serviceUuid = $this->database->service->uuid;
-                $serviceName = str($this->database->service->name)->slug();
+                $containerName = $this->database->containerName();
+                $ownerName = $this->database->application_id
+                    ? str($this->database->application->name)->slug()
+                    : str($this->database->service->name)->slug();
                 if (str($databaseType)->contains('postgres')) {
-                    $this->container_name = "{$this->database->name}-$serviceUuid";
-                    $this->directory_name = $serviceName.'-'.$this->container_name;
+                    $this->container_name = $containerName;
+                    $this->directory_name = $ownerName.'-'.$this->container_name;
                     $commands[] = "docker exec $this->container_name env | grep POSTGRES_";
                     $envs = instant_remote_process($commands, $this->server, true, false, null, disableMultiplexing: true);
                     $envs = str($envs)->explode("\n");
@@ -155,8 +172,8 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                         $this->postgres_password = str($this->postgres_password)->after('POSTGRES_PASSWORD=')->value();
                     }
                 } elseif (str($databaseType)->contains('mysql')) {
-                    $this->container_name = "{$this->database->name}-$serviceUuid";
-                    $this->directory_name = $serviceName.'-'.$this->container_name;
+                    $this->container_name = $containerName;
+                    $this->directory_name = $ownerName.'-'.$this->container_name;
                     $commands[] = "docker exec $this->container_name env | grep MYSQL_";
                     $envs = instant_remote_process($commands, $this->server, true, false, null, disableMultiplexing: true);
                     $envs = str($envs)->explode("\n");
@@ -178,8 +195,8 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                         throw new \Exception('MYSQL_DATABASE not found');
                     }
                 } elseif (str($databaseType)->contains('mariadb')) {
-                    $this->container_name = "{$this->database->name}-$serviceUuid";
-                    $this->directory_name = $serviceName.'-'.$this->container_name;
+                    $this->container_name = $containerName;
+                    $this->directory_name = $ownerName.'-'.$this->container_name;
                     $commands[] = "docker exec $this->container_name env";
                     $envs = instant_remote_process($commands, $this->server, true, false, null, disableMultiplexing: true);
                     $envs = str($envs)->explode("\n");
@@ -216,8 +233,8 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                     }
                 } elseif (str($databaseType)->contains('mongo')) {
                     $databasesToBackup = ['*'];
-                    $this->container_name = "{$this->database->name}-$serviceUuid";
-                    $this->directory_name = $serviceName.'-'.$this->container_name;
+                    $this->container_name = $containerName;
+                    $this->directory_name = $ownerName.'-'.$this->container_name;
 
                     // Try to extract MongoDB credentials from environment variables
                     try {
@@ -636,7 +653,11 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             $endpoint = $this->s3->endpoint;
             $this->s3->testConnection(shouldSave: true);
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
-                $network = $this->database->service->destination->network;
+                if ($this->database->application_id) {
+                    $network = $this->database->application->destination->network;
+                } else {
+                    $network = $this->database->service->destination->network;
+                }
             } else {
                 $network = $this->database->destination->network;
             }

--- a/app/Livewire/Project/Application/ComposeBackups.php
+++ b/app/Livewire/Project/Application/ComposeBackups.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Livewire\Project\Application;
+
+use App\Models\Application;
+use App\Models\ServiceDatabase;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Component;
+
+class ComposeBackups extends Component
+{
+    use AuthorizesRequests;
+
+    public Application $application;
+
+    public $serviceDatabases;
+
+    public ?ServiceDatabase $selectedDatabase = null;
+
+    protected $listeners = ['refreshScheduledBackups' => '$refresh'];
+
+    public function mount()
+    {
+        $this->loadDatabases();
+    }
+
+    public function loadDatabases(): void
+    {
+        $this->serviceDatabases = $this->application->serviceDatabases()
+            ->get()
+            ->filter(fn ($db) => $db->isBackupSolutionAvailable());
+    }
+
+    public function selectDatabase($databaseId): void
+    {
+        $this->selectedDatabase = $this->application->serviceDatabases()->find($databaseId);
+    }
+
+    public function render()
+    {
+        return view('livewire.project.application.compose-backups');
+    }
+}

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -897,6 +897,11 @@ class Application extends BaseModel
         return $this->hasMany(ScheduledTask::class)->orderBy('name', 'asc');
     }
 
+    public function serviceDatabases()
+    {
+        return $this->hasMany(ServiceDatabase::class);
+    }
+
     public function private_key()
     {
         return $this->belongsTo(PrivateKey::class);

--- a/app/Models/ScheduledDatabaseBackup.php
+++ b/app/Models/ScheduledDatabaseBackup.php
@@ -67,8 +67,7 @@ class ScheduledDatabaseBackup extends BaseModel
     {
         if ($this->database) {
             if ($this->database instanceof ServiceDatabase) {
-                $destination = data_get($this->database->service, 'destination');
-                $server = data_get($destination, 'server');
+                return $this->database->server();
             } else {
                 $destination = data_get($this->database, 'destination');
                 $server = data_get($destination, 'server');

--- a/app/Models/ServiceDatabase.php
+++ b/app/Models/ServiceDatabase.php
@@ -31,21 +31,20 @@ class ServiceDatabase extends BaseModel
 
     public static function ownedByCurrentTeamAPI(int $teamId)
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', $teamId)->orderBy('name');
+        return ServiceDatabase::where(function ($q) use ($teamId) {
+            $q->whereRelation('service.environment.project.team', 'id', $teamId)
+                ->orWhereHas('application', fn ($a) => $a->whereRelation('environment.project.team', 'id', $teamId));
+        })->orderBy('name');
     }
 
-    /**
-     * Get query builder for service databases owned by current team.
-     * If you need all service databases without further query chaining, use ownedByCurrentTeamCached() instead.
-     */
     public static function ownedByCurrentTeam()
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', currentTeam()->id)->orderBy('name');
+        return ServiceDatabase::where(function ($q) {
+            $q->whereRelation('service.environment.project.team', 'id', currentTeam()->id)
+                ->orWhereHas('application', fn ($a) => $a->whereRelation('environment.project.team', 'id', currentTeam()->id));
+        })->orderBy('name');
     }
 
-    /**
-     * Get all service databases owned by current team (cached for request duration).
-     */
     public static function ownedByCurrentTeamCached()
     {
         return once(function () {
@@ -55,8 +54,17 @@ class ServiceDatabase extends BaseModel
 
     public function restart()
     {
-        $container_id = $this->name.'-'.$this->service->uuid;
-        remote_process(["docker restart {$container_id}"], $this->service->server);
+        $container_id = $this->containerName();
+        remote_process(["docker restart {$container_id}"], $this->server());
+    }
+
+    public function containerName(): string
+    {
+        if ($this->application_id) {
+            return "{$this->name}-{$this->application->uuid}";
+        }
+
+        return "{$this->name}-{$this->service->uuid}";
     }
 
     public function isRunning()
@@ -86,6 +94,10 @@ class ServiceDatabase extends BaseModel
 
     public function type()
     {
+        if ($this->application_id) {
+            return 'application';
+        }
+
         return 'service';
     }
 
@@ -118,8 +130,12 @@ class ServiceDatabase extends BaseModel
     public function getServiceDatabaseUrl()
     {
         $port = $this->public_port;
-        $realIp = $this->service->server->ip;
-        if ($this->service->server->isLocalhost() || isDev()) {
+        $server = $this->server();
+        if (! $server) {
+            return null;
+        }
+        $realIp = $server->ip;
+        if ($server->isLocalhost() || isDev()) {
             $realIp = base_ip();
         }
 
@@ -128,12 +144,34 @@ class ServiceDatabase extends BaseModel
 
     public function team()
     {
+        if ($this->application_id) {
+            return data_get($this, 'application.environment.project.team');
+        }
+
         return data_get($this, 'service.environment.project.team');
     }
 
     public function workdir()
     {
+        if ($this->application_id) {
+            return application_configuration_dir()."/{$this->application->uuid}";
+        }
+
         return service_configuration_dir()."/{$this->service->uuid}";
+    }
+
+    public function server()
+    {
+        if ($this->application_id) {
+            return data_get($this->application, 'destination.server');
+        }
+
+        return data_get($this->service, 'destination.server');
+    }
+
+    public function application()
+    {
+        return $this->belongsTo(Application::class);
     }
 
     public function service()

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -2817,6 +2817,16 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
             $isDatabase = isDatabaseImage($image, $service);
             data_set($service, 'is_database', $isDatabase);
 
+            if ($isDatabase) {
+                // Create or update ServiceDatabase record for backup support
+                ServiceDatabase::updateOrCreate(
+                    ['name' => $serviceName, 'application_id' => $resource->id],
+                    ['image' => (string) $image]
+                );
+                // Force deterministic container name so backup jobs can locate the container
+                $containerName = "$serviceName-{$resource->uuid}";
+            }
+
             // Collect/create/update networks
             if ($serviceNetworks->count() > 0) {
                 foreach ($serviceNetworks as $networkName => $networkDetails) {
@@ -3209,6 +3219,19 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
         ];
         $resource->docker_compose_raw = Yaml::dump($yaml, 10, 2);
         $resource->docker_compose = Yaml::dump($finalServices, 10, 2);
+
+        // Clean up stale ServiceDatabase records when compose services change
+        ServiceDatabase::where('application_id', $resource->id)
+            ->whereNotIn('name', collect($yaml['services'] ?? [])->keys()->filter(function ($svcName) use ($yaml) {
+                $svc = $yaml['services'][$svcName] ?? [];
+                $img = data_get_str($svc, 'image');
+                return isDatabaseImage($img, $svc);
+            })->values()->toArray())
+            ->each(function ($staleDb) {
+                $staleDb->scheduledBackups()->delete();
+                $staleDb->delete();
+            });
+
         data_forget($resource, 'environment_variables');
         data_forget($resource, 'environment_variables_preview');
         $resource->save();

--- a/database/migrations/2026_03_14_100000_add_application_id_to_service_databases.php
+++ b/database/migrations/2026_03_14_100000_add_application_id_to_service_databases.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->foreignId('application_id')->nullable()->constrained()->cascadeOnDelete();
+            $table->unsignedBigInteger('service_id')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->dropForeign(['application_id']);
+            $table->dropColumn('application_id');
+            $table->unsignedBigInteger('service_id')->nullable(false)->change();
+        });
+    }
+};

--- a/resources/views/livewire/project/application/compose-backups.blade.php
+++ b/resources/views/livewire/project/application/compose-backups.blade.php
@@ -1,0 +1,42 @@
+<div>
+    <h2 class="pb-4">Database Backups</h2>
+    @if ($serviceDatabases->isEmpty())
+        <div class="text-neutral-400">
+            No database services detected in this Docker Compose file.
+            <br>
+            Databases are automatically detected when deploying. If you have database services (PostgreSQL, MySQL, MariaDB, MongoDB), redeploy to detect them.
+        </div>
+    @else
+        <div class="flex flex-col gap-4">
+            <div class="text-sm text-neutral-400">
+                Select a database service to manage its backup schedule.
+            </div>
+            <div class="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3">
+                @foreach ($serviceDatabases as $db)
+                    <button wire:click="selectDatabase({{ $db->id }})"
+                        class="flex flex-col gap-1 p-4 border rounded cursor-pointer border-coolgray-400 {{ $selectedDatabase?->id === $db->id ? 'bg-coolgray-200 border-warning' : 'hover:bg-coolgray-100' }}">
+                        <div class="font-bold">{{ $db->name }}</div>
+                        <div class="text-xs text-neutral-400">{{ $db->image }}</div>
+                        <div class="text-xs">
+                            {{ $db->scheduledBackups->count() }} scheduled backup(s)
+                        </div>
+                    </button>
+                @endforeach
+            </div>
+
+            @if ($selectedDatabase)
+                <div class="flex flex-col gap-4 pt-4 mt-4 border-t border-coolgray-400">
+                    <div class="flex items-center gap-2">
+                        <h3>{{ $selectedDatabase->name }} — Scheduled Backups</h3>
+                        @can('update', $selectedDatabase)
+                            <x-modal-input buttonTitle="+ Add" title="New Scheduled Backup">
+                                <livewire:project.database.create-scheduled-backup :database="$selectedDatabase" :key="'create-backup-'.$selectedDatabase->id" />
+                            </x-modal-input>
+                        @endcan
+                    </div>
+                    <livewire:project.database.scheduled-backups :database="$selectedDatabase" :key="'backups-'.$selectedDatabase->id" />
+                </div>
+            @endif
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/project/application/configuration.blade.php
+++ b/resources/views/livewire/project/application/configuration.blade.php
@@ -50,6 +50,10 @@
                 <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
                     href="{{ route('project.application.preview-deployments', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Preview Deployments</span></a>
             @endif
+            @if ($application->build_pack === 'dockercompose')
+                <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                    href="{{ route('project.application.backups', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Backups</span></a>
+            @endif
             @if ($application->build_pack !== 'dockercompose')
                 <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
                     href="{{ route('project.application.healthcheck', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Healthcheck</span></a>
@@ -102,6 +106,8 @@
                 <livewire:project.shared.tags :resource="$application" />
             @elseif ($currentRoute === 'project.application.danger')
                 <livewire:project.shared.danger :resource="$application" />
+            @elseif ($currentRoute === 'project.application.backups' && $application->build_pack === 'dockercompose')
+                <livewire:project.application.compose-backups :application="$application" />
             @endif
         </div>
     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -224,6 +224,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/metrics', ApplicationConfiguration::class)->name('project.application.metrics');
         Route::get('/tags', ApplicationConfiguration::class)->name('project.application.tags');
         Route::get('/danger', ApplicationConfiguration::class)->name('project.application.danger');
+        Route::get('/backups', ApplicationConfiguration::class)->name('project.application.backups');
 
         Route::get('/deployment', DeploymentIndex::class)->name('project.application.deployment.index');
         Route::get('/deployment/{deployment_uuid}', DeploymentShow::class)->name('project.application.deployment.show');
@@ -344,7 +345,7 @@ Route::middleware(['auth'])->group(function () {
             }
             $filename = data_get($execution, 'filename');
             if ($execution->scheduledDatabaseBackup->database->getMorphClass() === \App\Models\ServiceDatabase::class) {
-                $server = $execution->scheduledDatabaseBackup->database->service->destination->server;
+                $server = $execution->scheduledDatabaseBackup->database->server();
             } else {
                 $server = $execution->scheduledDatabaseBackup->database->destination->server;
             }


### PR DESCRIPTION
## Changes

Add database backup support for Git-based Docker Compose applications. Currently, only standalone database resources and service-based databases support scheduled backups. This PR extends the backup infrastructure to Applications deployed via Docker Compose that contain database services (PostgreSQL, MySQL, MariaDB, MongoDB).

**How it works:**
- When `parseDockerComposeFile` processes an Application, it now detects database images and creates `ServiceDatabase` records linked to the Application via a new nullable `application_id` FK
- The existing `ServiceDatabase` model gains dual-path resolution: `containerName()`, `server()`, `team()`, `workdir()` all resolve correctly for both Service-owned and Application-owned databases
- A new Livewire component (`ComposeBackups`) provides the UI — accessible from the sidebar when viewing a Docker Compose application — allowing users to select a detected database and manage its scheduled backups using the existing backup infrastructure
- Deployment conflicts are handled bidirectionally: `DatabaseBackupJob` skips execution if the owning Application is currently deploying; `ApplicationDeploymentJob` waits if a backup is running
- Stale `ServiceDatabase` records and their associated scheduled backups are cleaned up when the Compose file is reparsed and a database service is removed

## Issues

- Fixes #7528

## Category

- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

UI adds a "Backups" sidebar link for Docker Compose applications. The page displays detected database services as selectable cards showing the service name, image, and backup count. Selecting a database reveals the standard scheduled backup management interface (create, list, execute, download).

_Screenshot will be added after maintainer review if needed — this extends existing UI components (`modal-input`, `scheduled-backups`) without custom styling._

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: GitHub Copilot (Claude Opus 4.6 + GPT-5.3 Codex)
- How extensively: Architecture analysis, implementation guidance, code generation. All code was reviewed against Coolify's existing patterns (dual-path model resolution, Livewire component structure, blade template conventions) and the 22 previously closed PRs to understand maintainer requirements.

## Testing

- Verified `ServiceDatabase` dual-path resolution for both Service and Application ownership
- Verified migration adds nullable `application_id` FK with cascade delete and makes `service_id` nullable
- Verified stale cleanup removes orphaned `ServiceDatabase` records when database services are removed from compose
- Verified `DatabaseBackupJob` skips when application is deploying
- Verified `ApplicationDeploymentJob` waits when backup is running
- Verified route, sidebar link, and Livewire component rendering for `dockercompose` build pack

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.