### PR TITLE
feat: deployment reliability — auto retry, auto rollback, queue processor

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -12,6 +12,7 @@ use App\Jobs\PullTemplatesFromCDN;
 use App\Jobs\RegenerateSslCertJob;
 use App\Jobs\ScheduledJobManager;
 use App\Jobs\ServerManagerJob;
+use App\Jobs\ProcessStaleDeploymentsJob;
 use App\Jobs\UpdateCoolifyJob;
 use App\Models\InstanceSettings;
 use Illuminate\Console\Scheduling\Schedule;
@@ -51,6 +52,9 @@ class Kernel extends ConsoleKernel
             // Server Jobs
             $this->scheduleInstance->job(new ServerManagerJob)->everyMinute()->onOneServer();
 
+            // Deployment Queue Processor
+            $this->scheduleInstance->job(new ProcessStaleDeploymentsJob)->everyMinute()->onOneServer();
+
             // Scheduled Jobs (Backups & Tasks)
             $this->scheduleInstance->job(new ScheduledJobManager)->everyMinute()->onOneServer();
 
@@ -69,6 +73,9 @@ class Kernel extends ConsoleKernel
 
             // Server Jobs
             $this->scheduleInstance->job(new ServerManagerJob)->everyMinute()->onOneServer();
+
+            // Deployment Queue Processor
+            $this->scheduleInstance->job(new ProcessStaleDeploymentsJob)->everyMinute()->onOneServer();
 
             $this->pullImages();
 

--- a/app/Enums/ApplicationDeploymentStatus.php
+++ b/app/Enums/ApplicationDeploymentStatus.php
@@ -8,5 +8,6 @@ enum ApplicationDeploymentStatus: string
     case IN_PROGRESS = 'in_progress';
     case FINISHED = 'finished';
     case FAILED = 'failed';
+    case FAILED_WITH_ROLLBACK = 'failed-rolled-back';
     case CANCELLED_BY_USER = 'cancelled-by-user';
 }

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -347,6 +347,37 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             if ($this->pull_request_id !== 0 && $this->application->is_github_based()) {
                 ApplicationPullRequestUpdateJob::dispatch(application: $this->application, preview: $this->preview, deployment_uuid: $this->deployment_uuid, status: ProcessStatus::ERROR);
             }
+
+            // Auto-retry logic: if retries remain, re-queue instead of failing
+            $retryCount = $this->application_deployment_queue->retry_count ?? 0;
+            $maxRetries = $this->application_deployment_queue->max_retries ?? 0;
+
+            if ($retryCount < $maxRetries) {
+                $nextRetry = $retryCount + 1;
+                $backoffSeconds = (int) (30 * pow(2, $retryCount)); // 30s, 60s, 120s...
+
+                $this->application_deployment_queue->addLogEntry(
+                    "Deployment failed. Retrying in {$backoffSeconds}s (attempt {$nextRetry}/{$maxRetries})...",
+                    'stderr'
+                );
+
+                // Create a new queued deployment for retry
+                $retryDeployment = $this->application_deployment_queue->replicate();
+                $retryDeployment->deployment_uuid = (string) new \Visus\Cuid2\Cuid2;
+                $retryDeployment->status = ApplicationDeploymentStatus::QUEUED->value;
+                $retryDeployment->retry_count = $nextRetry;
+                $retryDeployment->started_at = null;
+                $retryDeployment->finished_at = null;
+                $retryDeployment->save();
+
+                \Log::info("Deployment {$this->deployment_uuid} failed. Scheduled retry {$nextRetry}/{$maxRetries} in {$backoffSeconds}s.");
+
+                // Dispatch retry with delay
+                ApplicationDeploymentJob::dispatch(
+                    application_deployment_queue_id: $retryDeployment->id,
+                )->delay(now()->addSeconds($backoffSeconds));
+            }
+
             $this->fail($e);
             throw $e;
         } finally {
@@ -1810,9 +1841,37 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                     $this->application_deployment_queue->addLogEntry('----------------------------------------');
                     $this->application_deployment_queue->addLogEntry('Rolling update started.');
                     $this->start_by_compose_file();
-                    $this->health_check();
-                    $this->stop_running_container();
-                    $this->application_deployment_queue->addLogEntry('Rolling update completed.');
+
+                    try {
+                        $this->health_check();
+                        $this->stop_running_container();
+                        $this->application_deployment_queue->addLogEntry('Rolling update completed.');
+                    } catch (Exception $healthException) {
+                        // Auto-rollback: health check failed on new container
+                        $autoRollback = $this->application->settings->auto_rollback_on_failure ?? true;
+
+                        if ($autoRollback) {
+                            $this->application_deployment_queue->addLogEntry('Health check failed on new container. Rolling back to previous version.', 'stderr');
+
+                            // Stop the new (unhealthy) container
+                            try {
+                                $this->graceful_shutdown_container($this->container_name);
+                            } catch (Exception $cleanupError) {
+                                \Log::warning("Failed to stop unhealthy container: {$cleanupError->getMessage()}");
+                            }
+
+                            // Previous container is still running — it was never stopped
+                            $this->application_deployment_queue->addLogEntry('Rollback complete. Previous container is still serving traffic.');
+                            $this->application_deployment_queue->update([
+                                'status' => ApplicationDeploymentStatus::FAILED_WITH_ROLLBACK->value,
+                            ]);
+
+                            // Don't throw — the rollback succeeded, app is still up
+                            return;
+                        }
+
+                        throw new DeploymentException('Health check failed and auto-rollback is disabled: '.$healthException->getMessage(), $healthException->getCode(), $healthException);
+                    }
                 }
             }
         } catch (Exception $e) {

--- a/app/Jobs/ProcessStaleDeploymentsJob.php
+++ b/app/Jobs/ProcessStaleDeploymentsJob.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Enums\ApplicationDeploymentStatus;
+use App\Models\ApplicationDeploymentQueue;
+use App\Models\Server;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Carbon;
+
+/**
+ * Process stale deployments that are stuck in 'queued' status.
+ *
+ * Runs every minute via the scheduler. Finds deployments that have been
+ * queued for longer than the stale threshold and starts them if the
+ * server has capacity (respects concurrent_builds limit).
+ *
+ * This prevents queue starvation — previously, queued deployments only
+ * advanced when a new deployment triggered next_queuable().
+ */
+class ProcessStaleDeploymentsJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    private const STALE_THRESHOLD_MINUTES = 2;
+
+    public function handle(): void
+    {
+        $staleDeployments = ApplicationDeploymentQueue::where('status', ApplicationDeploymentStatus::QUEUED->value)
+            ->where('created_at', '<=', Carbon::now()->subMinutes(self::STALE_THRESHOLD_MINUTES))
+            ->orderBy('created_at', 'asc')
+            ->get();
+
+        foreach ($staleDeployments as $deployment) {
+            $serverId = $deployment->server_id;
+            $server = Server::find($serverId);
+
+            if (! $server) {
+                continue;
+            }
+
+            $concurrentLimit = $server->settings->concurrent_builds ?? 1;
+            $inProgressCount = ApplicationDeploymentQueue::where('server_id', $serverId)
+                ->where('status', ApplicationDeploymentStatus::IN_PROGRESS->value)
+                ->count();
+
+            if ($inProgressCount < $concurrentLimit) {
+                $deployment->update([
+                    'status' => ApplicationDeploymentStatus::IN_PROGRESS->value,
+                ]);
+
+                ApplicationDeploymentJob::dispatch(
+                    application_deployment_queue_id: $deployment->id,
+                );
+
+                \Log::info("ProcessStaleDeployments: Started stale deployment {$deployment->deployment_uuid} (queued for ".
+                    Carbon::parse($deployment->created_at)->diffForHumans().")");
+            }
+        }
+    }
+}

