### PR TITLE
feat(horizon): suppress failed job entries for deployment/timeout errors on cloud

### DIFF
--- a/app/Providers/HorizonServiceProvider.php
+++ b/app/Providers/HorizonServiceProvider.php
@@ -3,9 +3,12 @@
 namespace App\Providers;
 
 use App\Contracts\CustomJobRepositoryInterface;
+use App\Exceptions\DeploymentException;
 use App\Models\ApplicationDeploymentQueue;
 use App\Models\User;
 use App\Repositories\CustomJobRepository;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Queue\TimeoutExceededException;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Laravel\Horizon\Contracts\JobRepository;
@@ -46,6 +49,26 @@ class HorizonServiceProvider extends HorizonApplicationServiceProvider
                 $deploymentQueue->update([
                     'horizon_job_id' => $id,
                 ]);
+            }
+        });
+
+        Event::listen(function (JobFailed $event) {
+            if (! isCloud()) {
+                return;
+            }
+
+            $exception = $event->exception;
+            if (! ($exception instanceof DeploymentException) && ! ($exception instanceof TimeoutExceededException)) {
+                return;
+            }
+
+            try {
+                $uuid = $event->job->uuid();
+                if ($uuid) {
+                    app(JobRepository::class)->deleteFailed($uuid);
+                }
+            } catch (\Throwable $e) {
+                // Best-effort scrub; never mask the original failure.
             }
         });
     }

--- a/tests/Feature/SuppressHorizonJobFailuresTest.php
+++ b/tests/Feature/SuppressHorizonJobFailuresTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use App\Exceptions\DeploymentException;
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Queue\TimeoutExceededException;
+use Laravel\Horizon\Contracts\JobRepository;
+use Mockery\MockInterface;
+
+function fakeJob(string $uuid): Job
+{
+    $job = Mockery::mock(Job::class)->shouldIgnoreMissing();
+    $job->shouldReceive('uuid')->andReturn($uuid);
+    $job->shouldReceive('getJobId')->andReturn($uuid);
+
+    return $job;
+}
+
+function fireJobFailed(Job $job, Throwable $exception): void
+{
+    event(new JobFailed('redis', $job, $exception));
+}
+
+beforeEach(function () {
+    config(['constants.coolify.self_hosted' => false]);
+});
+
+test('scrubs Horizon failed entry for DeploymentException on cloud', function () {
+    $uuid = 'uuid-deployment-1';
+
+    $this->mock(JobRepository::class, function (MockInterface $mock) use ($uuid) {
+        $mock->shouldReceive('deleteFailed')->once()->with($uuid);
+    });
+
+    fireJobFailed(fakeJob($uuid), new DeploymentException('build failed'));
+});
+
+test('scrubs Horizon failed entry for TimeoutExceededException on cloud', function () {
+    $uuid = 'uuid-timeout-1';
+
+    $this->mock(JobRepository::class, function (MockInterface $mock) use ($uuid) {
+        $mock->shouldReceive('deleteFailed')->once()->with($uuid);
+    });
+
+    fireJobFailed(fakeJob($uuid), new TimeoutExceededException('worker timeout'));
+});
+
+test('does not scrub generic exceptions on cloud', function () {
+    $this->mock(JobRepository::class, function (MockInterface $mock) {
+        $mock->shouldNotReceive('deleteFailed');
+    });
+
+    fireJobFailed(fakeJob('uuid-generic-1'), new RuntimeException('boom'));
+});
+
+test('does not scrub when self-hosted even for filtered exceptions', function () {
+    config(['constants.coolify.self_hosted' => true]);
+
+    $this->mock(JobRepository::class, function (MockInterface $mock) {
+        $mock->shouldNotReceive('deleteFailed');
+    });
+
+    fireJobFailed(fakeJob('uuid-deployment-2'), new DeploymentException('build failed'));
+    fireJobFailed(fakeJob('uuid-timeout-2'), new TimeoutExceededException('worker timeout'));
+});


### PR DESCRIPTION
## Summary

- Listens for `JobFailed` events in `HorizonServiceProvider` and deletes the failed entry from Horizon's job repository when the exception is `DeploymentException` or `TimeoutExceededException`
- Suppression is cloud-only (`isCloud()` guard); self-hosted instances retain existing behavior
- Deletion is best-effort — any error from `deleteFailed` is swallowed to avoid masking the original failure
- Adds feature tests covering all four cases: deployment exception on cloud, timeout exception on cloud, generic exception on cloud (no scrub), and filtered exceptions on self-hosted (no scrub)
