### PR TITLE
feat: enable database backups for dockercompose buildpack (#7528)

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -912,6 +912,15 @@ class Application extends BaseModel
         return $this->hasMany(ApplicationPreview::class)->orderBy('pull_request_id', 'desc');
     }
 
+    /**
+     * Database services detected in this application's docker-compose file
+     * (used for backup scheduling when build_pack is 'dockercompose').
+     */
+    public function serviceDatabases()
+    {
+        return $this->hasMany(ServiceDatabase::class);
+    }
+
     public function deployment_queue()
     {
         return $this->hasMany(ApplicationDeploymentQueue::class);

--- a/app/Models/ServiceDatabase.php
+++ b/app/Models/ServiceDatabase.php
@@ -31,16 +31,25 @@ class ServiceDatabase extends BaseModel
 
     public static function ownedByCurrentTeamAPI(int $teamId)
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', $teamId)->orderBy('name');
+        return ServiceDatabase::where(function ($query) use ($teamId) {
+            $query->whereRelation('service.environment.project.team', 'id', $teamId)
+                ->orWhereRelation('application.environment.project.team', 'id', $teamId);
+        })->orderBy('name');
     }
 
     /**
      * Get query builder for service databases owned by current team.
+     * Includes databases from both Service and Application (dockercompose buildpack) resources.
      * If you need all service databases without further query chaining, use ownedByCurrentTeamCached() instead.
      */
     public static function ownedByCurrentTeam()
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', currentTeam()->id)->orderBy('name');
+        $teamId = currentTeam()->id;
+
+        return ServiceDatabase::where(function ($query) use ($teamId) {
+            $query->whereRelation('service.environment.project.team', 'id', $teamId)
+                ->orWhereRelation('application.environment.project.team', 'id', $teamId);
+        })->orderBy('name');
     }
 
     /**
@@ -55,8 +64,9 @@ class ServiceDatabase extends BaseModel
 
     public function restart()
     {
-        $container_id = $this->name.'-'.$this->service->uuid;
-        remote_process(["docker restart {$container_id}"], $this->service->server);
+        $parent = $this->service ?? $this->application;
+        $container_id = $this->name.'-'.$parent->uuid;
+        remote_process(["docker restart {$container_id}"], $parent->destination->server ?? $parent->server);
     }
 
     public function isRunning()
@@ -118,8 +128,11 @@ class ServiceDatabase extends BaseModel
     public function getServiceDatabaseUrl()
     {
         $port = $this->public_port;
-        $realIp = $this->service->server->ip;
-        if ($this->service->server->isLocalhost() || isDev()) {
+        $server = $this->service_id
+            ? $this->service->server
+            : $this->application->destination->server;
+        $realIp = $server->ip;
+        if ($server->isLocalhost() || isDev()) {
             $realIp = base_ip();
         }
 
@@ -128,17 +141,27 @@ class ServiceDatabase extends BaseModel
 
     public function team()
     {
-        return data_get($this, 'service.environment.project.team');
+        return data_get($this, 'service.environment.project.team')
+            ?? data_get($this, 'application.environment.project.team');
     }
 
     public function workdir()
     {
-        return service_configuration_dir()."/{$this->service->uuid}";
+        if ($this->service_id) {
+            return service_configuration_dir()."/{$this->service->uuid}";
+        }
+
+        return application_configuration_dir()."/{$this->application->uuid}";
     }
 
     public function service()
     {
         return $this->belongsTo(Service::class);
+    }
+
+    public function application()
+    {
+        return $this->belongsTo(Application::class);
     }
 
     public function persistentStorages()

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -2817,6 +2817,27 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
             $isDatabase = isDatabaseImage($image, $service);
             data_set($service, 'is_database', $isDatabase);
 
+            // For Application (dockercompose buildpack) resources, create or update
+            // ServiceDatabase records for detected database services so that
+            // automated backup scheduling is available (mirrors Service model path).
+            if ($isDatabase) {
+                $existingServiceDb = \App\Models\ServiceDatabase::where([
+                    'name' => $serviceName,
+                    'application_id' => $resource->id,
+                ])->first();
+
+                if (is_null($existingServiceDb)) {
+                    \App\Models\ServiceDatabase::create([
+                        'name' => $serviceName,
+                        'image' => $image,
+                        'application_id' => $resource->id,
+                    ]);
+                } elseif ($existingServiceDb->image !== $image->value()) {
+                    $existingServiceDb->image = $image;
+                    $existingServiceDb->save();
+                }
+            }
+
             // Collect/create/update networks
             if ($serviceNetworks->count() > 0) {
                 foreach ($serviceNetworks as $networkName => $networkDetails) {

--- a/database/migrations/2026_03_14_000000_add_application_id_to_service_databases.php
+++ b/database/migrations/2026_03_14_000000_add_application_id_to_service_databases.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Add application_id to service_databases to support database services
+     * within Application (dockercompose buildpack) deployments. Also makes
+     * service_id nullable since application-linked databases don't have a
+     * parent Service.
+     */
+    public function up(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->foreignId('application_id')->nullable()->after('service_id');
+            $table->foreignId('service_id')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->dropColumn('application_id');
+            // Note: reverting service_id nullability is handled by re-running original migration
+        });
+    }
+};


### PR DESCRIPTION
/claim #7528

## Summary

When deploying Docker Compose files via GitHub App (dockercompose buildpack), database services were detected but no ServiceDatabase records were created, making automated backups unavailable.

## Changes
- Migration: add nullable `application_id` FK to `service_databases`, make `service_id` nullable
- ServiceDatabase model: add `application()` relationship, update team scopes and helper methods
- Application model: add `serviceDatabases()` relationship
- `parseDockerComposeFile()`: create ServiceDatabase records in Application path when database image detected

Closes #7528