### PR TITLE
feat: add healthcheck visibility for Docker Compose deployments

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -865,7 +865,8 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             }
         }
 
-        $this->application_deployment_queue->addLogEntry('New container started.');
+        $this->application_deployment_queue->addLogEntry('New containers started.');
+        $this->health_check_compose();
     }
 
     private function deploy_dockerfile_buildpack()
@@ -1947,6 +1948,171 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             ],
         );
         $this->application_deployment_queue->addLogEntry('----------------------------------------');
+    }
+
+    private function health_check_compose(): void
+    {
+        try {
+            if ($this->server->isSwarm()) {
+                // Swarm healthcheck polling not yet implemented
+                return;
+            }
+
+            $projectName = $this->application->uuid;
+
+            // Enumerate all containers belonging to this compose project
+            $this->execute_remote_command(
+                [
+                    'command' => "docker ps -a --filter 'label=com.docker.compose.project={$projectName}' --format '{{.Names}}|{{.Label \"com.docker.compose.service\"}}'",
+                    'hidden' => true,
+                    'save' => 'compose_containers',
+                    'append' => false,
+                ],
+            );
+
+            $containerOutput = $this->saved_outputs->get('compose_containers');
+            if (empty($containerOutput)) {
+                return;
+            }
+
+            $containers = collect(explode("\n", trim($containerOutput)))
+                ->filter()
+                ->map(function ($line) {
+                    $parts = explode('|', $line, 2);
+
+                    return [
+                        'name' => trim($parts[0]),
+                        'service' => trim($parts[1] ?? $parts[0]),
+                    ];
+                });
+
+            if ($containers->isEmpty()) {
+                return;
+            }
+
+            // Check which containers have healthchecks configured
+            $healthcheckedContainers = collect();
+            foreach ($containers as $container) {
+                $this->execute_remote_command(
+                    [
+                        'command' => "docker inspect --format='{{if .State.Health}}true{{else}}false{{end}}' {$container['name']}",
+                        'hidden' => true,
+                        'save' => 'has_healthcheck',
+                        'append' => false,
+                        'ignore_errors' => true,
+                    ],
+                );
+
+                if (str($this->saved_outputs->get('has_healthcheck'))->trim()->replace("'", '')->value() === 'true') {
+                    $healthcheckedContainers->push($container);
+                }
+            }
+
+            if ($healthcheckedContainers->isEmpty()) {
+                $this->application_deployment_queue->addLogEntry('No healthchecks defined in compose services.');
+
+                return;
+            }
+
+            $serviceNames = $healthcheckedContainers->pluck('service')->implode(', ');
+            $this->application_deployment_queue->addLogEntry("Waiting for healthchecks to pass: {$serviceNames}");
+
+            $startPeriod = (int) $this->application->health_check_start_period;
+            if ($startPeriod > 0) {
+                $this->application_deployment_queue->addLogEntry("Waiting for start period ({$startPeriod} seconds) before checking healthchecks.");
+                $sleeptime = 0;
+                while ($sleeptime < $startPeriod) {
+                    Sleep::for(1)->seconds();
+                    $sleeptime++;
+                }
+            }
+
+            $maxRetries = max((int) $this->application->health_check_retries, 1);
+            $interval = max((int) $this->application->health_check_interval, 5);
+            $pending = $healthcheckedContainers->keyBy('name');
+            $unhealthyContainers = collect();
+            $counter = 1;
+
+            while ($counter <= $maxRetries && $pending->isNotEmpty()) {
+                foreach ($pending as $containerName => $container) {
+                    $this->execute_remote_command(
+                        [
+                            'command' => "docker inspect --format='{{json .State.Health.Status}}' {$containerName}",
+                            'hidden' => true,
+                            'save' => 'compose_hc_status',
+                            'append' => false,
+                            'ignore_errors' => true,
+                        ],
+                        [
+                            'command' => "docker inspect --format='{{json .State.Health.Log}}' {$containerName}",
+                            'hidden' => true,
+                            'save' => 'compose_hc_logs',
+                            'append' => false,
+                            'ignore_errors' => true,
+                        ],
+                    );
+
+                    $status = str($this->saved_outputs->get('compose_hc_status'))->trim()->replace('"', '')->value();
+                    $healthLogs = str($this->saved_outputs->get('compose_hc_logs'))->trim()->replaceMatches("/^'|'$/", '')->value();
+                    $lastLog = collect(json_decode($healthLogs, true))->last();
+                    $logOutput = trim(data_get($lastLog, 'Output', ''));
+                    $exitCode = data_get($lastLog, 'ExitCode');
+
+                    $statusLine = "Healthcheck Attempt {$counter}/{$maxRetries} | Service {$container['service']}: {$status}";
+                    if ($exitCode !== null) {
+                        $statusLine .= " (exit {$exitCode})";
+                    }
+                    if (! empty($logOutput)) {
+                        $statusLine .= " — {$logOutput}";
+                    }
+                    $logType = ($exitCode !== null && $exitCode !== 0) ? 'error' : 'info';
+                    $this->application_deployment_queue->addLogEntry($statusLine, type: $logType);
+
+                    if ($status === 'healthy') {
+                        $pending->forget($containerName);
+                    } elseif ($status === 'unhealthy') {
+                        $unhealthyContainers->push($container);
+                        $pending->forget($containerName);
+                    }
+                }
+
+                if ($pending->isNotEmpty()) {
+                    $counter++;
+                    $sleeptime = 0;
+                    while ($sleeptime < $interval) {
+                        Sleep::for(1)->seconds();
+                        $sleeptime++;
+                    }
+                }
+            }
+
+            // Log remaining containers that never resolved (still "starting" after all retries)
+            foreach ($pending as $containerName => $container) {
+                $this->application_deployment_queue->addLogEntry("Service {$container['service']}: healthcheck did not resolve within retry limit.", type: 'warning');
+            }
+
+            // Log container output for unhealthy services
+            if ($unhealthyContainers->isNotEmpty()) {
+                foreach ($unhealthyContainers as $container) {
+                    $this->application_deployment_queue->addLogEntry('----------------------------------------');
+                    $this->application_deployment_queue->addLogEntry("Container logs for {$container['service']}:");
+                    $this->execute_remote_command(
+                        [
+                            'command' => "docker logs -n 100 {$container['name']}",
+                            'type' => 'stderr',
+                            'ignore_errors' => true,
+                        ],
+                    );
+                }
+                $this->application_deployment_queue->addLogEntry('----------------------------------------');
+            }
+
+            if ($unhealthyContainers->isEmpty() && $pending->isEmpty()) {
+                $this->application_deployment_queue->addLogEntry('All compose services are healthy.');
+            }
+        } catch (Exception $e) {
+            $this->application_deployment_queue->addLogEntry("Healthcheck polling failed: {$e->getMessage()}", type: 'warning');
+        }
     }
 
     private function deploy_pull_request()

