### PR TITLE
fix: preserve deployment log indentation

### DIFF
--- a/app/Livewire/Project/Application/Deployment/Show.php
+++ b/app/Livewire/Project/Application/Deployment/Show.php
@@ -114,7 +114,7 @@ class Show extends Component
             ->map(function ($line) {
                 return $line['timestamp'].' '.
                        (isset($line['command']) && $line['command'] ? '[CMD]: ' : '').
-                       trim($line['line']);
+                       rtrim($line['line'], "\r\n");
             })
             ->join("\n");
 
@@ -133,7 +133,7 @@ class Show extends Component
                     $prefix .= '[CMD]: ';
                 }
 
-                return $line['timestamp'].' '.$prefix.trim($line['line']);
+                return $line['timestamp'].' '.$prefix.rtrim($line['line'], "\r\n");
             })
             ->join("\n");
 

--- a/app/Traits/ExecuteRemoteCommand.php
+++ b/app/Traits/ExecuteRemoteCommand.php
@@ -161,7 +161,7 @@ trait ExecuteRemoteCommand
 
         $remote_command = SshMultiplexingHelper::generateSshCommand($this->server, $command);
         $process = Process::timeout(config('constants.ssh.command_timeout'))->idleTimeout(3600)->start($remote_command, function (string $type, string $output) use ($command, $hidden, $customType, $append, $command_hidden) {
-            $output = str($output)->trim();
+            $output = str($output)->trim("\r\n");
             if ($output->startsWith('╔')) {
                 $output = "\n".$output;
             }

--- a/resources/views/livewire/project/application/deployment/show.blade.php
+++ b/resources/views/livewire/project/application/deployment/show.blade.php
@@ -336,7 +336,7 @@
                             </div>
                             @forelse ($this->logLines as $line)
                                 @php
-                                    $lineContent = (isset($line['command']) && $line['command'] ? '[CMD]: ' : '') . trim($line['line']);
+                                    $lineContent = (isset($line['command']) && $line['command'] ? '[CMD]: ' : '') . rtrim($line['line'], "\r\n");
                                     $searchableContent = $line['timestamp'] . ' ' . $lineContent;
                                 @endphp
                                 <div data-log-line data-log-content="{{ htmlspecialchars($searchableContent) }}"


### PR DESCRIPTION
## Summary
- stop trimming leading spaces from streamed deployment log output during capture
- preserve that indentation when rendering and exporting deployment logs

## Test plan
- inspected the deployment log capture and view paths to confirm they now trim only line endings, not leading spaces
- ran git diff --check
- did not run PHP tests locally because php is not available in this environment

Fixes coollabsio/coolify#9468