### PR TITLE
[Enhancement] Add new deployment page

### DIFF
--- a/app/Livewire/Deployments.php
+++ b/app/Livewire/Deployments.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\ApplicationDeploymentQueue;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+use Livewire\Component;
+
+class Deployments extends Component
+{
+    public ?string $status = null;
+
+    public ?string $project = null;
+
+    public ?string $server = null;
+
+    public ?string $source = null;
+
+    protected $queryString = [
+        'status' => ['except' => ''],
+        'project' => ['except' => ''],
+        'server' => ['except' => ''],
+        'source' => ['except' => ''],
+    ];
+
+    public function render()
+    {
+        $baseQuery = ApplicationDeploymentQueue::query()
+            ->with(['application.environment.project'])
+            ->whereHas('application.environment.project', function (Builder $query) {
+                $query->where('team_id', currentTeam()->id);
+            });
+
+        $deployments = (clone $baseQuery)
+            ->when($this->status, fn (Builder $query) => $query->where('status', $this->status))
+            ->when($this->project, function (Builder $query) {
+                $query->whereHas('application.environment.project', function (Builder $projectQuery) {
+                    $projectQuery->where('name', $this->project);
+                });
+            })
+            ->when($this->server, fn (Builder $query) => $query->where('server_name', $this->server))
+            ->when($this->source, fn (Builder $query) => $query->where('git_type', $this->source))
+            ->latest()
+            ->get();
+
+        return view('livewire.deployments', [
+            'deployments' => $deployments,
+            'availableProjects' => $this->availableProjects($baseQuery),
+            'availableServers' => $this->availableServers($baseQuery),
+            'availableSources' => $this->availableSources($baseQuery),
+            'availableStatuses' => $this->availableStatuses($baseQuery),
+        ]);
+    }
+
+    private function availableProjects(Builder $query): Collection
+    {
+        return (clone $query)
+            ->get()
+            ->map(fn (ApplicationDeploymentQueue $deployment) => data_get($deployment, 'application.environment.project.name'))
+            ->filter()
+            ->unique()
+            ->sort()
+            ->values();
+    }
+
+    private function availableServers(Builder $query): Collection
+    {
+        return (clone $query)
+            ->pluck('server_name')
+            ->filter()
+            ->unique()
+            ->sort()
+            ->values();
+    }
+
+    private function availableSources(Builder $query): Collection
+    {
+        return (clone $query)
+            ->pluck('git_type')
+            ->filter()
+            ->unique()
+            ->sort()
+            ->values();
+    }
+
+    private function availableStatuses(Builder $query): Collection
+    {
+        return (clone $query)
+            ->pluck('status')
+            ->filter()
+            ->unique()
+            ->sort()
+            ->values();
+    }
+}

--- a/resources/views/components/navbar.blade.php
+++ b/resources/views/components/navbar.blade.php
@@ -150,6 +150,21 @@
                     </li>
 
                     <li>
+                        <a title="Deployments" {{ wireNavigate() }}
+                            class="{{ request()->is('deployments') ? 'menu-item-active menu-item' : 'menu-item' }}"
+                            href="{{ route('deployments.index') }}">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="menu-item-icon" viewBox="0 0 24 24" fill="none"
+                                stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M4 7h16" />
+                                <path d="M4 12h10" />
+                                <path d="M4 17h7" />
+                                <path d="m17 14l3 3l-3 3" />
+                                <path d="M20 17h-6" />
+                            </svg>
+                            <span class="menu-item-label">Deployments</span>
+                        </a>
+                    </li>
+                    <li>
                         <a title="Sources" {{ wireNavigate() }}
                             class="{{ request()->is('source*') ? 'menu-item-active menu-item' : 'menu-item' }}"
                             href="{{ route('source.all') }}">

