### PR TITLE
fix: report Coolify deployments to GitHub with branch-aware refs

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -4359,15 +4359,12 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
 
     private function resolveGitHubDeploymentRef(): string
     {
-        if ($this->commit && $this->commit !== 'HEAD') {
-            return $this->commit;
-        }
-
-        if ($this->application->git_commit_sha && $this->application->git_commit_sha !== 'HEAD') {
-            return $this->application->git_commit_sha;
-        }
-
-        return $this->application->git_branch;
+        return determineGitHubDeploymentRef(
+            pullRequestId: $this->pull_request_id,
+            branch: $this->application->git_branch,
+            commit: $this->commit ?: $this->application->git_commit_sha,
+            rollback: $this->rollback,
+        );
     }
 
     private function resolveGitHubDeploymentEnvironment(): string

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -180,6 +180,8 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
 
     private Collection|string $build_secrets;
 
+    private ?int $github_deployment_id = null;
+
     public function tags()
     {
         // Do not remove this one, it needs to properly identify which worker is running the job
@@ -284,6 +286,8 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             'status' => ApplicationDeploymentStatus::IN_PROGRESS->value,
             'horizon_job_worker' => gethostname(),
         ]);
+        $this->createSyncedGitHubDeployment();
+        $this->syncGitHubDeploymentStatus('in_progress', 'Deployment started.');
         if ($this->server->isFunctional() === false) {
             $this->application_deployment_queue->addLogEntry('Server is not functional.');
             $this->fail('Server is not functional.');
@@ -4178,6 +4182,7 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
         $this->application_deployment_queue->refresh();
         if ($this->application_deployment_queue->status === ApplicationDeploymentStatus::CANCELLED_BY_USER->value) {
             $this->application_deployment_queue->addLogEntry('Deployment cancelled by user, stopping execution.');
+            $this->syncGitHubDeploymentStatus('error', 'Deployment cancelled by user.');
             throw new DeploymentException('Deployment cancelled by user', 69420);
         }
     }
@@ -4215,6 +4220,7 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
 
         if ($this->application_deployment_queue->status === ApplicationDeploymentStatus::CANCELLED_BY_USER->value) {
             $this->application_deployment_queue->addLogEntry('Deployment cancelled by user, stopping execution.');
+            $this->syncGitHubDeploymentStatus('error', 'Deployment cancelled by user.');
             throw new DeploymentException('Deployment cancelled by user', 69420);
         }
 
@@ -4264,6 +4270,7 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
         }
 
         $this->sendDeploymentNotification(DeploymentSuccess::class);
