### PR TITLE
fix: normalize generated COOLIFY_FQDN values

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -2446,9 +2446,11 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                 }
             }
             if ($this->application->environment_variables_preview->where('key', 'COOLIFY_URL')->isEmpty()) {
-                $url = str($this->preview->fqdn)->replace('http://', '')->replace('https://', '');
+                $url = Url::fromString($this->preview->fqdn);
+                $fqdn = $url->getHost();
+                $url = $url->withHost($fqdn)->withPort(null)->__toString();
                 if ((int) $this->application->compose_parsing_version >= 3) {
-                    $coolify_envs->put('COOLIFY_FQDN', $url);
+                    $coolify_envs->put('COOLIFY_FQDN', $fqdn);
                 } else {
                     $coolify_envs->put('COOLIFY_URL', $url);
                 }
@@ -2490,9 +2492,11 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                 }
             }
             if ($this->application->environment_variables->where('key', 'COOLIFY_URL')->isEmpty()) {
-                $url = str($this->application->fqdn)->replace('http://', '')->replace('https://', '');
+                $url = Url::fromString($this->application->fqdn);
+                $fqdn = $url->getHost();
+                $url = $url->withHost($fqdn)->withPort(null)->__toString();
                 if ((int) $this->application->compose_parsing_version >= 3) {
-                    $coolify_envs->put('COOLIFY_FQDN', $url);
+                    $coolify_envs->put('COOLIFY_FQDN', $fqdn);
                 } else {
                     $coolify_envs->put('COOLIFY_URL', $url);
                 }


### PR DESCRIPTION
## Summary
- use the same URL parsing logic for generated Coolify env files that deployment commands already use
- strip paths and ports from generated COOLIFY_FQDN values so build-time and runtime envs stay consistent

## Test plan
- inspected pp/Jobs/ApplicationDeploymentJob.php to confirm both generated env paths now normalize FQDNs via Spatie\\Url\\Url
- ran git diff --check
- did not run PHP tests locally because php is not available in this environment

Fixes coollabsio/coolify#9649