### PR TITLE
fix(docker): append unit suffix to memory limit values

### DIFF
--- a/app/Actions/Database/StartClickhouse.php
+++ b/app/Actions/Database/StartClickhouse.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Database;
 
+use App\Helpers\DockerHelper;
 use App\Models\StandaloneClickhouse;
 use Lorisleiva\Actions\Concerns\AsAction;
 use Symfony\Component\Yaml\Yaml;
@@ -57,10 +58,10 @@ class StartClickhouse
                         'retries' => 10,
                         'start_period' => '5s',
                     ],
-                    'mem_limit' => $this->database->limits_memory,
-                    'memswap_limit' => $this->database->limits_memory_swap,
+                    'mem_limit' => DockerHelper::normalizeMemoryLimit($this->database->limits_memory),
+                    'memswap_limit' => DockerHelper::normalizeMemoryLimit($this->database->limits_memory_swap),
                     'mem_swappiness' => $this->database->limits_memory_swappiness,
-                    'mem_reservation' => $this->database->limits_memory_reservation,
+                    'mem_reservation' => DockerHelper::normalizeMemoryLimit($this->database->limits_memory_reservation),
                     'cpus' => (float) $this->database->limits_cpus,
                     'cpu_shares' => $this->database->limits_cpu_shares,
                 ],

--- a/app/Actions/Database/StartDragonfly.php
+++ b/app/Actions/Database/StartDragonfly.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Database;
 
+use App\Helpers\DockerHelper;
 use App\Helpers\SslHelper;
 use App\Models\SslCertificate;
 use App\Models\StandaloneDragonfly;
@@ -113,10 +114,10 @@ class StartDragonfly
                         'retries' => 10,
                         'start_period' => '5s',
                     ],
-                    'mem_limit' => $this->database->limits_memory,
-                    'memswap_limit' => $this->database->limits_memory_swap,
+                    'mem_limit' => DockerHelper::normalizeMemoryLimit($this->database->limits_memory),
+                    'memswap_limit' => DockerHelper::normalizeMemoryLimit($this->database->limits_memory_swap),
                     'mem_swappiness' => $this->database->limits_memory_swappiness,
-                    'mem_reservation' => $this->database->limits_memory_reservation,
+                    'mem_reservation' => DockerHelper::normalizeMemoryLimit($this->database->limits_memory_reservation),
                     'cpus' => (float) $this->database->limits_cpus,
                     'cpu_shares' => $this->database->limits_cpu_shares,
                 ],

--- a/app/Actions/Database/StartKeydb.php
+++ b/app/Actions/Database/StartKeydb.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Database;
 
+use App\Helpers\DockerHelper;
 use App\Helpers\SslHelper;
 use App\Models\SslCertificate;
 use App\Models\StandaloneKeydb;
@@ -115,10 +116,10 @@ class StartKeydb
                         'retries' => 10,
                         'start_period' => '5s',
                     ],
-                    'mem_limit' => $this->database->limits_memory,
-                    'memswap_limit' => $this->database->limits_memory_swap,
+                    'mem_limit' => DockerHelper::normalizeMemoryLimit($this->database->limits_memory),
+                    'memswap_limit' => DockerHelper::normalizeMemoryLimit($this->database->limits_memory_swap),
                     'mem_swappiness' => $this->database->limits_memory_swappiness,
-                    'mem_reservation' => $this->database->limits_memory_reservation,
+                    'mem_reservation' => DockerHelper::normalizeMemoryLimit($this->database->limits_memory_reservation),
                     'cpus' => (float) $this->database->limits_cpus,
                     'cpu_shares' => $this->database->limits_cpu_shares,
                 ],

--- a/app/Actions/Database/StartMariadb.php
+++ b/app/Actions/Database/StartMariadb.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Database;
 
+use App\Helpers\DockerHelper;
 use App\Helpers\SslHelper;
 use App\Models\SslCertificate;
 use App\Models\StandaloneMariadb;
@@ -110,10 +111,10 @@ class StartMariadb
                         'retries' => 10,
                         'start_period' => '5s',
                     ],
-                    'mem_limit' => $this->database->limits_memory,
-                    'memswap_limit' => $this->database->limits_memory_swap,
+                    'mem_limit' => DockerHelper::normalizeMemoryLimit($this->database->limits_memory),
+                    'memswap_limit' => DockerHelper::normalizeMemoryLimit($this->database->limits_memory_swap),
                     'mem_swappiness' => $this->database->limits_memory_swappiness,
-                    'mem_reservation' => $this->database->limits_memory_reservation,
+                    'mem_reservation' => DockerHelper::normalizeMemoryLimit($this->database->limits_memory_reservation),
                     'cpus' => (float) $this->database->limits_cpus,
                     'cpu_shares' => $this->database->limits_cpu_shares,
                 ],

--- a/app/Actions/Database/StartMongodb.php
+++ b/app/Actions/Database/StartMongodb.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Database;
 
