### PR TITLE
fix(traefik): use HostRegexp for wildcard FQDN router rules

### DIFF
--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -411,6 +411,23 @@ function fqdnLabelsForCaddy(string $network, string $uuid, Collection $domains, 
     return $labels->sort();
 }
 
+function traefikHostRule(string $host): string
+{
+    if (! str_contains($host, '*')) {
+        return "Host(`{$host}`)";
+    }
+    // Strict allowlist: only "*.<dns-labels>" is converted to HostRegexp.
+    // Anything else (multi-`*`, wildcard not at leftmost position, illegal
+    // chars) falls through to Host() so Traefik rejects it exactly as it
+    // does today — no new behaviour for unsupported shapes.
+    if (! preg_match('/^\*(?:\.[a-z0-9-]+)+$/i', $host)) {
+        return "Host(`{$host}`)";
+    }
+    $regex = '^[a-z0-9-]+'.str_replace('.', '\\.', substr($host, 1)).'$';
+
+    return "HostRegexp(`{$regex}`)";
+}
+
 function fqdnLabelsForTraefik(string $uuid, Collection $domains, bool $is_force_https_enabled = false, $onlyPort = null, ?Collection $serviceLabels = null, ?bool $is_gzip_enabled = true, ?bool $is_stripprefix_enabled = true, ?string $service_name = null, bool $generate_unique_uuid = false, ?string $image = null, string $redirect_direction = 'both', bool $is_http_basic_auth_enabled = false, ?string $http_basic_auth_username = null, ?string $http_basic_auth_password = null)
 {
     $labels = collect([]);
@@ -498,7 +515,15 @@ function fqdnLabelsForTraefik(string $uuid, Collection $domains, bool $is_force_
             ];
             if ($schema === 'https') {
                 // Set labels for https
-                $labels->push("traefik.http.routers.{$https_label}.rule=Host(`{$host}`) && PathPrefix(`{$path}`)");
+                $traefik_rule = traefikHostRule($host);
+                $labels->push("traefik.http.routers.{$https_label}.rule={$traefik_rule} && PathPrefix(`{$path}`)");
+                if (str_starts_with($traefik_rule, 'HostRegexp')) {
+                    // Wildcard route — set low priority so any sibling exact
+                    // Host() route on the same parent domain wins. Traefik's
+                    // default priority is rule-string length, so HostRegexp
+                    // would otherwise outrank shorter Host() rules.
+                    $labels->push("traefik.http.routers.{$https_label}.priority=1");
+                }
                 $labels->push("traefik.http.routers.{$https_label}.entryPoints=https");
                 if ($port) {
                     $labels->push("traefik.http.routers.{$https_label}.service={$https_label}");
@@ -566,7 +591,11 @@ function fqdnLabelsForTraefik(string $uuid, Collection $domains, bool $is_force_
                 $labels->push("traefik.http.routers.{$https_label}.tls.certresolver=letsencrypt");
 
                 // Set labels for http (redirect to https)
-                $labels->push("traefik.http.routers.{$http_label}.rule=Host(`{$host}`) && PathPrefix(`{$path}`)");
+                $traefik_rule = traefikHostRule($host);
+                $labels->push("traefik.http.routers.{$http_label}.rule={$traefik_rule} && PathPrefix(`{$path}`)");
+                if (str_starts_with($traefik_rule, 'HostRegexp')) {
+                    $labels->push("traefik.http.routers.{$http_label}.priority=1");
+                }
                 $labels->push("traefik.http.routers.{$http_label}.entryPoints=http");
                 if ($port) {
                     $labels->push("traefik.http.services.{$http_label}.loadbalancer.server.port=$port");
@@ -577,7 +606,11 @@ function fqdnLabelsForTraefik(string $uuid, Collection $domains, bool $is_force_
                 }
             } else {
                 // Set labels for http
-                $labels->push("traefik.http.routers.{$http_label}.rule=Host(`{$host}`) && PathPrefix(`{$path}`)");
+                $traefik_rule = traefikHostRule($host);
+                $labels->push("traefik.http.routers.{$http_label}.rule={$traefik_rule} && PathPrefix(`{$path}`)");
+                if (str_starts_with($traefik_rule, 'HostRegexp')) {
+                    $labels->push("traefik.http.routers.{$http_label}.priority=1");
+                }
                 $labels->push("traefik.http.routers.{$http_label}.entryPoints=http");
                 if ($port) {
                     $labels->push("traefik.http.services.{$http_label}.loadbalancer.server.port=$port");

--- a/tests/Unit/TraefikHostRuleTest.php
+++ b/tests/Unit/TraefikHostRuleTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * Unit tests for the traefikHostRule() helper in bootstrap/helpers/docker.php.
+ *
+ * Verifies that:
+ *  - Non-wildcard hosts produce byte-identical Host(`...`) rules (no regression).
+ *  - Supported wildcard shapes ("*.<dns-labels>") are converted to anchored
+ *    HostRegexp(`^[a-z0-9-]+\....\.tld$`) rules.
+ *  - Unsupported shapes (multi-`*`, mid-`*`, illegal chars) fall through to
+ *    Host(`...`) unchanged so Traefik rejects them exactly as it does today —
+ *    no new behaviour for shapes outside the allowlist.
+ */
+
+test('non-wildcard hosts produce byte-identical Host() rules', function () {
+    expect(traefikHostRule('example.com'))->toBe('Host(`example.com`)');
+    expect(traefikHostRule('app.example.com'))->toBe('Host(`app.example.com`)');
+    expect(traefikHostRule('a-b-c.example.com'))->toBe('Host(`a-b-c.example.com`)');
+    expect(traefikHostRule('www.example.com'))->toBe('Host(`www.example.com`)');
+    expect(traefikHostRule('deeply.nested.sub.example.com'))->toBe('Host(`deeply.nested.sub.example.com`)');
+});
+
+test('wildcard at apex is converted to anchored HostRegexp', function () {
+    expect(traefikHostRule('*.example.com'))
+        ->toBe('HostRegexp(`^[a-z0-9-]+\.example\.com$`)');
+});
+
+test('wildcard with deeper parent domain is converted to anchored HostRegexp', function () {
+    expect(traefikHostRule('*.something.example.com'))
+        ->toBe('HostRegexp(`^[a-z0-9-]+\.something\.example\.com$`)');
+    expect(traefikHostRule('*.dev.example.com'))
+        ->toBe('HostRegexp(`^[a-z0-9-]+\.dev\.example\.com$`)');
+});
+
+test('emitted regex is anchored on both ends', function () {
+    // Anchoring matters: without ^…$, HostRegexp would match attacker-controlled
+    // suffixes/prefixes like "evil.example.com.attacker.tld".
+    $rule = traefikHostRule('*.example.com');
+    expect($rule)->toContain('`^[');
+    expect($rule)->toContain('com$`');
+});
+
+test('multi-wildcard hosts fall through to Host() unchanged', function () {
+    expect(traefikHostRule('*.*.example.com'))->toBe('Host(`*.*.example.com`)');
+});
+
+test('wildcard not at leftmost position falls through to Host() unchanged', function () {
+    expect(traefikHostRule('foo.*.example.com'))->toBe('Host(`foo.*.example.com`)');
+});
+
+test('bare wildcard and malformed wildcard inputs fall through to Host() unchanged', function () {
+    expect(traefikHostRule('*'))->toBe('Host(`*`)');
+    expect(traefikHostRule('*.'))->toBe('Host(`*.`)');
+    expect(traefikHostRule('*example.com'))->toBe('Host(`*example.com`)');
+});
+
+test('trailing dot in wildcard host falls through to Host() unchanged', function () {
+    expect(traefikHostRule('*.example.com.'))->toBe('Host(`*.example.com.`)');
+});
+
+test('hyphenated DNS labels are preserved through the transform', function () {
+    expect(traefikHostRule('*.my-app.example.com'))
+        ->toBe('HostRegexp(`^[a-z0-9-]+\.my-app\.example\.com$`)');
+});


### PR DESCRIPTION
## Changes

When an application's FQDN is a wildcard (e.g. `*.example.com`), Coolify currently emits ``Host(`*.example.com`)`` in the Traefik labels. Traefik 3.x rejects this — the rule compiles to `HostSNI` for the TLS router and `HostSNI` does not accept wildcards — so the router never registers and every request to any wildcard subdomain returns 503.

This PR fixes label generation in `fqdnLabelsForTraefik()`:

- New `traefikHostRule()` helper that converts `*.<dns-labels>` hosts to anchored `HostRegexp(`^[a-z0-9-]+\.…\.tld$`)`. Non-wildcard hosts return ``Host(`...`)`` byte-identical to today.
- Strict allowlist regex `^\*(?:\.[a-z0-9-]+)+$` — only single-leading-wildcard hosts get the new treatment. Anything else (multi-`*`, mid-`*`, illegal chars) falls through to today's `Host()` behaviour, so unsupported shapes have **zero** new surface.
- Each of the three call sites that emit a router rule (HTTPS, HTTP-redirect, plain HTTP) also emits `priority=1` when the rule is `HostRegexp`. Without this, Traefik's default rule-string-length priority would make the longer `HostRegexp` rule outrank shorter sibling `Host()` rules on the same parent domain — exactly the wrong way around. **Verified locally** — see Testing.
- Added `tests/Unit/TraefikHostRuleTest.php` (9 tests / 17 assertions) covering all branches of the helper.

## Issues

- Fixes #9623

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A — label-generation change with no UI impact.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: AI located the three label-emit sites in `fqdnLabelsForTraefik()`, drafted the helper, and ran the validation suite below. Each change was reviewed against the existing `fqdnLabelsForCaddy` precedent and adversarial test cases.

## Testing

### Pest unit tests (included in this PR)

Added `tests/Unit/TraefikHostRuleTest.php` — 9 tests, 17 assertions, all passing in the `coolify:dev` image (built from `docker/development/Dockerfile`):

```
   PASS  Tests\Unit\TraefikHostRuleTest
  ✓ non-wildcard hosts produce byte-identical Host() rules
  ✓ wildcard at apex is converted to anchored HostRegexp
  ✓ wildcard with deeper parent domain is converted to anchored HostRegexp
  ✓ emitted regex is anchored on both ends
  ✓ multi-wildcard hosts fall through to Host() unchanged
  ✓ wildcard not at leftmost position falls through to Host() unchanged
  ✓ bare wildcard and malformed wildcard inputs fall through to Host() unchanged
  ✓ trailing dot in wildcard host falls through to Host() unchanged
  ✓ hyphenated DNS labels are preserved through the transform

  Tests:    9 passed (17 assertions)
```

Also re-ran the existing `tests/Unit/DockerComposeLabelParsingTest.php` (which makes structural assertions about `bootstrap/helpers/docker.php`) — all 6 still pass, confirming the structural patterns those tests check for are unaffected.

### Live Traefik (v3.6.13, matching upstream coolify-proxy)

Spun up two `traefik/whoami` containers behind a real Traefik instance — one with `Host(`exact.priority-test.local`)`, one with `HostRegexp(`^[a-z0-9-]+\.priority-test\.local$`)` + `priority=1`:

- `Host: exact.priority-test.local` → exact router (priority 33 beats wildcard priority 1) ✓
- `Host: other.priority-test.local` → wildcard router ✓
- `Host: weird-sub.priority-test.local` → wildcard router (regex matches subdomain with hyphen) ✓

Adversarial / smuggling checks via Traefik API:
- `weird-sub.priority-test.local.attacker.tld` → 404 (anchor `$` blocks suffix smuggling) ✓
- `attacker.weird-sub.priority-test.local` → 404 (regex requires exactly one label after wildcard position) ✓
- `foo.bar.priority-test.local` → 404 (multi-label subdomain rejected) ✓

Without the `priority=1` emission, `exact.priority-test.local` was incorrectly routed to the wildcard service (verified by the Traefik API showing wildcard auto-priority 48 vs exact auto-priority 33). With `priority=1`, exact wins as intended.

## Notes for reviewers

- **Scope is intentionally tight**: no changes to `fqdnLabelsForCaddy` (Caddy supports wildcards natively), no refactor of the three near-duplicate code paths inside `fqdnLabelsForTraefik`, no opinion on multi-`*` or mid-`*` shapes (DNS-01 / Let's Encrypt won't issue certs for those anyway, so they would 503 on TLS regardless).
- **TLS HostSNI behaviour**: `HostRegexp` routers do not auto-derive a TCP-layer `HostSNI` rule, unlike `Host()` routers. This is correct for wildcards — the wildcard cert (provisioned via DNS-01) terminates TLS for any matching SNI, then the HTTP layer matches via `HostRegexp`. Non-wildcard routers are completely unaffected because the helper short-circuits to the original `Host()` string.
- **ReDoS**: Traefik's regexp engine is RE2 (Go stdlib) — linear-time by design, no catastrophic backtracking possible.
- **Strict allowlist input validation**: Spatie's URL parser already rejects regex metacharacters as illegal hostname chars before our helper sees the input. The allowlist `preg_match('/^\*(?:\.[a-z0-9-]+)+$/i', ...)` is belt-and-braces — no untrusted character can reach the regex template.

## Contributor Agreement

- [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
- [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
- [x] I have tested all the changes thoroughly with a local development instance of Coolify (`coolify:dev` built from `docker/development/Dockerfile`, full `composer install` with dev deps, `vendor/bin/pest` against the Unit suite) and I am confident that they will work as expected when a maintainer tests them.
