### PR TITLE
fix(github-webhook): handle unsupported event types gracefully

### DIFF
--- a/app/Http/Controllers/Webhook/Github.php
+++ b/app/Http/Controllers/Webhook/Github.php
@@ -55,6 +55,9 @@ class Github extends Controller
                 $after_sha = data_get($payload, 'after', data_get($payload, 'pull_request.head.sha'));
                 $author_association = data_get($payload, 'pull_request.author_association');
             }
+            if (! in_array($x_github_event, ['push', 'pull_request'])) {
+                return response("Nothing to do. Event '$x_github_event' is not supported.");
+            }
             if (! $branch) {
                 return response('Nothing to do. No branch found in the request.');
             }
@@ -245,6 +248,9 @@ class Github extends Controller
                 $before_sha = data_get($payload, 'before');
                 $after_sha = data_get($payload, 'after', data_get($payload, 'pull_request.head.sha'));
                 $author_association = data_get($payload, 'pull_request.author_association');
+            }
+            if (! in_array($x_github_event, ['push', 'pull_request'])) {
+                return response("Nothing to do. Event '$x_github_event' is not supported.");
             }
             if (! $id || ! $branch) {
                 return response('Nothing to do. No id or branch found.');

--- a/tests/Feature/GithubWebhookTest.php
+++ b/tests/Feature/GithubWebhookTest.php
@@ -1,0 +1,70 @@
+<?php
+
+describe('GitHub Manual Webhook', function () {
+    test('ping event returns pong', function () {
+        $response = $this->postJson('/webhooks/source/github/events/manual', [], [
+            'X-GitHub-Event' => 'ping',
+        ]);
+
+        $response->assertOk();
+        $response->assertSee('pong');
+    });
+
+    test('unsupported event type returns graceful response instead of 500', function () {
+        $payload = [
+            'action' => 'published',
+            'registry_package' => [
+                'ecosystem' => 'CONTAINER',
+                'package_type' => 'CONTAINER',
+                'package_version' => [
+                    'target_commitish' => 'main',
+                ],
+            ],
+            'repository' => [
+                'full_name' => 'test-org/test-repo',
+                'default_branch' => 'main',
+            ],
+        ];
+
+        $response = $this->postJson('/webhooks/source/github/events/manual', $payload, [
+            'X-GitHub-Event' => 'registry_package',
+            'X-Hub-Signature-256' => 'sha256=fake',
+        ]);
+
+        $response->assertOk();
+        $response->assertSee('not supported');
+    });
+
+    test('unknown event type returns graceful response', function () {
+        $response = $this->postJson('/webhooks/source/github/events/manual', ['foo' => 'bar'], [
+            'X-GitHub-Event' => 'some_unknown_event',
+            'X-Hub-Signature-256' => 'sha256=fake',
+        ]);
+
+        $response->assertOk();
+        $response->assertSee('not supported');
+    });
+});
+
+describe('GitHub Normal Webhook', function () {
+    test('unsupported event type returns graceful response instead of 500', function () {
+        $payload = [
+            'action' => 'published',
+            'registry_package' => [
+                'ecosystem' => 'CONTAINER',
+            ],
+            'repository' => [
+                'full_name' => 'test-org/test-repo',
+            ],
+        ];
+
+        $response = $this->postJson('/webhooks/source/github/events', $payload, [
+            'X-GitHub-Event' => 'registry_package',
+            'X-GitHub-Hook-Installation-Target-Id' => '12345',
+            'X-Hub-Signature-256' => 'sha256=fake',
+        ]);
+
+        // Should not be a 500 error - either 200 with "not supported" or "No GitHub App found"
+        $response->assertOk();
+    });
+});


### PR DESCRIPTION
## Summary

- Add validation to reject unsupported GitHub webhook event types before accessing event-specific fields
- Fixes 500 error when `registry_package.published` events are received (undefined `$branch` variable)
- Returns graceful HTTP 200 response with clear message for unsupported events instead of crashing
- Applied to both `manual()` and `normal()` webhook endpoints
- Includes tests to prevent regression

## Details

The webhook handler was attempting to access `$branch` without verifying the event type supports that field. Events like `registry_package.published` don't contain branch information, causing an "Undefined variable $branch" error.

The fix adds an early validation check that rejects any event type not in the whitelist (`push`, `pull_request`), returning a 200 OK response with a descriptive message instead of a 500 error.

---

Fixes #9090