### PR TITLE
Add pull_request_id support to start, restart, and stop API endpoints

### DIFF
--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -9,6 +9,7 @@ use App\Enums\BuildPackTypes;
 use App\Http\Controllers\Controller;
 use App\Jobs\DeleteResourceJob;
 use App\Models\Application;
+use App\Models\ApplicationPreview;
 use App\Models\EnvironmentVariable;
 use App\Models\GithubApp;
 use App\Models\LocalFileVolume;
@@ -3604,6 +3605,14 @@ class ApplicationsController extends Controller
                     default: false,
                 )
             ),
+            new OA\Parameter(
+                name: 'pull_request_id',
+                in: 'query',
+                description: 'Pull request number. When provided, deploys a preview container for this PR. Auto-creates the preview if it does not exist.',
+                schema: new OA\Schema(
+                    type: 'integer',
+                )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -3655,11 +3664,27 @@ class ApplicationsController extends Controller
 
         $this->authorize('deploy', $application);
 
+        $pullRequestId = $request->input('pull_request_id', $request->input('pr'));
+        $pr = $pullRequestId ? max((int) $pullRequestId, 0) : 0;
+
+        if ($pr !== 0) {
+            $preview = $application->previews()->where('pull_request_id', $pr)->first();
+            if (! $preview) {
+                $preview = ApplicationPreview::create([
+                    'application_id' => $application->id,
+                    'pull_request_id' => $pr,
+                    'pull_request_html_url' => '',
+                ]);
+                $preview->generate_preview_fqdn();
+            }
+        }
+
         $deployment_uuid = new Cuid2;
 
         $result = queue_application_deployment(
             application: $application,
             deployment_uuid: $deployment_uuid,
+            pull_request_id: $pr,
             force_rebuild: $force,
             is_api: true,
             no_questions_asked: $instant_deploy
@@ -3710,6 +3735,14 @@ class ApplicationsController extends Controller
                     default: true,
                 )
             ),
+            new OA\Parameter(
+                name: 'pull_request_id',
+                in: 'query',
+                description: 'Pull request number. When provided, stops only the preview container for this PR instead of the main application.',
+                schema: new OA\Schema(
+                    type: 'integer',
+                )
+            ),
         ],
         responses: [
             new OA\Response(
@@ -3758,6 +3791,30 @@ class ApplicationsController extends Controller
 
         $this->authorize('deploy', $application);
 
+        $pullRequestId = $request->input('pull_request_id', $request->input('pr'));
+        $pr = $pullRequestId ? max((int) $pullRequestId, 0) : 0;
+
+        if ($pr !== 0) {
+            $preview = $application->previews()->where('pull_request_id', $pr)->first();
+            if (! $preview) {
+                return response()->json(['message' => "Pull request {$pr} not found."], 404);
+            }
+
+            $server = $application->destination->server;
+            $containers = getCurrentApplicationContainerStatus($server, $application->id, $pr);
+            if ($containers->isEmpty()) {
+                return response()->json(['message' => "No running container found for PR #{$pr}."], 404);
+            }
+            foreach ($containers->pluck('Names') as $containerName) {
+                instant_remote_process(command: [
+                    "docker stop -t 30 $containerName",
+                    "docker rm -f $containerName",
+                ], server: $server, throwError: false);
+            }
+
+            return response()->json(['message' => "Preview container for PR #{$pr} stopping request queued."]);
+        }
+
         $dockerCleanup = $request->boolean('docker_cleanup', true);
         StopApplication::dispatch($application, false, $dockerCleanup);
 
@@ -3785,6 +3842,14 @@ class ApplicationsController extends Controller
                 required: true,
                 schema: new OA\Schema(
                     type: 'string',
+                )
+            ),
+            new OA\Parameter(
+                name: 'pull_request_id',
+                in: 'query',
+                description: 'Pull request number. When provided, restarts only the preview container for this PR. Auto-creates the preview if it does not exist.',
+                schema: new OA\Schema(
+                    type: 'integer',
                 )
             ),
         ],
@@ -3837,11 +3902,27 @@ class ApplicationsController extends Controller
 
         $this->authorize('deploy', $application);
 
+        $pullRequestId = $request->input('pull_request_id', $request->input('pr'));
+        $pr = $pullRequestId ? max((int) $pullRequestId, 0) : 0;
+
+        if ($pr !== 0) {
+            $preview = $application->previews()->where('pull_request_id', $pr)->first();
+            if (! $preview) {
+                $preview = ApplicationPreview::create([
+                    'application_id' => $application->id,
+                    'pull_request_id' => $pr,
+                    'pull_request_html_url' => '',
+                ]);
+                $preview->generate_preview_fqdn();
+            }
+        }
+
         $deployment_uuid = new Cuid2;
 
         $result = queue_application_deployment(
             application: $application,
             deployment_uuid: $deployment_uuid,
+            pull_request_id: $pr,
             restart_only: true,
             is_api: true,
         );

