### PR TITLE
[v5.x] feat: scaffold workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 Most breaking changes are automatically handled by the upgrade migration. See the [v5 Upgrade Guide](docs) for details.
 
+- Most description fields are now limited to 255 characters, as descriptions should rarely need more
 - Database primary keys unified from two columns (numeric `id` + CUIDv2 `uuid`) into a single ULID `id` column
 
 ### Security
@@ -21,10 +22,21 @@ Most breaking changes are automatically handled by the upgrade migration. See th
 - Complete redesign of the Coolify User Interface and User Experience
 - Separate notification email in addition to the user's account email
 - "Remember me" option on login, keeping users authenticated for 14 days (without it, sessions expire after 24 hours of inactivity)
+- **Workspaces**
+  - Workspaces replacing v4 teams (clearer name, fully self-contained and isolated from each other)
+  - Option to require 2FA workspace-wide
+  - Concurrent builds limit and default deployment timeout to workspace settings
+  - Workspace global scope and middleware (~114 lines) replacing ~1,970 manual team checks, written in 12 different ways (~2,800 lines) across ~400 files
+  - Support for multiple workspaces open simultaneously in different browser tabs (via query parameter, avoiding a long and ugly path segment)
+  - Automatic workspace selection via URL parameter > cookie > session > auto-select (single workspace)
+- **Permission System**
+  - `UserRole` enum defining all predefined roles in one place, replacing scattered role-check methods (`isAdmin()`, `isMember()`, etc.) with a single enum-based approach supporting granular permissions and adding new permissions to existing roles without a database migration
+  - `Permission` enum with granular permissions per feature (e.g. `WorkspaceRead`, `WorkspaceCreate`, `WorkspaceUpdate`, `WorkspaceDestroy`), defined as string-backed enums so changes are code-only, not database migrations
+  - Custom roles with configurable permissions assignable to workspace members
 - **v4 to v5 upgrade migration**
   - Coolify v4 database as `old_pgsql` connection
   -
-- Worker Servers that replace build servers with servers that can also run jobs (Horizon workers) in addition to building Docker images
+- Worker servers replacing build servers, capable of running Horizon workers (queue job workers) in addition to building Docker images
 
 ### Changed
 
@@ -58,8 +70,8 @@ Most breaking changes are automatically handled by the upgrade migration. See th
 
 - `laravel.log` file growing indefinitely and consuming excessive disk space
 - Failed jobs being logged into the database (Horizon already handles this) causing excessive disk usage in some cases
-- Maximum concurrent builds setting not being respected when set to more than 4 on v4.x because only 4 Horizon workers are available by default
--
+- Maximum concurrent builds setting not respected when set above 4 in v4, as only 4 Horizon workers were available by default
+- Concurrent builds setting incorrectly scoped per-server instead of workspace-wide
 
 ### Removed
 
@@ -70,6 +82,7 @@ Most breaking changes are automatically handled by the upgrade migration. See th
 
 - All database migrations for a cleaner, more consistent and stable database schema (no more `down()` methods, no more defaults in the DB...)
 - All database models for improved maintainability, consistency and database interoperability (SQLite and Postgres)
+- Many hardcoded or static strings stored in DB columns into automatically cast PHP string-backed enums
 - Hardcoded queue strings replaced with a `ProcessingQueue` enum
 - `config/constants.php` to `config/coolify.php` for all Coolify-specific settings
 - Environment variable naming to be shorter and more consistent

--- a/app/Enums/InvitationMethod.php
+++ b/app/Enums/InvitationMethod.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum InvitationMethod: string
+{
+    case Email = 'email';
+    case Link = 'link';
+}

--- a/app/Enums/Permission.php
+++ b/app/Enums/Permission.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum Permission: string
+{
+    case WorkspaceRead = 'workspaceRead';
+    case WorkspaceCreate = 'workspaceCreate';
+    case WorkspaceUpdate = 'workspaceUpdate';
+    case WorkspaceDestroy = 'workspaceDestroy';
+}

