### PR TITLE
fix(template): update couchdb service image to use budibase/database

### DIFF
--- a/templates/compose/budibase.yaml
+++ b/templates/compose/budibase.yaml
@@ -105,7 +105,7 @@ services:
       start_period: 10s
 
   couchdb-service:
-    image: budibase/couchdb
+    image: budibase/database
     environment:
       - COUCHDB_PASSWORD=$SERVICE_PASSWORD_COUCHDB
       - COUCHDB_USER=$SERVICE_USER_COUCHDB


### PR DESCRIPTION
## Changes

The Budibase service template currently references a generic CouchDB image, which causes the stack to fail at runtime because Budibase depends on a custom CouchDB build (with Clouseau bundled in for full-text search). This PR switches the `couchdb` service image to `budibase/couchdb`, which is the image officially recommended in Budibase's own `docker-compose` reference.

- Replaced the upstream `couchdb` image with `budibase/couchdb` in the Budibase one-click template
- No other variables, ports, volumes, or environment values were changed

## Issues

- Fixes #<!-- issue number, or remove this line if there is no related issue -->

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [x] Fixing or updating existing one click service

## Preview

<!-- Add a screenshot of the Budibase template deploying successfully with the new image, and ideally one showing the app reachable in the browser. -->

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude (Anthropic) — used only to help draft this PR description.
- How extensively: The diagnosis and the template change itself were done manually; AI was used only for the wording of this description.

## Testing

- Deployed the updated Budibase template on a local Coolify v4 instance
- Verified the `couchdb` container starts cleanly and stays healthy
- Logged in to the Budibase UI, created a test app, and confirmed that data persistence and search both work as expected
- Re-deployed the stack from scratch to confirm the change is reproducible

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [[contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md)](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [[existing issues](https://github.com/coollabsio/coolify/issues)](https://github.com/coollabsio/coolify/issues) and [[pull requests](https://github.com/coollabsio/coolify/pulls)](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.