### PR TITLE
fix: add max validation to CPU Weight input to prevent error 500

### DIFF
--- a/app/Livewire/Project/Shared/ResourceLimits.php
+++ b/app/Livewire/Project/Shared/ResourceLimits.php
@@ -34,7 +34,7 @@ class ResourceLimits extends Component
         'limitsMemoryReservation' => ['required', 'string', 'regex:/^(0|\d+[bBkKmMgG])$/'],
         'limitsCpus' => ['nullable', 'regex:/^\d*\.?\d+$/'],
         'limitsCpuset' => ['nullable', 'regex:/^\d+([,-]\d+)*$/'],
-        'limitsCpuShares' => 'nullable|integer|min:0',
+        'limitsCpuShares' => 'nullable|integer|min:0|max:1024',
     ];
 
     protected $validationAttributes = [
@@ -57,7 +57,8 @@ class ResourceLimits extends Component
         'limitsMemorySwappiness.min' => 'Swappiness must be between 0 and 100.',
         'limitsMemorySwappiness.max' => 'Swappiness must be between 0 and 100.',
         'limitsCpuShares.integer' => 'CPU Weight must be a whole number.',
-        'limitsCpuShares.min' => 'CPU Weight must be a positive number.',
+        'limitsCpuShares.min' => 'CPU Weight must be between 0 and 1024.',
+        'limitsCpuShares.max' => 'CPU Weight must be between 0 and 1024.',
     ];
 
     /**


### PR DESCRIPTION
## Changes

Added max validation (1024) to the CPU Weight input in the resource limits form. Docker CPU shares must be between 0 and 1024. Previously there was no upper bound, so entering a large value like "100K" caused an unhandled error 500 instead of showing a validation message.

- Added `max:1024` to the `limitsCpuShares` validation rule
- Updated error messages to show the valid range (0-1024)

## Issues

- Fixes #9237

## Category

- [x] Bug fix

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude
- How extensively: Located the validation rule in ResourceLimits.php and added the missing max constraint

## Testing

Verified the validation rule now rejects values above 1024 with a clear error message instead of throwing a 500 error.

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
