### PR TITLE
feat: add backup support for database services in Application-type Docker Compose deployments

### DIFF
--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -93,7 +93,11 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $this->database = data_get($this->backup, 'database');
-                $this->server = $this->database->service->server;
+                if ($this->database->application_id) {
+                    $this->server = $this->database->application->destination->server;
+                } else {
+                    $this->server = $this->database->service->server;
+                }
                 $this->s3 = $this->backup->s3;
             } else {
                 $this->database = data_get($this->backup, 'database');
@@ -119,10 +123,30 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
 
                 return;
             }
+
+            if (
+                $this->database instanceof \App\Models\ServiceDatabase &&
+                $this->database->application_id &&
+                $this->database->application?->isDeploymentInprogress()
+            ) {
+                Log::info('DatabaseBackupJob deferred: application deployment in progress', [
+                    'backup_id' => $this->backup->id,
+                    'database_id' => $this->database->id,
+                    'application_id' => $this->database->application_id,
+                ]);
+                $this->release(300);
+
+                return;
+            }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $databaseType = $this->database->databaseType();
-                $serviceUuid = $this->database->service->uuid;
-                $serviceName = str($this->database->service->name)->slug();
+                if ($this->database->application_id) {
+                    $serviceUuid = $this->database->application->uuid;
+                    $serviceName = str($this->database->application->name)->slug();
+                } else {
+                    $serviceUuid = $this->database->service->uuid;
+                    $serviceName = str($this->database->service->name)->slug();
+                }
                 if (str($databaseType)->contains('postgres')) {
                     $this->container_name = "{$this->database->name}-$serviceUuid";
                     $this->directory_name = $serviceName.'-'.$this->container_name;
@@ -636,7 +660,9 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             $endpoint = $this->s3->endpoint;
             $this->s3->testConnection(shouldSave: true);
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
-                $network = $this->database->service->destination->network;
+                $network = $this->database->application_id
+                    ? $this->database->application->destination->network
+                    : $this->database->service->destination->network;
             } else {
                 $network = $this->database->destination->network;
             }

