### PR TITLE
fix: retry HTTPS git clones with HTTP/1.1 fallback

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -1359,6 +1359,7 @@ class Application extends BaseModel
                     $fullRepoUrl = "{$this->source->html_url}/{$customRepository}";
                     $escapedRepoUrl = escapeshellarg("{$this->source->html_url}/{$customRepository}");
                     $git_clone_command = "{$git_clone_command} {$escapedRepoUrl} {$escapedBaseDir}";
+                    $git_clone_command = wrapGitCloneCommandWithHttpTransportFallback($git_clone_command, $baseDir, $fullRepoUrl);
                     if (! $only_checkout) {
                         $git_clone_command = $this->setGitImportSettings($deployment_uuid, $git_clone_command, public: true, commit: $commit);
                     }
@@ -1381,6 +1382,7 @@ class Application extends BaseModel
                         $git_clone_command = "{$git_clone_command} {$escapedRepoUrl} {$escapedBaseDir}";
                         $fullRepoUrl = $repoUrl;
                     }
+                    $git_clone_command = wrapGitCloneCommandWithHttpTransportFallback($git_clone_command, $baseDir, $repoUrl);
                     if (! $only_checkout) {
                         $git_clone_command = $this->setGitImportSettings($deployment_uuid, $git_clone_command, public: false, commit: $commit);
                     }
@@ -1466,6 +1468,7 @@ class Application extends BaseModel
                 $fullRepoUrl = $customRepository;
                 $escapedCustomRepository = escapeshellarg($customRepository);
                 $git_clone_command = "{$git_clone_command} {$escapedCustomRepository} {$escapedBaseDir}";
