### PR TITLE
Support backups for compose-managed application databases

### DIFF
--- a/app/Actions/Database/StartDatabaseProxy.php
+++ b/app/Actions/Database/StartDatabaseProxy.php
@@ -11,6 +11,7 @@ use App\Models\StandaloneMongodb;
 use App\Models\StandaloneMysql;
 use App\Models\StandalonePostgresql;
 use App\Models\StandaloneRedis;
+use App\Notifications\Container\ContainerRestarted;
 use Lorisleiva\Actions\Concerns\AsAction;
 use Symfony\Component\Yaml\Yaml;
 
@@ -29,11 +30,15 @@ class StartDatabaseProxy
         $proxyContainerName = "{$database->uuid}-proxy";
         $isSSLEnabled = $database->enable_ssl ?? false;
 
-        if ($database->getMorphClass() === \App\Models\ServiceDatabase::class) {
+        if ($database->getMorphClass() === ServiceDatabase::class) {
             $databaseType = $database->databaseType();
-            $network = $database->service->uuid;
-            $server = data_get($database, 'service.destination.server');
-            $containerName = "{$database->name}-{$database->service->uuid}";
+            $network = $database->parentNetworkName();
+            $server = $database->parentServer();
+            $containerName = $database->currentContainerName();
+        }
+
+        if (! $network || ! $server || ! $containerName) {
+            throw new \Exception('Unable to resolve database network/container/server for proxy startup.');
         }
         $internalPort = match ($databaseType) {
             'standalone-mariadb', 'standalone-mysql' => 3306,
@@ -129,10 +134,11 @@ class StartDatabaseProxy
                 $database->update(['is_public' => false]);
 
                 $team = data_get($database, 'environment.project.team')
-                    ?? data_get($database, 'service.environment.project.team');
+                    ?? data_get($database, 'service.environment.project.team')
+                    ?? $database->team();
 
                 $team?->notify(
-                    new \App\Notifications\Container\ContainerRestarted(
+                    new ContainerRestarted(
                         "TCP Proxy for {$database->name} database has been disabled due to error: {$e->getMessage()}",
                         $server,
                     )

--- a/app/Actions/Database/StopDatabaseProxy.php
+++ b/app/Actions/Database/StopDatabaseProxy.php
@@ -24,8 +24,8 @@ class StopDatabaseProxy
     {
         $server = data_get($database, 'destination.server');
         $uuid = $database->uuid;
-        if ($database->getMorphClass() === \App\Models\ServiceDatabase::class) {
-            $server = data_get($database, 'service.server');
+        if ($database->getMorphClass() === ServiceDatabase::class) {
+            $server = $database->parentServer();
         }
         instant_remote_process(["docker rm -f {$uuid}-proxy"], $server);
 

--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -93,7 +93,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
             if (data_get($this->backup, 'database_type') === ServiceDatabase::class) {
                 $this->database = data_get($this->backup, 'database');
-                $this->server = $this->database->service->server;
+                $this->server = $this->database->parentServer();
                 $this->s3 = $this->backup->s3;
             } else {
                 $this->database = data_get($this->backup, 'database');
@@ -110,7 +110,8 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             BackupCreated::dispatch($this->team->id);
 
             $status = str(data_get($this->database, 'status'));
-            if (! $status->startsWith('running') && $this->database->id !== 0) {
+            $isApplicationBackedServiceDatabase = $this->database instanceof ServiceDatabase && filled($this->database->application_id);
+            if (! $isApplicationBackedServiceDatabase && ! $status->startsWith('running') && $this->database->id !== 0) {
                 Log::info('DatabaseBackupJob skipped: database not running', [
                     'backup_id' => $this->backup->id,
                     'database_id' => $this->database->id,
@@ -121,11 +122,12 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
             if (data_get($this->backup, 'database_type') === ServiceDatabase::class) {
                 $databaseType = $this->database->databaseType();
-                $serviceUuid = $this->database->service->uuid;
-                $serviceName = str($this->database->service->name)->slug();
+                $this->container_name = $this->database->currentContainerName();
+                $this->directory_name = $this->database->backupDirectoryName();
+                if (blank($this->container_name) || blank($this->directory_name)) {
+                    throw new \Exception('Unable to resolve the running container for compose database backup.');
+                }
                 if (str($databaseType)->contains('postgres')) {
-                    $this->container_name = "{$this->database->name}-$serviceUuid";
-                    $this->directory_name = $serviceName.'-'.$this->container_name;
                     $commands[] = "docker exec $this->container_name env | grep POSTGRES_";
                     $envs = instant_remote_process($commands, $this->server, true, false, null, disableMultiplexing: true);
                     $envs = str($envs)->explode("\n");
@@ -155,8 +157,6 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                         $this->postgres_password = str($this->postgres_password)->after('POSTGRES_PASSWORD=')->value();
                     }
                 } elseif (str($databaseType)->contains('mysql')) {
-                    $this->container_name = "{$this->database->name}-$serviceUuid";
-                    $this->directory_name = $serviceName.'-'.$this->container_name;
                     $commands[] = "docker exec $this->container_name env | grep MYSQL_";
                     $envs = instant_remote_process($commands, $this->server, true, false, null, disableMultiplexing: true);
                     $envs = str($envs)->explode("\n");
@@ -178,8 +178,6 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                         throw new \Exception('MYSQL_DATABASE not found');
                     }
                 } elseif (str($databaseType)->contains('mariadb')) {
-                    $this->container_name = "{$this->database->name}-$serviceUuid";
-                    $this->directory_name = $serviceName.'-'.$this->container_name;
                     $commands[] = "docker exec $this->container_name env";
                     $envs = instant_remote_process($commands, $this->server, true, false, null, disableMultiplexing: true);
                     $envs = str($envs)->explode("\n");
@@ -216,8 +214,6 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                     }
                 } elseif (str($databaseType)->contains('mongo')) {
                     $databasesToBackup = ['*'];
-                    $this->container_name = "{$this->database->name}-$serviceUuid";
-                    $this->directory_name = $serviceName.'-'.$this->container_name;
 
                     // Try to extract MongoDB credentials from environment variables
                     try {
@@ -674,7 +670,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             $endpoint = $this->s3->endpoint;
             $this->s3->testConnection(shouldSave: true);
             if (data_get($this->backup, 'database_type') === ServiceDatabase::class) {
-                $network = $this->database->service->destination->network;
+                $network = $this->database->parentNetworkName();
             } else {
                 $network = $this->database->destination->network;
             }

--- a/app/Livewire/Project/Application/ComposeDatabaseBackups.php
+++ b/app/Livewire/Project/Application/ComposeDatabaseBackups.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Livewire\Project\Application;
+
+use App\Models\Application;
+use App\Models\ServiceDatabase;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Component;
+
+class ComposeDatabaseBackups extends Component
+{
+    use AuthorizesRequests;
+
+    public ?Application $application = null;
+
+    public ?ServiceDatabase $serviceDatabase = null;
+
+    public array $parameters;
+
+    public bool $isImportSupported = false;
+
+    public function mount()
+    {
+        try {
+            $this->parameters = get_route_parameters();
+            $this->application = Application::whereUuid($this->parameters['application_uuid'])->first();
+            if (! $this->application) {
+                return redirect()->route('dashboard');
+            }
+            $this->authorize('view', $this->application);
+
+            $this->serviceDatabase = $this->application->databases()->whereUuid($this->parameters['stack_service_uuid'])->first();
+            if (! $this->serviceDatabase) {
+                return redirect()->route('project.application.configuration', [
+                    'project_uuid' => $this->parameters['project_uuid'],
+                    'environment_uuid' => $this->parameters['environment_uuid'],
+                    'application_uuid' => $this->parameters['application_uuid'],
+                ]);
+            }
+
+            if (! $this->serviceDatabase->isBackupSolutionAvailable() && ! $this->serviceDatabase->is_migrated) {
+                return redirect()->route('project.application.configuration', [
+                    'project_uuid' => $this->parameters['project_uuid'],
+                    'environment_uuid' => $this->parameters['environment_uuid'],
+                    'application_uuid' => $this->parameters['application_uuid'],
+                ]);
+            }
+
+            $dbType = $this->serviceDatabase->databaseType();
+            $supportedTypes = ['mysql', 'mariadb', 'postgres', 'mongo'];
+            $this->isImportSupported = collect($supportedTypes)->contains(fn ($type) => str_contains($dbType, $type));
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function render()
+    {
+        return view('livewire.project.application.compose-database-backups');
+    }
+}

--- a/app/Livewire/Project/Database/BackupEdit.php
+++ b/app/Livewire/Project/Database/BackupEdit.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\Project\Database;
 
 use App\Models\ScheduledDatabaseBackup;
+use App\Models\ServiceDatabase;
 use Exception;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Livewire\Attributes\Locked;
@@ -144,8 +145,8 @@ class BackupEdit extends Component
 
         try {
             $server = null;
-            if ($this->backup->database instanceof \App\Models\ServiceDatabase) {
-                $server = $this->backup->database->service->destination->server;
+            if ($this->backup->database instanceof ServiceDatabase) {
+                $server = $this->backup->database->parentServer();
             } elseif ($this->backup->database->destination && $this->backup->database->destination->server) {
                 $server = $this->backup->database->destination->server;
             }
@@ -170,8 +171,17 @@ class BackupEdit extends Component
 
             $this->backup->delete();
 
-            if ($this->backup->database->getMorphClass() === \App\Models\ServiceDatabase::class) {
+            if ($this->backup->database->getMorphClass() === ServiceDatabase::class) {
                 $serviceDatabase = $this->backup->database;
+
+                if ($serviceDatabase->application) {
+                    return redirect()->route('project.application.compose-database.backups', [
+                        'project_uuid' => $this->parameters['project_uuid'],
+                        'environment_uuid' => $this->parameters['environment_uuid'],
+                        'application_uuid' => $serviceDatabase->application->uuid,
+                        'stack_service_uuid' => $serviceDatabase->uuid,
+                    ]);
+                }
 
                 return redirect()->route('project.service.database.backups', [
                     'project_uuid' => $this->parameters['project_uuid'],
@@ -182,7 +192,7 @@ class BackupEdit extends Component
             } else {
                 return redirect()->route('project.database.backup.index', $this->parameters);
             }
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->dispatch('error', 'Failed to delete backup: '.$e->getMessage());
 
             return handleError($e, $this);
@@ -214,7 +224,7 @@ class BackupEdit extends Component
 
         $isValid = validate_cron_expression($this->backup->frequency);
         if (! $isValid) {
-            throw new \Exception('Invalid Cron / Human expression');
+            throw new Exception('Invalid Cron / Human expression');
         }
         $this->validate();
     }

--- a/app/Livewire/Project/Database/BackupExecutions.php
+++ b/app/Livewire/Project/Database/BackupExecutions.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\Project\Database;
 
 use App\Models\ScheduledDatabaseBackup;
+use App\Models\ServiceDatabase;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Component;
@@ -78,8 +79,8 @@ class BackupExecutions extends Component
             return;
         }
 
-        $server = $execution->scheduledDatabaseBackup->database->getMorphClass() === \App\Models\ServiceDatabase::class
-            ? $execution->scheduledDatabaseBackup->database->service->destination->server
+        $server = $execution->scheduledDatabaseBackup->database->getMorphClass() === ServiceDatabase::class
+            ? $execution->scheduledDatabaseBackup->database->parentServer()
             : $execution->scheduledDatabaseBackup->database->destination->server;
 
         try {
@@ -185,8 +186,8 @@ class BackupExecutions extends Component
         if ($this->database) {
             $server = null;
 
-            if ($this->database instanceof \App\Models\ServiceDatabase) {
-                $server = $this->database->service->destination->server;
+            if ($this->database instanceof ServiceDatabase) {
+                $server = $this->database->parentServer();
             } elseif ($this->database->destination && $this->database->destination->server) {
                 $server = $this->database->destination->server;
             }

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -595,6 +595,11 @@ class Application extends BaseModel
         return $this->morphMany(LocalFileVolume::class, 'resource');
     }
 
+    public function databases()
+    {
+        return $this->hasMany(ServiceDatabase::class);
+    }
+
     public function type()
     {
         return 'application';

--- a/app/Models/ScheduledDatabaseBackup.php
+++ b/app/Models/ScheduledDatabaseBackup.php
@@ -87,8 +87,7 @@ class ScheduledDatabaseBackup extends BaseModel
     {
         if ($this->database) {
             if ($this->database instanceof ServiceDatabase) {
-                $destination = data_get($this->database->service, 'destination');
-                $server = data_get($destination, 'server');
+                $server = $this->database->parentServer();
             } else {
                 $destination = data_get($this->database, 'destination');
                 $server = data_get($destination, 'server');

--- a/app/Models/ServiceDatabase.php
+++ b/app/Models/ServiceDatabase.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Str;
 
 class ServiceDatabase extends BaseModel
 {
@@ -11,6 +12,7 @@ class ServiceDatabase extends BaseModel
 
     protected $fillable = [
         'service_id',
+        'application_id',
         'name',
         'human_name',
         'description',
@@ -52,7 +54,10 @@ class ServiceDatabase extends BaseModel
 
     public static function ownedByCurrentTeamAPI(int $teamId)
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', $teamId)->orderBy('name');
+        return ServiceDatabase::where(function ($query) use ($teamId) {
+            $query->whereRelation('service.environment.project.team', 'id', $teamId)
+                ->orWhereRelation('application.environment.project.team', 'id', $teamId);
+        })->orderBy('name');
     }
 
     /**
@@ -61,7 +66,10 @@ class ServiceDatabase extends BaseModel
      */
     public static function ownedByCurrentTeam()
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', currentTeam()->id)->orderBy('name');
+        return ServiceDatabase::where(function ($query) {
+            $query->whereRelation('service.environment.project.team', 'id', currentTeam()->id)
+                ->orWhereRelation('application.environment.project.team', 'id', currentTeam()->id);
+        })->orderBy('name');
     }
 
     /**
@@ -139,8 +147,12 @@ class ServiceDatabase extends BaseModel
     public function getServiceDatabaseUrl()
     {
         $port = $this->public_port;
-        $realIp = $this->service->server->ip;
-        if ($this->service->server->isLocalhost() || isDev()) {
+        $server = $this->parentServer();
+        if (! $server) {
+            return null;
+        }
+        $realIp = $server->ip;
+        if ($server->isLocalhost() || isDev()) {
             $realIp = base_ip();
         }
 
@@ -149,17 +161,30 @@ class ServiceDatabase extends BaseModel
 
     public function team()
     {
-        return data_get($this, 'service.environment.project.team');
+        return data_get($this, 'service.environment.project.team')
+            ?? data_get($this, 'application.environment.project.team');
     }
 
     public function workdir()
     {
-        return service_configuration_dir()."/{$this->service->uuid}";
+        if ($this->service) {
+            return service_configuration_dir()."/{$this->service->uuid}";
+        }
+        if ($this->application) {
+            return base_configuration_dir()."/applications/{$this->application->uuid}";
+        }
+
+        return service_configuration_dir();
     }
 
     public function service()
     {
         return $this->belongsTo(Service::class);
+    }
+
+    public function application()
+    {
+        return $this->belongsTo(Application::class);
     }
 
     public function persistentStorages()
@@ -190,5 +215,89 @@ class ServiceDatabase extends BaseModel
             str($this->databaseType())->contains('mariadb') ||
             str($this->databaseType())->contains('mongo') ||
             filled($this->custom_type);
+    }
+
+    public function parentServer()
+    {
+        return data_get($this, 'service.destination.server')
+            ?? data_get($this, 'application.destination.server');
+    }
+
+    public function parentDestination()
+    {
+        return data_get($this, 'service.destination')
+            ?? data_get($this, 'application.destination');
+    }
+
+    public function parentEnvironment()
+    {
+        return data_get($this, 'service.environment')
+            ?? data_get($this, 'application.environment');
+    }
+
+    public function parentProject()
+    {
+        return data_get($this, 'service.environment.project')
+            ?? data_get($this, 'application.environment.project');
+    }
+
+    public function parentNetworkName(int $pullRequestId = 0): ?string
+    {
+        if ($this->service) {
+            return $this->service->uuid;
+        }
+        if ($this->application) {
+            return $pullRequestId !== 0
+                ? "{$this->application->uuid}-{$pullRequestId}"
+                : $this->application->uuid;
+        }
+
+        return null;
+    }
+
+    public function currentContainerName(int $pullRequestId = 0): ?string
+    {
+        if ($this->service) {
+            return "{$this->name}-{$this->service->uuid}";
+        }
+
+        if (! $this->application) {
+            return null;
+        }
+
+        $server = $this->parentServer();
+        if (! $server) {
+            return null;
+        }
+
+        $serviceSlug = Str::slug($this->name);
+        $containers = getCurrentApplicationContainerStatus($server, $this->application->id, $pullRequestId, false)
+            ->filter(function ($container) use ($serviceSlug) {
+                $labels = data_get($container, 'Labels', '');
+
+                return str($labels)->contains("coolify.serviceName={$serviceSlug}");
+            });
+
+        $runningContainer = $containers->first(function ($container) {
+            $status = (string) (data_get($container, 'State') ?: data_get($container, 'Status', ''));
+
+            return str($status)->lower()->contains('running') || str($status)->contains('Up');
+        });
+
+        return data_get($runningContainer ?: $containers->first(), 'Names');
+    }
+
+    public function backupDirectoryName(int $pullRequestId = 0): ?string
+    {
+        $containerName = $this->currentContainerName($pullRequestId);
+        if (! $containerName) {
+            return null;
+        }
+
+        $parentName = $this->service
+            ? str($this->service->name)->slug()->value()
+            : ($this->application ? str($this->application->name)->slug()->value() : str($this->name)->slug()->value());
+
+        return $parentName.'-'.$containerName;
     }
 }

--- a/bootstrap/helpers/databases.php
+++ b/bootstrap/helpers/databases.php
@@ -3,6 +3,7 @@
 use App\Models\EnvironmentVariable;
 use App\Models\S3Storage;
 use App\Models\Server;
+use App\Models\ServiceDatabase;
 use App\Models\StandaloneClickhouse;
 use App\Models\StandaloneDocker;
 use App\Models\StandaloneDragonfly;
@@ -14,6 +15,7 @@ use App\Models\StandalonePostgresql;
 use App\Models\StandaloneRedis;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use Visus\Cuid2\Cuid2;
 
 function create_standalone_postgresql($environmentId, $destinationUuid, ?array $otherData = null, string $databaseImage = 'postgres:16-alpine'): StandalonePostgresql
@@ -23,7 +25,7 @@ function create_standalone_postgresql($environmentId, $destinationUuid, ?array $
     $database->uuid = (new Cuid2);
     $database->name = 'postgresql-database-'.$database->uuid;
     $database->image = $databaseImage;
-    $database->postgres_password = \Illuminate\Support\Str::password(length: 64, symbols: false);
+    $database->postgres_password = Str::password(length: 64, symbols: false);
     $database->environment_id = $environmentId;
     $database->destination_id = $destination->id;
     $database->destination_type = $destination->getMorphClass();
@@ -42,7 +44,7 @@ function create_standalone_redis($environment_id, $destination_uuid, ?array $oth
     $database->uuid = (new Cuid2);
     $database->name = 'redis-database-'.$database->uuid;
 
-    $redis_password = \Illuminate\Support\Str::password(length: 64, symbols: false);
+    $redis_password = Str::password(length: 64, symbols: false);
     if ($otherData && isset($otherData['redis_password'])) {
         $redis_password = $otherData['redis_password'];
         unset($otherData['redis_password']);
@@ -81,7 +83,7 @@ function create_standalone_mongodb($environment_id, $destination_uuid, ?array $o
     $database = new StandaloneMongodb;
     $database->uuid = (new Cuid2);
     $database->name = 'mongodb-database-'.$database->uuid;
-    $database->mongo_initdb_root_password = \Illuminate\Support\Str::password(length: 64, symbols: false);
+    $database->mongo_initdb_root_password = Str::password(length: 64, symbols: false);
     $database->environment_id = $environment_id;
     $database->destination_id = $destination->id;
     $database->destination_type = $destination->getMorphClass();
@@ -99,8 +101,8 @@ function create_standalone_mysql($environment_id, $destination_uuid, ?array $oth
     $database = new StandaloneMysql;
     $database->uuid = (new Cuid2);
     $database->name = 'mysql-database-'.$database->uuid;
-    $database->mysql_root_password = \Illuminate\Support\Str::password(length: 64, symbols: false);
-    $database->mysql_password = \Illuminate\Support\Str::password(length: 64, symbols: false);
+    $database->mysql_root_password = Str::password(length: 64, symbols: false);
+    $database->mysql_password = Str::password(length: 64, symbols: false);
     $database->environment_id = $environment_id;
     $database->destination_id = $destination->id;
     $database->destination_type = $destination->getMorphClass();
@@ -118,8 +120,8 @@ function create_standalone_mariadb($environment_id, $destination_uuid, ?array $o
     $database = new StandaloneMariadb;
     $database->uuid = (new Cuid2);
     $database->name = 'mariadb-database-'.$database->uuid;
-    $database->mariadb_root_password = \Illuminate\Support\Str::password(length: 64, symbols: false);
-    $database->mariadb_password = \Illuminate\Support\Str::password(length: 64, symbols: false);
+    $database->mariadb_root_password = Str::password(length: 64, symbols: false);
+    $database->mariadb_password = Str::password(length: 64, symbols: false);
     $database->environment_id = $environment_id;
     $database->destination_id = $destination->id;
     $database->destination_type = $destination->getMorphClass();
@@ -137,7 +139,7 @@ function create_standalone_keydb($environment_id, $destination_uuid, ?array $oth
     $database = new StandaloneKeydb;
     $database->uuid = (new Cuid2);
     $database->name = 'keydb-database-'.$database->uuid;
-    $database->keydb_password = \Illuminate\Support\Str::password(length: 64, symbols: false);
+    $database->keydb_password = Str::password(length: 64, symbols: false);
     $database->environment_id = $environment_id;
     $database->destination_id = $destination->id;
     $database->destination_type = $destination->getMorphClass();
@@ -155,7 +157,7 @@ function create_standalone_dragonfly($environment_id, $destination_uuid, ?array 
     $database = new StandaloneDragonfly;
     $database->uuid = (new Cuid2);
     $database->name = 'dragonfly-database-'.$database->uuid;
-    $database->dragonfly_password = \Illuminate\Support\Str::password(length: 64, symbols: false);
+    $database->dragonfly_password = Str::password(length: 64, symbols: false);
     $database->environment_id = $environment_id;
     $database->destination_id = $destination->id;
     $database->destination_type = $destination->getMorphClass();
@@ -173,7 +175,7 @@ function create_standalone_clickhouse($environment_id, $destination_uuid, ?array
     $database = new StandaloneClickhouse;
     $database->uuid = (new Cuid2);
     $database->name = 'clickhouse-database-'.$database->uuid;
-    $database->clickhouse_admin_password = \Illuminate\Support\Str::password(length: 64, symbols: false);
+    $database->clickhouse_admin_password = Str::password(length: 64, symbols: false);
     $database->environment_id = $environment_id;
     $database->destination_id = $destination->id;
     $database->destination_type = $destination->getMorphClass();
@@ -279,7 +281,7 @@ function removeOldBackups($backup): void
             ->whereNull('s3_uploaded')
             ->delete();
 
-    } catch (\Exception $e) {
+    } catch (Exception $e) {
         throw $e;
     }
 }
@@ -345,8 +347,8 @@ function deleteOldBackupsLocally($backup): Collection
     $processedBackups = collect();
 
     $server = null;
-    if ($backup->database_type === \App\Models\ServiceDatabase::class) {
-        $server = $backup->database->service->server;
+    if ($backup->database_type === ServiceDatabase::class) {
+        $server = $backup->database->parentServer();
     } else {
         $server = $backup->database->destination->server;
     }

--- a/bootstrap/helpers/parsers.php
+++ b/bootstrap/helpers/parsers.php
@@ -681,6 +681,18 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
         $coolifyEnvironments = collect([]);
 
         $isDatabase = isDatabaseImage($image, $service);
+        if ($isDatabase && $pullRequestId === 0) {
+            ServiceDatabase::updateOrCreate(
+                [
+                    'name' => $serviceName,
+                    'application_id' => $resource->id,
+                ],
+                [
+                    'image' => $image,
+                    'service_id' => null,
+                ]
+            );
+        }
         $volumesParsed = collect([]);
 
         $baseName = generateApplicationContainerName(

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -2916,6 +2916,18 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
             // Decide if the service is a database
             $image = data_get_str($service, 'image');
             $isDatabase = isDatabaseImage($image, $service);
+            if ($isDatabase && $pull_request_id === 0) {
+                ServiceDatabase::updateOrCreate(
+                    [
+                        'name' => $serviceName,
+                        'application_id' => $resource->id,
+                    ],
+                    [
+                        'image' => $image,
+                        'service_id' => null,
+                    ]
+                );
+            }
             data_set($service, 'is_database', $isDatabase);
 
             // Collect/create/update networks

--- a/database/migrations/2026_03_31_170000_add_application_id_to_service_databases_table.php
+++ b/database/migrations/2026_03_31_170000_add_application_id_to_service_databases_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->foreignId('application_id')->nullable()->after('service_id');
+            $table->foreign('application_id')->references('id')->on('applications')->nullOnDelete();
+            $table->foreignId('service_id')->nullable()->change();
+            $table->index(['application_id', 'name']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->dropIndex('service_databases_application_id_name_index');
+            $table->dropForeign(['application_id']);
+            $table->dropColumn('application_id');
+            $table->foreignId('service_id')->nullable(false)->change();
+        });
+    }
+};

--- a/resources/views/livewire/project/application/compose-database-backups.blade.php
+++ b/resources/views/livewire/project/application/compose-database-backups.blade.php
@@ -1,0 +1,25 @@
+<div>
+    <x-slot:title>
+        {{ data_get_str($application, 'name')->limit(10) }} >
+        {{ data_get_str($serviceDatabase, 'name')->limit(10) }} > Backups | Coolify
+    </x-slot>
+    <h1>Backups</h1>
+    <livewire:project.shared.configuration-checker :resource="$application" />
+    <livewire:project.application.heading :application="$application" />
+    <div class="flex flex-col gap-2">
+        <div class="flex gap-2">
+            <h2 class="pb-4">Scheduled Backups</h2>
+            @if (filled($serviceDatabase->custom_type) || !$serviceDatabase->is_migrated)
+                @can('update', $serviceDatabase)
+                    <x-modal-input buttonTitle="+ Add" title="New Scheduled Backup">
+                        <livewire:project.database.create-scheduled-backup :database="$serviceDatabase" />
+                    </x-modal-input>
+                @endcan
+            @endif
+        </div>
+        <p class="text-sm text-gray-600 dark:text-gray-400">
+            Manage backups for the <span class="font-medium">{{ $serviceDatabase->name }}</span> database service inside this Docker Compose application.
+        </p>
+        <livewire:project.database.scheduled-backups :database="$serviceDatabase" />
+    </div>
+</div>

--- a/resources/views/livewire/project/application/general.blade.php
+++ b/resources/views/livewire/project/application/general.blade.php
@@ -69,6 +69,30 @@
                                                 Domain</x-forms.button>
                                         @endcan
                                     </div>
+                                @else
+                                    @php
+                                        $serviceDatabase = $application->databases()->where('name', $serviceName)->first();
+                                    @endphp
+                                    @if ($serviceDatabase && $serviceDatabase->isBackupSolutionAvailable())
+                                        <div class="flex items-center gap-2 rounded-lg border border-dashed border-gray-300 px-4 py-3 dark:border-coolgray-400">
+                                            <div class="flex-1">
+                                                <div class="font-medium">{{ $serviceName }}</div>
+                                                <div class="text-sm text-gray-600 dark:text-gray-400">
+                                                    This compose-managed database supports scheduled backups.
+                                                </div>
+                                            </div>
+                                            <a {{ wireNavigate() }}
+                                                href="{{ route('project.application.compose-database.backups', [
+                                                    'project_uuid' => $application->project()->uuid,
+                                                    'environment_uuid' => $application->environment->uuid,
+                                                    'application_uuid' => $application->uuid,
+                                                    'stack_service_uuid' => $serviceDatabase->uuid,
+                                                ]) }}"
+                                                class="inline-flex items-center rounded-md bg-coollabs px-3 py-2 text-sm font-medium text-white transition hover:opacity-90">
+                                                Manage Backups
+                                            </a>
+                                        </div>
+                                    @endif
                                 @endif
                             @endforeach
                         @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,6 +16,7 @@ use App\Livewire\Notifications\Slack as NotificationSlack;
 use App\Livewire\Notifications\Telegram as NotificationTelegram;
 use App\Livewire\Notifications\Webhook as NotificationWebhook;
 use App\Livewire\Profile\Index as ProfileIndex;
+use App\Livewire\Project\Application\ComposeDatabaseBackups as ApplicationComposeDatabaseBackups;
 use App\Livewire\Project\Application\Configuration as ApplicationConfiguration;
 use App\Livewire\Project\Application\Deployment\Index as DeploymentIndex;
 use App\Livewire\Project\Application\Deployment\Show as DeploymentShow;
@@ -33,7 +34,6 @@ use App\Livewire\Project\Service\DatabaseBackups as ServiceDatabaseBackups;
 use App\Livewire\Project\Service\Index as ServiceIndex;
 use App\Livewire\Project\Shared\ExecuteContainerCommand;
 use App\Livewire\Project\Shared\Logs;
-use App\Livewire\Project\Shared\ScheduledTask\Show as ScheduledTaskShow;
 use App\Livewire\Project\Show as ProjectShow;
 use App\Livewire\Security\ApiTokens;
 use App\Livewire\Security\CloudInitScripts;
@@ -232,6 +232,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
         Route::get('/deployment', DeploymentIndex::class)->name('project.application.deployment.index');
         Route::get('/deployment/{deployment_uuid}', DeploymentShow::class)->name('project.application.deployment.show');
+        Route::get('/compose-database/{stack_service_uuid}/backups', ApplicationComposeDatabaseBackups::class)->name('project.application.compose-database.backups');
         Route::get('/logs', Logs::class)->name('project.application.logs');
         Route::get('/terminal', ExecuteContainerCommand::class)->name('project.application.command')->middleware('can.access.terminal');
         Route::get('/tasks/{task_uuid}', ApplicationConfiguration::class)->name('project.application.scheduled-tasks');
@@ -349,7 +350,7 @@ Route::middleware(['auth'])->group(function () {
             }
             $filename = data_get($execution, 'filename');
             if ($execution->scheduledDatabaseBackup->database->getMorphClass() === ServiceDatabase::class) {
-                $server = $execution->scheduledDatabaseBackup->database->service->destination->server;
+                $server = $execution->scheduledDatabaseBackup->database->parentServer();
             } else {
                 $server = $execution->scheduledDatabaseBackup->database->destination->server;
             }

--- a/tests/Feature/ApplicationComposeDatabaseBackupParsingTest.php
+++ b/tests/Feature/ApplicationComposeDatabaseBackupParsingTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\Project;
+use App\Models\ScheduledDatabaseBackup;
+use App\Models\Server;
+use App\Models\ServiceDatabase;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->team = Team::factory()->create();
+    $this->user->teams()->attach($this->team, ['role' => 'owner']);
+
+    $this->server = Server::factory()->create(['team_id' => $this->team->id]);
+    $this->destination = $this->server->standaloneDockers()->firstOrFail();
+    $this->project = Project::factory()->create(['team_id' => $this->team->id]);
+    $this->environment = Environment::factory()->create(['project_id' => $this->project->id]);
+
+    $this->application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => $this->destination->getMorphClass(),
+        'build_pack' => 'dockercompose',
+        'docker_compose_raw' => <<<'YAML'
+services:
+  web:
+    image: ghcr.io/acme/example-web:latest
+    environment:
+      APP_ENV: production
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: secret
+      POSTGRES_DB: app
+YAML,
+        'compose_parsing_version' => '5',
+    ]);
+
+    $this->actingAs($this->user);
+    session(['currentTeam' => $this->team]);
+});
+
+test('application docker compose parsing persists service databases for compose-backed apps', function () {
+    $parsed = $this->application->parse();
+
+    expect($parsed)->not->toBeNull();
+
+    $database = ServiceDatabase::query()
+        ->where('application_id', $this->application->id)
+        ->where('name', 'postgres')
+        ->first();
+
+    expect($database)->not->toBeNull()
+        ->and($database->service_id)->toBeNull()
+        ->and($database->image)->toBe('postgres:16');
+});
+
+test('scheduled backup resolves server for application-backed compose databases', function () {
+    $database = ServiceDatabase::create([
+        'name' => 'postgres',
+        'image' => 'postgres:16',
+        'application_id' => $this->application->id,
+        'service_id' => null,
+    ]);
+
+    $backup = ScheduledDatabaseBackup::create([
+        'team_id' => $this->team->id,
+        'frequency' => '0 2 * * *',
+        'database_type' => ServiceDatabase::class,
+        'database_id' => $database->id,
+    ]);
+
+    expect($backup->server())->not->toBeNull()
+        ->and($backup->server()->id)->toBe($this->server->id);
+});


### PR DESCRIPTION
STRAWBERRY

## Changes

Compose-managed database services (e.g., postgres, mysql, mariadb, mongodb) declared inside an Application's `docker-compose.yml` now support scheduled backups.

- **Schema**: Added `application_id` nullable FK to `service_databases` table, made `service_id` nullable, added composite index on `(application_id, name)`.
- **Model**: `ServiceDatabase` now has an `application()` relation and `Application` has a `databases()` relation. Added parent-resolution helpers (`parentServer`, `parentDestination`, `parentNetworkName`, `currentContainerName`, `backupDirectoryName`, etc.) so backup and proxy code works whether the DB belongs to a Service or Application.
- **Parser**: Both `applicationParser` functions now detect database images in compose YAML and upsert a `ServiceDatabase` row with `application_id` set and `service_id` null.
- **Backup runtime**: `DatabaseBackupJob` resolves server, container, and network from the parent helpers instead of assuming service-based paths. Status check bypassed for application-backed DBs since their container status is sourced from application container scanning.
- **Proxy**: `StartDatabaseProxy` / `StopDatabaseProxy` handle application-backed compose DBs via the parent-resolution helpers.
- **UI**: New `ComposeDatabaseBackups` Livewire component at route `project.application.compose-database.backups`. Application general page shows a "Manage Backups" button for compose-managed DBs that support backups.
- **Tests**: `ApplicationComposeDatabaseBackupParsingTest` covers DB persistence on compose parse and server resolution for scheduled backups.

## Issues

- Fixes #7528

## Category

- [ ] Bug fix
- [x] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Coming soon.

## AI Assistance

- [x] AI was used

**If AI was used:**

- Tools used: Claude Code (this session), droid exec
- How extensively: Full implementation — all code changes, tests, and validation

## Testing

- New tests: 2/2 pass (ApplicationComposeDatabaseBackupParsingTest)
- Existing related tests: ServiceDatabaseTeamTest 2/2, ModelFillableRegressionTest 42/42, ServiceParserImageUpdateTest 4/4 — all pass
- Migration tested with `--pretend` on the dev database
- Diff verified clean with `git diff --check`

## Contributor Agreement

- [x] I have read and understood the contributor guidelines
- [x] I have searched existing issues and pull requests to ensure this is not a duplicate
- [x] I have tested all changes with a local development instance of Coolify