### PR TITLE
[v5.x] feat(backup): standardize v4 database backups

### DIFF
--- a/app/Http/Controllers/Api/DatabasesController.php
+++ b/app/Http/Controllers/Api/DatabasesController.php
@@ -635,7 +635,7 @@ class DatabasesController extends Controller
                         'save_s3' => ['type' => 'boolean', 'description' => 'Whether to save backups to S3', 'default' => false],
                         's3_storage_uuid' => ['type' => 'string', 'description' => 'S3 storage UUID (required if save_s3 is true)'],
                         'databases_to_backup' => ['type' => 'string', 'description' => 'Comma separated list of databases to backup'],
-                        'dump_all' => ['type' => 'boolean', 'description' => 'Whether to dump all databases', 'default' => false],
+                        'dump_all' => ['type' => 'boolean', 'description' => 'Whether to dump all databases', 'default' => true],
                         'backup_now' => ['type' => 'boolean', 'description' => 'Whether to trigger backup immediately after creation'],
                         'database_backup_retention_amount_locally' => ['type' => 'integer', 'description' => 'Number of backups to retain locally'],
                         'database_backup_retention_days_locally' => ['type' => 'integer', 'description' => 'Number of days to retain backups locally'],
@@ -786,15 +786,11 @@ class DatabasesController extends Controller
             unset($backupData['s3_storage_uuid']);
         }
 
-        // Set default databases_to_backup based on database type if not provided
-        if (! isset($backupData['databases_to_backup']) || empty($backupData['databases_to_backup'])) {
-            if ($database->type() === 'standalone-postgresql') {
-                $backupData['databases_to_backup'] = $database->postgres_db;
-            } elseif ($database->type() === 'standalone-mysql') {
-                $backupData['databases_to_backup'] = $database->mysql_database;
-            } elseif ($database->type() === 'standalone-mariadb') {
-                $backupData['databases_to_backup'] = $database->mariadb_database;
-            }
+        if (array_key_exists('dump_all', $backupData) && $backupData['dump_all'] === false && blank($backupData['databases_to_backup'] ?? null)) {
+            return response()->json([
+                'message' => 'Validation failed.',
+                'errors' => ['databases_to_backup' => ['databases_to_backup is required when dump_all is false.']],
+            ], 422);
         }
 
         // Validate databases_to_backup input
@@ -1025,6 +1021,20 @@ class DatabasesController extends Controller
                 ], 422);
             }
             unset($backupData['s3_storage_uuid']);
+        }
+
+        $effectiveDumpAll = array_key_exists('dump_all', $backupData)
+            ? $backupData['dump_all']
+            : $backupConfig->dump_all;
+        $effectiveDatabasesToBackup = array_key_exists('databases_to_backup', $backupData)
+            ? $backupData['databases_to_backup']
+            : $backupConfig->databases_to_backup;
+
+        if ($effectiveDumpAll === false && blank($effectiveDatabasesToBackup)) {
+            return response()->json([
+                'message' => 'Validation failed.',
+                'errors' => ['databases_to_backup' => ['databases_to_backup is required when dump_all is false.']],
+            ], 422);
         }
 
         // Validate databases_to_backup input

--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -262,26 +262,11 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                 $databaseType = $this->database->type();
                 $databasesToBackup = data_get($this->backup, 'databases_to_backup');
             }
-            if (filled($databasesToBackup)) {
-                if (str($databaseType)->contains('postgres')) {
-                    // Format: db1,db2,db3
-                    $databasesToBackup = explode(',', $databasesToBackup);
-                    $databasesToBackup = array_map('trim', $databasesToBackup);
-                } elseif (str($databaseType)->contains('mongo')) {
-                    // Format: db1:collection1,collection2|db2:collection3,collection4
-                    if (is_string($databasesToBackup)) {
-                        $databasesToBackup = explode('|', $databasesToBackup);
-                        $databasesToBackup = array_map('trim', $databasesToBackup);
-                    }
-                } elseif (str($databaseType)->contains('mysql')) {
-                    // Format: db1,db2,db3
-                    $databasesToBackup = explode(',', $databasesToBackup);
-                    $databasesToBackup = array_map('trim', $databasesToBackup);
-                } elseif (str($databaseType)->contains('mariadb')) {
-                    // Format: db1,db2,db3
-                    $databasesToBackup = explode(',', $databasesToBackup);
-                    $databasesToBackup = array_map('trim', $databasesToBackup);
-                }
+            if (filled($databasesToBackup) && is_string($databasesToBackup)) {
+                // MongoDB format: db1:collection1,collection2|db2:collection3,collection4
+                // All others: db1,db2,db3
+                $separator = str($databaseType)->contains('mongo') ? '|' : ',';
+                $databasesToBackup = array_map('trim', explode($separator, $databasesToBackup));
             }
             $this->backup_dir = backup_dir().'/databases/'.str($this->team->name)->slug().'-'.$this->team->id.'/'.$this->directory_name;
             if ($this->database->name === 'coolify-db') {

--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -225,7 +225,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                         }
                     }
                 } elseif (str($databaseType)->contains('mongo')) {
-                    $databasesToBackup = ['*'];
+                    $databasesToBackup = data_get($this->backup, 'databases_to_backup');
                     $this->container_name = "{$this->database->name}-$serviceUuid";
                     $this->directory_name = $serviceName.'-'.$this->container_name;
 
@@ -262,26 +262,13 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                 $databaseType = $this->database->type();
                 $databasesToBackup = data_get($this->backup, 'databases_to_backup');
             }
