### PR TITLE
Feature: Hetzner Servers - Add support for Hetzner firewalls and internal networks when creating the Server

### DIFF
--- a/app/Http/Controllers/Api/HetznerController.php
+++ b/app/Http/Controllers/Api/HetznerController.php
@@ -454,6 +454,193 @@ class HetznerController extends Controller
         }
     }
 
+    #[OA\Get(
+        summary: 'Get Hetzner Firewalls',
+        description: 'Get all existing Hetzner firewalls for the current project.',
+        path: '/hetzner/firewalls',
+        operationId: 'get-hetzner-firewalls',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Hetzner'],
+        parameters: [
+            new OA\Parameter(
+                name: 'cloud_provider_token_uuid',
+                in: 'query',
+                required: false,
+                description: 'Cloud provider token UUID. Required if cloud_provider_token_id is not provided.',
+                schema: new OA\Schema(type: 'string')
+            ),
+            new OA\Parameter(
+                name: 'cloud_provider_token_id',
+                in: 'query',
+                required: false,
+                deprecated: true,
+                description: 'Deprecated: Use cloud_provider_token_uuid instead. Cloud provider token UUID.',
+                schema: new OA\Schema(type: 'string')
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'List of Hetzner firewalls.',
+                content: [
+                    new OA\MediaType(
+                        mediaType: 'application/json',
+                        schema: new OA\Schema(
+                            type: 'array',
+                            items: new OA\Items(
+                                type: 'object',
+                                properties: [
+                                    'id' => ['type' => 'integer'],
+                                    'name' => ['type' => 'string'],
+                                ]
+                            )
+                        )
+                    ),
+                ]),
+            new OA\Response(
+                response: 401,
+                ref: '#/components/responses/401',
+            ),
+            new OA\Response(
+                response: 404,
+                ref: '#/components/responses/404',
+            ),
+        ]
+    )]
+    public function firewalls(Request $request)
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+
+        $validator = customApiValidator($request->all(), [
+            'cloud_provider_token_uuid' => 'required_without:cloud_provider_token_id|string',
+            'cloud_provider_token_id' => 'required_without:cloud_provider_token_uuid|string',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'message' => 'Validation failed.',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $tokenUuid = $this->getCloudProviderTokenUuid($request);
+        $token = CloudProviderToken::whereTeamId($teamId)
+            ->whereUuid($tokenUuid)
+            ->where('provider', 'hetzner')
+            ->first();
+
+        if (! $token) {
+            return response()->json(['message' => 'Hetzner cloud provider token not found.'], 404);
+        }
+
+        try {
+            $hetznerService = new HetznerService($token->token);
+
+            return response()->json($hetznerService->getFirewalls());
+        } catch (\Throwable $e) {
+            return response()->json(['message' => 'Failed to fetch firewalls: '.$e->getMessage()], 500);
+        }
+    }
+
+    #[OA\Get(
+        summary: 'Get Hetzner Networks',
+        description: 'Get all existing Hetzner private networks for the current project.',
+        path: '/hetzner/networks',
+        operationId: 'get-hetzner-networks',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Hetzner'],
+        parameters: [
+            new OA\Parameter(
+                name: 'cloud_provider_token_uuid',
+                in: 'query',
+                required: false,
+                description: 'Cloud provider token UUID. Required if cloud_provider_token_id is not provided.',
+                schema: new OA\Schema(type: 'string')
+            ),
+            new OA\Parameter(
+                name: 'cloud_provider_token_id',
+                in: 'query',
+                required: false,
+                deprecated: true,
+                description: 'Deprecated: Use cloud_provider_token_uuid instead. Cloud provider token UUID.',
+                schema: new OA\Schema(type: 'string')
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'List of Hetzner networks.',
+                content: [
+                    new OA\MediaType(
+                        mediaType: 'application/json',
+                        schema: new OA\Schema(
+                            type: 'array',
+                            items: new OA\Items(
+                                type: 'object',
+                                properties: [
+                                    'id' => ['type' => 'integer'],
+                                    'name' => ['type' => 'string'],
+                                    'ip_range' => ['type' => 'string'],
+                                ]
+                            )
+                        )
+                    ),
+                ]),
+            new OA\Response(
+                response: 401,
+                ref: '#/components/responses/401',
+            ),
+            new OA\Response(
+                response: 404,
+                ref: '#/components/responses/404',
+            ),
+        ]
+    )]
+    public function networks(Request $request)
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+
+        $validator = customApiValidator($request->all(), [
+            'cloud_provider_token_uuid' => 'required_without:cloud_provider_token_id|string',
+            'cloud_provider_token_id' => 'required_without:cloud_provider_token_uuid|string',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'message' => 'Validation failed.',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $tokenUuid = $this->getCloudProviderTokenUuid($request);
+        $token = CloudProviderToken::whereTeamId($teamId)
+            ->whereUuid($tokenUuid)
+            ->where('provider', 'hetzner')
+            ->first();
+
+        if (! $token) {
+            return response()->json(['message' => 'Hetzner cloud provider token not found.'], 404);
+        }
+
+        try {
+            $hetznerService = new HetznerService($token->token);
+
+            return response()->json($hetznerService->getNetworks());
+        } catch (\Throwable $e) {
+            return response()->json(['message' => 'Failed to fetch networks: '.$e->getMessage()], 500);
+        }
+    }
+
     #[OA\Post(
         summary: 'Create Hetzner Server',
         description: 'Create a new server on Hetzner and register it in Coolify.',
@@ -482,6 +669,8 @@ class HetznerController extends Controller
                         'enable_ipv4' => ['type' => 'boolean', 'example' => true, 'description' => 'Enable IPv4 (default: true)'],
                         'enable_ipv6' => ['type' => 'boolean', 'example' => true, 'description' => 'Enable IPv6 (default: true)'],
                         'hetzner_ssh_key_ids' => ['type' => 'array', 'items' => ['type' => 'integer'], 'description' => 'Additional Hetzner SSH key IDs'],
+                        'hetzner_firewall_ids' => ['type' => 'array', 'items' => ['type' => 'integer'], 'description' => 'Existing Hetzner firewall IDs to apply during server creation'],
+                        'hetzner_network_ids' => ['type' => 'array', 'items' => ['type' => 'integer'], 'description' => 'Existing Hetzner network IDs to attach during server creation'],
                         'cloud_init_script' => ['type' => 'string', 'description' => 'Cloud-init YAML script (optional)'],
                         'instant_validate' => ['type' => 'boolean', 'example' => false, 'description' => 'Validate server immediately after creation'],
                     ],
