### PR TITLE
feat: allow OAuth-only self-registration (#8042)

### DIFF
--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -22,7 +22,8 @@ class OauthController extends Controller
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                // Allow OAuth registration if either general registration is enabled OR OAuth-only registration is enabled
+                if (! $settings->is_registration_enabled && ! $settings->is_oauth_only_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -15,6 +15,9 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $is_oauth_only_registration_enabled;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -41,6 +44,7 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_only_registration_enabled' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => 'nullable|string',
@@ -62,6 +66,7 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_only_registration_enabled = $this->settings->is_oauth_only_registration_enabled;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -142,6 +147,7 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_only_registration_enabled = $this->is_oauth_only_registration_enabled;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -31,6 +31,7 @@ class InstanceSettings extends Model
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',
         'is_wire_navigate_enabled' => 'boolean',
+        'is_oauth_only_registration_enabled' => 'boolean',
     ];
 
     protected static function booted(): void

--- a/database/migrations/2026_03_25_222209_add_oauth_only_registration_to_instance_settings.php
+++ b/database/migrations/2026_03_25_222209_add_oauth_only_registration_to_instance_settings.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_only_registration_enabled')->default(false)->after('is_registration_enabled');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn('is_oauth_only_registration_enabled');
+        });
+    }
+};

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -18,8 +18,13 @@
                 <div class="flex flex-col gap-1">
                     <div class="md:w-96">
                         <x-forms.checkbox instantSave id="is_registration_enabled"
-                            helper="Allow users to self-register. If disabled, only administrators can create accounts."
-                            label="Registration Allowed" />
+                            helper="Allow users to self-register with password. If disabled, only administrators can create password-based accounts."
+                            label="Password Registration Allowed" />
+                    </div>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_only_registration_enabled"
+                            helper="Allow users to self-register using OAuth providers, even when password registration is disabled. When enabled and password registration is disabled, only OAuth-based accounts can be created (unless invited by an admin)."
+                            label="OAuth Self-Registration" />
                     </div>
                     <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"


### PR DESCRIPTION
## Summary

Closes #8042

This PR allows OAuth2 users to self-register even when general password-based registration is disabled, and adds an admin toggle for "OAuth-only" registration mode.

## Changes

- **New migration**: adds `is_oauth_only_registration_enabled` boolean column to `instance_settings` (default: `false`)
- **InstanceSettings model**: adds cast for new boolean field
- **OauthController**: registration check now allows OAuth registration if *either* `is_registration_enabled` OR `is_oauth_only_registration_enabled` is true
- **Settings/Advanced**: new Livewire property + validation + persistence
- **Advanced settings UI**: new "OAuth Self-Registration" toggle with clear distinction from password registration

## Behavior

| is_registration_enabled | is_oauth_only_registration_enabled | OAuth can register? |
|---|---|---|
| true | any | ✅ Yes (existing behavior) |
| false | true | ✅ Yes (new) |
| false | false | ❌ No (existing behavior) |

## Testing
1. Run migration
2. Disable password registration, enable OAuth registration
3. Verify new OAuth user can self-register
4. Verify password registration is blocked
5. Existing OAuth users should still log in normally

Backward compatible — new column defaults to `false`, no behavior change for existing installations.