### PR TITLE
Add Stalwart Mail service template

### DIFF
--- a/templates/compose/stalwart-mail.yaml
+++ b/templates/compose/stalwart-mail.yaml
@@ -1,0 +1,31 @@
+# documentation: https://stalw.art/docs/install/docker
+# slogan: Modern all-in-one mail server with a web admin console for managing client email domains.
+# category: email
+# tags: mail,email-server,smtp,imap,jmap,stalwart
+# port: 8080
+
+services:
+  stalwart-mail:
+    image: stalwartlabs/stalwart:latest
+    environment:
+      - SERVICE_URL_STALWARTMAIL_8080
+      - STALWART_DOMAIN=${STALWART_DOMAIN:-example.com}
+      - STALWART_HOSTNAME=${STALWART_HOSTNAME:-mail.example.com}
+      - STALWART_ADMIN_SECRET=${SERVICE_PASSWORD_STALWARTADMIN}
+    volumes:
+      - stalwart-mail-data:/opt/stalwart-mail
+    ports:
+      - "25:25"
+      - "465:465"
+      - "587:587"
+      - "993:993"
+      - "4190:4190"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "wget -q --spider http://127.0.0.1:8080/login || exit 1",
+        ]
+      interval: 10s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
## Changes
- Added a new one-click service template for Stalwart Mail.
- Includes the web admin route on port 8080, persistent data storage, generated admin secret, configurable mail domain/hostname, and common SMTP/IMAP/submission/Sieve ports.

## Issues
- Fixes #8266
- /claim #8266

## Category
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview
N/A, this is a service template addition.

## AI Assistance
- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**
- Tools used: OpenClaw/Codex
- How extensively: Used to inspect existing Coolify service templates and draft the YAML template. Human/operator reviewed and submitted the final change.

## Testing
- Validated the template parses as YAML with Ruby's YAML loader.
- Attempted to run `php artisan generate:services`, but local Composer dependencies were not installed in this checkout (`vendor/autoload.php` missing), so full Coolify generation could not be completed locally.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
