### PR TITLE
fix(deployment): respect pinned commit SHA for deployments

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -2189,7 +2189,17 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                 ],
             );
         }
-        if ($this->saved_outputs->get('git_commit_sha') && ! $this->rollback) {
+        // Skip overwriting the commit when the application has a pinned SHA
+        $pinnedCommit = str(data_get($this->application, 'git_commit_sha'))->trim()->value();
+        $hasPinnedCommit = $this->pull_request_id === 0 && ! $this->rollback && $pinnedCommit !== '' && $pinnedCommit !== 'HEAD';
+
+        if ($hasPinnedCommit) {
+            $this->commit = $pinnedCommit;
+            if ($this->application_deployment_queue->commit !== $pinnedCommit) {
+                $this->application_deployment_queue->commit = $pinnedCommit;
+                $this->application_deployment_queue->save();
+            }
+        } elseif ($this->saved_outputs->get('git_commit_sha') && ! $this->rollback) {
             // Extract commit SHA from git ls-remote output, handling multi-line output (e.g., redirect warnings)
             // Expected format: "commit_sha\trefs/heads/branch" possibly preceded by warning lines
             // Note: Git warnings can be on the same line as the result (no newline)

--- a/bootstrap/helpers/applications.php
+++ b/bootstrap/helpers/applications.php
@@ -29,6 +29,15 @@ function queue_application_deployment(Application $application, string $deployme
         $destination_id = $destination->id;
     }
 
+    // Use the application's pinned commit SHA when no specific commit was requested
+    // and this is not a PR or rollback deployment
+    if ($pull_request_id === 0 && ! $rollback) {
+        $pinnedCommit = str($application->git_commit_sha ?? '')->trim()->value();
+        if ($pinnedCommit !== '' && $pinnedCommit !== 'HEAD') {
+            $commit = $pinnedCommit;
+        }
+    }
+
     // Check if the deployment queue is full for this server
     $serverForQueueCheck = $server ?? Server::find($server_id);
     $queue_limit = $serverForQueueCheck->settings->deployment_queue_limit ?? 25;

--- a/tests/Unit/PinnedCommitDeploymentTest.php
+++ b/tests/Unit/PinnedCommitDeploymentTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use App\Models\Application;
+use App\Models\ApplicationSetting;
+
+describe('Pinned commit propagation', function () {
+    beforeEach(function () {
+        $this->application = new Application;
+        $this->application->forceFill([
+            'uuid' => 'test-app-uuid',
+            'git_commit_sha' => 'HEAD',
+        ]);
+
+        $settings = new ApplicationSetting;
+        $settings->is_git_shallow_clone_enabled = false;
+        $settings->is_git_submodules_enabled = false;
+        $settings->is_git_lfs_enabled = false;
+        $this->application->setRelation('settings', $settings);
+    });
+
+    test('setGitImportSettings uses pinned commit when no explicit commit is passed', function () {
+        $pinnedSha = str_repeat('a', 40);
+        $this->application->git_commit_sha = $pinnedSha;
+
+        $result = $this->application->setGitImportSettings(
+            deployment_uuid: 'test-uuid',
+            git_clone_command: 'git clone',
+            public: true,
+        );
+
+        expect($result)->toContain($pinnedSha);
+    });
+
+    test('setGitImportSettings prefers explicit commit over pinned commit', function () {
+        $pinnedSha = str_repeat('a', 40);
+        $explicitSha = str_repeat('b', 40);
+        $this->application->git_commit_sha = $pinnedSha;
+
+        $result = $this->application->setGitImportSettings(
+            deployment_uuid: 'test-uuid',
+            git_clone_command: 'git clone',
+            public: true,
+            commit: $explicitSha,
+        );
+
+        expect($result)
+            ->toContain($explicitSha)
+            ->not->toContain($pinnedSha);
+    });
+
+    test('setGitImportSettings does not checkout when git_commit_sha is HEAD', function () {
+        $this->application->git_commit_sha = 'HEAD';
+
+        $result = $this->application->setGitImportSettings(
+            deployment_uuid: 'test-uuid',
+            git_clone_command: 'git clone',
+            public: true,
+        );
+
+        expect($result)->not->toContain('advice.detachedHead=false checkout');
+    });
+
+});


### PR DESCRIPTION
Thank you for coolify, using it for my everyday life and projects, just wanna fix this because it can be annoying sometimes 💜

## Changes

The Commit SHA field in Git Source doesnt actually do anything right now. You can set a specific commit but deploys still pull the latest from the branch every time.

Turns out the deploy function just ignores the saved SHA and defaults to "HEAD". And even if it didnt, the job runs git ls-remote after and overwrites it anyway with the branch head.

Fixed both spots so now the pinned SHA is actually used. Rollbacks and PR deploys stil work as before, they keep using their own commit.

## Issues

- Fixes #9204
- Related: #6881
- Supersedes #7910 (stale, merge conflicts)

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No visual changes, its a backend fix for deployment commit resolution.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Used to explore the codebase and help identify root cause. I reviewed and tested all changes myself.

## Testing

1. Set a specific commit SHA in the app git source settings
2. Clicked deploy, checked the deployment queue and it has the right SHA now instead of HEAD
3. Removed the SHA (back to HEAD), deployed again and it uses HEAD like normal
4. Tested rollback, it still uses its own commit and doesnt get overriden by the pin
5. Force rebuild with a pinned SHA, works correctly
6. `php artisan test --compact tests/Unit/PinnedCommitDeploymentTest.php` - 3 pass
7. `php artisan test --compact tests/Feature/ApplicationRollbackTest.php` - no regressions
8. `php artisan test --compact tests/Unit/GitLsRemoteParsingTest.php` - no regressions

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.