### PR TITLE
feat: add public host support for service databases

### DIFF
--- a/app/Livewire/Project/Service/Index.php
+++ b/app/Livewire/Project/Service/Index.php
@@ -158,6 +158,7 @@ class Index extends Component
         if ($toModel) {
             $this->serviceDatabase->human_name = $this->humanName;
             $this->serviceDatabase->description = $this->description;
+            $this->serviceDatabase->fqdn = ServiceDatabase::normalizePublicHost($this->fqdn);
             $this->serviceDatabase->image = $this->image;
             $this->serviceDatabase->exclude_from_status = $this->excludeFromStatus;
             $this->serviceDatabase->public_port = $this->publicPort ?: null;
@@ -167,6 +168,7 @@ class Index extends Component
         } else {
             $this->humanName = $this->serviceDatabase->human_name;
             $this->description = $this->serviceDatabase->description;
+            $this->fqdn = $this->serviceDatabase->fqdn;
             $this->image = $this->serviceDatabase->image;
             $this->excludeFromStatus = $this->serviceDatabase->exclude_from_status ?? false;
             $this->publicPort = $this->serviceDatabase->public_port;

--- a/app/Models/ServiceDatabase.php
+++ b/app/Models/ServiceDatabase.php
@@ -139,12 +139,45 @@ class ServiceDatabase extends BaseModel
     public function getServiceDatabaseUrl()
     {
         $port = $this->public_port;
+        $publicHost = $this->getPublicHost();
+
+        if (blank($port) || blank($publicHost)) {
+            return null;
+        }
+
+        return "{$publicHost}:{$port}";
+    }
+
+    public static function normalizePublicHost(?string $host): ?string
+    {
+        $normalizedHost = str($host)
+            ->trim()
+            ->replaceStart('tcp://', '')
+            ->replaceStart('udp://', '')
+            ->replaceStart('http://', '')
+            ->replaceStart('https://', '')
+            ->trim('/')
+            ->trim()
+            ->lower()
+            ->value();
+
+        return filled($normalizedHost) ? $normalizedHost : null;
+    }
+
+    public function getPublicHost(): ?string
+    {
+        $host = self::normalizePublicHost(data_get($this, 'fqdn'));
+
+        if (filled($host)) {
+            return $host;
+        }
+
         $realIp = $this->service->server->ip;
         if ($this->service->server->isLocalhost() || isDev()) {
             $realIp = base_ip();
         }
 
-        return "{$realIp}:{$port}";
+        return filled($realIp) ? $realIp : null;
     }
 
     public function team()

--- a/resources/views/livewire/project/service/index.blade.php
+++ b/resources/views/livewire/project/service/index.blade.php
@@ -250,10 +250,14 @@
                                     <x-forms.checkbox canGate="update" :canResource="$serviceDatabase" instantSave id="isPublic"
                                         label="Make it publicly available" />
                                 </div>
+                                <x-forms.input canGate="update" :canResource="$serviceDatabase" id="fqdn"
+                                    label="Host / Domain"
+                                    placeholder="db.example.com"
+                                    helper="Optional. If set, the public database address will use this host instead of the server IP. Enter only the host or domain name." />
                                 <x-forms.input type="number" canGate="update" :canResource="$serviceDatabase" placeholder="5432"
                                     disabled="{{ $serviceDatabase->is_public }}" id="publicPort" label="Public Port" />
                                 @if ($db_url_public)
-                                    <x-forms.input label="Database IP:PORT (public)"
+                                    <x-forms.input label="Database Host:PORT (public)"
                                         helper="Your credentials are available in your environment variables." type="password"
                                         readonly wire:model="db_url_public" />
                                 @endif

--- a/tests/Feature/ServiceDatabasePublicHostTest.php
+++ b/tests/Feature/ServiceDatabasePublicHostTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use App\Models\Server;
+use App\Models\Service;
+use App\Models\ServiceDatabase;
+
+function makeServiceDatabaseWithServer(array $database = [], array $server = []): ServiceDatabase
+{
+    $serverModel = new Server(array_merge([
+        'ip' => '10.0.0.8',
+        'name' => 'test-server',
+    ], $server));
+
+    $serviceModel = new Service([
+        'name' => 'test-service',
+    ]);
+    $serviceModel->setRelation('server', $serverModel);
+
+    $serviceDatabase = new ServiceDatabase(array_merge([
+        'public_port' => 5432,
+    ], $database));
+    $serviceDatabase->setRelation('service', $serviceModel);
+
+    return $serviceDatabase;
+}
+
+test('service database public url prefers configured host', function () {
+    $serviceDatabase = makeServiceDatabaseWithServer([
+        'fqdn' => 'db.example.com',
+        'public_port' => 5432,
+    ]);
+
+    expect($serviceDatabase->getPublicHost())->toBe('db.example.com')
+        ->and($serviceDatabase->getServiceDatabaseUrl())->toBe('db.example.com:5432');
+});
+
+test('service database public url falls back to server ip when host is blank', function () {
+    $serviceDatabase = makeServiceDatabaseWithServer([
+        'fqdn' => null,
+        'public_port' => 3306,
+    ], [
+        'ip' => '203.0.113.10',
+    ]);
+
+    expect($serviceDatabase->getPublicHost())->toBe('203.0.113.10')
+        ->and($serviceDatabase->getServiceDatabaseUrl())->toBe('203.0.113.10:3306');
+});
+
+test('service database host normalization strips scheme casing and trailing slash', function () {
+    $serviceDatabase = makeServiceDatabaseWithServer([
+        'fqdn' => ' HTTPS://DB.Example.COM/ ',
+        'public_port' => 27017,
+    ]);
+
+    expect(ServiceDatabase::normalizePublicHost(' HTTPS://DB.Example.COM/ '))->toBe('db.example.com')
+        ->and($serviceDatabase->getPublicHost())->toBe('db.example.com')
+        ->and($serviceDatabase->getServiceDatabaseUrl())->toBe('db.example.com:27017');
+});
+
+test('service database public url is null without a public port', function () {
+    $serviceDatabase = makeServiceDatabaseWithServer([
+        'fqdn' => 'db.example.com',
+        'public_port' => null,
+    ]);
+
+    expect($serviceDatabase->getServiceDatabaseUrl())->toBeNull();
+});


### PR DESCRIPTION
## Changes

- wire the service database UI so a custom public host/domain can be stored
- normalize the configured host value before persistence
- prefer the configured public host over the raw server IP when generating the public database URL
- add a regression test covering host normalization and public URL generation for service databases

## Issues

- Fixes #2377
- /claim #2377
- This is a smaller service-database-focused implementation of the same general direction discussed previously in #8499.

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

- Demo video: not attached yet in this draft PR.
- I can add a short UI happy-path demo once I have a runnable local PHP environment for recording.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Hermes Agent for code drafting, diffing, and GitHub workflow automation
- How extensively: AI helped draft the patch and PR text, but the issue history, repo rules, changed files, and submission flow were manually checked before opening the PR

## Testing

- Added regression test file: `tests/Feature/ServiceDatabasePublicHostTest.php`
- I reviewed the touched UI/model flow locally and kept the patch limited to the service database path
- I could not run Pest / pint in this environment because PHP is currently unavailable on this machine

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
