### PR TITLE
fix: resolve supabase self-hosted MCP setup issues (#7458)

### DIFF
--- a/templates/compose/supabase.yaml
+++ b/templates/compose/supabase.yaml
@@ -22,7 +22,7 @@ services:
       - KONG_DECLARATIVE_CONFIG=/home/kong/kong.yml
       # https://github.com/supabase/cli/issues/14
       - KONG_DNS_ORDER=LAST,A,CNAME
-      - KONG_PLUGINS=request-transformer,cors,key-auth,acl,basic-auth
+      - KONG_PLUGINS=request-transformer,cors,key-auth,acl,basic-auth,ip-restriction
       - KONG_NGINX_PROXY_PROXY_BUFFER_SIZE=160k
       - KONG_NGINX_PROXY_PROXY_BUFFERS=64 160k
       - SUPABASE_ANON_KEY=${SERVICE_SUPABASEANON_KEY}
@@ -274,6 +274,27 @@ services:
                     hide_groups_header: true
                     allow:
                       - admin
+
+            ## MCP endpoint - local access only via SSH tunnel or VPN
+            ## Do NOT expose to the Internet. Add your Docker bridge gateway IP below.
+            ## Run: docker inspect supabase-kong --format '{{ "{{" }}range .NetworkSettings.Networks{{ "}}" }}{{ "{{" }}println .Gateway{{ "}}" }}{{ "{{" }}end{{ "}}" }}'
+            - name: mcp
+              _comment: 'MCP: /mcp -> http://supabase-studio:3000/api/mcp'
+              url: http://supabase-studio:3000/api/mcp
+              routes:
+                - name: mcp-all
+                  strip_path: true
+                  paths:
+                    - /mcp
+              plugins:
+                - name: cors
+                - name: ip-restriction
+                  config:
+                    allow:
+                      - 127.0.0.1
+                      - ::1
+                      # Add your Docker bridge gateway IP here for SSH tunnel access
+                    deny: []
 
             ## Protected Dashboard - catch all remaining routes
             - name: dashboard


### PR DESCRIPTION
## Description
Add MCP (Model Context Protocol) endpoint to the Coolify Supabase service template, enabling secure local access to self-hosted Supabase MCP via SSH tunnel or VPN.

### Changes
- 	emplates/compose/supabase.yaml: Added ip-restriction to Kong plugins list and added MCP route configuration before the dashboard catch-all route

### Tech Stack / Functions Used
- Kong declarative YAML configuration (route + plugin system)
- ip-restriction plugin for network-level access control
- cors plugin for cross-origin MCP client support

### Acceptance Criteria (from issue)
- [x] MCP endpoint available at /mcp on deployed Supabase instances
- [x] Secure by default - IP restriction allows only localhost (127.0.0.1, ::1)
- [x] Multiple Supabase instances on same Coolify server work without port collisions (each gets unique URL via Traefik)
- [x] Configuration documented inline with how to add Docker bridge gateway IP for SSH tunnel access

### Setup Instructions
1. Deploy Supabase via Coolify as usual
2. Find Docker bridge gateway IP: `docker inspect supabase-kong --format '{{range .NetworkSettings.Networks}}{{println .Gateway}}{{end}}'`
3. Add that IP to the llow list in the MCP route's ip-restriction config
4. Create SSH tunnel: ssh -L localhost:8080:localhost:8000 you@your-host
5. Configure MCP client (Cursor/Claude Code/Windsurf) to use http://localhost:8080/mcp

Closes #7458

### Contributor Agreement
> [!IMPORTANT]
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and this pull request is not a duplicate.