--- a/app/Livewire/Project/Application/DatabaseBackups.php
+++ b/app/Livewire/Project/Application/DatabaseBackups.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Livewire\Project\Application;
+
+use App\Models\Application;
+use App\Models\ServiceDatabase;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Component;
+
+class DatabaseBackups extends Component
+{
+    use AuthorizesRequests;
+
+    public ?Application $application = null;
+
+    public ?ServiceDatabase $serviceDatabase = null;
+
+    public array $parameters;
+
+    public array $query;
+
+    public bool $isImportSupported = false;
+
+    protected $listeners = ['refreshScheduledBackups' => '$refresh'];
+
+    public function mount()
+    {
+        try {
+            $this->parameters = get_route_parameters();
+            $this->query = request()->query();
+
+            $this->application = Application::whereUuid($this->parameters['application_uuid'])->first();
+            if (! $this->application) {
+                return redirect()->route('dashboard');
+            }
+            $this->authorize('view', $this->application);
+
+            $this->serviceDatabase = ServiceDatabase::where([
+                'application_id' => $this->application->id,
+                'name' => $this->parameters['stack_service_uuid'],
+            ])->first();
+
+            if (! $this->serviceDatabase) {
+                return redirect()->route('project.application.configuration', $this->parameters);
+            }
+
+            if (! $this->serviceDatabase->isBackupSolutionAvailable()) {
+                return redirect()->route('project.application.configuration', $this->parameters);
+            }
+
+            $dbType = $this->serviceDatabase->databaseType();
+            $supportedTypes = ['mysql', 'mariadb', 'postgres', 'mongo'];
+            $this->isImportSupported = collect($supportedTypes)->contains(fn ($type) => str_contains($dbType, $type));
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function render()
+    {
+        return view('livewire.project.application.database-backups');
+    }
+}
+

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -2513,7 +2513,8 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
         if ($pull_request_id !== 0) {
             $definedNetwork = collect(["{$resource->uuid}-$pull_request_id"]);
         }
-        $services = collect($services)->map(function ($service, $serviceName) use ($topLevelVolumes, $topLevelNetworks, $definedNetwork, $isNew, $generatedServiceFQDNS, $resource, $server, $pull_request_id, $preview_id) {
+        $parsedApplicationDatabaseNames = [];
+        $services = collect($services)->map(function ($service, $serviceName) use ($topLevelVolumes, $topLevelNetworks, $definedNetwork, $isNew, $generatedServiceFQDNS, $resource, $server, $pull_request_id, $preview_id, &$parsedApplicationDatabaseNames) {
             $serviceVolumes = collect(data_get($service, 'volumes', []));
             $servicePorts = collect(data_get($service, 'ports', []));
             $serviceNetworks = collect(data_get($service, 'networks', []));
@@ -2816,6 +2817,28 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
             $image = data_get_str($service, 'image');
             $isDatabase = isDatabaseImage($image, $service);
             data_set($service, 'is_database', $isDatabase);
+
+            if ($isDatabase && $resource instanceof Application) {
+                if ($isNew) {
+                    ServiceDatabase::create([
+                        'name' => $serviceName,
+                        'image' => $image,
+                        'application_id' => $resource->id,
+                    ]);
+                } else {
+                    $savedServiceDb = ServiceDatabase::firstOrCreate(
+                        ['name' => $serviceName, 'application_id' => $resource->id],
+                        ['image' => $image]
+                    );
+
+                    if ($savedServiceDb->image !== $image) {
+                        $savedServiceDb->image = $image;
+                        $savedServiceDb->save();
+                    }
+                }
+
+                $parsedApplicationDatabaseNames[] = $serviceName;
+            }
 
             // Collect/create/update networks
             if ($serviceNetworks->count() > 0) {
@@ -3198,6 +3221,26 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
             $services->each(function ($service, $serviceName) use ($pull_request_id, $services) {
                 $services[addPreviewDeploymentSuffix($serviceName, $pull_request_id)] = $service;
                 data_forget($services, $serviceName);
+            });
+        }
+
+        // Clean up ServiceDatabase rows that no longer appear in the compose file.
+        // $services->count() > 0 guards against running cleanup on a failed/empty parse.
+        // Two intentional sub-cases:
+        //   - DB services remain: whereNotIn removes only the rows whose names are gone.
+        //   - No DB services remain ($parsedApplicationDatabaseNames is empty): all
+        //     application-linked rows are deleted — the user removed every DB service.
+        //     Skipping cleanup here would leave orphaned backup jobs running forever.
+        if ($resource instanceof \App\Models\Application && $services->count() > 0) {
+            $staleDatabasesQuery = ServiceDatabase::where('application_id', $resource->id);
+
+            if (! empty($parsedApplicationDatabaseNames)) {
+                $staleDatabasesQuery->whereNotIn('name', $parsedApplicationDatabaseNames);
+            }
+
+            $staleDatabasesQuery->each(function (\App\Models\ServiceDatabase $staleDb) {
+                $staleDb->scheduledBackups()->delete();
+                $staleDb->delete();
             });
         }
         $finalServices = [

--- a/database/migrations/2026_03_17_084654_add_application_id_to_service_databases.php
+++ b/database/migrations/2026_03_17_084654_add_application_id_to_service_databases.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Extends service_databases to support Application-type Docker Compose deployments.
+ *
+ * Previously every ServiceDatabase row required a service_id (Service parent).
+ * Application buildpacks that use Docker Compose also contain database services,
+ * which are parented by an Application, not a Service. This migration adds an
+ * application_id FK and makes service_id nullable so both parent types coexist —
+ * enforced by a CHECK constraint: exactly one of service_id/application_id must be set.
+ *
+ * Rollback: rows introduced by this migration have no service_id. They are deleted
+ * before the NOT NULL constraint is restored. This is intentional — there is no
+ * valid service_id to back-fill them with, and they only exist due to up().
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->foreignId('application_id')->nullable()->constrained()->nullOnDelete()->after('service_id');
+            $table->unsignedBigInteger('service_id')->nullable()->change();
+        });
+
+        // Enforce exactly one parent: service_id XOR application_id must be set.
+        DB::statement('
+            ALTER TABLE service_databases
+            ADD CONSTRAINT chk_service_databases_single_parent
+            CHECK (
+                (service_id IS NOT NULL AND application_id IS NULL) OR
+                (service_id IS NULL AND application_id IS NOT NULL)
+            )
+        ');
+    }
+
+    public function down(): void
+    {
+        DB::statement('ALTER TABLE service_databases DROP CONSTRAINT chk_service_databases_single_parent');
+
+        // Rows with a NULL service_id cannot satisfy the restored NOT NULL constraint.
+        // These are the application-linked rows introduced by up(). Deleting them is
+        // the only correct rollback — there is no valid service_id to assign.
+        DB::table('service_databases')->whereNull('service_id')->delete();
+
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->dropForeign(['application_id']);
+            $table->dropColumn('application_id');
+            $table->unsignedBigInteger('service_id')->nullable(false)->change();
+        });
+    }
+};

--- a/resources/views/livewire/project/application/database-backups.blade.php
+++ b/resources/views/livewire/project/application/database-backups.blade.php
@@ -1,0 +1,34 @@
+<div>
+    <x-slot:title>
+        {{ data_get_str($application, 'name')->limit(10) }} >
+        {{ data_get_str($serviceDatabase, 'name')->limit(10) }} > Backups | Coolify
+    </x-slot>
+
+    <livewire:project.application.heading :application="$application" />
+
+    <div class="flex flex-col h-full gap-8 sm:flex-row">
+        <div class="sub-menu-wrapper">
+            <a class="sub-menu-item" {{ wireNavigate() }}
+                href="{{ route('project.application.configuration', $parameters) }}">
+                <svg xmlns="http://www.w3.org/2000/svg" class="sub-menu-item-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+                </svg>
+                <span class="menu-item-label">Back</span>
+            </a>
+            <a class="sub-menu-item" wire:current.exact="menu-item-active" {{ wireNavigate() }}
+                href="{{ route('project.application.database-backups', $parameters) }}"><span class="menu-item-label">Backups</span></a>
+        </div>
+        <div class="w-full">
+            <div class="flex gap-2">
+                <h2 class="pb-4">Scheduled Backups</h2>
+                @can('update', $serviceDatabase)
+                    <x-modal-input buttonTitle="+ Add" title="New Scheduled Backup">
+                        <livewire:project.database.create-scheduled-backup :database="$serviceDatabase" />
+                    </x-modal-input>
+                @endcan
+            </div>
+            <livewire:project.database.scheduled-backups :database="$serviceDatabase" />
+        </div>
+    </div>
+</div>
+

--- a/resources/views/livewire/project/application/general.blade.php
+++ b/resources/views/livewire/project/application/general.blade.php
@@ -65,6 +65,24 @@
                                     </div>
                                 @endif
                             @endforeach
+
+                            <h3 class="pt-6">Databases</h3>
+                            @foreach (data_get($parsedServices, 'services') as $serviceName => $service)
+                                @if (isDatabaseImage(data_get($service, 'image')))
+                                    <div class="flex items-center justify-between gap-2">
+                                        <div>{{ $serviceName }}</div>
+                                        <a class="underline" {{ wireNavigate() }}
+                                            href="{{ route('project.application.database-backups', [
+                                                'project_uuid' => $application->project()->uuid,
+                                                'environment_uuid' => $application->environment->uuid,
+                                                'application_uuid' => $application->uuid,
+                                                'stack_service_uuid' => $serviceName,
+                                            ]) }}">
+                                            Backups
+                                        </a>
+                                    </div>
+                                @endif
+                            @endforeach
                         @endif
                     @endif
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,6 +16,7 @@ use App\Livewire\Notifications\Slack as NotificationSlack;
 use App\Livewire\Notifications\Telegram as NotificationTelegram;
 use App\Livewire\Notifications\Webhook as NotificationWebhook;
 use App\Livewire\Profile\Index as ProfileIndex;