@@ -540,6 +729,8 @@ class HetznerController extends Controller
             'enable_ipv4',
             'enable_ipv6',
             'hetzner_ssh_key_ids',
+            'hetzner_firewall_ids',
+            'hetzner_network_ids',
             'cloud_init_script',
             'instant_validate',
         ];
@@ -566,6 +757,10 @@ class HetznerController extends Controller
             'enable_ipv6' => 'nullable|boolean',
             'hetzner_ssh_key_ids' => 'nullable|array',
             'hetzner_ssh_key_ids.*' => 'integer',
+            'hetzner_firewall_ids' => 'nullable|array',
+            'hetzner_firewall_ids.*' => 'integer',
+            'hetzner_network_ids' => 'nullable|array',
+            'hetzner_network_ids.*' => 'integer',
             'cloud_init_script' => ['nullable', 'string', new ValidCloudInitYaml],
             'instant_validate' => 'nullable|boolean',
         ]);
@@ -603,6 +798,12 @@ class HetznerController extends Controller
         }
         if (is_null($request->hetzner_ssh_key_ids)) {
             $request->offsetSet('hetzner_ssh_key_ids', []);
+        }
+        if (is_null($request->hetzner_firewall_ids)) {
+            $request->offsetSet('hetzner_firewall_ids', []);
+        }
+        if (is_null($request->hetzner_network_ids)) {
+            $request->offsetSet('hetzner_network_ids', []);
         }
         if (is_null($request->instant_validate)) {
             $request->offsetSet('instant_validate', false);
@@ -678,6 +879,18 @@ class HetznerController extends Controller
                     'enable_ipv6' => $request->enable_ipv6,
                 ],
             ];
