### PR TITLE
fix: resolve issue #8042

### DIFF
--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -17,6 +17,10 @@ class ResetUserPassword implements ResetsUserPasswords
      */
     public function reset(User $user, array $input): void
     {
+        if ($user->isPasswordLoginDisabled()) {
+            abort(403, 'Password login is disabled for OAuth users on this instance.');
+        }
+
         Validator::make($input, [
             'password' => ['required', Password::defaults(), 'confirmed'],
         ])->validate();

--- a/app/Actions/Fortify/UpdateUserPassword.php
+++ b/app/Actions/Fortify/UpdateUserPassword.php
@@ -17,6 +17,10 @@ class UpdateUserPassword implements UpdatesUserPasswords
      */
     public function update(User $user, array $input): void
     {
+        if ($user->isPasswordLoginDisabled()) {
+            abort(403, 'Password login is disabled for OAuth users on this instance.');
+        }
+
         Validator::make($input, [
             'current_password' => ['required', 'string', 'current_password:web'],
             'password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -22,14 +22,21 @@ class OauthController extends Controller
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                $registrationAllowed = $settings->is_registration_enabled
+                    || $settings->is_oauth_self_registration_enabled;
+                if (! $registrationAllowed) {
                     abort(403, 'Registration is disabled');
                 }
 
                 $user = User::create([
                     'name' => $oauthUser->name,
                     'email' => $oauthUser->email,
+                    'oauth_provider' => $provider,
                 ]);
+            } elseif (empty($user->oauth_provider)) {
+                // Mark pre-existing accounts that authenticate via OAuth as OAuth users
+                // so admins can disable their password login through the instance setting.
+                $user->forceFill(['oauth_provider' => $provider])->save();
             }
             Auth::login($user);
 

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -16,6 +16,12 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $is_oauth_self_registration_enabled;
+
+    #[Validate('boolean')]
+    public bool $disable_password_login_for_oauth_users;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -41,6 +47,8 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_self_registration_enabled' => 'boolean',
+            'disable_password_login_for_oauth_users' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => ['nullable', 'string', new ValidDnsServers],
@@ -62,6 +70,8 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_self_registration_enabled = (bool) $this->settings->is_oauth_self_registration_enabled;
+        $this->disable_password_login_for_oauth_users = (bool) $this->settings->disable_password_login_for_oauth_users;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -142,6 +152,8 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_self_registration_enabled = $this->is_oauth_self_registration_enabled;
+            $this->settings->disable_password_login_for_oauth_users = $this->disable_password_login_for_oauth_users;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -18,6 +18,8 @@ class InstanceSettings extends Model
         'do_not_track',
         'is_auto_update_enabled',
         'is_registration_enabled',
+        'is_oauth_self_registration_enabled',
+        'disable_password_login_for_oauth_users',
         'next_channel',
         'smtp_enabled',
         'smtp_from_address',
@@ -67,6 +69,8 @@ class InstanceSettings extends Model
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',
         'is_wire_navigate_enabled' => 'boolean',
+        'is_oauth_self_registration_enabled' => 'boolean',
+        'disable_password_login_for_oauth_users' => 'boolean',
     ];
 
     protected static function booted(): void

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -52,6 +52,7 @@ class User extends Authenticatable implements SendsEmail
         'pending_email',
         'email_change_code',
         'email_change_code_expires_at',
+        'oauth_provider',
     ];
 
     protected $hidden = [
@@ -486,5 +487,30 @@ class User extends Authenticatable implements SendsEmail
     public function hasPassword(): bool
     {
         return ! empty($this->password);
+    }
+
+    /**
+     * Check if the user was provisioned via an OAuth provider.
+     */
+    public function isOauthUser(): bool
+    {
+        return ! empty($this->oauth_provider);
+    }
+
+    /**
+     * Determine whether this user is forbidden from logging in with or
+     * managing a password locally. This is true when the user came from an
+     * OAuth provider AND the instance is configured to disable password
+     * login for OAuth users.
+     */
+    public function isPasswordLoginDisabled(): bool
+    {
+        if (! $this->isOauthUser()) {
+            return false;
+        }
+
+        $settings = instanceSettings();
+
+        return (bool) ($settings->disable_password_login_for_oauth_users ?? false);
     }
 }

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -7,6 +7,7 @@ use App\Actions\Fortify\ResetUserPassword;
 use App\Actions\Fortify\UpdateUserPassword;
 use App\Actions\Fortify\UpdateUserProfileInformation;
 use App\Models\OauthSetting;
+use App\Models\TeamInvitation;
 use App\Models\User;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
@@ -78,11 +79,15 @@ class FortifyServiceProvider extends ServiceProvider
                 $user &&
                 Hash::check($request->password, $user->password)
             ) {
+                if ($user->isPasswordLoginDisabled()) {
+                    // Password login has been disabled for this OAuth-provisioned user.
+                    return null;
+                }
                 $user->updated_at = now();
                 $user->save();
 
                 // Check if user has a pending invitation they haven't accepted yet
-                $invitation = \App\Models\TeamInvitation::whereEmail($email)->first();
+                $invitation = TeamInvitation::whereEmail($email)->first();
                 if ($invitation && $invitation->isValid()) {
                     // User is logging in for the first time after being invited
                     // Attach them to the invited team if not already attached

--- a/database/migrations/2026_04_21_000000_add_oauth_self_registration_to_instance_settings_table.php
+++ b/database/migrations/2026_04_21_000000_add_oauth_self_registration_to_instance_settings_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_self_registration_enabled')->default(false);
+            $table->boolean('disable_password_login_for_oauth_users')->default(false);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn(['is_oauth_self_registration_enabled', 'disable_password_login_for_oauth_users']);
+        });
+    }
+};

