### PR TITLE
feat(backup): automated backups for git-based Docker Compose databases

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -623,6 +623,10 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         $this->generate_build_env_variables();
 
         $this->application->loadComposeFile(isInit: false);
+
+        // Sync companion service databases for automated backup support
+        syncCompanionServiceDatabases($this->application);
+
         if ($this->application->settings->is_raw_compose_deployment_enabled) {
             $this->application->oldRawParser();
             $yaml = $composeFile = $this->application->docker_compose_raw;

--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -95,6 +95,20 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                 $this->database = data_get($this->backup, 'database');
                 $this->server = $this->database->service->server;
                 $this->s3 = $this->backup->s3;
+
+                // Skip backup if this is a companion service database and a deployment is in progress
+                if ($this->database->service->isCompanion()) {
+                    $linkedApplication = $this->database->service->application;
+                    if ($linkedApplication && $linkedApplication->isDeploymentInprogress()) {
+                        Log::info('DatabaseBackupJob skipped: deployment in progress for companion service', [
+                            'backup_id' => $this->backup->id,
+                            'database_id' => $this->database->id,
+                            'application_id' => $linkedApplication->id,
+                        ]);
+
+                        return;
+                    }
+                }
             } else {
                 $this->database = data_get($this->backup, 'database');
                 $this->server = $this->database->destination->server;

--- a/app/Livewire/Project/Application/DatabaseBackups.php
+++ b/app/Livewire/Project/Application/DatabaseBackups.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Livewire\Project\Application;
+
+use App\Models\Application;
+use App\Models\ServiceDatabase;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Component;
+
+class DatabaseBackups extends Component
+{
+    use AuthorizesRequests;
+
+    public Application $application;
+
+    public $companionDatabases = [];
+
+    protected $listeners = ['refreshScheduledBackups' => '$refresh'];
+
+    public function mount()
+    {
+        try {
+            $this->authorize('view', $this->application);
+            $this->loadCompanionDatabases();
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function loadCompanionDatabases()
+    {
+        $companion = $this->application->companionService;
+        if ($companion) {
+            $this->companionDatabases = $companion->databases()->get();
+        } else {
+            $this->companionDatabases = collect([]);
+        }
+    }
+
+    public function render()
+    {
+        return view('livewire.project.application.database-backups');
+    }
+}

--- a/app/Livewire/Project/Resource/Index.php
+++ b/app/Livewire/Project/Resource/Index.php
@@ -142,11 +142,13 @@ class Index extends Component
             });
         }
 
