### PR TITLE
fix(healthcheck): respect health_check_return_code field

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -2889,11 +2889,18 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             $this->full_healthcheck_url = "{$method}: {$scheme}://{$host}:{$health_check_port}/";
         }
 
-        $generated_healthchecks_commands = [
-            "curl -s -X {$escapedMethod} -f {$url} > /dev/null || wget -q -O- {$url} > /dev/null || exit 1",
-        ];
+        $returnCode = (int) ($this->application->health_check_return_code ?? 200);
 
-        return implode(' ', $generated_healthchecks_commands);
+        if ($returnCode === 200) {
+            // Default behavior: use -f flag (fails on non-2xx) with wget fallback
+            $generated_healthchecks_commands = "curl -s -X {$escapedMethod} -f {$url} > /dev/null || wget -q -O- {$url} > /dev/null || exit 1";
+        } else {
+            // Custom return code: check explicit HTTP status code
+            $escapedReturnCode = escapeshellarg((string) $returnCode);
+            $generated_healthchecks_commands = "test \"$(curl -s -o /dev/null -w '%{http_code}' -X {$escapedMethod} {$url})\" = {$escapedReturnCode} || exit 1";
+        }
+
+        return $generated_healthchecks_commands;
     }
 
     private function sanitizeHealthCheckValue(string $value, string $pattern, string $default): string

--- a/tests/Unit/HealthCheckCommandInjectionTest.php
+++ b/tests/Unit/HealthCheckCommandInjectionTest.php
@@ -284,6 +284,94 @@ it('validates healthCheckCommand accepts strings under 1000 characters', functio
     expect($validator->fails())->toBeFalse();
 });
 
+// --- Return code tests (#2218) ---
+
+it('uses -f flag (default behavior) when health_check_return_code is 200', function () {
+    $result = callGenerateHealthcheckCommands([
+        'health_check_return_code' => 200,
+    ]);
+
+    expect($result)->toContain('-f')
+        ->and($result)->toContain('wget -q -O-');
+});
+
+it('checks explicit HTTP status code when health_check_return_code is not 200', function () {
+    $result = callGenerateHealthcheckCommands([
+        'health_check_return_code' => 401,
+    ]);
+
+    // Should use curl -w to check status code, not -f
+    expect($result)->not->toContain('-f')
+        ->and($result)->toContain('%{http_code}')
+        ->and($result)->toContain('401');
+});
+
+it('handles health_check_return_code 204 (no content)', function () {
+    $result = callGenerateHealthcheckCommands([
+        'health_check_return_code' => 204,
+    ]);
+
+    expect($result)->not->toContain('-f')
+        ->and($result)->toContain('204');
+});
+
+it('handles health_check_return_code 301 (redirect)', function () {
+    $result = callGenerateHealthcheckCommands([
+        'health_check_return_code' => 301,
+    ]);
+
+    expect($result)->not->toContain('-f')
+        ->and($result)->toContain('301');
+});
+
+it('does not include wget fallback for custom return codes', function () {
+    $result = callGenerateHealthcheckCommands([
+        'health_check_return_code' => 401,
+    ]);
+
+    // wget cannot easily check HTTP status codes
+    expect($result)->not->toContain('wget');
+});
+
+it('ignores return code for CMD type healthchecks', function () {
+    $result = callGenerateHealthcheckCommands([
+        'health_check_type' => 'cmd',
+        'health_check_command' => 'pg_isready -U postgres',
+        'health_check_return_code' => 401,
+    ]);
+
+    expect($result)->toBe('pg_isready -U postgres');
+});
+
+it('falls back to default 200 behavior when health_check_return_code is null', function () {
+    $result = callGenerateHealthcheckCommands([
+        'health_check_return_code' => null,
+    ]);
+
+    // null ?? 200 = 200, should use -f flag (default path)
+    expect($result)->toContain('-f')
+        ->and($result)->toContain('wget -q -O-');
+});
+
+it('sanitizes return code via integer cast', function () {
+    // DB could store string "401" — (int) cast must handle it
+    $result = callGenerateHealthcheckCommands([
+        'health_check_return_code' => '401',
+    ]);
+
+    expect($result)->toContain('401')
+        ->and($result)->not->toContain('-f');
+});
+
+it('uses escapeshellarg on custom return code to prevent injection', function () {
+    $result = callGenerateHealthcheckCommands([
+        'health_check_return_code' => 401,
+    ]);
+
+    // Return code should be wrapped in single quotes by escapeshellarg
+    expect($result)->toContain("'401'");
+});
+
 /**
  * Helper: Invokes the private generate_healthcheck_commands() method via reflection.
  */
@@ -297,6 +385,7 @@ function callGenerateHealthcheckCommands(array $overrides = []): string
         'health_check_host' => 'localhost',
         'health_check_port' => null,
         'health_check_path' => '/',
+        'health_check_return_code' => 200,
         'ports_exposes' => '80',
     ];
 
@@ -310,6 +399,7 @@ function callGenerateHealthcheckCommands(array $overrides = []): string
     $application->shouldReceive('getAttribute')->with('health_check_host')->andReturn($values['health_check_host']);
     $application->shouldReceive('getAttribute')->with('health_check_port')->andReturn($values['health_check_port']);
     $application->shouldReceive('getAttribute')->with('health_check_path')->andReturn($values['health_check_path']);
+    $application->shouldReceive('getAttribute')->with('health_check_return_code')->andReturn($values['health_check_return_code']);
     $application->shouldReceive('getAttribute')->with('ports_exposes_array')->andReturn(explode(',', $values['ports_exposes']));
     $application->shouldReceive('getAttribute')->with('build_pack')->andReturn('nixpacks');
 


### PR DESCRIPTION
## Changes

The `health_check_return_code` field was stored in the database, rendered in the UI, and validated by the API but never actually used in `generate_healthcheck_commands()`. The curl command always used the `-f` flag, which hardcodes failure on any non-2xx HTTP response, making it impossible to healthcheck applications that intentionally return non-200 codes (e.g., 401, 204).

A previous fix was attempted and reverted in v284 because it changed behavior for all users, causing unexpected failures. This PR avoids that by branching only when `health_check_return_code != 200`:

- Return code = 200 (default): Behavior is completely unchanged, uses `curl -f` with `wget` fallback. Zero risk to existing deployments.
- Custom return code: Uses `curl -s -o /dev/null -w '%{http_code}'` to compare the actual HTTP status code against the configured value. The `wget` fallback is intentionally dropped for this path since `wget` cannot check HTTP status codes.

## Issues

- Fixes #2218

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A - backend logic only, no UI changes.

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Implementation, test writing, and Docker integration verification were AI-assisted. All code was reviewed and validated by a human.

## Testing

- 33 Pest unit tests pass (9 new, 24 pre-existing), 54 assertions
- Shell command validated in `/bin/sh` (POSIX, what Docker CMD-SHELL uses)
- YAML round-trip verified (`Symfony\Component\Yaml\Yaml::dump/parse` preserves `%{http_code}`)
- Docker integration tested on real containers: 200 (default), 401, and 204 all report healthy
- Null return code (old DB rows) falls back to default 200 behavior
- `escapeshellarg` applied to return code to prevent injection

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.