### PR TITLE
feat: skip deployment when commit message contains [skip coolify] or [coolify skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### 🚀 Features
 
+- Skip deployment when commit message includes `[skip coolify]` or `[coolify skip]` (supported for GitHub, GitLab, Gitea, and Bitbucket webhooks). Skipped deployments are recorded and visible in the deployment history UI with a "Skipped" status.
 - Use tags in update
 - New update process (#115)
 - VaultWarden service

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ npm run build                   # production build
 - **Services/** — Business logic services (ConfigurationGenerator, DockerImageParser, ContainerStatusAggregator, HetznerService, etc.). Use Services for complex orchestration; use Actions for single-purpose domain operations.
 - **Helpers/** — Global helpers loaded via `bootstrap/includeHelpers.php` from `bootstrap/helpers/` — organized into `shared.php`, `constants.php`, `versions.php`, `subscriptions.php`, `domains.php`, `docker.php`, `services.php`, `github.php`, `proxy.php`, `notifications.php`.
 - **Data/** — Spatie Laravel Data DTOs (e.g., `ServerMetadata`).
-- **Enums/** — PHP enums (TitleCase keys). Key enums: `ProcessStatus`, `Role` (MEMBER/ADMIN/OWNER with rank comparison), `BuildPackTypes`, `ProxyTypes`, `ContainerStatusTypes`.
+- **Enums/** — PHP enums (TitleCase keys). Key enums: `ProcessStatus`, `Role` (MEMBER/ADMIN/OWNER with rank comparison), `BuildPackTypes`, `ProxyTypes`, `ContainerStatusTypes`, `ApplicationDeploymentStatus` (includes `SKIPPED_BY_COMMIT_MESSAGE` for webhook deployments skipped via `[skip coolify]` or `[coolify skip]` in the commit message).
 - **Rules/** — Custom validation rules (`ValidGitRepositoryUrl`, `ValidServerIp`, `ValidHostname`, `DockerImageFormat`, etc.).
 
 ### API Layer

--- a/app/Enums/ApplicationDeploymentStatus.php
+++ b/app/Enums/ApplicationDeploymentStatus.php
@@ -9,4 +9,5 @@ enum ApplicationDeploymentStatus: string
     case FINISHED = 'finished';
     case FAILED = 'failed';
     case CANCELLED_BY_USER = 'cancelled-by-user';
+    case SKIPPED_BY_COMMIT_MESSAGE = 'skipped-by-commit-message';
 }

--- a/app/Http/Controllers/Webhook/Bitbucket.php
+++ b/app/Http/Controllers/Webhook/Bitbucket.php
@@ -31,6 +31,7 @@ class Bitbucket extends Controller
                 $branch = data_get($payload, 'push.changes.0.new.name');
                 $full_name = data_get($payload, 'repository.full_name');
                 $commit = data_get($payload, 'push.changes.0.new.target.hash');
+                $commit_message = data_get($payload, 'push.changes.0.new.target.message');
 
                 if (! $branch) {
                     return response([
@@ -107,7 +108,8 @@ class Bitbucket extends Controller
                             deployment_uuid: $deployment_uuid,
                             commit: $commit,
                             force_rebuild: false,
-                            is_webhook: true
+                            is_webhook: true,
+                            commit_message: $commit_message,
                         );
                         if ($result['status'] === 'queue_full') {
                             return response($result['message'], 429)->header('Retry-After', 60);

--- a/app/Http/Controllers/Webhook/Gitea.php
+++ b/app/Http/Controllers/Webhook/Gitea.php
@@ -40,6 +40,7 @@ class Gitea extends Controller
                 $removed_files = data_get($payload, 'commits.*.removed');
                 $modified_files = data_get($payload, 'commits.*.modified');
                 $changed_files = collect($added_files)->concat($removed_files)->concat($modified_files)->unique()->flatten();
+                $commit_message = data_get($payload, 'head_commit.message');
             }
             if ($x_gitea_event === 'pull_request') {
                 $action = data_get($payload, 'action');
@@ -107,6 +108,7 @@ class Gitea extends Controller
                                 force_rebuild: false,
                                 commit: data_get($payload, 'after', 'HEAD'),
                                 is_webhook: true,
+                                commit_message: $commit_message,
                             );
                             if ($result['status'] === 'queue_full') {
                                 return response($result['message'], 429)->header('Retry-After', 60);

--- a/app/Http/Controllers/Webhook/Github.php
+++ b/app/Http/Controllers/Webhook/Github.php
@@ -43,6 +43,7 @@ class Github extends Controller
                 $removed_files = data_get($payload, 'commits.*.removed');
                 $modified_files = data_get($payload, 'commits.*.modified');
                 $changed_files = collect($added_files)->concat($removed_files)->concat($modified_files)->unique()->flatten();
+                $commit_message = data_get($payload, 'head_commit.message');
             }
             if ($x_github_event === 'pull_request') {
                 $action = data_get($payload, 'action');
@@ -121,6 +122,7 @@ class Github extends Controller
                                     force_rebuild: false,
                                     commit: data_get($payload, 'after', 'HEAD'),
                                     is_webhook: true,
+                                    commit_message: $commit_message,
                                 );
                                 if ($result['status'] === 'queue_full') {
                                     return response($result['message'], 429)->header('Retry-After', 60);
@@ -246,6 +248,7 @@ class Github extends Controller
                 $removed_files = data_get($payload, 'commits.*.removed');
                 $modified_files = data_get($payload, 'commits.*.modified');
                 $changed_files = collect($added_files)->concat($removed_files)->concat($modified_files)->unique()->flatten();
+                $commit_message = data_get($payload, 'head_commit.message');
             }
             if ($x_github_event === 'pull_request') {
                 $action = data_get($payload, 'action');
@@ -307,6 +310,7 @@ class Github extends Controller
                                     commit: data_get($payload, 'after', 'HEAD'),
                                     force_rebuild: false,
                                     is_webhook: true,
+                                    commit_message: $commit_message,
                                 );
                                 if ($result['status'] === 'queue_full') {
                                     return response($result['message'], 429)->header('Retry-After', 60);

--- a/app/Http/Controllers/Webhook/Gitlab.php
+++ b/app/Http/Controllers/Webhook/Gitlab.php
@@ -58,6 +58,7 @@ class Gitlab extends Controller
                 $removed_files = data_get($payload, 'commits.*.removed');
                 $modified_files = data_get($payload, 'commits.*.modified');
                 $changed_files = collect($added_files)->concat($removed_files)->concat($modified_files)->unique()->flatten();
+                $commit_message = data_get($payload, 'commits.0.message');
             }
             if ($x_gitlab_event === 'merge_request') {
                 $action = data_get($payload, 'object_attributes.action');
@@ -139,6 +140,7 @@ class Gitlab extends Controller
                                 commit: data_get($payload, 'after', 'HEAD'),
                                 force_rebuild: false,
                                 is_webhook: true,
+                                commit_message: $commit_message,
                             );
                             if ($result['status'] === 'queue_full') {
                                 return response($result['message'], 429)->header('Retry-After', 60);

--- a/bootstrap/helpers/applications.php
+++ b/bootstrap/helpers/applications.php
@@ -12,7 +12,53 @@ use App\Models\StandaloneDocker;
 use Spatie\Url\Url;
 use Visus\Cuid2\Cuid2;
 
-function queue_application_deployment(Application $application, string $deployment_uuid, ?int $pull_request_id = 0, string $commit = 'HEAD', bool $force_rebuild = false, bool $is_webhook = false, bool $is_api = false, bool $restart_only = false, ?string $git_type = null, bool $no_questions_asked = false, ?Server $server = null, ?StandaloneDocker $destination = null, bool $only_this_server = false, bool $rollback = false, ?string $docker_registry_image_tag = null)
+/**
+ * Determine whether a commit message contains a Coolify skip tag.
+ *
+ * Returns true when the message (compared case-insensitively) includes
+ * `[skip coolify]` or `[coolify skip]`.
+ */
+function commit_message_has_skip_deployment_tag(?string $commit_message): bool
+{
+    if (! $commit_message) {
+        return false;
+    }
+
+    $lower = mb_strtolower($commit_message);
+
+    return str_contains($lower, '[skip coolify]') || str_contains($lower, '[coolify skip]');
+}
+
+/**
+ * Queue an application deployment.
+ *
+ * When called from a webhook (`$is_webhook = true`) and a `$commit_message` is provided,
+ * the function checks whether the message contains `[skip coolify]` or `[coolify skip]`
+ * (case-insensitive) via {@see commit_message_has_skip_deployment_tag()}. If found — and
+ * `$force_rebuild` is not set — a deployment record with status
+ * `SKIPPED_BY_COMMIT_MESSAGE` is persisted for UI visibility and the function returns
+ * early without dispatching a job. When `$force_rebuild` is `true` the skip tag is
+ * intentionally ignored so that manual force-rebuilds always proceed.
+ *
+ * @param  Application           $application
+ * @param  string                $deployment_uuid
+ * @param  int|null              $pull_request_id
+ * @param  string                $commit
+ * @param  bool                  $force_rebuild            When true, skip tags are ignored.
+ * @param  bool                  $is_webhook
+ * @param  bool                  $is_api
+ * @param  bool                  $restart_only
+ * @param  string|null           $git_type
+ * @param  bool                  $no_questions_asked
+ * @param  Server|null           $server
+ * @param  StandaloneDocker|null $destination
+ * @param  bool                  $only_this_server
+ * @param  bool                  $rollback
+ * @param  string|null           $docker_registry_image_tag
+ * @param  string|null           $commit_message            Head commit message from the webhook payload.
+ * @return array{status: string, message: string, deployment_uuid?: string, existing_deployment?: ApplicationDeploymentQueue}
+ */
+function queue_application_deployment(Application $application, string $deployment_uuid, ?int $pull_request_id = 0, string $commit = 'HEAD', bool $force_rebuild = false, bool $is_webhook = false, bool $is_api = false, bool $restart_only = false, ?string $git_type = null, bool $no_questions_asked = false, ?Server $server = null, ?StandaloneDocker $destination = null, bool $only_this_server = false, bool $rollback = false, ?string $docker_registry_image_tag = null, ?string $commit_message = null)
 {
     $application_id = $application->id;
     $deployment_link = Url::fromString($application->link()."/deployment/{$deployment_uuid}");
@@ -40,6 +86,35 @@ function queue_application_deployment(Application $application, string $deployme
         return [
             'status' => 'queue_full',
             'message' => 'Deployment queue is full. Please wait for existing deployments to complete.',
+        ];
+    }
+
+    if ($is_webhook && ! $force_rebuild && commit_message_has_skip_deployment_tag($commit_message)) {
+        // Record the skipped deployment so it appears in the UI deployment history.
+        ApplicationDeploymentQueue::create([
+            'application_id' => $application_id,
+            'application_name' => $application->name,
+            'server_id' => $server_id,
+            'server_name' => $server_name,
+            'destination_id' => $destination_id,
+            'deployment_uuid' => $deployment_uuid,
+            'deployment_url' => $deployment_url,
+            'pull_request_id' => $pull_request_id,
+            'force_rebuild' => false,
+            'is_webhook' => true,
+            'commit' => $commit,
+            'rollback' => false,
+            'git_type' => $git_type,
+            'only_this_server' => $only_this_server,
+            'status' => ApplicationDeploymentStatus::SKIPPED_BY_COMMIT_MESSAGE->value,
+            'commit_message' => $commit_message,
+            'finished_at' => now(),
+        ]);
+
+        return [
+            'status' => 'skipped',
+            'message' => 'Deployment skipped due to [skip coolify] in commit message.',
+            'deployment_uuid' => $deployment_uuid,
         ];
     }
 
@@ -82,6 +157,7 @@ function queue_application_deployment(Application $application, string $deployme
         'rollback' => $rollback,
         'git_type' => $git_type,
         'only_this_server' => $only_this_server,
+        'commit_message' => $commit_message,
     ]);
 
     if ($no_questions_asked) {

--- a/resources/views/livewire/project/application/deployment/index.blade.php
+++ b/resources/views/livewire/project/application/deployment/index.blade.php
@@ -44,6 +44,8 @@
                     data_get($deployment, 'status') === 'cancelled-by-user',
                 'border-error' => data_get($deployment, 'status') === 'failed',
                 'border-success' => data_get($deployment, 'status') === 'finished',
+                'border-warning border-dashed' =>
+                    data_get($deployment, 'status') === 'skipped-by-commit-message',
             ])>
                 <a href="{{ $current_url . '/' . data_get($deployment, 'deployment_uuid') }}" {{ wireNavigate() }} class="block">
                     <div class="flex flex-col">
@@ -60,6 +62,8 @@
                                     data_get($deployment, 'status') === 'finished',
                                 'bg-gray-100 text-gray-700 dark:bg-gray-600/30 dark:text-gray-300' =>
                                     data_get($deployment, 'status') === 'cancelled-by-user',
+                                'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-200' =>
+                                    data_get($deployment, 'status') === 'skipped-by-commit-message',
                             ])>
                                 @php
                                     $statusText = match (data_get($deployment, 'status')) {
@@ -67,6 +71,7 @@
                                         'in_progress' => 'In Progress',
                                         'cancelled-by-user' => 'Cancelled',
                                         'queued' => 'Queued',
+                                        'skipped-by-commit-message' => 'Skipped',
                                         default => ucfirst(data_get($deployment, 'status')),
                                     };
                                 @endphp

