### PR TITLE
fix(team): do not block invites because of other-team pending invitations

### DIFF
--- a/app/Livewire/Team/InviteLink.php
+++ b/app/Livewire/Team/InviteLink.php
@@ -76,7 +76,9 @@ class InviteLink extends Component
                 $token = Crypt::encryptString("{$user->email}@@@$password");
                 $link = route('auth.link', ['token' => $token]);
             }
-            $invitation = TeamInvitation::whereEmail($this->email)->first();
+            $invitation = TeamInvitation::where('team_id', currentTeam()->id)
+                ->whereEmail($this->email)
+                ->first();
             if (! is_null($invitation)) {
                 $invitationValid = $invitation->isValid();
                 if ($invitationValid) {

--- a/tests/Feature/TeamInvitationPrivilegeEscalationTest.php
+++ b/tests/Feature/TeamInvitationPrivilegeEscalationTest.php
@@ -173,4 +173,36 @@ describe('privilege escalation prevention', function () {
             ->call('viaEmail')
             ->assertDispatched('error');
     });
+
+    test('pending invitation in another team does not block current team invite', function () {
+        $otherTeam = Team::factory()->create();
+        $otherOwner = User::factory()->create();
+        $otherTeam->members()->attach($otherOwner->id, ['role' => 'owner']);
+
+        // Existing pending invite for same email in another team
+        \App\Models\TeamInvitation::create([
+            'team_id' => $otherTeam->id,
+            'uuid' => (string) \Illuminate\Support\Str::uuid(),
+            'email' => 'shared@example.com',
+            'role' => 'member',
+            'link' => 'https://example.test/invite/other-team',
+            'via' => 'link',
+        ]);
+
+        // Owner of current team should still be able to invite same email
+        $this->actingAs($this->owner);
+        session(['currentTeam' => $this->team]);
+
+        Livewire::test(InviteLink::class)
+            ->set('email', 'shared@example.com')
+            ->set('role', 'member')
+            ->call('viaLink')
+            ->assertDispatched('success');
+
+        $this->assertDatabaseHas('team_invitations', [
+            'team_id' => $this->team->id,
+            'email' => 'shared@example.com',
+            'role' => 'member',
+        ]);
+    });
 });


### PR DESCRIPTION
Related audit target: #6894\n\n## Summary\n- scope pending invitation lookup by  (current team) before checking duplicates\n- prevents cross-team invitation collisions for same email\n- adds regression test for same-email invite existing in another team\n\n## Why\nTeam invitations are team-scoped. A pending invite in team A should not block owners/admins from inviting the same email into team B.\n\n## Test\n- extended  with cross-team pending-invitation scenario.