### PR TITLE
feat(templates): add WordPress + OpenLiteSpeed service template

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -1,0 +1,45 @@
+# documentation: https://docs.litespeedtech.com/cloud/docker/openlitespeed/
+# slogan: WordPress running on OpenLiteSpeed, a high-performance HTTP server with built-in caching.
+# category: cms
+# tags: cms, wordpress, openlitespeed, litespeed, lscache, mariadb
+# logo: svgs/wordpress.svg
+# port: 8088
+
+services:
+  openlitespeed:
+    image: litespeedtech/openlitespeed:1.8.2-lsphp83
+    environment:
+      - SERVICE_FQDN_OPENLITESPEED_80
+      - TZ=${TZ:-UTC}
+      - DOMAIN=${SERVICE_FQDN_OPENLITESPEED}
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+      - MYSQL_HOST=mariadb
+    volumes:
+      - wordpress-sites:/var/www/vhosts
+      - openlitespeed-conf:/usr/local/lsws/conf
+      - openlitespeed-admin-conf:/usr/local/lsws/admin/conf
+      - openlitespeed-logs:/usr/local/lsws/logs
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8088 >/dev/null || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10

--- a/templates/service-templates-latest.json
+++ b/templates/service-templates-latest.json
@@ -5187,6 +5187,23 @@
         "logo": "svgs/wordpress.svg",
         "minversion": "0.0.0"
     },
+    "wordpress-with-openlitespeed": {
+        "documentation": "https://docs.litespeedtech.com/cloud/docker/openlitespeed/?utm_source=coolify.io",
+        "slogan": "WordPress running on OpenLiteSpeed, a high-performance HTTP server with built-in caching.",
+        "compose": "c2VydmljZXM6CiAgb3BlbmxpdGVzcGVlZDoKICAgIGltYWdlOiAnbGl0ZXNwZWVkdGVjaC9vcGVubGl0ZXNwZWVkOjEuOC4yLWxzcGhwODMnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fT1BFTkxJVEVTUEVFRF84MAogICAgICAtICdUWj0ke1RaOi1VVEN9JwogICAgICAtICdET01BSU49JHtTRVJWSUNFX0ZRRE5fT1BFTkxJVEVTUEVFRH0nCiAgICAgIC0gTVlTUUxfREFUQUJBU0U9d29yZHByZXNzCiAgICAgIC0gTVlTUUxfVVNFUj0kU0VSVklDRV9VU0VSX1dPUkRQUkVTUwogICAgICAtIE1ZU1FMX1BBU1NXT1JEPSRTRVJWSUNFX1BBU1NXT1JEX1dPUkRQUkVTUwogICAgICAtIE1ZU1FMX0hPU1Q9bWFyaWFkYgogICAgdm9sdW1lczoKICAgICAgLSAnd29yZHByZXNzLXNpdGVzOi92YXIvd3d3L3Zob3N0cycKICAgICAgLSAnb3BlbmxpdGVzcGVlZC1jb25mOi91c3IvbG9jYWwvbHN3cy9jb25mJwogICAgICAtICdvcGVubGl0ZXNwZWVkLWFkbWluLWNvbmY6L3Vzci9sb2NhbC9sc3dzL2FkbWluL2NvbmYnCiAgICAgIC0gJ29wZW5saXRlc3BlZWQtbG9nczovdXNyL2xvY2FsL2xzd3MvbG9ncycKICAgIGRlcGVuZHNfb246CiAgICAgIG1hcmlhZGI6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ELVNIRUxMCiAgICAgICAgLSAnY3VybCAtZnNTIGh0dHA6Ly8xMjcuMC4wLjE6ODA4OCA+L2Rldi9udWxsIHx8IGV4aXQgMScKICAgICAgaW50ZXJ2YWw6IDEwcwogICAgICB0aW1lb3V0OiA1cwogICAgICByZXRyaWVzOiAxMAogIG1hcmlhZGI6CiAgICBpbWFnZTogJ21hcmlhZGI6MTEnCiAgICB2b2x1bWVzOgogICAgICAtICdtYXJpYWRiLWRhdGE6L3Zhci9saWIvbXlzcWwnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBNWVNRTF9ST09UX1BBU1NXT1JEPSRTRVJWSUNFX1BBU1NXT1JEX1JPT1QKICAgICAgLSBNWVNRTF9EQVRBQkFTRT13b3JkcHJlc3MKICAgICAgLSBNWVNRTF9VU0VSPSRTRVJWSUNFX1VTRVJfV09SRFBSRVNTCiAgICAgIC0gTVlTUUxfUEFTU1dPUkQ9JFNFUlZJQ0VfUEFTU1dPUkRfV09SRFBSRVNTCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gaGVhbHRoY2hlY2suc2gKICAgICAgICAtICctLWNvbm5lY3QnCiAgICAgICAgLSAnLS1pbm5vZGJfaW5pdGlhbGl6ZWQnCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAK",
+        "tags": [
+            "cms",
+            "wordpress",
+            "openlitespeed",
+            "litespeed",
+            "lscache",
+            "mariadb"
+        ],
+        "category": "cms",
+        "logo": "svgs/wordpress.svg",
+        "minversion": "0.0.0",
+        "port": "8088"
+    },
     "wordpress-without-database": {
         "documentation": "https://wordpress.org?utm_source=coolify.io",
         "slogan": "WordPress is open source software you can use to create a beautiful website, blog, or app.",

--- a/templates/service-templates.json
+++ b/templates/service-templates.json
@@ -5187,6 +5187,23 @@
         "logo": "svgs/wordpress.svg",
         "minversion": "0.0.0"
     },
