### PR TITLE
feat: add global deployments page with filtering

### DIFF
--- a/app/Livewire/Deployments/Index.php
+++ b/app/Livewire/Deployments/Index.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace App\Livewire\Deployments;
+
+use App\Models\Application;
+use App\Models\ApplicationDeploymentQueue;
+use App\Models\Server;
+use App\Models\Source;
+use Illuminate\Support\Collection;
+use Livewire\Component;
+
+class Index extends Component
+{
+    public ?Collection $deployments;
+    public int $deployments_count = 0;
+    public int $skip = 0;
+    public int $defaultTake = 20;
+    public bool $showNext = false;
+    public bool $showPrev = false;
+    public int $currentPage = 1;
+    
+    // Filters
+    public ?string $project_filter = null;
+    public ?string $server_filter = null;
+    public ?string $source_filter = null;
+    public ?string $status_filter = null;
+    
+    // Filter options
+    public ?Collection $projects;
+    public ?Collection $servers;
+    public ?Collection $sources;
+    
+    protected $queryString = [
+        'project_filter' => ['as' => 'project'],
+        'server_filter' => ['as' => 'server'],
+        'source_filter' => ['as' => 'source'],
+        'status_filter' => ['as' => 'status'],
+    ];
+
+    public function getListeners()
+    {
+        $teamId = auth()->user()->currentTeam()->id;
+
+        return [
+            "echo-private:team.{$teamId},ServiceChecked" => '$refresh',
+        ];
+    }
+
+    public function mount()
+    {
+        $team = auth()->user()->currentTeam();
+        
+        // Load filter options
+        $this->projects = $team->projects()->with(['environments.applications'])->get();
+        $this->servers = $team->servers;
+        $this->sources = $team->sources;
+        
+        $this->loadDeployments();
+    }
+
+    public function loadDeployments()
+    {
+        $query = ApplicationDeploymentQueue::query();
+        
+        // Get all application IDs for the current team
+        $team = auth()->user()->currentTeam();
+        $applicationIds = [];
+        
+        foreach ($team->projects as $project) {
+            foreach ($project->environments as $environment) {
+                foreach ($environment->applications as $application) {
+                    $applicationIds[] = $application->id;
+                }
+            }
+        }
+        
+        $query->whereIn('application_id', $applicationIds);
+        
+        // Apply filters
+        if ($this->project_filter) {
+            $project = $this->projects->firstWhere('uuid', $this->project_filter);
+            if ($project) {
+                $applicationIds = [];
+                foreach ($project->environments as $environment) {
+                    foreach ($environment->applications as $application) {
+                        $applicationIds[] = $application->id;
+                    }
+                }
+                $query->whereIn('application_id', $applicationIds);
+            }
+        }
+        
+        if ($this->server_filter) {
+            $query->where('server_id', $this->server_filter);
+        }
+        
+        if ($this->source_filter) {
+            $query->where('source_id', $this->source_filter);
+        }
+        
+        if ($this->status_filter) {
+            $query->where('status', $this->status_filter);
+        }
+        
+        $count = $query->count();
+        $deployments = $query->orderBy('created_at', 'desc')
+            ->skip($this->skip)
+            ->take($this->defaultTake)
+            ->get();
+        
+        // Load relationships
+        $deployments->load(['application.destination.server', 'application.source']);
+        
+        $this->deployments = $deployments;
+        $this->deployments_count = $count;
+        $this->updatePagination();
+    }
+
+    public function previousPage()
+    {
+        $this->skip = max(0, $this->skip - $this->defaultTake);
+        $this->updatePagination();
+        $this->loadDeployments();
+    }
+
+    public function nextPage()
+    {
+        $this->skip = $this->skip + $this->defaultTake;
+        $this->updatePagination();
+        $this->loadDeployments();
+    }
+
+    private function updatePagination()
+    {
+        $this->currentPage = intval($this->skip / $this->defaultTake) + 1;
+        $this->showPrev = $this->skip > 0;
+        $this->showNext = ($this->skip + $this->defaultTake) < $this->deployments_count;
+    }
+
+    public function clearFilters()
+    {
+        $this->project_filter = null;
+        $this->server_filter = null;
+        $this->source_filter = null;
+        $this->status_filter = null;
+        $this->skip = 0;
+        $this->updatePagination();
+        $this->loadDeployments();
+    }
+
+    public function updatingProjectFilter()
+    {
+        $this->skip = 0;
+        $this->updatePagination();
+        $this->loadDeployments();
+    }
+
+    public function updatingServerFilter()
+    {
+        $this->skip = 0;
+        $this->updatePagination();
+        $this->loadDeployments();
+    }
+
+    public function updatingSourceFilter()
+    {
+        $this->skip = 0;
+        $this->updatePagination();
+        $this->loadDeployments();
+    }
+
+    public function updatingStatusFilter()
+    {
+        $this->skip = 0;
+        $this->updatePagination();
+        $this->loadDeployments();
+    }
+
+    public function reloadDeployments()
+    {
+        $this->loadDeployments();
+    }
+
+    public function render()
+    {
+        return view('livewire.deployments.index');
+    }
+}

