### PR TITLE
Draft: Sablier hibernation UI scaffolding

### DIFF
--- a/app/Livewire/Project/Application/Advanced.php
+++ b/app/Livewire/Project/Application/Advanced.php
@@ -82,6 +82,21 @@ class Advanced extends Component
     #[Validate(['boolean'])]
     public bool $isConnectToDockerNetworkEnabled = false;
 
+    #[Validate(['boolean'])]
+    public bool $isSablierEnabled = false;
+
+    #[Validate(['string', 'nullable'])]
+    public ?string $sablierGroup = null;
+
+    #[Validate(['string', 'nullable'])]
+    public ?string $sablierNetworkAlias = null;
+
+    #[Validate(['string'])]
+    public string $sablierSessionDuration = '10m';
+
+    #[Validate(['string'])]
+    public string $sablierTimeout = '60s';
+
     public function mount()
     {
         try {
@@ -144,6 +159,107 @@ class Advanced extends Component
             $this->disableBuildCache = $this->application->settings->disable_build_cache;
             $this->injectBuildArgsToDockerfile = $this->application->settings->inject_build_args_to_dockerfile ?? true;
             $this->includeSourceCommitInBuild = $this->application->settings->include_source_commit_in_build ?? false;
+            $this->syncSablierDataFromLabels();
+        }
+    }
+
+    private function decodedCustomLabels(): array
+    {
+        if (blank($this->application->custom_labels)) {
+            return [];
+        }
+
+        $decoded = base64_decode($this->application->custom_labels, true);
+        if ($decoded === false) {
+            return [];
+        }
+
+        return preg_split('/\r\n|\r|\n/', $decoded) ?: [];
+    }
+
+    private function customLabelsAsMap(): array
+    {
+        return collect($this->decodedCustomLabels())
+            ->filter(fn ($line) => str($line)->contains('='))
+            ->mapWithKeys(function ($line) {
+                [$key, $value] = explode('=', $line, 2);
+
+                return [trim($key) => trim($value)];
+            })
+            ->all();
+    }
+
+    private function setCustomLabel(array $lines, string $key, ?string $value): array
+    {
+        $found = false;
+        $lines = collect($lines)->map(function ($line) use ($key, $value, &$found) {
+            if (str($line)->before('=')->trim()->value() === $key) {
+                $found = true;
+
+                return is_null($value) ? null : "{$key}={$value}";
+            }
+
+            return $line;
+        })->filter(fn ($line) => ! is_null($line))->values()->all();
+
+        if (! $found && ! is_null($value)) {
+            $lines[] = "{$key}={$value}";
+        }
+
+        return $lines;
+    }
+
+    private function syncSablierDataFromLabels(): void
+    {
+        $labels = $this->customLabelsAsMap();
+        $this->isSablierEnabled = str(data_get($labels, 'sablier.enable', 'false'))->lower()->value() === 'true';
+        $this->sablierGroup = data_get($labels, 'sablier.group') ?: str($this->application->name)->slug()->value();
+        $this->sablierNetworkAlias = data_get($labels, 'sablier.alias') ?: data_get(explode(',', $this->application->custom_network_aliases ?? ''), 0) ?: str($this->sablierGroup)->slug()->append('-sablier')->value();
+        $this->sablierSessionDuration = data_get($labels, 'sablier.session_duration', '10m');
+        $this->sablierTimeout = data_get($labels, 'sablier.timeout', '60s');
+    }
+
+    public function saveSablierSettings(): void
+    {
+        try {
+            $this->authorize('update', $this->application);
+            $this->validate([
+                'isSablierEnabled' => 'boolean',
+                'sablierGroup' => 'nullable|string|max:255',
+                'sablierNetworkAlias' => 'nullable|string|max:255',
+                'sablierSessionDuration' => 'required|string|max:32',
+                'sablierTimeout' => 'required|string|max:32',
+            ]);
+
+            $group = str($this->sablierGroup ?: $this->application->name)->slug()->value();
+            $alias = str($this->sablierNetworkAlias ?: "{$group}-sablier")->slug()->value();
+            $middleware = "sablier-{$group}@file";
+            $routerMiddlewareLabel = "traefik.http.routers.https-0-{$this->application->uuid}.middlewares";
+            $labels = $this->customLabelsAsMap();
+            $middlewares = collect(explode(',', data_get($labels, $routerMiddlewareLabel, 'gzip')))
+                ->filter()
+                ->when($this->isSablierEnabled, fn ($items) => $items->contains($middleware) ? $items : $items->push($middleware))
+                ->when(! $this->isSablierEnabled, fn ($items) => $items->reject(fn ($item) => str($item)->startsWith('sablier-')))
+                ->implode(',');
+
+            $lines = $this->decodedCustomLabels();
+            $lines = $this->setCustomLabel($lines, $routerMiddlewareLabel, $middlewares ?: 'gzip');
+            $lines = $this->setCustomLabel($lines, 'sablier.enable', $this->isSablierEnabled ? 'true' : null);
+            $lines = $this->setCustomLabel($lines, 'sablier.group', $this->isSablierEnabled ? $group : null);
+            $lines = $this->setCustomLabel($lines, 'sablier.alias', $this->isSablierEnabled ? $alias : null);
+            $lines = $this->setCustomLabel($lines, 'sablier.session_duration', $this->isSablierEnabled ? $this->sablierSessionDuration : null);
+            $lines = $this->setCustomLabel($lines, 'sablier.timeout', $this->isSablierEnabled ? $this->sablierTimeout : null);
+
+            $this->application->custom_labels = base64_encode(implode("\n", $lines));
+            if ($this->isSablierEnabled) {
+                $this->application->custom_network_aliases = $alias;
+            }
+            $this->application->save();
+            $this->syncSablierDataFromLabels();
+            $this->dispatch('success', 'Sablier settings saved. Regenerate the proxy dynamic configuration and redeploy the application.');
+            $this->dispatch('configurationChanged');
+        } catch (\Throwable $e) {
+            handleError($e, $this);
         }
     }
 

