### PR TITLE
feat: OAuth2-only self-registration and OAuth2-only login restriction (#8042)

### DIFF
--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -22,7 +22,8 @@ class OauthController extends Controller
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                // Allow registration if general registration is enabled OR OAuth-only registration is enabled
+                if (! $settings->is_registration_enabled && ! $settings->is_oauth_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -15,6 +15,12 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $is_oauth_registration_enabled;
+
+    #[Validate('boolean')]
+    public bool $is_oauth_login_only;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -41,6 +47,8 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_registration_enabled' => 'boolean',
+            'is_oauth_login_only' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => 'nullable|string',
@@ -62,6 +70,8 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled ?? false;
+        $this->is_oauth_login_only = $this->settings->is_oauth_login_only ?? false;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -142,6 +152,8 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
+            $this->settings->is_oauth_login_only = $this->is_oauth_login_only;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -67,6 +67,8 @@ class FortifyServiceProvider extends ServiceProvider
 
             return view('auth.login', [
                 'is_registration_enabled' => $settings->is_registration_enabled,
+                'is_oauth_registration_enabled' => $settings->is_oauth_registration_enabled ?? false,
+                'is_oauth_login_only' => $settings->is_oauth_login_only ?? false,
                 'enabled_oauth_providers' => $enabled_oauth_providers,
             ]);
         });
@@ -74,6 +76,14 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::authenticateUsing(function (Request $request) {
             $email = strtolower($request->email);
             $user = User::where('email', $email)->with('teams')->first();
+
+            // If OAuth-only login is enforced, block password authentication
+            // for users that have no password set (i.e. registered via OAuth)
+            $settings = instanceSettings();
+            if ($user && $settings->is_oauth_login_only && empty($user->password)) {
+                return null;
+            }
+
             if (
                 $user &&
                 Hash::check($request->password, $user->password)

--- a/database/migrations/2026_03_29_000001_add_oauth_registration_settings_to_instance_settings.php
+++ b/database/migrations/2026_03_29_000001_add_oauth_registration_settings_to_instance_settings.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            // Allow users to self-register via OAuth2 even when general registration is disabled
+            $table->boolean('is_oauth_registration_enabled')->default(false)->after('is_registration_enabled');
+            // Restrict OAuth2-linked users to OAuth2 login only (block password auth)
+            $table->boolean('is_oauth_login_only')->default(false)->after('is_oauth_registration_enabled');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn(['is_oauth_registration_enabled', 'is_oauth_login_only']);
+        });
+    }
+};

--- a/lang/en.json
+++ b/lang/en.json
@@ -19,6 +19,7 @@
     "auth.logout": "Logout",
     "auth.register": "Register",
     "auth.registration_disabled": "Registration is disabled. Please contact the administrator.",
+    "auth.registration_oauth_only": "Registration is available via OAuth2 only. Use one of the login options below.",
     "auth.reset_password": "Reset password",
     "auth.failed": "These credentials do not match our records.",
     "auth.failed.callback": "Failed to process callback from login provider.",

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -70,6 +70,10 @@
                             class="block w-full text-center py-3 px-4 rounded-lg border border-neutral-300 dark:border-coolgray-400 font-medium hover:border-coollabs dark:hover:border-warning transition-colors">
                             {{ __('auth.register_now') }}
                         </a>
+                    @elseif ($is_oauth_registration_enabled && $enabled_oauth_providers->isNotEmpty())
+                        <div class="mt-6 text-center text-sm text-neutral-500 dark:text-neutral-400">
+                            {{ __('auth.registration_oauth_only') }}
+                        </div>
                     @else
                         <div class="mt-6 text-center text-sm text-neutral-500 dark:text-neutral-400">
                             {{ __('auth.registration_disabled') }}

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -22,6 +22,16 @@
                             label="Registration Allowed" />
                     </div>
                     <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_registration_enabled"
+                            helper="Allow users to self-register via OAuth2 (e.g. GitHub, Google, Authentik) even when general self-registration is disabled. This lets you control access through your OAuth2 provider without opening registration to everyone."
+                            label="Allow OAuth2-Only Self-Registration" />
+                    </div>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_login_only"
+                            helper="Restrict users who registered via OAuth2 (i.e. have no password set) to OAuth2 login only. Prevents them from setting and using a password — useful for enforcing access control through tools like Authentik."
+                            label="Restrict OAuth2 Users to OAuth2 Login Only" />
+                    </div>
+                    <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"
                             helper="Opt out of anonymous usage tracking. When enabled, this instance will not report to coolify.io's installation count and will not send error reports to help improve Coolify."
                             label="Do Not Track" />


### PR DESCRIPTION
## Summary

Implements the feature requested in #8042 - OAuth2-only self-registration and OAuth2-only login restriction.

## New Settings (Admin > Settings > Advanced)

### Allow OAuth2-Only Self-Registration
When **general self-registration is disabled**, this setting allows users to still self-register by authenticating via an OAuth2 provider (GitHub, Google, Authentik, etc.).

This is useful when you want to control *who* can access the instance through your IdP (e.g. Authentik group membership) without opening registration to anyone with an email/password.

### Restrict OAuth2 Users to OAuth2 Login Only
When enabled, users who registered via OAuth2 (i.e. have no password set) **cannot log in with a password**. All their authentication goes through the OAuth2 provider.

This means revoking the user in Authentik/GitHub org/etc. immediately suspends their access - they can't fall back to a local password.

## Changes

| File | What changed |
|------|-------------|
| database/migrations/2026_03_29_000001_...php | Adds is_oauth_registration_enabled and is_oauth_login_only columns to instance_settings |
| pp/Http/Controllers/OauthController.php | Allows OAuth registration when is_oauth_registration_enabled is true even if general registration is off |
| pp/Providers/FortifyServiceProvider.php | Blocks password login for users with no password (OAuth-only) when is_oauth_login_only is on |
| pp/Livewire/Settings/Advanced.php | Exposes both settings as Livewire properties |
| esources/views/livewire/settings/advanced.blade.php | Two new checkboxes with helper text |
| esources/views/auth/login.blade.php | Shows informational message when OAuth-only registration is active |
| lang/en.json | New translation key uth.registration_oauth_only |

## Testing

1. Enable an OAuth2 provider (e.g. GitHub) and disable general registration
2. Enable **Allow OAuth2-Only Self-Registration** ? new users can self-register via OAuth2
3. Enable **Restrict OAuth2 Users to OAuth2 Login Only** ? existing OAuth2-only users cannot log in with password

Closes #8042