### PR TITLE
feat(service): add Docker Mailserver service template

### DIFF
--- a/public/svgs/docker-mailserver.svg
+++ b/public/svgs/docker-mailserver.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#3B82F6" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="2" y="4" width="20" height="16" rx="2"/>
+  <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/>
+</svg>

--- a/templates/compose/docker-mailserver.yaml
+++ b/templates/compose/docker-mailserver.yaml
@@ -1,0 +1,30 @@
+# documentation: https://docker-mailserver.github.io/docker-mailserver/latest/
+# slogan: A fullstack but simple mail server with SMTP, IMAP, DKIM, and anti-spam.
+# category: hosting
+# tags: email, mail, smtp, imap, postfix, dovecot, dkim
+# logo: svgs/docker-mailserver.svg
+# port: 25
+
+services:
+  mailserver:
+    image: ghcr.io/docker-mailserver/docker-mailserver:latest
+    hostname: ${MAIL_HOSTNAME:-mail.example.com}
+    environment:
+      - OVERRIDE_HOSTNAME=${MAIL_HOSTNAME:-mail.example.com}
+      - POSTMASTER_ADDRESS=${POSTMASTER_ADDRESS:-postmaster@example.com}
+      - ENABLE_CLAMAV=0
+      - ENABLE_SPAMASSASSIN=1
+      - SPOOF_PROTECTION=1
+      - PERMIT_DOCKER=none
+      - ONE_DIR=1
+    volumes:
+      - mail-data:/var/mail
+      - mail-state:/var/mail-state
+      - mail-logs:/var/log/mail
+      - mail-config:/tmp/docker-mailserver
+    stop_grace_period: 1m
+    healthcheck:
+      test: ["CMD-SHELL", "ss --listening --tcp | grep -P 'LISTEN.+:smtp' || exit 1"]
+      interval: 20s
+      timeout: 10s
+      retries: 5


### PR DESCRIPTION
## Changes

Add Docker Mailserver service template for self-hosted email with SMTP, IMAP, DKIM, and anti-spam. Uses the official ghcr.io/docker-mailserver image with healthcheck, volume persistence, and sensible defaults.

## Issues

- Fixes #8266

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A — service template, no UI changes.

## AI Assistance

- [x] AI was NOT used to create this PR

## Testing

- Started container, created email account via `setup email add`
- Verified SMTP and IMAP ports listening
- Sent test email via sendmail — delivered to mailbox
- Docker healthcheck reports healthy

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.