-        // Load services with their tags and server
-        $this->services = $this->environment->services()->with([
-            'tags',
-            'destination.server.settings',
-        ])->get()->sortBy('name');
+        // Load services with their tags and server (exclude companion services for git-based compose)
+        $this->services = $this->environment->services()
+            ->whereNull('application_id')
+            ->with([
+                'tags',
+                'destination.server.settings',
+            ])->get()->sortBy('name');
         $this->services = $this->services->map(function ($service) use ($projectUuid, $environmentUuid) {
             $service->hrefLink = route('project.service.configuration', [
                 'project_uuid' => $projectUuid,

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -249,6 +249,16 @@ class Application extends BaseModel
             foreach ($application->deployment_queue as $deployment) {
                 $deployment->delete();
             }
+            // Clean up companion service and its databases/backups
+            if ($companion = $application->companionService) {
+                $companion->databases()->each(function ($db) {
+                    $db->scheduledBackups()->delete();
+                    $db->persistentStorages()->delete();
+                    $db->fileStorages()->delete();
+                    $db->forceDelete();
+                });
+                $companion->forceDelete();
+            }
         });
     }
 
@@ -925,6 +935,11 @@ class Application extends BaseModel
     public function source()
     {
         return $this->morphTo();
+    }
+
+    public function companionService()
+    {
+        return $this->hasOne(Service::class);
     }
 
     public function isDeploymentInprogress()

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -159,7 +159,9 @@ class Service extends BaseModel
      */
     public static function ownedByCurrentTeam()
     {
-        return Service::whereRelation('environment.project.team', 'id', currentTeam()->id)->orderBy('name');
+        return Service::whereRelation('environment.project.team', 'id', currentTeam()->id)
+            ->whereNull('application_id')
+            ->orderBy('name');
     }
 
     /**
@@ -1479,6 +1481,16 @@ class Service extends BaseModel
     public function server()
     {
         return $this->belongsTo(Server::class);
+    }
+
+    public function application()
+    {
+        return $this->belongsTo(Application::class);
+    }
+
+    public function isCompanion(): bool
+    {
+        return $this->application_id !== null;
     }
 
     public function byUuid(string $uuid)

--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -1483,3 +1483,138 @@ function injectDockerComposeBuildArgs(string $command, string $buildArgsString):
 
     return $modifiedCommand ?? $command;
 }
+
+/**
+ * Synchronize companion Service and ServiceDatabase records for a git-based
+ * Docker Compose Application. This enables automated backups for database
+ * services detected in the compose file.
+ *
+ * Creates a "companion" Service record linked to the Application, with
+ * ServiceDatabase child records for each detected database image.
+ * The companion Service's UUID matches the Application UUID so that
+ * container names align with the backup system's expectations.
+ *
+ * On subsequent calls (e.g. redeployments), the function:
+ * - Creates new ServiceDatabase records for newly added databases
+ * - Updates images for existing databases that changed
+ * - Removes ServiceDatabase records (and their backups) for removed databases
+ * - Cleans up the companion Service if no databases remain
+ */
+function syncCompanionServiceDatabases(Application $application): void
+{
+    // Only applies to git-based docker compose deployments
+    if ($application->build_pack !== 'dockercompose') {
+        return;
+    }
+    if (blank($application->docker_compose_raw)) {
+        return;
+    }
+    // Only for git-based applications (not pasted compose which uses Service model directly)
+    if (blank($application->git_repository) && blank($application->git_full_url)) {
+        return;
+    }
+
+    try {
+        $yaml = \Symfony\Component\Yaml\Yaml::parse($application->docker_compose_raw);
+    } catch (\Exception) {
+        return;
+    }
+
+    $services = data_get($yaml, 'services', []);
+    if (empty($services)) {
+        return;
+    }
+
+    // Detect database services
+    $databaseServices = [];
+    foreach ($services as $serviceName => $serviceConfig) {
+        $image = data_get($serviceConfig, 'image', '');
+        if (blank($image)) {
+            continue;
+        }
+        if (isDatabaseImage($image, $serviceConfig)) {
+            $databaseServices[$serviceName] = $image;
+        }
+    }
+
+    $companion = \App\Models\Service::where('application_id', $application->id)->first();
+
+    // No databases detected
+    if (empty($databaseServices)) {
+        // Clean up existing companion if databases were removed
+        if ($companion) {
+            $companion->databases()->each(function ($db) {
+                $db->scheduledBackups()->delete();
+                $db->persistentStorages()->delete();
+                $db->fileStorages()->delete();
+                $db->delete();
+            });
+            $companion->delete();
+        }
+
+        return;
+    }
+
+    // Ensure consistent container naming is enabled (required for backup container name resolution)
+    if (! $application->settings->is_consistent_container_name_enabled) {
+        $application->settings->is_consistent_container_name_enabled = true;
+        $application->settings->save();
+    }
+
+    // Resolve server_id through the destination relationship
+    $server = data_get($application, 'destination.server');
+    $serverId = $server ? $server->id : null;
+
+    // Create or retrieve companion service
+    if (! $companion) {
+        $companion = \App\Models\Service::create([
+            'application_id' => $application->id,
+            'uuid' => $application->uuid,
+            'name' => $application->name.' (databases)',
+            'environment_id' => $application->environment_id,
+            'server_id' => $serverId,
+            'destination_type' => $application->destination_type,
+            'destination_id' => $application->destination_id,
+            'docker_compose_raw' => $application->docker_compose_raw,
+        ]);
+    } else {
+        // Keep companion in sync with application
+        $companion->update([
+            'docker_compose_raw' => $application->docker_compose_raw,
+            'server_id' => $serverId,
+            'name' => $application->name.' (databases)',
+        ]);
+    }
+
+    // Sync ServiceDatabase records
+    $existingDatabases = $companion->databases()->get()->keyBy('name');
+    $detectedNames = collect(array_keys($databaseServices));
+
+    // Remove databases no longer present in compose
+    foreach ($existingDatabases as $name => $db) {
+        if (! $detectedNames->contains($name)) {
+            $db->scheduledBackups()->delete();
+            $db->persistentStorages()->delete();
+            $db->fileStorages()->delete();
+            $db->delete();
+        }
+    }
+
+    // Create or update databases
+    foreach ($databaseServices as $serviceName => $image) {
+        $existing = $existingDatabases->get($serviceName);
+        if ($existing) {
+            // Update image if changed
+            if ($existing->image !== $image) {
+                $existing->image = $image;
+                $existing->save();
+            }
+        } else {
+            \App\Models\ServiceDatabase::create([
+                'name' => $serviceName,
+                'image' => $image,
+                'service_id' => $companion->id,
+            ]);
+        }
+    }
+}

--- a/database/migrations/2026_03_16_000000_add_application_id_to_services_table.php
+++ b/database/migrations/2026_03_16_000000_add_application_id_to_services_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('services', function (Blueprint $table) {
+            $table->foreignId('application_id')->nullable()->after('id')
+                ->constrained('applications')->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('services', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('application_id');
+        });
+    }
+};

