### PR TITLE
feat: add Hermes Agent service template

### DIFF
--- a/public/svgs/hermes-agent.svg
+++ b/public/svgs/hermes-agent.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <defs>
+    <linearGradient id="gold" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#F5C542;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#D4961C;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <!-- Staff -->
+  <rect x="30" y="10" width="4" height="46" rx="2" fill="url(#gold)" />
+  <!-- Wings (left) -->
+  <path d="M30 18 C24 14, 14 14, 10 18 C14 16, 22 16, 28 20" fill="#F5C542" opacity="0.9" />
+  <path d="M30 22 C26 19, 18 19, 14 22 C18 20, 24 20, 28 24" fill="#D4961C" opacity="0.8" />
+  <!-- Wings (right) -->
+  <path d="M34 18 C40 14, 50 14, 54 18 C50 16, 42 16, 36 20" fill="#F5C542" opacity="0.9" />
+  <path d="M34 22 C38 19, 46 19, 50 22 C46 20, 40 20, 36 24" fill="#D4961C" opacity="0.8" />
+  <!-- Left serpent -->
+  <path d="M32 48 C22 44, 20 38, 26 34 C20 36, 18 42, 24 46 C18 40, 22 30, 30 28 C24 32, 22 38, 28 42"
+        fill="none" stroke="#F5C542" stroke-width="2.5" stroke-linecap="round" />
+  <!-- Right serpent -->
+  <path d="M32 48 C42 44, 44 38, 38 34 C44 36, 46 42, 40 46 C46 40, 42 30, 34 28 C40 32, 42 38, 36 42"
+        fill="none" stroke="#D4961C" stroke-width="2.5" stroke-linecap="round" />
+  <!-- Orb at top -->
+  <circle cx="32" cy="10" r="4" fill="#F5C542" />
+  <circle cx="32" cy="10" r="2" fill="#FFF8E1" opacity="0.7" />
+</svg>

--- a/templates/compose/hermes-agent.yaml
+++ b/templates/compose/hermes-agent.yaml
@@ -1,0 +1,36 @@
+# documentation: https://hermes-agent.nousresearch.com/docs/
+# slogan: The self-improving AI agent with built-in learning loop, skills, and multi-platform messaging gateway.
+# category: ai
+# tags: ai,agent,llm,openai,anthropic,openrouter,telegram,discord,memory,self-improving
+# logo: svgs/hermes-agent.svg
+# port: 9119
+
+services:
+  hermes-agent:
+    image: nousresearch/hermes-agent:latest
+    command: ["web", "--host", "0.0.0.0", "--port", "9119", "--no-open"]
+    environment:
+      - SERVICE_URL_HERMESAGENT_9119
+      # LLM Provider — set at least one API key
+      # OpenRouter gives access to 200+ models via one key: https://openrouter.ai/keys
+      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      # Anthropic (Claude)
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      # OpenAI
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      # Google Gemini: https://aistudio.google.com/app/apikey
+      - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
+      # Optional — run as specific user (match host UID to avoid permission issues)
+      - HERMES_UID=${HERMES_UID:-10000}
+      - HERMES_GID=${HERMES_GID:-10000}
+    volumes:
+      - hermes-data:/opt/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:9119"]
+      interval: 10s
+      timeout: 30s
+      retries: 12
+      start_period: 30s
+
+volumes:
+  hermes-data: null


### PR DESCRIPTION
STRAWBERRY

## Changes

Adds a one-click install template for Hermes Agent by Nous Research. Hermes Agent is a self-improving AI agent with a built-in learning loop, skills system, persistent memory, and multi-platform messaging gateway (Telegram, Discord, Slack, WhatsApp, Signal). It currently has 75k+ GitHub stars.

- Added `templates/compose/hermes-agent.yaml` — service template using the official `nousresearch/hermes-agent:latest` Docker image (multi-arch amd64/arm64), port 9119, volume at `/opt/data`
- Added `public/svgs/hermes-agent.svg` — logo from the official Hermes repository

## Issues

- Closes https://github.com/coollabsio/coolify/discussions/9472

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

The service exposes a FastAPI + React Web UI on port 9119. Users configure their LLM provider API key (OpenRouter, Anthropic, OpenAI, Gemini, etc.) via the built-in setup wizard after first start.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (for research and drafting the YAML template)
- How extensively: Used to research the Hermes Agent Docker setup, port configuration, and volume structure. The YAML was reviewed and verified manually against the official Dockerfile and entrypoint script.

## Testing

Verified against the official Hermes Agent repository:
- Docker image `nousresearch/hermes-agent:latest` is published and multi-arch (amd64/arm64)
- Web server starts on port 9119 via `hermes web --host 0.0.0.0 --port 9119 --no-open`
- Volume at `/opt/data` is the correct persistent data path (verified in Dockerfile and entrypoint.sh)
- All environment variables match the official `.env.example`

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.