--- a/database/migrations/2026_04_21_000001_add_oauth_provider_to_users_table.php
+++ b/database/migrations/2026_04_21_000001_add_oauth_provider_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('oauth_provider')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('oauth_provider');
+        });
+    }
+};

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -42,6 +42,16 @@
                         </div>
                     @endif
                     <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_self_registration_enabled"
+                            helper="Allow users authenticating through a configured OAuth provider to self-register, even when general registration is disabled. Combine with your OAuth provider's access controls (e.g. Authentik groups) to gate who can sign up."
+                            label="OAuth Self-Registration Allowed" />
+                    </div>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="disable_password_login_for_oauth_users"
+                            helper="When enabled, users who registered (or first signed in) via an OAuth provider can no longer log in with a password and cannot set or reset one. Disabling the user at the OAuth provider effectively suspends their access to this Coolify instance."
+                            label="Disable Password Login for OAuth Users" />
+                    </div>
+                    <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"
                             helper="Opt out of anonymous usage tracking. When enabled, this instance will not report to coolify.io's installation count and will not send error reports to help improve Coolify."
                             label="Do Not Track" />

--- a/tests/Feature/OauthSelfRegistrationTest.php
+++ b/tests/Feature/OauthSelfRegistrationTest.php
@@ -1,0 +1,189 @@
+<?php
+
+use App\Actions\Fortify\ResetUserPassword;
+use App\Actions\Fortify\UpdateUserPassword;
+use App\Models\InstanceSettings;
+use App\Models\OauthSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Socialite\Facades\Socialite;
+use Laravel\Socialite\Two\AbstractProvider;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    if (! InstanceSettings::find(0)) {
+        $instanceSettings = new InstanceSettings;
+        $instanceSettings->forceFill([
+            'id' => 0,
+            'is_registration_enabled' => false,
+            'is_oauth_self_registration_enabled' => false,
+            'disable_password_login_for_oauth_users' => false,
+            'smtp_enabled' => false,
+        ])->save();
+    }
+
+    // Make sure we have an existing user so the login/registration redirects don't trigger.
+    User::factory()->create([
+        'email' => 'existing-admin@example.com',
+        'password' => Hash::make('password'),
+    ]);
+
+    OauthSetting::firstOrCreate(['provider' => 'authentik'], [
+        'enabled' => true,
+        'client_id' => 'test-client',
+        'client_secret' => 'test-secret',
+        'redirect_uri' => 'http://localhost/auth/authentik/callback',
+        'base_url' => 'https://authentik.example.com',
+    ]);
+});
+
+function fakeSocialiteUser(string $email, string $name = 'OAuth User'): void
+{
+    $abstractUser = Mockery::mock(Laravel\Socialite\Two\User::class);
+    $abstractUser->shouldReceive('getEmail')->andReturn($email);
+    $abstractUser->shouldReceive('getName')->andReturn($name);
+    $abstractUser->email = $email;
+    $abstractUser->name = $name;
+
+    $provider = Mockery::mock(AbstractProvider::class);
+    $provider->shouldReceive('user')->andReturn($abstractUser);
+    $provider->shouldReceive('redirect')->andReturn(redirect('/'));
+    $provider->shouldReceive('setConfig')->andReturnSelf();
+    $provider->shouldReceive('setHost')->andReturnSelf();
+    $provider->shouldReceive('with')->andReturnSelf();
+
+    Socialite::shouldReceive('driver')->andReturn($provider);
+    Socialite::shouldReceive('buildProvider')->andReturn($provider);
+}
+
+it('blocks oauth registration when both general and oauth registration are disabled', function () {
+    $this->withoutMiddleware();
+    $settings = InstanceSettings::find(0);
+    $settings->is_registration_enabled = false;
+    $settings->is_oauth_self_registration_enabled = false;
+    $settings->save();
+
+    fakeSocialiteUser('newcomer@example.com');
+
+    $response = $this->get('/auth/authentik/callback');
+
+    $response->assertStatus(302);
+    $response->assertRedirect(route('login'));
+    expect(User::where('email', 'newcomer@example.com')->exists())->toBeFalse();
+});
+
+it('allows oauth registration when oauth self-registration is enabled even if general registration is disabled', function () {
+    $this->withoutMiddleware();
+    $settings = InstanceSettings::find(0);
+    $settings->is_registration_enabled = false;
+    $settings->is_oauth_self_registration_enabled = true;
+    $settings->save();
+
+    fakeSocialiteUser('newcomer@example.com', 'New Comer');
+
+    $this->get('/auth/authentik/callback');
+
+    $created = User::where('email', 'newcomer@example.com')->first();
+    expect($created)->not->toBeNull();
+    expect($created->oauth_provider)->toBe('authentik');
+    expect($created->password)->toBeNull();
+});
+
+it('marks pre-existing users with the oauth provider on first oauth login', function () {
+    $this->withoutMiddleware();
+    $settings = InstanceSettings::find(0);
+    $settings->is_oauth_self_registration_enabled = true;
+    $settings->save();
+
+    $user = User::factory()->create([
+        'email' => 'preexisting@example.com',
+        'oauth_provider' => null,
+    ]);
+
+    fakeSocialiteUser('preexisting@example.com');
+
+    $this->get('/auth/authentik/callback');
+
+    expect($user->fresh()->oauth_provider)->toBe('authentik');
+});
+
+it('blocks password login for oauth users when disable_password_login_for_oauth_users is enabled', function () {
+    $this->withoutMiddleware();
+
+    $settings = InstanceSettings::find(0);
+    $settings->disable_password_login_for_oauth_users = true;
+    $settings->save();
+
+    User::factory()->create([
+        'email' => 'oauth-only@example.com',
+        'password' => Hash::make('correct-password'),
+        'oauth_provider' => 'authentik',
+    ]);
+
+    $this->post('/login', [
+        'email' => 'oauth-only@example.com',
+        'password' => 'correct-password',
+    ]);
+
+    expect(auth()->check())->toBeFalse();
+});
+
+it('still allows password login for non-oauth users when the restriction is enabled', function () {
+    $this->withoutMiddleware();
+
+    $settings = InstanceSettings::find(0);
+    $settings->disable_password_login_for_oauth_users = true;
+    $settings->save();
+
+    User::factory()->create([
+        'email' => 'local-user@example.com',
+        'password' => Hash::make('correct-password'),
+        'oauth_provider' => null,
+    ]);
+
+    $this->post('/login', [
+        'email' => 'local-user@example.com',
+        'password' => 'correct-password',
+    ]);
+
+    expect(auth()->check())->toBeTrue();
+    expect(auth()->user()->email)->toBe('local-user@example.com');
+});
+
+it('blocks password reset for oauth-only users when the restriction is enabled', function () {
+    $settings = InstanceSettings::find(0);
+    $settings->disable_password_login_for_oauth_users = true;
+    $settings->save();
+
+    $user = User::factory()->create([
+        'email' => 'oauth-reset@example.com',
+        'password' => Hash::make('old'),
+        'oauth_provider' => 'authentik',
+    ]);
+
+    expect(fn () => app(ResetUserPassword::class)->reset($user, [
+        'password' => 'NewPassword!1',
+        'password_confirmation' => 'NewPassword!1',
+    ]))->toThrow(HttpException::class);
+});
+
+it('blocks password update for oauth-only users when the restriction is enabled', function () {
+    $settings = InstanceSettings::find(0);
+    $settings->disable_password_login_for_oauth_users = true;
+    $settings->save();
+
+    $user = User::factory()->create([
+        'email' => 'oauth-update@example.com',
+        'password' => Hash::make('old'),
+        'oauth_provider' => 'authentik',
+    ]);
+
+    expect(fn () => app(UpdateUserPassword::class)->update($user, [
+        'current_password' => 'old',
+        'password' => 'NewPassword!1',
+        'password_confirmation' => 'NewPassword!1',
+    ]))->toThrow(HttpException::class);
+});


