### PR TITLE
n8n - Expose Ports and Update to latest stable version

### DIFF
--- a/templates/compose/n8n-with-postgres-and-worker.yaml
+++ b/templates/compose/n8n-with-postgres-and-worker.yaml
@@ -7,7 +7,7 @@
 
 services:
   n8n:
-    image: n8nio/n8n:2.10.4
+    image: n8nio/n8n:2.16.1
     ports:
       - '0.0.0.0:5678:5678'
     environment:
@@ -56,7 +56,7 @@ services:
       retries: 10
 
   n8n-worker:
-    image: n8nio/n8n:2.10.4
+    image: n8nio/n8n:2.16.1
     command: worker
     environment:
       - GENERIC_TIMEZONE=${GENERIC_TIMEZONE:-UTC}
@@ -124,7 +124,7 @@ services:
       retries: 10
 
   task-runners:
-    image: n8nio/runners:2.10.4
+    image: n8nio/runners:2.16.1
     environment:
       - N8N_RUNNERS_TASK_BROKER_URI=${N8N_RUNNERS_TASK_BROKER_URI:-http://n8n-worker:5679}
       - N8N_RUNNERS_AUTH_TOKEN=$SERVICE_PASSWORD_N8N

--- a/templates/compose/n8n-with-postgres-and-worker.yaml
+++ b/templates/compose/n8n-with-postgres-and-worker.yaml
@@ -8,6 +8,8 @@
 services:
   n8n:
     image: n8nio/n8n:2.10.4
+    ports:
+      - '0.0.0.0:5678:5678'
     environment:
       - SERVICE_URL_N8N_5678
       - N8N_EDITOR_BASE_URL=${SERVICE_URL_N8N}

--- a/templates/compose/n8n-with-postgresql.yaml
+++ b/templates/compose/n8n-with-postgresql.yaml
@@ -8,6 +8,8 @@
 services:
   n8n:
     image: n8nio/n8n:2.10.2
+    ports:
+      - '0.0.0.0:5678:5678'
     environment:
       - SERVICE_URL_N8N_5678
       - N8N_EDITOR_BASE_URL=${SERVICE_URL_N8N}

--- a/templates/compose/n8n-with-postgresql.yaml
+++ b/templates/compose/n8n-with-postgresql.yaml
@@ -7,7 +7,7 @@
 
 services:
   n8n:
-    image: n8nio/n8n:2.10.2
+    image: n8nio/n8n:2.16.1
     ports:
       - '0.0.0.0:5678:5678'
     environment:
@@ -49,7 +49,7 @@ services:
       retries: 10
 
   task-runners:
-    image: n8nio/runners:2.10.2
+    image: n8nio/runners:2.16.1
     environment:
       - N8N_RUNNERS_TASK_BROKER_URI=${N8N_RUNNERS_TASK_BROKER_URI:-http://n8n:5679}
       - N8N_RUNNERS_AUTH_TOKEN=$SERVICE_PASSWORD_N8N

--- a/templates/compose/n8n.yaml
+++ b/templates/compose/n8n.yaml
@@ -7,7 +7,7 @@
 
 services:
   n8n:
-    image: n8nio/n8n:2.10.2
+    image: n8nio/n8n:2.16.1
     ports:
       - '0.0.0.0:5678:5678'
     environment:
@@ -40,7 +40,7 @@ services:
       retries: 10
 
   task-runners:
-    image: n8nio/runners:2.10.2
+    image: n8nio/runners:2.16.1
     environment:
       - N8N_RUNNERS_TASK_BROKER_URI=${N8N_RUNNERS_TASK_BROKER_URI:-http://n8n:5679}
       - N8N_RUNNERS_AUTH_TOKEN=${SERVICE_PASSWORD_N8N}

--- a/templates/compose/n8n.yaml
+++ b/templates/compose/n8n.yaml
@@ -8,6 +8,8 @@
 services:
   n8n:
     image: n8nio/n8n:2.10.2
+    ports:
+      - '0.0.0.0:5678:5678'
     environment:
       - SERVICE_URL_N8N_5678
       - N8N_EDITOR_BASE_URL=${SERVICE_URL_N8N}


### PR DESCRIPTION
## Changes

The n8n Docker compose templates did not expose the ports required to reach the Web UI. It was impossible to reach n8n although it was up and running. In particular using Cloudflared which is not part of the n8n network was a problem with the previous config. I as well updated n8n to the last available **stable** version.

-

## Issues

## Category

- [ X ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ X ] Fixing or updating existing one click service

## Preview

## AI Assistance

- [ X ] AI was NOT used to create this PR
- [ ] AI was used (please describe below)

## Testing

Re-Setup the n8n services with the new compose templates and was able to connect to it with a Cloudflare Tunnel using `http://localhost:5678` as target host in Cloudflare.

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [ X ] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [ X ] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ X ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
