### PR TITLE
fix: prevent double sudo in parseCommandsByLineForSudo

### DIFF
--- a/bootstrap/helpers/sudo.php
+++ b/bootstrap/helpers/sudo.php
@@ -112,14 +112,14 @@ function parseCommandsByLineForSudo(Collection $commands, Server $server): array
             $line = $line->replace('$(', '$(sudo ');
         }
         if (! $isComplexPipeCommand && str($line)->contains('||')) {
-            $line = $line->replace('||', '|| sudo');
+            $line = str(preg_replace('/\|\|(\s+)(?!sudo\s)/', '||$1sudo ', $line->value()));
         }
         if (! $isComplexPipeCommand && str($line)->contains('&&')) {
-            $line = $line->replace('&&', '&& sudo');
+            $line = str(preg_replace('/&&(\s+)(?!sudo\s)/', '&&$1sudo ', $line->value()));
         }
         // Don't insert sudo into pipes for complex commands
         if (! $isComplexPipeCommand && str($line)->contains(' | ')) {
-            $line = $line->replace(' | ', ' | sudo ');
+            $line = str(preg_replace('/ \| (?!sudo\s)/', ' | sudo ', $line->value()));
         }
 
         return $line->value();

--- a/tests/Unit/ParseCommandsByLineForSudoTest.php
+++ b/tests/Unit/ParseCommandsByLineForSudoTest.php
@@ -183,9 +183,7 @@ test('adds ownership changes for Coolify data paths', function () {
 
     $result = parseCommandsByLineForSudo($commands, $this->server);
 
-    // Note: The && operator adds another sudo, creating double sudo for chown/chmod
-    // This is existing behavior that may need refactoring but isn't part of this bug fix
-    expect($result[0])->toBe('sudo mkdir -p /data/coolify/logs && sudo sudo chown -R ubuntu:ubuntu /data/coolify/logs && sudo sudo chmod -R o-rwx /data/coolify/logs');
+    expect($result[0])->toBe('sudo mkdir -p /data/coolify/logs && sudo chown -R ubuntu:ubuntu /data/coolify/logs && sudo chmod -R o-rwx /data/coolify/logs');
 });
 
 test('adds ownership changes for Coolify tmp paths', function () {
@@ -195,9 +193,7 @@ test('adds ownership changes for Coolify tmp paths', function () {
 
     $result = parseCommandsByLineForSudo($commands, $this->server);
 
-    // Note: The && operator adds another sudo, creating double sudo for chown/chmod
-    // This is existing behavior that may need refactoring but isn't part of this bug fix
-    expect($result[0])->toBe('sudo mkdir -p /tmp/coolify/cache && sudo sudo chown -R ubuntu:ubuntu /tmp/coolify/cache && sudo sudo chmod -R o-rwx /tmp/coolify/cache');
+    expect($result[0])->toBe('sudo mkdir -p /tmp/coolify/cache && sudo chown -R ubuntu:ubuntu /tmp/coolify/cache && sudo chmod -R o-rwx /tmp/coolify/cache');
 });
 
 test('does not add ownership changes for system paths', function () {
@@ -620,4 +616,91 @@ test('do keyword with word boundary is not given sudo', function () {
     $result = parseCommandsByLineForSudo($commands, $this->server);
 
     expect($result[0])->toBe('do');
+});
+
+// ---------------------------------------------------------------------------
+// Regression tests: prevent double sudo in operator replacements
+//
+// Root cause: the third map pass replaced every `&&`, `||`, and ` | ` with
+// `&& sudo`, `|| sudo`, and ` | sudo ` — even when the next token was already
+// `sudo` (produced by the second map pass that appended `&& sudo chown ...`).
+// Fix: use a negative lookahead so sudo is only inserted when not already present.
+// ---------------------------------------------------------------------------
+
+test('does not produce double sudo after && when chown already starts with sudo', function () {
+    // The second map pass produces:
+    //   sudo mkdir -p /data/coolify/proxy && sudo chown -R ubuntu:ubuntu ... && sudo chmod -R o-rwx ...
+    // The third map pass must NOT turn `&& sudo` into `&& sudo sudo`.
+    $commands = collect([
+        'mkdir -p /data/coolify/proxy',
+    ]);
+
+    $result = parseCommandsByLineForSudo($commands, $this->server);
+
+    expect($result[0])->not->toContain('sudo sudo');
+    expect($result[0])->toBe('sudo mkdir -p /data/coolify/proxy && sudo chown -R ubuntu:ubuntu /data/coolify/proxy && sudo chmod -R o-rwx /data/coolify/proxy');
+});
+
+test('does not produce double sudo when input already contains && sudo', function () {
+    // Simulate a line that already has `&& sudo` tokens (e.g. pre-built by another pass).
+    $commands = collect([
+        'sudo mkdir -p /data/coolify/test && sudo chown -R ubuntu:ubuntu /data/coolify/test && sudo chmod -R o-rwx /data/coolify/test',
+    ]);
+
+    $result = parseCommandsByLineForSudo($commands, $this->server);
+
+    expect($result[0])->not->toContain('sudo sudo');
+    expect($result[0])->toBe('sudo mkdir -p /data/coolify/test && sudo chown -R ubuntu:ubuntu /data/coolify/test && sudo chmod -R o-rwx /data/coolify/test');
+});
+
+test('does not produce double sudo after || when next token is already sudo', function () {
+    $commands = collect([
+        'sudo docker stop proxy 2>/dev/null || sudo true',
+    ]);
+
+    $result = parseCommandsByLineForSudo($commands, $this->server);
+
+    expect($result[0])->not->toContain('sudo sudo');
+    expect($result[0])->toBe('sudo docker stop proxy 2>/dev/null || sudo true');
+});
+
+test('does not produce double sudo after pipe when next token is already sudo', function () {
+    $commands = collect([
+        'sudo cat file | sudo grep pattern',
+    ]);
+
+    $result = parseCommandsByLineForSudo($commands, $this->server);
+
+    expect($result[0])->not->toContain('sudo sudo');
+    expect($result[0])->toBe('sudo cat file | sudo grep pattern');
+});
+
+test('still injects sudo after && when next token is not sudo', function () {
+    $commands = collect([
+        'mkdir -p /foo && chown ubuntu /foo',
+    ]);
+
+    $result = parseCommandsByLineForSudo($commands, $this->server);
+
+    expect($result[0])->toBe('sudo mkdir -p /foo && sudo chown ubuntu /foo');
+});
+
+test('still injects sudo after || when next token is not sudo', function () {
+    $commands = collect([
+        'sudo docker stop proxy 2>/dev/null || true',
+    ]);
+
+    $result = parseCommandsByLineForSudo($commands, $this->server);
+
+    expect($result[0])->toBe('sudo docker stop proxy 2>/dev/null || sudo true');
+});
+
+test('still injects sudo after pipe when next token is not sudo', function () {
+    $commands = collect([
+        'sudo cat file | grep pattern',
+    ]);
+
+    $result = parseCommandsByLineForSudo($commands, $this->server);
+
+    expect($result[0])->toBe('sudo cat file | sudo grep pattern');
 });


### PR DESCRIPTION
## Changes

<!-- Describe what changes were made and why in your own words. This "Changes" section must be human-written and not AI-generated. -->

- Ran into an issue that the proxy did not start when the server had access to a different account than the `root` account.
- Fixed a bug in `bootstrap/helpers/sudo.php` where `parseCommandsByLineForSudo()` inadvertently generated double `sudo sudo` commands. 
- The operator replacements for `&&`, `||`, and `|` were naive string replacements. If a previous step already prepended `sudo` (e.g. `&& sudo chown -R ...`), the third pass would turn this into `&& sudo sudo chown ...`. This causes execution to fail when PTY is required.
- This PR adds a negative lookahead to the `preg_replace` statements for `&&`, `||`, and `|`, ensuring `sudo` is only injected if the subsequent token is not already `sudo`.
- Updated existing tests that previously documented the buggy double sudo behavior as expected, and added comprehensive new regression tests for all three operator variants.

**Additional Context for Documentation:**

1. During debugging on an Ubuntu 24.04 machine we identified that CIS-hardened servers with `Defaults log_input, log_output` or `requiretty` in sudoers will cause programmatic Coolify deployments to fail silently because `sudo` allocates a PTY and consumes the bash heredoc stdin. It is highly recommended to add `!use_pty`, `!log_input`, and `!log_output` to the Coolify user's sudoers configuration to ensure smooth proxy startups and queue job executions. 
2. Furthermore, `/data/coolify/proxy/` must be owned by the SSH user executing Coolify, otherwise the SSH session will encounter permission denied errors when attempting to write `docker-compose.yml`.

## Issues

<!-- Link related issues or discussions. If reopening a closed PR, explain why it should be reconsidered. -->

- Fixes [4255](https://github.com/coollabsio/coolify/issues/4255)

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

<!-- Screenshot or short video showing your changes in action. Mandatory for new features. -->
N/A - backend logic change.

## AI Assistance

<!-- AI-assisted PRs that are human reviewed are welcome, just let us know so we can review appropriately. -->

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: AI was used to debug the execution traces of the `parseCommandsByLineForSudo` pipeline, write the negative lookahead regular expressions, update the Pest tests, and format the PR description. I (human) thoroughly verified the findings and architecture on my VPS.

## Testing

<!-- Describe how you tested these changes. -->
- **Automated Tests:** Wrote and updated Pest regression tests in `tests/Unit/ParseCommandsByLineForSudoTest.php` confirming the negative lookahead correctly prevents double `sudo` injection.
- **Manual Verification:** Deployed the patch manually inside a running Coolify container on a CIS Level 1-hardened Ubuntu 24.04 VPS. Verified that clicking "Start Proxy" in the UI successfully generates the correct single `sudo` execution chain, creates the `docker-compose.yml` with the correct ownership via the SSH session, and successfully starts the `coolify-proxy` container without exiting silently.

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.