### PR TITLE
fix(service): add missing database alteration step for Logto latest image

### DIFF
--- a/templates/compose/logto.yaml
+++ b/templates/compose/logto.yaml
@@ -10,7 +10,7 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-    entrypoint: ["sh", "-c", "npm run cli db seed -- --swe && npm start"]
+    entrypoint: ["sh", "-c", "npm run cli db seed -- --swe && npm run alteration deploy latest && npm start"]
     environment:
       - SERVICE_URL_LOGTO
       - TRUST_PROXY_HEADER=1


### PR DESCRIPTION
When upgrading to the latest image version, the database alteration command was missing, causing the application to fail due to schema mismatch. This change ensures the database is properly migrated to the latest version during startup.

## Changes

- Added missing database alteration command during container startup to ensure schema is updated when upgrading the image version.
- Prevents runtime failures caused by schema mismatch between application and database.

## Issues

- Fixes startup failure when upgrading Logto image due to missing DB migration step

## Category


- [x] Fixing or updating existing one click service

## Preview

N/A

## AI Assistance

- [x] AI was NOT used to create this PR

## Testing

- Deployed the updated configuration on Coolify
- Verified that the container starts successfully after upgrading the image
- Confirmed that database migrations are applied and the application runs without schema errors

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.