### PR TITLE
feat: add OAuth-only self-registration controls

### DIFF
--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\ResetsUserPasswords;
 
 class ResetUserPassword implements ResetsUserPasswords
@@ -17,6 +18,12 @@ class ResetUserPassword implements ResetsUserPasswords
      */
     public function reset(User $user, array $input): void
     {
+        if ($user->mustUseOauth()) {
+            throw ValidationException::withMessages([
+                'password' => 'Password reset is disabled for OAuth-only accounts. Please sign in with your OAuth provider.',
+            ]);
+        }
+
         Validator::make($input, [
             'password' => ['required', Password::defaults(), 'confirmed'],
         ])->validate();

--- a/app/Actions/Fortify/UpdateUserPassword.php
+++ b/app/Actions/Fortify/UpdateUserPassword.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\UpdatesUserPasswords;
 
 class UpdateUserPassword implements UpdatesUserPasswords
@@ -17,6 +18,12 @@ class UpdateUserPassword implements UpdatesUserPasswords
      */
     public function update(User $user, array $input): void
     {
+        if ($user->mustUseOauth()) {
+            throw ValidationException::withMessages([
+                'current_password' => 'Password changes are disabled for OAuth-only accounts. Please sign in with your OAuth provider.',
+            ]);
+        }
+
         Validator::make($input, [
             'current_password' => ['required', 'string', 'current_password:web'],
             'password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -78,6 +78,11 @@ class Controller extends BaseController
                 return response()->json(['message' => 'Transactional emails are not active'], 400);
             }
             $request->validate([Fortify::email() => 'required|email']);
+            $user = User::whereEmail($request->input(Fortify::email()))->first();
+            if ($user?->mustUseOauth()) {
+                return app(FailedPasswordResetLinkRequestResponse::class, ['status' => Password::INVALID_USER]);
+            }
+
             $status = Password::broker(config('fortify.passwords'))->sendResetLink(
                 $request->only(Fortify::email())
             );
@@ -104,6 +109,9 @@ class Controller extends BaseController
             $user = User::whereEmail($email)->first();
             if (! $user) {
                 return redirect()->route('login');
+            }
+            if ($user->mustUseOauth()) {
+                return redirect()->route('login')->with('error', 'Password login is disabled for OAuth-only accounts. Please sign in with your OAuth provider.');
             }
             if (Hash::check($password, $user->password)) {
                 $invitation = TeamInvitation::whereEmail($email);

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\InstanceSettings;
+use App\Models\OauthSetting;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -10,6 +12,8 @@ class OauthController extends Controller
 {
     public function redirect(string $provider)
     {
+        $this->ensureProviderIsEnabled($provider);
+
         $socialite_provider = get_socialite_provider($provider);
 
         return $socialite_provider->redirect();
@@ -18,6 +22,8 @@ class OauthController extends Controller
     public function callback(string $provider)
     {
         try {
+            $this->ensureProviderIsEnabled($provider);
+
             $oauthUser = get_socialite_provider($provider)->user();
             $email = trim((string) $oauthUser->email);
             if ($email === '') {
@@ -25,18 +31,20 @@ class OauthController extends Controller
             }
             $email = strtolower($email);
             $user = User::whereEmail($email)->first();
+            $settings = instanceSettings();
             if (! $user) {
-                $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! $settings->is_oauth_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 
-                $user = User::create([
-                    'name' => $oauthUser->name,
-                    'email' => $email,
-                ]);
+                $user = $this->createOauthUser($oauthUser, $email, $provider, $settings);
+            } elseif ($user->oauth_provider !== $provider) {
+                $user->forceFill([
+                    'oauth_provider' => $provider,
+                ])->save();
             }
             Auth::login($user);
+            $this->setCurrentTeam($user);
 
             return redirect('/');
         } catch (\Exception $e) {
@@ -44,5 +52,54 @@ class OauthController extends Controller
 
             return redirect()->route('login')->withErrors([__($errorCode)]);
         }
+    }
+
+    private function ensureProviderIsEnabled(string $provider): void
+    {
+        abort_unless(
+            OauthSetting::where('provider', $provider)->where('enabled', true)->exists(),
+            404
+        );
+    }
+
+    private function createOauthUser(object $oauthUser, string $email, string $provider, InstanceSettings $settings): User
+    {
+        $name = data_get($oauthUser, 'name') ?: $email;
+
+        if (User::count() === 0) {
+            $user = (new User)->forceFill([
+                'id' => 0,
+                'name' => $name,
+                'email' => $email,
+                'oauth_provider' => $provider,
+            ]);
+            $user->save();
+
+            $settings->is_registration_enabled = false;
+            $settings->save();
+
+            return $user;
+        }
+
+        $user = User::create([
+            'name' => $name,
+            'email' => $email,
+        ]);
+        $user->forceFill([
+            'oauth_provider' => $provider,
+        ])->save();
+
+        return $user;
+    }
+
+    private function setCurrentTeam(User $user): void
+    {
+        $user->loadMissing('teams');
+        $currentTeam = $user->teams->firstWhere('personal_team', true)
+            ?? $user->teams->first()
+            ?? $user->recreate_personal_team();
+
+        $user->currentTeam = $currentTeam;
+        session(['currentTeam' => $currentTeam]);
     }
 }

--- a/app/Livewire/ForcePasswordReset.php
+++ b/app/Livewire/ForcePasswordReset.php
@@ -30,6 +30,14 @@ class ForcePasswordReset extends Component
         if (auth()->user()->force_password_reset === false) {
             return redirect()->route('dashboard');
         }
+        if (auth()->user()->mustUseOauth()) {
+            auth()->user()->forceFill([
+                'password' => null,
+                'force_password_reset' => false,
+            ])->save();
+
+            return redirect()->route('dashboard');
+        }
         $this->email = auth()->user()->email;
     }
 
@@ -41,6 +49,14 @@ class ForcePasswordReset extends Component
     public function submit()
     {
         if (auth()->user()->force_password_reset === false) {
+            return redirect()->route('dashboard');
+        }
+        if (auth()->user()->mustUseOauth()) {
+            auth()->user()->forceFill([
+                'password' => null,
+                'force_password_reset' => false,
+            ])->save();
+
             return redirect()->route('dashboard');
         }
 

--- a/app/Livewire/Profile/Index.php
+++ b/app/Livewire/Profile/Index.php
@@ -240,6 +240,12 @@ class Index extends Component
     public function resetPassword()
     {
         try {
+            if (auth()->user()->mustUseOauth()) {
+                $this->dispatch('error', 'Password changes are disabled for OAuth-only accounts. Please sign in with your OAuth provider.');
+
+                return;
+            }
+
             $this->validate([
                 'current_password' => ['required'],
                 'new_password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Livewire/SettingsOauth.php
+++ b/app/Livewire/SettingsOauth.php
@@ -2,11 +2,18 @@
 
 namespace App\Livewire;
 
+use App\Models\InstanceSettings;
 use App\Models\OauthSetting;
 use Livewire\Component;
 
 class SettingsOauth extends Component
 {
+    public InstanceSettings $settings;
+
+    public bool $is_oauth_registration_enabled;
+
+    public bool $is_oauth_only_enabled;
+
     public $oauth_settings_map;
 
     protected function rules()
@@ -20,7 +27,10 @@ class SettingsOauth extends Component
             $carry["oauth_settings_map.$setting->provider.base_url"] = 'nullable';
 
             return $carry;
-        }, []);
+        }, [
+            'is_oauth_registration_enabled' => 'boolean',
+            'is_oauth_only_enabled' => 'boolean',
+        ]);
     }
 
     public function mount()
@@ -28,6 +38,9 @@ class SettingsOauth extends Component
         if (! isInstanceAdmin()) {
             return redirect()->route('home');
         }
+        $this->settings = instanceSettings();
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled;
+        $this->is_oauth_only_enabled = $this->settings->is_oauth_only_enabled;
         $this->oauth_settings_map = OauthSetting::all()->sortBy('provider')->reduce(function ($carry, $setting) {
             $carry[$setting->provider] = [
                 'id' => $setting->id,
@@ -42,6 +55,13 @@ class SettingsOauth extends Component
 
             return $carry;
         }, []);
+    }
+
+    private function updateInstanceSettings(): void
+    {
+        $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
+        $this->settings->is_oauth_only_enabled = $this->is_oauth_only_enabled;
+        $this->settings->save();
     }
 
     private function updateOauthSettings(?string $provider = null)
@@ -137,8 +157,19 @@ class SettingsOauth extends Component
         }
     }
 
+    public function instantSaveInstanceSettings()
+    {
+        try {
+            $this->updateInstanceSettings();
+            $this->dispatch('success', 'OAuth settings updated successfully!');
+        } catch (\Exception $e) {
+            return handleError($e, $this);
+        }
+    }
+
     public function submit()
     {
+        $this->updateInstanceSettings();
         $this->updateOauthSettings();
         $this->dispatch('success', 'Instance settings updated successfully!');
     }

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -18,6 +18,8 @@ class InstanceSettings extends Model
         'do_not_track',
         'is_auto_update_enabled',
         'is_registration_enabled',
+        'is_oauth_registration_enabled',
+        'is_oauth_only_enabled',
         'next_channel',
         'smtp_enabled',
         'smtp_from_address',
@@ -63,6 +65,9 @@ class InstanceSettings extends Model
 
         'allowed_ip_ranges' => 'array',
         'is_auto_update_enabled' => 'boolean',
+        'is_registration_enabled' => 'boolean',
+        'is_oauth_registration_enabled' => 'boolean',
+        'is_oauth_only_enabled' => 'boolean',
         'auto_update_frequency' => 'string',
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -487,4 +487,20 @@ class User extends Authenticatable implements SendsEmail
     {
         return ! empty($this->password);
     }
+
+    /**
+     * Check if the user has authenticated through an OAuth provider.
+     */
+    public function hasOauthProvider(): bool
+    {
+        return filled($this->oauth_provider);
+    }
+
+    /**
+     * Check if local password authentication is disabled for this OAuth user.
+     */
+    public function mustUseOauth(): bool
+    {
+        return $this->hasOauthProvider() && (bool) data_get(instanceSettings(), 'is_oauth_only_enabled', false);
+    }
 }

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -7,6 +7,7 @@ use App\Actions\Fortify\ResetUserPassword;
 use App\Actions\Fortify\UpdateUserPassword;
 use App\Actions\Fortify\UpdateUserProfileInformation;
 use App\Models\OauthSetting;
+use App\Models\TeamInvitation;
 use App\Models\User;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
@@ -67,6 +68,7 @@ class FortifyServiceProvider extends ServiceProvider
 
             return view('auth.login', [
                 'is_registration_enabled' => $settings->is_registration_enabled,
+                'is_oauth_registration_enabled' => $settings->is_oauth_registration_enabled,
                 'enabled_oauth_providers' => $enabled_oauth_providers,
             ]);
         });
@@ -74,6 +76,10 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::authenticateUsing(function (Request $request) {
             $email = strtolower($request->email);
             $user = User::where('email', $email)->with('teams')->first();
+            if ($user?->mustUseOauth()) {
+                return null;
+            }
+
             if (
                 $user &&
                 Hash::check($request->password, $user->password)
@@ -82,7 +88,7 @@ class FortifyServiceProvider extends ServiceProvider
                 $user->save();
 
                 // Check if user has a pending invitation they haven't accepted yet
-                $invitation = \App\Models\TeamInvitation::whereEmail($email)->first();
+                $invitation = TeamInvitation::whereEmail($email)->first();
                 if ($invitation && $invitation->isValid()) {
                     // User is logging in for the first time after being invited
                     // Attach them to the invited team if not already attached

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -3954,6 +3954,7 @@ function formatContainerStatus(string $status): string
  * Returns true if:
  * - Two-step confirmation is globally disabled
  * - User has no password (OAuth users)
+ * - User is restricted to OAuth-only authentication
  *
  * Used by modal-confirmation.blade.php to determine if password step should be shown.
  *
@@ -3971,6 +3972,11 @@ function shouldSkipPasswordConfirmation(): bool
         return true;
     }
 
+    // Skip if local password authentication is disabled for this OAuth user
+    if (Auth::user()?->mustUseOauth()) {
+        return true;
+    }
+
     return false;
 }
 
@@ -3979,6 +3985,7 @@ function shouldSkipPasswordConfirmation(): bool
  * Skips verification if:
  * - Two-step confirmation is globally disabled
  * - User has no password (OAuth users)
+ * - User is restricted to OAuth-only authentication
  *
  * @param  mixed  $password  The password to verify (may be array if skipped by frontend)
  * @param  Component|null  $component  Optional Livewire component to add errors to

--- a/database/migrations/2026_05_02_000000_add_oauth_registration_settings_to_instance_settings_table.php
+++ b/database/migrations/2026_05_02_000000_add_oauth_registration_settings_to_instance_settings_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_registration_enabled')->default(false);
+            $table->boolean('is_oauth_only_enabled')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn([
+                'is_oauth_registration_enabled',
+                'is_oauth_only_enabled',
+            ]);
+        });
+    }
+};

