### PR TITLE
fix(deployment): disable build server during restart operations

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -1103,10 +1103,21 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
     private function just_restart()
     {
         $this->application_deployment_queue->addLogEntry("Restarting {$this->customRepository}:{$this->application->git_branch} on {$this->server->name}.");
+
+        // Restart doesn't need the build server — disable it so the helper container
+        // is created on the deployment server with the correct network/flags.
+        $originalUseBuildServer = $this->use_build_server;
+        $this->use_build_server = false;
+
         $this->prepare_builder_image();
         $this->check_git_if_build_needed();
         $this->generate_image_names();
         $this->check_image_locally_or_remotely();
+
+        // Restore before should_skip_build() — it may re-enter decide_what_to_do()
+        // for a full rebuild which needs the build server.
+        $this->use_build_server = $originalUseBuildServer;
+
         $this->should_skip_build();
         $this->completeDeployment();
     }


### PR DESCRIPTION
## Summary
- Disable external build server during restart operations to prevent container not found errors
- Ensures helper container is created on the deployment server with correct network configuration
- Temporarily disables build server for restart workflow, then restores it for potential full rebuilds

## Background
When restarting a deployment with an external build server configured, the application would fail to locate helper containers. This occurred because the containers were being created on the build server instead of the deployment server, causing a mismatch in the expected network and container setup.

## Changes
- Modified `just_restart()` to temporarily disable `use_build_server` during the restart workflow
- Helper container and image preparation now happens on the deployment server
- Restore `use_build_server` setting before `should_skip_build()` to handle cases where a full rebuild is needed

---

Fixes #9013