### PR TITLE
fix(helper): stop info icon click from propagating to parent on mobile

### DIFF
--- a/resources/views/components/helper.blade.php
+++ b/resources/views/components/helper.blade.php
@@ -1,4 +1,5 @@
-<div {{ $attributes->merge(['class' => 'group']) }}>
+<div x-data="{ open: false }" @click.stop="open = !open" @click.outside="open = false"
+    {{ $attributes->merge(['class' => 'group']) }}>
     <div class="info-helper">
         @isset($icon)
             {{ $icon }}
@@ -10,7 +11,7 @@
         @endisset
 
     </div>
-    <div class="info-helper-popup">
+    <div class="info-helper-popup" :class="{ 'block': open }">
         <div class="p-4">
             {!! $helper !!}
         </div>


### PR DESCRIPTION
## Summary

- Closes #4834
- Info helper popup now uses Alpine.js `x-data` toggle instead of CSS-only hover, so tap on mobile opens popup without triggering parent element's click handler
- Added `@click.stop` to prevent click event from bubbling up to parent (e.g. checkbox/toggle)
- Added `@click.outside` to close popup when tapping elsewhere
- `:class="{ 'block': open }"` drives visibility on mobile where hover is unavailable


---

Fixes #4834