### PR TITLE
feat: add healthcheck visibility for Docker Compose deployments

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -1965,11 +1965,14 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                     'hidden' => true,
                     'save' => 'compose_containers',
                     'append' => false,
+                    'ignore_errors' => true,
                 ],
             );
 
             $containerOutput = $this->saved_outputs->get('compose_containers');
             if (empty($containerOutput)) {
+                $this->application_deployment_queue->addLogEntry('No compose containers found for healthcheck polling.');
+
                 return;
             }
 
@@ -1985,6 +1988,8 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                 });
 
             if ($containers->isEmpty()) {
+                $this->application_deployment_queue->addLogEntry('No compose containers found for healthcheck polling.');
+
                 return;
             }
 
@@ -2040,18 +2045,20 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                 }
             }
 
+            // Cap values to prevent unbounded deployment blocking
+            $maxStartPeriod = min($maxStartPeriod, 300);
+            $interval = min(max($maxInterval, 5), 60);
+            $maxRetries = min(max($maxRetries + 2, 3), 30);
+
             if ($maxStartPeriod > 0) {
                 $this->application_deployment_queue->addLogEntry("Waiting for start period ({$maxStartPeriod} seconds) before checking healthchecks.");
                 $sleeptime = 0;
                 while ($sleeptime < $maxStartPeriod) {
+                    $this->checkForCancellation();
                     Sleep::for(1)->seconds();
                     $sleeptime++;
                 }
             }
-
-            $interval = max($maxInterval, 5);
-            // Allow extra retries beyond Docker's own limit so we can observe the final state
-            $maxRetries = max($maxRetries + 2, 3);
             $pending = $healthcheckedContainers->keyBy('name');
             $unhealthyContainers = collect();
             $counter = 1;
@@ -2076,6 +2083,14 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                     );
 
                     $status = str($this->saved_outputs->get('compose_hc_status'))->trim()->replace('"', '')->value();
+
+                    if (empty($status)) {
+                        $this->application_deployment_queue->addLogEntry("Could not retrieve healthcheck status for {$container['service']}. Container may have stopped.", type: 'warning');
+                        $pending->forget($containerName);
+
+                        continue;
+                    }
+
                     $healthLogs = str($this->saved_outputs->get('compose_hc_logs'))->trim()->replaceMatches("/^'|'$/", '')->value();
                     $lastLog = collect(json_decode($healthLogs, true))->last();
                     $logOutput = trim(data_get($lastLog, 'Output', ''));
@@ -2103,6 +2118,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                     $counter++;
                     $sleeptime = 0;
                     while ($sleeptime < $interval) {
+                        $this->checkForCancellation();
                         Sleep::for(1)->seconds();
                         $sleeptime++;
                     }

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -1985,7 +1985,8 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                         'name' => trim($parts[0]),
                         'service' => trim($parts[1] ?? $parts[0]),
                     ];
-                });
+                })
+                ->filter(fn (array $container) => ValidationPatterns::isValidContainerName($container['name']));
 
             if ($containers->isEmpty()) {
                 $this->application_deployment_queue->addLogEntry('No compose containers found for healthcheck polling.');

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -816,7 +816,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                 $command = "{$this->coolify_variables} docker compose";
                 // Always use .env file
                 $command .= " --env-file {$server_workdir}/.env";
-                $command .= " --project-directory {$server_workdir} -f {$server_workdir}{$this->docker_compose_location} up -d";
+                $command .= " --project-directory {$server_workdir} -f {$server_workdir}{$this->docker_compose_location} up -d --remove-orphans";
                 $this->execute_remote_command(
                     ['command' => $command, 'hidden' => false, 'type' => 'stdout', 'command_hidden' => true],
                 );
@@ -847,7 +847,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                 if ($this->preserveRepository) {
                     // Always use .env file
                     $command .= " --env-file {$server_workdir}/.env";
-                    $command .= " --project-name {$this->application->uuid} --project-directory {$server_workdir} -f {$server_workdir}{$this->docker_compose_location} up -d";
+                    $command .= " --project-name {$this->application->uuid} --project-directory {$server_workdir} -f {$server_workdir}{$this->docker_compose_location} up -d --remove-orphans";
                     $this->write_deployment_configurations();
 
                     $this->execute_remote_command(
@@ -856,7 +856,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                 } else {
                     // Always use .env file
                     $command .= " --env-file {$this->workdir}/.env";
-                    $command .= " --project-name {$this->application->uuid} --project-directory {$this->workdir} -f {$this->workdir}{$this->docker_compose_location} up -d";
+                    $command .= " --project-name {$this->application->uuid} --project-directory {$this->workdir} -f {$this->workdir}{$this->docker_compose_location} up -d --remove-orphans";
                     $this->execute_remote_command(
                         [executeInDocker($this->deployment_uuid, $command), 'hidden' => false, 'type' => 'stdout', 'command_hidden' => true],
                     );
@@ -1988,8 +1988,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                 return;
             }
 
-            $healthcheckedContainers = collect();
-            foreach ($containers as $container) {
+            $healthcheckedContainers = $containers->filter(function (array $container): bool {
                 $this->execute_remote_command(
                     [
                         'command' => "docker inspect --format='{{if .State.Health}}true{{else}}false{{end}}' {$container['name']}",
@@ -2000,10 +1999,8 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                     ],
                 );
 
-                if (str($this->saved_outputs->get('has_healthcheck'))->trim()->replace("'", '')->value() === 'true') {
-                    $healthcheckedContainers->push($container);
-                }
-            }
+                return str($this->saved_outputs->get('has_healthcheck'))->trim()->replace("'", '')->value() === 'true';
+            })->values();
 
             if ($healthcheckedContainers->isEmpty()) {
                 $this->application_deployment_queue->addLogEntry('No healthchecks defined in compose services.');
@@ -2014,18 +2011,47 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             $serviceNames = $healthcheckedContainers->pluck('service')->implode(', ');
             $this->application_deployment_queue->addLogEntry("Waiting for healthchecks to pass: {$serviceNames}");
 
-            $startPeriod = (int) $this->application->health_check_start_period;
-            if ($startPeriod > 0) {
-                $this->application_deployment_queue->addLogEntry("Waiting for start period ({$startPeriod} seconds) before checking healthchecks.");
+            // Derive timing from the containers' actual Docker healthcheck config
+            // rather than using Application model defaults which come from Dockerfile parsing
+            $maxStartPeriod = 0;
+            $maxInterval = 5;
+            $maxRetries = 1;
+            foreach ($healthcheckedContainers as $container) {
+                $this->execute_remote_command(
+                    [
+                        'command' => "docker inspect --format='{{json .Config.Healthcheck}}' {$container['name']}",
+                        'hidden' => true,
+                        'save' => 'hc_config',
+                        'append' => false,
+                        'ignore_errors' => true,
+                    ],
+                );
+                $rawConfig = str($this->saved_outputs->get('hc_config'))->trim()->replace("'", '')->value();
+                $hcConfig = json_decode($rawConfig, true);
+                if (is_array($hcConfig)) {
+                    // Docker stores durations in nanoseconds
+                    $startPeriodNs = data_get($hcConfig, 'StartPeriod', 0);
+                    $intervalNs = data_get($hcConfig, 'Interval', 0);
+                    $retriesVal = data_get($hcConfig, 'Retries', 0);
+
+                    $maxStartPeriod = max($maxStartPeriod, (int) ($startPeriodNs / 1_000_000_000));
+                    $maxInterval = max($maxInterval, (int) ($intervalNs / 1_000_000_000));
+                    $maxRetries = max($maxRetries, (int) $retriesVal);
+                }
+            }
+
+            if ($maxStartPeriod > 0) {
+                $this->application_deployment_queue->addLogEntry("Waiting for start period ({$maxStartPeriod} seconds) before checking healthchecks.");
                 $sleeptime = 0;
-                while ($sleeptime < $startPeriod) {
+                while ($sleeptime < $maxStartPeriod) {
                     Sleep::for(1)->seconds();
                     $sleeptime++;
                 }
             }
 
-            $maxRetries = max((int) $this->application->health_check_retries, 1);
-            $interval = max((int) $this->application->health_check_interval, 5);
+            $interval = max($maxInterval, 5);
+            // Allow extra retries beyond Docker's own limit so we can observe the final state
+            $maxRetries = max($maxRetries + 2, 3);
             $pending = $healthcheckedContainers->keyBy('name');
             $unhealthyContainers = collect();
             $counter = 1;

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -2148,6 +2148,8 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             if ($unhealthyContainers->isEmpty() && $pending->isEmpty()) {
                 $this->application_deployment_queue->addLogEntry('All compose services are healthy.');
             }
+        } catch (DeploymentException $e) {
+            throw $e;
         } catch (Exception $e) {
             $this->application_deployment_queue->addLogEntry("Healthcheck polling failed: {$e->getMessage()}", type: 'warning');
         }

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -865,7 +865,8 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             }
         }
 
-        $this->application_deployment_queue->addLogEntry('New container started.');
+        $this->application_deployment_queue->addLogEntry('New containers started.');
+        $this->health_check_compose();
     }
 
     private function deploy_dockerfile_buildpack()
@@ -1947,6 +1948,166 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             ],
         );
         $this->application_deployment_queue->addLogEntry('----------------------------------------');
