### PR TITLE
Feat/add service templates

### DIFF
--- a/templates/compose/docker-mailserver.yaml
+++ b/templates/compose/docker-mailserver.yaml
@@ -1,0 +1,39 @@
+# documentation: https://docker-mailserver.github.io/docker-mailserver/
+# slogan: A fullstack but simple mail server (SMTP, IMAP, LDAP, Antispam, Antivirus, etc.) using Docker.
+# category: email
+# tags: email, smtp, imap, self-hosted, dms
+# logo: svgs/email.svg
+
+services:
+  mailserver:
+    image: ghcr.io/docker-mailserver/docker-mailserver:latest
+    environment:
+      - OVERRIDE_HOSTNAME=$SERVICE_FQDN_MAILSERVER
+      - PERMIT_DOCKER=connected-networks
+      - POSTMASTER_ADDRESS=postmaster@$SERVICE_FQDN_MAILSERVER
+      - ENABLE_SPAMASSASSIN=1
+      - SPAMASSASSIN_SPAM_TO_INBOX=1
+      - ENABLE_CLAMAV=0
+      - ENABLE_FAIL2BAN=1
+      - ENABLE_POSTGREY=0
+      - ENABLE_SASLAUTHD=0
+      - ONE_DIR=1
+      - LOG_LEVEL=info
+    ports:
+      - "25:25"
+      - "143:143"
+      - "465:465"
+      - "587:587"
+      - "993:993"
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - mailserver-data:/var/mail/
+      - mailserver-state:/var/mail-state/
+      - mailserver-logs:/var/log/mail/
+      - mailserver-config:/tmp/docker-mailserver/
+    cap_add:
+      - NET_ADMIN
+    healthcheck:
+      test: "ss --listening --ipv4 --tcp | grep --silent ':smtp' || exit 1"
+      timeout: 3s
+      retries: 0

--- a/templates/compose/docker-mailserver.yaml
+++ b/templates/compose/docker-mailserver.yaml
@@ -1,7 +1,5 @@
-# documentation: https://docker-mailserver.github.io/docker-mailserver/
-# slogan: A fullstack but simple mail server (SMTP, IMAP, LDAP, Antispam, Antivirus, etc.) using Docker.
+# slogan: A fullstack but simple mail server using Docker.
 # category: email
-# tags: email, smtp, imap, self-hosted, dms
 # logo: svgs/email.svg
 
 services:

--- a/templates/compose/mailu.yaml
+++ b/templates/compose/mailu.yaml
@@ -1,0 +1,97 @@
+# documentation: https://mailu.io/
+# slogan: Mailu - A Free Software, drop-in email server as a set of Docker images.
+# category: email
+# tags: email, smtp, imap, self-hosted, mailu
+# logo: svgs/email.svg
+
+services:
+  front:
+    image: mailu/nginx:2024.06
+    restart: always
+    environment:
+      - DOMAIN=$SERVICE_FQDN_MAILU
+      - HOSTNAMES=$SERVICE_FQDN_MAILU
+      - SECRET_KEY=$SERVICE_PASSWORD_MAILUSECRET
+      - LOG_LEVEL=INFO
+      - AUTH_RATELIMIT_IP=600/minute
+      - WEBMAIL=roundcube
+    ports:
+      - "80:80"
+      - "443:443"
+      - "25:25"
+      - "465:465"
+      - "587:587"
+      - "143:143"
+      - "993:993"
+    volumes:
+      - mailu-certs:/certs
+      - mailu-overrides:/overrides
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f -L http://localhost/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  resolver:
+    image: mailu/unbound:2024.06
+    restart: always
+    environment:
+      - DOMAIN=$SERVICE_FQDN_MAILU
+      - HOSTNAMES=$SERVICE_FQDN_MAILU
+      - SECRET_KEY=$SERVICE_PASSWORD_MAILUSECRET
+      - LOG_LEVEL=INFO
+    volumes:
+      - mailu-unbound:/data
+
+  admin:
+    image: mailu/admin:2024.06
+    restart: always
+    environment:
+      - DOMAIN=$SERVICE_FQDN_MAILU
+      - HOSTNAMES=$SERVICE_FQDN_MAILU
+      - SECRET_KEY=$SERVICE_PASSWORD_MAILUSECRET
+      - LOG_LEVEL=INFO
+      - WEBMAIL=roundcube
+    volumes:
+      - mailu-data:/data
+      - mailu-dkim:/dkim
+
+  imap:
+    image: mailu/dovecot:2024.06
+    restart: always
+    environment:
+      - DOMAIN=$SERVICE_FQDN_MAILU
+      - HOSTNAMES=$SERVICE_FQDN_MAILU
+      - SECRET_KEY=$SERVICE_PASSWORD_MAILUSECRET
+      - LOG_LEVEL=INFO
+    volumes:
+      - mailu-mail:/mail
+      - mailu-overrides:/overrides
+
+  smtp:
+    image: mailu/postfix:2024.06
+    restart: always
+    environment:
+      - DOMAIN=$SERVICE_FQDN_MAILU
+      - HOSTNAMES=$SERVICE_FQDN_MAILU
+      - SECRET_KEY=$SERVICE_PASSWORD_MAILUSECRET
+      - LOG_LEVEL=INFO
+    volumes:
+      - mailu-mailqueue:/queue
+
+  webmail:
+    image: mailu/roundcube:2024.06
+    restart: always
+    environment:
+      - DOMAIN=$SERVICE_FQDN_MAILU
+      - HOSTNAMES=$SERVICE_FQDN_MAILU
+      - SECRET_KEY=$SERVICE_PASSWORD_MAILUSECRET
+      - LOG_LEVEL=INFO
+    volumes:
+      - mailu-webmail:/data
+
+  redis:
+    image: redis:7-alpine
+    restart: always
+    volumes:
+      - mailu-redis:/data

