### PR TITLE
fix: validate docker-compose.yml before overwriting on upgrade

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -51,7 +51,16 @@ log_section "Step 1/6: Downloading configuration files"
 write_status "1" "Downloading configuration files"
 echo "1/6 Downloading latest configuration files..."
 log "Downloading docker-compose.yml from ${CDN}/docker-compose.yml"
-curl -fsSL -L $CDN/docker-compose.yml -o /data/coolify/source/docker-compose.yml
+DOWNLOADED_COMPOSE="/tmp/docker-compose-new.yml"
+curl -fsSL -L $CDN/docker-compose.yml -o "$DOWNLOADED_COMPOSE"
+if ! grep -q "image:" "$DOWNLOADED_COMPOSE" || ! grep -q "volumes:" "$DOWNLOADED_COMPOSE"; then
+    log "WARNING: Downloaded docker-compose.yml appears incomplete (missing 'image:' or 'volumes:'), keeping existing file"
+    echo "     WARNING: Downloaded docker-compose.yml appears incomplete, keeping existing file."
+else
+    cp "$DOWNLOADED_COMPOSE" /data/coolify/source/docker-compose.yml
+    log "docker-compose.yml updated successfully"
+fi
+rm -f "$DOWNLOADED_COMPOSE"
 log "Downloading docker-compose.prod.yml from ${CDN}/docker-compose.prod.yml"
 curl -fsSL -L $CDN/docker-compose.prod.yml -o /data/coolify/source/docker-compose.prod.yml
 log "Downloading .env.production from ${CDN}/.env.production"


### PR DESCRIPTION
## Changes

`upgrade.sh` unconditionally overwrites `/data/coolify/source/docker-compose.yml` by downloading a fresh copy from the CDN. When the CDN serves an incomplete file (missing `image:`, `volumes:`, etc.), `docker compose up` fails after every upgrade.

This fix downloads the file to a temp path first, validates that it contains both `image:` and `volumes:` fields, and only replaces the existing file if the check passes. Otherwise it logs a warning and keeps the existing file.

## Issues

- Fixes

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Kiro
- How extensively: Fix logic was based on the suggested fix in the bug report, verified against the existing upgrade.sh structure.

## Testing

1. Run `upgrade.sh` normally — behaves identically when CDN serves a valid file
2. Simulate a broken CDN response by pointing `CDN` to a server returning an incomplete compose file — upgrade logs a warning and keeps the existing `docker-compose.yml`

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this is not a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.