--- a/app/Livewire/Project/Shared/GetLogs.php
+++ b/app/Livewire/Project/Shared/GetLogs.php
@@ -57,6 +57,12 @@ class GetLogs extends Component
 
     public bool $collapsible = true;
 
+    public bool $showHealthcheckLogs = false;
+
+    public string $healthcheckOutputs = '';
+
+    public ?string $healthcheckStatus = null;
+
     public function mount()
     {
         if (! is_null($this->resource)) {
@@ -285,6 +291,102 @@ class GetLogs extends Component
         }
 
         return sanitizeLogsForExport($allLogs);
+    }
+
+    public function toggleHealthcheckLogs(): void
+    {
+        $this->showHealthcheckLogs = ! $this->showHealthcheckLogs;
+        if ($this->showHealthcheckLogs) {
+            $this->getHealthcheckLogs();
+        }
+    }
+
+    public function getHealthcheckLogs(): void
+    {
+        if (! Server::ownedByCurrentTeam()->where('id', $this->server->id)->exists()) {
+            $this->healthcheckOutputs = 'Unauthorized.';
+
+            return;
+        }
+        if (! $this->server->isFunctional()) {
+            return;
+        }
+        if ($this->container && ! ValidationPatterns::isValidContainerName($this->container)) {
+            $this->healthcheckOutputs = 'Invalid container name.';
+
+            return;
+        }
+        if (! $this->container) {
+            return;
+        }
+
+        $command = "docker inspect --format='{{json .State.Health}}' {$this->container}";
+        if ($this->server->isNonRoot()) {
+            $command = parseCommandsByLineForSudo(collect($command), $this->server);
+            $command = $command[0];
+        }
+        $sshCommand = SshMultiplexingHelper::generateSshCommand($this->server, $command);
+
+        $rawOutput = '';
+        Process::timeout(config('constants.ssh.command_timeout'))->run($sshCommand, function (string $type, string $output) use (&$rawOutput) {
+            $rawOutput .= $output;
+        });
+
+        $rawOutput = trim($rawOutput);
+
+        if (empty($rawOutput) || $rawOutput === 'null' || $rawOutput === '<nil>' || $rawOutput === "'null'") {
+            $this->healthcheckOutputs = 'No healthcheck configured for this container.';
+            $this->healthcheckStatus = null;
+
+            return;
+        }
+
+        // Strip surrounding single quotes if present (docker format output)
+        $rawOutput = trim($rawOutput, "'");
+
+        $health = json_decode($rawOutput, true);
+        if (! is_array($health)) {
+            $this->healthcheckOutputs = 'No healthcheck configured for this container.';
+            $this->healthcheckStatus = null;
+
+            return;
+        }
+
+        $this->healthcheckStatus = data_get($health, 'Status', 'unknown');
+        $failingStreak = data_get($health, 'FailingStreak', 0);
+        $logs = data_get($health, 'Log', []);
+
+        $lines = [];
+        $lines[] = "Status: {$this->healthcheckStatus} | Failing streak: {$failingStreak}";
+        $lines[] = '----------------------------------------';
+
+        if (empty($logs)) {
+            $lines[] = 'No healthcheck log entries yet.';
+        } else {
+            foreach (array_reverse($logs) as $entry) {
+                $start = data_get($entry, 'Start', '');
+                $exitCode = data_get($entry, 'ExitCode', '?');
+                $output = trim(data_get($entry, 'Output', ''));
+
+                $timestamp = $start;
+                if (! empty($start)) {
+                    try {
+                        $dt = new \DateTime($start);
+                        $timestamp = $dt->format('Y-m-d H:i:s');
+                    } catch (\Exception) {
+                    }
+                }
+
+                $statusIcon = $exitCode === 0 ? 'PASS' : 'FAIL';
+                $line = "[{$timestamp}] {$statusIcon} (exit {$exitCode})";
+                if (! empty($output)) {
+                    $line .= " — {$output}";
+                }
+                $lines[] = $line;
+            }
+        }
+
+        $this->healthcheckOutputs = implode("\n", $lines);
     }
 
     public function render()

