### PR TITLE
fix(traefik): use HostRegexp for wildcard FQDN router rules

### DIFF
--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -411,6 +411,20 @@ function fqdnLabelsForCaddy(string $network, string $uuid, Collection $domains, 
     return $labels->sort();
 }
 
+function traefikHostRule(string $host): string
+{
+    if (! str_contains($host, '*')) {
+        return "Host(`{$host}`)";
+    }
+    // Allowlist single-leading-wildcard shapes only; other shapes fall through to Host() unchanged.
+    if (! preg_match('/^\*(?:\.[a-z0-9-]+)+$/i', $host)) {
+        return "Host(`{$host}`)";
+    }
+    $regex = '^[a-z0-9-]+'.str_replace('.', '\\.', substr($host, 1)).'$';
+
+    return "HostRegexp(`{$regex}`)";
+}
+
 function fqdnLabelsForTraefik(string $uuid, Collection $domains, bool $is_force_https_enabled = false, $onlyPort = null, ?Collection $serviceLabels = null, ?bool $is_gzip_enabled = true, ?bool $is_stripprefix_enabled = true, ?string $service_name = null, bool $generate_unique_uuid = false, ?string $image = null, string $redirect_direction = 'both', bool $is_http_basic_auth_enabled = false, ?string $http_basic_auth_username = null, ?string $http_basic_auth_password = null)
 {
     $labels = collect([]);
@@ -498,7 +512,12 @@ function fqdnLabelsForTraefik(string $uuid, Collection $domains, bool $is_force_
             ];
             if ($schema === 'https') {
                 // Set labels for https
-                $labels->push("traefik.http.routers.{$https_label}.rule=Host(`{$host}`) && PathPrefix(`{$path}`)");
+                $traefik_rule = traefikHostRule($host);
+                $labels->push("traefik.http.routers.{$https_label}.rule={$traefik_rule} && PathPrefix(`{$path}`)");
+                if (str_starts_with($traefik_rule, 'HostRegexp')) {
+                    // Lower than any exact Host() rule (Traefik default priority = rule-string length).
+                    $labels->push("traefik.http.routers.{$https_label}.priority=1");
+                }
                 $labels->push("traefik.http.routers.{$https_label}.entryPoints=https");
                 if ($port) {
                     $labels->push("traefik.http.routers.{$https_label}.service={$https_label}");
@@ -566,7 +585,11 @@ function fqdnLabelsForTraefik(string $uuid, Collection $domains, bool $is_force_
                 $labels->push("traefik.http.routers.{$https_label}.tls.certresolver=letsencrypt");
 
                 // Set labels for http (redirect to https)
-                $labels->push("traefik.http.routers.{$http_label}.rule=Host(`{$host}`) && PathPrefix(`{$path}`)");
+                $traefik_rule = traefikHostRule($host);
+                $labels->push("traefik.http.routers.{$http_label}.rule={$traefik_rule} && PathPrefix(`{$path}`)");
+                if (str_starts_with($traefik_rule, 'HostRegexp')) {
+                    $labels->push("traefik.http.routers.{$http_label}.priority=1");
+                }
                 $labels->push("traefik.http.routers.{$http_label}.entryPoints=http");
                 if ($port) {
                     $labels->push("traefik.http.services.{$http_label}.loadbalancer.server.port=$port");
@@ -577,7 +600,11 @@ function fqdnLabelsForTraefik(string $uuid, Collection $domains, bool $is_force_
                 }
             } else {
                 // Set labels for http
-                $labels->push("traefik.http.routers.{$http_label}.rule=Host(`{$host}`) && PathPrefix(`{$path}`)");
+                $traefik_rule = traefikHostRule($host);
+                $labels->push("traefik.http.routers.{$http_label}.rule={$traefik_rule} && PathPrefix(`{$path}`)");
+                if (str_starts_with($traefik_rule, 'HostRegexp')) {
+                    $labels->push("traefik.http.routers.{$http_label}.priority=1");
+                }
                 $labels->push("traefik.http.routers.{$http_label}.entryPoints=http");
                 if ($port) {
                     $labels->push("traefik.http.services.{$http_label}.loadbalancer.server.port=$port");

--- a/tests/Unit/TraefikHostRuleTest.php
+++ b/tests/Unit/TraefikHostRuleTest.php
@@ -1,0 +1,48 @@
+<?php
+
+test('non-wildcard hosts produce byte-identical Host() rules', function () {
+    expect(traefikHostRule('example.com'))->toBe('Host(`example.com`)');
+    expect(traefikHostRule('app.example.com'))->toBe('Host(`app.example.com`)');
+    expect(traefikHostRule('a-b-c.example.com'))->toBe('Host(`a-b-c.example.com`)');
+    expect(traefikHostRule('www.example.com'))->toBe('Host(`www.example.com`)');
+    expect(traefikHostRule('deeply.nested.sub.example.com'))->toBe('Host(`deeply.nested.sub.example.com`)');
+});
+
+test('wildcard at apex is converted to anchored HostRegexp', function () {
+    expect(traefikHostRule('*.example.com'))
+        ->toBe('HostRegexp(`^[a-z0-9-]+\.example\.com$`)');
+});
+
+test('wildcard with deeper parent domain is converted to anchored HostRegexp', function () {
+    expect(traefikHostRule('*.sandbox.example.com'))
+        ->toBe('HostRegexp(`^[a-z0-9-]+\.sandbox\.example\.com$`)');
+});
+
+test('emitted regex is anchored on both ends to prevent host-header smuggling', function () {
+    $rule = traefikHostRule('*.example.com');
+    expect($rule)->toContain('`^[');
+    expect($rule)->toContain('com$`');
+});
+
+test('multi-wildcard hosts fall through to Host() unchanged', function () {
+    expect(traefikHostRule('*.*.example.com'))->toBe('Host(`*.*.example.com`)');
+});
+
+test('wildcard not at leftmost position falls through to Host() unchanged', function () {
+    expect(traefikHostRule('foo.*.example.com'))->toBe('Host(`foo.*.example.com`)');
+});
+
+test('bare wildcard and malformed wildcard inputs fall through to Host() unchanged', function () {
+    expect(traefikHostRule('*'))->toBe('Host(`*`)');
+    expect(traefikHostRule('*.'))->toBe('Host(`*.`)');
+    expect(traefikHostRule('*example.com'))->toBe('Host(`*example.com`)');
+});
+
+test('trailing dot in wildcard host falls through to Host() unchanged', function () {
+    expect(traefikHostRule('*.example.com.'))->toBe('Host(`*.example.com.`)');
+});
+
+test('hyphenated DNS labels are preserved through the transform', function () {
+    expect(traefikHostRule('*.my-app.example.com'))
+        ->toBe('HostRegexp(`^[a-z0-9-]+\.my-app\.example\.com$`)');
+});


### PR DESCRIPTION
## Changes

- Wildcard FQDNs like `*.example.com` currently emit `Host(...)` rules that Traefik 3.x rejects (HostSNI cannot be wildcarded), so every request to a wildcard subdomain returns 503.
- New `traefikHostRule()` helper converts wildcard hosts to anchored HostRegexp rules. Non-wildcard hosts produce byte-identical labels — no regression.
- Strict allowlist: only single-leading-wildcard shapes are converted; anything else falls through to the old behaviour (so unsupported shapes have zero new surface).
- Wildcard routes also emit `priority=1` so any sibling exact-host route on the same parent domain wins. Without this, Traefik's default rule-string-length priority would let the longer regex outrank shorter exact rules — confirmed against a live Traefik 3.6.13 instance during testing.

## Issues

- Fixes #9623

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A — label-generation change with no UI impact.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: located the three label-emit sites, drafted the helper and tests, ran local validation. Each change was reviewed against existing patterns and adversarial cases before submission.

## Testing

Added `tests/Unit/TraefikHostRuleTest.php` (9 tests). Ran the Pest Unit suite in coolify:dev — all TraefikHostRule tests plus the existing DockerComposeLabelParsing tests pass. Also validated priority resolution against a live Traefik 3.6.13 instance with two whoami services on a shared parent domain, and confirmed the anchored regex rejects host-header smuggling attempts (suffix and prefix nesting both return 404).

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
