### PR TITLE
feat: add global deployments page

### DIFF
--- a/app/Livewire/Deployments/Index.php
+++ b/app/Livewire/Deployments/Index.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace App\Livewire\Deployments;
+
+use App\Models\ApplicationDeploymentQueue;
+use App\Models\Project;
+use App\Models\Server;
+use Illuminate\Database\Eloquent\Builder;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class Index extends Component
+{
+    use WithPagination;
+
+    public string $filterProject = '';
+
+    public string $filterServer = '';
+
+    public string $filterSource = '';
+
+    public string $filterStatus = '';
+
+    /** @var array<string, mixed> */
+    protected $queryString = [
+        'filterProject' => ['except' => ''],
+        'filterServer' => ['except' => ''],
+        'filterSource' => ['except' => ''],
+        'filterStatus' => ['except' => ''],
+    ];
+
+    public function updatedFilterProject(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatedFilterServer(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatedFilterSource(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatedFilterStatus(): void
+    {
+        $this->resetPage();
+    }
+
+    public function reloadDeployments(): void
+    {
+        // Used by wire:poll; WithPagination will re-query on next render.
+    }
+
+    public function clearFilters(): void
+    {
+        $this->filterProject = '';
+        $this->filterServer = '';
+        $this->filterSource = '';
+        $this->filterStatus = '';
+        $this->resetPage();
+    }
+
+    public function deploymentPath(ApplicationDeploymentQueue $deployment): string
+    {
+        if (filled($deployment->deployment_url)) {
+            return $deployment->deployment_url;
+        }
+
+        $application = $deployment->application;
+
+        return route('project.application.deployment.show', [
+            'project_uuid' => $application->environment->project->uuid,
+            'environment_uuid' => $application->environment->uuid,
+            'application_uuid' => $application->uuid,
+            'deployment_uuid' => $deployment->deployment_uuid,
+        ], false);
+    }
+
+    public function render()
+    {
+        $this->sanitizeFilters();
+
+        $projects = Project::ownedByCurrentTeam()->orderByRaw('LOWER(name)')->get(['id', 'uuid', 'name']);
+        $teamServers = Server::ownedByCurrentTeam()->orderByRaw('LOWER(name)')->get(['id', 'name']);
+
+        $baseForMeta = $this->scopedDeploymentQuery();
+        $gitTypes = (clone $baseForMeta)
+            ->whereNotNull('git_type')
+            ->where('git_type', '!=', '')
+            ->distinct()
+            ->orderBy('git_type')
+            ->pluck('git_type');
+        $hasNullGitType = (clone $baseForMeta)->where(function (Builder $q): void {
+            $q->whereNull('git_type')->orWhere('git_type', '');
+        })->exists();
+
+        $statusValues = (clone $baseForMeta)
+            ->whereNotNull('status')
+            ->distinct()
+            ->orderBy('status')
+            ->pluck('status');
+
+        $showProjectFilter = $projects->count() > 1;
+        $showServerFilter = $teamServers->count() > 1;
+        $sourceOptionCount = $gitTypes->count() + ($hasNullGitType ? 1 : 0);
+        $showSourceFilter = $sourceOptionCount > 1;
+        $showStatusFilter = $statusValues->count() > 1;
+
+        $deployments = $this->filteredDeploymentQuery()
+            ->with([
+                'application.environment.project',
+                'application.destination.server',
+            ])
+            ->paginate(15);
+
+        return view('livewire.deployments.index', [
+            'projects' => $projects,
+            'teamServers' => $teamServers,
+            'gitTypes' => $gitTypes,
+            'hasNullGitType' => $hasNullGitType,
+            'statusValues' => $statusValues,
+            'showProjectFilter' => $showProjectFilter,
+            'showServerFilter' => $showServerFilter,
+            'showSourceFilter' => $showSourceFilter,
+            'showStatusFilter' => $showStatusFilter,
+            'deployments' => $deployments,
+        ]);
+    }
+
+    protected function scopedDeploymentQuery(): Builder
+    {
+        return ApplicationDeploymentQueue::query()
+            ->whereHas('application', function (Builder $query): void {
+                $query->whereRelation('environment.project', 'team_id', currentTeam()->id);
+            });
+    }
+
+    protected function filteredDeploymentQuery(): Builder
+    {
+        $query = $this->scopedDeploymentQuery();
+
+        if ($this->filterProject !== '') {
+            $query->whereHas('application.environment.project', function (Builder $q): void {
+                $q->where('uuid', $this->filterProject);
+            });
+        }
+
+        if ($this->filterServer !== '' && is_numeric($this->filterServer)) {
+            $query->where('server_id', (int) $this->filterServer);
+        }
+
+        if ($this->filterSource !== '') {
+            if ($this->filterSource === '__none__') {
+                $query->where(function (Builder $q): void {
+                    $q->whereNull('git_type')->orWhere('git_type', '');
+                });
+            } else {
+                $query->where('git_type', $this->filterSource);
+            }
+        }
+
+        if ($this->filterStatus !== '') {
+            $query->where('status', $this->filterStatus);
+        }
+
+        return $query->orderByDesc('created_at');
+    }
+
+    protected function sanitizeFilters(): void
+    {
+        $projectUuids = Project::ownedByCurrentTeam()->pluck('uuid')->all();
+        if ($this->filterProject !== '' && ! in_array($this->filterProject, $projectUuids, true)) {
+            $this->filterProject = '';
+        }
+
+        $serverIds = Server::ownedByCurrentTeam()->pluck('id')->all();
+        if ($this->filterServer !== '' && (! is_numeric($this->filterServer) || ! in_array((int) $this->filterServer, $serverIds, true))) {
+            $this->filterServer = '';
+        }
+
+        $base = $this->scopedDeploymentQuery();
+        $allowedStatuses = (clone $base)->distinct()->pluck('status')->filter()->all();
+        if ($this->filterStatus !== '' && ! in_array($this->filterStatus, $allowedStatuses, true)) {
+            $this->filterStatus = '';
+        }
+
+        $allowedGit = (clone $base)
+            ->whereNotNull('git_type')
+            ->where('git_type', '!=', '')
+            ->distinct()
+            ->pluck('git_type')
+            ->all();
+        $allowsNullGit = (clone $base)->where(function (Builder $q): void {
+            $q->whereNull('git_type')->orWhere('git_type', '');
+        })->exists();
+
+        if ($this->filterSource !== '') {
+            if ($this->filterSource === '__none__') {
+                if (! $allowsNullGit) {
+                    $this->filterSource = '';
+                }
+            } elseif (! in_array($this->filterSource, $allowedGit, true)) {
+                $this->filterSource = '';
+            }
+        }
+    }
+}

--- a/app/Livewire/DeploymentsIndicator.php
+++ b/app/Livewire/DeploymentsIndicator.php
@@ -41,7 +41,8 @@ class DeploymentsIndicator extends Component
     #[Computed]
     public function shouldReduceOpacity(): bool
     {
-        return request()->routeIs('project.application.deployment.*');
+        return request()->routeIs('project.application.deployment.*')
+            || request()->routeIs('deployments.index');
     }
 
     public function toggleExpanded()

--- a/app/Livewire/GlobalSearch.php
+++ b/app/Livewire/GlobalSearch.php
@@ -620,6 +620,13 @@ class GlobalSearch extends Component
                     'search_text' => 'projects all list view',
                 ],
                 [
+                    'name' => 'Deployments',
+                    'type' => 'navigation',
+                    'description' => 'View all application deployments',
+                    'link' => route('deployments.index'),
+                    'search_text' => 'deployments history releases builds rollout logs',
+                ],
+                [
                     'name' => 'Destinations',
                     'type' => 'navigation',
                     'description' => 'View all destinations',

--- a/resources/views/components/navbar.blade.php
+++ b/resources/views/components/navbar.blade.php
@@ -131,6 +131,18 @@
                         </a>
                     </li>
                     <li>
+                        <a title="Deployments" {{ wireNavigate() }}
+                            class="{{ request()->is('deployments') ? 'menu-item menu-item-active' : 'menu-item' }}"
+                            href="{{ route('deployments.index') }}">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="menu-item-icon" fill="none" viewBox="0 0 24 24"
+                                stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
+                            </svg>
+                            <span class="menu-item-label">Deployments</span>
+                        </a>
+                    </li>
+                    <li>
                         <a title="Servers" {{ wireNavigate() }}
                             class="{{ request()->is('server/*') || request()->is('servers') ? 'menu-item menu-item-active' : 'menu-item' }}"
                             href="/servers">

--- a/resources/views/livewire/deployments/index.blade.php
+++ b/resources/views/livewire/deployments/index.blade.php
@@ -1,0 +1,169 @@
+<div>
+    <x-slot:title>Deployments | Coolify</x-slot>
+    <h1>Deployments</h1>
+    <div class="subtitle">All application deployments for the current team.</div>
+
+    <div class="flex flex-col gap-4 pb-10"
+        @if ($deployments->currentPage() === 1) wire:poll.5000ms="reloadDeployments" @endif>
+        <div class="flex flex-wrap items-end gap-3">
+            @if ($showProjectFilter)
+                <div class="min-w-[10rem]">
+                    <label class="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1"
+                        for="filter-project">Project</label>
+                    <select id="filter-project" wire:model.live="filterProject"
+                        class="w-full rounded-md border-neutral-300 dark:border-coolgray-200 dark:bg-coolgray-100 shadow-xs text-sm">
+                        <option value="">All projects</option>
+                        @foreach ($projects as $project)
+                            <option value="{{ $project->uuid }}">{{ $project->name }}</option>
+                        @endforeach
+                    </select>
+                </div>
+            @endif
+            @if ($showServerFilter)
+                <div class="min-w-[10rem]">
+                    <label class="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1"
+                        for="filter-server">Server</label>
+                    <select id="filter-server" wire:model.live="filterServer"
+                        class="w-full rounded-md border-neutral-300 dark:border-coolgray-200 dark:bg-coolgray-100 shadow-xs text-sm">
+                        <option value="">All servers</option>
+                        @foreach ($teamServers as $server)
+                            <option value="{{ $server->id }}">{{ $server->name }}</option>
+                        @endforeach
+                    </select>
+                </div>
+            @endif
+            @if ($showSourceFilter)
+                <div class="min-w-[10rem]">
+                    <label class="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1"
+                        for="filter-source">Source (Git)</label>
+                    <select id="filter-source" wire:model.live="filterSource"
+                        class="w-full rounded-md border-neutral-300 dark:border-coolgray-200 dark:bg-coolgray-100 shadow-xs text-sm">
+                        <option value="">All sources</option>
+                        @if ($hasNullGitType)
+                            <option value="__none__">Not set</option>
+                        @endif
+                        @foreach ($gitTypes as $type)
+                            <option value="{{ $type }}">{{ str($type)->headline() }}</option>
+                        @endforeach
+                    </select>
+                </div>
+            @endif
+            @if ($showStatusFilter)
+                <div class="min-w-[10rem]">
+                    <label class="block text-sm font-medium text-gray-700 dark:text-neutral-300 mb-1"
+                        for="filter-status">Status</label>
+                    <select id="filter-status" wire:model.live="filterStatus"
+                        class="w-full rounded-md border-neutral-300 dark:border-coolgray-200 dark:bg-coolgray-100 shadow-xs text-sm">
+                        <option value="">All statuses</option>
+                        @foreach ($statusValues as $status)
+                            <option value="{{ $status }}">{{ str($status)->headline() }}</option>
+                        @endforeach
+                    </select>
+                </div>
+            @endif
+            @if ($filterProject !== '' || $filterServer !== '' || $filterSource !== '' || $filterStatus !== '')
+                <x-forms.button type="button" wire:click="clearFilters">Clear filters</x-forms.button>
+            @endif
+        </div>
+
+        <div class="flex items-center gap-2">
+            <h2 class="text-lg">History <span class="text-xs text-gray-600 dark:text-gray-400">({{ $deployments->total() }})</span>
+            </h2>
+        </div>
+
+        @forelse ($deployments as $deployment)
+            @php
+                $application = $deployment->application;
+                $project = $application?->environment?->project;
+                $serverForTz = $application?->destination?->server;
+            @endphp
+            <div @class([
+                'p-2 border-l-2 bg-white dark:bg-coolgray-100',
+                'border-blue-500/50 border-dashed' => data_get($deployment, 'status') === 'in_progress',
+                'border-purple-500/50 border-dashed' => data_get($deployment, 'status') === 'queued',
+                'border-white border-dashed' => data_get($deployment, 'status') === 'cancelled-by-user',
+                'border-error' => data_get($deployment, 'status') === 'failed',
+                'border-success' => data_get($deployment, 'status') === 'finished',
+            ])>
+                <a href="{{ $this->deploymentPath($deployment) }}" {{ wireNavigate() }} class="block">
+                    <div class="flex flex-col">
+                        <div class="flex flex-wrap items-center gap-2 mb-1">
+                            <span @class([
+                                'px-3 py-1 rounded-md text-xs font-medium shadow-xs',
+                                'bg-blue-100/80 text-blue-700 dark:bg-blue-500/20 dark:text-blue-300' =>
+                                    data_get($deployment, 'status') === 'in_progress',
+                                'bg-purple-100/80 text-purple-700 dark:bg-purple-500/20 dark:text-purple-300' =>
+                                    data_get($deployment, 'status') === 'queued',
+                                'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-200' =>
+                                    data_get($deployment, 'status') === 'failed',
+                                'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-200' =>
+                                    data_get($deployment, 'status') === 'finished',
+                                'bg-gray-100 text-gray-700 dark:bg-gray-600/30 dark:text-gray-300' =>
+                                    data_get($deployment, 'status') === 'cancelled-by-user',
+                            ])>
+                                @php
+                                    $statusText = match (data_get($deployment, 'status')) {
+                                        'finished' => 'Success',
+                                        'in_progress' => 'In Progress',
+                                        'cancelled-by-user' => 'Cancelled',
+                                        'queued' => 'Queued',
+                                        default => ucfirst(str_replace('-', ' ', (string) data_get($deployment, 'status'))),
+                                    };
+                                @endphp
+                                {{ $statusText }}
+                            </span>
+                            @if ($project)
+                                <span class="text-xs text-gray-500 dark:text-gray-400">{{ $project->name }}</span>
+                                <span class="text-xs text-gray-400 dark:text-gray-500">·</span>
+                            @endif
+                            <span class="text-sm font-medium text-gray-900 dark:text-neutral-100">
+                                {{ $deployment->application_name ?? $application?->name ?? 'Application' }}
+                            </span>
+                            @if ($deployment->server_name)
+                                <span class="text-xs text-gray-500 dark:text-gray-400">· {{ $deployment->server_name }}</span>
+                            @endif
+                            @if (filled($deployment->git_type))
+                                <span
+                                    class="text-xs bg-gray-200/70 dark:bg-gray-600/20 px-2 py-0.5 rounded-md text-gray-800 dark:text-gray-100 border border-gray-400/30">
+                                    {{ str($deployment->git_type)->headline() }}
+                                </span>
+                            @endif
+                        </div>
+
+                        @if (data_get($deployment, 'status') !== 'queued' && $serverForTz)
+                            <div class="text-gray-600 dark:text-gray-400 text-sm">
+                                Started:
+                                {{ formatDateInServerTimezone(data_get($deployment, 'created_at'), $serverForTz) }}
+                                @if ($deployment->status !== 'in_progress' && $deployment->status !== 'cancelled-by-user' && $deployment->finished_at)
+                                    <br>Ended:
+                                    {{ formatDateInServerTimezone(data_get($deployment, 'finished_at'), $serverForTz) }}
+                                    <br>Duration:
+                                    {{ calculateDuration(data_get($deployment, 'created_at'), data_get($deployment, 'finished_at')) }}
+                                @elseif($deployment->status === 'in_progress')
+                                    <br>Running for:
+                                    {{ calculateDuration(data_get($deployment, 'created_at'), now()) }}
+                                @endif
+                            </div>
+                        @endif
+
+                        @if (data_get($deployment, 'commit') && $application)
+                            <div class="text-gray-600 dark:text-gray-400 text-sm mt-2">
+                                <span class="font-medium">Commit:</span>
+                                <a href="{{ $application->gitCommitLink(data_get($deployment, 'commit')) }}" target="_blank"
+                                    class="underline" onclick="event.stopPropagation()">
+                                    {{ substr(data_get($deployment, 'commit'), 0, 7) }}
+                                </a>
+                            </div>
+                        @endif
+                    </div>
+                </a>
+            </div>
+        @empty
+            <div>No deployments found.</div>
+        @endforelse
+
+        <div class="pt-2">
+            {{ $deployments->links() }}
+        </div>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\UploadController;
 use App\Livewire\Admin\Index as AdminIndex;
 use App\Livewire\Boarding\Index as BoardingIndex;
 use App\Livewire\Dashboard;
+use App\Livewire\Deployments\Index as DeploymentsGlobalIndex;
 use App\Livewire\Destination\Index as DestinationIndex;
 use App\Livewire\Destination\Show as DestinationShow;
 use App\Livewire\ForcePasswordReset;
@@ -195,6 +196,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/{uuid}', [Controller::class, 'acceptInvitation'])->name('team.invitation.accept');
         Route::get('/{uuid}/revoke', [Controller::class, 'revokeInvitation'])->name('team.invitation.revoke');
     });
+
+    Route::get('/deployments', DeploymentsGlobalIndex::class)->name('deployments.index');
 
     Route::get('/projects', ProjectIndex::class)->name('project.index');
     Route::prefix('project/{project_uuid}')->group(function () {

--- a/tests/Feature/DeploymentsIndexPageTest.php
+++ b/tests/Feature/DeploymentsIndexPageTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use App\Enums\ApplicationDeploymentStatus;
+use App\Livewire\Deployments\Index as DeploymentsGlobalIndex;
+use App\Models\Application;
+use App\Models\ApplicationDeploymentQueue;
+use App\Models\InstanceSettings;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::updateOrCreate(['id' => 0]);
+
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+
+    $this->actingAs($this->user);
+    session(['currentTeam' => $this->team]);
+
+    $this->server = Server::factory()->create(['team_id' => $this->team->id]);
+    $this->destination = StandaloneDocker::where('server_id', $this->server->id)->first();
+    $this->project = Project::factory()->create(['team_id' => $this->team->id]);
+    $this->environment = $this->project->environments()->first();
+
+    $this->application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => $this->destination->getMorphClass(),
+        'name' => 'My Test App',
+    ]);
+});
+
+test('deployments index lists team deployment', function () {
+    ApplicationDeploymentQueue::create([
+        'deployment_uuid' => 'global-page-test-uuid',
+        'application_id' => $this->application->id,
+        'application_name' => $this->application->name,
+        'server_id' => $this->server->id,
+        'server_name' => $this->server->name,
+        'status' => ApplicationDeploymentStatus::FINISHED->value,
+        'deployment_url' => '/project/'.$this->project->uuid.'/environment/'.$this->environment->uuid.'/application/'.$this->application->uuid.'/deployment/global-page-test-uuid',
+        'git_type' => 'github',
+    ]);
+
+    Livewire::test(DeploymentsGlobalIndex::class)
+        ->assertOk()
+        ->assertSee('My Test App')
+        ->assertSee('Github');
+});
+
+test('deployments index hides other team deployments', function () {
+    $otherTeam = Team::factory()->create();
+    $otherServer = Server::factory()->create(['team_id' => $otherTeam->id]);
+    $otherDestination = StandaloneDocker::where('server_id', $otherServer->id)->first();
+    $otherProject = Project::factory()->create(['team_id' => $otherTeam->id]);
+    $otherEnvironment = $otherProject->environments()->first();
+    $otherApplication = Application::factory()->create([
+        'environment_id' => $otherEnvironment->id,
+        'destination_id' => $otherDestination->id,
+        'destination_type' => $otherDestination->getMorphClass(),
+        'name' => 'Secret Other App',
+    ]);
+
+    ApplicationDeploymentQueue::create([
+        'deployment_uuid' => 'other-team-deployment',
+        'application_id' => $otherApplication->id,
+        'application_name' => $otherApplication->name,
+        'server_id' => $otherServer->id,
+        'server_name' => $otherServer->name,
+        'status' => ApplicationDeploymentStatus::FINISHED->value,
+    ]);
+
+    Livewire::test(DeploymentsGlobalIndex::class)
+        ->assertDontSee('Secret Other App');
+});
+
+test('deployments index component renders for authenticated users', function () {
+    Livewire::test(DeploymentsGlobalIndex::class)
+        ->assertOk()
+        ->assertSee('Deployments')
+        ->assertSee('History');
+});


### PR DESCRIPTION
/claim #7596

## Summary
- add a global Deployments page with a sidebar entry
- list deployment history across the current team with filters for project/server/source/status
- hide singleton filters, add first-page polling, and add Deployments to global search
- reduce deployments indicator opacity on the deployments page

## Validation
- ./vendor/bin/pint --dirty --format agent
- php artisan test --compact tests/Feature/DeploymentsIndexPageTest.php

## Notes
- This keeps the UI aligned with the existing application deployment history patterns.
- A short demo video will be added in follow-up if needed for bounty review.