### PR TITLE
fix(deployment-logs): preserve leading whitespace

### DIFF
--- a/app/Livewire/Project/Application/Deployment/Show.php
+++ b/app/Livewire/Project/Application/Deployment/Show.php
@@ -114,7 +114,7 @@ class Show extends Component
             ->map(function ($line) {
                 return $line['timestamp'].' '.
                        (isset($line['command']) && $line['command'] ? '[CMD]: ' : '').
-                       trim($line['line']);
+                       rtrim($line['line']);
             })
             ->join("\n");
 
@@ -133,7 +133,7 @@ class Show extends Component
                     $prefix .= '[CMD]: ';
                 }
 
-                return $line['timestamp'].' '.$prefix.trim($line['line']);
+                return $line['timestamp'].' '.$prefix.rtrim($line['line']);
             })
             ->join("\n");
 

--- a/app/Traits/ExecuteRemoteCommand.php
+++ b/app/Traits/ExecuteRemoteCommand.php
@@ -161,7 +161,7 @@ trait ExecuteRemoteCommand
 
         $remote_command = SshMultiplexingHelper::generateSshCommand($this->server, $command);
         $process = Process::timeout(config('constants.ssh.command_timeout'))->idleTimeout(3600)->start($remote_command, function (string $type, string $output) use ($command, $hidden, $customType, $append, $command_hidden) {
-            $output = str($output)->trim();
+            $output = str($output)->rtrim();
             if ($output->startsWith('╔')) {
                 $output = "\n".$output;
             }

--- a/resources/views/livewire/project/application/deployment/show.blade.php
+++ b/resources/views/livewire/project/application/deployment/show.blade.php
@@ -336,7 +336,7 @@
                             </div>
                             @forelse ($this->logLines as $line)
                                 @php
-                                    $lineContent = (isset($line['command']) && $line['command'] ? '[CMD]: ' : '') . trim($line['line']);
+                                    $lineContent = (isset($line['command']) && $line['command'] ? '[CMD]: ' : '') . rtrim($line['line']);
                                     $searchableContent = $line['timestamp'] . ' ' . $lineContent;
                                 @endphp
                                 <div data-log-line data-log-content="{{ htmlspecialchars($searchableContent) }}"

--- a/tests/Feature/DeploymentLogLeadingWhitespaceTest.php
+++ b/tests/Feature/DeploymentLogLeadingWhitespaceTest.php
@@ -1,0 +1,96 @@
+<?php
+
+use App\Enums\ApplicationDeploymentStatus;
+use App\Livewire\Project\Application\Deployment\Show;
+use App\Models\Application;
+use App\Models\ApplicationDeploymentQueue;
+use App\Models\Environment;
+use App\Models\InstanceSettings;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->team = Team::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+
+    InstanceSettings::unguarded(function () {
+        InstanceSettings::query()->create([
+            'id' => 0,
+            'is_registration_enabled' => true,
+        ]);
+    });
+
+    $this->actingAs($this->user);
+    session(['currentTeam' => $this->team]);
+
+    $this->server = Server::factory()->create(['team_id' => $this->team->id]);
+    $this->destination = StandaloneDocker::query()->where('server_id', $this->server->id)->firstOrFail();
+    $this->project = Project::factory()->create(['team_id' => $this->team->id]);
+    $this->environment = Environment::factory()->create(['project_id' => $this->project->id]);
+    $this->application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => $this->destination->getMorphClass(),
+        'status' => 'running',
+    ]);
+
+    $this->deployment = ApplicationDeploymentQueue::create([
+        'application_id' => $this->application->id,
+        'deployment_uuid' => 'deploy-whitespace-test',
+        'server_id' => $this->server->id,
+        'status' => ApplicationDeploymentStatus::FINISHED->value,
+        'logs' => json_encode([
+            [
+                'command' => null,
+                'output' => "    indented once\n        indented twice\nno indent",
+                'type' => 'stdout',
+                'timestamp' => now()->toISOString(),
+                'hidden' => false,
+                'batch' => 1,
+                'order' => 1,
+            ],
+        ], JSON_THROW_ON_ERROR),
+    ]);
+});
+
+it('preserves leading whitespace when rendering deployment logs', function () {
+    $response = $this->get(route('project.application.deployment.show', [
+        'project_uuid' => $this->project->uuid,
+        'environment_uuid' => $this->environment->uuid,
+        'application_uuid' => $this->application->uuid,
+        'deployment_uuid' => $this->deployment->deployment_uuid,
+    ]));
+
+    $response->assertSuccessful();
+    expect($response->getContent())
+        ->toContain('    indented once')
+        ->and($response->getContent())
+        ->toContain('        indented twice')
+        ->and($response->getContent())
+        ->toContain('no indent');
+});
+
+it('preserves leading whitespace in copyLogs and downloadAllLogs', function () {
+    $component = new Show;
+    $component->application = $this->application;
+    $component->application_deployment_queue = $this->deployment;
+
+    $copied = $component->copyLogs();
+    $downloaded = $component->downloadAllLogs();
+
+    expect($copied)
+        ->toContain('    indented once')
+        ->toContain('        indented twice')
+        ->toContain('no indent')
+        ->and($downloaded)
+        ->toContain('    indented once')
+        ->toContain('        indented twice')
+        ->toContain('no indent');
+});


### PR DESCRIPTION
## Changes

The deployment log pipeline called trim() on every streamed chunk at capture time in ExecuteRemoteCommand, and on every line at render / copy / download time in the Show Livewire component and the deployment Blade template. trim() strips leading and trailing whitespace, destroying indentation for console.log output, stack frames, Nixpacks plan output, nested YAML/JSON dumps, etc.

Replace the four trim() calls with rtrim() so trailing newlines are still stripped but leading spaces are preserved: at capture time the stored JSON logs keep original indentation, and at render / copy / download time the per-line output keeps the original column alignment.

decode_remote_command_output already splits stored output on PHP_EOL, so nothing useful trails an individual line. Follow-up to #7862 and supersedes the closed #9740 (wrong base, no regression coverage).

## Issues

- Fixes #9468

## Category

- [x] Bug fix

## Preview

No UI change. After the fix, a deployment that logs four-space and eight-space indented lines shows up in the UI, in the Copy Logs button output, and in the downloaded log export with the original column alignment preserved instead of collapsed to the left margin.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

- Tools used: Devin
- How extensively: Used to locate every trim() call and draft the Pest test. Every changed line and this description were reviewed manually.

## Testing

- Added tests/Feature/DeploymentLogLeadingWhitespaceTest.php with two tests covering HTTP render, copyLogs() and downloadAllLogs().
- php artisan test --compact tests/Feature/DeploymentLogLeadingWhitespaceTest.php: 2 passed / 10 assertions / 1.20s.
- vendor/bin/pint --dirty --format agent: clean.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.

/claim #9468
