### PR TITLE
fix(installer): use RHEL Docker repo for Rocky Linux

### DIFF
--- a/other/nightly/install.sh
+++ b/other/nightly/install.sh
@@ -539,6 +539,15 @@ install_docker_manually() {
         echo "Docker installed successfully."
     fi
 }
+
+install_docker_from_rhel_repo() {
+    echo " - Installing Docker from the RHEL repository for Rocky Linux..."
+    rm -f /etc/yum.repos.d/docker-ce.repo /etc/yum.repos.d/docker-ce-staging.repo
+    dnf config-manager --add-repo https://download.docker.com/linux/rhel/docker-ce.repo
+    dnf install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+    systemctl --now enable docker
+}
+
 log_section "Step 3/9: Checking Docker installation"
 echo "3/9 Checking Docker installation..."
 if ! [ -x "$(command -v docker)" ]; then
@@ -576,6 +585,13 @@ if ! [ -x "$(command -v docker)" ]; then
         if ! [ -x "$(command -v docker)" ]; then
             echo " - Failed to install Docker with dnf. Try to install it manually."
             echo "   Please visit https://www.cyberciti.biz/faq/how-to-install-docker-on-amazon-linux-2/ for more information."
+            exit 1
+        fi
+        ;;
+    "rocky")
+        install_docker_from_rhel_repo
+        if ! [ -x "$(command -v docker)" ]; then
+            echo " - Docker could not be installed automatically. Please visit https://docs.docker.com/engine/install/ and install Docker manually to continue."
             exit 1
         fi
         ;;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -539,6 +539,15 @@ install_docker_manually() {
         echo "Docker installed successfully."
     fi
 }
+
+install_docker_from_rhel_repo() {
+    echo " - Installing Docker from the RHEL repository for Rocky Linux..."
+    rm -f /etc/yum.repos.d/docker-ce.repo /etc/yum.repos.d/docker-ce-staging.repo
+    dnf config-manager --add-repo https://download.docker.com/linux/rhel/docker-ce.repo
+    dnf install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+    systemctl --now enable docker
+}
+
 log_section "Step 3/9: Checking Docker installation"
 echo "3/9 Checking Docker installation..."
 if ! [ -x "$(command -v docker)" ]; then
@@ -576,6 +585,13 @@ if ! [ -x "$(command -v docker)" ]; then
         if ! [ -x "$(command -v docker)" ]; then
             echo " - Failed to install Docker with dnf. Try to install it manually."
             echo "   Please visit https://www.cyberciti.biz/faq/how-to-install-docker-on-amazon-linux-2/ for more information."
+            exit 1
+        fi
+        ;;
+    "rocky")
+        install_docker_from_rhel_repo
+        if ! [ -x "$(command -v docker)" ]; then
+            echo " - Docker could not be installed automatically. Please visit https://docs.docker.com/engine/install/ and install Docker manually to continue."
             exit 1
         fi
         ;;

--- a/tests/Unit/InstallScriptRockyDockerRepoTest.php
+++ b/tests/Unit/InstallScriptRockyDockerRepoTest.php
@@ -1,0 +1,28 @@
+<?php
+
+function expectRockyInstallScriptToUseRhelRepo(string $path): void
+{
+    $installScript = file_get_contents(base_path($path));
+
+    expect($installScript)
+        ->toContain('install_docker_from_rhel_repo() {')
+        ->toContain('echo " - Installing Docker from the RHEL repository for Rocky Linux..."')
+        ->toContain('rm -f /etc/yum.repos.d/docker-ce.repo /etc/yum.repos.d/docker-ce-staging.repo')
+        ->toContain('dnf config-manager --add-repo https://download.docker.com/linux/rhel/docker-ce.repo')
+        ->toContain('dnf install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin')
+        ->toContain('systemctl --now enable docker')
+        ->toContain('"rocky")')
+        ->toContain('install_docker_from_rhel_repo')
+        ->not->toContain('dnf -y -q --setopt=install_weak_deps=False install dnf-plugins-core')
+        ->not->toContain('dnf5 config-manager addrepo --overwrite --save-filename=docker-ce.repo --from-repofile=https://download.docker.com/linux/rhel/docker-ce.repo')
+        ->not->toContain('dnf makecache')
+        ->not->toContain('"ubuntu" | "debian" | "raspbian" | "centos" | "fedora" | "rhel" | "rocky" | "sles")');
+}
+
+it('uses the rocky linux documented docker install flow in the stable install script', function () {
+    expectRockyInstallScriptToUseRhelRepo('scripts/install.sh');
+});
+
+it('uses the rocky linux documented docker install flow in the nightly install script', function () {
+    expectRockyInstallScriptToUseRhelRepo('other/nightly/install.sh');
+});


### PR DESCRIPTION
## Summary
- route Rocky Linux Docker installation through Docker's RHEL repository instead of the generic install script flow
- add a dedicated Rocky Linux branch in both stable and nightly installer scripts
- remove conflicting Docker repo files before adding the RHEL repo, then install and enable Docker with the required plugins
- add unit coverage to verify both installer scripts use the Rocky-specific RHEL repository flow

## Breaking Changes
- None

---

Fixes #8730