--- a/app/Http/Controllers/Api/DeployController.php
+++ b/app/Http/Controllers/Api/DeployController.php
@@ -405,6 +405,14 @@ class DeployController extends Controller
                         $dockerTagForResource = $preview?->docker_registry_image_tag;
                     } else {
                         $preview = $resource->previews()->where('pull_request_id', $pr)->first();
+                        if (! $preview && $resource instanceof Application) {
+                            $preview = ApplicationPreview::create([
+                                'application_id' => $resource->id,
+                                'pull_request_id' => $pr,
+                                'pull_request_html_url' => '',
+                            ]);
+                            $preview->generate_preview_fqdn();
+                        }
                     }
                     if (! $preview) {
                         $deployments->push(['message' => "Pull request {$pr} not found for this resource.", 'resource_uuid' => $uuid]);

--- a/tests/Feature/PreviewDeploymentApiTest.php
+++ b/tests/Feature/PreviewDeploymentApiTest.php
@@ -1,0 +1,165 @@
+<?php
+
+use App\Models\Application;
+use App\Models\ApplicationPreview;
+use App\Models\Environment;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Str;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Queue::fake();
+
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+
+    $plainTextToken = Str::random(40);
+    $token = $this->user->tokens()->create([
+        'name' => 'test-token',
+        'token' => hash('sha256', $plainTextToken),
+        'abilities' => ['*'],
+        'team_id' => $this->team->id,
+    ]);
+    $this->bearerToken = $token->getKey().'|'.$plainTextToken;
+
+    $this->server = Server::factory()->create(['team_id' => $this->team->id]);
+    $this->destination = StandaloneDocker::factory()->create([
+        'server_id' => $this->server->id,
+        'network' => 'coolify-'.Str::lower(Str::random(8)),
+    ]);
+    $this->project = Project::factory()->create(['team_id' => $this->team->id]);
+    $this->environment = Environment::factory()->create(['project_id' => $this->project->id]);
+});
+
+function createApplication(Environment $environment, StandaloneDocker $destination): Application
+{
+    return Application::factory()->create([
+        'uuid' => (string) Str::uuid(),
+        'environment_id' => $environment->id,
+        'destination_id' => $destination->id,
+        'destination_type' => StandaloneDocker::class,
+        'build_pack' => 'nixpacks',
+        'git_repository' => 'https://github.com/example/repo',
+        'git_branch' => 'main',
+    ]);
+}
+
+test('start endpoint auto-creates preview when pull_request_id is provided', function () {
+    $application = createApplication($this->environment, $this->destination);
+
+    $response = $this->withHeaders([
+        'Authorization' => 'Bearer '.$this->bearerToken,
+    ])->postJson("/api/v1/applications/{$application->uuid}/start", [
+        'pull_request_id' => 42,
+    ]);
+
+    $response->assertSuccessful();
+
+    $preview = ApplicationPreview::query()
+        ->where('application_id', $application->id)
+        ->where('pull_request_id', 42)
+        ->first();
+
+    expect($preview)->not()->toBeNull();
+    expect($preview->pull_request_id)->toBe(42);
+});
+
+test('start endpoint reuses existing preview', function () {
+    $application = createApplication($this->environment, $this->destination);
+
+    $existingPreview = ApplicationPreview::create([
+        'application_id' => $application->id,
+        'pull_request_id' => 42,
+        'pull_request_html_url' => 'https://github.com/example/repo/pull/42',
+    ]);
+
+    $response = $this->withHeaders([
+        'Authorization' => 'Bearer '.$this->bearerToken,
+    ])->postJson("/api/v1/applications/{$application->uuid}/start", [
+        'pull_request_id' => 42,
+    ]);
+
+    $response->assertSuccessful();
+
+    $previewCount = ApplicationPreview::query()
+        ->where('application_id', $application->id)
+        ->where('pull_request_id', 42)
+        ->count();
+
+    expect($previewCount)->toBe(1);
+});
+
+test('restart endpoint auto-creates preview when pull_request_id is provided', function () {
+    $application = createApplication($this->environment, $this->destination);
+
+    $response = $this->withHeaders([
+        'Authorization' => 'Bearer '.$this->bearerToken,
+    ])->postJson("/api/v1/applications/{$application->uuid}/restart", [
+        'pull_request_id' => 55,
+    ]);
+
+    $response->assertSuccessful();
+
+    $preview = ApplicationPreview::query()
+        ->where('application_id', $application->id)
+        ->where('pull_request_id', 55)
+        ->first();
+
+    expect($preview)->not()->toBeNull();
+});
+
+test('deploy endpoint auto-creates preview for non-dockerimage apps', function () {
+    $application = createApplication($this->environment, $this->destination);
+
+    $response = $this->withHeaders([
+        'Authorization' => 'Bearer '.$this->bearerToken,
+    ])->postJson('/api/v1/deploy', [
+        'uuid' => $application->uuid,
+        'pull_request_id' => 77,
+    ]);
+
+    $response->assertSuccessful();
+
+    $preview = ApplicationPreview::query()
+        ->where('application_id', $application->id)
+        ->where('pull_request_id', 77)
+        ->first();
+
+    expect($preview)->not()->toBeNull();
+});
+
+test('start endpoint without pull_request_id deploys main app', function () {
+    $application = createApplication($this->environment, $this->destination);
+
+    $response = $this->withHeaders([
+        'Authorization' => 'Bearer '.$this->bearerToken,
+    ])->postJson("/api/v1/applications/{$application->uuid}/start");
+
+    $response->assertSuccessful();
+
+    $previewCount = ApplicationPreview::query()
+        ->where('application_id', $application->id)
+        ->count();
+
+    expect($previewCount)->toBe(0);
+});
+
+test('stop endpoint returns 404 for non-existent preview', function () {
+    $application = createApplication($this->environment, $this->destination);
+
+    $response = $this->withHeaders([
+        'Authorization' => 'Bearer '.$this->bearerToken,
+    ])->postJson("/api/v1/applications/{$application->uuid}/stop", [
+        'pull_request_id' => 999,
+    ]);
+
+    $response->assertStatus(404);
+});


