### PR TITLE
[v5.x] chore(deps): harden bun install settings

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@ianvs/prettier-plugin-sort-imports": "^4.7.1",
+        "@inertiajs/core": "^3.0.0",
         "@inertiajs/svelte": "^3.0.0",
         "@inertiajs/vite": "^3.0.0",
         "@sveltejs/vite-plugin-svelte": "^7.0.0",

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,9 @@
+telemetry = false
+
+[env]
+file = false
+
+[install]
+linker = "isolated"
+frozenLockfile = true
+minimumReleaseAge = 604800 # 7 days

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"devDependencies": {
 		"@eslint/js": "^10.0.1",
 		"@ianvs/prettier-plugin-sort-imports": "^4.7.1",
+		"@inertiajs/core": "^3.0.0",
 		"@inertiajs/svelte": "^3.0.0",
 		"@inertiajs/vite": "^3.0.0",
 		"@sveltejs/vite-plugin-svelte": "^7.0.0",


### PR DESCRIPTION
Harden Bun to protect against supply chain attacks (e.g. [Axios compromised](https://socket.dev/blog/axios-npm-package-compromised)) and ensure reproducible installs.

## Changes

- Set linker to `isolated` to eliminate phantom dependencies (packages accessible without being declared in `package.json`)
  - Explicitly install `@inertiajs/core`, previously resolved as a transitive dependency of `@inertiajs/svelte`
- Enable `frozenLockfile` to ensure each developer and also production Docker image builds (in the future) install the exact dependency versions from the lockfile
- Require a minimum package release age of 7 days to avoid installing freshly published or potentially hijacked packages and prevent supply chain attacks
- Disable telemetry
- Disable automatic `.env` file loading

## TODO

- [ ] Possibly remove `frozenLockfile`, as it seems broken - it also prevents the installation of new packages (`bun add`) because it runs all the time, not only during a `bun install`?
