### PR TITLE
fix(api/docs): correct list-deployments response schema

### DIFF
--- a/app/Http/Controllers/Api/DeployController.php
+++ b/app/Http/Controllers/Api/DeployController.php
@@ -629,7 +629,7 @@ class DeployController extends Controller
                         mediaType: 'application/json',
                         schema: new OA\Schema(
                             type: 'array',
-                            items: new OA\Items(ref: '#/components/schemas/Application'),
+                            items: new OA\Items(ref: '#/components/schemas/ApplicationDeploymentQueue'),
                         )
                     ),
                 ]),

--- a/openapi.json
+++ b/openapi.json
@@ -7459,7 +7459,7 @@
                                 "schema": {
                                     "type": "array",
                                     "items": {
-                                        "$ref": "#\/components\/schemas\/Application"
+                                        "$ref": "#\/components\/schemas\/ApplicationDeploymentQueue"
                                     }
                                 }
                             }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4829,7 +4829,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Application'
+                  $ref: '#/components/schemas/ApplicationDeploymentQueue'
         '401':
           $ref: '#/components/responses/401'
         '400':

--- a/tests/Unit/Api/DeploymentsListResponseSchemaTest.php
+++ b/tests/Unit/Api/DeploymentsListResponseSchemaTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Regression test for #5874.
+ *
+ * The OpenAPI annotation on DeployController::get_application_deployments
+ * declared its 200 response as an array of `Application` objects, but the
+ * endpoint actually returns `ApplicationDeploymentQueue` records (deployments
+ * have fields like `logs`, `commit`, `deployment_uuid` that do not exist on
+ * `Application`).
+ *
+ * Clients generated from the OpenAPI spec therefore decoded the response into
+ * the wrong type. The test verifies the checked-in `openapi.yaml` and
+ * `openapi.json` documents reference the correct schema for this path.
+ */
+it('documents /deployments/applications/{uuid} as returning ApplicationDeploymentQueue items', function () {
+    $path = '/deployments/applications/{uuid}';
+
+    $root = dirname(__DIR__, 3);
+    $yamlPath = $root.'/openapi.yaml';
+    $jsonPath = $root.'/openapi.json';
+
+    expect(is_file($yamlPath))->toBeTrue("Expected {$yamlPath} to exist");
+    expect(is_file($jsonPath))->toBeTrue("Expected {$jsonPath} to exist");
+
+    $yaml = Yaml::parseFile($yamlPath);
+    $json = json_decode(file_get_contents($jsonPath), true, flags: JSON_THROW_ON_ERROR);
+
+    $yamlRef = data_get($yaml, "paths.{$path}.get.responses.200.content.application/json.schema.items.\$ref");
+    $jsonRef = data_get($json, "paths.{$path}.get.responses.200.content.application/json.schema.items.\$ref");
+
+    expect($yamlRef)->toBe('#/components/schemas/ApplicationDeploymentQueue');
+    expect($jsonRef)->toBe('#/components/schemas/ApplicationDeploymentQueue');
+});


### PR DESCRIPTION
## Changes

DeployController::get_application_deployments declared its 200 response in the OpenAPI annotation as an array of Application objects (OA\Items ref #/components/schemas/Application), but the endpoint actually returns ApplicationDeploymentQueue records. The deployment queue rows have fields like logs, commit and deployment_uuid that do not exist on Application, so clients generated from the checked-in spec decoded the response into the wrong type.

Change the OA\Items ref to ApplicationDeploymentQueue and regenerate openapi.yaml and openapi.json via php artisan generate:openapi. Also add a regression test that parses the checked-in openapi.yaml / openapi.json and asserts the response items for /deployments/applications/{uuid} reference ApplicationDeploymentQueue.

## Issues

- Fixes #5874

## Category

- [x] Bug fix

## Preview

No UI change. Regenerated openapi.yaml excerpt for this path now reads: items: $ref: '#/components/schemas/ApplicationDeploymentQueue' (previously '#/components/schemas/Application').

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

- Tools used: Devin
- How extensively: Used to locate the mismatched annotation and draft the regression test. Every changed line and this description were reviewed manually.

## Testing

- Added tests/Unit/Api/DeploymentsListResponseSchemaTest.php.
- Verified the test fails when openapi.yaml / openapi.json are reverted to the pre-fix content and passes with the fix (1 passed / 4 assertions / 0.35s).
- Ran php artisan test --compact tests/Unit/Api/DeploymentsListResponseSchemaTest.php.
- Ran vendor/bin/pint --dirty --format agent (clean).

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.

/claim #5874
