### PR TITLE
feat: implement oauth-only login and self registration #8042

### DIFF
--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -22,7 +22,7 @@ class OauthController extends Controller
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! $settings->is_oauth_only) {
                     abort(403, 'Registration is disabled');
                 }
 

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -16,6 +16,9 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $is_oauth_only;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -41,6 +44,7 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_only' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => ['nullable', 'string', new ValidDnsServers],
@@ -62,6 +66,7 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_only = $this->settings->is_oauth_only;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -142,6 +147,7 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_only = $this->is_oauth_only;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -18,6 +18,7 @@ class InstanceSettings extends Model
         'do_not_track',
         'is_auto_update_enabled',
         'is_registration_enabled',
+        'is_oauth_only',
         'next_channel',
         'smtp_enabled',
         'smtp_from_address',
@@ -63,6 +64,7 @@ class InstanceSettings extends Model
 
         'allowed_ip_ranges' => 'array',
         'is_auto_update_enabled' => 'boolean',
+        'is_oauth_only' => 'boolean',
         'auto_update_frequency' => 'string',
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -47,12 +47,13 @@ class FortifyServiceProvider extends ServiceProvider
             $isFirstUser = User::count() === 0;
 
             $settings = instanceSettings();
-            if (! $settings->is_registration_enabled) {
+            if (! $settings->is_registration_enabled && ! $settings->is_oauth_only) {
                 return redirect()->route('login');
             }
 
             return view('auth.register', [
                 'isFirstUser' => $isFirstUser,
+                'is_oauth_only' => $settings->is_oauth_only,
             ]);
         });
 
@@ -67,13 +68,20 @@ class FortifyServiceProvider extends ServiceProvider
 
             return view('auth.login', [
                 'is_registration_enabled' => $settings->is_registration_enabled,
+                'is_oauth_only' => $settings->is_oauth_only,
                 'enabled_oauth_providers' => $enabled_oauth_providers,
             ]);
         });
 
         Fortify::authenticateUsing(function (Request $request) {
+            $settings = instanceSettings();
             $email = strtolower($request->email);
             $user = User::where('email', $email)->with('teams')->first();
+
+            if ($settings->is_oauth_only && $user && $user->id !== 0) {
+                return null;
+            }
+
             if (
                 $user &&
                 Hash::check($request->password, $user->password)

--- a/database/migrations/2026_04_06_135546_add_is_oauth_only_to_instance_settings_table.php
+++ b/database/migrations/2026_04_06_135546_add_is_oauth_only_to_instance_settings_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_only')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn('is_oauth_only');
+        });
+    }
+};

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -29,31 +29,64 @@
                         </div>
                     @endif
 
-                    <form action="/login" method="POST" class="flex flex-col gap-4">
-                        @csrf
-                        @env('local')
-                            <x-forms.input value="test@example.com" type="email" autocomplete="email" name="email" required
-                                label="{{ __('input.email') }}" />
-                            <x-forms.input value="password" type="password" autocomplete="current-password" name="password"
-                                required label="{{ __('input.password') }}" />
-                        @else
-                            <x-forms.input type="email" name="email" autocomplete="email" required
-                                label="{{ __('input.email') }}" />
-                            <x-forms.input type="password" name="password" autocomplete="current-password" required
-                                label="{{ __('input.password') }}" />
-                        @endenv
-
-                        <div class="flex items-center justify-between">
-                            <a href="/forgot-password"
-                                class="text-sm dark:text-neutral-400 hover:text-coollabs dark:hover:text-warning hover:underline transition-colors">
-                                {{ __('auth.forgot_password_link') }}
-                            </a>
+                    @if ($is_oauth_only && $enabled_oauth_providers->isNotEmpty())
+                        <div x-data="{ showForm: false }">
+                            <x-callout type="warning" title="Note" class="mb-4">
+                                Password-based login is disabled for this instance. Please use an OAuth provider below.
+                            </x-callout>
+                            <div class="text-center mb-4">
+                                <button type="button" @click="showForm = !showForm"
+                                    class="text-xs dark:text-neutral-500 hover:text-coollabs dark:hover:text-warning transition-colors underline">
+                                    I am an administrator
+                                </button>
+                            </div>
+                            <div x-show="showForm" x-cloak class="space-y-4">
+                                <form action="/login" method="POST" class="flex flex-col gap-4">
+                                    @csrf
+                                    <x-forms.input type="email" name="email" autocomplete="email" required
+                                        label="{{ __('input.email') }}" />
+                                    <x-forms.input type="password" name="password" autocomplete="current-password" required
+                                        label="{{ __('input.password') }}" />
+                                    <div class="flex items-center justify-between">
+                                        <a href="/forgot-password"
+                                            class="text-sm dark:text-neutral-400 hover:text-coollabs dark:hover:text-warning hover:underline transition-colors">
+                                            {{ __('auth.forgot_password_link') }}
+                                        </a>
+                                    </div>
+                                    <x-forms.button class="w-full justify-center py-3 box-boarding" type="submit"
+                                        isHighlighted>
+                                        {{ __('auth.login') }}
+                                    </x-forms.button>
+                                </form>
+                            </div>
                         </div>
