### PR TITLE
fix(settings): add toggle to disable resource breadcrumb for large environments

### DIFF
--- a/app/Livewire/Project/Resource/Index.php
+++ b/app/Livewire/Project/Resource/Index.php
@@ -37,6 +37,8 @@ class Index extends Component
 
     public Collection $allEnvironments;
 
+    public bool $isResourceBreadcrumbEnabled;
+
     public array $parameters;
 
     public function mount()
@@ -55,31 +57,51 @@ class Index extends Component
 
         $this->project = $project;
 
-        // Load projects and environments for breadcrumb navigation (avoids inline queries in view)
+        $this->isResourceBreadcrumbEnabled = instanceSettings()->is_resource_breadcrumb_enabled ?? true;
+
+        // Load projects and environments for breadcrumb navigation
         $this->allProjects = Project::ownedByCurrentTeamCached();
-        $this->allEnvironments = $project->environments()
-            ->with([
-                'applications.additional_servers',
-                'applications.destination.server',
-                'services',
-                'services.destination.server',
-                'postgresqls',
-                'postgresqls.destination.server',
-                'redis',
-                'redis.destination.server',
-                'mongodbs',
-                'mongodbs.destination.server',
-                'mysqls',
-                'mysqls.destination.server',
-                'mariadbs',
-                'mariadbs.destination.server',
-                'keydbs',
-                'keydbs.destination.server',
-                'dragonflies',
-                'dragonflies.destination.server',
-                'clickhouses',
-                'clickhouses.destination.server',
-            ])->get();
+
+        if ($this->isResourceBreadcrumbEnabled) {
+            $this->allEnvironments = $project->environments()
+                ->with([
+                    'applications.additional_servers',
+                    'applications.destination.server',
+                    'services',
+                    'services.destination.server',
+                    'postgresqls',
+                    'postgresqls.destination.server',
+                    'redis',
+                    'redis.destination.server',
+                    'mongodbs',
+                    'mongodbs.destination.server',
+                    'mysqls',
+                    'mysqls.destination.server',
+                    'mariadbs',
+                    'mariadbs.destination.server',
+                    'keydbs',
+                    'keydbs.destination.server',
+                    'dragonflies',
+                    'dragonflies.destination.server',
+                    'clickhouses',
+                    'clickhouses.destination.server',
+                ])->get();
+        } else {
+            $this->allEnvironments = $project->environments()
+                ->select('id', 'uuid', 'name', 'project_id')
+                ->withCount([
+                    'applications',
+                    'postgresqls',
+                    'redis',
+                    'mongodbs',
+                    'mysqls',
+                    'mariadbs',
+                    'keydbs',
+                    'dragonflies',
+                    'clickhouses',
+                    'services',
+                ])->get();
+        }
 
         $this->environment = $environment->loadCount([
             'applications',

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -37,6 +37,9 @@ class Advanced extends Component
     #[Validate('boolean')]
     public bool $is_wire_navigate_enabled;
 
+    #[Validate('boolean')]
+    public bool $is_resource_breadcrumb_enabled;
+
     public function rules()
     {
         return [
@@ -49,6 +52,7 @@ class Advanced extends Component
             'is_sponsorship_popup_enabled' => 'boolean',
             'disable_two_step_confirmation' => 'boolean',
             'is_wire_navigate_enabled' => 'boolean',
+            'is_resource_breadcrumb_enabled' => 'boolean',
         ];
     }
 
@@ -67,6 +71,7 @@ class Advanced extends Component
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
         $this->is_sponsorship_popup_enabled = $this->settings->is_sponsorship_popup_enabled;
         $this->is_wire_navigate_enabled = $this->settings->is_wire_navigate_enabled ?? true;
+        $this->is_resource_breadcrumb_enabled = $this->settings->is_resource_breadcrumb_enabled ?? true;
     }
 
     public function submit()
@@ -150,6 +155,7 @@ class Advanced extends Component
             $this->settings->is_sponsorship_popup_enabled = $this->is_sponsorship_popup_enabled;
             $this->settings->disable_two_step_confirmation = $this->disable_two_step_confirmation;
             $this->settings->is_wire_navigate_enabled = $this->is_wire_navigate_enabled;
+            $this->settings->is_resource_breadcrumb_enabled = $this->is_resource_breadcrumb_enabled;
             $this->settings->save();
             $this->dispatch('success', 'Settings updated!');
         } catch (\Exception $e) {

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -31,6 +31,7 @@ class InstanceSettings extends Model
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',
         'is_wire_navigate_enabled' => 'boolean',
+        'is_resource_breadcrumb_enabled' => 'boolean',
     ];
 
     protected static function booted(): void