--- a/docs/drafts/sablier-hibernation.md
+++ b/docs/drafts/sablier-hibernation.md
@@ -1,0 +1,77 @@
+# Draft: Sablier hibernation for applications
+
+This draft sketches first-class Sablier hibernation support in Coolify.
+
+## Status
+
+Draft / blocked for upstream readiness.
+
+A reliable upstream feature depends on Traefik plugin cache behavior fixed by:
+
+- https://github.com/traefik/traefik/pull/13006
+
+Related Sablier issue:
+
+- https://github.com/sablierapp/sablier/issues/773
+
+Until that lands in a released Traefik version, the feature should be gated behind an explicit warning or only enabled when users bring a patched Traefik image.
+
+## Why Coolify needs more than labels
+
+A stopped application container is removed from Traefik's Docker provider. If the only router lives on Docker labels, there is no route left to invoke Sablier and wake the container.
+
+Coolify therefore needs to generate persistent file-provider routers under the proxy dynamic configuration, for example:
+
+```text
+/data/coolify/proxy/dynamic/sablier-apps.yml
+```
+
+The application container still needs Docker labels so Sablier's Docker provider can discover the group:
+
+```text
+sablier.enable=true
+sablier.group=<group>
+sablier.alias=<stable-network-alias>
+sablier.session_duration=10m
+sablier.timeout=60s
+```
+
+The application should also receive a stable network alias:
+
+```text
+<group>-sablier
+```
+
+The file-provider service points to that alias:
+
+```yaml
+services:
+  my-app-svc:
+    loadBalancer:
+      servers:
+        - url: http://my-app-sablier:3000
+```
+
+## Proposed UI
+
+Application → Advanced → Hibernate / Sablier
+
+Fields:
+
+- Enable Sablier Hibernate
+- Sablier Group
+- Stable Network Alias
+- Session Duration
+- Wake Timeout
+
+## Proposed implementation phases
+
+1. Store Sablier settings on the application, initially via labels/custom_network_aliases.
+2. Add a server-side reconciler that scans enabled applications per server and writes `sablier-apps.yml`.
+3. Ensure proxy generation preserves/installs the Sablier Traefik plugin only when supported.
+4. Regenerate dynamic config on application save, deploy, domain change, port change, and delete.
+5. Add tests for generated labels and dynamic config.
+
+## Draft PR scope
+
+This PR intentionally only adds UI scaffolding and label/alias persistence. The proxy dynamic-config reconciler should be added before marking the feature ready for review.

