### PR TITLE
fix: prevent service domain FQDN corruption when ports are present

### DIFF
--- a/bootstrap/helpers/parsers.php
+++ b/bootstrap/helpers/parsers.php
@@ -1263,7 +1263,7 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
         // Add COOLIFY_FQDN & COOLIFY_URL to environment
         if (! $isDatabase && $fqdns instanceof Collection && $fqdns->count() > 0) {
             $fqdnsWithoutPort = $fqdns->map(function ($fqdn) {
-                return str($fqdn)->after('://')->before(':')->prepend(str($fqdn)->before('://')->append('://'));
+                return getFqdnWithoutPort($fqdn);
             });
             $coolifyEnvironments->put('COOLIFY_URL', $fqdnsWithoutPort->implode(','));
 
@@ -1755,8 +1755,8 @@ function serviceParser(Service $resource): Collection
                     $fqdn = generateFqdn(server: $server, random: "$fqdnFor-$uuid", parserVersion: $resource->compose_parsing_version);
                     $url = generateUrl($server, "$fqdnFor-$uuid");
                 } elseif ($isServiceApplication) {
-                    $fqdn = str($savedService->fqdn)->after('://')->before(':')->prepend(str($savedService->fqdn)->before('://')->append('://'))->value();
-                    $url = str($savedService->fqdn)->after('://')->before(':')->prepend(str($savedService->fqdn)->before('://')->append('://'))->value();
+                    $fqdn = getFqdnWithoutPort($savedService->fqdn);
+                    $url = $fqdn;
                 } else {
                     // For ServiceDatabase, generate fqdn/url without saving to the model
                     $fqdn = generateFqdn(server: $server, random: "$fqdnFor-$uuid", parserVersion: $resource->compose_parsing_version);
@@ -1787,10 +1787,10 @@ function serviceParser(Service $resource): Collection
                 $urlWithPort = $url;
                 $fqdnValueForEnvWithPort = $fqdnValueForEnv;
                 if ($fqdn && $port) {
-                    $fqdnValueForEnvWithPort = "$fqdnValueForEnv:$port";
+                    $fqdnValueForEnvWithPort = str(addPortToUrl("http://$fqdnValueForEnv", $port))->after('://')->value();
                 }
                 if ($url && $port) {
-                    $urlWithPort = "$url:$port";
+                    $urlWithPort = addPortToUrl($url, $port);
                 }
 
                 // Only save fqdn to ServiceApplication, not ServiceDatabase
@@ -2538,8 +2538,8 @@ function serviceParser(Service $resource): Collection
                 return str($fqdn)->replace('http://', '')->replace('https://', '')->before(':');
             });
             $coolifyEnvironments->put('COOLIFY_FQDN', $fqdnsWithoutPort->implode(','));
-            $urls = $fqdns->map(function ($fqdn): Stringable {
-                return str($fqdn)->after('://')->before(':')->prepend(str($fqdn)->before('://')->append('://'));
+            $urls = $fqdns->map(function ($fqdn) {
+                return getFqdnWithoutPort($fqdn);
             });
             $coolifyEnvironments->put('COOLIFY_URL', $urls->implode(','));
         }

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -375,17 +375,25 @@ function base_ip(): string
 
     return 'localhost';
 }