--- a/database/migrations/2026_03_16_133443_add_is_resource_breadcrumb_enabled_to_instance_settings_table.php
+++ b/database/migrations/2026_03_16_133443_add_is_resource_breadcrumb_enabled_to_instance_settings_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_resource_breadcrumb_enabled')->default(true);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn('is_resource_breadcrumb_enabled');
+        });
+    }
+};

--- a/resources/views/livewire/project/resource/index.blade.php
+++ b/resources/views/livewire/project/resource/index.blade.php
@@ -60,6 +60,7 @@
                         </div>
                     </div>
                 </li>
+                @if ($isResourceBreadcrumbEnabled)
                 <li class="inline-flex items-center" x-data="{ envOpen: false, activeEnv: null, envPositions: {}, activeRes: null, resPositions: {}, activeMenuEnv: null, menuPositions: {}, closeTimeout: null, envTimeout: null, resTimeout: null, menuTimeout: null, toggle() { this.envOpen = !this.envOpen; if (!this.envOpen) { this.activeEnv = null;
                             this.activeRes = null;
                             this.activeMenuEnv = null; } }, open() { clearTimeout(this.closeTimeout);
@@ -448,6 +449,60 @@
                         </div>
                     </div>
                 </li>
+                @else
+                <li class="inline-flex items-center" x-data="{ envOpen: false, closeTimeout: null, toggle() { this.envOpen = !this.envOpen }, open() { clearTimeout(this.closeTimeout); this.envOpen = true }, close() { this.closeTimeout = setTimeout(() => { this.envOpen = false }, 100) } }">
+                    <div class="flex items-center relative" @mouseenter="open()" @mouseleave="close()">
+                        <a class="text-xs truncate lg:text-sm hover:text-warning" {{ wireNavigate() }}
+                            href="{{ route('project.resource.index', ['project_uuid' => data_get($parameters, 'project_uuid'), 'environment_uuid' => $environment->uuid]) }}">
+                            {{ $environment->name }}
+                        </a>
+                        <button type="button" @click.stop="toggle()" class="px-1 text-warning">
+                            <svg class="w-3 h-3 transition-transform" :class="{ 'rotate-90': envOpen }" fill="none"
+                                stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="4" d="M9 5l7 7-7 7">
+                                </path>
+                            </svg>
+                        </button>
+
+                        <div x-show="envOpen" @click.outside="close()"
+                            x-transition:enter="transition ease-out duration-200"
+                            x-transition:enter-start="opacity-0 scale-95" x-transition:enter-end="opacity-100 scale-100"
+                            x-transition:leave="transition ease-in duration-75"
+                            x-transition:leave-start="opacity-100 scale-100" x-transition:leave-end="opacity-0 scale-95"
+                            class="absolute z-20 top-full mt-1 left-0 sm:left-auto max-w-[calc(100vw-1rem)]">
+                            <div
+                                class="relative w-56 bg-white dark:bg-coolgray-100 rounded-md shadow-lg py-1 border border-neutral-200 dark:border-coolgray-200 max-h-96 overflow-y-auto scrollbar">
+                                @foreach ($allEnvironments as $env)
+                                    @php
+                                        $envResourceCount = ($env->applications_count ?? 0) + ($env->postgresqls_count ?? 0) + ($env->redis_count ?? 0) + ($env->mongodbs_count ?? 0) + ($env->mysqls_count ?? 0) + ($env->mariadbs_count ?? 0) + ($env->keydbs_count ?? 0) + ($env->dragonflies_count ?? 0) + ($env->clickhouses_count ?? 0) + ($env->services_count ?? 0);
+                                    @endphp
+                                    <a href="{{ route('project.resource.index', ['project_uuid' => data_get($parameters, 'project_uuid'), 'environment_uuid' => $env->uuid]) }}"
+                                        {{ wireNavigate() }}
+                                        class="flex items-center justify-between gap-2 px-4 py-2 text-sm hover:bg-neutral-100 dark:hover:bg-coolgray-200 {{ $env->uuid === $environment->uuid ? 'dark:text-warning font-semibold' : '' }}"
+                                        title="{{ $env->name }}">
+                                        <span class="truncate">{{ $env->name }}</span>
+                                        @if ($envResourceCount > 0)
+                                            <span class="text-xs text-neutral-400 shrink-0">{{ $envResourceCount }}</span>
+                                        @endif
+                                    </a>
+                                @endforeach
+                                <div class="border-t border-neutral-200 dark:border-coolgray-200 mt-1 pt-1">
+                                    <a href="{{ route('project.show', ['project_uuid' => data_get($parameters, 'project_uuid')]) }}"
+                                        {{ wireNavigate() }}
+                                        class="flex items-center gap-2 px-4 py-2 text-sm hover:bg-neutral-100 dark:hover:bg-coolgray-200">
+                                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z">
+                                            </path>
+                                        </svg>
+                                        Create / Edit
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </li>
+                @endif
             </ol>
         </nav>
     </div>

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -55,6 +55,10 @@
                         <x-forms.checkbox instantSave id="is_wire_navigate_enabled" label="SPA Navigation"
                             helper="Enable single-page application (SPA) style navigation with prefetching on hover. When enabled, page transitions are smoother without full page reloads and pages are prefetched when hovering over links. Disable if you experience navigation issues." />
                     </div>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_resource_breadcrumb_enabled" label="Resource Breadcrumb Navigation"
+                            helper="Show a detailed resource navigation menu in the breadcrumb on environment pages. Disable this if you have many resources and experience slow page loads or memory issues." />
+                    </div>
                     <h4 class="pt-4">Confirmation Settings</h4>
                     <div class="md:w-96">
                         <x-forms.checkbox instantSave id="is_sponsorship_popup_enabled" label="Show Sponsorship Popup"


### PR DESCRIPTION
## Summary
- Adds `is_resource_breadcrumb_enabled` instance setting (Settings > Advanced)
- When disabled, the breadcrumb mega-menu is replaced with a lightweight dropdown showing environment names and resource counts
- Default is enabled — no change in behavior for existing instances

Fixes #9009

## What was the problem
The environment resource page breadcrumb eagerly loads ALL resources across ALL environments with 20+ nested relationships, then renders a 4-level deep nested menu for every resource. With 500+ resources, this causes OOM crashes (256MB limit) or 30+ second load times.

## What this changes
- **Migration**: adds `is_resource_breadcrumb_enabled` boolean to `instance_settings` (default `true`)
- **InstanceSettings model**: adds boolean cast
- **Settings > Advanced**: adds checkbox toggle with `instantSave`
- **Project Resource Index**: conditionally loads either full relationships (enabled) or just `withCount()` (disabled)
- **Blade view**: renders full mega-menu or simple dropdown based on the setting

## How to test
1. Import or create an environment with 500+ applications
2. Navigate to the environment resource page — observe slow load or OOM
3. Go to Settings > Advanced, uncheck "Resource Breadcrumb Navigation"
4. Reload the environment resource page — should load fast
5. Breadcrumb still shows environment names with resource counts