--- a/resources/views/livewire/project/application/advanced.blade.php
+++ b/resources/views/livewire/project/application/advanced.blade.php
@@ -65,6 +65,31 @@
                     canGate="update" :canResource="$application" />
             @endif
 
+            <h3 class="pt-4">Hibernate / Sablier</h3>
+            <div class="flex flex-col gap-2 rounded border border-warning p-3 dark:border-warning">
+                <div class="text-sm text-warning">
+                    Draft integration. Requires Traefik with the Sablier plugin and a build containing
+                    <a class="underline" href="https://github.com/traefik/traefik/pull/13006" target="_blank">traefik/traefik#13006</a>
+                    for reliable plugin cache behavior after restarts. Coolify still needs to generate the persistent
+                    Traefik file-provider router for stopped containers.
+                </div>
+                <x-forms.checkbox id="isSablierEnabled" label="Enable Sablier Hibernate" canGate="update"
+                    :canResource="$application" />
+                <div class="grid grid-cols-1 gap-2 md:grid-cols-2">
+                    <x-forms.input id="sablierGroup" label="Sablier Group" placeholder="my-app" canGate="update"
+                        :canResource="$application" />
+                    <x-forms.input id="sablierNetworkAlias" label="Stable Network Alias" placeholder="my-app-sablier"
+                        canGate="update" :canResource="$application" />
+                    <x-forms.input id="sablierSessionDuration" label="Session Duration" placeholder="10m" canGate="update"
+                        :canResource="$application" />
+                    <x-forms.input id="sablierTimeout" label="Wake Timeout" placeholder="60s" canGate="update"
+                        :canResource="$application" />
+                </div>
+                <x-forms.button wire:click="saveSablierSettings" canGate="update" :canResource="$application">
+                    Save Sablier Settings
+                </x-forms.button>
+            </div>
+
             <h3 class="pt-4">Proxy</h3>
             @if ($application->settings->is_container_label_readonly_enabled)
                 <x-forms.checkbox


### PR DESCRIPTION
## Summary

Draft scaffolding for first-class Sablier hibernation support in Coolify applications.

This PR intentionally starts small:

- adds an Advanced page UI section for Sablier / Hibernate settings
- stores the settings via existing application custom labels and `custom_network_aliases`
- documents the required follow-up work for persistent Traefik file-provider router generation

## Why draft

Full upstream support depends on reliable Traefik plugin loading/caching behavior. In particular, this should wait for or explicitly gate on:

- https://github.com/traefik/traefik/pull/13006

Related Sablier issue:

- https://github.com/sablierapp/sablier/issues/773

Without the Traefik plugin cache fix, Traefik restarts can intermittently invalidate plugin-backed middlewares.

## Required follow-up before ready for review

- Add a server-side reconciler that generates `/data/coolify/proxy/dynamic/sablier-apps.yml` from Sablier-enabled apps.
- Regenerate that file on app save/deploy/delete/domain/port changes.
- Gate or warn based on proxy image/Traefik version/plugin support.
- Add tests for label generation and dynamic Traefik config generation.
- Decide whether settings should remain label-backed or be persisted in dedicated DB columns.

## Notes

A stopped container disappears from Traefik's Docker provider, so labels alone are insufficient for true hibernation. Coolify needs persistent file-provider routers that call the Sablier middleware even while the target container is stopped.
