### PR TITLE
feat: add WordPress + OpenLiteSpeed service template

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -1,0 +1,42 @@
+# documentation: https://wordpress.org
+# slogan: WordPress with OpenLiteSpeed - high-performance web server for WordPress hosting.
+# category: cms
+# tags: cms, blog, content, management, openlitespeed, litespeed, performance
+# logo: svgs/wordpress.svg
+# port: 80
+
+services:
+  wordpress:
+    image: litespeedtech/openlitespeed-wordpress:latest
+    volumes:
+      - wordpress-files:/var/www/vhosts/localhost/html
+      - lsws-conf:/usr/local/lsws/conf
+      - lsws-admin-conf:/usr/local/lsws/admin/conf
+    environment:
+      - SERVICE_URL_WORDPRESS
+      - WORDPRESS_DB_HOST=mariadb
+      - WORDPRESS_DB_USER=$SERVICE_USER_WORDPRESS
+      - WORDPRESS_DB_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+      - WORDPRESS_DB_NAME=wordpress
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1"]
+      interval: 5s
+      timeout: 10s
+      retries: 10
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
## Summary

Closes #8264

Adds a one-click service template for **WordPress running on OpenLiteSpeed** web server with MariaDB backend.

## What's included

- Uses official \litespeedtech/openlitespeed-wordpress\ Docker image
- MariaDB 11 database backend
- Persistent volumes for WordPress files, LSWS config, admin config, and database
- Health checks on both services
- Compatible with Coolify's built-in proxy
- Follows existing Coolify template conventions (same pattern as \wordpress-with-mariadb.yaml\)

## Why OpenLiteSpeed?

OpenLiteSpeed is a high-performance, lightweight web server that's significantly faster than Apache for WordPress workloads, with built-in LSCache support. This was requested by agencies managing multiple WordPress sites on Coolify.