### PR TITLE
feat(preview): per-application cap on simultaneous PR previews

### DIFF
--- a/app/Livewire/Project/Application/Preview/Form.php
+++ b/app/Livewire/Project/Application/Preview/Form.php
@@ -17,10 +17,14 @@ class Form extends Component
     #[Validate('required')]
     public string $previewUrlTemplate;
 
+    #[Validate(['integer', 'min:0', 'max:1000'])]
+    public int $maxPreviewDeployments = 0;
+
     public function mount()
     {
         try {
             $this->previewUrlTemplate = $this->application->preview_url_template;
+            $this->maxPreviewDeployments = (int) ($this->application->settings->max_preview_deployments ?? 0);
             $this->generateRealUrl();
         } catch (\Throwable $e) {
             return handleError($e, $this);
@@ -35,7 +39,9 @@ class Form extends Component
             $this->validate();
             $this->application->preview_url_template = str_replace(' ', '', $this->previewUrlTemplate);
             $this->application->save();
-            $this->dispatch('success', 'Preview url template updated.');
+            $this->application->settings->max_preview_deployments = $this->maxPreviewDeployments;
+            $this->application->settings->save();
+            $this->dispatch('success', 'Preview settings updated.');
             $this->generateRealUrl();
         } catch (\Throwable $e) {
             return handleError($e, $this);

--- a/app/Models/ApplicationSetting.php
+++ b/app/Models/ApplicationSetting.php
@@ -26,6 +26,7 @@ class ApplicationSetting extends Model
         'is_git_lfs_enabled' => 'boolean',
         'is_git_shallow_clone_enabled' => 'boolean',
         'docker_images_to_keep' => 'integer',
+        'max_preview_deployments' => 'integer',
     ];
 
     protected $fillable = [
@@ -64,6 +65,7 @@ class ApplicationSetting extends Model
         'inject_build_args_to_dockerfile',
         'include_source_commit_in_build',
         'docker_images_to_keep',
+        'max_preview_deployments',
     ];
 
     public function isStatic(): Attribute

--- a/bootstrap/helpers/applications.php
+++ b/bootstrap/helpers/applications.php
@@ -43,6 +43,43 @@ function queue_application_deployment(Application $application, string $deployme
         ];
     }
 
+    // Per-application cap on simultaneous PR preview deployments (issue #9064).
+    // Counts running previews + queued/in-progress deployments for *other* PRs of the same app,
+    // so a flood of PR webhooks cannot all pass the gate before any container has finished building.
+    if ($pull_request_id > 0) {
+        $maxPreviews = (int) ($application->settings->max_preview_deployments ?? 0);
+        if ($maxPreviews > 0) {
+            $runningCount = $application->previews()
+                ->where('status', 'LIKE', 'running%')
+                ->count();
+
+            $pendingPrCount = ApplicationDeploymentQueue::where('application_id', $application_id)
+                ->where('pull_request_id', '!=', $pull_request_id)
+                ->where('pull_request_id', '>', 0)
+                ->whereIn('status', [
+                    ApplicationDeploymentStatus::QUEUED->value,
+                    ApplicationDeploymentStatus::IN_PROGRESS->value,
+                ])
+                ->distinct('pull_request_id')
+                ->count('pull_request_id');
+
+            if (($runningCount + $pendingPrCount) >= $maxPreviews) {
+                \Log::info('Preview deployment skipped: max_preview_deployments reached', [
+                    'application_id' => $application_id,
+                    'pull_request_id' => $pull_request_id,
+                    'limit' => $maxPreviews,
+                    'running' => $runningCount,
+                    'pending' => $pendingPrCount,
+                ]);
+
+                return [
+                    'status' => 'skipped',
+                    'message' => "Max simultaneous preview deployments ({$maxPreviews}) reached for this application. New PR deployment will be skipped until an existing preview is stopped.",
+                ];
+            }
+        }
+    }
+
     // Check if there's already a deployment in progress or queued for this application and commit
     $existing_deployment = ApplicationDeploymentQueue::where('application_id', $application_id)
         ->where('commit', $commit)

