### PR TITLE
fix(s3): preserve endpoint URL as-is to support R2 EU jurisdiction

### DIFF
--- a/app/Livewire/Storage/Create.php
+++ b/app/Livewire/Storage/Create.php
@@ -5,7 +5,6 @@ namespace App\Livewire\Storage;
 use App\Models\S3Storage;
 use App\Support\ValidationPatterns;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
-use Illuminate\Support\Uri;
 use Livewire\Component;
 
 class Create extends Component
@@ -73,25 +72,15 @@ class Create extends Component
 
     public function updatedEndpoint($value)
     {
-        try {
-            if (empty($value)) {
-                return;
-            }
-            if (str($value)->contains('digitaloceanspaces.com')) {
-                $uri = Uri::of($value);
-                $host = $uri->host();
-
-                if (preg_match('/^(.+)\.([^.]+\.digitaloceanspaces\.com)$/', $host, $matches)) {
-                    $host = $matches[2];
-                    $value = "https://{$host}";
-                }
-            }
-        } finally {
-            if (! str($value)->startsWith('https://') && ! str($value)->startsWith('http://')) {
-                $value = 'https://'.$value;
-            }
-            $this->endpoint = $value;
+        if (empty($value)) {
+            return;
         }
+
+        if (! str($value)->startsWith('https://') && ! str($value)->startsWith('http://')) {
+            $value = 'https://'.$value;
+        }
+
+        $this->endpoint = $value;
     }
 
     public function submit()

--- a/resources/views/livewire/storage/create.blade.php
+++ b/resources/views/livewire/storage/create.blade.php
@@ -7,7 +7,7 @@
                 <x-forms.input required label="Name" id="name" />
                 <x-forms.input label="Description" id="description" />
             </div>
-            <x-forms.input required type="url" label="Endpoint" wire:model.blur="endpoint" />
+            <x-forms.input required label="Endpoint" id="endpoint" />
             <div class="flex gap-2">
                 <x-forms.input required label="Bucket" id="bucket" />
                 <x-forms.input required helper="Region only required for AWS. Leave it as-is for other providers."

--- a/tests/Feature/S3StorageEndpointTest.php
+++ b/tests/Feature/S3StorageEndpointTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use App\Livewire\Storage\Create;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+
+    $this->actingAs($this->user);
+    session(['currentTeam' => $this->team]);
+});
+
+describe('S3 Storage Endpoint Preservation', function () {
+    test('preserves Cloudflare R2 EU jurisdiction endpoint', function () {
+        $euEndpoint = 'https://b52bf1144d4001acd18a39a8f258f90b.eu.r2.cloudflarestorage.com';
+
+        Livewire::test(Create::class)
+            ->set('endpoint', $euEndpoint)
+            ->call('updatedEndpoint', $euEndpoint)
+            ->assertSet('endpoint', $euEndpoint);
+    });
+
+    test('preserves Cloudflare R2 standard endpoint', function () {
+        $endpoint = 'https://b52bf1144d4001acd18a39a8f258f90b.r2.cloudflarestorage.com';
+
+        Livewire::test(Create::class)
+            ->set('endpoint', $endpoint)
+            ->call('updatedEndpoint', $endpoint)
+            ->assertSet('endpoint', $endpoint);
+    });
+
+    test('adds https prefix when missing', function () {
+        $endpoint = 'b52bf1144d4001acd18a39a8f258f90b.eu.r2.cloudflarestorage.com';
+
+        Livewire::test(Create::class)
+            ->call('updatedEndpoint', $endpoint)
+            ->assertSet('endpoint', 'https://'.$endpoint);
+    });
+
+    test('preserves http prefix', function () {
+        $endpoint = 'http://minio.local:9000';
+
+        Livewire::test(Create::class)
+            ->call('updatedEndpoint', $endpoint)
+            ->assertSet('endpoint', $endpoint);
+    });
+
+    test('preserves DigitalOcean Spaces endpoint', function () {
+        $endpoint = 'https://sfo3.digitaloceanspaces.com';
+
+        Livewire::test(Create::class)
+            ->call('updatedEndpoint', $endpoint)
+            ->assertSet('endpoint', $endpoint);
+    });
+
+    test('preserves AWS S3 endpoint', function () {
+        $endpoint = 'https://s3.eu-west-1.amazonaws.com';
+
+        Livewire::test(Create::class)
+            ->call('updatedEndpoint', $endpoint)
+            ->assertSet('endpoint', $endpoint);
+    });
+});


### PR DESCRIPTION
## Summary

- Stop modifying S3 endpoint URLs during storage creation — the endpoint is now stored exactly as entered
- Remove DigitalOcean Spaces-specific subdomain stripping from `updatedEndpoint()`, which was inconsistent (no equivalent for other providers) and risked corrupting endpoints for other S3 providers
- Change HTML input from `type="url"` to plain text input, consistent with the edit form
- Add tests verifying endpoint preservation for R2 EU, R2 standard, DigitalOcean, AWS, and protocol-less URLs

## Context

Cloudflare R2 EU jurisdiction requires a `.eu.` subdomain in the S3 endpoint (`https://<ACCOUNT_ID>.eu.r2.cloudflarestorage.com`). On save, Coolify silently stripped this subdomain, making it impossible to use R2 EU jurisdiction buckets for backups.

The previous `updatedEndpoint()` method contained provider-specific URL manipulation for DigitalOcean Spaces (stripping bucket name from subdomain). This approach doesn't scale — every S3 provider has different URL conventions — and the safest behavior is to trust the user's input.

Fixes #9305

## Test plan

- [ ] Create S3 storage with Cloudflare R2 EU jurisdiction endpoint (`https://<ID>.eu.r2.cloudflarestorage.com`) — endpoint should be preserved exactly
- [ ] Create S3 storage with standard R2 endpoint — should still work as before
- [ ] Create S3 storage with DigitalOcean Spaces endpoint (`https://sfo3.digitaloceanspaces.com`) — should be preserved as-is
- [ ] Create S3 storage with endpoint missing `https://` — should auto-prepend protocol
- [ ] Run `php artisan test tests/Feature/S3StorageEndpointTest.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)