### PR TITLE
fix(clone): generate new UUID for cloned persistent volumes

### DIFF
--- a/app/Livewire/Project/CloneMe.php
+++ b/app/Livewire/Project/CloneMe.php
@@ -187,11 +187,11 @@ class CloneMe extends Component
                         'id',
                         'created_at',
                         'updated_at',
-                        'uuid',
                     ])->fill([
                         'name' => $newName,
                         'resource_id' => $newDatabase->id,
                     ]);
+                    $newPersistentVolume->uuid = (string) new Cuid2;
                     $newPersistentVolume->save();
 
                     if ($this->cloneVolumeData) {
@@ -316,11 +316,11 @@ class CloneMe extends Component
                             'id',
                             'created_at',
                             'updated_at',
-                            'uuid',
                         ])->fill([
                             'name' => $newName,
                             'resource_id' => $application->id,
                         ]);
+                        $newPersistentVolume->uuid = (string) new Cuid2;
                         $newPersistentVolume->save();
 
                         if ($this->cloneVolumeData) {
@@ -371,11 +371,11 @@ class CloneMe extends Component
                             'id',
                             'created_at',
                             'updated_at',
-                            'uuid',
                         ])->fill([
                             'name' => $newName,
                             'resource_id' => $database->id,
                         ]);
+                        $newPersistentVolume->uuid = (string) new Cuid2;
                         $newPersistentVolume->save();
 
                         if ($this->cloneVolumeData) {

--- a/app/Livewire/Project/Shared/ResourceOperations.php
+++ b/app/Livewire/Project/Shared/ResourceOperations.php
@@ -142,11 +142,11 @@ class ResourceOperations extends Component
                     'id',
                     'created_at',
                     'updated_at',
-                    'uuid',
                 ])->fill([
                     'name' => $newName,
                     'resource_id' => $new_resource->id,
                 ]);
+                $newPersistentVolume->uuid = (string) new Cuid2;
                 $newPersistentVolume->save();
 
                 if ($this->cloneVolumeData) {
@@ -281,11 +281,11 @@ class ResourceOperations extends Component
                         'id',
                         'created_at',
                         'updated_at',
-                        'uuid',
                     ])->fill([
                         'name' => $newName,
                         'resource_id' => $application->id,
                     ]);
+                    $newPersistentVolume->uuid = (string) new Cuid2;
                     $newPersistentVolume->save();
 
                     if ($this->cloneVolumeData) {
@@ -324,11 +324,11 @@ class ResourceOperations extends Component
                         'id',
                         'created_at',
                         'updated_at',
-                        'uuid',
                     ])->fill([
                         'name' => $newName,
                         'resource_id' => $database->id,
                     ]);
+                    $newPersistentVolume->uuid = (string) new Cuid2;
                     $newPersistentVolume->save();
 
                     if ($this->cloneVolumeData) {

--- a/bootstrap/helpers/applications.php
+++ b/bootstrap/helpers/applications.php
@@ -303,11 +303,11 @@ function clone_application(Application $source, $destination, array $overrides =
             'id',
             'created_at',
             'updated_at',
-            'uuid',
         ])->fill([
             'name' => $newName,
             'resource_id' => $newApplication->id,
         ]);
+        $newPersistentVolume->uuid = (string) new Cuid2;
         $newPersistentVolume->save();
 
         if ($cloneVolumeData) {


### PR DESCRIPTION
## Changes

When cloning a resource with persistent volumes, the volume UUID is not reliably regenerated. The code uses `replicate(['uuid'])` and relies on `BaseModel::creating` boot event to assign a new UUID, but the old UUID can survive — causing a unique constraint violation:

```
SQLSTATE[23505]: duplicate key value violates unique constraint "local_persistent_volumes_uuid_unique"
```

This fix explicitly sets `$newPersistentVolume->uuid = (string) new Cuid2` before saving, in all 7 volume clone locations across 3 files.

## Issues

- Fixes #5082
- Fixes #9270

## Category

- [x] Bug fix

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Root cause analysis across clone code paths; fix applied manually to all 7 locations after review.

## Testing

1. Clone an application with persistent volumes — no more 500 error
2. Cloned volumes get unique UUIDs (verified via DB query)
3. Volume data cloning still works when enabled

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.