### PR TITLE
fix(deploy): cast force param as boolean to prevent cache bust on every deploy

### DIFF
--- a/app/Http/Controllers/Api/DeployController.php
+++ b/app/Http/Controllers/Api/DeployController.php
@@ -358,7 +358,7 @@ class DeployController extends Controller
 
         $uuids = $request->input('uuid');
         $tags = $request->input('tag');
-        $force = $request->input('force') ?? false;
+        $force = $request->boolean('force');
         $pullRequestId = $request->input('pull_request_id', $request->input('pr'));
         $pr = $pullRequestId ? max((int) $pullRequestId, 0) : 0;
         $dockerTag = $request->string('docker_tag')->trim()->value() ?: null;


### PR DESCRIPTION
## Problem

When deploying via the API with `force=false`, every build runs with `--no-cache`, bypassing Docker BuildKit layer caching entirely.

**Root cause:** `$request->input('force') ?? false` reads `"false"` as a string. PHP coerces a non-empty string to `true`, so `force_rebuild` is always set to `true` when the `force` query param is present — even when the caller explicitly passes `false`.

```php
// Before: "false" string → truthy → always rebuilds
$force = $request->input('force') ?? false;
```

This affects any API caller that passes `?force=false` — including Coolify's own UI when initiating a normal (non-forced) deploy.

## Fix

Use `$request->boolean()`, which delegates to `filter_var($value, FILTER_VALIDATE_BOOLEAN)` and correctly maps `"false"` → `false`, `"0"` → `false`, `"true"` → `true`, `"1"` → `true`.

```php
// After: correctly maps "false" → false
$force = $request->boolean('force');
```

## Impact

Before this fix, Docker layer caching was never used in practice (even for unchanged layers like `composer install`, `npm ci`, `apk add`). A typical Laravel app build that should take ~20s on a warm cache was taking 300+ seconds on every deploy.

After passing no `force` param (or with this fix), warm cache builds drop from ~300s to ~20s.