### PR TITLE
fix: allow quotes in Custom Docker Options to match docs example

### DIFF
--- a/app/Support/ValidationPatterns.php
+++ b/app/Support/ValidationPatterns.php
@@ -38,10 +38,11 @@ class ValidationPatterns
     /**
      * Pattern for shell-safe command strings (docker compose commands, docker run options)
      * Blocks dangerous shell metacharacters: ; & | ` $ ( ) > < newlines and carriage returns
-     * Also blocks backslashes, single quotes, and double quotes to prevent escape-sequence attacks
+     * Also blocks backslashes to prevent escape-sequence attacks
+     * Allows single and double quotes to support --entrypoint "sh -c '...'" syntax as documented
      * Uses [ \t] instead of \s to explicitly exclude \n and \r (which act as command separators)
      */
-    public const SHELL_SAFE_COMMAND_PATTERN = '/^[a-zA-Z0-9 \t._\-\/=:@,+\[\]{}#%^~]+$/';
+    public const SHELL_SAFE_COMMAND_PATTERN = '/^[a-zA-Z0-9 \t._\-\/=:@,+\[\]{}#%^~"\']+$/';
 
     /**
      * Pattern for Docker container names


### PR DESCRIPTION
STRAWBERRY

## Changes

The `SHELL_SAFE_COMMAND_PATTERN` whitelist in `ValidationPatterns.php` blocked double and single quotes, preventing use of `--entrypoint` with quoted arguments. Changed the regex to allow `"` and `'` while keeping all dangerous operators blocked (`;`, `&`, `|`, `$`, backticks, backslashes).

## Issues

- Fixes #9343

## Category

- [x] Bug fix

## Preview

**Before:** Entering `--entrypoint "sh -c 'php artisan schedule:work'"` in Custom Docker Options shows:
> The custom Docker run options contain invalid characters. Shell operators like ;, &, |, $, and backticks are not allowed.

**After:** Saves successfully and the container starts with the correct entrypoint.

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Used to identify root cause and generate the one-line regex fix. Reviewed and understood before submission.

## Testing

1. Go to any application → Configuration → General → Custom Docker Options
2. Enter: `--entrypoint "sh -c 'php artisan schedule:work'"`
3. Save — succeeds without validation error
4. Redeploy — container starts with correct entrypoint

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md).
> - [x] I have searched existing issues and pull requests to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify.