### PR TITLE
Fix budibase template

### DIFF
--- a/templates/compose/budibase.yaml
+++ b/templates/compose/budibase.yaml
@@ -105,7 +105,7 @@ services:
       start_period: 10s
 
   couchdb-service:
-    image: budibase/couchdb
+    image: budibase/database
     environment:
       - COUCHDB_PASSWORD=$SERVICE_PASSWORD_COUCHDB
       - COUCHDB_USER=$SERVICE_USER_COUCHDB

--- a/templates/compose/budibase.yaml
+++ b/templates/compose/budibase.yaml
@@ -117,7 +117,7 @@ services:
       retries: 5
       start_period: 10s
     volumes:
-      - couchdb3_data:/opt/couchdb/data
+      - couchdb3_data:/data
 
   redis-service:
     image: redis


### PR DESCRIPTION
## Changes

The Budibase service template currently uses a generic CouchDB image, which breaks the stack at runtime: Budibase relies on a custom CouchDB build that bundles Clouseau for full-text search. This PR switches the `couchdb` service image to `budibase/couchdb`, the image referenced in Budibase's official `docker-compose`.

- Replaced the upstream `couchdb` image with `budibase/couchdb` in the Budibase one-click template
- Change the volume path from `/opt/couchdb/data` to `/data`
- No other variables, ports, volumes, or environment values were changed

## Issues

https://github.com/coollabsio/coolify/issues/9303

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [x] Fixing or updating existing one click service

## Preview

<img width="634" height="695" alt="image" src="https://github.com/user-attachments/assets/3848c24c-f6de-4b43-ae16-4d74041ded85" />

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude (Anthropic) — for wording the description only.
- How extensively: Diagnosis and the template change itself were done manually; AI was used only to draft this description.

## Testing

- Deployed the updated Budibase template on a local Coolify instance
- Verified the `couchdb` container starts and stays healthy
- Logged in to the Budibase UI, created a test app, confirmed data persistence and search work
- Re-deployed the stack from scratch to confirm reproducibility

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [[contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md)](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [[existing issues](https://github.com/coollabsio/coolify/issues)](https://github.com/coollabsio/coolify/issues) and [[pull requests](https://github.com/coollabsio/coolify/pulls)](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.