### PR TITLE
fix(service): fix Chaskiq entrypoint script execution order

### DIFF
--- a/templates/compose/chaskiq.yaml
+++ b/templates/compose/chaskiq.yaml
@@ -55,7 +55,6 @@ services:
           #!/bin/sh
           set -e
           rm -f /usr/src/app/tmp/pids/server.pid
-          exec "$@"
           echo "Running database migrations..."
           bundle exec rails db:setup || true
           bundle exec rails db:migrate
@@ -69,7 +68,7 @@ services:
               touch /usr/src/app/admin_generated
               echo "Admin generation finished !"
           fi
-          bundle exec rails s -b 0.0.0.0 -p 3000
+          exec bundle exec rails s -b 0.0.0.0 -p 3000
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:3000"]
       interval: 5s


### PR DESCRIPTION
## Changes

Fixed Chaskiq entrypoint script execution order. The script had `exec $@` before the database migration commands, causing the shell process to be replaced before migrations, package updates, and admin generation could run. This resulted in a 500 error on first deploy.

Moved `exec` to the final `rails s` command so all setup steps complete before the server starts.

## Issues

- Fixes #6094

## Category

- [x] Fixing or updating existing one click service

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude
- How extensively: Identified the exec ordering bug from reading the entrypoint script

## Testing

Verified the entrypoint script now runs in correct order: remove pid, migrate, update packages, generate admin, then start server.

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.