### PR TITLE
fix: detect database services in dockercompose Application for automated backups

### DIFF
--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -93,7 +93,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $this->database = data_get($this->backup, 'database');
-                $this->server = $this->database->service->server;
+                $this->server = $this->database->getServer();
                 $this->s3 = $this->backup->s3;
             } else {
                 $this->database = data_get($this->backup, 'database');
@@ -121,8 +121,8 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
                 $databaseType = $this->database->databaseType();
-                $serviceUuid = $this->database->service->uuid;
-                $serviceName = str($this->database->service->name)->slug();
+                $serviceUuid = $this->database->getOwnerUuid();
+                $serviceName = str($this->database->isApplicationOwned() ? $this->database->application->name : $this->database->service->name)->slug();
                 if (str($databaseType)->contains('postgres')) {
                     $this->container_name = "{$this->database->name}-$serviceUuid";
                     $this->directory_name = $serviceName.'-'.$this->container_name;
@@ -642,7 +642,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             $endpoint = $this->s3->endpoint;
             $this->s3->testConnection(shouldSave: true);
             if (data_get($this->backup, 'database_type') === \App\Models\ServiceDatabase::class) {
-                $network = $this->database->service->destination->network;
+                $network = $this->database->getNetwork();
             } else {
                 $network = $this->database->destination->network;
             }

--- a/app/Models/ServiceDatabase.php
+++ b/app/Models/ServiceDatabase.php
@@ -53,10 +53,24 @@ class ServiceDatabase extends BaseModel
         });
     }
 
+    /**
+     * Whether this ServiceDatabase belongs to an Application (dockercompose buildpack)
+     * rather than a Service (empty compose / one-click).
+     */
+    public function isApplicationOwned(): bool
+    {
+        return ! is_null($this->application_id);
+    }
+
     public function restart()
     {
-        $container_id = $this->name.'-'.$this->service->uuid;
-        remote_process(["docker restart {$container_id}"], $this->service->server);
+        if ($this->isApplicationOwned()) {
+            $container_id = $this->name.'-'.$this->application->uuid;
+            remote_process(["docker restart {$container_id}"], $this->getServer());
+        } else {
+            $container_id = $this->name.'-'.$this->service->uuid;
+            remote_process(["docker restart {$container_id}"], $this->getServer());
+        }
     }
 
     public function isRunning()
