### PR TITLE
feat: add OpenReplay service template

### DIFF
--- a/templates/compose/openreplay.yaml
+++ b/templates/compose/openreplay.yaml
@@ -1,0 +1,208 @@
+# documentation: https://docs.openreplay.com
+# slogan: Open-source session replay and product analytics you can self-host.
+# category: analytics
+# tags: openreplay,session-replay,analytics,monitoring,product-analytics
+# logo: svgs/openreplay.png
+# port: 80
+
+services:
+  http:
+    image: public.ecr.aws/p1t3u8a3/http:latest
+    environment:
+      - SERVICE_URL_HTTP_80
+    volumes:
+      - openreplay-shared:/shared-volume
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:80"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+
+  api:
+    image: public.ecr.aws/p1t3u8a3/api:latest
+    environment:
+      - LICENSE_KEY=${LICENSE_KEY:-}
+      - pg_host=postgres
+      - pg_port=5432
+      - pg_dbname=${POSTGRES_DB:-openreplay}
+      - pg_user=$SERVICE_USER_POSTGRES
+      - pg_password=$SERVICE_PASSWORD_POSTGRES
+      - S3_HOST=minio
+      - S3_PORT=9000
+      - S3_KEY=${SERVICE_USER_MINIO}
+      - S3_SECRET=${SERVICE_PASSWORD_MINIO}
+      - REDIS_STRING=redis://redis:6379
+      - SITE_URL=${SERVICE_URL_HTTP}
+      - JWT_SECRET=${SERVICE_PASSWORD_64_JWT}
+    volumes:
+      - openreplay-shared:/shared-volume
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+
+  sink:
+    image: public.ecr.aws/p1t3u8a3/sink:latest
+    environment:
+      - pg_host=postgres
+      - pg_port=5432
+      - pg_dbname=${POSTGRES_DB:-openreplay}
+      - pg_user=$SERVICE_USER_POSTGRES
+      - pg_password=$SERVICE_PASSWORD_POSTGRES
+      - REDIS_STRING=redis://redis:6379
+      - S3_HOST=minio
+      - S3_PORT=9000
+      - S3_KEY=${SERVICE_USER_MINIO}
+      - S3_SECRET=${SERVICE_PASSWORD_MINIO}
+    volumes:
+      - openreplay-shared:/shared-volume
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  storage:
+    image: public.ecr.aws/p1t3u8a3/storage:latest
+    environment:
+      - pg_host=postgres
+      - pg_port=5432
+      - pg_dbname=${POSTGRES_DB:-openreplay}
+      - pg_user=$SERVICE_USER_POSTGRES
+      - pg_password=$SERVICE_PASSWORD_POSTGRES
+      - S3_HOST=minio
+      - S3_PORT=9000
+      - S3_KEY=${SERVICE_USER_MINIO}
+      - S3_SECRET=${SERVICE_PASSWORD_MINIO}
+    volumes:
+      - openreplay-shared:/shared-volume
+    depends_on:
+      postgres:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+
+  assets:
+    image: public.ecr.aws/p1t3u8a3/assets:latest
+    environment:
+      - SITE_URL=${SERVICE_URL_HTTP}
+      - S3_HOST=minio
+      - S3_PORT=9000
+      - S3_KEY=${SERVICE_USER_MINIO}
+      - S3_SECRET=${SERVICE_PASSWORD_MINIO}
+    volumes:
+      - openreplay-shared:/shared-volume
+    depends_on:
+      minio:
+        condition: service_healthy
+
+  ender:
+    image: public.ecr.aws/p1t3u8a3/ender:latest
+    environment:
+      - pg_host=postgres
+      - pg_port=5432
+      - pg_dbname=${POSTGRES_DB:-openreplay}
+      - pg_user=$SERVICE_USER_POSTGRES
+      - pg_password=$SERVICE_PASSWORD_POSTGRES
+      - REDIS_STRING=redis://redis:6379
+      - S3_HOST=minio
+      - S3_PORT=9000
+      - S3_KEY=${SERVICE_USER_MINIO}
+      - S3_SECRET=${SERVICE_PASSWORD_MINIO}
+    volumes:
+      - openreplay-shared:/shared-volume
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  alerts:
+    image: public.ecr.aws/p1t3u8a3/alerts:latest
+    environment:
+      - pg_host=postgres
+      - pg_port=5432
+      - pg_dbname=${POSTGRES_DB:-openreplay}
+      - pg_user=$SERVICE_USER_POSTGRES
+      - pg_password=$SERVICE_PASSWORD_POSTGRES
+      - REDIS_STRING=redis://redis:6379
+    volumes:
+      - openreplay-shared:/shared-volume
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  frontend:
+    image: public.ecr.aws/p1t3u8a3/frontend:latest
+    environment:
+      - SITE_URL=${SERVICE_URL_HTTP}
+    volumes:
+      - openreplay-shared:/shared-volume
+    depends_on:
+      - api
+
+  postgres:
+    image: postgres:16-alpine
+    volumes:
+      - openreplay-postgres-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=$SERVICE_USER_POSTGRES
+      - POSTGRES_PASSWORD=$SERVICE_PASSWORD_POSTGRES
+      - POSTGRES_DB=${POSTGRES_DB:-openreplay}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+
+  redis:
+    image: redis:7-alpine
+    volumes:
+      - openreplay-redis-data:/data
+    healthcheck:
+      test:
+        - CMD
+        - redis-cli
+        - PING
+      interval: 5s
+      timeout: 10s
+      retries: 20
+
+  clickhouse:
+    image: clickhouse/clickhouse-server:24.3
+    volumes:
+      - openreplay-clickhouse-data:/var/lib/clickhouse
+    environment:
+      - CLICKHOUSE_DB=${CLICKHOUSE_DB:-openreplay}
+      - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
+    healthcheck:
+      test: ["CMD-SHELL", "clickhouse-client --query 'SELECT 1'"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+
+  minio:
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    volumes:
+      - openreplay-minio-data:/data
+    environment:
+      - MINIO_ROOT_USER=${SERVICE_USER_MINIO}
+      - MINIO_ROOT_PASSWORD=${SERVICE_PASSWORD_MINIO}
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
## Summary
- Adds a new Coolify service template for [OpenReplay](https://openreplay.com), an open-source session replay and product analytics platform
- Includes all core microservices: http, api, sink, storage, assets, ender, alerts, frontend
- Infrastructure: PostgreSQL, Redis, ClickHouse, and MinIO with healthchecks
- Based on the [official docker-compose](https://github.com/openreplay/openreplay/blob/main/scripts/docker-compose/docker-compose.yaml) referenced by maintainers in the issue
- Template file: `templates/compose/openreplay.yaml`

Closes #8232
/claim #8232

## Test plan
- [ ] Deploy the template in Coolify and verify OpenReplay starts
- [ ] Verify all infrastructure healthchecks pass (PostgreSQL, Redis, ClickHouse, MinIO)
- [ ] Verify the web UI is accessible on port 80

🤖 Generated with [Claude Code](https://claude.com/claude-code)