--- a/database/migrations/2026_05_02_000001_add_oauth_provider_to_users_table.php
+++ b/database/migrations/2026_05_02_000001_add_oauth_provider_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('oauth_provider')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('oauth_provider');
+        });
+    }
+};

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -72,7 +72,11 @@
                         </a>
                     @else
                         <div class="mt-6 text-center text-sm text-neutral-500 dark:text-neutral-400">
-                            {{ __('auth.registration_disabled') }}
+                            @if ($is_oauth_registration_enabled && $enabled_oauth_providers->isNotEmpty())
+                                Account creation is available through OAuth providers.
+                            @else
+                                {{ __('auth.registration_disabled') }}
+                            @endif
                         </div>
                     @endif
 

--- a/resources/views/components/modal-confirmation.blade.php
+++ b/resources/views/components/modal-confirmation.blade.php
@@ -31,7 +31,7 @@
     use App\Models\InstanceSettings;
     // Global setting to disable ALL two-step confirmation (text + password)
     $disableTwoStepConfirmation = data_get(InstanceSettings::get(), 'disable_two_step_confirmation');
-    // Skip ONLY password confirmation for OAuth users (they have no password)
+    // Skip password confirmation for users who cannot use a local password.
     $skipPasswordConfirmation = shouldSkipPasswordConfirmation();
     if ($temporaryDisableTwoStepConfirmation) {
         $disableTwoStepConfirmation = false;

--- a/resources/views/livewire/profile/index.blade.php
+++ b/resources/views/livewire/profile/index.blade.php
@@ -55,20 +55,29 @@
             </form>
         @endif
     </div>
-    <form wire:submit='resetPassword' class="flex flex-col pt-4">
-        <div class="flex items-center gap-2 pb-2">
-            <h2>Change Password</h2>
-            <x-forms.button type="submit" label="Save">Save</x-forms.button>
+    @if (auth()->user()->mustUseOauth())
+        <div class="flex flex-col pt-4">
+            <h2 class="pb-2">Change Password</h2>
+            <x-callout type="warning" title="OAuth-only account">
+                Password changes are disabled for this account. Please sign in with your OAuth provider.
+            </x-callout>
         </div>
-        <div class="text-xs font-bold dark:text-warning pb-2">Resetting the password will logout all sessions.</div>
-        <div class="flex flex-col gap-2">
-            <x-forms.input id="current_password" label="Current Password" required type="password" />
-            <div class="flex gap-2">
-                <x-forms.input id="new_password" label="New Password" required type="password" />
-                <x-forms.input id="new_password_confirmation" label="New Password Again" required type="password" />
+    @else
+        <form wire:submit='resetPassword' class="flex flex-col pt-4">
+            <div class="flex items-center gap-2 pb-2">
+                <h2>Change Password</h2>
+                <x-forms.button type="submit" label="Save">Save</x-forms.button>
             </div>
-        </div>
-    </form>
+            <div class="text-xs font-bold dark:text-warning pb-2">Resetting the password will logout all sessions.</div>
+            <div class="flex flex-col gap-2">
+                <x-forms.input id="current_password" label="Current Password" required type="password" />
+                <div class="flex gap-2">
+                    <x-forms.input id="new_password" label="New Password" required type="password" />
+                    <x-forms.input id="new_password_confirmation" label="New Password Again" required type="password" />
+                </div>
+            </div>
+        </form>
+    @endif
     <h2 class="py-4">Two-factor Authentication</h2>
     @if (session('status') == 'two-factor-authentication-enabled')
         <div class="mb-4 font-medium">

--- a/resources/views/livewire/settings-oauth.blade.php
+++ b/resources/views/livewire/settings-oauth.blade.php
@@ -14,6 +14,21 @@
             <div class="pb-4 ">Custom authentication (OAuth) configurations.</div>
         </div>
         <div class="flex flex-col gap-2 pt-4">
+            <div class="p-4 border dark:border-coolgray-300 border-neutral-200">
+                <h3>OAuth Access</h3>
+                <div class="flex flex-col gap-2 pt-2">
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave="instantSaveInstanceSettings"
+                            id="is_oauth_registration_enabled" label="OAuth Registration Allowed"
+                            helper="Allow new users to self-register with enabled OAuth providers even when general registration is disabled." />
+                    </div>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave="instantSaveInstanceSettings" id="is_oauth_only_enabled"
+                            label="OAuth-only Accounts"
+                            helper="When enabled, users who sign in with OAuth cannot use password login, password reset, or profile password changes." />
+                    </div>
+                </div>
+            </div>
             @foreach ($oauth_settings_map as $oauth_setting)
                 <div class="p-4 border dark:border-coolgray-300 border-neutral-200">
                     <h3>{{ ucfirst($oauth_setting['provider']) }}</h3>

--- a/tests/Feature/OauthSelfRegistrationTest.php
+++ b/tests/Feature/OauthSelfRegistrationTest.php
@@ -1,0 +1,184 @@
+<?php
+
+use App\Actions\Fortify\ResetUserPassword;
+use App\Actions\Fortify\UpdateUserPassword;
+use App\Models\InstanceSettings;
+use App\Models\OauthSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
+use Laravel\Socialite\Facades\Socialite;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    config([
+        'app.maintenance.store' => 'array',
+        'cache.default' => 'array',
+    ]);
+    InstanceSettings::unguarded(fn () => InstanceSettings::create(['id' => 0]));
+});
+
+function enabledOauthProvider(string $provider = 'google'): void
+{
+    OauthSetting::create([
+        'provider' => $provider,
+        'enabled' => true,
+        'client_id' => 'client-id',
+        'client_secret' => 'client-secret',
+        'redirect_uri' => route('auth.callback', $provider),
+    ]);
+}
+
+function mockOauthUser(string $email = 'oauth@example.com', string $name = 'OAuth User'): void
+{
+    $provider = Mockery::mock();
+    $provider->shouldReceive('setConfig')->andReturnSelf();
+    $provider->shouldReceive('with')->andReturnSelf();
+    $provider->shouldReceive('user')->andReturn((object) [
+        'email' => $email,
+        'name' => $name,
+    ]);
+
+    Socialite::shouldReceive('driver')->with('google')->andReturn($provider);
+}
+
+test('oauth self registration stays disabled by default when general registration is disabled', function () {
+    instanceSettings()->update([
+        'is_registration_enabled' => false,
+        'is_oauth_registration_enabled' => false,
+    ]);
+    enabledOauthProvider();
+    mockOauthUser();
+
+    $this->get(route('auth.callback', 'google'))
+        ->assertRedirect(route('login'));
+
+    expect(User::whereEmail('oauth@example.com')->exists())->toBeFalse();
+});
+
+test('oauth users can self register when oauth registration is enabled', function () {
+    instanceSettings()->update([
+        'is_registration_enabled' => false,
+        'is_oauth_registration_enabled' => true,
+    ]);
+    enabledOauthProvider();
+    mockOauthUser();
+
+    $this->get(route('auth.callback', 'google'))
+        ->assertRedirect('/');
+
+    $user = User::whereEmail('oauth@example.com')->first();
+
+    expect($user)->not->toBeNull()
+        ->and($user->id)->toBe(0)
+        ->and($user->oauth_provider)->toBe('google')
+        ->and($user->password)->toBeNull();
+    $this->assertAuthenticatedAs($user);
+});
+
+test('password login is blocked for oauth users when oauth only accounts are enabled', function () {
+    instanceSettings()->update([
+        'is_oauth_only_enabled' => true,
+    ]);
+    $user = User::factory()->create([
+        'email' => 'oauth@example.com',
+        'password' => Hash::make('Password1!'),
+    ]);
+    $user->forceFill(['oauth_provider' => 'google'])->save();
+
+    $this->post('/login', [
+        'email' => $user->email,
+        'password' => 'Password1!',
+    ]);
+
+    $this->assertGuest();
+});
+
+test('password login still works for local users when oauth only accounts are enabled', function () {
+    instanceSettings()->update([
+        'is_oauth_only_enabled' => true,
+    ]);
+    $user = User::factory()->create([
+        'email' => 'local@example.com',
+        'password' => Hash::make('Password1!'),
+    ]);
+
+    $this->post('/login', [
+        'email' => $user->email,
+        'password' => 'Password1!',
+    ]);
+
+    $this->assertAuthenticatedAs($user);
+});
+
+test('oauth only users cannot reset or change passwords', function () {
+    instanceSettings()->update([
+        'is_oauth_only_enabled' => true,
+    ]);
+    $user = User::factory()->create([
+        'password' => Hash::make('Password1!'),
+    ]);
+    $user->forceFill(['oauth_provider' => 'google'])->save();
+
+    (new ResetUserPassword)->reset($user, [
+        'password' => 'NewPassword1!',
+        'password_confirmation' => 'NewPassword1!',
+    ]);
+})->throws(ValidationException::class);
+
+test('oauth only users cannot update their existing password', function () {
+    instanceSettings()->update([
+        'is_oauth_only_enabled' => true,
+    ]);
+    $user = User::factory()->create([
+        'password' => Hash::make('Password1!'),
+    ]);
+    $user->forceFill(['oauth_provider' => 'google'])->save();
+
+    (new UpdateUserPassword)->update($user, [
+        'current_password' => 'Password1!',
+        'password' => 'NewPassword1!',
+        'password_confirmation' => 'NewPassword1!',
+    ]);
+})->throws(ValidationException::class);
+
+test('oauth only users cannot use password based invitation links', function () {
+    instanceSettings()->update([
+        'is_oauth_only_enabled' => true,
+    ]);
+    $user = User::factory()->create([
+        'email' => 'oauth-link@example.com',
+        'password' => Hash::make('Password1!'),
+    ]);
+    $user->forceFill(['oauth_provider' => 'google'])->save();
+    $token = Crypt::encryptString("{$user->email}@@@Password1!");
+
+    $this->get(route('auth.link', ['token' => $token]))
+        ->assertRedirect(route('login'))
+        ->assertSessionHas('error');
+
+    $this->assertGuest();
+});
+
+test('oauth only users skip local password confirmation checks', function () {
+    instanceSettings()->update([
+        'is_oauth_only_enabled' => true,
+    ]);
+    $user = User::factory()->create([
+        'password' => Hash::make('Password1!'),
+    ]);
+    $user->forceFill(['oauth_provider' => 'google'])->save();
+
+    $this->actingAs($user);
+
+    expect(shouldSkipPasswordConfirmation())->toBeTrue();
+});
+
+test('oauth provider cannot be mass assigned onto users', function () {
+    $user = new User;
+
+    expect($user->isFillable('oauth_provider'))->toBeFalse();
+});


### PR DESCRIPTION
/claim #8042

## Changes

- Added instance settings for OAuth self-registration and OAuth-only accounts.
- Allowed enabled OAuth providers to create users even when normal registration is disabled, when OAuth registration is enabled.
- Stored the OAuth provider on OAuth-created users.
- Blocked local password login, password reset, password change, and password invitation links for OAuth-only users.
- Added feature coverage for the new OAuth registration and OAuth-only behavior.

## Issues

- Fixes #8042

## Category

- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Demo video will be attached in a follow-up comment.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: AI coding assistant
- How extensively: Used to help implement the change, resolve conflicts, and add tests. I reviewed and tested the final changes locally.

## Testing

- `php artisan test --compact tests/Feature/OauthSelfRegistrationTest.php`
- `vendor/bin/pint --dirty --format agent`
- `git diff --check HEAD~1..HEAD`
- `php -l app/Http/Controllers/OauthController.php`

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