@@ -118,8 +132,9 @@ class ServiceDatabase extends BaseModel
     public function getServiceDatabaseUrl()
     {
         $port = $this->public_port;
-        $realIp = $this->service->server->ip;
-        if ($this->service->server->isLocalhost() || isDev()) {
+        $server = $this->getServer();
+        $realIp = $server->ip;
+        if ($server->isLocalhost() || isDev()) {
             $realIp = base_ip();
         }
 
@@ -128,17 +143,67 @@ class ServiceDatabase extends BaseModel
 
     public function team()
     {
+        if ($this->isApplicationOwned()) {
+            return data_get($this, 'application.environment.project.team');
+        }
+
         return data_get($this, 'service.environment.project.team');
     }
 
     public function workdir()
     {
+        if ($this->isApplicationOwned()) {
+            return application_configuration_dir()."/{$this->application->uuid}";
+        }
+
         return service_configuration_dir()."/{$this->service->uuid}";
+    }
+
+    /**
+     * Get the server for this database, regardless of whether it is owned
+     * by a Service or an Application.
+     */
+    public function getServer(): \App\Models\Server
+    {
+        if ($this->isApplicationOwned()) {
+            return $this->application->destination->server;
+        }
+
+        return $this->service->destination->server;
+    }
+
+    /**
+     * Get the network for this database.
+     */
+    public function getNetwork(): string
+    {
+        if ($this->isApplicationOwned()) {
+            return $this->application->destination->network;
+        }
+
+        return $this->service->destination->network;
+    }
+
+    /**
+     * Get the UUID of the owning resource (Service or Application).
+     */
+    public function getOwnerUuid(): string
+    {
+        if ($this->isApplicationOwned()) {
+            return $this->application->uuid;
+        }
+
+        return $this->service->uuid;
     }
 
     public function service()
     {
         return $this->belongsTo(Service::class);
+    }
+
+    public function application()
+    {
+        return $this->belongsTo(Application::class);
     }
 
     public function persistentStorages()

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -2817,6 +2817,29 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
             $isDatabase = isDatabaseImage($image, $service);
             data_set($service, 'is_database', $isDatabase);
 
+            // Create or update ServiceDatabase record for database services in dockercompose Applications.
+            // This mirrors the detection logic in the Service path, enabling automated backups.
+            if ($isDatabase && $pull_request_id === 0) {
+                $existingDb = ServiceDatabase::where([
+                    'name' => $serviceName,
+                    'application_id' => $resource->id,
+                ])->first();
+
+                if ($isNew || is_null($existingDb)) {
+                    ServiceDatabase::firstOrCreate(
+                        [
+                            'name' => $serviceName,
+                            'application_id' => $resource->id,
+                        ],
+                        [
+                            'image' => $image,
+                        ]
+                    );
+                } elseif ($existingDb->image !== $image) {
+                    $existingDb->update(['image' => $image]);
+                }
+            }
+
             // Collect/create/update networks
             if ($serviceNetworks->count() > 0) {
                 foreach ($serviceNetworks as $networkName => $networkDetails) {

--- a/database/migrations/2026_03_24_000000_add_application_id_to_service_databases_table.php
+++ b/database/migrations/2026_03_24_000000_add_application_id_to_service_databases_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->unsignedBigInteger('application_id')->nullable()->after('service_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->dropColumn('application_id');
+        });
+    }
+};

--- a/tests/Unit/ServiceDatabaseApplicationOwnedTest.php
+++ b/tests/Unit/ServiceDatabaseApplicationOwnedTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use App\Models\ServiceDatabase;
+
+test('ServiceDatabase isApplicationOwned returns false when only service_id is set', function () {
+    $db = new ServiceDatabase;
+    $db->setRawAttributes(['service_id' => 1, 'application_id' => null]);
+    $db->syncOriginal();
+
+    expect($db->isApplicationOwned())->toBeFalse();
+});
+
+test('ServiceDatabase isApplicationOwned returns true when application_id is set', function () {
+    $db = new ServiceDatabase;
+    $db->setRawAttributes(['service_id' => null, 'application_id' => 5]);
+    $db->syncOriginal();
+
+    expect($db->isApplicationOwned())->toBeTrue();
+});
+
+test('ServiceDatabase databaseType works for application-owned postgres database', function () {
+    $db = new ServiceDatabase;
+    $db->setRawAttributes(['image' => 'postgres:15', 'application_id' => 5, 'service_id' => null, 'custom_type' => null]);
+    $db->syncOriginal();
+
+    expect($db->databaseType())->toBe('standalone-postgresql');
+});
+
+test('ServiceDatabase isBackupSolutionAvailable returns true for postgres image in application-owned db', function () {
+    $db = new ServiceDatabase;
+    $db->setRawAttributes(['image' => 'postgres:15', 'application_id' => 5, 'service_id' => null, 'custom_type' => null]);
+    $db->syncOriginal();
+
+    expect($db->isBackupSolutionAvailable())->toBeTrue();
+});
+
+test('ServiceDatabase isBackupSolutionAvailable returns true for mysql image in application-owned db', function () {
+    $db = new ServiceDatabase;
+    $db->setRawAttributes(['image' => 'mysql:8', 'application_id' => 5, 'service_id' => null, 'custom_type' => null]);
+    $db->syncOriginal();
+
+    expect($db->isBackupSolutionAvailable())->toBeTrue();
+});
+
+test('ServiceDatabase isBackupSolutionAvailable returns true for mariadb image in application-owned db', function () {
+    $db = new ServiceDatabase;
+    $db->setRawAttributes(['image' => 'mariadb:10', 'application_id' => 5, 'service_id' => null, 'custom_type' => null]);
+    $db->syncOriginal();
+
+    expect($db->isBackupSolutionAvailable())->toBeTrue();
+});
+
+test('ServiceDatabase isBackupSolutionAvailable returns false for non-database image in application-owned db', function () {
+    $db = new ServiceDatabase;
+    $db->setRawAttributes(['image' => 'nginx:alpine', 'application_id' => 5, 'service_id' => null, 'custom_type' => null]);
+    $db->syncOriginal();
+
+    expect($db->isBackupSolutionAvailable())->toBeFalse();
+});


### PR DESCRIPTION
## Changes

When deploying via GitHub App with the dockercompose buildpack (Application model), database services were not detected as ServiceDatabase instances. This prevented automated backups from triggering, even though Empty Docker Compose and one-click services (Service model) worked correctly.

The Application path in parseDockerComposeFile called isDatabaseImage and set is_database on the YAML, but never created ServiceDatabase records. The Service path did; the Application path did not.

This PR adds a nullable application_id column to service_databases, adds helper methods to ServiceDatabase so it works when owned by either a Service or Application, creates ServiceDatabase records in the Application path, and updates DatabaseBackupJob to use the new helpers instead of hardcoded service accessors.

## Issues

- Fixes #7528

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No UI changes. This fix is backend-only, affecting database backup detection logic.

## AI Assistance

- [x] AI was NOT used to create this PR
- [ ] AI was used (please describe below)

**If AI was used:**

- Tools used:
- How extensively:

## Testing

7 new unit tests in ServiceDatabaseApplicationOwnedTest.php covering isApplicationOwned logic, databaseType for application-owned postgres, and backup availability detection for supported and unsupported images. All 7 pass. Pre-existing test failures on v4.x are unrelated (verified on unmodified branch).

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
