### PR TITLE
Add server-scoped shared environment variables

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -2108,6 +2108,11 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             $this->coolify_variables .= "COOLIFY_BRANCH={$this->application->git_branch} ";
         }
         $this->coolify_variables .= "COOLIFY_RESOURCE_UUID={$this->application->uuid} ";
+
+        $serverSharedVars = $this->server->environment_variables;
+        foreach ($serverSharedVars as $var) {
+            $this->coolify_variables .= "{$var->key}={$var->value} ";
+        }
     }
 
     private function check_git_if_build_needed()

--- a/app/Livewire/SharedVariables/Server/Index.php
+++ b/app/Livewire/SharedVariables/Server/Index.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Livewire\SharedVariables\Server;
+
+use App\Models\Server;
+use Illuminate\Support\Collection;
+use Livewire\Component;
+
+class Index extends Component
+{
+    public Collection $servers;
+
+    public function mount(): void
+    {
+        $this->servers = Server::ownedByCurrentTeamCached();
+    }
+
+    public function render()
+    {
+        return view('livewire.shared-variables.server.index');
+    }
+}

--- a/app/Livewire/SharedVariables/Server/Show.php
+++ b/app/Livewire/SharedVariables/Server/Show.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace App\Livewire\SharedVariables\Server;
+
+use App\Models\Server;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Facades\DB;
+use Livewire\Component;
+
+class Show extends Component
+{
+    use AuthorizesRequests;
+
+    public Server $server;
+
+    public string $view = 'normal';
+
+    public ?string $variables = null;
+
+    protected $listeners = ['refreshEnvs' => 'refreshEnvs', 'saveKey', 'environmentVariableDeleted' => 'refreshEnvs'];
+
+    public function saveKey($data): void
+    {
+        try {
+            $this->authorize('update', $this->server);
+
+            $found = $this->server->environment_variables()->where('key', $data['key'])->first();
+            if ($found) {
+                throw new \Exception('Variable already exists.');
+            }
+            $this->server->environment_variables()->create([
+                'key' => $data['key'],
+                'value' => $data['value'],
+                'is_multiline' => $data['is_multiline'],
+                'is_literal' => $data['is_literal'],
+                'comment' => $data['comment'] ?? null,
+                'type' => 'server',
+                'team_id' => currentTeam()->id,
+            ]);
+            $this->server->refresh();
+            $this->getDevView();
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function mount(): void
+    {
+        $this->server = Server::ownedByCurrentTeam()->where('uuid', request()->route('server_uuid'))->firstOrFail();
+        $this->getDevView();
+    }
+
+    public function switch(): void
+    {
+        $this->authorize('view', $this->server);
+        $this->view = $this->view === 'normal' ? 'dev' : 'normal';
+        $this->getDevView();
+    }
+
+    public function getDevView(): void
+    {
+        $this->variables = $this->formatEnvironmentVariables($this->server->environment_variables->sortBy('key'));
+    }
+
+    private function formatEnvironmentVariables($variables): string
+    {
+        return $variables->map(function ($item) {
+            if ($item->is_shown_once) {
+                return "$item->key=(Locked Secret, delete and add again to change)";
+            }
+            if ($item->is_multiline) {
+                return "$item->key=(Multiline environment variable, edit in normal view)";
+            }
+
+            return "$item->key=$item->value";
+        })->join("\n");
+    }
+
+    public function submit(): void
+    {
+        try {
+            $this->authorize('update', $this->server);
+            $this->handleBulkSubmit();
+            $this->getDevView();
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        } finally {
+            $this->refreshEnvs();
+        }
+    }
+
+    private function handleBulkSubmit(): void
+    {
+        $variables = parseEnvFormatToArray($this->variables);
+        $changesMade = false;
+
+        DB::transaction(function () use ($variables, &$changesMade) {
+            $deletedCount = $this->deleteRemovedVariables($variables);
+            if ($deletedCount > 0) {
+                $changesMade = true;
+            }
+
+            $updatedCount = $this->updateOrCreateVariables($variables);
+            if ($updatedCount > 0) {
+                $changesMade = true;
+            }
+        });
+
+        if ($changesMade) {
+            $this->dispatch('success', 'Environment variables updated.');
+        }
+    }
+
+    private function deleteRemovedVariables($variables): int
+    {
+        $variablesToDelete = $this->server->environment_variables()->whereNotIn('key', array_keys($variables))->get();
+
+        if ($variablesToDelete->isEmpty()) {
+            return 0;
+        }
+
+        $this->server->environment_variables()->whereNotIn('key', array_keys($variables))->delete();
+
+        return $variablesToDelete->count();
+    }
+
+    private function updateOrCreateVariables($variables): int
+    {
+        $count = 0;
+        foreach ($variables as $key => $data) {
+            $value = is_array($data) ? ($data['value'] ?? '') : $data;
+
+            $found = $this->server->environment_variables()->where('key', $key)->first();
+
+            if ($found) {
+                if (! $found->is_shown_once && ! $found->is_multiline) {
+                    if ($found->value !== $value) {
+                        $found->value = $value;
+                        $found->save();
+                        $count++;
+                    }
+                }
+            } else {
+                $this->server->environment_variables()->create([
+                    'key' => $key,
+                    'value' => $value,
+                    'is_multiline' => false,
+                    'is_literal' => false,
+                    'type' => 'server',
+                    'team_id' => currentTeam()->id,
+                ]);
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    public function refreshEnvs(): void
+    {
+        $this->server->refresh();
+        $this->getDevView();
+    }
+
+    public function render()
+    {
+        return view('livewire.shared-variables.server.show');
+    }
+}

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -1015,6 +1015,11 @@ $schema://$host {
         return $this->belongsTo(Team::class);
     }
 
+    public function environment_variables()
+    {
+        return $this->hasMany(SharedEnvironmentVariable::class);
+    }
+
     public function isProxyShouldRun()
     {
         // TODO: Do we need "|| $this->proxy->force_stop" here?

--- a/app/Models/SharedEnvironmentVariable.php
+++ b/app/Models/SharedEnvironmentVariable.php
@@ -17,6 +17,7 @@ class SharedEnvironmentVariable extends Model
         'team_id',
         'project_id',
         'environment_id',
+        'server_id',
 
         // Boolean flags
         'is_multiline',
@@ -42,5 +43,10 @@ class SharedEnvironmentVariable extends Model
     public function environment()
     {
         return $this->belongsTo(Environment::class);
+    }
+
+    public function server()
+    {
+        return $this->belongsTo(Server::class);
     }
 }

--- a/bootstrap/helpers/constants.php
+++ b/bootstrap/helpers/constants.php
@@ -81,4 +81,4 @@ const NEEDS_TO_DISABLE_GZIP = [
 const NEEDS_TO_DISABLE_STRIPPREFIX = [
     'appwrite' => ['appwrite', 'appwrite-console', 'appwrite-realtime'],
 ];
-const SHARED_VARIABLE_TYPES = ['team', 'project', 'environment'];
+const SHARED_VARIABLE_TYPES = ['team', 'project', 'environment', 'server'];

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -4043,6 +4043,8 @@ function resolveSharedEnvironmentVariables(?string $value, $resource): ?string
             $id = $resource->environment->project->id;
         } elseif ($type->value() === 'team') {
             $id = $resource->team()->id;
+        } elseif ($type->value() === 'server') {
+            $id = $resource->destination?->server?->id;
         }
         if (is_null($id)) {
             continue;

--- a/database/migrations/2026_03_30_000000_add_server_id_to_shared_environment_variables_table.php
+++ b/database/migrations/2026_03_30_000000_add_server_id_to_shared_environment_variables_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('shared_environment_variables', function (Blueprint $table) {
+            $table->foreignId('server_id')->nullable()->constrained()->onDelete('cascade')->after('environment_id');
+            $table->unique(['key', 'server_id', 'team_id']);
+        });
+
+        if (DB::getDriverName() === 'mysql') {
+            DB::statement("ALTER TABLE shared_environment_variables MODIFY COLUMN type ENUM('team', 'project', 'environment', 'server') NOT NULL DEFAULT 'team'");
+        }
+    }
+
+    public function down(): void
+    {
+        if (DB::getDriverName() === 'mysql') {
+            DB::statement("ALTER TABLE shared_environment_variables MODIFY COLUMN type ENUM('team', 'project', 'environment') NOT NULL DEFAULT 'team'");
+        }
+
+        Schema::table('shared_environment_variables', function (Blueprint $table) {
+            $table->dropUnique(['key', 'server_id', 'team_id']);
+            $table->dropConstrainedForeignId('server_id');
+        });
+    }
+};

--- a/resources/views/livewire/shared-variables/index.blade.php
+++ b/resources/views/livewire/shared-variables/index.blade.php
@@ -5,7 +5,7 @@
     <div class="flex items-start gap-2">
         <h1>Shared Variables</h1>
     </div>
-    <div class="subtitle">Set Team / Project / Environment wide variables.</div>
+    <div class="subtitle">Set Team / Project / Environment / Server wide variables.</div>
 
     <div class="flex flex-col gap-2 -mt-1">
         <a class="coolbox group" href="{{ route('shared-variables.team.index') }}" {{ wireNavigate() }}>
@@ -24,6 +24,12 @@
             <div class="flex flex-col justify-center mx-6">
                 <div class="box-title">Environment wide</div>
                 <div class="box-description">Usable for all resources in an environment.</div>
+            </div>
+        </a>
+        <a class="coolbox group" href="{{ route('shared-variables.server.index') }}" {{ wireNavigate() }}>
+            <div class="flex flex-col justify-center mx-6">
+                <div class="box-title">Server wide</div>
+                <div class="box-description">Injected into all deployments running on a server.</div>
             </div>
         </a>
 

--- a/resources/views/livewire/shared-variables/server/index.blade.php
+++ b/resources/views/livewire/shared-variables/server/index.blade.php
@@ -1,0 +1,24 @@
+<div>
+    <x-slot:title>
+        Server Variables | Coolify
+    </x-slot>
+    <div class="flex gap-2">
+        <h1>Servers</h1>
+    </div>
+    <div class="subtitle">List of your servers.</div>
+    <div class="flex flex-col gap-2">
+        @forelse ($servers as $server)
+            <a class="coolbox group"
+                href="{{ route('shared-variables.server.show', ['server_uuid' => data_get($server, 'uuid')]) }}" {{ wireNavigate() }}>
+                <div class="flex flex-col justify-center mx-6">
+                    <div class="box-title">{{ $server->name }}</div>
+                    <div class="box-description">{{ $server->description }}</div>
+                </div>
+            </a>
+        @empty
+            <div>
+                <div>No server found.</div>
+            </div>
+        @endforelse
+    </div>
+</div>

--- a/resources/views/livewire/shared-variables/server/show.blade.php
+++ b/resources/views/livewire/shared-variables/server/show.blade.php
@@ -1,0 +1,34 @@
+<div>
+    <x-slot:title>
+        Server Variable | Coolify
+    </x-slot>
+    <div class="flex gap-2">
+        <h1>Shared Variables for {{ $server->name }}</h1>
+        @can('update', $server)
+            <x-modal-input buttonTitle="+ Add" title="New Shared Variable">
+                <livewire:project.shared.environment-variable.add :shared="true" />
+            </x-modal-input>
+        @endcan
+        <x-forms.button canGate="update" :canResource="$server" wire:click='switch'>{{ $view === 'normal' ? 'Developer view' : 'Normal view' }}</x-forms.button>
+    </div>
+    <div class="flex items-center gap-1 subtitle">You can use these variables anywhere with <span
+            class="dark:text-warning text-coollabs">@{{ server.VARIABLENAME }}</span><x-helper
+            helper="More info <a class='underline dark:text-white' href='https://coolify.io/docs/knowledge-base/environment-variables#shared-variables' target='_blank'>here</a>."></x-helper>
+    </div>
+    @if ($view === 'normal')
+        <div class="flex flex-col gap-2">
+            @forelse ($server->environment_variables->sort()->sortBy('key') as $env)
+                <livewire:project.shared.environment-variable.show wire:key="environment-{{ $env->id }}"
+                    :env="$env" type="server" />
+            @empty
+                <div>No environment variables found.</div>
+            @endforelse
+        </div>
+    @else
+        <form wire:submit='submit' class="flex flex-col gap-2">
+            <x-forms.textarea canGate="update" :canResource="$server" rows="20" class="whitespace-pre-wrap" id="variables" wire:model="variables"
+                label="Server Shared Variables"></x-forms.textarea>
+            <x-forms.button canGate="update" :canResource="$server" type="submit" class="btn btn-primary">Save All Environment Variables</x-forms.button>
+        </form>
+    @endif
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -72,6 +72,8 @@ use App\Livewire\SharedVariables\Environment\Show as EnvironmentSharedVariablesS
 use App\Livewire\SharedVariables\Index as SharedVariablesIndex;
 use App\Livewire\SharedVariables\Project\Index as ProjectSharedVariablesIndex;
 use App\Livewire\SharedVariables\Project\Show as ProjectSharedVariablesShow;
+use App\Livewire\SharedVariables\Server\Index as ServerSharedVariablesIndex;
+use App\Livewire\SharedVariables\Server\Show as ServerSharedVariablesShow;
 use App\Livewire\SharedVariables\Team\Index as TeamSharedVariablesIndex;
 use App\Livewire\Source\Github\Change as GitHubChange;
 use App\Livewire\Storage\Index as StorageIndex;
@@ -149,6 +151,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/project/{project_uuid}', ProjectSharedVariablesShow::class)->name('shared-variables.project.show');
         Route::get('/environments', EnvironmentSharedVariablesIndex::class)->name('shared-variables.environment.index');
         Route::get('/environments/project/{project_uuid}/environment/{environment_uuid}', EnvironmentSharedVariablesShow::class)->name('shared-variables.environment.show');
+        Route::get('/servers', ServerSharedVariablesIndex::class)->name('shared-variables.server.index');
+        Route::get('/servers/{server_uuid}', ServerSharedVariablesShow::class)->name('shared-variables.server.show');
     });
 
     Route::prefix('team')->group(function () {

--- a/tests/Feature/ServerSharedVariablesTest.php
+++ b/tests/Feature/ServerSharedVariablesTest.php
@@ -1,0 +1,102 @@
+<?php
+
+use App\Models\Server;
+use App\Models\SharedEnvironmentVariable;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->team = $this->user->teams()->first();
+    $this->server = Server::factory()->create(['team_id' => $this->team->id]);
+
+    $this->actingAs($this->user);
+    session(['currentTeam' => $this->team]);
+});
+
+test('SHARED_VARIABLE_TYPES includes server', function () {
+    expect(SHARED_VARIABLE_TYPES)->toContain('server');
+});
+
+test('server environment_variables relationship returns server-scoped shared variables', function () {
+    SharedEnvironmentVariable::create([
+        'key' => 'SERVER_VAR',
+        'value' => 'server_value',
+        'type' => 'server',
+        'server_id' => $this->server->id,
+        'team_id' => $this->team->id,
+    ]);
+
+    $vars = $this->server->environment_variables;
+    expect($vars)->toHaveCount(1)
+        ->and($vars->first()->key)->toBe('SERVER_VAR')
+        ->and($vars->first()->value)->toBe('server_value');
+});
+
+test('shared environment variable belongs to server', function () {
+    $var = SharedEnvironmentVariable::create([
+        'key' => 'MY_KEY',
+        'value' => 'my_value',
+        'type' => 'server',
+        'server_id' => $this->server->id,
+        'team_id' => $this->team->id,
+    ]);
+
+    expect($var->server->id)->toBe($this->server->id);
+});
+
+test('server shared variable dev view creates new variables', function () {
+    Livewire\Livewire::test(\App\Livewire\SharedVariables\Server\Show::class)
+        ->set('variables', 'SERVER_KEY=server_val')
+        ->call('submit')
+        ->assertHasNoErrors();
+
+    $vars = $this->server->environment_variables()->pluck('value', 'key')->toArray();
+    expect($vars)->toHaveKey('SERVER_KEY')
+        ->and($vars['SERVER_KEY'])->toBe('server_val');
+});
+
+test('server shared variable dev view updates existing variable', function () {
+    SharedEnvironmentVariable::create([
+        'key' => 'EXISTING_VAR',
+        'value' => 'old_value',
+        'type' => 'server',
+        'server_id' => $this->server->id,
+        'team_id' => $this->team->id,
+    ]);
+
+    Livewire\Livewire::test(\App\Livewire\SharedVariables\Server\Show::class)
+        ->set('variables', 'EXISTING_VAR=new_value')
+        ->call('submit')
+        ->assertHasNoErrors();
+
+    $var = $this->server->environment_variables()->where('key', 'EXISTING_VAR')->first();
+    expect($var->value)->toBe('new_value');
+});
+
+test('server shared variable dev view deletes removed variables', function () {
+    SharedEnvironmentVariable::create([
+        'key' => 'VAR_TO_KEEP',
+        'value' => 'keep',
+        'type' => 'server',
+        'server_id' => $this->server->id,
+        'team_id' => $this->team->id,
+    ]);
+    SharedEnvironmentVariable::create([
+        'key' => 'VAR_TO_DELETE',
+        'value' => 'delete',
+        'type' => 'server',
+        'server_id' => $this->server->id,
+        'team_id' => $this->team->id,
+    ]);
+
+    Livewire\Livewire::test(\App\Livewire\SharedVariables\Server\Show::class)
+        ->set('variables', 'VAR_TO_KEEP=keep')
+        ->call('submit')
+        ->assertHasNoErrors();
+
+    expect($this->server->environment_variables()->where('key', 'VAR_TO_DELETE')->exists())->toBeFalse()
+        ->and($this->server->environment_variables()->where('key', 'VAR_TO_KEEP')->exists())->toBeTrue();
+});

--- a/tests/Feature/SharedVariableComposeResolutionTest.php
+++ b/tests/Feature/SharedVariableComposeResolutionTest.php
@@ -126,3 +126,9 @@ test('EnvironmentVariable real_value still resolves shared variables after refac
 
     expect($env->real_value)->toBe('redis://dragonfly:6379');
 });
