### PR TITLE
fix: Docker apt source uses codename not numeric version on Debian 13 (Trixie)

### DIFF
--- a/app/Actions/Server/CheckUpdates.php
+++ b/app/Actions/Server/CheckUpdates.php
@@ -89,6 +89,9 @@ class CheckUpdates
 
                     return $out;
                 case 'apt':
+                    // Fix docker.list if it contains numeric VERSION_CODENAME (e.g. "13" instead of "trixie" on Debian 13)
+                    // This happens when Coolify's InstallDocker created the file with an empty/numeric VERSION_CODENAME
+                    instant_remote_process(["sed -i 's|download.docker.com/linux/debian] 13 |download.docker.com/linux/debian trixie |g' /etc/apt/sources.list.d/docker.list 2>/dev/null || true"], $server);
                     instant_remote_process(['apt-get update -qq'], $server);
                     $output = instant_remote_process(['LANG=C apt list --upgradable 2>/dev/null'], $server);
 

--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -120,7 +120,7 @@ class InstallDocker
             'install -m 0755 -d /etc/apt/keyrings && '.
             'curl -fsSL https://download.docker.com/linux/${ID}/gpg -o /etc/apt/keyrings/docker.asc && '.
             'chmod a+r /etc/apt/keyrings/docker.asc && '.
-            'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${ID} ${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list && '.
+            'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${ID} ${UBUNTU_CODENAME:-$VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list && '.
             'apt-get update && '.
             'apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin'.
             ')';


### PR DESCRIPTION
## Fix: Docker apt source numeric version issue on Debian 13

### Problem
On Debian 13 (Trixie), `$VERSION_CODENAME` may be set to `13` (numeric) instead of `trixie` (the codename). This causes Coolify's Docker installation to generate an invalid apt sources list:

```
E: The repository 'https://download.docker.com/linux/debian 13 Release' does not have a Release file.
```

This breaks:
1. **Server patch check** — `CheckUpdates` runs `apt-get update` which fails
2. **Docker installation fallback** — The manual install path writes an invalid docker.list

### Changes

**`app/Actions/Server/InstallDocker.php`**
- Use `${UBUNTU_CODENAME:-$VERSION_CODENAME}` instead of just `${VERSION_CODENAME}` in the docker apt sources.list entry (matching the already-fixed `install.sh` approach)

**`app/Actions/Server/CheckUpdates.php`**
- Add `sed` fix to detect and repair docker.list files that contain `13` instead of `trixie`, applied before `apt-get update`

/attempt #9455
/claim #9455
/bounty $100