### PR TITLE
feat: add OpenReplay service template

### DIFF
--- a/svgs/openreplay.svg
+++ b/svgs/openreplay.svg
@@ -1,0 +1,5 @@
+<svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="100" cy="100" r="80" fill="#394EFF"/>
+  <path d="M70 100L90 120L130 80" stroke="white" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="100" cy="100" r="65" stroke="white" stroke-width="4" fill="none"/>
+</svg>

--- a/templates/compose/openreplay.yaml
+++ b/templates/compose/openreplay.yaml
@@ -1,0 +1,124 @@
+# documentation: https://docs.openreplay.com
+# slogan: OpenReplay is an open-source session replay stack for developers. Self-host it for full control over your data.
+# category: analytics
+# tags: analytics, session-replay, monitoring, debugging, privacy
+# logo: svgs/openreplay.svg
+# port: 80
+
+services:
+  postgresql:
+    image: ghcr.io/openreplay/postgres:15.8.0-2
+    volumes:
+      - postgresql-data:/bitnami/postgresql
+    environment:
+      - POSTGRESQL_PASSWORD=${SERVICE_PASSWORD_POSTGRES}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+
+  clickhouse:
+    image: clickhouse/clickhouse-server:24.12-alpine
+    volumes:
+      - clickhouse-data:/var/lib/clickhouse
+    environment:
+      - CLICKHOUSE_USER=default
+      - CLICKHOUSE_PASSWORD=
+      - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 -O - http://127.0.0.1:8123/ping || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  redis:
+    image: ghcr.io/openreplay/valkey:8.0.1-1
+    volumes:
+      - redis-data:/data
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  minio:
+    image: ghcr.io/openreplay/minio:2024.11.7-0
+    volumes:
+      - minio-data:/bitnami/minio/data
+    environment:
+      - MINIO_ROOT_USER=${SERVICE_USER_MINIO}
+      - MINIO_ROOT_PASSWORD=${SERVICE_PASSWORD_MINIO}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:9000/minio/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  alerts:
+    image: public.ecr.aws/p1t3u8a3/alerts:v1.23.0
+    depends_on:
+      postgresql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    volumes:
+      - shared-data:/mnt/efs
+    restart: unless-stopped
+
+  api:
+    image: public.ecr.aws/p1t3u8a3/api:v1.23.0
+    depends_on:
+      postgresql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    volumes:
+      - shared-data:/mnt/efs
+    restart: unless-stopped
+
+  http:
+    image: public.ecr.aws/p1t3u8a3/http:v1.23.0
+    depends_on:
+      postgresql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    volumes:
+      - shared-data:/mnt/efs
+    restart: unless-stopped
+
+  frontend:
+    image: public.ecr.aws/p1t3u8a3/frontend:v1.23.0
+    environment:
+      - SERVICE_FQDN_OPENREPLAY_80
+    depends_on:
+      - api
+      - http
+    volumes:
+      - shared-data:/mnt/efs
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:80"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  sink:
+    image: public.ecr.aws/p1t3u8a3/sink:v1.23.0
+    depends_on:
+      - clickhouse
+    volumes:
+      - shared-data:/mnt/efs
+    restart: unless-stopped
+
+  storage:
+    image: public.ecr.aws/p1t3u8a3/storage:v1.23.0
+    depends_on:
+      - minio
+    volumes:
+      - shared-data:/mnt/efs
+    restart: unless-stopped


### PR DESCRIPTION
Closes #8232

This PR adds OpenReplay as a one-click service template in Coolify.

## What's included:
- **OpenReplay service template** (	emplates/compose/openreplay.yaml)
  - PostgreSQL database
  - ClickHouse for analytics storage
  - Redis for caching
  - MinIO for object storage
  - Core OpenReplay services:
    - alerts
    - api
    - http
    - frontend (main web interface)
    - sink (data ingestion)
    - storage
- **OpenReplay logo** (svgs/openreplay.svg)

## Service Details:
- **Category**: Analytics
- **Port**: 80
- **Documentation**: https://docs.openreplay.com
- **Description**: OpenReplay is an open-source session replay stack for developers. Self-host it for full control over your data.

The template follows the same pattern as other analytics services in Coolify (Plausible, Umami) and provides a complete, production-ready deployment of OpenReplay with all required dependencies.