--- a/resources/views/livewire/project/application/configuration.blade.php
+++ b/resources/views/livewire/project/application/configuration.blade.php
@@ -64,6 +64,10 @@
                 href="{{ route('project.application.metrics', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Metrics</span></a>
             <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
                 href="{{ route('project.application.tags', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Tags</span></a>
+            @if ($application->build_pack === 'dockercompose' && $application->git_based() && $application->companionService?->databases()->count() > 0)
+                <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                    href="{{ route('project.application.database-backups', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Database Backups</span></a>
+            @endif
             <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
                 href="{{ route('project.application.danger', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Danger Zone</span></a>
         </div>
@@ -100,6 +104,8 @@
                 <livewire:project.shared.metrics :resource="$application" />
             @elseif ($currentRoute === 'project.application.tags')
                 <livewire:project.shared.tags :resource="$application" />
+            @elseif ($currentRoute === 'project.application.database-backups' && $application->build_pack === 'dockercompose')
+                <livewire:project.application.database-backups :application="$application" />
             @elseif ($currentRoute === 'project.application.danger')
                 <livewire:project.shared.danger :resource="$application" />
             @endif

--- a/resources/views/livewire/project/application/database-backups.blade.php
+++ b/resources/views/livewire/project/application/database-backups.blade.php
@@ -1,0 +1,34 @@
+<div>
+    <h2 class="pb-4">Database Backups</h2>
+    <p class="pb-4 text-sm text-gray-600 dark:text-gray-400">
+        Manage automated backups for database services detected in your Docker Compose file.
+    </p>
+    @if ($companionDatabases->count() === 0)
+        <div class="text-gray-500">No database services detected in your Docker Compose file. Deploy your application first to detect database services.</div>
+    @else
+        <div class="flex flex-col gap-6">
+            @foreach ($companionDatabases as $db)
+                <div class="p-4 border rounded-lg bg-white dark:bg-coolgray-100 border-gray-200 dark:border-coolgray-300">
+                    <div class="flex items-center justify-between mb-4">
+                        <div>
+                            <h3 class="font-semibold text-lg">{{ $db->name }}</h3>
+                            <span class="text-sm text-gray-500 dark:text-gray-400">{{ $db->image }} &middot; {{ str($db->databaseType())->after('standalone-')->title() }}</span>
+                        </div>
+                        @if ($db->isBackupSolutionAvailable())
+                            @can('update', $db)
+                                <x-modal-input buttonTitle="+ Add Backup" title="New Scheduled Backup for {{ $db->name }}">
+                                    <livewire:project.database.create-scheduled-backup :database="$db" wire:key="create-backup-{{ $db->id }}" />
+                                </x-modal-input>
+                            @endcan
+                        @else
+                            <span class="text-sm text-gray-400">Backups not supported for this database type</span>
+                        @endif
+                    </div>
+                    @if ($db->isBackupSolutionAvailable())
+                        <livewire:project.database.scheduled-backups :database="$db" :type="'service-database'" wire:key="backups-{{ $db->id }}" />
+                    @endif
+                </div>
+            @endforeach
+        </div>
+    @endif
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -224,6 +224,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/metrics', ApplicationConfiguration::class)->name('project.application.metrics');
         Route::get('/tags', ApplicationConfiguration::class)->name('project.application.tags');
         Route::get('/danger', ApplicationConfiguration::class)->name('project.application.danger');