--- a/database/migrations/2026_04_26_000000_add_max_preview_deployments_to_application_settings.php
+++ b/database/migrations/2026_04_26_000000_add_max_preview_deployments_to_application_settings.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('application_settings', 'max_preview_deployments')) {
+            Schema::table('application_settings', function (Blueprint $table) {
+                $table->integer('max_preview_deployments')->default(0);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('application_settings', 'max_preview_deployments')) {
+            Schema::table('application_settings', function (Blueprint $table) {
+                $table->dropColumn('max_preview_deployments');
+            });
+        }
+    }
+};

--- a/resources/views/livewire/project/application/preview/form.blade.php
+++ b/resources/views/livewire/project/application/preview/form.blade.php
@@ -13,5 +13,8 @@
         @if ($previewUrlTemplate)
             <div class="">Domain Preview: {{ $previewUrlTemplate }}</div>
         @endif
+        <x-forms.input id="maxPreviewDeployments" type="number" min="0"
+            label="Max Concurrent Preview Deployments"
+            helper="Maximum simultaneous PR preview environments for this application. <span class='text-helper'>0</span> means unlimited. New PR webhooks beyond this limit will be skipped (and logged) until an existing preview is stopped." canGate="update" :canResource="$application" />
     </div>
 </form>

--- a/tests/Feature/MaxPreviewDeploymentsTest.php
+++ b/tests/Feature/MaxPreviewDeploymentsTest.php
@@ -1,0 +1,176 @@
+<?php
+
+use App\Enums\ApplicationDeploymentStatus;
+use App\Models\Application;
+use App\Models\ApplicationDeploymentQueue;
+use App\Models\ApplicationPreview;
+use App\Models\Environment;
+use App\Models\InstanceSettings;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use App\Jobs\ApplicationDeploymentJob;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Visus\Cuid2\Cuid2;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    // Fake the deployment job so dispatch() does not actually run handle().
+    // Without this, ApplicationDeploymentJob (ShouldBeEncrypted + ShouldQueue) executes synchronously
+    // under QUEUE_CONNECTION=sync and tries to SSH to a non-existent server.
+    Bus::fake([ApplicationDeploymentJob::class]);
+    InstanceSettings::unguarded(fn () => InstanceSettings::firstOrCreate(['id' => 0]));
+
+    $this->team = Team::factory()->create();
+    $this->server = Server::factory()->create(['team_id' => $this->team->id]);
+    $this->destination = StandaloneDocker::where('server_id', $this->server->id)->first();
+    $this->project = Project::factory()->create(['team_id' => $this->team->id]);
+    $this->environment = Environment::factory()->create(['project_id' => $this->project->id]);
+
+    $this->application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => $this->destination->getMorphClass(),
+    ]);
+});
+
+function deployPr(Application $application, int $prId): array
+{
+    // Mirror production flow: ProcessGithubPullRequestWebhook always creates the
+    // ApplicationPreview row before invoking queue_application_deployment().
+    // Without it, ApplicationDeploymentJob::__construct() throws on findPreviewByApplicationAndPullId.
+    ApplicationPreview::firstOrCreate(
+        ['application_id' => $application->id, 'pull_request_id' => $prId],
+        ['pull_request_html_url' => "https://example.test/pr/{$prId}", 'git_type' => 'github']
+    );
+
+    return queue_application_deployment(
+        application: $application,
+        deployment_uuid: (new Cuid2)->toString(),
+        pull_request_id: $prId,
+        commit: 'sha-'.$prId,
+        is_webhook: true,
+        git_type: 'github'
+    );
+}
+
+function makeRunningPreview(Application $application, int $prId): ApplicationPreview
+{
+    return ApplicationPreview::create([
+        'application_id' => $application->id,
+        'pull_request_id' => $prId,
+        'pull_request_html_url' => "https://example.test/pr/{$prId}",
+        'git_type' => 'github',
+        'status' => 'running',
+    ]);
+}
+
+function makeQueuedDeployment(Application $application, int $prId, string $status = 'queued'): ApplicationDeploymentQueue
+{
+    return ApplicationDeploymentQueue::create([
+        'application_id' => $application->id,
+        'application_name' => $application->name,
+        'server_id' => $application->destination->server->id,
+        'server_name' => $application->destination->server->name,
+        'destination_id' => $application->destination->id,
+        'deployment_uuid' => (new Cuid2)->toString(),
+        'deployment_url' => '/test',
+        'pull_request_id' => $prId,
+        'force_rebuild' => false,
+        'is_webhook' => true,
+        'is_api' => false,
+        'restart_only' => false,
+        'commit' => 'sha-'.$prId,
+        'rollback' => false,
+        'git_type' => 'github',
+        'only_this_server' => false,
+        'status' => $status,
+    ]);
+}
+
+describe('Max Preview Deployments gate', function () {
+    test('with limit=0 (unlimited), PR deployments queue normally', function () {
+        $this->application->settings->max_preview_deployments = 0;
+        $this->application->settings->save();
+
+        // Even with 5 running previews, a new PR should still queue.
+        for ($i = 1; $i <= 5; $i++) {
+            makeRunningPreview($this->application, $i);
+        }
+
+        $result = deployPr($this->application, 99);
+
+        expect($result['status'])->toBe('queued');
+    });
+
+    test('with limit=2 and no active previews, deployment queues', function () {
+        $this->application->settings->max_preview_deployments = 2;
+        $this->application->settings->save();
+
+        $result = deployPr($this->application, 1);
+
+        expect($result['status'])->toBe('queued');
+    });
+
+    test('with limit=2 and 2 running previews, new PR is skipped', function () {
+        $this->application->settings->max_preview_deployments = 2;
+        $this->application->settings->save();
+
+        makeRunningPreview($this->application, 1);
+        makeRunningPreview($this->application, 2);
+
+        $result = deployPr($this->application, 3);
+
+        expect($result['status'])->toBe('skipped');
+        expect($result['message'])->toContain('Max simultaneous preview deployments');
+    });
+
+    test('limit counts both running previews and queued deployments for OTHER PRs', function () {
+        $this->application->settings->max_preview_deployments = 2;
+        $this->application->settings->save();
+
+        makeRunningPreview($this->application, 1);
+        makeQueuedDeployment($this->application, 2);
+
+        $result = deployPr($this->application, 3);
+
+        expect($result['status'])->toBe('skipped');
+    });
+
+    test('a re-sync of an already-queued PR is not blocked by its own queued row', function () {
+        $this->application->settings->max_preview_deployments = 2;
+        $this->application->settings->save();
+
+        makeRunningPreview($this->application, 1);
+        makeQueuedDeployment($this->application, 5); // PR 5 already queued — total active = 2
+
+        // Re-syncing PR 5 must not count PR 5's own queued row toward the cap.
+        // The downstream existing-deployment guard may still return 'skipped' for the
+        // duplicate commit, so we assert by message that the cap-gate is what did NOT fire.
+        $result = deployPr($this->application, 5);
+
+        expect($result['message'] ?? '')->not->toContain('Max simultaneous preview deployments');
+    });
+
+    test('non-PR deployments (pull_request_id=0) are never gated', function () {
+        $this->application->settings->max_preview_deployments = 1;
+        $this->application->settings->save();
+
+        makeRunningPreview($this->application, 1);
+        makeRunningPreview($this->application, 2);
+
+        $result = queue_application_deployment(
+            application: $this->application,
+            deployment_uuid: (new Cuid2)->toString(),
+            pull_request_id: 0,
+            commit: 'main-sha',
+            is_webhook: true,
+            git_type: 'github'
+        );
+
+        expect($result['status'])->toBe('queued');
+    });
+});