+                $git_clone_command = wrapGitCloneCommandWithHttpTransportFallback($git_clone_command, $baseDir, $fullRepoUrl);
                 $git_clone_command = $this->setGitImportSettings($deployment_uuid, $git_clone_command, public: true, commit: $commit);
 
                 if ($exec_in_docker) {
@@ -1552,6 +1555,7 @@ class Application extends BaseModel
             $fullRepoUrl = $customRepository;
             $escapedCustomRepository = escapeshellarg($customRepository);
             $git_clone_command = "{$git_clone_command} {$escapedCustomRepository} {$escapedBaseDir}";
+            $git_clone_command = wrapGitCloneCommandWithHttpTransportFallback($git_clone_command, $baseDir, $fullRepoUrl);
             $git_clone_command = $this->setGitImportSettings($deployment_uuid, $git_clone_command, public: true, commit: $commit);
 
             if ($pull_request_id !== 0) {

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -3416,6 +3416,32 @@ function loadConfigFromGit(string $repository, string $branch, string $base_dire
     }
 }
 
+function wrapGitCloneCommandWithHttpTransportFallback(string $gitCloneCommand, string $baseDir, ?string $repositoryUrl = null): string
+{
+    if (blank($repositoryUrl)) {
+        return $gitCloneCommand;
+    }
+
+    $normalizedBaseDir = trim($baseDir);
+    if ($normalizedBaseDir === '' || $normalizedBaseDir === '.' || $normalizedBaseDir === './' || $normalizedBaseDir === '/') {
+        return $gitCloneCommand;
+    }
+
+    $normalizedRepositoryUrl = strtolower(trim($repositoryUrl));
+    if (! str_starts_with($normalizedRepositoryUrl, 'http://') && ! str_starts_with($normalizedRepositoryUrl, 'https://')) {
+        return $gitCloneCommand;
+    }
+
+    $fallbackCommand = preg_replace('/\bgit clone\b/', 'git -c http.version=HTTP/1.1 clone', $gitCloneCommand, 1);
+    if ($fallbackCommand === null || $fallbackCommand === $gitCloneCommand) {
+        return $gitCloneCommand;
+    }
+
+    $escapedBaseDir = escapeshellarg($baseDir);
+
+    return "({$gitCloneCommand}) || (rm -rf {$escapedBaseDir} && echo 'Primary git clone failed, retrying with HTTP/1.1' >&2 && {$fallbackCommand})";
+}
+
 function loggy($message = null, array $context = [])
 {
     if (! isDev()) {

--- a/tests/Feature/GitCloneHttpTransportFallbackTest.php
+++ b/tests/Feature/GitCloneHttpTransportFallbackTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use App\Models\Application;
+use App\Models\ApplicationSetting;
+use App\Models\GithubApp;
+
+it('wraps https clone commands with an HTTP/1.1 retry after cleanup', function () {
+    $command = "git clone --depth=1 -b 'main' 'https://github.com/coollabsio/coolify' '/artifacts/test-uuid'";
+
+    $result = wrapGitCloneCommandWithHttpTransportFallback(
+        $command,
+        '/artifacts/test-uuid',
+        'https://github.com/coollabsio/coolify'
+    );
+
+    expect($result)
+        ->toContain("(git clone --depth=1 -b 'main' 'https://github.com/coollabsio/coolify' '/artifacts/test-uuid')")
+        ->toContain("rm -rf '/artifacts/test-uuid'")
+        ->toContain("Primary git clone failed, retrying with HTTP/1.1")
+        ->toContain("git -c http.version=HTTP/1.1 clone --depth=1 -b 'main' 'https://github.com/coollabsio/coolify' '/artifacts/test-uuid'");
+});
+
+it('leaves ssh clone commands unchanged', function () {
+    $command = "GIT_SSH_COMMAND=\"ssh -i /root/.ssh/id_rsa\" git clone -b 'main' 'git@github.com:coollabsio/coolify.git' '/artifacts/test-uuid'";
+
+    $result = wrapGitCloneCommandWithHttpTransportFallback(
+        $command,
+        '/artifacts/test-uuid',
+        'git@github.com:coollabsio/coolify.git'
+    );
+
+    expect($result)->toBe($command);
+});
+
+it('skips cleanup fallback when cloning into the current directory', function () {
+    $command = "git clone --no-checkout -b 'main' 'https://github.com/coollabsio/coolify' .";
+
+    $result = wrapGitCloneCommandWithHttpTransportFallback(
+        $command,
+        '.',
+        'https://github.com/coollabsio/coolify'
+    );
+
+    expect($result)->toBe($command);
+});
+
+it('adds the http fallback to github app source clone commands', function () {
+    $application = new Application;
+    $application->forceFill([
+        'git_branch' => 'main',
+        'git_repository' => 'coollabsio/coolify',
+        'git_commit_sha' => 'HEAD',
+    ]);
+
+    $settings = new ApplicationSetting;
+    $settings->is_git_shallow_clone_enabled = true;
+    $settings->is_git_submodules_enabled = false;
+    $settings->is_git_lfs_enabled = false;
+    $application->setRelation('settings', $settings);
+
+    $source = new GithubApp;
+    $source->html_url = 'https://github.com';
+    $source->is_public = true;
+    $application->setRelation('source', $source);
+
+    $result = $application->generateGitImportCommands(
+        deployment_uuid: 'test-uuid',
+        exec_in_docker: false
+    );
+
+    expect($result['commands'])
+        ->toContain("git -c http.version=HTTP/1.1 clone --depth=1 -b 'main' 'https://github.com/coollabsio/coolify' '/artifacts/test-uuid'")
+        ->toContain("rm -rf '/artifacts/test-uuid'");
+});

--- a/tests/Feature/GitCloneHttpTransportFallbackTest.php
+++ b/tests/Feature/GitCloneHttpTransportFallbackTest.php
@@ -16,7 +16,7 @@ it('wraps https clone commands with an HTTP/1.1 retry after cleanup', function (
     expect($result)
         ->toContain("(git clone --depth=1 -b 'main' 'https://github.com/coollabsio/coolify' '/artifacts/test-uuid')")
         ->toContain("rm -rf '/artifacts/test-uuid'")
-        ->toContain("Primary git clone failed, retrying with HTTP/1.1")
+        ->toContain('Primary git clone failed, retrying with HTTP/1.1')
         ->toContain("git -c http.version=HTTP/1.1 clone --depth=1 -b 'main' 'https://github.com/coollabsio/coolify' '/artifacts/test-uuid'");
 });
 


### PR DESCRIPTION
## Changes

- Retry HTTPS repository clones once with `git -c http.version=HTTP/1.1 clone ...` after deleting the partial `/artifacts/<deployment_uuid>` checkout directory.
- Apply the fallback only to HTTPS-based clone flows so SSH and deploy-key clone paths keep their existing behavior.
- Add regression coverage for the fallback helper, the current-directory safety guard, and GitHub App command generation wiring.

## Issues

- Fixes #5251
- /claim #5251

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Browser-only demo video showing a redeploy hitting the new HTTP/1.1 clone retry path and continuing past the clone step:

- [coolify-http11-fallback-demo.mp4](https://github.com/javery556/coolify/releases/download/pr-9037-demo-video/coolify-http11-fallback-demo.mp4)

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex
- How extensively: Used to draft the patch and tests, then manually reviewed against the issue thread and contribution guidelines before submission.

## Testing

Issue-specific verification:

- `./vendor/bin/pint --test app/Models/Application.php bootstrap/helpers/shared.php tests/Feature/GitCloneHttpTransportFallbackTest.php`
- `php artisan test tests/Feature/GitCloneHttpTransportFallbackTest.php`
- Verified `wraps https clone commands with an HTTP/1.1 retry after cleanup`, `leaves ssh clone commands unchanged`, `skips cleanup fallback when cloning into the current directory`, and `adds the http fallback to github app source clone commands`
- Booted a local Coolify instance with `APP_PORT=18000 DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 ./vendor/bin/spin up`
- Ran a local redeploy against `https://github.com/coollabsio/coolify-examples` while forcing the first plain HTTPS clone attempt to fail once in the helper image; the deployment logs then showed `Primary git clone failed, retrying with HTTP/1.1`, followed by the `git -c http.version=HTTP/1.1 clone ...` retry, and the deployment continued past the clone step
- The browser-only demo in `Preview` is the capture of that redeploy flow

Secondary local smoke checks:

- `curl -I http://127.0.0.1:18000/login` returned `200 OK`
- Posted the local login form with `test@example.com` / `password` and received a `302` redirect back to `http://127.0.0.1:18000`

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this is not a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