+        Route::get('/database-backups', ApplicationConfiguration::class)->name('project.application.database-backups');
 
         Route::get('/deployment', DeploymentIndex::class)->name('project.application.deployment.index');
         Route::get('/deployment/{deployment_uuid}', DeploymentShow::class)->name('project.application.deployment.show');


### PR DESCRIPTION
## Summary

Fixes #7528 — Git-based Docker Compose deployments (`build_pack=dockercompose`) don't create `ServiceDatabase` records, making automated database backups impossible.

This PR introduces a **companion Service pattern**: when a git-based Docker Compose application is deployed and database images are detected in the compose file, a linked `Service` record is created with `ServiceDatabase` children. This reuses the entire existing backup infrastructure (`ScheduledDatabaseBackup`, `DatabaseBackupJob`, backup UI) without modification.

### Key changes:

- **Database detection during deployment** — `syncCompanionServiceDatabases()` parses the compose file using the existing `isDatabaseImage()` function and creates/updates/removes `ServiceDatabase` records on each deploy
- **Companion Service** — A hidden `Service` record (linked via `application_id` FK) whose UUID matches the Application UUID, ensuring container names align with the backup system's `{db_name}-{service_uuid}` pattern
- **Redeploy locking** — `DatabaseBackupJob` skips backup if the linked Application has a deployment in progress
- **Compose change handling** — On each deploy, databases removed from compose have their `ServiceDatabase` and `ScheduledDatabaseBackup` records cleaned up; new databases get new records; image changes are updated
- **Consistent container naming** — Auto-enabled when databases are detected (required for backup container name resolution)
- **UI integration** — "Database Backups" menu item appears in Application configuration when companion databases exist
- **Cleanup** — Companion service and all related records are deleted when the Application is force-deleted

### Files changed:

| File | Change |
|------|--------|
| `database/migrations/2026_03_16_*` | Add `application_id` FK to `services` table |
| `bootstrap/helpers/docker.php` | Add `syncCompanionServiceDatabases()` function |
| `app/Jobs/ApplicationDeploymentJob.php` | Call sync after loading compose file |
| `app/Jobs/DatabaseBackupJob.php` | Skip backup during active deployment |
| `app/Models/Service.php` | Add `application()` relationship, `isCompanion()`, filter from listings |
| `app/Models/Application.php` | Add `companionService()` relationship, cascade delete |
| `app/Livewire/Project/Application/DatabaseBackups.php` | New Livewire component |
| `resources/views/.../database-backups.blade.php` | New Blade template |
| `resources/views/.../configuration.blade.php` | Add menu item and content section |
| `routes/web.php` | Add database-backups route |
| `app/Livewire/Project/Resource/Index.php` | Hide companion services from listing |

## Test plan

- [ ] Deploy a git-based Docker Compose app containing a PostgreSQL/MySQL/MariaDB/MongoDB service
- [ ] Verify "Database Backups" menu item appears in Application configuration after first deployment
- [ ] Create a scheduled backup and verify it runs successfully
- [ ] Redeploy and verify backup is skipped during deployment, then resumes after
- [ ] Remove the database service from compose, redeploy, and verify ServiceDatabase + backups are cleaned up
- [ ] Add a new database service to compose, redeploy, and verify new ServiceDatabase is created
- [ ] Change database image (e.g., postgres:15 → postgres:16), redeploy, verify image is updated
- [ ] Delete the Application and verify companion Service is cleaned up
- [ ] Verify companion services don't appear in the Services resource listing
- [ ] Verify existing pasted Docker Compose services are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)