### PR TITLE
fix(clone): exclude uuid when replicating persistent volumes

### DIFF
--- a/app/Livewire/Project/CloneMe.php
+++ b/app/Livewire/Project/CloneMe.php
@@ -187,6 +187,7 @@ class CloneMe extends Component
                         'id',
                         'created_at',
                         'updated_at',
+                        'uuid',
                     ])->forceFill([
                         'name' => $newName,
                         'resource_id' => $newDatabase->id,
@@ -315,6 +316,7 @@ class CloneMe extends Component
                             'id',
                             'created_at',
                             'updated_at',
+                            'uuid',
                         ])->forceFill([
                             'name' => $newName,
                             'resource_id' => $application->id,
@@ -369,6 +371,7 @@ class CloneMe extends Component
                             'id',
                             'created_at',
                             'updated_at',
+                            'uuid',
                         ])->forceFill([
                             'name' => $newName,
                             'resource_id' => $database->id,

--- a/app/Livewire/Project/Shared/ResourceOperations.php
+++ b/app/Livewire/Project/Shared/ResourceOperations.php
@@ -142,6 +142,7 @@ class ResourceOperations extends Component
                     'id',
                     'created_at',
                     'updated_at',
+                    'uuid',
                 ])->forceFill([
                     'name' => $newName,
                     'resource_id' => $new_resource->id,
@@ -280,6 +281,7 @@ class ResourceOperations extends Component
                         'id',
                         'created_at',
                         'updated_at',
+                        'uuid',
                     ])->forceFill([
                         'name' => $newName,
                         'resource_id' => $application->id,
@@ -322,6 +324,7 @@ class ResourceOperations extends Component
                         'id',
                         'created_at',
                         'updated_at',
+                        'uuid',
                     ])->forceFill([
                         'name' => $newName,
                         'resource_id' => $database->id,

--- a/bootstrap/helpers/applications.php
+++ b/bootstrap/helpers/applications.php
@@ -300,6 +300,7 @@ function clone_application(Application $source, $destination, array $overrides =
             'id',
             'created_at',
             'updated_at',
+            'uuid',
         ])->fill([
             'name' => $newName,
             'resource_id' => $newApplication->id,

--- a/tests/Feature/ClonePersistentVolumeUuidTest.php
+++ b/tests/Feature/ClonePersistentVolumeUuidTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use App\Livewire\Project\Shared\ResourceOperations;
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\LocalPersistentVolume;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use App\Models\User;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->team = Team::factory()->create();
+    $this->user->teams()->attach($this->team, ['role' => 'owner']);
+
+    $this->server = Server::factory()->create(['team_id' => $this->team->id]);
+    $this->destination = StandaloneDocker::factory()->create(['server_id' => $this->server->id]);
+    $this->project = Project::factory()->create(['team_id' => $this->team->id]);
+    $this->environment = Environment::factory()->create(['project_id' => $this->project->id]);
+
+    $this->application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => $this->destination->getMorphClass(),
+    ]);
+
+    $this->actingAs($this->user);
+    session(['currentTeam' => $this->team]);
+});
+
+test('cloning application generates new uuid for persistent volumes', function () {
+    $volume = LocalPersistentVolume::create([
+        'name' => $this->application->uuid.'-data',
+        'mount_path' => '/data',
+        'resource_id' => $this->application->id,
+        'resource_type' => $this->application->getMorphClass(),
+    ]);
+
+    $originalUuid = $volume->uuid;
+
+    $newApp = clone_application($this->application, $this->destination, [
+        'environment_id' => $this->environment->id,
+    ]);
+
+    $clonedVolume = $newApp->persistentStorages()->first();
+
+    expect($clonedVolume)->not->toBeNull();
+    expect($clonedVolume->uuid)->not->toBe($originalUuid);
+    expect($clonedVolume->mount_path)->toBe('/data');
+});
+
+test('cloning application with multiple persistent volumes generates unique uuids', function () {
+    $volume1 = LocalPersistentVolume::create([
+        'name' => $this->application->uuid.'-data',
+        'mount_path' => '/data',
+        'resource_id' => $this->application->id,
+        'resource_type' => $this->application->getMorphClass(),
+    ]);
+
+    $volume2 = LocalPersistentVolume::create([
+        'name' => $this->application->uuid.'-config',
+        'mount_path' => '/config',
+        'resource_id' => $this->application->id,
+        'resource_type' => $this->application->getMorphClass(),
+    ]);
+
+    $newApp = clone_application($this->application, $this->destination, [
+        'environment_id' => $this->environment->id,
+    ]);
+
+    $clonedVolumes = $newApp->persistentStorages()->get();
+
+    expect($clonedVolumes)->toHaveCount(2);
+
+    $clonedUuids = $clonedVolumes->pluck('uuid')->toArray();
+    $originalUuids = [$volume1->uuid, $volume2->uuid];
+
+    // All cloned UUIDs should be unique and different from originals
+    expect($clonedUuids)->each->not->toBeIn($originalUuids);
+    expect(array_unique($clonedUuids))->toHaveCount(2);
+});


### PR DESCRIPTION
## Summary

- Fixes 500 error when cloning resources (issue #9270) caused by duplicate UUID constraint violation
- Adds `uuid` to the list of excluded fields when replicating `LocalPersistentVolume` instances
- Ensures each cloned volume gets a unique UUID instead of inheriting the original
- Updates 4 cloning locations: CloneMe, ResourceOperations, and the clone_application helper
- Adds comprehensive test coverage for persistent volume cloning

## Breaking Changes

None

---

Fixes #9270