### PR TITLE
fix(team): resolve server limit checks for API token authentication

### DIFF
--- a/app/Http/Controllers/Api/HetznerController.php
+++ b/app/Http/Controllers/Api/HetznerController.php
@@ -586,7 +586,8 @@ class HetznerController extends Controller
         }
 
         // Check server limit
-        if (Team::serverLimitReached()) {
+        $team = Team::find($teamId);
+        if (Team::serverLimitReached($team)) {
             return response()->json(['message' => 'Server limit reached for your subscription.'], 400);
         }
 

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -89,10 +89,13 @@ class Team extends Model implements SendsDiscord, SendsEmail, SendsPushover, Sen
         });
     }
 
-    public static function serverLimitReached()
+    public static function serverLimitReached(?Team $team = null)
     {
-        $serverLimit = Team::serverLimit();
-        $team = currentTeam();
+        $team = $team ?? currentTeam();
+        if (! $team) {
+            return true;
+        }
+        $serverLimit = Team::serverLimit($team);
         $servers = $team->servers->count();
 
         return $servers >= $serverLimit;
@@ -116,12 +119,16 @@ class Team extends Model implements SendsDiscord, SendsEmail, SendsPushover, Sen
         return false;
     }
 
-    public static function serverLimit()
+    public static function serverLimit(?Team $team = null)
     {
-        if (currentTeam()->id === 0 && isDev()) {
+        $team = $team ?? currentTeam();
+        if (! $team) {
+            return 0;
+        }
+        if ($team->id === 0 && isDev()) {
             return 9999999;
         }
-        $team = Team::find(currentTeam()->id);
+        $team = Team::find($team->id);
         if (! $team) {
             return 0;
         }

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -112,7 +112,7 @@ class Team extends Model implements SendsDiscord, SendsEmail, SendsPushover, Sen
 
     public function serverOverflow()
     {
-        if ($this->serverLimit() < $this->servers->count()) {
+        if (Team::serverLimit($this) < $this->servers->count()) {
             return true;
         }
 

--- a/tests/Feature/TeamServerLimitTest.php
+++ b/tests/Feature/TeamServerLimitTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use App\Models\Server;
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    config()->set('constants.coolify.self_hosted', true);
+});
+
+it('returns server limit when team is passed directly without session', function () {
+    $team = Team::factory()->create();
+
+    $limit = Team::serverLimit($team);
+
+    // self_hosted returns 999999999999
+    expect($limit)->toBe(999999999999);
+});
+
+it('returns 0 when no team is provided and no session exists', function () {
+    $limit = Team::serverLimit();
+
+    expect($limit)->toBe(0);
+});
+
+it('returns true for serverLimitReached when no team and no session', function () {
+    $result = Team::serverLimitReached();
+
+    expect($result)->toBeTrue();
+});
+
+it('returns false for serverLimitReached when team has servers under limit', function () {
+    $team = Team::factory()->create();
+    Server::factory()->create(['team_id' => $team->id]);
+
+    $result = Team::serverLimitReached($team);
+
+    // self_hosted has very high limit, 1 server is well under
+    expect($result)->toBeFalse();
+});
+
+it('returns true for serverLimitReached when team has servers at limit', function () {
+    config()->set('constants.coolify.self_hosted', false);
+
+    $team = Team::factory()->create(['custom_server_limit' => 1]);
+    Server::factory()->create(['team_id' => $team->id]);
+
+    $result = Team::serverLimitReached($team);
+
+    expect($result)->toBeTrue();
+});


### PR DESCRIPTION
## Summary

- Fixed 500 error on `POST /api/v1/servers/hetzner` when using API token authentication
- `serverLimit()` and `serverLimitReached()` now accept optional `Team` parameter, enabling usage outside session context
- HetznerController explicitly passes team to server limit checks instead of relying on `currentTeam()`
- Added null-safety fallback: methods return safe defaults (0 and true) when no team context is available
- Added comprehensive test coverage for API token authentication scenarios

## Breaking Changes

None. Changes are backward compatible—methods fall back to `currentTeam()` when no team is passed.

---

Fixes #9116