### PR TITLE
feat(api): Service Application Management API

### DIFF
--- a/app/Actions/Service/DeployServiceApplication.php
+++ b/app/Actions/Service/DeployServiceApplication.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Actions\Service;
+
+use App\Models\ServiceApplication;
+use Lorisleiva\Actions\Concerns\AsAction;
+use Spatie\Activitylog\Contracts\Activity;
+
+class DeployServiceApplication
+{
+    use AsAction;
+
+    public string $jobQueue = 'high';
+
+    public function handle(ServiceApplication $serviceApplication, bool $pullLatestImages = false, bool $forceRebuild = false): Activity
+    {
+        $service = $serviceApplication->service;
+        $composeServiceName = $serviceApplication->name;
+
+        $service->parse();
+        $service->saveComposeConfigs();
+        $service->isConfigurationChanged(save: true);
+
+        $workdir = $service->workdir();
+        $commands = collect([
+            "echo 'Saved configuration files to {$workdir}.'",
+            "touch {$workdir}/.env",
+        ]);
+
+        if ($pullLatestImages) {
+            $commands->push('echo Pulling image for service.');
+            $commands->push("docker compose --project-directory {$workdir} -f {$workdir}/docker-compose.yml --project-name {$service->uuid} pull {$composeServiceName}");
+        }
+
+        if ($service->networks()->count() > 0) {
+            $commands->push('echo Creating Docker network.');
+            $commands->push("docker network inspect {$service->uuid} >/dev/null 2>&1 || docker network create --attachable {$service->uuid}");
+        }
+
+        $upCommand = "docker compose --project-directory {$workdir} -f {$workdir}/docker-compose.yml --project-name {$service->uuid} up -d --no-deps";
+        if ($forceRebuild) {
+            $upCommand .= ' --build';
+        }
+        $upCommand .= " {$composeServiceName}";
+        $commands->push('echo Starting service container.');
+        $commands->push($upCommand);
+
+        $commands->push("docker network connect {$service->uuid} coolify-proxy >/dev/null 2>&1 || true");
+
+        if (data_get($service, 'connect_to_docker_network')) {
+            $compose = data_get($service, 'docker_compose', []);
+            $network = $service->destination->network;
+            $commands->push("docker network connect --alias {$composeServiceName}-{$service->uuid} {$network} {$composeServiceName}-{$service->uuid} >/dev/null 2>&1 || true");
+        }
+
+        return remote_process($commands->toArray(), $service->server, type_uuid: $service->uuid, callEventOnFinish: 'ServiceStatusChanged');
+    }
+}

--- a/app/Actions/Service/RestartServiceApplication.php
+++ b/app/Actions/Service/RestartServiceApplication.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Actions\Service;
+
+use App\Models\ServiceApplication;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class RestartServiceApplication
+{
+    use AsAction;
+
+    public string $jobQueue = 'high';
+
+    public function handle(ServiceApplication $serviceApplication): void
+    {
+        $service = $serviceApplication->service;
+        $server = $service->destination->server;
+        $containerName = $serviceApplication->name.'-'.$service->uuid;
+
+        instant_remote_process([
+            "docker restart {$containerName}",
+        ], $server);
+    }
+}

--- a/app/Actions/Service/StopServiceApplication.php
+++ b/app/Actions/Service/StopServiceApplication.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Actions\Service;
+
+use App\Models\ServiceApplication;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class StopServiceApplication
+{
+    use AsAction;
+
+    public string $jobQueue = 'high';
+
+    public function handle(ServiceApplication $serviceApplication): void
+    {
+        $service = $serviceApplication->service;
+        $server = $service->destination->server;
+        $containerName = $serviceApplication->name.'-'.$service->uuid;
+
+        instant_remote_process([
+            "docker stop {$containerName}",
+        ], $server);
+    }
+}

