### PR TITLE
fix(ui): close CA certificate modal after successful regeneration/save

### DIFF
--- a/app/Livewire/Server/CaCertificate/Show.php
+++ b/app/Livewire/Server/CaCertificate/Show.php
@@ -84,6 +84,8 @@ class Show extends Component
                 ));
             }
             $this->dispatch('success', 'CA Certificate saved successfully.');
+
+            return true;
         } catch (\Throwable $e) {
             return handleError($e, $this);
         }
@@ -111,6 +113,8 @@ class Show extends Component
 
             $this->loadCaCertificate();
             $this->dispatch('success', 'CA Certificate regenerated successfully.');
+
+            return true;
         } catch (\Throwable $e) {
             return handleError($e, $this);
         }


### PR DESCRIPTION
## Changes

The CA certificate confirmation modal (both "Save" and "Regenerate") stayed open after successful operations. The `modal-confirmation` component's `submitForm()` checks for `return true` to close the modal, but neither `saveCaCertificate()` nor `regenerateCaCertificate()` returned a value on success — so the modal remained visible even though the action completed.

Added `return true` to both methods on success, matching the pattern used by other Livewire components that use this modal (e.g., `Subscription\Actions`, `Settings\Advanced`).

## Issues

- Fixes the CA certificate regeneration/save modal not closing after successful operation

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No visual changes — behavior fix. The modal now properly closes after a successful certificate save or regeneration.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Used to explore codebase, identify root cause by tracing the modal-confirmation component's `submitForm()` logic, and verify the fix pattern against other Livewire components. I reviewed and verified all changes.

## Testing

- Navigate to Server → CA Certificate page
- Click "Regenerate" button
- Complete the multi-step confirmation (text + password)
- **Before:** Modal stays open after successful regeneration, success toast appears behind modal
- **After:** Modal closes, success toast is visible
- Same test for "Save" button with custom certificate content

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.