+    }
+
+    private function health_check_compose(): void
+    {
+        try {
+            if ($this->server->isSwarm()) {
+                return;
+            }
+
+            $projectName = $this->application->uuid;
+
+            $this->execute_remote_command(
+                [
+                    'command' => "docker ps -a --filter 'label=com.docker.compose.project={$projectName}' --format '{{.Names}}|{{.Label \"com.docker.compose.service\"}}'",
+                    'hidden' => true,
+                    'save' => 'compose_containers',
+                    'append' => false,
+                ],
+            );
+
+            $containerOutput = $this->saved_outputs->get('compose_containers');
+            if (empty($containerOutput)) {
+                return;
+            }
+
+            $containers = collect(explode("\n", trim($containerOutput)))
+                ->filter()
+                ->map(function ($line) {
+                    $parts = explode('|', $line, 2);
+
+                    return [
+                        'name' => trim($parts[0]),
+                        'service' => trim($parts[1] ?? $parts[0]),
+                    ];
+                });
+
+            if ($containers->isEmpty()) {
+                return;
+            }
+
+            $healthcheckedContainers = collect();
+            foreach ($containers as $container) {
+                $this->execute_remote_command(
+                    [
+                        'command' => "docker inspect --format='{{if .State.Health}}true{{else}}false{{end}}' {$container['name']}",
+                        'hidden' => true,
+                        'save' => 'has_healthcheck',
+                        'append' => false,
+                        'ignore_errors' => true,
+                    ],
+                );
+
+                if (str($this->saved_outputs->get('has_healthcheck'))->trim()->replace("'", '')->value() === 'true') {
+                    $healthcheckedContainers->push($container);
+                }
+            }
+
+            if ($healthcheckedContainers->isEmpty()) {
+                $this->application_deployment_queue->addLogEntry('No healthchecks defined in compose services.');
+
+                return;
+            }
+
+            $serviceNames = $healthcheckedContainers->pluck('service')->implode(', ');
+            $this->application_deployment_queue->addLogEntry("Waiting for healthchecks to pass: {$serviceNames}");
+
+            $startPeriod = (int) $this->application->health_check_start_period;
+            if ($startPeriod > 0) {
+                $this->application_deployment_queue->addLogEntry("Waiting for start period ({$startPeriod} seconds) before checking healthchecks.");
+                $sleeptime = 0;
+                while ($sleeptime < $startPeriod) {
+                    Sleep::for(1)->seconds();
+                    $sleeptime++;
+                }
+            }
+
+            $maxRetries = max((int) $this->application->health_check_retries, 1);
+            $interval = max((int) $this->application->health_check_interval, 5);
+            $pending = $healthcheckedContainers->keyBy('name');
+            $unhealthyContainers = collect();
+            $counter = 1;
+
+            while ($counter <= $maxRetries && $pending->isNotEmpty()) {
+                foreach ($pending as $containerName => $container) {
+                    $this->execute_remote_command(
+                        [
+                            'command' => "docker inspect --format='{{json .State.Health.Status}}' {$containerName}",
+                            'hidden' => true,
+                            'save' => 'compose_hc_status',
+                            'append' => false,
+                            'ignore_errors' => true,
+                        ],
+                        [
+                            'command' => "docker inspect --format='{{json .State.Health.Log}}' {$containerName}",
+                            'hidden' => true,
+                            'save' => 'compose_hc_logs',
+                            'append' => false,
+                            'ignore_errors' => true,
+                        ],
+                    );
+
+                    $status = str($this->saved_outputs->get('compose_hc_status'))->trim()->replace('"', '')->value();
+                    $healthLogs = str($this->saved_outputs->get('compose_hc_logs'))->trim()->replaceMatches("/^'|'$/", '')->value();
+                    $lastLog = collect(json_decode($healthLogs, true))->last();
+                    $logOutput = trim(data_get($lastLog, 'Output', ''));
+                    $exitCode = data_get($lastLog, 'ExitCode');
+
+                    $statusLine = "Healthcheck Attempt {$counter}/{$maxRetries} | Service {$container['service']}: {$status}";
+                    if ($exitCode !== null) {
+                        $statusLine .= " (exit {$exitCode})";
+                    }
+                    if (! empty($logOutput)) {
+                        $statusLine .= " — {$logOutput}";
+                    }
+                    $logType = ($exitCode !== null && $exitCode !== 0) ? 'error' : 'info';
+                    $this->application_deployment_queue->addLogEntry($statusLine, type: $logType);
+
+                    if ($status === 'healthy') {
+                        $pending->forget($containerName);
+                    } elseif ($status === 'unhealthy') {
+                        $unhealthyContainers->push($container);
+                        $pending->forget($containerName);
+                    }
+                }
+
+                if ($pending->isNotEmpty()) {
+                    $counter++;
+                    $sleeptime = 0;
+                    while ($sleeptime < $interval) {
+                        Sleep::for(1)->seconds();
+                        $sleeptime++;
+                    }
+                }
+            }
+
+            foreach ($pending as $containerName => $container) {
+                $this->application_deployment_queue->addLogEntry("Service {$container['service']}: healthcheck did not resolve within retry limit.", type: 'warning');
+            }
+
+            if ($unhealthyContainers->isNotEmpty()) {
+                foreach ($unhealthyContainers as $container) {
+                    $this->application_deployment_queue->addLogEntry('----------------------------------------');
+                    $this->application_deployment_queue->addLogEntry("Container logs for {$container['service']}:");
+                    $this->execute_remote_command(
+                        [
+                            'command' => "docker logs -n 100 {$container['name']}",
+                            'type' => 'stderr',
+                            'ignore_errors' => true,
+                        ],
+                    );
+                }
+                $this->application_deployment_queue->addLogEntry('----------------------------------------');
+            }
+
+            if ($unhealthyContainers->isEmpty() && $pending->isEmpty()) {
+                $this->application_deployment_queue->addLogEntry('All compose services are healthy.');
+            }
+        } catch (Exception $e) {
+            $this->application_deployment_queue->addLogEntry("Healthcheck polling failed: {$e->getMessage()}", type: 'warning');
+        }
     }
 
     private function deploy_pull_request()

