### PR TITLE
feat(observability): add structured audit log channel for API and webhook events

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -4,8 +4,10 @@ namespace App\Exceptions;
 
 use App\Models\InstanceSettings;
 use App\Models\User;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Psr\Log\LogLevel;
 use RuntimeException;
 use Sentry\Laravel\Integration;
 use Sentry\State\Scope;
@@ -16,7 +18,7 @@ class Handler extends ExceptionHandler
     /**
      * A list of exception types with their corresponding custom log levels.
      *
-     * @var array<class-string<\Throwable>, \Psr\Log\LogLevel::*>
+     * @var array<class-string<Throwable>, LogLevel::*>
      */
     protected $levels = [
         //
@@ -25,7 +27,7 @@ class Handler extends ExceptionHandler
     /**
      * A list of the exception types that are not reported.
      *
-     * @var array<int, class-string<\Throwable>>
+     * @var array<int, class-string<Throwable>>
      */
     protected $dontReport = [
         ProcessException::class,
@@ -49,6 +51,13 @@ class Handler extends ExceptionHandler
     protected function unauthenticated($request, AuthenticationException $exception)
     {
         if ($request->is('api/*') || $request->expectsJson() || $this->shouldReturnJson($request, $exception)) {
+            if ($request->is('api/*')) {
+                auditLog('api.auth.unauthenticated', [
+                    'reason' => $exception->getMessage(),
+                    'guards' => $exception->guards(),
+                ], 'warning');
+            }
+
             return response()->json(['message' => $exception->getMessage()], 401);
         }
 
@@ -61,8 +70,15 @@ class Handler extends ExceptionHandler
     public function render($request, Throwable $e)
     {
         // Handle authorization exceptions for API routes
-        if ($e instanceof \Illuminate\Auth\Access\AuthorizationException) {
+        if ($e instanceof AuthorizationException) {
             if ($request->is('api/*') || $request->expectsJson()) {
+                if ($request->is('api/*')) {
+                    auditLog('api.auth.policy_denied', [
+                        'reason' => $e->getMessage(),
+                        'route' => $request->route()?->getName() ?? $request->path(),
+                    ], 'warning');
+                }
+
                 // Get the custom message from the policy if available
                 $message = $e->getMessage();
 

--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -1309,6 +1309,15 @@ class ApplicationsController extends Controller
                 }
             }
 
+            auditLog('api.application.created', [
+                'team_id' => $teamId,
+                'application_uuid' => data_get($application, 'uuid'),
+                'application_name' => data_get($application, 'name'),
+                'application_type' => $type,
+                'build_pack' => data_get($application, 'build_pack'),
+                'instant_deploy' => (bool) ($instantDeploy ?? false),
+            ]);
+
             return response()->json(serializeApiResponse([
                 'uuid' => data_get($application, 'uuid'),
                 'domains' => data_get($application, 'fqdn'),
@@ -1539,6 +1548,15 @@ class ApplicationsController extends Controller
                 }
             }
 
+            auditLog('api.application.created', [
+                'team_id' => $teamId,
+                'application_uuid' => data_get($application, 'uuid'),
+                'application_name' => data_get($application, 'name'),
+                'application_type' => $type,
+                'build_pack' => data_get($application, 'build_pack'),
+                'instant_deploy' => (bool) ($instantDeploy ?? false),
+            ]);
+
             return response()->json(serializeApiResponse([
                 'uuid' => data_get($application, 'uuid'),
                 'domains' => data_get($application, 'fqdn'),
@@ -1739,6 +1757,15 @@ class ApplicationsController extends Controller
                 }
             }
 
+            auditLog('api.application.created', [
+                'team_id' => $teamId,
+                'application_uuid' => data_get($application, 'uuid'),
+                'application_name' => data_get($application, 'name'),
+                'application_type' => $type,
+                'build_pack' => data_get($application, 'build_pack'),
+                'instant_deploy' => (bool) ($instantDeploy ?? false),
+            ]);
+
             return response()->json(serializeApiResponse([
                 'uuid' => data_get($application, 'uuid'),
                 'domains' => data_get($application, 'fqdn'),
@@ -1845,6 +1872,15 @@ class ApplicationsController extends Controller
                     ], 200);
                 }
             }
+
+            auditLog('api.application.created', [
+                'team_id' => $teamId,
+                'application_uuid' => data_get($application, 'uuid'),
+                'application_name' => data_get($application, 'name'),
+                'application_type' => $type,
+                'build_pack' => data_get($application, 'build_pack'),
+                'instant_deploy' => (bool) ($instantDeploy ?? false),
+            ]);
 
             return response()->json(serializeApiResponse([
                 'uuid' => data_get($application, 'uuid'),
@@ -1956,6 +1992,15 @@ class ApplicationsController extends Controller
                 }
             }
 
+            auditLog('api.application.created', [
+                'team_id' => $teamId,
+                'application_uuid' => data_get($application, 'uuid'),
+                'application_name' => data_get($application, 'name'),
+                'application_type' => $type,
+                'build_pack' => data_get($application, 'build_pack'),
+                'instant_deploy' => (bool) ($instantDeploy ?? false),
+            ]);
+
             return response()->json(serializeApiResponse([
                 'uuid' => data_get($application, 'uuid'),
                 'domains' => data_get($application, 'fqdn'),
@@ -2038,6 +2083,14 @@ class ApplicationsController extends Controller
             if ($instantDeploy) {
                 StartService::dispatch($service);
             }
+
+            auditLog('api.application.created', [
+                'team_id' => $teamId,
+                'service_uuid' => data_get($service, 'uuid'),
+                'service_name' => data_get($service, 'name'),
+                'application_type' => $type,
+                'instant_deploy' => (bool) ($instantDeploy ?? false),
+            ]);
 
             return response()->json(serializeApiResponse([
                 'uuid' => data_get($service, 'uuid'),
@@ -2296,6 +2349,12 @@ class ApplicationsController extends Controller
             deleteConfigurations: $request->boolean('delete_configurations', true),
             dockerCleanup: $request->boolean('docker_cleanup', true)
         );
+
+        auditLog('api.application.deleted', [
+            'team_id' => $teamId,
+            'application_uuid' => $application->uuid,
+            'application_name' => $application->name,
+        ]);
 
         return response()->json([
             'message' => 'Application deletion request queued.',
@@ -2796,6 +2855,13 @@ class ApplicationsController extends Controller
         }
         $application->save();
 
+        auditLog('api.application.updated', [
+            'team_id' => $teamId,
+            'application_uuid' => $application->uuid,
+            'application_name' => $application->name,
+            'changed_fields' => array_values(array_intersect($allowedFields, array_keys($request->all()))),
+        ]);
+
         if ($instantDeploy) {
             $deployment_uuid = new Cuid2;
 
@@ -3048,6 +3114,14 @@ class ApplicationsController extends Controller
                 }
                 $env->save();
 
+                auditLog('api.application.env_updated', [
+                    'team_id' => $teamId,
+                    'application_uuid' => $application->uuid,
+                    'env_uuid' => $env->uuid,
+                    'env_key' => $env->key,
+                    'is_preview' => (bool) $is_preview,
+                ]);
+
                 return response()->json($this->removeSensitiveData($env))->setStatusCode(201);
             } else {
                 return response()->json([
@@ -3080,6 +3154,14 @@ class ApplicationsController extends Controller
                     $env->comment = $request->comment;
                 }
                 $env->save();
+
+                auditLog('api.application.env_updated', [
+                    'team_id' => $teamId,
+                    'application_uuid' => $application->uuid,
+                    'env_uuid' => $env->uuid,
+                    'env_key' => $env->key,
+                    'is_preview' => (bool) $is_preview,
+                ]);
 
                 return response()->json($this->removeSensitiveData($env))->setStatusCode(201);
             } else {
@@ -3307,6 +3389,12 @@ class ApplicationsController extends Controller
             $returnedEnvs->push($this->removeSensitiveData($env));
         }
 
+        auditLog('api.application.env_bulk_upserted', [
+            'team_id' => $teamId,
+            'application_uuid' => $application->uuid,
+            'env_count' => $returnedEnvs->count(),
+        ]);
+
         return response()->json($returnedEnvs)->setStatusCode(201);
     }
 
@@ -3446,6 +3534,14 @@ class ApplicationsController extends Controller
                     'resourceable_id' => $application->id,
                 ]);
 
+                auditLog('api.application.env_created', [
+                    'team_id' => $teamId,
+                    'application_uuid' => $application->uuid,
+                    'env_uuid' => $env->uuid,
+                    'env_key' => $env->key,
+                    'is_preview' => (bool) $is_preview,
+                ]);
+
                 return response()->json([
                     'uuid' => $env->uuid,
                 ])->setStatusCode(201);
@@ -3469,6 +3565,14 @@ class ApplicationsController extends Controller
                     'comment' => $request->comment ?? null,
                     'resourceable_type' => get_class($application),
                     'resourceable_id' => $application->id,
+                ]);
+
+                auditLog('api.application.env_created', [
+                    'team_id' => $teamId,
+                    'application_uuid' => $application->uuid,
+                    'env_uuid' => $env->uuid,
+                    'env_key' => $env->key,
+                    'is_preview' => (bool) $is_preview,
                 ]);
 
                 return response()->json([
@@ -3562,7 +3666,16 @@ class ApplicationsController extends Controller
                 'message' => 'Environment variable not found.',
             ], 404);
         }
+        $envKey = $found_env->key;
+        $envUuid = $found_env->uuid;
         $found_env->forceDelete();
+
+        auditLog('api.application.env_deleted', [
+            'team_id' => $teamId,
+            'application_uuid' => $application->uuid,
+            'env_uuid' => $envUuid,
+            'env_key' => $envKey,
+        ]);
 
         return response()->json([
             'message' => 'Environment variable deleted.',
@@ -3675,6 +3788,15 @@ class ApplicationsController extends Controller
             );
         }
 
+        auditLog('api.application.deployed', [
+            'team_id' => $teamId,
+            'application_uuid' => $application->uuid,
+            'application_name' => $application->name,
+            'deployment_uuid' => $deployment_uuid->toString(),
+            'force_rebuild' => $force,
+            'instant_deploy' => $instant_deploy,
+        ]);
+
         return response()->json(
             [
                 'message' => 'Deployment request queued.',
@@ -3762,6 +3884,13 @@ class ApplicationsController extends Controller
 
         $dockerCleanup = $request->boolean('docker_cleanup', true);
         StopApplication::dispatch($application, false, $dockerCleanup);
+
+        auditLog('api.application.stopped', [
+            'team_id' => $teamId,
+            'application_uuid' => $application->uuid,
+            'application_name' => $application->name,
+            'docker_cleanup' => $dockerCleanup,
+        ]);
 
         return response()->json(
             [
@@ -3852,6 +3981,13 @@ class ApplicationsController extends Controller
                 'message' => $result['message'],
             ], 200);
         }
+
+        auditLog('api.application.restarted', [
+            'team_id' => $teamId,
+            'application_uuid' => $application->uuid,
+            'application_name' => $application->name,
+            'deployment_uuid' => $deployment_uuid->toString(),
+        ]);
 
         return response()->json(
             [
@@ -4221,6 +4357,15 @@ class ApplicationsController extends Controller
 
         $storage->save();
 
+        auditLog('api.application.storage_updated', [
+            'team_id' => $teamId,
+            'application_uuid' => $application->uuid,
+            'storage_uuid' => $storage->uuid ?? null,
+            'storage_id' => $storage->id,
+            'storage_type' => $request->type,
+            'mount_path' => $storage->mount_path ?? null,
+        ]);
+
         return response()->json($storage);
     }
 
@@ -4399,6 +4544,15 @@ class ApplicationsController extends Controller
             ]);
         }
 
+        auditLog('api.application.storage_created', [
+            'team_id' => $teamId,
+            'application_uuid' => $application->uuid,
+            'storage_uuid' => $storage->uuid ?? null,
+            'storage_id' => $storage->id,
+            'storage_type' => $request->type,
+            'mount_path' => $storage->mount_path,
+        ]);
+
         return response()->json($storage, 201);
     }
 
@@ -4472,7 +4626,17 @@ class ApplicationsController extends Controller
             $storage->deleteStorageOnServer();
         }
 
+        $storageType = $storage instanceof LocalFileVolume ? 'file' : 'persistent';
+        $storageMountPath = $storage->mount_path ?? null;
         $storage->delete();
+
+        auditLog('api.application.storage_deleted', [
+            'team_id' => $teamId,
+            'application_uuid' => $application->uuid,
+            'storage_uuid' => $storageUuid,
+            'storage_type' => $storageType,
+            'mount_path' => $storageMountPath,
+        ]);
 
         return response()->json(['message' => 'Storage deleted.']);
     }
@@ -4542,6 +4706,12 @@ class ApplicationsController extends Controller
 
         $preview->delete();
         CleanupPreviewDeployment::run($application, $pullRequestId, $preview);
+
+        auditLog('api.application.preview_deleted', [
+            'team_id' => $teamId,
+            'application_uuid' => $application->uuid,
+            'pull_request_id' => $pullRequestId,
+        ]);
 
         return response()->json(['message' => 'Preview deletion request queued.']);
     }

--- a/app/Http/Controllers/Api/CloudProviderTokensController.php
+++ b/app/Http/Controllers/Api/CloudProviderTokensController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Models\CloudProviderToken;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -244,7 +245,7 @@ class CloudProviderTokensController extends Controller
         }
 
         $return = validateIncomingRequest($request);
-        if ($return instanceof \Illuminate\Http\JsonResponse) {
+        if ($return instanceof JsonResponse) {
             return $return;
         }
 
@@ -284,6 +285,13 @@ class CloudProviderTokensController extends Controller
             'provider' => $body['provider'],
             'token' => $body['token'],
             'name' => $body['name'],
+        ]);
+
+        auditLog('api.cloud_token.created', [
+            'team_id' => $teamId,
+            'cloud_token_uuid' => $cloudProviderToken->uuid,
+            'cloud_token_name' => $cloudProviderToken->name,
+            'provider' => $cloudProviderToken->provider,
         ]);
 
         return response()->json([
@@ -355,7 +363,7 @@ class CloudProviderTokensController extends Controller
         }
 
         $return = validateIncomingRequest($request);
-        if ($return instanceof \Illuminate\Http\JsonResponse) {
+        if ($return instanceof JsonResponse) {
             return $return;
         }
 
@@ -388,6 +396,14 @@ class CloudProviderTokensController extends Controller
         }
 
         $token->update(array_intersect_key($body, array_flip($allowedFields)));
+
+        auditLog('api.cloud_token.updated', [
+            'team_id' => $teamId,
+            'cloud_token_uuid' => $token->uuid,
+            'cloud_token_name' => $token->name,
+            'provider' => $token->provider,
+            'changed_fields' => array_values(array_intersect($allowedFields, array_keys($body))),
+        ]);
 
         return response()->json([
             'uuid' => $token->uuid,
@@ -464,7 +480,17 @@ class CloudProviderTokensController extends Controller
             return response()->json(['message' => 'Cannot delete token that is used by servers.'], 400);
         }
 
+        $tokenUuid = $token->uuid;
+        $tokenName = $token->name;
+        $tokenProvider = $token->provider;
         $token->delete();
+
+        auditLog('api.cloud_token.deleted', [
+            'team_id' => $teamId,
+            'cloud_token_uuid' => $tokenUuid,
+            'cloud_token_name' => $tokenName,
+            'provider' => $tokenProvider,
+        ]);
 
         return response()->json(['message' => 'Cloud provider token deleted.']);
     }

--- a/app/Http/Controllers/Api/DatabasesController.php
+++ b/app/Http/Controllers/Api/DatabasesController.php
@@ -596,6 +596,14 @@ class DatabasesController extends Controller
             StopDatabaseProxy::dispatch($database);
         }
 