+
+            $firewallIds = array_values(array_unique($request->hetzner_firewall_ids));
+            if ($firewallIds !== []) {
+                $params['firewalls'] = array_map(function (int $firewallId): array {
+                    return ['firewall' => $firewallId];
+                }, $firewallIds);
+            }
+
+            $networkIds = array_values(array_unique($request->hetzner_network_ids));
+            if ($networkIds !== []) {
+                $params['networks'] = $networkIds;
+            }
 
             // Add cloud-init script if provided
             if (! empty($request->cloud_init_script)) {

--- a/app/Livewire/Server/New/ByHetzner.php
+++ b/app/Livewire/Server/New/ByHetzner.php
@@ -46,6 +46,10 @@ class ByHetzner extends Component
 
     public array $hetznerSshKeys = [];
 
+    public array $hetznerFirewalls = [];
+
+    public array $hetznerNetworks = [];
+
     public ?string $selected_location = null;
 
     public ?int $selected_image = null;
@@ -53,6 +57,10 @@ class ByHetzner extends Component
     public ?string $selected_server_type = null;
 
     public array $selectedHetznerSshKeyIds = [];
+
+    public array $selectedHetznerFirewallIds = [];
+
+    public array $selectedHetznerNetworkIds = [];
 
     public string $server_name = '';
 
@@ -112,6 +120,9 @@ class ByHetzner extends Component
         $this->save_cloud_init_script = false;
         $this->cloud_init_script_name = null;
         $this->selected_cloud_init_script_id = null;
+        $this->selectedHetznerSshKeyIds = [];
+        $this->selectedHetznerFirewallIds = [];
+        $this->selectedHetznerNetworkIds = [];
     }
 
     public function loadTokens()
@@ -160,6 +171,10 @@ class ByHetzner extends Component
                 'private_key_id' => 'required|integer|exists:private_keys,id,team_id,'.currentTeam()->id,
                 'selectedHetznerSshKeyIds' => 'nullable|array',
                 'selectedHetznerSshKeyIds.*' => 'integer',
+                'selectedHetznerFirewallIds' => 'nullable|array',
+                'selectedHetznerFirewallIds.*' => 'integer',
+                'selectedHetznerNetworkIds' => 'nullable|array',
+                'selectedHetznerNetworkIds.*' => 'integer',
                 'enable_ipv4' => 'required|boolean',
                 'enable_ipv6' => 'required|boolean',
                 'cloud_init_script' => ['nullable', 'string', new ValidCloudInitYaml],
@@ -241,6 +256,9 @@ class ByHetzner extends Component
     private function loadHetznerData(string $token)
     {
         $this->loading_data = true;
+        $this->selectedHetznerSshKeyIds = [];
+        $this->selectedHetznerFirewallIds = [];
+        $this->selectedHetznerNetworkIds = [];
 
         try {
             $hetznerService = new HetznerService($token);
@@ -270,6 +288,14 @@ class ByHetzner extends Component
                 ->toArray();
             // Load SSH keys from Hetzner
             $this->hetznerSshKeys = $hetznerService->getSshKeys();
+            $this->hetznerFirewalls = collect($hetznerService->getFirewalls())
+                ->sortBy('name')
+                ->values()
+                ->toArray();
+            $this->hetznerNetworks = collect($hetznerService->getNetworks())
+                ->sortBy('name')
+                ->values()
+                ->toArray();
             $this->loading_data = false;
         } catch (\Throwable $e) {
             $this->loading_data = false;
@@ -345,6 +371,37 @@ class ByHetzner extends Component
         return $filtered;
     }
 
+    public function getAvailableNetworksProperty(): array
+    {
+        $attachableNetworks = collect($this->hetznerNetworks)
+            ->filter(function (array $network) {
+                return collect($network['subnets'] ?? [])->contains(function (array $subnet) {
+                    return in_array($subnet['type'] ?? null, ['cloud', 'server'], true);
+                });
+            });
+
+        if (! $this->selected_location) {
+            return $attachableNetworks->values()->toArray();
+        }
+
+        $location = collect($this->locations)->firstWhere('name', $this->selected_location);
+        $networkZone = $location['network_zone'] ?? null;
+
+        if (! $networkZone) {
+            return $attachableNetworks->values()->toArray();
+        }
+
+        return $attachableNetworks
+            ->filter(function (array $network) use ($networkZone) {
+                return collect($network['subnets'] ?? [])->contains(function (array $subnet) use ($networkZone) {
+                    return in_array($subnet['type'] ?? null, ['cloud', 'server'], true)
+                        && ($subnet['network_zone'] ?? null) === $networkZone;
+                });
+            })
+            ->values()
+            ->toArray();
+    }
+
     public function getSelectedServerPriceProperty(): ?string
     {
         if (! $this->selected_server_type) {
@@ -367,6 +424,13 @@ class ByHetzner extends Component
         // Reset server type and image when location changes
         $this->selected_server_type = null;
         $this->selected_image = null;
+
+        $this->selectedHetznerNetworkIds = array_values(array_filter(
+            $this->selectedHetznerNetworkIds,
+            function (int $selectedNetworkId): bool {
+                return collect($this->availableNetworks)->contains('id', $selectedNetworkId);
+            }
+        ));
     }
 
     public function updatedSelectedServerType($value)
@@ -453,6 +517,18 @@ class ByHetzner extends Component
                 'enable_ipv6' => $this->enable_ipv6,
             ],
         ];