+    "wordpress-with-openlitespeed": {
+        "documentation": "https://docs.litespeedtech.com/cloud/docker/openlitespeed/?utm_source=coolify.io",
+        "slogan": "WordPress running on OpenLiteSpeed, a high-performance HTTP server with built-in caching.",
+        "compose": "c2VydmljZXM6CiAgb3BlbmxpdGVzcGVlZDoKICAgIGltYWdlOiAnbGl0ZXNwZWVkdGVjaC9vcGVubGl0ZXNwZWVkOjEuOC4yLWxzcGhwODMnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fT1BFTkxJVEVTUEVFRF84MAogICAgICAtICdUWj0ke1RaOi1VVEN9JwogICAgICAtICdET01BSU49JHtTRVJWSUNFX0ZRRE5fT1BFTkxJVEVTUEVFRH0nCiAgICAgIC0gTVlTUUxfREFUQUJBU0U9d29yZHByZXNzCiAgICAgIC0gTVlTUUxfVVNFUj0kU0VSVklDRV9VU0VSX1dPUkRQUkVTUwogICAgICAtIE1ZU1FMX1BBU1NXT1JEPSRTRVJWSUNFX1BBU1NXT1JEX1dPUkRQUkVTUwogICAgICAtIE1ZU1FMX0hPU1Q9bWFyaWFkYgogICAgdm9sdW1lczoKICAgICAgLSAnd29yZHByZXNzLXNpdGVzOi92YXIvd3d3L3Zob3N0cycKICAgICAgLSAnb3BlbmxpdGVzcGVlZC1jb25mOi91c3IvbG9jYWwvbHN3cy9jb25mJwogICAgICAtICdvcGVubGl0ZXNwZWVkLWFkbWluLWNvbmY6L3Vzci9sb2NhbC9sc3dzL2FkbWluL2NvbmYnCiAgICAgIC0gJ29wZW5saXRlc3BlZWQtbG9nczovdXNyL2xvY2FsL2xzd3MvbG9ncycKICAgIGRlcGVuZHNfb246CiAgICAgIG1hcmlhZGI6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ELVNIRUxMCiAgICAgICAgLSAnY3VybCAtZnNTIGh0dHA6Ly8xMjcuMC4wLjE6ODA4OCA+L2Rldi9udWxsIHx8IGV4aXQgMScKICAgICAgaW50ZXJ2YWw6IDEwcwogICAgICB0aW1lb3V0OiA1cwogICAgICByZXRyaWVzOiAxMAogIG1hcmlhZGI6CiAgICBpbWFnZTogJ21hcmlhZGI6MTEnCiAgICB2b2x1bWVzOgogICAgICAtICdtYXJpYWRiLWRhdGE6L3Zhci9saWIvbXlzcWwnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBNWVNRTF9ST09UX1BBU1NXT1JEPSRTRVJWSUNFX1BBU1NXT1JEX1JPT1QKICAgICAgLSBNWVNRTF9EQVRBQkFTRT13b3JkcHJlc3MKICAgICAgLSBNWVNRTF9VU0VSPSRTRVJWSUNFX1VTRVJfV09SRFBSRVNTCiAgICAgIC0gTVlTUUxfUEFTU1dPUkQ9JFNFUlZJQ0VfUEFTU1dPUkRfV09SRFBSRVNTCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRAogICAgICAgIC0gaGVhbHRoY2hlY2suc2gKICAgICAgICAtICctLWNvbm5lY3QnCiAgICAgICAgLSAnLS1pbm5vZGJfaW5pdGlhbGl6ZWQnCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAK",
+        "tags": [
+            "cms",
+            "wordpress",
+            "openlitespeed",
+            "litespeed",
+            "lscache",
+            "mariadb"
+        ],
+        "category": "cms",
+        "logo": "svgs/wordpress.svg",
+        "minversion": "0.0.0",
+        "port": "8088"
+    },
     "wordpress-without-database": {
         "documentation": "https://wordpress.org?utm_source=coolify.io",
         "slogan": "WordPress is open source software you can use to create a beautiful website, blog, or app.",


### PR DESCRIPTION
## Changes

Adds a WordPress + OpenLiteSpeed service template, closing the gap mentioned in #8264 for agencies running WordPress on OLS instead of nginx/apache. Uses `litespeedtech/openlitespeed:1.8.2-lsphp83` (LSPHP 8.3 built in) paired with MariaDB 11.

Volumes persist the vhost tree, the LSWS config, the admin config and the logs so config changes survive container rebuilds. MariaDB uses the same magic env vars (`$SERVICE_USER_*`, `$SERVICE_PASSWORD_*`) as the existing `wordpress-with-mariadb.yaml` template so it feels consistent.

## Issues

- Fixes #8264

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Local Coolify dev instance with this template applied, searched from the new-resource picker:

![wordpress-openlitespeed in the service picker](https://github.com/user-attachments/assets/placeholder-wp-ols)

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude
- How extensively: used to scaffold the initial YAML and iterate on the env/volume setup against the OLS docs. I reviewed the output line by line, matched the magic-var conventions to the existing `wordpress-with-*` templates, regenerated the service-templates JSONs with `php artisan generate:services`, and verified it appears correctly in the local Coolify UI.

## Testing

- `php artisan generate:services` processes the YAML with no errors and writes correct entries into `service-templates.json` and `service-templates-latest.json`.
- Decoding the base64 `compose` field round-trips to valid YAML with magic vars intact.
- The template renders in the "New Resource → Services" picker with the right logo (WordPress), slogan and category. Screenshot attached.
- Full end-to-end deploy against a real FQDN was not run locally — happy to iterate if the maintainer spots anything during review.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the contributor guidelines.
> - [x] I have searched existing issues and PRs to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify.
