### PR TITLE
feat(auth): allow OAuth signup when password registration disabled (#8042)

### DIFF
--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -22,7 +22,17 @@ class OauthController extends Controller
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                // OAuth signup is allowed when either:
+                //   (a) general self-registration is enabled, or
+                //   (b) the admin has explicitly opted in to OAuth-only
+                //       signups via allow_oauth_when_registration_disabled.
+                // This decouples password-based registration from OAuth-
+                // based registration so an instance can run in "OAuth-only"
+                // mode (e.g. Authentik, Google Workspace) without leaving
+                // a password form open to the public internet.
+                $oauthSignupAllowed = $settings->is_registration_enabled
+                    || $settings->allow_oauth_when_registration_disabled;
+                if (! $oauthSignupAllowed) {
                     abort(403, 'Registration is disabled');
                 }
 

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -16,6 +16,9 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $allow_oauth_when_registration_disabled;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -41,6 +44,7 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'allow_oauth_when_registration_disabled' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => ['nullable', 'string', new ValidDnsServers],
@@ -62,6 +66,7 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->allow_oauth_when_registration_disabled = $this->settings->allow_oauth_when_registration_disabled ?? false;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -142,6 +147,7 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->allow_oauth_when_registration_disabled = $this->allow_oauth_when_registration_disabled;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -18,6 +18,7 @@ class InstanceSettings extends Model
         'do_not_track',
         'is_auto_update_enabled',
         'is_registration_enabled',
+        'allow_oauth_when_registration_disabled',
         'next_channel',
         'smtp_enabled',
         'smtp_from_address',
@@ -63,6 +64,7 @@ class InstanceSettings extends Model
 
         'allowed_ip_ranges' => 'array',
         'is_auto_update_enabled' => 'boolean',
+        'allow_oauth_when_registration_disabled' => 'boolean',
         'auto_update_frequency' => 'string',
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -67,6 +67,7 @@ class FortifyServiceProvider extends ServiceProvider
 
             return view('auth.login', [
                 'is_registration_enabled' => $settings->is_registration_enabled,
+                'allow_oauth_when_registration_disabled' => $settings->allow_oauth_when_registration_disabled ?? false,
                 'enabled_oauth_providers' => $enabled_oauth_providers,
             ]);
         });

--- a/database/migrations/2026_04_27_000000_add_allow_oauth_when_registration_disabled_to_instance_settings_table.php
+++ b/database/migrations/2026_04_27_000000_add_allow_oauth_when_registration_disabled_to_instance_settings_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('allow_oauth_when_registration_disabled')
+                ->default(false)
+                ->after('is_registration_enabled');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn('allow_oauth_when_registration_disabled');
+        });
+    }
+};

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -70,6 +70,10 @@
                             class="block w-full text-center py-3 px-4 rounded-lg border border-neutral-300 dark:border-coolgray-400 font-medium hover:border-coollabs dark:hover:border-warning transition-colors">
                             {{ __('auth.register_now') }}
                         </a>
+                    @elseif ($allow_oauth_when_registration_disabled && $enabled_oauth_providers->isNotEmpty())
+                        {{-- Password registration is off, but OAuth-based signup is allowed.
+                             Don't show the "registration disabled" copy because that's misleading
+                             — the OAuth buttons below DO let new accounts sign up. --}}
                     @else
                         <div class="mt-6 text-center text-sm text-neutral-500 dark:text-neutral-400">
                             {{ __('auth.registration_disabled') }}

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -41,6 +41,11 @@
                                 shortConfirmationLabel="Confirmation text" />
                         </div>
                     @endif
+                    <div class="md:w-96" wire:key="allow-oauth-when-registration-disabled">
+                        <x-forms.checkbox instantSave id="allow_oauth_when_registration_disabled"
+                            helper="When enabled, OAuth sign-in (e.g. Authentik, Google, GitHub) can still create new accounts even if 'Registration Allowed' is off. Use this to run an OAuth-only instance: external IdP controls who can sign up, while the password registration form stays disabled."
+                            label="Allow OAuth Signup When Registration Disabled" />
+                    </div>
                     <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"
                             helper="Opt out of anonymous usage tracking. When enabled, this instance will not report to coolify.io's installation count and will not send error reports to help improve Coolify."

