### PR TITLE
fix(server): exclude persistent resources from container prune

### DIFF
--- a/app/Actions/Server/CleanupDocker.php
+++ b/app/Actions/Server/CleanupDocker.php
@@ -48,7 +48,7 @@ class CleanupDocker
         );
 
         $commands = [
-            'docker container prune -f --filter "label=coolify.managed=true" --filter "label!=coolify.proxy=true"',
+            'docker container prune -f --filter "label=coolify.managed=true" --filter "label!=coolify.proxy=true" --filter "label!=coolify.type=database" --filter "label!=coolify.type=application" --filter "label!=coolify.type=service"',
             $imagePruneCmd,
             'docker builder prune -af',
             "docker images --filter before=$helperImageWithVersion --filter reference=$helperImage | grep $helperImage | awk '{print $3}' | xargs -r docker rmi -f",

--- a/tests/Unit/Actions/Server/CleanupDockerTest.php
+++ b/tests/Unit/Actions/Server/CleanupDockerTest.php
@@ -437,6 +437,16 @@ it('deletes all build images when retention is disabled', function () {
     expect($buildImagesToDelete->pluck('tag')->toArray())->toContain('commit1-build');
 });
 
+it('container prune excludes persistent resource types', function () {
+    $sourceFile = file_get_contents(__DIR__.'/../../../../app/Actions/Server/CleanupDocker.php');
+
+    expect($sourceFile)->toContain('label!=coolify.type=database');
+    expect($sourceFile)->toContain('label!=coolify.type=application');
+    expect($sourceFile)->toContain('label!=coolify.type=service');
+    expect($sourceFile)->toContain('label!=coolify.proxy=true');
+    expect($sourceFile)->toContain('label=coolify.managed=true');
+});
+
 it('preserves build image for currently running tag', function () {
     $images = collect([
         ['repository' => 'app-uuid', 'tag' => 'commit1', 'created_at' => '2024-01-01 10:00:00', 'image_ref' => 'app-uuid:commit1'],


### PR DESCRIPTION
## Summary

- Fixes #9582: `CleanupDocker` was pruning stopped standalone database/application/service containers during any service deletion
- Adds three exclusion filters to `docker container prune`: `label!=coolify.type=database`, `label!=coolify.type=application`, `label!=coolify.type=service`
- Prevents data loss when a persistent container is transiently stopped (OOM, crash, restart loop) while a service deletion triggers cleanup
- Adds unit test verifying all exclusion filters are present in the prune command


---

Fixes #9582