+use App\Helpers\DockerHelper;
 use App\Helpers\SslHelper;
 use App\Models\SslCertificate;
 use App\Models\StandaloneMongodb;
@@ -120,10 +121,10 @@ class StartMongodb
                         'retries' => 10,
                         'start_period' => '5s',
                     ],
-                    'mem_limit' => $this->database->limits_memory,
-                    'memswap_limit' => $this->database->limits_memory_swap,
+                    'mem_limit' => DockerHelper::normalizeMemoryLimit($this->database->limits_memory),
+                    'memswap_limit' => DockerHelper::normalizeMemoryLimit($this->database->limits_memory_swap),
                     'mem_swappiness' => $this->database->limits_memory_swappiness,
-                    'mem_reservation' => $this->database->limits_memory_reservation,
+                    'mem_reservation' => DockerHelper::normalizeMemoryLimit($this->database->limits_memory_reservation),
                     'cpus' => (float) $this->database->limits_cpus,
                     'cpu_shares' => $this->database->limits_cpu_shares,
                 ],

--- a/app/Actions/Database/StartMysql.php
+++ b/app/Actions/Database/StartMysql.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Database;
 
+use App\Helpers\DockerHelper;
 use App\Helpers\SslHelper;
 use App\Models\SslCertificate;
 use App\Models\StandaloneMysql;
@@ -110,10 +111,10 @@ class StartMysql
                         'retries' => 10,
                         'start_period' => '5s',
                     ],
-                    'mem_limit' => $this->database->limits_memory,
-                    'memswap_limit' => $this->database->limits_memory_swap,
+                    'mem_limit' => DockerHelper::normalizeMemoryLimit($this->database->limits_memory),
+                    'memswap_limit' => DockerHelper::normalizeMemoryLimit($this->database->limits_memory_swap),
                     'mem_swappiness' => $this->database->limits_memory_swappiness,
-                    'mem_reservation' => $this->database->limits_memory_reservation,
+                    'mem_reservation' => DockerHelper::normalizeMemoryLimit($this->database->limits_memory_reservation),
                     'cpus' => (float) $this->database->limits_cpus,
                     'cpu_shares' => $this->database->limits_cpu_shares,
                 ],

--- a/app/Actions/Database/StartPostgresql.php
+++ b/app/Actions/Database/StartPostgresql.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Database;
 
+use App\Helpers\DockerHelper;
 use App\Helpers\SslHelper;
 use App\Models\SslCertificate;
 use App\Models\StandalonePostgresql;
@@ -120,10 +121,10 @@ class StartPostgresql
                         'retries' => 10,
                         'start_period' => '5s',
                     ],
-                    'mem_limit' => $this->database->limits_memory,
-                    'memswap_limit' => $this->database->limits_memory_swap,
+                    'mem_limit' => DockerHelper::normalizeMemoryLimit($this->database->limits_memory),
+                    'memswap_limit' => DockerHelper::normalizeMemoryLimit($this->database->limits_memory_swap),
                     'mem_swappiness' => $this->database->limits_memory_swappiness,
-                    'mem_reservation' => $this->database->limits_memory_reservation,
+                    'mem_reservation' => DockerHelper::normalizeMemoryLimit($this->database->limits_memory_reservation),
                     'cpus' => (float) $this->database->limits_cpus,
                     'cpu_shares' => $this->database->limits_cpu_shares,
                 ],

--- a/app/Actions/Database/StartRedis.php
+++ b/app/Actions/Database/StartRedis.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Database;
 
+use App\Helpers\DockerHelper;
 use App\Helpers\SslHelper;
 use App\Models\SslCertificate;
 use App\Models\StandaloneRedis;
@@ -116,10 +117,10 @@ class StartRedis
                         'retries' => 10,
                         'start_period' => '5s',
                     ],
-                    'mem_limit' => $this->database->limits_memory,
-                    'memswap_limit' => $this->database->limits_memory_swap,
+                    'mem_limit' => DockerHelper::normalizeMemoryLimit($this->database->limits_memory),
+                    'memswap_limit' => DockerHelper::normalizeMemoryLimit($this->database->limits_memory_swap),
                     'mem_swappiness' => $this->database->limits_memory_swappiness,
-                    'mem_reservation' => $this->database->limits_memory_reservation,
+                    'mem_reservation' => DockerHelper::normalizeMemoryLimit($this->database->limits_memory_reservation),
                     'cpus' => (float) $this->database->limits_cpus,
                     'cpu_shares' => $this->database->limits_cpu_shares,
                 ],

