### PR TITLE
fix(compose): preserve Traefik backend labels for Docker Compose applications

### DIFF
--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -406,7 +406,82 @@ function fqdnLabelsForCaddy(string $network, string $uuid, Collection $domains, 
     return $labels->sort();
 }
 
-function fqdnLabelsForTraefik(string $uuid, Collection $domains, bool $is_force_https_enabled = false, $onlyPort = null, ?Collection $serviceLabels = null, ?bool $is_gzip_enabled = true, ?bool $is_stripprefix_enabled = true, ?string $service_name = null, bool $generate_unique_uuid = false, ?string $image = null, string $redirect_direction = 'both', bool $is_http_basic_auth_enabled = false, ?string $http_basic_auth_username = null, ?string $http_basic_auth_password = null)
+function normalizeProxyTargetPort(mixed $port): ?string
+{
+    if (is_null($port) || $port === '') {
+        return null;
+    }
+
+    $port = str((string) $port)->trim()->before('/')->value();
+    if ($port === '') {
+        return null;
+    }
+
+    if (preg_match('/(\d+(?:-\d+)?)$/', $port, $matches) !== 1) {
+        return null;
+    }
+
+    $port = str($matches[1])->before('-')->value();
+
+    if (! is_numeric($port)) {
+        return null;
+    }
+
+    $port = (int) $port;
+    if ($port < 1 || $port > 65535) {
+        return null;
+    }
+
+    return (string) $port;
+}
+
+function getServiceProxyTargetPort(array $service, mixed $fallbackPort = null): ?string
+{
+    $ports = collect([]);
+
+    $pushPort = function (mixed $candidate) use ($ports) {
+        $normalizedPort = normalizeProxyTargetPort($candidate);
+        if (! is_null($normalizedPort)) {
+            $ports->push($normalizedPort);
+        }
+    };
+
+    $normalizedFallbackPort = normalizeProxyTargetPort($fallbackPort);
+
+    collect(data_get($service, 'expose', []))->each(function ($exposedPort) use ($pushPort) {
+        if (is_array($exposedPort)) {
+            $pushPort(data_get($exposedPort, 'target') ?? data_get($exposedPort, 'published') ?? data_get($exposedPort, 'port'));
+
+            return;
+        }
+
+        $pushPort($exposedPort);
+    });
+
+    collect(data_get($service, 'ports', []))->each(function ($portMapping) use ($pushPort) {
+        if (is_array($portMapping)) {
+            $pushPort(data_get($portMapping, 'target'));
+
+            return;
+        }
+
+        $pushPort($portMapping);
+    });
+
+    $ports = $ports->unique()->values();
+
+    if ($ports->count() === 1) {
+        return $ports->first();
+    }
+
+    if (! is_null($normalizedFallbackPort) && $ports->contains($normalizedFallbackPort)) {
+        return $normalizedFallbackPort;
+    }
+
+    return $normalizedFallbackPort;
+}
+
+function fqdnLabelsForTraefik(string $uuid, Collection $domains, bool $is_force_https_enabled = false, $onlyPort = null, ?Collection $serviceLabels = null, ?bool $is_gzip_enabled = true, ?bool $is_stripprefix_enabled = true, ?string $service_name = null, bool $generate_unique_uuid = false, ?string $image = null, string $redirect_direction = 'both', bool $is_http_basic_auth_enabled = false, ?string $http_basic_auth_username = null, ?string $http_basic_auth_password = null, ?string $predefinedPort = null)
 {
     $labels = collect([]);
     $labels->push('traefik.enable=true');
@@ -464,6 +539,9 @@ function fqdnLabelsForTraefik(string $uuid, Collection $domains, bool $is_force_
             $port = $url->getPort();
             if (is_null($port) && ! is_null($onlyPort)) {
                 $port = $onlyPort;
+            }
+            if (is_null($port) && ! is_null($predefinedPort)) {
+                $port = $predefinedPort;
             }
             $http_label = "http-{$loop}-{$uuid}";
             $https_label = "https-{$loop}-{$uuid}";

--- a/bootstrap/helpers/parsers.php
+++ b/bootstrap/helpers/parsers.php
@@ -688,7 +688,7 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
             pull_request_id: $pullRequestId
         );
         $containerName = "$serviceName-$baseName";
-        $predefinedPort = null;
+        $predefinedPort = getServiceProxyTargetPort($service);
 
         $originalResource = $resource;
 
@@ -1337,7 +1337,8 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
                             is_gzip_enabled: $originalResource->isGzipEnabled(),
                             is_stripprefix_enabled: $originalResource->isStripprefixEnabled(),
                             service_name: $serviceName,
-                            image: $image
+                            image: $image,
+                            predefinedPort: $predefinedPort
                         ));
                         break;
                     case ProxyTypes::CADDY->value:
