### PR TITLE
fix(templates): fix n8n and task-runners health check endpoints

### DIFF
--- a/templates/compose/n8n-with-postgres-and-worker.yaml
+++ b/templates/compose/n8n-with-postgres-and-worker.yaml
@@ -48,7 +48,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:5678/"]
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:5678/healthz"]
       interval: 5s
       timeout: 20s
       retries: 10
@@ -133,7 +133,7 @@ services:
     healthcheck:
       test:
         - CMD-SHELL
-        - 'wget -qO- http://127.0.0.1:5680/'
+        - 'wget -qO- http://127.0.0.1:5680/healthz'
       interval: 5s
       timeout: 20s
       retries: 10

--- a/templates/compose/n8n-with-postgresql.yaml
+++ b/templates/compose/n8n-with-postgresql.yaml
@@ -41,7 +41,7 @@ services:
       postgresql:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:5678/"]
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:5678/healthz"]
       interval: 5s
       timeout: 20s
       retries: 10
@@ -58,7 +58,7 @@ services:
     healthcheck:
       test:
         - CMD-SHELL
-        - 'wget -qO- http://127.0.0.1:5680/'
+        - 'wget -qO- http://127.0.0.1:5680/healthz'
       interval: 5s
       timeout: 20s
       retries: 10

--- a/templates/compose/n8n.yaml
+++ b/templates/compose/n8n.yaml
@@ -32,7 +32,7 @@ services:
     volumes:
       - n8n-data:/home/node/.n8n
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:5678/"]
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:5678/healthz"]
       interval: 5s
       timeout: 20s
       retries: 10
@@ -49,7 +49,7 @@ services:
     healthcheck:
       test:
         - CMD-SHELL
-        - 'wget -qO- http://127.0.0.1:5680/'
+        - 'wget -qO- http://127.0.0.1:5680/healthz'
       interval: 5s
       timeout: 20s
       retries: 10


### PR DESCRIPTION
STRAWBERRY
## Changes

Updated the `healthcheck.test` command in all three n8n templates to use `/healthz` instead of `/` for both the `n8n` (port 5678) and `task-runners` (port 5680) services.

- `n8n` service: `/` → `/healthz` — root path returns HTML (not a health signal), `/healthz` returns `{"status":"ok"}`
- `task-runners` service: `/` → `/healthz` — root path returns 404, permanently marking the service unhealthy

## Issues

- Fixes #9306

## Category

- [x] Fixing or updating existing one click service

## Testing

Verified correct endpoints by connecting to the container terminal:
- `wget -qO- http://127.0.0.1:5678/healthz` → `{"status":"ok"}`
- `wget -qO- http://127.0.0.1:5680/healthz` → `{"status":"ok"}`

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**
- Tools used: GitHub Copilot
- How extensively: Suggested the fix based on the upstream issue

## Contributor Agreement

- [x] I have read and understood the contributor guidelines...
- [x] I have searched existing issues and pull requests...
- [x] I have tested all changes thoroughly...