+        $this->syncGitHubDeploymentStatus('success', 'Deployment finished successfully.');
     }
 
     /**
@@ -4272,6 +4279,171 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
     private function handleFailedDeployment(): void
     {
         $this->sendDeploymentNotification(DeploymentFailed::class);
+        $this->syncGitHubDeploymentStatus('failure', 'Deployment failed.');
+    }
+
+    private function createSyncedGitHubDeployment(): void
+    {
+        if (! $this->shouldSyncGitHubDeployment()) {
+            return;
+        }
+
+        try {
+            ['repository' => $repository] = $this->application->customRepository();
+            $this->github_deployment_id = createGitHubDeployment(
+                source: $this->source,
+                repository: $repository,
+                ref: $this->resolveGitHubDeploymentRef(),
+                environment: $this->resolveGitHubDeploymentEnvironment(),
+                description: $this->resolveGitHubDeploymentDescription(),
+                transientEnvironment: $this->pull_request_id !== 0,
+                productionEnvironment: $this->pull_request_id === 0,
+            );
+
+            if ($this->github_deployment_id) {
+                $this->application_deployment_queue->addLogEntry(
+                    "GitHub deployment {$this->github_deployment_id} created.",
+                    hidden: true
+                );
+            }
+        } catch (Throwable $e) {
+            \Log::warning('Failed to create GitHub deployment.', [
+                'application_id' => $this->application->id,
+                'deployment_uuid' => $this->deployment_uuid,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    private function syncGitHubDeploymentStatus(string $state, string $description): void
+    {
+        if (! $this->shouldSyncGitHubDeployment() || ! $this->github_deployment_id) {
+            return;
+        }
+
+        try {
+            ['repository' => $repository] = $this->application->customRepository();
+
+            updateGitHubDeploymentStatus(
+                source: $this->source,
+                repository: $repository,
+                deploymentId: $this->github_deployment_id,
+                state: $state,
+                description: $description,
+                logUrl: route('project.application.deployment.show', [
+                    'project_uuid' => data_get($this->application, 'environment.project.uuid'),
+                    'application_uuid' => data_get($this->application, 'uuid'),
+                    'deployment_uuid' => $this->deployment_uuid,
+                    'environment_uuid' => data_get($this->application, 'environment.uuid'),
+                ]),
+                environmentUrl: in_array($state, ['in_progress', 'success'], true)
+                    ? $this->resolveGitHubDeploymentEnvironmentUrl()
+                    : null,
+            );
+        } catch (Throwable $e) {
+            \Log::warning('Failed to update GitHub deployment status.', [
+                'application_id' => $this->application->id,
+                'deployment_uuid' => $this->deployment_uuid,
+                'state' => $state,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    private function shouldSyncGitHubDeployment(): bool
+    {
+        return $this->source instanceof GithubApp
+            && ! $this->is_this_additional_server
+            && hasGitHubDeploymentsPermission($this->source);
+    }
+
+    private function resolveGitHubDeploymentRef(): string
+    {
+        if ($this->commit && $this->commit !== 'HEAD') {
+            return $this->commit;
+        }
+
+        if ($this->application->git_commit_sha && $this->application->git_commit_sha !== 'HEAD') {
+            return $this->application->git_commit_sha;
+        }
+
+        return $this->application->git_branch;
+    }
+
+    private function resolveGitHubDeploymentEnvironment(): string
+    {
+        if ($this->pull_request_id !== 0) {
+            return "preview/pr-{$this->pull_request_id}";
+        }
+
+        return $this->application->git_branch ?: 'production';
+    }
+
+    private function resolveGitHubDeploymentDescription(): string
+    {
+        if ($this->pull_request_id !== 0) {
+            return Str::limit("Coolify preview deployment for PR #{$this->pull_request_id}", 140, '');
+        }
+
+        return Str::limit("Coolify deployment for branch {$this->application->git_branch}", 140, '');
+    }
+
+    private function resolveGitHubDeploymentEnvironmentUrl(): ?string
+    {
+        if ($this->pull_request_id !== 0) {
+            if ($this->application->build_pack === 'dockercompose') {
+                return $this->resolveDockerComposeDeploymentUrl($this->preview?->docker_compose_domains);
+            }
+
+            return $this->normalizeGitHubDeploymentUrl($this->preview?->fqdn);
+        }
+
+        if ($this->application->build_pack === 'dockercompose') {
+            return $this->resolveDockerComposeDeploymentUrl($this->application->docker_compose_domains);
+        }
+
+        return $this->normalizeGitHubDeploymentUrl($this->application->fqdn);
+    }
+
+    private function resolveDockerComposeDeploymentUrl(?string $domains): ?string
+    {
+        if (blank($domains)) {
+            return null;
+        }
+
+        $dockerComposeDomains = json_decode($domains, true);
+        if (! is_array($dockerComposeDomains)) {
+            return null;
+        }
+
+        foreach ($dockerComposeDomains as $config) {
+            $domain = data_get($config, 'domain');
+            if (blank($domain)) {
+                continue;
+            }
+
+            return $this->normalizeGitHubDeploymentUrl($domain);
+        }
+
+        return null;
+    }
+
+    private function normalizeGitHubDeploymentUrl(?string $url): ?string
+    {
+        if (blank($url)) {
+            return null;
+        }
+
+        $firstUrl = trim(str($url)->explode(',')->first());
+        if ($firstUrl === '') {
+            return null;
+        }
+
+        if (! str($firstUrl)->startsWith('http://') && ! str($firstUrl)->startsWith('https://')) {
+            return "http://{$firstUrl}";
+        }
+
+        return $firstUrl;
     }
 
     /**

--- a/app/Jobs/GithubAppPermissionJob.php
+++ b/app/Jobs/GithubAppPermissionJob.php
@@ -44,6 +44,7 @@ class GithubAppPermissionJob implements ShouldBeEncrypted, ShouldQueue
             $this->github_app->contents = data_get($permissions, 'contents');
             $this->github_app->metadata = data_get($permissions, 'metadata');
             $this->github_app->pull_requests = data_get($permissions, 'pull_requests');
+            $this->github_app->deployments = data_get($permissions, 'deployments');
             $this->github_app->administration = data_get($permissions, 'administration');
 
             $this->github_app->save();

--- a/app/Livewire/Source/Github/Change.php
+++ b/app/Livewire/Source/Github/Change.php
@@ -251,7 +251,7 @@ class Change extends Component
             if (isCloud() && ! isDev()) {
                 $this->webhook_endpoint = config('app.url');
             } else {
-                $this->webhook_endpoint = $this->fqdn ?? $this->ipv4 ?? '';
+                $this->webhook_endpoint = $this->fqdn ?: $this->ipv4 ?: config('app.url') ?: '';
                 $this->is_system_wide = $this->github_app->is_system_wide;
             }
         } catch (\Throwable $e) {

--- a/app/Livewire/Source/Github/Change.php
+++ b/app/Livewire/Source/Github/Change.php
@@ -29,6 +29,8 @@ class Change extends Component
 
     public ?bool $preview_deployment_permissions = true;
 
+    public ?bool $deployment_statuses_permissions = true;
+
     public ?bool $administration = false;
 
     public $parameters;
@@ -68,6 +70,8 @@ class Change extends Component
 
     public ?string $pullRequests = null;
 
+    public ?string $deployments = null;
+
     public $applications;
 
     public $privateKeys;
@@ -90,6 +94,7 @@ class Change extends Component
             'contents' => 'nullable|string',
             'metadata' => 'nullable|string',
             'pullRequests' => 'nullable|string',
+            'deployments' => 'nullable|string',
             'privateKeyId' => 'nullable|int',
         ];
     }
@@ -126,6 +131,7 @@ class Change extends Component
             $this->github_app->contents = $this->contents;
             $this->github_app->metadata = $this->metadata;
             $this->github_app->pull_requests = $this->pullRequests;
+            $this->github_app->deployments = $this->deployments;
         } else {
             // Sync FROM model (on load/refresh)
             $this->name = $this->github_app->name;
@@ -144,6 +150,7 @@ class Change extends Component
             $this->contents = $this->github_app->contents;
             $this->metadata = $this->github_app->metadata;
             $this->pullRequests = $this->github_app->pull_requests;
+            $this->deployments = $this->github_app->deployments;
         }
     }
 
@@ -179,6 +186,7 @@ class Change extends Component
 
             GithubAppPermissionJob::dispatchSync($this->github_app);
             $this->github_app->refresh()->makeVisible('client_secret')->makeVisible('webhook_secret');
+            $this->syncData(false);
             $this->dispatch('success', 'Github App permissions updated.');
         } catch (\Throwable $e) {
             // Provide better error message for unsupported key formats

--- a/app/Models/GithubApp.php
+++ b/app/Models/GithubApp.php
@@ -25,6 +25,7 @@ class GithubApp extends BaseModel
         'contents',
         'metadata',
         'pull_requests',
+        'deployments',
         'administration',
     ];
 

--- a/bootstrap/helpers/github.php
+++ b/bootstrap/helpers/github.php
@@ -20,7 +20,7 @@ function generateGithubToken(GithubApp $source, string $type)
     $timeDiff = abs($serverTime->diffInSeconds($githubTime));
 
     if ($timeDiff > 50) {
-        throw new \Exception(
+        throw new Exception(
             'System time is out of sync with GitHub API time:<br>'.
             '- System time: '.$serverTime->format('Y-m-d H:i:s').' UTC<br>'.
             '- GitHub time: '.$githubTime->format('Y-m-d H:i:s').' UTC<br>'.
@@ -60,7 +60,7 @@ function generateGithubToken(GithubApp $source, string $type)
 
             return $response->json()['token'];
         })(),
-        default => throw new \InvalidArgumentException("Unsupported token type: {$type}")
+        default => throw new InvalidArgumentException("Unsupported token type: {$type}")
     };
 }
 
@@ -77,11 +77,11 @@ function generateGithubJwt(GithubApp $source)
 function githubApi(GithubApp|GitlabApp|null $source, string $endpoint, string $method = 'get', ?array $data = null, bool $throwError = true)
 {
     if (is_null($source)) {
-        throw new \Exception('Source is required for API calls');
+        throw new Exception('Source is required for API calls');
     }
 
     if ($source->getMorphClass() !== GithubApp::class) {
-        throw new \InvalidArgumentException("Unsupported source type: {$source->getMorphClass()}");
+        throw new InvalidArgumentException("Unsupported source type: {$source->getMorphClass()}");
     }
 
     if ($source->is_public) {
@@ -100,7 +100,7 @@ function githubApi(GithubApp|GitlabApp|null $source, string $endpoint, string $m
         $errorMessage = data_get($response->json(), 'message', 'no error message found');
         $remainingCalls = $response->header('X-RateLimit-Remaining', '0');
 
-        throw new \Exception(
+        throw new Exception(
             'GitHub API call failed:<br>'.
             "Error: {$errorMessage}<br>".
             'Rate Limit Status:<br>'.
@@ -162,6 +162,90 @@ function loadRepositoryByPage(GithubApp $source, string $token, int $page)
         'repositories' => $json['repositories'],
     ];
 }
+
+function hasGitHubDeploymentsPermission(GithubApp $source): bool
+{
+    return $source->deployments === 'write';
+}
+
+function createGitHubDeployment(
+    GithubApp $source,
+    string $repository,
+    string $ref,
+    string $environment,
+    ?string $description = null,
+    bool $transientEnvironment = false,
+    bool $productionEnvironment = false
+): ?int {
+    try {
+        $payload = [
+            'ref' => $ref,
+            'environment' => $environment,
+            'auto_merge' => false,
+            'required_contexts' => [],
+            'transient_environment' => $transientEnvironment,
+            'production_environment' => $productionEnvironment,
+        ];
+
+        if ($description) {
+            $payload['description'] = $description;
+        }
+
+        $response = githubApi($source, "repos/{$repository}/deployments", 'post', $payload);
+
+        return data_get($response, 'data.id');
+    } catch (Exception $e) {
+        Log::warning('Failed to create GitHub deployment.', [
+            'repository' => $repository,
+            'environment' => $environment,
+            'error' => $e->getMessage(),
+        ]);
+
+        return null;
+    }
+}
+
+function updateGitHubDeploymentStatus(
+    GithubApp $source,
+    string $repository,
+    int $deploymentId,
+    string $state,
+    ?string $description = null,
+    ?string $logUrl = null,
+    ?string $environmentUrl = null
+): bool {
+    try {
+        $payload = [
+            'state' => $state,
+        ];
+
+        if ($description) {
+            $payload['description'] = $description;
+        }
+
+        if ($logUrl) {
+            $payload['log_url'] = $logUrl;
+        }
+
+        if ($environmentUrl) {
+            $payload['environment_url'] = $environmentUrl;
+        }
+
+        githubApi($source, "repos/{$repository}/deployments/{$deploymentId}/statuses", 'post', $payload);
+
+        return true;
+    } catch (Exception $e) {
+        Log::warning('Failed to update GitHub deployment status.', [
+            'repository' => $repository,
+            'deployment_id' => $deploymentId,
+            'state' => $state,
+            'error' => $e->getMessage(),
+        ]);
+
+        return false;
+    }
+}
+
 function getGithubCommitRangeFiles(?GithubApp $source, string $owner, string $repo, string $beforeSha, string $afterSha): array
 {
     try {

--- a/bootstrap/helpers/github.php
+++ b/bootstrap/helpers/github.php
@@ -168,6 +168,23 @@ function hasGitHubDeploymentsPermission(GithubApp $source): bool
     return $source->deployments === 'write';
 }
 
+function determineGitHubDeploymentRef(int $pullRequestId, ?string $branch = null, ?string $commit = null, bool $rollback = false): string
+{
+    if ($pullRequestId !== 0) {
+        return "refs/pull/{$pullRequestId}/head";
+    }
+
+    if (! $rollback && filled($branch)) {
+        return $branch;
+    }
+
+    if (filled($commit) && $commit !== 'HEAD') {
+        return $commit;
+    }
+
+    return filled($branch) ? $branch : 'HEAD';
+}
+
 function createGitHubDeployment(
     GithubApp $source,
     string $repository,

--- a/database/migrations/2026_04_15_190000_add_deployments_to_github_apps_table.php
+++ b/database/migrations/2026_04_15_190000_add_deployments_to_github_apps_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('github_apps', function (Blueprint $table) {
+            $table->string('deployments')->nullable()->after('pull_requests');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('github_apps', function (Blueprint $table) {
+            $table->dropColumn('deployments');
+        });
+    }
+};

--- a/resources/views/livewire/source/github/change.blade.php
+++ b/resources/views/livewire/source/github/change.blade.php
@@ -136,6 +136,9 @@
                         <x-forms.input id="pullRequests"
                             helper="write access needed to use deployment status update in previews."
                             label="Pull Request" readonly placeholder="N/A" />
+                        <x-forms.input id="deployments"
+                            helper="write access needed to sync deployment status back to GitHub."
+                            label="Deployments" readonly placeholder="N/A" />
                     </div>
                 </div>
             @endif
@@ -256,7 +259,7 @@
                                     @endif
                                 </x-forms.select>
                                 <x-forms.button isHighlighted
-                                    x-on:click.prevent="createGithubApp('{{ $webhook_endpoint }}','{{ $preview_deployment_permissions }}',{{ $administration }})">
+                                    x-on:click.prevent="createGithubApp('{{ $webhook_endpoint }}','{{ $preview_deployment_permissions }}','{{ $deployment_statuses_permissions }}',{{ $administration }})">
                                     Register Now
                                 </x-forms.button>
                             </div>
@@ -264,7 +267,7 @@
                             <div class="flex flex-col sm:flex-row gap-2">
                                 <h2>Register a GitHub App</h2>
                                 <x-forms.button isHighlighted
-                                    x-on:click.prevent="createGithubApp('{{ $webhook_endpoint }}','{{ $preview_deployment_permissions }}',{{ $administration }})">
+                                    x-on:click.prevent="createGithubApp('{{ $webhook_endpoint }}','{{ $preview_deployment_permissions }}','{{ $deployment_statuses_permissions }}',{{ $administration }})">
                                     Register Now
                                 </x-forms.button>
                             </div>
@@ -276,6 +279,8 @@
                                 helper="Contents: read<br>Metadata: read<br>Email: read" />
                             <x-forms.checkbox id="preview_deployment_permissions" label="Preview Deployments "
                                 helper="Necessary for updating pull requests with useful comments (deployment status, links, etc.)<br><br>Pull Request: read & write" />
+                            <x-forms.checkbox id="deployment_statuses_permissions" label="GitHub Deployment Statuses"
+                                helper="Necessary for syncing deployment progress back to GitHub.<br><br>Deployments: write" />
                             {{-- <x-forms.checkbox id="administration" label="Administration (for Github Runners)"
                             helper="Necessary for adding Github Runners to repositories.<br><br>Administration: read & write" /> --}}
                         </div>
@@ -287,7 +292,7 @@
                 </div>
             </div>
             <script>
-                function createGithubApp(webhook_endpoint, preview_deployment_permissions, administration) {
+                function createGithubApp(webhook_endpoint, preview_deployment_permissions, deployment_statuses_permissions, administration) {
                     const {
                         organization,
                         uuid,
@@ -317,6 +322,9 @@
                     if (preview_deployment_permissions) {
                         default_permissions.pull_requests = 'write';
                         default_events.push('pull_request');
+                    }
+                    if (deployment_statuses_permissions) {
+                        default_permissions.deployments = 'write';
                     }
                     if (administration) {
                         default_permissions.administration = 'write';

--- a/resources/views/livewire/source/github/change.blade.php
+++ b/resources/views/livewire/source/github/change.blade.php
@@ -259,7 +259,7 @@
                                     @endif
                                 </x-forms.select>
                                 <x-forms.button isHighlighted
-                                    x-on:click.prevent="createGithubApp('{{ $webhook_endpoint }}','{{ $preview_deployment_permissions }}','{{ $deployment_statuses_permissions }}',{{ $administration }})">
+                                    x-on:click.prevent="createGithubApp($wire.webhook_endpoint, $wire.preview_deployment_permissions, $wire.deployment_statuses_permissions, $wire.administration)">
                                     Register Now
                                 </x-forms.button>
                             </div>
@@ -267,7 +267,7 @@
                             <div class="flex flex-col sm:flex-row gap-2">
                                 <h2>Register a GitHub App</h2>
                                 <x-forms.button isHighlighted
-                                    x-on:click.prevent="createGithubApp('{{ $webhook_endpoint }}','{{ $preview_deployment_permissions }}','{{ $deployment_statuses_permissions }}',{{ $administration }})">
+                                    x-on:click.prevent="createGithubApp($wire.webhook_endpoint, $wire.preview_deployment_permissions, $wire.deployment_statuses_permissions, $wire.administration)">
                                     Register Now
                                 </x-forms.button>
                             </div>
@@ -310,6 +310,7 @@
                     if (isDev && devWebhook) {
                         baseUrl = devWebhook;
                     }
+                    baseUrl = baseUrl.replace(/\/+$/, '');
                     const webhookBaseUrl = `${baseUrl}/webhooks`;
                     const path = organization ? `organizations/${organization}/settings/apps/new` : 'settings/apps/new';
                     const default_permissions = {
@@ -338,7 +339,6 @@
                             active: true,
                         },
                         redirect_url: `${webhookBaseUrl}/source/github/redirect`,
-                        callback_urls: [`${baseUrl}/login/github/app`],
                         public: false,
                         request_oauth_on_install: false,
                         setup_url: `${webhookBaseUrl}/source/github/install?source=${uuid}`,

--- a/tests/Feature/GithubSourceChangeTest.php
+++ b/tests/Feature/GithubSourceChangeTest.php
@@ -63,6 +63,25 @@ describe('GitHub Source Change Component', function () {
             ->assertSet('privateKeyId', null);
     });
 
+    test('mount falls back to app url for webhook endpoint when instance urls are missing', function () {
+        config()->set('app.url', 'https://coolify.example.test');
+
+        $githubApp = GithubApp::create([
+            'name' => 'Test GitHub App',
+            'api_url' => 'https://api.github.com',
+            'html_url' => 'https://github.com',
+            'custom_user' => 'git',
+            'custom_port' => 22,
+            'team_id' => $this->team->id,
+            'is_system_wide' => false,
+        ]);
+
+        Livewire::withQueryParams(['github_app_uuid' => $githubApp->uuid])
+            ->test(Change::class)
+            ->assertSuccessful()
+            ->assertSet('webhook_endpoint', 'https://coolify.example.test');
+    });
+
     test('can mount with fully configured github app', function () {
         $privateKey = PrivateKey::create([
             'name' => 'Test Key',
@@ -276,5 +295,24 @@ describe('GitHub Source Change Component', function () {
         $githubApp->refresh();
 
         expect($githubApp->deployments)->toBe('write');
+    });
+
+    test('automated installation manifest does not include invalid github app callback url', function () {
+        config()->set('app.url', 'https://coolify.example.test');
+
+        $githubApp = GithubApp::create([
+            'name' => 'Test GitHub App',
+            'api_url' => 'https://api.github.com',
+            'html_url' => 'https://github.com',
+            'custom_user' => 'git',
+            'custom_port' => 22,
+            'team_id' => $this->team->id,
+            'is_system_wide' => false,
+        ]);
+
+        Livewire::withQueryParams(['github_app_uuid' => $githubApp->uuid])
+            ->test(Change::class)
+            ->assertSee('redirect_url:', false)
+            ->assertDontSee('/login/github/app', false);
     });
 });

--- a/tests/Feature/GithubSourceChangeTest.php
+++ b/tests/Feature/GithubSourceChangeTest.php
@@ -2,15 +2,25 @@
 
 use App\Livewire\Source\Github\Change;
 use App\Models\GithubApp;
+use App\Models\InstanceSettings;
 use App\Models\PrivateKey;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
 use Livewire\Livewire;
 
 uses(RefreshDatabase::class);
 
 beforeEach(function () {
+    InstanceSettings::unguarded(function () {
+        InstanceSettings::query()->updateOrCreate([
+            'id' => 0,
+        ], [
+            'is_registration_enabled' => true,
+        ]);
+    });
+
     // Create a team with owner
     $this->team = Team::factory()->create();
     $this->user = User::factory()->create();
@@ -19,6 +29,12 @@ beforeEach(function () {
     // Set current team
     $this->actingAs($this->user);
     session(['currentTeam' => $this->team]);
+
+    $rsaKey = openssl_pkey_new([
+        'private_key_bits' => 2048,
+        'private_key_type' => OPENSSL_KEYTYPE_RSA,
+    ]);
+    openssl_pkey_export($rsaKey, $this->validPrivateKey);
 });
 
 describe('GitHub Source Change Component', function () {
@@ -50,7 +66,7 @@ describe('GitHub Source Change Component', function () {
     test('can mount with fully configured github app', function () {
         $privateKey = PrivateKey::create([
             'name' => 'Test Key',
-            'private_key' => 'test-private-key-content',
+            'private_key' => $this->validPrivateKey,
             'team_id' => $this->team->id,
         ]);
 
@@ -84,7 +100,7 @@ describe('GitHub Source Change Component', function () {
     test('can update github app from null to valid values', function () {
         $privateKey = PrivateKey::create([
             'name' => 'Test Key',
-            'private_key' => 'test-private-key-content',
+            'private_key' => $this->validPrivateKey,
             'team_id' => $this->team->id,
         ]);
 
@@ -157,8 +173,8 @@ describe('GitHub Source Change Component', function () {
 
         // Verify the database was updated
         $githubApp->refresh();
-        expect($githubApp->app_id)->toBe('1234567890');
-        expect($githubApp->installation_id)->toBe('1234567890');
+        expect($githubApp->app_id)->toBe(1234567890);
+        expect($githubApp->installation_id)->toBe(1234567890);
     });
 
     test('checkPermissions validates required fields', function () {
@@ -178,7 +194,9 @@ describe('GitHub Source Change Component', function () {
             ->test(Change::class)
             ->assertSuccessful()
             ->call('checkPermissions')
-            ->assertDispatched('error', function ($event, $message) {
+            ->assertDispatched('error', function ($event, $params) {
+                $message = data_get($params, '0', '');
+
                 return str_contains($message, 'App ID') && str_contains($message, 'Private Key');
             });
     });
@@ -201,8 +219,62 @@ describe('GitHub Source Change Component', function () {
             ->test(Change::class)
             ->assertSuccessful()
             ->call('checkPermissions')
-            ->assertDispatched('error', function ($event, $message) {
+            ->assertDispatched('error', function ($event, $params) {
+                $message = data_get($params, '0', '');
+
                 return str_contains($message, 'Private Key not found');
             });
+    });
+
+    test('checkPermissions stores deployments permission', function () {
+        $rsaKey = openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+        openssl_pkey_export($rsaKey, $pemKey);
+
+        $privateKey = PrivateKey::create([
+            'name' => 'GitHub App Key',
+            'private_key' => $pemKey,
+            'team_id' => $this->team->id,
+        ]);
+
+        $githubApp = GithubApp::create([
+            'name' => 'Test GitHub App',
+            'api_url' => 'https://api.github.com',
+            'html_url' => 'https://github.com',
+            'custom_user' => 'git',
+            'custom_port' => 22,
+            'app_id' => 12345,
+            'private_key_id' => $privateKey->id,
+            'team_id' => $this->team->id,
+            'is_system_wide' => false,
+        ]);
+
+        Http::preventStrayRequests();
+        Http::fake([
+            'https://api.github.com/zen' => Http::response('Keep it logically awesome.', 200, [
+                'Date' => now()->toRfc7231String(),
+            ]),
+            'https://api.github.com/app' => Http::response([
+                'permissions' => [
+                    'contents' => 'read',
+                    'metadata' => 'read',
+                    'pull_requests' => 'write',
+                    'deployments' => 'write',
+                    'administration' => 'read',
+                ],
+            ], 200),
+        ]);
+
+        Livewire::withQueryParams(['github_app_uuid' => $githubApp->uuid])
+            ->test(Change::class)
+            ->call('checkPermissions')
+            ->assertSet('deployments', 'write')
+            ->assertDispatched('success');
+
+        $githubApp->refresh();
+
+        expect($githubApp->deployments)->toBe('write');
     });
 });

--- a/tests/Feature/ModelFillableCreationTest.php
+++ b/tests/Feature/ModelFillableCreationTest.php
@@ -1051,6 +1051,7 @@ it('creates GithubApp with all fillable attributes', function () {
         'contents' => 'read',
         'metadata' => 'read',
         'pull_requests' => 'write',
+        'deployments' => 'write',
         'administration' => 'read',
     ]);
 
@@ -1062,6 +1063,7 @@ it('creates GithubApp with all fillable attributes', function () {
     expect($githubApp->client_id)->toBe('Iv1.abc123');
     expect($githubApp->team_id)->toBe($this->team->id);
     expect($githubApp->private_key_id)->toBe($this->server->private_key_id);
+    expect($githubApp->deployments)->toBe('write');
 });
 
 it('creates Subscription with all fillable attributes', function () {

--- a/tests/Unit/GithubDeploymentHelpersTest.php
+++ b/tests/Unit/GithubDeploymentHelpersTest.php
@@ -1,0 +1,124 @@
+<?php
+
+use App\Models\GithubApp;
+use App\Models\PrivateKey;
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+beforeEach(function () {
+    $team = Team::query()->create([
+        'name' => 'GitHub Deployments Team',
+        'description' => 'Team for GitHub deployment helper tests',
+        'personal_team' => false,
+        'show_boarding' => false,
+    ]);
+
+    $rsaKey = openssl_pkey_new([
+        'private_key_bits' => 2048,
+        'private_key_type' => OPENSSL_KEYTYPE_RSA,
+    ]);
+    openssl_pkey_export($rsaKey, $pemKey);
+
+    $privateKey = PrivateKey::create([
+        'name' => 'GitHub Deployments Key',
+        'private_key' => $pemKey,
+        'team_id' => $team->id,
+    ]);
+
+    $this->githubApp = GithubApp::create([
+        'name' => 'GitHub Deployments App',
+        'api_url' => 'https://api.github.com',
+        'html_url' => 'https://github.com',
+        'custom_user' => 'git',
+        'custom_port' => 22,
+        'app_id' => 12345,
+        'installation_id' => 67890,
+        'private_key_id' => $privateKey->id,
+        'team_id' => $team->id,
+        'is_system_wide' => false,
+        'deployments' => 'write',
+    ]);
+});
+
+it('detects github deployments permission from the app record', function () {
+    expect(hasGitHubDeploymentsPermission($this->githubApp))->toBeTrue();
+    expect(hasGitHubDeploymentsPermission($this->githubApp->forceFill(['deployments' => 'read'])))->toBeFalse();
+});
+
+it('creates GitHub deployments with the expected payload', function () {
+    Http::fake([
+        'https://api.github.com/zen' => Http::response('Keep it logically awesome.', 200, [
+            'Date' => now()->toRfc7231String(),
+        ]),
+        'https://api.github.com/app/installations/67890/access_tokens' => Http::response([
+            'token' => 'fake-installation-token',
+        ], 201),
+        'https://api.github.com/repos/coollabsio/coolify/deployments' => Http::response([
+            'id' => 42,
+        ], 201),
+    ]);
+
+    $deploymentId = createGitHubDeployment(
+        source: $this->githubApp,
+        repository: 'coollabsio/coolify',
+        ref: 'abc123def456',
+        environment: 'preview/pr-12',
+        description: 'Coolify preview deployment for PR #12',
+        transientEnvironment: true,
+        productionEnvironment: false,
+    );
+
+    expect($deploymentId)->toBe(42);
+
+    Http::assertSent(function (Request $request) {
+        return $request->method() === 'POST'
+            && $request->url() === 'https://api.github.com/repos/coollabsio/coolify/deployments'
+            && $request['ref'] === 'abc123def456'
+            && $request['environment'] === 'preview/pr-12'
+            && $request['auto_merge'] === false
+            && $request['required_contexts'] === []
+            && $request['transient_environment'] === true
+            && $request['production_environment'] === false;
+    });
+});
+
+it('updates GitHub deployment statuses with log and environment urls', function () {
+    Http::preventStrayRequests();
+    Http::fake([
+        'https://api.github.com/zen' => Http::response('Keep it logically awesome.', 200, [
+            'Date' => now()->toRfc7231String(),
+        ]),
+        'https://api.github.com/app/installations/67890/access_tokens' => Http::response([
+            'token' => 'fake-installation-token',
+        ], 201),
+        'https://api.github.com/repos/coollabsio/coolify/deployments/42/statuses' => Http::response([
+            'id' => 1,
+        ], 201),
+    ]);
+
+    $updated = updateGitHubDeploymentStatus(
+        source: $this->githubApp,
+        repository: 'coollabsio/coolify',
+        deploymentId: 42,
+        state: 'success',
+        description: 'Deployment finished successfully.',
+        logUrl: 'https://coolify.example/deployments/42',
+        environmentUrl: 'https://preview.example',
+    );
+
+    expect($updated)->toBeTrue();
+
+    Http::assertSent(function (Request $request) {
+        return $request->method() === 'POST'
+            && $request->url() === 'https://api.github.com/repos/coollabsio/coolify/deployments/42/statuses'
+            && $request['state'] === 'success'
+            && $request['description'] === 'Deployment finished successfully.'
+            && $request['log_url'] === 'https://coolify.example/deployments/42'
+            && $request['environment_url'] === 'https://preview.example';
+    });
+});

--- a/tests/Unit/GithubDeploymentHelpersTest.php
+++ b/tests/Unit/GithubDeploymentHelpersTest.php
@@ -50,6 +50,33 @@ it('detects github deployments permission from the app record', function () {
     expect(hasGitHubDeploymentsPermission($this->githubApp->forceFill(['deployments' => 'read'])))->toBeFalse();
 });
 
+it('uses the pull request ref for preview deployments', function () {
+    expect(determineGitHubDeploymentRef(
+        pullRequestId: 12,
+        branch: 'main',
+        commit: 'abc123def456',
+        rollback: false,
+    ))->toBe('refs/pull/12/head');
+});
+
+it('uses the branch name for non-rollback deployments', function () {
+    expect(determineGitHubDeploymentRef(
+        pullRequestId: 0,
+        branch: 'main',
+        commit: 'abc123def456',
+        rollback: false,
+    ))->toBe('main');
+});
+
+it('uses the exact commit for rollback deployments', function () {
+    expect(determineGitHubDeploymentRef(
+        pullRequestId: 0,
+        branch: 'main',
+        commit: 'abc123def456',
+        rollback: true,
+    ))->toBe('abc123def456');
+});
+
 it('creates GitHub deployments with the expected payload', function () {
     Http::fake([
         'https://api.github.com/zen' => Http::response('Keep it logically awesome.', 200, [


### PR DESCRIPTION
## Changes

- Adds GitHub Deployments API sync for GitHub App sources and stores the `deployments: write` permission.
- Creates deployment records when Coolify starts a deploy and updates them to `in_progress`, `success`, `failure`, or `error`.
- Uses the branch ref for normal deployments and `refs/pull/{pr}/head` for preview deployments so GitHub attaches preview deployments to the PR branch.
- Fixes automated GitHub App registration by using the live webhook endpoint and removing the invalid manifest callback URL.

## Issues

- Fixes #9583

## Category

- [x] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

![before-change](https://github.com/user-attachments/assets/eb6c0c7b-60cf-49ce-9cf6-4d6f587a1b63)

![deploying-after-change](https://github.com/user-attachments/assets/7e442891-cc40-4111-851a-24343cbe6d56)

![deployed-after-change](https://github.com/user-attachments/assets/6b8fc9f6-6800-47ef-a21c-bb7446a00cf5)

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: AI assistant
- How extensively: Used to refine the implementation and tests. Changes were manually reviewed and validated locally.

## Testing

- `php vendor/bin/pint --dirty --format agent`
- `php artisan test --compact tests/Unit/GithubDeploymentHelpersTest.php tests/Feature/GithubSourceChangeTest.php tests/Feature/ModelFillableCreationTest.php tests/Feature/GithubPrivateRepositoryTest.php`
- Manual: created and installed a GitHub App with `deployments: write`, verified `main` deployments in GitHub, and verified preview deployments now show the PR branch as deploying and deployed.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
