### PR TITLE
feat: add WordPress with OpenLiteSpeed service template

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -1,0 +1,73 @@
+# documentation: https://openlitespeed.org
+# slogan: High-performance WordPress powered by OpenLiteSpeed web server with HTTP/3 and LSCache support.
+# category: cms
+# tags: cms, wordpress, openlitespeed, litespeed, lscache, http3, blog
+# logo: svgs/wordpress.svg
+# port: 80
+
+services:
+  openlitespeed:
+    image: litespeedtech/openlitespeed:1.8.5-lsphp85
+    environment:
+      - SERVICE_URL_OPENLITESPEED_80
+      - WORDPRESS_DB_HOST=mariadb
+      - WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME:-wordpress}
+      - WORDPRESS_DB_USER=$SERVICE_USER_WORDPRESS
+      - WORDPRESS_DB_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    volumes:
+      - ols-conf:/usr/local/lsws/conf
+      - ols-admin-conf:/usr/local/lsws/admin/conf
+      - wordpress-files:/var/www/vhosts/localhost/html
+    entrypoint:
+      - bash
+      - -c
+      - |
+        set -e
+        DOC_ROOT="/var/www/vhosts/localhost/html"
+        if [ ! -f "$$DOC_ROOT/wp-config-sample.php" ]; then
+          echo "[init-wp] Downloading WordPress..."
+          curl -sSfL https://wordpress.org/latest.tar.gz -o /tmp/wordpress.tar.gz
+          tar -xzf /tmp/wordpress.tar.gz --strip-components=1 -C "$$DOC_ROOT/"
+          rm -f /tmp/wordpress.tar.gz
+          chown -R nobody:nogroup "$$DOC_ROOT"
+        fi
+        if [ ! -f "$$DOC_ROOT/wp-config.php" ] && [ -f "$$DOC_ROOT/wp-config-sample.php" ]; then
+          cp "$$DOC_ROOT/wp-config-sample.php" "$$DOC_ROOT/wp-config.php"
+          sed -i "s/database_name_here/$$WORDPRESS_DB_NAME/" "$$DOC_ROOT/wp-config.php"
+          sed -i "s/username_here/$$WORDPRESS_DB_USER/" "$$DOC_ROOT/wp-config.php"
+          sed -i "s/password_here/$$WORDPRESS_DB_PASSWORD/" "$$DOC_ROOT/wp-config.php"
+          sed -i "s/localhost/$$WORDPRESS_DB_HOST/" "$$DOC_ROOT/wp-config.php"
+        fi
+        /usr/local/lsws/bin/lswsctrl start
+        tail -f /usr/local/lsws/logs/error.log
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://127.0.0.1:80/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  mariadb:
+    image: mariadb:11.4
+    command: ["--max-allowed-packet=512M"]
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MYSQL_DATABASE=${WORDPRESS_DB_NAME:-wordpress}
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+
+volumes:
+  ols-conf:
+  ols-admin-conf:
+  wordpress-files:
+  mariadb-data:


### PR DESCRIPTION
## Changes

<img width="1710" height="1112" alt="step1-language" src="https://github.com/user-attachments/assets/0c6443c9-e8e7-4d03-9fed-07975881badf" />
<img width="1710" height="1112" alt="step2-info-form" src="https://github.com/user-attachments/assets/5532c334-e3a6-45e6-966c-122f02e00e3c" />
<img width="1710" height="1112" alt="step2-info-form-filled" src="https://github.com/user-attachments/assets/a8b6c192-baf7-4248-ad47-7c10a39c482f" />
<img width="1710" height="1112" alt="step3-success" src="https://github.com/user-attachments/assets/70d212a5-cbe0-495f-ac30-15f1cd164cf3" />
<img width="1710" height="1112" alt="step4-login" src="https://github.com/user-attachments/assets/ee4ce678-70b1-4459-b656-374a35c72615" />
<img width="1710" height="1112" alt="step5-dashboard" src="https://github.com/user-attachments/assets/b89888cb-a272-4c0f-9ee9-f90ad266411a" />

Adds a service template for WordPress with OpenLiteSpeed web server and MariaDB. OLS is a common Apache/Nginx alternative for WordPress — supports HTTP/3, has a native LSCache plugin, and benchmarks faster for PHP workloads. The existing `wordpress-with-mariadb.yaml` uses Apache; this adds a high-performance alternative.

The init script is inlined in the entrypoint: downloads WordPress on first boot only (skips if `wp-config-sample.php` already exists), and generates `wp-config.php` idempotently. `SERVICE_URL_OPENLITESPEED_80` follows the same pattern as `SERVICE_URL_WORDPRESS` in the existing template.

## Issues

- Fixes #8264

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

<!-- Upload WordPress setup wizard screenshot here after creating PR -->

WordPress setup wizard appears on first boot. On restart, the named volume retains all files and OLS starts without re-downloading WordPress.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Used to help structure the initial implementation. Reviewed and validated all decisions manually against official OLS and LiteSpeedTech docker-compose documentation.

## Testing

Tested with Docker Compose locally using `litespeedtech/openlitespeed:1.8.5-lsphp85` and `mariadb:11.4`.

- First boot: init script downloaded WordPress, extracted into doc root, generated `wp-config.php` from env vars. OLS started and WordPress setup wizard appeared.
- Restart: init script found `wp-config-sample.php` in the named volume, skipped download. OLS started directly. WordPress still served (HTTP 302).
- MariaDB connection: `wp-config.php` generated with correct `DB_HOST`, `DB_NAME`, `DB_USER`, `DB_PASSWORD` from environment.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
