### PR TITLE
fix: stop injecting shared .env into Docker Compose containers

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -645,14 +645,9 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             }
         } else {
             $composeFile = $this->application->parse(pull_request_id: $this->pull_request_id, preview_id: data_get($this->preview, 'id'), commit: $this->commit);
-            // Always add .env file to services
-            $services = collect(data_get($composeFile, 'services', []));
-            $services = $services->map(function ($service, $name) {
-                $service['env_file'] = ['.env'];
-
-                return $service;
-            });
-            $composeFile['services'] = $services->toArray();
+            // Don't inject shared env_file — each service's environment: section
+            // already contains only its own variables (set by the parser).
+            // Injecting a shared .env would leak all variables to all containers (#7655).
             if (empty($composeFile)) {
                 $this->application_deployment_queue->addLogEntry('Failed to parse docker-compose file.');
                 $this->fail('Failed to parse docker-compose file.');
@@ -1359,9 +1354,10 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
 
         // Handle empty environment variables
         if ($environment_variables->isEmpty()) {
-            // For Docker Compose and Docker Image, we need to create an empty .env file
-            // because we always reference it in the compose file
-            if ($this->build_pack === 'dockercompose' || $this->build_pack === 'dockerimage') {
+            // For Docker Image, we need to create an empty .env file
+            // because we reference it via env_file in the compose file.
+            // Docker Compose no longer needs this — env vars are in the environment: section (#7655).
+            if ($this->build_pack === 'dockerimage') {
                 $this->application_deployment_queue->addLogEntry('Creating empty .env file (no environment variables defined).');
 
                 // Create empty .env file

--- a/bootstrap/helpers/parsers.php
+++ b/bootstrap/helpers/parsers.php
@@ -1416,15 +1416,19 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
         if ($depends_on->count() > 0) {
             $payload['depends_on'] = $depends_on;
         }
-        // Auto-inject .env file so Coolify environment variables are available inside containers
-        // This makes Applications behave consistently with manual .env file usage
+        // Preserve user-defined env_file entries if present (don't inject shared .env —
+        // environment variables are already set per-service via the environment: section above,
+        // injecting a shared .env would leak all variables to all containers, see #7655)
         $existingEnvFiles = data_get($service, 'env_file');
-        $envFiles = collect(is_null($existingEnvFiles) ? [] : (is_array($existingEnvFiles) ? $existingEnvFiles : [$existingEnvFiles]))
-            ->push('.env')
-            ->unique()
-            ->values();
-
-        $payload['env_file'] = $envFiles;
+        if (! is_null($existingEnvFiles)) {
+            $envFiles = collect(is_array($existingEnvFiles) ? $existingEnvFiles : [$existingEnvFiles])
+                ->reject(fn ($f) => $f === '.env')
+                ->unique()
+                ->values();
+            if ($envFiles->isNotEmpty()) {
+                $payload['env_file'] = $envFiles;
+            }
+        }
 
         // Inject commit-based image tag for services with build directive (for rollback support)
         // Only inject if service has build but no explicit image defined
@@ -2684,15 +2688,19 @@ function serviceParser(Service $resource): Collection
         if ($depends_on->count() > 0) {
             $payload['depends_on'] = $depends_on;
         }
-        // Auto-inject .env file so Coolify environment variables are available inside containers
-        // This makes Services behave consistently with Applications
+        // Preserve user-defined env_file entries if present (don't inject shared .env —
+        // environment variables are already set per-service via the environment: section above,
+        // injecting a shared .env would leak all variables to all containers, see #7655)
         $existingEnvFiles = data_get($service, 'env_file');
-        $envFiles = collect(is_null($existingEnvFiles) ? [] : (is_array($existingEnvFiles) ? $existingEnvFiles : [$existingEnvFiles]))
-            ->push('.env')
-            ->unique()
-            ->values();
-
-        $payload['env_file'] = $envFiles;
+        if (! is_null($existingEnvFiles)) {
+            $envFiles = collect(is_array($existingEnvFiles) ? $existingEnvFiles : [$existingEnvFiles])
+                ->reject(fn ($f) => $f === '.env')
+                ->unique()
+                ->values();
+            if ($envFiles->isNotEmpty()) {
+                $payload['env_file'] = $envFiles;
+            }
+        }
 
         $parsedServices->put($serviceName, $payload);
     }

--- a/tests/Unit/DockerComposeEnvFileIsolationTest.php
+++ b/tests/Unit/DockerComposeEnvFileIsolationTest.php
@@ -1,0 +1,203 @@
+<?php
+
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Tests for environment variable isolation in Docker Compose deployments.
+ *
+ * Verifies the fix for #7655: previously, a shared .env file containing ALL
+ * environment variables was injected into every container via env_file,
+ * meaning any container could read secrets meant for other containers.
+ *
+ * The fix: stop injecting env_file: ['.env']. Each service's environment:
+ * section already contains only its own variables (set by the parser).
+ */
+
+// -- Parser: no longer injects .env into env_file --
+
+it('does not inject shared .env into service env_file', function () {
+    $parsersFile = file_get_contents(__DIR__.'/../../bootstrap/helpers/parsers.php');
+
+    // The old code pushed '.env' into every service's env_file.
+    // After fix: no parser function should push '.env' into env_file.
+    expect($parsersFile)->not->toContain("->push('.env')",
+        'No parser should inject .env into env_file — environment: section handles per-service vars'
+    );
+});
+
+it('preserves user-defined env_file entries except .env', function () {
+    // Simulate the new parser logic for env_file handling
+    $testCases = [
+        // User has custom env files — they should be preserved
+        [
+            'input' => ['./secrets.env', './shared.env'],
+            'expected' => ['./secrets.env', './shared.env'],
+        ],
+        // User had .env explicitly — it should be stripped
+        [
+            'input' => ['.env', './custom.env'],
+            'expected' => ['./custom.env'],
+        ],
+        // User had only .env — env_file should be omitted entirely
+        [
+            'input' => ['.env'],
+            'expected' => [],
+        ],
+        // No env_file defined — nothing added
+        [
+            'input' => null,
+            'expected' => null,
+        ],
+        // String format (single file)
+        [
+            'input_raw' => './my.env',
+            'expected' => ['./my.env'],
+        ],
+    ];
+
+    foreach ($testCases as $i => $case) {
+        $existingEnvFiles = $case['input_raw'] ?? $case['input'];
+        $expected = $case['expected'];
+
+        // Replicate the exact logic from parsers.php
+        if (! is_null($existingEnvFiles)) {
+            $envFiles = collect(is_array($existingEnvFiles) ? $existingEnvFiles : [$existingEnvFiles])
+                ->reject(fn ($f) => $f === '.env')
+                ->unique()
+                ->values();
+            $result = $envFiles->isNotEmpty() ? $envFiles->toArray() : [];
+        } else {
+            $result = null;
+        }
+
+        if ($expected === null) {
+            expect($result)->toBeNull("Case {$i}: null input should produce null output");
+        } else {
+            expect($result)->toBe($expected, "Case {$i}: env_file filtering failed");
+        }
+    }
+});
+
+// -- Deployment job: no longer overwrites env_file --
+
+it('does not overwrite service env_file in deployment job', function () {
+    $jobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
+
+    // The old code had: $service['env_file'] = ['.env'];
+    // inside a map() over compose services. Verify this pattern is gone
+    // (but still exists for single-container dockerimage at line ~2762, which is fine).
+    $lines = explode("\n", $jobFile);
+    $composeEnvFileInjections = 0;
+
+    foreach ($lines as $lineNum => $line) {
+        // Match the pattern: env_file'] = ['.env'] in a map/foreach over services
+        if (str_contains($line, "env_file'] = ['.env']")) {
+            // Check context: is this inside the compose service loop or the single-container section?
+            // The single-container one references $this->container_name (line ~2762)
+            $context = implode("\n", array_slice($lines, max(0, $lineNum - 5), 10));
+            if (! str_contains($context, 'container_name')) {
+                $composeEnvFileInjections++;
+            }
+        }
+    }
+
+    expect($composeEnvFileInjections)->toBe(0,
+        'Shared .env should not be injected into Docker Compose services (only single-container deployments)'
+    );
+});
+
+// -- Compose output: environment section is per-service --
+
+it('parser sets per-service environment sections (not shared)', function () {
+    $parsersFile = file_get_contents(__DIR__.'/../../bootstrap/helpers/parsers.php');
+
+    // The parser merges environment per-service: each service gets its own variables
+    // Verify the pattern: $payload['environment'] = $environment->merge($coolifyEnvironments)
+    expect($parsersFile)->toContain(
+        "\$payload['environment'] = \$environment->merge(\$coolifyEnvironments)->merge(\$serviceNameEnvironments)"
+    );
+});
+
+it('parser environment merge is per-service, not global', function () {
+    $parsersFile = file_get_contents(__DIR__.'/../../bootstrap/helpers/parsers.php');
+
+    // Environment is merged into $payload per-service, not a shared variable
+    expect(str_contains($parsersFile, "payload['environment'] = \$environment->merge"))->toBeTrue(
+        'Environment merge should assign to per-service payload'
+    );
+
+    // Each service's payload is stored independently
+    expect(str_contains($parsersFile, 'parsedServices->put($serviceName, $payload)'))->toBeTrue(
+        'Each service payload should be stored independently'
+    );
+});
+
+// -- Regression: dockerimage still uses env_file --
+
+it('single-container dockerimage still uses env_file', function () {
+    $jobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
+
+    // For non-compose single-container deployments (dockerimage, dockerfile, etc.),
+    // env_file: ['.env'] is correct because there's only one container.
+    expect($jobFile)->toContain(
+        "\$docker_compose['services'][\$this->container_name]['env_file'] = ['.env']"
+    );
+});
+
+// -- End-to-end: compose YAML output should not have .env in env_file --
+
+it('generated compose YAML does not contain env_file .env for multi-service apps', function () {
+    // Simulate what the parser outputs for a multi-service compose
+    $inputCompose = [
+        'services' => [
+            'app' => [
+                'image' => 'node:18',
+                'environment' => ['OPENAI_KEY' => 'sk-xxx'],
+            ],
+            'db' => [
+                'image' => 'postgres:16',
+                'environment' => ['POSTGRES_PASSWORD' => 'secret'],
+            ],
+            'redis' => [
+                'image' => 'redis:7',
+            ],
+        ],
+    ];
+
+    // Apply the same env_file logic as the parser (the new version)
+    foreach ($inputCompose['services'] as $name => &$service) {
+        $existingEnvFiles = data_get($service, 'env_file');
+        if (! is_null($existingEnvFiles)) {
+            $envFiles = collect(is_array($existingEnvFiles) ? $existingEnvFiles : [$existingEnvFiles])
+                ->reject(fn ($f) => $f === '.env')
+                ->unique()
+                ->values();
+            if ($envFiles->isNotEmpty()) {
+                $service['env_file'] = $envFiles->toArray();
+            } else {
+                unset($service['env_file']);
+            }
+        }
+        // If env_file was not defined, don't add it
+    }
+
+    $yaml = Yaml::dump($inputCompose, 10);
+
+    // The output YAML should NOT contain env_file: ['.env'] for any service
+    expect($yaml)->not->toContain("env_file:\n            - .env");
+    expect($yaml)->not->toContain("env_file:\n        - .env");
+
+    // Each service should still have its own environment section
+    expect($yaml)->toContain('OPENAI_KEY');
+    expect($yaml)->toContain('POSTGRES_PASSWORD');
+
+    // Verify isolation: OPENAI_KEY should NOT appear under db service
+    $parsed = Yaml::parse($yaml);
+    $dbEnv = data_get($parsed, 'services.db.environment', []);
+    $appEnv = data_get($parsed, 'services.app.environment', []);
+
+    expect($appEnv)->toHaveKey('OPENAI_KEY');
+    expect($appEnv)->not->toHaveKey('POSTGRES_PASSWORD');
+    expect($dbEnv)->toHaveKey('POSTGRES_PASSWORD');
+    expect($dbEnv)->not->toHaveKey('OPENAI_KEY');
+});


### PR DESCRIPTION
## Changes

I previously submitted #9106 for this issue — that approach was wrong. I was creating per-service `.env.{name}` files (550 lines of new code), essentially building a complex workaround without understanding the real problem. I closed it, went back to the code, and found the actual root cause. This is a much simpler fix.

**The real bug:** The compose parser (`parsers.php:1411`) already builds a correct, isolated `environment:` section for each service — merging only that service's own variables with Coolify metadata. So each service *should* only see its own secrets. But then two things undo that isolation:

1. The parser (`parsers.php:1419-1427`) injects `env_file: ['.env']` into every service
2. The deployment job (`ApplicationDeploymentJob.php:648-654`) does the same thing again

Since `.env` contains ALL runtime variables from ALL services, this `env_file` injection leaks everything to every container. The `environment:` section was doing the right thing all along — `env_file` was overriding it.

**The fix:** Remove the `env_file: ['.env']` injection from both locations. That's it. The environment isolation that the parser already implemented is no longer undermined.

User-defined `env_file` entries (like `env_file: [./custom.env]`) in compose files are preserved — only the Coolify-injected `.env` is removed.

```
BEFORE (all containers see all secrets):
  app      → environment: {OPENAI_KEY: sk-xxx}     ← correct
             env_file: [.env]                       ← leaks POSTGRES_PASSWORD, REDIS_MAXMEM
  postgres → environment: {POSTGRES_PASSWORD: xxx}  ← correct
             env_file: [.env]                       ← leaks OPENAI_KEY, REDIS_MAXMEM

AFTER (env_file removed, environment: section does the job):
  app      → environment: {OPENAI_KEY: sk-xxx}      ← only its own vars
  postgres → environment: {POSTGRES_PASSWORD: xxx}   ← only its own vars
```

## Issues

- Fixes #7655

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Review guide

The core fix is small — just removing redundant code:

1. **`bootstrap/helpers/parsers.php`** — Removed `->push('.env')` from env_file injection in both `applicationParser` and `parseDockerComposeFile`. User-defined env_file entries are preserved.
2. **`app/Jobs/ApplicationDeploymentJob.php`** — Removed the `env_file: ['.env']` override loop. Adjusted empty `.env` creation to skip `dockercompose` (no longer needed since env_file is not injected).

Single-container deployments (`dockerimage`, `dockerfile`, etc.) are untouched — they still use `env_file: ['.env']` because there's only one container and no isolation concern.

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (code exploration and test generation)
- How extensively: Used to explore the codebase and trace the data flow through parser → deployment job → container. The root cause analysis and fix approach are my own — I realized the first attempt was wrong after tracing how `environment:` and `env_file:` interact in Docker Compose.

## Testing

7 unit tests, 19 assertions, all passing:

```
✓ does not inject shared .env into service env_file
✓ preserves user-defined env_file entries except .env (5 edge cases)
✓ does not overwrite service env_file in deployment job
✓ parser sets per-service environment sections (not shared)
✓ parser environment merge is per-service, not global
✓ single-container dockerimage still uses env_file (regression)
✓ generated compose YAML does not contain .env, and service vars are isolated
```

Full unit suite: 0 new failures introduced.

Run: `php vendor/bin/pest tests/Unit/DockerComposeEnvFileIsolationTest.php`

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.