--- a/app/Actions/Service/UpdateServiceApplicationFromApi.php
+++ b/app/Actions/Service/UpdateServiceApplicationFromApi.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Actions\Service;
+
+use App\Models\ServiceApplication;
+use App\Support\ServiceComposeUrl;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class UpdateServiceApplicationFromApi
+{
+    public function execute(ServiceApplication $serviceApplication, Request $request, string $teamId): ?JsonResponse
+    {
+        $forceDomainOverride = $request->boolean('force_domain_override');
+
+        if ($request->has('url')) {
+            $urlRaw = $request->input('url');
+            if ($urlRaw !== null && ! is_string($urlRaw)) {
+                return response()->json([
+                    'message' => 'Validation failed.',
+                    'errors' => ['url' => 'The url must be a string.'],
+                ], 422);
+            }
+
+            $parsed = ServiceComposeUrl::validateUrlString(
+                is_string($urlRaw) ? $urlRaw : null,
+                $forceDomainOverride
+            );
+
+            if (count($parsed['errors']) > 0) {
+                return response()->json([
+                    'message' => 'Validation failed.',
+                    'errors' => $parsed['errors'],
+                ], 422);
+            }
+
+            if ($parsed['normalized'] !== null) {
+                $containerUrls = str($parsed['normalized'])
+                    ->explode(',')
+                    ->map(fn ($url) => str(trim((string) $url))->lower());
+
+                $result = checkIfDomainIsAlreadyUsedViaAPI($containerUrls, $teamId, $serviceApplication->uuid);
+                if (isset($result['error'])) {
+                    return response()->json([
+                        'message' => 'Validation failed.',
+                        'errors' => [$result['error']],
+                    ], 422);
+                }
+
+                if ($result['hasConflicts'] && ! $forceDomainOverride) {
+                    return response()->json([
+                        'message' => 'Domain conflicts detected. Use force_domain_override=true to proceed.',
+                        'conflicts' => $result['conflicts'],
+                        'warning' => 'Using the same domain for multiple resources can cause routing conflicts and unpredictable behavior.',
+                    ], 409);
+                }
+            }
+
+            $serviceApplication->fqdn = $parsed['normalized'];
+        }
+
+        if ($request->has('human_name')) {
+            $serviceApplication->human_name = $request->input('human_name');
+        }
+
+        if ($request->has('description')) {
+            $serviceApplication->description = $request->input('description');
+        }
+
+        if ($request->has('image')) {
+            $serviceApplication->image = $request->input('image');
+        }
+
+        if ($request->has('exclude_from_status')) {
+            $serviceApplication->exclude_from_status = $request->boolean('exclude_from_status');
+        }
+
+        if ($request->has('is_gzip_enabled')) {
+            $serviceApplication->is_gzip_enabled = $request->boolean('is_gzip_enabled');
+        }
+
+        if ($request->has('is_stripprefix_enabled')) {
+            $serviceApplication->is_stripprefix_enabled = $request->boolean('is_stripprefix_enabled');
+        }
+
+        if ($request->has('is_log_drain_enabled')) {
+            $enabled = $request->boolean('is_log_drain_enabled');
+            $server = $serviceApplication->service->destination->server;
+            if ($enabled && ! $server->isLogDrainEnabled()) {
+                return response()->json([
+                    'message' => 'Validation failed.',
+                    'errors' => [
+                        'is_log_drain_enabled' => 'Log drain is not enabled on the server for this service.',
+                    ],
+                ], 422);
+            }
+            $serviceApplication->is_log_drain_enabled = $enabled;
+        }
+
+        $serviceApplication->save();
+        $serviceApplication->refresh();
+
+        updateCompose($serviceApplication);
+
+        return null;
+    }
+}

