### PR TITLE
feat: allow OAuth-only self-registration when general registration is disabled

### DIFF
--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -22,7 +22,10 @@ class OauthController extends Controller
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                // Allow new user creation via OAuth when either:
+                // 1. General registration is enabled, OR
+                // 2. OAuth-only registration is explicitly enabled
+                if (! $settings->is_registration_enabled && ! $settings->is_oauth_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 
@@ -31,6 +34,7 @@ class OauthController extends Controller
                     'email' => $oauthUser->email,
                 ]);
             }
+
             Auth::login($user);
 
             return redirect('/');

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -16,6 +16,9 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $is_oauth_registration_enabled;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -41,6 +44,7 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_registration_enabled' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => ['nullable', 'string', new ValidDnsServers],
@@ -62,6 +66,7 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled ?? false;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -142,6 +147,7 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -18,6 +18,7 @@ class InstanceSettings extends Model
         'do_not_track',
         'is_auto_update_enabled',
         'is_registration_enabled',
+        'is_oauth_registration_enabled',
         'next_channel',
         'smtp_enabled',
         'smtp_from_address',
@@ -63,6 +64,7 @@ class InstanceSettings extends Model
 
         'allowed_ip_ranges' => 'array',
         'is_auto_update_enabled' => 'boolean',
+        'is_oauth_registration_enabled' => 'boolean',
         'auto_update_frequency' => 'string',
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',

--- a/database/migrations/2026_04_16_000000_add_oauth_registration_to_instance_settings.php
+++ b/database/migrations/2026_04_16_000000_add_oauth_registration_to_instance_settings.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_registration_enabled')->default(false)->after('is_registration_enabled');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn('is_oauth_registration_enabled');
+        });
+    }
+};

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -40,7 +40,13 @@
                                 confirmationLabel="Please type the confirmation text to enable registration."
                                 shortConfirmationLabel="Confirmation text" />
                         </div>
+                        <div class="md:w-96" wire:key="oauth-registration">
+                            <x-forms.checkbox instantSave id="is_oauth_registration_enabled"
+                                helper="Allow users to self-register via OAuth providers (e.g. GitHub, Google) even when general registration is disabled. Existing OAuth logins are always allowed — this only controls new account creation via OAuth."
+                                label="Allow OAuth Registration" />
+                        </div>
                     @endif
+
                     <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"
                             helper="Opt out of anonymous usage tracking. When enabled, this instance will not report to coolify.io's installation count and will not send error reports to help improve Coolify."


### PR DESCRIPTION
Fixes #8042

## Problem
When an admin disables general registration (`is_registration_enabled = false`),
users cannot create accounts via OAuth (GitHub, Google, etc.) even if the admin
wants OAuth to be the *only* allowed registration method. The current behaviour
forces a binary choice: open registration for everyone, or block it entirely.

## Solution
Add a new `is_oauth_registration_enabled` setting that allows new accounts to
be created exclusively via OAuth providers, while keeping password-based
self-registration disabled.

## Changes
- **Migration**: new `is_oauth_registration_enabled` boolean column (default: `false`)
- **`InstanceSettings` model**: added to `$fillable` and `$casts`
- **`OauthController`**: registration gate now allows OAuth signups when either flag is true
- **`Settings/Advanced` Livewire**: property, validation, mount, and save wired up
- **`advanced.blade.php`**: "Allow OAuth Registration" checkbox shown contextually (only when general registration is off)

## Behaviour Matrix
| `is_registration_enabled` | `is_oauth_registration_enabled` | Result |
|---|---|---|
| `true` | any | All registrations allowed (unchanged) |
| `false` | `false` | No self-registration (unchanged) |
| `false` | `true` | ✅ OAuth-only self-registration |

Existing OAuth users (already have accounts) can **always** log in — this only
affects new account creation.
