### PR TITLE
fix(docker): add apk upgrade to helper, realtime, and development Dockerfiles

### DIFF
--- a/config/constants.php
+++ b/config/constants.php
@@ -3,8 +3,8 @@
 return [
     'coolify' => [
         'version' => '4.0.0-beta.471',
-        'helper_version' => '1.0.12',
-        'realtime_version' => '1.0.11',
+        'helper_version' => '1.0.13',
+        'realtime_version' => '1.0.12',
         'self_hosted' => env('SELF_HOSTED', true),
         'autoupdate' => env('AUTOUPDATE'),
         'base_config_path' => env('BASE_CONFIG_PATH', '/data/coolify'),

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -60,7 +60,7 @@ services:
       retries: 10
       timeout: 2s
   soketi:
-    image: '${REGISTRY_URL:-ghcr.io}/coollabsio/coolify-realtime:1.0.11'
+    image: '${REGISTRY_URL:-ghcr.io}/coollabsio/coolify-realtime:1.0.12'
     ports:
       - "${SOKETI_PORT:-6001}:6001"
       - "6002:6002"

--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -96,7 +96,7 @@ services:
       retries: 10
       timeout: 2s
   soketi:
-    image: 'ghcr.io/coollabsio/coolify-realtime:1.0.10'
+    image: 'ghcr.io/coollabsio/coolify-realtime:1.0.12'
     pull_policy: always
     container_name: coolify-realtime
     restart: always

--- a/docker/coolify-helper/Dockerfile
+++ b/docker/coolify-helper/Dockerfile
@@ -28,7 +28,8 @@ ARG NIXPACKS_VERSION
 
 USER root
 WORKDIR /artifacts
-RUN apk add --no-cache bash curl git git-lfs openssh-client tar tini
+RUN apk upgrade --no-cache && \
+    apk add --no-cache bash curl git git-lfs openssh-client tar tini
 RUN mkdir -p ~/.docker/cli-plugins
 RUN if [[ ${TARGETPLATFORM} == 'linux/amd64' ]]; then \
     curl -sSL https://github.com/docker/buildx/releases/download/v${DOCKER_BUILDX_VERSION}/buildx-v${DOCKER_BUILDX_VERSION}.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx && \

--- a/docker/coolify-realtime/Dockerfile
+++ b/docker/coolify-realtime/Dockerfile
@@ -10,7 +10,8 @@ ARG TARGETPLATFORM
 ARG CLOUDFLARED_VERSION
 
 WORKDIR /terminal
-RUN apk add --no-cache openssh-client make g++ python3 curl
+RUN apk upgrade --no-cache && \
+    apk add --no-cache openssh-client make g++ python3 curl
 COPY docker/coolify-realtime/package.json ./
 RUN npm i
 RUN npm rebuild node-pty --update-binary

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -33,7 +33,8 @@ RUN docker-php-serversideup-set-id www-data $USER_ID:$GROUP_ID && \
     docker-php-serversideup-set-file-permissions --owner $USER_ID:$GROUP_ID --service nginx
 
 # Install PostgreSQL repository and keys
-RUN apk add --no-cache gnupg && \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache gnupg && \
     mkdir -p /usr/share/keyrings && \
     curl -fSsL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor > /usr/share/keyrings/postgresql.gpg
 

--- a/other/nightly/docker-compose.prod.yml
+++ b/other/nightly/docker-compose.prod.yml
@@ -60,7 +60,7 @@ services:
       retries: 10
       timeout: 2s
   soketi:
-    image: '${REGISTRY_URL:-ghcr.io}/coollabsio/coolify-realtime:1.0.11'
+    image: '${REGISTRY_URL:-ghcr.io}/coollabsio/coolify-realtime:1.0.12'
     ports:
       - "${SOKETI_PORT:-6001}:6001"
       - "6002:6002"

--- a/other/nightly/docker-compose.windows.yml
+++ b/other/nightly/docker-compose.windows.yml
@@ -96,7 +96,7 @@ services:
       retries: 10
       timeout: 2s
   soketi:
-    image: 'ghcr.io/coollabsio/coolify-realtime:1.0.10'
+    image: 'ghcr.io/coollabsio/coolify-realtime:1.0.12'
     pull_policy: always
     container_name: coolify-realtime
     restart: always

--- a/other/nightly/versions.json
+++ b/other/nightly/versions.json
@@ -7,10 +7,10 @@
             "version": "4.0.0"
         },
         "helper": {
-            "version": "1.0.12"
+            "version": "1.0.13"
         },
         "realtime": {
-            "version": "1.0.11"
+            "version": "1.0.12"
         },
         "sentinel": {
             "version": "0.0.21"

--- a/versions.json
+++ b/versions.json
@@ -7,10 +7,10 @@
             "version": "4.0.0"
         },
         "helper": {
-            "version": "1.0.12"
+            "version": "1.0.13"
         },
         "realtime": {
-            "version": "1.0.11"
+            "version": "1.0.12"
         },
         "sentinel": {
             "version": "0.0.21"


### PR DESCRIPTION
## Changes

Adds `apk upgrade --no-cache` before `apk add` in the helper, realtime, and development Dockerfiles to keep Alpine packages up to date at build time — matching the approach already used in the production Dockerfile.

- `docker/coolify-helper/Dockerfile`
- `docker/coolify-realtime/Dockerfile`
- `docker/development/Dockerfile`

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A — Dockerfile changes only.

## AI Assistance

- [x] AI was NOT used to create this PR
- [ ] AI was used (please describe below)

## Testing

```bash
docker build -t helper-test docker/coolify-helper/
docker build -t realtime-test docker/coolify-realtime/
docker build -f docker/development/Dockerfile -t dev-test .
```

All images build successfully with upgraded packages.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.