### PR TITLE
fix(templates): use /healthz endpoint for n8n healthchecks

### DIFF
--- a/templates/compose/n8n-with-postgres-and-worker.yaml
+++ b/templates/compose/n8n-with-postgres-and-worker.yaml
@@ -48,7 +48,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:5678/"]
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:5678/healthz"]
       interval: 5s
       timeout: 20s
       retries: 10

--- a/templates/compose/n8n-with-postgresql.yaml
+++ b/templates/compose/n8n-with-postgresql.yaml
@@ -41,7 +41,7 @@ services:
       postgresql:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:5678/"]
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:5678/healthz"]
       interval: 5s
       timeout: 20s
       retries: 10

--- a/templates/compose/n8n.yaml
+++ b/templates/compose/n8n.yaml
@@ -32,7 +32,7 @@ services:
     volumes:
       - n8n-data:/home/node/.n8n
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:5678/"]
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:5678/healthz"]
       interval: 5s
       timeout: 20s
       retries: 10


### PR DESCRIPTION
## Summary

Updated all three n8n templates to use `/healthz` instead of `/` for healthcheck endpoints.

- `/` returns HTML (frontend), not a reliable health indicator
- `/healthz` returns `{"status":"ok"}` — the proper health endpoint
- The n8n-worker template already used `/healthz`, this brings the main n8n services in line

## Changes

- `templates/compose/n8n.yaml`
- `templates/compose/n8n-with-postgresql.yaml`
- `templates/compose/n8n-with-postgres-and-worker.yaml`

Closes #9306