### PR TITLE
feat(auth): support OAuth self-registration and OAuth-only accounts

### DIFF
--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\ResetsUserPasswords;
 
 class ResetUserPassword implements ResetsUserPasswords
@@ -17,6 +18,13 @@ class ResetUserPassword implements ResetsUserPasswords
      */
     public function reset(User $user, array $input): void
     {
+        $settings = instanceSettings();
+        if (($settings->is_oauth_only_enabled ?? false) && is_null($user->password)) {
+            throw ValidationException::withMessages([
+                'email' => 'Password reset is disabled for OAuth-only accounts. Please sign in with your OAuth provider.',
+            ]);
+        }
+
         Validator::make($input, [
             'password' => ['required', Password::defaults(), 'confirmed'],
         ])->validate();

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -53,6 +53,13 @@ class Controller extends BaseController
             $request->merge([
                 'email' => Str::lower($arrayOfRequest['email']),
             ]);
+            $settings = instanceSettings();
+            $user = User::whereEmail($request->input(Fortify::email()))->first();
+            if (($settings->is_oauth_only_enabled ?? false) && $user && is_null($user->password)) {
+                return back()->withErrors([
+                    'email' => 'Password reset is disabled for OAuth-only accounts. Please sign in with your OAuth provider.',
+                ]);
+            }
             $type = set_transanctional_email_settings();
             if (blank($type)) {
                 return response()->json(['message' => 'Transactional emails are not active'], 400);

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -22,8 +22,8 @@ class OauthController extends Controller
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
-                    abort(403, 'Registration is disabled');
+                if (! $settings->is_registration_enabled && ! ($settings->is_oauth_registration_enabled ?? false)) {
+                    abort(403, 'OAuth registration is disabled');
                 }
 
                 $user = User::create([
@@ -35,6 +35,10 @@ class OauthController extends Controller
 
             return redirect('/');
         } catch (\Exception $e) {
+            if ($e instanceof HttpException && filled($e->getMessage())) {
+                return redirect()->route('login')->withErrors([$e->getMessage()]);
+            }
+
             $errorCode = $e instanceof HttpException ? 'auth.failed' : 'auth.failed.callback';
 
             return redirect()->route('login')->withErrors([__($errorCode)]);

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -15,6 +15,12 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $is_oauth_registration_enabled;
+
+    #[Validate('boolean')]
+    public bool $is_oauth_only_enabled;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -41,6 +47,8 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_registration_enabled' => 'boolean',
+            'is_oauth_only_enabled' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => 'nullable|string',
@@ -62,6 +70,8 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled ?? false;
+        $this->is_oauth_only_enabled = $this->settings->is_oauth_only_enabled ?? false;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -142,6 +152,8 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
+            $this->settings->is_oauth_only_enabled = $this->is_oauth_only_enabled;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -31,6 +31,8 @@ class InstanceSettings extends Model
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',
         'is_wire_navigate_enabled' => 'boolean',
+        'is_oauth_registration_enabled' => 'boolean',
+        'is_oauth_only_enabled' => 'boolean',
     ];
 
     protected static function booted(): void

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -67,6 +67,7 @@ class FortifyServiceProvider extends ServiceProvider
 
             return view('auth.login', [
                 'is_registration_enabled' => $settings->is_registration_enabled,
+                'is_oauth_registration_enabled' => $settings->is_oauth_registration_enabled ?? false,
                 'enabled_oauth_providers' => $enabled_oauth_providers,
             ]);
         });

--- a/database/migrations/2026_03_28_120000_add_oauth_auth_settings_to_instance_settings.php
+++ b/database/migrations/2026_03_28_120000_add_oauth_auth_settings_to_instance_settings.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_registration_enabled')->default(false)->after('is_registration_enabled');
+            $table->boolean('is_oauth_only_enabled')->default(false)->after('is_oauth_registration_enabled');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn(['is_oauth_registration_enabled', 'is_oauth_only_enabled']);
+        });
+    }
+};

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -70,6 +70,10 @@
                             class="block w-full text-center py-3 px-4 rounded-lg border border-neutral-300 dark:border-coolgray-400 font-medium hover:border-coollabs dark:hover:border-warning transition-colors">
                             {{ __('auth.register_now') }}
                         </a>
+                    @elseif ($enabled_oauth_providers->isNotEmpty() && $is_oauth_registration_enabled)
+                        <div class="mt-6 text-center text-sm text-neutral-500 dark:text-neutral-400">
+                            Self-registration is available through the OAuth providers below.
+                        </div>
                     @else
                         <div class="mt-6 text-center text-sm text-neutral-500 dark:text-neutral-400">
                             {{ __('auth.registration_disabled') }}

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -16,10 +16,21 @@
                 <div class="pb-4">Advanced settings for your Coolify instance.</div>
 
                 <div class="flex flex-col gap-1">