+
+        $firewallIds = array_values(array_unique($this->selectedHetznerFirewallIds));
+        if ($firewallIds !== []) {
+            $params['firewalls'] = array_map(function (int $firewallId): array {
+                return ['firewall' => $firewallId];
+            }, $firewallIds);
+        }
+
+        $networkIds = array_values(array_unique($this->selectedHetznerNetworkIds));
+        if ($networkIds !== []) {
+            $params['networks'] = $networkIds;
+        }
 
         // Add cloud-init script if provided
         if (! empty($this->cloud_init_script)) {

--- a/app/Services/HetznerService.php
+++ b/app/Services/HetznerService.php
@@ -117,6 +117,16 @@ class HetznerService
         return $this->requestPaginated('get', '/ssh_keys', 'ssh_keys');
     }
 
+    public function getFirewalls(): array
+    {
+        return $this->requestPaginated('get', '/firewalls', 'firewalls');
+    }
+
+    public function getNetworks(): array
+    {
+        return $this->requestPaginated('get', '/networks', 'networks');
+    }
+
     public function uploadSshKey(string $name, string $publicKey): array
     {
         $response = $this->request('post', '/ssh_keys', [

--- a/resources/views/components/modal-input.blade.php
+++ b/resources/views/components/modal-input.blade.php
@@ -36,32 +36,34 @@
     <template x-teleport="body">
         <div x-show="modalOpen"
             x-init="$watch('modalOpen', value => { if(value) { $nextTick(() => { const firstInput = $el.querySelector('input, textarea, select'); firstInput?.focus(); }) } })"
-            class="fixed top-0 left-0 z-99 flex items-center justify-center w-screen h-screen p-4">
+            class="fixed inset-0 z-99 overflow-y-auto">
             <div x-show="modalOpen" x-transition:enter="ease-out duration-100" x-transition:enter-start="opacity-0"
                 x-transition:enter-end="opacity-100" x-transition:leave="ease-in duration-100"
                 x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0"
                 @if ($closeOutside) @click="modalOpen=false" @endif
                 class="absolute inset-0 w-full h-full bg-black/20 backdrop-blur-xs"></div>
-            <div id="{{ $modalId }}" x-show="modalOpen" x-trap.inert.noscroll="modalOpen"
-                x-transition:enter="ease-out duration-100"
-                x-transition:enter-start="opacity-0 -translate-y-2 sm:scale-95"
-                x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"
-                x-transition:leave="ease-in duration-100"
-                x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
-                x-transition:leave-end="opacity-0 -translate-y-2 sm:scale-95"
-                class="relative w-full lg:w-auto lg:min-w-2xl lg:max-w-4xl border rounded-sm drop-shadow-sm bg-white border-neutral-200 dark:bg-base dark:border-coolgray-300 flex flex-col">
-                <div class="flex items-center justify-between py-6 px-6 shrink-0">
-                    <h3 class="text-2xl font-bold">{{ $title }}</h3>
-                    <button @click="modalOpen=false"
-                        class="absolute top-0 right-0 flex items-center justify-center w-8 h-8 mt-5 mr-5 rounded-full dark:text-white hover:bg-neutral-100 dark:hover:bg-coolgray-300 outline-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coollabs dark:focus-visible:ring-warning focus-visible:ring-offset-2 dark:focus-visible:ring-offset-base">
-                        <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
-                            stroke-width="1.5" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-                        </svg>
-                    </button>
-                </div>
-                <div class="relative flex items-center justify-center w-auto px-6 pb-6">
-                    {{ $slot }}
+            <div class="relative flex min-h-full items-start justify-center p-4 sm:items-center">
+                <div id="{{ $modalId }}" x-show="modalOpen" x-trap.inert.noscroll="modalOpen"
+                    x-transition:enter="ease-out duration-100"
+                    x-transition:enter-start="opacity-0 -translate-y-2 sm:scale-95"
+                    x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"
+                    x-transition:leave="ease-in duration-100"
+                    x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
+                    x-transition:leave-end="opacity-0 -translate-y-2 sm:scale-95"
+                    class="relative flex max-h-[calc(100dvh-2rem)] w-full flex-col overflow-hidden rounded-sm border border-neutral-200 bg-white drop-shadow-sm dark:border-coolgray-300 dark:bg-base lg:w-auto lg:min-w-2xl lg:max-w-4xl">
+                    <div class="flex items-center justify-between py-6 px-6 shrink-0">
+                        <h3 class="text-2xl font-bold">{{ $title }}</h3>
+                        <button @click="modalOpen=false"
+                            class="absolute top-0 right-0 flex items-center justify-center w-8 h-8 mt-5 mr-5 rounded-full dark:text-white hover:bg-neutral-100 dark:hover:bg-coolgray-300 outline-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coollabs dark:focus-visible:ring-warning focus-visible:ring-offset-2 dark:focus-visible:ring-offset-base">
+                            <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                                stroke-width="1.5" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="relative min-h-0 flex-1 overflow-y-auto px-6 pb-6">
+                        {{ $slot }}
+                    </div>
                 </div>
             </div>
         </div>

--- a/resources/views/livewire/server/new/by-hetzner.blade.php
+++ b/resources/views/livewire/server/new/by-hetzner.blade.php
@@ -149,6 +149,37 @@
                         </x-forms.datalist>
                     </div>
 
+                    <div>
+                        <x-forms.datalist label="Firewalls (from Hetzner)" id="selectedHetznerFirewallIds"
+                            helper="Optionally apply existing Hetzner firewalls when the server is created."
+                            :multiple="true" :disabled="count($hetznerFirewalls) === 0" :placeholder="count($hetznerFirewalls) > 0
+                                ? 'Search and select firewalls...'
+                                : 'No firewalls found in Hetzner account'">
+                            @foreach ($hetznerFirewalls as $firewall)
+                                <option value="{{ $firewall['id'] }}">
+                                    {{ $firewall['name'] }}
+                                    @if (isset($firewall['rules']))
+                                        - {{ count($firewall['rules']) }} rules
+                                    @endif
+                                </option>
+                            @endforeach
+                        </x-forms.datalist>
+                    </div>
+
+                    <div>
+                        <x-forms.datalist label="Internal Networks (from Hetzner)" id="selectedHetznerNetworkIds"
+                            helper="Optionally attach one or more private networks. Networks are filtered to the selected location's network zone when possible."
+                            :multiple="true" :disabled="count($this->availableNetworks) === 0" :placeholder="count($this->availableNetworks) > 0
+                                ? 'Search and select networks...'
+                                : 'No compatible networks found'">
+                            @foreach ($this->availableNetworks as $network)
+                                <option value="{{ $network['id'] }}">
+                                    {{ $network['name'] }} - {{ $network['ip_range'] }}
+                                </option>
+                            @endforeach
+                        </x-forms.datalist>
+                    </div>
+
                     <div class="flex flex-col gap-2">
                         <label class="text-sm font-medium">Network Configuration</label>
                         <div class="flex gap-4">

--- a/routes/api.php
+++ b/routes/api.php
@@ -94,6 +94,8 @@ Route::group([
     Route::get('/hetzner/server-types', [HetznerController::class, 'serverTypes'])->middleware(['api.ability:read']);
     Route::get('/hetzner/images', [HetznerController::class, 'images'])->middleware(['api.ability:read']);
     Route::get('/hetzner/ssh-keys', [HetznerController::class, 'sshKeys'])->middleware(['api.ability:read']);
+    Route::get('/hetzner/firewalls', [HetznerController::class, 'firewalls'])->middleware(['api.ability:read']);
+    Route::get('/hetzner/networks', [HetznerController::class, 'networks'])->middleware(['api.ability:read']);
     Route::post('/servers/hetzner', [HetznerController::class, 'createServer'])->middleware(['api.ability:write']);
 
     Route::get('/resources', [ResourcesController::class, 'resources'])->middleware(['api.ability:read']);

--- a/tests/Feature/HetznerApiTest.php
+++ b/tests/Feature/HetznerApiTest.php
@@ -4,6 +4,7 @@ use App\Models\CloudProviderToken;
 use App\Models\PrivateKey;
 use App\Models\Team;
 use App\Models\User;
+use Illuminate\Http\Client\Request as HttpRequest;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 
@@ -207,6 +208,52 @@ describe('GET /api/v1/hetzner/ssh-keys', function () {
         $response->assertStatus(200);
         $response->assertJsonCount(2);
         $response->assertJsonFragment(['name' => 'my-key']);
+    });
+});
+
+describe('GET /api/v1/hetzner/firewalls', function () {
+    test('gets Hetzner firewalls', function () {
+        Http::fake([
+            'https://api.hetzner.cloud/v1/firewalls*' => Http::response([
+                'firewalls' => [
+                    ['id' => 38, 'name' => 'web-firewall', 'rules' => []],
+                    ['id' => 39, 'name' => 'ssh-firewall', 'rules' => []],
+                ],
+                'meta' => ['pagination' => ['next_page' => null]],
+            ], 200),
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->getJson('/api/v1/hetzner/firewalls?cloud_provider_token_id='.$this->hetznerToken->uuid);
+
+        $response->assertSuccessful();
+        $response->assertJsonCount(2);
+        $response->assertJsonFragment(['name' => 'web-firewall']);
+    });
+});
+
+describe('GET /api/v1/hetzner/networks', function () {
+    test('gets Hetzner networks', function () {
+        Http::fake([
+            'https://api.hetzner.cloud/v1/networks*' => Http::response([
+                'networks' => [
+                    ['id' => 456, 'name' => 'private-eu', 'ip_range' => '10.0.0.0/16', 'subnets' => []],
+                    ['id' => 457, 'name' => 'private-us', 'ip_range' => '10.1.0.0/16', 'subnets' => []],
+                ],
+                'meta' => ['pagination' => ['next_page' => null]],
+            ], 200),
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->getJson('/api/v1/hetzner/networks?cloud_provider_token_id='.$this->hetznerToken->uuid);
+
+        $response->assertSuccessful();
+        $response->assertJsonCount(2);
+        $response->assertJsonFragment(['name' => 'private-eu']);
     });
 });
 
@@ -416,6 +463,53 @@ describe('POST /api/v1/servers/hetzner', function () {
 
         $response->assertStatus(201);
         $response->assertJsonFragment(['ip' => '2001:db8::1']);
+    });
+
+    test('passes selected firewalls and networks to Hetzner server creation', function () {
+        Http::fake([
+            'https://api.hetzner.cloud/v1/ssh_keys*' => Http::response([
+                'ssh_keys' => [],
+                'meta' => ['pagination' => ['next_page' => null]],
+            ], 200),
+            'https://api.hetzner.cloud/v1/ssh_keys' => Http::response([
+                'ssh_key' => ['id' => 123],
+            ], 201),
+            'https://api.hetzner.cloud/v1/servers' => Http::response([
+                'server' => [
+                    'id' => 456,
+                    'public_net' => [
+                        'ipv4' => ['ip' => '1.2.3.4'],
+                        'ipv6' => ['ip' => '2001:db8::1'],
+                    ],
+                ],
+            ], 201),
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->postJson('/api/v1/servers/hetzner', [
+            'cloud_provider_token_id' => $this->hetznerToken->uuid,
+            'location' => 'nbg1',
+            'server_type' => 'cx11',
+            'image' => 15512617,
+            'name' => 'test-server',
+            'private_key_uuid' => $this->privateKey->uuid,
+            'hetzner_firewall_ids' => [38, 39],
+            'hetzner_network_ids' => [456, 457, 456],
+        ]);
+
+        $response->assertCreated();
+
+        Http::assertSent(function (HttpRequest $request): bool {
+            return $request->method() === 'POST'
+                && $request->url() === 'https://api.hetzner.cloud/v1/servers'
+                && $request['networks'] === [456, 457]
+                && $request['firewalls'] === [
+                    ['firewall' => 38],
+                    ['firewall' => 39],
+                ];
+        });
     });
 
     test('rejects extra fields not in allowed list', function () {

--- a/tests/Feature/HetznerServerCreationTest.php
+++ b/tests/Feature/HetznerServerCreationTest.php
@@ -1,9 +1,12 @@
 <?php
 
 use App\Livewire\Server\New\ByHetzner;
+use App\Models\CloudProviderToken;
+use App\Models\PrivateKey;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
 use Livewire\Livewire;
 
 // Note: Full Livewire integration tests require database setup
@@ -141,6 +144,15 @@ it('validates deduplication when Coolify key is also in selected keys', function
         ->and(count($sshKeys))->toBe(3);
 });
 
+it('validates network array merging removes duplicate Hetzner network ids', function () {
+    $selectedHetznerNetworkIds = [456, 789, 456];
+
+    $networkIds = array_values(array_unique($selectedHetznerNetworkIds));
+
+    expect($networkIds)->toBe([456, 789])
+        ->and(count($networkIds))->toBe(2);
+});
+
 describe('Boarding Flow Integration', function () {
     uses(RefreshDatabase::class);
 
@@ -184,5 +196,82 @@ describe('Boarding Flow Integration', function () {
 
         // Boarding should still be enabled since it wasn't created from onboarding
         expect($this->team->fresh()->show_boarding)->toBeTrue();
+    });
+});
+
+describe('Hetzner data loading', function () {
+    uses(RefreshDatabase::class);
+
+    beforeEach(function () {
+        $this->team = Team::factory()->create();
+        $this->user = User::factory()->create();
+        $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+
+        $this->actingAs($this->user);
+        session(['currentTeam' => $this->team]);
+
+        $this->hetznerToken = CloudProviderToken::factory()->create([
+            'team_id' => $this->team->id,
+            'provider' => 'hetzner',
+            'token' => 'test-hetzner-api-token',
+        ]);
+
+        PrivateKey::factory()->create([
+            'team_id' => $this->team->id,
+        ]);
+    });
+
+    test('loads firewalls and networks for the selected Hetzner token', function () {
+        Http::fake([
+            'https://api.hetzner.cloud/v1/locations*' => Http::response([
+                'locations' => [
+                    ['id' => 1, 'name' => 'nbg1', 'city' => 'Nuremberg', 'country' => 'DE', 'network_zone' => 'eu-central'],
+                ],
+                'meta' => ['pagination' => ['next_page' => null]],
+            ], 200),
+            'https://api.hetzner.cloud/v1/server_types*' => Http::response([
+                'server_types' => [
+                    ['id' => 1, 'name' => 'cx11', 'description' => 'CX11', 'locations' => [['name' => 'nbg1']], 'architecture' => 'x86'],
+                ],
+                'meta' => ['pagination' => ['next_page' => null]],
+            ], 200),
+            'https://api.hetzner.cloud/v1/images*' => Http::response([
+                'images' => [
+                    ['id' => 15512617, 'name' => 'ubuntu-24.04', 'type' => 'system', 'deprecated' => false, 'architecture' => 'x86'],
+                ],
+                'meta' => ['pagination' => ['next_page' => null]],
+            ], 200),
+            'https://api.hetzner.cloud/v1/ssh_keys*' => Http::response([
+                'ssh_keys' => [],
+                'meta' => ['pagination' => ['next_page' => null]],
+            ], 200),
+            'https://api.hetzner.cloud/v1/firewalls*' => Http::response([
+                'firewalls' => [
+                    ['id' => 38, 'name' => 'web-firewall', 'rules' => []],
+                ],
+                'meta' => ['pagination' => ['next_page' => null]],
+            ], 200),
+            'https://api.hetzner.cloud/v1/networks*' => Http::response([
+                'networks' => [
+                    [
+                        'id' => 456,
+                        'name' => 'private-eu',
+                        'ip_range' => '10.0.0.0/16',
+                        'subnets' => [
+                            ['type' => 'cloud', 'network_zone' => 'eu-central'],
+                        ],
+                    ],
+                ],
+                'meta' => ['pagination' => ['next_page' => null]],
+            ], 200),
+        ]);
+
+        $component = Livewire::test(ByHetzner::class)
+            ->set('selected_token_id', $this->hetznerToken->id)
+            ->call('nextStep')
+            ->assertSet('current_step', 2);
+
+        expect($component->get('hetznerFirewalls'))->toHaveCount(1)
+            ->and($component->get('hetznerNetworks'))->toHaveCount(1);
     });
 });


### PR DESCRIPTION
## Changes

Creating a Hetzner Server is straight forward in Coolify. Yet it lacks some essential features of the Hetzner Cloud. Primarily the ability to assign Firewalls and Internal Networks at the time of server creation. To do that you have to switch to the Hetzner console afterwards and assign them manually.
This PR introduces these two options to the Coolify Create Hetzner Server Dialog. You can select as many pre-existing firewalls and internal networks that are assigned to the Server at Hetzner when creating it.

As a little side-goodi this PR as well introduces the ability to scroll the Create Server Dialog. On my Mac M4 Pro the dialog grew bigger than the screen height with the new fields rendering it impossible to use as parts of the Dialog were outside of the viewport.

## Issues

<!-- Link related issues or discussions. If reopening a closed PR, explain why it should be reconsidered. -->

- Fixes #9618 
- Fixes #9619 

## Category

- [x] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

**Hetzner Server Create new options in Coolify:**
<img width="689" height="674" alt="Bildschirmfoto 2026-04-17 um 18 19 08" src="https://github.com/user-attachments/assets/45e738bc-cf77-4f72-8504-2b58e053e215" />

**Proof at Hetzner Console:**
<img width="600" alt="Screenshot 2026-04-17 181631" src="https://github.com/user-attachments/assets/c674d465-0f03-46f8-b7be-bc6ba1e9a77a" />
<img width="600" alt="Screenshot 2026-04-17 181717" src="https://github.com/user-attachments/assets/162d7e54-4159-4d69-94ee-1e3ab7100b92" />

**Scrollable Dialog:**
This animated GIF shows the new Hetzner Create Server Dialog on a Mac Book Pro with the ability to scroll the content of the Dialog. Tested on Chrome and Safari.
<img width="640" height="313" alt="chrome-capture-2026-04-17" src="https://github.com/user-attachments/assets/192bf21a-df6a-4be1-9a9d-9417a87d3ca1" />


## AI Assistance

<!-- AI-assisted PRs that are human reviewed are welcome, just let us know so we can review appropriately. -->

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex with GPT-5.4 "High" Reasoning on an OpenAI "Plus" paid account with exclusion of data usage enabled for trainings.
- How extensively: 
  - Codex was instructed to add the ability to select and use the Hetzner Firewall + Internal Network via API and 
  - to extend the UI based on the existing patterns for the SSH Keys. 
  - Codex was as well used to identify the issue with the missing scrolling ability and provide a fix.

All code written by AI was manually reviewed and locally tested using PHPStorm.

## Testing

**Hetzner:**
- Server -> Add -> Hetzner
- Select a valid Token for a Hetzner Cloud Project with a Firewall and Internal Networks present
- Checked for all relevant items being present in the Select in the Coolify UI
- Selected a number of both and verified they were assigned to the new Server using the Hetzner Console UI

**Scrolling Dialog:**
- Open any dialog (current "Hetzner Create Server" works fine)
- Reduce the window size manually so that the dialog is higher than the window
- Now you can scroll the content and reach even the parts outside of the viewport
- Tested with Chrome on Mac & Windows and Safari on Mac

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