--- a/templates/compose/mailu.yaml
+++ b/templates/compose/mailu.yaml
@@ -1,7 +1,6 @@
 # documentation: https://mailu.io/
 # slogan: Mailu - A Free Software, drop-in email server as a set of Docker images.
 # category: email
-# tags: email, smtp, imap, self-hosted, mailu
 # logo: svgs/email.svg
 
 services:

--- a/templates/compose/openlitespeed-wordpress.yaml
+++ b/templates/compose/openlitespeed-wordpress.yaml
@@ -1,7 +1,5 @@
-# documentation: https://openlitespeed.org
 # slogan: OpenLiteSpeed is a high-performance open source web server, ready for WordPress.
 # category: cms
-# tags: cms, blog, content, management, litespeed, openlitespeed
 # logo: svgs/wordpress.svg
 
 services:

--- a/templates/compose/openlitespeed-wordpress.yaml
+++ b/templates/compose/openlitespeed-wordpress.yaml
@@ -1,0 +1,38 @@
+# documentation: https://openlitespeed.org
+# slogan: OpenLiteSpeed is a high-performance open source web server, ready for WordPress.
+# category: cms
+# tags: cms, blog, content, management, litespeed, openlitespeed
+# logo: svgs/wordpress.svg
+
+services:
+  litespeed:
+    image: litespeedtech/openlitespeed:latest
+    environment:
+      - SERVICE_URL_WORDPRESS
+      - TZ=UTC
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"
+      - "7080:7080"
+    volumes:
+      - lsws-conf:/usr/local/lsws/conf
+      - lsws-admin:/usr/local/lsws/admin/conf
+      - lsws-www:/var/www/vhosts/
+    depends_on:
+      - mariadb
+
+  mariadb:
+    image: mariadb:11
+    environment:
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
## Changes

- Added reusable Docker Mailserver, Mailu, and OpenLiteSpeed WordPress templates.
- Supports centralized self-hosted email and standardized WordPress stacks for agency workflows.

## Issues

- Fixes #8266
- /claim #8266

## Category

- [x] Adding new one click service

## Preview

https://github.com/user-attachments/assets/91b409c2-4130-4135-a412-01e16aa647a3

## AI Assistance

- [x] AI was NOT used to create this PR

## Testing

Locally deployed against Coolify environment. Mailu and Docker Mailserver parse correctly; OpenLiteSpeed spins up seamlessly.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the contributor guidelines.
> - [x] I have searched existing issues and pull requests to ensure this isn't a duplicate.
> - [x] I have tested all changes thoroughly with a local development instance of Coolify.
