### PR TITLE
fix(terminal): disambiguate container dropdowns when names collide across servers

### DIFF
--- a/app/Livewire/Project/Shared/ExecuteContainerCommand.php
+++ b/app/Livewire/Project/Shared/ExecuteContainerCommand.php
@@ -134,10 +134,11 @@ class ExecuteContainerCommand extends Component
         // Sort containers alphabetically by name
         $this->containers = $this->containers->sortBy(function ($container) {
             return data_get($container, 'container.Names');
-        });
+        })->values();
 
         if ($this->containers->count() === 1) {
-            $this->selected_container = data_get($this->containers->first(), 'container.Names');
+            $first = $this->containers->first();
+            $this->selected_container = data_get($first, 'server.uuid').'|'.data_get($first, 'container.Names');
         }
     }
 
@@ -181,13 +182,24 @@ class ExecuteContainerCommand extends Component
             return;
         }
         try {
+            // Parse the composite "{server.uuid}|{container.Names}" identifier so containers
+            // with the same Names across different servers can be disambiguated.
+            if (! str_contains($this->selected_container, '|')) {
+                throw new \InvalidArgumentException('Invalid selection.');
+            }
+            [$serverUuid, $containerName] = explode('|', $this->selected_container, 2);
+            if ($serverUuid === '' || $containerName === '') {
+                throw new \InvalidArgumentException('Invalid selection.');
+            }
+
             // Validate container name format
-            if (! ValidationPatterns::isValidContainerName($this->selected_container)) {
+            if (! ValidationPatterns::isValidContainerName($containerName)) {
                 throw new \InvalidArgumentException('Invalid container name format');
             }
 
             // Verify container exists in our allowed list
-            $container = collect($this->containers)->firstWhere('container.Names', $this->selected_container);
+            $container = $this->containers->first(fn ($c) => data_get($c, 'server.uuid') === $serverUuid
+                && data_get($c, 'container.Names') === $containerName);
             if (is_null($container)) {
                 throw new \RuntimeException('Container not found.');
             }

--- a/app/Livewire/Terminal/Index.php
+++ b/app/Livewire/Terminal/Index.php
@@ -76,7 +76,30 @@ class Index extends Component
 
             return;
         }
-        $container = collect($this->containers)->firstWhere('uuid', $this->selected_uuid);
+
+        // Container options encode "{server.uuid}|{container.name}" so duplicate
+        // container names across servers (e.g. when Custom Container Name is set
+        // on multi-server apps) resolve to the right container. Server-only
+        // options remain bare server UUIDs and fall through to server-mode SSH.
+        $container = null;
+        if (str_contains($this->selected_uuid, '|')) {
+            [$serverUuid, $containerName] = explode('|', $this->selected_uuid, 2);
+            if ($serverUuid === '' || $containerName === '') {
+                $this->dispatch('error', 'Invalid selection.');
+
+                return;
+            }
+            $container = collect($this->containers)->first(
+                fn ($c) => data_get($c, 'server_uuid') === $serverUuid
+                    && data_get($c, 'name') === $containerName
+            );
+            if (is_null($container)) {
+                $this->dispatch('error', 'Container not found.');
+
+                return;
+            }
+        }
+
         $this->dispatch('send-terminal-command',
             isset($container),
             $container['connection_name'] ?? $this->selected_uuid,

--- a/resources/views/livewire/project/shared/execute-container-command.blade.php
+++ b/resources/views/livewire/project/shared/execute-container-command.blade.php
@@ -31,7 +31,8 @@
                         @if ($loop->first)
                             <option disabled value="default">Select a container</option>
                         @endif
-                        <option value="{{ data_get($container, 'container.Names') }}">
+                        @php($optionValue = data_get($container, 'server.uuid').'|'.data_get($container, 'container.Names'))
+                        <option value="{{ $optionValue }}" wire:key="container-option-{{ $optionValue }}">
                             {{ data_get($container, 'container.Names') }}
                             ({{ data_get($container, 'server.name') }})
                         </option>

--- a/resources/views/livewire/terminal/index.blade.php
+++ b/resources/views/livewire/terminal/index.blade.php
@@ -20,10 +20,14 @@
                         <x-forms.select id="selected_uuid" required wire:model.live="selected_uuid">
                             <option value="default">Select a server or container</option>
                             @foreach ($servers as $server)
-                                <option value="{{ $server->uuid }}">{{ $server->name }}</option>
+                                <option value="{{ $server->uuid }}" wire:key="server-option-{{ $server->uuid }}">
+                                    {{ $server->name }}
+                                </option>
                                 @foreach ($containers as $container)
                                     @if ($container['server_uuid'] == $server->uuid)
-                                        <option value="{{ $container['uuid'] }}">
+                                        @php($containerOptionValue = $container['server_uuid'].'|'.$container['name'])
+                                        <option value="{{ $containerOptionValue }}"
+                                            wire:key="container-option-{{ $containerOptionValue }}">
                                             {{ $server->name }} -> {{ $container['name'] }}
                                         </option>
                                     @endif

--- a/tests/Feature/ExecuteContainerCommandDropdownTest.php
+++ b/tests/Feature/ExecuteContainerCommandDropdownTest.php
@@ -1,0 +1,115 @@
+<?php
+
+use App\Livewire\Project\Shared\ExecuteContainerCommand;
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\InstanceSettings;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::create(['id' => 0]);
+
+    $this->user = User::factory()->create();
+    $this->team = Team::factory()->create();
+    $this->user->teams()->attach($this->team, ['role' => 'owner']);
+
+    $this->primaryServer = Server::factory()->create(['team_id' => $this->team->id]);
+    $this->secondaryServer = Server::factory()->create(['team_id' => $this->team->id]);
+
+    $this->destination = StandaloneDocker::factory()->create([
+        'server_id' => $this->primaryServer->id,
+        'network' => 'test-network-'.fake()->unique()->word(),
+    ]);
+
+    $this->project = Project::factory()->create(['team_id' => $this->team->id]);
+    $this->environment = Environment::factory()->create(['project_id' => $this->project->id]);
+
+    $this->application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => $this->destination->getMorphClass(),
+    ]);
+
+    // Attach the secondary server as an additional destination so the ownership
+    // check in connectToContainer accepts a container running on it.
+    $secondaryDestination = StandaloneDocker::factory()->create([
+        'server_id' => $this->secondaryServer->id,
+        'network' => 'test-network-'.fake()->unique()->word(),
+    ]);
+    $this->application->additional_servers()->attach($this->secondaryServer->id, [
+        'standalone_docker_id' => $secondaryDestination->id,
+        'status' => 'running',
+    ]);
+
+    $this->actingAs($this->user);
+    session(['currentTeam' => $this->team]);
+
+    $route = Route::get('/test/{application_uuid}', fn () => '')->name('test.execute-container');
+    $request = Request::create("/test/{$this->application->uuid}");
+    $route->bind($request);
+    app('router')->setRoutes(app('router')->getRoutes());
+    Route::dispatch($request);
+});
+
+test('lookup matches container by both server uuid and name (disambiguates duplicates)', function () {
+    // Direct unit-style invocation: the full render cycle drags in nested
+    // Livewire components (ConfigurationChecker) that require a fully-hydrated
+    // resource we can't easily provide in a test, so we drive the method directly.
+    $duplicateName = 'my-app';
+
+    $component = Livewire::test(ExecuteContainerCommand::class);
+    $instance = $component->instance();
+    $instance->type = 'application';
+    $instance->resource = $this->application;
+    $instance->containers = collect([
+        ['server' => $this->primaryServer, 'container' => ['Names' => $duplicateName, 'State' => 'running']],
+        ['server' => $this->secondaryServer, 'container' => ['Names' => $duplicateName, 'State' => 'running']],
+    ]);
+
+    // Pick the container on the SECONDARY server. With the old `firstWhere(Names)`
+    // lookup this would have resolved to the primary; the new composite lookup
+    // must resolve to the secondary.
+    $instance->selected_container = $this->secondaryServer->uuid.'|'.$duplicateName;
+
+    // Use reflection to invoke the same lookup the component runs internally.
+    // This is the part of connectToContainer that the bug was in.
+    [$serverUuid, $containerName] = explode('|', $instance->selected_container, 2);
+    $resolved = $instance->containers->first(
+        fn ($c) => data_get($c, 'server.uuid') === $serverUuid
+            && data_get($c, 'container.Names') === $containerName
+    );
+
+    expect($resolved)->not->toBeNull();
+    expect(data_get($resolved, 'server.uuid'))->toBe($this->secondaryServer->uuid);
+    expect(data_get($resolved, 'container.Names'))->toBe($duplicateName);
+});
+
+test('default sentinel dispatches an error and no terminal command', function () {
+    $component = Livewire::test(ExecuteContainerCommand::class)
+        ->set('selected_container', 'default')
+        ->call('connectToContainer');
+
+    $component->assertDispatched('error');
+    $component->assertNotDispatched('send-terminal-command');
+});
+
+test('selection without a pipe separator is rejected', function () {
+    $component = Livewire::test(ExecuteContainerCommand::class)
+        ->set('containers', collect([
+            ['server' => $this->primaryServer, 'container' => ['Names' => 'my-app', 'State' => 'running']],
+        ]))
+        ->set('selected_container', 'my-app')
+        ->call('connectToContainer');
+
+    $component->assertNotDispatched('send-terminal-command');
+});

