### PR TITLE
feat(ui): add copyable prop to input component for database credentials

### DIFF
--- a/app/View/Components/Forms/Input.php
+++ b/app/View/Components/Forms/Input.php
@@ -34,6 +34,7 @@ class Input extends Component
         public ?string $canGate = null,
         public mixed $canResource = null,
         public bool $autoDisable = true,
+        public bool $copyable = false,
     ) {
         // Handle authorization-based disabling
         if ($this->canGate && $this->canResource && $this->autoDisable) {

--- a/resources/views/components/forms/input.blade.php
+++ b/resources/views/components/forms/input.blade.php
@@ -13,7 +13,10 @@
         </label>
     @endif
     @if ($type === 'password')
-        <div class="relative" x-data="{ type: 'password' }">
+        @if ($copyable)
+            <div class="flex gap-2 items-center">
+        @endif
+        <div class="relative {{ $copyable ? 'flex-1' : '' }}" x-data="{ type: 'password' }">
             @if ($allowToPeak)
                 <div x-on:click="changePasswordFieldType; type = type === 'password' ? 'text' : 'password'"
                     class="flex absolute inset-y-0 right-0 items-center pr-2 cursor-pointer dark:hover:text-white">
@@ -44,7 +47,29 @@
                 @if ($autofocus) x-ref="autofocusInput" @endif>
 
         </div>
+        @if ($copyable)
+                <button type="button" x-data="{ copied: false }"
+                    x-show="window.isSecureContext"
+                    @click.prevent="
+                        const input = $el.closest('.flex').querySelector('input');
+                        const val = input.value;
+                        if (val) { navigator.clipboard.writeText(val); copied = true; setTimeout(() => copied = false, 1500) }
+                    "
+                    class="p-1.5 text-neutral-400 hover:text-neutral-200 transition-colors shrink-0" title="Copy">
+                    <svg x-show="!copied" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                            d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                    </svg>
+                    <svg x-show="copied" x-cloak class="w-5 h-5 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+                    </svg>
+                </button>
+            </div>
+        @endif
     @else
+        @if ($copyable)
+            <div class="flex gap-2 items-center">
+        @endif
         <input autocomplete="{{ $autocomplete }}" @if ($value) value="{{ $value }}" @endif
             {{ $attributes->merge(['class' => $defaultClass]) }} @required($required) @readonly($readonly)
             @if ($modelBinding !== 'null') wire:model={{ $modelBinding }} wire:dirty.class="[box-shadow:inset_4px_0_0_#6b16ed,inset_0_0_0_2px_#e5e5e5] dark:[box-shadow:inset_4px_0_0_#fcd452,inset_0_0_0_2px_#242424]" @endif
@@ -55,6 +80,25 @@
             @if ($htmlId !== 'null') id={{ $htmlId }} @endif name="{{ $name }}"
             placeholder="{{ $attributes->get('placeholder') }}"
             @if ($autofocus) x-ref="autofocusInput" @endif>
+        @if ($copyable)
+                <button type="button" x-data="{ copied: false }"
+                    x-show="window.isSecureContext"
+                    @click.prevent="
+                        const input = $el.closest('.flex').querySelector('input');
+                        const val = input.value;
+                        if (val) { navigator.clipboard.writeText(val); copied = true; setTimeout(() => copied = false, 1500) }
+                    "
+                    class="p-1.5 text-neutral-400 hover:text-neutral-200 transition-colors shrink-0" title="Copy">
+                    <svg x-show="!copied" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                            d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                    </svg>
+                    <svg x-show="copied" x-cloak class="w-5 h-5 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+                    </svg>
+                </button>
+            </div>
+        @endif
     @endif
     @if (!$label && $helper)
         <x-helper :helper="$helper" />

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -206,7 +206,7 @@
         function changePasswordFieldType(event) {
             let element = event.target
             for (let i = 0; i < 10; i++) {
-                if (element.className === "relative") {
+                if (element.classList.contains("relative")) {
                     break;
                 }
                 element = element.parentElement;

--- a/resources/views/livewire/project/database/clickhouse/general.blade.php
+++ b/resources/views/livewire/project/database/clickhouse/general.blade.php
@@ -16,8 +16,8 @@
         @if ($database->started_at)
             <div class="flex gap-2">
                 <x-forms.input label="Initial Username" id="clickhouseAdminUser" placeholder="If empty: clickhouse"
-                    readonly helper="You can only change this in the database." canGate="update" :canResource="$database" />
-                <x-forms.input label="Initial Password" id="clickhouseAdminPassword" type="password" required readonly
+                    readonly copyable helper="You can only change this in the database." canGate="update" :canResource="$database" />
+                <x-forms.input label="Initial Password" id="clickhouseAdminPassword" type="password" required readonly copyable
                     helper="You can only change this in the database." canGate="update" :canResource="$database" />
             </div>
         @else
@@ -43,11 +43,11 @@
             </div>
             <x-forms.input label="Clickhouse URL (internal)"
                 helper="If you change the user/password/port, this could be different. This is with the default values."
-                type="password" readonly wire:model="dbUrl" canGate="update" :canResource="$database" />
+                type="password" readonly copyable wire:model="dbUrl" canGate="update" :canResource="$database" />
             @if ($dbUrlPublic)
                 <x-forms.input label="Clickhouse URL (public)"
                     helper="If you change the user/password/port, this could be different. This is with the default values."
-                    type="password" readonly wire:model="dbUrlPublic" canGate="update" :canResource="$database" />
+                    type="password" readonly copyable wire:model="dbUrlPublic" canGate="update" :canResource="$database" />
             @else
                 <x-forms.input label="Clickhouse URL (public)"
                     helper="If you change the user/password/port, this could be different. This is with the default values."

--- a/resources/views/livewire/project/database/dragonfly/general.blade.php
+++ b/resources/views/livewire/project/database/dragonfly/general.blade.php
@@ -18,7 +18,7 @@
 
         @if ($database->started_at)
             <div class="flex gap-2">
-                <x-forms.input label="Initial Password" id="dragonflyPassword" type="password" required readonly
+                <x-forms.input label="Initial Password" id="dragonflyPassword" type="password" required readonly copyable
                     helper="You can only change this in the database." canGate="update" :canResource="$database" />
             </div>
         @else
@@ -39,12 +39,12 @@
             </div>
             <x-forms.input label="Dragonfly URL (internal)"
                 helper="If you change the user/password/port, this could be different. This is with the default values."
-                type="password" readonly wire:model="dbUrl" canGate="update" :canResource="$database" />
+                type="password" readonly copyable wire:model="dbUrl" canGate="update" :canResource="$database" />
 
             @if ($dbUrlPublic)
                 <x-forms.input label="Dragonfly URL (public)"
                     helper="If you change the user/password/port, this could be different. This is with the default values."
-                    type="password" readonly wire:model="dbUrlPublic" canGate="update" :canResource="$database" />
+                    type="password" readonly copyable wire:model="dbUrlPublic" canGate="update" :canResource="$database" />
             @else
                 <x-forms.input label="Dragonfly URL (public)"
                     helper="If you change the user/password/port, this could be different. This is with the default values."

--- a/resources/views/livewire/project/database/keydb/general.blade.php
+++ b/resources/views/livewire/project/database/keydb/general.blade.php
@@ -15,7 +15,7 @@
 
         @if ($database->started_at)
             <div class="flex gap-2">
-                <x-forms.input label="Initial Password" id="keydbPassword" type="password" required readonly
+                <x-forms.input label="Initial Password" id="keydbPassword" type="password" required readonly copyable
                     helper="You can only change this in the database." canGate="update" :canResource="$database" />
             </div>
         @else
@@ -40,11 +40,11 @@
             </div>
             <x-forms.input label="KeyDB URL (internal)"
                 helper="If you change the user/password/port, this could be different. This is with the default values."
-                type="password" readonly wire:model="dbUrl" canGate="update" :canResource="$database" />
+                type="password" readonly copyable wire:model="dbUrl" canGate="update" :canResource="$database" />
             @if ($dbUrlPublic)
                 <x-forms.input label="KeyDB URL (public)"
                     helper="If you change the user/password/port, this could be different. This is with the default values."
-                    type="password" readonly wire:model="dbUrlPublic" canGate="update" :canResource="$database" />
+                    type="password" readonly copyable wire:model="dbUrlPublic" canGate="update" :canResource="$database" />
             @else
                 <x-forms.input label="KeyDB URL (public)"
                     helper="If you change the user/password/port, this could be different. This is with the default values."

--- a/resources/views/livewire/project/database/mariadb/general.blade.php
+++ b/resources/views/livewire/project/database/mariadb/general.blade.php
@@ -17,18 +17,18 @@
         </div>
         @if ($database->started_at)
             <div class="flex xl:flex-row flex-col gap-2">
-                <x-forms.input label="Root Password" id="mariadbRootPassword" type="password" required
+                <x-forms.input label="Root Password" id="mariadbRootPassword" type="password" required copyable
                     helper="If you change this in the database, please sync it here, otherwise automations (like backups) won't work."
                     canGate="update" :canResource="$database" />
-                <x-forms.input label="Normal User" id="mariadbUser" required
+                <x-forms.input label="Normal User" id="mariadbUser" required copyable
                     helper="If you change this in the database, please sync it here, otherwise automations (like backups) won't work."
                     canGate="update" :canResource="$database" />
-                <x-forms.input label="Normal User Password" id="mariadbPassword" type="password" required
+                <x-forms.input label="Normal User Password" id="mariadbPassword" type="password" required copyable
                     helper="If you change this in the database, please sync it here, otherwise automations (like backups) won't work."
                     canGate="update" :canResource="$database" />
             </div>
             <div class="flex flex-col gap-2">
-                <x-forms.input label="Initial Database" id="mariadbDatabase"
+                <x-forms.input label="Initial Database" id="mariadbDatabase" copyable
                     placeholder="If empty, it will be the same as Username." readonly
                     helper="You can only change this in the database." />
             </div>
@@ -63,11 +63,11 @@
             </div>
             <x-forms.input label="MariaDB URL (internal)"
                 helper="If you change the user/password/port, this could be different. This is with the default values."
-                type="password" readonly wire:model="db_url" canGate="update" :canResource="$database" />
+                type="password" readonly copyable wire:model="db_url" canGate="update" :canResource="$database" />
             @if ($db_url_public)
                 <x-forms.input label="MariaDB URL (public)"
                     helper="If you change the user/password/port, this could be different. This is with the default values."
-                    type="password" readonly wire:model="db_url_public" canGate="update" :canResource="$database" />
+                    type="password" readonly copyable wire:model="db_url_public" canGate="update" :canResource="$database" />
             @endif
         </div>
 

--- a/resources/views/livewire/project/database/mongodb/general.blade.php
+++ b/resources/views/livewire/project/database/mongodb/general.blade.php
@@ -17,15 +17,15 @@
         </div>
         @if ($database->started_at)
             <div class="flex xl:flex-row flex-col gap-2">
-                <x-forms.input label="Initial Username" id="mongoInitdbRootUsername"
+                <x-forms.input label="Initial Username" id="mongoInitdbRootUsername" copyable
                     placeholder="If empty: postgres"
                     helper="If you change this in the database, please sync it here, otherwise automations (like backups) won't work."
                     canGate="update" :canResource="$database" />
-                <x-forms.input label="Initial Password" id="mongoInitdbRootPassword" type="password"
+                <x-forms.input label="Initial Password" id="mongoInitdbRootPassword" type="password" copyable
                     required
                     helper="If you change this in the database, please sync it here, otherwise automations (like backups) won't work."
                     canGate="update" :canResource="$database" />
-                <x-forms.input label="Initial Database" id="mongoInitdbDatabase"
+                <x-forms.input label="Initial Database" id="mongoInitdbDatabase" copyable
                     placeholder="If empty, it will be the same as Username." readonly
                     helper="You can only change this in the database." canGate="update" :canResource="$database" />
             </div>
@@ -52,11 +52,11 @@
             </div>
             <x-forms.input label="Mongo URL (internal)"
                 helper="If you change the user/password/port, this could be different. This is with the default values."
-                type="password" readonly wire:model="db_url" canGate="update" :canResource="$database" />
+                type="password" readonly copyable wire:model="db_url" canGate="update" :canResource="$database" />
             @if ($db_url_public)
                 <x-forms.input label="Mongo URL (public)"
                     helper="If you change the user/password/port, this could be different. This is with the default values."
-                    type="password" readonly wire:model="db_url_public" canGate="update" :canResource="$database" />
+                    type="password" readonly copyable wire:model="db_url_public" canGate="update" :canResource="$database" />
             @endif
         </div>
 

--- a/resources/views/livewire/project/database/mysql/general.blade.php
+++ b/resources/views/livewire/project/database/mysql/general.blade.php
@@ -17,16 +17,16 @@
         </div>
         @if ($database->started_at)
             <div class="flex xl:flex-row flex-col gap-2">
-                <x-forms.input label="Root Password" id="mysqlRootPassword" type="password" required
+                <x-forms.input label="Root Password" id="mysqlRootPassword" type="password" required copyable
                     helper="If you change this in the database, please sync it here, otherwise automations (like backups) won't work." canGate="update" :canResource="$database" />
-                <x-forms.input label="Normal User" id="mysqlUser" required
+                <x-forms.input label="Normal User" id="mysqlUser" required copyable
                     helper="If you change this in the database, please sync it here, otherwise automations (like backups) won't work." canGate="update" :canResource="$database" />
-                <x-forms.input label="Normal User Password" id="mysqlPassword" type="password" required
+                <x-forms.input label="Normal User Password" id="mysqlPassword" type="password" required copyable
                     helper="If you change this in the database, please sync it here, otherwise automations (like backups) won't work." canGate="update" :canResource="$database" />
             </div>
             <div class="flex flex-col gap-2">
                 <x-forms.input label="Initial Database" id="mysqlDatabase"
-                    placeholder="If empty, it will be the same as Username." readonly
+                    placeholder="If empty, it will be the same as Username." readonly copyable
                     helper="You can only change this in the database." canGate="update" :canResource="$database" />
             </div>
         @else
@@ -58,11 +58,11 @@
             </div>
             <x-forms.input label="MySQL URL (internal)"
                 helper="If you change the user/password/port, this could be different. This is with the default values."
-                type="password" readonly wire:model="db_url" />
+                type="password" readonly copyable wire:model="db_url" />
             @if ($db_url_public)
                 <x-forms.input label="MySQL URL (public)"
                     helper="If you change the user/password/port, this could be different. This is with the default values."
-                    type="password" readonly wire:model="db_url_public" />
+                    type="password" readonly copyable wire:model="db_url_public" />
             @endif
         </div>
 

--- a/resources/views/livewire/project/database/postgresql/general.blade.php
+++ b/resources/views/livewire/project/database/postgresql/general.blade.php
@@ -32,13 +32,13 @@
         @if ($database->started_at)
             <div class="flex xl:flex-row flex-col gap-2">
                 <x-forms.input label="Username" id="postgresUser" placeholder="If empty: postgres" canGate="update"
-                    :canResource="$database"
+                    :canResource="$database" copyable
                     helper="If you change this in the database, please sync it here, otherwise automations (like backups) won't work." />
                 <x-forms.input label="Password" id="postgresPassword" type="password" required canGate="update"
-                    :canResource="$database"
+                    :canResource="$database" copyable
                     helper="If you change this in the database, please sync it here, otherwise automations (like backups) won't work." />
                 <x-forms.input label="Initial Database" id="postgresDb"
-                    placeholder="If empty, it will be the same as Username." readonly
+                    placeholder="If empty, it will be the same as Username." readonly copyable
                     helper="You can only change this in the database." />
             </div>
         @else
@@ -71,11 +71,11 @@
 
             <x-forms.input label="Postgres URL (internal)"
                 helper="If you change the user/password/port, this could be different. This is with the default values."
-                type="password" readonly wire:model="db_url" />
+                type="password" readonly copyable wire:model="db_url" />
             @if ($db_url_public)
                 <x-forms.input label="Postgres URL (public)"
                     helper="If you change the user/password/port, this could be different. This is with the default values."
-                    type="password" readonly wire:model="db_url_public" />
+                    type="password" readonly copyable wire:model="db_url_public" />
             @endif
         </div>
         <div class="flex flex-col gap-2">

--- a/resources/views/livewire/project/database/redis/general.blade.php
+++ b/resources/views/livewire/project/database/redis/general.blade.php
@@ -20,10 +20,10 @@
                 </div>
                 <div class="flex gap-2">
                     @if (version_compare($redisVersion, '6.0', '>='))
-                        <x-forms.input label="Username" id="redisUsername"
+                        <x-forms.input label="Username" id="redisUsername" copyable
                             helper="You can only change this in the database." canGate="update" :canResource="$database" />
                     @endif
-                    <x-forms.input label="Password" id="redisPassword" type="password"
+                    <x-forms.input label="Password" id="redisPassword" type="password" copyable
                         helper="You can only change this in the database." canGate="update" :canResource="$database" />
                 </div>
             @else
@@ -62,11 +62,11 @@
             </div>
             <x-forms.input label="Redis URL (internal)"
                 helper="If you change the user/password/port, this could be different. This is with the default values."
-                type="password" readonly wire:model="dbUrl" canGate="update" :canResource="$database" />
+                type="password" readonly copyable wire:model="dbUrl" canGate="update" :canResource="$database" />
             @if ($dbUrlPublic)
                 <x-forms.input label="Redis URL (public)"
                     helper="If you change the user/password/port, this could be different. This is with the default values."
-                    type="password" readonly wire:model="dbUrlPublic" canGate="update" :canResource="$database" />
+                    type="password" readonly copyable wire:model="dbUrlPublic" canGate="update" :canResource="$database" />
             @endif
         </div>
         <div class="flex flex-col gap-2">


### PR DESCRIPTION
## Changes

- Added a `copyable` prop to the `x-forms.input` Blade component (default `false`, fully backward compatible)
- When enabled, a copy-to-clipboard button appears next to the input that copies the current value
- Works with both password and text type inputs without affecting existing functionality
- The flex wrapper and copy button are only rendered when `copyable` is set, so the DOM structure is unchanged for all existing inputs
- Fixed `changePasswordFieldType()` in `base.blade.php` to use `classList.contains()` instead of strict `className ===` comparison, so the eye toggle works correctly when additional CSS classes are present on the container
- Enabled `copyable` on all 8 database type configuration pages for credentials (username, password, database name) and connection URLs (internal + public), only for started databases

### Database types updated:
PostgreSQL, MySQL, MariaDB, MongoDB, Redis, ClickHouse, KeyDB, Dragonfly

## Issues

- Related discussion: https://github.com/coollabsio/coolify/discussions/9252

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

<img width="1917" height="1075" alt="image" src="https://github.com/user-attachments/assets/b7b0eab1-da0e-43fc-8f84-6cd7310fdd25" />


## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Used for initial implementation, all code was reviewed and tested manually

## Testing

- Verified copy button appears and works on all 8 database configuration pages
- Verified eye toggle still works on all password fields (with and without `copyable`)
- Verified no visual or functional regression on inputs without `copyable`
- Verified the `changePasswordFieldType` fix works with additional CSS classes on the relative container
- Verified copy button reads the current input value (works with Livewire-bound properties)

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