--- a/app/Http/Controllers/Api/ServiceApplicationsController.php
+++ b/app/Http/Controllers/Api/ServiceApplicationsController.php
@@ -1,0 +1,754 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Actions\Service\DeployServiceApplication;
+use App\Actions\Service\RestartServiceApplication;
+use App\Actions\Service\StopServiceApplication;
+use App\Actions\Service\UpdateServiceApplicationFromApi;
+use App\Http\Controllers\Controller;
+use App\Models\Service;
+use App\Models\ServiceApplication;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+use OpenApi\Attributes as OA;
+
+class ServiceApplicationsController extends Controller
+{
+    private function removeSensitiveData(ServiceApplication $serviceApplication): array
+    {
+        $serviceApplication->makeHidden([
+            'id',
+            'resourceable',
+            'resourceable_id',
+            'resourceable_type',
+        ]);
+
+        return serializeApiResponse($serviceApplication);
+    }
+
+    private function resolveService(Request $request, int $teamId): ?Service
+    {
+        $uuid = $request->route('uuid');
+        if (! $uuid) {
+            return null;
+        }
+
+        return Service::whereRelation('environment.project.team', 'id', $teamId)
+            ->whereUuid($uuid)
+            ->first();
+    }
+
+    private function resolveServiceApplicationForService(Request $request, Service $service): ?ServiceApplication
+    {
+        $appUuid = $request->route('app_uuid');
+        if (! $appUuid) {
+            return null;
+        }
+
+        return $service->applications()
+            ->where('uuid', $appUuid)
+            ->with(['service.destination.server'])
+            ->first();
+    }
+
+    private function swarmNotSupportedResponse(): JsonResponse
+    {
+        return response()->json([
+            'message' => 'This operation is not supported for Swarm servers yet.',
+        ], 501);
+    }
+
+    #[OA\Get(
+        summary: 'List service applications',
+        description: 'List compose service applications (containers) for a single service.',
+        path: '/services/{uuid}/applications',
+        operationId: 'list-service-applications-by-service-uuid',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Service applications'],
+        parameters: [
+            new OA\Parameter(
+                name: 'uuid',
+                in: 'path',
+                description: 'Service UUID.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Service applications for this service.',
+                content: [
+                    new OA\MediaType(
+                        mediaType: 'application/json',
+                        schema: new OA\Schema(
+                            type: 'array',
+                            items: new OA\Items(type: 'object')
+                        )
+                    ),
+                ]
+            ),
+            new OA\Response(
+                response: 401,
+                ref: '#/components/responses/401',
+            ),
+            new OA\Response(
+                response: 404,
+                ref: '#/components/responses/404',
+            ),
+        ]
+    )]
+    public function index(Request $request): JsonResponse
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+
+        $service = $this->resolveService($request, $teamId);
+        if (! $service) {
+            return response()->json(['message' => 'Service not found.'], 404);
+        }
+
+        $this->authorize('view', $service);
+
+        $items = $service->applications()
+            ->get()
+            ->map(fn (ServiceApplication $sa) => $this->removeSensitiveData($sa));
+
+        return response()->json($items);
+    }
+
+    #[OA\Get(
+        summary: 'Get service application',
+        description: 'Get a single compose service application by service UUID and application UUID.',
+        path: '/services/{uuid}/applications/{app_uuid}',
+        operationId: 'get-service-application-by-service-and-app-uuid',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Service applications'],
+        parameters: [
+            new OA\Parameter(
+                name: 'uuid',
+                in: 'path',
+                description: 'Service UUID.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+            new OA\Parameter(
+                name: 'app_uuid',
+                in: 'path',
+                description: 'Service application UUID.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Service application.',
+                content: [
+                    new OA\MediaType(
+                        mediaType: 'application/json',
+                        schema: new OA\Schema(type: 'object')
+                    ),
+                ]
+            ),
+            new OA\Response(
+                response: 401,
+                ref: '#/components/responses/401',
+            ),
+            new OA\Response(
+                response: 404,
+                ref: '#/components/responses/404',
+            ),
+        ]
+    )]
+    public function show(Request $request): JsonResponse
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+
+        $service = $this->resolveService($request, $teamId);
+        if (! $service) {
+            return response()->json(['message' => 'Service not found.'], 404);
+        }
+
+        $serviceApplication = $this->resolveServiceApplicationForService($request, $service);
+        if (! $serviceApplication) {
+            return response()->json(['message' => 'Service application not found.'], 404);
+        }
+
+        $this->authorize('view', $serviceApplication);
+
+        return response()->json($this->removeSensitiveData($serviceApplication));
+    }
+
+    #[OA\Patch(
+        summary: 'Update service application',
+        description: 'Update fields for a compose service application. Use `url` for comma-separated public URLs (same rules as `urls[].url` on PATCH /services/{uuid}).',
+        path: '/services/{uuid}/applications/{app_uuid}',
+        operationId: 'patch-service-application-by-service-and-app-uuid',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Service applications'],
+        parameters: [
+            new OA\Parameter(
+                name: 'uuid',
+                in: 'path',
+                description: 'Service UUID.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+            new OA\Parameter(
+                name: 'app_uuid',
+                in: 'path',
+                description: 'Service application UUID.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+            new OA\Parameter(
+                name: 'force_domain_override',
+                in: 'query',
+                description: 'When true, allow duplicate URLs in the request and proceed despite domain conflicts (same as service PATCH).',
+                required: false,
+                schema: new OA\Schema(type: 'boolean', default: false)
+            ),
+        ],
+        requestBody: new OA\RequestBody(
+            content: new OA\MediaType(
+                mediaType: 'application/json',
+                schema: new OA\Schema(
+                    type: 'object',
+                    properties: [
+                        'url' => new OA\Property(
+                            property: 'url',
+                            type: 'string',
+                            nullable: true,
+                            description: 'Comma-separated list of URLs (e.g. "http://app.example.com:8080,https://app2.example.com"). Stored as fqdn.'
+                        ),
+                        'human_name' => new OA\Property(property: 'human_name', type: 'string', nullable: true),
+                        'description' => new OA\Property(property: 'description', type: 'string', nullable: true),
+                        'image' => new OA\Property(property: 'image', type: 'string', nullable: true),
+                        'exclude_from_status' => new OA\Property(property: 'exclude_from_status', type: 'boolean', nullable: true),
+                        'is_log_drain_enabled' => new OA\Property(property: 'is_log_drain_enabled', type: 'boolean', nullable: true),
+                        'is_gzip_enabled' => new OA\Property(property: 'is_gzip_enabled', type: 'boolean', nullable: true),
+                        'is_stripprefix_enabled' => new OA\Property(property: 'is_stripprefix_enabled', type: 'boolean', nullable: true),
+                    ]
+                )
+            )
+        ),
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Updated service application.',
+                content: [
+                    new OA\MediaType(
+                        mediaType: 'application/json',
+                        schema: new OA\Schema(type: 'object')
+                    ),
+                ]
+            ),
+            new OA\Response(
+                response: 401,
+                ref: '#/components/responses/401',
+            ),
+            new OA\Response(
+                response: 404,
+                ref: '#/components/responses/404',
+            ),
+            new OA\Response(
+                response: 409,
+                description: 'Domain conflicts (unless force_domain_override).',
+            ),
+            new OA\Response(
+                response: 422,
+                ref: '#/components/responses/422',
+            ),
+        ]
+    )]
+    public function update(Request $request, UpdateServiceApplicationFromApi $updateServiceApplicationFromApi): JsonResponse
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+
+        $return = validateIncomingRequest($request);
+        if ($return instanceof JsonResponse) {
+            return $return;
+        }
+
+        $service = $this->resolveService($request, $teamId);
+        if (! $service) {
+            return response()->json(['message' => 'Service not found.'], 404);
+        }
+
+        $serviceApplication = $this->resolveServiceApplicationForService($request, $service);
+        if (! $serviceApplication) {
+            return response()->json(['message' => 'Service application not found.'], 404);
+        }
+
+        $this->authorize('update', $serviceApplication);
+
+        $allowedFields = [
+            'url',
+            'human_name',
+            'description',
+            'image',
+            'exclude_from_status',
+            'is_log_drain_enabled',
+            'is_gzip_enabled',
+            'is_stripprefix_enabled',
+        ];
+
+        $validationRules = [
+            'url' => 'nullable|string',
+            'human_name' => 'nullable|string|max:255',
+            'description' => 'nullable|string',
+            'image' => 'nullable|string',
+            'exclude_from_status' => 'sometimes|boolean',
+            'is_log_drain_enabled' => 'sometimes|boolean',
+            'is_gzip_enabled' => 'sometimes|boolean',
+            'is_stripprefix_enabled' => 'sometimes|boolean',
+        ];
+
+        $validator = Validator::make($request->all(), $validationRules);
+
+        $extraFields = array_diff(array_keys($request->all()), $allowedFields);
+        if ($validator->fails() || ! empty($extraFields)) {
+            $errors = $validator->errors();
+            foreach ($extraFields as $field) {
+                $errors->add($field, 'This field is not allowed.');
+            }
+
+            return response()->json([
+                'message' => 'Validation failed.',
+                'errors' => $errors,
+            ], 422);
+        }
+
+        $response = $updateServiceApplicationFromApi->execute($serviceApplication, $request, $teamId);
+        if ($response instanceof JsonResponse) {
+            return $response;
+        }
+
+        $serviceApplication->refresh();
+
+        return response()->json($this->removeSensitiveData($serviceApplication));
+    }
+
+    #[OA\Get(
+        summary: 'Get service application logs',
+        description: 'Get Docker logs for a single compose service container.',
+        path: '/services/{uuid}/applications/{app_uuid}/logs',
+        operationId: 'get-service-application-logs-by-service-and-app-uuid',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Service applications'],
+        parameters: [
+            new OA\Parameter(
+                name: 'uuid',
+                in: 'path',
+                description: 'Service UUID.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+            new OA\Parameter(
+                name: 'app_uuid',
+                in: 'path',
+                description: 'Service application UUID.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+            new OA\Parameter(
+                name: 'lines',
+                in: 'query',
+                description: 'Number of lines to show from the end of the logs.',
+                required: false,
+                schema: new OA\Schema(type: 'integer', format: 'int32', default: 100)
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Logs.',
+                content: [
+                    new OA\MediaType(
+                        mediaType: 'application/json',
+                        schema: new OA\Schema(
+                            type: 'object',
+                            properties: [
+                                'logs' => new OA\Property(property: 'logs', type: 'string'),
+                            ]
+                        )
+                    ),
+                ]
+            ),
+            new OA\Response(
+                response: 400,
+                ref: '#/components/responses/400',
+            ),
+            new OA\Response(
+                response: 401,
+                ref: '#/components/responses/401',
+            ),
+            new OA\Response(
+                response: 404,
+                ref: '#/components/responses/404',
+            ),
+            new OA\Response(
+                response: 501,
+                description: 'Swarm not supported.',
+            ),
+        ]
+    )]
+    public function logs_by_uuid(Request $request): JsonResponse
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+
+        $service = $this->resolveService($request, $teamId);
+        if (! $service) {
+            return response()->json(['message' => 'Service not found.'], 404);
+        }
+
+        $serviceApplication = $this->resolveServiceApplicationForService($request, $service);
+        if (! $serviceApplication) {
+            return response()->json(['message' => 'Service application not found.'], 404);
+        }
+
+        $this->authorize('view', $serviceApplication);
+
+        $server = $serviceApplication->service->destination->server;
+        if ($server->isSwarm()) {
+            return $this->swarmNotSupportedResponse();
+        }
+
+        if (! $server->isFunctional()) {
+            return response()->json([
+                'message' => 'Server is not functional.',
+            ], 400);
+        }
+
+        $containerName = $serviceApplication->name.'-'.$serviceApplication->service->uuid;
+
+        $status = getContainerStatus($server, $containerName);
+        if ($status !== 'running') {
+            return response()->json([
+                'message' => 'Service application container is not running.',
+            ], 400);
+        }
+
+        $lines = (int) ($request->query('lines', 100) ?: 100);
+        $logs = getContainerLogs($server, $containerName, $lines);
+
+        return response()->json([
+            'logs' => $logs,
+        ]);
+    }
+
+    #[OA\Get(
+        summary: 'Start or redeploy service application container',
+        description: 'Runs docker compose up for a single compose service (no-deps), optionally pulling the image and rebuilding.',
+        path: '/services/{uuid}/applications/{app_uuid}/start',
+        operationId: 'start-service-application-by-service-and-app-uuid',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Service applications'],
+        parameters: [
+            new OA\Parameter(
+                name: 'uuid',
+                in: 'path',
+                description: 'Service UUID.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+            new OA\Parameter(
+                name: 'app_uuid',
+                in: 'path',
+                description: 'Service application UUID.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+            new OA\Parameter(
+                name: 'force',
+                in: 'query',
+                description: 'When true, passes --build to docker compose up.',
+                required: false,
+                schema: new OA\Schema(type: 'boolean', default: false)
+            ),
+            new OA\Parameter(
+                name: 'latest',
+                in: 'query',
+                description: 'When true, pulls the image for this compose service before up.',
+                required: false,
+                schema: new OA\Schema(type: 'boolean', default: false)
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Deploy request queued.',
+                content: [
+                    new OA\MediaType(
+                        mediaType: 'application/json',
+                        schema: new OA\Schema(
+                            type: 'object',
+                            properties: [
+                                'message' => new OA\Property(property: 'message', type: 'string'),
+                            ]
+                        )
+                    ),
+                ]
+            ),
+            new OA\Response(
+                response: 401,
+                ref: '#/components/responses/401',
+            ),
+            new OA\Response(
+                response: 404,
+                ref: '#/components/responses/404',
+            ),
+            new OA\Response(
+                response: 501,
+                description: 'Swarm not supported.',
+            ),
+        ]
+    )]
+    public function action_start(Request $request): JsonResponse
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+
+        $service = $this->resolveService($request, $teamId);
+        if (! $service) {
+            return response()->json(['message' => 'Service not found.'], 404);
+        }
+
+        $serviceApplication = $this->resolveServiceApplicationForService($request, $service);
+        if (! $serviceApplication) {
+            return response()->json(['message' => 'Service application not found.'], 404);
+        }
+
+        $this->authorize('deploy', $serviceApplication);
+
+        $server = $serviceApplication->service->destination->server;
+        if ($server->isSwarm()) {
+            return $this->swarmNotSupportedResponse();
+        }
+
+        if (! $server->isFunctional()) {
+            return response()->json([
+                'message' => 'Server is not functional.',
+            ], 400);
+        }
+
+        $pullLatest = $request->boolean('latest', false);
+        $forceRebuild = $request->boolean('force', false);
+
+        DeployServiceApplication::dispatch($serviceApplication, $pullLatest, $forceRebuild);
+
+        return response()->json([
+            'message' => 'Service application deploy request queued.',
+        ], 200);
+    }
+
+    #[OA\Get(
+        summary: 'Restart service application container',
+        description: 'Restarts a single compose service container (docker restart).',
+        path: '/services/{uuid}/applications/{app_uuid}/restart',
+        operationId: 'restart-service-application-by-service-and-app-uuid',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Service applications'],
+        parameters: [
+            new OA\Parameter(
+                name: 'uuid',
+                in: 'path',
+                description: 'Service UUID.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+            new OA\Parameter(
+                name: 'app_uuid',
+                in: 'path',
+                description: 'Service application UUID.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Restart queued.',
+                content: [
+                    new OA\MediaType(
+                        mediaType: 'application/json',
+                        schema: new OA\Schema(
+                            type: 'object',
+                            properties: [
+                                'message' => new OA\Property(property: 'message', type: 'string'),
+                            ]
+                        )
+                    ),
+                ]
+            ),
+            new OA\Response(
+                response: 401,
+                ref: '#/components/responses/401',
+            ),
+            new OA\Response(
+                response: 404,
+                ref: '#/components/responses/404',
+            ),
+            new OA\Response(
+                response: 501,
+                description: 'Swarm not supported.',
+            ),
+        ]
+    )]
+    public function action_restart(Request $request): JsonResponse
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+
+        $service = $this->resolveService($request, $teamId);
+        if (! $service) {
+            return response()->json(['message' => 'Service not found.'], 404);
+        }
+
+        $serviceApplication = $this->resolveServiceApplicationForService($request, $service);
+        if (! $serviceApplication) {
+            return response()->json(['message' => 'Service application not found.'], 404);
+        }
+
+        $this->authorize('deploy', $serviceApplication);
+
+        $server = $serviceApplication->service->destination->server;
+        if ($server->isSwarm()) {
+            return $this->swarmNotSupportedResponse();
+        }
+
+        if (! $server->isFunctional()) {
+            return response()->json([
+                'message' => 'Server is not functional.',
+            ], 400);
+        }
+
+        RestartServiceApplication::dispatch($serviceApplication);
+
+        return response()->json([
+            'message' => 'Service application restart request queued.',
+        ], 200);
+    }
+
+    #[OA\Get(
+        summary: 'Stop service application container',
+        description: 'Stops a single compose service container (docker stop).',
+        path: '/services/{uuid}/applications/{app_uuid}/stop',
+        operationId: 'stop-service-application-by-service-and-app-uuid',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Service applications'],
+        parameters: [
+            new OA\Parameter(
+                name: 'uuid',
+                in: 'path',
+                description: 'Service UUID.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+            new OA\Parameter(
+                name: 'app_uuid',
+                in: 'path',
+                description: 'Service application UUID.',
+                required: true,
+                schema: new OA\Schema(type: 'string')
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Stop queued.',
+                content: [
+                    new OA\MediaType(
+                        mediaType: 'application/json',
+                        schema: new OA\Schema(
+                            type: 'object',
+                            properties: [
+                                'message' => new OA\Property(property: 'message', type: 'string'),
+                            ]
+                        )
+                    ),
+                ]
+            ),
+            new OA\Response(
+                response: 401,
+                ref: '#/components/responses/401',
+            ),
+            new OA\Response(
+                response: 404,
+                ref: '#/components/responses/404',
+            ),
+            new OA\Response(
+                response: 501,
+                description: 'Swarm not supported.',
+            ),
+        ]
+    )]
+    public function action_stop(Request $request): JsonResponse
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+
+        $service = $this->resolveService($request, $teamId);
+        if (! $service) {
+            return response()->json(['message' => 'Service not found.'], 404);
+        }
+
+        $serviceApplication = $this->resolveServiceApplicationForService($request, $service);
+        if (! $serviceApplication) {
+            return response()->json(['message' => 'Service application not found.'], 404);
+        }
+
+        $this->authorize('deploy', $serviceApplication);
+
+        $server = $serviceApplication->service->destination->server;
+        if ($server->isSwarm()) {
+            return $this->swarmNotSupportedResponse();
+        }
+
+        if (! $server->isFunctional()) {
+            return response()->json([
+                'message' => 'Server is not functional.',
+            ], 400);
+        }
+
+        StopServiceApplication::dispatch($serviceApplication);
+
+        return response()->json([
+            'message' => 'Service application stop request queued.',
+        ], 200);
+    }
+}