-            if (blank($databasesToBackup)) {
-                if (str($databaseType)->contains('postgres')) {
-                    $databasesToBackup = [$this->database->postgres_db];
-                } elseif (str($databaseType)->contains('mongo')) {
-                    $databasesToBackup = ['*'];
-                } elseif (str($databaseType)->contains('mysql')) {
-                    $databasesToBackup = [$this->database->mysql_database];
-                } elseif (str($databaseType)->contains('mariadb')) {
-                    $databasesToBackup = [$this->database->mariadb_database];
-                } else {
-                    return;
-                }
-            } else {
+            if (filled($databasesToBackup)) {
                 if (str($databaseType)->contains('postgres')) {
                     // Format: db1,db2,db3
                     $databasesToBackup = explode(',', $databasesToBackup);
                     $databasesToBackup = array_map('trim', $databasesToBackup);
                 } elseif (str($databaseType)->contains('mongo')) {
                     // Format: db1:collection1,collection2|db2:collection3,collection4
-                    // Only explode if it's a string, not if it's already an array
                     if (is_string($databasesToBackup)) {
                         $databasesToBackup = explode('|', $databasesToBackup);
                         $databasesToBackup = array_map('trim', $databasesToBackup);
@@ -294,8 +281,6 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                     // Format: db1,db2,db3
                     $databasesToBackup = explode(',', $databasesToBackup);
                     $databasesToBackup = array_map('trim', $databasesToBackup);
-                } else {
-                    return;
                 }
             }
             $this->backup_dir = backup_dir().'/databases/'.str($this->team->name)->slug().'-'.$this->team->id.'/'.$this->directory_name;
@@ -305,17 +290,12 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                 $ip = Str::slug($this->server->ip);
                 $this->backup_dir = backup_dir().'/coolify'."/coolify-db-$ip";
             }
-            foreach ($databasesToBackup as $database) {
-                // Generate unique UUID for each database backup execution
-                $attempts = 0;
-                do {
-                    $this->backup_log_uuid = (string) new Cuid2;
-                    $exists = ScheduledDatabaseBackupExecution::where('uuid', $this->backup_log_uuid)->exists();
-                    $attempts++;
-                    if ($attempts >= 3 && $exists) {
-                        throw new \Exception('Unable to generate unique UUID for backup execution after 3 attempts');
-                    }
-                } while ($exists);
+
+            $shouldCreateArchive = ! $this->backup->dump_all
+                && (str($databaseType)->contains('postgres') || str($databaseType)->contains('mongo') || str($databaseType)->contains('mysql') || str($databaseType)->contains('mariadb'));
+
+            $runBackup = function (string $database, string $loggedDatabases) use ($databaseType, $shouldCreateArchive, $databasesToBackup) {
+                $this->backup_log_uuid = (string) new Cuid2;
 
                 $size = 0;
                 $localBackupSucceeded = false;
@@ -324,68 +304,146 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                 // Step 1: Create local backup
                 try {
                     if (str($databaseType)->contains('postgres')) {
-                        $this->backup_file = "/pg-dump-$database-".Carbon::now()->timestamp.'.dmp';
-                        if ($this->backup->dump_all) {
-                            $this->backup_file = '/pg-dump-all-'.Carbon::now()->timestamp.'.gz';
-                        }
-                        $this->backup_location = $this->backup_dir.$this->backup_file;
-                        $this->backup_log = ScheduledDatabaseBackupExecution::create([
-                            'uuid' => $this->backup_log_uuid,
-                            'database_name' => $database,
-                            'filename' => $this->backup_location,
-                            'scheduled_database_backup_id' => $this->backup->id,
-                            'local_storage_deleted' => false,
-                        ]);
-                        $this->backup_standalone_postgresql($database);
-                    } elseif (str($databaseType)->contains('mongo')) {
-                        if ($database === '*') {
-                            $database = 'all';
-                            $databaseName = 'all';
+                        if ($shouldCreateArchive) {
+                            $this->backup_file = '/dbs-'.Carbon::now()->timestamp.'.tar.gz';
                         } else {
-                            if (str($database)->contains(':')) {
-                                $databaseName = str($database)->before(':');
-                            } else {
-                                $databaseName = $database;
+                            $this->backup_file = '/dumpall-'.Carbon::now()->timestamp.'.sql.gz';
+                        }
+                        $this->backup_location = $this->backup_dir.$this->backup_file;
+                        $this->backup_log = ScheduledDatabaseBackupExecution::create([
+                            'uuid' => $this->backup_log_uuid,
+                            'databases' => $loggedDatabases,
+                            'filename' => $this->backup_location,
+                            'scheduled_database_backup_id' => $this->backup->id,
+                            'local_storage_deleted' => false,
+                        ]);
+                        if ($shouldCreateArchive) {
+                            $stagingDir = '/tmp/coolify-db-backup-'.$this->backup_log_uuid;
+                            instant_remote_process(['mkdir -p '.$this->backup_dir, 'mkdir -p '.$stagingDir], $this->server, true, false, null, disableMultiplexing: true);
+
+                            try {
+                                foreach ($databasesToBackup as $databaseToBackup) {
+                                    validateShellSafePath($databaseToBackup, 'database name');
+                                    $this->backup_standalone_postgresql($databaseToBackup, $stagingDir.'/pg-dump-'.$databaseToBackup.'.dmp');
+                                }
+
+                                $escapedArchivePath = escapeshellarg($this->backup_location);
+                                $escapedStagingDir = escapeshellarg($stagingDir);
+                                instant_remote_process(["tar -czf {$escapedArchivePath} -C {$escapedStagingDir} . && rm -rf {$escapedStagingDir}"], $this->server, true, false, $this->timeout, disableMultiplexing: true);
+                            } catch (Throwable $e) {
+                                instant_remote_process(['rm -rf '.$stagingDir], $this->server, false, false, null, disableMultiplexing: true);
+
+                                throw $e;
                             }
+                        } else {
+                            $this->backup_standalone_postgresql($database);
                         }
-                        $this->backup_file = "/mongo-dump-$databaseName-".Carbon::now()->timestamp.'.tar.gz';
+                    } elseif (str($databaseType)->contains('mongo')) {
+                        if ($shouldCreateArchive) {
+                            $this->backup_file = '/dbs-'.Carbon::now()->timestamp.'.tar.gz';
+                        } else {
+                            $this->backup_file = '/dumpall-'.Carbon::now()->timestamp.'.tar.gz';
+                        }
                         $this->backup_location = $this->backup_dir.$this->backup_file;
                         $this->backup_log = ScheduledDatabaseBackupExecution::create([
                             'uuid' => $this->backup_log_uuid,
-                            'database_name' => $databaseName,
+                            'databases' => $loggedDatabases,
                             'filename' => $this->backup_location,
                             'scheduled_database_backup_id' => $this->backup->id,
                             'local_storage_deleted' => false,
                         ]);
-                        $this->backup_standalone_mongodb($database);
+                        if ($shouldCreateArchive) {
+                            $stagingDir = '/tmp/coolify-db-backup-'.$this->backup_log_uuid;
+                            instant_remote_process(['mkdir -p '.$this->backup_dir, 'mkdir -p '.$stagingDir], $this->server, true, false, null, disableMultiplexing: true);
+
+                            try {
+                                foreach ($databasesToBackup as $databaseToBackup) {
+                                    $databaseName = str($databaseToBackup)->contains(':') ? (string) str($databaseToBackup)->before(':') : $databaseToBackup;
+                                    validateShellSafePath($databaseName, 'database name');
+                                    $this->backup_standalone_mongodb($databaseToBackup, $stagingDir.'/mongo-dump-'.$databaseName.'.archive.gz');
+                                }
+
+                                $escapedArchivePath = escapeshellarg($this->backup_location);
+                                $escapedStagingDir = escapeshellarg($stagingDir);
+                                instant_remote_process(["tar -czf {$escapedArchivePath} -C {$escapedStagingDir} . && rm -rf {$escapedStagingDir}"], $this->server, true, false, $this->timeout, disableMultiplexing: true);
+                            } catch (Throwable $e) {
+                                instant_remote_process(['rm -rf '.$stagingDir], $this->server, false, false, null, disableMultiplexing: true);
+
+                                throw $e;
+                            }
+                        } else {
+                            $this->backup_standalone_mongodb($database);
+                        }
                     } elseif (str($databaseType)->contains('mysql')) {
-                        $this->backup_file = "/mysql-dump-$database-".Carbon::now()->timestamp.'.dmp';
-                        if ($this->backup->dump_all) {
-                            $this->backup_file = '/mysql-dump-all-'.Carbon::now()->timestamp.'.gz';
+                        if ($shouldCreateArchive) {
+                            $this->backup_file = '/dbs-'.Carbon::now()->timestamp.'.tar.gz';
+                        } else {
+                            $this->backup_file = '/dumpall-'.Carbon::now()->timestamp.'.sql.gz';
                         }
                         $this->backup_location = $this->backup_dir.$this->backup_file;
                         $this->backup_log = ScheduledDatabaseBackupExecution::create([
                             'uuid' => $this->backup_log_uuid,
-                            'database_name' => $database,
+                            'databases' => $loggedDatabases,
                             'filename' => $this->backup_location,
                             'scheduled_database_backup_id' => $this->backup->id,
                             'local_storage_deleted' => false,
                         ]);
-                        $this->backup_standalone_mysql($database);
+                        if ($shouldCreateArchive) {
+                            $stagingDir = '/tmp/coolify-db-backup-'.$this->backup_log_uuid;
+                            instant_remote_process(['mkdir -p '.$this->backup_dir, 'mkdir -p '.$stagingDir], $this->server, true, false, null, disableMultiplexing: true);
+
+                            try {
+                                foreach ($databasesToBackup as $databaseToBackup) {
+                                    validateShellSafePath($databaseToBackup, 'database name');
+                                    $this->backup_standalone_mysql($databaseToBackup, $stagingDir.'/mysql-dump-'.$databaseToBackup.'.sql');
+                                }
+
+                                $escapedArchivePath = escapeshellarg($this->backup_location);
+                                $escapedStagingDir = escapeshellarg($stagingDir);
+                                instant_remote_process(["tar -czf {$escapedArchivePath} -C {$escapedStagingDir} . && rm -rf {$escapedStagingDir}"], $this->server, true, false, $this->timeout, disableMultiplexing: true);
+                            } catch (Throwable $e) {
+                                instant_remote_process(['rm -rf '.$stagingDir], $this->server, false, false, null, disableMultiplexing: true);
+
+                                throw $e;
+                            }
+                        } else {
+                            $this->backup_standalone_mysql($database);
+                        }
                     } elseif (str($databaseType)->contains('mariadb')) {
-                        $this->backup_file = "/mariadb-dump-$database-".Carbon::now()->timestamp.'.dmp';
-                        if ($this->backup->dump_all) {
-                            $this->backup_file = '/mariadb-dump-all-'.Carbon::now()->timestamp.'.gz';
+                        if ($shouldCreateArchive) {
+                            $this->backup_file = '/dbs-'.Carbon::now()->timestamp.'.tar.gz';
+                        } else {
+                            $this->backup_file = '/dumpall-'.Carbon::now()->timestamp.'.sql.gz';
                         }
                         $this->backup_location = $this->backup_dir.$this->backup_file;
                         $this->backup_log = ScheduledDatabaseBackupExecution::create([
                             'uuid' => $this->backup_log_uuid,
-                            'database_name' => $database,
+                            'databases' => $loggedDatabases,
                             'filename' => $this->backup_location,
                             'scheduled_database_backup_id' => $this->backup->id,
                             'local_storage_deleted' => false,
                         ]);
-                        $this->backup_standalone_mariadb($database);
+                        if ($shouldCreateArchive) {
+                            $stagingDir = '/tmp/coolify-db-backup-'.$this->backup_log_uuid;
+                            instant_remote_process(['mkdir -p '.$this->backup_dir, 'mkdir -p '.$stagingDir], $this->server, true, false, null, disableMultiplexing: true);
+
+                            try {
+                                foreach ($databasesToBackup as $databaseToBackup) {
+                                    validateShellSafePath($databaseToBackup, 'database name');
+                                    $this->backup_standalone_mariadb($databaseToBackup, $stagingDir.'/mariadb-dump-'.$databaseToBackup.'.sql');
+                                }
+
+                                $escapedArchivePath = escapeshellarg($this->backup_location);
+                                $escapedStagingDir = escapeshellarg($stagingDir);
+                                instant_remote_process(["tar -czf {$escapedArchivePath} -C {$escapedStagingDir} . && rm -rf {$escapedStagingDir}"], $this->server, true, false, $this->timeout, disableMultiplexing: true);
+                            } catch (Throwable $e) {
+                                instant_remote_process(['rm -rf '.$stagingDir], $this->server, false, false, null, disableMultiplexing: true);
+
+                                throw $e;
+                            }
+                        } else {
+                            $this->backup_standalone_mariadb($database);
+                        }
                     } else {
                         throw new \Exception('Unsupported database type');
                     }
@@ -410,16 +468,16 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                         ]);
                     }
                     try {
-                        $this->team?->notify(new BackupFailed($this->backup, $this->database, $this->error_output ?? $this->backup_output ?? $e->getMessage(), $database));
+                        $this->team?->notify(new BackupFailed($this->backup, $this->database, $this->error_output ?? $this->backup_output ?? $e->getMessage(), $loggedDatabases));
                     } catch (Throwable $notifyException) {
                         Log::channel('scheduled-errors')->warning('Failed to send backup failure notification', [
                             'backup_id' => $this->backup->uuid,
-                            'database' => $database,
+                            'database' => $loggedDatabases,
                             'error' => $notifyException->getMessage(),
                         ]);
                     }
 
-                    continue;
+                    return;
                 }
 
                 // Step 2: Upload to S3 if enabled (independent of local backup)
@@ -461,19 +519,36 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                     // failures never affect backup status — see GitHub issue #9088)
                     try {
                         if ($s3UploadError) {
-                            $this->team->notify(new BackupSuccessWithS3Warning($this->backup, $this->database, $database, $s3UploadError));
+                            $this->team->notify(new BackupSuccessWithS3Warning($this->backup, $this->database, $loggedDatabases, $s3UploadError));
                         } else {
-                            $this->team->notify(new BackupSuccess($this->backup, $this->database, $database));
+                            $this->team->notify(new BackupSuccess($this->backup, $this->database, $loggedDatabases));
                         }
                     } catch (Throwable $e) {
                         Log::channel('scheduled-errors')->warning('Failed to send backup success notification', [
                             'backup_id' => $this->backup->uuid,
-                            'database' => $database,
+                            'database' => $loggedDatabases,
                             'error' => $e->getMessage(),
                         ]);
                     }
                 }
+
+            };
+
+            if ($this->backup->dump_all) {
+                $runBackup('all', 'all');
+            } elseif ($shouldCreateArchive) {
+                $runBackup(collect($databasesToBackup)->filter()->implode(', '), collect($databasesToBackup)->filter()->implode(', '));
+            } else {
+                foreach ($databasesToBackup as $database) {
+                    $loggedDatabases = $database;
+                    if (str($databaseType)->contains('mongo') && str($database)->contains(':')) {
+                        $loggedDatabases = (string) str($database)->before(':');
+                    }
+
+                    $runBackup($database, $loggedDatabases);
+                }
             }
+
             if ($this->backup_log && $this->backup_log->status === 'success') {
                 removeOldBackups($this->backup);
             }
@@ -491,9 +566,10 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
         }
     }
 
