### PR TITLE
fix: close SSH mux connections before rewriting key file

### DIFF
--- a/app/Helpers/SshMultiplexingHelper.php
+++ b/app/Helpers/SshMultiplexingHelper.php
@@ -229,6 +229,9 @@ class SshMultiplexingHelper
 
         if ($needsRewrite) {
             $privateKey->storeInFileSystem();
+            // Close existing mux connections using the old key to prevent permission denied errors
+            // when the key file is rewritten while an active mux connection exists
+            refresh_server_connection($privateKey);
         }
 
         // Ensure correct permissions (SSH requires 0600)

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -286,6 +286,8 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         try {
             // Make sure the private key is stored in the filesystem
             $this->server->privateKey->storeInFileSystem();
+            // Close any existing mux connections that may be using a stale key file
+            refresh_server_connection($this->server->privateKey);
             // Generate custom host<->ip mapping
             $allContainers = instant_remote_process(["docker network inspect {$this->destination->network} -f '{{json .Containers}}' "], $this->server);
 


### PR DESCRIPTION
/claim #7724

## Summary
Fixes sporadic SSH permission denied errors that occur when Coolify rewrites the SSH private key file while an active SSH mux connection still exists.

## Root Cause
In validateSshKey(), when the SSH key file is rewritten (e.g., after key rotation), any existing mux connection continues to reference the stale key file. New SSH commands fail with permission denied.

## Fix
Call refresh_server_connection() after storeInFileSystem() in both SshMultiplexingHelper::validateSshKey() and ApplicationDeploymentJob to close mux connections before rewriting the key file.

## Bounty
$250 USD via Algora - ETH: 0x5a134107516ecccc83232711efa50eb4e87602c7 | Solana: eB51DWp1uECrLZRLsE2cnyZUzfRWvzUzaJzkatTpQV9