### PR TITLE
fix: enable Supabase MCP access for local and private networks

### DIFF
--- a/templates/compose/supabase.yaml
+++ b/templates/compose/supabase.yaml
@@ -426,32 +426,26 @@ services:
                     status_code: 403
                     message: "Access is forbidden."
 
-            ## MCP endpoint - local access
-            - name: mcp
-              _comment: 'MCP: /mcp -> http://supabase-studio:3000/api/mcp (local access)'
-              url: http://supabase-studio:3000/api/mcp
-              routes:
-                - name: mcp
-                  strip_path: true
-                  paths:
-                    - /mcp
-              plugins:
-                # Block access to /mcp by default
-                - name: request-termination
-                  config:
-                    status_code: 403
-                    message: "Access is forbidden."
-                # Enable local access (danger zone!)
-                # 1. Comment out the 'request-termination' section above
-                # 2. Uncomment the entire section below, including 'deny'
-                # 3. Add your local IPs to the 'allow' list
-                #- name: cors
-                #- name: ip-restriction
-                #  config:
-                #    allow:
-                #      - 127.0.0.1
-                #      - ::1
-                #    deny: []
+## MCP endpoint - local access only
+- name: mcp
+  _comment: 'MCP: /mcp -> http://supabase-studio:3000/api/mcp (local/trusted access)'
+  url: http://supabase-studio:3000/api/mcp
+  routes:
+  - name: mcp
+    strip_path: true
+    paths:
+    - /mcp
+  plugins:
+  - name: cors
+  - name: ip-restriction
+    config:
+      allow:
+      - 127.0.0.1
+      - ::1
+      - 172.16.0.0/12
+      - 192.168.0.0/16
+      - 10.0.0.0/8
+      deny: []
 
             ## Protected Dashboard - catch all remaining routes
             - name: dashboard


### PR DESCRIPTION
## Summary

Replaces the `request-termination` plugin on the MCP `/mcp` endpoint with `ip-restriction` + `cors`, enabling MCP access from local and private networks while still blocking public internet access.

Closes #7458

## Problem

The current Supabase template blocks all MCP access using `request-termination` (returns 403 to all requests). Users must manually:
1. Comment out the request-termination section
2. Uncomment the ip-restriction section
3. Add their local IPs

This is error-prone and the instructions are buried in YAML comments.

## Solution

Switch the default MCP plugin from `request-termination` to `ip-restriction` with sensible defaults:

- **Allowed**: `127.0.0.1`, `::1` (localhost), `172.16.0.0/12` (Docker networks), `192.168.0.0/16` and `10.0.0.0/8` (private networks)
- **CORS**: Enabled for proper MCP client integration

This covers the standard use cases:
- **Local network**: Works by default for LAN clients
- **Docker network**: Works for containers on the same Docker network
- **Wireguard**: Add your Wireguard tunnel IP range (e.g. `10.13.0.0/16`) to the `allow` list in the Kong config
- **Multiple Supabase instances**: Each instance's `/mcp` endpoint is accessible on its own domain via the Coolify proxy, so Traefik routing separates them naturally

## How to use MCP with Cursor/Claude Code/Windsurf

After deploying, configure your MCP client to connect to:
```
https://<your-supabase-domain>/mcp
```

For Wireguard access:
1. Connect to your Wireguard tunnel
2. Your Wireguard IP will be in a private range (e.g. `10.x.x.x`) which is already allowed
3. Point your MCP client to the Supabase instance URL + `/mcp`

For multiple Supabase instances on the same Coolify server:
- Each instance gets its own domain (e.g. `supabase1.example.com/mcp`, `supabase2.example.com/mcp`)
- Traefik handles the routing based on domain, so there are no port conflicts

## Testing

1. Deploy a Supabase service using this template
2. From a machine on the local/Docker network, run:
   ```bash
   curl -v https://<your-supabase-domain>/mcp
   ```
3. Should now return a valid MCP response instead of 403
4. From a public IP (not in allowed ranges), should return 403