### PR TITLE
feat: add public host support for service databases

### DIFF
--- a/app/Livewire/Project/Service/Index.php
+++ b/app/Livewire/Project/Service/Index.php
@@ -158,6 +158,7 @@ class Index extends Component
         if ($toModel) {
             $this->serviceDatabase->human_name = $this->humanName;
             $this->serviceDatabase->description = $this->description;
+            $this->serviceDatabase->fqdn = ServiceDatabase::normalizePublicHost($this->fqdn);
             $this->serviceDatabase->image = $this->image;
             $this->serviceDatabase->exclude_from_status = $this->excludeFromStatus;
             $this->serviceDatabase->public_port = $this->publicPort ?: null;
@@ -167,6 +168,7 @@ class Index extends Component
         } else {
             $this->humanName = $this->serviceDatabase->human_name;
             $this->description = $this->serviceDatabase->description;
+            $this->fqdn = $this->serviceDatabase->fqdn;
             $this->image = $this->serviceDatabase->image;
             $this->excludeFromStatus = $this->serviceDatabase->exclude_from_status ?? false;
             $this->publicPort = $this->serviceDatabase->public_port;

--- a/app/Models/ServiceDatabase.php
+++ b/app/Models/ServiceDatabase.php
@@ -139,12 +139,45 @@ class ServiceDatabase extends BaseModel
     public function getServiceDatabaseUrl()
     {
         $port = $this->public_port;
+        $publicHost = $this->getPublicHost();
+
+        if (blank($port) || blank($publicHost)) {
+            return null;
+        }
+
+        return "{$publicHost}:{$port}";
+    }
+
+    public static function normalizePublicHost(?string $host): ?string
+    {
+        $normalizedHost = str($host)
+            ->trim()
+            ->replaceStart('tcp://', '')
+            ->replaceStart('udp://', '')
+            ->replaceStart('http://', '')
+            ->replaceStart('https://', '')
+            ->trim('/')
+            ->trim()
+            ->lower()
+            ->value();
+
+        return filled($normalizedHost) ? $normalizedHost : null;
+    }
+
+    public function getPublicHost(): ?string
+    {
+        $host = self::normalizePublicHost(data_get($this, 'fqdn'));
+
+        if (filled($host)) {
+            return $host;
+        }
+
         $realIp = $this->service->server->ip;
         if ($this->service->server->isLocalhost() || isDev()) {
             $realIp = base_ip();
         }
 
-        return "{$realIp}:{$port}";
+        return filled($realIp) ? $realIp : null;
     }
 
     public function team()

--- a/resources/views/livewire/project/service/index.blade.php
+++ b/resources/views/livewire/project/service/index.blade.php
@@ -233,10 +233,14 @@
                                     <x-forms.checkbox canGate="update" :canResource="$serviceDatabase" instantSave id="isPublic"
                                         label="Make it publicly available" />
                                 </div>
+                                <x-forms.input canGate="update" :canResource="$serviceDatabase" id="fqdn"
+                                    label="Host / Domain"
+                                    placeholder="db.example.com"
+                                    helper="Optional. If set, the public database address will use this host instead of the server IP. Enter only the host or domain name." />
                                 <x-forms.input type="number" canGate="update" :canResource="$serviceDatabase" placeholder="5432"
                                     disabled="{{ $serviceDatabase->is_public }}" id="publicPort" label="Public Port" />
                                 @if ($db_url_public)
-                                    <x-forms.input label="Database IP:PORT (public)"
+                                    <x-forms.input label="Database Host:PORT (public)"
                                         helper="Your credentials are available in your environment variables." type="password"
                                         readonly wire:model="db_url_public" />
                                 @endif

--- a/tests/Feature/ServiceDatabasePublicHostTest.php
+++ b/tests/Feature/ServiceDatabasePublicHostTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use App\Models\Server;
+use App\Models\Service;
+use App\Models\ServiceDatabase;
+
+function makeServiceDatabaseWithServer(array $database = [], array $server = []): ServiceDatabase
+{
+    $serverModel = new Server(array_merge([
+        'ip' => '10.0.0.8',
+        'name' => 'test-server',
+    ], $server));
+
+    $serviceModel = new Service([
+        'name' => 'test-service',
+    ]);
+    $serviceModel->setRelation('server', $serverModel);
+
+    $serviceDatabase = new ServiceDatabase(array_merge([
+        'public_port' => 5432,
+    ], $database));
+    $serviceDatabase->setRelation('service', $serviceModel);
+
+    return $serviceDatabase;
+}
+
+test('service database public url prefers configured host', function () {
+    $serviceDatabase = makeServiceDatabaseWithServer([
+        'fqdn' => 'db.example.com',
+        'public_port' => 5432,
+    ]);
+
+    expect($serviceDatabase->getPublicHost())->toBe('db.example.com')
+        ->and($serviceDatabase->getServiceDatabaseUrl())->toBe('db.example.com:5432');
+});
+
+test('service database public url falls back to server ip when host is blank', function () {
+    $serviceDatabase = makeServiceDatabaseWithServer([
+        'fqdn' => null,
+        'public_port' => 3306,
+    ], [
+        'ip' => '203.0.113.10',
+    ]);
+
+    expect($serviceDatabase->getPublicHost())->toBe('203.0.113.10')
+        ->and($serviceDatabase->getServiceDatabaseUrl())->toBe('203.0.113.10:3306');
+});
+
+test('service database host normalization strips scheme casing and trailing slash', function () {
+    $serviceDatabase = makeServiceDatabaseWithServer([
+        'fqdn' => ' HTTPS://DB.Example.COM/ ',
+        'public_port' => 27017,
+    ]);
+
+    expect(ServiceDatabase::normalizePublicHost(' HTTPS://DB.Example.COM/ '))->toBe('db.example.com')
+        ->and($serviceDatabase->getPublicHost())->toBe('db.example.com')
+        ->and($serviceDatabase->getServiceDatabaseUrl())->toBe('db.example.com:27017');
+});
+
+test('service database public url is null without a public port', function () {
+    $serviceDatabase = makeServiceDatabaseWithServer([
+        'fqdn' => 'db.example.com',
+        'public_port' => null,
+    ]);
+
+    expect($serviceDatabase->getServiceDatabaseUrl())->toBeNull();
+});


### PR DESCRIPTION
Draft PR to validate contribution path for #2377.

Summary:
- add normalized host/domain support for service databases
- prefer configured host over raw server IP for public DB URL
- add regression test for host normalization and URL generation

Notes:
- created as draft first to validate PR path
- local PHP tooling is currently unavailable in my environment, so full test/pint verification is still pending

Refs: #2377