+        auditLog('api.database.updated', [
+            'team_id' => $teamId,
+            'database_uuid' => $database->uuid,
+            'database_name' => $database->name,
+            'database_type' => $database->type(),
+            'changed_fields' => array_values(array_intersect($allowedFields, array_keys($request->all()))),
+        ]);
+
         return response()->json([
             'message' => 'Database updated.',
         ]);
@@ -826,6 +834,15 @@ class DatabasesController extends Controller
             dispatch(new DatabaseBackupJob($backupConfig));
         }
 
+        auditLog('api.database.backup_created', [
+            'team_id' => $teamId,
+            'database_uuid' => $database->uuid,
+            'backup_uuid' => $backupConfig->uuid,
+            'frequency' => $backupConfig->frequency,
+            'save_s3' => (bool) $backupConfig->save_s3,
+            'backup_now' => (bool) $request->backup_now,
+        ]);
+
         return response()->json([
             'uuid' => $backupConfig->uuid,
             'message' => 'Backup configuration created successfully.',
@@ -1044,6 +1061,14 @@ class DatabasesController extends Controller
         if ($request->backup_now) {
             dispatch(new DatabaseBackupJob($backupConfig));
         }
+
+        auditLog('api.database.backup_updated', [
+            'team_id' => $teamId,
+            'backup_uuid' => $backupConfig->uuid,
+            'database_id' => $backupConfig->database_id,
+            'changed_fields' => array_values(array_intersect($backupConfigFields, array_keys($request->all()))),
+            'backup_now' => (bool) $request->backup_now,
+        ]);
 
         return response()->json([
             'message' => 'Database backup configuration updated',
@@ -1779,6 +1804,16 @@ class DatabasesController extends Controller
                 $payload['external_db_url'] = $database->external_db_url;
             }
 
+            auditLog('api.database.created', [
+                'team_id' => $teamId,
+                'database_uuid' => $database->uuid,
+                'database_name' => $database->name,
+                'database_type' => $type->value,
+                'server_uuid' => $serverUuid,
+                'is_public' => (bool) $database->is_public,
+                'instant_deploy' => (bool) $instantDeploy,
+            ]);
+
             return response()->json(serializeApiResponse($payload))->setStatusCode(201);
         } elseif ($type === NewDatabaseTypes::MARIADB) {
             $allowedFields = ['name', 'description', 'image', 'public_port', 'public_port_timeout', 'is_public', 'project_uuid', 'environment_name', 'environment_uuid', 'server_uuid', 'destination_uuid', 'instant_deploy', 'limits_memory', 'limits_memory_swap', 'limits_memory_swappiness', 'limits_memory_reservation', 'limits_cpus', 'limits_cpuset', 'limits_cpu_shares', 'mariadb_conf', 'mariadb_root_password', 'mariadb_user', 'mariadb_password', 'mariadb_database'];
@@ -1837,6 +1872,16 @@ class DatabasesController extends Controller
             if ($database->is_public && $database->public_port) {
                 $payload['external_db_url'] = $database->external_db_url;
             }
+
+            auditLog('api.database.created', [
+                'team_id' => $teamId,
+                'database_uuid' => $database->uuid,
+                'database_name' => $database->name,
+                'database_type' => $type->value,
+                'server_uuid' => $serverUuid,
+                'is_public' => (bool) $database->is_public,
+                'instant_deploy' => (bool) $instantDeploy,
+            ]);
 
             return response()->json(serializeApiResponse($payload))->setStatusCode(201);
         } elseif ($type === NewDatabaseTypes::MYSQL) {
@@ -1897,6 +1942,16 @@ class DatabasesController extends Controller
                 $payload['external_db_url'] = $database->external_db_url;
             }
 
+            auditLog('api.database.created', [
+                'team_id' => $teamId,
+                'database_uuid' => $database->uuid,
+                'database_name' => $database->name,
+                'database_type' => $type->value,
+                'server_uuid' => $serverUuid,
+                'is_public' => (bool) $database->is_public,
+                'instant_deploy' => (bool) $instantDeploy,
+            ]);
+
             return response()->json(serializeApiResponse($payload))->setStatusCode(201);
         } elseif ($type === NewDatabaseTypes::REDIS) {
             $allowedFields = ['name', 'description', 'image', 'public_port', 'public_port_timeout', 'is_public', 'project_uuid', 'environment_name', 'environment_uuid', 'server_uuid', 'destination_uuid', 'instant_deploy', 'limits_memory', 'limits_memory_swap', 'limits_memory_swappiness', 'limits_memory_reservation', 'limits_cpus', 'limits_cpuset', 'limits_cpu_shares', 'redis_password', 'redis_conf'];
@@ -1952,6 +2007,16 @@ class DatabasesController extends Controller
             if ($database->is_public && $database->public_port) {
                 $payload['external_db_url'] = $database->external_db_url;
             }
+
+            auditLog('api.database.created', [
+                'team_id' => $teamId,
+                'database_uuid' => $database->uuid,
+                'database_name' => $database->name,
+                'database_type' => $type->value,
+                'server_uuid' => $serverUuid,
+                'is_public' => (bool) $database->is_public,
+                'instant_deploy' => (bool) $instantDeploy,
+            ]);
 
             return response()->json(serializeApiResponse($payload))->setStatusCode(201);
         } elseif ($type === NewDatabaseTypes::DRAGONFLY) {
@@ -2039,6 +2104,16 @@ class DatabasesController extends Controller
                 $payload['external_db_url'] = $database->external_db_url;
             }
 
+            auditLog('api.database.created', [
+                'team_id' => $teamId,
+                'database_uuid' => $database->uuid,
+                'database_name' => $database->name,
+                'database_type' => $type->value,
+                'server_uuid' => $serverUuid,
+                'is_public' => (bool) $database->is_public,
+                'instant_deploy' => (bool) $instantDeploy,
+            ]);
+
             return response()->json(serializeApiResponse($payload))->setStatusCode(201);
         } elseif ($type === NewDatabaseTypes::CLICKHOUSE) {
             $allowedFields = ['name', 'description', 'image', 'public_port', 'public_port_timeout', 'is_public', 'project_uuid', 'environment_name', 'environment_uuid', 'server_uuid', 'destination_uuid', 'instant_deploy', 'limits_memory', 'limits_memory_swap', 'limits_memory_swappiness', 'limits_memory_reservation', 'limits_cpus', 'limits_cpuset', 'limits_cpu_shares',  'clickhouse_admin_user', 'clickhouse_admin_password'];
@@ -2074,6 +2149,16 @@ class DatabasesController extends Controller
             if ($database->is_public && $database->public_port) {
                 $payload['external_db_url'] = $database->external_db_url;
             }
+
+            auditLog('api.database.created', [
+                'team_id' => $teamId,
+                'database_uuid' => $database->uuid,
+                'database_name' => $database->name,
+                'database_type' => $type->value,
+                'server_uuid' => $serverUuid,
+                'is_public' => (bool) $database->is_public,
+                'instant_deploy' => (bool) $instantDeploy,
+            ]);
 
             return response()->json(serializeApiResponse($payload))->setStatusCode(201);
         } elseif ($type === NewDatabaseTypes::MONGODB) {
@@ -2132,6 +2217,16 @@ class DatabasesController extends Controller
             if ($database->is_public && $database->public_port) {
                 $payload['external_db_url'] = $database->external_db_url;
             }
+
+            auditLog('api.database.created', [
+                'team_id' => $teamId,
+                'database_uuid' => $database->uuid,
+                'database_name' => $database->name,
+                'database_type' => $type->value,
+                'server_uuid' => $serverUuid,
+                'is_public' => (bool) $database->is_public,
+                'instant_deploy' => (bool) $instantDeploy,
+            ]);
 
             return response()->json(serializeApiResponse($payload))->setStatusCode(201);
         }
@@ -2216,6 +2311,13 @@ class DatabasesController extends Controller
             deleteConfigurations: $request->boolean('delete_configurations', true),
             dockerCleanup: $request->boolean('docker_cleanup', true)
         );