+                    <h4 class="pt-2">Authentication Settings</h4>
                     <div class="md:w-96">
                         <x-forms.checkbox instantSave id="is_registration_enabled"
                             helper="Allow users to self-register. If disabled, only administrators can create accounts."
                             label="Registration Allowed" />
+                    </div>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_registration_enabled"
+                            helper="Allow users signing in with an enabled OAuth provider to create an account even when password registration is disabled."
+                            label="OAuth Self-Registration" />
+                    </div>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_only_enabled"
+                            helper="Users created through OAuth cannot create or reset passwords and must continue signing in with their OAuth provider."
+                            label="OAuth-Only Accounts" />
                     </div>
                     <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"

--- a/tests/Feature/OauthAuthenticationSettingsTest.php
+++ b/tests/Feature/OauthAuthenticationSettingsTest.php
@@ -1,0 +1,116 @@
+<?php
+
+use App\Actions\Fortify\ResetUserPassword;
+use App\Models\InstanceSettings;
+use App\Models\OauthSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Validation\ValidationException;
+use Laravel\Socialite\Facades\Socialite;
+use Mockery;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::create(['id' => 0]);
+});
+
+it('allows oauth self registration when password registration is disabled', function () {
+    instanceSettings()->update([
+        'is_registration_enabled' => false,
+        'is_oauth_registration_enabled' => true,
+    ]);
+
+    OauthSetting::create([
+        'provider' => 'github',
+        'enabled' => true,
+        'client_id' => 'client-id',
+        'client_secret' => 'client-secret',
+    ]);
+
+    $oauthProvider = Mockery::mock();
+    $oauthProvider->shouldReceive('user')->once()->andReturn((object) [
+        'name' => 'OAuth User',
+        'email' => 'oauth@example.com',
+    ]);
+
+    Socialite::shouldReceive('buildProvider')->once()->andReturn($oauthProvider);
+
+    $response = $this->get('/auth/github/callback');
+
+    $response->assertRedirect('/');
+    $this->assertAuthenticated();
+    expect(User::whereEmail('oauth@example.com')->exists())->toBeTrue();
+});
+
+it('blocks oauth self registration when both registration paths are disabled', function () {
+    instanceSettings()->update([
+        'is_registration_enabled' => false,
+        'is_oauth_registration_enabled' => false,
+    ]);
+
+    OauthSetting::create([
+        'provider' => 'github',
+        'enabled' => true,
+        'client_id' => 'client-id',
+        'client_secret' => 'client-secret',
+    ]);
+
+    $oauthProvider = Mockery::mock();
+    $oauthProvider->shouldReceive('user')->once()->andReturn((object) [
+        'name' => 'OAuth User',
+        'email' => 'oauth@example.com',
+    ]);
+
+    Socialite::shouldReceive('buildProvider')->once()->andReturn($oauthProvider);
+
+    $response = $this->get('/auth/github/callback');
+
+    $response->assertRedirect('/login');
+    $response->assertSessionHasErrors();
+    $this->assertGuest();
+    expect(User::whereEmail('oauth@example.com')->exists())->toBeFalse();
+});
+
+it('renders oauth self registration messaging on the login page', function () {
+    instanceSettings()->update([
+        'is_registration_enabled' => false,
+        'is_oauth_registration_enabled' => true,
+    ]);
+
+    OauthSetting::create([
+        'provider' => 'github',
+        'enabled' => true,
+        'client_id' => 'client-id',
+        'client_secret' => 'client-secret',
+    ]);
+
+    User::factory()->create([
+        'email' => 'existing@example.com',
+    ]);
+
+    $response = $this->get('/login');
+
+    $response->assertOk();
+    $response->assertSee('Self-registration is available through the OAuth providers below.');
+    $response->assertDontSee('Register Now');
+});
+
+it('prevents oauth-only accounts from creating passwords through reset flow', function () {
+    instanceSettings()->update([
+        'is_oauth_only_enabled' => true,
+    ]);
+
+    $user = User::factory()->create([
+        'email' => 'oauth@example.com',
+        'password' => null,
+    ]);
+
+    expect(fn () => app(ResetUserPassword::class)->reset($user, [
+        'password' => 'Password1!@',
+        'password_confirmation' => 'Password1!@',
+    ]))->toThrow(ValidationException::class);
+
+    $user->refresh();
+    expect($user->password)->toBeNull();
+});


### PR DESCRIPTION
Closes #8042

## Summary
- allow OAuth sign-in to create accounts even when password registration is disabled
- add instance-level toggles for OAuth self-registration and OAuth-only accounts
- block password reset for OAuth-only users that do not have a local password
- add feature coverage for OAuth registration gating and OAuth-only password-reset restrictions

## Notes
- I could not run the Laravel test suite locally in this runner because `php` is not available on PATH.
- The PR targets `next`, matching the issue scope and current implementation branch.