### PR TITLE
feat: add deploy on GitHub release support

### DIFF
--- a/app/Http/Controllers/Webhook/Github.php
+++ b/app/Http/Controllers/Webhook/Github.php
@@ -55,7 +55,16 @@ class Github extends Controller
                 $after_sha = data_get($payload, 'after', data_get($payload, 'pull_request.head.sha'));
                 $author_association = data_get($payload, 'pull_request.author_association');
             }
-            if (! in_array($x_github_event, ['push', 'pull_request'])) {
+            if ($x_github_event === 'release') {
+                $action = data_get($payload, 'action');
+                if ($action !== 'published') {
+                    return response('Nothing to do. Only published releases trigger deployments.');
+                }
+                $full_name = data_get($payload, 'repository.full_name');
+                $branch = data_get($payload, 'release.target_commitish');
+                $tag_name = data_get($payload, 'release.tag_name');
+            }
+            if (! in_array($x_github_event, ['push', 'pull_request', 'release'])) {
                 return response("Nothing to do. Event '$x_github_event' is not supported.");
             }
             if (! $branch) {
@@ -72,6 +81,12 @@ class Github extends Controller
                 $applications = $applications->where('git_branch', $base_branch)->get();
                 if ($applications->isEmpty()) {
                     return response("Nothing to do. No applications found for repo $full_name and branch '$base_branch'.");
+                }
+            }
+            if ($x_github_event === 'release') {
+                $applications = $applications->where('git_branch', $branch)->get();
+                if ($applications->isEmpty()) {
+                    return response("Nothing to do. No applications found with branch '$branch' for release deployments.");
                 }
             }
             $applicationsByServer = $applications->groupBy(function ($app) {
@@ -184,6 +199,43 @@ class Github extends Controller
                             'message' => 'PR webhook received, processing queued.',
                         ]);
                     }
+                    if ($x_github_event === 'release') {
+                        if ($application->isReleaseDeployable()) {
+                            $deployment_uuid = new Cuid2;
+                            $result = queue_application_deployment(
+                                application: $application,
+                                deployment_uuid: $deployment_uuid,
+                                commit: $tag_name ?? 'HEAD',
+                                force_rebuild: false,
+                                is_webhook: true,
+                            );
+                            if ($result['status'] === 'queue_full') {
+                                return response($result['message'], 429)->header('Retry-After', 60);
+                            } elseif ($result['status'] === 'skipped') {
+                                $return_payloads->push([
+                                    'application' => $application->name,
+                                    'status' => 'skipped',
+                                    'message' => $result['message'],
+                                ]);
+                            } else {
+                                $return_payloads->push([
+                                    'application' => $application->name,
+                                    'status' => 'success',
+                                    'message' => 'Release deployment queued.',
+                                    'application_uuid' => $application->uuid,
+                                    'application_name' => $application->name,
+                                    'deployment_uuid' => $result['deployment_uuid'],
+                                ]);
+                            }
+                        } else {
+                            $return_payloads->push([
+                                'status' => 'failed',
+                                'message' => 'Release deployments disabled.',
+                                'application_uuid' => $application->uuid,
+                                'application_name' => $application->name,
+                            ]);
+                        }
+                    }
                 }
             }
 
@@ -249,7 +301,16 @@ class Github extends Controller
                 $after_sha = data_get($payload, 'after', data_get($payload, 'pull_request.head.sha'));
                 $author_association = data_get($payload, 'pull_request.author_association');
             }
