### PR TITLE
fix: add Rybbit API path routing

### DIFF
--- a/templates/compose/rybbit.yaml
+++ b/templates/compose/rybbit.yaml
@@ -25,6 +25,7 @@ services:
   rybbit_backend:
     image: 'ghcr.io/rybbit-io/rybbit-backend:v2.2.3'
     environment:
+      - SERVICE_URL_RYBBIT_3001=/api
       - NODE_ENV=production
       - TRUST_PROXY=true
       - 'BASE_URL=${SERVICE_URL_RYBBIT}'


### PR DESCRIPTION
## Summary
- add a /api route for the Rybbit backend service on port 3001
- keep the existing client catch-all route unchanged so frontend traffic still lands on port 3002

## Test plan
- inspected 	emplates/compose/rybbit.yaml to confirm the backend now declares SERVICE_URL_RYBBIT_3001=/api
- verified this matches the existing same-domain path-routing pattern used by templates such as Appwrite
- ran git diff --check

Fixes coollabsio/coolify#9055