### PR TITLE
feat: add unlock functionality for locked environment variables

### DIFF
--- a/app/Livewire/Project/Shared/EnvironmentVariable/Show.php
+++ b/app/Livewire/Project/Shared/EnvironmentVariable/Show.php
@@ -182,6 +182,16 @@ class Show extends Component
         $this->dispatch('refreshEnvs');
     }
 
+    public function unlock()
+    {
+        $this->authorize('update', $this->env);
+
+        $this->env->is_shown_once = false;
+        $this->env->save();
+        $this->checkEnvs();
+        $this->dispatch('refreshEnvs');
+    }
+
     public function instantSave()
     {
         $this->submit();

--- a/resources/views/livewire/project/shared/environment-variable/show.blade.php
+++ b/resources/views/livewire/project/shared/environment-variable/show.blade.php
@@ -30,6 +30,9 @@
                             helper="Add a note to document what this environment variable is used for." maxlength="256" />
                     </div>
                     <x-forms.button type="submit">Update</x-forms.button>
+                    @if (!$isMagicVariable)
+                        <x-forms.button wire:click='unlock'>Unlock</x-forms.button>
+                    @endif
                 </div>
                 <div class="flex flex-col w-full gap-3">
                     <div class="flex flex-wrap w-full items-center gap-4">


### PR DESCRIPTION
STRAWBERRY

Fixes #6803

## Description

Environment variables can be locked via the Lock button, which sets `is_shown_once = true` and hides the value from the UI. However, once locked, there was no way to unlock them through the UI — users had to edit the database directly.

This PR adds an `unlock()` method and an Unlock button to reverse the lock.

## Changes

**`app/Livewire/Project/Shared/EnvironmentVariable/Show.php`**
- Added `unlock()` method that sets `is_shown_once = false`, saves the model, and dispatches `refreshEnvs` — mirroring the existing `lock()` method

**`resources/views/livewire/project/shared/environment-variable/show.blade.php`**
- Added an "Unlock" button next to the "Update" button in the locked variable view (hidden for magic variables, consistent with Lock button visibility rules)

## Testing

1. Create an environment variable for any application/service
2. Click "Lock" — the variable becomes locked (value hidden, lock icon shown)
3. Verify the new "Unlock" button appears next to "Update" in the locked view
4. Click "Unlock" — the variable returns to the editable state with all fields visible

## AI Usage Disclosure

I used AI assistance to help identify the affected files and draft the implementation. The logic mirrors the existing `lock()` method symmetrically.