### PR TITLE
feat: add configurable Horizon dashboard admin access

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -24,6 +24,11 @@ RAY_ENABLED=false
 # Enable Laravel Telescope for debugging
 TELESCOPE_ENABLED=false
 
+# Laravel Horizon Admin Access
+# Comma-separated list of email addresses allowed to access /horizon dashboard
+# The root user (User ID 0) always has access
+# HORIZON_ALLOWED_EMAILS=admin@example.com,devops@example.com
+
 # Enable Laravel Nightwatch monitoring
 NIGHTWATCH_ENABLED=false
 NIGHTWATCH_TOKEN=

--- a/app/Providers/HorizonServiceProvider.php
+++ b/app/Providers/HorizonServiceProvider.php
@@ -55,9 +55,18 @@ class HorizonServiceProvider extends HorizonApplicationServiceProvider
         Gate::define('viewHorizon', function ($user) {
             $root_user = User::find(0);
 
-            return in_array($user->email, [
-                $root_user->email,
-            ]);
+            // Get additional allowed emails from environment variable
+            $allowedEmails = array_filter(
+                array_map('trim', explode(',', env('HORIZON_ALLOWED_EMAILS', '')))
+            );
+
+            // Merge root user email with additional allowed emails
+            $authorizedEmails = array_merge(
+                [$root_user->email],
+                $allowedEmails
+            );
+
+            return in_array($user->email, $authorizedEmails);
         });
     }
 }


### PR DESCRIPTION
## Related Issue

Fixes #9351

## Description

Adds support for `HORIZON_ALLOWED_EMAILS` environment variable to grant additional users access to the Horizon dashboard (`/horizon`). Currently, only the root user (User ID 0) can access Horizon, which limits monitoring capabilities in multi-admin team environments.

## Changes Made

- Modified `HorizonServiceProvider::gate()` to check `HORIZON_ALLOWED_EMAILS` environment variable
- Accepts comma-separated list of email addresses
- Root user (User ID 0) always retains access (backward compatible)
- Added documentation to `.env.development.example` with usage examples
- Empty/whitespace values are filtered out automatically

## Why This Is Needed

In production environments with multiple team administrators, restricting Horizon access to only the root user creates operational bottlenecks. DevOps team members need visibility into queue health, job failures, and worker performance without requiring root user credentials.

## How to Test

1. Start development environment:
   ```bash
   spin up
   ```

2. Add additional admin emails to `.env`:
   ```bash
   HORIZON_ALLOWED_EMAILS=admin@example.com,devops@example.com
   ```

3. Restart Horizon:
   ```bash
   docker exec coolify php artisan horizon:terminate
   ```

4. Test access scenarios:
   - Login as root user → Access `/horizon` → Should work ✅
   - Login as user in `HORIZON_ALLOWED_EMAILS` → Access `/horizon` → Should work ✅
   - Login as any other user → Access `/horizon` → Should get 403 Forbidden ✅
   - Remove env var → Only root user should have access ✅

## Breaking Changes

None. This change is fully backward compatible. Without the `HORIZON_ALLOWED_EMAILS` environment variable, behavior remains unchanged (only root user has access).

## Contributor Agreement

- [x] I understand and agree that my contribution will be subject to the project's license
- [x] I have tested these changes locally
- [x] I understand the changes I am making