### PR TITLE
fix(service): update Umami to latest to fix CSP blob errors

### DIFF
--- a/templates/compose/umami.yaml
+++ b/templates/compose/umami.yaml
@@ -7,7 +7,7 @@
 
 services:
   umami:
-    image: ghcr.io/umami-software/umami:3.0.3
+    image: ghcr.io/umami-software/umami:latest
     environment:
       - SERVICE_URL_UMAMI_3000
       - DATABASE_URL=postgres://$SERVICE_USER_POSTGRES:$SERVICE_PASSWORD_POSTGRES@postgresql:5432/$POSTGRES_DB


### PR DESCRIPTION
## Changes

Updated Umami image from pinned `3.0.3` to `latest` to fix Content Security Policy errors that block `blob:` script sources in the browser console, preventing event tracking from working.

This CSP issue was resolved in newer Umami releases.

## Issues

- Fixes #5252

## Category

- [x] Fixing or updating existing one click service

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude
- How extensively: Identified version pin as root cause from issue report

## Testing

Verified YAML syntax is valid.

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.