### PR TITLE
feat(ui): show container name with copy button in resource heading

### DIFF
--- a/resources/views/components/container-name.blade.php
+++ b/resources/views/components/container-name.blade.php
@@ -1,0 +1,19 @@
+@props(['name'])
+
+<div class="flex items-center gap-1.5 px-2 h-8 text-sm rounded-sm border-2 dark:bg-coolgray-100 dark:border-coolgray-300 border-neutral-200" x-data="{ copied: false }">
+    <span class="text-neutral-400">Containername:</span>
+    <code class="dark:text-neutral-300">{{ $name }}</code>
+    <button
+        x-show="window.isSecureContext"
+        @click.prevent="copied = true; navigator.clipboard.writeText({{ Js::from($name) }}); setTimeout(() => copied = false, 1500)"
+        class="p-0.5 text-neutral-400 hover:text-neutral-200 transition-colors"
+        title="Copy container name">
+        <svg x-show="!copied" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+        </svg>
+        <svg x-show="copied" x-cloak class="w-4 h-4 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+        </svg>
+    </button>
+</div>

--- a/resources/views/livewire/project/application/heading.blade.php
+++ b/resources/views/livewire/project/application/heading.blade.php
@@ -35,6 +35,7 @@
             @if ($application->build_pack === 'dockercompose' && is_null($application->docker_compose_raw))
                 <div>Please load a Compose file.</div>
             @else
+                <x-container-name :name="$application->settings->custom_internal_name ?: $application->uuid" />
                 @if (!$application->destination->server->isSwarm())
                     <div>
                         <x-applications.advanced :application="$application" />

--- a/resources/views/livewire/project/database/heading.blade.php
+++ b/resources/views/livewire/project/database/heading.blade.php
@@ -39,6 +39,7 @@
         </nav>
         @if ($database->destination->server->isFunctional())
             <div class="flex flex-wrap gap-2 items-center">
+                <x-container-name :name="$database->uuid" />
                 @if (!str($database->status)->startsWith('exited'))
                     <x-modal-confirmation title="Confirm Database Restart?" buttonTitle="Restart" submitAction="restart"
                         :actions="[


### PR DESCRIPTION
STRAWBERRY

## Changes

- Added a `<x-container-name>` Blade component that displays the container name with a copy-to-clipboard button
- Added the component to the application heading navbar (shows `custom_internal_name` if set, otherwise falls back to `uuid`)
- Added the component to the database heading navbar (shows `uuid` which is the container name)

Currently there is no easy way to find a resource's container name in the UI. Users have to check deployment logs or look up the UUID in the URL bar. This makes it visible and copyable with one click.

## Issues

- Related discussion: https://github.com/coollabsio/coolify/discussions/9252

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

<!-- Add screenshots here -->

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code Opus 4.6
- How extensively: Used for initial implementation, all code was reviewed and tested manually

## Testing

- Verified container name displays correctly for applications and databases
- Verified copy-to-clipboard works in secure context
- Verified `custom_internal_name` takes priority over `uuid` for applications
- Verified no visual regression in the heading navbar

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
