### PR TITLE
fix(service): fix Open Archiver database name mismatch

### DIFF
--- a/templates/compose/open-archiver.yaml
+++ b/templates/compose/open-archiver.yaml
@@ -18,7 +18,7 @@ services:
       - POSTGRES_DB=${POSTGRES_DB:-open_archive}
       - POSTGRES_USER=${SERVICE_USER_POSTGRES}
       - POSTGRES_PASSWORD=${SERVICE_PASSWORD_POSTGRES}
-      - DATABASE_URL=postgresql://${SERVICE_USER_POSTGRES}:${SERVICE_PASSWORD_POSTGRES}@postgres:5432/${POSTGRES_DB:-open-archiver-db}
+      - DATABASE_URL=postgresql://${SERVICE_USER_POSTGRES}:${SERVICE_PASSWORD_POSTGRES}@postgres:5432/${POSTGRES_DB:-open_archive}
       - MEILI_MASTER_KEY=${SERVICE_PASSWORD_MEILISEARCH}
       - MEILI_HOST=http://meilisearch:7700
       - REDIS_HOST=valkey
@@ -51,7 +51,7 @@ services:
   postgres:
     image: postgres:17-alpine
     environment:
-      - POSTGRES_DB=${POSTGRES_DB:-open-archiver-db}
+      - POSTGRES_DB=${POSTGRES_DB:-open_archive}
       - POSTGRES_USER=${SERVICE_USER_POSTGRES}
       - POSTGRES_PASSWORD=${SERVICE_PASSWORD_POSTGRES}
       - LC_ALL=C


### PR DESCRIPTION
## Changes

Fixed database name mismatch in Open Archiver template. The app connects to `open_archive` but PostgreSQL was creating `open-archiver-db`. Aligned both to use `open_archive`.

## Category

- [x] Fixing or updating existing one click service

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude
- How extensively: Pattern-scanned all 352 templates for database name mismatches

## Testing

Verified both POSTGRES_DB references now use the same default value.

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.