### PR DESCRIPTION
## Summary

Closes #9064.

Adds a per-application **Max Concurrent Preview Deployments** setting (`application_settings.max_preview_deployments`, default `0` = unlimited). When set, `queue_application_deployment()` skips PR webhook deploys whose count of running previews + queued/in-progress deployments for *other* PRs of the same app would exceed the cap.

Motivation: on resource-constrained hosts, a repo with many open PRs spawns one preview environment per PR with no upper bound, exhausting RAM. The existing `Max Concurrent Builds` server setting only throttles build parallelism — it does not cap the count of *running* preview containers. Issue #9064 has more context.

## Behavior

- **`max_preview_deployments = 0`** → unchanged from today (unlimited). Backward compatible.
- **`max_preview_deployments = N` (N > 0)** → when a PR webhook arrives and `(running previews) + (queued/in-progress deployments for other PRs of this app) >= N`, the deploy returns `['status' => 'skipped', 'message' => '...']` and logs at INFO level. The webhook controllers already surface `'skipped'` results in their HTTP response, so the Git provider sees a clean acknowledgement.
- The current PR's own queued row is excluded from the count, so a re-sync of an already-deploying PR never blocks itself.
- Non-PR deploys (`pull_request_id = 0`) are never gated.

The gate sits in `queue_application_deployment()` — the single chokepoint for GitHub / GitLab / Bitbucket / Gitea webhook flows — so all four providers benefit without provider-specific changes.

