### PR TITLE
fix: correct application deployments OpenAPI schema

### DIFF
--- a/app/Http/Controllers/Api/DeployController.php
+++ b/app/Http/Controllers/Api/DeployController.php
@@ -629,7 +629,7 @@ class DeployController extends Controller
                         mediaType: 'application/json',
                         schema: new OA\Schema(
                             type: 'array',
-                            items: new OA\Items(ref: '#/components/schemas/Application'),
+                            items: new OA\Items(ref: '#/components/schemas/ApplicationDeploymentQueue'),
                         )
                     ),
                 ]),

--- a/openapi.json
+++ b/openapi.json
@@ -7459,7 +7459,7 @@
                                 "schema": {
                                     "type": "array",
                                     "items": {
-                                        "$ref": "#\/components\/schemas\/Application"
+                                        "$ref": "#\/components\/schemas\/ApplicationDeploymentQueue"
                                     }
                                 }
                             }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4829,7 +4829,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Application'
+                  $ref: '#/components/schemas/ApplicationDeploymentQueue'
         '401':
           $ref: '#/components/responses/401'
         '400':


### PR DESCRIPTION
## Summary
- Correct the `/deployments/applications/{uuid}` response schema to use `ApplicationDeploymentQueue`.
- Keep the committed OpenAPI YAML and JSON artifacts aligned with the controller annotation.

## Test plan
- Verified the controller annotation now references `ApplicationDeploymentQueue`.
- Ran `git diff --check` to confirm a clean diff.
- Confirmed the matching schema reference in `openapi.yaml` and `openapi.json`.
- Could not run `php -l` or regenerate OpenAPI locally because `php` and `vendor/` dependencies are not available in this environment.

## Changes
- Update the deployment endpoint OA annotation in `DeployController`.
- Update the checked-in `openapi.yaml` and `openapi.json` entries for the same endpoint.

## Issues
- Fixes #5874

## Category
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview
- N/A (OpenAPI spec change only)

## AI Assistance
- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**
- Tools used: Codex
- How extensively: I used it to prepare the patch and then reviewed the issue context and final diff manually.

## Testing
- `git diff --check`
- Verified the endpoint schema reference is `ApplicationDeploymentQueue` in the controller, `openapi.yaml`, and `openapi.json`.
- I could not run `php -l` or regenerate the OpenAPI files locally because `php` and `vendor/` dependencies are not available in this environment.

## Contributor Agreement
> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.