--- a/resources/views/livewire/deployments.blade.php
+++ b/resources/views/livewire/deployments.blade.php
@@ -1,0 +1,103 @@
+<div>
+    <x-slot:title>
+        Deployments | Coolify
+    </x-slot>
+
+    <div class="flex items-center gap-2">
+        <h1>Deployments</h1>
+        <span class="text-xs">({{ $deployments->count() }})</span>
+    </div>
+    <div class="subtitle">Track recent and historical deployments across the current team.</div>
+
+    @php
+        $filterColumns = 2 + ($availableServers->count() > 1 ? 1 : 0) + ($availableSources->count() > 1 ? 1 : 0);
+        $filterGridClass = match ($filterColumns) {
+            2 => 'xl:grid-cols-2',
+            3 => 'xl:grid-cols-3',
+            default => 'xl:grid-cols-4',
+        };
+    @endphp
+
+    <div class="grid grid-cols-1 gap-3 md:grid-cols-2 mb-6 {{ $filterGridClass }}">
+        <div>
+            <label class="label">Project</label>
+            <select wire:model.live="project" class="w-full rounded border border-neutral-300 bg-white px-3 py-2 dark:border-coolgray-200 dark:bg-coolgray-100">
+                <option value="">All projects</option>
+                @foreach ($availableProjects as $projectName)
+                    <option value="{{ $projectName }}">{{ $projectName }}</option>
+                @endforeach
+            </select>
+        </div>
+        @if ($availableServers->count() > 1)
+            <div>
+                <label class="label">Server</label>
+                <select wire:model.live="server" class="w-full rounded border border-neutral-300 bg-white px-3 py-2 dark:border-coolgray-200 dark:bg-coolgray-100">
+                    <option value="">All servers</option>
+                    @foreach ($availableServers as $serverName)
+                        <option value="{{ $serverName }}">{{ $serverName }}</option>
+                    @endforeach
+                </select>
+            </div>
+        @endif
+        @if ($availableSources->count() > 1)
+            <div>
+                <label class="label">Source</label>
+                <select wire:model.live="source" class="w-full rounded border border-neutral-300 bg-white px-3 py-2 dark:border-coolgray-200 dark:bg-coolgray-100">
+                    <option value="">All sources</option>
+                    @foreach ($availableSources as $sourceName)
+                        <option value="{{ $sourceName }}">{{ str($sourceName)->headline() }}</option>
+                    @endforeach
+                </select>
+            </div>
+        @endif
+        <div>
+            <label class="label">Status</label>
+            <select wire:model.live="status" class="w-full rounded border border-neutral-300 bg-white px-3 py-2 dark:border-coolgray-200 dark:bg-coolgray-100">
+                <option value="">All statuses</option>
+                @foreach ($availableStatuses as $statusName)
+                    <option value="{{ $statusName }}">{{ str($statusName)->headline() }}</option>
+                @endforeach
+            </select>
+        </div>
+    </div>
+
+    <div class="flex flex-col gap-3" wire:poll.5000ms>
+        @forelse ($deployments as $deployment)
+            <a href="{{ data_get($deployment, 'deployment_url') ?: '#' }}" {{ wireNavigate() }} class="block">
+                <div @class([
+                    'p-4 border-l-2 bg-white dark:bg-coolgray-100 rounded-r-md',
+                    'border-purple-500/50 border-dashed' => data_get($deployment, 'status') === 'queued',
+                    'border-blue-500/50 border-dashed' => data_get($deployment, 'status') === 'in_progress',
+                    'border-success' => data_get($deployment, 'status') === 'finished',
+                    'border-error' => data_get($deployment, 'status') === 'failed',
+                    'border-white border-dashed' => data_get($deployment, 'status') === 'cancelled-by-user',
+                ])>
+                    <div class="flex items-start justify-between gap-4">
+                        <div class="min-w-0">
+                            <div class="box-title">{{ data_get($deployment, 'application_name') }}</div>
+                            <div class="box-description">
+                                {{ data_get($deployment, 'application.environment.project.name') }}
+                            </div>
+                        </div>
+                        <span class="text-xs px-2 py-1 rounded bg-neutral-100 dark:bg-coolgray-200">
+                            {{ str(data_get($deployment, 'status'))->headline() }}
+                        </span>
+                    </div>
+                    <div class="mt-3 text-sm text-neutral-600 dark:text-neutral-400 grid gap-1 md:grid-cols-2 xl:grid-cols-4">
+                        <div>Server: {{ data_get($deployment, 'server_name') ?: 'Unknown' }}</div>
+                        <div>Source: {{ str(data_get($deployment, 'git_type') ?: 'unknown')->headline() }}</div>
+                        <div>Created: {{ data_get($deployment, 'created_at') }}</div>
+                        <div>Commit: {{ str(data_get($deployment, 'commit') ?: 'HEAD')->limit(12) }}</div>
+                    </div>
+                    @if (data_get($deployment, 'commit_message'))
+                        <div class="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
+                            {{ data_get($deployment, 'commit_message') }}
+                        </div>
+                    @endif
+                </div>
+            </a>
+        @empty
+            <div>No deployments found.</div>
+        @endforelse
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\UploadController;
 use App\Livewire\Admin\Index as AdminIndex;
 use App\Livewire\Boarding\Index as BoardingIndex;
 use App\Livewire\Dashboard;
+use App\Livewire\Deployments as DeploymentsIndex;
 use App\Livewire\Destination\Index as DestinationIndex;
 use App\Livewire\Destination\Show as DestinationShow;
 use App\Livewire\ForcePasswordReset;
@@ -125,6 +126,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/settings/scheduled-jobs', SettingsScheduledJobs::class)->name('settings.scheduled-jobs');
 
     Route::get('/profile', ProfileIndex::class)->name('profile');