## Files changed

| File | Change |
|---|---|
| `database/migrations/2026_04_26_000000_add_max_preview_deployments_to_application_settings.php` | New: integer column, default 0 (mirrors the recent \`docker_images_to_keep\` migration) |
| \`app/Models/ApplicationSetting.php\` | +2 lines: fillable + integer cast |
| \`bootstrap/helpers/applications.php\` | +37 lines: the gate inside \`queue_application_deployment()\` |
| \`app/Livewire/Project/Application/Preview/Form.php\` | +8 lines: bind / validate / save the new field |
| \`resources/views/livewire/project/application/preview/form.blade.php\` | +3 lines: number input alongside the URL template |
| \`tests/Feature/MaxPreviewDeploymentsTest.php\` | New: 6 cases, ~150 lines |

## Test plan

Automated (\`tests/Feature/MaxPreviewDeploymentsTest.php\`, 6 cases — all passing):
- [x] limit=0 → PR deploys queue normally even with many running previews (backward-compat)
- [x] limit=2, no active previews → deploy queues
- [x] limit=2, 2 running previews → new PR returns \`'skipped'\` with the cap-gate message
- [x] limit counts both running previews **and** queued deployments for *other* PRs (validates the count-both design that prevents webhook bursts from racing past the cap)
- [x] re-sync of an already-queued PR is not blocked by its own queued row
- [x] non-PR deploys (\`pull_request_id=0\`) are never gated

Manual:
- [x] Migration applies cleanly to a real Postgres instance (\`php artisan migrate\` against \`docker-compose.dev.yml\` postgres).
- [x] End-to-end run of \`queue_application_deployment()\` against the live Postgres returned \`['status' => 'skipped', 'message' => 'Max simultaneous preview deployments (2) reached…']\` exactly as expected.

\`vendor/bin/pint --dirty --format agent\` is clean.

## Considered, deferred

- **"Replace oldest" or "queue and wait" behaviors** (alternatives mentioned in #9064) — more complex; this PR ships the simple "skip + log" first.
- **Cleaning up the orphan \`ApplicationPreview\` row** that the webhook handler creates *before* invoking \`queue_application_deployment()\` (so a skipped deploy leaves an \`ApplicationPreview\` row with \`status='exited'\`). It doesn't consume runtime resources and gets reused if/when that PR is re-triggered. Leaving as-is to keep this PR focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)