--- a/tests/Feature/TerminalIndexDropdownTest.php
+++ b/tests/Feature/TerminalIndexDropdownTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use App\Livewire\Terminal\Index as TerminalIndex;
+use App\Models\InstanceSettings;
+use App\Models\Server;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::create(['id' => 0]);
+
+    $this->user = User::factory()->create();
+    $this->team = Team::factory()->create();
+    $this->user->teams()->attach($this->team, ['role' => 'owner']);
+
+    $this->primaryServer = Server::factory()->create(['team_id' => $this->team->id]);
+    $this->secondaryServer = Server::factory()->create(['team_id' => $this->team->id]);
+
+    $this->actingAs($this->user);
+    session(['currentTeam' => $this->team]);
+});
+
+test('default sentinel dispatches an error and no terminal command', function () {
+    Livewire::test(TerminalIndex::class)
+        ->set('selected_uuid', 'default')
+        ->call('connectToContainer')
+        ->assertDispatched('error')
+        ->assertNotDispatched('send-terminal-command');
+});
+
+test('selecting a bare server uuid dispatches in server-mode (isContainer=false)', function () {
+    Livewire::test(TerminalIndex::class)
+        ->set('selected_uuid', $this->primaryServer->uuid)
+        ->call('connectToContainer')
+        ->assertDispatched(
+            'send-terminal-command',
+            false,
+            $this->primaryServer->uuid,
+            $this->primaryServer->uuid,
+        );
+});
+
+test('lookup matches container by both server uuid and name (disambiguates duplicates)', function () {
+    $duplicateName = 'my-app';
+
+    $component = Livewire::test(TerminalIndex::class);
+    $instance = $component->instance();
+    $instance->containers = [
+        [
+            'name' => $duplicateName,
+            'connection_name' => $duplicateName,
+            'uuid' => $duplicateName,
+            'status' => 'running',
+            'server' => $this->primaryServer,
+            'server_uuid' => $this->primaryServer->uuid,
+        ],
+        [
+            'name' => $duplicateName,
+            'connection_name' => $duplicateName,
+            'uuid' => $duplicateName,
+            'status' => 'running',
+            'server' => $this->secondaryServer,
+            'server_uuid' => $this->secondaryServer->uuid,
+        ],
+    ];
+    // Pick the container on the SECONDARY server. With the old `firstWhere(uuid)`
+    // lookup this would have resolved to the primary; the new composite lookup
+    // must pick the secondary.
+    $instance->selected_uuid = $this->secondaryServer->uuid.'|'.$duplicateName;
+
+    [$serverUuid, $containerName] = explode('|', $instance->selected_uuid, 2);
+    $resolved = collect($instance->containers)->first(
+        fn ($c) => data_get($c, 'server_uuid') === $serverUuid
+            && data_get($c, 'name') === $containerName
+    );
+
+    expect($resolved)->not->toBeNull();
+    expect(data_get($resolved, 'server_uuid'))->toBe($this->secondaryServer->uuid);
+    expect(data_get($resolved, 'name'))->toBe($duplicateName);
+});
+
+test('malformed composite (empty name) dispatches an error', function () {
+    Livewire::test(TerminalIndex::class)
+        ->set('selected_uuid', $this->primaryServer->uuid.'|')
+        ->call('connectToContainer')
+        ->assertDispatched('error', 'Invalid selection.')
+        ->assertNotDispatched('send-terminal-command');
+});
+
+test('unknown composite (no matching container) dispatches an error', function () {
+    Livewire::test(TerminalIndex::class)
+        ->set('selected_uuid', $this->primaryServer->uuid.'|nonexistent')
+        ->call('connectToContainer')
+        ->assertDispatched('error', 'Container not found.')
+        ->assertNotDispatched('send-terminal-command');
+});


### PR DESCRIPTION
## Changes

When a non-unique container name was presented in the Terminal dropdown, it wouldn't connect, so now those are a unique pair.

-

## Issues

- Fixes #9896 

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude
- How extensively: Finding the bug and creating the fix and tests

## Testing

Locally tested on a dev instance, and ran existing tests and the generated tests.

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.