### PR TITLE
fix(install): correct grammar typo in env variable log message

### DIFF
--- a/other/nightly/install.sh
+++ b/other/nightly/install.sh
@@ -815,7 +815,7 @@ update_env_var() {
     # If variable "key=" doesn't exist, append it to the file with value
     elif ! grep -q "^${key}=" "$ENV_FILE"; then
         printf '%s=%s\n' "$key" "$value" >>"$ENV_FILE"
-        echo " - Added ${key} and it's value as the variable was missing"
+        echo " - Added ${key} and its value as the variable was missing"
     fi
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -815,7 +815,7 @@ update_env_var() {
     # If variable "key=" doesn't exist, append it to the file with value
     elif ! grep -q "^${key}=" "$ENV_FILE"; then
         printf '%s=%s\n' "$key" "$value" >>"$ENV_FILE"
-        echo " - Added ${key} and it's value as the variable was missing"
+        echo " - Added ${key} and its value as the variable was missing"
     fi
 }
 


### PR DESCRIPTION
## Summary

Fixed `"it's value"` → `"its value"` in the install script log output. "it's" is a contraction of "it is"; the possessive form is "its".

## Changes

- `scripts/install.sh` line 818
- `other/nightly/install.sh` line 818

Closes #9208