### PR TITLE
Update Convex image tags to latest release

### DIFF
--- a/templates/compose/convex.yaml
+++ b/templates/compose/convex.yaml
@@ -7,7 +7,7 @@
 
 services:
   backend:
-    image: ghcr.io/get-convex/convex-backend:00bd92723422f3bff968230c94ccdeb8c1719832
+    image: ghcr.io/get-convex/convex-backend:a9a760ca10399ed42e1b4bb87c78539a235488c7
     volumes:
       - data:/convex/data
     environment:
@@ -47,7 +47,7 @@ services:
       start_period: 10s
 
   dashboard:
-    image: ghcr.io/get-convex/convex-dashboard:33cef775a8a6228cbacee4a09ac2c4073d62ed13
+    image: ghcr.io/get-convex/convex-dashboard:a9a760ca10399ed42e1b4bb87c78539a235488c7
     environment:
       - SERVICE_URL_DASHBOARD_6791
       # URL of the Convex API as accessed by the dashboard (browser).


### PR DESCRIPTION
## Changes

Update Convex backend and dashboard Docker image tags from stale Nov 2025 commit hashes to a current release. The old pinned tags (`00bd9272`, `33cef775`) are incompatible with `convex` npm package >=1.30, causing deploy failures with `missing field 'functions'` error on `start_push`. See [get-convex/convex-backend#343](https://github.com/get-convex/convex-backend/issues/343).

## Issues

- Fixes incompatibility between Coolify's Convex template and current `convex` npm CLI

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [x] Fixing or updating existing one click service

## Preview

N/A — no UI changes, only Docker image tag update in compose template.

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Investigated the version mismatch, identified the fix, verified locally

## Testing

- Deployed locally with `docker compose up` using the updated image tags
- Verified `convex@1.34.1` (latest npm) successfully pushes functions to the updated backend
- Confirmed the old tags fail with `BadJsonBody: appDefinition: missing field 'functions'`

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.