--- a/bootstrap/helpers/applications.php
+++ b/bootstrap/helpers/applications.php
@@ -79,6 +79,8 @@ function queue_application_deployment(Application $application, string $deployme
         'rollback' => $rollback,
         'git_type' => $git_type,
         'only_this_server' => $only_this_server,
+        'retry_count' => 0,
+        'max_retries' => $application->settings->max_deployment_retries ?? 2,
     ]);
 
     if ($no_questions_asked) {

--- a/database/migrations/2026_03_21_000001_add_deployment_retry_and_rollback_fields.php
+++ b/database/migrations/2026_03_21_000001_add_deployment_retry_and_rollback_fields.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Add retry tracking to deployment queue
+        Schema::table('application_deployment_queues', function (Blueprint $table) {
+            $table->integer('retry_count')->default(0)->after('rollback');
+            $table->integer('max_retries')->default(0)->after('retry_count');
+        });
+
+        // Add retry and rollback settings to application settings
+        Schema::table('application_settings', function (Blueprint $table) {
+            $table->integer('max_deployment_retries')->default(2)->after('is_raw_compose_deployment_enabled');
+            $table->boolean('auto_rollback_on_failure')->default(true)->after('max_deployment_retries');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('application_deployment_queues', function (Blueprint $table) {
+            $table->dropColumn(['retry_count', 'max_retries']);
+        });
+
+        Schema::table('application_settings', function (Blueprint $table) {
+            $table->dropColumn(['max_deployment_retries', 'auto_rollback_on_failure']);
+        });
+    }
+};


### PR DESCRIPTION
## Summary

Three high-impact improvements to deployment reliability:

### 1. Queue Starvation Fix
- **Problem:** Deployments stuck in `queued` status sit forever because `next_queuable()` is only called when new deployments are created
- **Fix:** New `ProcessStaleDeploymentsJob` runs every minute, finds deployments queued > 2 minutes, starts them if server has capacity (respects `concurrent_builds`)

### 2. Automatic Retry on Failure
- **Problem:** Failed deployments stay failed. Users must manually re-deploy
- **Fix:** Failed deployments auto-retry with exponential backoff (30s, 60s, 120s). Configurable `max_deployment_retries` setting (default: 2). Retry count shown in deployment logs

### 3. Auto-Rollback on Health Check Failure
- **Problem:** During rolling updates, health check failure marks deployment as FAILED and the app goes down
- **Fix:** On health check failure, the previous container is preserved (still serving traffic), the unhealthy new container is stopped, deployment marked as `FAILED_WITH_ROLLBACK`. Configurable `auto_rollback_on_failure` setting (default: true)

## Changes

| File | Change |
|------|--------|
| `app/Jobs/ProcessStaleDeploymentsJob.php` | NEW — scheduled queue processor |
| `app/Console/Kernel.php` | Register queue processor (dev + prod) |
| `app/Jobs/ApplicationDeploymentJob.php` | Retry logic in catch block + auto-rollback in rolling update |
| `app/Enums/ApplicationDeploymentStatus.php` | New `FAILED_WITH_ROLLBACK` status |
| `bootstrap/helpers/applications.php` | Pass retry settings when queuing |
| `database/migrations/...` | `retry_count`, `max_retries`, `max_deployment_retries`, `auto_rollback_on_failure` |

## Test plan
- [ ] Deploy an app with a bad health check URL — should auto-rollback, previous container stays up
- [ ] Deploy an app that fails to build — should retry 2x with backoff, then fail
- [ ] Queue 5+ deployments on a server with concurrent_builds=1 — stale queue processor should advance them
- [ ] Verify existing deployments work unchanged (backward compatible)
- [ ] Verify API force=true still works