--- a/app/Helpers/DockerHelper.php
+++ b/app/Helpers/DockerHelper.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Helpers;
+
+class DockerHelper
+{
+    /**
+     * Normalize a memory limit value for Docker Compose.
+     *
+     * Docker Compose interprets bare numbers as bytes (e.g., "4096" = 4096 bytes = 4KB).
+     * Coolify stores memory limits as bare numbers representing megabytes (e.g., "4096" = 4096MB).
+     * This method appends the "m" suffix when the value is a bare number to ensure
+     * Docker interprets it correctly as megabytes.
+     *
+     * Values that already have a unit suffix (k, m, g, b) or are "0" (unlimited) are returned as-is.
+     *
+     * @param  string|int|null  $value  The memory limit value from the database
+     * @return string|int The normalized value safe for Docker Compose
+     */
+    public static function normalizeMemoryLimit(string|int|null $value): string|int
+    {
+        if ($value === null || $value === '' || $value === '0' || $value === 0) {
+            return $value ?? 0;
+        }
+
+        $stringValue = (string) $value;
+
+        // If it already has a unit suffix, return as-is
+        if (preg_match('/[bkmgBKMG]$/', $stringValue)) {
+            return $stringValue;
+        }
+
+        // Bare number — append 'm' to interpret as megabytes
+        if (is_numeric($stringValue)) {
+            return $stringValue.'m';
+        }
+
+        return $value;
+    }
+}

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -4,6 +4,7 @@ namespace App\Jobs;
 
 use App\Actions\Docker\GetContainersStatus;
 use App\Enums\ApplicationDeploymentStatus;
+use App\Helpers\DockerHelper;
 use App\Enums\ProcessStatus;
 use App\Events\ApplicationConfigurationChanged;
 use App\Events\ServiceStatusChanged;
@@ -2577,10 +2578,10 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                             ),
                         ],
                     ],
-                    'mem_limit' => $this->application->limits_memory,
-                    'memswap_limit' => $this->application->limits_memory_swap,
+                    'mem_limit' => DockerHelper::normalizeMemoryLimit($this->application->limits_memory),
+                    'memswap_limit' => DockerHelper::normalizeMemoryLimit($this->application->limits_memory_swap),
                     'mem_swappiness' => $this->application->limits_memory_swappiness,
-                    'mem_reservation' => $this->application->limits_memory_reservation,
+                    'mem_reservation' => DockerHelper::normalizeMemoryLimit($this->application->limits_memory_reservation),
                     'cpus' => (float) $this->application->limits_cpus,
                     'cpu_shares' => $this->application->limits_cpu_shares,
                 ],


### PR DESCRIPTION
## Summary

Docker Compose interprets bare numbers in `mem_limit`, `memswap_limit`, and `mem_reservation` as **bytes**. Coolify stores these values as bare numbers representing megabytes (e.g., `"4096"` meaning 4096 MB), but passes them directly to Docker Compose without a unit suffix.

This causes:
```yaml
mem_limit: 4096  # Docker reads this as 4096 bytes = 4 KB
```

Which fails with:
```
Error: Minimum memory limit allowed is 6MB
```

### Root cause

In `ApplicationDeploymentJob.php` and all `Start*.php` database actions:
```php
'mem_limit' => $this->application->limits_memory,  // "4096" → 4096 bytes
```

### Fix

Added `DockerHelper::normalizeMemoryLimit()` which appends `m` to bare numeric values:

```php
'mem_limit' => DockerHelper::normalizeMemoryLimit($this->application->limits_memory),  // "4096" → "4096m"
```

The helper handles edge cases:
- `"0"` or `0` → returned as-is (Docker treats 0 as unlimited)
- `null` or `""` → returned as `0`
- `"4096m"`, `"2g"`, `"512k"` → returned as-is (already has unit)
- `"4096"` → `"4096m"` (the bug fix)

### Files changed

- **New:** `app/Helpers/DockerHelper.php` — `normalizeMemoryLimit()` helper
- **Modified (9 files):**
  - `app/Jobs/ApplicationDeploymentJob.php` (application deployments)
  - `app/Actions/Database/Start{Postgresql,Mysql,Mariadb,Mongodb,Redis,Keydb,Dragonfly,Clickhouse}.php` (database deployments)

### How to reproduce

1. Set memory limit to `4096` via UI or API (no unit suffix)
2. Deploy any application or database
3. Deploy fails with "Minimum memory limit allowed is 6MB"

### Additional context

Also discovered that some kernels (e.g., Debian 12 with kernel 6.1.0 on cgroup v2) don't support `mem_swappiness`. Docker warns but doesn't fail:
```
Your kernel does not support memory swappiness capabilities or the cgroup is not mounted.
```

This is a separate issue but worth noting — users should be warned in the UI if their server doesn't support swappiness.

## Test plan

- [ ] Set memory limit to `4096` (bare number) via API → deploy succeeds with 4 GB limit
- [ ] Set memory limit to `2g` (with suffix) → deploy succeeds with 2 GB limit
- [ ] Set memory limit to `0` → deploy succeeds with no limit (unlimited)
- [ ] Set memory limit to empty → deploy succeeds with no limit
- [ ] Verify database deployments (PostgreSQL, MySQL, Redis, etc.) also work with bare numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)