--- a/app/Enums/Permission.php
+++ b/app/Enums/Permission.php
@@ -6,8 +6,8 @@ namespace App\Enums;
 
 enum Permission: string
 {
-    case WorkspaceRead = 'workspaceRead';
     case WorkspaceCreate = 'workspaceCreate';
+    case WorkspaceRead = 'workspaceRead';
     case WorkspaceUpdate = 'workspaceUpdate';
-    case WorkspaceDestroy = 'workspaceDestroy';
+    case WorkspaceDelete = 'workspaceDelete';
 }

--- a/app/Enums/UserRole.php
+++ b/app/Enums/UserRole.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum UserRole: string
+{
+    case Admin = 'admin';
+    case Custom = 'custom';
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Middleware;
 
+use App\Models\Workspace;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
 
@@ -50,6 +51,11 @@ final class HandleInertiaRequests extends Middleware
         return [
             ...parent::share($request),
             'appName' => config()->string('app.name'),
+            'workspace' => function (): ?array {
+                $id = session('workspace');
+
+                return is_string($id) ? Workspace::find($id)?->only('id', 'name') : null;
+            },
         ];
     }
 }

--- a/app/Http/Middleware/SetWorkspace.php
+++ b/app/Http/Middleware/SetWorkspace.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Models\User;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+use function is_string;
+
+final class SetWorkspace
+{
+    /**
+     * @param  Closure(Request): Response  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        if ($request->query->has('workspace')) {
+            $workspaceId = $request->query->getString('workspace');
+
+            // Abort if the workspace ID was tampered with, does not exist, or the user is not a member.
+            abort_unless($this->isMember($user, $workspaceId), 404);
+
+            $this->persist($workspaceId);
+
+            return $next($request);
+        }
+
+        return $this->resolveWorkspace($user, $request);
+    }
+
+    private function resolveWorkspace(User $user, Request $request): Response
+    {
+        $candidate = $request->cookie('workspace');
+
+        if (is_string($candidate) && $this->isMember($user, $candidate)) {
+            return $this->redirectWithWorkspace($request, $candidate);
+        }
+
+        $candidate = session('workspace');
+
+        if (is_string($candidate) && $this->isMember($user, $candidate)) {
+            return $this->redirectWithWorkspace($request, $candidate);
+        }
+
+        $count = $user->workspaces()->count();
+
+        if ($count === 1) {
+            return $this->redirectWithWorkspace($request, $user->workspaces()->sole()->id);
+        }
+
+        // TODO: Redirect to workspace selector.
+        // if ($count > 1) {
+        //     return redirect('/');
+        // }
+
+        // TODO: Redirect to workspace creation.
+        return redirect('/');
+    }
+
+    private function redirectWithWorkspace(Request $request, string $workspaceId): Response
+    {
+        return redirect()->to($request->fullUrlWithQuery(['workspace' => $workspaceId]));
+    }
+
+    private function isMember(User $user, string $workspaceId): bool
+    {
+        return $user->workspaces()->whereKey($workspaceId)->exists();
+    }
+
+    private function persist(string $workspaceId): void
+    {
+        session(['workspace' => $workspaceId]);
+        context(['workspace' => $workspaceId]);
+        cookie()->queue('workspace', $workspaceId, 30 * 24 * 60);
+    }
+}

--- a/app/Models/CustomRole.php
+++ b/app/Models/CustomRole.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Enums\Permission;
+use App\Models\Scopes\WorkspaceScope;
 use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Attributes\ScopedBy;
 use Illuminate\Database\Eloquent\Casts\AsEnumCollection;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Model;
@@ -22,6 +24,7 @@ use Illuminate\Support\Collection;
  * @property-read CarbonInterface $created_at
  * @property-read CarbonInterface $updated_at
  */
+#[ScopedBy([WorkspaceScope::class])]
 final class CustomRole extends Model
 {
     use HasUlids;

--- a/app/Models/CustomRole.php
+++ b/app/Models/CustomRole.php
@@ -4,42 +4,45 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Enums\Permission;
 use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Casts\AsEnumCollection;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Collection;
 
 /**
  * @property-read string $id
+ * @property-read string $workspace_id
  * @property-read string $name
+ * @property-read string $identifier
  * @property-read string|null $description
- * @property-read int $concurrent_builds
- * @property-read int $default_deployment_timeout
- * @property-read bool $is_2fa_required
+ * @property-read Collection<int, Permission> $permissions
  * @property-read CarbonInterface $created_at
  * @property-read CarbonInterface $updated_at
  */
-final class Workspace extends Model
+final class CustomRole extends Model
 {
     use HasUlids;
 
     /**
-     * @return HasMany<CustomRole, $this>
+     * @return BelongsTo<Workspace, $this>
      */
-    public function customRoles(): HasMany
+    public function workspace(): BelongsTo
     {
-        return $this->hasMany(CustomRole::class);
+        return $this->belongsTo(Workspace::class);
     }
 
     protected function casts(): array
     {
         return [
             'id' => 'string',
+            'workspace_id' => 'string',
             'name' => 'string',
+            'identifier' => 'string',
             'description' => 'string',
-            'concurrent_builds' => 'integer',
-            'default_deployment_timeout' => 'integer',
-            'is_2fa_required' => 'boolean',
+            'permissions' => AsEnumCollection::of(Permission::class),
             'created_at' => 'datetime',
             'updated_at' => 'datetime',
         ];

--- a/app/Models/Scopes/WorkspaceScope.php
+++ b/app/Models/Scopes/WorkspaceScope.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Scopes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+final class WorkspaceScope implements Scope
+{
+    public function apply(Builder $builder, Model $model): void
+    {
+        $workspaceId = session('workspace')
+            ?? context('workspace') // context fallback is needed for queued jobs where session is unavailable
+            ?? '';
+
+        $builder->where($model->qualifyColumn('workspace_id'), $workspaceId);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -9,6 +9,7 @@ use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 
 /**
@@ -32,6 +33,14 @@ final class User extends Authenticatable
     /** @use HasFactory<UserFactory> */
     use HasFactory;
     use HasUlids;
+
+    /**
+     * @return BelongsToMany<Workspace, $this>
+     */
+    public function workspaces(): BelongsToMany
+    {
+        return $this->belongsToMany(Workspace::class, 'workspace_members');
+    }
 
     protected function casts(): array
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 
 /**
@@ -40,6 +41,14 @@ final class User extends Authenticatable
     public function workspaces(): BelongsToMany
     {
         return $this->belongsToMany(Workspace::class, 'workspace_members');
+    }
+
+    /**
+     * @return HasMany<WorkspaceMember, $this>
+     */
+    public function memberships(): HasMany
+    {
+        return $this->hasMany(WorkspaceMember::class);
     }
 
     protected function casts(): array

--- a/app/Models/Workspace.php
+++ b/app/Models/Workspace.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property-read string $id
+ * @property-read string $name
+ * @property-read string|null $description
+ * @property-read int $concurrent_builds
+ * @property-read int $default_deployment_timeout
+ * @property-read bool $is_2fa_required
+ * @property-read CarbonInterface $created_at
+ * @property-read CarbonInterface $updated_at
+ */
+final class Workspace extends Model
+{
+    use HasUlids;
+
+    protected function casts(): array
+    {
+        return [
+            'id' => 'string',
+            'name' => 'string',
+            'description' => 'string',
+            'concurrent_builds' => 'integer',
+            'default_deployment_timeout' => 'integer',
+            'is_2fa_required' => 'boolean',
+            'created_at' => 'datetime',
+            'updated_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/Workspace.php
+++ b/app/Models/Workspace.php
@@ -40,6 +40,14 @@ final class Workspace extends Model
         return $this->hasMany(CustomRole::class);
     }
 
+    /**
+     * @return HasMany<WorkspaceMember, $this>
+     */
+    public function members(): HasMany
+    {
+        return $this->hasMany(WorkspaceMember::class);
+    }
+
     protected function casts(): array
     {
         return [

--- a/app/Models/Workspace.php
+++ b/app/Models/Workspace.php
@@ -7,6 +7,7 @@ namespace App\Models;
 use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
@@ -22,6 +23,14 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 final class Workspace extends Model
 {
     use HasUlids;
+
+    /**
+     * @return BelongsToMany<User, $this>
+     */
+    public function users(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'workspace_members');
+    }
 
     /**
      * @return HasMany<CustomRole, $this>

--- a/app/Models/WorkspaceInvitation.php
+++ b/app/Models/WorkspaceInvitation.php
@@ -6,7 +6,9 @@ namespace App\Models;
 
 use App\Enums\InvitationMethod;
 use App\Enums\UserRole;
+use App\Models\Scopes\WorkspaceScope;
 use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Attributes\ScopedBy;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -22,6 +24,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property-read CarbonInterface $created_at
  * @property-read CarbonInterface $updated_at
  */
+#[ScopedBy([WorkspaceScope::class])]
 final class WorkspaceInvitation extends Model
 {
     use HasUlids;

--- a/app/Models/WorkspaceInvitation.php
+++ b/app/Models/WorkspaceInvitation.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\InvitationMethod;
+use App\Enums\UserRole;
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property-read string $id
+ * @property-read string $workspace_id
+ * @property-read string $email
+ * @property-read UserRole $role
+ * @property-read string|null $custom_role_id
+ * @property-read InvitationMethod $via
+ * @property-read CarbonInterface $expires_at
+ * @property-read CarbonInterface $created_at
+ * @property-read CarbonInterface $updated_at
+ */
+final class WorkspaceInvitation extends Model
+{
+    use HasUlids;
+
+    /**
+     * @return BelongsTo<Workspace, $this>
+     */
+    public function workspace(): BelongsTo
+    {
+        return $this->belongsTo(Workspace::class);
+    }
+
+    /**
+     * @return BelongsTo<CustomRole, $this>
+     */
+    public function customRole(): BelongsTo
+    {
+        return $this->belongsTo(CustomRole::class);
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'id' => 'string',
+            'workspace_id' => 'string',
+            'email' => 'string',
+            'role' => UserRole::class,
+            'custom_role_id' => 'string',
+            'via' => InvitationMethod::class,
+            'expires_at' => 'datetime',
+            'created_at' => 'datetime',
+            'updated_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/WorkspaceMember.php
+++ b/app/Models/WorkspaceMember.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\UserRole;
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property-read string $id
+ * @property-read string $workspace_id
+ * @property-read string $user_id
+ * @property-read UserRole $role
+ * @property-read string|null $custom_role_id
+ * @property-read CarbonInterface $created_at
+ * @property-read CarbonInterface $updated_at
+ */
+final class WorkspaceMember extends Model
+{
+    use HasUlids;
+
+    /**
+     * @return BelongsTo<Workspace, $this>
+     */
+    public function workspace(): BelongsTo
+    {
+        return $this->belongsTo(Workspace::class);
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return BelongsTo<CustomRole, $this>
+     */
+    public function customRole(): BelongsTo
+    {
+        return $this->belongsTo(CustomRole::class);
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'id' => 'string',
+            'workspace_id' => 'string',
+            'user_id' => 'string',
+            'role' => UserRole::class,
+            'custom_role_id' => 'string',
+            'created_at' => 'datetime',
+            'updated_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/WorkspaceMember.php
+++ b/app/Models/WorkspaceMember.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Enums\UserRole;
+use App\Models\Scopes\WorkspaceScope;
 use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Attributes\ScopedBy;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -19,6 +21,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property-read CarbonInterface $created_at
  * @property-read CarbonInterface $updated_at
  */
+#[ScopedBy([WorkspaceScope::class])]
 final class WorkspaceMember extends Model
 {
     use HasUlids;

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Http\Middleware\HandleInertiaRequests;
+use App\Http\Middleware\SetWorkspace;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -15,6 +16,10 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->web(append: [
             HandleInertiaRequests::class,
+        ]);
+
+        $middleware->alias([
+            'workspace' => SetWorkspace::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {})->create();

--- a/database/migrations/2026_03_29_212354_create_workspaces_table.php
+++ b/database/migrations/2026_03_29_212354_create_workspaces_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('workspaces', function (Blueprint $table): void {
+            $table->ulid('id')->primary();
+            $table->string('name');
+            $table->string('description')->nullable();
+            $table->smallInteger('concurrent_builds');
+            $table->smallInteger('default_deployment_timeout');
+            $table->boolean('is_2fa_required');
+            $table->timestamps();
+        });
+    }
+};

--- a/database/migrations/2026_03_29_212414_create_custom_roles_table.php
+++ b/database/migrations/2026_03_29_212414_create_custom_roles_table.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('custom_roles', function (Blueprint $table): void {
+            $table->ulid('id')->primary();
+            $table->foreignUlid('workspace_id')->index()->constrained();
+            $table->string('name');
+            $table->string('identifier');
+            $table->string('description')->nullable();
+            $table->jsonb('permissions');
+            $table->timestamps();
+
+            $table->unique(['workspace_id', 'identifier']);
+        });
+    }
+};

--- a/database/migrations/2026_03_29_212434_create_workspace_members_table.php
+++ b/database/migrations/2026_03_29_212434_create_workspace_members_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('workspace_members', function (Blueprint $table): void {
+            $table->ulid('id')->primary();
+            $table->foreignUlid('workspace_id')->index()->constrained();
+            $table->foreignUlid('user_id')->index()->constrained();
+            $table->string('role', 50);
+            $table->foreignUlid('custom_role_id')->nullable()->index()->constrained();
+            $table->timestamps();
+
+            $table->unique(['workspace_id', 'user_id']);
+        });
+    }
+};

--- a/database/migrations/2026_03_29_212455_create_workspace_invitations_table.php
+++ b/database/migrations/2026_03_29_212455_create_workspace_invitations_table.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('workspace_invitations', function (Blueprint $table): void {
+            $table->ulid('id')->primary();
+            $table->foreignUlid('workspace_id')->index()->constrained();
+            $table->string('email')->index();
+            $table->string('role', 50);
+            $table->foreignUlid('custom_role_id')->nullable()->index()->constrained();
+            $table->string('via', 50);
+            $table->timestamp('expires_at');
+            $table->timestamps();
+
+            $table->unique(['workspace_id', 'email']);
+        });
+    }
+};

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -1,7 +1,19 @@
 import "../css/app.css";
-import { createInertiaApp } from "@inertiajs/svelte";
+import { createInertiaApp, http, page } from "@inertiajs/svelte";
 import Layout from "./layouts/Layout.svelte";
 
 createInertiaApp({
 	layout: () => Layout,
 }).catch(console.error);
+
+// Auto-append workspace query parameter to every Inertia request.
+http.onRequest((config) => {
+	const url = new URL(config.url, window.location.origin);
+
+	if (!url.searchParams.has("workspace") && page.props.workspace?.id) {
+		url.searchParams.set("workspace", page.props.workspace.id);
+		config.url = url.pathname + url.search;
+	}
+
+	return config;
+});

--- a/resources/js/types/inertia.d.ts
+++ b/resources/js/types/inertia.d.ts
@@ -4,6 +4,10 @@ declare module "@inertiajs/core" {
 	export interface InertiaConfig {
 		sharedPageProps: {
 			appName: string;
+			workspace: {
+				id: string;
+				name: string;
+			} | null;
 		};
 		// flashDataType: {
 		//     toast?: { type: "success" | "error"; message: string };


### PR DESCRIPTION
Scaffold the full workspaces system (replacing v4 teams) including a workspace global scope and middleware that reduce ~2,800 lines of manual team checks across ~400 files down to ~114 lines across 2 files (and models).

## Changes

- Scaffold workspace model and migration
- Scaffold workspace member model and migration
- Scaffold `InvitationMethod` enum
- Scaffold workspace invitation model and migration
- Scaffold `Permission` enum
- Scaffold `UserRole` enum
- Scaffold custom role model and migration
- Add global `WorkspaceScope` that automatically applies `WHERE workspace_id = ULID` to every scoped model query
- Add `SetWorkspace` middleware which resolves workspaces via URL parameter > cookie > session > auto-select (single workspace) and validates membership
- Add Inertia HTTP interceptor that auto-appends the workspace ID as a query parameter to every request
  - The middleware would do that too but that would result in 1 additional 304 redirect on each request, creating unnecessary overhead
- Share workspace id and name via Inertia shared props
- Apply workspace scope to models via `#[ScopedBy]`

## v4 Comparison

- **Workspaces**
  - Added workspaces replacing v4 teams (clearer name, fully self-contained and isolated from each other)
  - Added option to require 2FA workspace-wide
  - Added concurrent builds limit and default deployment timeout to workspace settings (incorrectly scoped per-server on v4)
  - Added workspace global scope and middleware (~114 lines) replacing ~1,970 manual team checks, written in 12 different ways (~2,800 lines) across ~400 files
  - Added support for multiple workspaces open simultaneously in different browser tabs (via query parameter, avoiding a long and ugly path segment)
  - Added automatic workspace selection via URL parameter > cookie > session > auto-select (single workspace)
- **Permission System**
  - Added `UserRole` enum defining all predefined roles in one place, replacing scattered role-check methods (`isAdmin()`, `isMember()`, etc.) with a single enum-based approach supporting granular permissions and adding new permissions to existing roles without a database migration
  - Added `Permission` enum with granular permissions per feature (e.g. `WorkspaceRead`, `WorkspaceCreate`, `WorkspaceUpdate`, `WorkspaceDestroy`), defined as string-backed enums so changes are code-only, not database migrations
  - Added custom roles with configurable permissions assignable to workspace members
  
### Workspace scope
  
|                                  | v4.x                                                                                                  | v5.x                                               |
| -------------------------------- | ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| Scoping patterns                 | 12: `ownedByCurrentTeam()`, `currentTeam()->id`, `teams->contains()`, `whereTeamId()`…                | 1: `#[ScopedBy]`                                   |
| Consistency                      | Very inconsistent - 12 different ways to scope across the codebase                                    | Consistent - 1 unified pattern everywhere          |
| Security risk                    | High - every unscoped query leaks data (see [#9230](https://github.com/coollabsio/coolify/pull/9230)) | Near zero - automatic scoping                      |
| Per-model effort                 | ~10 lines + manual scope call on each query                                                           | 1 line, scoping is automatic                       |
| Total checks                     | ~1,970                                                                                                | ~36 (in all needed models)                         |
| Total affected files             | ~400 (36 models, 122 Livewire, 17 controllers, 14 jobs, 9 actions, …)                                 | ~36 (~36 models + 1 scope + 1 middleware)          |
| Total lines                      | ~2,800 (1,970 call sites + scope definitions + middleware)                                            | ~114 (~36 attributes + ~10 scope + ~68 middleware) |
| Multiple workspaces open at once | Not supported                                                                                         | Supported                                          |
| Propagation to queued jobs       | Manual                                                                                                | Automatic via `context()`                          |

## TODO

- [ ] Investigate if any additional permissions are needed for all scaffolded models in this PR

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #9362 
- <kbd>&nbsp;2&nbsp;</kbd> #9247 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #9246 
<!-- GitButler Footer Boundary Bottom -->

