### PR TITLE
feat: add Project Zomboid service template

### DIFF
--- a/svgs/project-zomboid.svg
+++ b/svgs/project-zomboid.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
+  <title id="title">Project Zomboid</title>
+  <desc id="desc">A simple Project Zomboid server icon with PZ initials.</desc>
+  <rect width="256" height="256" rx="40" fill="#141a16"/>
+  <path d="M48 42h160c13.3 0 24 10.7 24 24v124c0 13.3-10.7 24-24 24H48c-13.3 0-24-10.7-24-24V66c0-13.3 10.7-24 24-24Z" fill="#253326"/>
+  <path d="M53 70h150v22H92v29h85v22H92v43H53V70Z" fill="#d7dfc4"/>
+  <path d="M112 70h91v20l-48 76h50v20h-96v-20l48-76h-45V70Z" fill="#80a66b"/>
+  <path d="M46 207h164" stroke="#80a66b" stroke-width="10" stroke-linecap="round"/>
+</svg>

--- a/templates/compose/project-zomboid.yaml
+++ b/templates/compose/project-zomboid.yaml
@@ -1,0 +1,45 @@
+# documentation: https://hub.docker.com/r/m4lagon/project-zomboid-server
+# slogan: Project Zomboid dedicated server with persistent saves, Steam Workshop support, presets, and RCON.
+# category: games
+# tags: project-zomboid,zomboid,game-server,dedicated-server,steam,workshop,survival
+# logo: svgs/project-zomboid.svg
+# port: 16261
+# amd_only: true
+
+services:
+  project-zomboid:
+    image: m4lagon/project-zomboid-server:latest
+    restart: unless-stopped
+    stop_grace_period: 2m
+    ports:
+      - '${PROJECT_ZOMBOID_PORT:-16261}:16261/udp'
+      - '${PROJECT_ZOMBOID_PLAYER_PORT:-16262}:16262/udp'
+      - '${PROJECT_ZOMBOID_RCON_PORT:-27015}:27015/tcp'
+    volumes:
+      - project-zomboid-data:/root/Zomboid
+      - project-zomboid-workshop:/root/.local/share/Steam/steamapps/workshop
+    environment:
+      - 'SERVER_NAME=${PROJECT_ZOMBOID_SERVER_NAME:-CoolifyZomboid}'
+      - 'PUBLIC_NAME=${PROJECT_ZOMBOID_PUBLIC_NAME:-Coolify Project Zomboid}'
+      - 'ADMIN_USERNAME=${PROJECT_ZOMBOID_ADMIN_USERNAME:-admin}'
+      - 'ADMIN_PASSWORD=${SERVICE_PASSWORD_ADMIN}'
+      - 'SERVER_MEMORY=${PROJECT_ZOMBOID_SERVER_MEMORY:-4096m}'
+      - 'MAX_PLAYERS=${PROJECT_ZOMBOID_MAX_PLAYERS:-16}'
+      - 'PUBLIC=${PROJECT_ZOMBOID_PUBLIC:-true}'
+      - 'PASSWORD=${PROJECT_ZOMBOID_PASSWORD:-}'
+      - 'PVP=${PROJECT_ZOMBOID_PVP:-true}'
+      - 'PAUSE_EMPTY=${PROJECT_ZOMBOID_PAUSE_EMPTY:-true}'
+      - 'SERVER_PRESET=${PROJECT_ZOMBOID_SERVER_PRESET:-Survival}'
+      - 'FORCE_PRESET=${PROJECT_ZOMBOID_FORCE_PRESET:-0}'
+      - 'MAP=${PROJECT_ZOMBOID_MAP:-Muldraugh, KY}'
+      - 'NO_STEAM=${PROJECT_ZOMBOID_NO_STEAM:-0}'
+      - 'STEAM_VAC=${PROJECT_ZOMBOID_STEAM_VAC:-true}'
+      - 'WORKSHOP_ITEMS=${PROJECT_ZOMBOID_WORKSHOP_ITEMS:-}'
+      - 'MODS=${PROJECT_ZOMBOID_MODS:-}'
+      - 'RCON_PASSWORD=${SERVICE_PASSWORD_RCON}'
+      - 'RCON_PORT=27015'
+      - 'TZ=${PROJECT_ZOMBOID_TZ:-UTC}'
+
+volumes:
+  project-zomboid-data: null
+  project-zomboid-workshop: null


### PR DESCRIPTION
## Changes

- Adds a Project Zomboid dedicated server one-click service template.
- Uses Docker Hub image m4lagon/project-zomboid-server:latest, documented from its Docker Hub page and linked source repo.
- Persists saves, configs, logs, player data, and Steam Workshop downloads in named volumes.
- Exposes 16261/udp, 16262/udp, and optional RCON on 27015/tcp.
- Adds Coolify-generated admin and RCON passwords plus common server, preset, mod, and timezone variables.
- Marks the service amd_only because the public image manifest currently exposes Linux amd64.

## Issues

- Fixes #9919

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Smoke-tested with Docker Compose locally. The server reached the Project Zomboid startup success logs and listened on the expected ports.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex CLI/app, GitHub CLI, Docker CLI.
- How extensively: Used to research the image options, draft the Coolify service template, run validation commands, and prepare the PR. Human review is still requested before merge.

## Testing

- Passed: docker compose config validation for the new compose template. The local warnings about missing generated password env vars are expected outside Coolify.
- Passed: public Docker image manifest lookup for m4lagon/project-zomboid-server:latest.
- Passed: pulled and started the service with Docker Compose using generated-style admin/RCON passwords.
- Passed: startup logs reached Project Zomboid server ready state: SERVER STARTED, Steam enabled, listening on 16261 and 16262, LuaNet initialized, and RCON listening on 27015.
- Passed: stopped the smoke-test Compose project and removed its test volumes.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
