### PR TITLE
feat: add Huly self-host service template

### DIFF
--- a/templates/compose/huly.yaml
+++ b/templates/compose/huly.yaml
@@ -1,123 +1,174 @@
-# ignore: true
-# documentation: https://huly.io/
-# category: cms
-# slogan: Open Source All-in-One Project Management Platform
-# tags: linear,jira,slack,project,management,notion,motion
+# documentation: https://huly.io
+# slogan: Huly is an open-source project management platform — an all-in-one replacement for Linear, Jira, Slack, and Notion.
+# category: project-management
+# tags: project-management, collaboration, issue-tracking, documents, chat, open-source
+# logo: svgs/huly.svg
 # port: 8080
 
 services:
-  mongodb:
-    image: "mongo:7-jammy"
-    container_name: mongodb
-    environment:
-      - PUID=1000
-      - PGID=1000
-    volumes:
-      - huly-db:/data/db
-  minio:
-    image: ghcr.io/coollabsio/minio:RELEASE.2025-10-15T17-29-55Z # Released on 15 October 2025
-    command: server /data --address ":9000" --console-address ":9001"
-    volumes:
-      - huly-files:/data      
-    healthcheck:
-      test: ["CMD", "mc", "ready", "local"]
-      interval: 5s
-      timeout: 20s
-      retries: 10
-  elastic:
-    image: "elasticsearch:7.14.2"
-    command: |
-      /bin/sh -c "./bin/elasticsearch-plugin list | grep -q ingest-attachment || yes | ./bin/elasticsearch-plugin install --silent ingest-attachment;
-      /usr/local/bin/docker-entrypoint.sh eswrapper"
-    volumes:
-      - huly-elastic:/usr/share/elasticsearch/data
-    environment:
-      - ELASTICSEARCH_PORT_NUMBER=9200
-      - BITNAMI_DEBUG=true
-      - discovery.type=single-node
-      - ES_JAVA_OPTS=-Xms1024m -Xmx1024m
-      - http.cors.enabled=true
-      - http.cors.allow-origin=http://localhost:8082
-    healthcheck:
-      test: curl -s http://127.0.0.1:9200/_cluster/health | grep -vq '"status":"red"'
-      interval: 5s
-      retries: 10
-  account:
-    image: hardcoreeng/account:v0.6.246
-    environment:
-      - SERVICE_URL_HULY_3000
-      - SERVER_PORT=3000
-      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
-      - MONGO_URL=mongodb://mongodb:27017
-      - TRANSACTOR_URL=ws://transactor:3333
-      - ENDPOINT_URL=ws://transactor:3333
-      - MINIO_ENDPOINT=minio
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadmin
-      - FRONT_URL=http://front:8080
-      - INIT_WORKSPACE=demo-tracker
-      - MODEL_ENABLED=*
-      - ACCOUNTS_URL=http://localhost:3000
   front:
-    image: hardcoreeng/front:v0.6.246
+    image: hardcoreeng/front:${HULY_VERSION:-latest}
     environment:
       - SERVICE_URL_HULY_8080
-      - MONGO_URL=mongodb://mongodb:27017
       - SERVER_PORT=8080
-      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
-      - ACCOUNTS_URL=http://account:3000
-      - REKONI_URL=http://rekoni:4004
-      - CALENDAR_URL=http://localhost:8095
-      - GMAIL_URL=http://localhost:8088
-      - TELEGRAM_URL=http://localhost:8086
+      - SERVER_SECRET=$SERVICE_PASSWORD_64_HULYSECRET
+      - ACCOUNTS_URL=$SERVICE_URL_HULY/_accounts
+      - ACCOUNTS_URL_INTERNAL=http://account:3000
+      - REKONI_URL=$SERVICE_URL_HULY/_rekoni
       - UPLOAD_URL=/files
-      - TRANSACTOR_URL=ws://transactor:3333
       - ELASTIC_URL=http://elastic:9200
-      - COLLABORATOR_URL=ws://collaborator:3078
-      - COLLABORATOR_API_URL=http://collaborator:3078
-      - MINIO_ENDPOINT=minio
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadmin
-      - TITLE=Huly Self Hosted
-      - DEFAULT_LANGUAGE=en
-      - LAST_NAME_FIRST=true
-    restart: unless-stopped
-  collaborator:
-    image: hardcoreeng/collaborator:v0.6.246
+      - COLLABORATOR_URL=$SERVICE_URL_HULY/_collaborator
+      - STATS_URL=$SERVICE_URL_HULY/_stats
+      - STORAGE_CONFIG=minio|minio?accessKey=$SERVICE_USER_MINIO&secretKey=$SERVICE_PASSWORD_MINIO
+      - TITLE=${TITLE:-Huly}
+      - DEFAULT_LANGUAGE=${DEFAULT_LANGUAGE:-en}
+      - LAST_NAME_FIRST=${LAST_NAME_FIRST:-true}
+    depends_on:
+      - account
+      - transactor
+      - collaborator
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8080"]
+      interval: 10s
+      timeout: 10s
+      retries: 15
+
+  account:
+    image: hardcoreeng/account:${HULY_VERSION:-latest}
     environment:
-      - COLLABORATOR_PORT=3078
-      - SECRET=secret
-      - ACCOUNTS_URL=http://account:3000
+      - SERVER_PORT=3000
+      - SERVER_SECRET=$SERVICE_PASSWORD_64_HULYSECRET
+      - DB_URL=postgresql://cockroach@cockroach:26257/huly?sslmode=disable
       - TRANSACTOR_URL=ws://transactor:3333
-      - UPLOAD_URL=/files
-      - MONGO_URL=mongodb://mongodb:27017
-      - MINIO_ENDPOINT=minio
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadmin
+      - STORAGE_CONFIG=minio|minio?accessKey=$SERVICE_USER_MINIO&secretKey=$SERVICE_PASSWORD_MINIO
+      - FRONT_URL=$SERVICE_URL_HULY
+      - ACCOUNTS_URL=$SERVICE_URL_HULY/_accounts
+      - ACCOUNT_PORT=3000
+      - MODEL_ENABLED=*
+      - QUEUE_CONFIG=redpanda:9092
+      - STATS_URL=http://stats:4900
+
   transactor:
-    image: hardcoreeng/transactor:v0.6.246
+    image: hardcoreeng/transactor:${HULY_VERSION:-latest}
     environment:
       - SERVER_PORT=3333
-      - ELASTIC_INDEX_NAME=huly
-      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
-      - SERVER_CURSOR_MAXTIMEMS=30000
-      - ELASTIC_URL=http://elastic:9200
-      - MONGO_URL=mongodb://mongodb:27017
-      - METRICS_CONSOLE=false
-      - METRICS_FILE=metrics.txt
-      - MINIO_ENDPOINT=minio
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadmin
-      - REKONI_URL=http://rekoni:4004
-      - FRONT_URL=http://localhost:8087
-      - SERVER_PROVIDER=ws
+      - SERVER_SECRET=$SERVICE_PASSWORD_64_HULYSECRET
+      - DB_URL=postgresql://cockroach@cockroach:26257/huly?sslmode=disable
+      - STORAGE_CONFIG=minio|minio?accessKey=$SERVICE_USER_MINIO&secretKey=$SERVICE_PASSWORD_MINIO
+      - FRONT_URL=$SERVICE_URL_HULY
       - ACCOUNTS_URL=http://account:3000
-      - LAST_NAME_FIRST=true
-      - UPLOAD_URL=/files
-    restart: unless-stopped
+      - FULLTEXT_URL=http://fulltext:4700
+      - STATS_URL=http://stats:4900
+      - LAST_NAME_FIRST=${LAST_NAME_FIRST:-true}
+      - QUEUE_CONFIG=redpanda:9092
+
+  collaborator:
+    image: hardcoreeng/collaborator:${HULY_VERSION:-latest}
+    environment:
+      - COLLABORATOR_PORT=3078
+      - SECRET=$SERVICE_PASSWORD_64_HULYSECRET
+      - ACCOUNTS_URL=http://account:3000
+      - STATS_URL=http://stats:4900
+      - STORAGE_CONFIG=minio|minio?accessKey=$SERVICE_USER_MINIO&secretKey=$SERVICE_PASSWORD_MINIO
+
+  workspace:
+    image: hardcoreeng/workspace:${HULY_VERSION:-latest}
+    environment:
+      - SERVER_SECRET=$SERVICE_PASSWORD_64_HULYSECRET
+      - DB_URL=postgresql://cockroach@cockroach:26257/huly?sslmode=disable
+      - TRANSACTOR_URL=ws://transactor:3333
+      - STORAGE_CONFIG=minio|minio?accessKey=$SERVICE_USER_MINIO&secretKey=$SERVICE_PASSWORD_MINIO
+      - MODEL_ENABLED=*
+      - ACCOUNTS_URL=http://account:3000
+      - STATS_URL=http://stats:4900
+      - QUEUE_CONFIG=redpanda:9092
+      - ACCOUNTS_DB_URL=postgresql://cockroach@cockroach:26257/huly?sslmode=disable
+
+  fulltext:
+    image: hardcoreeng/fulltext:${HULY_VERSION:-latest}
+    environment:
+      - SERVER_SECRET=$SERVICE_PASSWORD_64_HULYSECRET
+      - DB_URL=postgresql://cockroach@cockroach:26257/huly?sslmode=disable
+      - FULLTEXT_DB_URL=http://elastic:9200
+      - ELASTIC_INDEX_NAME=huly_storage_index
+      - STORAGE_CONFIG=minio|minio?accessKey=$SERVICE_USER_MINIO&secretKey=$SERVICE_PASSWORD_MINIO
+      - REKONI_URL=http://rekoni:4004
+      - ACCOUNTS_URL=http://account:3000
+      - STATS_URL=http://stats:4900
+      - QUEUE_CONFIG=redpanda:9092
+
   rekoni:
-    image: hardcoreeng/rekoni-service:latest
+    image: hardcoreeng/rekoni-service:${HULY_VERSION:-latest}
+    environment:
+      - SECRET=$SERVICE_PASSWORD_64_HULYSECRET
     deploy:
       resources:
         limits:
           memory: 500M
+
+  stats:
+    image: hardcoreeng/stats:${HULY_VERSION:-latest}
+    environment:
+      - PORT=4900
+      - SERVER_SECRET=$SERVICE_PASSWORD_64_HULYSECRET
+
+  cockroach:
+    image: cockroachdb/cockroach:latest-v24.2
+    command: start-single-node --accept-sql-without-tls
+    environment:
+      - COCKROACH_DATABASE=huly
+      - COCKROACH_USER=cockroach
+    volumes:
+      - cockroach-data:/cockroach/cockroach-data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  redpanda:
+    image: docker.redpanda.com/redpandadata/redpanda:v24.3.6
+    command:
+      - redpanda
+      - start
+      - --kafka-addr internal://0.0.0.0:9092
+      - --advertise-kafka-addr internal://redpanda:9092
+      - --mode dev-container
+      - --smp 1
+      - --default-log-level=info
+    volumes:
+      - redpanda-data:/var/lib/redpanda/data
+    healthcheck:
+      test: ["CMD", "rpk", "cluster", "info"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  minio:
+    image: minio/minio:latest
+    command: server /data --address ":9000" --console-address ":9001"
+    volumes:
+      - minio-data:/data
+    environment:
+      - MINIO_ROOT_USER=$SERVICE_USER_MINIO
+      - MINIO_ROOT_PASSWORD=$SERVICE_PASSWORD_MINIO
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      retries: 10
+
+  elastic:
+    image: elasticsearch:7.14.2
+    command: |
+      /bin/sh -c "./bin/elasticsearch-plugin list | grep -q ingest-attachment || yes | ./bin/elasticsearch-plugin install --silent ingest-attachment;
+      /usr/local/bin/docker-entrypoint.sh eswrapper"
+    volumes:
+      - elastic-data:/usr/share/elasticsearch/data
+    environment:
+      - discovery.type=single-node
+      - ES_JAVA_OPTS=-Xms1024m -Xmx1024m
+      - http.cors.enabled=true
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s http://localhost:9200/_cluster/health | grep -vq '\"status\":\"red\"'"]
+      interval: 20s
+      retries: 10


### PR DESCRIPTION
## Summary

Closes #2543

Adds a one-click service template for **Huly**, an open-source project management platform — an all-in-one replacement for Linear, Jira, Slack, and Notion.

## Services Included

| Service | Image | Purpose |
|---------|-------|---------|
| front | hardcoreeng/front | Web UI |
| account | hardcoreeng/account | Account management |
| transactor | hardcoreeng/transactor | Real-time data sync |
| collaborator | hardcoreeng/collaborator | Collaborative editing |
| workspace | hardcoreeng/workspace | Workspace management |
| fulltext | hardcoreeng/fulltext | Full-text search |
| rekoni | hardcoreeng/rekoni-service | Document processing |
| stats | hardcoreeng/stats | Statistics service |
| CockroachDB | cockroachdb/cockroach | Primary database |
| Redpanda | redpandadata/redpanda | Message queue (Kafka-compatible) |
| MinIO | minio/minio | S3-compatible object storage |
| Elasticsearch | elasticsearch:7.14.2 | Search indexing |

## Notes
- Based on the official [huly-selfhost](https://github.com/hcengineering/huly-selfhost) compose file
- All services use Coolify's environment variable conventions
- Health checks on CockroachDB, Redpanda, MinIO, Elasticsearch, and the front service
- Persistent volumes for all data stores
- Configurable Huly version via \HULY_VERSION\ env var