--- a/app/Livewire/Project/Shared/GetLogs.php
+++ b/app/Livewire/Project/Shared/GetLogs.php
@@ -220,6 +220,9 @@ class GetLogs extends Component
 
     public function downloadAllLogs(): string
     {
+        if ($this->showHealthcheckLogs) {
+            return sanitizeLogsForExport($this->healthcheckOutputs);
+        }
         if (! Server::ownedByCurrentTeam()->where('id', $this->server->id)->exists()) {
             return '';
         }
@@ -307,81 +310,93 @@ class GetLogs extends Component
 
     public function getHealthcheckLogs(): void
     {
-        if (! Server::ownedByCurrentTeam()->where('id', $this->server->id)->exists()) {
-            $this->healthcheckOutputs = 'Unauthorized.';
+        try {
+            if (! Server::ownedByCurrentTeam()->where('id', $this->server->id)->exists()) {
+                $this->healthcheckOutputs = 'Unauthorized.';
 
-            return;
-        }
-        if (! $this->server->isFunctional()) {
-            return;
-        }
-        if (! $this->container) {
-            return;
-        }
-        if (! ValidationPatterns::isValidContainerName($this->container)) {
-            $this->healthcheckOutputs = 'Invalid container name.';
-
-            return;
-        }
-
-        $command = "docker inspect --format='{{json .State.Health}}' {$this->container}";
-        if ($this->server->isNonRoot()) {
-            $command = parseCommandsByLineForSudo(collect($command), $this->server);
-            $command = $command[0];
-        }
-        $sshCommand = SshMultiplexingHelper::generateSshCommand($this->server, $command);
-
-        $rawOutput = '';
-        Process::timeout(config('constants.ssh.command_timeout'))->run($sshCommand, function (string $type, string $output) use (&$rawOutput) {
-            $rawOutput .= $output;
-        });
-
-        $rawOutput = trim(trim($rawOutput), "'");
-
-        $health = json_decode($rawOutput, true);
-        if (! is_array($health)) {
-            $this->healthcheckOutputs = 'No healthcheck configured for this container.';
-            $this->healthcheckStatus = null;
-
-            return;
-        }
-
-        $this->healthcheckStatus = data_get($health, 'Status', 'unknown');
-        $failingStreak = data_get($health, 'FailingStreak', 0);
-        $logs = data_get($health, 'Log', []);
-
-        $lines = [
-            "Status: {$this->healthcheckStatus} | Failing streak: {$failingStreak}",
-            '----------------------------------------',
-        ];
-
-        if (empty($logs)) {
-            $lines[] = 'No healthcheck log entries yet.';
-        } else {
-            foreach (array_reverse($logs) as $entry) {
-                $start = data_get($entry, 'Start', '');
-                $exitCode = data_get($entry, 'ExitCode', '?');
-                $output = trim(data_get($entry, 'Output', ''));
-
-                $timestamp = $start;
-                if (! empty($start)) {
-                    try {
-                        $dt = new \DateTime($start);
-                        $timestamp = $dt->format('Y-m-d H:i:s');
-                    } catch (\Exception) {
-                    }
-                }
-
-                $statusIcon = $exitCode === 0 ? 'PASS' : 'FAIL';
-                $line = "[{$timestamp}] {$statusIcon} (exit {$exitCode})";
-                if (! empty($output)) {
-                    $line .= " — {$output}";
-                }
-                $lines[] = $line;
+                return;
             }
-        }
+            if (! $this->server->isFunctional()) {
+                $this->healthcheckOutputs = 'Server is not reachable.';
+                $this->healthcheckStatus = null;
 
-        $this->healthcheckOutputs = implode("\n", $lines);
+                return;
+            }
+            if (! $this->container) {
+                $this->healthcheckOutputs = 'No container selected.';
+                $this->healthcheckStatus = null;
+
+                return;
+            }
+            if (! ValidationPatterns::isValidContainerName($this->container)) {
+                $this->healthcheckOutputs = 'Invalid container name.';
+
+                return;
+            }
+
+            $command = "docker inspect --format='{{json .State.Health}}' {$this->container}";
+            if ($this->server->isNonRoot()) {
+                $command = parseCommandsByLineForSudo(collect($command), $this->server);
+                $command = $command[0];
+            }
+            $sshCommand = SshMultiplexingHelper::generateSshCommand($this->server, $command);
+
+            $rawOutput = '';
+            Process::timeout(config('constants.ssh.command_timeout'))->run($sshCommand, function (string $type, string $output) use (&$rawOutput) {
+                $rawOutput .= $output;
+            });
+
+            $rawOutput = trim(trim($rawOutput), "'");
+
+            $health = json_decode($rawOutput, true);
+            if (! is_array($health)) {
+                $this->healthcheckOutputs = 'No healthcheck configured for this container.';
+                $this->healthcheckStatus = null;
+
+                return;
+            }
+
+            $this->healthcheckStatus = data_get($health, 'Status', 'unknown');
+            $failingStreak = data_get($health, 'FailingStreak', 0);
+            $logs = data_get($health, 'Log', []);
+
+            $lines = [
+                "Status: {$this->healthcheckStatus} | Failing streak: {$failingStreak}",
+                '----------------------------------------',
+            ];
+
+            if (empty($logs)) {
+                $lines[] = 'No healthcheck log entries yet.';
+            } else {
+                foreach (array_reverse($logs) as $entry) {
+                    $start = data_get($entry, 'Start', '');
+                    $exitCode = data_get($entry, 'ExitCode', '?');
+                    $output = trim(data_get($entry, 'Output', ''));
+
+                    $timestamp = $start;
+                    if (! empty($start)) {
+                        try {
+                            $dt = new \DateTime($start);
+                            $timestamp = $dt->format('Y-m-d H:i:s');
+                        } catch (\Exception $e) {
+                            \Log::debug("Failed to parse healthcheck timestamp: {$start}");
+                        }
+                    }
+
+                    $statusIcon = $exitCode === 0 ? 'PASS' : 'FAIL';
+                    $line = "[{$timestamp}] {$statusIcon} (exit {$exitCode})";
+                    if (! empty($output)) {
+                        $line .= " — {$output}";
+                    }
+                    $lines[] = $line;
+                }
+            }
+
+            $this->healthcheckOutputs = implode("\n", $lines);
+        } catch (\Throwable $e) {
+            $this->healthcheckOutputs = 'Failed to retrieve healthcheck data: '.$e->getMessage();
+            $this->healthcheckStatus = null;
+        }
     }
 
     public function render()

--- a/app/Livewire/Project/Shared/GetLogs.php
+++ b/app/Livewire/Project/Shared/GetLogs.php
@@ -61,6 +61,9 @@ class GetLogs extends Component
 
     public string $healthcheckOutputs = '';
 
+    /** @var array<int, array{exitCode: int|string, text: string}> */
+    public array $healthcheckEntries = [];
+
     public ?string $healthcheckStatus = null;
 
     public function mount()
@@ -364,6 +367,7 @@ class GetLogs extends Component
                 "Status: {$this->healthcheckStatus} | Failing streak: {$failingStreak}",
                 '----------------------------------------',
             ];
+            $entries = [];
 
             if (empty($logs)) {
                 $lines[] = 'No healthcheck log entries yet.';
@@ -389,9 +393,11 @@ class GetLogs extends Component
                         $line .= " — {$output}";
                     }
                     $lines[] = $line;
+                    $entries[] = ['exitCode' => $exitCode, 'text' => $line];
                 }
             }
 
