### PR TITLE
feat: add WordPress OpenLiteSpeed service template

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed-and-mariadb.yaml
+++ b/templates/compose/wordpress-with-openlitespeed-and-mariadb.yaml
@@ -1,0 +1,67 @@
+# documentation: https://docs.litespeedtech.com/cloud/docker/ols-wordpress/
+# slogan: WordPress served by OpenLiteSpeed with MariaDB and persistent storage.
+# category: cms
+# tags: cms, blog, wordpress, openlitespeed, litespeed, mariadb
+# logo: svgs/wordpress.svg
+# port: 80
+
+services:
+  openlitespeed:
+    image: litespeedtech/openlitespeed:1.8.5-lsphp84
+    volumes:
+      - openlitespeed-conf:/usr/local/lsws/conf
+      - openlitespeed-admin-conf:/usr/local/lsws/admin/conf
+      - openlitespeed-logs:/usr/local/lsws/logs
+      - wordpress-files:/var/www/vhosts/localhost/html
+    environment:
+      - SERVICE_URL_OPENLITESPEED_80
+      - WORDPRESS_DB_HOST=mariadb
+      - WORDPRESS_DB_USER=$SERVICE_USER_WORDPRESS
+      - WORDPRESS_DB_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+      - WORDPRESS_DB_NAME=wordpress
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    command: >
+      bash -lc '
+        set -e;
+        install_dir=/var/www/vhosts/localhost/html;
+        mkdir -p "$install_dir";
+        cd "$install_dir";
+        if [ ! -f wp-load.php ]; then
+          wp core download --allow-root;
+        fi;
+        if [ ! -f wp-config.php ]; then
+          wp config create
+            --dbname="$WORDPRESS_DB_NAME"
+            --dbuser="$WORDPRESS_DB_USER"
+            --dbpass="$WORDPRESS_DB_PASSWORD"
+            --dbhost="$WORDPRESS_DB_HOST"
+            --skip-check
+            --allow-root;
+          if [ -n "$SERVICE_URL_OPENLITESPEED_80" ]; then
+            wp config set WP_HOME "$SERVICE_URL_OPENLITESPEED_80" --type=constant --allow-root;
+            wp config set WP_SITEURL "$SERVICE_URL_OPENLITESPEED_80" --type=constant --allow-root;
+          fi;
+        fi;
+        wp plugin install litespeed-cache --activate --allow-root || true;
+      '
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10

--- a/templates/service-templates-latest.json
+++ b/templates/service-templates-latest.json
@@ -5225,6 +5225,23 @@
         "logo": "svgs/wordpress.svg",
         "minversion": "0.0.0"
     },
