### PR TITLE
fix(application): persist redirect value in setRedirect

### DIFF
--- a/app/Livewire/Project/Application/General.php
+++ b/app/Livewire/Project/Application/General.php
@@ -735,6 +735,7 @@ class General extends Component
         $this->authorize('update', $this->application);
 
         try {
+            $this->application->redirect = $this->redirect;
             $has_www = collect($this->application->fqdns)->filter(fn ($fqdn) => str($fqdn)->contains('www.'))->count();
             if ($has_www === 0 && $this->application->redirect === 'www') {
                 $this->dispatch('error', 'You want to redirect to www, but you do not have a www domain set.<br><br>Please add www to your domain list and as an A DNS record (if applicable).');

--- a/tests/Feature/ApplicationRedirectTest.php
+++ b/tests/Feature/ApplicationRedirectTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use App\Livewire\Project\Application\General;
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\Project;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+
+    $this->actingAs($this->user);
+    session(['currentTeam' => $this->team]);
+
+    $this->project = Project::factory()->create(['team_id' => $this->team->id]);
+    $this->environment = Environment::factory()->create(['project_id' => $this->project->id]);
+});
+
+describe('Application Redirect', function () {
+    test('setRedirect persists the redirect value to the database', function () {
+        $application = Application::factory()->create([
+            'environment_id' => $this->environment->id,
+            'fqdn' => 'https://example.com,https://www.example.com',
+            'redirect' => 'both',
+        ]);
+
+        Livewire::test(General::class, ['application' => $application])
+            ->assertSuccessful()
+            ->set('redirect', 'www')
+            ->call('setRedirect')
+            ->assertDispatched('success');
+
+        $application->refresh();
+        expect($application->redirect)->toBe('www');
+    });
+
+    test('setRedirect rejects www redirect when no www domain exists', function () {
+        $application = Application::factory()->create([
+            'environment_id' => $this->environment->id,
+            'fqdn' => 'https://example.com',
+            'redirect' => 'both',
+        ]);
+
+        Livewire::test(General::class, ['application' => $application])
+            ->assertSuccessful()
+            ->set('redirect', 'www')
+            ->call('setRedirect')
+            ->assertDispatched('error');
+
+        $application->refresh();
+        expect($application->redirect)->toBe('both');
+    });
+});


### PR DESCRIPTION
## Summary
- Fix `General::setRedirect()` to assign the selected Livewire `redirect` state to the `Application` model before saving.
- Preserve existing validation that blocks `www` redirect when no `www` domain is configured.
- Add `ApplicationRedirectTest` feature tests to verify:
- `setRedirect` persists a valid redirect change to the database.
- `setRedirect` dispatches an error and does not persist when `www` is selected without a matching domain.

## Breaking Changes
- None.