### PR TITLE
fix(ui): dashboard homepage add buttons are invisible in light mode

### DIFF
--- a/resources/views/livewire/dashboard.blade.php
+++ b/resources/views/livewire/dashboard.blade.php
@@ -15,7 +15,7 @@
                 <x-modal-input buttonTitle="Add" title="New Project">
                     <x-slot:content>
                         <button
-                            class="flex items-center justify-center size-4 text-white rounded hover:bg-coolgray-400 dark:hover:bg-coolgray-300 cursor-pointer">
+                            class="flex items-center justify-center size-4 text-black dark:text-white rounded hover:bg-coolgray-400 dark:hover:bg-coolgray-300 cursor-pointer">
                             <svg class="size-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
                                 stroke-width="2" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
@@ -81,7 +81,7 @@
                 <x-modal-input buttonTitle="Add" title="New Server" :closeOutside="false">
                     <x-slot:content>
                         <button
-                            class="flex items-center justify-center size-4 text-white rounded hover:bg-coolgray-400 dark:hover:bg-coolgray-300 cursor-pointer">
+                            class="flex items-center justify-center size-4 text-black dark:text-white rounded hover:bg-coolgray-400 dark:hover:bg-coolgray-300 cursor-pointer">
                             <svg class="size-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
                                 stroke-width="2" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />


### PR DESCRIPTION
## Changes

The "+" icon buttons next to the "Projects" and "Servers" headings on the dashboard are invisible in light mode. Both buttons use `text-white` without a `dark:` prefix, so the white SVG icon (which uses `stroke="currentColor"`) renders on the light background with no contrast.

Changed `text-white` to `text-black dark:text-white` on both buttons in `resources/views/livewire/dashboard.blade.php`.

## Issues

Fixes #9454

## Category

- [x] Bug fix


## Preview

N/A (two-line CSS class change)

## AI Assistance

- [x] I used AI tools to help with this PR

Claude Code (Anthropic) identified the root cause (`text-white` without dark variant) and suggested the fix. The change was human-reviewed and verified.

## Testing

1. Switch to light mode (Settings > Theme > Light)
2. Navigate to Dashboard
3. Verify the "+" button is visible next to "Projects" and "Servers" headings
4. Switch to dark mode and verify the button is still visible

## Contributor Agreement

- [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/next/CONTRIBUTING.md)
- [x] I have searched existing issues/PRs to avoid duplicates
- [x] I have tested my changes thoroughly and am confident they work