+    "wordpress-with-openlitespeed-and-mariadb": {
+        "documentation": "https://docs.litespeedtech.com/cloud/docker/ols-wordpress/?utm_source=coolify.io",
+        "slogan": "WordPress served by OpenLiteSpeed with MariaDB and persistent storage.",
+        "compose": "c2VydmljZXM6CiAgb3BlbmxpdGVzcGVlZDoKICAgIGltYWdlOiBsaXRlc3BlZWR0ZWNoL29wZW5saXRlc3BlZWQ6MS44LjUtbHNwaHA4NAogICAgdm9sdW1lczoKICAgIC0gb3BlbmxpdGVzcGVlZC1jb25mOi91c3IvbG9jYWwvbHN3cy9jb25mCiAgICAtIG9wZW5saXRlc3BlZWQtYWRtaW4tY29uZjovdXNyL2xvY2FsL2xzd3MvYWRtaW4vY29uZgogICAgLSBvcGVubGl0ZXNwZWVkLWxvZ3M6L3Vzci9sb2NhbC9sc3dzL2xvZ3MKICAgIC0gd29yZHByZXNzLWZpbGVzOi92YXIvd3d3L3Zob3N0cy9sb2NhbGhvc3QvaHRtbAogICAgZW52aXJvbm1lbnQ6CiAgICAtIFNFUlZJQ0VfVVJMX09QRU5MSVRFU1BFRURfODAKICAgIC0gV09SRFBSRVNTX0RCX0hPU1Q9bWFyaWFkYgogICAgLSBXT1JEUFJFU1NfREJfVVNFUj0kU0VSVklDRV9VU0VSX1dPUkRQUkVTUwogICAgLSBXT1JEUFJFU1NfREJfUEFTU1dPUkQ9JFNFUlZJQ0VfUEFTU1dPUkRfV09SRFBSRVNTCiAgICAtIFdPUkRQUkVTU19EQl9OQU1FPXdvcmRwcmVzcwogICAgZGVwZW5kc19vbjoKICAgICAgbWFyaWFkYjoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfaGVhbHRoeQogICAgY29tbWFuZDogImJhc2ggLWxjICdcbiAgc2V0IC1lO1xuICBpbnN0YWxsX2Rpcj0vdmFyL3d3dy92aG9zdHMvbG9jYWxob3N0L2h0bWw7XG4gIG1rZGlyIC1wIFwiJGluc3RhbGxfZGlyXCI7XG4gIGNkIFwiJGluc3RhbGxfZGlyXCI7XG4gIGlmIFsgISAtZiB3cC1sb2FkLnBocCBdOyB0aGVuXG4gICAgd3AgY29yZSBkb3dubG9hZCAtLWFsbG93LXJvb3Q7XG4gIGZpO1xuICBpZiBbICEgLWYgd3AtY29uZmlnLnBocCBdOyB0aGVuXG4gICAgd3AgY29uZmlnIGNyZWF0ZVxuICAgICAgLS1kYm5hbWU9XCIkV09SRFBSRVNTX0RCX05BTUVcIlxuICAgICAgLS1kYnVzZXI9XCIkV09SRFBSRVNTX0RCX1VTRVJcIlxuICAgICAgLS1kYnBhc3M9XCIkV09SRFBSRVNTX0RCX1BBU1NXT1JEXCJcbiAgICAgIC0tZGJob3N0PVwiJFdPUkRQUkVTU19EQl9IT1NUXCJcbiAgICAgIC0tc2tpcC1jaGVja1xuICAgICAgLS1hbGxvdy1yb290O1xuICAgIGlmIFsgLW4gXCIkU0VSVklDRV9VUkxfT1BFTkxJVEVTUEVFRF84MFwiIF07IHRoZW5cbiAgICAgIHdwIGNvbmZpZyBzZXQgV1BfSE9NRSBcIiRTRVJWSUNFX1VSTF9PUEVOTElURVNQRUVEXzgwXCIgLS10eXBlPWNvbnN0YW50IC0tYWxsb3ctcm9vdDtcbiAgICAgIHdwIGNvbmZpZyBzZXQgV1BfU0lURVVSTCBcIiRTRVJWSUNFX1VSTF9PUEVOTElURVNQRUVEXzgwXCIgLS10eXBlPWNvbnN0YW50IC0tYWxsb3ctcm9vdDtcbiAgICBmaTtcbiAgZmk7XG4gIHdwIHBsdWdpbiBpbnN0YWxsIGxpdGVzcGVlZC1jYWNoZSAtLWFjdGl2YXRlIC0tYWxsb3ctcm9vdCB8fCB0cnVlO1xuJ1xuIgogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgIC0gQ01ECiAgICAgIC0gY3VybAogICAgICAtIC1mCiAgICAgIC0gaHR0cDovLzEyNy4wLjAuMQogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCiAgbWFyaWFkYjoKICAgIGltYWdlOiBtYXJpYWRiOjExCiAgICB2b2x1bWVzOgogICAgLSBtYXJpYWRiLWRhdGE6L3Zhci9saWIvbXlzcWwKICAgIGVudmlyb25tZW50OgogICAgLSBNWVNRTF9ST09UX1BBU1NXT1JEPSRTRVJWSUNFX1BBU1NXT1JEX1JPT1QKICAgIC0gTVlTUUxfREFUQUJBU0U9d29yZHByZXNzCiAgICAtIE1ZU1FMX1VTRVI9JFNFUlZJQ0VfVVNFUl9XT1JEUFJFU1MKICAgIC0gTVlTUUxfUEFTU1dPUkQ9JFNFUlZJQ0VfUEFTU1dPUkRfV09SRFBSRVNTCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgLSBDTUQKICAgICAgLSBoZWFsdGhjaGVjay5zaAogICAgICAtIC0tY29ubmVjdAogICAgICAtIC0taW5ub2RiX2luaXRpYWxpemVkCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAK",
+        "tags": [
+            "cms",
+            "blog",
+            "wordpress",
+            "openlitespeed",
+            "litespeed",
+            "mariadb"
+        ],
+        "category": "cms",
+        "logo": "svgs/wordpress.svg",
+        "minversion": "0.0.0",
+        "port": "80"
+    },
     "wordpress-without-database": {
         "documentation": "https://wordpress.org?utm_source=coolify.io",
         "slogan": "WordPress is open source software you can use to create a beautiful website, blog, or app.",

--- a/templates/service-templates.json
+++ b/templates/service-templates.json
@@ -5225,6 +5225,23 @@
         "logo": "svgs/wordpress.svg",
         "minversion": "0.0.0"
     },
