### PR TITLE
feat: add WordPress + OpenLiteSpeed service template

### DIFF
--- a/svgs/wordpress-openlitespeed.svg
+++ b/svgs/wordpress-openlitespeed.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="14" fill="#1E293B"/>
+  <circle cx="32" cy="32" r="18" fill="#0F172A" stroke="#F97316" stroke-width="2"/>
+  <text x="32" y="38" text-anchor="middle" font-family="Arial,sans-serif" font-weight="bold" font-size="16" fill="#F97316">LS</text>
+  <path d="M14 20h8l-4 12z" fill="#38BDF8" opacity="0.6"/>
+  <path d="M42 20h8l-4 12z" fill="#38BDF8" opacity="0.6"/>
+</svg>

--- a/templates/compose/wordpress-openlitespeed.yaml
+++ b/templates/compose/wordpress-openlitespeed.yaml
@@ -1,0 +1,61 @@
+# documentation: https://openlitespeed.org/
+# slogan: High-performance WordPress hosting with OpenLiteSpeed web server, LSCache, and built-in ACME SSL.
+# category: cms
+# tags: wordpress,openlitespeed,litespeed,cms,php,mysql,mariadb
+# logo: svgs/wordpress-openlitespeed.svg
+# port: 80
+
+services:
+  litespeed:
+    image: litespeedtech/openlitespeed:${OLS_VERSION:-1.8.5}-${PHP_VERSION:-lsphp85}
+    environment:
+      - SERVICE_URL_LITESPEED
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MYSQL_DATABASE=${MYSQL_DATABASE:-wordpress}
+      - MYSQL_USER=$SERVICE_USER_MYSQL
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_MYSQL
+      - DOMAIN=${DOMAIN:-localhost}
+    volumes:
+      - litespeed-sites:/var/www/vhosts/
+      - litespeed-conf:/usr/local/lsws/conf
+      - litespeed-admin-conf:/usr/local/lsws/admin/conf
+      - litespeed-logs:/usr/local/lsws/logs/
+      - litespeed-acme:/root/.acme.sh/
+    depends_on:
+      mysql:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:80"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  mysql:
+    image: mariadb:11.4
+    environment:
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MYSQL_DATABASE=${MYSQL_DATABASE:-wordpress}
+      - MYSQL_USER=$SERVICE_USER_MYSQL
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_MYSQL
+    volumes:
+      - mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+      start_period: 60s
+
+  redis:
+    image: redis:7-alpine
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test:
+        - CMD
+        - redis-cli
+        - PING
+      interval: 5s
+      timeout: 10s
+      retries: 20


### PR DESCRIPTION
## Summary

Adds a one-click service template for WordPress + OpenLiteSpeed, providing high-performance WordPress hosting with built-in LSCache, ACME SSL, MariaDB, and Redis object cache.

Closes #8264

## What this adds

- `templates/compose/wordpress-openlitespeed.yaml` — Service template with Coolify magic environment variables
- `svgs/wordpress-openlitespeed.svg` — Logo for the service

## Template details

- **OpenLiteSpeed** (`litespeedtech/openlitespeed`): High-performance web server with built-in WordPress support and LSCache
- **MariaDB 11.4**: Database backend for WordPress
- **Redis 7**: Object cache backend for LSCache
- **Persistent volumes**: WordPress site files, OLS config, admin config, logs, ACME certs, MySQL data, Redis data
- **Health checks**: HTTP health check for OLS, `healthcheck.sh` for MariaDB, `redis-cli PING` for Redis

## How to test

1. Deploy using "Docker Compose Empty" option in Coolify with this template's content
2. Set the `DOMAIN` environment variable to your domain (e.g. `example.com`)
3. Access WordPress at the configured service URL
4. Access OpenLiteSpeed admin console on port 7080 (if needed, expose via compose override)
5. Verify WordPress installation page loads correctly
6. Verify MariaDB and Redis health checks pass

## Notes

- OpenLiteSpeed main repository has 1,432+ GitHub stars: https://github.com/litespeedtech/openlitespeed
- The `DOMAIN` variable is used by OLS for ACME SSL certificate generation
- Redis is included for LSCache object caching, which significantly improves WordPress performance