### PR TITLE
fix: pr-quality workflow - allow targeting default branch and don't auto-close PRs

### DIFF
--- a/.github/workflows/pr-quality.yaml
+++ b/.github/workflows/pr-quality.yaml
@@ -16,16 +16,15 @@ jobs:
       - uses: peakoss/anti-slop@v0
         with:
           # General Settings
-          max-failures: 4
+          max-failures: 6
 
           # PR Branch Checks
-          allowed-target-branches: "next"
+          allowed-target-branches: ""
           blocked-target-branches: ""
           allowed-source-branches: ""
           blocked-source-branches: |
             main
             master
-            v4.x
 
           # PR Quality Checks
           max-negative-reactions: 0
@@ -106,6 +105,6 @@ jobs:
           failure-remove-pr-labels: ""
           failure-remove-all-pr-labels: true
           failure-add-pr-labels: "quality/rejected"
-          failure-pr-message: "This PR did not pass quality checks so it will be closed. If you believe this is a mistake please let us know."
-          close-pr: true
+          failure-pr-message: "This PR did not pass quality checks. Please address the failures listed above and update your PR. If you believe this is a mistake please let us know."
+          close-pr: false
           lock-pr: false


### PR DESCRIPTION
## Summary

Fixes the PR Quality workflow that was incorrectly rejecting and closing legitimate PRs.

### Problems Fixed

1. **Blocked target branch 'next' that doesn't exist**: The workflow had `allowed-target-branches: "next"` but the 'next' branch doesn't exist in this repo. The default branch is 'v4.x', so ALL contributor PRs were being rejected at the branch check.

2. **Blocked source branch 'v4.x'**: The default branch was incorrectly blocked as a source branch.

3. **Auto-closing PRs with fixable issues**: `close-pr: true` was immediately closing PRs for minor issues like a missing final newline or template checkbox formatting issues, instead of letting contributors fix them.

### Changes

- Removed `allowed-target-branches: "next"` - contributors can now target any branch
- Removed `v4.x` from `blocked-source-branches` - you should be able to branch from default
- Changed `close-pr: false` - PRs with quality failures won't be auto-closed
- Increased `max-failures` from 4 to 6 - more forgiving threshold
- Updated failure message to reflect that PRs won't be auto-closed

### Context

The PR Quality bot was rejecting PRs like #9072 with message 'This PR did not pass quality checks so it will be closed' even though the contributor correctly filled out the template and the target branch was the default branch. The `allowed-target-branches: "next"` setting was the root cause - since 'next' doesn't exist, no PRs could pass the branch check.

Fixes #9073