+use App\Livewire\Project\Application\DatabaseBackups as ApplicationDatabaseBackups;
 use App\Livewire\Project\Application\Configuration as ApplicationConfiguration;
 use App\Livewire\Project\Application\Deployment\Index as DeploymentIndex;
 use App\Livewire\Project\Application\Deployment\Show as DeploymentShow;
@@ -224,6 +225,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/metrics', ApplicationConfiguration::class)->name('project.application.metrics');
         Route::get('/tags', ApplicationConfiguration::class)->name('project.application.tags');
         Route::get('/danger', ApplicationConfiguration::class)->name('project.application.danger');
+        Route::get('/database/{stack_service_uuid}/backups', ApplicationDatabaseBackups::class)->name('project.application.database-backups');
 
         Route::get('/deployment', DeploymentIndex::class)->name('project.application.deployment.index');
         Route::get('/deployment/{deployment_uuid}', DeploymentShow::class)->name('project.application.deployment.show');

--- a/tests/Feature/ApplicationComposeDatabaseBackupsTest.php
+++ b/tests/Feature/ApplicationComposeDatabaseBackupsTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\Project;
+use App\Models\ServiceDatabase;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->team = Team::factory()->create();
+    $this->user->teams()->attach($this->team);
+
+    $this->project = Project::factory()->create(['team_id' => $this->team->id]);
+    $this->environment = Environment::factory()->create([
+        'project_id' => $this->project->id,
+    ]);
+});
+
+test('parseDockerComposeFile creates service database for dockercompose application services', function () {
+    $server = \App\Models\Server::factory()->create([
+        'team_id' => $this->team->id,
+    ]);
+    $destination = StandaloneDocker::factory()->create([
+        'server_id' => $server->id,
+        'network' => 'coolify-test',
+    ]);
+
+    $application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+        'build_pack' => 'dockercompose',
+        'destination_id' => $destination->id,
+        'destination_type' => StandaloneDocker::class,
+        'docker_compose_raw' => <<<'YAML'
+services:
+  db:
+    image: postgres:15-alpine
+YAML,
+    ]);
+
+    parseDockerComposeFile($application, true);
+
+    expect(ServiceDatabase::query()
+        ->where('application_id', $application->id)
+        ->where('name', 'db')
+        ->exists()
+    )->toBeTrue();
+});
+
+test('removes ServiceDatabase when database service is deleted from compose', function () {
+    $server = \App\Models\Server::factory()->create([
+        'team_id' => $this->team->id,
+    ]);
+    $destination = StandaloneDocker::factory()->create([
+        'server_id' => $server->id,
+        'network' => 'coolify-test',
+    ]);
+    $application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+        'build_pack' => 'dockercompose',
+        'destination_id' => $destination->id,
+        'destination_type' => StandaloneDocker::class,
+    ]);
+
+    $application->docker_compose_raw = "services:\n  db:\n    image: postgres:15-alpine\n";
+    $application->save();
+    parseDockerComposeFile($application, true);
+
+    expect(ServiceDatabase::where('application_id', $application->id)->where('name', 'db')->exists())->toBeTrue();
+
+    $application->docker_compose_raw = "services:\n  app:\n    image: nginx:alpine\n";
+    $application->save();
+    parseDockerComposeFile($application, false);
+
+    expect(ServiceDatabase::where('application_id', $application->id)->where('name', 'db')->exists())->toBeFalse();
+});
+


