### PR TITLE
fix(db): widen encrypted columns to text to prevent overflow

### DIFF
--- a/database/migrations/2026_04_25_000000_widen_encrypted_columns_on_applications_table.php
+++ b/database/migrations/2026_04_25_000000_widen_encrypted_columns_on_applications_table.php
@@ -13,10 +13,6 @@ return new class extends Migration
     {
         Schema::table('applications', function (Blueprint $table) {
             $table->text('http_basic_auth_password')->nullable()->default(null)->change();
-            $table->text('manual_webhook_secret_github')->nullable()->change();
-            $table->text('manual_webhook_secret_gitlab')->nullable()->change();
-            $table->text('manual_webhook_secret_bitbucket')->nullable()->change();
-            $table->text('manual_webhook_secret_gitea')->nullable()->change();
         });
     }
 
@@ -27,10 +23,6 @@ return new class extends Migration
     {
         Schema::table('applications', function (Blueprint $table) {
             $table->string('http_basic_auth_password')->nullable()->default(null)->change();
-            $table->string('manual_webhook_secret_github')->nullable()->change();
-            $table->string('manual_webhook_secret_gitlab')->nullable()->change();
-            $table->string('manual_webhook_secret_bitbucket')->nullable()->change();
-            $table->string('manual_webhook_secret_gitea')->nullable()->change();
         });
     }
 };

--- a/database/migrations/2026_04_25_000000_widen_encrypted_columns_on_applications_table.php
+++ b/database/migrations/2026_04_25_000000_widen_encrypted_columns_on_applications_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('applications', function (Blueprint $table) {
+            $table->text('http_basic_auth_password')->nullable()->default(null)->change();
+            $table->text('manual_webhook_secret_github')->nullable()->change();
+            $table->text('manual_webhook_secret_gitlab')->nullable()->change();
+            $table->text('manual_webhook_secret_bitbucket')->nullable()->change();
+            $table->text('manual_webhook_secret_gitea')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('applications', function (Blueprint $table) {
+            $table->string('http_basic_auth_password')->nullable()->default(null)->change();
+            $table->string('manual_webhook_secret_github')->nullable()->change();
+            $table->string('manual_webhook_secret_gitlab')->nullable()->change();
+            $table->string('manual_webhook_secret_bitbucket')->nullable()->change();
+            $table->string('manual_webhook_secret_gitea')->nullable()->change();
+        });
+    }
+};

--- a/tests/Feature/EncryptedColumnOverflowTest.php
+++ b/tests/Feature/EncryptedColumnOverflowTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Support\Facades\Crypt;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 uses(Illuminate\Foundation\Testing\RefreshDatabase::class);
@@ -11,15 +10,6 @@ it('stores encrypted http basic auth password longer than 31 characters', functi
     $encrypted = Crypt::encryptString($longPassword);
 
     $columnType = Schema::getColumnType('applications', 'http_basic_auth_password');
-    expect($columnType)->toBe('text');
-    expect(strlen($encrypted))->toBeGreaterThan(255);
-});
-
-it('stores encrypted webhook secret longer than 31 characters', function () {
-    $longSecret = str_repeat('x', 128);
-    $encrypted = Crypt::encryptString($longSecret);
-
-    $columnType = Schema::getColumnType('applications', 'manual_webhook_secret_github');
     expect($columnType)->toBe('text');
     expect(strlen($encrypted))->toBeGreaterThan(255);
 });

--- a/tests/Feature/EncryptedColumnOverflowTest.php
+++ b/tests/Feature/EncryptedColumnOverflowTest.php
@@ -1,15 +1,34 @@
 <?php
 
-use Illuminate\Support\Facades\Crypt;
-use Illuminate\Support\Facades\Schema;
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\Project;
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 
-uses(Illuminate\Foundation\Testing\RefreshDatabase::class);
+uses(RefreshDatabase::class);
 
-it('stores encrypted http basic auth password longer than 31 characters', function () {
+beforeEach(function () {
+    $this->team = Team::factory()->create();
+    $this->project = Project::factory()->create(['team_id' => $this->team->id]);
+    $this->environment = Environment::factory()->create(['project_id' => $this->project->id]);
+});
+
+it('persists and decrypts a 64-char http basic auth password', function () {
     $longPassword = str_repeat('a', 64);
-    $encrypted = Crypt::encryptString($longPassword);
 
-    $columnType = Schema::getColumnType('applications', 'http_basic_auth_password');
-    expect($columnType)->toBe('text');
-    expect(strlen($encrypted))->toBeGreaterThan(255);
+    $application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+        'http_basic_auth_password' => $longPassword,
+    ]);
+
+    $raw = DB::table('applications')
+        ->where('id', $application->id)
+        ->value('http_basic_auth_password');
+
+    expect(strlen($raw))->toBeGreaterThan(255);
+
+    $application->refresh();
+    expect($application->http_basic_auth_password)->toBe($longPassword);
 });

--- a/tests/Feature/EncryptedColumnOverflowTest.php
+++ b/tests/Feature/EncryptedColumnOverflowTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+uses(Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+it('stores encrypted http basic auth password longer than 31 characters', function () {
+    $longPassword = str_repeat('a', 64);
+    $encrypted = Crypt::encryptString($longPassword);
+
+    $columnType = Schema::getColumnType('applications', 'http_basic_auth_password');
+    expect($columnType)->toBe('text');
+    expect(strlen($encrypted))->toBeGreaterThan(255);
+});
+
+it('stores encrypted webhook secret longer than 31 characters', function () {
+    $longSecret = str_repeat('x', 128);
+    $encrypted = Crypt::encryptString($longSecret);
+
+    $columnType = Schema::getColumnType('applications', 'manual_webhook_secret_github');
+    expect($columnType)->toBe('text');
+    expect(strlen($encrypted))->toBeGreaterThan(255);
+});


### PR DESCRIPTION
## Changes

Widened the `http_basic_auth_password` encrypted column on the `applications` table from `varchar(255)` to `text`. Laravel's `Crypt::encryptString()` expands values well beyond 255 characters (a 32-char password produces ~220+ chars of ciphertext), causing a SQL truncation error when saving.

This follows the same pattern used in existing migrations `2024_05_22_103942` and `2024_12_10_122142` which widened other encrypted/long-value columns to `text`.

> **Note:** The `manual_webhook_secret_*` columns were removed from this migration as they are already widened to `text` in `2026_04_19_000000_backfill_and_encrypt_webhook_secrets`.

## Issues

Fixes #9643

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview
<img width="1612" height="880" alt="Screenshot 2026-04-25 at 11 20 58 PM" src="https://github.com/user-attachments/assets/b014879e-6375-4404-8e6c-bcc38c8765e8" />
<img width="1154" height="798" alt="Screenshot 2026-04-25 at 11 20 23 PM" src="https://github.com/user-attachments/assets/afacdea7-ab2d-4d37-80df-85446528a468" />


## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Opus 4.7
- How extensively: Research and code generation. Migration and test were manually verified and tested on a local dev instance (migrations run, 64-char password saves and decrypts correctly, pint passes).

## Testing

1. Ran migration on local dev instance — completes in 20ms
2. Saved a 64-char HTTP Basic Auth password via the UI — saved successfully (previously failed with SQL truncation error at 32+ chars)
3. Verified password decrypts correctly after save
4. Ran `vendor/bin/pint --dirty --format agent` — pass
5. Ran Pest test `EncryptedColumnOverflowTest` — 1 test, 2 assertions, pass

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.