--- a/tests/Feature/OauthRegistrationGatingTest.php
+++ b/tests/Feature/OauthRegistrationGatingTest.php
@@ -1,0 +1,158 @@
+<?php
+
+use App\Livewire\Settings\Advanced as AdvancedSettings;
+use App\Models\InstanceSettings;
+use App\Models\OauthSetting;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Socialite\Facades\Socialite;
+use Laravel\Socialite\Two\User as SocialiteUser;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::unguarded(function () {
+        InstanceSettings::query()->updateOrCreate(
+            ['id' => 0],
+            [
+                'is_registration_enabled' => false,
+                'allow_oauth_when_registration_disabled' => false,
+            ],
+        );
+    });
+
+    // Required for OauthController::callback — get_socialite_provider() looks
+    // up the OauthSetting row before invoking Socialite.
+    OauthSetting::query()->updateOrCreate(
+        ['provider' => 'github'],
+        [
+            'enabled' => true,
+            'client_id' => 'test-client-id',
+            'client_secret' => 'test-client-secret',
+            'redirect_uri' => 'https://example.test/auth/github/callback',
+        ],
+    );
+});
+
+function fakeSocialiteUser(string $email = 'oauth@example.com', string $name = 'OAuth User'): SocialiteUser
+{
+    $user = new SocialiteUser;
+    $user->id = 'remote-id-1';
+    $user->email = $email;
+    $user->name = $name;
+    $user->token = 'fake-token';
+
+    return $user;
+}
+
+function mockSocialiteWith(SocialiteUser $oauthUser): void
+{
+    $providerMock = Mockery::mock(Laravel\Socialite\Two\AbstractProvider::class);
+    $providerMock->shouldReceive('user')->andReturn($oauthUser);
+    Socialite::shouldReceive('buildProvider')->andReturn($providerMock);
+    Socialite::shouldReceive('driver')->andReturn($providerMock);
+}
+
+test('the new setting column exists and defaults to false', function () {
+    $settings = InstanceSettings::find(0);
+    expect($settings->allow_oauth_when_registration_disabled)->toBeFalse();
+});
+
+test('admin can toggle allow_oauth_when_registration_disabled via the Advanced settings Livewire component', function () {
+    $rootTeam = Team::find(0) ?? Team::factory()->create(['id' => 0]);
+    $rootUser = User::factory()->create(['id' => 0]);
+    $rootTeam->members()->attach($rootUser->id, ['role' => 'owner']);
+
+    $this->actingAs($rootUser);
+    session(['currentTeam' => ['id' => $rootTeam->id]]);
+
+    Livewire::test(AdvancedSettings::class)
+        ->assertSet('allow_oauth_when_registration_disabled', false)
+        ->set('allow_oauth_when_registration_disabled', true)
+        ->call('instantSave')
+        ->assertHasNoErrors();
+
+    expect(InstanceSettings::find(0)->fresh()->allow_oauth_when_registration_disabled)
+        ->toBeTrue();
+});
+
+test('oauth callback creates new user when general registration is enabled', function () {
+    $settings = instanceSettings();
+    $settings->is_registration_enabled = true;
+    $settings->save();
+
+    mockSocialiteWith(fakeSocialiteUser());
+
+    $response = $this->get('/auth/github/callback');
+
+    $response->assertRedirect('/');
+    expect(User::whereEmail('oauth@example.com')->exists())->toBeTrue();
+});
+
+test('oauth callback blocks signup when both registration flags are off', function () {
+    $settings = instanceSettings();
+    $settings->is_registration_enabled = false;
+    $settings->allow_oauth_when_registration_disabled = false;
+    $settings->save();
+
+    mockSocialiteWith(fakeSocialiteUser());
+
+    $response = $this->get('/auth/github/callback');
+
+    // The controller catches the abort(403) and redirects to /login with an
+    // error message — either is acceptable as long as no user got created.
+    expect(User::whereEmail('oauth@example.com')->exists())->toBeFalse();
+});
+
+test('oauth callback creates new user when registration is disabled but oauth-only mode is enabled', function () {
+    $settings = instanceSettings();
+    $settings->is_registration_enabled = false;
+    $settings->allow_oauth_when_registration_disabled = true;
+    $settings->save();
+
+    mockSocialiteWith(fakeSocialiteUser());
+
+    $response = $this->get('/auth/github/callback');
+
+    $response->assertRedirect('/');
+    expect(User::whereEmail('oauth@example.com')->exists())->toBeTrue();
+});
+
+test('oauth callback signs in existing user regardless of registration flags', function () {
+    $settings = instanceSettings();
+    $settings->is_registration_enabled = false;
+    $settings->allow_oauth_when_registration_disabled = false;
+    $settings->save();
+
+    User::factory()->create(['email' => 'existing@example.com']);
+
+    mockSocialiteWith(fakeSocialiteUser('existing@example.com', 'Existing User'));
+
+    $response = $this->get('/auth/github/callback');
+
+    $response->assertRedirect('/');
+    expect(auth()->check())->toBeTrue();
+    expect(auth()->user()->email)->toBe('existing@example.com');
+});
+
+test('password registration still aborts when registration is disabled even with oauth-only mode on', function () {
+    // OAuth-only mode must NOT loosen the password registration gate —
+    // that's the whole point of decoupling the two flows.
+    $settings = instanceSettings();
+    $settings->is_registration_enabled = false;
+    $settings->allow_oauth_when_registration_disabled = true;
+    $settings->save();
+
+    $createNewUser = new App\Actions\Fortify\CreateNewUser;
+
+    expect(fn () => $createNewUser->create([
+        'name' => 'Pass Word',
+        'email' => 'pw@example.com',
+        'password' => 'password123',
+        'password_confirmation' => 'password123',
+    ]))->toThrow(Symfony\Component\HttpKernel\Exception\HttpException::class);
+
+    expect(User::whereEmail('pw@example.com')->exists())->toBeFalse();
+});