+
+        auditLog('api.database.deleted', [
+            'team_id' => $teamId,
+            'database_uuid' => $database->uuid,
+            'database_name' => $database->name,
+            'database_type' => $database->type(),
+        ]);
 
         return response()->json([
             'message' => 'Database deletion request queued.',
@@ -2328,6 +2430,14 @@ class DatabasesController extends Controller
             // Delete the backup configuration itself
             $backup->delete();
             DB::commit();
+
+            auditLog('api.database.backup_deleted', [
+                'team_id' => $teamId,
+                'database_uuid' => $database->uuid,
+                'backup_uuid' => $request->scheduled_backup_uuid,
+                'delete_s3' => $deleteS3,
+                'executions_deleted' => $executions->count(),
+            ]);
 
             return response()->json([
                 'message' => 'Backup configuration and all executions deleted.',
@@ -2450,6 +2560,14 @@ class DatabasesController extends Controller
             }
 
             $execution->delete();
+
+            auditLog('api.database.backup_execution_deleted', [
+                'team_id' => $teamId,
+                'database_uuid' => $database->uuid,
+                'backup_uuid' => $request->scheduled_backup_uuid,
+                'execution_uuid' => $request->execution_uuid,
+                'delete_s3' => $deleteS3,
+            ]);
 
             return response()->json([
                 'message' => 'Backup execution deleted.',
@@ -2633,6 +2751,13 @@ class DatabasesController extends Controller
         }
         StartDatabase::dispatch($database);
 
+        auditLog('api.database.started', [
+            'team_id' => $teamId,
+            'database_uuid' => $database->uuid,
+            'database_name' => $database->name,
+            'database_type' => $database->type(),
+        ]);
+
         return response()->json(
             [
                 'message' => 'Database starting request queued.',
@@ -2724,6 +2849,14 @@ class DatabasesController extends Controller
         $dockerCleanup = $request->boolean('docker_cleanup', true);
         StopDatabase::dispatch($database, $dockerCleanup);
 
+        auditLog('api.database.stopped', [
+            'team_id' => $teamId,
+            'database_uuid' => $database->uuid,
+            'database_name' => $database->name,
+            'database_type' => $database->type(),
+            'docker_cleanup' => $dockerCleanup,
+        ]);
+
         return response()->json(
             [
                 'message' => 'Database stopping request queued.',
@@ -2800,6 +2933,13 @@ class DatabasesController extends Controller
         $this->authorize('manage', $database);
 
         RestartDatabase::dispatch($database);
+
+        auditLog('api.database.restarted', [
+            'team_id' => $teamId,
+            'database_uuid' => $database->uuid,
+            'database_name' => $database->name,
+            'database_type' => $database->type(),
+        ]);
 
         return response()->json(
             [
@@ -3017,6 +3157,13 @@ class DatabasesController extends Controller
         }
         $env->save();
 
+        auditLog('api.database.env_updated', [
+            'team_id' => $teamId,
+            'database_uuid' => $database->uuid,
+            'env_uuid' => $env->uuid,
+            'env_key' => $env->key,
+        ]);
+
         return response()->json($this->removeSensitiveEnvData($env))->setStatusCode(201);
     }
 
@@ -3145,6 +3292,12 @@ class DatabasesController extends Controller
             $updatedEnvs->push($this->removeSensitiveEnvData($env));
         }
 
+        auditLog('api.database.env_bulk_upserted', [
+            'team_id' => $teamId,
+            'database_uuid' => $database->uuid,
+            'env_count' => $updatedEnvs->count(),
+        ]);
+
         return response()->json($updatedEnvs)->setStatusCode(201);
     }
 
@@ -3266,6 +3419,13 @@ class DatabasesController extends Controller
             'comment' => $request->comment ?? null,
         ]);
 
+        auditLog('api.database.env_created', [
+            'team_id' => $teamId,
+            'database_uuid' => $database->uuid,
+            'env_uuid' => $env->uuid,
+            'env_key' => $env->key,
+        ]);
+
         return response()->json($this->removeSensitiveEnvData($env))->setStatusCode(201);
     }
 
@@ -3351,7 +3511,16 @@ class DatabasesController extends Controller
             return response()->json(['message' => 'Environment variable not found.'], 404);
         }
 
+        $envKey = $env->key;
+        $envUuid = $env->uuid;
         $env->forceDelete();
+
+        auditLog('api.database.env_deleted', [
+            'team_id' => $teamId,
+            'database_uuid' => $database->uuid,
+            'env_uuid' => $envUuid,
+            'env_key' => $envKey,
+        ]);
 
         return response()->json(['message' => 'Environment variable deleted.']);
     }
@@ -3599,6 +3768,15 @@ class DatabasesController extends Controller
             ]);
         }
 
+        auditLog('api.database.storage_created', [
+            'team_id' => $teamId,
+            'database_uuid' => $database->uuid,
+            'storage_uuid' => $storage->uuid ?? null,
+            'storage_id' => $storage->id,
+            'storage_type' => $request->type,
+            'mount_path' => $storage->mount_path,
+        ]);
+
         return response()->json($storage, 201);
     }
 
@@ -3797,6 +3975,15 @@ class DatabasesController extends Controller
 
         $storage->save();
 
+        auditLog('api.database.storage_updated', [
+            'team_id' => $teamId,
+            'database_uuid' => $database->uuid,
+            'storage_uuid' => $storage->uuid ?? null,
+            'storage_id' => $storage->id,
+            'storage_type' => $request->type,
+            'mount_path' => $storage->mount_path ?? null,
+        ]);
+
         return response()->json($storage);
     }
 
@@ -3870,7 +4057,17 @@ class DatabasesController extends Controller
             $storage->deleteStorageOnServer();
         }
 
+        $storageType = $storage instanceof LocalFileVolume ? 'file' : 'persistent';
+        $storageMountPath = $storage->mount_path ?? null;
         $storage->delete();
+
+        auditLog('api.database.storage_deleted', [
+            'team_id' => $teamId,
+            'database_uuid' => $database->uuid,
+            'storage_uuid' => $storageUuid,
+            'storage_type' => $storageType,
+            'mount_path' => $storageMountPath,
+        ]);
 
         return response()->json(['message' => 'Storage deleted.']);
     }

--- a/app/Http/Controllers/Api/DeployController.php
+++ b/app/Http/Controllers/Api/DeployController.php
@@ -281,6 +281,14 @@ class DeployController extends Controller
                 }
             }
 
+            auditLog('api.deployment.cancelled', [
+                'team_id' => $teamId,
+                'deployment_uuid' => $deployment->deployment_uuid,
+                'application_id' => $application?->id,
+                'application_uuid' => $application?->uuid,
+                'server_id' => $deployment->server_id,
+            ]);
+
             return response()->json([
                 'message' => 'Deployment cancelled successfully.',
                 'deployment_uuid' => $deployment->deployment_uuid,
@@ -518,6 +526,14 @@ class DeployController extends Controller
                     $message = $result['message'];
                 } else {
                     $message = "Application {$resource->name} deployment queued.";
+                    auditLog('api.deployment.triggered', [
+                        'resource_type' => 'application',
+                        'application_uuid' => $resource->uuid,
+                        'application_name' => $resource->name,
+                        'deployment_uuid' => $deployment_uuid?->toString(),
+                        'force_rebuild' => $force,
+                        'pull_request_id' => $pr,
+                    ]);
                 }
                 break;
             case Service::class:
@@ -529,6 +545,10 @@ class DeployController extends Controller
                 }
                 StartService::run($resource);
                 $message = "Service {$resource->name} started. It could take a while, be patient.";
+                auditLog('api.service.deployed', [
+                    'service_uuid' => $resource->uuid,
+                    'service_name' => $resource->name,
+                ]);
                 break;
             default:
                 // Database resource - check authorization
@@ -543,6 +563,11 @@ class DeployController extends Controller
                 $resource->save();
 
                 $message = "Database {$resource->name} started.";
+                auditLog('api.database.started', [
+                    'database_uuid' => $resource->uuid,
+                    'database_name' => $resource->name,
+                    'database_type' => $resource->getMorphClass(),
+                ]);
                 break;
         }
 

--- a/app/Http/Controllers/Api/GithubController.php
+++ b/app/Http/Controllers/Api/GithubController.php
@@ -271,6 +271,12 @@ class GithubController extends Controller
 
             $githubApp = GithubApp::create($payload);
 
+            auditLog('api.github_app.created', [
+                'team_id' => $teamId,
+                'github_app_uuid' => $githubApp->uuid,
+                'github_app_name' => $githubApp->name,
+            ]);
+
             return response()->json($githubApp, 201);
         } catch (\Throwable $e) {
             return handleError($e);
@@ -650,6 +656,13 @@ class GithubController extends Controller
             // Update the GitHub app
             $githubApp->update($payload);
 
+            auditLog('api.github_app.updated', [
+                'team_id' => $teamId,
+                'github_app_uuid' => $githubApp->uuid,
+                'github_app_name' => $githubApp->name,
+                'changed_fields' => array_values(array_diff($allowedFields, ['client_secret', 'webhook_secret', 'private_key_uuid'])),
+            ]);
+
             return response()->json([
                 'message' => 'GitHub app updated successfully',
                 'data' => $githubApp,
@@ -734,7 +747,15 @@ class GithubController extends Controller
                 ], 409);
             }
 
+            $deletedUuid = $githubApp->uuid;
+            $deletedName = $githubApp->name;
             $githubApp->delete();
+
+            auditLog('api.github_app.deleted', [
+                'team_id' => $teamId,
+                'github_app_uuid' => $deletedUuid,
+                'github_app_name' => $deletedName,
+            ]);
 
             return response()->json([
                 'message' => 'GitHub app deleted successfully',

--- a/app/Http/Controllers/Api/HetznerController.php
+++ b/app/Http/Controllers/Api/HetznerController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Actions\Server\ValidateServer;
 use App\Enums\ProxyTypes;
 use App\Exceptions\RateLimitException;
 use App\Http\Controllers\Controller;
@@ -12,6 +13,7 @@ use App\Models\Team;
 use App\Rules\ValidCloudInitYaml;
 use App\Rules\ValidHostname;
 use App\Services\HetznerService;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use OpenApi\Attributes as OA;
 
@@ -550,7 +552,7 @@ class HetznerController extends Controller
         }
 
         $return = validateIncomingRequest($request);
-        if ($return instanceof \Illuminate\Http\JsonResponse) {
+        if ($return instanceof JsonResponse) {
             return $return;
         }
 
@@ -717,8 +719,16 @@ class HetznerController extends Controller
 
             // Validate server if requested
             if ($request->instant_validate) {
-                \App\Actions\Server\ValidateServer::dispatch($server);
+                ValidateServer::dispatch($server);
             }
+
+            auditLog('api.hetzner_server.created', [
+                'team_id' => $teamId,
+                'server_uuid' => $server->uuid,
+                'server_name' => $server->name,
+                'hetzner_server_id' => $hetznerServer['id'],
+                'ip' => $ipAddress,
+            ]);
 
             return response()->json([
                 'uuid' => $server->uuid,

--- a/app/Http/Controllers/Api/OtherController.php
+++ b/app/Http/Controllers/Api/OtherController.php
@@ -85,10 +85,14 @@ class OtherController extends Controller
             return invalidTokenResponse();
         }
         if ($teamId !== '0') {
+            auditLog('api.instance.enable_denied', ['team_id' => $teamId], 'warning');
+
             return response()->json(['message' => 'You are not allowed to enable the API.'], 403);
         }
         $settings = instanceSettings();
         $settings->update(['is_api_enabled' => true]);
+
+        auditLog('api.instance.enabled', ['team_id' => $teamId]);
 
         return response()->json(['message' => 'API enabled.'], 200);
     }
@@ -137,10 +141,14 @@ class OtherController extends Controller
             return invalidTokenResponse();
         }
         if ($teamId !== '0') {
+            auditLog('api.instance.disable_denied', ['team_id' => $teamId], 'warning');
+
             return response()->json(['message' => 'You are not allowed to disable the API.'], 403);
         }
         $settings = instanceSettings();
         $settings->update(['is_api_enabled' => false]);
+
+        auditLog('api.instance.disabled', ['team_id' => $teamId]);
 
         return response()->json(['message' => 'API disabled.'], 200);
     }

--- a/app/Http/Controllers/Api/ProjectController.php
+++ b/app/Http/Controllers/Api/ProjectController.php
@@ -264,6 +264,12 @@ class ProjectController extends Controller
             'team_id' => $teamId,
         ]);
 
+        auditLog('api.project.created', [
+            'team_id' => $teamId,
+            'project_uuid' => $project->uuid,
+            'project_name' => $project->name,
+        ]);
+
         return response()->json([
             'uuid' => $project->uuid,
         ])->setStatusCode(201);
