### PR TITLE
feat: allow OAuth-only self-registration when general registration is disabled

### DIFF
--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -22,7 +22,10 @@ class OauthController extends Controller
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                // Allow new user creation via OAuth when either:
+                // 1. General registration is enabled, OR
+                // 2. OAuth-only registration is explicitly enabled
+                if (! $settings->is_registration_enabled && ! $settings->is_oauth_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 
@@ -31,6 +34,7 @@ class OauthController extends Controller
                     'email' => $oauthUser->email,
                 ]);
             }
+
             Auth::login($user);
 
             return redirect('/');

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -16,6 +16,9 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $is_oauth_registration_enabled;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -41,6 +44,7 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_registration_enabled' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => ['nullable', 'string', new ValidDnsServers],
@@ -62,6 +66,7 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled ?? false;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -142,6 +147,7 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -18,6 +18,7 @@ class InstanceSettings extends Model
         'do_not_track',
         'is_auto_update_enabled',
         'is_registration_enabled',
+        'is_oauth_registration_enabled',
         'next_channel',
         'smtp_enabled',
         'smtp_from_address',
@@ -63,6 +64,7 @@ class InstanceSettings extends Model
 
         'allowed_ip_ranges' => 'array',
         'is_auto_update_enabled' => 'boolean',
+        'is_oauth_registration_enabled' => 'boolean',
         'auto_update_frequency' => 'string',
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',

--- a/database/migrations/2026_04_16_000000_add_oauth_registration_to_instance_settings.php
+++ b/database/migrations/2026_04_16_000000_add_oauth_registration_to_instance_settings.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_registration_enabled')->default(false)->after('is_registration_enabled');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn('is_oauth_registration_enabled');
+        });
+    }
+};

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -40,7 +40,13 @@
                                 confirmationLabel="Please type the confirmation text to enable registration."
                                 shortConfirmationLabel="Confirmation text" />
                         </div>
+                        <div class="md:w-96" wire:key="oauth-registration">
+                            <x-forms.checkbox instantSave id="is_oauth_registration_enabled"
+                                helper="Allow users to self-register via OAuth providers (e.g. GitHub, Google) even when general registration is disabled. Existing OAuth logins are always allowed — this only controls new account creation via OAuth."
+                                label="Allow OAuth Registration" />
+                        </div>
                     @endif
+
                     <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"
                             helper="Opt out of anonymous usage tracking. When enabled, this instance will not report to coolify.io's installation count and will not send error reports to help improve Coolify."


### PR DESCRIPTION
## Changes

When general registration is disabled, users could not self-register even via OAuth providers (GitHub, Google, etc). This adds a dedicated `is_oauth_registration_enabled` toggle so admins can allow OAuth-only signups while keeping password-based registration locked down.

The checkbox appears in **Settings → Advanced** only when "Registration Allowed" is turned off — so it never shows redundantly when open registration is active.

**Files changed:**
- `database/migrations/2026_04_16_000000_add_oauth_registration_to_instance_settings.php` — boolean column, default `false`
- `app/Models/InstanceSettings.php` — added to `$fillable` and `$casts`
- `app/Http/Controllers/OauthController.php` — allow OAuth user creation when `is_oauth_registration_enabled` is true
- `app/Livewire/Settings/Advanced.php` — property, validation, mount, instantSave
- `resources/views/livewire/settings/advanced.blade.php` — checkbox inside `@else` block (registration disabled state)

## Issues

- Fixes #8042

## Category

- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Tested on local instance v4.0.0-beta.474. When "Registration Allowed" is OFF, the "Allow OAuth Registration" checkbox appears below it, saves instantly, and persists on reload.

![Allow OAuth Registration checkbox](https://github.com/coollabsio/coolify/assets/oauth-registration-preview)

## AI Assistance

- [ ] AI was used

## Testing

1. Spin up dev instance, run `php artisan migrate:fresh --seed`
2. Login as `test@example.com` / `password`
3. Go to **Settings → Advanced**
4. Disable "Registration Allowed" → "Allow OAuth Registration" checkbox appears
5. Enable it → saves and persists on reload
6. OAuth callback (`/auth/{provider}/callback`) now creates new users when `is_oauth_registration_enabled = true`

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
