### PR TITLE
feat: add Payram service template

### DIFF
--- a/templates/compose/payram.yaml
+++ b/templates/compose/payram.yaml
@@ -1,0 +1,45 @@
+# documentation: https://docs.payram.com
+# slogan: Payram is a self-hosted, open-source crypto payment gateway.
+# category: payments
+# tags: payram,crypto,payments,blockchain,gateway
+# logo: svgs/payram.png
+# port: 80
+
+services:
+  payram:
+    image: payramapp/payram:latest
+    environment:
+      - SERVICE_URL_PAYRAM_80
+      - SSL_CERT_PATH=
+      - BLOCKCHAIN_NETWORK_TYPE=${BLOCKCHAIN_NETWORK_TYPE:-mainnet}
+      - SERVER=${SERVER:-PRODUCTION}
+      - AES_KEY=${SERVICE_PASSWORD_64_AES}
+      - POSTGRES_HOST=postgres
+      - POSTGRES_PORT=5432
+      - POSTGRES_DATABASE=${POSTGRES_DB:-payram}
+      - POSTGRES_USERNAME=$SERVICE_USER_POSTGRES
+      - POSTGRES_PASSWORD=$SERVICE_PASSWORD_POSTGRES
+    volumes:
+      - payram-data:/home/payram
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:80"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+
+  postgres:
+    image: postgres:16-alpine
+    volumes:
+      - payram-postgres-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=$SERVICE_USER_POSTGRES
+      - POSTGRES_PASSWORD=$SERVICE_PASSWORD_POSTGRES
+      - POSTGRES_DB=${POSTGRES_DB:-payram}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
## Summary
- Adds a new Coolify service template for [Payram](https://payram.com), a self-hosted open-source crypto payment gateway
- Includes PostgreSQL database with healthchecks and proper Coolify service variable conventions
- Template file: `templates/compose/payram.yaml`

Closes #9043
/claim #9043

## Test plan
- [ ] Deploy the template in Coolify and verify Payram starts correctly
- [ ] Verify PostgreSQL healthcheck works
- [ ] Verify the web UI is accessible on port 80

🤖 Generated with [Claude Code](https://claude.com/claude-code)