### PR TITLE
feat: enable automated database backups for applications (Algora Bounty #7528)

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -1013,6 +1013,11 @@ class Application extends BaseModel
         return $this->belongsTo(Environment::class);
     }
 
+    public function databases()
+    {
+        return $this->hasMany(ServiceDatabase::class);
+    }
+
     public function previews()
     {
         return $this->hasMany(ApplicationPreview::class)->orderBy('pull_request_id', 'desc');

--- a/app/Models/ServiceDatabase.php
+++ b/app/Models/ServiceDatabase.php
@@ -11,6 +11,7 @@ class ServiceDatabase extends BaseModel
 
     protected $fillable = [
         'service_id',
+        'application_id',
         'name',
         'human_name',
         'description',
@@ -52,7 +53,10 @@ class ServiceDatabase extends BaseModel
 
     public static function ownedByCurrentTeamAPI(int $teamId)
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', $teamId)->orderBy('name');
+        return ServiceDatabase::where(function ($query) use ($teamId) {
+            $query->whereRelation('service.environment.project.team', 'id', $teamId)
+                  ->orWhereRelation('application.environment.project.team', 'id', $teamId);
+        })->orderBy('name');
     }
 
     /**
@@ -61,7 +65,10 @@ class ServiceDatabase extends BaseModel
      */
     public static function ownedByCurrentTeam()
     {
-        return ServiceDatabase::whereRelation('service.environment.project.team', 'id', currentTeam()->id)->orderBy('name');
+        return ServiceDatabase::where(function ($query) {
+            $query->whereRelation('service.environment.project.team', 'id', currentTeam()->id)
+                  ->orWhereRelation('application.environment.project.team', 'id', currentTeam()->id);
+        })->orderBy('name');
     }
 
     /**
@@ -76,8 +83,9 @@ class ServiceDatabase extends BaseModel
 
     public function restart()
     {
-        $container_id = $this->name.'-'.$this->service->uuid;
-        remote_process(["docker restart {$container_id}"], $this->service->server);
+        $container_id = $this->name.'-'.$this->parent()->uuid;
+        $server = $this->parent() instanceof Application ? $this->parent()->destination->server : $this->parent()->server;
+        remote_process(["docker restart {$container_id}"], $server);
     }
 
     public function isRunning()
@@ -139,8 +147,9 @@ class ServiceDatabase extends BaseModel
     public function getServiceDatabaseUrl()
     {
         $port = $this->public_port;
-        $realIp = $this->service->server->ip;
-        if ($this->service->server->isLocalhost() || isDev()) {
+        $server = $this->parent() instanceof Application ? $this->parent()->destination->server : $this->parent()->server;
+        $realIp = $server->ip;
+        if ($server->isLocalhost() || isDev()) {
             $realIp = base_ip();
         }
 
@@ -149,17 +158,30 @@ class ServiceDatabase extends BaseModel
 
     public function team()
     {
-        return data_get($this, 'service.environment.project.team');
+        return data_get($this, 'service.environment.project.team') ?? data_get($this, 'application.environment.project.team');
     }
 
     public function workdir()
     {
+        if ($this->application) {
+            return base_configuration_dir()."/applications/{$this->application->uuid}";
+        }
         return service_configuration_dir()."/{$this->service->uuid}";
     }
 
     public function service()
     {
         return $this->belongsTo(Service::class);
+    }
+
+    public function application()
+    {
+        return $this->belongsTo(Application::class);
+    }
+
+    public function parent()
+    {
+        return $this->service ?? $this->application;
     }
 
     public function persistentStorages()

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -2997,6 +2997,21 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
             $isDatabase = isDatabaseImage($image, $service);
             data_set($service, 'is_database', $isDatabase);
 
+            if ($pull_request_id === 0 && $isDatabase) {
+                $savedDatabase = ServiceDatabase::where([
+                    'name' => $serviceName,
+                    'application_id' => $resource->id,
+                ])->first();
+                if (is_null($savedDatabase)) {
+                    ServiceDatabase::create([
+                        'name' => $serviceName,
+                        'image' => $image,
+                        'application_id' => $resource->id,
+                        'is_migrated' => true,
+                    ]);
+                }
+            }
+
             // Collect/create/update networks
             if ($serviceNetworks->count() > 0) {
                 foreach ($serviceNetworks as $networkName => $networkDetails) {

--- a/database/migrations/2026_04_25_000000_add_application_id_to_service_databases.php
+++ b/database/migrations/2026_04_25_000000_add_application_id_to_service_databases.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->foreignId('application_id')->nullable();
+            $table->foreignId('service_id')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('service_databases', function (Blueprint $table) {
+            $table->dropColumn('application_id');
+            // Reverting service_id to not null might fail if there are nulls, 
+            // but we leave it best effort.
+            $table->foreignId('service_id')->nullable(false)->change();
+        });
+    }
+};

--- a/resources/views/livewire/project/application/configuration.blade.php
+++ b/resources/views/livewire/project/application/configuration.blade.php
@@ -67,6 +67,10 @@
                 href="{{ route('project.application.tags', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Tags</span></a>
             <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
                 href="{{ route('project.application.danger', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Danger Zone</span></a>
+            @if ($application->databases()->count() > 0)
+                <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                    href="{{ route('project.application.backups', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Backups</span></a>
+            @endif
         </div>
         <div class="w-full sm:flex-grow">
             @if ($currentRoute === 'project.application.configuration')
@@ -105,6 +109,15 @@
                 <livewire:project.shared.tags :resource="$application" />
             @elseif ($currentRoute === 'project.application.danger')
                 <livewire:project.shared.danger :resource="$application" />
+            @elseif ($currentRoute === 'project.application.backups')
+                <div>
+                    @foreach($application->databases as $database)
+                        <div class="mb-10">
+                            <h2 class="pb-4">Scheduled Backups for {{ Str::headline($database->name) }}</h2>
+                            <livewire:project.database.scheduled-backups :database="$database" wire:key="database-backups-{{ $database->id }}" />
+                        </div>
+                    @endforeach
+                </div>
             @endif
         </div>
     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -229,6 +229,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/metrics', ApplicationConfiguration::class)->name('project.application.metrics');
         Route::get('/tags', ApplicationConfiguration::class)->name('project.application.tags');
         Route::get('/danger', ApplicationConfiguration::class)->name('project.application.danger');
+        Route::get('/backups', ApplicationConfiguration::class)->name('project.application.backups');
 
         Route::get('/deployment', DeploymentIndex::class)->name('project.application.deployment.index');
         Route::get('/deployment/{deployment_uuid}', DeploymentShow::class)->name('project.application.deployment.show');


### PR DESCRIPTION
Enables automated database backup support for Git-based Docker Compose applications by allowing ServiceDatabase models to be securely attached to Application models, fulfilling Issue #7528 on Algora.

## Changes:
1. **Migration:** Added pplication_id to service_databases to accommodate association with Application records while keeping backwards compatibility.
2. **Relationships:** Polymorphic-like relationships established in ServiceDatabase via parent() abstraction acting across both service and pplication.
3. **Detection Logic:** Augmented parseDockerComposeFile within ootstrap/helpers/shared.php to actively detect and materialize ServiceDatabase entities for standard Git applications automatically upon Docker pull deployments (at pull_request_id === 0).
4. **User Interface:** Added Backups configuration tab nested inside Application views whenever the application has 1 or more initialized databases, rendering the familiar livewire:project.database.scheduled-backups component.