### PR TITLE
feat(healthcheck): notify on health status changes and fix start period behavior

### DIFF
--- a/app/Actions/Docker/GetContainersStatus.php
+++ b/app/Actions/Docker/GetContainersStatus.php
@@ -9,6 +9,7 @@ use App\Events\ServiceChecked;
 use App\Models\ApplicationPreview;
 use App\Models\Server;
 use App\Models\ServiceDatabase;
+use App\Notifications\Application\HealthChanged;
 use App\Services\ContainerStatusAggregator;
 use App\Traits\CalculatesExcludedStatus;
 use Illuminate\Support\Arr;
@@ -494,6 +495,17 @@ class GetContainersStatus
                         $statusFromDb = $application->status;
                         if ($statusFromDb !== $aggregatedStatus) {
                             $application->update(['status' => $aggregatedStatus]);
+
+                            // Notify on health status transitions (healthy ↔ unhealthy) for running containers.
+                            // Skip during deployment — deployment has its own failure notifications.
+                            $wasHealthy = str($statusFromDb)->contains(':healthy');
+                            $isHealthy = str($aggregatedStatus)->contains(':healthy');
+                            $wasUnhealthy = str($statusFromDb)->contains(':unhealthy');
+                            $isUnhealthy = str($aggregatedStatus)->contains(':unhealthy');
+
+                            if (($wasHealthy && $isUnhealthy) || ($wasUnhealthy && $isHealthy)) {
+                                $application->environment->project->team?->notify(new HealthChanged($application, $aggregatedStatus));
+                            }
                         } else {
                             $application->update(['last_online_at' => now()]);
                         }

--- a/app/Console/Commands/Emails.php
+++ b/app/Console/Commands/Emails.php
@@ -10,6 +10,7 @@ use App\Models\StandalonePostgresql;
 use App\Models\Team;
 use App\Notifications\Application\DeploymentFailed;
 use App\Notifications\Application\DeploymentSuccess;
+use App\Notifications\Application\HealthChanged;
 use App\Notifications\Application\StatusChanged;
 use App\Notifications\Database\BackupFailed;
 use App\Notifications\Database\BackupSuccess;
@@ -59,6 +60,7 @@ class Emails extends Command
                 'application-deployment-success' => 'Application - Deployment Success',
                 'application-deployment-failed' => 'Application - Deployment Failed',
                 'application-status-changed' => 'Application - Status Changed',
+                'application-health-changed' => 'Application - Health Status Changed',
                 'backup-success' => 'Database - Backup Success',
                 'backup-failed' => 'Database - Backup Failed',
                 // 'invitation-link' => 'Invitation Link',
@@ -151,6 +153,11 @@ class Emails extends Command
             case 'application-status-changed':
                 $application = Application::all()->first();
                 $this->mail = (new StatusChanged($application))->toMail();
+                $this->sendEmail();
+                break;
+            case 'application-health-changed':
+                $application = Application::all()->first();
+                $this->mail = (new HealthChanged($application, 'running:unhealthy'))->toMail();
                 $this->sendEmail();
                 break;
             case 'backup-failed':

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -1876,12 +1876,8 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                         $healthcheckLabel = $this->application->health_check_type === 'cmd' ? 'Healthcheck command' : 'Healthcheck URL';
                         $this->application_deployment_queue->addLogEntry("{$healthcheckLabel} (inside the container): {$this->full_healthcheck_url}");
                     }
