### PR TITLE
feat: add independent toggle for OAuth registration

### DIFF
--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -22,7 +22,7 @@ class OauthController extends Controller
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! $settings->is_oauth_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -16,6 +16,9 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $is_oauth_registration_enabled;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -41,6 +44,7 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_registration_enabled' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => ['nullable', 'string', new ValidDnsServers],
@@ -67,6 +71,7 @@ class Advanced extends Component
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
         $this->is_sponsorship_popup_enabled = $this->settings->is_sponsorship_popup_enabled;
         $this->is_wire_navigate_enabled = $this->settings->is_wire_navigate_enabled ?? true;
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled;
     }
 
     public function submit()
@@ -150,6 +155,7 @@ class Advanced extends Component
             $this->settings->is_sponsorship_popup_enabled = $this->is_sponsorship_popup_enabled;
             $this->settings->disable_two_step_confirmation = $this->disable_two_step_confirmation;
             $this->settings->is_wire_navigate_enabled = $this->is_wire_navigate_enabled;
+            $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
             $this->settings->save();
             $this->dispatch('success', 'Settings updated!');
         } catch (\Exception $e) {
@@ -166,6 +172,19 @@ class Advanced extends Component
         $this->settings->is_registration_enabled = $this->is_registration_enabled = true;
         $this->settings->save();
         $this->dispatch('success', 'Registration has been enabled.');
+
+        return true;
+    }
+
+    public function toggleOauthRegistration($password): bool
+    {
+        if (! verifyPasswordConfirmation($password, $this)) {
+            return false;
+        }
+
+        $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled = true;
+        $this->settings->save();
+        $this->dispatch('success', 'OAuth registration has been enabled.');
 
         return true;
     }

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -45,6 +45,7 @@ class InstanceSettings extends Model
         'is_sponsorship_popup_enabled',
         'dev_helper_version',
         'is_wire_navigate_enabled',
+        'is_oauth_registration_enabled',
     ];
 
     protected $casts = [
@@ -67,6 +68,7 @@ class InstanceSettings extends Model
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',
         'is_wire_navigate_enabled' => 'boolean',
+        'is_oauth_registration_enabled' => 'boolean',
     ];
 
     protected static function booted(): void

--- a/database/migrations/2025_04_05_000000_add_oauth_registration_enabled_to_instance_settings_table.php
+++ b/database/migrations/2025_04_05_000000_add_oauth_registration_enabled_to_instance_settings_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_registration_enabled')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn('is_oauth_registration_enabled');
+        });
+    }
+};

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -41,6 +41,33 @@
                                 shortConfirmationLabel="Confirmation text" />
                         </div>
                     @endif
+                    <div class="flex flex-col gap-1">
+                        @if ($is_oauth_registration_enabled)
+                            <div class="md:w-96" wire:key="oauth-registration-enabled">
+                                <x-forms.checkbox instantSave id="is_oauth_registration_enabled"
+                                    helper="Allow users to self-register via OAuth (Google, GitHub, etc.) even if general registration is disabled."
+                                    label="OAuth Registration Allowed" />
+                            </div>
+                        @else
+                            <div class="flex items-center justify-between gap-2 md:w-96"
+                                wire:key="oauth-registration-disabled">
+                                <label class="flex items-center gap-2">
+                                    OAuth Registration Allowed
+                                    <x-helper
+                                        helper="Allow users to self-register via OAuth (Google, GitHub, etc.) even if general registration is disabled.">
+                                    </x-helper>
+                                </label>
+                                <x-modal-confirmation title="Enable OAuth Registration?" buttonTitle="Enable" isErrorButton
+                                    submitAction="toggleOauthRegistration" :actions="[
+                                        'Enables registration specifically for OAuth providers',
+                                    ]"
+                                    warningMessage="Enabling OAuth registration allows anyone with a valid account from your configured OAuth providers to create an account on this instance."
+                                    confirmationText="ENABLE OAUTH REGISTRATION"
+                                    confirmationLabel="Please type the confirmation text to enable OAuth registration."
+                                    shortConfirmationLabel="Confirmation text" />
+                            </div>
+                        @endif
+                    </div>
                     <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"
                             helper="Opt out of anonymous usage tracking. When enabled, this instance will not report to coolify.io's installation count and will not send error reports to help improve Coolify."


### PR DESCRIPTION
### Changes
- Added `is_oauth_registration_enabled` to `instance_settings` table.
- Added a new toggle in Advanced Settings to allow OAuth-only self-registration.
- Updated `OauthController` to allow registration if either the global toggle or the new OAuth-specific toggle is enabled.

### Category
- [x] Enhancement

### AI Assistance
- [x] I used AI to help me with this PR.

### Testing
- Manually verified the toggle appears in the dashboard.
- Verified that OAuth registration works when the toggle is enabled, even if general registration is disabled.

### Contributor Agreement
- [x] I agree to the [Contributor Agreement](https://github.com/coollabsio/coolify/blob/next/CONTRIBUTING.md).
