### PR TITLE
fix: focus confirmation modal on open

### DIFF
--- a/resources/views/components/modal-confirmation.blade.php
+++ b/resources/views/components/modal-confirmation.blade.php
@@ -43,6 +43,7 @@
 
 <div {{ $ignoreWire ? 'wire:ignore' : '' }} x-data="{
     modalOpen: false,
+    previouslyFocusedElement: null,
     step: {{ empty($checkboxes) ? 2 : 1 }},
     initialStep: {{ empty($checkboxes) ? 2 : 1 }},
     finalStep: {{ $confirmWithPassword && !$skipPasswordConfirmation ? 3 : 2 }},
@@ -127,6 +128,17 @@
         }
     }
 }"
+    x-init="$watch('modalOpen', value => {
+        if (value) {
+            previouslyFocusedElement = document.activeElement;
+            $nextTick(() => {
+                const focusTarget = $refs.confirmationModal?.querySelector('[data-modal-initial-focus], input, textarea, select, button:not([disabled]), [href], [tabindex]:not([tabindex=\'-1\'])');
+                focusTarget?.focus();
+            });
+        } else if (previouslyFocusedElement) {
+            $nextTick(() => previouslyFocusedElement?.focus?.());
+        }
+    })"
     @keydown.escape.window="if (modalOpen) { modalOpen = false; resetModal(); }" :class="{ 'z-40': modalOpen }"
     class="relative w-auto h-auto">
     @if (isset($trigger))
@@ -197,7 +209,7 @@
             class="fixed top-0 left-0 z-99 flex items-center justify-center w-screen h-screen p-0 sm:p-4" x-cloak>
             <div x-show="modalOpen" class="absolute inset-0 w-full h-full bg-black/20 backdrop-blur-xs">
             </div>
-            <div x-show="modalOpen" x-trap.inert.noscroll="modalOpen" x-transition:enter="ease-out duration-100"
+            <div x-show="modalOpen" x-ref="confirmationModal" x-trap.inert.noscroll="modalOpen" x-transition:enter="ease-out duration-100"
                 x-transition:enter-start="opacity-0 -translate-y-2 sm:scale-95"
                 x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"
                 x-transition:leave="ease-in duration-100"
@@ -206,7 +218,7 @@
                 class="relative w-full border rounded-none sm:rounded-sm min-w-full lg:min-w-[36rem] max-w-full sm:max-w-[48rem] h-screen sm:h-auto max-h-screen sm:max-h-[calc(100vh-2rem)] bg-neutral-100 border-neutral-400 dark:bg-base dark:border-coolgray-300 flex flex-col">
                 <div class="flex justify-between items-center py-6 px-7 shrink-0">
                     <h3 class="pr-8 text-2xl font-bold">{{ $title }}</h3>
-                    <button @click="modalOpen = false; resetModal()"
+                    <button data-modal-initial-focus @click="modalOpen = false; resetModal()"
                         class="flex absolute top-2 right-2 justify-center items-center w-8 h-8 rounded-full dark:text-white hover:bg-coolgray-300">
                         <svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
                             stroke-width="1.5" stroke="currentColor">

--- a/tests/Feature/ModalConfirmationComponentTest.php
+++ b/tests/Feature/ModalConfirmationComponentTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use App\Models\InstanceSettings;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\MessageBag;
+use Illuminate\Support\ViewErrorBag;
+
+beforeEach(function () {
+    InstanceSettings::updateOrCreate(['id' => 0]);
+
+    $errors = new ViewErrorBag;
+    $errors->put('default', new MessageBag);
+    view()->share('errors', $errors);
+});
+
+it('moves focus into the confirmation modal when it opens', function () {
+    $html = Blade::render('<x-modal-confirmation buttonTitle="Delete" />');
+
+    expect($html)
+        ->toContain('previouslyFocusedElement: null')
+        ->toContain("x-ref=\"confirmationModal\"")
+        ->toContain('data-modal-initial-focus')
+        ->toContain("const focusTarget = \$refs.confirmationModal?.querySelector('[data-modal-initial-focus], input, textarea, select, button:not([disabled]), [href], [tabindex]:not([tabindex=\\'-1\\'])')")
+        ->toContain('focusTarget?.focus();');
+});


### PR DESCRIPTION
## Summary
- Move focus into `x-modal-confirmation` when it opens so the triggering button does not remain focused behind the teleported dialog.
- Add a render-level component test that covers the new modal focus hook.

## Test plan
- Reviewed the rendered Blade changes to confirm the modal now tracks the previously focused element, focuses an element inside the dialog on open, and marks the close button as the initial focus target.
- Added a feature test that asserts the focus-management hooks are present in the rendered component markup.
- Could not run the PHP test suite in this environment because `php` is not available locally.

## Changes
- Add focus management to `resources/views/components/modal-confirmation.blade.php` so the shared confirmation modal focuses an element inside the dialog after opening.
- Add `tests/Feature/ModalConfirmationComponentTest.php` to cover the focus-management markup.

## Issues
- Fixes #5334

## Category
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview
- N/A (shared modal behavior change)

## AI Assistance
- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**
- Tools used: Codex
- How extensively: I used it to prepare the patch and then reviewed the issue context and final diff manually.

## Testing
- Reviewed the updated Blade markup and confirmed the modal now moves focus into the teleported dialog on open.
- Added a render-level component test for the focus-management markup.
- I could not run the PHP test suite locally because `php` is not available in this environment.

## Contributor Agreement
> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.