+
+test('resolveSharedEnvironmentVariables returns original when server has no destination', function () {
+    // When a resource has no destination (destination?->server is null), server vars are skipped gracefully
+    $resolved = resolveSharedEnvironmentVariables('{{server.SOME_VAR}}', $this->application);
+    expect($resolved)->toBe('{{server.SOME_VAR}}');
+});


### PR DESCRIPTION
## Summary

Closes #7738

Adds server-scoped predefined environment variables, following the same pattern as the existing team, project, and environment scoped variables.

- **Migration**: adds `server_id` (nullable FK) to `shared_environment_variables` and adds `'server'` to the type enum
- **Model layer**: `SharedEnvironmentVariable` gains a `server()` relationship; `Server` gains an `environment_variables()` `hasMany`
- **Constant**: `SHARED_VARIABLE_TYPES` updated to `['team', 'project', 'environment', 'server']`
- **Resolver**: `resolveSharedEnvironmentVariables()` handles `{{server.KEY}}` syntax via `$resource->destination?->server?->id`
- **Deployment injection**: `ApplicationDeploymentJob::set_coolify_variables()` injects server-level shared vars into every deployment on that server
- **UI**: new Livewire `Server/Index` and `Server/Show` components + blade views; "Server wide" card added to the shared variables index
- **Routes**: `/shared-variables/servers` and `/shared-variables/servers/{server_uuid}`
- **Tests**: model relationship, resolver null-safe behavior, and Livewire CRUD behavior

## Usage

After setting a variable on a server (e.g. `REGISTRY_HOST=registry.example.com`), it can be referenced from any resource deployed on that server with `{{server.REGISTRY_HOST}}`, or it is automatically injected into every deployment on that server.