### PR TITLE
fix: harden large repo HTTPS bootstrap path

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -1200,11 +1200,28 @@ class Application extends BaseModel
         return application_configuration_dir()."/{$this->uuid}";
     }
 
-    public function setGitImportSettings(string $deployment_uuid, string $git_clone_command, bool $public = false, ?string $commit = null, ?string $git_ssh_command = null)
+    private function buildGitCommand(bool $forceHttpVersionOne = false, array $config = []): string
+    {
+        $gitCommand = 'git';
+
+        if ($forceHttpVersionOne) {
+            $config = array_merge(['http.version' => 'HTTP/1.1'], $config);
+        }
+
+        foreach ($config as $key => $value) {
+            $gitCommand .= ' -c '.escapeshellarg("{$key}={$value}");
+        }
+
+        return $gitCommand;
+    }
+
+    public function setGitImportSettings(string $deployment_uuid, string $git_clone_command, bool $public = false, ?string $commit = null, ?string $git_ssh_command = null, bool $forceHttpVersionOne = false)
     {
         $baseDir = $this->generateBaseDir($deployment_uuid);
         $escapedBaseDir = escapeshellarg($baseDir);
         $isShallowCloneEnabled = $this->settings?->is_git_shallow_clone_enabled ?? false;
+        $gitCommand = $this->buildGitCommand($forceHttpVersionOne);
+        $gitCheckoutCommand = $this->buildGitCommand($forceHttpVersionOne, ['advice.detachedHead' => 'false']);
 
         // Use the full GIT_SSH_COMMAND (including -i for SSH key and port options) when provided,
         // so that git fetch, submodule update, and lfs pull can authenticate the same way as git clone.
@@ -1219,23 +1236,23 @@ class Application extends BaseModel
             // If shallow clone is enabled and we need a specific commit,
             // we need to fetch that specific commit with depth=1
             if ($isShallowCloneEnabled) {
-                $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && {$sshCommand} git fetch --depth=1 origin {$escapedCommit} && git -c advice.detachedHead=false checkout {$escapedCommit} >/dev/null 2>&1";
+                $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && {$sshCommand} {$gitCommand} fetch --depth=1 origin {$escapedCommit} && {$gitCheckoutCommand} checkout {$escapedCommit} >/dev/null 2>&1";
             } else {
-                $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && {$sshCommand} git -c advice.detachedHead=false checkout {$escapedCommit} >/dev/null 2>&1";
+                $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && {$sshCommand} {$gitCheckoutCommand} checkout {$escapedCommit} >/dev/null 2>&1";
             }
         }
         if ($this->settings->is_git_submodules_enabled) {
             // Check if .gitmodules file exists before running submodule commands
             $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && if [ -f .gitmodules ]; then";
             if ($public) {
-                $git_clone_command = "{$git_clone_command} sed -i \"s#git@\(.*\):#https://\\1/#g\" {$escapedBaseDir}/.gitmodules || true &&";
+                $git_clone_command = "{$git_clone_command} sed -i \"s#git@\\(.*\\):#https://\\1/#g\" {$escapedBaseDir}/.gitmodules || true &&";
             }
             // Add shallow submodules flag if shallow clone is enabled
             $submoduleFlags = $isShallowCloneEnabled ? '--depth=1' : '';
-            $git_clone_command = "{$git_clone_command} git submodule sync && {$sshCommand} git submodule update --init --recursive {$submoduleFlags}; fi";
+            $git_clone_command = "{$git_clone_command} {$gitCommand} submodule sync && {$sshCommand} {$gitCommand} submodule update --init --recursive {$submoduleFlags}; fi";
         }
         if ($this->settings->is_git_lfs_enabled) {
-            $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && {$sshCommand} git lfs pull";
+            $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && {$sshCommand} {$gitCommand} lfs pull";
         }
 
         return $git_clone_command;
@@ -1438,6 +1455,7 @@ class Application extends BaseModel
         // Check if shallow clone is enabled
         $isShallowCloneEnabled = $this->settings?->is_git_shallow_clone_enabled ?? false;
         $depthFlag = $isShallowCloneEnabled ? ' --depth=1' : '';