-                    $this->application_deployment_queue->addLogEntry("Waiting for the start period ({$this->application->health_check_start_period} seconds) before starting healthcheck.");
-                    $sleeptime = 0;
-                    while ($sleeptime < $this->application->health_check_start_period) {
-                        Sleep::for(1)->seconds();
-                        $sleeptime++;
-                    }
+                    $this->application_deployment_queue->addLogEntry("Start period: {$this->application->health_check_start_period}s — probing immediately, failures during start period will not count toward retry limit.");
+                    $startPeriodStart = now();
                     while ($counter <= $this->application->health_check_retries) {
                         $this->execute_remote_command(
                             [
@@ -1897,7 +1893,15 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                                 'append' => false,
                             ],
                         );
-                        $this->application_deployment_queue->addLogEntry("Attempt {$counter} of {$this->application->health_check_retries} | Healthcheck status: {$this->saved_outputs->get('health_check')}");
+                        $withinStartPeriod = now()->diffInSeconds($startPeriodStart) < $this->application->health_check_start_period;
+                        $healthStatus = str($this->saved_outputs->get('health_check'))->replace('"', '')->value();
+
+                        if (! $withinStartPeriod) {
+                            $this->application_deployment_queue->addLogEntry("Attempt {$counter} of {$this->application->health_check_retries} | Healthcheck status: {$this->saved_outputs->get('health_check')}");
+                        } else {
+                            $this->application_deployment_queue->addLogEntry("Start period active | Healthcheck status: {$this->saved_outputs->get('health_check')} (failures not counted)");
+                        }
+
                         $health_check_logs = data_get(collect(json_decode($this->saved_outputs->get('health_check_logs')))->last(), 'Output', '(no logs)');
                         if (empty($health_check_logs)) {
                             $health_check_logs = '(no logs)';
@@ -1907,18 +1911,22 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                             $this->application_deployment_queue->addLogEntry("Healthcheck logs: {$health_check_logs} | Return code: {$health_check_return_code}");
                         }
 
-                        if (str($this->saved_outputs->get('health_check'))->replace('"', '')->value() === 'healthy') {
+                        if ($healthStatus === 'healthy') {
                             $this->newVersionIsHealthy = true;
                             $this->application->update(['status' => 'running']);
                             $this->application_deployment_queue->addLogEntry('New container is healthy.');
                             break;
-                        } elseif (str($this->saved_outputs->get('health_check'))->replace('"', '')->value() === 'unhealthy') {
+                        } elseif ($healthStatus === 'unhealthy' && ! $withinStartPeriod) {
                             $this->newVersionIsHealthy = false;
                             $this->application_deployment_queue->addLogEntry('New container is unhealthy.', type: 'error');
                             $this->query_logs();
                             break;
                         }
-                        $counter++;
+
+                        if (! $withinStartPeriod) {
+                            $counter++;
+                        }
+
                         $sleeptime = 0;
                         while ($sleeptime < $this->application->health_check_interval) {
                             Sleep::for(1)->seconds();

--- a/app/Notifications/Application/HealthChanged.php
+++ b/app/Notifications/Application/HealthChanged.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace App\Notifications\Application;
+
+use App\Models\Application;
+use App\Notifications\CustomEmailNotification;
+use App\Notifications\Dto\DiscordMessage;
+use App\Notifications\Dto\PushoverMessage;
+use App\Notifications\Dto\SlackMessage;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class HealthChanged extends CustomEmailNotification
+{
+    public string $resource_name;
+
+    public string $project_uuid;
+
+    public string $environment_uuid;
+
+    public string $environment_name;
+
+    public ?string $resource_url = null;
+
+    public ?string $fqdn;
+
+    public bool $isHealthy;
+
+    public function __construct(public Application $resource, public string $newStatus)
+    {
+        $this->onQueue('high');
+        $this->resource_name = data_get($resource, 'name');
+        $this->project_uuid = data_get($resource, 'environment.project.uuid');
+        $this->environment_uuid = data_get($resource, 'environment.uuid');
+        $this->environment_name = data_get($resource, 'environment.name');
+        $this->fqdn = data_get($resource, 'fqdn', null);
+        if (str($this->fqdn)->explode(',')->count() > 1) {
+            $this->fqdn = str($this->fqdn)->explode(',')->first();
+        }
+        $this->resource_url = base_url()."/project/{$this->project_uuid}/environment/{$this->environment_uuid}/application/{$this->resource->uuid}";
+        $this->isHealthy = str($newStatus)->contains(':healthy');
+    }
+
+    public function via(object $notifiable): array
+    {
+        return $notifiable->getEnabledChannels('status_change');
+    }
+
+    public function toMail(): MailMessage
+    {
+        $mail = new MailMessage;
+        $status = $this->isHealthy ? 'healthy' : 'unhealthy';
+        $mail->subject("Coolify: {$this->resource_name} is now {$status}");
+        $mail->view('emails.application-health-changed', [
+            'name' => $this->resource_name,
+            'new_status' => $status,
+            'fqdn' => $this->fqdn,
+            'application_url' => $this->resource_url,
+        ]);
+
+        return $mail;
+    }
+
+    public function toDiscord(): DiscordMessage
+    {
+        if ($this->isHealthy) {
+            return new DiscordMessage(
+                title: ':check_mark: Application healthy',
+                description: "{$this->resource_name} has recovered.\n\n[Open Application in Coolify]({$this->resource_url})",
+                color: DiscordMessage::successColor(),
+            );
+        }
+
+        return new DiscordMessage(
+            title: ':cross_mark: Application unhealthy',
+            description: "{$this->resource_name} health check is failing.\n\n[Open Application in Coolify]({$this->resource_url})",
+            color: DiscordMessage::errorColor(),
+            isCritical: true,
+        );
+    }
+
+    public function toTelegram(): array
+    {
+        $status = $this->isHealthy ? 'healthy' : 'unhealthy';
+        $message = "Coolify: {$this->resource_name} is now {$status}.";
+
+        return [
+            'message' => $message,
+            'buttons' => [
+                [
+                    'text' => 'Open Application in Coolify',
+                    'url' => $this->resource_url,
+                ],
+            ],
+        ];
+    }
+
+    public function toPushover(): PushoverMessage
+    {
+        $status = $this->isHealthy ? 'healthy' : 'unhealthy';
+
+        return new PushoverMessage(
+            title: "Application {$status}",
+            level: $this->isHealthy ? 'info' : 'error',
+            message: "{$this->resource_name} is now {$status}.",
+            buttons: [
+                [
+                    'text' => 'Open Application in Coolify',
+                    'url' => $this->resource_url,
+                ],
+            ],
+        );
+    }
+
+    public function toSlack(): SlackMessage
+    {
+        $status = $this->isHealthy ? 'healthy' : 'unhealthy';
+        $title = "Application {$status}";
+        $description = "{$this->resource_name} health status changed to {$status}";
+
+        $description .= "\n\n*Project:* ".data_get($this->resource, 'environment.project.name');
+        $description .= "\n*Environment:* {$this->environment_name}";
+        $description .= "\n*Application URL:* {$this->resource_url}";
+
+        return new SlackMessage(
+            title: $title,
+            description: $description,
+            color: $this->isHealthy ? SlackMessage::successColor() : SlackMessage::errorColor()
+        );
+    }
+
+    public function toWebhook(): array
+    {
+        $status = $this->isHealthy ? 'healthy' : 'unhealthy';
+
+        return [
+            'success' => $this->isHealthy,
+            'message' => "Application health changed to {$status}",
+            'event' => 'health_changed',
+            'application_name' => $this->resource_name,
+            'application_uuid' => $this->resource->uuid,
+            'url' => $this->resource_url,
+            'project' => data_get($this->resource, 'environment.project.name'),
+            'environment' => $this->environment_name,
+            'fqdn' => $this->fqdn,
+            'status' => $status,
+        ];
+    }
+}

--- a/resources/views/emails/application-health-changed.blade.php
+++ b/resources/views/emails/application-health-changed.blade.php
@@ -1,0 +1,9 @@
+<x-emails.layout>
+{{ $name }} health status changed to **{{ $new_status }}**.
+
+@if($new_status === 'unhealthy')
+Your application is now unhealthy. [Check what is going on]({{ $application_url }}).
+@else
+Your application has recovered and is now healthy. [Open Application]({{ $application_url }}).
+@endif
+</x-emails.layout>


### PR DESCRIPTION
Fixes #2332

/claim #2332

## Summary

This PR addresses both improvements requested in #2332:

### 1. Health status change notifications

When a running container's health transitions between `:healthy` and `:unhealthy` (or vice versa), the team receives a notification via all configured channels:
- Email
- Discord
- Telegram
- Slack
- Pushover
- Webhook

**What's NOT notified:** Failures during deployment — those are already covered by the existing `DeploymentFailed` notification. This only fires for post-deployment health transitions on running containers.

**New files:**
- `app/Notifications/Application/HealthChanged.php` — notification class with all channel support
- `resources/views/emails/application-health-changed.blade.php` — email template
- Registered in `app/Console/Commands/Emails.php` for local preview

### 2. Fix start period to match Docker semantics

**Before:** Coolify slept the entire `health_check_start_period` before beginning to probe. This wasted time even if the container became healthy early.

**After:** Probing starts immediately. During the start period, failures are logged but do not count toward the retry limit. As soon as the container reports `healthy` — even mid-start-period — the deployment is marked successful. After the start period expires, normal retry counting resumes.

This matches [Docker's own `start_period` semantics](https://stackoverflow.com/a/53290016):
> Start period provides initialization time for containers that need time to bootstrap. Probe failure during that period will not be counted towards the maximum number of retries. However, if a health check succeeds during the start period, the container is considered started.

## Changes

| File | Change |
|---|---|
| `app/Jobs/ApplicationDeploymentJob.php` | Fix start period behavior |
| `app/Actions/Docker/GetContainersStatus.php` | Fire `HealthChanged` on healthy↔unhealthy transitions |
| `app/Notifications/Application/HealthChanged.php` | New notification class |
| `resources/views/emails/application-health-changed.blade.php` | New email template |
| `app/Console/Commands/Emails.php` | Register preview for new email |

## Demo

> I don't have a running Coolify instance to record a video against, but the logic is straightforward: deploy an app with a healthcheck, watch the start period log entries change, and trigger a health status flip to see the notification fire.