-    private function backup_standalone_mongodb(string $databaseWithCollections): void
+    private function backup_standalone_mongodb(string $databaseWithCollections, ?string $outputPath = null): void
     {
         try {
+            $targetPath = $outputPath ?? $this->backup_location;
             $url = $this->database->internal_db_url;
             if (blank($url)) {
                 // For service-based MongoDB, try to build URL from environment variables
@@ -510,12 +586,12 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
             }
             Log::info('MongoDB backup URL configured', ['has_url' => filled($url), 'using_env_vars' => blank($this->database->internal_db_url)]);
             $escapedUrl = escapeshellarg($url);
-            if ($databaseWithCollections === 'all') {
-                $commands[] = 'mkdir -p '.$this->backup_dir;
+            if (in_array($databaseWithCollections, ['*', 'all'], true)) {
+                $commands[] = 'mkdir -p '.dirname($targetPath);
                 if (str($this->database->image)->startsWith('mongo:4')) {
-                    $commands[] = "docker exec $this->container_name mongodump --uri=$escapedUrl --gzip --archive > $this->backup_location";
+                    $commands[] = "docker exec $this->container_name mongodump --uri=$escapedUrl --gzip --archive > $targetPath";
                 } else {
-                    $commands[] = "docker exec $this->container_name mongodump --authenticationDatabase=admin --uri=$escapedUrl --gzip --archive > $this->backup_location";
+                    $commands[] = "docker exec $this->container_name mongodump --authenticationDatabase=admin --uri=$escapedUrl --gzip --archive > $targetPath";
                 }
             } else {
                 if (str($databaseWithCollections)->contains(':')) {
@@ -525,7 +601,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                     $databaseName = $databaseWithCollections;
                     $collectionsToExclude = collect();
                 }
-                $commands[] = 'mkdir -p '.$this->backup_dir;
+                $commands[] = 'mkdir -p '.dirname($targetPath);
 
                 // Validate and escape database name to prevent command injection
                 validateShellSafePath($databaseName, 'database name');
@@ -533,9 +609,9 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
 
                 if ($collectionsToExclude->count() === 0) {
                     if (str($this->database->image)->startsWith('mongo:4')) {
-                        $commands[] = "docker exec $this->container_name mongodump --uri=$escapedUrl --gzip --archive > $this->backup_location";
+                        $commands[] = "docker exec $this->container_name mongodump --uri=$escapedUrl --db $escapedDatabaseName --gzip --archive > $targetPath";
                     } else {
-                        $commands[] = "docker exec $this->container_name mongodump --authenticationDatabase=admin --uri=$escapedUrl --db $escapedDatabaseName --gzip --archive > $this->backup_location";
+                        $commands[] = "docker exec $this->container_name mongodump --authenticationDatabase=admin --uri=$escapedUrl --db $escapedDatabaseName --gzip --archive > $targetPath";
                     }
                 } else {
                     // Validate and escape each collection name
@@ -547,9 +623,9 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                     });
 
                     if (str($this->database->image)->startsWith('mongo:4')) {
-                        $commands[] = "docker exec $this->container_name mongodump --uri=$escapedUrl --gzip --excludeCollection ".$escapedCollections->implode(' --excludeCollection ')." --archive > $this->backup_location";
+                        $commands[] = "docker exec $this->container_name mongodump --uri=$escapedUrl --db $escapedDatabaseName --gzip --excludeCollection ".$escapedCollections->implode(' --excludeCollection ')." --archive > $targetPath";
                     } else {
-                        $commands[] = "docker exec $this->container_name mongodump --authenticationDatabase=admin --uri=$escapedUrl --db $escapedDatabaseName --gzip --excludeCollection ".$escapedCollections->implode(' --excludeCollection ')." --archive > $this->backup_location";
+                        $commands[] = "docker exec $this->container_name mongodump --authenticationDatabase=admin --uri=$escapedUrl --db $escapedDatabaseName --gzip --excludeCollection ".$escapedCollections->implode(' --excludeCollection ')." --archive > $targetPath";
                     }
                 }
             }
@@ -564,22 +640,23 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
         }
     }
 
-    private function backup_standalone_postgresql(string $database): void
+    private function backup_standalone_postgresql(string $database, ?string $outputPath = null): void
     {
         try {
-            $commands[] = 'mkdir -p '.$this->backup_dir;
+            $targetPath = $outputPath ?? $this->backup_location;
+            $commands[] = 'mkdir -p '.dirname($targetPath);
             $backupCommand = 'docker exec';
             if ($this->postgres_password) {
                 $backupCommand .= ' -e PGPASSWORD='.escapeshellarg($this->postgres_password);
             }
             $escapedUsername = escapeshellarg($this->database->postgres_user);
             if ($this->backup->dump_all) {
-                $backupCommand .= " $this->container_name pg_dumpall --username $escapedUsername | gzip > $this->backup_location";
+                $backupCommand .= " $this->container_name pg_dumpall --username $escapedUsername | gzip > $targetPath";
             } else {
                 // Validate and escape database name to prevent command injection
                 validateShellSafePath($database, 'database name');
                 $escapedDatabase = escapeshellarg($database);
-                $backupCommand .= " $this->container_name pg_dump --format=custom --no-acl --no-owner --username $escapedUsername $escapedDatabase > $this->backup_location";
+                $backupCommand .= " $this->container_name pg_dump --format=custom --no-acl --no-owner --username $escapedUsername $escapedDatabase > $targetPath";
             }
 
             $commands[] = $backupCommand;
@@ -594,18 +671,19 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
         }
     }
 
-    private function backup_standalone_mysql(string $database): void
+    private function backup_standalone_mysql(string $database, ?string $outputPath = null): void
     {
         try {
-            $commands[] = 'mkdir -p '.$this->backup_dir;
+            $targetPath = $outputPath ?? $this->backup_location;
+            $commands[] = 'mkdir -p '.dirname($targetPath);
             $escapedPassword = escapeshellarg($this->database->mysql_root_password);
             if ($this->backup->dump_all) {
-                $commands[] = "docker exec $this->container_name mysqldump -u root -p$escapedPassword --all-databases --single-transaction --quick --lock-tables=false --compress | gzip > $this->backup_location";
+                $commands[] = "docker exec $this->container_name mysqldump -u root -p$escapedPassword --all-databases --single-transaction --quick --lock-tables=false | gzip > $targetPath";
             } else {
                 // Validate and escape database name to prevent command injection
                 validateShellSafePath($database, 'database name');
                 $escapedDatabase = escapeshellarg($database);
-                $commands[] = "docker exec $this->container_name mysqldump -u root -p$escapedPassword $escapedDatabase > $this->backup_location";
+                $commands[] = "docker exec $this->container_name mysqldump -u root -p$escapedPassword $escapedDatabase > $targetPath";
             }
             $this->backup_output = instant_remote_process($commands, $this->server, true, false, $this->timeout, disableMultiplexing: true);
             $this->backup_output = trim($this->backup_output);
@@ -618,18 +696,19 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
         }
     }
 