--- a/tests/Feature/Webhook/SkipDeploymentCommitMessageTest.php
+++ b/tests/Feature/Webhook/SkipDeploymentCommitMessageTest.php
@@ -1,0 +1,375 @@
+<?php
+
+use App\Enums\ApplicationDeploymentStatus;
+use App\Models\Application;
+use App\Models\ApplicationDeploymentQueue;
+use App\Models\Environment;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function createSkipTestApplication(string $repo = 'test-org/test-repo', string $branch = 'main'): Application
+{
+    $team = Team::factory()->create();
+    $project = Project::factory()->create(['team_id' => $team->id]);
+    $environment = Environment::factory()->create(['project_id' => $project->id]);
+    $server = Server::factory()->create(['team_id' => $team->id]);
+    $destination = $server->standaloneDockers()->firstOrFail();
+
+    return Application::create([
+        'name' => 'skip-test-app',
+        'git_repository' => "https://github.com/{$repo}",
+        'git_branch' => $branch,
+        'build_pack' => 'nixpacks',
+        'ports_exposes' => '3000',
+        'environment_id' => $environment->id,
+        'destination_id' => $destination->id,
+        'destination_type' => $destination->getMorphClass(),
+    ]);
+}
+
+// ---------------------------------------------------------------------------
+// GitHub Manual Webhook
+// ---------------------------------------------------------------------------
+describe('GitHub manual webhook – skip deployment', function () {
+    test('skips deployment when commit message contains [skip coolify]', function () {
+        $app = createSkipTestApplication();
+        $secret = $app->manual_webhook_secret_github;
+
+        $payload = json_encode([
+            'ref' => 'refs/heads/main',
+            'repository' => ['full_name' => 'test-org/test-repo'],
+            'after' => 'abc1234',
+            'commits' => [],
+            'head_commit' => ['message' => 'Fix bug [skip coolify]'],
+        ]);
+
+        $hmac = hash_hmac('sha256', $payload, $secret);
+
+        $response = $this->call('POST', '/webhooks/source/github/events/manual', [], [], [], [
+            'HTTP_X-GitHub-Event' => 'push',
+            'HTTP_X-Hub-Signature-256' => "sha256={$hmac}",
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+
+        $response->assertOk();
+        expect($response->getContent())->toContain('skipped');
+
+        $queue = ApplicationDeploymentQueue::where('application_id', $app->id)->first();
+        expect($queue)->not->toBeNull();
+        expect($queue->status)->toBe(ApplicationDeploymentStatus::SKIPPED_BY_COMMIT_MESSAGE->value);
+        expect($queue->commit_message)->toContain('[skip coolify]');
+    });
+
+    test('skips deployment when commit message contains [coolify skip]', function () {
+        $app = createSkipTestApplication();
+        $secret = $app->manual_webhook_secret_github;
+
+        $payload = json_encode([
+            'ref' => 'refs/heads/main',
+            'repository' => ['full_name' => 'test-org/test-repo'],
+            'after' => 'abc1235',
+            'commits' => [],
+            'head_commit' => ['message' => '[coolify skip] chore: update deps'],
+        ]);
+
+        $hmac = hash_hmac('sha256', $payload, $secret);
+
+        $response = $this->call('POST', '/webhooks/source/github/events/manual', [], [], [], [
+            'HTTP_X-GitHub-Event' => 'push',
+            'HTTP_X-Hub-Signature-256' => "sha256={$hmac}",
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+
+        $response->assertOk();
+        expect($response->getContent())->toContain('skipped');
+
+        $queue = ApplicationDeploymentQueue::where('application_id', $app->id)->first();
+        expect($queue->status)->toBe(ApplicationDeploymentStatus::SKIPPED_BY_COMMIT_MESSAGE->value);
+    });
+
+    test('skips deployment when skip tag is mixed case', function () {
+        $app = createSkipTestApplication();
+        $secret = $app->manual_webhook_secret_github;
+
+        $payload = json_encode([
+            'ref' => 'refs/heads/main',
+            'repository' => ['full_name' => 'test-org/test-repo'],
+            'after' => 'abc1236',
+            'commits' => [],
+            'head_commit' => ['message' => 'ci: lint [SKIP COOLIFY]'],
+        ]);
+
+        $hmac = hash_hmac('sha256', $payload, $secret);
+
+        $response = $this->call('POST', '/webhooks/source/github/events/manual', [], [], [], [
+            'HTTP_X-GitHub-Event' => 'push',
+            'HTTP_X-Hub-Signature-256' => "sha256={$hmac}",
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+
+        $response->assertOk();
+        expect($response->getContent())->toContain('skipped');
+    });
+
+    test('does not skip deployment without skip tag', function () {
+        $app = createSkipTestApplication();
+        $secret = $app->manual_webhook_secret_github;
+
+        $payload = json_encode([
+            'ref' => 'refs/heads/main',
+            'repository' => ['full_name' => 'test-org/test-repo'],
+            'after' => 'abc1237',
+            'commits' => [],
+            'head_commit' => ['message' => 'feat: add new feature'],
+        ]);
+
+        $hmac = hash_hmac('sha256', $payload, $secret);
+
+        $response = $this->call('POST', '/webhooks/source/github/events/manual', [], [], [], [
+            'HTTP_X-GitHub-Event' => 'push',
+            'HTTP_X-Hub-Signature-256' => "sha256={$hmac}",
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+
+        $response->assertOk();
+
+        $queue = ApplicationDeploymentQueue::where('application_id', $app->id)->first();
+        expect($queue)->not->toBeNull();
+        expect($queue->status)->not->toBe(ApplicationDeploymentStatus::SKIPPED_BY_COMMIT_MESSAGE->value);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// GitLab Manual Webhook
+// ---------------------------------------------------------------------------
+describe('GitLab manual webhook – skip deployment', function () {
+    test('skips deployment when commit message contains [skip coolify]', function () {
+        $app = createSkipTestApplication();
+        $secret = $app->manual_webhook_secret_gitlab;
+
+        $response = $this->postJson('/webhooks/source/gitlab/events/manual', [
+            'object_kind' => 'push',
+            'ref' => 'refs/heads/main',
+            'project' => ['path_with_namespace' => 'test-org/test-repo'],
+            'after' => 'def1234',
+            'commits' => [
+                ['message' => 'hotfix [skip coolify]'],
+            ],
+        ], [
+            'X-Gitlab-Token' => $secret,
+        ]);
+
+        $response->assertOk();
+        expect($response->getContent())->toContain('skipped');
+
+        $queue = ApplicationDeploymentQueue::where('application_id', $app->id)->first();
+        expect($queue)->not->toBeNull();
+        expect($queue->status)->toBe(ApplicationDeploymentStatus::SKIPPED_BY_COMMIT_MESSAGE->value);
+    });
+
+    test('skips deployment when commit message contains [coolify skip]', function () {
+        $app = createSkipTestApplication();
+        $secret = $app->manual_webhook_secret_gitlab;
+
+        $response = $this->postJson('/webhooks/source/gitlab/events/manual', [
+            'object_kind' => 'push',
+            'ref' => 'refs/heads/main',
+            'project' => ['path_with_namespace' => 'test-org/test-repo'],
+            'after' => 'def1235',
+            'commits' => [
+                ['message' => '[coolify skip] docs: update readme'],
+            ],
+        ], [
+            'X-Gitlab-Token' => $secret,
+        ]);
+
+        $response->assertOk();
+        expect($response->getContent())->toContain('skipped');
+    });
+
+    test('does not skip deployment without skip tag', function () {
+        $app = createSkipTestApplication();
+        $secret = $app->manual_webhook_secret_gitlab;
+
+        $response = $this->postJson('/webhooks/source/gitlab/events/manual', [
+            'object_kind' => 'push',
+            'ref' => 'refs/heads/main',
+            'project' => ['path_with_namespace' => 'test-org/test-repo'],
+            'after' => 'def1236',
+            'commits' => [
+                ['message' => 'feat: new login page'],
+            ],
+        ], [
+            'X-Gitlab-Token' => $secret,
+        ]);
+
+        $response->assertOk();
+
+        $queue = ApplicationDeploymentQueue::where('application_id', $app->id)->first();
+        expect($queue)->not->toBeNull();
+        expect($queue->status)->not->toBe(ApplicationDeploymentStatus::SKIPPED_BY_COMMIT_MESSAGE->value);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Gitea Manual Webhook
+// ---------------------------------------------------------------------------
+describe('Gitea manual webhook – skip deployment', function () {
+    test('skips deployment when commit message contains [skip coolify]', function () {
+        $app = createSkipTestApplication();
+        $secret = $app->manual_webhook_secret_gitea;
+
+        $payload = json_encode([
+            'ref' => 'refs/heads/main',
+            'repository' => ['full_name' => 'test-org/test-repo'],
+            'after' => 'ghi1234',
+            'commits' => [],
+            'head_commit' => ['message' => 'chore: bump version [skip coolify]'],
+        ]);
+
+        $hmac = hash_hmac('sha256', $payload, $secret);
+
+        $response = $this->call('POST', '/webhooks/source/gitea/events/manual', [], [], [], [
+            'HTTP_X-Gitea-Event' => 'push',
+            'HTTP_X-Hub-Signature-256' => "sha256={$hmac}",
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+
+        $response->assertOk();
+        expect($response->getContent())->toContain('skipped');
+
+        $queue = ApplicationDeploymentQueue::where('application_id', $app->id)->first();
+        expect($queue)->not->toBeNull();
+        expect($queue->status)->toBe(ApplicationDeploymentStatus::SKIPPED_BY_COMMIT_MESSAGE->value);
+    });
+
+    test('skips deployment when commit message contains [coolify skip]', function () {
+        $app = createSkipTestApplication();
+        $secret = $app->manual_webhook_secret_gitea;
+
+        $payload = json_encode([
+            'ref' => 'refs/heads/main',
+            'repository' => ['full_name' => 'test-org/test-repo'],
+            'after' => 'ghi1235',
+            'commits' => [],
+            'head_commit' => ['message' => '[coolify skip] test: fix flaky tests'],
+        ]);
+
+        $hmac = hash_hmac('sha256', $payload, $secret);
+
+        $response = $this->call('POST', '/webhooks/source/gitea/events/manual', [], [], [], [
+            'HTTP_X-Gitea-Event' => 'push',
+            'HTTP_X-Hub-Signature-256' => "sha256={$hmac}",
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+
+        $response->assertOk();
+        expect($response->getContent())->toContain('skipped');
+    });
+
+    test('does not skip deployment without skip tag', function () {
+        $app = createSkipTestApplication();
+        $secret = $app->manual_webhook_secret_gitea;
+
+        $payload = json_encode([
+            'ref' => 'refs/heads/main',
+            'repository' => ['full_name' => 'test-org/test-repo'],
+            'after' => 'ghi1236',
+            'commits' => [],
+            'head_commit' => ['message' => 'fix: resolve null pointer'],
+        ]);
+
+        $hmac = hash_hmac('sha256', $payload, $secret);
+
+        $response = $this->call('POST', '/webhooks/source/gitea/events/manual', [], [], [], [
+            'HTTP_X-Gitea-Event' => 'push',
+            'HTTP_X-Hub-Signature-256' => "sha256={$hmac}",
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+
+        $response->assertOk();
+
+        $queue = ApplicationDeploymentQueue::where('application_id', $app->id)->first();
+        expect($queue)->not->toBeNull();
+        expect($queue->status)->not->toBe(ApplicationDeploymentStatus::SKIPPED_BY_COMMIT_MESSAGE->value);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Bitbucket Manual Webhook
+// ---------------------------------------------------------------------------
+describe('Bitbucket manual webhook – skip deployment', function () {
+    test('skips deployment when commit message contains [skip coolify]', function () {
+        $app = createSkipTestApplication();
+        $secret = $app->manual_webhook_secret_bitbucket;
+
+        $payload = json_encode([
+            'push' => ['changes' => [['new' => ['name' => 'main', 'target' => ['hash' => 'jkl1234', 'message' => 'style: format code [skip coolify]']]]]],
+            'repository' => ['full_name' => 'test-org/test-repo'],
+        ]);
+
+        $hmac = hash_hmac('sha256', $payload, $secret);
+
+        $response = $this->call('POST', '/webhooks/source/bitbucket/events/manual', [], [], [], [
+            'HTTP_X-Event-Key' => 'repo:push',
+            'HTTP_X-Hub-Signature' => "sha256={$hmac}",
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+
+        $response->assertOk();
+        expect($response->getContent())->toContain('skipped');
+
+        $queue = ApplicationDeploymentQueue::where('application_id', $app->id)->first();
+        expect($queue)->not->toBeNull();
+        expect($queue->status)->toBe(ApplicationDeploymentStatus::SKIPPED_BY_COMMIT_MESSAGE->value);
+    });
+
+    test('skips deployment when commit message contains [coolify skip]', function () {
+        $app = createSkipTestApplication();
+        $secret = $app->manual_webhook_secret_bitbucket;
+
+        $payload = json_encode([
+            'push' => ['changes' => [['new' => ['name' => 'main', 'target' => ['hash' => 'jkl1235', 'message' => '[coolify skip] refactor: rename vars']]]]],
+            'repository' => ['full_name' => 'test-org/test-repo'],
+        ]);
+
+        $hmac = hash_hmac('sha256', $payload, $secret);
+
+        $response = $this->call('POST', '/webhooks/source/bitbucket/events/manual', [], [], [], [
+            'HTTP_X-Event-Key' => 'repo:push',
+            'HTTP_X-Hub-Signature' => "sha256={$hmac}",
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+
+        $response->assertOk();
+        expect($response->getContent())->toContain('skipped');
+    });
+
+    test('does not skip deployment without skip tag', function () {
+        $app = createSkipTestApplication();
+        $secret = $app->manual_webhook_secret_bitbucket;
+
+        $payload = json_encode([
+            'push' => ['changes' => [['new' => ['name' => 'main', 'target' => ['hash' => 'jkl1236', 'message' => 'feat: dark mode support']]]]],
+            'repository' => ['full_name' => 'test-org/test-repo'],
+        ]);
+
+        $hmac = hash_hmac('sha256', $payload, $secret);
+
+        $response = $this->call('POST', '/webhooks/source/bitbucket/events/manual', [], [], [], [
+            'HTTP_X-Event-Key' => 'repo:push',
+            'HTTP_X-Hub-Signature' => "sha256={$hmac}",
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+
+        $response->assertOk();
+
+        $queue = ApplicationDeploymentQueue::where('application_id', $app->id)->first();
+        expect($queue)->not->toBeNull();
+        expect($queue->status)->not->toBe(ApplicationDeploymentStatus::SKIPPED_BY_COMMIT_MESSAGE->value);
+    });
+});


### PR DESCRIPTION
## Changes

- This will skip a deployment if the commit message contains `[skip coolify]` or `[coolify skip]` and display it in the UI, too.

## Issues

- Fixes https://github.com/coollabsio/coolify/discussions/4358.

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

<img width="558" height="397" alt="image" src="https://github.com/user-attachments/assets/2895cc2e-5bb2-407d-bbe7-2541fa1c9c34" />
<br />
<img width="453" height="254" alt="image" src="https://github.com/user-attachments/assets/e5116f1f-b994-4ac9-8f4b-1dc63ebce321" />

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: GitHub Copilot
- How extensively: mostly for the PHP part since I don't know PHP that well.

## Testing

- Added tests
- Tested manually on localhost by sending two webhooks (see screenshots)

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