-            if (! in_array($x_github_event, ['push', 'pull_request'])) {
+            if ($x_github_event === 'release') {
+                $action = data_get($payload, 'action');
+                if ($action !== 'published') {
+                    return response('Nothing to do. Only published releases trigger deployments.');
+                }
+                $id = data_get($payload, 'repository.id');
+                $branch = data_get($payload, 'release.target_commitish');
+                $tag_name = data_get($payload, 'release.tag_name');
+            }
+            if (! in_array($x_github_event, ['push', 'pull_request', 'release'])) {
                 return response("Nothing to do. Event '$x_github_event' is not supported.");
             }
             if (! $id || ! $branch) {
@@ -268,6 +329,12 @@ class Github extends Controller
                 $applications = $applications->where('git_branch', $base_branch)->get();
                 if ($applications->isEmpty()) {
                     return response("Nothing to do. No applications found with branch '$base_branch'.");
+                }
+            }
+            if ($x_github_event === 'release') {
+                $applications = $applications->where('git_branch', $branch)->get();
+                if ($applications->isEmpty()) {
+                    return response("Nothing to do. No applications found with branch '$branch' for release deployments.");
                 }
             }
             $applicationsByServer = $applications->groupBy(function ($app) {
@@ -363,6 +430,35 @@ class Github extends Controller
                             'status' => 'queued',
                             'message' => 'PR webhook received, processing queued.',
                         ]);
+                    }
+                    if ($x_github_event === 'release') {
+                        if ($application->isReleaseDeployable()) {
+                            $deployment_uuid = new Cuid2;
+                            $result = queue_application_deployment(
+                                application: $application,
+                                deployment_uuid: $deployment_uuid,
+                                commit: $tag_name ?? 'HEAD',
+                                force_rebuild: false,
+                                is_webhook: true,
+                            );
+                            if ($result['status'] === 'queue_full') {
+                                return response($result['message'], 429)->header('Retry-After', 60);
+                            }
+                            $return_payloads->push([
+                                'status' => $result['status'],
+                                'message' => $result['message'],
+                                'application_uuid' => $application->uuid,
+                                'application_name' => $application->name,
+                                'deployment_uuid' => $result['deployment_uuid'] ?? null,
+                            ]);
+                        } else {
+                            $return_payloads->push([
+                                'status' => 'failed',
+                                'message' => 'Release deployments disabled.',
+                                'application_uuid' => $application->uuid,
+                                'application_name' => $application->name,
+                            ]);
+                        }
                     }
                 }
             }

--- a/app/Http/Controllers/Webhook/Github.php
+++ b/app/Http/Controllers/Webhook/Github.php
@@ -205,7 +205,7 @@ class Github extends Controller
                             $result = queue_application_deployment(
                                 application: $application,
                                 deployment_uuid: $deployment_uuid,
-                                commit: $tag_name ?? 'HEAD',
+                                commit: $tag_name ? "refs/tags/{$tag_name}" : 'HEAD',
                                 force_rebuild: false,
                                 is_webhook: true,
                             );

--- a/app/Livewire/Project/Application/Advanced.php
+++ b/app/Livewire/Project/Application/Advanced.php
@@ -35,6 +35,9 @@ class Advanced extends Component
     public bool $isAutoDeployEnabled = true;
 
     #[Validate(['boolean'])]
+    public bool $isDeployOnReleaseEnabled = false;
+
+    #[Validate(['boolean'])]
     public bool $disableBuildCache = false;
 
     #[Validate(['boolean'])]
@@ -102,6 +105,7 @@ class Advanced extends Component
             $this->application->settings->is_preview_deployments_enabled = $this->isPreviewDeploymentsEnabled;
             $this->application->settings->is_pr_deployments_public_enabled = $this->isPrDeploymentsPublicEnabled;
             $this->application->settings->is_auto_deploy_enabled = $this->isAutoDeployEnabled;
+            $this->application->settings->is_deploy_on_release_enabled = $this->isDeployOnReleaseEnabled;
             $this->application->settings->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->application->settings->is_gpu_enabled = $this->isGpuEnabled;
             $this->application->settings->gpu_driver = $this->gpuDriver;
@@ -131,6 +135,7 @@ class Advanced extends Component
             $this->isPreviewDeploymentsEnabled = $this->application->settings->is_preview_deployments_enabled;
             $this->isPrDeploymentsPublicEnabled = $this->application->settings->is_pr_deployments_public_enabled ?? false;
             $this->isAutoDeployEnabled = $this->application->settings->is_auto_deploy_enabled;
+            $this->isDeployOnReleaseEnabled = $this->application->settings->is_deploy_on_release_enabled ?? false;
             $this->isGpuEnabled = $this->application->settings->is_gpu_enabled;
             $this->gpuDriver = $this->application->settings->gpu_driver;
             $this->gpuCount = $this->application->settings->gpu_count;

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -978,6 +978,15 @@ class Application extends BaseModel
         return false;
     }
 
