### PR TITLE
fix: prevent git clone failures on large repositories

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -1434,9 +1434,14 @@ class Application extends BaseModel
             }
         }
 
-        $git_clone_command = "git clone{$depthFlag}{$submoduleFlags} -b {$escapedBranch}";
+        // Pre-clone HTTP config to prevent failures on large repositories.
+        // HTTP/2 stream resets (curl 92) cause clones to abort mid-transfer;
+        // forcing HTTP/1.1 and a generous post buffer avoids the issue.
+        $gitHttpConfig = 'git -c http.postBuffer=524288000 -c http.version=HTTP/1.1';
+
+        $git_clone_command = "{$gitHttpConfig} clone{$depthFlag}{$submoduleFlags} -b {$escapedBranch}";
         if ($only_checkout) {
-            $git_clone_command = "git clone{$depthFlag}{$submoduleFlags} --no-checkout -b {$escapedBranch}";
+            $git_clone_command = "{$gitHttpConfig} clone{$depthFlag}{$submoduleFlags} --no-checkout -b {$escapedBranch}";
         }
         if ($pull_request_id !== 0) {
             $pr_branch_name = "pr-{$pull_request_id}-coolify";


### PR DESCRIPTION
## Problem

When deploying applications from large repositories, the git clone operation fails with HTTP/2 stream cancellation errors:

```
error: RPC failed; curl 92 HTTP/2 stream 7 was not closed cleanly: CANCEL (err 8)
error: 11567 bytes of body are still expected
fetch-pack: unexpected disconnect while reading sideband packet
fatal: early EOF
fatal: fetch-pack: invalid index-pack output
```

This happens because HTTP/2 multiplexes multiple streams over a single TCP connection, and when transferring large pack files, the server or an intermediary proxy (e.g., Cloudflare) may cancel individual streams, causing the entire clone to fail.

## Solution

This PR adds two git configuration flags to the clone command:

1. **`http.postBuffer=524288000`** (500MB) — Increases the HTTP buffer size from the default 1MB to handle large pack file transfers without buffer overflow.

2. **`http.version=HTTP/1.1`** — Forces HTTP/1.1 instead of HTTP/2, which avoids the stream multiplexing issues that cause premature disconnects. HTTP/1.1 uses a dedicated connection per request, so the entire TCP connection is for the clone transfer.

The flags are applied using `git -c key=value clone ...` which sets the config for that command only — no global config changes.

## Testing

- Existing tests in `ApplicationRollbackTest` and `ApplicationGitSecurityTest` continue to pass (they test downstream methods that aren't affected).
- The change is minimal (2 lines modified, 5 lines added) and only affects the git clone command string.

Fixes #5251

💎 Bounty: https://github.com/coollabsio/coolify/issues/5251