### PR TITLE
feat(services): add Velix API one-click template

### DIFF
--- a/svgs/velix-api.svg
+++ b/svgs/velix-api.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none">
+  <!-- Background: rounded square with gradient -->
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="128" y2="128" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#22c55e"/>
+      <stop offset="100%" stop-color="#15803d"/>
+    </linearGradient>
+    <linearGradient id="bubble" x1="20" y1="20" x2="108" y2="108" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)"/>
+      <stop offset="100%" stop-color="rgba(255,255,255,0.08)"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Base rounded rect -->
+  <rect width="128" height="128" rx="28" fill="url(#bg)"/>
+
+  <!-- Chat bubble shape (subtle background element) -->
+  <path d="M30 36 C30 28, 36 22, 44 22 L84 22 C92 22, 98 28, 98 36 L98 72 C98 80, 92 86, 84 86 L52 86 L38 98 L38 86 L44 86 C36 86, 30 80, 30 72 Z"
+        fill="url(#bubble)"/>
+
+  <!-- Stylized V mark — bold, modern -->
+  <path d="M42 38 L58 82 C59 84.5, 61 86, 64 86 C67 86, 69 84.5, 70 82 L86 38"
+        stroke="white" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+
+  <!-- Small checkmark accent at the bottom of V — indicates "delivered/verified" -->
+  <path d="M56 92 L62 98 L76 84"
+        stroke="rgba(255,255,255,0.6)" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/templates/compose/velix-api.yaml
+++ b/templates/compose/velix-api.yaml
@@ -20,7 +20,7 @@ services:
       - ENGINE_STORE_PATH=/data/instances
       - ENGINE_AUTO_RECONNECT=true
       - ENGINE_MAX_INSTANCES=200
-      - REGISTRATION_ENABLED=true
+      - REGISTRATION_ENABLED=false
     volumes:
       - velix-data:/data
     depends_on:

--- a/templates/compose/velix-api.yaml
+++ b/templates/compose/velix-api.yaml
@@ -1,0 +1,59 @@
+# documentation: https://github.com/paulolinder/velix-api
+# slogan: Self-hosted WhatsApp API with multi-instance support, webhooks, n8n node, and Chatwoot integration.
+# category: communication
+# tags: whatsapp, api, messaging, chatbot, automation, n8n, chatwoot
+# logo: svgs/velix-api.svg
+# port: 8080
+
+services:
+  velix-api:
+    image: ghcr.io/paulolinder/velix-api:0.1.0
+    environment:
+      - SERVICE_FQDN_VELIXAPI_8080
+      - DATABASE_URL=postgres://postgres:${SERVICE_PASSWORD_POSTGRES}@postgres:5432/velix?sslmode=disable
+      - REDIS_URL=redis://redis:6379
+      - JWT_SECRET=${SERVICE_BASE64_64_JWTSECRET}
+      - HTTP_PORT=8080
+      - APP_ENV=production
+      - LOG_LEVEL=info
+      - MEDIA_STORAGE_PATH=/data/media
+      - ENGINE_STORE_PATH=/data/instances
+      - ENGINE_AUTO_RECONNECT=true
+      - ENGINE_MAX_INSTANCES=200
+      - REGISTRATION_ENABLED=true
+    volumes:
+      - velix-data:/data
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:8080/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      - POSTGRES_DB=velix
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=${SERVICE_PASSWORD_POSTGRES}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: redis:7-alpine
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10


### PR DESCRIPTION
## Changes

Added Velix API as a new one-click service template. Velix is a self-hosted WhatsApp API built in Go with multi-instance support, webhooks, n8n node, and Chatwoot integration. The template includes the main service, PostgreSQL 16, and Redis 7.

## Issues

- N/A (new service addition)

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Service runs on port 8080 with a web admin panel for QR code pairing and WhatsApp instance management. Registration is disabled by default for security.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: AI assisted with template formatting
- How extensively: Template file structure and YAML formatting

## Testing

Tested locally with Docker Compose. All three services (velix-api, postgres, redis) start correctly. Health checks pass. Admin panel accessible on port 8080.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.