### PR TITLE
fix: detect database services in git-based docker compose deployments

### DIFF
--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -2589,6 +2589,25 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                 }
             }
 
+
+            // Detect if this service is a database
+            $image = data_get_str($service, 'image');
+            $isDatabase = isDatabaseImage($image, $service);
+
+            // If database detected, create Service and ServiceDatabase records for backup support
+            if ($isDatabase) {
+                // Create or find Service record for this Application
+                $dbService = \App\Models\Service::firstOrCreate(
+                    ['name' => $serviceName, 'environment_id' => $resource->environment_id],
+                    ['server_id' => $resource->destination->server_id, 'destination_id' => $resource->destination_id, 'destination_type' => get_class($resource->destination)]
+                );
+                // Create ServiceDatabase record
+                \App\Models\ServiceDatabase::firstOrCreate(
+                    ['name' => $serviceName, 'service_id' => $dbService->id],
+                    ['image' => $image->value()]
+                );
+            }
+            data_set($service, 'is_database', $isDatabase);
             $baseName = generateApplicationContainerName($resource, $pull_request_id);
             $containerName = "$serviceName-$baseName";
             if ($resource->compose_parsing_version === '1') {


### PR DESCRIPTION
## Problem
When deploying a Docker Compose file via GitHub App (using the dockercompose buildpack), database services are not detected and ServiceDatabase records are not created. This means automated backups are not available for databases in these deployments.

However, when using Empty Docker Compose or one-click services (like Supabase), database detection works correctly and backups are available.

## Solution
Added database detection logic to the Application model parsing path in parseDockerComposeFile():

1. Detect database services using isDatabaseImage() function
2. Create Service and ServiceDatabase records for detected databases to enable backup functionality
3. Set is_database flag on the service

## Changes
- Modified bootstrap/helpers/shared.php:
  - Added database detection in Application path (lines 2592-2610)
  - Creates ServiceDatabase records for detected database services
  - Enables backup functionality for databases in git-based compose deployments

## Testing
- Tested with git-based docker compose deployments containing database services
- Verified ServiceDatabase records are created correctly
- Confirmed backup functionality is now available

Fixes #7528
