### PR TITLE
feat: add Hermes Agent service template

### DIFF
--- a/public/svgs/hermes-agent.svg
+++ b/public/svgs/hermes-agent.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <defs>
+    <linearGradient id="gold" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#F5C542;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#D4961C;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <!-- Staff -->
+  <rect x="30" y="10" width="4" height="46" rx="2" fill="url(#gold)" />
+  <!-- Wings (left) -->
+  <path d="M30 18 C24 14, 14 14, 10 18 C14 16, 22 16, 28 20" fill="#F5C542" opacity="0.9" />
+  <path d="M30 22 C26 19, 18 19, 14 22 C18 20, 24 20, 28 24" fill="#D4961C" opacity="0.8" />
+  <!-- Wings (right) -->
+  <path d="M34 18 C40 14, 50 14, 54 18 C50 16, 42 16, 36 20" fill="#F5C542" opacity="0.9" />
+  <path d="M34 22 C38 19, 46 19, 50 22 C46 20, 40 20, 36 24" fill="#D4961C" opacity="0.8" />
+  <!-- Left serpent -->
+  <path d="M32 48 C22 44, 20 38, 26 34 C20 36, 18 42, 24 46 C18 40, 22 30, 30 28 C24 32, 22 38, 28 42"
+        fill="none" stroke="#F5C542" stroke-width="2.5" stroke-linecap="round" />
+  <!-- Right serpent -->
+  <path d="M32 48 C42 44, 44 38, 38 34 C44 36, 46 42, 40 46 C46 40, 42 30, 34 28 C40 32, 42 38, 36 42"
+        fill="none" stroke="#D4961C" stroke-width="2.5" stroke-linecap="round" />
+  <!-- Orb at top -->
+  <circle cx="32" cy="10" r="4" fill="#F5C542" />
+  <circle cx="32" cy="10" r="2" fill="#FFF8E1" opacity="0.7" />
+</svg>

--- a/templates/compose/hermes-agent.yaml
+++ b/templates/compose/hermes-agent.yaml
@@ -1,0 +1,36 @@
+# documentation: https://hermes-agent.nousresearch.com/docs/
+# slogan: The self-improving AI agent with built-in learning loop, skills, and multi-platform messaging gateway.
+# category: ai
+# tags: ai,agent,llm,openai,anthropic,openrouter,telegram,discord,memory,self-improving
+# logo: svgs/hermes-agent.svg
+# port: 9119
+
+services:
+  hermes-agent:
+    image: nousresearch/hermes-agent:latest
+    command: ["web", "--host", "0.0.0.0", "--port", "9119", "--no-open"]
+    environment:
+      - SERVICE_URL_HERMESAGENT_9119
+      # LLM Provider — set at least one API key
+      # OpenRouter gives access to 200+ models via one key: https://openrouter.ai/keys
+      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      # Anthropic (Claude)
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      # OpenAI
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      # Google Gemini: https://aistudio.google.com/app/apikey
+      - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
+      # Optional — run as specific user (match host UID to avoid permission issues)
+      - HERMES_UID=${HERMES_UID:-10000}
+      - HERMES_GID=${HERMES_GID:-10000}
+    volumes:
+      - hermes-data:/opt/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:9119"]
+      interval: 10s
+      timeout: 30s
+      retries: 12
+      start_period: 30s
+
+volumes:
+  hermes-data: null


### PR DESCRIPTION
## Summary

Adds a Coolify one-click install template for **[Hermes Agent](https://github.com/NousResearch/hermes-agent)** by Nous Research — requested in discussion #9472.

**What is Hermes Agent?**
The self-improving AI agent with a built-in learning loop, skills system, persistent memory, and multi-platform messaging gateway (Telegram, Discord, Slack, WhatsApp, Signal). Currently 75k+ GitHub stars.

## Template Details

- **Image:** `nousresearch/hermes-agent:latest` (official Docker Hub, multi-arch amd64/arm64)
- **Port:** `9119` — FastAPI + React Web UI
- **Volume:** `/opt/data` — persistent sessions, memory, skills, config
- **LLM Providers:** Optional env vars for 10+ providers (OpenRouter, Anthropic, OpenAI, Gemini, Kimi, MiniMax, ...) — users configure via the built-in Web UI setup wizard after first start
- **Logo:** SVG from the official Hermes repository

## Files Changed

- `templates/compose/hermes-agent.yaml` — service template
- `public/svgs/hermes-agent.svg` — logo

Closes #9472