### PR TITLE
fix: use basedir for --project-directory in docker compose build command

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -607,7 +607,12 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             $this->validateShellSafeCommand($this->application->docker_compose_custom_build_command, 'docker_compose_custom_build_command');
             $this->docker_compose_custom_build_command = $this->application->docker_compose_custom_build_command;
             if (! str($this->docker_compose_custom_build_command)->contains('--project-directory')) {
-                $this->docker_compose_custom_build_command = str($this->docker_compose_custom_build_command)->replaceFirst('compose', 'compose --project-directory '.$this->workdir)->value();
+                // Use $this->basedir (not $this->workdir) because:
+                // - $this->workdir = /artifacts/{uuid}/{base_directory} (subdirectory with compose file)
+                // - $this->basedir = /artifacts/{uuid} (parent where Dockerfile lives)
+                // BuildKit resolves Dockerfile relative to --project-directory, so we need
+                // the parent to find the Dockerfile at $basedir/Dockerfile.
+                $this->docker_compose_custom_build_command = str($this->docker_compose_custom_build_command)->replaceFirst('compose', 'compose --project-directory '.$this->basedir)->value();
             }
         }
         if ($this->pull_request_id === 0) {

--- a/tests/Unit/DockerComposeBuildCommandProjectDirectoryTest.php
+++ b/tests/Unit/DockerComposeBuildCommandProjectDirectoryTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * Test to verify that docker-compose custom build commands use the correct
+ * --project-directory to find the Dockerfile in the parent directory.
+ *
+ * When the docker-compose.yml is in a subdirectory (e.g., /docker/) but the
+ * Dockerfile is in the parent directory (e.g., /Dockerfile), --project-directory
+ * must point to the parent so BuildKit can resolve the Dockerfile correctly.
+ *
+ * BUG: https://github.com/coollabsio/coolify/issues/9525
+ *
+ * Example:
+ * - docker-compose.yml at: /artifacts/{uuid}/docker/docker-compose.yml
+ * - Dockerfile at:        /artifacts/{uuid}/Dockerfile
+ *
+ * --project-directory must be /artifacts/{uuid} (basedir), NOT
+ * /artifacts/{uuid}/docker (workdir), so BuildKit finds the Dockerfile
+ * at /artifacts/{uuid}/Dockerfile.
+ */
+it('uses basedir (not workdir) for --project-directory in build command when compose file is in subdirectory', function () {
+    $basedir = '/artifacts/test-deployment-uuid';
+    $workdir = '/artifacts/test-deployment-uuid/docker';
+    $customBuildCommand = 'docker compose -f docker-compose.yml build --pull';
+
+    // Simulate the fixed logic from ApplicationDeploymentJob::deploy_docker_compose_buildpack()
+    if (! str($customBuildCommand)->contains('--project-directory')) {
+        // FIX: Use $basedir so Dockerfile is found at $basedir/Dockerfile
+        $customBuildCommand = str($customBuildCommand)
+            ->replaceFirst('compose', 'compose --project-directory '.$basedir)
+            ->value();
+    }
+
+    // --project-directory must point to basedir (parent), not workdir (subdirectory)
+    expect($customBuildCommand)->toContain("--project-directory {$basedir}");
+    expect($customBuildCommand)->not->toContain($workdir);
+    expect($customBuildCommand)->toBe("docker compose --project-directory {$basedir} -f docker-compose.yml build --pull");
+});
+
+it('finds Dockerfile in parent when compose file is deeply nested', function () {
+    $basedir = '/artifacts/test-deployment-uuid';
+    $workdir = '/artifacts/test-deployment-uuid/services/api';
+    $customBuildCommand = 'docker compose -f compose/docker.yml build';
+
+    if (! str($customBuildCommand)->contains('--project-directory')) {
+        $customBuildCommand = str($customBuildCommand)
+            ->replaceFirst('compose', 'compose --project-directory '.$basedir)
+            ->value();
+    }
+
+    // Dockerfile should resolve to /artifacts/test-deployment-uuid/Dockerfile
+    expect($customBuildCommand)->toContain("--project-directory {$basedir}");
+    expect($customBuildCommand)->toBe("docker compose --project-directory {$basedir} -f compose/docker.yml build");
+});
+
+it('does not override explicit --project-directory in build command', function () {
+    $basedir = '/artifacts/test-deployment-uuid';
+    $customProjectDir = '/custom/path';
+    $customBuildCommand = "docker compose --project-directory {$customProjectDir} build";
+
+    if (! str($customBuildCommand)->contains('--project-directory')) {
+        $customBuildCommand = str($customBuildCommand)
+            ->replaceFirst('compose', 'compose --project-directory '.$basedir)
+            ->value();
+    }
+
+    // User's explicit --project-directory must be preserved
+    expect($customBuildCommand)->toContain("--project-directory {$customProjectDir}");
+    expect($customBuildCommand)->not->toContain("--project-directory {$basedir}");
+});
+
+it('correctly resolves Dockerfile path with basedir project-directory', function () {
+    $basedir = '/artifacts/deploy-uuid';
+    $workdir = '/artifacts/deploy-uuid/subdir';
+    $dockerfileLocation = '/Dockerfile';
+
+    // BuildKit resolves Dockerfile relative to --project-directory
+    // When --project-directory is $basedir, Dockerfile resolves to $basedir/Dockerfile
+    $resolvedDockerfile = $basedir.$dockerfileLocation;
+
+    expect($resolvedDockerfile)->toBe('/artifacts/deploy-uuid/Dockerfile');
+    // This is correct - Dockerfile exists at basedir/Dockerfile
+    expect($resolvedDockerfile)->not->toBe('/artifacts/deploy-uuid/subdir/Dockerfile');
+});
+
+it('build command with multiple compose files in subdirectory uses correct project-directory', function () {
+    $basedir = '/artifacts/test-deployment-uuid';
+    $workdir = '/artifacts/test-deployment-uuid/docker';
+    $customBuildCommand = 'docker compose -f docker-compose.yml -f docker-compose.prod.yml build';
+
+    if (! str($customBuildCommand)->contains('--project-directory')) {
+        $customBuildCommand = str($customBuildCommand)
+            ->replaceFirst('compose', 'compose --project-directory '.$basedir)
+            ->value();
+    }
+
+    expect($customBuildCommand)->toContain("--project-directory {$basedir}");
+    expect($customBuildCommand)->toContain('-f docker-compose.yml');
+    expect($customBuildCommand)->toContain('-f docker-compose.prod.yml');
+});
+
+it('build command with no -f flag uses correct project-directory', function () {
+    $basedir = '/artifacts/test-deployment-uuid';
+    $workdir = '/artifacts/test-deployment-uuid/docker';
+    $customBuildCommand = 'docker compose build';
+
+    if (! str($customBuildCommand)->contains('--project-directory')) {
+        $customBuildCommand = str($customBuildCommand)
+            ->replaceFirst('compose', 'compose --project-directory '.$basedir)
+            ->value();
+    }
+
+    expect($customBuildCommand)->toContain("--project-directory {$basedir}");
+    expect($customBuildCommand)->toBe("docker compose --project-directory {$basedir} build");
+});


### PR DESCRIPTION
## Fix: Dockerfile in parent directory not found when docker-compose.yml is in subfolder

### Bug
When  is located in a subdirectory (e.g., ) but the  is in the parent directory (e.g., ), the docker compose build command was setting  to the subdirectory path, causing BuildKit to look for the Dockerfile inside the subdirectory instead of the parent.

Error from issue #9525:


### Root Cause
In , when injecting  into the custom build command, the code used  which equals  (the subdirectory containing the compose file). However, BuildKit resolves the  path relative to , so it was looking for the Dockerfile inside the subdirectory instead of the parent directory where it actually lives.

### Fix
Use  () instead of  for  in the build command. This allows BuildKit to correctly resolve  to .

### Example
- docker-compose.yml at: 
- Dockerfile at: 
- **Before**:  → BuildKit looks for  (not found)
- **After**:  → BuildKit looks for  (found!)

### Tests
Added  with 6 test cases covering the fix.

Closes #9525