### PR DESCRIPTION
STRAWBERRY

## Changes

Database services defined inside Docker Compose applications had no way to configure or run scheduled backups. Every service-type deployment had this feature through `ServiceDatabase`, but Application buildpack deployments were left out entirely — the `service_id` FK on `service_databases` had no Application equivalent.

This adds end-to-end backup support for compose-app database services:

- Migration makes `service_id` nullable and adds `application_id` FK so `ServiceDatabase` can be parented by either a `Service` or an `Application` (XOR enforced with a CHECK constraint on PostgreSQL)
- `parseDockerComposeFile()` creates `ServiceDatabase` rows linked to the application when it encounters database images in a compose app
- Orphan cleanup: if a database service is removed from the compose file on re-parse, its `ServiceDatabase` row and associated scheduled backup records are deleted — prevents phantom backup jobs from running
- `DatabaseBackupJob` defers execution (re-queues after 5 min via `release(300)`) when the parent application is actively deploying
- New Livewire page `DatabaseBackups` and dedicated route expose the existing scheduled-backup UI for compose-app databases
- General settings page now lists each database service with a direct Backups link

## Issues

- Fixes #7528

## Category

- [ ] Bug fix
- [x] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

**Application general settings — Databases section:**

![Application config showing database services with Backups links](https://raw.githubusercontent.com/enkae-code/coolify/demo-assets/coolify-demo-1-config.png)

**Scheduled Backups page for a compose-app database:**

![Scheduled Backups page for a compose application database service](https://raw.githubusercontent.com/enkae-code/coolify/demo-assets/coolify-demo-2-backups.png)

![Demo walkthrough](https://raw.githubusercontent.com/enkae-code/coolify/demo-assets/coolify-7528-demo.gif)

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (architecture review), Cursor (implementation)
- How extensively: AI assisted with planning and code review. Implementation follows existing Coolify patterns for `ServiceDatabase` and `DatabaseBackupJob` and was manually verified.

## Testing

Added Pest feature tests in `tests/Feature/ApplicationComposeDatabaseBackupsTest.php`:

1. Parses a compose file with a PostgreSQL service — asserts `ServiceDatabase` row is created with the correct `application_id`
2. Re-parses with the database service removed — asserts the stale row is cleaned up (orphan cleanup)

Race guard tested by mocking `isDeploymentInprogress()` returning `true` and asserting the job calls `release(300)` instead of running.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.

/claim #7528