### PR TITLE
feat: redesign deployment page

### DIFF
--- a/app/Livewire/Deployments/Index.php
+++ b/app/Livewire/Deployments/Index.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace App\Livewire\Deployments;
+
+use App\Models\ApplicationDeploymentQueue;
+use App\Models\Server;
+use Livewire\Component;
+
+class Index extends Component
+{
+    public $deployments;
+
+    public int $deployments_count = 0;
+
+    public int $skip = 0;
+
+    public int $defaultTake = 20;
+
+    public bool $showNext = false;
+
+    public bool $showPrev = false;
+
+    public int $currentPage = 1;
+
+    public ?string $filterProject = null;
+
+    public ?string $filterServer = null;
+
+    public ?string $filterStatus = null;
+
+    protected $queryString = [
+        'filterProject' => ['except' => null],
+        'filterServer' => ['except' => null],
+        'filterStatus' => ['except' => null],
+    ];
+
+    public function getListeners()
+    {
+        $teamId = auth()->user()->currentTeam()->id;
+
+        return [
+            "echo-private:team.{$teamId},ServiceChecked" => '$refresh',
+        ];
+    }
+
+    public function mount()
+    {
+        $this->loadDeployments();
+    }
+
+    public function reloadDeployments()
+    {
+        $this->loadDeployments();
+    }
+
+    public function updatedFilterProject()
+    {
+        $this->skip = 0;
+        $this->showPrev = false;
+        $this->updateCurrentPage();
+        $this->loadDeployments();
+    }
+
+    public function updatedFilterServer()
+    {
+        $this->skip = 0;
+        $this->showPrev = false;
+        $this->updateCurrentPage();
+        $this->loadDeployments();
+    }
+
+    public function updatedFilterStatus()
+    {
+        $this->skip = 0;
+        $this->showPrev = false;
+        $this->updateCurrentPage();
+        $this->loadDeployments();
+    }
+
+    public function clearFilters()
+    {
+        $this->filterProject = null;
+        $this->filterServer = null;
+        $this->filterStatus = null;
+        $this->skip = 0;
+        $this->showPrev = false;
+        $this->updateCurrentPage();
+        $this->loadDeployments();
+    }
+
+    public function previousPage(?int $take = null)
+    {
+        if ($take) {
+            $this->skip = $this->skip - $take;
+        }
+        $this->skip = $this->skip - $this->defaultTake;
+        if ($this->skip < 0) {
+            $this->showPrev = false;
+            $this->skip = 0;
+        }
+        $this->updateCurrentPage();
+        $this->loadDeployments();
+    }
+
+    public function nextPage(?int $take = null)
+    {
+        if ($take) {
+            $this->skip = $this->skip + $take;
+        }
+        $this->showPrev = true;
+        $this->updateCurrentPage();
+        $this->loadDeployments();
+    }
+
+    private function loadDeployments()
+    {
+        $servers = Server::ownedByCurrentTeamCached();
+        $serverIds = $servers->pluck('id');
+
+        $query = ApplicationDeploymentQueue::with(['application.environment.project'])
+            ->whereIn('server_id', $serverIds)
+            ->orderBy('created_at', 'desc');
+
+        if ($this->filterServer) {
+            $query->where('server_id', $this->filterServer);
+        }
+
+        if ($this->filterProject) {
+            $query->whereHas('application.environment.project', function ($q) {
+                $q->where('uuid', $this->filterProject);
+            });
+        }
+
+        if ($this->filterStatus) {
+            $query->where('status', $this->filterStatus);
+        }
+
+        $this->deployments_count = $query->count();
+        $this->deployments = $query->skip($this->skip)->take($this->defaultTake)->get();
+
+        $this->showNext = false;
+        if ($this->deployments->count() !== 0) {
+            $this->showNext = true;
+            if ($this->deployments->count() < $this->defaultTake) {
+                $this->showNext = false;
+            }
+        }
+    }
+
+    private function updateCurrentPage()
+    {
+        $this->currentPage = intval($this->skip / $this->defaultTake) + 1;
+    }
+
+    public function getProjectsProperty()
+    {
+        $team = currentTeam()->load(['projects']);
+
+        return $team->projects->sortBy('name');
+    }
+
+    public function getServersProperty()
+    {
+        return Server::ownedByCurrentTeamCached()->sortBy('name');
+    }
+
+    public function render()
+    {
+        return view('livewire.deployments.index');
+    }
+}

