### PR TITLE
fix: make redis_password nullable to prevent NOT NULL violation

### DIFF
--- a/database/migrations/2026_04_02_000000_make_redis_password_nullable.php
+++ b/database/migrations/2026_04_02_000000_make_redis_password_nullable.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * On instances where migration 2024_10_16_120026 failed or was rolled back
+     * (e.g. after a crash), the redis_password column still exists as NOT NULL.
+     * Since redis_password was moved to environment_variables, make it nullable
+     * so Redis instance creation doesn't fail with a NOT NULL constraint violation.
+     */
+    public function up(): void
+    {
+        if (Schema::hasColumn('standalone_redis', 'redis_password')) {
+            Schema::table('standalone_redis', function (Blueprint $table) {
+                $table->text('redis_password')->nullable()->change();
+            });
+        }
+    }
+};


### PR DESCRIPTION
## Summary

- Adds a migration that makes `redis_password` nullable in `standalone_redis` if the column still exists
- On instances where migration `2024_10_16_120026` (move redis password to envs) failed or was rolled back after a crash, the column remains as NOT NULL while the creation code no longer sets it — causing a constraint violation when creating new Redis instances

## Root Cause

The `create_standalone_redis()` function in `bootstrap/helpers/databases.php` stores the password in `environment_variables` (post-migration behavior), but never assigns `redis_password` on the model. If the column still exists as NOT NULL (incomplete migration), the INSERT fails.

## Fix

A new migration checks if `redis_password` column exists and makes it nullable, allowing both migrated and non-migrated instances to create Redis databases.

Fixes #9401

/claim #9401