@@ -1364,7 +1365,8 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
                     is_gzip_enabled: $originalResource->isGzipEnabled(),
                     is_stripprefix_enabled: $originalResource->isStripprefixEnabled(),
                     service_name: $serviceName,
-                    image: $image
+                    image: $image,
+                    predefinedPort: $predefinedPort
                 ));
                 $serviceLabels = $serviceLabels->merge(fqdnLabelsForCaddy(
                     network: $labelNetwork,

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -2522,6 +2522,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
             $serviceLabels = collect(data_get($service, 'labels', []));
             $serviceBuildVariables = collect(data_get($service, 'build.args', []));
             $serviceVariables = $serviceVariables->merge($serviceBuildVariables);
+            $predefinedPort = getServiceProxyTargetPort($service);
             if ($serviceLabels->count() > 0) {
                 $removedLabels = collect([]);
                 $serviceLabels = $serviceLabels->filter(function ($serviceLabel, $serviceLabelName) use ($removedLabels) {
@@ -3109,6 +3110,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                                             is_force_https_enabled: $resource->isForceHttpsEnabled(),
                                             is_gzip_enabled: $resource->isGzipEnabled(),
                                             is_stripprefix_enabled: $resource->isStripprefixEnabled(),
+                                            predefinedPort: $predefinedPort,
                                         )
                                     );
                                     break;
@@ -3123,6 +3125,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                                             is_force_https_enabled: $resource->isForceHttpsEnabled(),
                                             is_gzip_enabled: $resource->isGzipEnabled(),
                                             is_stripprefix_enabled: $resource->isStripprefixEnabled(),
+                                            predefinedPort: $predefinedPort,
                                         )
                                     );
                                     break;
@@ -3138,6 +3141,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                                     is_force_https_enabled: $resource->isForceHttpsEnabled(),
                                     is_gzip_enabled: $resource->isGzipEnabled(),
                                     is_stripprefix_enabled: $resource->isStripprefixEnabled(),
+                                    predefinedPort: $predefinedPort,
                                 )
                             );
                             $serviceLabels = $serviceLabels->merge(
@@ -3150,6 +3154,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                                     is_force_https_enabled: $resource->isForceHttpsEnabled(),
                                     is_gzip_enabled: $resource->isGzipEnabled(),
                                     is_stripprefix_enabled: $resource->isStripprefixEnabled(),
+                                    predefinedPort: $predefinedPort,
                                 )
                             );
                         }

--- a/tests/Feature/DockerComposeTraefikLabelsRegressionTest.php
+++ b/tests/Feature/DockerComposeTraefikLabelsRegressionTest.php
@@ -83,12 +83,69 @@ YAML, 'https://test.example.com');
         );
     }
 