+                    @else
+                        <form action="/login" method="POST" class="flex flex-col gap-4">
+                            @csrf
+                            @env('local')
+                                <x-forms.input value="test@example.com" type="email" autocomplete="email" name="email"
+                                    required label="{{ __('input.email') }}" />
+                                <x-forms.input value="password" type="password" autocomplete="current-password" name="password"
+                                    required label="{{ __('input.password') }}" />
+                            @else
+                                <x-forms.input type="email" name="email" autocomplete="email" required
+                                    label="{{ __('input.email') }}" />
+                                <x-forms.input type="password" name="password" autocomplete="current-password" required
+                                    label="{{ __('input.password') }}" />
+                            @endenv
 
-                        <x-forms.button class="w-full justify-center py-3 box-boarding" type="submit" isHighlighted>
-                            {{ __('auth.login') }}
-                        </x-forms.button>
-                    </form>
+                            <div class="flex items-center justify-between">
+                                <a href="/forgot-password"
+                                    class="text-sm dark:text-neutral-400 hover:text-coollabs dark:hover:text-warning hover:underline transition-colors">
+                                    {{ __('auth.forgot_password_link') }}
+                                </a>
+                            </div>
+
+                            <x-forms.button class="w-full justify-center py-3 box-boarding" type="submit" isHighlighted>
+                                {{ __('auth.login') }}
+                            </x-forms.button>
+                        </form>
+                    @endif
 
                     @if ($is_registration_enabled)
                         <div class="relative my-6">

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -50,30 +50,36 @@ $email = getOldOrLocal('email', 'test3@example.com');
                         </div>
                     @endif
 
-                    <form action="/register" method="POST" class="flex flex-col gap-4">
-                        @csrf
-                        <x-forms.input id="name" required type="text" name="name" value="{{ $name }}"
-                            label="{{ __('input.name') }}" />
-                        <x-forms.input id="email" required type="email" name="email" value="{{ $email }}"
-                            label="{{ __('input.email') }}" />
-                        <x-forms.input id="password" required type="password" name="password"
-                            label="{{ __('input.password') }}" />
-                        <x-forms.input id="password_confirmation" required type="password" name="password_confirmation"
-                            label="{{ __('input.password.again') }}" />
+                    @if ($is_oauth_only && !$isFirstUser)
+                        <x-callout type="warning" title="Note" class="mb-4">
+                            Registration is only allowed via OAuth providers. Please go back to the login page and use an OAuth provider.
+                        </x-callout>
+                    @else
+                        <form action="/register" method="POST" class="flex flex-col gap-4">
+                            @csrf
+                            <x-forms.input id="name" required type="text" name="name" value="{{ $name }}"
+                                label="{{ __('input.name') }}" />
+                            <x-forms.input id="email" required type="email" name="email" value="{{ $email }}"
+                                label="{{ __('input.email') }}" />
+                            <x-forms.input id="password" required type="password" name="password"
+                                label="{{ __('input.password') }}" />
+                            <x-forms.input id="password_confirmation" required type="password" name="password_confirmation"
+                                label="{{ __('input.password.again') }}" />
 
-                        <div
-                            class="p-4 bg-neutral-50 dark:bg-coolgray-200 rounded-lg border border-neutral-200 dark:border-coolgray-400">
-                            <p class="text-xs dark:text-neutral-400">
-                                Your password should be min 8 characters long and contain at least one uppercase letter,
-                                one lowercase letter, one number, and one symbol.
-                            </p>
-                        </div>
+                            <div
+                                class="p-4 bg-neutral-50 dark:bg-coolgray-200 rounded-lg border border-neutral-200 dark:border-coolgray-400">
+                                <p class="text-xs dark:text-neutral-400">
+                                    Your password should be min 8 characters long and contain at least one uppercase letter,
+                                    one lowercase letter, one number, and one symbol.
+                                </p>
+                            </div>
 
-                        <x-forms.button class="w-full justify-center py-3 box-boarding mt-2" type="submit"
-                            isHighlighted>
-                            Create Account
-                        </x-forms.button>
-                    </form>
+                            <x-forms.button class="w-full justify-center py-3 box-boarding mt-2" type="submit"
+                                isHighlighted>
+                                Create Account
+                            </x-forms.button>
+                        </form>
+                    @endif
 
                     @if (!$isFirstUser)
                         <div class="relative my-6">

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -42,6 +42,11 @@
                         </div>
                     @endif
                     <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_only"
+                            helper="Only allow login via configured OAuth providers. Password-based login will be disabled except for the first administrator."
+                            label="OAuth Only Login" />
+                    </div>
+                    <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"
                             helper="Opt out of anonymous usage tracking. When enabled, this instance will not report to coolify.io's installation count and will not send error reports to help improve Coolify."
                             label="Do Not Track" />


### PR DESCRIPTION
Hey Team,

I've implemented a way to restrict loging and registration to OAuth only. This is usefull if you have a private instance and you want to ensure eveyone uses Google Workspace etc.

## Changes:
- Added `is_oauth_only` flag to `instance_settings` (defualt false).
- Toggle in **Settings > Advanced**.
- Blocked password login if OAuth providers are enabled and `is_oauth_only` is true (except for root user at UID 0 to avoid lockouts).
- Allowed OAuth self-reg even if general registration is off, when `is_oauth_only` is true.

I've verified the paths, and it should work fine. Let me know what you think! 

/claim #8042