+    Route::get('/deployments', DeploymentsIndex::class)->name('deployments.index');
 
     Route::prefix('tags')->group(function () {
         Route::get('/{tagName?}', TagsShow::class)->name('tags.show');

--- a/tests/Feature/DeploymentsPageTest.php
+++ b/tests/Feature/DeploymentsPageTest.php
@@ -1,0 +1,135 @@
+<?php
+
+use App\Models\Application;
+use App\Models\ApplicationDeploymentQueue;
+use App\Models\Environment;
+use App\Models\InstanceSettings;
+use App\Models\Project;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::query()->forceCreate([
+        'id' => 0,
+        'is_registration_enabled' => true,
+    ]);
+
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->user->teams()->attach($this->team, ['role' => 'owner']);
+
+    $this->actingAs($this->user);
+    session(['currentTeam' => $this->team]);
+});
+
+function createDeploymentForTeam(Team $team, array $deploymentOverrides = [], array $applicationOverrides = [], array $projectOverrides = []): ApplicationDeploymentQueue
+{
+    $project = Project::factory()->create(array_merge([
+        'team_id' => $team->id,
+        'name' => 'Alpha Project',
+    ], $projectOverrides));
+
+    $environment = Environment::factory()->create([
+        'project_id' => $project->id,
+    ]);
+
+    $application = Application::factory()->create(array_merge([
+        'environment_id' => $environment->id,
+        'name' => 'Alpha App',
+    ], $applicationOverrides));
+
+    return ApplicationDeploymentQueue::query()->create(array_merge([
+        'application_id' => (string) $application->id,
+        'deployment_uuid' => 'dep-'.$application->id.'-'.str()->random(8),
+        'status' => 'queued',
+        'application_name' => $application->name,
+        'server_name' => 'Main Server',
+        'server_id' => 101,
+        'git_type' => 'github',
+        'deployment_url' => '/project/test/environment/test/application/test/deployment',
+        'commit_message' => 'Deploy alpha app',
+    ], $deploymentOverrides));
+}
+
+it('shows deployments page link in the main navbar', function () {
+    $response = $this->get('/');
+
+    $response->assertOk();
+    $response->assertSee('Deployments');
+    $response->assertSee('/deployments', false);
+});
+
+it('lists deployments belonging to the current team', function () {
+    createDeploymentForTeam($this->team);
+    createDeploymentForTeam($this->team, [
+        'status' => 'finished',
+        'server_name' => 'Build Server',
+    ], [
+        'name' => 'Beta App',
+    ], [
+        'name' => 'Beta Project',
+    ]);
+
+    $otherTeam = Team::factory()->create();
+    createDeploymentForTeam($otherTeam, [], ['name' => 'Hidden App'], ['name' => 'Hidden Project']);
+
+    $response = $this->get('/deployments');
+
+    $response->assertOk();
+    $response->assertSee('Alpha App');
+    $response->assertSee('Beta App');
+    $response->assertDontSee('Hidden App');
+    $response->assertSee('Alpha Project');
+    $response->assertSee('Beta Project');
+});
+
+it('filters deployments by status, project, server, and source', function () {
+    createDeploymentForTeam($this->team, [
+        'status' => 'queued',
+        'server_name' => 'Queue Server',
+        'git_type' => 'github',
+    ], [
+        'name' => 'Queued App',
+    ], [
+        'name' => 'Queued Project',
+    ]);
+
+    createDeploymentForTeam($this->team, [
+        'status' => 'failed',
+        'server_name' => 'Fail Server',
+        'git_type' => 'gitlab',
+    ], [
+        'name' => 'Failed App',
+    ], [
+        'name' => 'Failed Project',
+    ]);
+
+    $response = $this->get('/deployments?status=queued&project=Queued+Project&server=Queue+Server&source=github');
+
+    $response->assertOk();
+    $response->assertSee('Queued App');
+    $response->assertDontSee('Failed App');
+});
+
+it('hides server and source filters when there is only one choice', function () {
+    createDeploymentForTeam($this->team, [
+        'status' => 'queued',
+        'server_name' => 'Solo Server',
+        'git_type' => 'github',
+    ], [
+        'name' => 'Solo App',
+    ], [
+        'name' => 'Solo Project',
+    ]);
+
+    $response = $this->get('/deployments');
+
+    $response->assertOk();
+    $response->assertSee('Project');
+    $response->assertSee('Status');
+    $response->assertDontSee('All servers');
+    $response->assertDontSee('All sources');
+});


### PR DESCRIPTION
/claim #7596

## Summary
- add a new Deployments page for the current team
- add a Deployments link to the main navbar
- support filtering deployments by status, project, server, and source

## Motivation
This PR implements the first version of the deployments overview requested in #7596.

It adds a dedicated page where users can review recent and historical deployments across the current team, with lightweight filters to make the list easier to navigate.

## Changes
- add `Deployments` Livewire page component
- add `/deployments` route (`deployments.index`)
- add a `Deployments` entry to the main navbar
- render deployment records for the current team
- add filters for:
  - status
  - project
  - server
  - source
- add feature tests covering navigation visibility, team-scoped listing, and filtering behavior

## Test Plan
- [x] run `php artisan test tests/Feature/DeploymentsPageTest.php`
- [x] verify the Deployments link appears in the main navbar
- [x] verify the page lists deployments for the current team only
- [x] verify filtering works for status, project, server, and source

## Notes for Reviewers
This is an initial implementation focused on the core list + filtering workflow requested by the issue.
