### PR TITLE
feat: add read-only container info cards

### DIFF
--- a/app/Livewire/Project/Application/General.php
+++ b/app/Livewire/Project/Application/General.php
@@ -5,6 +5,7 @@ namespace App\Livewire\Project\Application;
 use App\Actions\Application\GenerateConfig;
 use App\Jobs\ApplicationDeploymentJob;
 use App\Models\Application;
+use App\Support\ContainerInfo;
 use App\Support\ValidationPatterns;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
@@ -23,6 +24,8 @@ class General extends Component
     public Application $application;
 
     public Collection $services;
+
+    public ?array $containerInfo = null;
 
     public string $name;
 
@@ -341,6 +344,22 @@ class General extends Component
         // Sync data from model to properties at the END, after all business logic
         // This ensures any modifications to $this->application during mount() are reflected in properties
         $this->syncData();
+        $this->loadContainerInfo();
+    }
+
+    private function loadContainerInfo(): void
+    {
+        $server = $this->application->destination?->server;
+
+        if (request()->route()?->getName() !== 'project.application.configuration' || ! $server || $server->isSwarm()) {
+            return;
+        }
+
+        $inspect = instant_remote_process([
+            ContainerInfo::inspectCommandForApplication($this->application->id),
+        ], $server, false);
+
+        $this->containerInfo = ContainerInfo::fromDockerInspect($inspect);
     }
 
     public function syncData(bool $toModel = false): void

--- a/app/Livewire/Project/Service/Index.php
+++ b/app/Livewire/Project/Service/Index.php
@@ -159,13 +159,13 @@ class Index extends Component
 
     private function loadContainerInfo(): void
     {
-        if (! $this->server || $this->server->isSwarm()) {
+        if (! $this->shouldLoadContainerInfo()) {
             return;
         }
 
         $command = match ($this->resourceType) {
-            'application' => $this->serviceApplication ? ContainerInfo::inspectCommandForServiceSub($this->serviceApplication->id) : null,
-            'database' => $this->serviceDatabase ? ContainerInfo::inspectCommandForServiceSub($this->serviceDatabase->id) : null,
+            'application' => $this->serviceApplication ? ContainerInfo::inspectCommandForServiceSub($this->service->id, 'application', $this->serviceApplication->id) : null,
+            'database' => $this->serviceDatabase ? ContainerInfo::inspectCommandForServiceSub($this->service->id, 'database', $this->serviceDatabase->id) : null,
             default => null,
         };
 
@@ -175,6 +175,13 @@ class Index extends Component
 
         $inspect = instant_remote_process([$command], $this->server, false);
         $this->containerInfo = ContainerInfo::fromDockerInspect($inspect);
+    }
+
+    private function shouldLoadContainerInfo(): bool
+    {
+        return $this->currentRoute === 'project.service.index'
+            && $this->server
+            && ! $this->server->isSwarm();
     }
 
     private function syncDatabaseData(bool $toModel = false): void

--- a/app/Livewire/Project/Service/Index.php
+++ b/app/Livewire/Project/Service/Index.php
@@ -8,6 +8,7 @@ use App\Models\Server;
 use App\Models\Service;
 use App\Models\ServiceApplication;
 use App\Models\ServiceDatabase;
+use App\Support\ContainerInfo;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
@@ -27,6 +28,8 @@ class Index extends Component
     public ?string $resourceType = null;
 
     public ?string $currentRoute = null;
+
+    public ?array $containerInfo = null;
 
     public array $parameters;
 
@@ -132,6 +135,7 @@ class Index extends Component
                 $this->serviceDatabase->getFilesFromServer();
                 $this->initializeDatabaseProperties();
             }
+            $this->loadContainerInfo();
             $this->s3s = currentTeam()->s3s;
         } catch (\Throwable $e) {
             return handleError($e, $this);
@@ -151,6 +155,26 @@ class Index extends Component
         $dbType = $this->serviceDatabase->databaseType();
         $supportedTypes = ['mysql', 'mariadb', 'postgres', 'mongo'];
         $this->isImportSupported = collect($supportedTypes)->contains(fn ($type) => str_contains($dbType, $type));
+    }
+
+    private function loadContainerInfo(): void
+    {
+        if (! $this->server || $this->server->isSwarm()) {
+            return;
+        }
+
+        $command = match ($this->resourceType) {
+            'application' => $this->serviceApplication ? ContainerInfo::inspectCommandForServiceSub($this->serviceApplication->id) : null,
+            'database' => $this->serviceDatabase ? ContainerInfo::inspectCommandForServiceSub($this->serviceDatabase->id) : null,
+            default => null,
+        };
+
+        if (blank($command)) {
+            return;
+        }
+
+        $inspect = instant_remote_process([$command], $this->server, false);
+        $this->containerInfo = ContainerInfo::fromDockerInspect($inspect);
     }
 
     private function syncDatabaseData(bool $toModel = false): void
@@ -329,6 +353,7 @@ class Index extends Component
     // Application-specific methods
     private function initializeApplicationProperties(): void
     {
+        $this->server = $this->serviceApplication->service->destination->server;
         $this->requiredPort = $this->serviceApplication->getRequiredPort();
         $this->syncApplicationData(false);
     }

--- a/app/Support/ContainerInfo.php
+++ b/app/Support/ContainerInfo.php
@@ -38,6 +38,21 @@ class ContainerInfo
         ];
     }
 
+    public static function inspectCommandForApplication(int $applicationId): string
+    {
+        return self::inspectCommandForLabel("coolify.applicationId={$applicationId}");
+    }
+
+    public static function inspectCommandForServiceSub(int $serviceSubId): string
+    {
+        return self::inspectCommandForLabel("coolify.service.subId={$serviceSubId}");
+    }
+
+    private static function inspectCommandForLabel(string $label): string
+    {
+        return "CONTAINER_ID=\$(docker ps --filter='label={$label}' --format '{{.ID}}' | head -n 1); if [ -z \"\$CONTAINER_ID\" ]; then CONTAINER_ID=\$(docker ps -a --filter='label={$label}' --format '{{.ID}}' | head -n 1); fi; if [ -n \"\$CONTAINER_ID\" ]; then docker inspect \"\$CONTAINER_ID\"; fi";
+    }
+
     private static function filledTimestamp(mixed $value): ?string
     {
         if (blank($value) || $value === '0001-01-01T00:00:00Z') {

--- a/app/Support/ContainerInfo.php
+++ b/app/Support/ContainerInfo.php
@@ -40,7 +40,10 @@ class ContainerInfo
 
     public static function inspectCommandForApplication(int $applicationId): string
     {
-        return self::inspectCommandForLabel("coolify.applicationId={$applicationId}");
+        return self::inspectCommandForLabels([
+            "coolify.applicationId={$applicationId}",
+            'coolify.pullRequestId=0',
+        ]);
     }
 
     public static function inspectCommandForServiceSub(int $serviceId, string $serviceSubType, int $serviceSubId): string

--- a/app/Support/ContainerInfo.php
+++ b/app/Support/ContainerInfo.php
@@ -43,14 +43,30 @@ class ContainerInfo
         return self::inspectCommandForLabel("coolify.applicationId={$applicationId}");
     }
 
-    public static function inspectCommandForServiceSub(int $serviceSubId): string
+    public static function inspectCommandForServiceSub(int $serviceId, string $serviceSubType, int $serviceSubId): string
     {
-        return self::inspectCommandForLabel("coolify.service.subId={$serviceSubId}");
+        return self::inspectCommandForLabels([
+            "coolify.serviceId={$serviceId}",
+            "coolify.service.subType={$serviceSubType}",
+            "coolify.service.subId={$serviceSubId}",
+        ]);
     }
 
     private static function inspectCommandForLabel(string $label): string
     {
-        return "CONTAINER_ID=\$(docker ps --filter='label={$label}' --format '{{.ID}}' | head -n 1); if [ -z \"\$CONTAINER_ID\" ]; then CONTAINER_ID=\$(docker ps -a --filter='label={$label}' --format '{{.ID}}' | head -n 1); fi; if [ -n \"\$CONTAINER_ID\" ]; then docker inspect \"\$CONTAINER_ID\"; fi";
+        return self::inspectCommandForLabels([$label]);
+    }
+
+    /**
+     * @param  array<int, string>  $labels
+     */
+    private static function inspectCommandForLabels(array $labels): string
+    {
+        $filters = collect($labels)
+            ->map(fn (string $label) => "--filter='label={$label}'")
+            ->implode(' ');
+
+        return "CONTAINER_ID=\$(docker ps {$filters} --format '{{.ID}}' | head -n 1); if [ -z \"\$CONTAINER_ID\" ]; then CONTAINER_ID=\$(docker ps -a {$filters} --format '{{.ID}}' | head -n 1); fi; if [ -n \"\$CONTAINER_ID\" ]; then docker inspect \"\$CONTAINER_ID\"; fi";
     }
 
     private static function filledTimestamp(mixed $value): ?string

--- a/app/Support/ContainerInfo.php
+++ b/app/Support/ContainerInfo.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Support;
+
+class ContainerInfo
+{
+    /**
+     * @param  array<int, array<string, mixed>>|array<string, mixed>|string|null  $inspect
+     * @return array{id: ?string, name: ?string, image: ?string, created_at: ?string, started_at: ?string, ipv4_addresses: array<int, string>, ipv6_addresses: array<int, string>}|null
+     */
+    public static function fromDockerInspect(array|string|null $inspect): ?array
+    {
+        if (blank($inspect)) {
+            return null;
+        }
+
+        if (is_string($inspect)) {
+            $decodedInspect = json_decode($inspect, true);
+            if (! is_array($decodedInspect)) {
+                return null;
+            }
+            $inspect = $decodedInspect;
+        }
+
+        $container = array_is_list($inspect) ? ($inspect[0] ?? null) : $inspect;
+        if (! is_array($container) || blank($container)) {
+            return null;
+        }
+
+        return [
+            'id' => data_get($container, 'Id'),
+            'name' => str((string) data_get($container, 'Name'))->ltrim('/')->toString() ?: null,
+            'image' => data_get($container, 'Config.Image') ?: data_get($container, 'Image'),
+            'created_at' => data_get($container, 'Created'),
+            'started_at' => self::filledTimestamp(data_get($container, 'State.StartedAt')),
+            'ipv4_addresses' => self::networkAddresses($container, 'IPAddress'),
+            'ipv6_addresses' => self::networkAddresses($container, 'GlobalIPv6Address'),
+        ];
+    }
+
+    private static function filledTimestamp(mixed $value): ?string
+    {
+        if (blank($value) || $value === '0001-01-01T00:00:00Z') {
+            return null;
+        }
+
+        return (string) $value;
+    }
+
+    /**
+     * @param  array<string, mixed>  $container
+     * @return array<int, string>
+     */
+    private static function networkAddresses(array $container, string $field): array
+    {
+        $networks = data_get($container, 'NetworkSettings.Networks', []);
+        if (! is_array($networks)) {
+            return [];
+        }
+
+        return collect($networks)
+            ->pluck($field)
+            ->filter(fn ($address) => filled($address))
+            ->map(fn ($address) => (string) $address)
+            ->unique()
+            ->values()
+            ->all();
+    }
+}

--- a/resources/views/components/container-info.blade.php
+++ b/resources/views/components/container-info.blade.php
@@ -1,0 +1,96 @@
+@props(['containerInfo' => null])
+
+@if ($containerInfo)
+    <div class="rounded border border-neutral-200 bg-white p-4 dark:border-coolgray-300 dark:bg-coolgray-100">
+        <div class="flex items-center gap-2">
+            <h3>Container Info</h3>
+            <span class="text-xs text-neutral-500 dark:text-neutral-400">Read-only details from Docker inspect.</span>
+        </div>
+        <div class="grid gap-4 pt-4 xl:grid-cols-2">
+            <div class="space-y-1">
+                <div class="text-xs uppercase text-neutral-500 dark:text-neutral-400">Container ID</div>
+                <div class="flex items-start justify-between gap-2 rounded border border-neutral-200 px-3 py-2 dark:border-coolgray-300">
+                    <code class="break-all text-xs">{{ data_get($containerInfo, 'id') }}</code>
+                    @if (filled(data_get($containerInfo, 'id')))
+                        <button type="button" class="text-xs font-semibold text-coollabs hover:underline dark:text-warning"
+                            x-on:click="copyToClipboard(@js(data_get($containerInfo, 'id')))" aria-label="Copy container ID"
+                            title="Copy container ID">
+                            Copy
+                        </button>
+                    @endif
+                </div>
+            </div>
+
+            <div class="space-y-1">
+                <div class="text-xs uppercase text-neutral-500 dark:text-neutral-400">Container Name</div>
+                <div class="flex items-start justify-between gap-2 rounded border border-neutral-200 px-3 py-2 dark:border-coolgray-300">
+                    <code class="break-all text-xs">{{ data_get($containerInfo, 'name') }}</code>
+                    @if (filled(data_get($containerInfo, 'name')))
+                        <button type="button" class="text-xs font-semibold text-coollabs hover:underline dark:text-warning"
+                            x-on:click="copyToClipboard(@js(data_get($containerInfo, 'name')))" aria-label="Copy container name"
+                            title="Copy container name">
+                            Copy
+                        </button>
+                    @endif
+                </div>
+            </div>
+
+            <div class="space-y-1 xl:col-span-2">
+                <div class="text-xs uppercase text-neutral-500 dark:text-neutral-400">Image</div>
+                <div class="rounded border border-neutral-200 px-3 py-2 dark:border-coolgray-300">
+                    <code class="break-all text-xs">{{ data_get($containerInfo, 'image') }}</code>
+                </div>
+            </div>
+
+            <div class="space-y-1">
+                <div class="text-xs uppercase text-neutral-500 dark:text-neutral-400">Created At</div>
+                <div class="rounded border border-neutral-200 px-3 py-2 text-xs dark:border-coolgray-300">
+                    {{ data_get($containerInfo, 'created_at') ?? '—' }}
+                </div>
+            </div>
+
+            <div class="space-y-1">
+                <div class="text-xs uppercase text-neutral-500 dark:text-neutral-400">Started At</div>
+                <div class="rounded border border-neutral-200 px-3 py-2 text-xs dark:border-coolgray-300">
+                    {{ data_get($containerInfo, 'started_at') ?? '—' }}
+                </div>
+            </div>
+
+            <div class="space-y-2">
+                <div class="text-xs uppercase text-neutral-500 dark:text-neutral-400">IPv4</div>
+                @forelse (data_get($containerInfo, 'ipv4_addresses', []) as $ipv4Address)
+                    <div class="flex items-start justify-between gap-2 rounded border border-neutral-200 px-3 py-2 dark:border-coolgray-300">
+                        <code class="break-all text-xs">{{ $ipv4Address }}</code>
+                        <button type="button" class="text-xs font-semibold text-coollabs hover:underline dark:text-warning"
+                            x-on:click="copyToClipboard(@js($ipv4Address))" aria-label="Copy IPv4 address"
+                            title="Copy IPv4 address">
+                            Copy
+                        </button>
+                    </div>
+                @empty
+                    <div class="rounded border border-dashed border-neutral-200 px-3 py-2 text-xs text-neutral-500 dark:border-coolgray-300 dark:text-neutral-400">
+                        —
+                    </div>
+                @endforelse
+            </div>
+
+            <div class="space-y-2">
+                <div class="text-xs uppercase text-neutral-500 dark:text-neutral-400">IPv6</div>
+                @forelse (data_get($containerInfo, 'ipv6_addresses', []) as $ipv6Address)
+                    <div class="flex items-start justify-between gap-2 rounded border border-neutral-200 px-3 py-2 dark:border-coolgray-300">
+                        <code class="break-all text-xs">{{ $ipv6Address }}</code>
+                        <button type="button" class="text-xs font-semibold text-coollabs hover:underline dark:text-warning"
+                            x-on:click="copyToClipboard(@js($ipv6Address))" aria-label="Copy IPv6 address"
+                            title="Copy IPv6 address">
+                            Copy
+                        </button>
+                    </div>
+                @empty
+                    <div class="rounded border border-dashed border-neutral-200 px-3 py-2 text-xs text-neutral-500 dark:border-coolgray-300 dark:text-neutral-400">
+                        —
+                    </div>
+                @endforelse
+            </div>
+        </div>
+    </div>
+@endif

--- a/resources/views/livewire/project/application/general.blade.php
+++ b/resources/views/livewire/project/application/general.blade.php
@@ -5,6 +5,7 @@
         return this.initLoadingCompose || !this.canUpdate;
     }
 }">
+    <x-container-info :container-info="$containerInfo" />
     <form wire:submit='submit' class="flex flex-col pb-32">
         <div class="flex items-center gap-2">
             <h2>General</h2>

--- a/resources/views/livewire/project/service/index.blade.php
+++ b/resources/views/livewire/project/service/index.blade.php
@@ -49,6 +49,7 @@
                             instantSave="instantSaveApplicationAdvanced" id="isLogDrainEnabled" label="Drain Logs" />
                     </div>
                 @else
+                    <x-container-info :container-info="$containerInfo" />
                     <form wire:submit='submitApplication'>
                         <div class="flex items-center gap-2 pb-4">
                             @if ($serviceApplication->human_name)
@@ -196,6 +197,7 @@
                             instantSave="instantSaveLogDrain" id="isLogDrainEnabled" label="Drain Logs" />
                     </div>
                 @else
+                    <x-container-info :container-info="$containerInfo" />
                     <form wire:submit='submitDatabase'>
                         <div class="flex items-center gap-2 pb-4">
                             @if ($serviceDatabase->human_name)

--- a/tests/Feature/ContainerInfoViewTest.php
+++ b/tests/Feature/ContainerInfoViewTest.php
@@ -1,40 +1,212 @@
 <?php
 
-it('renders the read-only container info card with copy actions only for stable identifiers and IPs', function () {
-    $view = view('components.container-info', [
-        'containerInfo' => [
-            'id' => 'c9248632fb1f1ba4b0d885f78ebadf6af6233799a645d2f5c749088dbf55d79f',
-            'name' => 'web-service-uuid',
+namespace App\Livewire\Project\Service {
+    use App\Models\Server;
+
+    class ContainerInfoTestSpy
+    {
+        public static array $commands = [];
+
+        public static ?string $inspectResponse = null;
+
+        public static function reset(): void
+        {
+            self::$commands = [];
+            self::$inspectResponse = null;
+        }
+    }
+
+    function instant_remote_process(array $command, Server $server, bool $throwError = true): ?string
+    {
+        ContainerInfoTestSpy::$commands[] = $command[0] ?? null;
+
+        return ContainerInfoTestSpy::$inspectResponse;
+    }
+}
+
+namespace App\Models {
+    function getFilesystemVolumesFromServer(ServiceApplication|ServiceDatabase|Application $oneService, bool $isInit = false): void {}
+}
+
+namespace {
+
+    use App\Livewire\Project\Service\ContainerInfoTestSpy;
+    use App\Models\Environment;
+    use App\Models\InstanceSettings;
+    use App\Models\PrivateKey;
+    use App\Models\Project;
+    use App\Models\Server;
+    use App\Models\Service;
+    use App\Models\StandaloneDocker;
+    use App\Models\Team;
+    use App\Models\User;
+    use Illuminate\Foundation\Testing\RefreshDatabase;
+    use Illuminate\Support\Str;
+
+    uses(RefreshDatabase::class);
+
+    beforeEach(function () {
+        ContainerInfoTestSpy::reset();
+
+        $this->team = Team::factory()->create();
+        $this->user = User::factory()->create();
+        $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+
+        $this->actingAs($this->user);
+        $this->withoutVite();
+        session(['currentTeam' => $this->team]);
+
+        InstanceSettings::unguarded(fn () => InstanceSettings::query()->create(['id' => 0]));
+
+        $privateKey = PrivateKey::create([
+            'name' => 'Test Key',
+            'private_key' => generateSSHKey()['private'],
+            'team_id' => $this->team->id,
+        ]);
+
+        $this->server = Server::factory()->create([
+            'team_id' => $this->team->id,
+            'private_key_id' => $privateKey->id,
+            'ip' => 'coolify-testing-host',
+        ]);
+
+        $this->destination = StandaloneDocker::factory()->create([
+            'server_id' => $this->server->id,
+            'network' => 'coolify-'.Str::random(8),
+        ]);
+
+        $this->project = Project::factory()->create([
+            'team_id' => $this->team->id,
+        ]);
+
+        $this->environment = Environment::factory()->create([
+            'project_id' => $this->project->id,
+        ]);
+
+        $this->service = Service::factory()->create([
+            'server_id' => $this->server->id,
+            'destination_id' => $this->destination->id,
+            'destination_type' => $this->destination->getMorphClass(),
+            'environment_id' => $this->environment->id,
+        ]);
+    });
+
+    it('renders the read-only container info card with copy actions only for stable identifiers and IPs', function () {
+        $view = view('components.container-info', [
+            'containerInfo' => [
+                'id' => 'c9248632fb1f1ba4b0d885f78ebadf6af6233799a645d2f5c749088dbf55d79f',
+                'name' => 'web-service-uuid',
+                'image' => 'ghcr.io/example/app:1.2.3',
+                'created_at' => '2026-04-24T12:34:56.123456789Z',
+                'started_at' => '2026-04-24T12:35:10.987654321Z',
+                'ipv4_addresses' => ['172.18.0.5'],
+                'ipv6_addresses' => ['fd00::5'],
+            ],
+        ])->render();
+
+        expect($view)
+            ->toContain('Container Info')
+            ->toContain('Container ID')
+            ->toContain('Container Name')
+            ->toContain('Image')
+            ->toContain('Created At')
+            ->toContain('Started At')
+            ->toContain('IPv4')
+            ->toContain('IPv6')
+            ->toContain('web-service-uuid')
+            ->toContain('ghcr.io/example/app:1.2.3')
+            ->toContain('Copy container ID')
+            ->toContain('Copy container name')
+            ->toContain('Copy IPv4 address')
+            ->toContain('Copy IPv6 address')
+            ->not->toContain('Copy image')
+            ->not->toContain('Copy created at')
+            ->not->toContain('Copy started at');
+    });
+
+    it('loads container info for service application routes using the full service identity tuple', function () {
+        $serviceApplication = $this->service->applications()->create([
+            'uuid' => (string) Str::uuid(),
+            'name' => 'app',
             'image' => 'ghcr.io/example/app:1.2.3',
-            'created_at' => '2026-04-24T12:34:56.123456789Z',
-            'started_at' => '2026-04-24T12:35:10.987654321Z',
-            'ipv4_addresses' => ['172.18.0.5'],
-            'ipv6_addresses' => ['fd00::5'],
-        ],
-    ])->render();
+        ]);
 
-    expect($view)
-        ->toContain('Container Info')
-        ->toContain('Container ID')
-        ->toContain('Container Name')
-        ->toContain('Image')
-        ->toContain('Created At')
-        ->toContain('Started At')
-        ->toContain('IPv4')
-        ->toContain('IPv6')
-        ->toContain('web-service-uuid')
-        ->toContain('ghcr.io/example/app:1.2.3')
-        ->toContain('Copy container ID')
-        ->toContain('Copy container name')
-        ->toContain('Copy IPv4 address')
-        ->toContain('Copy IPv6 address')
-        ->not->toContain('Copy image')
-        ->not->toContain('Copy created at')
-        ->not->toContain('Copy started at');
-});
+        ContainerInfoTestSpy::$inspectResponse = json_encode([[
+            'Id' => 'container-id',
+            'Name' => '/service-application',
+            'Config' => ['Image' => 'ghcr.io/example/app:1.2.3'],
+            'Created' => '2026-04-24T12:34:56.123456789Z',
+            'State' => ['StartedAt' => '2026-04-24T12:35:10.987654321Z'],
+            'NetworkSettings' => ['Networks' => ['coolify' => ['IPAddress' => '172.18.0.5', 'GlobalIPv6Address' => '']]],
+        ]]);
 
-it('renders the service detail page with the container info slice', function () {
-    $view = file_get_contents(resource_path('views/livewire/project/service/index.blade.php'));
+        $response = $this->get(route('project.service.index', [
+            'project_uuid' => $this->project->uuid,
+            'environment_uuid' => $this->environment->uuid,
+            'service_uuid' => $this->service->uuid,
+            'stack_service_uuid' => $serviceApplication->uuid,
+        ]));
 
-    expect($view)->toContain('<x-container-info :container-info="$containerInfo" />');
-});
+        $response->assertOk()->assertSee('Container Info')->assertSee('service-application');
+
+        expect(ContainerInfoTestSpy::$commands)
+            ->toHaveCount(1)
+            ->and(ContainerInfoTestSpy::$commands[0])
+            ->toContain("coolify.serviceId={$this->service->id}")
+            ->toContain('coolify.service.subType=application')
+            ->toContain("coolify.service.subId={$serviceApplication->id}");
+    });
+
+    it('loads container info for service database routes using the full service identity tuple', function () {
+        $serviceDatabase = $this->service->databases()->create([
+            'uuid' => (string) Str::uuid(),
+            'name' => 'db',
+            'image' => 'postgres:16',
+        ]);
+
+        ContainerInfoTestSpy::$inspectResponse = json_encode([[
+            'Id' => 'db-container-id',
+            'Name' => '/service-database',
+            'Config' => ['Image' => 'postgres:16'],
+            'Created' => '2026-04-24T12:34:56.123456789Z',
+            'State' => ['StartedAt' => '2026-04-24T12:35:10.987654321Z'],
+            'NetworkSettings' => ['Networks' => ['coolify' => ['IPAddress' => '172.18.0.6', 'GlobalIPv6Address' => '']]],
+        ]]);
+
+        $response = $this->get(route('project.service.index', [
+            'project_uuid' => $this->project->uuid,
+            'environment_uuid' => $this->environment->uuid,
+            'service_uuid' => $this->service->uuid,
+            'stack_service_uuid' => $serviceDatabase->uuid,
+        ]));
+
+        $response->assertOk()->assertSee('Container Info')->assertSee('service-database');
+
+        expect(ContainerInfoTestSpy::$commands)
+            ->toHaveCount(1)
+            ->and(ContainerInfoTestSpy::$commands[0])
+            ->toContain("coolify.serviceId={$this->service->id}")
+            ->toContain('coolify.service.subType=database')
+            ->toContain("coolify.service.subId={$serviceDatabase->id}");
+    });
+
+    it('skips the remote container inspect when the advanced route does not render the container card', function () {
+        $serviceApplication = $this->service->applications()->create([
+            'uuid' => (string) Str::uuid(),
+            'name' => 'app',
+            'image' => 'ghcr.io/example/app:1.2.3',
+        ]);
+
+        $response = $this->get(route('project.service.index.advanced', [
+            'project_uuid' => $this->project->uuid,
+            'environment_uuid' => $this->environment->uuid,
+            'service_uuid' => $this->service->uuid,
+            'stack_service_uuid' => $serviceApplication->uuid,
+        ]));
+
+        $response->assertOk()->assertDontSee('Container Info');
+
+        expect(ContainerInfoTestSpy::$commands)->toBeEmpty();
+    });
+
+}

--- a/tests/Feature/ContainerInfoViewTest.php
+++ b/tests/Feature/ContainerInfoViewTest.php
@@ -1,0 +1,40 @@
+<?php
+
+it('renders the read-only container info card with copy actions only for stable identifiers and IPs', function () {
+    $view = view('components.container-info', [
+        'containerInfo' => [
+            'id' => 'c9248632fb1f1ba4b0d885f78ebadf6af6233799a645d2f5c749088dbf55d79f',
+            'name' => 'web-service-uuid',
+            'image' => 'ghcr.io/example/app:1.2.3',
+            'created_at' => '2026-04-24T12:34:56.123456789Z',
+            'started_at' => '2026-04-24T12:35:10.987654321Z',
+            'ipv4_addresses' => ['172.18.0.5'],
+            'ipv6_addresses' => ['fd00::5'],
+        ],
+    ])->render();
+
+    expect($view)
+        ->toContain('Container Info')
+        ->toContain('Container ID')
+        ->toContain('Container Name')
+        ->toContain('Image')
+        ->toContain('Created At')
+        ->toContain('Started At')
+        ->toContain('IPv4')
+        ->toContain('IPv6')
+        ->toContain('web-service-uuid')
+        ->toContain('ghcr.io/example/app:1.2.3')
+        ->toContain('Copy container ID')
+        ->toContain('Copy container name')
+        ->toContain('Copy IPv4 address')
+        ->toContain('Copy IPv6 address')
+        ->not->toContain('Copy image')
+        ->not->toContain('Copy created at')
+        ->not->toContain('Copy started at');
+});
+
+it('renders the service detail page with the container info slice', function () {
+    $view = file_get_contents(resource_path('views/livewire/project/service/index.blade.php'));
+
+    expect($view)->toContain('<x-container-info :container-info="$containerInfo" />');
+});