### PR DESCRIPTION
STRAWBERRY

## Changes

Adds a new instance setting, `allow_oauth_when_registration_disabled`, that splits the existing self-registration toggle into two concerns: password-form registration and OAuth-callback registration. By default the new flag is off, so existing behavior is preserved. When an admin turns it on while leaving "Registration Allowed" off, OAuth providers (Authentik, Google, GitHub, etc.) can still create new accounts while the public `/register` form stays gated. This is the "OAuth-only" mode the issue describes — the IdP becomes the authoritative gate for who can sign up, and a Coolify instance can run without a password registration form open to the internet.

The OauthController callback now gates new-user creation on `(is_registration_enabled OR allow_oauth_when_registration_disabled)` instead of `is_registration_enabled` alone. Existing-user login through OAuth is unchanged. Password registration via Fortify still aborts when registration is disabled — the two flows are intentionally kept decoupled.

UI:
- New checkbox on Settings → Advanced with helper copy explaining the use case.
- Login page no longer shows the "registration disabled" copy when OAuth-only mode is active and at least one OAuth provider is enabled, since that text is misleading in that state — the OAuth buttons below the form do let new users sign up.

## Issues

- Fixes #8042

## Category

- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

I don't have a Docker/Spin environment on this machine, so I haven't been able to capture a UI screenshot myself. The blade change is purely additive (one extra `<x-forms.checkbox>` block matching the surrounding pattern in `resources/views/livewire/settings/advanced.blade.php`) and the rendered behaviour follows exactly the same `instantSave` flow as `is_sponsorship_popup_enabled` directly above it. Happy to add a screenshot as soon as a maintainer or reviewer can run the branch, or to revise the layout/copy if you want it grouped differently.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Anthropic)
- How extensively: Exploration of the existing auth code paths and drafting of the implementation, blade additions, and Pest tests. Each change was reviewed against the surrounding conventions (sibling files, existing instance-setting migrations, the existing Advanced settings Livewire component) before committing.

## Testing

Pest feature tests added in `tests/Feature/OauthRegistrationGatingTest.php`:

- Column exists and defaults to `false`.
- Admin can toggle the flag via the Settings → Advanced Livewire component (`Livewire::test(...)`).
- OAuth callback creates a new user when general registration is enabled.
- OAuth callback blocks signup when both flags are off.
- OAuth callback creates a new user when registration is off but OAuth-only mode is on (the new behaviour).
- OAuth callback signs in existing users regardless of flags.
- Password registration (`CreateNewUser`) still aborts when registration is disabled even when OAuth-only mode is on (regression guard so the two flows stay decoupled).

I was not able to run `php artisan test` locally (no Docker/Spin on this machine). Please run the suite in CI / locally — happy to iterate on anything that comes up. The migration matches the existing pattern in `2025_06_25_131350_add_is_sponsorship_popup_enabled_to_instance_settings_table.php`.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them. *(See "Testing" — local Coolify instance was not available; tests were authored against the existing test conventions and are ready to run in CI.)*