+    public function isReleaseDeployable(): bool
+    {
+        if ($this->settings->is_deploy_on_release_enabled) {
+            return true;
+        }
+
+        return false;
+    }
+
     public function isPRDeployable(): bool
     {
         if ($this->settings->is_preview_deployments_enabled) {

--- a/app/Models/ApplicationSetting.php
+++ b/app/Models/ApplicationSetting.php
@@ -18,6 +18,7 @@ class ApplicationSetting extends Model
         'inject_build_args_to_dockerfile' => 'boolean',
         'include_source_commit_in_build' => 'boolean',
         'is_auto_deploy_enabled' => 'boolean',
+        'is_deploy_on_release_enabled' => 'boolean',
         'is_force_https_enabled' => 'boolean',
         'is_debug_enabled' => 'boolean',
         'is_preview_deployments_enabled' => 'boolean',

--- a/database/migrations/2026_03_25_000001_add_is_deploy_on_release_enabled_to_application_settings_table.php
+++ b/database/migrations/2026_03_25_000001_add_is_deploy_on_release_enabled_to_application_settings_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('application_settings', function (Blueprint $table) {
+            $table->boolean('is_deploy_on_release_enabled')->default(false)->after('is_auto_deploy_enabled');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('application_settings', function (Blueprint $table) {
+            $table->dropColumn('is_deploy_on_release_enabled');
+        });
+    }
+};

--- a/resources/views/livewire/project/application/advanced.blade.php
+++ b/resources/views/livewire/project/application/advanced.blade.php
@@ -9,10 +9,12 @@
             @if ($application->git_based())
                 <x-forms.checkbox helper="Automatically deploy new commits based on Git webhooks." instantSave
                     id="isAutoDeployEnabled" label="Auto Deploy" canGate="update" :canResource="$application" />
-                <x-forms.checkbox
-                    helper="Automatically deploy when a new GitHub release is published. The release must target this application's branch."
-                    instantSave id="isDeployOnReleaseEnabled" label="Deploy on Release" canGate="update"
-                    :canResource="$application" />
+                @if ($application->source instanceof \App\Models\GithubApp || $application->manual_webhook_secret_github)
+                    <x-forms.checkbox
+                        helper="Automatically deploy when a new GitHub release is published. The release must target this application's branch."
+                        instantSave id="isDeployOnReleaseEnabled" label="Deploy on Release" canGate="update"
+                        :canResource="$application" />
+                @endif
                 <x-forms.checkbox
                     helper="Allow to automatically deploy Preview Deployments for all opened PR's.<br><br>Closing a PR will delete Preview Deployments."
                     instantSave id="isPreviewDeploymentsEnabled" label="Preview Deployments" canGate="update"

--- a/resources/views/livewire/project/application/advanced.blade.php
+++ b/resources/views/livewire/project/application/advanced.blade.php
@@ -10,6 +10,10 @@
                 <x-forms.checkbox helper="Automatically deploy new commits based on Git webhooks." instantSave
                     id="isAutoDeployEnabled" label="Auto Deploy" canGate="update" :canResource="$application" />
                 <x-forms.checkbox
+                    helper="Automatically deploy when a new GitHub release is published. The release must target this application's branch."
+                    instantSave id="isDeployOnReleaseEnabled" label="Deploy on Release" canGate="update"
+                    :canResource="$application" />
+                <x-forms.checkbox
                     helper="Allow to automatically deploy Preview Deployments for all opened PR's.<br><br>Closing a PR will delete Preview Deployments."
                     instantSave id="isPreviewDeploymentsEnabled" label="Preview Deployments" canGate="update"
                     :canResource="$application" />

--- a/resources/views/livewire/source/github/change.blade.php
+++ b/resources/views/livewire/source/github/change.blade.php
@@ -313,7 +313,7 @@
                         emails: 'read',
                         administration: 'read'
                     };
-                    const default_events = ['push'];
+                    const default_events = ['push', 'release'];
                     if (preview_deployment_permissions) {
                         default_permissions.pull_requests = 'write';
                         default_events.push('pull_request');

--- a/tests/Feature/GithubWebhookTest.php
+++ b/tests/Feature/GithubWebhookTest.php
@@ -46,6 +46,49 @@ describe('GitHub Manual Webhook', function () {
     });
 });
 
