### PR TITLE
feat(service): add OpenLiteSpeed and Docker Mailserver templates

### DIFF
--- a/public/svgs/docker-mailserver.svg
+++ b/public/svgs/docker-mailserver.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" fill="#1A6FB5"/>
+  <path d="M12 18h40v28H12z" fill="#fff" opacity="0.9"/>
+  <path d="M12 18l20 16 20-16" fill="none" stroke="#1A6FB5" stroke-width="2.5"/>
+</svg>

--- a/public/svgs/openlitespeed.svg
+++ b/public/svgs/openlitespeed.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" fill="#2B9F3E"/>
+  <path d="M36 8L22 34h10L26 56l18-30H34z" fill="#fff"/>
+</svg>

--- a/templates/compose/docker-mailserver.yaml
+++ b/templates/compose/docker-mailserver.yaml
@@ -1,0 +1,38 @@
+# documentation: https://docker-mailserver.github.io/docker-mailserver/latest/
+# slogan: Production-ready, full-featured mail server in a Docker container.
+# category: email
+# tags: email, smtp, imap, mail-server, postfix, dovecot
+# logo: svgs/docker-mailserver.svg
+# port: 1080
+
+services:
+  docker-mailserver:
+    image: ghcr.io/docker-mailserver/docker-mailserver:latest
+    ports:
+      - "25:25"
+      - "143:143"
+      - "465:465"
+      - "587:587"
+      - "993:993"
+    environment:
+      - SERVICE_URL_DOCKERMAILSERVER_1080
+      - OVERRIDE_HOSTNAME=${SERVICE_FQDN_DOCKERMAILSERVER}
+      - POSTMASTER_ADDRESS=${POSTMASTER_ADDRESS:-postmaster@example.com}
+      - TZ=${TZ:-UTC}
+      - ENABLE_SPAMASSASSIN=${ENABLE_SPAMASSASSIN:-1}
+      - ENABLE_CLAMAV=${ENABLE_CLAMAV:-1}
+      - ENABLE_FAIL2BAN=${ENABLE_FAIL2BAN:-1}
+      - ENABLE_POSTGREY=${ENABLE_POSTGREY:-0}
+      - ONE_DIR=${ONE_DIR:-1}
+      - SPOOF_PROTECTION=${SPOOF_PROTECTION:-1}
+      - SSL_TYPE=${SSL_TYPE:-}
+    volumes:
+      - mail-data:/var/mail
+      - mail-state:/var/mail-state
+      - mail-logs:/var/log/mail
+      - mail-config:/tmp/docker-mailserver
+    healthcheck:
+      test: ["CMD-SHELL", "ss -tlnp | grep -q ':25 ' || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 10

--- a/templates/compose/openlitespeed.yaml
+++ b/templates/compose/openlitespeed.yaml
@@ -1,0 +1,21 @@
+# documentation: https://openlitespeed.org/kb/
+# slogan: High-performance, lightweight open-source web server.
+# category: development
+# tags: web-server, http, litespeed, php, lsphp
+# logo: svgs/openlitespeed.svg
+# port: 8088
+
+services:
+  openlitespeed:
+    image: litespeedtech/openlitespeed:latest
+    environment:
+      - SERVICE_URL_OPENLITESPEED_8088
+      - OLS_ADMIN_PASSWORD=${SERVICE_PASSWORD_64_ADMIN}
+    volumes:
+      - lsws-conf:/usr/local/lsws/conf
+      - lsws-webroot:/var/www/vhosts/localhost/html
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://127.0.0.1:8088/ > /dev/null || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10


### PR DESCRIPTION
## Summary
- Adds **OpenLiteSpeed** standalone web server template (closes #8264)
- Adds **Docker Mailserver** full-featured mail server template (closes #8266)

## OpenLiteSpeed (`openlitespeed.yaml`)
- Image: `litespeedtech/openlitespeed:latest`
- Standalone web server (not coupled with WordPress — per reviewer feedback on #8271)
- Admin UI on port 8088 with auto-generated password
- Volumes for config and web root
- Health check via curl

## Docker Mailserver (`docker-mailserver.yaml`)
- Image: `ghcr.io/docker-mailserver/docker-mailserver:latest`
- Full mail stack: Postfix, Dovecot, SpamAssassin, ClamAV, Fail2Ban
- Raw TCP ports: 25 (SMTP), 143 (IMAP), 465 (SMTPS), 587 (Submission), 993 (IMAPS)
- 4 persistent volumes for mail data, state, logs, config
- Configurable via environment variables with sane defaults

## Checklist
- [x] Templates in `templates/compose/`
- [x] SVG logos in `public/svgs/`
- [x] No `networks:`, `container_name:`, or `restart:` (per conventions)
- [x] Coolify magic variables used (`SERVICE_URL_*`, `SERVICE_PASSWORD_64_*`, `SERVICE_FQDN_*`)
- [x] Health checks on all services

/claim #8264
/claim #8266

🤖 Generated with [Claude Code](https://claude.com/claude-code)