+    "wordpress-with-openlitespeed-and-mariadb": {
+        "documentation": "https://docs.litespeedtech.com/cloud/docker/ols-wordpress/?utm_source=coolify.io",
+        "slogan": "WordPress served by OpenLiteSpeed with MariaDB and persistent storage.",
+        "compose": "c2VydmljZXM6CiAgb3BlbmxpdGVzcGVlZDoKICAgIGltYWdlOiBsaXRlc3BlZWR0ZWNoL29wZW5saXRlc3BlZWQ6MS44LjUtbHNwaHA4NAogICAgdm9sdW1lczoKICAgIC0gb3BlbmxpdGVzcGVlZC1jb25mOi91c3IvbG9jYWwvbHN3cy9jb25mCiAgICAtIG9wZW5saXRlc3BlZWQtYWRtaW4tY29uZjovdXNyL2xvY2FsL2xzd3MvYWRtaW4vY29uZgogICAgLSBvcGVubGl0ZXNwZWVkLWxvZ3M6L3Vzci9sb2NhbC9sc3dzL2xvZ3MKICAgIC0gd29yZHByZXNzLWZpbGVzOi92YXIvd3d3L3Zob3N0cy9sb2NhbGhvc3QvaHRtbAogICAgZW52aXJvbm1lbnQ6CiAgICAtIFNFUlZJQ0VfRlFETl9PUEVOTElURVNQRUVEXzgwCiAgICAtIFdPUkRQUkVTU19EQl9IT1NUPW1hcmlhZGIKICAgIC0gV09SRFBSRVNTX0RCX1VTRVI9JFNFUlZJQ0VfVVNFUl9XT1JEUFJFU1MKICAgIC0gV09SRFBSRVNTX0RCX1BBU1NXT1JEPSRTRVJWSUNFX1BBU1NXT1JEX1dPUkRQUkVTUwogICAgLSBXT1JEUFJFU1NfREJfTkFNRT13b3JkcHJlc3MKICAgIGRlcGVuZHNfb246CiAgICAgIG1hcmlhZGI6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICAgIGNvbW1hbmQ6ICJiYXNoIC1sYyAnXG4gIHNldCAtZTtcbiAgaW5zdGFsbF9kaXI9L3Zhci93d3cvdmhvc3RzL2xvY2FsaG9zdC9odG1sO1xuICBta2RpciAtcCBcIiRpbnN0YWxsX2RpclwiO1xuICBjZCBcIiRpbnN0YWxsX2RpclwiO1xuICBpZiBbICEgLWYgd3AtbG9hZC5waHAgXTsgdGhlblxuICAgIHdwIGNvcmUgZG93bmxvYWQgLS1hbGxvdy1yb290O1xuICBmaTtcbiAgaWYgWyAhIC1mIHdwLWNvbmZpZy5waHAgXTsgdGhlblxuICAgIHdwIGNvbmZpZyBjcmVhdGVcbiAgICAgIC0tZGJuYW1lPVwiJFdPUkRQUkVTU19EQl9OQU1FXCJcbiAgICAgIC0tZGJ1c2VyPVwiJFdPUkRQUkVTU19EQl9VU0VSXCJcbiAgICAgIC0tZGJwYXNzPVwiJFdPUkRQUkVTU19EQl9QQVNTV09SRFwiXG4gICAgICAtLWRiaG9zdD1cIiRXT1JEUFJFU1NfREJfSE9TVFwiXG4gICAgICAtLXNraXAtY2hlY2tcbiAgICAgIC0tYWxsb3ctcm9vdDtcbiAgICBpZiBbIC1uIFwiJFNFUlZJQ0VfRlFETl9PUEVOTElURVNQRUVEXzgwXCIgXTsgdGhlblxuICAgICAgd3AgY29uZmlnIHNldCBXUF9IT01FIFwiJFNFUlZJQ0VfRlFETl9PUEVOTElURVNQRUVEXzgwXCIgLS10eXBlPWNvbnN0YW50IC0tYWxsb3ctcm9vdDtcbiAgICAgIHdwIGNvbmZpZyBzZXQgV1BfU0lURVVSTCBcIiRTRVJWSUNFX0ZRRE5fT1BFTkxJVEVTUEVFRF84MFwiIC0tdHlwZT1jb25zdGFudCAtLWFsbG93LXJvb3Q7XG4gICAgZmk7XG4gIGZpO1xuICB3cCBwbHVnaW4gaW5zdGFsbCBsaXRlc3BlZWQtY2FjaGUgLS1hY3RpdmF0ZSAtLWFsbG93LXJvb3QgfHwgdHJ1ZTtcbidcbiIKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAtIENNRAogICAgICAtIGN1cmwKICAgICAgLSAtZgogICAgICAtIGh0dHA6Ly8xMjcuMC4wLjEKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogIG1hcmlhZGI6CiAgICBpbWFnZTogbWFyaWFkYjoxMQogICAgdm9sdW1lczoKICAgIC0gbWFyaWFkYi1kYXRhOi92YXIvbGliL215c3FsCiAgICBlbnZpcm9ubWVudDoKICAgIC0gTVlTUUxfUk9PVF9QQVNTV09SRD0kU0VSVklDRV9QQVNTV09SRF9ST09UCiAgICAtIE1ZU1FMX0RBVEFCQVNFPXdvcmRwcmVzcwogICAgLSBNWVNRTF9VU0VSPSRTRVJWSUNFX1VTRVJfV09SRFBSRVNTCiAgICAtIE1ZU1FMX1BBU1NXT1JEPSRTRVJWSUNFX1BBU1NXT1JEX1dPUkRQUkVTUwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgIC0gQ01ECiAgICAgIC0gaGVhbHRoY2hlY2suc2gKICAgICAgLSAtLWNvbm5lY3QKICAgICAgLSAtLWlubm9kYl9pbml0aWFsaXplZAogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCg==",
+        "tags": [
+            "cms",
+            "blog",
+            "wordpress",
+            "openlitespeed",
+            "litespeed",
+            "mariadb"
+        ],
+        "category": "cms",
+        "logo": "svgs/wordpress.svg",
+        "minversion": "0.0.0",
+        "port": "80"
+    },
     "wordpress-without-database": {
         "documentation": "https://wordpress.org?utm_source=coolify.io",
         "slogan": "WordPress is open source software you can use to create a beautiful website, blog, or app.",


### PR DESCRIPTION
## Changes

- Added a `wordpress-with-openlitespeed-and-mariadb` one-click service template.
- Uses the official `litespeedtech/openlitespeed:1.8.5-lsphp84` image with MariaDB 11.
- Persists WordPress files, OpenLiteSpeed config/admin config/logs, and database data.
- Wires Coolify's generated service URL into WordPress config when available and includes the LiteSpeed Cache plugin install path.
- Updated both generated service template manifests.

## Issues

- Fixes #8264
- /claim #8264

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No screenshot/video is attached from this environment because Docker is not available here to run a local Coolify deployment. The template is a compose-only service entry and was validated by parsing the compose YAML and generated manifests locally.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Hermes Agent via CLI/editor automation.
- How extensively: AI-assisted implementation and local validation; changes were kept to a single service template plus generated manifests.

## Testing

- `git diff --check`
- `python3` YAML/JSON validation:
  - parsed `templates/compose/wordpress-with-openlitespeed-and-mariadb.yaml`
  - parsed `templates/service-templates.json` and `templates/service-templates-latest.json`
  - base64-decoded and parsed the new manifest compose payloads
  - verified latest manifest uses `SERVICE_URL_OPENLITESPEED_80` and FQDN manifest uses `SERVICE_FQDN_OPENLITESPEED_80`
- Not run: `php artisan generate:services` / PHP tests because `php` is not installed in this environment.
- Not run: Composer commands because `composer` is not installed in this environment.
- Not run: Docker compose deployment because `docker` is not installed in this environment.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