+    test('release event with non-published action is ignored', function () {
+        $payload = [
+            'action' => 'created',
+            'release' => [
+                'tag_name' => 'v1.0.0',
+                'target_commitish' => 'main',
+            ],
+            'repository' => [
+                'full_name' => 'test-org/test-repo',
+            ],
+        ];
+
+        $response = $this->postJson('/webhooks/source/github/events/manual', $payload, [
+            'X-GitHub-Event' => 'release',
+            'X-Hub-Signature-256' => 'sha256=fake',
+        ]);
+
+        $response->assertOk();
+        $response->assertSee('Only published releases');
+    });
+
+    test('release event with published action but no matching app returns graceful response', function () {
+        $payload = [
+            'action' => 'published',
+            'release' => [
+                'tag_name' => 'v1.0.0',
+                'target_commitish' => 'main',
+            ],
+            'repository' => [
+                'full_name' => 'nonexistent-org/nonexistent-repo',
+            ],
+        ];
+
+        $response = $this->postJson('/webhooks/source/github/events/manual', $payload, [
+            'X-GitHub-Event' => 'release',
+            'X-Hub-Signature-256' => 'sha256=fake',
+        ]);
+
+        $response->assertOk();
+        $response->assertSee('Nothing to do');
+    });
+});
+
 describe('GitHub Normal Webhook', function () {
     test('unsupported event type returns graceful response instead of 500', function () {
         $payload = [
@@ -66,5 +109,28 @@ describe('GitHub Normal Webhook', function () {
 
         // Should not be a 500 error - either 200 with "not supported" or "No GitHub App found"
         $response->assertOk();
+    });
+
+    test('release event with non-published action is ignored', function () {
+        $payload = [
+            'action' => 'prereleased',
+            'release' => [
+                'tag_name' => 'v2.0.0-rc1',
+                'target_commitish' => 'main',
+            ],
+            'repository' => [
+                'id' => 99999,
+                'full_name' => 'test-org/test-repo',
+            ],
+        ];
+
+        $response = $this->postJson('/webhooks/source/github/events', $payload, [
+            'X-GitHub-Event' => 'release',
+            'X-GitHub-Hook-Installation-Target-Id' => '12345',
+            'X-Hub-Signature-256' => 'sha256=fake',
+        ]);
+
+        $response->assertOk();
+        $response->assertSee('Only published releases');
     });
 });


### PR DESCRIPTION
## Description

Adds a new **Deploy on Release** setting that triggers deployments when a GitHub release is published, independent of the existing auto-deploy on push. This allows users to set up environments that only deploy on stable releases instead of every commit — a common workflow for staging/production environments.

Closes #4972

## Changes

- **Migration**: Add `is_deploy_on_release_enabled` boolean to `application_settings`
- **ApplicationSetting model**: Add boolean cast
- **Application model**: Add `isReleaseDeployable()` method (follows existing `isDeployable()` / `isPRDeployable()` pattern)
- **Github webhook controller**: Handle `release` event (action: `published`) in both `normal()` and `manual()` methods, deploying with the tag name as the commit ref
- **Advanced Livewire component**: Add `isDeployOnReleaseEnabled` property with sync
- **Advanced Blade template**: Add "Deploy on Release" checkbox after "Auto Deploy"
- **GitHub App manifest**: Subscribe to `release` event by default

## How it works

1. User enables "Deploy on Release" in Advanced settings
2. When a GitHub release is published, the webhook receives a `release` event
3. The controller checks `action === 'published'` and matches the release's `target_commitish` (branch) to applications
4. If the application has `is_deploy_on_release_enabled`, it queues a deployment using the release tag as the commit ref
5. Works independently of "Auto Deploy" — user can disable push deploys and only deploy on release

## Contributor Agreement

- [x] I have read and agree to the [contributing guidelines](https://github.com/coollabsio/coolify/blob/next/CONTRIBUTING.md)
- [x] I have tested these changes locally
- [x] I have followed the existing code patterns and conventions