### PR TITLE
fix: preserve hyphenated values in custom Docker run options parser

### DIFF
--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -991,7 +991,7 @@ function convertDockerRunToCompose(?string $custom_docker_run_options = null)
 {
     $options = [];
     $compose_options = collect([]);
-    preg_match_all('/(--\w+(?:-\w+)*)(?:\s|=)?([^\s-]+)?/', $custom_docker_run_options, $matches, PREG_SET_ORDER);
+    preg_match_all('/(--\w+(?:-\w+)*)(?:\s|=)?((?!--)[^\s]+)?/', $custom_docker_run_options, $matches, PREG_SET_ORDER);
     $list_options = collect([
         '--cap-add',
         '--cap-drop',

--- a/tests/Feature/DockerCustomCommandsTest.php
+++ b/tests/Feature/DockerCustomCommandsTest.php
@@ -215,3 +215,44 @@ test('ConvertIpAndIp6Together', function () {
         'ip6' => ['2001:db8::1'],
     ]);
 });
+
+test('ConvertSecurityOptWithHyphenatedValue', function () {
+    $input = '--security-opt no-new-privileges:true';
+    $output = convertDockerRunToCompose($input);
+    expect($output)->toBe([
+        'security_opt' => ['no-new-privileges:true'],
+    ]);
+});
+
+test('ConvertSecurityOptWithEquals', function () {
+    $input = '--security-opt=no-new-privileges:true';
+    $output = convertDockerRunToCompose($input);
+    expect($output)->toBe([
+        'security_opt' => ['no-new-privileges:true'],
+    ]);
+});
+
+test('ConvertSecurityOptApparmor', function () {
+    $input = '--security-opt apparmor:unconfined';
+    $output = convertDockerRunToCompose($input);
+    expect($output)->toBe([
+        'security_opt' => ['apparmor:unconfined'],
+    ]);
+});
+
+test('ConvertCapDropWithSecurityOpt', function () {
+    $input = '--cap-drop ALL --security-opt no-new-privileges:true';
+    $output = convertDockerRunToCompose($input);
+    expect($output)->toBe([
+        'cap_drop' => ['ALL'],
+        'security_opt' => ['no-new-privileges:true'],
+    ]);
+});
+
+test('ConvertSysctlWithHyphenatedValue', function () {
+    $input = '--sysctl net.ipv4.ip-forward=1';
+    $output = convertDockerRunToCompose($input);
+    expect($output)->toBe([
+        'sysctls' => ['net.ipv4.ip-forward=1'],
+    ]);
+});


### PR DESCRIPTION
## Changes

The regex in `convertDockerRunToCompose()` (`bootstrap/helpers/docker.php:994`) used `[^\s-]+` for the value capture group, which excluded hyphens from matched values. This caused options like `--security-opt no-new-privileges:true` to be truncated to just `"no"`, producing `invalid security-opt: "no"` on deployment.

Changed the value capture group from `([^\s-]+)?` to `((?!--)[^\s]+)?` — hyphens within values are now preserved while `--flag` boundaries are still correctly detected via negative lookahead.

## Issues

- Fixes #8173
- Previously attempted in #8179 / #8181 (closed due to branch target / template)

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A — backend logic change, no UI changes.

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (root cause analysis, regex verification, test generation)
- How extensively: AI assisted with regex debugging and test case generation. Fix approach was derived from the issue's root cause analysis.

## Testing

```bash
./vendor/bin/pest tests/Feature/DockerCustomCommandsTest.php
# 27 passed (32 assertions) — 22 existing + 5 new
```

New test cases:
1. `--security-opt no-new-privileges:true` (space syntax)
2. `--security-opt=no-new-privileges:true` (equals syntax)
3. `--security-opt apparmor:unconfined` (non-hyphenated value, regression check)
4. `--cap-drop ALL --security-opt no-new-privileges:true` (combined options)
5. `--sysctl net.ipv4.ip-forward=1` (another hyphenated value option)

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.