### PR TITLE
feat(services): add OpenLiteSpeed one-click service template

### DIFF
--- a/templates/compose/openlitespeed.yaml
+++ b/templates/compose/openlitespeed.yaml
@@ -1,0 +1,22 @@
+# documentation: https://openlitespeed.org/kb/
+# slogan: OpenLiteSpeed is a high-performance, lightweight, open-source HTTP server.
+# category: web
+# tags: web,openlitespeed,litespeed,php,http-server
+# logo: svgs/default.webp
+# port: 8088
+
+services:
+  openlitespeed:
+    image: litespeedtech/openlitespeed:latest
+    environment:
+      - SERVICE_URL_OPENLITESPEED_8088
+      - TZ=${TZ:-UTC}
+    volumes:
+      - openlitespeed-sites:/var/www/vhosts
+      - openlitespeed-config:/usr/local/lsws/conf
+      - openlitespeed-logs:/usr/local/lsws/logs
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8088"]
+      interval: 5s
+      timeout: 10s
+      retries: 15


### PR DESCRIPTION
/claim #8264

## Summary

Adds a new **OpenLiteSpeed** one-click service template following the maintainer's guidance in #8264 to provide OpenLiteSpeed as an **unopinionated, standalone base service** (not coupled with WordPress).

## Changes

- Added `templates/compose/openlitespeed.yaml` using the official `litespeedtech/openlitespeed:latest` image
- Persistent volumes for site files (`/var/www/vhosts`), server config (`/usr/local/lsws/conf`), and logs
- Standard `SERVICE_URL_OPENLITESPEED_8088` env var for Coolify proxy compatibility
- Optional `TZ` timezone variable
- HTTP healthcheck on port 8088

## Why standalone (not WordPress-coupled)

As requested by @Cinzya: "It probably makes more sense to add OpenLiteSpeed as a unopinionated service without being coupled with WordPress, as some users might want to use it standalone."

Users can deploy this template as a base and add WordPress (or any other PHP app) by placing files in the `/var/www/vhosts` volume.

## Test Plan

- Deploy using "Docker Compose Empty" option in Coolify, paste the compose content, and deploy
- Verify the container starts and healthcheck passes on port 8088
- Verify the WebAdmin panel is accessible on port 7080
