### PR TITLE
fix(deployments): use app git_commit_sha when commit not explicitly set

### DIFF
--- a/bootstrap/helpers/applications.php
+++ b/bootstrap/helpers/applications.php
@@ -12,8 +12,9 @@ use App\Models\StandaloneDocker;
 use Spatie\Url\Url;
 use Visus\Cuid2\Cuid2;
 
-function queue_application_deployment(Application $application, string $deployment_uuid, ?int $pull_request_id = 0, string $commit = 'HEAD', bool $force_rebuild = false, bool $is_webhook = false, bool $is_api = false, bool $restart_only = false, ?string $git_type = null, bool $no_questions_asked = false, ?Server $server = null, ?StandaloneDocker $destination = null, bool $only_this_server = false, bool $rollback = false, ?string $docker_registry_image_tag = null)
+function queue_application_deployment(Application $application, string $deployment_uuid, ?int $pull_request_id = 0, ?string $commit = null, bool $force_rebuild = false, bool $is_webhook = false, bool $is_api = false, bool $restart_only = false, ?string $git_type = null, bool $no_questions_asked = false, ?Server $server = null, ?StandaloneDocker $destination = null, bool $only_this_server = false, bool $rollback = false, ?string $docker_registry_image_tag = null)
 {
+    $commit = $commit ?: ($application->git_commit_sha ?: 'HEAD');
     $application_id = $application->id;
     $deployment_link = Url::fromString($application->link()."/deployment/{$deployment_uuid}");
     $deployment_url = $deployment_link->getPath();

--- a/tests/Feature/QueueApplicationDeploymentCommitTest.php
+++ b/tests/Feature/QueueApplicationDeploymentCommitTest.php
@@ -1,0 +1,107 @@
+<?php
+
+use App\Jobs\ApplicationDeploymentJob;
+use App\Models\Application;
+use App\Models\ApplicationDeploymentQueue;
+use App\Models\Environment;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Bus::fake([ApplicationDeploymentJob::class]);
+
+    $this->team = Team::factory()->create();
+    $this->server = Server::factory()->create(['team_id' => $this->team->id]);
+    $this->destination = StandaloneDocker::factory()->create([
+        'server_id' => $this->server->id,
+        'network' => 'test-network-'.fake()->unique()->word(),
+    ]);
+    $this->project = Project::factory()->create(['team_id' => $this->team->id]);
+    $this->environment = Environment::factory()->create(['project_id' => $this->project->id]);
+});
+
+function makeApplication(int $environmentId, int $destinationId, ?string $gitCommitSha): Application
+{
+    $attributes = [
+        'environment_id' => $environmentId,
+        'destination_id' => $destinationId,
+        'destination_type' => StandaloneDocker::class,
+    ];
+
+    if ($gitCommitSha !== null) {
+        $attributes['git_commit_sha'] = $gitCommitSha;
+    }
+
+    return Application::factory()->create($attributes);
+}
+
+describe('queue_application_deployment commit resolution', function () {
+    test('uses application git_commit_sha when commit parameter omitted', function () {
+        $pinnedSha = 'abc123def456abc123def456abc123def456abc1';
+        $application = makeApplication($this->environment->id, $this->destination->id, $pinnedSha);
+
+        $result = queue_application_deployment(
+            application: $application,
+            deployment_uuid: 'test-deploy-uuid-1',
+        );
+
+        expect($result['status'])->toBe('queued');
+
+        $deployment = ApplicationDeploymentQueue::where('deployment_uuid', 'test-deploy-uuid-1')->first();
+        expect($deployment)->not->toBeNull();
+        expect($deployment->commit)->toBe($pinnedSha);
+    });
+
+    test('falls back to HEAD when both commit parameter and git_commit_sha are unset', function () {
+        $application = makeApplication($this->environment->id, $this->destination->id, 'HEAD');
+
+        $result = queue_application_deployment(
+            application: $application,
+            deployment_uuid: 'test-deploy-uuid-2',
+        );
+
+        expect($result['status'])->toBe('queued');
+
+        $deployment = ApplicationDeploymentQueue::where('deployment_uuid', 'test-deploy-uuid-2')->first();
+        expect($deployment->commit)->toBe('HEAD');
+    });
+
+    test('explicit commit parameter overrides application git_commit_sha', function () {
+        $pinnedSha = 'abc123def456abc123def456abc123def456abc1';
+        $webhookSha = '111222333444555666777888999000aaabbbccc1';
+        $application = makeApplication($this->environment->id, $this->destination->id, $pinnedSha);
+
+        $result = queue_application_deployment(
+            application: $application,
+            deployment_uuid: 'test-deploy-uuid-3',
+            commit: $webhookSha,
+        );
+
+        expect($result['status'])->toBe('queued');
+
+        $deployment = ApplicationDeploymentQueue::where('deployment_uuid', 'test-deploy-uuid-3')->first();
+        expect($deployment->commit)->toBe($webhookSha);
+    });
+
+    test('treats empty string commit parameter as unset and uses git_commit_sha', function () {
+        $pinnedSha = 'abc123def456abc123def456abc123def456abc1';
+        $application = makeApplication($this->environment->id, $this->destination->id, $pinnedSha);
+
+        $result = queue_application_deployment(
+            application: $application,
+            deployment_uuid: 'test-deploy-uuid-4',
+            commit: '',
+        );
+
+        expect($result['status'])->toBe('queued');
+
+        $deployment = ApplicationDeploymentQueue::where('deployment_uuid', 'test-deploy-uuid-4')->first();
+        expect($deployment->commit)->toBe($pinnedSha);
+    });
+});


### PR DESCRIPTION
## Summary

- `queue_application_deployment` `$commit` param changed from `string = 'HEAD'` to `?string = null`
- On null/empty commit, resolves to `$application->git_commit_sha` first, then falls back to `'HEAD'`
- Fixes bug where Commit SHA field in Git Source settings was ignored — deploys always used HEAD
- Adds feature tests covering all four resolution cases: pinned SHA, HEAD fallback, explicit override, empty string

Closes #9204


---

Fixes #9204