### PR TITLE
fix: add container metadata info tab to application view

### DIFF
--- a/app/Livewire/Project/Application/ContainerInfo.php
+++ b/app/Livewire/Project/Application/ContainerInfo.php
@@ -1,0 +1,67 @@
+
+<?php
+
+namespace App\Livewire\Project\Application;
+
+use App\Models\Application;
+use Livewire\Component;
+use Illuminate\Support\Carbon;
+
+class ContainerInfo extends Component
+{
+    public Application $application;
+
+    public array $parameters;
+
+    public function mount()
+    {
+        $this->parameters = [
+            'project_uuid' => $this->application->project()->uuid,
+            'environment_uuid' => $this->application->environment->uuid,
+            'application_uuid' => $this->application->uuid,
+        ];
+    }
+
+    public function getContainerInfoProperty()
+    {
+        $server = $this->application->destination->server;
+        $containerId = $this->application->uuid;
+
+        $containerData = getContainerStatus($server, $containerId, true);
+
+        if ($containerData === 'exited' || empty($containerData)) {
+            return null;
+        }
+
+        $container = $containerData;
+
+        $createdAt = Carbon::parse(data_get($container, 'Created'));
+        $status = data_get($container, 'State.Status');
+        $image = data_get($container, 'Config.Image');
+        $imageId = data_get($container, 'Image');
+
+        $startedAt = null;
+        $uptime = null;
+
+        if ($status === 'running') {
+            $startedAt = Carbon::parse(data_get($container, 'State.StartedAt'));
+            $uptime = $startedAt->diffForHumans(null, true);
+        }
+
+        return [
+            'id' => data_get($container, 'Id'),
+            'image' => $image,
+            'image_id' => $imageId,
+            'created_at' => $createdAt->format('Y-m-d H:i:s'),
+            'created_at_human' => $createdAt->diffForHumans(),
+            'status' => $status,
+            'started_at' => $startedAt ? $startedAt->format('Y-m-d H:i:s') : null,
+            'uptime' => $uptime,
+        ];
+    }
+
+    public function render()
+    {
+        return view('livewire.project.application.container-info');
+    }
+}

--- a/resources/views/livewire/project/application/container-info.blade.php
+++ b/resources/views/livewire/project/application/container-info.blade.php
@@ -1,0 +1,71 @@
+
+<div>
+    <div class="flex flex-col gap-4">
+        @if($this->containerInfo)
+            <div class="card">
+                <div class="flex flex-col gap-2">
+                    <div class="flex items-center gap-2">
+                        <h3 class="text-lg font-bold">Container Information</h3>
+                    </div>
+
+                    <div class="overflow-x-auto">
+                        <table class="w-full text-left text-sm">
+                            <tbody>
+                                <tr class="border-b border-coolgray-200 dark:border-coolgray-700">
+                                    <td class="py-2 font-medium">Container ID</td>
+                                    <td class="py-2">{{ Str::limit($this->containerInfo['id'], 12) }}</td>
+                                </tr>
+                                <tr class="border-b border-coolgray-200 dark:border-coolgray-700">
+                                    <td class="py-2 font-medium">Docker Image</td>
+                                    <td class="py-2">{{ $this->containerInfo['image'] }}</td>
+                                </tr>
+                                <tr class="border-b border-coolgray-200 dark:border-coolgray-700">
+                                    <td class="py-2 font-medium">Image ID</td>
+                                    <td class="py-2">{{ Str::limit($this->containerInfo['image_id'], 12) }}</td>
+                                </tr>
+                                <tr class="border-b border-coolgray-200 dark:border-coolgray-700">
+                                    <td class="py-2 font-medium">Created At</td>
+                                    <td class="py-2">
+                                        {{ $this->containerInfo['created_at'] }}
+                                        <span class="text-xs text-coolgray-500 dark:text-coolgray-400">
+                                            ({{ $this->containerInfo['created_at_human'] }})
+                                        </span>
+                                    </td>
+                                </tr>
+                                <tr class="border-b border-coolgray-200 dark:border-coolgray-700">
+                                    <td class="py-2 font-medium">Status</td>
+                                    <td class="py-2">
+                                        <span class="badge badge-{{ $this->containerInfo['status'] === 'running' ? 'success' : 'warning' }}">
+                                            {{ ucfirst($this->containerInfo['status']) }}
+                                        </span>
+                                    </td>
+                                </tr>
+                                @if($this->containerInfo['status'] === 'running')
+                                    <tr class="border-b border-coolgray-200 dark:border-coolgray-700">
+                                        <td class="py-2 font-medium">Started At</td>
+                                        <td class="py-2">{{ $this->containerInfo['started_at'] }}</td>
+                                    </tr>
+                                    <tr class="border-b border-coolgray-200 dark:border-coolgray-700">
+                                        <td class="py-2 font-medium">Uptime</td>
+                                        <td class="py-2">{{ $this->containerInfo['uptime'] }}</td>
+                                    </tr>
+                                @endif
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        @else
+            <div class="card">
+                <div class="flex flex-col items-center justify-center gap-2 p-8">
+                    <div class="text-center">
+                        <h3 class="text-lg font-bold">Container Offline</h3>
+                        <p class="text-coolgray-500 dark:text-coolgray-400">
+                            Metadata unavailable. The container is not running.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        @endif
+    </div>
+</div>

--- a/resources/views/livewire/project/application/heading.blade.php
+++ b/resources/views/livewire/project/application/heading.blade.php
@@ -22,6 +22,10 @@
                     @endif
                 </div>
             </a>
+            <a class="shrink-0 {{ request()->routeIs('project.application.container-info') ? 'dark:text-white' : '' }}" {{ wireNavigate() }}
+                href="{{ route('project.application.container-info', $parameters) }}">
+                Container Info
+            </a>
             @if (!$application->destination->server->isSwarm())
                 @can('canAccessTerminal')
                     <a class="shrink-0 {{ request()->routeIs('project.application.command') ? 'dark:text-white' : '' }}"

--- a/routes/web.php
+++ b/routes/web.php
@@ -234,6 +234,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/deployment/{deployment_uuid}', DeploymentShow::class)->name('project.application.deployment.show');
         Route::get('/logs', Logs::class)->name('project.application.logs');
         Route::get('/terminal', ExecuteContainerCommand::class)->name('project.application.command')->middleware('can.access.terminal');
+        Route::get('/container-info', \App\Livewire\Project\Application\ContainerInfo::class)->name('project.application.container-info');
         Route::get('/tasks/{task_uuid}', ApplicationConfiguration::class)->name('project.application.scheduled-tasks');
     });
     Route::prefix('project/{project_uuid}/environment/{environment_uuid}/database/{database_uuid}')->group(function () {


### PR DESCRIPTION
Addresses #2495. Adds a simple tab to display the running container's metadata (ID, Image Hash, Uptime, Created timestamp) directly via Livewire hooks. 

To test:
1. Spin up an app resource.
2. Click the new Container Info tab to verify it safely displays the active container specs.