### PR TITLE
feat: add OAuth-only registration mode

### DIFF
--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -22,7 +22,8 @@ class OauthController extends Controller
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                $isOauthOnly = $settings->is_oauth_only_enabled;
+                if (! $settings->is_registration_enabled && ! $isOauthOnly) {
                     abort(403, 'Registration is disabled');
                 }
 

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -16,6 +16,9 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $is_oauth_only_enabled;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -41,6 +44,7 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_only_enabled' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => ['nullable', 'string', new ValidDnsServers],
@@ -62,6 +66,7 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_only_enabled = $this->settings->is_oauth_only_enabled ?? false;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -142,6 +147,7 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_only_enabled = $this->is_oauth_only_enabled;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -18,6 +18,7 @@ class InstanceSettings extends Model
         'do_not_track',
         'is_auto_update_enabled',
         'is_registration_enabled',
+        'is_oauth_only_enabled',
         'next_channel',
         'smtp_enabled',
         'smtp_from_address',

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -47,7 +47,7 @@ class FortifyServiceProvider extends ServiceProvider
             $isFirstUser = User::count() === 0;
 
             $settings = instanceSettings();
-            if (! $settings->is_registration_enabled) {
+            if (! $settings->is_registration_enabled && ! $settings->is_oauth_only_enabled) {
                 return redirect()->route('login');
             }
 
@@ -78,6 +78,10 @@ class FortifyServiceProvider extends ServiceProvider
                 $user &&
                 Hash::check($request->password, $user->password)
             ) {
+                $settings = instanceSettings();
+                if ($settings->is_oauth_only_enabled) {
+                    return null;
+                }
                 $user->updated_at = now();
                 $user->save();
 

--- a/database/migrations/2026_04_15_000000_add_is_oauth_only_enabled_to_instance_settings_table.php
+++ b/database/migrations/2026_04_15_000000_add_is_oauth_only_enabled_to_instance_settings_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_only_enabled')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn('is_oauth_only_enabled');
+        });
+    }
+};

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -42,6 +42,11 @@
                         </div>
                     @endif
                     <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_only_enabled"
+                            helper="Only allow users to self-register via OAuth providers (e.g., GitHub, Google). Password-based registration will be disabled. Requires at least one OAuth provider to be configured."
+                            label="OAuth-Only Registration" />
+                    </div>
+                    <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"
                             helper="Opt out of anonymous usage tracking. When enabled, this instance will not report to coolify.io's installation count and will not send error reports to help improve Coolify."
                             label="Do Not Track" />


### PR DESCRIPTION
## Summary
Adds a new 'is_oauth_only_enabled' setting that allows self-registration exclusively through OAuth providers while blocking password-based registration and login.

## Changes
- **Migration**: New column 'is_oauth_only_enabled' in 'instance_settings' table
- **InstanceSettings**: Added 'is_oauth_only_enabled' to fillable
- **OauthController**: Allow OAuth users to register when 'is_oauth_only_enabled=true' (even if 'is_registration_enabled=false')
- **FortifyServiceProvider**: Block password login when 'is_oauth_only_enabled=true'; allow register view
- **Advanced Settings (Livewire)**: New 'is_oauth_only_enabled' boolean property
- **Blade template**: New OAuth-Only Registration checkbox

## Behavior
| Setting | Password Register | Password Login | OAuth Register | OAuth Login |
|---------|------------------|----------------|----------------|-------------|
| is_oauth_only=true | Blocked | Blocked | Allowed | Allowed |
| is_registration=true | Allowed | Allowed | Allowed | Allowed |

## Algora Bounty
Addresses: https://github.com/coollabsio/coolify/issues/8042