### PR TITLE
Allow OAuth-only self registration

### DIFF
--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\ResetsUserPasswords;
 
 class ResetUserPassword implements ResetsUserPasswords
@@ -20,6 +21,12 @@ class ResetUserPassword implements ResetsUserPasswords
         Validator::make($input, [
             'password' => ['required', Password::defaults(), 'confirmed'],
         ])->validate();
+
+        if (instanceSettings()->is_oauth_password_creation_disabled && ! $user->hasPassword()) {
+            throw ValidationException::withMessages([
+                'email' => __('Password login is disabled for this OAuth account. Please continue with your OAuth provider.'),
+            ]);
+        }
 
         $user->fill([
             'password' => Hash::make($input['password']),

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -78,6 +78,11 @@ class Controller extends BaseController
                 return response()->json(['message' => 'Transactional emails are not active'], 400);
             }
             $request->validate([Fortify::email() => 'required|email']);
+            $user = User::whereEmail($request->input(Fortify::email()))->first();
+            if ($user && instanceSettings()->is_oauth_password_creation_disabled && ! $user->hasPassword()) {
+                return app(SuccessfulPasswordResetLinkRequestResponse::class, ['status' => Password::RESET_LINK_SENT]);
+            }
+
             $status = Password::broker(config('fortify.passwords'))->sendResetLink(
                 $request->only(Fortify::email())
             );

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -22,7 +22,7 @@ class OauthController extends Controller
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! $settings->is_oauth_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 

--- a/app/Livewire/SettingsOauth.php
+++ b/app/Livewire/SettingsOauth.php
@@ -2,12 +2,19 @@
 
 namespace App\Livewire;
 
+use App\Models\InstanceSettings;
 use App\Models\OauthSetting;
 use Livewire\Component;
 
 class SettingsOauth extends Component
 {
+    public InstanceSettings $settings;
+
     public $oauth_settings_map;
+
+    public bool $is_oauth_registration_enabled = false;
+
+    public bool $is_oauth_password_creation_disabled = false;
 
     protected function rules()
     {
@@ -20,7 +27,10 @@ class SettingsOauth extends Component
             $carry["oauth_settings_map.$setting->provider.base_url"] = 'nullable';
 
             return $carry;
-        }, []);
+        }, [
+            'is_oauth_registration_enabled' => 'boolean',
+            'is_oauth_password_creation_disabled' => 'boolean',
+        ]);
     }
 
     public function mount()
@@ -28,6 +38,9 @@ class SettingsOauth extends Component
         if (! isInstanceAdmin()) {
             return redirect()->route('home');
         }
+        $this->settings = instanceSettings();
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled;
+        $this->is_oauth_password_creation_disabled = $this->settings->is_oauth_password_creation_disabled;
         $this->oauth_settings_map = OauthSetting::all()->sortBy('provider')->reduce(function ($carry, $setting) {
             $carry[$setting->provider] = [
                 'id' => $setting->id,
@@ -42,6 +55,13 @@ class SettingsOauth extends Component
 
             return $carry;
         }, []);
+    }
+
+    private function updateInstanceSettings()
+    {
+        $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
+        $this->settings->is_oauth_password_creation_disabled = $this->is_oauth_password_creation_disabled;
+        $this->settings->save();
     }
 
     private function updateOauthSettings(?string $provider = null)
@@ -128,6 +148,20 @@ class SettingsOauth extends Component
         }
     }
 
+    public function saveInstanceSettings()
+    {
+        try {
+            $this->validate([
+                'is_oauth_registration_enabled' => 'boolean',
+                'is_oauth_password_creation_disabled' => 'boolean',
+            ]);
+            $this->updateInstanceSettings();
+            $this->dispatch('success', 'OAuth instance settings updated successfully!');
+        } catch (\Exception $e) {
+            return handleError($e, $this);
+        }
+    }
+
     public function instantSave(string $provider)
     {
         try {
@@ -139,6 +173,8 @@ class SettingsOauth extends Component
 
     public function submit()
     {
+        $this->validate();
+        $this->updateInstanceSettings();
         $this->updateOauthSettings();
         $this->dispatch('success', 'Instance settings updated successfully!');
     }

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -18,6 +18,8 @@ class InstanceSettings extends Model
         'do_not_track',
         'is_auto_update_enabled',
         'is_registration_enabled',
+        'is_oauth_registration_enabled',
+        'is_oauth_password_creation_disabled',
         'next_channel',
         'smtp_enabled',
         'smtp_from_address',
@@ -63,6 +65,9 @@ class InstanceSettings extends Model
 
         'allowed_ip_ranges' => 'array',
         'is_auto_update_enabled' => 'boolean',
+        'is_registration_enabled' => 'boolean',
+        'is_oauth_registration_enabled' => 'boolean',
+        'is_oauth_password_creation_disabled' => 'boolean',
         'auto_update_frequency' => 'string',
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',

--- a/database/migrations/2026_04_22_000000_add_oauth_registration_settings_to_instance_settings_table.php
+++ b/database/migrations/2026_04_22_000000_add_oauth_registration_settings_to_instance_settings_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_registration_enabled')->default(false);
+            $table->boolean('is_oauth_password_creation_disabled')->default(false);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn([
+                'is_oauth_registration_enabled',
+                'is_oauth_password_creation_disabled',
+            ]);
+        });
+    }
+};