### PR DESCRIPTION
## Summary

- The `/applications/{uuid}/start` and `/restart` endpoints now accept an optional `pull_request_id` (or `pr`) query parameter. When provided, they auto-create an `ApplicationPreview` record if one doesn't exist, then queue a deployment targeting that PR's preview container.
- The `/applications/{uuid}/stop` endpoint now accepts `pull_request_id` to stop only the preview container for that PR instead of the main application.
- The generic `/deploy` endpoint now auto-creates previews for **all** application types (previously only Docker Image apps got auto-created previews; other build packs like Nixpacks/Dockerfile returned a 404 if no preview existed).

## Motivation

CI/CD workflows (e.g. GitHub Actions) that provision preview infrastructure externally need to trigger preview deployments and restarts via the API without relying on GitHub webhooks to create the `ApplicationPreview` record first. Currently the only way to deploy a PR preview is through the `/deploy` endpoint, and even that fails for non-Docker-Image apps if the webhook hasn't fired.

This unlocks patterns like:
```bash
# Deploy PR preview via API (auto-creates preview if needed)
curl -X POST "https://coolify.example.com/api/v1/applications/{uuid}/start?pull_request_id=42" \
  -H "Authorization: Bearer $TOKEN"

# Restart just the PR preview container
curl -X POST "https://coolify.example.com/api/v1/applications/{uuid}/restart?pull_request_id=42" \
  -H "Authorization: Bearer $TOKEN"

# Stop just the PR preview container  
curl -X POST "https://coolify.example.com/api/v1/applications/{uuid}/stop?pull_request_id=42" \
  -H "Authorization: Bearer $TOKEN"
```

## Changes

- `ApplicationsController::action_deploy()` — accepts `pull_request_id`/`pr`, auto-creates preview, passes PR ID to `queue_application_deployment`
- `ApplicationsController::action_restart()` — accepts `pull_request_id`/`pr`, auto-creates preview, passes PR ID to `queue_application_deployment` with `restart_only: true`
- `ApplicationsController::action_stop()` — accepts `pull_request_id`/`pr`, stops only the PR container via `getCurrentApplicationContainerStatus`
- `DeployController::by_uuids()` — auto-creates preview for non-Docker-Image apps (Nixpacks, Dockerfile, etc.) instead of returning 404
- OpenAPI annotations updated for all three endpoints

## Test plan

- [ ] Added `tests/Feature/PreviewDeploymentApiTest.php` with 6 tests covering auto-creation, reuse, and 404 scenarios
- [ ] Verify `POST /applications/{uuid}/start?pull_request_id=42` creates preview + queues deployment
- [ ] Verify `POST /applications/{uuid}/restart?pull_request_id=42` creates preview + queues restart
- [ ] Verify `POST /applications/{uuid}/stop?pull_request_id=42` stops only PR container
- [ ] Verify existing behavior unchanged when `pull_request_id` is not provided
- [ ] Verify `/deploy?uuid={uuid}&pull_request_id=42` auto-creates preview for Nixpacks apps