### PR TITLE
fix(ssh): delete existing key file before write to prevent Flysystem failure

### DIFF
--- a/app/Models/PrivateKey.php
+++ b/app/Models/PrivateKey.php
@@ -217,6 +217,12 @@ class PrivateKey extends BaseModel
                 throw new \Exception("Failed to acquire lock for SSH key: {$keyLocation}");
             }
 
+            // Delete existing file first — Flysystem's put() returns false
+            // when overwriting a file with 0600 permissions (cannot set visibility)
+            if ($disk->exists($filename)) {
+                $disk->delete($filename);
+            }
+
             // Attempt to store the private key
             $success = $disk->put($filename, $this->private_key);
 

--- a/tests/Unit/PrivateKeyStorageTest.php
+++ b/tests/Unit/PrivateKeyStorageTest.php
@@ -220,6 +220,31 @@ uZx9iFkCELtxrh31QJ68AAAAEXNhaWxANzZmZjY2ZDJlMmRkAQIDBA==
     }
 
     /** @test */
+    public function it_successfully_overwrites_existing_key_file()
+    {
+        Storage::fake('ssh-keys');
+
+        $privateKey = PrivateKey::createAndStore([
+            'name' => 'Test Key',
+            'description' => 'Test Description',
+            'private_key' => $this->getValidPrivateKey(),
+            'team_id' => currentTeam()->id,
+        ]);
+
+        $filename = "ssh_key@{$privateKey->uuid}";
+        Storage::disk('ssh-keys')->assertExists($filename);
+
+        // Calling storeInFileSystem again should succeed (overwrite scenario)
+        $result = $privateKey->storeInFileSystem();
+        $this->assertNotNull($result);
+
+        // Verify file still exists with correct content
+        Storage::disk('ssh-keys')->assertExists($filename);
+        $storedContent = Storage::disk('ssh-keys')->get($filename);
+        $this->assertEquals($privateKey->private_key, $storedContent);
+    }
+
+    /** @test */
     public function it_successfully_deletes_private_key_from_filesystem()
     {
         Storage::fake('ssh-keys');


### PR DESCRIPTION
## Changes

`PrivateKey::storeInFileSystem()` chmods SSH key files to `0600` after writing. On subsequent deploys, Flysystem's `Storage::put()` returns `false` when overwriting a `0600` file because it cannot set the file's visibility. The content IS written, but the false return triggers `"Failed to write SSH key to filesystem"`.

The fix deletes the existing file before `put()` so Flysystem creates a fresh file. This is safe because the method already holds an exclusive file lock (`LOCK_EX`).

## Issues

- Fixes #9490

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No UI changes. This fixes a server-side deployment failure.

**Before fix:**
```
Deployment failed: Failed to write SSH key to filesystem. Check disk space and permissions for:
/var/www/html/storage/app/ssh/keys/ssh_key@<uuid>
```

**After fix:** Deploys succeed consistently. Verified by calling `storeInFileSystem()` twice in succession — both calls return successfully.

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Anthropic)
- How extensively: AI assisted with root cause analysis (tracing the Flysystem `put()` return value behavior on 0600 files) and drafting the fix. The fix was manually verified by testing `storeInFileSystem()` in production via artisan tinker — calling it twice (write + overwrite) both succeeded after the patch.

## Testing

1. Deployed an application via Coolify (first deploy succeeds as before)
2. Deployed the same application again — previously failed with "Failed to write SSH key", now succeeds
3. Verified via `artisan tinker`:
   ```php
   $k = App\Models\PrivateKey::find(1);
   $k->storeInFileSystem(); // SUCCESS
   $k->storeInFileSystem(); // SUCCESS (overwrite test)
   ```
4. Confirmed the key file has correct `0600` permissions after both writes
5. Confirmed file content matches the decrypted private key after both writes

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.