### PR TITLE
fix: limit initial changelog modal entries

### DIFF
--- a/resources/views/livewire/settings-dropdown.blade.php
+++ b/resources/views/livewire/settings-dropdown.blade.php
@@ -2,12 +2,18 @@
     dropdownOpen: false,
     search: '',
     allEntries: [],
+    visibleEntryCount: 10,
     darkColorContent: getComputedStyle($el).getPropertyValue('--color-base'),
     whiteColorContent: getComputedStyle($el).getPropertyValue('--color-white'),
     init() {
         this.mounted();
         // Load all entries when component initializes
         this.allEntries = @js($entries->toArray());
+        this.$watch('search', value => {
+            if (value.trim() === '') {
+                this.visibleEntryCount = 10;
+            }
+        });
     },
     markEntryAsRead(tagName) {
         // Update the entry in our local Alpine data
@@ -94,7 +100,7 @@
         }
 
         // Always sort: unread first, then by published date (newest first)
-        return entries.sort((a, b) => {
+        return [...entries].sort((a, b) => {
             // First sort by read status (unread first)
             if (a.is_read !== b.is_read) {
                 return a.is_read ? 1 : -1; // unread (false) comes before read (true)
@@ -102,6 +108,19 @@
             // Then sort by published date (newest first)
             return new Date(b.published_at) - new Date(a.published_at);
         });
+    },
+    get displayedEntries() {
+        if (this.search.trim() !== '') {
+            return this.filteredEntries;
+        }
+
+        return this.filteredEntries.slice(0, this.visibleEntryCount);
+    },
+    get hasMoreEntries() {
+        return this.search.trim() === '' && this.filteredEntries.length > this.visibleEntryCount;
+    },
+    showMoreEntries() {
+        this.visibleEntryCount += 10;
     }
 }" @click.outside="dropdownOpen = false">
     <!-- Custom Dropdown without arrow -->
@@ -134,7 +153,7 @@
                 <div class="flex flex-col gap-1">
                     <!-- What's New Section -->
                     @if ($unreadCount > 0)
-                        <button wire:click="openWhatsNewModal" @click="dropdownOpen = false"
+                        <button wire:click="openWhatsNewModal" @click="dropdownOpen = false; visibleEntryCount = 10; search = ''"
                             class="px-1 dropdown-item-no-padding flex items-center justify-between">
                             <div class="flex items-center gap-2">
                                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -149,7 +168,7 @@
                             </span>
                         </button>
                     @else
-                        <button wire:click="openWhatsNewModal" @click="dropdownOpen = false"
+                        <button wire:click="openWhatsNewModal" @click="dropdownOpen = false; visibleEntryCount = 10; search = ''"
                             class="px-1 dropdown-item-no-padding flex items-center gap-2">
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
@@ -300,9 +319,9 @@
 
                 <!-- Content -->
                 <div class="py-4 flex-1 overflow-y-auto scrollbar">
-                    <div x-show="filteredEntries.length > 0">
+                    <div x-show="displayedEntries.length > 0">
                         <div class="space-y-4">
-                            <template x-for="entry in filteredEntries" :key="entry.tag_name">
+                            <template x-for="entry in displayedEntries" :key="entry.tag_name">
                                 <div class="relative p-4 border dark:border-coolgray-300 rounded-sm"
                                     :class="!entry.is_read ? 'dark:bg-coolgray-200 border-warning' : 'dark:bg-coolgray-100'">
                                     <div class="flex items-start justify-between">
@@ -337,9 +356,19 @@
                                 </div>
                             </template>
                         </div>
+
+                        <div x-show="hasMoreEntries" class="mt-4 flex flex-col items-center gap-3">
+                            <x-forms.button @click="showMoreEntries()">
+                                Show 10 more
+                            </x-forms.button>
+                            <a href="https://github.com/coollabsio/coolify/releases" target="_blank" rel="noopener"
+                                class="text-sm text-blue-500 hover:text-blue-600 underline">
+                                View full changelog on GitHub
+                            </a>
+                        </div>
                     </div>
 
-                    <div x-show="filteredEntries.length === 0" class="text-center py-8">
+                    <div x-show="displayedEntries.length === 0" class="text-center py-8">
                         <svg class="mx-auto h-12 w-12 dark:text-neutral-400" fill="none" stroke="currentColor"
                             viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"

--- a/tests/Feature/SettingsDropdownChangelogLimitTest.php
+++ b/tests/Feature/SettingsDropdownChangelogLimitTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Support\Collection;
+
+it('renders changelog modal with an initial entry limit and show more control', function () {
+    $html = view('livewire.settings-dropdown', [
+        'entries' => new Collection,
+        'unreadCount' => 0,
+        'currentVersion' => 'v4.0.0-beta.999',
+        'showWhatsNewModal' => true,
+    ])->render();
+
+    expect($html)
+        ->toContain('visibleEntryCount: 10')
+        ->toContain('return this.filteredEntries.slice(0, this.visibleEntryCount);')
+        ->toContain('this.visibleEntryCount += 10;')
+        ->toContain('Show 10 more')
+        ->toContain('View full changelog on GitHub');
+});


### PR DESCRIPTION
## Summary
- Limit the changelog modal to the newest 10 entries by default to reduce initial render cost.
- Add a simple "Show 10 more" path and a GitHub releases link for older entries.
- Avoid sorting the same Alpine array in place on every computed access.

## Test plan
- Reviewed the rendered Blade changes to confirm the changelog modal now starts with a 10-entry limit, resets that limit on reopen, and exposes a "Show 10 more" control.
- Added a render-level feature test that asserts the new limit and expansion hooks are present in the rendered markup.
- Could not run the PHP test suite in this environment because `php` is not available locally.

## Changes
- Update `resources/views/livewire/settings-dropdown.blade.php` to render a limited initial changelog list and progressively reveal more entries.
- Add `tests/Feature/SettingsDropdownChangelogLimitTest.php` to cover the new changelog modal behavior in rendered markup.

## Issues
- Fixes #9523

## Category
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview
- N/A (changelog modal behavior change)

## AI Assistance
- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**
- Tools used: Codex
- How extensively: I used it to prepare the patch and then reviewed the issue context and final diff manually.

## Testing
- Reviewed the updated Blade markup and confirmed the changelog modal now limits the initial entry list and reveals more entries on demand.
- Added a render-level feature test for the new limit and expansion hooks.
- I could not run the PHP test suite locally because `php` is not available in this environment.

## Contributor Agreement
> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
