### PR TITLE
fix: make redis_password nullable to prevent crash-related NOT NULL violation

### DIFF
--- a/database/migrations/2026_04_03_000000_make_redis_password_nullable.php
+++ b/database/migrations/2026_04_03_000000_make_redis_password_nullable.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasColumn('standalone_redis', 'redis_password')) {
+            Schema::table('standalone_redis', function (Blueprint $table) {
+                $table->text('redis_password')->nullable()->change();
+            });
+        }
+    }
+};


### PR DESCRIPTION
﻿## Problem

After a severe crash (memory/CPU exhaustion), the redis_password column may remain in the standalone_redis table with a NOT NULL constraint due to migration 2024_10_16_120026_move_redis_password_to_envs not completing. The create_standalone_redis() function does not set redis_password on the model - it only creates the environment variable after save. This causes:

`
SQLSTATE[23502]: Not null violation: null value in column "redis_password" of relation "standalone_redis" violates not-null constraint
`

## Solution

Add a migration that makes redis_password nullable **if the column still exists**. This is a no-op on instances where the original migration completed successfully, and safely fixes the schema on instances where it did not.

## Changes

- `database/migrations/2026_04_03_000000_make_redis_password_nullable.php` - new migration

/claim #9401

Fixes #9401
