### PR TITLE
fix(auth): reject unknown/disabled OAuth providers early

### DIFF
--- a/bootstrap/helpers/socialite.php
+++ b/bootstrap/helpers/socialite.php
@@ -7,6 +7,9 @@ function get_socialite_provider(string $provider)
 {
     $oauth_setting = OauthSetting::firstWhere('provider', $provider);
 
+    abort_if(! $oauth_setting, 404, 'OAuth provider not found.');
+    abort_if(! $oauth_setting->enabled, 403, 'OAuth provider is disabled.');
+
     if (! filled($oauth_setting->redirect_uri)) {
         $oauth_setting->update(['redirect_uri' => route('auth.callback', $provider)]);
     }
@@ -69,6 +72,8 @@ function get_socialite_provider(string $provider)
         'gitlab' => \Laravel\Socialite\Two\GitlabProvider::class,
         'infomaniak' => \SocialiteProviders\Infomaniak\Provider::class,
     ];
+
+    abort_unless(array_key_exists($provider, $provider_class_map), 404, 'OAuth provider not found.');
 
     $socialite = Socialite::buildProvider(
         $provider_class_map[$provider],

--- a/tests/Feature/OauthProviderGuardTest.php
+++ b/tests/Feature/OauthProviderGuardTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use App\Models\OauthSetting;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('returns 404 for unknown oauth provider redirect', function () {
+    $response = $this->get('/auth/not-a-real-provider/redirect');
+
+    $response->assertNotFound();
+});
+
+it('returns 403 when oauth provider exists but is disabled', function () {
+    OauthSetting::create([
+        'provider' => 'github',
+        'enabled' => false,
+        'client_id' => 'id',
+        'client_secret' => 'secret',
+    ]);
+
+    $response = $this->get('/auth/github/redirect');
+
+    $response->assertForbidden();
+});


### PR DESCRIPTION
## Summary
- harden OAuth provider resolution by rejecting unknown providers with `404`
- reject disabled providers with `403` before building Socialite drivers
- add feature tests for unknown provider and disabled provider redirect paths

## Why
While auditing bounty threads (#8042 etc.), provider routes are publicly reachable (`/auth/{provider}/redirect`).
Without guards, unknown/disabled providers can flow into helper logic and trigger unexpected runtime paths.

## Test
- Added `tests/Feature/OauthProviderGuardTest.php` covering:
  - unknown provider => 404
  - disabled configured provider => 403

> Note: local runtime currently lacks `composer` in this environment, so I could not execute `php artisan test` here.