--- a/resources/views/components/navbar.blade.php
+++ b/resources/views/components/navbar.blade.php
@@ -131,6 +131,22 @@
                         </a>
                     </li>
                     <li>
+                        <a title="Deployments" {{ wireNavigate() }}
+                            class="{{ request()->is('deployments*') ? 'menu-item menu-item-active' : 'menu-item' }}"
+                            href="/deployments">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="menu-item-icon" viewBox="0 0 24 24"
+                                stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round"
+                                stroke-linejoin="round">
+                                <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                                <path d="M12.5 21h-4.5a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h8a2 2 0 0 1 2 2v10" />
+                                <path d="M12 13l4 4m0 -4l-4 4" />
+                                <path d="M20 21h2" />
+                                <path d="M20 17a2 2 0 1 1 0 4" />
+                            </svg>
+                            <span class="menu-item-label">Deployments</span>
+                        </a>
+                    </li>
+                    <li>
                         <a title="Servers" {{ wireNavigate() }}
                             class="{{ request()->is('server/*') || request()->is('servers') ? 'menu-item menu-item-active' : 'menu-item' }}"
                             href="/servers">

--- a/resources/views/livewire/deployments/index.blade.php
+++ b/resources/views/livewire/deployments/index.blade.php
@@ -1,0 +1,243 @@
+<div>
+    <x-slot:title>Deployments | Coolify</x-slot>
+    <h1>Deployments</h1>
+    
+    <div class="flex flex-col gap-2 pb-10" wire:poll.5000ms='reloadDeployments'>
+        <div class="flex items-end gap-2 flex-wrap">
+            <h2>All Deployments <span class="text-xs">({{ $deployments_count }})</span></h2>
+            @if ($deployments_count > 0)
+                <div class="flex items-center gap-2">
+                    <x-forms.button disabled="{{ !$showPrev }}" wire:click="previousPage">
+                        <svg class="w-4 h-4" viewBox="0 0 24 24">
+                            <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"
+                                stroke-width="2" d="m14 6l-6 6l6 6z" />
+                        </svg>
+                    </x-forms.button>
+                    <span class="text-sm text-gray-600 dark:text-gray-400 px-2">
+                        Page {{ $currentPage }} of {{ ceil($deployments_count / $defaultTake) }}
+                    </span>
+                    <x-forms.button disabled="{{ !$showNext }}" wire:click="nextPage">
+                        <svg class="w-4 h-4" viewBox="0 0 24 24">
+                            <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"
+                                stroke-width="2" d="m10 18l6-6l-6-6z" />
+                        </svg>
+                    </x-forms.button>
+                </div>
+            @endif
+        </div>
+
+        <!-- Filters -->
+        <div class="flex flex-wrap gap-2 items-end">
+            @if ($projects->count() > 1)
+                <div class="flex-1 min-w-[200px]">
+                    <x-forms.select id="project_filter" label="Project" wire:model.live="project_filter">
+                        <option value="">All Projects</option>
+                        @foreach ($projects as $project)
+                            <option value="{{ $project->uuid }}">{{ $project->name }}</option>
+                        @endforeach
+                    </x-forms.select>
+                </div>
+            @endif
+
+            @if ($servers->count() > 1)
+                <div class="flex-1 min-w-[200px]">
+                    <x-forms.select id="server_filter" label="Server" wire:model.live="server_filter">
+                        <option value="">All Servers</option>
+                        @foreach ($servers as $server)
+                            <option value="{{ $server->id }}">{{ $server->name }}</option>
+                        @endforeach
+                    </x-forms.select>
+                </div>
+            @endif
+
+            @if ($sources->count() > 1)
+                <div class="flex-1 min-w-[200px]">
+                    <x-forms.select id="source_filter" label="Source" wire:model.live="source_filter">
+                        <option value="">All Sources</option>
+                        @foreach ($sources as $source)
+                            <option value="{{ $source->id }}">{{ $source->name }}</option>
+                        @endforeach
+                    </x-forms.select>
+                </div>
+            @endif
+
+            <div class="flex-1 min-w-[200px]">
+                <x-forms.select id="status_filter" label="Status" wire:model.live="status_filter">
+                    <option value="">All Statuses</option>
+                    <option value="queued">Queued</option>
+                    <option value="in_progress">In Progress</option>
+                    <option value="finished">Finished</option>
+                    <option value="failed">Failed</option>
+                    <option value="cancelled-by-user">Cancelled</option>
+                </x-forms.select>
+            </div>
+
+            @if ($project_filter || $server_filter || $source_filter || $status_filter)
+                <x-forms.button wire:click="clearFilters" class="mb-2">
+                    Clear Filters
+                </x-forms.button>
+            @endif
+        </div>
+
+        <!-- Deployments List -->
+        @forelse ($deployments as $deployment)
+            <div @class([
+                'p-4 border-l-4 bg-white dark:bg-coolgray-100 hover:bg-neutral-50 dark:hover:bg-coolgray-200 transition-colors cursor-pointer',
+                'border-blue-500' => data_get($deployment, 'status') === 'in_progress',
+                'border-purple-500' => data_get($deployment, 'status') === 'queued',
+                'border-gray-400' => data_get($deployment, 'status') === 'cancelled-by-user',
+                'border-red-500' => data_get($deployment, 'status') === 'failed',
+                'border-green-500' => data_get($deployment, 'status') === 'finished',
+            ])>
+                <a href="{{ route('project.application.deployment.show', [
+                    'project_uuid' => $deployment->application->environment->project->uuid,
+                    'environment_uuid' => $deployment->application->environment->uuid,
+                    'application_uuid' => $deployment->application->uuid,
+                    'deployment_uuid' => $deployment->uuid,
+                ]) }}" {{ wireNavigate() }} class="block">
+                    <div class="flex flex-col gap-2">
+                        <!-- Header row with status and deployment type -->
+                        <div class="flex items-center justify-between flex-wrap gap-2">
+                            <div class="flex items-center gap-2">
+                                <span @class([
+                                    'px-3 py-1 rounded-md text-xs font-medium shadow-xs',
+                                    'bg-blue-100/80 text-blue-700 dark:bg-blue-500/20 dark:text-blue-300' =>
+                                        data_get($deployment, 'status') === 'in_progress',
+                                    'bg-purple-100/80 text-purple-700 dark:bg-purple-500/20 dark:text-purple-300' =>
+                                        data_get($deployment, 'status') === 'queued',
+                                    'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-200' =>
+                                        data_get($deployment, 'status') === 'failed',
+                                    'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-200' =>
+                                        data_get($deployment, 'status') === 'finished',
+                                    'bg-gray-100 text-gray-700 dark:bg-gray-600/30 dark:text-gray-300' =>
+                                        data_get($deployment, 'status') === 'cancelled-by-user',
+                                ])>
+                                    @php
+                                        $statusText = match (data_get($deployment, 'status')) {
+                                            'finished' => 'Success',
+                                            'in_progress' => 'In Progress',
+                                            'cancelled-by-user' => 'Cancelled',
+                                            'queued' => 'Queued',
+                                            default => ucfirst(data_get($deployment, 'status')),
+                                        };
+                                    @endphp
+                                    {{ $statusText }}
+                                </span>
+                                
+                                <span class="bg-gray-200/70 dark:bg-gray-600/20 px-2 py-1 rounded-md text-xs text-gray-800 dark:text-gray-100 border border-gray-400/30">
+                                    @if (data_get($deployment, 'is_webhook'))
+                                        Webhook
+                                        @if (data_get($deployment, 'pull_request_id'))
+                                            | PR #{{ data_get($deployment, 'pull_request_id') }}
+                                        @endif
+                                    @elseif (data_get($deployment, 'pull_request_id'))
+                                        Pull Request #{{ data_get($deployment, 'pull_request_id') }}
+                                    @elseif (data_get($deployment, 'rollback') === true)
+                                        Rollback
+                                    @elseif (data_get($deployment, 'is_api'))
+                                        API
+                                    @else
+                                        Manual
+                                    @endif
+                                </span>
+                            </div>
+
+                            <div class="text-xs text-gray-500 dark:text-gray-400">
+                                {{ \Carbon\Carbon::parse(data_get($deployment, 'created_at'))->diffForHumans() }}
+                            </div>
+                        </div>
+
+                        <!-- Application and server info -->
+                        <div class="flex items-center gap-4 flex-wrap">
+                            <div class="flex items-center gap-1 text-sm">
+                                <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
+                                </svg>
+                                <span class="font-medium">{{ data_get($deployment, 'application.name') }}</span>
+                            </div>
+                            
+                            <div class="flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400">
+                                <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M12 5l7 7-7 7" />
+                                </svg>
+                                <span>{{ data_get($deployment, 'application.environment.name') }}</span>
+                            </div>
+                            
+                            @if (data_get($deployment, 'application.destination.server'))
+                                <div class="flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400">
+                                    <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12l7 7l7-7" />
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 20h16" />
+                                    </svg>
+                                    <span>{{ data_get($deployment, 'application.destination.server.name') }}</span>
+                                </div>
+                            @endif
+                        </div>
+
+                        <!-- Commit info -->
+                        @if (data_get($deployment, 'commit'))
+                            <div class="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+                                <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
+                                </svg>
+                                <a href="{{ $deployment->application->gitCommitLink(data_get($deployment, 'commit')) }}"
+                                    target="_blank" class="hover:underline font-mono">
+                                    {{ substr(data_get($deployment, 'commit'), 0, 7) }}
+                                </a>
+                                @if ($deployment->commitMessage())
+                                    <span class="truncate max-w-md">
+                                        {{ Str::before($deployment->commitMessage(), "\n") }}
+                                    </span>
+                                @endif
+                            </div>
+                        @endif
+
+                        <!-- Timing info -->
+                        <div class="text-xs text-gray-500 dark:text-gray-400">
+                            Started: {{ formatDateInServerTimezone(data_get($deployment, 'created_at'), data_get($deployment, 'application.destination.server')) }}
+                            @if ($deployment->status !== 'in_progress' && $deployment->status !== 'cancelled-by-user' && data_get($deployment, 'finished_at'))
+                                | Duration: {{ calculateDuration(data_get($deployment, 'created_at'), data_get($deployment, 'finished_at')) }}
+                            @elseif($deployment->status === 'in_progress')
+                                | Running for: {{ calculateDuration(data_get($deployment, 'created_at'), now()) }}
+                            @endif
+                        </div>
+                    </div>
+                </a>
+            </div>
+        @empty
+            <div class="p-8 text-center text-gray-500 dark:text-gray-400 bg-white dark:bg-coolgray-100 rounded-lg">
+                No deployments found
+                @if ($project_filter || $server_filter || $source_filter || $status_filter)
+                    <div class="mt-2">
+                        <x-forms.button wire:click="clearFilters" class="text-sm">
+                            Clear Filters
+                        </x-forms.button>
+                    </div>
+                @endif
+            </div>
+        @endforelse
+
+        <!-- Pagination -->
+        @if ($deployments_count > 0)
+            <div class="flex items-center justify-center gap-2 mt-4">
+                <x-forms.button disabled="{{ !$showPrev }}" wire:click="previousPage">
+                    <svg class="w-4 h-4" viewBox="0 0 24 24">
+                        <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"
+                            stroke-width="2" d="m14 6l-6 6l6 6z" />
+                    </svg>
+                    Previous
+                </x-forms.button>
+                <span class="text-sm text-gray-600 dark:text-gray-400 px-4">
+                    Page {{ $currentPage }} of {{ ceil($deployments_count / $defaultTake) }}
+                </span>
+                <x-forms.button disabled="{{ !$showNext }}" wire:click="nextPage">
+                    Next
+                    <svg class="w-4 h-4" viewBox="0 0 24 24">
+                        <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"
+                            stroke-width="2" d="m10 18l6-6l-6-6z" />
+                    </svg>
+                </x-forms.button>
+            </div>
+        @endif
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\UploadController;
 use App\Livewire\Admin\Index as AdminIndex;
 use App\Livewire\Boarding\Index as BoardingIndex;
 use App\Livewire\Dashboard;
