### PR TITLE
fix(s3): preserve endpoint URL as-is to support R2 EU jurisdiction

### DIFF
--- a/app/Livewire/Storage/Create.php
+++ b/app/Livewire/Storage/Create.php
@@ -5,7 +5,6 @@ namespace App\Livewire\Storage;
 use App\Models\S3Storage;
 use App\Support\ValidationPatterns;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
-use Illuminate\Support\Uri;
 use Livewire\Component;
 
 class Create extends Component
@@ -73,25 +72,15 @@ class Create extends Component
 
     public function updatedEndpoint($value)
     {
-        try {
-            if (empty($value)) {
-                return;
-            }
-            if (str($value)->contains('digitaloceanspaces.com')) {
-                $uri = Uri::of($value);
-                $host = $uri->host();
-
-                if (preg_match('/^(.+)\.([^.]+\.digitaloceanspaces\.com)$/', $host, $matches)) {
-                    $host = $matches[2];
-                    $value = "https://{$host}";
-                }
-            }
-        } finally {
-            if (! str($value)->startsWith('https://') && ! str($value)->startsWith('http://')) {
-                $value = 'https://'.$value;
-            }
-            $this->endpoint = $value;
+        if (empty($value)) {
+            return;
         }
+
+        if (! str($value)->startsWith('https://') && ! str($value)->startsWith('http://')) {
+            $value = 'https://'.$value;
+        }
+
+        $this->endpoint = $value;
     }
 
     public function submit()

--- a/resources/views/livewire/storage/create.blade.php
+++ b/resources/views/livewire/storage/create.blade.php
@@ -7,7 +7,7 @@
                 <x-forms.input required label="Name" id="name" />
                 <x-forms.input label="Description" id="description" />
             </div>
-            <x-forms.input required type="url" label="Endpoint" wire:model.blur="endpoint" />
+            <x-forms.input required label="Endpoint" id="endpoint" />
             <div class="flex gap-2">
                 <x-forms.input required label="Bucket" id="bucket" />
                 <x-forms.input required helper="Region only required for AWS. Leave it as-is for other providers."

--- a/tests/Feature/S3StorageEndpointTest.php
+++ b/tests/Feature/S3StorageEndpointTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use App\Livewire\Storage\Create;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+
+    $this->actingAs($this->user);
+    session(['currentTeam' => $this->team]);
+});
+
+describe('S3 Storage Endpoint Preservation', function () {
+    test('preserves Cloudflare R2 EU jurisdiction endpoint', function () {
+        $euEndpoint = 'https://b52bf1144d4001acd18a39a8f258f90b.eu.r2.cloudflarestorage.com';
+
+        Livewire::test(Create::class)
+            ->set('endpoint', $euEndpoint)
+            ->call('updatedEndpoint', $euEndpoint)
+            ->assertSet('endpoint', $euEndpoint);
+    });
+
+    test('preserves Cloudflare R2 standard endpoint', function () {
+        $endpoint = 'https://b52bf1144d4001acd18a39a8f258f90b.r2.cloudflarestorage.com';
+
+        Livewire::test(Create::class)
+            ->set('endpoint', $endpoint)
+            ->call('updatedEndpoint', $endpoint)
+            ->assertSet('endpoint', $endpoint);
+    });
+
+    test('adds https prefix when missing', function () {
+        $endpoint = 'b52bf1144d4001acd18a39a8f258f90b.eu.r2.cloudflarestorage.com';
+
+        Livewire::test(Create::class)
+            ->call('updatedEndpoint', $endpoint)
+            ->assertSet('endpoint', 'https://'.$endpoint);
+    });
+
+    test('preserves http prefix', function () {
+        $endpoint = 'http://minio.local:9000';
+
+        Livewire::test(Create::class)
+            ->call('updatedEndpoint', $endpoint)
+            ->assertSet('endpoint', $endpoint);
+    });
+
+    test('preserves DigitalOcean Spaces endpoint', function () {
+        $endpoint = 'https://sfo3.digitaloceanspaces.com';
+
+        Livewire::test(Create::class)
+            ->call('updatedEndpoint', $endpoint)
+            ->assertSet('endpoint', $endpoint);
+    });
+
+    test('preserves AWS S3 endpoint', function () {
+        $endpoint = 'https://s3.eu-west-1.amazonaws.com';
+
+        Livewire::test(Create::class)
+            ->call('updatedEndpoint', $endpoint)
+            ->assertSet('endpoint', $endpoint);
+    });
+});


### PR DESCRIPTION
## Changes

When configuring an S3 storage with Cloudflare R2's EU jurisdiction endpoint (`https://<ACCOUNT_ID>.eu.r2.cloudflarestorage.com`), Coolify silently modifies the endpoint URL on save, stripping the `.eu.` subdomain. This makes EU jurisdiction R2 buckets unusable for backups.

The `updatedEndpoint()` method in the storage creation form contained provider-specific URL manipulation for DigitalOcean Spaces (stripping bucket names from subdomains). This approach is inconsistent — no other S3 provider gets equivalent handling — and risks corrupting endpoints. The endpoint field should store exactly what the user enters.

This PR:
- Simplifies `updatedEndpoint()` to only auto-prepend `https://` when no protocol is specified
- Removes the DigitalOcean-specific subdomain stripping logic and the unused `Uri` import
- Changes the endpoint HTML input from `type="url"` to plain text, consistent with the edit form
- Adds tests verifying endpoint preservation across providers (R2 EU, R2 standard, DO, AWS, protocol-less)

## Issues

- Fixes #9305

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Used to explore the codebase, identify the root cause, write the fix and tests. All changes were reviewed and validated by a human.

## Testing

- Verified that `updatedEndpoint()` preserves R2 EU jurisdiction endpoints (`*.eu.r2.cloudflarestorage.com`)
- Verified that standard R2, DigitalOcean Spaces, and AWS endpoints are preserved as-is
- Verified that endpoints without a protocol get `https://` prepended
- Added `tests/Feature/S3StorageEndpointTest.php` with 6 test cases covering all scenarios

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.