### PR TITLE
fix: allow unlocking compose-defined variables

### DIFF
--- a/app/Livewire/Project/Shared/EnvironmentVariable/Show.php
+++ b/app/Livewire/Project/Shared/EnvironmentVariable/Show.php
@@ -26,6 +26,8 @@ class Show extends Component
 
     public bool $isMagicVariable = false;
 
+    public bool $isDefinedInDockerCompose = false;
+
     public bool $isSharedVariable = false;
 
     public string $type;
@@ -151,11 +153,18 @@ class Show extends Component
     public function checkEnvs()
     {
         $this->isDisabled = false;
+        $this->isLocked = false;
         $this->isMagicVariable = false;
+        $this->isDefinedInDockerCompose = false;
 
         if (str($this->env->key)->startsWith('SERVICE_FQDN') || str($this->env->key)->startsWith('SERVICE_URL') || str($this->env->key)->startsWith('SERVICE_NAME')) {
             $this->isDisabled = true;
             $this->isMagicVariable = true;
+        }
+
+        if (in_array($this->type, ['application', 'service'], true) && $this->env->resourceable?->docker_compose) {
+            [$isUsedInDockerCompose] = $this->isEnvironmentVariableUsedInDockerCompose($this->env->key, $this->env->resourceable->docker_compose);
+            $this->isDefinedInDockerCompose = $isUsedInDockerCompose;
         }
 
         if ($this->env->is_shown_once) {
@@ -178,6 +187,25 @@ class Show extends Component
         }
         $this->serialize();
         $this->env->save();
+        $this->checkEnvs();
+        $this->dispatch('refreshEnvs');
+    }
+
+    public function unlock()
+    {
+        $this->authorize('update', $this->env);
+
+        if (! $this->isDefinedInDockerCompose) {
+            return;
+        }
+
+        $this->env->is_shown_once = false;
+        if ($this->isSharedVariable) {
+            unset($this->env->is_required);
+        }
+        $this->serialize();
+        $this->env->save();
+        $this->syncData(false);
         $this->checkEnvs();
         $this->dispatch('refreshEnvs');
     }

--- a/resources/views/livewire/project/shared/environment-variable/show.blade.php
+++ b/resources/views/livewire/project/shared/environment-variable/show.blade.php
@@ -29,6 +29,9 @@
                             placeholder="{{ $isMagicVariable ? 'This env cannot be edited manually, it is handled by Coolify.' : '' }}"
                             helper="Add a note to document what this environment variable is used for." maxlength="256" />
                     </div>
+                    @if ($isDefinedInDockerCompose)
+                        <x-forms.button type="button" wire:click="unlock">Unlock</x-forms.button>
+                    @endif
                     <x-forms.button type="submit">Update</x-forms.button>
                 </div>
                 <div class="flex flex-col w-full gap-3">


### PR DESCRIPTION
## Summary
- detect when a locked environment variable is still defined in the resource's Docker Compose file
- add a guarded unlock action for that case so users can edit the variable again without deleting a compose-managed entry

## Test plan
- inspected the environment variable Livewire component to confirm unlock is only offered for compose-defined variables
- ran git diff --check
- did not run PHP tests locally because php is not available in this environment

Fixes coollabsio/coolify#9688