@@ -382,6 +388,13 @@ class ProjectController extends Controller
 
         $project->update($request->only($allowedFields));
 
+        auditLog('api.project.updated', [
+            'team_id' => $teamId,
+            'project_uuid' => $project->uuid,
+            'project_name' => $project->name,
+            'changed_fields' => array_values(array_intersect($allowedFields, array_keys($request->all()))),
+        ]);
+
         return response()->json([
             'uuid' => $project->uuid,
             'name' => $project->name,
@@ -460,7 +473,15 @@ class ProjectController extends Controller
             return response()->json(['message' => 'Project has resources, so it cannot be deleted.'], 400);
         }
 
+        $projectUuid = $project->uuid;
+        $projectName = $project->name;
         $project->delete();
+
+        auditLog('api.project.deleted', [
+            'team_id' => $teamId,
+            'project_uuid' => $projectUuid,
+            'project_name' => $projectName,
+        ]);
 
         return response()->json(['message' => 'Project deleted.']);
     }
@@ -641,6 +662,13 @@ class ProjectController extends Controller
             'name' => $request->name,
         ]);
 
+        auditLog('api.project.environment_created', [
+            'team_id' => $teamId,
+            'project_uuid' => $project->uuid,
+            'environment_uuid' => $environment->uuid,
+            'environment_name' => $environment->name,
+        ]);
+
         return response()->json([
             'uuid' => $environment->uuid,
         ])->setStatusCode(201);
@@ -723,7 +751,16 @@ class ProjectController extends Controller
             return response()->json(['message' => 'Environment has resources, so it cannot be deleted.'], 400);
         }
 
+        $envUuid = $environment->uuid;
+        $envName = $environment->name;
         $environment->delete();
+
+        auditLog('api.project.environment_deleted', [
+            'team_id' => $teamId,
+            'project_uuid' => $project->uuid,
+            'environment_uuid' => $envUuid,
+            'environment_name' => $envName,
+        ]);
 
         return response()->json(['message' => 'Environment deleted.']);
     }

--- a/app/Http/Controllers/Api/ScheduledTasksController.php
+++ b/app/Http/Controllers/Api/ScheduledTasksController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Application;
 use App\Models\ScheduledTask;
 use App\Models\Service;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use OpenApi\Attributes as OA;
 
@@ -33,7 +34,7 @@ class ScheduledTasksController extends Controller
         return Service::whereRelation('environment.project.team', 'id', $teamId)->where('uuid', $request->uuid)->first();
     }
 
-    private function listTasks(Application|Service $resource): \Illuminate\Http\JsonResponse
+    private function listTasks(Application|Service $resource): JsonResponse
     {
         $this->authorize('view', $resource);
 
@@ -44,12 +45,12 @@ class ScheduledTasksController extends Controller
         return response()->json($tasks);
     }
 
-    private function createTask(Request $request, Application|Service $resource): \Illuminate\Http\JsonResponse
+    private function createTask(Request $request, Application|Service $resource): JsonResponse
     {
         $this->authorize('update', $resource);
 
         $return = validateIncomingRequest($request);
-        if ($return instanceof \Illuminate\Http\JsonResponse) {
+        if ($return instanceof JsonResponse) {
             return $return;
         }
 
@@ -105,15 +106,23 @@ class ScheduledTasksController extends Controller
 
         $task->save();
 
+        auditLog('api.scheduled_task.created', [
+            'team_id' => $teamId,
+            'task_uuid' => $task->uuid,
+            'task_name' => $task->name,
+            'resource_type' => $resource instanceof Application ? 'application' : 'service',
+            'resource_uuid' => $resource->uuid,
+        ]);
+
         return response()->json($this->removeSensitiveData($task), 201);
     }
 
-    private function updateTask(Request $request, Application|Service $resource): \Illuminate\Http\JsonResponse
+    private function updateTask(Request $request, Application|Service $resource): JsonResponse
     {
         $this->authorize('update', $resource);
 
         $return = validateIncomingRequest($request);
-        if ($return instanceof \Illuminate\Http\JsonResponse) {
+        if ($return instanceof JsonResponse) {
             return $return;
         }
 
@@ -161,22 +170,43 @@ class ScheduledTasksController extends Controller
 
         $task->update($request->only($allowedFields));
 
+        auditLog('api.scheduled_task.updated', [
+            'team_id' => getTeamIdFromToken(),
+            'task_uuid' => $task->uuid,
+            'task_name' => $task->name,
+            'resource_type' => $resource instanceof Application ? 'application' : 'service',
+            'resource_uuid' => $resource->uuid,
+            'changed_fields' => array_values(array_intersect($allowedFields, array_keys($request->all()))),
+        ]);
+
         return response()->json($this->removeSensitiveData($task), 200);
     }
 
-    private function deleteTask(Request $request, Application|Service $resource): \Illuminate\Http\JsonResponse
+    private function deleteTask(Request $request, Application|Service $resource): JsonResponse
     {
         $this->authorize('update', $resource);
 
-        $deleted = $resource->scheduled_tasks()->where('uuid', $request->task_uuid)->delete();
-        if (! $deleted) {
+        $task = $resource->scheduled_tasks()->where('uuid', $request->task_uuid)->first();
+        if (! $task) {
             return response()->json(['message' => 'Scheduled task not found.'], 404);
         }
+
+        $taskUuid = $task->uuid;
+        $taskName = $task->name;
+        $task->delete();
+
+        auditLog('api.scheduled_task.deleted', [
+            'team_id' => getTeamIdFromToken(),
+            'task_uuid' => $taskUuid,
+            'task_name' => $taskName,
+            'resource_type' => $resource instanceof Application ? 'application' : 'service',
+            'resource_uuid' => $resource->uuid,
+        ]);
 
         return response()->json(['message' => 'Scheduled task deleted.']);
     }
 
-    private function getExecutions(Request $request, Application|Service $resource): \Illuminate\Http\JsonResponse
+    private function getExecutions(Request $request, Application|Service $resource): JsonResponse
     {
         $this->authorize('view', $resource);
 
@@ -238,7 +268,7 @@ class ScheduledTasksController extends Controller
             ),
         ]
     )]
-    public function scheduled_tasks_by_application_uuid(Request $request): \Illuminate\Http\JsonResponse
+    public function scheduled_tasks_by_application_uuid(Request $request): JsonResponse
     {
         $teamId = getTeamIdFromToken();
         if (is_null($teamId)) {
@@ -317,7 +347,7 @@ class ScheduledTasksController extends Controller
             ),
         ]
     )]
-    public function create_scheduled_task_by_application_uuid(Request $request): \Illuminate\Http\JsonResponse
+    public function create_scheduled_task_by_application_uuid(Request $request): JsonResponse
     {
         $teamId = getTeamIdFromToken();
         if (is_null($teamId)) {
@@ -404,7 +434,7 @@ class ScheduledTasksController extends Controller
             ),
         ]
     )]
-    public function update_scheduled_task_by_application_uuid(Request $request): \Illuminate\Http\JsonResponse
+    public function update_scheduled_task_by_application_uuid(Request $request): JsonResponse
     {
         $teamId = getTeamIdFromToken();
         if (is_null($teamId)) {
@@ -474,7 +504,7 @@ class ScheduledTasksController extends Controller
             ),
         ]
     )]
-    public function delete_scheduled_task_by_application_uuid(Request $request): \Illuminate\Http\JsonResponse
+    public function delete_scheduled_task_by_application_uuid(Request $request): JsonResponse
     {
         $teamId = getTeamIdFromToken();
         if (is_null($teamId)) {
@@ -542,7 +572,7 @@ class ScheduledTasksController extends Controller
             ),
         ]
     )]
-    public function executions_by_application_uuid(Request $request): \Illuminate\Http\JsonResponse
+    public function executions_by_application_uuid(Request $request): JsonResponse
     {
         $teamId = getTeamIdFromToken();
         if (is_null($teamId)) {
@@ -601,7 +631,7 @@ class ScheduledTasksController extends Controller
             ),
         ]
     )]
-    public function scheduled_tasks_by_service_uuid(Request $request): \Illuminate\Http\JsonResponse
+    public function scheduled_tasks_by_service_uuid(Request $request): JsonResponse
     {
         $teamId = getTeamIdFromToken();
         if (is_null($teamId)) {
@@ -680,7 +710,7 @@ class ScheduledTasksController extends Controller
             ),
         ]
     )]
-    public function create_scheduled_task_by_service_uuid(Request $request): \Illuminate\Http\JsonResponse
+    public function create_scheduled_task_by_service_uuid(Request $request): JsonResponse
     {
         $teamId = getTeamIdFromToken();
         if (is_null($teamId)) {
@@ -767,7 +797,7 @@ class ScheduledTasksController extends Controller
             ),
         ]
     )]
-    public function update_scheduled_task_by_service_uuid(Request $request): \Illuminate\Http\JsonResponse
+    public function update_scheduled_task_by_service_uuid(Request $request): JsonResponse
     {
         $teamId = getTeamIdFromToken();
         if (is_null($teamId)) {
@@ -837,7 +867,7 @@ class ScheduledTasksController extends Controller
             ),
         ]
     )]
-    public function delete_scheduled_task_by_service_uuid(Request $request): \Illuminate\Http\JsonResponse
+    public function delete_scheduled_task_by_service_uuid(Request $request): JsonResponse
     {
         $teamId = getTeamIdFromToken();
         if (is_null($teamId)) {
@@ -905,7 +935,7 @@ class ScheduledTasksController extends Controller
             ),
         ]
     )]
-    public function executions_by_service_uuid(Request $request): \Illuminate\Http\JsonResponse
+    public function executions_by_service_uuid(Request $request): JsonResponse
     {
         $teamId = getTeamIdFromToken();
         if (is_null($teamId)) {

--- a/app/Http/Controllers/Api/SecurityController.php
+++ b/app/Http/Controllers/Api/SecurityController.php
@@ -232,6 +232,13 @@ class SecurityController extends Controller
             'private_key' => $request->private_key,
         ]);
 
+        auditLog('api.private_key.created', [
+            'team_id' => $teamId,
+            'private_key_uuid' => $key->uuid,
+            'private_key_name' => $key->name,
+            'fingerprint' => $fingerPrint,
+        ]);
+
         return response()->json(serializeApiResponse([
             'uuid' => $key->uuid,
         ]))->setStatusCode(201);
@@ -333,6 +340,13 @@ class SecurityController extends Controller
         }
         $foundKey->update($request->only($allowedFields));
 
+        auditLog('api.private_key.updated', [
+            'team_id' => $teamId,
+            'private_key_uuid' => $foundKey->uuid,
+            'private_key_name' => $foundKey->name,
+            'changed_fields' => array_values(array_intersect($allowedFields, array_keys($request->all()))),
+        ]);
+
         return response()->json(serializeApiResponse([
             'uuid' => $foundKey->uuid,
         ]))->setStatusCode(201);
@@ -415,7 +429,15 @@ class SecurityController extends Controller
             ], 422);
         }
 
+        $keyUuid = $key->uuid;
+        $keyName = $key->name;
         $key->forceDelete();