+        $forceHttpVersionOne = false;
 
         $submoduleFlags = '';
         if ($this->settings->is_git_submodules_enabled) {
@@ -1464,9 +1482,14 @@ class Application extends BaseModel
                 if ($this->source->is_public) {
                     $fullRepoUrl = "{$this->source->html_url}/{$customRepository}";
                     $escapedRepoUrl = escapeshellarg("{$this->source->html_url}/{$customRepository}");
-                    $git_clone_command = "{$git_clone_command} {$escapedRepoUrl} {$escapedBaseDir}";
+                    $forceHttpVersionOne = str($fullRepoUrl)->startsWith('https://');
+                    $gitCloneCommand = $this->buildGitCommand($forceHttpVersionOne).' clone'.$depthFlag.$submoduleFlags;
+                    if ($only_checkout) {
+                        $gitCloneCommand .= ' --no-checkout';
+                    }
+                    $git_clone_command = "{$gitCloneCommand} -b {$escapedBranch} {$escapedRepoUrl} {$escapedBaseDir}";
                     if (! $only_checkout) {
-                        $git_clone_command = $this->setGitImportSettings($deployment_uuid, $git_clone_command, public: true, commit: $commit);
+                        $git_clone_command = $this->setGitImportSettings($deployment_uuid, $git_clone_command, public: true, commit: $commit, forceHttpVersionOne: $forceHttpVersionOne);
                     }
                     if ($exec_in_docker) {
                         $commands->push(executeInDocker($deployment_uuid, $git_clone_command));
@@ -1479,16 +1502,26 @@ class Application extends BaseModel
                     if ($exec_in_docker) {
                         $repoUrl = "$source_html_url_scheme://x-access-token:$encodedToken@$source_html_url_host/{$customRepository}.git";
                         $escapedRepoUrl = escapeshellarg($repoUrl);
-                        $git_clone_command = "{$git_clone_command} {$escapedRepoUrl} {$escapedBaseDir}";
                         $fullRepoUrl = $repoUrl;
+                        $forceHttpVersionOne = str($fullRepoUrl)->startsWith('https://');
+                        $gitCloneCommand = $this->buildGitCommand($forceHttpVersionOne).' clone'.$depthFlag.$submoduleFlags;
+                        if ($only_checkout) {
+                            $gitCloneCommand .= ' --no-checkout';
+                        }
+                        $git_clone_command = "{$gitCloneCommand} -b {$escapedBranch} {$escapedRepoUrl} {$escapedBaseDir}";
                     } else {
                         $repoUrl = "$source_html_url_scheme://x-access-token:$encodedToken@$source_html_url_host/{$customRepository}";
                         $escapedRepoUrl = escapeshellarg($repoUrl);
-                        $git_clone_command = "{$git_clone_command} {$escapedRepoUrl} {$escapedBaseDir}";
                         $fullRepoUrl = $repoUrl;
+                        $forceHttpVersionOne = str($fullRepoUrl)->startsWith('https://');
+                        $gitCloneCommand = $this->buildGitCommand($forceHttpVersionOne).' clone'.$depthFlag.$submoduleFlags;
+                        if ($only_checkout) {
+                            $gitCloneCommand .= ' --no-checkout';
+                        }
+                        $git_clone_command = "{$gitCloneCommand} -b {$escapedBranch} {$escapedRepoUrl} {$escapedBaseDir}";
                     }
                     if (! $only_checkout) {
-                        $git_clone_command = $this->setGitImportSettings($deployment_uuid, $git_clone_command, public: false, commit: $commit);
+                        $git_clone_command = $this->setGitImportSettings($deployment_uuid, $git_clone_command, public: false, commit: $commit, forceHttpVersionOne: $forceHttpVersionOne);
                     }
                     if ($exec_in_docker) {
                         $commands->push(executeInDocker($deployment_uuid, $git_clone_command));
@@ -1499,12 +1532,13 @@ class Application extends BaseModel
                 if ($pull_request_id !== 0) {
                     $branch = "pull/{$pull_request_id}/head:$pr_branch_name";
 
-                    $git_checkout_command = $this->buildGitCheckoutCommand($pr_branch_name);
+                    $git_checkout_command = $this->buildGitCheckoutCommand($pr_branch_name, $forceHttpVersionOne);
                     $escapedPrBranch = escapeshellarg($branch);
+                    $gitFetchCommand = $this->buildGitCommand($forceHttpVersionOne).' fetch origin '.$escapedPrBranch;
                     if ($exec_in_docker) {
-                        $commands->push(executeInDocker($deployment_uuid, "cd {$escapedBaseDir} && git fetch origin {$escapedPrBranch} && $git_checkout_command"));
+                        $commands->push(executeInDocker($deployment_uuid, "cd {$escapedBaseDir} && {$gitFetchCommand} && $git_checkout_command"));
                     } else {
-                        $commands->push("cd {$escapedBaseDir} && git fetch origin {$escapedPrBranch} && $git_checkout_command");
+                        $commands->push("cd {$escapedBaseDir} && {$gitFetchCommand} && $git_checkout_command");
                     }
                 }
 
@@ -1571,8 +1605,15 @@ class Application extends BaseModel
                 // GitLab source without private key — use URL as-is (supports user-embedded basic auth)
                 $fullRepoUrl = $customRepository;
                 $escapedCustomRepository = escapeshellarg($customRepository);
-                $git_clone_command = "{$git_clone_command} {$escapedCustomRepository} {$escapedBaseDir}";
-                $git_clone_command = $this->setGitImportSettings($deployment_uuid, $git_clone_command, public: true, commit: $commit);
+                $forceHttpVersionOne = str($fullRepoUrl)->startsWith('https://');
+                $gitCloneCommand = $this->buildGitCommand($forceHttpVersionOne).' clone'.$depthFlag.$submoduleFlags;
+                if ($only_checkout) {
+                    $gitCloneCommand .= ' --no-checkout';
+                }
+                $git_clone_command = "{$gitCloneCommand} -b {$escapedBranch} {$escapedCustomRepository} {$escapedBaseDir}";
+                if (! $only_checkout) {
+                    $git_clone_command = $this->setGitImportSettings($deployment_uuid, $git_clone_command, public: true, commit: $commit, forceHttpVersionOne: $forceHttpVersionOne);
+                }
 
                 if ($exec_in_docker) {
                     $commands->push(executeInDocker($deployment_uuid, $git_clone_command));
@@ -1657,8 +1698,15 @@ class Application extends BaseModel
         if ($this->deploymentType() === 'other') {
             $fullRepoUrl = $customRepository;
             $escapedCustomRepository = escapeshellarg($customRepository);
-            $git_clone_command = "{$git_clone_command} {$escapedCustomRepository} {$escapedBaseDir}";
-            $git_clone_command = $this->setGitImportSettings($deployment_uuid, $git_clone_command, public: true, commit: $commit);
+            $forceHttpVersionOne = str($fullRepoUrl)->startsWith('https://');
+            $gitCloneCommand = $this->buildGitCommand($forceHttpVersionOne).' clone'.$depthFlag.$submoduleFlags;
+            if ($only_checkout) {
+                $gitCloneCommand .= ' --no-checkout';
+            }
+            $git_clone_command = "{$gitCloneCommand} -b {$escapedBranch} {$escapedCustomRepository} {$escapedBaseDir}";
+            if (! $only_checkout) {
+                $git_clone_command = $this->setGitImportSettings($deployment_uuid, $git_clone_command, public: true, commit: $commit, forceHttpVersionOne: $forceHttpVersionOne);
+            }
 
             if ($pull_request_id !== 0) {
                 if ($git_type === 'gitlab') {
@@ -1782,7 +1830,9 @@ class Application extends BaseModel
             return;
         }
         $uuid = new Cuid2;
-        ['commands' => $cloneCommand] = $this->generateGitImportCommands(deployment_uuid: $uuid, only_checkout: true, exec_in_docker: false, custom_base_dir: '.');
+        $checkoutDirectory = "/tmp/{$uuid}/checkout";
+        ['commands' => $cloneCommand] = $this->generateGitImportCommands(deployment_uuid: $uuid, only_checkout: true, exec_in_docker: false, custom_base_dir: $checkoutDirectory);
+        $escapedCheckoutDirectory = escapeshellarg($checkoutDirectory);
         $workdir = rtrim($this->base_directory, '/');
         $composeFile = $this->docker_compose_location;
         $fileList = collect([".$workdir$composeFile"]);
@@ -1810,8 +1860,8 @@ class Application extends BaseModel
             $commands = collect([
                 "rm -rf /tmp/{$uuid}",
                 "mkdir -p /tmp/{$uuid}",
-                "cd /tmp/{$uuid}",
                 $cloneCommand,
+                "cd {$escapedCheckoutDirectory}",
                 'git sparse-checkout init',
                 "git sparse-checkout set {$fileList->implode(' ')}",
                 'git read-tree -mu HEAD',
@@ -1821,8 +1871,8 @@ class Application extends BaseModel
             $commands = collect([
                 "rm -rf /tmp/{$uuid}",
                 "mkdir -p /tmp/{$uuid}",
-                "cd /tmp/{$uuid}",
                 $cloneCommand,
+                "cd {$escapedCheckoutDirectory}",
                 'git sparse-checkout init --cone',
                 "git sparse-checkout set {$fileList->implode(' ')}",
                 'git read-tree -mu HEAD',
@@ -1932,13 +1982,15 @@ class Application extends BaseModel
         );
     }
 
-    protected function buildGitCheckoutCommand($target): string
+    protected function buildGitCheckoutCommand($target, bool $forceHttpVersionOne = false): string
     {
         $escapedTarget = escapeshellarg($target);
-        $command = "git checkout {$escapedTarget}";
+        $gitCheckoutCommand = $this->buildGitCommand($forceHttpVersionOne, ['advice.detachedHead' => 'false']);
+        $gitCommand = $this->buildGitCommand($forceHttpVersionOne);
+        $command = "{$gitCheckoutCommand} checkout {$escapedTarget}";
 
         if ($this->settings->is_git_submodules_enabled) {
-            $command .= ' && git submodule update --init --recursive';
+            $command .= " && {$gitCommand} submodule update --init --recursive";
         }
 
         return $command;

--- a/tests/Feature/GitHttpTransportCommandsTest.php
+++ b/tests/Feature/GitHttpTransportCommandsTest.php
@@ -1,0 +1,164 @@
+<?php
+
+use App\Models\Application;
+use App\Models\ApplicationSetting;
+use App\Models\GithubApp;
+use App\Models\GitlabApp;
+
+function makeApplication(array $attributes = [], ?object $source = null): Application
+{
+    $application = new Application;
+    $application->fill(array_merge([
+        'uuid' => 'test-app-uuid',
+        'git_repository' => 'coollabsio/coolify',
+        'git_branch' => 'main',
+        'git_commit_sha' => 'HEAD',
+        'source_type' => GithubApp::class,
+        'source_id' => 1,
+    ], $attributes));
+
+    $settings = new ApplicationSetting;
+    $settings->is_git_shallow_clone_enabled = false;
+    $settings->is_git_submodules_enabled = false;
+    $settings->is_git_lfs_enabled = false;
+
+    $application->setRelation('settings', $settings);
+
+    if ($source !== null) {
+        $application->setRelation('source', $source);
+    }
+
+    return $application;
+}
+
+beforeEach(function () {
+    $this->application = makeApplication(source: new GithubApp([
+        'html_url' => 'https://github.com',
+        'is_public' => true,
+    ]));
+});
+
+test('generateGitImportCommands uses HTTP/1.1 for public github source checkout clones', function () {
+    $result = $this->application->generateGitImportCommands(
+        deployment_uuid: 'test-uuid',
+        exec_in_docker: false,
+        only_checkout: true,
+        custom_base_dir: '/tmp/test-checkout'
+    );
+
+    expect($result['commands'])
+        ->toContain("git -c 'http.version=HTTP/1.1' clone --no-checkout -b 'main'")
+        ->toContain("'https://github.com/coollabsio/coolify'")
+        ->toContain("'/tmp/test-checkout'");
+});
+
+test('setGitImportSettings applies HTTP/1.1 to the full git bootstrap sequence', function () {
+    $this->application->settings->is_git_shallow_clone_enabled = true;
+    $this->application->settings->is_git_submodules_enabled = true;
+    $this->application->settings->is_git_lfs_enabled = true;
+
+    $result = $this->application->setGitImportSettings(
+        deployment_uuid: 'test-uuid',
+        git_clone_command: 'git clone',
+        public: true,
+        commit: 'abc123def456abc123def456abc123def456abc1',
+        forceHttpVersionOne: true,
+    );
+
+    expect($result)
+        ->toContain("git -c 'http.version=HTTP/1.1' fetch --depth=1 origin 'abc123def456abc123def456abc123def456abc1'")
+        ->toContain("git -c 'http.version=HTTP/1.1' -c 'advice.detachedHead=false' checkout 'abc123def456abc123def456abc123def456abc1'")
+        ->toContain("git -c 'http.version=HTTP/1.1' submodule sync")
+        ->toContain("git -c 'http.version=HTTP/1.1' submodule update --init --recursive --depth=1")
+        ->toContain("git -c 'http.version=HTTP/1.1' lfs pull");
+});
+
+test('generateGitImportCommands uses HTTP/1.1 when fetching github pull request refs over https', function () {
+    $result = $this->application->generateGitImportCommands(
+        deployment_uuid: 'test-uuid',
+        pull_request_id: 42,
+        exec_in_docker: false,
+    );
+
+    expect($result['commands'])
+        ->toContain("git -c 'http.version=HTTP/1.1' clone -b 'main'")
+        ->toContain("git -c 'http.version=HTTP/1.1' fetch origin 'pull/42/head:pr-42-coolify'");
+});
+
+test('generateGitImportCommands uses HTTP/1.1 for github pull request checkouts with submodules', function () {
+    $this->application->settings->is_git_submodules_enabled = true;
+
+    $result = $this->application->generateGitImportCommands(
+        deployment_uuid: 'test-uuid',
+        pull_request_id: 42,
+        exec_in_docker: false,
+    );
+
+    expect($result['commands'])
+        ->toContain("git -c 'http.version=HTTP/1.1' fetch origin 'pull/42/head:pr-42-coolify'")
+        ->toContain("git -c 'http.version=HTTP/1.1' -c 'advice.detachedHead=false' checkout 'pr-42-coolify'")
+        ->toContain("git -c 'http.version=HTTP/1.1' submodule update --init --recursive");
+});
+
+test('setGitImportSettings keeps the public gitmodules rewrite backreference intact', function () {
+    $this->application->settings->is_git_submodules_enabled = true;
+
+    $result = $this->application->setGitImportSettings(
+        deployment_uuid: 'test-uuid',
+        git_clone_command: 'git clone',
+        public: true,
+        forceHttpVersionOne: true,
+    );
+
+    expect($result)
+        ->toContain('sed -i "s#git@\\(.*\\):#https://\\1/#g"');
+});
+
+test('generateGitImportCommands keeps gitlab https only-checkout clones checkout-free', function () {
+    $application = makeApplication(
+        attributes: [
+            'git_repository' => 'https://gitlab.com/coollabsio/coolify.git',
+            'source_type' => GitlabApp::class,
+            'source_id' => 2,
+        ],
+        source: new GitlabApp([
+            'html_url' => 'https://gitlab.com',
+        ]),
+    );
+
+    $result = $application->generateGitImportCommands(
+        deployment_uuid: 'test-uuid',
+        exec_in_docker: false,
+        only_checkout: true,
+        custom_base_dir: '/tmp/test-checkout',
+    );
+
+    expect($result['commands'])
+        ->toContain("git -c 'http.version=HTTP/1.1' clone --no-checkout -b 'main'")
+        ->not->toContain("advice.detachedHead=false' checkout")
+        ->not->toContain('submodule')
+        ->not->toContain('lfs pull');
+});
+
+test('generateGitImportCommands keeps generic https only-checkout clones checkout-free', function () {
+    $application = makeApplication(
+        attributes: [
+            'git_repository' => 'https://gitlab.com/coollabsio/coolify.git',
+            'source_type' => null,
+            'source_id' => null,
+        ],
+    );
+
+    $result = $application->generateGitImportCommands(
+        deployment_uuid: 'test-uuid',
+        exec_in_docker: false,
+        only_checkout: true,
+        custom_base_dir: '/tmp/test-checkout',
+    );
+
+    expect($result['commands'])
+        ->toContain("git -c 'http.version=HTTP/1.1' clone --no-checkout -b 'main'")
+        ->not->toContain("advice.detachedHead=false' checkout")
+        ->not->toContain('submodule')
+        ->not->toContain('lfs pull');
+});


### PR DESCRIPTION
## Changes
- force large HTTPS repo bootstrap steps onto HTTP/1.1 across clone, fetch, submodule, LFS, and PR checkout flows
- keep sparse compose checkout isolated in a dedicated temp checkout directory instead of cloning into the temp root
- preserve the public submodule URL rewrite and keep only-checkout paths free of checkout side effects
- add targeted regression coverage for the HTTPS command-generation paths

## Issues
- Fixes #5251
- /claim #5251

## Category
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview
- Demo video will be attached after this refreshed PR is up.

## AI Assistance
- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**
- Tools used: Hermes Agent
- How extensively: Used to inspect the existing import paths, implement the targeted fix, and add regression tests before local verification.

## Testing
- php vendor/pestphp/pest/bin/pest --compact tests/Feature/GitHttpTransportCommandsTest.php tests/Feature/ApplicationRollbackTest.php
- php vendor/laravel/pint/builds/pint --dirty --format agent

## Contributor Agreement
> [!IMPORTANT]
>
> - [x] I have read and understood the contributor guidelines. If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched existing issues and pull requests (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
