### PR TITLE
feat: add Docker Mailserver service template

### DIFF
--- a/svgs/docker-mailserver.svg
+++ b/svgs/docker-mailserver.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="14" fill="#1E293B"/>
+  <path d="M32 12L14 22v20l18 10 18-10V22L32 12z" stroke="#38BDF8" stroke-width="2" fill="#0F172A"/>
+  <rect x="22" y="26" width="20" height="14" rx="2" stroke="#38BDF8" stroke-width="1.5" fill="#1E293B"/>
+  <path d="M22 26l10 8 10-8" stroke="#38BDF8" stroke-width="1.5" fill="none"/>
+  <circle cx="46" cy="46" r="8" fill="#0F172A" stroke="#38BDF8" stroke-width="1.5"/>
+  <path d="M42 46h8M46 42v8" stroke="#38BDF8" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/templates/compose/docker-mailserver.yaml
+++ b/templates/compose/docker-mailserver.yaml
@@ -1,0 +1,52 @@
+# documentation: https://docker-mailserver.github.io/docker-mailserver/edge/
+# slogan: Production-ready, full-stack but simple mail server (SMTP, IMAP, LDAP, Antispam, Antivirus, etc.) running in a single Docker container.
+# category: email
+# tags: mail,smtp,imap,email,server,postfix,dovecot
+# logo: svgs/docker-mailserver.svg
+# port: 25
+
+services:
+  mailserver:
+    image: ghcr.io/docker-mailserver/docker-mailserver:latest
+    hostname: ${HOSTNAME:?Set your mail server FQDN, e.g. mail.example.com}
+    environment:
+      - SERVICE_URL_MAILSERVER_25
+      - TZ=${TZ:-Etc/UTC}
+      - SSL_TYPE=${SSL_TYPE:-letsencrypt}
+      - SSL_CERT_PATH=${SSL_CERT_PATH:-}
+      - SSL_KEY_PATH=${SSL_KEY_PATH:-}
+      - ENABLE_IMAP=${ENABLE_IMAP:-1}
+      - ENABLE_POP3=${ENABLE_POP3:-0}
+      - ENABLE_RSPAMD=${ENABLE_RSPAMD:-0}
+      - ENABLE_CLAMAV=${ENABLE_CLAMAV:-0}
+      - ENABLE_FAIL2BAN=${ENABLE_FAIL2BAN:-0}
+      - ENABLE_OPENDKIM=${ENABLE_OPENDKIM:-1}
+      - ENABLE_OPENDMARC=${ENABLE_OPENDMARC:-1}
+      - ENABLE_POLICYD_SPF=${ENABLE_POLICYD_SPF:-1}
+      - ENABLE_AMAVIS=${ENABLE_AMAVIS:-1}
+      - SPOOF_PROTECTION=${SPOOF_PROTECTION:-0}
+      - ENABLE_SRS=${ENABLE_SRS:-0}
+      - PERMIT_DOCKER=${PERMIT_DOCKER:-none}
+      - POSTMASTER_ADDRESS=${POSTMASTER_ADDRESS:-postmaster@${HOSTNAME}}
+      - POSTFIX_INET_PROTOCOLS=${POSTFIX_INET_PROTOCOLS:-ipv4}
+      - DOVECOT_INET_PROTOCOLS=${DOVECOT_INET_PROTOCOLS:-ipv4}
+      - MOVE_SPAM_TO_JUNK=${MOVE_SPAM_TO_JUNK:-1}
+      - LOG_LEVEL=${LOG_LEVEL:-info}
+    ports:
+      - "465:465"
+      - "587:587"
+      - "993:993"
+      - "110:110"
+      - "995:995"
+    volumes:
+      - mailserver-data:/var/mail/
+      - mailserver-state:/var/mail-state/
+      - mailserver-logs:/var/log/mail/
+      - mailserver-config:/tmp/docker-mailserver/
+      - /etc/localtime:/etc/localtime:ro
+    healthcheck:
+      test: "ss --listening --ipv4 --tcp | grep --silent ':smtp' || exit 1"
+      timeout: 3s
+      interval: 30s
+      retries: 3
+      start_period: 60s


### PR DESCRIPTION
## Summary

Adds a one-click service template for [Docker Mailserver](https://github.com/docker-mailserver/docker-mailserver) (18k+ ⭐), a production-ready full-stack mail server running in a single Docker container.

Closes #8266

## What this adds

- `templates/compose/docker-mailserver.yaml` — Service template with Coolify magic environment variables
- `svgs/docker-mailserver.svg` — Logo for the service

## Template details

- **Image**: `ghcr.io/docker-mailserver/docker-mailserver:latest`
- **Ports**: 25 (SMTP), 465 (SMTPS), 587 (Submission), 993 (IMAPS), 110 (POP3), 995 (POP3S)
- **Persistent volumes**: mail data, state, logs, config
- **Configurable via env vars**: SSL type, IMAP/POP3 toggle, Rspamd, ClamAV, Fail2Ban, DKIM, DMARC, SPF, Amavis, SRS, and more
- **Required env var**: `HOSTNAME` (FQDN of the mail server, e.g. `mail.example.com`)
- **Health check**: Checks SMTP port listening

## How to test

1. Deploy using "Docker Compose Empty" option in Coolify with this template's content
2. Set the `HOSTNAME` environment variable to your mail server FQDN (e.g. `mail.example.com`)
3. Configure DNS records (MX, A, PTR, SPF, DKIM, DMARC) for your domain
4. After deployment, add an email account: `docker exec -it <container> setup email add user@example.com`
5. Verify SMTP is listening on port 25 and IMAPS on port 993