+
+        auditLog('api.private_key.deleted', [
+            'team_id' => $teamId,
+            'private_key_uuid' => $keyUuid,
+            'private_key_name' => $keyName,
+        ]);
 
         return response()->json([
             'message' => 'Private Key deleted.',

--- a/app/Http/Controllers/Api/ServersController.php
+++ b/app/Http/Controllers/Api/ServersController.php
@@ -13,6 +13,7 @@ use App\Models\PrivateKey;
 use App\Models\Project;
 use App\Models\Server as ModelsServer;
 use App\Rules\ValidServerIp;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use OpenApi\Attributes as OA;
 use Stringable;
@@ -477,7 +478,7 @@ class ServersController extends Controller
         }
 
         $return = validateIncomingRequest($request);
-        if ($return instanceof \Illuminate\Http\JsonResponse) {
+        if ($return instanceof JsonResponse) {
             return $return;
         }
         $validator = customApiValidator($request->all(), [
@@ -564,6 +565,14 @@ class ServersController extends Controller
             ValidateServer::dispatch($server);
         }
 
+        auditLog('api.server.created', [
+            'team_id' => $teamId,
+            'server_uuid' => $server->uuid,
+            'server_name' => $server->name,
+            'ip' => $server->ip,
+            'is_build_server' => (bool) $request->is_build_server,
+        ]);
+
         return response()->json([
             'uuid' => $server->uuid,
         ])->setStatusCode(201);
@@ -647,7 +656,7 @@ class ServersController extends Controller
         }
 
         $return = validateIncomingRequest($request);
-        if ($return instanceof \Illuminate\Http\JsonResponse) {
+        if ($return instanceof JsonResponse) {
             return $return;
         }
         $validator = customApiValidator($request->all(), [
@@ -717,6 +726,13 @@ class ServersController extends Controller
         if ($request->instant_validate) {
             ValidateServer::dispatch($server);
         }
+
+        auditLog('api.server.updated', [
+            'team_id' => $teamId,
+            'server_uuid' => $server->uuid,
+            'server_name' => $server->name,
+            'changed_fields' => array_values(array_intersect($allowedFields, array_keys($request->all()))),
+        ]);
 
         return response()->json([
             'uuid' => $server->uuid,
@@ -807,6 +823,9 @@ class ServersController extends Controller
             }
         }
 
+        $deletedUuid = $server->uuid;
+        $deletedName = $server->name;
+        $deletedIp = $server->ip;
         $server->delete();
         DeleteServer::dispatch(
             $server->id,
@@ -815,6 +834,14 @@ class ServersController extends Controller
             $server->cloud_provider_token_id,
             $server->team_id
         );
+
+        auditLog('api.server.deleted', [
+            'team_id' => $teamId,
+            'server_uuid' => $deletedUuid,
+            'server_name' => $deletedName,
+            'ip' => $deletedIp,
+            'force' => $force,
+        ]);
 
         return response()->json(['message' => 'Server deleted.']);
     }
@@ -880,6 +907,12 @@ class ServersController extends Controller
             return response()->json(['message' => 'Server not found.'], 404);
         }
         ValidateServer::dispatch($server);
+
+        auditLog('api.server.validated', [
+            'team_id' => $teamId,
+            'server_uuid' => $server->uuid,
+            'server_name' => $server->name,
+        ]);
 
         return response()->json(['message' => 'Validation started.'], 201);
     }

--- a/app/Http/Controllers/Api/ServicesController.php
+++ b/app/Http/Controllers/Api/ServicesController.php
@@ -486,6 +486,14 @@ class ServicesController extends Controller
                     StartService::dispatch($service);
                 }
 
+                auditLog('api.service.created', [
+                    'team_id' => $teamId,
+                    'service_uuid' => $service->uuid,
+                    'service_name' => $service->name,
+                    'service_type' => $oneClickServiceName ?? null,
+                    'instant_deploy' => (bool) $instantDeploy,
+                ]);
+
                 return response()->json([
                     'uuid' => $service->uuid,
                     'domains' => $service->applications()->pluck('fqdn')->filter()->sort()->values(),
@@ -650,6 +658,14 @@ class ServicesController extends Controller
                 StartService::dispatch($service);
             }
 
+            auditLog('api.service.created', [
+                'team_id' => $teamId,
+                'service_uuid' => $service->uuid,
+                'service_name' => $service->name,
+                'service_type' => 'docker_compose',
+                'instant_deploy' => (bool) $instantDeploy,
+            ]);
+
             return response()->json([
                 'uuid' => $service->uuid,
                 'domains' => $service->applications()->pluck('fqdn')->filter()->sort()->values(),
@@ -791,6 +807,12 @@ class ServicesController extends Controller
             deleteConfigurations: $request->boolean('delete_configurations', true),
             dockerCleanup: $request->boolean('docker_cleanup', true)
         );
+
+        auditLog('api.service.deleted', [
+            'team_id' => $teamId,
+            'service_uuid' => $service->uuid,
+            'service_name' => $service->name,
+        ]);
 
         return response()->json([
             'message' => 'Service deletion request queued.',
@@ -1046,6 +1068,13 @@ class ServicesController extends Controller
             StartService::dispatch($service);
         }
 
+        auditLog('api.service.updated', [
+            'team_id' => $teamId,
+            'service_uuid' => $service->uuid,
+            'service_name' => $service->name,
+            'changed_fields' => array_values(array_intersect($allowedFields, array_keys($request->all()))),
+        ]);
+
         return response()->json([
             'uuid' => $service->uuid,
             'domains' => $service->applications()->pluck('fqdn')->filter()->sort()->values(),
@@ -1255,6 +1284,13 @@ class ServicesController extends Controller
         }
         $env->save();
 
+        auditLog('api.service.env_updated', [
+            'team_id' => $teamId,
+            'service_uuid' => $service->uuid,
+            'env_uuid' => $env->uuid,
+            'env_key' => $env->key,
+        ]);
+
         return response()->json($this->removeSensitiveData($env))->setStatusCode(201);
     }
 
@@ -1384,6 +1420,12 @@ class ServicesController extends Controller
             $updatedEnvs->push($this->removeSensitiveData($env));
         }
 
+        auditLog('api.service.env_bulk_upserted', [
+            'team_id' => $teamId,
+            'service_uuid' => $service->uuid,
+            'env_count' => $updatedEnvs->count(),
+        ]);
+
         return response()->json($updatedEnvs)->setStatusCode(201);
     }
 
@@ -1506,6 +1548,13 @@ class ServicesController extends Controller
             'comment' => $request->comment ?? null,
         ]);
 
+        auditLog('api.service.env_created', [
+            'team_id' => $teamId,
+            'service_uuid' => $service->uuid,
+            'env_uuid' => $env->uuid,
+            'env_key' => $env->key,
+        ]);
+
         return response()->json($this->removeSensitiveData($env))->setStatusCode(201);
     }
 
@@ -1591,7 +1640,16 @@ class ServicesController extends Controller
             return response()->json(['message' => 'Environment variable not found.'], 404);
         }
 
+        $envKey = $env->key;
+        $envUuid = $env->uuid;
         $env->forceDelete();
+
+        auditLog('api.service.env_deleted', [
+            'team_id' => $teamId,
+            'service_uuid' => $service->uuid,
+            'env_uuid' => $envUuid,
+            'env_key' => $envKey,
+        ]);
 
         return response()->json(['message' => 'Environment variable deleted.']);
     }
@@ -1667,6 +1725,12 @@ class ServicesController extends Controller
             return response()->json(['message' => 'Service is already running.'], 400);
         }
         StartService::dispatch($service);
+
+        auditLog('api.service.deployed', [
+            'team_id' => $teamId,
+            'service_uuid' => $service->uuid,
+            'service_name' => $service->name,
+        ]);
 
         return response()->json(
             [
@@ -1759,6 +1823,13 @@ class ServicesController extends Controller
         $dockerCleanup = $request->boolean('docker_cleanup', true);
         StopService::dispatch($service, false, $dockerCleanup);
 
+        auditLog('api.service.stopped', [
+            'team_id' => $teamId,
+            'service_uuid' => $service->uuid,
+            'service_name' => $service->name,
+            'docker_cleanup' => $dockerCleanup,
+        ]);
+
         return response()->json(
             [
                 'message' => 'Service stopping request queued.',
@@ -1845,6 +1916,13 @@ class ServicesController extends Controller
 
         $pullLatest = $request->boolean('latest');
         RestartService::dispatch($service, $pullLatest);
+
+        auditLog('api.service.restarted', [
+            'team_id' => $teamId,
+            'service_uuid' => $service->uuid,
+            'service_name' => $service->name,
+            'pull_latest' => $pullLatest,
+        ]);
 
         return response()->json(
             [
@@ -2126,6 +2204,15 @@ class ServicesController extends Controller
             ]);
         }
 
+        auditLog('api.service.storage_created', [
+            'team_id' => $teamId,
+            'service_uuid' => $service->uuid,
+            'storage_uuid' => $storage->uuid ?? null,
+            'storage_id' => $storage->id,
+            'storage_type' => $request->type,
+            'mount_path' => $storage->mount_path,
+        ]);
+
         return response()->json($storage, 201);
     }
 
@@ -2354,6 +2441,15 @@ class ServicesController extends Controller
 
         $storage->save();
 
+        auditLog('api.service.storage_updated', [
+            'team_id' => $teamId,
+            'service_uuid' => $service->uuid,
+            'storage_uuid' => $storage->uuid ?? null,
+            'storage_id' => $storage->id,
+            'storage_type' => $request->type,
+            'mount_path' => $storage->mount_path ?? null,
+        ]);
+
         return response()->json($storage);
     }
 
@@ -2454,7 +2550,17 @@ class ServicesController extends Controller
             $storage->deleteStorageOnServer();
         }
 
+        $storageType = $storage instanceof LocalFileVolume ? 'file' : 'persistent';
+        $storageMountPath = $storage->mount_path ?? null;
         $storage->delete();
+
+        auditLog('api.service.storage_deleted', [
+            'team_id' => $teamId,
+            'service_uuid' => $service->uuid,
+            'storage_uuid' => $storageUuid,
+            'storage_type' => $storageType,
+            'mount_path' => $storageMountPath,
+        ]);
 
         return response()->json(['message' => 'Storage deleted.']);
     }