--- a/resources/views/components/navbar.blade.php
+++ b/resources/views/components/navbar.blade.php
@@ -131,6 +131,19 @@
                         </a>
                     </li>
                     <li>
+                        <a title="Deployments" {{ wireNavigate() }}
+                            class="{{ request()->is('deployments') ? 'menu-item menu-item-active' : 'menu-item' }}"
+                            href="/deployments">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="menu-item-icon" viewBox="0 0 24 24"
+                                stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round"
+                                stroke-linejoin="round">
+                                <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                                <path d="M7 4v16l13 -8z" />
+                            </svg>
+                            <span class="menu-item-label">Deployments</span>
+                        </a>
+                    </li>
+                    <li>
                         <a title="Servers" {{ wireNavigate() }}
                             class="{{ request()->is('server/*') || request()->is('servers') ? 'menu-item menu-item-active' : 'menu-item' }}"
                             href="/servers">

--- a/resources/views/livewire/deployments/index.blade.php
+++ b/resources/views/livewire/deployments/index.blade.php
@@ -1,0 +1,239 @@
+<div>
+    <x-slot:title>Deployments | Coolify</x-slot>
+    <h1>Deployments</h1>
+    <div class="subtitle">All deployments across your projects.</div>
+    <div class="flex flex-col gap-2 pb-10" wire:poll.5000ms='reloadDeployments'>
+        {{-- Filters --}}
+        <div class="flex flex-wrap items-end gap-2 pb-2">
+            <div class="flex items-end gap-2">
+                <h2>Deployments <span class="text-xs">({{ $deployments_count }})</span></h2>
+                @if ($deployments_count > 0)
+                    <div class="flex items-center gap-2">
+                        <x-forms.button disabled="{{ !$showPrev }}" wire:click="previousPage('{{ $defaultTake }}')">
+                            <svg class="w-4 h-4" viewBox="0 0 24 24">
+                                <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"
+                                    stroke-width="2" d="m14 6l-6 6l6 6z" />
+                            </svg>
+                        </x-forms.button>
+                        <span class="text-sm text-gray-600 dark:text-gray-400 px-2">
+                            Page {{ $currentPage }} of {{ ceil($deployments_count / $defaultTake) }}
+                        </span>
+                        <x-forms.button disabled="{{ !$showNext }}" wire:click="nextPage('{{ $defaultTake }}')">
+                            <svg class="w-4 h-4" viewBox="0 0 24 24">
+                                <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"
+                                    stroke-width="2" d="m10 18l6-6l-6-6z" />
+                            </svg>
+                        </x-forms.button>
+                    </div>
+                @endif
+            </div>
+            <div class="flex-1"></div>
+            <div class="flex flex-wrap items-end gap-2">
+                @if ($this->projects->count() > 1)
+                    <div class="flex flex-col gap-1">
+                        <label class="text-xs text-gray-500 dark:text-gray-400">Project</label>
+                        <select wire:model.live="filterProject"
+                            class="input input-sm dark:bg-coolgray-200">
+                            <option value="">All Projects</option>
+                            @foreach ($this->projects as $project)
+                                <option value="{{ $project->uuid }}">{{ $project->name }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                @endif
+                @if ($this->servers->count() > 1)
+                    <div class="flex flex-col gap-1">
+                        <label class="text-xs text-gray-500 dark:text-gray-400">Server</label>
+                        <select wire:model.live="filterServer"
+                            class="input input-sm dark:bg-coolgray-200">
+                            <option value="">All Servers</option>
+                            @foreach ($this->servers as $server)
+                                <option value="{{ $server->id }}">{{ $server->name }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                @endif
+                <div class="flex flex-col gap-1">
+                    <label class="text-xs text-gray-500 dark:text-gray-400">Status</label>
+                    <select wire:model.live="filterStatus"
+                        class="input input-sm dark:bg-coolgray-200">
+                        <option value="">All Statuses</option>
+                        <option value="in_progress">In Progress</option>
+                        <option value="queued">Queued</option>
+                        <option value="finished">Finished</option>
+                        <option value="failed">Failed</option>
+                        <option value="cancelled-by-user">Cancelled</option>
+                    </select>
+                </div>
+                @if ($filterProject || $filterServer || $filterStatus)
+                    <x-forms.button wire:click="clearFilters">Clear</x-forms.button>
+                @endif
+            </div>
+        </div>
+        @forelse ($deployments as $deployment)
+            @php
+                $application = data_get($deployment, 'application');
+                $project = data_get($application, 'environment.project');
+                $deploymentUrl = data_get($deployment, 'deployment_url');
+            @endphp
+            <div @class([
+                'p-2 border-l-2 bg-white dark:bg-coolgray-100',
+                'border-blue-500/50 border-dashed' =>
+                    data_get($deployment, 'status') === 'in_progress',
+                'border-purple-500/50 border-dashed' =>
+                    data_get($deployment, 'status') === 'queued',
+                'border-white border-dashed' =>
+                    data_get($deployment, 'status') === 'cancelled-by-user',
+                'border-error' => data_get($deployment, 'status') === 'failed',
+                'border-success' => data_get($deployment, 'status') === 'finished',
+            ])>
+                @if ($deploymentUrl)
+                    <a href="{{ $deploymentUrl }}" {{ wireNavigate() }} class="block">
+                @endif
+                    <div class="flex flex-col">
+                        <div class="flex items-center gap-2 mb-2">
+                            <span @class([
+                                'px-3 py-1 rounded-md text-xs font-medium shadow-xs',
+                                'bg-blue-100/80 text-blue-700 dark:bg-blue-500/20 dark:text-blue-300' =>
+                                    data_get($deployment, 'status') === 'in_progress',
+                                'bg-purple-100/80 text-purple-700 dark:bg-purple-500/20 dark:text-purple-300' =>
+                                    data_get($deployment, 'status') === 'queued',
+                                'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-200' =>
+                                    data_get($deployment, 'status') === 'failed',
+                                'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-200' =>
+                                    data_get($deployment, 'status') === 'finished',
+                                'bg-gray-100 text-gray-700 dark:bg-gray-600/30 dark:text-gray-300' =>
+                                    data_get($deployment, 'status') === 'cancelled-by-user',
+                            ])>
+                                @php
+                                    $statusText = match (data_get($deployment, 'status')) {
+                                        'finished' => 'Success',
+                                        'in_progress' => 'In Progress',
+                                        'cancelled-by-user' => 'Cancelled',
+                                        'queued' => 'Queued',
+                                        default => ucfirst(data_get($deployment, 'status')),
+                                    };
+                                @endphp
+                                {{ $statusText }}
+                            </span>
+                            @if ($project)
+                                <span class="text-xs text-gray-500 dark:text-gray-400">
+                                    {{ $project->name }}
+                                </span>
+                            @endif
+                            @if ($application)
+                                <span class="text-xs font-medium text-gray-700 dark:text-gray-300">
+                                    {{ data_get($deployment, 'application_name', data_get($application, 'name')) }}
+                                </span>
+                            @endif
+                        </div>
+                        @if (data_get($deployment, 'status') !== 'queued')
+                            <div class="text-gray-600 dark:text-gray-400 text-sm">
+                                Started:
+                                {{ formatDateInServerTimezone(data_get($deployment, 'created_at'), data_get($application, 'destination.server')) }}
+                                @if ($deployment->status !== 'in_progress' && $deployment->status !== 'cancelled-by-user')
+                                    <br>Ended:
+                                    {{ formatDateInServerTimezone(data_get($deployment, 'finished_at'), data_get($application, 'destination.server')) }}
+                                    <br>Duration:
+                                    {{ calculateDuration(data_get($deployment, 'created_at'), data_get($deployment, 'finished_at')) }}
+                                    <br>Finished
+                                    {{ \Carbon\Carbon::parse(data_get($deployment, 'finished_at'))->diffForHumans() }}
+                                @elseif($deployment->status === 'in_progress')
+                                    <br>Running for:
+                                    {{ calculateDuration(data_get($deployment, 'created_at'), now()) }}
+                                @endif
+                            </div>
+                        @endif
+
+                        <div class="text-gray-600 dark:text-gray-400 text-sm mt-2">
+                            @if (data_get($deployment, 'commit'))
+                                <div x-data="{ expanded: false }">
+                                    <div class="flex items-center gap-2">
+                                        <span class="font-medium">Commit:</span>
+                                        <a href="{{ $application->gitCommitLink(data_get($deployment, 'commit')) }}"
+                                            target="_blank" class="underline">
+                                            {{ substr(data_get($deployment, 'commit'), 0, 7) }}
+                                        </a>
+                                        @if (!$deployment->commitMessage())
+                                            <span
+                                                class="bg-gray-200/70 dark:bg-gray-600/20 px-2 py-0.5 rounded-md text-xs text-gray-800 dark:text-gray-100 border border-gray-400/30">
+                                                @if (data_get($deployment, 'is_webhook'))
+                                                    Webhook
+                                                    @if (data_get($deployment, 'pull_request_id'))
+                                                        | Pull Request #{{ data_get($deployment, 'pull_request_id') }}
+                                                    @endif
+                                                @elseif (data_get($deployment, 'pull_request_id'))
+                                                    Pull Request #{{ data_get($deployment, 'pull_request_id') }}
+                                                @elseif (data_get($deployment, 'rollback') === true)
+                                                    Rollback
+                                                @elseif (data_get($deployment, 'is_api'))
+                                                    API
+                                                @else
+                                                    Manual
+                                                @endif
+                                            </span>
+                                        @endif
+                                        @if ($deployment->commitMessage())
+                                            <span class="text-gray-600 dark:text-gray-400">-</span>
+                                            <a href="{{ $application->gitCommitLink(data_get($deployment, 'commit')) }}"
+                                                target="_blank"
+                                                class="text-gray-600 dark:text-gray-400 truncate max-w-md underline">
+                                                {{ Str::before($deployment->commitMessage(), "\n") }}
+                                            </a>
+                                            @if ($deployment->commitMessage() !== Str::before($deployment->commitMessage(), "\n"))
+                                                <button @click="expanded = !expanded"
+                                                    class="text-gray-600 dark:text-gray-400 flex items-center gap-1">
+                                                    <svg x-bind:class="{ 'rotate-180': expanded }"
+                                                        class="w-4 h-4 transition-transform" viewBox="0 0 24 24">
+                                                        <path fill="none" stroke="currentColor"
+                                                            stroke-linecap="round" stroke-linejoin="round"
+                                                            stroke-width="2" d="m6 9l6 6l6-6" />
+                                                    </svg>
+                                                </button>
+                                            @endif
+                                            <span
+                                                class="bg-gray-200/70 dark:bg-gray-600/20 px-2 py-0.5 rounded-md text-xs text-gray-800 dark:text-gray-100 border border-gray-400/30">
+                                                @if (data_get($deployment, 'is_webhook'))
+                                                    Webhook
+                                                    @if (data_get($deployment, 'pull_request_id'))
+                                                        | Pull Request #{{ data_get($deployment, 'pull_request_id') }}
+                                                    @endif
+                                                @elseif (data_get($deployment, 'pull_request_id'))
+                                                    Pull Request #{{ data_get($deployment, 'pull_request_id') }}
+                                                @elseif (data_get($deployment, 'rollback') === true)
+                                                    Rollback
+                                                @elseif (data_get($deployment, 'is_api'))
+                                                    API
+                                                @else
+                                                    Manual
+                                                @endif
+                                            </span>
+                                        @endif
+                                    </div>
+                                    @if ($deployment->commitMessage())
+                                        <div x-show="expanded" x-transition:enter="transition ease-out duration-200"
+                                            x-transition:enter-start="opacity-0 transform -translate-y-2"
+                                            x-transition:enter-end="opacity-100 transform translate-y-0"
+                                            class="mt-2 ml-4 text-gray-600 dark:text-gray-400">
+                                            {{ Str::after($deployment->commitMessage(), "\n") }}
+                                        </div>
+                                    @endif
+                                </div>
+                            @endif
+                        </div>
+
+                        @if (data_get($deployment, 'server_name'))
+                            <div class="text-gray-600 dark:text-gray-400 text-sm mt-2">
+                                Server: {{ data_get($deployment, 'server_name') }}
+                            </div>
+                        @endif
+                    </div>
+                @if ($deploymentUrl)
+                    </a>
+                @endif
+            </div>
+        @empty
+            <div>No deployments found</div>
+        @endforelse
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,7 @@ use App\Livewire\Notifications\Telegram as NotificationTelegram;
 use App\Livewire\Notifications\Webhook as NotificationWebhook;
 use App\Livewire\Profile\Index as ProfileIndex;
 use App\Livewire\Project\Application\Configuration as ApplicationConfiguration;
+use App\Livewire\Deployments\Index as DeploymentsIndex;
 use App\Livewire\Project\Application\Deployment\Index as DeploymentIndex;
 use App\Livewire\Project\Application\Deployment\Show as DeploymentShow;
 use App\Livewire\Project\CloneMe as ProjectCloneMe;
@@ -108,6 +109,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     });
 
     Route::get('/', Dashboard::class)->name('dashboard');
