### PR TITLE
fix(dev): add Docker volume path mapping to testing-host for database deployments

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -112,6 +112,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - dev_coolify_data:/data/coolify
+      - dev_coolify_data:/var/lib/docker/volumes/coolify_dev_coolify_data/_data
       - dev_backups_data:/data/coolify/backups
       - dev_postgres_data:/data/coolify/_volumes/database
       - dev_redis_data:/data/coolify/_volumes/redis


### PR DESCRIPTION
## Changes

The testing-host container in `docker-compose.dev.yml` mounts `dev_coolify_data` at `/data/coolify`, but when Coolify generates Docker Compose configs for standalone database deployments (PostgreSQL, MongoDB, etc.), it creates bind mounts referencing the internal Docker volume path (`/var/lib/docker/volumes/coolify_dev_coolify_data/_data`). Since that path doesn't exist in the testing-host container, database deployments fail with "bind source path does not exist."

This adds a second volume mount mapping `dev_coolify_data` to the Docker volume path so both paths resolve correctly in the dev environment.

## Issues

- Fixes #9533
- Related: #3918

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Claude Opus)
- How extensively: Pair-programmed the fix, issue creation, and PR preparation

## Testing

1. `spin up` to start dev environment
2. Create a standalone PostgreSQL database in Coolify
3. Start the database — previously failed with bind source path error, now deploys successfully
4. Verified the volume mount makes `dev_coolify_data` accessible at both `/data/coolify` and `/var/lib/docker/volumes/coolify_dev_coolify_data/_data` inside the testing-host container

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.