### PR TITLE
fix(navigation): replace wire:navigate.hover with wire:navigate

### DIFF
--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -3532,10 +3532,10 @@ function wireNavigate(): string
     try {
         $settings = instanceSettings();
 
-        // Return wire:navigate.hover for SPA navigation with prefetching, or empty string if disabled
-        return ($settings->is_wire_navigate_enabled ?? true) ? 'wire:navigate.hover' : '';
+        // Return wire:navigate for SPA navigation with prefetching, or empty string if disabled
+        return ($settings->is_wire_navigate_enabled ?? true) ? 'wire:navigate' : '';
     } catch (Exception $e) {
-        return 'wire:navigate.hover';
+        return 'wire:navigate';
     }
 }
 


### PR DESCRIPTION
## Summary

- Replaces `wire:navigate.hover` with `wire:navigate` in the `wireNavigate()` helper
- The `.hover` modifier prefetches pages on hover, which caused race conditions and stale state when SPA is enabled
- Fixes buttons doing nothing, fields showing wrong values, and changes not persisting to backend
- Affects both the normal code path and the exception fallback in `bootstrap/helpers/shared.php`

Closes #9732


---

Fixes #9732