### PR TITLE
feat: add WordPress + OpenLiteSpeed service template

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -1,0 +1,59 @@
+# documentation: https://openlitespeed.org
+# slogan: WordPress with OpenLiteSpeed web server for high-performance hosting.
+# category: cms
+# tags: cms, blog, content, management, wordpress, openlitespeed, litespeed, mariadb, redis
+# logo: svgs/wordpress.svg
+
+services:
+  litespeed:
+    image: litespeedtech/openlitespeed:1.8.5-lsphp85
+    entrypoint: ["/bin/bash", "-c"]
+    command:
+      - |
+        # Download WordPress if not already installed
+        if [ ! -f /var/www/vhosts/localhost/html/wp-config.php ] && [ ! -f /var/www/vhosts/localhost/html/wp-login.php ]; then
+          echo "Installing WordPress..."
+          wp core download --path=/var/www/vhosts/localhost/html --allow-root
+          chown 1000:1000 /var/www/vhosts/localhost/html -R
+        fi
+        # Start entrypoint
+        exec /entrypoint.sh
+    volumes:
+      - wordpress-files:/var/www/vhosts/localhost/html
+      - litespeed-conf:/usr/local/lsws/conf
+      - litespeed-admin-conf:/usr/local/lsws/admin/conf
+      - litespeed-logs:/usr/local/lsws/logs
+    environment:
+      - SERVICE_FQDN_LITESPEED
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://127.0.0.1:80 || exit 1"]
+      interval: 5s
+      timeout: 10s
+      retries: 15
+  mariadb:
+    image: mariadb:11
+    command: ["--max-allowed-packet=512M"]
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MYSQL_DATABASE=${MYSQL_DATABASE:-wordpress}
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+  redis:
+    image: redis:7-alpine
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 10s
+      retries: 10


### PR DESCRIPTION
## Summary

Adds a new service template for running WordPress with the [OpenLiteSpeed](https://openlitespeed.org) web server, addressing #8264.

### What's included:
- **OpenLiteSpeed** (`litespeedtech/openlitespeed:1.8.5-lsphp85`) — high-performance web server with PHP 8.5 and LiteSpeed Cache support
- **MariaDB 11** — database with persistent storage and `--max-allowed-packet=512M` for large imports
- **Redis 7** — object caching support for WordPress plugins like LiteSpeed Cache
- **Auto WordPress install** — WordPress is automatically downloaded via `wp-cli` on first container start if not already present
- **Persistent volumes** — WordPress files, server configuration, admin configuration, logs, database, and Redis data all persist across restarts
- **Health checks** — all three services include health checks

### Template follows existing patterns:
- Uses Coolify's `$SERVICE_FQDN_*`, `$SERVICE_PASSWORD_*`, `$SERVICE_USER_*` environment variable conventions
- Uses the existing `svgs/wordpress.svg` logo
- Structured like `wordpress-with-mariadb.yaml` but with OpenLiteSpeed instead of Apache

### Testing
- Template YAML is valid docker-compose syntax
- Uses the official `litespeedtech/openlitespeed` Docker image (actively maintained, last updated 2026-03-20)
- WordPress download handled by `wp-cli` which is pre-installed in the OLS image

Closes #8264

/claim #8264