--- a/resources/views/livewire/project/shared/get-logs.blade.php
+++ b/resources/views/livewire/project/shared/get-logs.blade.php
@@ -245,7 +245,11 @@
                     <div>({{ $pull_request }})</div>
                 @endif
                 @if ($streamLogs)
-                    <x-loading wire:poll.2000ms='getLogs(true)' />
+                    @if ($showHealthcheckLogs)
+                        <x-loading wire:poll.5000ms='getHealthcheckLogs' />
+                    @else
+                        <x-loading wire:poll.2000ms='getLogs(true)' />
+                    @endif
                 @endif
             </div>
         @endif
@@ -389,6 +393,15 @@
                                     d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
                             </svg>
                         </button>
+                        <button wire:click="toggleHealthcheckLogs"
+                            title="{{ $showHealthcheckLogs ? 'Show Container Logs' : 'Show Healthcheck Logs' }}"
+                            class="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 {{ $showHealthcheckLogs ? '!text-warning' : '' }}">
+                            <svg class="w-4 h-4" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none"
+                                stroke="currentColor" stroke-width="2">
+                                <path stroke-linecap="round" stroke-linejoin="round"
+                                    d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z" />
+                            </svg>
+                        </button>
                         <button title="Toggle Log Colors" x-on:click="toggleColorLogs"
                             :class="colorLogs ? '!text-warning' : ''"
                             class="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