--- a/tests/Feature/ContainerInfoViewTest.php
+++ b/tests/Feature/ContainerInfoViewTest.php
@@ -235,7 +235,8 @@ namespace {
         expect(ContainerInfoTestSpy::$commands)
             ->toHaveCount(1)
             ->and(ContainerInfoTestSpy::$commands[0])
-            ->toContain("coolify.applicationId={$this->application->id}");
+            ->toContain("coolify.applicationId={$this->application->id}")
+            ->toContain('coolify.pullRequestId=0');
     });
 
     it('does not inspect standalone application containers on advanced routes that do not render the card', function () {

--- a/tests/Feature/ContainerInfoViewTest.php
+++ b/tests/Feature/ContainerInfoViewTest.php
@@ -24,6 +24,18 @@ namespace App\Livewire\Project\Service {
     }
 }
 
+namespace App\Livewire\Project\Application {
+    use App\Livewire\Project\Service\ContainerInfoTestSpy;
+    use App\Models\Server;
+
+    function instant_remote_process(array $command, Server $server, bool $throwError = true): ?string
+    {
+        ContainerInfoTestSpy::$commands[] = $command[0] ?? null;
+
+        return ContainerInfoTestSpy::$inspectResponse;
+    }
+}
+
 namespace App\Models {
     function getFilesystemVolumesFromServer(ServiceApplication|ServiceDatabase|Application $oneService, bool $isInit = false): void {}
 }
@@ -31,6 +43,7 @@ namespace App\Models {
 namespace {
 
     use App\Livewire\Project\Service\ContainerInfoTestSpy;
+    use App\Models\Application;
     use App\Models\Environment;
     use App\Models\InstanceSettings;
     use App\Models\PrivateKey;
@@ -81,6 +94,13 @@ namespace {
 
         $this->environment = Environment::factory()->create([
             'project_id' => $this->project->id,
+        ]);
+
+        $this->application = Application::factory()->create([
+            'environment_id' => $this->environment->id,
+            'destination_id' => $this->destination->id,
+            'destination_type' => $this->destination->getMorphClass(),
+            'status' => 'running',
         ]);
 
         $this->service = Service::factory()->create([
@@ -188,6 +208,46 @@ namespace {
             ->toContain("coolify.serviceId={$this->service->id}")
             ->toContain('coolify.service.subType=database')
             ->toContain("coolify.service.subId={$serviceDatabase->id}");
+    });
+
+    it('loads container info for standalone application general routes using the application label selector', function () {
+        ContainerInfoTestSpy::$inspectResponse = json_encode([[
+            'Id' => 'application-container-id',
+            'Name' => '/standalone-application',
+            'Config' => ['Image' => 'ghcr.io/example/app:9.9.9'],
+            'Created' => '2026-04-24T12:34:56.123456789Z',
+            'State' => ['StartedAt' => '2026-04-24T12:35:10.987654321Z'],
+            'NetworkSettings' => ['Networks' => ['coolify' => ['IPAddress' => '172.18.0.7', 'GlobalIPv6Address' => '']]],
+        ]]);
+
+        $response = $this->get(route('project.application.configuration', [
+            'project_uuid' => $this->project->uuid,
+            'environment_uuid' => $this->environment->uuid,
+            'application_uuid' => $this->application->uuid,
+        ]));
+
+        $response->assertOk()
+            ->assertSee('Container Info')
+            ->assertSee('standalone-application')
+            ->assertSee('Copy container ID')
+            ->assertSee('Copy IPv4 address');
+
+        expect(ContainerInfoTestSpy::$commands)
+            ->toHaveCount(1)
+            ->and(ContainerInfoTestSpy::$commands[0])
+            ->toContain("coolify.applicationId={$this->application->id}");
+    });
+
+    it('does not inspect standalone application containers on advanced routes that do not render the card', function () {
+        $response = $this->get(route('project.application.advanced', [
+            'project_uuid' => $this->project->uuid,
+            'environment_uuid' => $this->environment->uuid,
+            'application_uuid' => $this->application->uuid,
+        ]));
+
+        $response->assertOk()->assertDontSee('Container Info');
+
+        expect(ContainerInfoTestSpy::$commands)->toBeEmpty();
     });
 
     it('skips the remote container inspect when the advanced route does not render the container card', function () {

--- a/tests/Unit/ContainerInfoTest.php
+++ b/tests/Unit/ContainerInfoTest.php
@@ -38,9 +38,10 @@ it('normalizes docker inspect data for display', function () {
     ]);
 });
 
-it('builds a docker inspect command for applications', function () {
+it('builds a docker inspect command for base application containers only', function () {
     expect(ContainerInfo::inspectCommandForApplication(42))
         ->toContain('coolify.applicationId=42')
+        ->toContain('coolify.pullRequestId=0')
         ->toContain('docker ps --filter')
         ->toContain('docker ps -a --filter')
         ->toContain('docker inspect');

--- a/tests/Unit/ContainerInfoTest.php
+++ b/tests/Unit/ContainerInfoTest.php
@@ -37,3 +37,19 @@ it('normalizes docker inspect data for display', function () {
         'ipv6_addresses' => ['fd00::5'],
     ]);
 });
+
+it('builds a docker inspect command for applications', function () {
+    expect(ContainerInfo::inspectCommandForApplication(42))
+        ->toContain('coolify.applicationId=42')
+        ->toContain('docker ps --filter')
+        ->toContain('docker ps -a --filter')
+        ->toContain('docker inspect');
+});
+
+it('builds a docker inspect command for service sub resources', function () {
+    expect(ContainerInfo::inspectCommandForServiceSub(99))
+        ->toContain('coolify.service.subId=99')
+        ->toContain('docker ps --filter')
+        ->toContain('docker ps -a --filter')
+        ->toContain('docker inspect');
+});

--- a/tests/Unit/ContainerInfoTest.php
+++ b/tests/Unit/ContainerInfoTest.php
@@ -47,7 +47,9 @@ it('builds a docker inspect command for applications', function () {
 });
 
 it('builds a docker inspect command for service sub resources', function () {
-    expect(ContainerInfo::inspectCommandForServiceSub(99))
+    expect(ContainerInfo::inspectCommandForServiceSub(12, 'database', 99))
+        ->toContain('coolify.serviceId=12')
+        ->toContain('coolify.service.subType=database')
         ->toContain('coolify.service.subId=99')
         ->toContain('docker ps --filter')
         ->toContain('docker ps -a --filter')

--- a/tests/Unit/ContainerInfoTest.php
+++ b/tests/Unit/ContainerInfoTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Support\ContainerInfo;
+
+it('normalizes docker inspect data for display', function () {
+    $inspect = [[
+        'Id' => 'c9248632fb1f1ba4b0d885f78ebadf6af6233799a645d2f5c749088dbf55d79f',
+        'Name' => '/web-service-uuid',
+        'Config' => [
+            'Image' => 'ghcr.io/example/app:1.2.3',
+        ],
+        'Created' => '2026-04-24T12:34:56.123456789Z',
+        'State' => [
+            'StartedAt' => '2026-04-24T12:35:10.987654321Z',
+        ],
+        'NetworkSettings' => [
+            'Networks' => [
+                'coolify' => [
+                    'IPAddress' => '172.18.0.5',
+                    'GlobalIPv6Address' => 'fd00::5',
+                ],
+                'other' => [
+                    'IPAddress' => '172.19.0.7',
+                    'GlobalIPv6Address' => '',
+                ],
+            ],
+        ],
+    ]];
+
+    expect(ContainerInfo::fromDockerInspect($inspect))->toBe([
+        'id' => 'c9248632fb1f1ba4b0d885f78ebadf6af6233799a645d2f5c749088dbf55d79f',
+        'name' => 'web-service-uuid',
+        'image' => 'ghcr.io/example/app:1.2.3',
+        'created_at' => '2026-04-24T12:34:56.123456789Z',
+        'started_at' => '2026-04-24T12:35:10.987654321Z',
+        'ipv4_addresses' => ['172.18.0.5', '172.19.0.7'],
+        'ipv6_addresses' => ['fd00::5'],
+    ]);
+});


### PR DESCRIPTION
## Changes

- add a reusable read-only Container Info card
- show Docker inspect details for application and service containers
- include copy actions for stable identifiers/IP/network values
- keep network editing out of scope for this first slice

## Issues

- /claim #2495
- Part of #2495

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

- Container Info is shown on the application General page and service resource pages.
- Demo video: https://github.com/JasonDavis666/coolify/releases/download/demo-video-pr9787-20260425/coolify-pr9787-container-info-demo.mp4

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Hermes Agent for implementation and verification.
- How extensively: used for code/test changes, then verified with targeted tests.

## Testing

- `php artisan test tests/Unit/ContainerInfoTest.php tests/Feature/ContainerInfoViewTest.php`
- `vendor/bin/pint --dirty`

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.