+            $this->healthcheckEntries = $entries;
             $this->healthcheckOutputs = implode("\n", $lines);
         } catch (\Throwable $e) {
             $this->healthcheckOutputs = 'Failed to retrieve healthcheck data: '.$e->getMessage();

--- a/app/Livewire/Project/Shared/GetLogs.php
+++ b/app/Livewire/Project/Shared/GetLogs.php
@@ -211,6 +211,10 @@ class GetLogs extends Component
 
     public function copyLogs(): string
     {
+        if ($this->showHealthcheckLogs) {
+            return sanitizeLogsForExport($this->healthcheckOutputs);
+        }
+
         return sanitizeLogsForExport($this->outputs);
     }
 
@@ -311,12 +315,12 @@ class GetLogs extends Component
         if (! $this->server->isFunctional()) {
             return;
         }
-        if ($this->container && ! ValidationPatterns::isValidContainerName($this->container)) {
-            $this->healthcheckOutputs = 'Invalid container name.';
-
+        if (! $this->container) {
             return;
         }
-        if (! $this->container) {
+        if (! ValidationPatterns::isValidContainerName($this->container)) {
+            $this->healthcheckOutputs = 'Invalid container name.';
+
             return;
         }
 
@@ -332,16 +336,7 @@ class GetLogs extends Component
             $rawOutput .= $output;
         });
 
-        $rawOutput = trim($rawOutput);
-
-        if (empty($rawOutput) || $rawOutput === 'null' || $rawOutput === '<nil>' || $rawOutput === "'null'") {
-            $this->healthcheckOutputs = 'No healthcheck configured for this container.';
-            $this->healthcheckStatus = null;
-
-            return;
-        }
-
-        $rawOutput = trim($rawOutput, "'");
+        $rawOutput = trim(trim($rawOutput), "'");
 
         $health = json_decode($rawOutput, true);
         if (! is_array($health)) {
@@ -355,9 +350,10 @@ class GetLogs extends Component
         $failingStreak = data_get($health, 'FailingStreak', 0);
         $logs = data_get($health, 'Log', []);
 
-        $lines = [];
-        $lines[] = "Status: {$this->healthcheckStatus} | Failing streak: {$failingStreak}";
-        $lines[] = '----------------------------------------';
+        $lines = [
+            "Status: {$this->healthcheckStatus} | Failing streak: {$failingStreak}",
+            '----------------------------------------',
+        ];
 
         if (empty($logs)) {
             $lines[] = 'No healthcheck log entries yet.';

--- a/app/Livewire/Project/Shared/GetLogs.php
+++ b/app/Livewire/Project/Shared/GetLogs.php
@@ -57,6 +57,12 @@ class GetLogs extends Component
 
     public bool $collapsible = true;
 
+    public bool $showHealthcheckLogs = false;
+
+    public string $healthcheckOutputs = '';
+
+    public ?string $healthcheckStatus = null;
+
     public function mount()
     {
         if (! is_null($this->resource)) {
@@ -285,6 +291,101 @@ class GetLogs extends Component
         }
 
         return sanitizeLogsForExport($allLogs);
+    }
+
+    public function toggleHealthcheckLogs(): void
+    {
+        $this->showHealthcheckLogs = ! $this->showHealthcheckLogs;
+        if ($this->showHealthcheckLogs) {
+            $this->getHealthcheckLogs();
+        }
+    }
+
+    public function getHealthcheckLogs(): void
+    {
+        if (! Server::ownedByCurrentTeam()->where('id', $this->server->id)->exists()) {
+            $this->healthcheckOutputs = 'Unauthorized.';
+
+            return;
+        }
+        if (! $this->server->isFunctional()) {
+            return;
+        }
+        if ($this->container && ! ValidationPatterns::isValidContainerName($this->container)) {
+            $this->healthcheckOutputs = 'Invalid container name.';
+
+            return;
+        }
+        if (! $this->container) {
+            return;
+        }
+
+        $command = "docker inspect --format='{{json .State.Health}}' {$this->container}";
+        if ($this->server->isNonRoot()) {
+            $command = parseCommandsByLineForSudo(collect($command), $this->server);
+            $command = $command[0];
+        }
+        $sshCommand = SshMultiplexingHelper::generateSshCommand($this->server, $command);
+
+        $rawOutput = '';
+        Process::timeout(config('constants.ssh.command_timeout'))->run($sshCommand, function (string $type, string $output) use (&$rawOutput) {
+            $rawOutput .= $output;
+        });
+
+        $rawOutput = trim($rawOutput);
+
+        if (empty($rawOutput) || $rawOutput === 'null' || $rawOutput === '<nil>' || $rawOutput === "'null'") {
+            $this->healthcheckOutputs = 'No healthcheck configured for this container.';
+            $this->healthcheckStatus = null;
+
+            return;
+        }
+
+        $rawOutput = trim($rawOutput, "'");
+
+        $health = json_decode($rawOutput, true);
+        if (! is_array($health)) {
+            $this->healthcheckOutputs = 'No healthcheck configured for this container.';
+            $this->healthcheckStatus = null;
+
+            return;
+        }
+
+        $this->healthcheckStatus = data_get($health, 'Status', 'unknown');
+        $failingStreak = data_get($health, 'FailingStreak', 0);
+        $logs = data_get($health, 'Log', []);
+
+        $lines = [];
+        $lines[] = "Status: {$this->healthcheckStatus} | Failing streak: {$failingStreak}";
+        $lines[] = '----------------------------------------';
+
+        if (empty($logs)) {
+            $lines[] = 'No healthcheck log entries yet.';
+        } else {
+            foreach (array_reverse($logs) as $entry) {
+                $start = data_get($entry, 'Start', '');
+                $exitCode = data_get($entry, 'ExitCode', '?');
+                $output = trim(data_get($entry, 'Output', ''));
+
+                $timestamp = $start;
+                if (! empty($start)) {
+                    try {
+                        $dt = new \DateTime($start);
+                        $timestamp = $dt->format('Y-m-d H:i:s');
+                    } catch (\Exception) {
+                    }
+                }
+
+                $statusIcon = $exitCode === 0 ? 'PASS' : 'FAIL';
+                $line = "[{$timestamp}] {$statusIcon} (exit {$exitCode})";
+                if (! empty($output)) {
+                    $line .= " — {$output}";
+                }
+                $lines[] = $line;
+            }
+        }
+
+        $this->healthcheckOutputs = implode("\n", $lines);
     }
 
     public function render()

--- a/resources/views/livewire/project/shared/get-logs.blade.php
+++ b/resources/views/livewire/project/shared/get-logs.blade.php
@@ -513,13 +513,28 @@
                                 </div>
                             @endif
                             @if ($healthcheckOutputs)
-                                @foreach (explode("\n", $healthcheckOutputs) as $index => $line)
-                                    @if (trim($line) !== '')
-                                        <div wire:key="hc-{{ $index }}" data-log-line data-log-content="{{ $line }}" class="flex gap-2 log-line">
-                                            <span data-line-text="{{ $line }}" class="whitespace-pre-wrap break-all {{ str_contains($line, 'FAIL') ? 'text-red-500 dark:text-red-400' : '' }} {{ str_contains($line, 'PASS') ? 'text-green-600 dark:text-green-400' : '' }}">{{ $line }}</span>
-                                        </div>
-                                    @endif
+                                @php
+                                    $headerLines = collect(explode("\n", $healthcheckOutputs))
+                                        ->take(2)
+                                        ->filter(fn($line) => trim($line) !== '');
+                                @endphp
+                                @foreach ($headerLines as $index => $line)
+                                    <div wire:key="hc-header-{{ $index }}" data-log-line data-log-content="{{ $line }}" class="flex gap-2 log-line">
+                                        <span data-line-text="{{ $line }}" class="whitespace-pre-wrap break-all">{{ $line }}</span>
+                                    </div>
                                 @endforeach
+                                @forelse ($healthcheckEntries as $index => $entry)
+                                    <div wire:key="hc-{{ $index }}" data-log-line data-log-content="{{ $entry['text'] }}" class="flex gap-2 log-line">
+                                        <span data-line-text="{{ $entry['text'] }}" class="whitespace-pre-wrap break-all {{ $entry['exitCode'] === 0 ? 'text-green-600 dark:text-green-400' : 'text-red-500 dark:text-red-400' }}">{{ $entry['text'] }}</span>
+                                    </div>
+                                @empty
+                                    <div class="flex gap-2 log-line">
+                                        <span class="whitespace-pre-wrap break-all text-neutral-400">No healthcheck log entries yet.</span>
+                                    </div>
+                                @endforelse
+                                <div class="mt-2 pt-2 border-t dark:border-coolgray-300 border-neutral-200">
+                                    <span class="text-xs text-neutral-400">Docker stores only the last 5 healthcheck results per container.</span>
+                                </div>
                             @else
                                 <pre class="font-logs whitespace-pre-wrap break-all max-w-full text-neutral-400">No healthcheck data. Click refresh or enable streaming.</pre>
                             @endif

--- a/resources/views/livewire/project/shared/get-logs.blade.php
+++ b/resources/views/livewire/project/shared/get-logs.blade.php
@@ -261,7 +261,7 @@
                 <div
                     class="flex flex-wrap items-center justify-between gap-2 px-4 py-2 border-b dark:border-coolgray-300 border-neutral-200 shrink-0">
                     <div class="flex items-center gap-2">
-                        <form wire:submit="getLogs(true)" class="relative flex items-center">
+                        <form wire:submit="{{ $showHealthcheckLogs ? 'getHealthcheckLogs' : 'getLogs(true)' }}" class="relative flex items-center">
                             <span
                                 class="absolute left-2 top-1/2 -translate-y-1/2 text-xs text-gray-400 pointer-events-none">Lines:</span>
                             <input type="number" wire:model="numberOfLines" placeholder="100" min="1" max="50000"
@@ -290,7 +290,7 @@
                             </button>
                         </div>
                         <div class="flex flex-wrap items-center gap-1">
-                            <button wire:click="getLogs(true)" title="Refresh Logs" {{ $streamLogs ? 'disabled' : '' }}
+                            <button wire:click="{{ $showHealthcheckLogs ? 'getHealthcheckLogs' : 'getLogs(true)' }}" title="Refresh Logs" {{ $streamLogs ? 'disabled' : '' }}
                             class="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 disabled:opacity-50">
                             <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
                                 stroke-width="1.5" stroke="currentColor">
@@ -498,10 +498,16 @@
                                 <span>Viewing healthcheck logs only. Click the heart icon in the toolbar to switch back to container logs.</span>
                             </div>
                             @if ($healthcheckStatus)
+                                @php
+                                    $badgeClasses = match ($healthcheckStatus) {
+                                        'healthy' => 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+                                        'unhealthy' => 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
+                                        default => 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
+                                    };
+                                @endphp
                                 <div class="flex items-center gap-2 mb-2 pb-2 border-b dark:border-coolgray-300 border-neutral-200">
                                     <span class="text-sm font-medium dark:text-white">Health Status:</span>
-                                    <span class="px-2 py-0.5 text-xs font-medium rounded
-                                        {{ $healthcheckStatus === 'healthy' ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' : ($healthcheckStatus === 'unhealthy' ? 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400' : 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400') }}">
+                                    <span class="px-2 py-0.5 text-xs font-medium rounded {{ $badgeClasses }}">
                                         {{ ucfirst($healthcheckStatus) }}
                                     </span>
                                 </div>

--- a/resources/views/livewire/project/shared/get-logs.blade.php
+++ b/resources/views/livewire/project/shared/get-logs.blade.php
@@ -245,7 +245,11 @@
                     <div>({{ $pull_request }})</div>
                 @endif
                 @if ($streamLogs)
-                    <x-loading wire:poll.2000ms='getLogs(true)' />
+                    @if ($showHealthcheckLogs)
+                        <x-loading wire:poll.5000ms='getHealthcheckLogs' />
+                    @else
+                        <x-loading wire:poll.2000ms='getLogs(true)' />
+                    @endif
                 @endif
             </div>
         @endif
@@ -389,6 +393,15 @@
                                     d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
                             </svg>
                         </button>
+                        <button wire:click="toggleHealthcheckLogs"
+                            title="{{ $showHealthcheckLogs ? 'Show Container Logs' : 'Show Healthcheck Logs' }}"
+                            class="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 {{ $showHealthcheckLogs ? '!text-warning' : '' }}">
+                            <svg class="w-4 h-4" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none"
+                                stroke="currentColor" stroke-width="2">
+                                <path stroke-linecap="round" stroke-linejoin="round"
+                                    d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z" />
+                            </svg>
+                        </button>
                         <button title="Toggle Log Colors" x-on:click="toggleColorLogs"
                             :class="colorLogs ? '!text-warning' : ''"
                             class="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
@@ -476,7 +489,36 @@
                 <div id="logsContainer" @scroll="handleScroll"
                     class="flex overflow-y-auto overflow-x-hidden flex-col px-4 py-2 w-full min-w-0 scrollbar"
                     :class="fullscreen ? 'flex-1' : 'max-h-[40rem]'">
-                    @if ($outputs)
+                    @if ($showHealthcheckLogs)
+                        <div id="logs" class="font-logs max-w-full cursor-default">
+                            <div class="flex items-center gap-2 mb-2 pb-2 border-b dark:border-coolgray-300 border-neutral-200 text-sm text-gray-500 dark:text-gray-400">
+                                <svg class="w-4 h-4 shrink-0" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 11.25l.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z" />
+                                </svg>
+                                <span>Viewing healthcheck logs only. Click the heart icon in the toolbar to switch back to container logs.</span>
+                            </div>
+                            @if ($healthcheckStatus)
+                                <div class="flex items-center gap-2 mb-2 pb-2 border-b dark:border-coolgray-300 border-neutral-200">
+                                    <span class="text-sm font-medium dark:text-white">Health Status:</span>
+                                    <span class="px-2 py-0.5 text-xs font-medium rounded
+                                        {{ $healthcheckStatus === 'healthy' ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' : ($healthcheckStatus === 'unhealthy' ? 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400' : 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400') }}">
+                                        {{ ucfirst($healthcheckStatus) }}
+                                    </span>
+                                </div>
+                            @endif
+                            @if ($healthcheckOutputs)
+                                @foreach (explode("\n", $healthcheckOutputs) as $index => $line)
+                                    @if (trim($line) !== '')
+                                        <div wire:key="hc-{{ $index }}" data-log-line data-log-content="{{ $line }}" class="flex gap-2 log-line">
+                                            <span data-line-text="{{ $line }}" class="whitespace-pre-wrap break-all {{ str_contains($line, 'FAIL') ? 'text-red-500 dark:text-red-400' : '' }} {{ str_contains($line, 'PASS') ? 'text-green-600 dark:text-green-400' : '' }}">{{ $line }}</span>
+                                        </div>
+                                    @endif
+                                @endforeach
+                            @else
+                                <pre class="font-logs whitespace-pre-wrap break-all max-w-full text-neutral-400">No healthcheck data. Click refresh or enable streaming.</pre>
+                            @endif
+                        </div>
+                    @elseif ($outputs)
                         @php
                             $displayLines = collect(explode("\n", $outputs))->filter(fn($line) => trim($line) !== '');
                         @endphp

--- a/tests/Unit/ComposeHealthcheckTest.php
+++ b/tests/Unit/ComposeHealthcheckTest.php
@@ -121,6 +121,19 @@ it('logs a message when no containers are found for healthcheck polling', functi
         ->toContain('No compose containers found for healthcheck polling.');
 });
 
+it('rethrows DeploymentException from catch block so cancellation is not swallowed', function () {
+    // The catch block must rethrow DeploymentException before the generic Exception catch
+    $catchBlockStart = strpos($this->methodBody, 'catch (DeploymentException');
+    $genericCatchStart = strpos($this->methodBody, 'catch (Exception $e)');
+
+    expect($catchBlockStart)->not->toBeFalse('DeploymentException catch block must exist');
+    expect($catchBlockStart)->toBeLessThan($genericCatchStart, 'DeploymentException catch must come before generic Exception catch');
+
+    // Extract the DeploymentException catch body and verify it rethrows
+    $deploymentCatchBody = substr($this->methodBody, $catchBlockStart, $genericCatchStart - $catchBlockStart);
+    expect($deploymentCatchBody)->toContain('throw $e');
+});
+
 it('handles empty docker inspect status by skipping the container', function () {
     expect($this->methodBody)
         ->toContain('Could not retrieve healthcheck status for')

--- a/tests/Unit/ComposeHealthcheckTest.php
+++ b/tests/Unit/ComposeHealthcheckTest.php
@@ -89,3 +89,35 @@ it('derives healthcheck timings from container Docker config instead of Applicat
         ->not->toContain('$this->application->health_check_retries')
         ->not->toContain('$this->application->health_check_interval');
 });
+
+it('caps healthcheck wait times to prevent unbounded deployment blocking', function () {
+    expect($this->methodBody)
+        ->toContain('min($maxStartPeriod, 300)')
+        ->toContain('min(max($maxInterval, 5), 60)')
+        ->toContain('min(max($maxRetries + 2, 3), 30)');
+});
+
+it('checks for deployment cancellation during healthcheck sleep loops', function () {
+    expect($this->methodBody)
+        ->toContain('$this->checkForCancellation()');
+});
+
+it('uses ignore_errors on docker ps command for container enumeration', function () {
+    // The docker ps command block should include ignore_errors
+    $dockerPsStart = strpos($this->methodBody, 'docker ps -a');
+    $dockerPsBlock = substr($this->methodBody, $dockerPsStart, 400);
+
+    expect($dockerPsBlock)
+        ->toContain("'ignore_errors' => true");
+});
+
+it('logs a message when no containers are found for healthcheck polling', function () {
+    expect($this->methodBody)
+        ->toContain('No compose containers found for healthcheck polling.');
+});
+
+it('handles empty docker inspect status by skipping the container', function () {
+    expect($this->methodBody)
+        ->toContain('Could not retrieve healthcheck status for')
+        ->toContain('Container may have stopped.');
+});

--- a/tests/Unit/ComposeHealthcheckTest.php
+++ b/tests/Unit/ComposeHealthcheckTest.php
@@ -1,0 +1,103 @@
+<?php
+
+it('has health_check_compose method in ApplicationDeploymentJob', function () {
+    $deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
+
+    expect($deploymentJobFile)
+        ->toContain('private function health_check_compose(): void');
+});
+
+it('calls health_check_compose from deploy_docker_compose_buildpack', function () {
+    $deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
+
+    expect($deploymentJobFile)
+        ->toContain('$this->health_check_compose();')
+        ->toContain("addLogEntry('New containers started.')");
+});
+
+it('skips healthcheck polling for swarm mode', function () {
+    $deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
+
+    $methodStart = strpos($deploymentJobFile, 'private function health_check_compose(): void');
+    $methodBody = substr($deploymentJobFile, $methodStart, 3000);
+
+    expect($methodBody)
+        ->toContain('$this->server->isSwarm()')
+        ->toContain('return;');
+});
+
+it('uses docker ps to enumerate compose containers', function () {
+    $deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
+
+    $methodStart = strpos($deploymentJobFile, 'private function health_check_compose(): void');
+    $methodBody = substr($deploymentJobFile, $methodStart, 5000);
+
+    expect($methodBody)
+        ->toContain("docker ps -a --filter 'label=com.docker.compose.project=")
+        ->toContain('com.docker.compose.service');
+});
+
+it('checks each container for healthcheck configuration before polling', function () {
+    $deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
+
+    $methodStart = strpos($deploymentJobFile, 'private function health_check_compose(): void');
+    $methodBody = substr($deploymentJobFile, $methodStart, 5000);
+
+    expect($methodBody)
+        ->toContain('docker inspect')
+        ->toContain('.State.Health')
+        ->toContain('has_healthcheck');
+});
+
+it('logs when no healthchecks are defined in compose services', function () {
+    $deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
+
+    $methodStart = strpos($deploymentJobFile, 'private function health_check_compose(): void');
+    $methodBody = substr($deploymentJobFile, $methodStart, 5000);
+
+    expect($methodBody)
+        ->toContain('No healthchecks defined in compose services.');
+});
+
+it('inspects health status and logs for each container during polling', function () {
+    $deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
+
+    $methodStart = strpos($deploymentJobFile, 'private function health_check_compose(): void');
+    $methodBody = substr($deploymentJobFile, $methodStart, 5000);
+
+    expect($methodBody)
+        ->toContain("docker inspect --format='{{json .State.Health.Status}}'")
+        ->toContain("docker inspect --format='{{json .State.Health.Log}}'");
+});
+
+it('logs container output for unhealthy services', function () {
+    $deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
+
+    $methodStart = strpos($deploymentJobFile, 'private function health_check_compose(): void');
+    $methodBody = substr($deploymentJobFile, $methodStart, 8000);
+
+    expect($methodBody)
+        ->toContain('unhealthyContainers')
+        ->toContain('docker logs -n 100');
+});
+
+it('logs success when all compose services are healthy', function () {
+    $deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
+
+    $methodStart = strpos($deploymentJobFile, 'private function health_check_compose(): void');
+    $methodBody = substr($deploymentJobFile, $methodStart, 8000);
+
+    expect($methodBody)
+        ->toContain('All compose services are healthy.');
+});
+
+it('wraps health_check_compose in try-catch to avoid blocking deployment', function () {
+    $deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
+
+    $methodStart = strpos($deploymentJobFile, 'private function health_check_compose(): void');
+    $methodBody = substr($deploymentJobFile, $methodStart, 8000);
+
+    expect($methodBody)
+        ->toContain('catch (Exception $e)')
+        ->toContain('Healthcheck polling failed:');
+});

--- a/tests/Unit/ComposeHealthcheckTest.php
+++ b/tests/Unit/ComposeHealthcheckTest.php
@@ -1,103 +1,91 @@
 <?php
 
-it('has health_check_compose method in ApplicationDeploymentJob', function () {
-    $deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
+beforeEach(function () {
+    $this->deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
 
-    expect($deploymentJobFile)
+    $methodStart = strpos($this->deploymentJobFile, 'private function health_check_compose(): void');
+    $this->methodBody = substr($this->deploymentJobFile, $methodStart, 12000);
+});
+
+it('has health_check_compose method in ApplicationDeploymentJob', function () {
+    expect($this->deploymentJobFile)
         ->toContain('private function health_check_compose(): void');
 });
 
 it('calls health_check_compose from deploy_docker_compose_buildpack', function () {
-    $deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
-
-    expect($deploymentJobFile)
+    expect($this->deploymentJobFile)
         ->toContain('$this->health_check_compose();')
         ->toContain("addLogEntry('New containers started.')");
 });
 
 it('skips healthcheck polling for swarm mode', function () {
-    $deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
-
-    $methodStart = strpos($deploymentJobFile, 'private function health_check_compose(): void');
-    $methodBody = substr($deploymentJobFile, $methodStart, 3000);
-
-    expect($methodBody)
+    expect($this->methodBody)
         ->toContain('$this->server->isSwarm()')
         ->toContain('return;');
 });
 
 it('uses docker ps to enumerate compose containers', function () {
-    $deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
-
-    $methodStart = strpos($deploymentJobFile, 'private function health_check_compose(): void');
-    $methodBody = substr($deploymentJobFile, $methodStart, 5000);
-
-    expect($methodBody)
+    expect($this->methodBody)
         ->toContain("docker ps -a --filter 'label=com.docker.compose.project=")
         ->toContain('com.docker.compose.service');
 });
 
 it('checks each container for healthcheck configuration before polling', function () {
-    $deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
-
-    $methodStart = strpos($deploymentJobFile, 'private function health_check_compose(): void');
-    $methodBody = substr($deploymentJobFile, $methodStart, 5000);
-
-    expect($methodBody)
+    expect($this->methodBody)
         ->toContain('docker inspect')
         ->toContain('.State.Health')
         ->toContain('has_healthcheck');
 });
 
 it('logs when no healthchecks are defined in compose services', function () {
-    $deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
-
-    $methodStart = strpos($deploymentJobFile, 'private function health_check_compose(): void');
-    $methodBody = substr($deploymentJobFile, $methodStart, 5000);
-
-    expect($methodBody)
+    expect($this->methodBody)
         ->toContain('No healthchecks defined in compose services.');
 });
 
 it('inspects health status and logs for each container during polling', function () {
-    $deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
-
-    $methodStart = strpos($deploymentJobFile, 'private function health_check_compose(): void');
-    $methodBody = substr($deploymentJobFile, $methodStart, 5000);
-
-    expect($methodBody)
+    expect($this->methodBody)
         ->toContain("docker inspect --format='{{json .State.Health.Status}}'")
         ->toContain("docker inspect --format='{{json .State.Health.Log}}'");
 });
 
 it('logs container output for unhealthy services', function () {
-    $deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
-
-    $methodStart = strpos($deploymentJobFile, 'private function health_check_compose(): void');
-    $methodBody = substr($deploymentJobFile, $methodStart, 8000);
-
-    expect($methodBody)
+    expect($this->methodBody)
         ->toContain('unhealthyContainers')
         ->toContain('docker logs -n 100');
 });
 
 it('logs success when all compose services are healthy', function () {
-    $deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
-
-    $methodStart = strpos($deploymentJobFile, 'private function health_check_compose(): void');
-    $methodBody = substr($deploymentJobFile, $methodStart, 8000);
-
-    expect($methodBody)
+    expect($this->methodBody)
         ->toContain('All compose services are healthy.');
 });
 
 it('wraps health_check_compose in try-catch to avoid blocking deployment', function () {
-    $deploymentJobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
-
-    $methodStart = strpos($deploymentJobFile, 'private function health_check_compose(): void');
-    $methodBody = substr($deploymentJobFile, $methodStart, 8000);
-
-    expect($methodBody)
+    expect($this->methodBody)
         ->toContain('catch (Exception $e)')
         ->toContain('Healthcheck polling failed:');
+});
+
+it('uses --remove-orphans flag on all docker compose up commands', function () {
+    $composeMethodStart = strpos($this->deploymentJobFile, 'private function deploy_docker_compose_buildpack()');
+    $composeMethodBody = substr($this->deploymentJobFile, $composeMethodStart, 16000);
+
+    $upDOccurrences = preg_match_all('/up -d/', $composeMethodBody, $matches, PREG_OFFSET_CAPTURE);
+    $removeOrphansOccurrences = preg_match_all('/up -d --remove-orphans/', $composeMethodBody, $matches2);
+
+    expect($upDOccurrences)->toBeGreaterThan(0);
+    expect($removeOrphansOccurrences)->toBe($upDOccurrences);
+});
+
+it('derives healthcheck timings from container Docker config instead of Application model', function () {
+    expect($this->methodBody)
+        ->toContain("docker inspect --format='{{json .Config.Healthcheck}}'")
+        ->toContain('StartPeriod')
+        ->toContain('Interval')
+        ->toContain('Retries')
+        ->toContain('1_000_000_000');
+
+    expect($this->methodBody)
+        ->not->toContain('$this->application->health_check_start_period')
+        ->not->toContain('$this->application->health_check_retries')
+        ->not->toContain('$this->application->health_check_interval');
 });

--- a/tests/Unit/ComposeHealthcheckTest.php
+++ b/tests/Unit/ComposeHealthcheckTest.php
@@ -30,6 +30,11 @@ it('uses docker ps to enumerate compose containers', function () {
         ->toContain('com.docker.compose.service');
 });
 
+it('validates container names from docker ps output before using them', function () {
+    expect($this->methodBody)
+        ->toContain('ValidationPatterns::isValidContainerName');
+});
+
 it('checks each container for healthcheck configuration before polling', function () {
     expect($this->methodBody)
         ->toContain('docker inspect')

--- a/tests/Unit/GetLogsHealthcheckTest.php
+++ b/tests/Unit/GetLogsHealthcheckTest.php
@@ -1,0 +1,148 @@
+<?php
+
+it('has healthcheck properties on GetLogs component', function () {
+    $getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
+
+    expect($getLogsFile)
+        ->toContain('public bool $showHealthcheckLogs = false')
+        ->toContain('public string $healthcheckOutputs = ')
+        ->toContain('public ?string $healthcheckStatus = null');
+});
+
+it('has getHealthcheckLogs method on GetLogs component', function () {
+    $getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
+
+    expect($getLogsFile)
+        ->toContain('public function getHealthcheckLogs(): void');
+});
+
+it('has toggleHealthcheckLogs method on GetLogs component', function () {
+    $getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
+
+    expect($getLogsFile)
+        ->toContain('public function toggleHealthcheckLogs(): void')
+        ->toContain('$this->showHealthcheckLogs = ! $this->showHealthcheckLogs');
+});
+
+it('validates server ownership in getHealthcheckLogs', function () {
+    $getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
+
+    $methodStart = strpos($getLogsFile, 'public function getHealthcheckLogs(): void');
+    $methodBody = substr($getLogsFile, $methodStart, 2000);
+
+    expect($methodBody)
+        ->toContain('Server::ownedByCurrentTeam()')
+        ->toContain('Unauthorized');
+});
+
+it('validates container name in getHealthcheckLogs', function () {
+    $getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
+
+    $methodStart = strpos($getLogsFile, 'public function getHealthcheckLogs(): void');
+    $methodBody = substr($getLogsFile, $methodStart, 2000);
+
+    expect($methodBody)
+        ->toContain('ValidationPatterns::isValidContainerName');
+});
+
+it('uses docker inspect to fetch health data', function () {
+    $getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
+
+    $methodStart = strpos($getLogsFile, 'public function getHealthcheckLogs(): void');
+    $methodBody = substr($getLogsFile, $methodStart, 3000);
+
+    expect($methodBody)
+        ->toContain("docker inspect --format='{{json .State.Health}}'")
+        ->toContain('SshMultiplexingHelper::generateSshCommand');
+});
+
+it('handles containers without healthcheck configured', function () {
+    $getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
+
+    $methodStart = strpos($getLogsFile, 'public function getHealthcheckLogs(): void');
+    $methodBody = substr($getLogsFile, $methodStart, 3000);
+
+    expect($methodBody)
+        ->toContain('No healthcheck configured for this container.');
+});
+
+it('handles non-root servers with sudo in getHealthcheckLogs', function () {
+    $getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
+
+    $methodStart = strpos($getLogsFile, 'public function getHealthcheckLogs(): void');
+    $methodBody = substr($getLogsFile, $methodStart, 2000);
+
+    expect($methodBody)
+        ->toContain('$this->server->isNonRoot()')
+        ->toContain('parseCommandsByLineForSudo');
+});
+
+it('formats healthcheck log entries with PASS and FAIL indicators', function () {
+    $getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
+
+    $methodStart = strpos($getLogsFile, 'public function getHealthcheckLogs(): void');
+    $methodBody = substr($getLogsFile, $methodStart, 5000);
+
+    expect($methodBody)
+        ->toContain("'PASS'")
+        ->toContain("'FAIL'")
+        ->toContain('ExitCode')
+        ->toContain('Output');
+});
+
+it('parses health status and failing streak from docker inspect', function () {
+    $getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
+
+    $methodStart = strpos($getLogsFile, 'public function getHealthcheckLogs(): void');
+    $methodBody = substr($getLogsFile, $methodStart, 5000);
+
+    expect($methodBody)
+        ->toContain("data_get(\$health, 'Status'")
+        ->toContain("data_get(\$health, 'FailingStreak'")
+        ->toContain("data_get(\$health, 'Log'");
+});
+
+it('has healthcheck toggle button in blade template', function () {
+    $bladeFile = file_get_contents(__DIR__.'/../../resources/views/livewire/project/shared/get-logs.blade.php');
+
+    expect($bladeFile)
+        ->toContain('wire:click="toggleHealthcheckLogs"')
+        ->toContain('Show Healthcheck Logs')
+        ->toContain('Show Container Logs');
+});
+
+it('conditionally shows healthcheck display area in blade template', function () {
+    $bladeFile = file_get_contents(__DIR__.'/../../resources/views/livewire/project/shared/get-logs.blade.php');
+
+    expect($bladeFile)
+        ->toContain('$showHealthcheckLogs')
+        ->toContain('$healthcheckStatus')
+        ->toContain('$healthcheckOutputs');
+});
+
+it('shows health status badge with correct color classes', function () {
+    $bladeFile = file_get_contents(__DIR__.'/../../resources/views/livewire/project/shared/get-logs.blade.php');
+
+    expect($bladeFile)
+        ->toContain('Health Status:')
+        ->toContain('bg-green-100')
+        ->toContain('bg-red-100')
+        ->toContain('bg-yellow-100');
+});
+
+it('uses slower poll interval for healthcheck mode', function () {
+    $bladeFile = file_get_contents(__DIR__.'/../../resources/views/livewire/project/shared/get-logs.blade.php');
+
+    expect($bladeFile)
+        ->toContain("wire:poll.5000ms='getHealthcheckLogs'");
+});
+
+it('color-codes PASS and FAIL lines in healthcheck display', function () {
+    $bladeFile = file_get_contents(__DIR__.'/../../resources/views/livewire/project/shared/get-logs.blade.php');
+
+    expect($bladeFile)
+        ->toContain("str_contains(\$line, 'FAIL')")
+        ->toContain("str_contains(\$line, 'PASS')")
+        ->toContain('text-red-500')
+        ->toContain('text-green-600');
+});

--- a/tests/Unit/GetLogsHealthcheckTest.php
+++ b/tests/Unit/GetLogsHealthcheckTest.php
@@ -13,6 +13,7 @@ it('has healthcheck properties on GetLogs component', function () {
     expect($this->getLogsFile)
         ->toContain('public bool $showHealthcheckLogs = false')
         ->toContain('public string $healthcheckOutputs = ')
+        ->toContain('public array $healthcheckEntries = []')
         ->toContain('public ?string $healthcheckStatus = null');
 });
 
@@ -97,10 +98,9 @@ it('uses slower poll interval for healthcheck mode', function () {
         ->toContain("wire:poll.5000ms='getHealthcheckLogs'");
 });
 
-it('color-codes PASS and FAIL lines in healthcheck display', function () {
+it('color-codes healthcheck entries based on exit code', function () {
     expect($this->bladeFile)
-        ->toContain("str_contains(\$line, 'FAIL')")
-        ->toContain("str_contains(\$line, 'PASS')")
+        ->toContain("\$entry['exitCode'] === 0")
         ->toContain('text-red-500')
         ->toContain('text-green-600');
 });
@@ -139,6 +139,17 @@ it('logs failed DateTime parsing instead of swallowing the exception', function 
     expect($this->methodBody)
         ->toContain('Log::debug')
         ->toContain('Failed to parse healthcheck timestamp');
+});
+
+it('builds structured healthcheckEntries array with exitCode and text', function () {
+    expect($this->methodBody)
+        ->toContain("\$entries[] = ['exitCode' => \$exitCode, 'text' => \$line]")
+        ->toContain('$this->healthcheckEntries = $entries');
+});
+
+it('shows Docker limitation note about 5 healthcheck entries', function () {
+    expect($this->bladeFile)
+        ->toContain('Docker stores only the last 5 healthcheck results per container.');
 });
 
 it('downloadAllLogs returns healthcheck outputs when in healthcheck mode', function () {

--- a/tests/Unit/GetLogsHealthcheckTest.php
+++ b/tests/Unit/GetLogsHealthcheckTest.php
@@ -1,89 +1,62 @@
 <?php
 
-it('has healthcheck properties on GetLogs component', function () {
-    $getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
+beforeEach(function () {
+    $this->getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
 
-    expect($getLogsFile)
+    $methodStart = strpos($this->getLogsFile, 'public function getHealthcheckLogs(): void');
+    $this->methodBody = substr($this->getLogsFile, $methodStart, 5000);
+
+    $this->bladeFile = file_get_contents(__DIR__.'/../../resources/views/livewire/project/shared/get-logs.blade.php');
+});
+
+it('has healthcheck properties on GetLogs component', function () {
+    expect($this->getLogsFile)
         ->toContain('public bool $showHealthcheckLogs = false')
         ->toContain('public string $healthcheckOutputs = ')
         ->toContain('public ?string $healthcheckStatus = null');
 });
 
 it('has getHealthcheckLogs method on GetLogs component', function () {
-    $getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
-
-    expect($getLogsFile)
+    expect($this->getLogsFile)
         ->toContain('public function getHealthcheckLogs(): void');
 });
 
 it('has toggleHealthcheckLogs method on GetLogs component', function () {
-    $getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
-
-    expect($getLogsFile)
+    expect($this->getLogsFile)
         ->toContain('public function toggleHealthcheckLogs(): void')
         ->toContain('$this->showHealthcheckLogs = ! $this->showHealthcheckLogs');
 });
 
 it('validates server ownership in getHealthcheckLogs', function () {
-    $getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
-
-    $methodStart = strpos($getLogsFile, 'public function getHealthcheckLogs(): void');
-    $methodBody = substr($getLogsFile, $methodStart, 2000);
-
-    expect($methodBody)
+    expect($this->methodBody)
         ->toContain('Server::ownedByCurrentTeam()')
         ->toContain('Unauthorized');
 });
 
 it('validates container name in getHealthcheckLogs', function () {
-    $getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
-
-    $methodStart = strpos($getLogsFile, 'public function getHealthcheckLogs(): void');
-    $methodBody = substr($getLogsFile, $methodStart, 2000);
-
-    expect($methodBody)
+    expect($this->methodBody)
         ->toContain('ValidationPatterns::isValidContainerName');
 });
 
 it('uses docker inspect to fetch health data', function () {
-    $getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
-
-    $methodStart = strpos($getLogsFile, 'public function getHealthcheckLogs(): void');
-    $methodBody = substr($getLogsFile, $methodStart, 3000);
-
-    expect($methodBody)
+    expect($this->methodBody)
         ->toContain("docker inspect --format='{{json .State.Health}}'")
         ->toContain('SshMultiplexingHelper::generateSshCommand');
 });
 
 it('handles containers without healthcheck configured', function () {
-    $getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
-
-    $methodStart = strpos($getLogsFile, 'public function getHealthcheckLogs(): void');
-    $methodBody = substr($getLogsFile, $methodStart, 3000);
-
-    expect($methodBody)
+    expect($this->methodBody)
         ->toContain('No healthcheck configured for this container.');
 });
 
 it('handles non-root servers with sudo in getHealthcheckLogs', function () {
-    $getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
-
-    $methodStart = strpos($getLogsFile, 'public function getHealthcheckLogs(): void');
-    $methodBody = substr($getLogsFile, $methodStart, 2000);
-
-    expect($methodBody)
+    expect($this->methodBody)
         ->toContain('$this->server->isNonRoot()')
         ->toContain('parseCommandsByLineForSudo');
 });
 
 it('formats healthcheck log entries with PASS and FAIL indicators', function () {
-    $getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
-
-    $methodStart = strpos($getLogsFile, 'public function getHealthcheckLogs(): void');
-    $methodBody = substr($getLogsFile, $methodStart, 5000);
-
-    expect($methodBody)
+    expect($this->methodBody)
         ->toContain("'PASS'")
         ->toContain("'FAIL'")
         ->toContain('ExitCode')
@@ -91,39 +64,28 @@ it('formats healthcheck log entries with PASS and FAIL indicators', function () 
 });
 
 it('parses health status and failing streak from docker inspect', function () {
-    $getLogsFile = file_get_contents(__DIR__.'/../../app/Livewire/Project/Shared/GetLogs.php');
-
-    $methodStart = strpos($getLogsFile, 'public function getHealthcheckLogs(): void');
-    $methodBody = substr($getLogsFile, $methodStart, 5000);
-
-    expect($methodBody)
+    expect($this->methodBody)
         ->toContain("data_get(\$health, 'Status'")
         ->toContain("data_get(\$health, 'FailingStreak'")
         ->toContain("data_get(\$health, 'Log'");
 });
 
 it('has healthcheck toggle button in blade template', function () {
-    $bladeFile = file_get_contents(__DIR__.'/../../resources/views/livewire/project/shared/get-logs.blade.php');
-
-    expect($bladeFile)
+    expect($this->bladeFile)
         ->toContain('wire:click="toggleHealthcheckLogs"')
         ->toContain('Show Healthcheck Logs')
         ->toContain('Show Container Logs');
 });
 
 it('conditionally shows healthcheck display area in blade template', function () {
-    $bladeFile = file_get_contents(__DIR__.'/../../resources/views/livewire/project/shared/get-logs.blade.php');
-
-    expect($bladeFile)
+    expect($this->bladeFile)
         ->toContain('$showHealthcheckLogs')
         ->toContain('$healthcheckStatus')
         ->toContain('$healthcheckOutputs');
 });
 
 it('shows health status badge with correct color classes', function () {
-    $bladeFile = file_get_contents(__DIR__.'/../../resources/views/livewire/project/shared/get-logs.blade.php');
-
-    expect($bladeFile)
+    expect($this->bladeFile)
         ->toContain('Health Status:')
         ->toContain('bg-green-100')
         ->toContain('bg-red-100')
@@ -131,18 +93,28 @@ it('shows health status badge with correct color classes', function () {
 });
 
 it('uses slower poll interval for healthcheck mode', function () {
-    $bladeFile = file_get_contents(__DIR__.'/../../resources/views/livewire/project/shared/get-logs.blade.php');
-
-    expect($bladeFile)
+    expect($this->bladeFile)
         ->toContain("wire:poll.5000ms='getHealthcheckLogs'");
 });
 
 it('color-codes PASS and FAIL lines in healthcheck display', function () {
-    $bladeFile = file_get_contents(__DIR__.'/../../resources/views/livewire/project/shared/get-logs.blade.php');
-
-    expect($bladeFile)
+    expect($this->bladeFile)
         ->toContain("str_contains(\$line, 'FAIL')")
         ->toContain("str_contains(\$line, 'PASS')")
         ->toContain('text-red-500')
         ->toContain('text-green-600');
+});
+
+it('refresh button dispatches correct method based on healthcheck mode', function () {
+    expect($this->bladeFile)
+        ->toContain("\$showHealthcheckLogs ? 'getHealthcheckLogs' : 'getLogs(true)'");
+});
+
+it('copyLogs returns healthcheck outputs when in healthcheck mode', function () {
+    $copyMethodStart = strpos($this->getLogsFile, 'public function copyLogs(): string');
+    $copyMethodBody = substr($this->getLogsFile, $copyMethodStart, 500);
+
+    expect($copyMethodBody)
+        ->toContain('$this->showHealthcheckLogs')
+        ->toContain('$this->healthcheckOutputs');
 });

--- a/tests/Unit/GetLogsHealthcheckTest.php
+++ b/tests/Unit/GetLogsHealthcheckTest.php
@@ -118,3 +118,34 @@ it('copyLogs returns healthcheck outputs when in healthcheck mode', function () 
         ->toContain('$this->showHealthcheckLogs')
         ->toContain('$this->healthcheckOutputs');
 });
+
+it('wraps getHealthcheckLogs in try-catch to handle polling errors gracefully', function () {
+    expect($this->getLogsFile)
+        ->toContain('catch (\\Throwable $e)')
+        ->toContain('Failed to retrieve healthcheck data:');
+});
+
+it('sets informative message when server is not functional', function () {
+    expect($this->methodBody)
+        ->toContain('Server is not reachable.');
+});
+
+it('sets informative message when no container is selected', function () {
+    expect($this->methodBody)
+        ->toContain('No container selected.');
+});
+
+it('logs failed DateTime parsing instead of swallowing the exception', function () {
+    expect($this->methodBody)
+        ->toContain('Log::debug')
+        ->toContain('Failed to parse healthcheck timestamp');
+});
+
+it('downloadAllLogs returns healthcheck outputs when in healthcheck mode', function () {
+    $downloadMethodStart = strpos($this->getLogsFile, 'public function downloadAllLogs(): string');
+    $downloadMethodBody = substr($this->getLogsFile, $downloadMethodStart, 500);
+
+    expect($downloadMethodBody)
+        ->toContain('$this->showHealthcheckLogs')
+        ->toContain('$this->healthcheckOutputs');
+});


### PR DESCRIPTION
## Changes

- Added `health_check_compose()` function to poll Docker Compose container healthchecks during deployment, showing per-service health status in the deployment log output
- Added a runtime healthcheck log viewer in the Logs tab UI — toggled via a heart icon — that shows current container health states with refresh, copy, and download support
- Added cleanup logic to remove old containers when a service is renamed in compose

## Issues

- Fixes https://github.com/coollabsio/coolify/issues/9524

## Category

- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

<!-- Screenshots/video to be added after manual testing -->

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (claude.ai/code)
- How extensively: AI pair-programmed the implementation under human direction — architecture decisions, code review, and testing strategy were human-driven

## Testing

- Unit tests added: `ComposeHealthcheckTest.php` (health polling logic) and `GetLogsHealthcheckTest.php` (log viewer component)
- All tests pass via `php artisan test --compact`
- Pint formatting verified
- Manual testing pending: deploy a Docker Compose app with healthchecks, verify deployment log output, verify log viewer toggle, test service rename cleanup

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.