@@ -476,7 +489,36 @@
                 <div id="logsContainer" @scroll="handleScroll"
                     class="flex overflow-y-auto overflow-x-hidden flex-col px-4 py-2 w-full min-w-0 scrollbar"
                     :class="fullscreen ? 'flex-1' : 'max-h-[40rem]'">
-                    @if ($outputs)
+                    @if ($showHealthcheckLogs)
+                        <div id="logs" class="font-logs max-w-full cursor-default">
+                            <div class="flex items-center gap-2 mb-2 pb-2 border-b dark:border-coolgray-300 border-neutral-200 text-sm text-gray-500 dark:text-gray-400">
+                                <svg class="w-4 h-4 shrink-0" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 11.25l.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z" />
+                                </svg>
+                                <span>Viewing healthcheck logs only. Click the heart icon in the toolbar to switch back to container logs.</span>
+                            </div>
+                            @if ($healthcheckStatus)
+                                <div class="flex items-center gap-2 mb-2 pb-2 border-b dark:border-coolgray-300 border-neutral-200">
+                                    <span class="text-sm font-medium dark:text-white">Health Status:</span>
+                                    <span class="px-2 py-0.5 text-xs font-medium rounded
+                                        {{ $healthcheckStatus === 'healthy' ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' : ($healthcheckStatus === 'unhealthy' ? 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400' : 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400') }}">
+                                        {{ ucfirst($healthcheckStatus) }}
+                                    </span>
+                                </div>
+                            @endif
+                            @if ($healthcheckOutputs)
+                                @foreach (explode("\n", $healthcheckOutputs) as $index => $line)
+                                    @if (trim($line) !== '')
+                                        <div wire:key="hc-{{ $index }}" data-log-line data-log-content="{{ $line }}" class="flex gap-2 log-line">
+                                            <span data-line-text="{{ $line }}" class="whitespace-pre-wrap break-all {{ str_contains($line, 'FAIL') ? 'text-red-500 dark:text-red-400' : '' }} {{ str_contains($line, 'PASS') ? 'text-green-600 dark:text-green-400' : '' }}">{{ $line }}</span>
+                                        </div>
+                                    @endif
+                                @endforeach
+                            @else
+                                <pre class="font-logs whitespace-pre-wrap break-all max-w-full text-neutral-400">No healthcheck data. Click refresh or enable streaming.</pre>
+                            @endif
+                        </div>
+                    @elseif ($outputs)
                         @php
                             $displayLines = collect(explode("\n", $outputs))->filter(fn($line) => trim($line) !== '');
                         @endphp

--- a/tests/Unit/ComposeHealthcheckTest.php
+++ b/tests/Unit/ComposeHealthcheckTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * Unit tests for Docker Compose healthcheck polling during deployment.
+ *
+ * Tests verify that the health_check_compose() method in ApplicationDeploymentJob
+ * properly handles container enumeration, healthcheck detection, and status reporting.
+ */
+it('has health_check_compose method in ApplicationDeploymentJob', function () {
+    $deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
+
+    expect($deploymentJobFile)
+        ->toContain('private function health_check_compose(): void');
+});
+
+it('calls health_check_compose from deploy_docker_compose_buildpack', function () {
+    $deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
+
+    // Verify the compose deployment method calls health_check_compose
+    expect($deploymentJobFile)
+        ->toContain('$this->health_check_compose();')
+        ->toContain("addLogEntry('New containers started.')");
+});
+
+it('skips healthcheck polling for swarm mode', function () {
+    $deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
+
+    // Find the health_check_compose method and verify it checks for swarm
+    $methodStart = strpos($deploymentJobFile, 'private function health_check_compose(): void');
+    $methodBody = substr($deploymentJobFile, $methodStart, 3000);
+
+    expect($methodBody)
+        ->toContain('$this->server->isSwarm()')
+        ->toContain('return;');
+});
+
+it('uses docker ps to enumerate compose containers', function () {
+    $deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
+
+    $methodStart = strpos($deploymentJobFile, 'private function health_check_compose(): void');
+    $methodBody = substr($deploymentJobFile, $methodStart, 5000);
+
+    // Should filter by compose project label
+    expect($methodBody)
+        ->toContain("docker ps -a --filter 'label=com.docker.compose.project=")
+        ->toContain('com.docker.compose.service');
+});
+
+it('checks each container for healthcheck configuration before polling', function () {
+    $deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
+
+    $methodStart = strpos($deploymentJobFile, 'private function health_check_compose(): void');
+    $methodBody = substr($deploymentJobFile, $methodStart, 5000);
+
+    // Should use docker inspect to check if healthcheck exists
+    expect($methodBody)
+        ->toContain('docker inspect')
+        ->toContain('.State.Health')
+        ->toContain('has_healthcheck');
+});
+
+it('logs when no healthchecks are defined in compose services', function () {
+    $deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
+
+    $methodStart = strpos($deploymentJobFile, 'private function health_check_compose(): void');
+    $methodBody = substr($deploymentJobFile, $methodStart, 5000);
+
+    expect($methodBody)
+        ->toContain('No healthchecks defined in compose services.');
+});
+
+it('inspects health status and logs for each container during polling', function () {
+    $deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
+
+    $methodStart = strpos($deploymentJobFile, 'private function health_check_compose(): void');
+    $methodBody = substr($deploymentJobFile, $methodStart, 5000);
+
+    // Should inspect both status and log
+    expect($methodBody)
+        ->toContain("docker inspect --format='{{json .State.Health.Status}}'")
+        ->toContain("docker inspect --format='{{json .State.Health.Log}}'");
+});
+
+it('logs container output for unhealthy services', function () {
+    $deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
+
+    $methodStart = strpos($deploymentJobFile, 'private function health_check_compose(): void');
+    $methodBody = substr($deploymentJobFile, $methodStart, 8000);
+
+    // Should fetch docker logs for unhealthy containers
+    expect($methodBody)
+        ->toContain('unhealthyContainers')
+        ->toContain('docker logs -n 100');
+});
+
+it('logs success when all compose services are healthy', function () {
+    $deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
+
+    $methodStart = strpos($deploymentJobFile, 'private function health_check_compose(): void');
+    $methodBody = substr($deploymentJobFile, $methodStart, 8000);
+
+    expect($methodBody)
+        ->toContain('All compose services are healthy.');
+});
+
+it('wraps health_check_compose in try-catch to avoid blocking deployment', function () {
+    $deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
+
+    $methodStart = strpos($deploymentJobFile, 'private function health_check_compose(): void');
+    $methodBody = substr($deploymentJobFile, $methodStart, 8000);
+
+    // Should catch exceptions and log a warning rather than failing the deployment
+    expect($methodBody)
+        ->toContain('catch (Exception $e)')
+        ->toContain('Healthcheck polling failed:');
+});

--- a/tests/Unit/GetLogsHealthcheckTest.php
+++ b/tests/Unit/GetLogsHealthcheckTest.php
@@ -1,0 +1,157 @@
+<?php
+
+/**
+ * Unit tests for the healthcheck log viewer in the GetLogs Livewire component.
+ *
+ * Tests verify that the component has the correct properties and methods,
+ * and that the Blade template includes the healthcheck toggle and display.
+ */
+it('has healthcheck properties on GetLogs component', function () {
+    $getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
+
+    expect($getLogsFile)
+        ->toContain('public bool $showHealthcheckLogs = false')
+        ->toContain('public string $healthcheckOutputs = ')
+        ->toContain('public ?string $healthcheckStatus = null');
+});
+
+it('has getHealthcheckLogs method on GetLogs component', function () {
+    $getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
+
+    expect($getLogsFile)
+        ->toContain('public function getHealthcheckLogs(): void');
+});
+
+it('has toggleHealthcheckLogs method on GetLogs component', function () {
+    $getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
+
+    expect($getLogsFile)
+        ->toContain('public function toggleHealthcheckLogs(): void')
+        ->toContain('$this->showHealthcheckLogs = ! $this->showHealthcheckLogs');
+});
+
+it('validates server ownership in getHealthcheckLogs', function () {
+    $getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
+
+    // Find the method body
+    $methodStart = strpos($getLogsFile, 'public function getHealthcheckLogs(): void');
+    $methodBody = substr($getLogsFile, $methodStart, 2000);
+
+    // Should validate server ownership like getLogs does
+    expect($methodBody)
+        ->toContain('Server::ownedByCurrentTeam()')
+        ->toContain('Unauthorized');
+});
+
+it('validates container name in getHealthcheckLogs', function () {
+    $getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
+
+    $methodStart = strpos($getLogsFile, 'public function getHealthcheckLogs(): void');
+    $methodBody = substr($getLogsFile, $methodStart, 2000);
+
+    expect($methodBody)
+        ->toContain('ValidationPatterns::isValidContainerName');
+});
+
+it('uses docker inspect to fetch health data', function () {
+    $getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
+
+    $methodStart = strpos($getLogsFile, 'public function getHealthcheckLogs(): void');
+    $methodBody = substr($getLogsFile, $methodStart, 3000);
+
+    expect($methodBody)
+        ->toContain("docker inspect --format='{{json .State.Health}}'")
+        ->toContain('SshMultiplexingHelper::generateSshCommand');
+});
+
+it('handles containers without healthcheck configured', function () {
+    $getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
+
+    $methodStart = strpos($getLogsFile, 'public function getHealthcheckLogs(): void');
+    $methodBody = substr($getLogsFile, $methodStart, 3000);
+
+    expect($methodBody)
+        ->toContain('No healthcheck configured for this container.');
+});
+
+it('handles non-root servers with sudo in getHealthcheckLogs', function () {
+    $getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
+
+    $methodStart = strpos($getLogsFile, 'public function getHealthcheckLogs(): void');
+    $methodBody = substr($getLogsFile, $methodStart, 2000);
+
+    expect($methodBody)
+        ->toContain('$this->server->isNonRoot()')
+        ->toContain('parseCommandsByLineForSudo');
+});
+
+it('formats healthcheck log entries with PASS and FAIL indicators', function () {
+    $getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
+
+    $methodStart = strpos($getLogsFile, 'public function getHealthcheckLogs(): void');
+    $methodBody = substr($getLogsFile, $methodStart, 5000);
+
+    expect($methodBody)
+        ->toContain("'PASS'")
+        ->toContain("'FAIL'")
+        ->toContain('ExitCode')
+        ->toContain('Output');
+});
+
+it('parses health status and failing streak from docker inspect', function () {
+    $getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
+
+    $methodStart = strpos($getLogsFile, 'public function getHealthcheckLogs(): void');
+    $methodBody = substr($getLogsFile, $methodStart, 5000);
+
+    expect($methodBody)
+        ->toContain("data_get(\$health, 'Status'")
+        ->toContain("data_get(\$health, 'FailingStreak'")
+        ->toContain("data_get(\$health, 'Log'");
+});
+
+it('has healthcheck toggle button in blade template', function () {
+    $bladeFile = file_get_contents(__DIR__.'/../../resources/views/livewire/project/shared/get-logs.blade.php');
+
+    expect($bladeFile)
+        ->toContain('wire:click="toggleHealthcheckLogs"')
+        ->toContain('Show Healthcheck Logs')
+        ->toContain('Show Container Logs');
+});
+
+it('conditionally shows healthcheck display area in blade template', function () {
+    $bladeFile = file_get_contents(__DIR__.'/../../resources/views/livewire/project/shared/get-logs.blade.php');
+
+    expect($bladeFile)
+        ->toContain('$showHealthcheckLogs')
+        ->toContain('$healthcheckStatus')
+        ->toContain('$healthcheckOutputs');
+});
+
+it('shows health status badge with correct color classes', function () {
+    $bladeFile = file_get_contents(__DIR__.'/../../resources/views/livewire/project/shared/get-logs.blade.php');
+
+    expect($bladeFile)
+        ->toContain('Health Status:')
+        ->toContain('bg-green-100')
+        ->toContain('bg-red-100')
+        ->toContain('bg-yellow-100');
+});
+
+it('uses slower poll interval for healthcheck mode', function () {
+    $bladeFile = file_get_contents(__DIR__.'/../../resources/views/livewire/project/shared/get-logs.blade.php');
+
+    // Healthcheck mode should use 5s polling (less frequent than 2s for logs)
+    expect($bladeFile)
+        ->toContain("wire:poll.5000ms='getHealthcheckLogs'");
+});
+
+it('color-codes PASS and FAIL lines in healthcheck display', function () {
+    $bladeFile = file_get_contents(__DIR__.'/../../resources/views/livewire/project/shared/get-logs.blade.php');
+
+    expect($bladeFile)
+        ->toContain("str_contains(\$line, 'FAIL')")
+        ->toContain("str_contains(\$line, 'PASS')")
+        ->toContain('text-red-500')
+        ->toContain('text-green-600');
+});


### PR DESCRIPTION
## Summary

- **Deployment-time healthcheck polling**: Compose deployments skip the existing `health_check()` method (only non-compose apps use it via `rolling_update()`). Adds `health_check_compose()` to `ApplicationDeploymentJob` that enumerates compose containers, detects which have healthchecks configured, and polls their status with retries. Logs per-service results including healthcheck output and exit codes to the deployment log.
- **Runtime healthcheck log viewer**: Docker healthcheck results live in `State.Health.Log` (via `docker inspect`), not in `docker logs`, so the Logs tab never shows them. Adds a heart icon toggle to the Logs toolbar that switches to a dedicated healthcheck view showing status badge (healthy/unhealthy/starting) and PASS/FAIL entries with timestamps and output.
- **25 unit tests** covering both features.

### Deployment log example

```
New containers started.
Waiting for healthchecks to pass: postgrest, electric
Waiting for start period (5 seconds) before checking healthchecks.
Healthcheck Attempt 1/10 | Service postgrest: starting (exit 1) — ERROR: http://0.0.0.0:3001/ready
Healthcheck Attempt 1/10 | Service electric: healthy (exit 0) — {"status":"waiting"}
Healthcheck Attempt 2/10 | Service postgrest: healthy (exit 0) — OK: http://0.0.0.0:3001/ready
All compose services are healthy.
```

Closes #9524
Related: #9411, #2332

## Test plan

- [x] Deploy a Docker Compose app (build pack: `dockercompose`) with healthchecks defined — verify deployment log shows healthcheck polling with per-service status, exit codes, and output
- [x] Deploy a Docker Compose app without healthchecks — verify "No healthchecks defined in compose services." appears
- [x] Deploy with a deliberately broken healthcheck (e.g., `curl` not installed) — verify failure output shows the actual error, attempts show in red, and container logs are dumped for unhealthy services
- [x] In the Logs tab, select a container with a healthcheck and click the heart icon — verify it switches to healthcheck view with status badge and PASS/FAIL entries
- [x] Click heart icon again — verify it switches back to regular container logs
- [x] Toggle streaming while in healthcheck view — verify it polls at 5s intervals
- [x] 25 unit tests pass (`php artisan test --compact tests/Unit/ComposeHealthcheckTest.php tests/Unit/GetLogsHealthcheckTest.php`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)