### PR TITLE
fix: normalize OAuth email before lookup and create

### DIFF
--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -19,24 +19,23 @@ class OauthController extends Controller
     {
         try {
             $oauthUser = get_socialite_provider($provider)->user();
-            $user = User::whereEmail($oauthUser->email)->first();
+            $email = \Str::lower(trim($oauthUser->email));
+    
+            $user = User::whereEmail($email)->first();
             if (! $user) {
                 $settings = instanceSettings();
                 if (! $settings->is_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
-
                 $user = User::create([
                     'name' => $oauthUser->name,
-                    'email' => $oauthUser->email,
+                    'email' => $email,
                 ]);
             }
             Auth::login($user);
-
             return redirect('/');
         } catch (\Exception $e) {
             $errorCode = $e instanceof HttpException ? 'auth.failed' : 'auth.failed.callback';
-
             return redirect()->route('login')->withErrors([__($errorCode)]);
         }
     }


### PR DESCRIPTION

## Changes

- Normalize the OAuth email (`Str::lower` + `trim`) before lookup and create in `OauthController::callback`, so existing users are matched even when the IdP returns a different casing (e.g. `UserName@example.edu` vs. `user@example.edu`).
- Without this, the Postgres lookup is case-sensitive and misses the user, then the create fails with `users_email_unique` because the `User` model lowercases emails on save.

## Issues

- Fixes #9487

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A — backend-only fix, no UI changes.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude
- How extensively: Helped identify the root cause and draft the fix and PR description.

## Testing

I have not tested this locally — the fix was derived from the stack trace in #9487 and is a minimal change to the lookup/create path. Would appreciate a maintainer running it against a local instance.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [[contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md)](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [[existing issues](https://github.com/coollabsio/coolify/issues)](https://github.com/coollabsio/coolify/issues) and [[pull requests](https://github.com/coollabsio/coolify/pulls)](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
