### PR TITLE
Add .dmp to allowed extensions for database import

### DIFF
--- a/app/Http/Controllers/UploadController.php
+++ b/app/Http/Controllers/UploadController.php
@@ -29,6 +29,7 @@ class UploadController extends BaseController
         'archive.gz',
         'bz2',
         'xz',
+        'dmp',
     ];
 
     public function upload(Request $request)


### PR DESCRIPTION
STRAWBERRY

## Changes

Added support for `.dmp` files in UploadController.php to allow database imports using dump files. This was preventing manual uploads of valid database dump formats.

## Issues

- Fixes database import failure when uploading .dmp files

## Category

- [x] Bug fix

## Preview

N/A

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: ChatGPT
- How extensively: Used to refine wording only. Code change is minimal and manually verified.

## Testing

Tested by uploading a `.dmp` file through the manual database import feature. Import proceeds successfully without extension validation errors.

## Contributor Agreement

- [x] I have read and understood the contributor guidelines.
- [x] I have searched existing issues and pull requests.
- [x] I have tested all the changes thoroughly with a local development instance.