### PR TITLE
fix(ssh): pass custom timeout to SSH multiplexing command

### DIFF
--- a/app/Helpers/SshMultiplexingHelper.php
+++ b/app/Helpers/SshMultiplexingHelper.php
@@ -115,7 +115,7 @@ class SshMultiplexingHelper
         $sshKeyLocation = $sshConfig['sshKeyLocation'];
         $muxSocket = $sshConfig['muxFilename'];
 
-        $timeout = config('constants.ssh.command_timeout');
+        $timeout = $timeout ?? config('constants.ssh.command_timeout');
         $muxPersistTime = config('constants.ssh.mux_persist_time');
 
         $scp_command = "timeout $timeout scp ";
@@ -150,7 +150,7 @@ class SshMultiplexingHelper
         return $scp_command;
     }
 
-    public static function generateSshCommand(Server $server, string $command, bool $disableMultiplexing = false)
+    public static function generateSshCommand(Server $server, string $command, bool $disableMultiplexing = false, ?int $timeout = null)
     {
         if ($server->settings->force_disabled) {
             throw new \RuntimeException('Server is disabled.');
@@ -163,7 +163,7 @@ class SshMultiplexingHelper
 
         $muxSocket = $sshConfig['muxFilename'];
 
-        $timeout = config('constants.ssh.command_timeout');
+        $timeout = $timeout ?? config('constants.ssh.command_timeout');
         $muxPersistTime = config('constants.ssh.mux_persist_time');
 
         $ssh_command = "timeout $timeout ssh ";

--- a/bootstrap/helpers/remoteProcess.php
+++ b/bootstrap/helpers/remoteProcess.php
@@ -130,7 +130,7 @@ function instant_remote_process(Collection|array $command, Server $server, bool 
 
     return \App\Helpers\SshRetryHandler::retry(
         function () use ($server, $command_string, $effectiveTimeout, $disableMultiplexing) {
-            $sshCommand = SshMultiplexingHelper::generateSshCommand($server, $command_string, $disableMultiplexing);
+            $sshCommand = SshMultiplexingHelper::generateSshCommand($server, $command_string, $disableMultiplexing, $effectiveTimeout);
             $process = Process::timeout($effectiveTimeout)->run($sshCommand);
 
             $output = trim($process->output());


### PR DESCRIPTION
Resolves #7473.

### What the change does
This PR fixes the bug where custom database backup timeouts were ignored. The `$timeout` variable was received by `instant_remote_process` but was dropped before being passed to `SshMultiplexingHelper::generateSshCommand`. It now correctly passes the custom timeout down the chain, falling back to the default config only if one isn't provided.

### How to test it
1. Set a custom timeout for a database backup.
2. Trigger the backup.
3. Observe that the SSH command now correctly receives and utilizes the custom timeout instead of defaulting to 3600.

- [x] I have read and understood the contributor guidelines.
- [x] I have tested the changes thoroughly.