+    Route::get('/deployments', DeploymentsIndex::class)->name('deployments');
     Route::get('/onboarding', BoardingIndex::class)->name('onboarding');
 
     Route::get('/subscription', SubscriptionShow::class)->name('subscription.show');


### PR DESCRIPTION
## Description

Add a global Deployments page accessible from the sidebar that shows all deployments across all projects, with filtering capabilities and live updates.

### Changes
- pp/Livewire/Deployments/Index.php: New Livewire component for the global deployments page with filtering by project, server, and status, plus pagination
- esources/views/livewire/deployments/index.blade.php: Blade view with Vercel-inspired deployment list UI, status badges, commit info, and filter controls
- outes/web.php: Added /deployments route
- esources/views/components/navbar.blade.php: Added "Deployments" link to sidebar navigation

### Tech Stack / Functions Used
- Laravel Livewire 3 (Component, wire:poll, wire:model.live)
- Blade templating with conditional CSS classes
- ApplicationDeploymentQueue model with eager loading
- Server::ownedByCurrentTeamCached() for team-scoped queries

### Acceptance Criteria (from issue)
- [x] Add deployments to sidebar
- [x] Show past deployments (all of them)
- [x] Filter by project (dropdown, hidden if only 1 project)
- [x] Filter by server (dropdown, hidden if only 1 server)
- [x] Filter by status (queued, pending, done)
- [x] Show live updates / refresh (wire:poll.5000ms)
- [x] Hide filters if only 1 server / 1 source

### Test Verification
- Visit /deployments to see all deployments
- Filter by project, server, or status
- Live updates via polling every 5 seconds

Generated/reviewed with: claude-opus-4-6

?? USDT TRC20: TNiSqqJE6cms4e7HRmrvcg1BVaRgQhr367