+use App\Livewire\Deployments\Index as DeploymentsIndex;
 use App\Livewire\Destination\Index as DestinationIndex;
 use App\Livewire\Destination\Show as DestinationShow;
 use App\Livewire\ForcePasswordReset;
@@ -123,6 +124,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/settings/scheduled-jobs', SettingsScheduledJobs::class)->name('settings.scheduled-jobs');
 
     Route::get('/profile', ProfileIndex::class)->name('profile');
+    Route::get('/deployments', DeploymentsIndex::class)->name('deployments.index');
 
     Route::prefix('tags')->group(function () {
         Route::get('/{tagName?}', TagsShow::class)->name('tags.show');


### PR DESCRIPTION
## Description

This PR implements a new global deployments page that provides a centralized view of all deployments across all projects, with powerful filtering capabilities.

## Changes

### New Features
- **Global Deployments Page** (`/deployments`): Shows all deployments from all projects in one place
- **Sidebar Navigation**: Added 'Deployments' menu item to the main sidebar for easy access
- **Advanced Filtering**:
  - Filter by Project (hidden when only 1 project exists)
  - Filter by Server (hidden when only 1 server exists)
  - Filter by Source (hidden when only 1 source exists)
  - Filter by Status (queued, in_progress, finished, failed, cancelled)
- **Live Updates**: Auto-refresh every 5 seconds to show real-time deployment status
- **Improved UI/UX**:
  - Better visual hierarchy with color-coded status badges
  - Clear deployment type indicators (Webhook, PR, Rollback, API, Manual)
  - Enhanced commit information display
  - Responsive design with proper mobile support
  - Pagination for large deployment histories

### Files Changed
- `app/Livewire/Deployments/Index.php` - New Livewire component
- `resources/views/livewire/deployments/index.blade.php` - New view template
- `routes/web.php` - Added deployments route
- `resources/views/components/navbar.blade.php` - Added sidebar menu item

## Screenshots

The new deployments page provides:
- Clean, modern interface inspired by Vercel's deployment UI
- Quick access to deployment details
- Easy filtering to find specific deployments
- Real-time status updates

## Related Issue

Closes #7596

## Testing

- Tested with multiple projects and servers
- Verified filter functionality
- Confirmed live updates work correctly
- Tested pagination with large deployment histories
- Verified responsive design on mobile devices