### PR TITLE
feat: allow OAuth self-registration when general registration is disabled

### DIFF
--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -22,7 +22,7 @@ class OauthController extends Controller
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! $settings->is_oauth_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -15,6 +15,9 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $is_oauth_registration_enabled;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -41,6 +44,7 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_registration_enabled' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => 'nullable|string',
@@ -62,6 +66,7 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -142,6 +147,7 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/database/migrations/2026_03_22_000000_add_oauth_registration_to_instance_settings.php
+++ b/database/migrations/2026_03_22_000000_add_oauth_registration_to_instance_settings.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_registration_enabled')->default(false)->after('is_registration_enabled');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn('is_oauth_registration_enabled');
+        });
+    }
+};

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -22,6 +22,11 @@
                             label="Registration Allowed" />
                     </div>
                     <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_registration_enabled"
+                            helper="Allow users to self-register via OAuth providers (GitHub, Google, etc.) even when general registration is disabled. Existing OAuth users can always log in."
+                            label="OAuth Registration Allowed" />
+                    </div>
+                    <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"
                             helper="Opt out of anonymous usage tracking. When enabled, this instance will not report to coolify.io's installation count and will not send error reports to help improve Coolify."
                             label="Do Not Track" />


### PR DESCRIPTION
## Summary

Adds a new `is_oauth_registration_enabled` setting so administrators can allow OAuth-based self-registration while keeping general (password-based) registration disabled. Closes #8042.

## Changes

- **Migration**: Adds `is_oauth_registration_enabled` boolean column to `instance_settings` (default: `false`)
- **OauthController**: OAuth callback now allows new user creation when either `is_registration_enabled` OR `is_oauth_registration_enabled` is `true`
- **Advanced Settings (Livewire)**: Added property, validation rule, mount/save logic
- **Blade view**: Added checkbox toggle with helper text in admin Advanced settings

## How it works

| General Registration | OAuth Registration | Result |
|---------------------|-------------------|--------|
| ✓ Enabled | Any | Anyone can register (password + OAuth) |
| ✗ Disabled | ✓ Enabled | Only OAuth users can self-register |
| ✗ Disabled | ✗ Disabled | No self-registration (admin creates accounts) |

Existing OAuth users can always **log in** regardless of these settings — these only affect **new account creation**.

## Testing

Verified the OAuth callback logic handles all three scenarios correctly. The setting follows the same pattern as existing boolean settings (`is_registration_enabled`, `do_not_track`, etc.).

/claim #8042