-    private function createDockerComposeApplication(string $compose, string $domain): Application
+    public function test_it_keeps_caddy_backend_labels_across_regenerate_cycles(): void
+    {
+        $application = $this->createDockerComposeApplication(<<<'YAML'
+services:
+  proxy:
+    image: nginx:alpine
+    expose:
+      - "8080"
+YAML, 'https://test.example.com', ProxyTypes::CADDY->value);
+
+        $application->parse();
+        $this->assertCaddyBackendLabels(
+            $this->serviceLabelsFor($application, 'proxy'),
+            '8080'
+        );
+
+        $application->refresh();
+        $application->parse();
+        $this->assertCaddyBackendLabels(
+            $this->serviceLabelsFor($application, 'proxy'),
+            '8080'
+        );
+
+        $application->docker_compose_domains = json_encode([
+            'proxy' => ['domain' => 'https://test.example.com'],
+        ]);
+        $application->save();
+
+        $application->refresh();
+        $application->parse();
+        $this->assertCaddyBackendLabels(
+            $this->serviceLabelsFor($application, 'proxy'),
+            '8080'
+        );
+    }
+
+    public function test_it_uses_the_container_target_port_for_caddy_labels(): void
+    {
+        $application = $this->createDockerComposeApplication(<<<'YAML'
+services:
+  proxy:
+    image: nginx:alpine
+    ports:
+      - "127.0.0.1:18080:8080"
+YAML, 'https://test.example.com', ProxyTypes::CADDY->value);
+
+        $application->parse();
+
+        $labels = $this->serviceLabelsFor($application, 'proxy');
+
+        $this->assertCaddyBackendLabels($labels, '8080');
+        $this->assertNotContains(
+            'caddy_0.handle_path.0_reverse_proxy={{upstreams 18080}}',
+            $labels
+        );
+    }
+
+    private function createDockerComposeApplication(string $compose, string $domain, string $proxyType = ProxyTypes::TRAEFIK->value): Application
     {
         $team = Team::factory()->create();
         $server = Server::factory()->create([
             'team_id' => $team->id,
-            'proxy' => ['type' => ProxyTypes::TRAEFIK->value],
+            'proxy' => ['type' => $proxyType],
         ]);
         $server->settings->update(['generate_exact_labels' => true]);
 
@@ -141,6 +198,25 @@ YAML, 'https://test.example.com');
         );
         $this->assertContains(
             "traefik.http.services.https-0-{$applicationUuid}-{$serviceName}.loadbalancer.server.port={$port}",
+            $labels
+        );
+    }
+
+    /**
+     * @param  list<string>  $labels
+     */
+    private function assertCaddyBackendLabels(array $labels, string $port): void
+    {
+        $this->assertContains(
+            'caddy_0=https://test.example.com',
+            $labels
+        );
+        $this->assertContains(
+            'caddy_0.handle_path=/*',
+            $labels
+        );
+        $this->assertContains(
+            "caddy_0.handle_path.0_reverse_proxy={{upstreams {$port}}}",
             $labels
         );
     }