--- a/resources/views/livewire/settings-oauth.blade.php
+++ b/resources/views/livewire/settings-oauth.blade.php
@@ -13,6 +13,19 @@
             </div>
             <div class="pb-4 ">Custom authentication (OAuth) configurations.</div>
         </div>
+        <div class="flex flex-col gap-1 pb-4">
+            <h3>OAuth Registration</h3>
+            <div class="md:w-96">
+                <x-forms.checkbox instantSave="saveInstanceSettings" id="is_oauth_registration_enabled"
+                    label="OAuth Registration Allowed"
+                    helper="Allow new users to self-register through enabled OAuth providers even when normal registration is disabled." />
+            </div>
+            <div class="md:w-96">
+                <x-forms.checkbox instantSave="saveInstanceSettings" id="is_oauth_password_creation_disabled"
+                    label="OAuth Accounts Only"
+                    helper="Keep OAuth-created accounts without passwords by blocking password resets for accounts that do not already have a password." />
+            </div>
+        </div>
         <div class="flex flex-col gap-2 pt-4">
             @foreach ($oauth_settings_map as $oauth_setting)
                 <div class="p-4 border dark:border-coolgray-300 border-neutral-200">

--- a/tests/Feature/OauthRegistrationSettingsTest.php
+++ b/tests/Feature/OauthRegistrationSettingsTest.php
@@ -1,0 +1,108 @@
+<?php
+
+use App\Actions\Fortify\ResetUserPassword;
+use App\Models\InstanceSettings;
+use App\Models\OauthSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Once;
+use Illuminate\Validation\ValidationException;
+use Laravel\Socialite\Facades\Socialite;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::unguarded(function () {
+        InstanceSettings::query()->create([
+            'id' => 0,
+            'is_registration_enabled' => false,
+            'is_oauth_registration_enabled' => false,
+            'is_oauth_password_creation_disabled' => false,
+        ]);
+    });
+
+    OauthSetting::query()->create([
+        'provider' => 'github',
+        'enabled' => true,
+        'client_id' => 'github-client-id',
+        'client_secret' => 'github-client-secret',
+        'redirect_uri' => 'http://localhost/auth/github/callback',
+    ]);
+
+    Once::flush();
+});
+
+function mockGithubOauthUser(string $email = 'oauth@example.com', string $name = 'OAuth User'): void
+{
+    $provider = new class($email, $name)
+    {
+        public function __construct(
+            private string $email,
+            private string $name,
+        ) {}
+
+        public function user(): object
+        {
+            return (object) [
+                'email' => $this->email,
+                'name' => $this->name,
+            ];
+        }
+    };
+
+    Socialite::shouldReceive('buildProvider')->once()->andReturn($provider);
+}
+
+it('keeps oauth registration disabled by default when normal registration is disabled', function () {
+    mockGithubOauthUser();
+
+    $this->get(route('auth.callback', 'github'))
+        ->assertRedirect(route('login'));
+
+    expect(User::whereEmail('oauth@example.com')->exists())->toBeFalse();
+});
+
+it('allows oauth registration when enabled even if normal registration is disabled', function () {
+    InstanceSettings::findOrFail(0)->update(['is_oauth_registration_enabled' => true]);
+    Once::flush();
+
+    mockGithubOauthUser();
+
+    $this->get(route('auth.callback', 'github'))
+        ->assertRedirect('/');
+
+    $user = User::whereEmail('oauth@example.com')->first();
+
+    expect($user)->not->toBeNull()
+        ->and($user->hasPassword())->toBeFalse()
+        ->and(auth()->id())->toBe($user->id);
+});
+
+it('blocks password creation for passwordless oauth users when oauth-only accounts are enabled', function () {
+    InstanceSettings::findOrFail(0)->update(['is_oauth_password_creation_disabled' => true]);
+    Once::flush();
+
+    $user = User::factory()->create(['password' => null]);
+
+    expect(fn () => (new ResetUserPassword)->reset($user, [
+        'password' => 'Password123!',
+        'password_confirmation' => 'Password123!',
+    ]))->toThrow(ValidationException::class);
+
+    expect($user->refresh()->password)->toBeNull();
+});
+
+it('still allows password resets for users that already have a password', function () {
+    InstanceSettings::findOrFail(0)->update(['is_oauth_password_creation_disabled' => true]);
+    Once::flush();
+
+    $user = User::factory()->create(['password' => Hash::make('old-password')]);
+
+    (new ResetUserPassword)->reset($user, [
+        'password' => 'Password123!',
+        'password_confirmation' => 'Password123!',
+    ]);
+
+    expect(Hash::check('Password123!', $user->refresh()->password))->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- allow enabled OAuth providers to create users when normal registration is disabled if OAuth registration is enabled
- add instance settings to enable OAuth registration and block password creation for passwordless OAuth accounts
- cover callback and reset behavior with feature tests

Fixes #8042

## Tests
- php -l app/Http/Controllers/OauthController.php
- php -l app/Http/Controllers/Controller.php
- php -l app/Actions/Fortify/ResetUserPassword.php
- php -l app/Livewire/SettingsOauth.php
- php -l tests/Feature/OauthRegistrationSettingsTest.php
- git diff --check

Pest was not run locally because this machine has PHP 8.2 while the project requires PHP 8.4, and Composer could not complete due missing local zip/unzip/extensions.