### PR TITLE
Feat/9043 add payram service

### DIFF
--- a/templates/compose/payram.yaml
+++ b/templates/compose/payram.yaml
@@ -5,21 +5,28 @@ logo: https://raw.githubusercontent.com/payramapp/payram/main/logo.png
 services:
   payram:
     image: payramapp/payram:latest
+    platform: linux/amd64
     environment:
       - SERVER=PRODUCTION
       - BLOCKCHAIN_NETWORK_TYPE=mainnet
       - AES_KEY=${SERVICE_PASSWORD_AES_KEY}
-      - SSL_CERT_PATH=""
       - POSTGRES_HOST=db
       - POSTGRES_PORT=5432
-      - POSTGRES_DATABASE=${POSTGRES_DB}
-      - POSTGRES_USERNAME=${POSTGRES_USER}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DATABASE=${SERVICE_USER_POSTGRES}
+      - POSTGRES_USERNAME=${SERVICE_USER_POSTGRES}
+      - POSTGRES_PASSWORD=${SERVICE_PASSWORD_POSTGRES}
     volumes:
       - payram-data:/root/payram
       - payram-logs:/var/log
     depends_on:
-      - db
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     labels:
       - coolify.managed=true
       - coolify.connectionId=${CONNECTION_ID}

--- a/templates/compose/payram.yaml
+++ b/templates/compose/payram.yaml
@@ -1,0 +1,54 @@
+# documentation: https://docs.payram.com
+name: PayRam
+description: PayRam server setup with a dedicated PostgreSQL database.
+logo: https://raw.githubusercontent.com/payramapp/payram/main/logo.png
+services:
+  payram:
+    image: payramapp/payram:latest
+    environment:
+      - SERVER=PRODUCTION
+      - BLOCKCHAIN_NETWORK_TYPE=mainnet
+      - AES_KEY=${SERVICE_PASSWORD_AES_KEY}
+      - SSL_CERT_PATH=""
+      - POSTGRES_HOST=db
+      - POSTGRES_PORT=5432
+      - POSTGRES_DATABASE=${POSTGRES_DB}
+      - POSTGRES_USERNAME=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+    volumes:
+      - payram-data:/root/payram
+      - payram-logs:/var/log
+    depends_on:
+      - db
+    labels:
+      - coolify.managed=true
+      - coolify.connectionId=${CONNECTION_ID}
+      - coolify.proxyId=${PROXY_ID}
+      - traefik.enable=true
+      - traefik.http.routers.payram-${SERVICE_ID}.rule=Host(`${SERVICE_FQDN_PAYRAM}`)
+      - traefik.http.services.payram-${SERVICE_ID}.loadbalancer.server.port=8080
+
+  db:
+    image: postgres:15-alpine
+    environment:
+      - POSTGRES_USER=${SERVICE_USER_POSTGRES}
+      - POSTGRES_PASSWORD=${SERVICE_PASSWORD_POSTGRES}
+      - POSTGRES_DB=${SERVICE_USER_POSTGRES}
+    volumes:
+      - payram-db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${SERVICE_USER_POSTGRES}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+variables:
+  - SERVICE_PASSWORD_AES_KEY
+  - SERVICE_USER_POSTGRES
+  - SERVICE_PASSWORD_POSTGRES
+  - SERVICE_FQDN_PAYRAM
+
+volumes:
+  payram-data:
+  payram-logs:
+  payram-db-data:


### PR DESCRIPTION

/claim #9043

## Changes

Added Payram as a new one-click service. The template sets up the official `payramapp/payram:latest` image alongside a dedicated PostgreSQL 15 database. I mapped all required environment variables (including auto-generating the `AES_KEY` and database credentials) using Coolify's dynamic variables to ensure a secure, zero-config deployment. Traefik labels are also configured to properly route the internal API (port 8080) to the FQDN.

## Issues

- Fixes #9043

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

*(I will upload the demo video showing the successful local deployment and the working UI in a comment below right after opening this PR).*

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Cline (Claude 4.6 Sonnet)
- How extensively: Used strictly as a parser to quickly translate the official Payram Docker documentation into Coolify's v4 YAML syntax (mapping the dynamic variables). I manually audited the architecture and tested the final execution.

## Testing

I mocked the Coolify variables locally and spun up the architecture using `docker compose up -d`. I verified that the Postgres database initializes correctly, the Payram container connects to it without race conditions, and the web UI is successfully served on port 8080 with a 200 HTTP status.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
