### PR TITLE
feat(service): add OpenReplay service template

### DIFF
--- a/templates/compose/openreplay.yaml
+++ b/templates/compose/openreplay.yaml
@@ -1,0 +1,64 @@
+# documentation: https://openreplay.com
+# slogan: OpenReplay is an open-source session replay and product analytics suite.
+# category: analytics
+# tags: analytics, session-replay, monitoring, product-analytics, open-source
+# logo: svgs/openreplay.svg
+# port: 80
+
+services:
+  openreplay:
+    image: openreplay/openreplay:latest
+    volumes:
+      - openreplay-data:/mnt/openreplay
+    environment:
+      - SERVICE_URL_OPENREPLAY
+      - DOMAIN_NAME=$SERVICE_FQDN_OPENREPLAY
+      - LICENSE_KEY=${LICENSE_KEY:-}
+      - POSTGRES_STRING=postgresql://$SERVICE_USER_POSTGRESQL:$SERVICE_PASSWORD_POSTGRESQL@postgresql:5432/openreplay
+      - REDIS_STRING=redis://redis:6379
+      - S3_HOST=minio
+      - S3_PORT=9000
+      - S3_KEY=$SERVICE_USER_MINIO
+      - S3_SECRET=$SERVICE_PASSWORD_MINIO
+    depends_on:
+      postgresql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      minio:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1"]
+      interval: 10s
+      timeout: 10s
+      retries: 15
+  postgresql:
+    image: postgres:16
+    volumes:
+      - postgresql-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=$SERVICE_USER_POSTGRESQL
+      - POSTGRES_PASSWORD=$SERVICE_PASSWORD_POSTGRESQL
+      - POSTGRES_DB=openreplay
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+  redis:
+    image: redis:7
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 10s
+      retries: 10
+  minio:
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    volumes:
+      - minio-data:/data
+    environment:
+      - MINIO_ROOT_USER=$SERVICE_USER_MINIO
+      - MINIO_ROOT_PASSWORD=$SERVICE_PASSWORD_MINIO


### PR DESCRIPTION
## Changes

Added OpenReplay service template with PostgreSQL, Redis, and MinIO. Self-hosted session replay and product analytics suite.

## Issues

- Fixes #8232

## Category

- [x] Adding new one click service

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude
- How extensively: Generated from OpenReplay Docker docs, verified conventions

## Testing

Verified YAML syntax and health checks on all services.

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.