### PR DESCRIPTION
Fixes #8042

## Summary

The issue requests two enhancements to Coolify's OAuth2 authentication: (1) allow users to self-register via OAuth2 even when general self-registration is disabled, and (2) provide an admin setting to restrict OAuth2 users from setting/using passwords, so disabling them at the OAuth2 provider (e.g., Authentik) effectively suspends them across Coolify instances. The fix involves modifying the OAuth callback/registration logic to bypass the global registration toggle for OAuth flows, adding a new instance setting (e.g., `oauth_only_registration` or per-provider flag), and gating password login/reset for OAuth-provisioned users.

## Approach

1. Locate the OAuth callback handler (likely app/Http/Controllers/Auth/OauthController.php) and identify where it checks the `is_registration_enabled` instance setting before creating a new user. 2. Add a new boolean column to instance_settings (e.g., `is_oauth_self_registration_enabled`, default true) via a migration, and a `is_password_login_disabled_for_oauth_users` flag on OauthSetting or InstanceSettings. 3. Update the OAuth callback to check the OAuth-specific registration flag rather than the general one when provisioning new users. 4. Add a column to the users table (e.g., `oauth_provider` / `password_disabled`) to mark OAuth-only users, set during OAuth registration. 5. Modify Fortify login/password reset flows (CreateNewUser, password reset action, login response) to reject password authentication for users flagged as OAuth-only. 6. Expose the new toggles in the admin settings Livewire component and Blade view. 7. Add Pest tests covering: OAuth registration when global registration is off, password login blocked for OAuth-only users, and admin toggle behavior.

## Changes

- `app/Actions/Fortify/ResetUserPassword.php`
- `app/Actions/Fortify/UpdateUserPassword.php`
- `app/Http/Controllers/OauthController.php`
- `app/Livewire/Settings/Advanced.php`
- `app/Models/InstanceSettings.php`
- `app/Models/User.php`
- `app/Providers/FortifyServiceProvider.php`
- `resources/views/livewire/settings/advanced.blade.php`
- `database/migrations/2026_04_21_000000_add_oauth_self_registration_to_instance_settings_table.php`
- `database/migrations/2026_04_21_000001_add_oauth_provider_to_users_table.php`
- `tests/Feature/OauthSelfRegistrationTest.php`

### What was changed and why

fix: resolve issue #8042

## Tests

✅ All tests pass

---
*Automated fix — please review carefully and request changes if needed.*