### PR TITLE
fix: prevent UUID collision when cloning resource persistent volumes

### DIFF
--- a/app/Livewire/Project/Shared/ResourceOperations.php
+++ b/app/Livewire/Project/Shared/ResourceOperations.php
@@ -146,6 +146,7 @@ class ResourceOperations extends Component
                 ])->forceFill([
                     'name' => $newName,
                     'resource_id' => $new_resource->id,
+                    'uuid' => null,
                 ]);
                 $newPersistentVolume->save();
 


### PR DESCRIPTION
## Changes

Fixed UUID collision error when cloning a resource with persistent volumes. The `replicate()` call excluded `uuid` from the copy, but the attribute was not being properly cleared, causing a `duplicate key value violates unique constraint "local_persistent_volumes_uuid_unique"` error on save.

Explicitly set `uuid => null` in `forceFill()` so that `BaseModel`'s `creating` hook generates a fresh UUID via Cuid2.

## Issues

- Fixes #9270

## Category

- [x] Bug fix

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude
- How extensively: Traced the error from the SQL exception through the clone logic to the replicate call

## Testing

Verified the replicated volume now gets a null UUID before save, triggering the BaseModel creating hook to generate a new unique UUID.

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
