### PR TITLE
refactor: scope server and project queries to current team

### DIFF
--- a/app/Http/Controllers/Api/DeployController.php
+++ b/app/Http/Controllers/Api/DeployController.php
@@ -250,7 +250,7 @@ class DeployController extends Controller
             ]);
 
             // Get the server
-            $server = Server::find($build_server_id);
+            $server = Server::whereTeamId($teamId)->find($build_server_id);
 
             if ($server) {
                 // Add cancellation log entry

--- a/app/Livewire/Boarding/Index.php
+++ b/app/Livewire/Boarding/Index.php
@@ -432,6 +432,9 @@ class Index extends Component
     public function selectExistingProject()
     {
         $this->createdProject = Project::ownedByCurrentTeam()->find($this->selectedProject);
+        if (! $this->createdProject) {
+            return $this->dispatch('error', 'Project not found.');
+        }
         $this->currentState = 'create-resource';
     }
 

--- a/app/Livewire/Boarding/Index.php
+++ b/app/Livewire/Boarding/Index.php
@@ -121,7 +121,7 @@ class Index extends Component
             }
 
             if ($this->selectedExistingServer) {
-                $this->createdServer = Server::find($this->selectedExistingServer);
+                $this->createdServer = Server::ownedByCurrentTeam()->find($this->selectedExistingServer);
                 if ($this->createdServer) {
                     $this->serverPublicKey = $this->createdServer->privateKey->getPublicKey();
                     $this->updateServerDetails();
@@ -145,7 +145,7 @@ class Index extends Component
         }
 
         if ($this->selectedProject) {
-            $this->createdProject = Project::find($this->selectedProject);
+            $this->createdProject = Project::ownedByCurrentTeam()->find($this->selectedProject);
             if (! $this->createdProject) {
                 $this->projects = Project::ownedByCurrentTeam(['name'])->get();
             }
@@ -431,7 +431,7 @@ class Index extends Component
 
     public function selectExistingProject()
     {
-        $this->createdProject = Project::find($this->selectedProject);
+        $this->createdProject = Project::ownedByCurrentTeam()->find($this->selectedProject);
         $this->currentState = 'create-resource';
     }
 

--- a/app/Livewire/GlobalSearch.php
+++ b/app/Livewire/GlobalSearch.php
@@ -1203,7 +1203,7 @@ class GlobalSearch extends Component
     public function loadDestinations()
     {
         $this->loadingDestinations = true;
-        $server = Server::find($this->selectedServerId);
+        $server = Server::ownedByCurrentTeam()->find($this->selectedServerId);
 
         if (! $server) {
             $this->loadingDestinations = false;
@@ -1280,7 +1280,7 @@ class GlobalSearch extends Component
     public function loadEnvironments()
     {
         $this->loadingEnvironments = true;
-        $project = Project::where('uuid', $this->selectedProjectUuid)->first();
+        $project = Project::ownedByCurrentTeam()->where('uuid', $this->selectedProjectUuid)->first();
 
         if (! $project) {
             $this->loadingEnvironments = false;

--- a/app/Livewire/Project/CloneMe.php
+++ b/app/Livewire/Project/CloneMe.php
@@ -54,7 +54,7 @@ class CloneMe extends Component
     public function mount($project_uuid)
     {
         $this->project_uuid = $project_uuid;
-        $this->project = Project::where('uuid', $project_uuid)->firstOrFail();
+        $this->project = Project::ownedByCurrentTeam()->where('uuid', $project_uuid)->firstOrFail();
         $this->environment = $this->project->environments->where('uuid', $this->environment_uuid)->first();
         $this->project_id = $this->project->id;
         $this->servers = currentTeam()

--- a/app/Livewire/Project/DeleteProject.php
+++ b/app/Livewire/Project/DeleteProject.php
@@ -21,7 +21,7 @@ class DeleteProject extends Component
     public function mount()
     {
         $this->parameters = get_route_parameters();
-        $this->projectName = Project::findOrFail($this->project_id)->name;
+        $this->projectName = Project::ownedByCurrentTeam()->findOrFail($this->project_id)->name;
     }
 
     public function delete()
@@ -29,7 +29,7 @@ class DeleteProject extends Component
         $this->validate([
             'project_id' => 'required|int',
         ]);
-        $project = Project::findOrFail($this->project_id);
+        $project = Project::ownedByCurrentTeam()->findOrFail($this->project_id);
         $this->authorize('delete', $project);
 
         if ($project->isEmpty()) {

--- a/app/Livewire/Project/New/DockerCompose.php
+++ b/app/Livewire/Project/New/DockerCompose.php
@@ -41,7 +41,7 @@ class DockerCompose extends Component
             // Validate for command injection BEFORE saving to database
             validateDockerComposeForInjection($this->dockerComposeRaw);
 
-            $project = Project::where('uuid', $this->parameters['project_uuid'])->first();
+            $project = Project::ownedByCurrentTeam()->where('uuid', $this->parameters['project_uuid'])->first();
             $environment = $project->load(['environments'])->environments->where('uuid', $this->parameters['environment_uuid'])->first();
 
             $destination_uuid = $this->query['destination'];

--- a/app/Livewire/Project/New/DockerCompose.php
+++ b/app/Livewire/Project/New/DockerCompose.php
@@ -41,8 +41,8 @@ class DockerCompose extends Component
             // Validate for command injection BEFORE saving to database
             validateDockerComposeForInjection($this->dockerComposeRaw);
 
-            $project = Project::ownedByCurrentTeam()->where('uuid', $this->parameters['project_uuid'])->first();
-            $environment = $project->load(['environments'])->environments->where('uuid', $this->parameters['environment_uuid'])->first();
+            $project = Project::ownedByCurrentTeam()->where('uuid', $this->parameters['project_uuid'])->firstOrFail();
+            $environment = $project->environments()->where('uuid', $this->parameters['environment_uuid'])->firstOrFail();
 
             $destination_uuid = $this->query['destination'];
             $destination = StandaloneDocker::where('uuid', $destination_uuid)->first();

--- a/app/Livewire/Project/New/DockerImage.php
+++ b/app/Livewire/Project/New/DockerImage.php
@@ -121,8 +121,8 @@ class DockerImage extends Component
         }
         $destination_class = $destination->getMorphClass();
 
-        $project = Project::ownedByCurrentTeam()->where('uuid', $this->parameters['project_uuid'])->first();
-        $environment = $project->load(['environments'])->environments->where('uuid', $this->parameters['environment_uuid'])->first();
+        $project = Project::ownedByCurrentTeam()->where('uuid', $this->parameters['project_uuid'])->firstOrFail();
+        $environment = $project->environments()->where('uuid', $this->parameters['environment_uuid'])->firstOrFail();
 
         // Append @sha256 to image name if using digest and not already present
         $imageName = $parser->getFullImageNameWithoutTag();

--- a/app/Livewire/Project/New/DockerImage.php
+++ b/app/Livewire/Project/New/DockerImage.php
@@ -121,7 +121,7 @@ class DockerImage extends Component
         }
         $destination_class = $destination->getMorphClass();
 
-        $project = Project::where('uuid', $this->parameters['project_uuid'])->first();
+        $project = Project::ownedByCurrentTeam()->where('uuid', $this->parameters['project_uuid'])->first();
         $environment = $project->load(['environments'])->environments->where('uuid', $this->parameters['environment_uuid'])->first();
 
         // Append @sha256 to image name if using digest and not already present

--- a/app/Livewire/Project/New/GithubPrivateRepository.php
+++ b/app/Livewire/Project/New/GithubPrivateRepository.php
@@ -185,7 +185,7 @@ class GithubPrivateRepository extends Component
             }
             $destination_class = $destination->getMorphClass();
 
-            $project = Project::where('uuid', $this->parameters['project_uuid'])->first();
+            $project = Project::ownedByCurrentTeam()->where('uuid', $this->parameters['project_uuid'])->first();
             $environment = $project->load(['environments'])->environments->where('uuid', $this->parameters['environment_uuid'])->first();
 
             $application = Application::create([

--- a/app/Livewire/Project/New/GithubPrivateRepository.php
+++ b/app/Livewire/Project/New/GithubPrivateRepository.php
@@ -185,8 +185,8 @@ class GithubPrivateRepository extends Component
             }
             $destination_class = $destination->getMorphClass();
 
-            $project = Project::ownedByCurrentTeam()->where('uuid', $this->parameters['project_uuid'])->first();
-            $environment = $project->load(['environments'])->environments->where('uuid', $this->parameters['environment_uuid'])->first();
+            $project = Project::ownedByCurrentTeam()->where('uuid', $this->parameters['project_uuid'])->firstOrFail();
+            $environment = $project->environments()->where('uuid', $this->parameters['environment_uuid'])->firstOrFail();
 
             $application = Application::create([
                 'name' => generate_application_name($this->selected_repository_owner.'/'.$this->selected_repository_repo, $this->selected_branch_name),

--- a/app/Livewire/Project/New/GithubPrivateRepositoryDeployKey.php
+++ b/app/Livewire/Project/New/GithubPrivateRepositoryDeployKey.php
@@ -144,7 +144,7 @@ class GithubPrivateRepositoryDeployKey extends Component
             // Note: git_repository has already been validated and transformed in get_git_source()
             // It may now be in SSH format (git@host:repo.git) which is valid for deploy keys
 
-            $project = Project::where('uuid', $this->parameters['project_uuid'])->first();
+            $project = Project::ownedByCurrentTeam()->where('uuid', $this->parameters['project_uuid'])->first();
             $environment = $project->load(['environments'])->environments->where('uuid', $this->parameters['environment_uuid'])->first();
             if ($this->git_source === 'other') {
                 $application_init = [

--- a/app/Livewire/Project/New/GithubPrivateRepositoryDeployKey.php
+++ b/app/Livewire/Project/New/GithubPrivateRepositoryDeployKey.php
@@ -144,8 +144,8 @@ class GithubPrivateRepositoryDeployKey extends Component
             // Note: git_repository has already been validated and transformed in get_git_source()
             // It may now be in SSH format (git@host:repo.git) which is valid for deploy keys
 
-            $project = Project::ownedByCurrentTeam()->where('uuid', $this->parameters['project_uuid'])->first();
-            $environment = $project->load(['environments'])->environments->where('uuid', $this->parameters['environment_uuid'])->first();
+            $project = Project::ownedByCurrentTeam()->where('uuid', $this->parameters['project_uuid'])->firstOrFail();
+            $environment = $project->environments()->where('uuid', $this->parameters['environment_uuid'])->firstOrFail();
             if ($this->git_source === 'other') {
                 $application_init = [
                     'name' => generate_random_name(),

--- a/app/Livewire/Project/New/PublicGitRepository.php
+++ b/app/Livewire/Project/New/PublicGitRepository.php
@@ -278,7 +278,7 @@ class PublicGitRepository extends Component
             }
             $destination_class = $destination->getMorphClass();
 
-            $project = Project::where('uuid', $project_uuid)->first();
+            $project = Project::ownedByCurrentTeam()->where('uuid', $project_uuid)->first();
             $environment = $project->load(['environments'])->environments->where('uuid', $environment_uuid)->first();
 
             if ($this->build_pack === 'dockercompose' && isDev() && $this->new_compose_services) {

--- a/app/Livewire/Project/New/PublicGitRepository.php
+++ b/app/Livewire/Project/New/PublicGitRepository.php
@@ -278,8 +278,8 @@ class PublicGitRepository extends Component
             }
             $destination_class = $destination->getMorphClass();
 
-            $project = Project::ownedByCurrentTeam()->where('uuid', $project_uuid)->first();
-            $environment = $project->load(['environments'])->environments->where('uuid', $environment_uuid)->first();
+            $project = Project::ownedByCurrentTeam()->where('uuid', $project_uuid)->firstOrFail();
+            $environment = $project->environments()->where('uuid', $environment_uuid)->firstOrFail();
 
             if ($this->build_pack === 'dockercompose' && isDev() && $this->new_compose_services) {
                 $server = $destination->server;

--- a/app/Livewire/Project/New/Select.php
+++ b/app/Livewire/Project/New/Select.php
@@ -65,7 +65,7 @@ class Select extends Component
                 $this->existingPostgresqlUrl = 'postgres://coolify:password@coolify-db:5432';
             }
             $projectUuid = data_get($this->parameters, 'project_uuid');
-            $project = Project::whereUuid($projectUuid)->firstOrFail();
+            $project = Project::ownedByCurrentTeam()->whereUuid($projectUuid)->firstOrFail();
             $this->environments = $project->environments;
             $this->selectedEnvironment = $this->environments->where('uuid', data_get($this->parameters, 'environment_uuid'))->firstOrFail()->name;
 
@@ -79,7 +79,7 @@ class Select extends Component
                 $this->type = $queryType;
                 $this->server_id = $queryServerId;
                 $this->destination_uuid = $queryDestination;
-                $this->server = Server::find($queryServerId);
+                $this->server = Server::ownedByCurrentTeam()->find($queryServerId);
                 $this->current_step = 'select-postgresql-type';
             }
         } catch (\Exception $e) {

--- a/app/Livewire/Project/New/SimpleDockerfile.php
+++ b/app/Livewire/Project/New/SimpleDockerfile.php
@@ -45,8 +45,8 @@ CMD ["nginx", "-g", "daemon off;"]
         }
         $destination_class = $destination->getMorphClass();
 
-        $project = Project::ownedByCurrentTeam()->where('uuid', $this->parameters['project_uuid'])->first();
-        $environment = $project->load(['environments'])->environments->where('uuid', $this->parameters['environment_uuid'])->first();
+        $project = Project::ownedByCurrentTeam()->where('uuid', $this->parameters['project_uuid'])->firstOrFail();
+        $environment = $project->environments()->where('uuid', $this->parameters['environment_uuid'])->firstOrFail();
 
         $port = get_port_from_dockerfile($this->dockerfile);
         if (! $port) {

--- a/app/Livewire/Project/New/SimpleDockerfile.php
+++ b/app/Livewire/Project/New/SimpleDockerfile.php
@@ -45,7 +45,7 @@ CMD ["nginx", "-g", "daemon off;"]
         }
         $destination_class = $destination->getMorphClass();
 
-        $project = Project::where('uuid', $this->parameters['project_uuid'])->first();
+        $project = Project::ownedByCurrentTeam()->where('uuid', $this->parameters['project_uuid'])->first();
         $environment = $project->load(['environments'])->environments->where('uuid', $this->parameters['environment_uuid'])->first();
 
         $port = get_port_from_dockerfile($this->dockerfile);

--- a/tests/Feature/CrossTeamIdorServerProjectTest.php
+++ b/tests/Feature/CrossTeamIdorServerProjectTest.php
@@ -78,6 +78,7 @@ describe('Boarding Project IDOR (GHSA-qfcc-2fm3-9q42)', function () {
             ->call('selectExistingProject');
 
         expect($component->get('createdProject'))->toBeNull();
+        $component->assertDispatched('error');
     });
 
     test('boarding selectExistingProject can load own team project', function () {
@@ -115,8 +116,7 @@ describe('GlobalSearch Project IDOR (GHSA-qfcc-2fm3-9q42)', function () {
 describe('DeleteProject IDOR (GHSA-qfcc-2fm3-9q42)', function () {
     test('cannot mount DeleteProject with project from another team', function () {
         // Should throw ModelNotFoundException (404) because team-scoped query won't find it
-        Livewire::test(DeleteProject::class, ['project_id' => $this->projectB->id])
-            ->assertStatus(500); // findOrFail throws ModelNotFoundException
+        Livewire::test(DeleteProject::class, ['project_id' => $this->projectB->id]);
     })->throws(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
 
     test('can mount DeleteProject with own team project', function () {

--- a/tests/Feature/CrossTeamIdorServerProjectTest.php
+++ b/tests/Feature/CrossTeamIdorServerProjectTest.php
@@ -1,0 +1,182 @@
+<?php
+
+use App\Livewire\Boarding\Index as BoardingIndex;
+use App\Livewire\GlobalSearch;
+use App\Livewire\Project\CloneMe;
+use App\Livewire\Project\DeleteProject;
+use App\Models\Environment;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    // Attacker: Team A
+    $this->userA = User::factory()->create();
+    $this->teamA = Team::factory()->create();
+    $this->userA->teams()->attach($this->teamA, ['role' => 'owner']);
+
+    $this->serverA = Server::factory()->create(['team_id' => $this->teamA->id]);
+    $this->projectA = Project::factory()->create(['team_id' => $this->teamA->id]);
+    $this->environmentA = Environment::factory()->create(['project_id' => $this->projectA->id]);
+
+    // Victim: Team B
+    $this->userB = User::factory()->create();
+    $this->teamB = Team::factory()->create();
+    $this->userB->teams()->attach($this->teamB, ['role' => 'owner']);
+
+    $this->serverB = Server::factory()->create(['team_id' => $this->teamB->id]);
+    $this->projectB = Project::factory()->create(['team_id' => $this->teamB->id]);
+    $this->environmentB = Environment::factory()->create(['project_id' => $this->projectB->id]);
+
+    // Act as attacker (Team A)
+    $this->actingAs($this->userA);
+    session(['currentTeam' => $this->teamA]);
+});
+
+describe('Boarding Server IDOR (GHSA-qfcc-2fm3-9q42)', function () {
+    test('boarding mount cannot load server from another team via selectedExistingServer', function () {
+        $component = Livewire::test(BoardingIndex::class, [
+            'selectedServerType' => 'remote',
+            'selectedExistingServer' => $this->serverB->id,
+        ]);
+
+        // The server from Team B should NOT be loaded
+        expect($component->get('createdServer'))->toBeNull();
+    });
+
+    test('boarding mount can load own team server via selectedExistingServer', function () {
+        $component = Livewire::test(BoardingIndex::class, [
+            'selectedServerType' => 'remote',
+            'selectedExistingServer' => $this->serverA->id,
+        ]);
+
+        // Own team server should load successfully
+        expect($component->get('createdServer'))->not->toBeNull();
+        expect($component->get('createdServer')->id)->toBe($this->serverA->id);
+    });
+});
+
+describe('Boarding Project IDOR (GHSA-qfcc-2fm3-9q42)', function () {
+    test('boarding mount cannot load project from another team via selectedProject', function () {
+        $component = Livewire::test(BoardingIndex::class, [
+            'selectedProject' => $this->projectB->id,
+        ]);
+
+        // The project from Team B should NOT be loaded
+        expect($component->get('createdProject'))->toBeNull();
+    });
+
+    test('boarding selectExistingProject cannot load project from another team', function () {
+        $component = Livewire::test(BoardingIndex::class)
+            ->set('selectedProject', $this->projectB->id)
+            ->call('selectExistingProject');
+
+        expect($component->get('createdProject'))->toBeNull();
+    });
+
+    test('boarding selectExistingProject can load own team project', function () {
+        $component = Livewire::test(BoardingIndex::class)
+            ->set('selectedProject', $this->projectA->id)
+            ->call('selectExistingProject');
+
+        expect($component->get('createdProject'))->not->toBeNull();
+        expect($component->get('createdProject')->id)->toBe($this->projectA->id);
+    });
+});
+
+describe('GlobalSearch Server IDOR (GHSA-qfcc-2fm3-9q42)', function () {
+    test('loadDestinations cannot access server from another team', function () {
+        $component = Livewire::test(GlobalSearch::class)
+            ->set('selectedServerId', $this->serverB->id)
+            ->call('loadDestinations');
+
+        // Should dispatch error because server is not found (team-scoped)
+        $component->assertDispatched('error');
+    });
+});
+
+describe('GlobalSearch Project IDOR (GHSA-qfcc-2fm3-9q42)', function () {
+    test('loadEnvironments cannot access project from another team', function () {
+        $component = Livewire::test(GlobalSearch::class)
+            ->set('selectedProjectUuid', $this->projectB->uuid)
+            ->call('loadEnvironments');
+
+        // Should not load environments from another team's project
+        expect($component->get('availableEnvironments'))->toBeEmpty();
+    });
+});
+
+describe('DeleteProject IDOR (GHSA-qfcc-2fm3-9q42)', function () {
+    test('cannot mount DeleteProject with project from another team', function () {
+        // Should throw ModelNotFoundException (404) because team-scoped query won't find it
+        Livewire::test(DeleteProject::class, ['project_id' => $this->projectB->id])
+            ->assertStatus(500); // findOrFail throws ModelNotFoundException
+    })->throws(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+
+    test('can mount DeleteProject with own team project', function () {
+        $component = Livewire::test(DeleteProject::class, ['project_id' => $this->projectA->id]);
+
+        expect($component->get('projectName'))->toBe($this->projectA->name);
+    });
+});
+
+describe('CloneMe Project IDOR (GHSA-qfcc-2fm3-9q42)', function () {
+    test('cannot mount CloneMe with project UUID from another team', function () {
+        // Should throw ModelNotFoundException because team-scoped query won't find it
+        Livewire::test(CloneMe::class, [
+            'project_uuid' => $this->projectB->uuid,
+            'environment_uuid' => $this->environmentB->uuid,
+        ]);
+    })->throws(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+
+    test('can mount CloneMe with own team project UUID', function () {
+        $component = Livewire::test(CloneMe::class, [
+            'project_uuid' => $this->projectA->uuid,
+            'environment_uuid' => $this->environmentA->uuid,
+        ]);
+
+        expect($component->get('project_id'))->toBe($this->projectA->id);
+    });
+});
+
+describe('DeployController API Server IDOR (GHSA-qfcc-2fm3-9q42)', function () {
+    test('deploy cancel API cannot access build server from another team', function () {
+        // Create a deployment queue entry that references Team B's server as build_server
+        $application = \App\Models\Application::factory()->create([
+            'environment_id' => $this->environmentA->id,
+            'destination_id' => StandaloneDocker::factory()->create(['server_id' => $this->serverA->id])->id,
+            'destination_type' => StandaloneDocker::class,
+        ]);
+
+        $deployment = \App\Models\ApplicationDeploymentQueue::create([
+            'application_id' => $application->id,
+            'deployment_uuid' => 'test-deploy-' . fake()->uuid(),
+            'server_id' => $this->serverA->id,
+            'build_server_id' => $this->serverB->id, // Cross-team build server
+            'status' => \App\Enums\ApplicationDeploymentStatus::IN_PROGRESS->value,
+        ]);
+
+        $token = $this->userA->createToken('test-token', ['*']);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $token->plainTextToken,
+        ])->deleteJson("/api/v1/deployments/{$deployment->deployment_uuid}");
+
+        // The cancellation should proceed but the build_server should NOT be found
+        // (team-scoped query returns null for Team B's server)
+        // The deployment gets cancelled but no remote process runs on the wrong server
+        $response->assertOk();
+
+        // Verify the deployment was cancelled
+        $deployment->refresh();
+        expect($deployment->status)->toBe(
+            \App\Enums\ApplicationDeploymentStatus::CANCELLED_BY_USER->value
+        );
+    });
+});


### PR DESCRIPTION
## Summary

- Ensure all `Server` and `Project` lookups in Livewire components and API controllers use team-scoped queries (`ownedByCurrentTeam()` / `whereTeamId()`) instead of unscoped `find()` / `where()` calls
- Enforces consistent multi-tenant data isolation across all user-facing code paths
- Adds tests to verify team-scoped query behavior

## Changes

- `app/Livewire/Boarding/Index.php` — scope server and project lookups to current team
- `app/Livewire/GlobalSearch.php` — scope server and project lookups in destination/environment loading
- `app/Livewire/Project/New/Select.php` — scope project UUID and server ID lookups
- `app/Livewire/Project/DeleteProject.php` — scope project lookup before delete
- `app/Livewire/Project/CloneMe.php` — scope project UUID lookup
- `app/Livewire/Project/New/DockerCompose.php` — scope project UUID lookup
- `app/Livewire/Project/New/DockerImage.php` — scope project UUID lookup
- `app/Livewire/Project/New/GithubPrivateRepository.php` — scope project UUID lookup
- `app/Livewire/Project/New/GithubPrivateRepositoryDeployKey.php` — scope project UUID lookup
- `app/Livewire/Project/New/PublicGitRepository.php` — scope project UUID lookup
- `app/Livewire/Project/New/SimpleDockerfile.php` — scope project UUID lookup
- `app/Http/Controllers/Api/DeployController.php` — scope build server lookup in cancel endpoint
- `tests/Feature/CrossTeamIdorServerProjectTest.php` — new test coverage

## Test plan

- [ ] Run `php artisan test --compact --filter=CrossTeamIdorServerProject`
- [ ] Verify onboarding flow works with own team's servers and projects
- [ ] Verify global search resource creation flow works correctly
- [ ] Verify project deletion and cloning work for own team's projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)