-function getFqdnWithoutPort(string $fqdn)
+function getFqdnWithoutPort(string $fqdn): string
 {
     try {
         $url = Url::fromString($fqdn);
-        $host = $url->getHost();
-        $scheme = $url->getScheme();
-        $path = $url->getPath();
 
-        return "$scheme://$host$path";
+        return $url->withPort(null)->__toString();
     } catch (\Throwable) {
         return $fqdn;
+    }
+}
+
+function addPortToUrl(string $url, int|string $port): string
+{
+    try {
+        $parsed = Url::fromString($url);
+
+        return $parsed->withPort((int) $port)->__toString();
+    } catch (\Throwable) {
+        return "$url:$port";
     }
 }
 /**
@@ -2155,7 +2163,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                             if ($env) {
                                 $env_url = Url::fromString($savedService->fqdn);
                                 $env_port = $env_url->getPort();
-                                if ($env_port !== $predefinedPort) {
+                                if ((int) $env_port !== (int) $predefinedPort) {
                                     $env_url = $env_url->withPort($predefinedPort);
                                     $savedService->fqdn = $env_url->__toString();
                                     $savedService->save();
@@ -2240,7 +2248,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                                             if ($env) {
                                                 $env_url = Url::fromString($env->value);
                                                 $env_port = $env_url->getPort();
-                                                if ($env_port !== $predefinedPort) {
+                                                if ((int) $env_port !== (int) $predefinedPort) {
                                                     $env_url = $env_url->withPort($predefinedPort);
                                                     $savedService->fqdn = $env_url->__toString();
                                                     $savedService->save();

--- a/tests/Unit/FqdnPortHandlingTest.php
+++ b/tests/Unit/FqdnPortHandlingTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Regression tests for FQDN port handling.
+ *
+ * Covers the reported bug where URLs like http://git.example.com:80
+ * were corrupted during COOLIFY_URL/COOLIFY_FQDN generation,
+ * and ensures port insertion works correctly when paths are present.
+ */
+use Spatie\Url\Url;
+
+test('getFqdnWithoutPort strips port from URL', function () {
+    expect(getFqdnWithoutPort('http://git.example.com:80'))->toBe('http://git.example.com');
+    expect(getFqdnWithoutPort('https://app.example.com:8443'))->toBe('https://app.example.com');
+    expect(getFqdnWithoutPort('http://localhost:3000'))->toBe('http://localhost');
+});
+
+test('getFqdnWithoutPort preserves URL without port', function () {
+    expect(getFqdnWithoutPort('http://git.example.com'))->toBe('http://git.example.com');
+    expect(getFqdnWithoutPort('https://app.example.com'))->toBe('https://app.example.com');
+});
+
+test('getFqdnWithoutPort preserves path when stripping port', function () {
+    expect(getFqdnWithoutPort('http://git.example.com:80/api/v1'))->toBe('http://git.example.com/api/v1');
+    expect(getFqdnWithoutPort('https://app.example.com:443/dashboard'))->toBe('https://app.example.com/dashboard');
+});
+
+test('addPortToUrl inserts port correctly for simple URLs', function () {
+    expect(addPortToUrl('https://app.example.com', 8080))->toBe('https://app.example.com:8080');
+    expect(addPortToUrl('http://localhost', 3000))->toBe('http://localhost:3000');
+});
+
+test('addPortToUrl inserts port before path', function () {
+    expect(addPortToUrl('https://app.example.com/dashboard', 8080))->toBe('https://app.example.com:8080/dashboard');
+    expect(addPortToUrl('http://git.example.com/api/v1', 3000))->toBe('http://git.example.com:3000/api/v1');
+});
+
+test('addPortToUrl replaces existing port', function () {
+    expect(addPortToUrl('https://app.example.com:443', 8080))->toBe('https://app.example.com:8080');
+});
+
+test('original bug case: http://git.example.com:80 roundtrip', function () {
+    // The reported bug: FQDN http://git.example.com:80 was corrupted
+    $fqdn = 'http://git.example.com:80';
+
+    // Step 1: strip port (as done in COOLIFY_URL generation)
+    $withoutPort = getFqdnWithoutPort($fqdn);
+    expect($withoutPort)->toBe('http://git.example.com');
+
+    // Step 2: re-add port (as done in service parser for urlWithPort)
+    $withPort = addPortToUrl($withoutPort, 80);
+    expect($withPort)->toBe('http://git.example.com:80');
+});
+
+test('service parser port insertion with path does not corrupt URL', function () {
+    // Simulates the serviceParser flow: fqdn has path, port added later
+    $savedFqdn = 'https://service.example.com:8080/v1/realtime';
+
+    $fqdn = getFqdnWithoutPort($savedFqdn);
+    expect($fqdn)->toBe('https://service.example.com/v1/realtime');
+
+    $url = $fqdn;
+    $fqdnValueForEnv = str($fqdn)->after('://')->value();
+    expect($fqdnValueForEnv)->toBe('service.example.com/v1/realtime');
+
+    $port = 8080;
+    $urlWithPort = addPortToUrl($url, $port);
+    expect($urlWithPort)->toBe('https://service.example.com:8080/v1/realtime');
+
+    $fqdnValueForEnvWithPort = str(addPortToUrl("http://$fqdnValueForEnv", $port))->after('://')->value();
+    expect($fqdnValueForEnvWithPort)->toBe('service.example.com:8080/v1/realtime');
+});


### PR DESCRIPTION
## Summary

Fixes URL corruption when FQDNs include explicit ports (e.g. `http://git.example.com:80`). The old inline string manipulation (`after('://')→before(':')→prepend(...)`) would mangle URLs with ports or paths.

- Replace fragile string-based port stripping with `getFqdnWithoutPort()` using `Url::withPort(null)` in both `applicationParser` and `serviceParser`
- Add `addPortToUrl()` helper that uses proper URL parsing to insert ports before paths, preventing invalid URLs like `scheme://host/path:port`
- Fix port comparison in `parseDockerComposeFile()` by casting both sides to `int`, avoiding false mismatches between string and int types

## Test plan

- [x] Added `tests/Unit/FqdnPortHandlingTest.php` with 8 regression tests covering:
  - Port stripping from URLs with and without ports
  - Path preservation when stripping ports
  - Port insertion before URL paths
  - The reported bug case (`http://git.example.com:80` roundtrip)
  - Full service parser flow simulation with path + port
- [x] All existing unit tests continue to pass

Closes #7363