### PR TITLE
feat(service): add Docker Mailserver template

### DIFF
--- a/svgs/docker-mailserver.svg
+++ b/svgs/docker-mailserver.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" fill="none">
+  <rect width="120" height="120" rx="16" fill="#1a1a2e"/>
+  <rect x="20" y="30" width="80" height="60" rx="6" fill="#e2e8f0" stroke="#4a5568" stroke-width="2"/>
+  <polyline points="20,32 60,62 100,32" fill="none" stroke="#3b82f6" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <line x1="20" y1="88" x2="45" y2="62" stroke="#3b82f6" stroke-width="3" stroke-linecap="round"/>
+  <line x1="100" y1="88" x2="75" y2="62" stroke="#3b82f6" stroke-width="3" stroke-linecap="round"/>
+  <circle cx="60" cy="72" r="10" fill="#3b82f6"/>
+  <path d="M55 72 L58 75 L65 68" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/templates/compose/docker-mailserver.yaml
+++ b/templates/compose/docker-mailserver.yaml
@@ -1,0 +1,61 @@
+# documentation: https://docker-mailserver.github.io/docker-mailserver/latest/
+# slogan: Production-ready, full-featured mail server running in a single container. Includes Postfix (SMTP), Dovecot (IMAP/POP3), SpamAssassin, and Fail2ban.
+# category: email
+# tags: email, mail, smtp, imap, postfix, dovecot, spamassassin, self-hosted
+# logo: svgs/docker-mailserver.svg
+# port: 8080
+
+services:
+  docker-mailserver:
+    image: ghcr.io/docker-mailserver/docker-mailserver:latest
+    container_name: docker-mailserver
+    hostname: ${SERVICE_FQDN_MAILSERVER}
+    environment:
+      - ENABLE_SPAMASSASSIN=${ENABLE_SPAMASSASSIN:-1}
+      - ENABLE_CLAMAV=${ENABLE_CLAMAV:-0}
+      - ENABLE_FAIL2BAN=${ENABLE_FAIL2BAN:-0}
+      - ENABLE_POSTGREY=${ENABLE_POSTGREY:-0}
+      - ENABLE_SASLAUTHD=${ENABLE_SASLAUTHD:-0}
+      - ONE_DIR=${ONE_DIR:-1}
+      - TZ=${TZ:-Etc/UTC}
+      - POSTMASTER_ADDRESS=${POSTMASTER_ADDRESS:-postmaster@example.com}
+      - SSL_TYPE=${SSL_TYPE:-letsencrypt}
+      - ACCOUNT_PROVISIONER=${ACCOUNT_PROVISIONER:-FILE}
+      - SPOOF_PROTECTION=${SPOOF_PROTECTION:-0}
+      - ENABLE_UPDATE_CHECK=${ENABLE_UPDATE_CHECK:-1}
+      - ENABLE_RSPAMD=${ENABLE_RSPAMD:-0}
+      - ENABLE_AMAVIS=${ENABLE_AMAVIS:-1}
+      - LOG_LEVEL=${LOG_LEVEL:-info}
+    volumes:
+      - mail-data:/var/mail
+      - mail-state:/var/mail-state
+      - mail-logs:/var/log/mail
+      - ./config/:/tmp/docker-mailserver/
+      - /etc/localtime:/etc/localtime:ro
+    ports:
+      - "25:25"
+      - "465:465"
+      - "587:587"
+      - "993:993"
+      - "143:143"
+      - "110:110"
+      - "995:995"
+    restart: unless-stopped
+    stop_grace_period: 1m
+    cap_add:
+      - NET_ADMIN
+      - SYS_PTRACE
+    healthcheck:
+      test: ["CMD-SHELL", "ss -tlnp | grep -q ':25 ' || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
+volumes:
+  mail-data:
+    driver: local
+  mail-state:
+    driver: local
+  mail-logs:
+    driver: local


### PR DESCRIPTION
## What does this PR do?

Adds a reusable Docker Compose template for Docker Mailserver, a production-ready, full-featured mail server running in a single container.

## Why Docker Mailserver?

Docker Mailserver is one of the most popular self-hosted email solutions (15k+ GitHub stars). It bundles all the essential email components into a single container:

- **Postfix** - SMTP server for sending/receiving email
- **Dovecot** - IMAP/POP3 server for mailbox access
- **SpamAssassin** - Spam filtering
- **Amavis** - Content filtering
- **Fail2ban** - Brute force protection (optional)
- **ClamAV** - Antivirus scanning (optional)

## Template Details

- Exposes standard email ports: SMTP (25, 465, 587), IMAP (143, 993), POP3 (110, 995)
- Persistent volumes for mail data, state, and logs
- Healthcheck monitoring the SMTP port
- Configurable via environment variables for spam filtering, SSL, and security options

## Configuration

After deployment, users need to:
1. Add email accounts using the DMS setup script
2. Configure DNS records (MX, SPF, DKIM, DMARC) for their domain
3. Point their domain to the server IP

Addresses: #8266