--- a/app/Policies/ServiceApplicationPolicy.php
+++ b/app/Policies/ServiceApplicationPolicy.php
@@ -30,8 +30,15 @@ class ServiceApplicationPolicy
      */
     public function update(User $user, ServiceApplication $serviceApplication): bool
     {
-        // return Gate::allows('update', $serviceApplication->service);
-        return true;
+        return Gate::allows('update', $serviceApplication->service);
+    }
+
+    /**
+     * Determine whether the user can deploy or run lifecycle actions on the parent service stack.
+     */
+    public function deploy(User $user, ServiceApplication $serviceApplication): bool
+    {
+        return Gate::allows('deploy', $serviceApplication->service);
     }
 
     /**

--- a/app/Support/ServiceComposeUrl.php
+++ b/app/Support/ServiceComposeUrl.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Support;
+
+class ServiceComposeUrl
+{
+    /**
+     * Validate a comma-separated URL string like `urls[].url` on PATCH /services/{uuid}.
+     *
+     * @return array{errors: array<int, string>, normalized: ?string}
+     */
+    public static function validateUrlString(?string $urlValue, bool $forceDomainOverride = false): array
+    {
+        $errors = [];
+
+        if ($urlValue === null || $urlValue === '') {
+            return ['errors' => [], 'normalized' => null];
+        }
+
+        $urls = str($urlValue)
+            ->replaceStart(',', '')
+            ->replaceEnd(',', '')
+            ->trim()
+            ->explode(',')
+            ->map(fn ($url) => trim((string) $url))
+            ->filter();
+
+        foreach ($urls as $url) {
+            if (! filter_var($url, FILTER_VALIDATE_URL)) {
+                $errors[] = "Invalid URL: {$url}";
+            }
+            $scheme = parse_url($url, PHP_URL_SCHEME) ?? '';
+            if (! in_array(strtolower($scheme), ['http', 'https'], true)) {
+                $errors[] = "Invalid URL scheme: {$scheme} for URL: {$url}. Only http and https are supported.";
+            }
+        }
+
+        $duplicates = $urls->duplicates()->unique()->values();
+        if ($duplicates->isNotEmpty() && ! $forceDomainOverride) {
+            $errors[] = 'The current request contains duplicate URLs: '.implode(', ', $duplicates->toArray()).'. Use force_domain_override=true to proceed.';
+        }
+
+        if (count($errors) > 0) {
+            return ['errors' => $errors, 'normalized' => null];
+        }
+
+        $normalized = $urls
+            ->map(fn ($u) => str($u)->lower()->value())
+            ->unique()
+            ->filter(fn ($u) => filled($u))
+            ->implode(',');
+
+        return ['errors' => [], 'normalized' => $normalized !== '' ? $normalized : null];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\Api\ResourcesController;
 use App\Http\Controllers\Api\ScheduledTasksController;
 use App\Http\Controllers\Api\SecurityController;
 use App\Http\Controllers\Api\ServersController;
+use App\Http\Controllers\Api\ServiceApplicationsController;
 use App\Http\Controllers\Api\ServicesController;
 use App\Http\Controllers\Api\TeamController;
 use App\Http\Middleware\ApiAllowed;
@@ -192,6 +193,14 @@ Route::group([
     Route::match(['get', 'post'], '/services/{uuid}/start', [ServicesController::class, 'action_deploy'])->middleware(['api.ability:deploy']);
     Route::match(['get', 'post'], '/services/{uuid}/restart', [ServicesController::class, 'action_restart'])->middleware(['api.ability:deploy']);
     Route::match(['get', 'post'], '/services/{uuid}/stop', [ServicesController::class, 'action_stop'])->middleware(['api.ability:deploy']);
+
+    Route::get('/services/{uuid}/applications', [ServiceApplicationsController::class, 'index'])->middleware(['api.ability:read']);
+    Route::get('/services/{uuid}/applications/{app_uuid}', [ServiceApplicationsController::class, 'show'])->middleware(['api.ability:read']);
+    Route::patch('/services/{uuid}/applications/{app_uuid}', [ServiceApplicationsController::class, 'update'])->middleware(['api.ability:write']);
+    Route::match(['get', 'post'], '/services/{uuid}/applications/{app_uuid}/logs', [ServiceApplicationsController::class, 'logs_by_uuid'])->middleware(['api.ability:read']);
+    Route::match(['get', 'post'], '/services/{uuid}/applications/{app_uuid}/start', [ServiceApplicationsController::class, 'action_start'])->middleware(['api.ability:deploy']);
+    Route::match(['get', 'post'], '/services/{uuid}/applications/{app_uuid}/restart', [ServiceApplicationsController::class, 'action_restart'])->middleware(['api.ability:deploy']);
+    Route::match(['get', 'post'], '/services/{uuid}/applications/{app_uuid}/stop', [ServiceApplicationsController::class, 'action_stop'])->middleware(['api.ability:deploy']);
 
     Route::get('/applications/{uuid}/scheduled-tasks', [ScheduledTasksController::class, 'scheduled_tasks_by_application_uuid'])->middleware(['api.ability:read']);
     Route::post('/applications/{uuid}/scheduled-tasks', [ScheduledTasksController::class, 'create_scheduled_task_by_application_uuid'])->middleware(['api.ability:write']);

--- a/tests/Feature/ServiceApplicationsApiTest.php
+++ b/tests/Feature/ServiceApplicationsApiTest.php
@@ -1,0 +1,258 @@
+<?php
+
+use App\Actions\Service\DeployServiceApplication;
+use App\Actions\Service\RestartServiceApplication;
+use App\Actions\Service\StopServiceApplication;
+use App\Models\Environment;
+use App\Models\InstanceSettings;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\Service;
+use App\Models\ServiceApplication;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Str;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Queue::fake();
+    InstanceSettings::updateOrCreate(['id' => 0]);
+
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+
+    $plainTextToken = Str::random(40);
+    $token = $this->user->tokens()->create([
+        'name' => 'test-token',
+        'token' => hash('sha256', $plainTextToken),
+        'abilities' => ['*'],
+        'team_id' => $this->team->id,
+    ]);
+    $this->bearerToken = $token->getKey().'|'.$plainTextToken;
+
+    $this->server = Server::factory()->create(['team_id' => $this->team->id]);
+    $this->server->settings->update([
+        'is_reachable' => true,
+        'is_usable' => true,
+        'force_disabled' => false,
+    ]);
+    $this->destination = StandaloneDocker::where('server_id', $this->server->id)->first();
+    $this->project = Project::factory()->create(['team_id' => $this->team->id]);
+    $this->environment = Environment::factory()->create(['project_id' => $this->project->id]);
+});
+
+function createServiceWithApplicationForApiTest(object $ctx): object
+{
+    $service = Service::factory()->create([
+        'environment_id' => $ctx->environment->id,
+        'server_id' => $ctx->server->id,
+        'destination_id' => $ctx->destination->id,
+        'destination_type' => $ctx->destination->getMorphClass(),
+        'docker_compose_raw' => "services:\n  web:\n    image: nginx:alpine\n",
+    ]);
+
+    $sa = ServiceApplication::create([
+        'uuid' => (string) Str::uuid(),
+        'name' => 'web',
+        'service_id' => $service->id,
+        'image' => 'nginx:alpine',
+    ]);
+
+    return (object) ['service' => $service, 'serviceApplication' => $sa];
+}
+
+function createServiceWithoutApplicationsForApiTest(object $ctx): Service
+{
+    return Service::factory()->create([
+        'environment_id' => $ctx->environment->id,
+        'server_id' => $ctx->server->id,
+        'destination_id' => $ctx->destination->id,
+        'destination_type' => $ctx->destination->getMorphClass(),
+        'docker_compose_raw' => "services:\n  web:\n    image: nginx:alpine\n",
+    ]);
+}
+
+describe('GET /api/v1/services/{uuid}/applications', function () {
+    test('returns empty array when service has no applications', function () {
+        $service = createServiceWithoutApplicationsForApiTest($this);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+        ])->getJson("/api/v1/services/{$service->uuid}/applications");
+
+        $response->assertStatus(200);
+        $response->assertJson([]);
+    });
+
+    test('lists service applications for the service', function () {
+        $ctx = createServiceWithApplicationForApiTest($this);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+        ])->getJson("/api/v1/services/{$ctx->service->uuid}/applications");
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['uuid' => $ctx->serviceApplication->uuid]);
+    });
+
+    test('returns 404 when service does not exist', function () {
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+        ])->getJson('/api/v1/services/00000000-0000-0000-0000-000000000001/applications');
+
+        $response->assertStatus(404);
+        $response->assertJsonFragment(['message' => 'Service not found.']);
+    });
+});
+
+describe('GET /api/v1/services/{uuid}/applications/{app_uuid}', function () {
+    test('returns 404 for unknown service', function () {
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+        ])->getJson('/api/v1/services/00000000-0000-0000-0000-000000000002/applications/non-existent-uuid-12345');
+
+        $response->assertStatus(404);
+        $response->assertJsonFragment(['message' => 'Service not found.']);
+    });
+
+    test('returns 404 when application uuid is not under service', function () {
+        $ctx = createServiceWithApplicationForApiTest($this);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+        ])->getJson("/api/v1/services/{$ctx->service->uuid}/applications/00000000-0000-0000-0000-000000000003");
+
+        $response->assertStatus(404);
+        $response->assertJsonFragment(['message' => 'Service application not found.']);
+    });
+
+    test('returns service application', function () {
+        $ctx = createServiceWithApplicationForApiTest($this);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+        ])->getJson("/api/v1/services/{$ctx->service->uuid}/applications/{$ctx->serviceApplication->uuid}");
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['uuid' => $ctx->serviceApplication->uuid, 'name' => 'web']);
+    });
+});
+
+describe('PATCH /api/v1/services/{uuid}/applications/{app_uuid}', function () {
+    test('returns 400 without valid token', function () {
+        $response = $this->patchJson('/api/v1/services/some-uuid/applications/some-app', [
+            'human_name' => 'x',
+        ], ['Accept' => 'application/json', 'Content-Type' => 'application/json']);
+
+        $response->assertStatus(400);
+    });
+
+    test('updates human_name', function () {
+        $ctx = createServiceWithApplicationForApiTest($this);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+        ])->patchJson("/api/v1/services/{$ctx->service->uuid}/applications/{$ctx->serviceApplication->uuid}", [
+            'human_name' => 'Web UI',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['human_name' => 'Web UI']);
+        $ctx->serviceApplication->refresh();
+        expect($ctx->serviceApplication->human_name)->toBe('Web UI');
+    });
+
+    test('returns 422 for invalid url scheme', function () {
+        $ctx = createServiceWithApplicationForApiTest($this);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+        ])->patchJson("/api/v1/services/{$ctx->service->uuid}/applications/{$ctx->serviceApplication->uuid}", [
+            'url' => 'ftp://example.com',
+        ]);
+
+        $response->assertStatus(422);
+    });
+
+    test('returns 422 when enabling log drain but server has no log drain', function () {
+        $ctx = createServiceWithApplicationForApiTest($this);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+        ])->patchJson("/api/v1/services/{$ctx->service->uuid}/applications/{$ctx->serviceApplication->uuid}", [
+            'is_log_drain_enabled' => true,
+        ]);
+
+        $response->assertStatus(422);
+        expect((string) $response->json('errors.is_log_drain_enabled.0'))->toContain('Log drain');
+    });
+});
+
+describe('POST /api/v1/services/{uuid}/applications/{app_uuid}/restart', function () {
+    test('returns 400 without valid token', function () {
+        $response = $this->postJson('/api/v1/services/some-uuid/applications/some-app/restart');
+
+        $response->assertStatus(400);
+    });
+
+    test('queues restart for a service application', function () {
+        $ctx = createServiceWithApplicationForApiTest($this);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+        ])->postJson("/api/v1/services/{$ctx->service->uuid}/applications/{$ctx->serviceApplication->uuid}/restart");
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['message' => 'Service application restart request queued.']);
+        RestartServiceApplication::assertPushed();
+    });
+});
+
+describe('POST /api/v1/services/{uuid}/applications/{app_uuid}/start', function () {
+    test('queues deploy for a service application', function () {
+        $ctx = createServiceWithApplicationForApiTest($this);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+        ])->postJson("/api/v1/services/{$ctx->service->uuid}/applications/{$ctx->serviceApplication->uuid}/start?latest=1&force=1");
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['message' => 'Service application deploy request queued.']);
+        DeployServiceApplication::assertPushed();
+    });
+});
+
+describe('POST /api/v1/services/{uuid}/applications/{app_uuid}/stop', function () {
+    test('queues stop for a service application', function () {
+        $ctx = createServiceWithApplicationForApiTest($this);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+        ])->postJson("/api/v1/services/{$ctx->service->uuid}/applications/{$ctx->serviceApplication->uuid}/stop");
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['message' => 'Service application stop request queued.']);
+        StopServiceApplication::assertPushed();
+    });
+});
+
+describe('GET /api/v1/services/{uuid}/applications/{app_uuid}/logs', function () {
+    test('returns 400 when server is not functional', function () {
+        $ctx = createServiceWithApplicationForApiTest($this);
+        $this->server->settings->update([
+            'is_reachable' => false,
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+        ])->getJson("/api/v1/services/{$ctx->service->uuid}/applications/{$ctx->serviceApplication->uuid}/logs");
+
+        $response->assertStatus(400);
+        $response->assertJsonFragment(['message' => 'Server is not functional.']);
+    });
+});


