### PR TITLE
fix: retry transient GitHub HTTP and git network calls during deploy

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -67,13 +67,13 @@ class AppServiceProvider extends ServiceProvider
     {
         Http::macro('GitHub', function (string $api_url, ?string $github_access_token = null) {
             if ($github_access_token) {
-                return Http::withHeaders([
+                return Http::connectTimeout(8)->timeout(30)->retry(5, 500, throw: false)->withHeaders([
                     'X-GitHub-Api-Version' => '2022-11-28',
                     'Accept' => 'application/vnd.github.v3+json',
                     'Authorization' => "Bearer $github_access_token",
                 ])->baseUrl($api_url);
             } else {
-                return Http::withHeaders([
+                return Http::connectTimeout(8)->timeout(30)->retry(5, 500, throw: false)->withHeaders([
                     'Accept' => 'application/vnd.github.v3+json',
                 ])->baseUrl($api_url);
             }

--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -144,6 +144,20 @@ function escapeShellValue(string $value): string
 
 function executeInDocker(string $containerId, string $command)
 {
+    if (preg_match('/\\bgit\\s+(clone|ls-remote|fetch|pull)\\b/', $command)) {
+        $wrapped = "n=0; max=5; delay=3; while : ; do { {$command} ; } ; rc=\\$?; ".
+            'if [ $rc -eq 0 ]; then exit 0; fi; '.
+            'n=$((n+1)); '.
+            'if [ $n -ge $max ]; then exit $rc; fi; '.
+            'echo "[coolify-git-retry] attempt $n/$max failed rc=$rc, sleeping ${delay}s" 1>&2; '.
+            'sleep $delay; delay=$((delay*2)); '.
+            'done';
+
+        $escapedCommand = str_replace("'", "'\\''", $wrapped);
+
+        return "docker exec {$containerId} bash -c '{$escapedCommand}'";
+    }
+
     $escapedCommand = str_replace("'", "'\\''", $command);
 
     return "docker exec {$containerId} bash -c '{$escapedCommand}'";

--- a/bootstrap/helpers/github.php
+++ b/bootstrap/helpers/github.php
@@ -14,7 +14,7 @@ use Lcobucci\JWT\Token\Builder;
 
 function generateGithubToken(GithubApp $source, string $type)
 {
-    $response = Http::get("{$source->api_url}/zen");
+    $response = Http::connectTimeout(8)->timeout(20)->retry(5, 500, throw: false)->get("{$source->api_url}/zen");
     $serverTime = CarbonImmutable::now()->setTimezone('UTC');
     $githubTime = Carbon::parse($response->header('date'));
     $timeDiff = abs($serverTime->diffInSeconds($githubTime));
@@ -45,7 +45,7 @@ function generateGithubToken(GithubApp $source, string $type)
     return match ($type) {
         'jwt' => $jwt,
         'installation' => (function () use ($source, $jwt) {
-            $response = Http::withHeaders([
+            $response = Http::connectTimeout(8)->timeout(20)->retry(5, 500, throw: false)->withHeaders([
                 'Authorization' => "Bearer $jwt",
                 'Accept' => 'application/vnd.github.machine-man-preview+json',
             ])->post("{$source->api_url}/app/installations/{$source->installation_id}/access_tokens");


### PR DESCRIPTION
STRAWBERRY

## Changes

Making our deployments tougher against random GitHub network blips. 

* **API Calls:** Added timeouts and retries for GitHub API requests (app token generation & macros).
* **Git Commands:** Added exponential backoff retries for network-heavy git operations (`clone`, `fetch`, `pull`, `ls-remote`).

## Issues

- Fixes intermittent deployment failures caused by transient upstream connectivity issues to GitHub endpoints.

- Fixes

## Category

- [X] Bug fix
- [X] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

- N/A (backend reliability fix, no UI change)

## AI Assistance

<!-- AI-assisted PRs that are human reviewed are welcome, just let us know so we can review appropriately. -->

- [ ] AI was NOT used to create this PR
- [X] AI was used (please describe below)

**If AI was used:**

- Tools used:
  - GitHub Copilot Chat (GPT-5.3-Codex)
- How extensively:
  - Assisted with drafting and validating retry/timeout patch approach and PR wording; final changes were human-reviewed before submission.

## Testing

- Reproduced failing deployment pattern where GitHub calls occasionally timed out.
- Applied patch and re-ran deployment multiple times.
- Verified deployment reaches successful completion (finished) and services start healthy.
- Verified no behavioral change for successful paths other than added resiliency under transient network errors.

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [X] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [X] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [X] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
