### PR TITLE
fix: resolve broken git commit links for SSH and non-source repositories

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -582,28 +582,25 @@ class Application extends BaseModel
 
     public function gitCommitLink($link): string
     {
-        if (! is_null(data_get($this, 'source.html_url')) && ! is_null(data_get($this, 'git_repository')) && ! is_null(data_get($this, 'git_branch'))) {
-            if (str($this->source->html_url)->contains('bitbucket')) {
-                return "{$this->source->html_url}/{$this->git_repository}/commits/{$link}";
+        $git_repository = $this->git_repository;
+        $source_html_url = data_get($this, 'source.html_url');
+        $is_bitbucket = str($git_repository)->contains('bitbucket') || str($source_html_url)->contains('bitbucket');
+        $commit_path = $is_bitbucket ? 'commits' : 'commit';
+
+        if ($source_html_url && $git_repository && $this->git_branch) {
+            if (str_starts_with($git_repository, 'git@')) {
+                $git_repository = str($git_repository)->after(':')->before('.git')->value();
             }
 
-            return "{$this->source->html_url}/{$this->git_repository}/commit/{$link}";
+            return "{$source_html_url}/{$git_repository}/{$commit_path}/{$link}";
         }
-        if (str($this->git_repository)->contains('bitbucket')) {
-            $git_repository = str_replace('.git', '', $this->git_repository);
-            $url = Url::fromString($git_repository);
-            $url = $url->withUserInfo('');
-            $url = $url->withPath($url->getPath().'/commits/'.$link);
-
-            return $url->__toString();
-        }
-        if (strpos($this->git_repository, 'git@') === 0) {
+        if (str_starts_with($git_repository, 'git@')) {
             $git_repository = str_replace(['git@', ':', '.git'], ['', '/', ''], $this->git_repository);
-            if (data_get($this, 'source.html_url')) {
-                return "{$this->source->html_url}/{$git_repository}/commit/{$link}";
-            }
 
-            return "{$git_repository}/commit/{$link}";
+            return "https://{$git_repository}/{$commit_path}/{$link}";
+        }
+        if (str_starts_with($git_repository, 'http')) {
+            return str($git_repository)->replaceEnd('.git', '')->finish('/')->value()."{$commit_path}/{$link}";
         }
 
         return $this->git_repository;

--- a/tests/Unit/ApplicationGitLinkTest.php
+++ b/tests/Unit/ApplicationGitLinkTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use App\Models\Application;
+use App\Models\GithubApp;
+
+it('generates correct commit link for GitHub source with SSH', function () {
+    $application = Mockery::mock(Application::class)->makePartial();
+    $application->git_repository = 'git@github.com:coollabsio/coolify.git';
+
+    $source = Mockery::mock(GithubApp::class)->makePartial();
+    $source->shouldReceive('getAttribute')->with('html_url')->andReturn('https://github.com');
+    $application->source = $source;
+    $application->shouldReceive('getAttribute')->with('source')->andReturn($source);
+
+    $link = $application->gitCommitLink('sha123');
+    
+    // CURRENT BUG: https://github.com/github.com/coollabsio/coolify/commit/sha123 (nested domain)
+    // EXPECTED: https://github.com/coollabsio/coolify/commit/sha123
+    expect($link)->toBe('https://github.com/coollabsio/coolify/commit/sha123');
+});
+
+it('generates correct commit link for public SSH repo without source', function () {
+    $application = Mockery::mock(Application::class)->makePartial();
+    $application->git_repository = 'git@github.com:coollabsio/coolify.git';
+    $application->source = null;
+    $application->shouldReceive('getAttribute')->with('source')->andReturn(null);
+
+    $link = $application->gitCommitLink('sha123');
+    
+    // CURRENT BUG: github.com/coollabsio/coolify/commit/sha123 (relative link, no https://)
+    // EXPECTED: https://github.com/coollabsio/coolify/commit/sha123
+    expect($link)->toBe('https://github.com/coollabsio/coolify/commit/sha123');
+});
+
+it('generates correct commit link for public HTTPS repo without source', function () {
+    $application = Mockery::mock(Application::class)->makePartial();
+    $application->git_repository = 'https://github.com/coollabsio/coolify';
+    $application->source = null;
+    $application->shouldReceive('getAttribute')->with('source')->andReturn(null);
+
+    $link = $application->gitCommitLink('sha123');
+    
+    // CURRENT BUG: https://github.com/coollabsio/coolify (missing commit path)
+    // EXPECTED: https://github.com/coollabsio/coolify/commit/sha123
+    expect($link)->toBe('https://github.com/coollabsio/coolify/commit/sha123');
+});
+
+it('generates correct commit link for Bitbucket SSH repo', function () {
+    $application = Mockery::mock(Application::class)->makePartial();
+    $application->git_repository = 'git@bitbucket.org:user/repo.git';
+    $application->source = null;
+    $application->shouldReceive('getAttribute')->with('source')->andReturn(null);
+
+    $link = $application->gitCommitLink('sha123');
+    
+    // EXPECTED: https://bitbucket.org/user/repo/commits/sha123 (Bitbucket uses /commits/ for single commits too)
+    expect($link)->toBe('https://bitbucket.org/user/repo/commits/sha123');
+});


### PR DESCRIPTION
### Summary
Fixes a bug in the `Application` model where git commit links were incorrectly generated, leading to broken 404 or relative links in the deployment UI.

### Changes
- Improved `gitCommitLink` logic to handle SSH-based repository URLs correctly.
- Added `https://` prefix for public SSH repositories without a connected Source.
- Ensured `/commit/` (or `/commits/` for Bitbucket) is appended to all repository formats.
- Prevented nested domains when using SSH URLs with a connected Source.
- Added unit tests in `tests/Unit/ApplicationGitLinkTest.php` to verify the fix across various repository formats.

### Impact
Improves UX by providing working links to git commits in the deployment history, regardless of how the repository was added to Coolify.

Fixes #9186