-    private function backup_standalone_mariadb(string $database): void
+    private function backup_standalone_mariadb(string $database, ?string $outputPath = null): void
     {
         try {
-            $commands[] = 'mkdir -p '.$this->backup_dir;
+            $targetPath = $outputPath ?? $this->backup_location;
+            $commands[] = 'mkdir -p '.dirname($targetPath);
             $escapedPassword = escapeshellarg($this->database->mariadb_root_password);
             if ($this->backup->dump_all) {
-                $commands[] = "docker exec $this->container_name mariadb-dump -u root -p$escapedPassword --all-databases --single-transaction --quick --lock-tables=false --compress > $this->backup_location";
+                $commands[] = "docker exec $this->container_name mariadb-dump -u root -p$escapedPassword --all-databases --single-transaction --quick --lock-tables=false | gzip > $targetPath";
             } else {
                 // Validate and escape database name to prevent command injection
                 validateShellSafePath($database, 'database name');
                 $escapedDatabase = escapeshellarg($database);
-                $commands[] = "docker exec $this->container_name mariadb-dump -u root -p$escapedPassword $escapedDatabase > $this->backup_location";
+                $commands[] = "docker exec $this->container_name mariadb-dump -u root -p$escapedPassword $escapedDatabase > $targetPath";
             }
             $this->backup_output = instant_remote_process($commands, $this->server, true, false, $this->timeout, disableMultiplexing: true);
             $this->backup_output = trim($this->backup_output);
@@ -794,7 +873,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
 
         // Notify team about permanent failure (only if backup didn't already succeed)
         if ($this->team && $log?->status !== 'success') {
-            $databaseName = $log?->database_name ?? 'unknown';
+            $databaseName = $log?->databases ?? 'unknown';
             $output = $this->backup_output ?? $exception?->getMessage() ?? 'Unknown error';
             try {
                 $this->team->notify(new BackupFailed($this->backup, $this->database, $output, $databaseName));

--- a/app/Livewire/Project/Database/BackupEdit.php
+++ b/app/Livewire/Project/Database/BackupEdit.php
@@ -69,11 +69,11 @@ class BackupEdit extends Component
     #[Validate(['nullable', 'integer'])]
     public ?int $s3StorageId = 1;
 
-    #[Validate(['nullable', 'string'])]
+    #[Validate(['nullable', 'string', 'required_if:dumpAll,false'], message: ['required_if' => 'Please make sure to specify the databases to back up when disabling "Backup All Databases".'])]
     public ?string $databasesToBackup = null;
 
     #[Validate(['required', 'boolean'])]
-    public bool $dumpAll = false;
+    public bool $dumpAll = true;
 
     #[Validate(['required', 'int', 'min:60', 'max:36000'])]
     public int|string $timeout = 3600;

--- a/app/Livewire/Project/Database/Import.php
+++ b/app/Livewire/Project/Database/Import.php
@@ -5,6 +5,15 @@ namespace App\Livewire\Project\Database;
 use App\Models\S3Storage;
 use App\Models\Server;
 use App\Models\Service;
+use App\Models\ServiceDatabase;
+use App\Models\StandaloneClickhouse;
+use App\Models\StandaloneDragonfly;
+use App\Models\StandaloneKeydb;
+use App\Models\StandaloneMariadb;
+use App\Models\StandaloneMongodb;
+use App\Models\StandaloneMysql;
+use App\Models\StandalonePostgresql;
+use App\Models\StandaloneRedis;
 use App\Support\ValidationPatterns;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Facades\Auth;
@@ -147,21 +156,27 @@ class Import extends Component
 
     public array $importCommands = [];
 
-    public bool $dumpAll = false;
+    public bool $dumpAll = true;
 
-    public string $restoreCommandText = '';
+    public bool $legacySingleDb = false;
+
+    public bool $importDatabases = false;
+
+    public string $restoreMode = 'dump_all';
+
+    public string $databasesToRestore = '';
 
     public string $customLocation = '';
 
     public ?int $activityId = null;
 
-    public string $postgresqlRestoreCommand = 'pg_restore -U $POSTGRES_USER -d ${POSTGRES_DB:-${POSTGRES_USER:-postgres}}';
+    public string $postgresqlRestoreCommand = '(gunzip -cf $tmpPath 2>/dev/null || cat $tmpPath) | psql -X -U ${POSTGRES_USER} -d ${POSTGRES_DB:-${POSTGRES_USER:-postgres}}';
 
-    public string $mysqlRestoreCommand = 'mysql -u $MYSQL_USER -p$MYSQL_PASSWORD $MYSQL_DATABASE';
+    public string $mysqlRestoreCommand = '(gunzip -cf $tmpPath 2>/dev/null || cat $tmpPath) | mysql -u root -p$MYSQL_ROOT_PASSWORD';
 
-    public string $mariadbRestoreCommand = 'mariadb -u $MARIADB_USER -p$MARIADB_PASSWORD $MARIADB_DATABASE';
+    public string $mariadbRestoreCommand = '(gunzip -cf $tmpPath 2>/dev/null || cat $tmpPath) | mariadb -u root -p$MARIADB_ROOT_PASSWORD';
 
-    public string $mongodbRestoreCommand = 'mongorestore --authenticationDatabase=admin --username $MONGO_INITDB_ROOT_USERNAME --password $MONGO_INITDB_ROOT_PASSWORD --uri mongodb://localhost:27017 --gzip --archive=';
+    public string $mongodbRestoreCommand = 'mongorestore --uri="mongodb://$MONGO_INITDB_ROOT_USERNAME:$MONGO_INITDB_ROOT_PASSWORD@localhost:27017" --gzip --archive=$tmpPath';
 
     // S3 Restore properties
     public array $availableS3Storages = [];
@@ -212,14 +227,28 @@ class Import extends Component
         $this->parameters = get_route_parameters();
         $this->getContainers();
         $this->loadAvailableS3Storages();
+        $this->updatedRestoreMode($this->restoreMode);
     }
 
-    public function updatedDumpAll($value)
+    public function updatedRestoreMode($value)
     {
+        $this->dumpAll = $value === 'dump_all';
+        $this->importDatabases = $value === 'archive';
+        $this->legacySingleDb = $value === 'legacy';
+
+        $this->updateRestoreCommands();
+    }
+
+    private function updateRestoreCommands()
+    {
+        if (! $this->dumpAll && ! $this->legacySingleDb && ! $this->importDatabases) {
+            $this->dumpAll = true;
+        }
+
         $morphClass = $this->resource->getMorphClass();
 
         // Handle ServiceDatabase by checking the database type
-        if ($morphClass === \App\Models\ServiceDatabase::class) {
+        if ($morphClass === ServiceDatabase::class) {
             $dbType = $this->resource->databaseType();
             if (str_contains($dbType, 'mysql')) {
                 $morphClass = 'mysql';
@@ -227,53 +256,88 @@ class Import extends Component
                 $morphClass = 'mariadb';
             } elseif (str_contains($dbType, 'postgres')) {
                 $morphClass = 'postgresql';
+            } elseif (str_contains($dbType, 'mongo')) {
+                $morphClass = 'mongodb';
             }
         }
 
         switch ($morphClass) {
-            case \App\Models\StandaloneMariadb::class:
+            case StandaloneMariadb::class:
             case 'mariadb':
-                if ($value === true) {
+                if ($this->dumpAll) {
                     $this->mariadbRestoreCommand = <<<'EOD'
 for pid in $(mariadb -u root -p$MARIADB_ROOT_PASSWORD -N -e "SELECT id FROM information_schema.processlist WHERE user != 'root';"); do
   mariadb -u root -p$MARIADB_ROOT_PASSWORD -e "KILL $pid" 2>/dev/null || true
 done && \
 mariadb -u root -p$MARIADB_ROOT_PASSWORD -N -e "SELECT CONCAT('DROP DATABASE IF EXISTS \`',schema_name,'\`;') FROM information_schema.schemata WHERE schema_name NOT IN ('information_schema','mysql','performance_schema','sys');" | mariadb -u root -p$MARIADB_ROOT_PASSWORD && \
-mariadb -u root -p$MARIADB_ROOT_PASSWORD -e "CREATE DATABASE IF NOT EXISTS \`${MARIADB_DATABASE:-default}\`;" && \
-(gunzip -cf $tmpPath 2>/dev/null || cat $tmpPath) | sed -e '/^CREATE DATABASE/d' -e '/^USE \`mysql\`/d' | mariadb -u root -p$MARIADB_ROOT_PASSWORD ${MARIADB_DATABASE:-default}
+(gunzip -cf $tmpPath 2>/dev/null || cat $tmpPath) | mariadb -u root -p$MARIADB_ROOT_PASSWORD
 EOD;
-                    $this->restoreCommandText = $this->mariadbRestoreCommand.' && (gunzip -cf <temp_backup_file> 2>/dev/null || cat <temp_backup_file>) | mariadb -u root -p$MARIADB_ROOT_PASSWORD ${MARIADB_DATABASE:-default}';
+                } elseif ($this->importDatabases) {
+                    $this->mariadbRestoreCommand = 'tar -xzf $tmpPath -C /tmp/coolify-restore && mariadb -u root -p$MARIADB_ROOT_PASSWORD < /tmp/coolify-restore/mariadb-dump-<database>.sql';
+                } elseif ($this->legacySingleDb) {
+                    $this->mariadbRestoreCommand = <<<'EOD'
+mariadb -u root -p$MARIADB_ROOT_PASSWORD -e "DROP DATABASE IF EXISTS \`<database>\`; CREATE DATABASE \`<database>\`;" && \
+mariadb -u root -p$MARIADB_ROOT_PASSWORD <database> < $tmpPath
+EOD;
                 } else {
-                    $this->mariadbRestoreCommand = 'mariadb -u $MARIADB_USER -p$MARIADB_PASSWORD $MARIADB_DATABASE';
+                    $this->mariadbRestoreCommand = 'mariadb -u root -p$MARIADB_ROOT_PASSWORD ${MARIADB_DATABASE:-default}';
                 }
                 break;
-            case \App\Models\StandaloneMysql::class:
+            case StandaloneMysql::class:
             case 'mysql':
-                if ($value === true) {
+                if ($this->dumpAll) {
                     $this->mysqlRestoreCommand = <<<'EOD'
 for pid in $(mysql -u root -p$MYSQL_ROOT_PASSWORD -N -e "SELECT id FROM information_schema.processlist WHERE user != 'root';"); do
   mysql -u root -p$MYSQL_ROOT_PASSWORD -e "KILL $pid" 2>/dev/null || true
 done && \
 mysql -u root -p$MYSQL_ROOT_PASSWORD -N -e "SELECT CONCAT('DROP DATABASE IF EXISTS \`',schema_name,'\`;') FROM information_schema.schemata WHERE schema_name NOT IN ('information_schema','mysql','performance_schema','sys');" | mysql -u root -p$MYSQL_ROOT_PASSWORD && \
-mysql -u root -p$MYSQL_ROOT_PASSWORD -e "CREATE DATABASE IF NOT EXISTS \`${MYSQL_DATABASE:-default}\`;" && \
-(gunzip -cf $tmpPath 2>/dev/null || cat $tmpPath) | sed -e '/^CREATE DATABASE/d' -e '/^USE \`mysql\`/d' | mysql -u root -p$MYSQL_ROOT_PASSWORD ${MYSQL_DATABASE:-default}
+(gunzip -cf $tmpPath 2>/dev/null || cat $tmpPath) | mysql -u root -p$MYSQL_ROOT_PASSWORD
 EOD;
-                    $this->restoreCommandText = $this->mysqlRestoreCommand.' && (gunzip -cf <temp_backup_file> 2>/dev/null || cat <temp_backup_file>) | mysql -u root -p$MYSQL_ROOT_PASSWORD ${MYSQL_DATABASE:-default}';
+                } elseif ($this->importDatabases) {
+                    $this->mysqlRestoreCommand = 'tar -xzf $tmpPath -C /tmp/coolify-restore && mysql -u root -p$MYSQL_ROOT_PASSWORD < /tmp/coolify-restore/mysql-dump-<database>.sql';
+                } elseif ($this->legacySingleDb) {
+                    $this->mysqlRestoreCommand = <<<'EOD'
+mysql -u root -p$MYSQL_ROOT_PASSWORD -e "DROP DATABASE IF EXISTS \`<database>\`; CREATE DATABASE \`<database>\`;" && \
+mysql -u root -p$MYSQL_ROOT_PASSWORD <database> < $tmpPath
+EOD;
                 } else {
-                    $this->mysqlRestoreCommand = 'mysql -u $MYSQL_USER -p$MYSQL_PASSWORD $MYSQL_DATABASE';
+                    $this->mysqlRestoreCommand = 'mysql -u root -p$MYSQL_ROOT_PASSWORD ${MYSQL_DATABASE:-default}';
                 }
                 break;
-            case \App\Models\StandalonePostgresql::class:
+            case StandalonePostgresql::class:
             case 'postgresql':
-                if ($value === true) {
+                if ($this->dumpAll) {
                     $this->postgresqlRestoreCommand = <<<'EOD'
-psql -U ${POSTGRES_USER} -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname IS NOT NULL AND pid <> pg_backend_pid()" && \
-psql -U ${POSTGRES_USER} -t -c "SELECT datname FROM pg_database WHERE NOT datistemplate" | xargs -I {} dropdb -U ${POSTGRES_USER} --if-exists {} && \
-createdb -U ${POSTGRES_USER} ${POSTGRES_DB:-${POSTGRES_USER:-postgres}}
+psql -U ${POSTGRES_USER} -d template1 -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname IS NOT NULL AND pid <> pg_backend_pid()" && \
+psql -U ${POSTGRES_USER} -d template1 -t -c "SELECT datname FROM pg_database WHERE NOT datistemplate" | xargs -r -I {} dropdb -U ${POSTGRES_USER} --if-exists {} && \
+createdb -U ${POSTGRES_USER} ${POSTGRES_DB:-${POSTGRES_USER:-postgres}} && \
+(gunzip -cf $tmpPath 2>/dev/null || cat $tmpPath) | psql -X -U ${POSTGRES_USER} -d ${POSTGRES_DB:-${POSTGRES_USER:-postgres}}
 EOD;
-                    $this->restoreCommandText = $this->postgresqlRestoreCommand.' && (gunzip -cf <temp_backup_file> 2>/dev/null || cat <temp_backup_file>) | psql -U ${POSTGRES_USER} -d ${POSTGRES_DB:-${POSTGRES_USER:-postgres}}';
+                } elseif ($this->importDatabases) {
+                    $this->postgresqlRestoreCommand = <<<'EOD'
+tar -xzf $tmpPath -C /tmp/coolify-restore && \
+psql -U ${POSTGRES_USER} -d template1 -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '<database>' AND pid <> pg_backend_pid()" && \
+dropdb -U ${POSTGRES_USER} --if-exists <database> && \
+createdb -U ${POSTGRES_USER} <database> && \
+pg_restore -U ${POSTGRES_USER} -d <database> /tmp/coolify-restore/pg-dump-<database>.dmp
+EOD;
+                } elseif ($this->legacySingleDb) {
+                    $this->postgresqlRestoreCommand = <<<'EOD'
+psql -U ${POSTGRES_USER} -d template1 -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '<database>' AND pid <> pg_backend_pid()" && \
+dropdb -U ${POSTGRES_USER} --if-exists <database> && \
+createdb -U ${POSTGRES_USER} <database> && \
+pg_restore -U ${POSTGRES_USER} -d <database> $tmpPath
+EOD;
                 } else {
                     $this->postgresqlRestoreCommand = 'pg_restore -U ${POSTGRES_USER} -d ${POSTGRES_DB:-${POSTGRES_USER:-postgres}}';
+                }
+                break;
+            case StandaloneMongodb::class:
+            case 'mongodb':
+                if ($this->importDatabases) {
+                    $this->mongodbRestoreCommand = 'tar -xzf $tmpPath -C /tmp/coolify-restore && for archive in /tmp/coolify-restore/mongo-dump-*; do [ -e "$archive" ] || continue; mongorestore --uri="mongodb://$MONGO_INITDB_ROOT_USERNAME:$MONGO_INITDB_ROOT_PASSWORD@localhost:27017" --drop --gzip --archive="$archive"; done && rm -rf /tmp/coolify-restore';
+                } else {
+                    $this->mongodbRestoreCommand = 'mongorestore --uri="mongodb://$MONGO_INITDB_ROOT_USERNAME:$MONGO_INITDB_ROOT_PASSWORD@localhost:27017" --drop --gzip --archive=$tmpPath';
                 }
                 break;
         }
@@ -321,7 +385,7 @@ EOD;
         $this->resourceStatus = $resource->status ?? '';
 
         // Handle ServiceDatabase server access differently
-        if ($resource->getMorphClass() === \App\Models\ServiceDatabase::class) {
+        if ($resource->getMorphClass() === ServiceDatabase::class) {
             $server = $resource->service?->server;
             if (! $server) {
                 abort(404, 'Server not found for this service database.');
@@ -359,16 +423,16 @@ EOD;
         }
 
         if (
-            $resource->getMorphClass() === \App\Models\StandaloneRedis::class ||
-            $resource->getMorphClass() === \App\Models\StandaloneKeydb::class ||
-            $resource->getMorphClass() === \App\Models\StandaloneDragonfly::class ||
-            $resource->getMorphClass() === \App\Models\StandaloneClickhouse::class
+            $resource->getMorphClass() === StandaloneRedis::class ||
+            $resource->getMorphClass() === StandaloneKeydb::class ||
+            $resource->getMorphClass() === StandaloneDragonfly::class ||
+            $resource->getMorphClass() === StandaloneClickhouse::class
         ) {
             $this->unsupported = true;
         }
 
         // Mark unsupported ServiceDatabase types (Redis, KeyDB, etc.)
-        if ($resource->getMorphClass() === \App\Models\ServiceDatabase::class) {
+        if ($resource->getMorphClass() === ServiceDatabase::class) {
             $dbType = $resource->databaseType();
             if (str_contains($dbType, 'redis') || str_contains($dbType, 'keydb') ||
                 str_contains($dbType, 'dragonfly') || str_contains($dbType, 'clickhouse')) {
@@ -664,7 +728,7 @@ EOD;
             $fullImageName = "{$helperImage}:{$latestVersion}";
 
             // Get the database destination network
-            if ($this->resource->getMorphClass() === \App\Models\ServiceDatabase::class) {
+            if ($this->resource->getMorphClass() === ServiceDatabase::class) {
                 $destinationNetwork = $this->resource->service->destination->network ?? 'coolify';
             } else {
                 $destinationNetwork = $this->resource->destination->network ?? 'coolify';
@@ -754,9 +818,10 @@ EOD;
     public function buildRestoreCommand(string $tmpPath): string
     {
         $morphClass = $this->resource->getMorphClass();
+        $databaseToRestore = null;
 
         // Handle ServiceDatabase by checking the database type
-        if ($morphClass === \App\Models\ServiceDatabase::class) {
+        if ($morphClass === ServiceDatabase::class) {
             $dbType = $this->resource->databaseType();
             if (str_contains($dbType, 'mysql')) {
                 $morphClass = 'mysql';
@@ -769,40 +834,84 @@ EOD;
             }
         }
 
+        if ($this->legacySingleDb) {
+            $databases = collect(explode(',', $this->databasesToRestore))
+                ->map(fn ($database) => trim($database))
+                ->filter();
+
+            if ($databases->count() !== 1) {
+                throw new \Exception('Please specify exactly one database to restore for a legacy backup file.');
+            }
+
+            $databaseToRestore = $databases->first();
+            validateShellSafePath($databaseToRestore, 'database name');
+        }
+
+        if ($this->importDatabases) {
+            validateDatabasesBackupInput($this->databasesToRestore);
+            $databases = collect(explode(',', $this->databasesToRestore))
+                ->map(fn ($database) => trim($database))
+                ->filter();
+
+            if ($databases->isEmpty()) {
+                throw new \Exception('Please specify at least one database to restore from the archive.');
+            }
+
+            $extractPath = '/tmp/coolify-restore';
+
+            $commands = ["rm -rf {$extractPath}", "mkdir -p {$extractPath}", "tar -xzf {$tmpPath} -C {$extractPath}"];
+
+            foreach ($databases as $database) {
+                $escapedDatabase = escapeshellarg($database);
+
+                switch ($morphClass) {
+                    case StandaloneMariadb::class:
+                    case 'mariadb':
+                        $commands[] = "for pid in \$(mariadb -u root -p\$MARIADB_ROOT_PASSWORD -N -e \"SELECT id FROM information_schema.processlist WHERE user != 'root';\"); do mariadb -u root -p\$MARIADB_ROOT_PASSWORD -e \"KILL \$pid\" 2>/dev/null || true; done";
+                        $commands[] = "mariadb -u root -p\$MARIADB_ROOT_PASSWORD -e \"DROP DATABASE IF EXISTS \\`{$database}\\`; CREATE DATABASE \\`{$database}\\`;\"";
+                        $commands[] = "mariadb -u root -p\$MARIADB_ROOT_PASSWORD {$escapedDatabase} < {$extractPath}/mariadb-dump-{$database}.sql";
+                        break;
+                    case StandaloneMysql::class:
+                    case 'mysql':
+                        $commands[] = "for pid in \$(mysql -u root -p\$MYSQL_ROOT_PASSWORD -N -e \"SELECT id FROM information_schema.processlist WHERE user != 'root';\"); do mysql -u root -p\$MYSQL_ROOT_PASSWORD -e \"KILL \$pid\" 2>/dev/null || true; done";
+                        $commands[] = "mysql -u root -p\$MYSQL_ROOT_PASSWORD -e \"DROP DATABASE IF EXISTS \\`{$database}\\`; CREATE DATABASE \\`{$database}\\`;\"";
+                        $commands[] = "mysql -u root -p\$MYSQL_ROOT_PASSWORD {$escapedDatabase} < {$extractPath}/mysql-dump-{$database}.sql";
+                        break;
+                    case StandalonePostgresql::class:
+                    case 'postgresql':
+                        $commands[] = "psql -U \${POSTGRES_USER} -d template1 -c \"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = {$escapedDatabase} AND pid <> pg_backend_pid()\"";
+                        $commands[] = "dropdb -U \${POSTGRES_USER} --if-exists {$escapedDatabase}";
+                        $commands[] = "createdb -U \${POSTGRES_USER} {$escapedDatabase}";
+                        $commands[] = "pg_restore -U \${POSTGRES_USER} -d {$escapedDatabase} {$extractPath}/pg-dump-{$database}.dmp";
+                        break;
+                    case StandaloneMongodb::class:
+                    case 'mongodb':
+                        $commands[] = "mongorestore --uri=\"mongodb://\$MONGO_INITDB_ROOT_USERNAME:\$MONGO_INITDB_ROOT_PASSWORD@localhost:27017\" --drop --gzip --archive={$extractPath}/mongo-dump-{$database}.archive.gz";
+                        break;
+                }
+            }
+
+            $commands[] = "rm -rf {$extractPath}";
+
+            return implode(' && ', $commands);
+        }
+
         switch ($morphClass) {
-            case \App\Models\StandaloneMariadb::class:
+            case StandaloneMariadb::class:
             case 'mariadb':
-                $restoreCommand = $this->mariadbRestoreCommand;
-                if ($this->dumpAll) {
-                    $restoreCommand .= " && (gunzip -cf {$tmpPath} 2>/dev/null || cat {$tmpPath}) | mariadb -u root -p\$MARIADB_ROOT_PASSWORD \${MARIADB_DATABASE:-default}";
-                } else {
-                    $restoreCommand .= " < {$tmpPath}";
-                }
+                $restoreCommand = str_replace(['$tmpPath', '<database>'], [$tmpPath, $databaseToRestore ?? '<database>'], $this->mariadbRestoreCommand);
                 break;
-            case \App\Models\StandaloneMysql::class:
+            case StandaloneMysql::class:
             case 'mysql':
-                $restoreCommand = $this->mysqlRestoreCommand;
-                if ($this->dumpAll) {
-                    $restoreCommand .= " && (gunzip -cf {$tmpPath} 2>/dev/null || cat {$tmpPath}) | mysql -u root -p\$MYSQL_ROOT_PASSWORD \${MYSQL_DATABASE:-default}";
-                } else {
-                    $restoreCommand .= " < {$tmpPath}";
-                }
+                $restoreCommand = str_replace(['$tmpPath', '<database>'], [$tmpPath, $databaseToRestore ?? '<database>'], $this->mysqlRestoreCommand);
                 break;
-            case \App\Models\StandalonePostgresql::class:
+            case StandalonePostgresql::class:
             case 'postgresql':
-                $restoreCommand = $this->postgresqlRestoreCommand;
-                if ($this->dumpAll) {
-                    $restoreCommand .= " && (gunzip -cf {$tmpPath} 2>/dev/null || cat {$tmpPath}) | psql -U \${POSTGRES_USER} -d \${POSTGRES_DB:-\${POSTGRES_USER:-postgres}}";
-                } else {
-                    $restoreCommand .= " {$tmpPath}";
-                }
+                $restoreCommand = str_replace(['$tmpPath', '<database>'], [$tmpPath, $databaseToRestore ?? '<database>'], $this->postgresqlRestoreCommand);
                 break;
-            case \App\Models\StandaloneMongodb::class:
+            case StandaloneMongodb::class:
             case 'mongodb':
-                $restoreCommand = $this->mongodbRestoreCommand;
-                if ($this->dumpAll === false) {
-                    $restoreCommand .= "{$tmpPath}";
-                }
+                $restoreCommand = str_replace('$tmpPath', $tmpPath, $this->mongodbRestoreCommand);
                 break;
             default:
                 $restoreCommand = '';

--- a/app/Models/ScheduledDatabaseBackupExecution.php
+++ b/app/Models/ScheduledDatabaseBackupExecution.php
@@ -13,7 +13,7 @@ class ScheduledDatabaseBackupExecution extends BaseModel
         'message',
         'size',
         'filename',
-        'database_name',
+        'databases',
         'finished_at',
         'local_storage_deleted',
         's3_storage_deleted',

--- a/app/Models/ScheduledDatabaseBackupExecution.php
+++ b/app/Models/ScheduledDatabaseBackupExecution.php
@@ -18,6 +18,7 @@ class ScheduledDatabaseBackupExecution extends BaseModel
         'local_storage_deleted',
         's3_storage_deleted',
         's3_uploaded',
+        'legacy',
     ];
 
     protected function casts(): array
@@ -26,6 +27,7 @@ class ScheduledDatabaseBackupExecution extends BaseModel
             's3_uploaded' => 'boolean',
             'local_storage_deleted' => 'boolean',
             's3_storage_deleted' => 'boolean',
+            'legacy' => 'boolean',
         ];
     }
 

--- a/database/migrations/2026_04_18_090000_default_new_database_backups_to_dumpall.php
+++ b/database/migrations/2026_04_18_090000_default_new_database_backups_to_dumpall.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('scheduled_database_backups', function (Blueprint $table) {
+            $table->boolean('dump_all')->default(true)->change();
+        });
+    }
+};

--- a/database/migrations/2026_04_18_090020_enable_dump_all_for_backups_without_databases.php
+++ b/database/migrations/2026_04_18_090020_enable_dump_all_for_backups_without_databases.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::table('scheduled_database_backups')
+            ->where('dump_all', false)
+            ->where(function ($query) {
+                $query->whereNull('databases_to_backup')
+                    ->orWhere('databases_to_backup', '');
+            })
+            ->update(['dump_all' => true]);
+    }
+};

--- a/database/migrations/2026_04_18_090100_rename_database_name_to_databases.php
+++ b/database/migrations/2026_04_18_090100_rename_database_name_to_databases.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('scheduled_database_backup_executions', function (Blueprint $table) {
+            $table->renameColumn('database_name', 'databases');
+        });
+    }
+};

--- a/database/migrations/2026_04_18_090200_mark_legacy_database_backup_executions.php
+++ b/database/migrations/2026_04_18_090200_mark_legacy_database_backup_executions.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('scheduled_database_backup_executions', function (Blueprint $table) {
+            $table->boolean('legacy')->default(false);
+        });
+
+        DB::table('scheduled_database_backup_executions')
+            ->where(function ($query) {
+                $query->where(function ($q) {
+                    $q->where('filename', 'like', '%/pg-dump-%')
+                        ->where('filename', 'not like', '%/pg-dump-all-%');
+                })->orWhere(function ($q) {
+                    $q->where('filename', 'like', '%/mysql-dump-%')
+                        ->where('filename', 'not like', '%/mysql-dump-all-%');
+                })->orWhere(function ($q) {
+                    $q->where('filename', 'like', '%/mariadb-dump-%')
+                        ->where('filename', 'not like', '%/mariadb-dump-all-%');
+                })->orWhere(function ($q) {
+                    $q->where('filename', 'like', '%/mongo-dump-%')
+                        ->where('filename', 'not like', '%/mongo-dump-all-%');
+                });
+            })
+            ->update(['legacy' => true]);
+    }
+};

--- a/openapi.json
+++ b/openapi.json
@@ -4302,7 +4302,7 @@
                                     "dump_all": {
                                         "type": "boolean",
                                         "description": "Whether to dump all databases",
-                                        "default": false
+                                        "default": true
                                     },
                                     "backup_now": {
                                         "type": "boolean",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2712,7 +2712,7 @@ paths:
                 dump_all:
                   type: boolean
                   description: 'Whether to dump all databases'
-                  default: false
+                  default: true
                 backup_now:
                   type: boolean
                   description: 'Whether to trigger backup immediately after creation'

--- a/resources/views/components/helper.blade.php
+++ b/resources/views/components/helper.blade.php
@@ -1,3 +1,5 @@
+@props(['helper', 'icon' => null, 'popupClass' => ''])
+
 <div {{ $attributes->merge(['class' => 'group']) }}>
     <div class="info-helper">
         @isset($icon)
@@ -10,7 +12,7 @@
         @endisset
 
     </div>
-    <div class="info-helper-popup">
+    <div class="{{ trim('info-helper-popup '.$popupClass) }}">
         <div class="p-4">
             {!! $helper !!}
         </div>

--- a/resources/views/livewire/project/database/backup-edit.blade.php
+++ b/resources/views/livewire/project/database/backup-edit.blade.php
@@ -48,40 +48,43 @@
         <h3>Settings</h3>
         <div class="flex gap-2 flex-col ">
             @if ($backup->database_type === 'App\Models\StandalonePostgresql' && $backup->database_id !== 0)
-                <div class="w-48">
-                    <x-forms.checkbox label="Backup All Databases" id="dumpAll" instantSave />
+                <div class="w-64">
+                    <x-forms.checkbox label="Backup All Databases" id="dumpAll" instantSave fullWidth
+                        helper="When enabled, dumps every database in the cluster via pg_dumpall." />
                 </div>
                 @if (!$backup->dump_all)
-                    <x-forms.input label="Databases To Backup"
-                        helper="Comma separated list of databases to backup. Empty will include the default one."
+                    <x-forms.input label="Databases To Backup" required
+                        helper="Comma separated list of databases to backup. Each database is dumped individually and bundled into a single .tar.gz archive."
                         id="databasesToBackup" />
                 @endif
             @elseif($backup->database_type === 'App\Models\StandaloneMongodb')
-                <div class="max-w-md">
+                <div class="w-64">
                     <x-forms.checkbox label="Backup All Databases" id="dumpAll" instantSave fullWidth
                         helper="When enabled, dumps every database in the cluster via mongodump --archive." />
                 </div>
                 @if (!$backup->dump_all)
-                    <x-forms.input label="Databases To Include"
-                        helper="Pipe separated list of databases to back up. You can optionally exclude collections per database with the format <code>database:collection1,collection2</code>. This field is required when Backup All Databases is disabled.<br><br>Example:<br><br><code>database1:collection1,collection2|database2:collection3,collection4</code><br><br><code>database1</code> will exclude <code>collection1</code> and <code>collection2</code>.<br><code>database2</code> will exclude <code>collection3</code> and <code>collection4</code>.<br><br>Another example:<br><br><code>database1:collection1|database2</code><br><br><code>database1</code> will exclude <code>collection1</code>.<br><code>database2</code> will include all collections."
+                    <x-forms.input label="Databases To Include" required
+                        helper="Pipe separated list of databases to back up. You can optionally exclude collections per database with the format <code>database:collection1,collection2</code>.<br><br>Example:<br><br><code>database1:collection1,collection2|database2:collection3,collection4</code><br><br><code>database1</code> will exclude <code>collection1</code> and <code>collection2</code>.<br><code>database2</code> will exclude <code>collection3</code> and <code>collection4</code>.<br><br>Another example:<br><br><code>database1:collection1|database2</code><br><br><code>database1</code> will exclude <code>collection1</code>.<br><code>database2</code> will include all collections."
                         id="databasesToBackup" />
                 @endif
             @elseif($backup->database_type === 'App\Models\StandaloneMysql')
-                <div class="w-48">
-                    <x-forms.checkbox label="Backup All Databases" id="dumpAll" instantSave />
+                <div class="w-64">
+                    <x-forms.checkbox label="Backup All Databases" id="dumpAll" instantSave fullWidth
+                        helper="When enabled, dumps every database in the cluster via mysqldump --all-databases." />
                 </div>
                 @if (!$backup->dump_all)
-                    <x-forms.input label="Databases To Backup"
-                        helper="Comma separated list of databases to backup. Empty will include the default one."
+                    <x-forms.input label="Databases To Backup" required
+                        helper="Comma separated list of databases to backup. Each database is dumped individually and bundled into a single .tar.gz archive."
                         id="databasesToBackup" />
                 @endif
             @elseif($backup->database_type === 'App\Models\StandaloneMariadb')
-                <div class="w-48">
-                    <x-forms.checkbox label="Backup All Databases" id="dumpAll" instantSave />
+                <div class="w-64">
+                    <x-forms.checkbox label="Backup All Databases" id="dumpAll" instantSave fullWidth
+                        helper="When enabled, dumps every database in the cluster via mariadb-dump --all-databases." />
                 </div>
                 @if (!$backup->dump_all)
-                    <x-forms.input label="Databases To Backup"
-                        helper="Comma separated list of databases to backup. Empty will include the default one."
+                    <x-forms.input label="Databases To Backup" required
+                        helper="Comma separated list of databases to backup. Each database is dumped individually and bundled into a single .tar.gz archive."
                         id="databasesToBackup" />
                 @endif
             @endif

--- a/resources/views/livewire/project/database/backup-edit.blade.php
+++ b/resources/views/livewire/project/database/backup-edit.blade.php
@@ -57,9 +57,15 @@
                         id="databasesToBackup" />
                 @endif
             @elseif($backup->database_type === 'App\Models\StandaloneMongodb')
-                <x-forms.input label="Databases To Include"
-                    helper="A list of databases to backup. You can specify which collection(s) per database to exclude from the backup. Empty will include all databases and collections.<br><br>Example:<br><br>database1:collection1,collection2|database2:collection3,collection4<br><br> database1 will include all collections except collection1 and collection2. <br>database2 will include all collections except collection3 and collection4.<br><br>Another Example:<br><br>database1:collection1|database2<br><br> database1 will include all collections except collection1.<br>database2 will include ALL collections."
-                    id="databasesToBackup" />
+                <div class="max-w-md">
+                    <x-forms.checkbox label="Backup All Databases" id="dumpAll" instantSave fullWidth
+                        helper="When enabled, dumps every database in the cluster via mongodump --archive." />
+                </div>
+                @if (!$backup->dump_all)
+                    <x-forms.input label="Databases To Include"
+                        helper="Pipe separated list of databases to back up. You can optionally exclude collections per database with the format <code>database:collection1,collection2</code>. This field is required when Backup All Databases is disabled.<br><br>Example:<br><br><code>database1:collection1,collection2|database2:collection3,collection4</code><br><br><code>database1</code> will exclude <code>collection1</code> and <code>collection2</code>.<br><code>database2</code> will exclude <code>collection3</code> and <code>collection4</code>.<br><br>Another example:<br><br><code>database1:collection1|database2</code><br><br><code>database1</code> will exclude <code>collection1</code>.<br><code>database2</code> will include all collections."
+                        id="databasesToBackup" />
+                @endif
             @elseif($backup->database_type === 'App\Models\StandaloneMysql')
                 <div class="w-48">
                     <x-forms.checkbox label="Backup All Databases" id="dumpAll" instantSave />

--- a/resources/views/livewire/project/database/backup-executions.blade.php
+++ b/resources/views/livewire/project/database/backup-executions.blade.php
@@ -66,6 +66,13 @@
                             @endphp
                             {{ $statusText }}
                         </span>
+                        @if (data_get($execution, 'legacy'))
+                            <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium leading-normal rounded-full bg-warning/15 text-warning border border-warning/30">
+                                <span>Legacy</span>
+                                <x-helper class="relative" popupClass="w-xl max-w-xl left-0"
+                                    helper="This is a legacy backup. It was created before <code class='whitespace-nowrap'>v4.0.0-beta.474</code>. Multiple databases were backed up separately before that version. They are now stored in a single archive to simplify backup and restore, and to prepare for v5." />
+                            </span>
+                        @endif
                     </div>
                     <div class="text-gray-600 dark:text-gray-400 text-sm">
                         @if (data_get($execution, 'status') === 'running')
@@ -79,9 +86,11 @@
                                 • {{ \Carbon\Carbon::parse(data_get($execution, 'finished_at'))->format('M j, H:i') }}
                             </span>
                         @endif
-                        • Database: {{ data_get($execution, 'database_name', 'N/A') }}
                         @if(data_get($execution, 'size'))
                             • Size: {{ formatBytes(data_get($execution, 'size')) }}
+                        @endif
+                        @if (filled(data_get($execution, 'databases')))
+                            • Databases: {{ data_get($execution, 'databases') }}
                         @endif
                     </div>
                     <div class="text-gray-600 dark:text-gray-400 text-sm">

--- a/resources/views/livewire/project/database/import.blade.php
+++ b/resources/views/livewire/project/database/import.blade.php
@@ -60,40 +60,37 @@
         </div>
         @if (str($resourceStatus)->startsWith('running'))
             {{-- Restore Command Configuration --}}
-            @if ($resourceDbType === 'standalone-postgresql')
-                @if ($dumpAll)
-                    <x-forms.textarea rows="6" readonly label="Custom Import Command"
-                        wire:model='restoreCommandText'></x-forms.textarea>
-                @else
-                    <x-forms.input label="Custom Import Command" wire:model='postgresqlRestoreCommand'></x-forms.input>
-                    <div class="flex flex-col gap-1 pt-1">
-                        <span class="text-xs">You can add "--clean" to drop objects before creating them, avoiding
-                            conflicts.</span>
-                        <span class="text-xs">You can add "--verbose" to log more things.</span>
+            @if (in_array($resourceDbType, ['standalone-postgresql', 'standalone-mysql', 'standalone-mariadb', 'standalone-mongodb']))
+                <div class="flex flex-col gap-2 pt-2">
+                    <div class="w-full max-w-xl">
+                        <x-forms.select label="Restore Mode" wire:model.live="restoreMode">
+                            <option value="dump_all">Restore all databases (dumpall-*.sql.gz / dumpall-*.tar.gz)</option>
+                            <option value="archive">Restore database(s) (dbs-*.tar.gz)</option>
+                            <option value="legacy">Restore legacy backup files (.sql or .dmp)</option>
+                        </x-forms.select>
                     </div>
-                @endif
-                <div class="w-64 pt-2">
-                    <x-forms.checkbox label="Backup includes all databases" wire:model.live='dumpAll'></x-forms.checkbox>
-                </div>
-            @elseif ($resourceDbType === 'standalone-mysql')
-                @if ($dumpAll)
-                    <x-forms.textarea rows="14" readonly label="Custom Import Command"
-                        wire:model='restoreCommandText'></x-forms.textarea>
-                @else
-                    <x-forms.input label="Custom Import Command" wire:model='mysqlRestoreCommand'></x-forms.input>
-                @endif
-                <div class="w-64 pt-2">
-                    <x-forms.checkbox label="Backup includes all databases" wire:model.live='dumpAll'></x-forms.checkbox>
-                </div>
-            @elseif ($resourceDbType === 'standalone-mariadb')
-                @if ($dumpAll)
-                    <x-forms.textarea rows="14" readonly label="Custom Import Command"
-                        wire:model='restoreCommandText'></x-forms.textarea>
-                @else
-                    <x-forms.input label="Custom Import Command" wire:model='mariadbRestoreCommand'></x-forms.input>
-                @endif
-                <div class="w-64 pt-2">
-                    <x-forms.checkbox label="Backup includes all databases" wire:model.live='dumpAll'></x-forms.checkbox>
+
+                    @php
+                        $databasesToRestoreHelper = $importDatabases
+                            ? 'Enter a comma separated list of databases to restore. The archive can contain 1 or more separate database backup files.'
+                            : 'Enter exactly one database name to restore this legacy backup file into.';
+                    @endphp
+
+                    @if ($importDatabases || $legacySingleDb)
+                        <x-forms.input label="Databases to restore" id="databasesToRestore" required
+                            :helper="$databasesToRestoreHelper" />
+                    @endif
+
+                    @if ($resourceDbType === 'standalone-postgresql')
+                        <x-forms.textarea rows="8" label="Import Command" wire:model='postgresqlRestoreCommand'></x-forms.textarea>
+                    @elseif ($resourceDbType === 'standalone-mysql')
+                        <x-forms.textarea rows="8" label="Import Command" wire:model='mysqlRestoreCommand'></x-forms.textarea>
+                    @elseif ($resourceDbType === 'standalone-mariadb')
+                        <x-forms.textarea rows="8" label="Import Command" wire:model='mariadbRestoreCommand'></x-forms.textarea>
+                    @elseif ($resourceDbType === 'standalone-mongodb')
+                        <x-forms.textarea rows="8" label="Import Command" wire:model='mongodbRestoreCommand'></x-forms.textarea>
+                    @endif
+
                 </div>
             @endif
 

--- a/tests/Feature/BackupRetentionAndStaleDetectionTest.php
+++ b/tests/Feature/BackupRetentionAndStaleDetectionTest.php
@@ -71,7 +71,7 @@ test('markStaleExecutionsAsFailed marks stale running executions as failed', fun
     // Create a stale execution (3 hours old, timeout is 1h, threshold is 2h)
     $staleExecution = ScheduledDatabaseBackupExecution::create([
         'uuid' => 'stale-exec-uuid',
-        'database_name' => 'test_db',
+        'databases' => 'test_db',
         'scheduled_database_backup_id' => $backup->id,
         'status' => 'running',
     ]);
@@ -105,7 +105,7 @@ test('markStaleExecutionsAsFailed does not mark recent running executions as fai
     // Create a recent execution (30 minutes old, threshold is 2 hours)
     $recentExecution = ScheduledDatabaseBackupExecution::create([
         'uuid' => 'recent-exec-uuid',
-        'database_name' => 'test_db',
+        'databases' => 'test_db',
         'scheduled_database_backup_id' => $backup->id,
         'status' => 'running',
     ]);
@@ -173,7 +173,7 @@ test('cleanup instance stuffs job calls retention enforcement without errors', f
     foreach (range(1, 3) as $i) {
         ScheduledDatabaseBackupExecution::create([
             'uuid' => "exec-uuid-{$i}",
-            'database_name' => 'test_db',
+            'databases' => 'test_db',
             'filename' => "/backup/test_{$i}.dmp",
             'scheduled_database_backup_id' => $backup->id,
             'status' => 'success',
@@ -209,7 +209,7 @@ test('deleteOldBackupsLocally identifies correct backups for deletion by retenti
     foreach (range(1, 3) as $i) {
         $exec = ScheduledDatabaseBackupExecution::create([
             'uuid' => "exec-uuid-{$i}",
-            'database_name' => 'test_db',
+            'databases' => 'test_db',
             'filename' => "/backup/test_{$i}.dmp",
             'scheduled_database_backup_id' => $backup->id,
             'status' => 'success',

--- a/tests/Feature/DatabaseBackupJobTest.php
+++ b/tests/Feature/DatabaseBackupJobTest.php
@@ -133,7 +133,7 @@ test('failed method does not overwrite successful backup status', function () {
 
     $log = ScheduledDatabaseBackupExecution::create([
         'uuid' => 'test-uuid-success-guard',
-        'database_name' => 'test_db',
+        'databases' => 'test_db',
         'filename' => '/backup/test.dmp',
         'scheduled_database_backup_id' => $backup->id,
         'status' => 'success',
@@ -157,7 +157,7 @@ test('failed method does not overwrite successful backup status', function () {
     $log->refresh();
     expect($log->status)->toBe('success');
     expect($log->message)->toBe('Backup completed successfully');
-    expect($log->size)->toBe(1024);
+    expect((int) $log->size)->toBe(1024);
 });
 
 test('failed method updates status when backup was not successful', function () {
@@ -173,7 +173,7 @@ test('failed method updates status when backup was not successful', function () 
 
     $log = ScheduledDatabaseBackupExecution::create([
         'uuid' => 'test-uuid-pending-guard',
-        'database_name' => 'test_db',
+        'databases' => 'test_db',
         'filename' => '/backup/test.dmp',
         'scheduled_database_backup_id' => $backup->id,
         'status' => 'pending',

--- a/tests/Feature/ModelFillableCreationTest.php
+++ b/tests/Feature/ModelFillableCreationTest.php
@@ -978,7 +978,7 @@ it('creates ScheduledDatabaseBackupExecution with all fillable attributes', func
         'message' => 'Backup completed successfully',
         'size' => 1048576,
         'filename' => 'backup-2026-03-31.sql.gz',
-        'database_name' => 'testdb',
+        'databases' => 'testdb',
         'finished_at' => now()->toISOString(),
         'local_storage_deleted' => false,
         's3_storage_deleted' => false,
@@ -989,7 +989,7 @@ it('creates ScheduledDatabaseBackupExecution with all fillable attributes', func
     expect($execution->uuid)->toBe('custom-exec-uuid');
     expect($execution->status)->toBe('success');
     expect($execution->filename)->toBe('backup-2026-03-31.sql.gz');
-    expect($execution->database_name)->toBe('testdb');
+    expect($execution->databases)->toBe('testdb');
     expect($execution->size)->toBe(1048576);
 });
 

--- a/tests/Feature/StartupExecutionCleanupTest.php
+++ b/tests/Feature/StartupExecutionCleanupTest.php
@@ -101,20 +101,20 @@ test('app:init marks stuck database backup executions as failed', function () {
     $runningBackup1 = ScheduledDatabaseBackupExecution::create([
         'scheduled_database_backup_id' => $scheduledBackup->id,
         'status' => 'running',
-        'database_name' => 'test_db',
+        'databases' => 'test_db',
     ]);
 
     $runningBackup2 = ScheduledDatabaseBackupExecution::create([
         'scheduled_database_backup_id' => $scheduledBackup->id,
         'status' => 'running',
-        'database_name' => 'test_db_2',
+        'databases' => 'test_db_2',
     ]);
 
     // Create a successful backup (should not be affected)
     $successfulBackup = ScheduledDatabaseBackupExecution::create([
         'scheduled_database_backup_id' => $scheduledBackup->id,
         'status' => 'success',
-        'database_name' => 'test_db_3',
+        'databases' => 'test_db_3',
         'finished_at' => Carbon::now()->subMinutes(20),
     ]);
 

--- a/tests/Unit/Livewire/Database/S3RestoreTest.php
+++ b/tests/Unit/Livewire/Database/S3RestoreTest.php
@@ -1,79 +1,123 @@
 <?php
 
 use App\Livewire\Project\Database\Import;
+use App\Models\StandaloneMariadb;
+use App\Models\StandaloneMongodb;
+use App\Models\StandaloneMysql;
+use App\Models\StandalonePostgresql;
 
-test('buildRestoreCommand handles PostgreSQL without dumpAll', function () {
-    $component = new Import;
-    $component->dumpAll = false;
-    $component->postgresqlRestoreCommand = 'pg_restore -U $POSTGRES_USER -d $POSTGRES_DB';
+class TestImportComponent extends Import
+{
+    public mixed $resource;
+}
 
-    $database = Mockery::mock('App\Models\StandalonePostgresql');
-    $database->shouldReceive('getMorphClass')->andReturn('App\Models\StandalonePostgresql');
+function importComponentFor(object $database): TestImportComponent
+{
+    $component = new TestImportComponent;
     $component->resource = $database;
 
-    $result = $component->buildRestoreCommand('/tmp/test.dump');
+    return $component;
+}
 
-    expect($result)->toContain('pg_restore');
-    expect($result)->toContain('/tmp/test.dump');
-});
+test('buildRestoreCommand handles PostgreSQL dump all by default', function () {
+    $database = Mockery::mock(StandalonePostgresql::class);
+    $database->shouldReceive('getMorphClass')->andReturn(StandalonePostgresql::class);
 
-test('buildRestoreCommand handles PostgreSQL with dumpAll', function () {
-    $component = new Import;
-    $component->dumpAll = true;
-    // This is the full dump-all command prefix that would be set in the updatedDumpAll method
-    $component->postgresqlRestoreCommand = 'psql -U $POSTGRES_USER -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname IS NOT NULL AND pid <> pg_backend_pid()" && psql -U $POSTGRES_USER -t -c "SELECT datname FROM pg_database WHERE NOT datistemplate" | xargs -I {} dropdb -U $POSTGRES_USER --if-exists {} && createdb -U $POSTGRES_USER postgres';
-
-    $database = Mockery::mock('App\Models\StandalonePostgresql');
-    $database->shouldReceive('getMorphClass')->andReturn('App\Models\StandalonePostgresql');
-    $component->resource = $database;
+    $component = importComponentFor($database);
+    $component->updatedRestoreMode('dump_all');
 
     $result = $component->buildRestoreCommand('/tmp/test.dump');
 
     expect($result)->toContain('gunzip -cf /tmp/test.dump');
-    expect($result)->toContain('psql -U $POSTGRES_USER postgres');
+    expect($result)->toContain('{ gunzip -cf /tmp/test.dump 2>/dev/null || cat /tmp/test.dump; }');
+    expect($result)->toContain('psql -X -U ${POSTGRES_USER} -d postgres');
 });
 
-test('buildRestoreCommand handles MySQL without dumpAll', function () {
-    $component = new Import;
-    $component->dumpAll = false;
-    $component->mysqlRestoreCommand = 'mysql -u $MYSQL_USER -p$MYSQL_PASSWORD $MYSQL_DATABASE';
+test('buildRestoreCommand handles PostgreSQL legacy single db restore', function () {
+    $database = Mockery::mock(StandalonePostgresql::class);
+    $database->shouldReceive('getMorphClass')->andReturn(StandalonePostgresql::class);
 
-    $database = Mockery::mock('App\Models\StandaloneMysql');
-    $database->shouldReceive('getMorphClass')->andReturn('App\Models\StandaloneMysql');
-    $component->resource = $database;
+    $component = importComponentFor($database);
+    $component->updatedRestoreMode('legacy');
+    $component->databasesToRestore = 'legacy_db';
 
     $result = $component->buildRestoreCommand('/tmp/test.dump');
+
+    expect($result)->toContain('pg_restore');
+    expect($result)->toContain('--clean --if-exists');
+    expect($result)->toContain('-d legacy_db');
+    expect($result)->toContain('/tmp/test.dump');
+});
+
+test('buildRestoreCommand handles PostgreSQL archive import restore', function () {
+    $database = Mockery::mock(StandalonePostgresql::class);
+    $database->shouldReceive('getMorphClass')->andReturn(StandalonePostgresql::class);
+
+    $component = importComponentFor($database);
+    $component->updatedRestoreMode('archive');
+    $component->databasesToRestore = 'app_one,app_two';
+
+    $result = $component->buildRestoreCommand('/tmp/test.tar.gz');
+
+    expect($result)->toContain('tar -xzf /tmp/test.tar.gz -C /tmp/coolify-restore');
+    expect($result)->toContain('pg_restore --clean --if-exists');
+    expect($result)->toContain('pg-dump-app_one.dmp');
+    expect($result)->toContain('pg-dump-app_two.dmp');
+    expect($result)->toContain('pg_restore --clean --if-exists -U ${POSTGRES_USER} -d');
+    expect($result)->toContain('rm -rf /tmp/coolify-restore');
+});
+
+test('buildRestoreCommand handles MySQL legacy single db restore', function () {
+    $database = Mockery::mock(StandaloneMysql::class);
+    $database->shouldReceive('getMorphClass')->andReturn(StandaloneMysql::class);
+
+    $component = importComponentFor($database);
+    $component->updatedRestoreMode('legacy');
+    $component->databasesToRestore = 'legacy_db';
+
+    $result = $component->buildRestoreCommand('/tmp/test.sql');
 
     expect($result)->toContain('mysql -u $MYSQL_USER');
-    expect($result)->toContain('< /tmp/test.dump');
+    expect($result)->toContain('legacy_db < /tmp/test.sql');
+    expect($result)->toContain('< /tmp/test.sql');
 });
 
-test('buildRestoreCommand handles MariaDB without dumpAll', function () {
-    $component = new Import;
-    $component->dumpAll = false;
-    $component->mariadbRestoreCommand = 'mariadb -u $MARIADB_USER -p$MARIADB_PASSWORD $MARIADB_DATABASE';
+test('buildRestoreCommand handles MariaDB legacy single db restore', function () {
+    $database = Mockery::mock(StandaloneMariadb::class);
+    $database->shouldReceive('getMorphClass')->andReturn(StandaloneMariadb::class);
 
-    $database = Mockery::mock('App\Models\StandaloneMariadb');
-    $database->shouldReceive('getMorphClass')->andReturn('App\Models\StandaloneMariadb');
-    $component->resource = $database;
+    $component = importComponentFor($database);
+    $component->updatedRestoreMode('legacy');
+    $component->databasesToRestore = 'legacy_db';
 
-    $result = $component->buildRestoreCommand('/tmp/test.dump');
+    $result = $component->buildRestoreCommand('/tmp/test.sql');
 
     expect($result)->toContain('mariadb -u $MARIADB_USER');
-    expect($result)->toContain('< /tmp/test.dump');
+    expect($result)->toContain('legacy_db < /tmp/test.sql');
+    expect($result)->toContain('< /tmp/test.sql');
+});
+
+test('buildRestoreCommand requires exactly one database for PostgreSQL legacy restore', function () {
+    $database = Mockery::mock(StandalonePostgresql::class);
+    $database->shouldReceive('getMorphClass')->andReturn(StandalonePostgresql::class);
+
+    $component = importComponentFor($database);
+    $component->updatedRestoreMode('legacy');
+    $component->databasesToRestore = 'db_one,db_two';
+
+    expect(fn () => $component->buildRestoreCommand('/tmp/test.dump'))
+        ->toThrow(Exception::class, 'Please specify exactly one database to restore for a legacy backup file.');
 });
 
 test('buildRestoreCommand handles MongoDB', function () {
-    $component = new Import;
-    $component->dumpAll = false;
-    $component->mongodbRestoreCommand = 'mongorestore --authenticationDatabase=admin --username $MONGO_INITDB_ROOT_USERNAME --password $MONGO_INITDB_ROOT_PASSWORD --uri mongodb://localhost:27017 --gzip --archive=';
+    $database = Mockery::mock(StandaloneMongodb::class);
+    $database->shouldReceive('getMorphClass')->andReturn(StandaloneMongodb::class);
 
-    $database = Mockery::mock('App\Models\StandaloneMongodb');
-    $database->shouldReceive('getMorphClass')->andReturn('App\Models\StandaloneMongodb');
-    $component->resource = $database;
+    $component = importComponentFor($database);
 
     $result = $component->buildRestoreCommand('/tmp/test.dump');
 
     expect($result)->toContain('mongorestore');
+    expect($result)->toContain('--uri="mongodb://$MONGO_INITDB_ROOT_USERNAME:$MONGO_INITDB_ROOT_PASSWORD@localhost:27017/admin"');
     expect($result)->toContain('/tmp/test.dump');
 });


### PR DESCRIPTION
## Why?

This PR standardizes the `v4.x` database backup format to prepare for the `v5.x` upgrade migration, turning what would be a high-impact breaking change into a low-impact one.

In v5, backup and restore will be consolidated onto a single page. `Legacy` backup formats, the import page and `legacy` import logic will be removed entirely.

To facilitate this switch while maintaining the ability to restore some v4 backups in v5 the backup format needs to be standardized now in v4 so that backups created after this change are directly compatible with v5.

PR https://github.com/coollabsio/coolify/pull/8131 documents the problems with the current backup system in detail (3 different backup methods, confusing defaults, overcomplicated restores). That PR solved it by removing the per-database backup option entirely and always backing up all databases. While that simplified things, it introduced drawbacks that matter in practice:

- Users with large clusters cannot exclude databases they don't need, wasting storage and backup execution time.
- Restoring a single database requires restoring the entire cluster, which is more destructive and slower. For example, restoring a corrupted database would also overwrite every other database in the cluster with potentially stale data.
- Per-database dumps preserve granular restore capabilities that full-cluster dumps lose: `pg_restore --table` can restore a single table, for example.

This PR takes a different approach that standardizes the format without removing flexibility:

- "Backup all databases" becomes the default. This is the easiest, recommend and safest option for most users. Existing backup jobs without specified databases are migrated to this default to simplify the backup job UI.
  - No configuration needed
  - No risk of forgetting a database
  - Restoring always restores all databases
- The individual database(s) backup feature stays but produces 1 single archive (v5 format). When users specify databases, each is dumped individually and bundled into one `.tar.gz` archive.
  - This means one backup execution per scheduled run (not one per database) - which is better UX.
  - Cleaner execution history
  - And especially on v5 much simpler restores with a multi select for which database to restore and an optional table input.
- Old per-database backups are marked as `legacy`. But the backup files (`.dmp` and `.sql`) remain fully restorable in v4. They are marked as `legacy` now as these files will not be migrated over to v5.


## Changes

- Default new backup job schedules to "backup all databases"
- Migrate existing backup schedules that have no `databases_to_backup` (empty or `null`) to `dump_all = true`
- Standardize the backup job
  - When one database or multiple are listed for backup, back them up one by one and then bundle them into an archive. This eliminates multiple execution logs per backup (previously one for each database backed up) and consolidates them into a single execution regardless of how many separate databases are backed up, making backups and restores simpler and preparing for v5
  - Fixes `mongo:4` single-DB backups dumping all databases instead of the selected one (missing `--db` flag)
  - Fixes mariadb `dump_all` backup output not being compressed despite `.gz` extension (`--compress` does not compress output)
  - Removes `--compress` from mysql `dump_all` backup (already gzipped)
  - Simplify databasesToBackup parsing
- Add improved restore functionality
  - Add new restore commands to restore one or more databases from an archive (v5 format)
  - Move single database restore command into a legacy option
  - Improve ui with a select component instead of checkboxes
  - Fixes postgres restore failing when the default database does not exist (use `template1` which is guaranteed to exist)
  - Fixes mysql/mariadb `dump_all` restore piping all databases into one target database instead of restoring each to its own
- Mark existing single-database backup executions as legacy
  - Add legacy badge with helper tooltip to the backup executions UI
- Update backup job settings UI
  - Add `dump_all` checkbox to MongoDB (previously used empty `databases_to_backup` to mean "all")
  - Add or improve helper text for all backup settings
  - Make "databases to backup" required when `dump_all` is disabled
- Rename backup executions `database_name` column to `databases`
  - One backup execution can now contain multiple databases, not just one. Therefore, we will store the database names or "all" in this column instead of just one database per backup execution.
- Align backup api endpoints with standardized backup logic
- Allow custom classes on the helper popup component

## Supersedes

- https://github.com/coollabsio/coolify/pull/8131