### PR DESCRIPTION
## Changes

The existing `/api/v1/applications/{uuid}`API targets Application resources (standalone apps and the main service app). For a Service with multiple compose applications (ServiceApplication rows), there was no API to Stream or fetch logs for a single service application, Restart or deploy (start) one compose service without treating the whole stack like a generic application UUID (which does not map cleanly to per-service containers).

## Issues
- Fixes: Related: [Discussion #7337](https://github.com/coollabsio/coolify/discussions/7337)

## Category
- [x] New feature

## Preview
```http
GET /api/v1/services/{service-uuid}/applications
GET /api/v1/services/{service-uuid}/applications/{app-uuid}
PATCH /api/v1/services/{service-uuid}/applications/{app-uuid}
PATCH /api/v1/services/{service-uuid}/applications/{app-uuid}?force_domain_override=true
POST /api/v1/services/{service-uuid}/applications/{app-uuid}/logs?lines=100
POST /api/v1/services/{service-uuid}/applications/{app-uuid}/start?latest=1&force=1
POST /api/v1/services/{service-uuid}/applications/{app-uuid}/restart
POST /api/v1/services/{service-uuid}/applications/{app-uuid}/stop
```

Allowed fields in PATCH body: `url`, `human_name`, `description`, `image`, `exclude_from_status`, `is_log_drain_enabled`, `is_gzip_enabled`, `is_stripprefix_enabled`

## AI Assistance
- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**
- Tools used: Cursor
- How extensively:  All the code changes **with manual check and small fixes**

## Testing
docker exec coolify php artisan test tests/Feature/ServiceApplicationsApiTest.php

## Contributor Agreement
<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.