### PR TITLE
fix: allow decimal values in backup max storage inputs

### DIFF
--- a/resources/views/livewire/project/database/backup-edit.blade.php
+++ b/resources/views/livewire/project/database/backup-edit.blade.php
@@ -106,7 +106,7 @@
                         min="0"
                         helper="Automatically removes backups older than the specified number of days. Set to 0 for no time limit." required />
                     <x-forms.input label="Maximum storage (GB)" id="databaseBackupRetentionMaxStorageLocally"
-                        type="number" min="0"
+                        type="number" min="0" step="any"
                         helper="When total size of all backups in the current backup job exceeds this limit in GB, the oldest backups will be removed. Decimal values are supported (e.g. 0.001 for 1MB). Set to 0 for unlimited storage." required />
                 </div>
             </div>
@@ -122,7 +122,7 @@
                             min="0"
                             helper="Automatically removes S3 backups older than the specified number of days. Set to 0 for no time limit." required />
                         <x-forms.input label="Maximum storage (GB)" id="databaseBackupRetentionMaxStorageS3"
-                            type="number" min="0"
+                            type="number" min="0" step="any"
                             helper="When total size of all backups in the current backup job exceeds this limit in GB, the oldest backups will be removed. Decimal values are supported (e.g. 0.5 for 500MB). Set to 0 for unlimited storage." required />
                     </div>
                 </div>

--- a/tests/Feature/NumberInputStepAttributeTest.php
+++ b/tests/Feature/NumberInputStepAttributeTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Support\MessageBag;
+use Illuminate\Support\ViewErrorBag;
+
+beforeEach(function () {
+    $errors = new ViewErrorBag;
+    $errors->put('default', new MessageBag);
+    view()->share('errors', $errors);
+});
+
+it('renders number input with step attribute for decimal values', function () {
+    $html = Blade::render('<x-forms.input type="number" id="maxStorage" min="0" step="any" />');
+
+    expect($html)
+        ->toContain('type="number"')
+        ->toContain('step="any"')
+        ->toContain('min="0"');
+});


### PR DESCRIPTION
## Changes

Added `step="any"` to both Maximum storage (GB) number inputs (local and S3 backup retention) in the backup schedule edit page. Without this, browsers enforce `step="1"` (integers only), blocking decimal values like `0.001` (1MB) or `0.5` (500MB) that the helper text explicitly documents as supported.

## Issues

- Fixes #9794

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

<img width="1042" height="693" alt="Screenshot 2026-04-25 at 8 57 21 PM" src="https://github.com/user-attachments/assets/2cd8bad5-fbcd-45b0-9b37-917c1c4c4877" />


## AI Assistance

- [x] AI was NOT used to create this PR
- [x] AI was used (please describe below)

AI was used to structure the comment

## Testing

Opened the backup schedule edit page and entered `0.001` in the Maximum storage (GB) field. Before the fix, the browser shows a validation error ("Please enter a valid value. The two nearest valid values are 0 and 1."). After adding `step="any"`, the decimal value is accepted.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.