### PR TITLE
feat: allow OAuth users to self-register when general registration is disabled (#8042)

### DIFF
--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -21,14 +21,12 @@ class OauthController extends Controller
             $oauthUser = get_socialite_provider($provider)->user();
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
-                $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
-                    abort(403, 'Registration is disabled');
-                }
-
+                // Allow OAuth users to self-register even when general registration is disabled.
+                // If an admin has configured OAuth providers, they expect those users to be able to log in.
                 $user = User::create([
                     'name' => $oauthUser->name,
                     'email' => $oauthUser->email,
+                    'oauth_provider' => $provider,
                 ]);
             }
             Auth::login($user);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -52,6 +52,7 @@ class User extends Authenticatable implements SendsEmail
         'pending_email',
         'email_change_code',
         'email_change_code_expires_at',
+        'oauth_provider',
     ];
 
     protected $hidden = [

--- a/database/migrations/2026_04_15_000000_add_oauth_provider_to_users_table.php
+++ b/database/migrations/2026_04_15_000000_add_oauth_provider_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('oauth_provider')->nullable()->after('email');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('oauth_provider');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
Resolves #8042

Currently, when general self-registration is disabled, OAuth users who don't already have an account are blocked with a 403 error. This prevents admins from using OAuth as the sole authentication method.

## Changes

### 1. `app/Http/Controllers/OauthController.php`
- Removed the `is_registration_enabled` check in `callback()`
- OAuth users can now always self-register, even when general registration is disabled
- Saves `oauth_provider` on new user creation for audit/future features

### 2. `app/Models/User.php`
- Added `oauth_provider` to the fillable array

### 3. `database/migrations/2026_04_15_000000_add_oauth_provider_to_users_table.php`
- New migration adding `oauth_provider` column to the users table
- Tracks which OAuth provider the user registered through

## Behavior After This Change
- **General registration disabled + OAuth configured**: OAuth users CAN register, password users CANNOT
- **General registration enabled**: Both OAuth and password users CAN register (no change)
- **No OAuth configured**: No change in behavior

## Testing
1. Disable general registration in Settings > Advanced
2. Configure an OAuth provider (GitHub, GitLab, etc.)
3. Try logging in with an OAuth account that doesn't exist yet
4. Verify the user is created and logged in successfully
5. Verify password registration is still blocked