### PR TITLE
[v5.x] chore: mark v4 docker swarm support as deprecated

### DIFF
--- a/config/deprecations.php
+++ b/config/deprecations.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'swarm' => 'Docker Swarm is deprecated and will be removed in Coolify v5. Coolify v5 will be replacing Swarm with native Docker Compose replicas and our own scaling solution. Existing Swarm deployments will continue to work on v4 as-is. We do not recommend setting up new Swarm deployments for the time being.',
+];

--- a/resources/views/components/deprecated-badge.blade.php
+++ b/resources/views/components/deprecated-badge.blade.php
@@ -1,0 +1,6 @@
+<span {{ $attributes->merge(['class' => 'inline-flex items-center']) }}>
+    <span
+        class="px-2 py-0.5 text-xs font-medium leading-normal rounded-full bg-warning/15 text-warning border border-warning/30">
+        Deprecated
+    </span>
+</span>

--- a/resources/views/components/server/sidebar.blade.php
+++ b/resources/views/components/server/sidebar.blade.php
@@ -41,7 +41,7 @@
     @endif
     @if (!$server->isBuildServer() && !$server->settings->is_cloudflare_tunnel)
         <a class="sub-menu-item {{ $activeMenu === 'swarm' ? 'menu-item-active' : '' }}" {{ wireNavigate() }}
-            href="{{ route('server.swarm', ['server_uuid' => $server->uuid]) }}"><span class="menu-item-label">Swarm (experimental)</span>
+            href="{{ route('server.swarm', ['server_uuid' => $server->uuid]) }}"><span class="menu-item-label">Swarm</span>
         </a>
     @endif
     @if (!$server->isLocalhost())

--- a/resources/views/livewire/destination/index.blade.php
+++ b/resources/views/livewire/destination/index.blade.php
@@ -29,7 +29,10 @@
                     <a class="coolbox group" {{ wireNavigate() }}
                         href="{{ route('destination.show', ['destination_uuid' => data_get($destination, 'uuid')]) }}">
                         <div class="flex flex-col mx-6">
-                            <div class="box-title">{{ $destination->name }}</div>
+                            <div class="box-title">
+                                {{ $destination->name }}
+                                <x-deprecated-badge />
+                            </div>
                             <div class="box-description">server: {{ $destination->server->name }}</div>
                         </div>
                     </a>

--- a/resources/views/livewire/destination/show.blade.php
+++ b/resources/views/livewire/destination/show.blade.php
@@ -16,7 +16,9 @@
         @if ($destination->getMorphClass() === 'App\Models\StandaloneDocker')
             <div class="subtitle ">A simple Docker network.</div>
         @else
-            <div class="subtitle ">A swarm Docker network. WIP</div>
+            <div class="subtitle flex items-center gap-2">A swarm Docker network.
+                <x-deprecated-badge />
+            </div>
         @endif
         <div class="flex gap-2">
             <x-forms.input canGate="update" :canResource="$destination" id="name" label="Name" />

--- a/resources/views/livewire/project/application/configuration.blade.php
+++ b/resources/views/livewire/project/application/configuration.blade.php
@@ -14,7 +14,8 @@
                 href="{{ route('project.application.advanced', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Advanced</span></a>
             @if ($application->destination->server->isSwarm())
                 <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
-                    href="{{ route('project.application.swarm', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Swarm Configuration</span></a>
+                    href="{{ route('project.application.swarm', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Swarm</span>
+                </a>
             @endif
             <a class='sub-menu-item' {{ wireNavigate() }} wire:current.exact="menu-item-active"
                 href="{{ route('project.application.environment-variables', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Environment Variables</span></a>

--- a/resources/views/livewire/project/application/swarm.blade.php
+++ b/resources/views/livewire/project/application/swarm.blade.php
@@ -2,6 +2,7 @@
     <form wire:submit='submit' class="flex flex-col">
         <div class="flex items-center gap-2">
             <h2>Swarm Configuration</h2>
+            <x-deprecated-badge />
             @can('update', $application)
                 <x-forms.button type="submit">
                     Save
@@ -13,6 +14,9 @@
                 </x-forms.button>
             @endcan
         </div>
+        <x-callout type="warning" title="Deprecated" class="my-4">
+            {{ config('deprecations.swarm') }}
+        </x-callout>
         <div class="flex flex-col gap-2 py-4">
             <div class="flex flex-col items-end gap-2 xl:flex-row">
                 <x-forms.input id="swarmReplicas" label="Replicas" required canGate="update" :canResource="$application" />

--- a/resources/views/livewire/project/new/select.blade.php
+++ b/resources/views/livewire/project/new/select.blade.php
@@ -452,6 +452,7 @@
                         <div class="flex flex-col mx-6">
                             <div class="font-bold dark:group-hover:text-white">
                                 Swarm Docker <span class="text-xs">({{ $swarmDocker->name }})</span>
+                                <x-deprecated-badge />
                             </div>
                         </div>
                     </div>

--- a/resources/views/livewire/server/swarm.blade.php
+++ b/resources/views/livewire/server/swarm.blade.php
@@ -8,8 +8,12 @@
         <div class="w-full">
             <div>
                 <div class="flex items-center gap-2">
-                    <h2>Swarm <span class="text-xs text-neutral-500">(experimental)</span></h2>
+                    <h2>Swarm</h2>
+                    <x-deprecated-badge />
                 </div>
+                <x-callout type="warning" title="Deprecated" class="my-4">
+                    {{ config('deprecations.swarm') }}
+                </x-callout>
                 <div class="pb-4">Read the docs <a class='underline dark:text-white'
                         href='https://coolify.io/docs/knowledge-base/docker/swarm' target='_blank'>here</a>.
                 </div>


### PR DESCRIPTION
## Why?

- Coolify v4 Docker Swarm support is moving from `experimental` to `deprecated` because v5 will remove Swarm support entirely and replace it with native Docker Compose replicas and our own scaling solution. While Swarm resources will be automatically migrated to standalone Docker Compose during the v5 upgrade, marking Swarm as deprecated now gives users more then enough time to migrate existing Swarm deployments to plain Compose for the smoothest v5 upgrade experience and also helps new users avoid building their infrastructure around a feature that's being removed.
- This change also reflects the broader direction of the Swarm ecosystem. See https://www.portainer.io/blog/technical-advisory-docker-swarm for more context.
- There are also several other reasons why Docker Swarm's future looks uncertain. Just one example is that Swarm does not support the current Compose Specification and still relies on the legacy Compose file v3 format, which is no longer actively developed (see [docs](https://docs.docker.com/engine/swarm/stack-deploy/)).

## Changes

- Add a deprecated notice component
- Mark docker swarm as deprecated

### Preview

<img width="888" height="274" alt="image" src="https://github.com/user-attachments/assets/a11281c6-0dbc-496b-b8f2-8c8ae94fc024" />
