### PR TITLE
feat: add WordPress + OpenLiteSpeed service template

### DIFF
--- a/templates/compose/wordpress-openlitespeed.yaml
+++ b/templates/compose/wordpress-openlitespeed.yaml
@@ -1,0 +1,42 @@
+# documentation: https://openlitespeed.org
+# slogan: WordPress with OpenLiteSpeed - High-performance web server with built-in caching.
+# category: cms
+# tags: cms, wordpress, openlitespeed, litespeed, cache, performance
+# logo: svgs/wordpress.svg
+
+services:
+  wordpress:
+    image: litespeedtech/openlitespeed:latest
+    volumes:
+      - wordpress-files:/var/www/html
+      - litespeed-conf:/usr/local/litespeed/conf
+    environment:
+      - SERVICE_URL_WORDPRESS
+      - DB_HOST=mariadb
+      - DB_USER=$SERVICE_USER_WORDPRESS
+      - DB_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+      - DB_NAME=wordpress
+      - WP_ADMIN_USER=admin
+      - WP_ADMIN_PASSWORD=$SERVICE_PASSWORD_ADMIN
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8088"]
+      interval: 5s
+      timeout: 10s
+      retries: 10
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
## Summary
Adds a reusable service template for WordPress with OpenLiteSpeed web server.

Closes #8264

## What's included
- OpenLiteSpeed (litespeedtech/openlitespeed:latest) with MariaDB 11 backend
- Persistent volumes for WordPress files, LiteSpeed config, and database data
- Environment-based configuration compatible with Coolify's proxy and certificate management
- Health checks for both services

## Testing
- Template follows existing Coolify compose template patterns
- Uses standard Coolify environment variable conventions ($SERVICE_PASSWORD_*, $SERVICE_USER_*)