--- a/app/Http/Controllers/Webhook/Bitbucket.php
+++ b/app/Http/Controllers/Webhook/Bitbucket.php
@@ -58,6 +58,12 @@ class Bitbucket extends Controller
             foreach ($applications as $application) {
                 $webhook_secret = data_get($application, 'manual_webhook_secret_bitbucket');
                 if (empty($webhook_secret)) {
+                    auditLogWebhookFailure('bitbucket', 'webhook_secret_missing', [
+                        'application_uuid' => $application->uuid,
+                        'application_name' => $application->name,
+                        'repository' => $full_name ?? null,
+                        'event' => $x_bitbucket_event,
+                    ]);
                     $return_payloads->push([
                         'application' => $application->name,
                         'status' => 'failed',
@@ -70,6 +76,12 @@ class Bitbucket extends Controller
 
                 $parts = explode('=', $x_bitbucket_token, 2);
                 if (count($parts) !== 2 || $parts[0] !== 'sha256') {
+                    auditLogWebhookFailure('bitbucket', 'malformed_signature', [
+                        'application_uuid' => $application->uuid,
+                        'application_name' => $application->name,
+                        'repository' => $full_name ?? null,
+                        'event' => $x_bitbucket_event,
+                    ]);
                     $return_payloads->push([
                         'application' => $application->name,
                         'status' => 'failed',
@@ -81,6 +93,12 @@ class Bitbucket extends Controller
                 $hash = $parts[1];
                 $payloadHash = hash_hmac('sha256', $payload, $webhook_secret);
                 if (! hash_equals($hash, $payloadHash) && ! isDev()) {
+                    auditLogWebhookFailure('bitbucket', 'invalid_signature', [
+                        'application_uuid' => $application->uuid,
+                        'application_name' => $application->name,
+                        'repository' => $full_name ?? null,
+                        'event' => $x_bitbucket_event,
+                    ]);
                     $return_payloads->push([
                         'application' => $application->name,
                         'status' => 'failed',
@@ -118,6 +136,15 @@ class Bitbucket extends Controller
                                 'message' => $result['message'],
                             ]);
                         } else {
+                            auditLog('webhook.deployment.queued', [
+                                'provider' => 'bitbucket',
+                                'mode' => 'manual',
+                                'application_uuid' => $application->uuid,
+                                'application_name' => $application->name,
+                                'deployment_uuid' => $deployment_uuid->toString(),
+                                'commit' => $commit,
+                                'repository' => $full_name ?? null,
+                            ]);
                             $return_payloads->push([
                                 'application' => $application->name,
                                 'status' => 'success',

--- a/app/Http/Controllers/Webhook/Gitea.php
+++ b/app/Http/Controllers/Webhook/Gitea.php
@@ -68,6 +68,12 @@ class Gitea extends Controller
             foreach ($applications as $application) {
                 $webhook_secret = data_get($application, 'manual_webhook_secret_gitea');
                 if (empty($webhook_secret)) {
+                    auditLogWebhookFailure('gitea', 'webhook_secret_missing', [
+                        'application_uuid' => $application->uuid,
+                        'application_name' => $application->name,
+                        'repository' => $full_name ?? null,
+                        'event' => $x_gitea_event,
+                    ]);
                     $return_payloads->push([
                         'application' => $application->name,
                         'status' => 'failed',
@@ -78,6 +84,12 @@ class Gitea extends Controller
                 }
                 $hmac = hash_hmac('sha256', $request->getContent(), $webhook_secret);
                 if (! hash_equals($x_hub_signature_256, $hmac) && ! isDev()) {
+                    auditLogWebhookFailure('gitea', 'invalid_signature', [
+                        'application_uuid' => $application->uuid,
+                        'application_name' => $application->name,
+                        'repository' => $full_name ?? null,
+                        'event' => $x_gitea_event,
+                    ]);
                     $return_payloads->push([
                         'application' => $application->name,
                         'status' => 'failed',
@@ -117,6 +129,15 @@ class Gitea extends Controller
                                     'message' => $result['message'],
                                 ]);
                             } else {
+                                auditLog('webhook.deployment.queued', [
+                                    'provider' => 'gitea',
+                                    'mode' => 'manual',
+                                    'application_uuid' => $application->uuid,
+                                    'application_name' => $application->name,
+                                    'deployment_uuid' => $deployment_uuid->toString(),
+                                    'commit' => data_get($payload, 'after'),
+                                    'repository' => $full_name ?? null,
+                                ]);
                                 $return_payloads->push([
                                     'status' => 'success',
                                     'message' => 'Deployment queued.',

--- a/app/Http/Controllers/Webhook/Github.php
+++ b/app/Http/Controllers/Webhook/Github.php
@@ -82,6 +82,12 @@ class Github extends Controller
                 foreach ($serverApplications as $application) {
                     $webhook_secret = data_get($application, 'manual_webhook_secret_github');
                     if (empty($webhook_secret)) {
+                        auditLogWebhookFailure('github', 'webhook_secret_missing', [
+                            'application_uuid' => $application->uuid,
+                            'application_name' => $application->name,
+                            'repository' => $full_name ?? null,
+                            'mode' => 'manual',
+                        ]);
                         $return_payloads->push([
                             'application' => $application->name,
                             'status' => 'failed',
@@ -92,6 +98,12 @@ class Github extends Controller
                     }
                     $hmac = hash_hmac('sha256', $request->getContent(), $webhook_secret);
                     if (! hash_equals($x_hub_signature_256, $hmac) && ! isDev()) {
+                        auditLogWebhookFailure('github', 'invalid_signature', [
+                            'application_uuid' => $application->uuid,
+                            'application_name' => $application->name,
+                            'repository' => $full_name ?? null,
+                            'mode' => 'manual',
+                        ]);
                         $return_payloads->push([
                             'application' => $application->name,
                             'status' => 'failed',
@@ -131,6 +143,15 @@ class Github extends Controller
                                         'message' => $result['message'],
                                     ]);
                                 } else {
+                                    auditLog('webhook.deployment.queued', [
+                                        'provider' => 'github',
+                                        'mode' => 'manual',
+                                        'application_uuid' => $application->uuid,
+                                        'application_name' => $application->name,
+                                        'deployment_uuid' => $result['deployment_uuid'],
+                                        'commit' => data_get($payload, 'after'),
+                                        'repository' => $full_name ?? null,
+                                    ]);
                                     $return_payloads->push([
                                         'application' => $application->name,
                                         'status' => 'success',
@@ -224,6 +245,13 @@ class Github extends Controller
             $hmac = hash_hmac('sha256', $request->getContent(), $webhook_secret);
             if (config('app.env') !== 'local') {
                 if (! hash_equals($x_hub_signature_256, $hmac)) {
+                    auditLogWebhookFailure('github', 'invalid_signature', [
+                        'mode' => 'app',
+                        'github_app_id' => $github_app->id,
+                        'github_app_name' => $github_app->name,
+                        'installation_target_id' => $x_github_hook_installation_target_id,
+                    ]);
+
                     return response('Invalid signature.');
                 }
             }
@@ -310,6 +338,17 @@ class Github extends Controller
                                 );
                                 if ($result['status'] === 'queue_full') {
                                     return response($result['message'], 429)->header('Retry-After', 60);
+                                }
+                                if ($result['status'] !== 'skipped' && ! empty($result['deployment_uuid'])) {
+                                    auditLog('webhook.deployment.queued', [
+                                        'provider' => 'github',
+                                        'mode' => 'app',
+                                        'application_uuid' => $application->uuid,
+                                        'application_name' => $application->name,
+                                        'deployment_uuid' => $result['deployment_uuid'],
+                                        'commit' => data_get($payload, 'after'),
+                                        'github_app_id' => $github_app->id,
+                                    ]);
                                 }
                                 $return_payloads->push([
                                     'status' => $result['status'],

--- a/app/Http/Controllers/Webhook/Gitlab.php
+++ b/app/Http/Controllers/Webhook/Gitlab.php
@@ -32,6 +32,9 @@ class Gitlab extends Controller
             }
 
             if (empty($x_gitlab_token)) {
+                auditLogWebhookFailure('gitlab', 'webhook_token_missing', [
+                    'event' => $x_gitlab_event,
+                ]);
                 $return_payloads->push([
                     'status' => 'failed',
                     'message' => 'Invalid signature.',
@@ -101,6 +104,12 @@ class Gitlab extends Controller
             foreach ($applications as $application) {
                 $webhook_secret = data_get($application, 'manual_webhook_secret_gitlab');
                 if (empty($webhook_secret)) {
+                    auditLogWebhookFailure('gitlab', 'webhook_secret_missing', [
+                        'application_uuid' => $application->uuid,
+                        'application_name' => $application->name,
+                        'repository' => $full_name ?? null,
+                        'event' => $x_gitlab_event,
+                    ]);
                     $return_payloads->push([
                         'application' => $application->name,
                         'status' => 'failed',
@@ -110,6 +119,12 @@ class Gitlab extends Controller
                     continue;
                 }
                 if (! hash_equals($webhook_secret, $x_gitlab_token ?? '')) {
+                    auditLogWebhookFailure('gitlab', 'invalid_signature', [
+                        'application_uuid' => $application->uuid,
+                        'application_name' => $application->name,
+                        'repository' => $full_name ?? null,
+                        'event' => $x_gitlab_event,
+                    ]);
                     $return_payloads->push([
                         'application' => $application->name,
                         'status' => 'failed',
@@ -150,6 +165,15 @@ class Gitlab extends Controller
                                     'application_name' => $application->name,
                                 ]);
                             } else {
+                                auditLog('webhook.deployment.queued', [
+                                    'provider' => 'gitlab',
+                                    'mode' => 'manual',
+                                    'application_uuid' => $application->uuid,
+                                    'application_name' => $application->name,
+                                    'deployment_uuid' => $deployment_uuid->toString(),
+                                    'commit' => data_get($payload, 'after'),
+                                    'repository' => $full_name ?? null,
+                                ]);
                                 $return_payloads->push([
                                     'status' => 'success',
                                     'message' => 'Deployment queued.',

--- a/app/Http/Controllers/Webhook/Stripe.php
+++ b/app/Http/Controllers/Webhook/Stripe.php
@@ -6,6 +6,8 @@ use App\Http\Controllers\Controller;
 use App\Jobs\StripeProcessJob;
 use Exception;
 use Illuminate\Http\Request;
+use Stripe\Exception\SignatureVerificationException;
+use Stripe\Webhook;
 
 class Stripe extends Controller
 {
@@ -14,7 +16,7 @@ class Stripe extends Controller
         try {
             $webhookSecret = config('subscription.stripe_webhook_secret');
             $signature = $request->header('Stripe-Signature');
-            $event = \Stripe\Webhook::constructEvent(
+            $event = Webhook::constructEvent(
                 $request->getContent(),
                 $signature,
                 $webhookSecret
@@ -22,6 +24,12 @@ class Stripe extends Controller
             StripeProcessJob::dispatch($event);
 
             return response('Webhook received. Cool cool cool cool cool.', 200);
+        } catch (SignatureVerificationException $e) {
+            auditLogWebhookFailure('stripe', 'invalid_signature', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return response($e->getMessage(), 400);
         } catch (Exception $e) {
             return response($e->getMessage(), 400);
         }

--- a/app/Http/Middleware/ApiAbility.php
+++ b/app/Http/Middleware/ApiAbility.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use Illuminate\Auth\AuthenticationException;
 use Laravel\Sanctum\Http\Middleware\CheckForAnyAbility;
 
 class ApiAbility extends CheckForAnyAbility
@@ -14,11 +15,22 @@ class ApiAbility extends CheckForAnyAbility
             }
 
             return parent::handle($request, $next, ...$abilities);
-        } catch (\Illuminate\Auth\AuthenticationException $e) {
+        } catch (AuthenticationException $e) {
+            auditLog('api.auth.unauthenticated', [
+                'reason' => $e->getMessage(),
+                'required_abilities' => $abilities,
+            ], 'warning');
+
             return response()->json([
                 'message' => 'Unauthenticated.',
             ], 401);
         } catch (\Exception $e) {
+            auditLog('api.auth.ability_denied', [
+                'required_abilities' => $abilities,
+                'token_id' => $request->user()?->currentAccessToken()?->id,
+                'reason' => $e->getMessage(),
+            ], 'warning');
+
             return response()->json([
                 'message' => 'Missing required permissions: '.implode(', ', $abilities),
             ], 403);

--- a/bootstrap/helpers/audit.php
+++ b/bootstrap/helpers/audit.php
@@ -1,0 +1,81 @@
+<?php
+
+use Illuminate\Support\Facades\Log;
+
+if (! function_exists('auditLog')) {
+    /**
+     * Write a security-relevant audit entry to the dedicated `audit` log channel.
+     *
+     * Never include secrets (private keys, passwords, tokens, webhook secrets,
+     * signature header values, env-var values) in $context.
+     *
+     * @param  string  $event  Dot-namespaced event name, e.g. `api.private_key.created`.
+     * @param  array<string, mixed>  $context  Identifiers + outcome details.
+     * @param  string  $level  Log level: info | warning | error.
+     */
+    function auditLog(string $event, array $context = [], string $level = 'info'): void
+    {
+        try {
+            $request = app()->bound('request') ? request() : null;
+            $user = auth()->check() ? auth()->user() : null;
+            $token = $user?->currentAccessToken();
+
+            $base = [
+                'event' => $event,
+                'ip' => $request?->ip(),
+                'ua' => substr((string) $request?->userAgent(), 0, 200),
+                'user_id' => $user?->id,
+                'user_email' => $user?->email,
+                'team_id' => $token ? data_get($token, 'team_id') : null,
+                'token_id' => $token?->id ?? null,
+                'token_name' => $token?->name ?? null,
+                'method' => $request?->method(),
+                'path' => $request?->path(),
+            ];
+
+            $payload = array_merge($base, $context);
+
+            Log::channel('audit')->{$level}($event, $payload);
+        } catch (Throwable $e) {
+            // Audit logging must never break the request path.
+            try {
+                Log::warning('auditLog failed: '.$e->getMessage(), ['event' => $event]);
+            } catch (Throwable) {
+            }
+        }
+    }
+}
+
+if (! function_exists('auditLogWebhookFailure')) {
+    /**
+     * Record a webhook signature/auth verification failure to the `audit` channel.
+     */
+    function auditLogWebhookFailure(string $provider, string $reason, array $context = []): void
+    {
+        try {
+            $request = app()->bound('request') ? request() : null;
+
+            $event = "webhook.{$provider}.signature_failed";
+
+            $base = [
+                'event' => $event,
+                'reason' => $reason,
+                'ip' => $request?->ip(),
+                'ua' => substr((string) $request?->userAgent(), 0, 200),
+                'method' => $request?->method(),
+                'path' => $request?->path(),
+                'event_header' => $request?->header('X-GitHub-Event')
+                    ?? $request?->header('X-Gitlab-Event')
+                    ?? $request?->header('X-Gitea-Event')
+                    ?? $request?->header('X-Event-Key'),
+            ];
+
+            Log::channel('audit')->warning($event, array_merge($base, $context));
+        } catch (Throwable $e) {
+            try {
+                Log::warning('auditLogWebhookFailure failed: '.$e->getMessage(), ['provider' => $provider]);
+            } catch (Throwable) {
+            }
+        }
+    }
+}

--- a/config/logging.php
+++ b/config/logging.php
@@ -132,6 +132,14 @@ return [
             'level' => 'warning',
             'days' => 14,
         ],
+
+        'audit' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/audit.log'),
+            'level' => env('LOG_AUDIT_LEVEL', 'info'),
+            'days' => env('LOG_AUDIT_DAYS', 90),
+            'replace_placeholders' => true,
+        ],
     ],
 
 ];

--- a/openapi.json
+++ b/openapi.json
@@ -4381,8 +4381,8 @@
                                         "description": "Number of days to retain backups locally"
                                     },
                                     "database_backup_retention_max_storage_locally": {
-                                        "type": "integer",
-                                        "description": "Max storage (MB) for local backups"
+                                        "type": "number",
+                                        "description": "Max storage (GB) for local backups"
                                     },
                                     "database_backup_retention_amount_s3": {
                                         "type": "integer",
@@ -4393,8 +4393,8 @@
                                         "description": "Number of days to retain backups in S3"
                                     },
                                     "database_backup_retention_max_storage_s3": {
-                                        "type": "integer",
-                                        "description": "Max storage (MB) for S3 backups"
+                                        "type": "number",
+                                        "description": "Max storage (GB) for S3 backups"
                                     },
                                     "timeout": {
                                         "type": "integer",
@@ -4951,7 +4951,7 @@
                                         "description": "Retention days of the backup locally"
                                     },
                                     "database_backup_retention_max_storage_locally": {
-                                        "type": "integer",
+                                        "type": "number",
                                         "description": "Max storage of the backup locally"
                                     },
                                     "database_backup_retention_amount_s3": {
@@ -4963,7 +4963,7 @@
                                         "description": "Retention days of the backup in s3"
                                     },
                                     "database_backup_retention_max_storage_s3": {
-                                        "type": "integer",
+                                        "type": "number",
                                         "description": "Max storage of the backup in S3"
                                     },
                                     "timeout": {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2765,8 +2765,8 @@ paths:
                   type: integer
                   description: 'Number of days to retain backups locally'
                 database_backup_retention_max_storage_locally:
-                  type: integer
-                  description: 'Max storage (MB) for local backups'
+                  type: number
+                  description: 'Max storage (GB) for local backups'
                 database_backup_retention_amount_s3:
                   type: integer
                   description: 'Number of backups to retain in S3'
@@ -2774,8 +2774,8 @@ paths:
                   type: integer
                   description: 'Number of days to retain backups in S3'
                 database_backup_retention_max_storage_s3:
-                  type: integer
-                  description: 'Max storage (MB) for S3 backups'
+                  type: number
+                  description: 'Max storage (GB) for S3 backups'
                 timeout:
                   type: integer
                   description: 'Backup job timeout in seconds (min: 60, max: 36000)'
@@ -3160,7 +3160,7 @@ paths:
                   type: integer
                   description: 'Retention days of the backup locally'
                 database_backup_retention_max_storage_locally:
-                  type: integer
+                  type: number
                   description: 'Max storage of the backup locally'
                 database_backup_retention_amount_s3:
                   type: integer
@@ -3169,7 +3169,7 @@ paths:
                   type: integer
                   description: 'Retention days of the backup in s3'
                 database_backup_retention_max_storage_s3:
-                  type: integer
+                  type: number
                   description: 'Max storage of the backup in S3'
                 timeout:
                   type: integer

--- a/routes/api.php
+++ b/routes/api.php
@@ -215,6 +215,8 @@ Route::group([
     Route::post('/sentinel/push', function () {
         $token = request()->header('Authorization');
         if (! $token) {
+            auditLogWebhookFailure('sentinel', 'token_missing');
+
             return response()->json(['message' => 'Unauthorized'], 401);
         }
         $naked_token = str_replace('Bearer ', '', $token);
@@ -222,32 +224,60 @@ Route::group([
             $decrypted = decrypt($naked_token);
             $decrypted_token = json_decode($decrypted, true);
         } catch (Exception $e) {
+            auditLogWebhookFailure('sentinel', 'decrypt_failed');
+
             return response()->json(['message' => 'Invalid token'], 401);
         }
         $server_uuid = data_get($decrypted_token, 'server_uuid');
         if (! $server_uuid) {
+            auditLogWebhookFailure('sentinel', 'invalid_token_payload');
+
             return response()->json(['message' => 'Invalid token'], 401);
         }
         $server = Server::where('uuid', $server_uuid)->first();
         if (! $server) {
+            auditLogWebhookFailure('sentinel', 'server_not_found', [
+                'server_uuid' => $server_uuid,
+            ]);
+
             return response()->json(['message' => 'Server not found'], 404);
         }
 
         if (isCloud() && data_get($server->team->subscription, 'stripe_invoice_paid', false) === false && $server->team->id !== 0) {
+            auditLogWebhookFailure('sentinel', 'subscription_unpaid', [
+                'server_uuid' => $server->uuid,
+                'team_id' => $server->team_id,
+            ]);
+
             return response()->json(['message' => 'Unauthorized'], 401);
         }
 
         if ($server->isFunctional() === false) {
+            auditLogWebhookFailure('sentinel', 'server_not_functional', [
+                'server_uuid' => $server->uuid,
+                'team_id' => $server->team_id,
+            ]);
+
             return response()->json(['message' => 'Server is not functional'], 401);
         }
 
         if ($server->settings->sentinel_token !== $naked_token) {
+            auditLogWebhookFailure('sentinel', 'token_mismatch', [
+                'server_uuid' => $server->uuid,
+                'team_id' => $server->team_id,
+            ]);
+
             return response()->json(['message' => 'Unauthorized'], 401);
         }
         $data = request()->all();
 
         // \App\Jobs\ServerCheckNewJob::dispatch($server, $data);
         PushServerUpdateJob::dispatch($server, $data);
+
+        auditLog('sentinel.metrics_pushed', [
+            'server_uuid' => $server->uuid,
+            'team_id' => $server->team_id,
+        ]);
 
         return response()->json(['message' => 'ok'], 200);
     });

--- a/tests/Feature/Security/AuditLogTest.php
+++ b/tests/Feature/Security/AuditLogTest.php
@@ -1,0 +1,445 @@
+<?php
+
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+uses(RefreshDatabase::class);
+
+function makeAuditTeamUser(): array
+{
+    $team = Team::factory()->create();
+    $user = User::factory()->create();
+    $team->members()->attach($user->id, ['role' => 'owner']);
+    session(['currentTeam' => $team]);
+    test()->actingAs($user);
+
+    return [$team, $user];
+}
+
+function makeAuditApiToken(User $user, Team $team, array $abilities = ['root']): string
+{
+    $token = $user->createToken('audit-test', $abilities);
+    DB::table('personal_access_tokens')->where('id', $token->accessToken->id)->update([
+        'team_id' => $team->id,
+    ]);
+
+    return $token->plainTextToken;
+}
+
+function makeAuditApplication(string $repo = 'test-org/test-repo'): Application
+{
+    $team = Team::factory()->create();
+    $project = Project::factory()->create(['team_id' => $team->id]);
+    $environment = Environment::factory()->create(['project_id' => $project->id]);
+    $server = Server::factory()->create(['team_id' => $team->id]);
+    $destination = $server->standaloneDockers()->firstOrFail();
+
+    return Application::create([
+        'name' => 'audit-test-app',
+        'git_repository' => "https://github.com/{$repo}",
+        'git_branch' => 'main',
+        'build_pack' => 'nixpacks',
+        'ports_exposes' => '3000',
+        'environment_id' => $environment->id,
+        'destination_id' => $destination->id,
+        'destination_type' => $destination->getMorphClass(),
+    ]);
+}
+
+describe('audit channel helper', function () {
+    test('auditLog writes structured payload to audit channel', function () {
+        $auditChannel = Mockery::mock();
+        $auditChannel->shouldReceive('info')
+            ->once()
+            ->with('test.event', Mockery::on(function ($context) {
+                return $context['event'] === 'test.event'
+                    && $context['custom_field'] === 'value'
+                    && array_key_exists('ip', $context)
+                    && array_key_exists('user_id', $context);
+            }));
+
+        Log::shouldReceive('channel')->with('audit')->andReturn($auditChannel);
+
+        auditLog('test.event', ['custom_field' => 'value']);
+    });
+
+    test('auditLog warning level routes correctly', function () {
+        $auditChannel = Mockery::mock();
+        $auditChannel->shouldReceive('warning')->once()->with('test.failed', Mockery::any());
+
+        Log::shouldReceive('channel')->with('audit')->andReturn($auditChannel);
+
+        auditLog('test.failed', [], 'warning');
+    });
+
+    test('auditLogWebhookFailure logs warning with provider tag', function () {
+        $auditChannel = Mockery::mock();
+        $auditChannel->shouldReceive('warning')
+            ->once()
+            ->with('webhook.github.signature_failed', Mockery::on(function ($context) {
+                return $context['reason'] === 'invalid_signature'
+                    && $context['event'] === 'webhook.github.signature_failed'
+                    && array_key_exists('ip', $context);
+            }));
+
+        Log::shouldReceive('channel')->with('audit')->andReturn($auditChannel);
+
+        auditLogWebhookFailure('github', 'invalid_signature', ['extra' => 'context']);
+    });
+
+    test('auditLog never includes raw secret keys in context', function () {
+        $captured = null;
+        $auditChannel = Mockery::mock();
+        $auditChannel->shouldReceive('info')
+            ->once()
+            ->with(Mockery::any(), Mockery::on(function ($context) use (&$captured) {
+                $captured = $context;
+
+                return true;
+            }));
+
+        Log::shouldReceive('channel')->with('audit')->andReturn($auditChannel);
+
+        auditLog('test.private_key.created', [
+            'team_id' => '1',
+            'private_key_uuid' => 'abc',
+            'fingerprint' => 'SHA256:xyz',
+        ]);
+
+        expect($captured)->toBeArray();
+        // Helper itself never injects secret-bearing keys.
+        $disallowed = ['private_key', 'password', 'token', 'webhook_secret', 'signature', 'client_secret'];
+        foreach (array_keys($captured) as $key) {
+            expect(in_array(strtolower($key), $disallowed, true))->toBeFalse();
+        }
+    });
+});
+
+describe('webhook signature failure logging', function () {
+    test('GitHub manual webhook with bad signature logs to audit channel', function () {
+        $app = makeAuditApplication();
+
+        $auditChannel = Mockery::mock();
+        $auditChannel->shouldReceive('warning')
+            ->atLeast()
+            ->once()
+            ->with('webhook.github.signature_failed', Mockery::any());
+
+        Log::shouldReceive('channel')->with('audit')->andReturn($auditChannel);
+        Log::shouldReceive('warning')->andReturnNull();
+        Log::shouldReceive('info')->andReturnNull();
+        Log::shouldReceive('error')->andReturnNull();
+
+        $payload = json_encode([
+            'ref' => 'refs/heads/main',
+            'repository' => ['full_name' => 'test-org/test-repo'],
+            'after' => 'abc123',
+            'commits' => [],
+        ]);
+
+        $response = $this->call('POST', '/webhooks/source/github/events/manual', [], [], [], [
+            'HTTP_X-GitHub-Event' => 'push',
+            'HTTP_X-Hub-Signature-256' => 'sha256=forgedhashvalue',
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+
+        $response->assertOk();
+        expect($response->getContent())->toContain('Invalid signature');
+    });
+
+    test('GitLab manual webhook with bad token logs to audit channel', function () {
+        $app = makeAuditApplication();
+
+        $auditChannel = Mockery::mock();
+        $auditChannel->shouldReceive('warning')
+            ->atLeast()
+            ->once()
+            ->with('webhook.gitlab.signature_failed', Mockery::any());
+
+        Log::shouldReceive('channel')->with('audit')->andReturn($auditChannel);
+        Log::shouldReceive('warning')->andReturnNull();
+        Log::shouldReceive('info')->andReturnNull();
+        Log::shouldReceive('error')->andReturnNull();
+
+        $response = $this->postJson('/webhooks/source/gitlab/events/manual', [
+            'object_kind' => 'push',
+            'ref' => 'refs/heads/main',
+            'project' => ['path_with_namespace' => 'test-org/test-repo'],
+            'after' => 'abc123',
+            'commits' => [],
+        ], [
+            'X-Gitlab-Token' => 'wrong-token',
+        ]);
+
+        $response->assertOk();
+        expect($response->getContent())->toContain('Invalid signature');
+    });
+
+    test('Bitbucket manual webhook with malformed signature logs to audit channel', function () {
+        $app = makeAuditApplication();
+
+        $auditChannel = Mockery::mock();
+        $auditChannel->shouldReceive('warning')
+            ->atLeast()
+            ->once()
+            ->with('webhook.bitbucket.signature_failed', Mockery::any());
+
+        Log::shouldReceive('channel')->with('audit')->andReturn($auditChannel);
+        Log::shouldReceive('warning')->andReturnNull();
+        Log::shouldReceive('info')->andReturnNull();
+        Log::shouldReceive('error')->andReturnNull();
+
+        $payload = json_encode([
+            'push' => ['changes' => [['new' => ['name' => 'main', 'target' => ['hash' => 'abc123']]]]],
+            'repository' => ['full_name' => 'test-org/test-repo'],
+        ]);
+
+        $response = $this->call('POST', '/webhooks/source/bitbucket/events/manual', [], [], [], [
+            'HTTP_X-Event-Key' => 'repo:push',
+            'HTTP_X-Hub-Signature' => 'sha1=anyvalue',
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+
+        $response->assertOk();
+        expect($response->getContent())->toContain('Invalid signature');
+    });
+
+    test('Gitea manual webhook with bad signature logs to audit channel', function () {
+        $app = makeAuditApplication();
+
+        $auditChannel = Mockery::mock();
+        $auditChannel->shouldReceive('warning')
+            ->atLeast()
+            ->once()
+            ->with('webhook.gitea.signature_failed', Mockery::any());
+
+        Log::shouldReceive('channel')->with('audit')->andReturn($auditChannel);
+        Log::shouldReceive('warning')->andReturnNull();
+        Log::shouldReceive('info')->andReturnNull();
+        Log::shouldReceive('error')->andReturnNull();
+
+        $payload = json_encode([
+            'ref' => 'refs/heads/main',
+            'repository' => ['full_name' => 'test-org/test-repo'],
+            'after' => 'abc123',
+            'commits' => [],
+        ]);
+
+        $response = $this->call('POST', '/webhooks/source/gitea/events/manual', [], [], [], [
+            'HTTP_X-Gitea-Event' => 'push',
+            'HTTP_X-Hub-Signature-256' => 'sha256=forgedhashvalue',
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+
+        $response->assertOk();
+        expect($response->getContent())->toContain('Invalid signature');
+    });
+});
+
+describe('API mutation audit logging', function () {
+    test('private key creation emits api.private_key.created audit event', function () {
+        [$team, $user] = makeAuditTeamUser();
+        $token = makeAuditApiToken($user, $team);
+
+        $auditChannel = Mockery::mock();
+        $auditChannel->shouldReceive('info')
+            ->atLeast()
+            ->once()
+            ->with('api.private_key.created', Mockery::on(function ($context) {
+                return $context['event'] === 'api.private_key.created'
+                    && ! array_key_exists('private_key', $context);
+            }));
+
+        Log::shouldReceive('channel')->with('audit')->andReturn($auditChannel);
+        Log::shouldReceive('warning')->andReturnNull();
+        Log::shouldReceive('info')->andReturnNull();
+        Log::shouldReceive('error')->andReturnNull();
+
+        // Generate a valid OpenSSH-format private key for the test.
+        $opensshKey = "-----BEGIN OPENSSH PRIVATE KEY-----\n".
+            base64_encode(str_repeat('a', 256)).
+            "\n-----END OPENSSH PRIVATE KEY-----";
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'Content-Type' => 'application/json',
+        ])->postJson('/api/v1/security/keys', [
+            'name' => 'test-key',
+            'description' => 'audit test',
+            'private_key' => $opensshKey,
+        ]);
+
+        // Either 201 or 422 acceptable depending on validation; the assertion above verifies log if 201.
+        expect($response->status())->toBeIn([201, 422]);
+    });
+
+    test('enable_api denial for non-root team emits warning audit event', function () {
+        [$team, $user] = makeAuditTeamUser();
+        $token = makeAuditApiToken($user, $team);
+
+        $auditChannel = Mockery::mock();
+        $auditChannel->shouldReceive('warning')
+            ->atLeast()
+            ->once()
+            ->with('api.instance.enable_denied', Mockery::any());
+
+        Log::shouldReceive('channel')->with('audit')->andReturn($auditChannel);
+        Log::shouldReceive('warning')->andReturnNull();
+        Log::shouldReceive('info')->andReturnNull();
+        Log::shouldReceive('error')->andReturnNull();
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson('/api/v1/enable');
+
+        $response->assertStatus(403);
+    });
+
+    test('project creation emits api.project.created audit event', function () {
+        [$team, $user] = makeAuditTeamUser();
+        $token = makeAuditApiToken($user, $team);
+
+        $auditChannel = Mockery::mock();
+        $auditChannel->shouldReceive('info')
+            ->atLeast()
+            ->once()
+            ->with('api.project.created', Mockery::on(function ($context) {
+                return $context['event'] === 'api.project.created'
+                    && ! empty($context['project_uuid'])
+                    && $context['project_name'] === 'audit-project';
+            }));
+
+        Log::shouldReceive('channel')->with('audit')->andReturn($auditChannel);
+        Log::shouldReceive('warning')->andReturnNull();
+        Log::shouldReceive('info')->andReturnNull();
+        Log::shouldReceive('error')->andReturnNull();
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'Content-Type' => 'application/json',
+        ])->postJson('/api/v1/projects', [
+            'name' => 'audit-project',
+            'description' => 'audit',
+        ]);
+
+        $response->assertStatus(201);
+    });
+});
+
+describe('threat-detection audit logging (Phase 2)', function () {
+    test('missing bearer token logs api.auth.unauthenticated', function () {
+        $auditChannel = Mockery::mock();
+        $auditChannel->shouldReceive('warning')
+            ->atLeast()
+            ->once()
+            ->with('api.auth.unauthenticated', Mockery::any());
+
+        Log::shouldReceive('channel')->with('audit')->andReturn($auditChannel);
+        Log::shouldReceive('warning')->andReturnNull();
+        Log::shouldReceive('info')->andReturnNull();
+        Log::shouldReceive('error')->andReturnNull();
+
+        $response = $this->getJson('/api/v1/projects');
+
+        $response->assertStatus(401);
+    });
+
+    test('expired bearer token logs api.auth.unauthenticated', function () {
+        [$team, $user] = makeAuditTeamUser();
+        $token = $user->createToken('expired-audit', ['read'], now()->subDay());
+        DB::table('personal_access_tokens')->where('id', $token->accessToken->id)->update([
+            'team_id' => $team->id,
+        ]);
+
+        $auditChannel = Mockery::mock();
+        $auditChannel->shouldReceive('warning')
+            ->atLeast()
+            ->once()
+            ->with('api.auth.unauthenticated', Mockery::any());
+
+        Log::shouldReceive('channel')->with('audit')->andReturn($auditChannel);
+        Log::shouldReceive('warning')->andReturnNull();
+        Log::shouldReceive('info')->andReturnNull();
+        Log::shouldReceive('error')->andReturnNull();
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token->plainTextToken,
+        ])->getJson('/api/v1/projects');
+
+        $response->assertStatus(401);
+    });
+
+    test('read-only token hitting write endpoint logs api.auth.ability_denied', function () {
+        [$team, $user] = makeAuditTeamUser();
+        $readToken = makeAuditApiToken($user, $team, ['read']);
+
+        $auditChannel = Mockery::mock();
+        $auditChannel->shouldReceive('warning')
+            ->atLeast()
+            ->once()
+            ->with('api.auth.ability_denied', Mockery::on(function ($ctx) {
+                return in_array('write', $ctx['required_abilities'] ?? [], true);
+            }));
+
+        Log::shouldReceive('channel')->with('audit')->andReturn($auditChannel);
+        Log::shouldReceive('warning')->andReturnNull();
+        Log::shouldReceive('info')->andReturnNull();
+        Log::shouldReceive('error')->andReturnNull();
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$readToken,
+            'Content-Type' => 'application/json',
+        ])->postJson('/api/v1/projects', [
+            'name' => 'should-fail',
+        ]);
+
+        $response->assertStatus(403);
+    });
+
+    test('sentinel push without Authorization logs token_missing', function () {
+        $auditChannel = Mockery::mock();
+        $auditChannel->shouldReceive('warning')
+            ->atLeast()
+            ->once()
+            ->with('webhook.sentinel.signature_failed', Mockery::on(function ($ctx) {
+                return $ctx['reason'] === 'token_missing';
+            }));
+
+        Log::shouldReceive('channel')->with('audit')->andReturn($auditChannel);
+        Log::shouldReceive('warning')->andReturnNull();
+        Log::shouldReceive('info')->andReturnNull();
+        Log::shouldReceive('error')->andReturnNull();
+
+        $response = $this->postJson('/api/v1/sentinel/push', []);
+
+        $response->assertStatus(401);
+    });
+
+    test('sentinel push with un-decryptable bearer logs decrypt_failed', function () {
+        $auditChannel = Mockery::mock();
+        $auditChannel->shouldReceive('warning')
+            ->atLeast()
+            ->once()
+            ->with('webhook.sentinel.signature_failed', Mockery::on(function ($ctx) {
+                return $ctx['reason'] === 'decrypt_failed';
+            }));
+
+        Log::shouldReceive('channel')->with('audit')->andReturn($auditChannel);
+        Log::shouldReceive('warning')->andReturnNull();
+        Log::shouldReceive('info')->andReturnNull();
+        Log::shouldReceive('error')->andReturnNull();
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer not-a-valid-encrypted-payload',
+        ])->postJson('/api/v1/sentinel/push', []);
+
+        $response->assertStatus(401);
+    });
+});


### PR DESCRIPTION
## Summary

- Adds a dedicated `audit` log channel (daily rotation, 90-day retention) plus an `auditLog` / `auditLogWebhookFailure` helper that records state-mutating API operations and webhook events as structured JSON.
- Instruments every API controller create / update / delete / deploy / start / stop / restart endpoint, plus webhook signature failures + deployment-queued events for GitHub, GitLab, Bitbucket, Gitea, Stripe and the Sentinel push endpoint.
- Captures Sanctum authentication failures, ability mismatches and policy denials at single chokepoints in `ApiAbility` middleware and the exception handler.

## Why

Operators currently have no greppable record of who triggered which API or webhook action, which makes incident investigation and ops forensics painful. A separate `audit` channel keeps these events out of the noisy app log and lets operators rotate / ship them independently. Verbosity is tunable via `LOG_AUDIT_LEVEL` (defaults to `info`) and retention via `LOG_AUDIT_DAYS` (defaults to 90).

The helper attaches request metadata automatically (ip, user agent, user/team/token ids, method, path) and never reads request bodies, so values like passwords, private keys or webhook secrets cannot leak into the log. Helper failures are swallowed — audit logging can never break the request path.

## Test plan

- [ ] `php artisan test --compact --filter=AuditLog` passes
- [ ] `tail -f storage/logs/audit-\$(date +%Y-%m-%d).log` shows entries while exercising:
  - [ ] API token CRUD and project / application / database / service create + delete
  - [ ] Application / service / database start / stop / restart
  - [ ] GitHub / GitLab / Bitbucket / Gitea webhook with bad signature → warning entry, deployment-queued info entry on valid hit
  - [ ] Stripe webhook with malformed `Stripe-Signature`
  - [ ] `POST /api/v1/sentinel/push` with no / bad / mismatched bearer token
  - [ ] `GET /api/v1/projects` with no bearer or expired bearer → `api.auth.unauthenticated`
  - [ ] `read`-scoped token hitting a write endpoint → `api.auth.ability_denied`
- [ ] Set `LOG_AUDIT_LEVEL=warning` and confirm only failure events are written