--- a/tests/Feature/DockerComposeTraefikLabelsRegressionTest.php
+++ b/tests/Feature/DockerComposeTraefikLabelsRegressionTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\ProxyTypes;
+use App\Models\Application;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Symfony\Component\Yaml\Yaml;
+use Tests\TestCase;
+
+class DockerComposeTraefikLabelsRegressionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_keeps_traefik_backend_labels_across_regenerate_cycles(): void
+    {
+        $application = $this->createDockerComposeApplication(<<<'YAML'
+services:
+  proxy:
+    image: nginx:alpine
+    expose:
+      - "8080"
+YAML, 'https://test.example.com');
+
+        $application->parse();
+        $this->assertTraefikBackendLabels(
+            $this->serviceLabelsFor($application, 'proxy'),
+            $application->uuid,
+            'proxy',
+            '8080'
+        );
+
+        $application->refresh();
+        $application->parse();
+        $this->assertTraefikBackendLabels(
+            $this->serviceLabelsFor($application, 'proxy'),
+            $application->uuid,
+            'proxy',
+            '8080'
+        );
+
+        $application->docker_compose_domains = json_encode([
+            'proxy' => ['domain' => 'https://test.example.com'],
+        ]);
+        $application->save();
+
+        $application->refresh();
+        $application->parse();
+        $this->assertTraefikBackendLabels(
+            $this->serviceLabelsFor($application, 'proxy'),
+            $application->uuid,
+            'proxy',
+            '8080'
+        );
+    }
+
+    public function test_it_uses_the_container_target_port_for_traefik_labels(): void
+    {
+        $application = $this->createDockerComposeApplication(<<<'YAML'
+services:
+  proxy:
+    image: nginx:alpine
+    ports:
+      - "127.0.0.1:18080:8080"
+YAML, 'https://test.example.com');
+
+        $application->parse();
+
+        $labels = $this->serviceLabelsFor($application, 'proxy');
+
+        $this->assertTraefikBackendLabels($labels, $application->uuid, 'proxy', '8080');
+        $this->assertNotContains(
+            "traefik.http.services.http-0-{$application->uuid}-proxy.loadbalancer.server.port=18080",
+            $labels
+        );
+        $this->assertNotContains(
+            "traefik.http.services.https-0-{$application->uuid}-proxy.loadbalancer.server.port=18080",
+            $labels
+        );
+    }
+
+    private function createDockerComposeApplication(string $compose, string $domain): Application
+    {
+        $team = Team::factory()->create();
+        $server = Server::factory()->create([
+            'team_id' => $team->id,
+            'proxy' => ['type' => ProxyTypes::TRAEFIK->value],
+        ]);
+        $server->settings->update(['generate_exact_labels' => true]);
+
+        $destination = StandaloneDocker::query()
+            ->where('server_id', $server->id)
+            ->firstOrFail();
+
+        $project = Project::factory()->create(['team_id' => $team->id]);
+        $environment = $project->environments()->firstOrFail();
+
+        return Application::factory()->create([
+            'name' => 'compose-traefik-test',
+            'build_pack' => 'dockercompose',
+            'environment_id' => $environment->id,
+            'destination_id' => $destination->id,
+            'destination_type' => $destination->getMorphClass(),
+            'docker_compose_raw' => $compose,
+            'docker_compose_domains' => json_encode([
+                'proxy' => ['domain' => $domain],
+            ]),
+        ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function serviceLabelsFor(Application $application, string $serviceName): array
+    {
+        $parsedCompose = Yaml::parse($application->docker_compose);
+
+        return data_get($parsedCompose, "services.{$serviceName}.labels", []);
+    }
+
+    /**
+     * @param  list<string>  $labels
+     */
+    private function assertTraefikBackendLabels(array $labels, string $applicationUuid, string $serviceName, string $port): void
+    {
+        $this->assertContains(
+            "traefik.http.routers.http-0-{$applicationUuid}-{$serviceName}.service=http-0-{$applicationUuid}-{$serviceName}",
+            $labels
+        );
+        $this->assertContains(
+            "traefik.http.services.http-0-{$applicationUuid}-{$serviceName}.loadbalancer.server.port={$port}",
+            $labels
+        );
+        $this->assertContains(
+            "traefik.http.routers.https-0-{$applicationUuid}-{$serviceName}.service=https-0-{$applicationUuid}-{$serviceName}",
+            $labels
+        );
+        $this->assertContains(
+            "traefik.http.services.https-0-{$applicationUuid}-{$serviceName}.loadbalancer.server.port={$port}",
+            $labels
+        );
+    }
+}


### PR DESCRIPTION
## Changes

This fixes a Docker Compose application regression where Traefik labels are regenerated from the saved domain configuration without recovering the backend target port from the compose service.

This matches the behavior reported in #6599 for Docker Compose applications, where "Generate Domain" adds the labels, but changing the domain and pressing "Save" removes them again.

When the FQDN does not include an explicit port, saving the domain settings, regenerating the compose, or redeploying could drop the Traefik router-to-service binding and the load balancer port label. That leaves Traefik with a router but no backend even though the container itself is still healthy on the internal network.

This change resolves the target/internal port from the compose service definition and uses it as a fallback during label generation. It covers values coming from `expose`, short `ports`, and long `ports` syntax with `target`.

It also adds regression coverage for:
- initial compose parsing
- repeated regenerate/redeploy-style parsing
- saving `docker_compose_domains` again
- git-backed compose loading
- published-to-target mappings such as `127.0.0.1:18080:8080`

## Issues

- Fixes #6599
- Related to #6233

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A - backend-only Docker Compose / Traefik label generation fix.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex
- How extensively: Used for code search, drafting the fix, writing the regression test, and helping drive the local verification. I reviewed the affected code paths, validated the root cause, and ran the local tests myself.

## Testing

- `php artisan test tests/Feature/DockerComposeTraefikLabelsRegressionTest.php`
- local live verification of `parse -> reparse -> save docker_compose_domains -> parse` on an initialized Coolify instance
- local git-backed `loadComposeFile()` verification for a Docker Compose application
- full local end-to-end deployment through `ApplicationDeploymentJob` to a local testing host for Traefik, with runtime verification that the deployed container keeps:
  - `traefik.http.routers.http-0-<uuid>-proxy.service`
  - `traefik.http.routers.https-0-<uuid>-proxy.service`
  - `traefik.http.services.http-0-<uuid>-proxy.loadbalancer.server.port=8080`
  - `traefik.http.services.https-0-<uuid>-proxy.loadbalancer.server.port=8080`
- regression coverage for the equivalent Caddy path, including regenerate/save cycles and published-to-target port mappings
- full local end-to-end deployment through `ApplicationDeploymentJob` to a local testing host for Caddy, with runtime verification that the deployed container keeps:
  - `caddy_0=https://test.example.com`
  - `caddy_0.handle_path=/*`
  - `caddy_0.handle_path.0_reverse_proxy={{upstreams 8080}}`

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.