### PR TITLE
fix: install mysql-client in Pterodactyl panel entrypoint

### DIFF
--- a/templates/compose/pterodactyl-panel.yaml
+++ b/templates/compose/pterodactyl-panel.yaml
@@ -46,6 +46,9 @@ services:
           #!/bin/sh
           set -e
 
+           echo "Installing mysql-client..."
+           apk add --no-cache mysql-client
+
            echo "Setting logs permissions..."
            chown -R nginx: /app/storage/logs/
 

--- a/templates/compose/pterodactyl-with-wings.yaml
+++ b/templates/compose/pterodactyl-with-wings.yaml
@@ -48,6 +48,9 @@ services:
           #!/bin/sh
           set -e
 
+           echo "Installing mysql-client..."
+           apk add --no-cache mysql-client
+
            echo "Setting logs permissions..."
            chown -R nginx: /app/storage/logs/
 


### PR DESCRIPTION
## Summary

Fix for issue #8508: Pterodactyl set up is broken (mysql: not found)

### Problem

The Pterodactyl panel Docker image (ghcr.io/pterodactyl/panel:v1.12.0) is based on `php:8.3-fpm-alpine` which does not include the `mysql` client binary. When Pterodactyl's automatic database migrations or seeders try to run SQL operations that require the mysql client, they fail with:

```
sh: mysql: not found
```

### Solution

Added `apk add --no-cache mysql-client` to the entrypoint script in both Pterodactyl templates (`pterodactyl-panel.yaml` and `pterodactyl-with-wings.yaml`), ensuring the mysql client is available before any database operations that might need it.

### Testing

The workaround was suggested by maintainer @andrasbacsai in the original issue:
```
apk add mysql-client && php artisan migrate --force --seed
```

This fix implements the same approach in the entrypoint script.

### Files Changed

- templates/compose/pterodactyl-panel.yaml
- templates/compose/pterodactyl-with-wings.yaml

Both files: Added mysql-client installation to entrypoint.

---

Note: Template remains with `ignore: true` as per maintainer request until this fix is confirmed working.