### PR TITLE
fix: use compose file directory for compose builds

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -607,7 +607,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             $this->validateShellSafeCommand($this->application->docker_compose_custom_build_command, 'docker_compose_custom_build_command');
             $this->docker_compose_custom_build_command = $this->application->docker_compose_custom_build_command;
             if (! str($this->docker_compose_custom_build_command)->contains('--project-directory')) {
-                $this->docker_compose_custom_build_command = str($this->docker_compose_custom_build_command)->replaceFirst('compose', 'compose --project-directory '.$this->workdir)->value();
+                $this->docker_compose_custom_build_command = str($this->docker_compose_custom_build_command)->replaceFirst('compose', 'compose --project-directory '.$this->dockerComposeBuildProjectDirectory())->value();
             }
         }
         if ($this->pull_request_id === 0) {
@@ -744,10 +744,11 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             }
             // Use build-time .env file from /artifacts (outside Docker context to prevent it from being in the image)
             $command .= ' --env-file '.self::BUILD_TIME_ENV_PATH;
+            $buildProjectDirectory = $this->dockerComposeBuildProjectDirectory();
             if ($this->force_rebuild) {
-                $command .= " --project-name {$this->application->uuid} --project-directory {$this->workdir} -f {$this->workdir}{$this->docker_compose_location} build --pull --no-cache";
+                $command .= " --project-name {$this->application->uuid} --project-directory {$buildProjectDirectory} -f {$this->workdir}{$this->docker_compose_location} build --pull --no-cache";
             } else {
-                $command .= " --project-name {$this->application->uuid} --project-directory {$this->workdir} -f {$this->workdir}{$this->docker_compose_location} build --pull";
+                $command .= " --project-name {$this->application->uuid} --project-directory {$buildProjectDirectory} -f {$this->workdir}{$this->docker_compose_location} build --pull";
             }
 
             if (! $this->application->settings->use_build_secrets && $this->build_args instanceof Collection && $this->build_args->isNotEmpty()) {
@@ -866,6 +867,17 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         }
 
         $this->application_deployment_queue->addLogEntry('New container started.');
+    }
+
+    private function dockerComposeBuildProjectDirectory(): string
+    {
+        $composeDirectory = dirname($this->docker_compose_location);
+
+        if ($composeDirectory === '/' || $composeDirectory === '.') {
+            return rtrim($this->workdir, '/');
+        }
+
+        return rtrim($this->workdir, '/').'/'.ltrim($composeDirectory, '/');
     }
 
     private function deploy_dockerfile_buildpack()

--- a/tests/Unit/ApplicationDeploymentCustomBuildCommandTest.php
+++ b/tests/Unit/ApplicationDeploymentCustomBuildCommandTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Jobs\ApplicationDeploymentJob;
+
 /**
  * Test to verify that custom Docker Compose build commands properly inject flags.
  *
@@ -614,6 +616,36 @@ it('produces correct preview path with normalized baseDirectory', function () {
         expect($path)->toBe($case['expected'], "Failed for baseDir: {$case['baseDir']}");
         expect($path)->not->toContain('//', "Double slash found for baseDir: {$case['baseDir']}");
     }
+});
+
+it('uses the compose file directory as the project directory for nested compose builds', function () {
+    $reflection = new \ReflectionClass(ApplicationDeploymentJob::class);
+    $job = $reflection->newInstanceWithoutConstructor();
+
+    $workdir = $reflection->getProperty('workdir');
+    $workdir->setValue($job, '/artifacts/deployment-uuid');
+
+    $composeLocation = $reflection->getProperty('docker_compose_location');
+    $composeLocation->setValue($job, '/docker/docker-compose.yml');
+
+    $method = $reflection->getMethod('dockerComposeBuildProjectDirectory');
+
+    expect($method->invoke($job))->toBe('/artifacts/deployment-uuid/docker');
+});
+
+it('uses the workdir as the project directory for root compose builds', function () {
+    $reflection = new \ReflectionClass(ApplicationDeploymentJob::class);
+    $job = $reflection->newInstanceWithoutConstructor();
+
+    $workdir = $reflection->getProperty('workdir');
+    $workdir->setValue($job, '/artifacts/deployment-uuid');
+
+    $composeLocation = $reflection->getProperty('docker_compose_location');
+    $composeLocation->setValue($job, '/docker-compose.yml');
+
+    $method = $reflection->getMethod('dockerComposeBuildProjectDirectory');
+
+    expect($method->invoke($job))->toBe('/artifacts/deployment-uuid');
 });
 
 // Tests for injectDockerComposeBuildArgs() helper function


### PR DESCRIPTION
## Changes

- Use the compose file directory as the build-time project directory when a Docker Compose file lives in a subfolder.
- Keep root-level compose files on the existing deployment workdir behavior.
- Apply the same calculation to custom compose build commands unless the user already supplied a project directory.
- Add regression coverage for nested and root compose file locations.

## Issues

- Fixes #9525
- Supersedes #9813, which was auto-closed by the repository quality gate before the description was shortened.

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A; backend deployment command fix.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Hermes Agent/Codex for investigation, edit, and validation.
- How extensively: AI-assisted implementation with human-directed scope and local verification.

## Testing

- Focused Pest regression for nested/root compose build commands passed.
- Full custom compose build command unit test file passed.
- Related compose start command unit test file passed.
- Pint dirty format check passed.
- PHP syntax checks passed for the changed PHP files.
- Docker Compose smoke confirmed that a nested compose file resolves parent build context from the compose directory, not the deployment root.
- Local Coolify dev stack was built and started successfully; health, login, dashboard, Horizon, and Mailpit responded.
- The focused and related compose tests also passed inside the running local dev container.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.