### PR TITLE
feat: add Docker Mailserver service template

### DIFF
--- a/public/svgs/docker-mailserver.svg
+++ b/public/svgs/docker-mailserver.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><polyline points="22,6 12,13 2,6"/></svg>

--- a/templates/compose/docker-mailserver.yaml
+++ b/templates/compose/docker-mailserver.yaml
@@ -1,0 +1,42 @@
+# documentation: https://docker-mailserver.github.io/docker-mailserver/latest/
+# slogan: A fullstack, production-ready mail server in a Docker container.
+# category: email
+# tags: email, mail, smtp, imap, postfix, dovecot, self-hosted
+# logo: svgs/docker-mailserver.svg
+
+services:
+  mailserver:
+    image: ghcr.io/docker-mailserver/docker-mailserver:latest
+    hostname: ${MAIL_HOSTNAME:-mail.example.com}
+    ports:
+      - "25:25"
+      - "143:143"
+      - "465:465"
+      - "587:587"
+      - "993:993"
+    volumes:
+      - mail-data:/var/mail
+      - mail-state:/var/mail-state
+      - mail-logs:/var/log/mail
+      - mail-config:/tmp/docker-mailserver
+    environment:
+      - OVERRIDE_HOSTNAME=${MAIL_HOSTNAME:-mail.example.com}
+      - LOG_LEVEL=${LOG_LEVEL:-info}
+      - ENABLE_CLAMAV=${ENABLE_CLAMAV:-0}
+      - ENABLE_FAIL2BAN=${ENABLE_FAIL2BAN:-0}
+      - ENABLE_SPAMASSASSIN=${ENABLE_SPAMASSASSIN:-1}
+      - SPAMASSASSIN_SPAM_TO_INBOX=${SPAMASSASSIN_SPAM_TO_INBOX:-1}
+      - ENABLE_FETCHMAIL=${ENABLE_FETCHMAIL:-0}
+      - ENABLE_POSTGREY=${ENABLE_POSTGREY:-0}
+      - SSL_TYPE=${SSL_TYPE:-}
+      - PERMIT_DOCKER=${PERMIT_DOCKER:-none}
+      - ONE_DIR=1
+      - POSTMASTER_ADDRESS=${POSTMASTER_ADDRESS:-}
+      - ENABLE_UPDATE_CHECK=${ENABLE_UPDATE_CHECK:-1}
+    restart: always
+    stop_grace_period: 1m
+    healthcheck:
+      test: ["CMD-SHELL", "ss --listening --ipv4 --tcp | grep --silent ':smtp' || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10


### PR DESCRIPTION
## Summary

Adds a service template for [Docker Mailserver](https://docker-mailserver.github.io/docker-mailserver/latest/), a fullstack production-ready mail server based on Postfix and Dovecot, addressing #8266.

### What's included:
- **Docker Mailserver** (`ghcr.io/docker-mailserver/docker-mailserver:latest`) — battle-tested, actively maintained mail server
- **Standard mail ports** — SMTP (25), IMAP (143), ESMTP with TLS (465, 587), IMAPS (993)
- **Persistent volumes** — mail data, mail state, logs, and configuration all persist across restarts
- **Configurable options** — hostname, SpamAssassin, ClamAV, Fail2Ban, Postgrey, SSL type, and more via environment variables
- **Health check** — monitors SMTP port availability
- **SVG logo** — simple mail icon for the service listing

### Configuration after deployment:
Users will need to:
1. Set `MAIL_HOSTNAME` to their mail server's FQDN
2. Configure DNS records (MX, SPF, DKIM, DMARC)
3. Add email accounts via `docker exec -it <container> setup email add user@domain.com`

### Notes:
- The template uses Docker Mailserver as recommended in the issue (over Mailu) for its simpler single-container architecture
- Compatible with Coolify's proxy and certificate management via the `SSL_TYPE` environment variable
- SpamAssassin enabled by default, ClamAV disabled by default (resource-intensive)

Closes #8266

/claim #8266