### PR TITLE
fix(lang): add missing keys for Authentik and Zitadel OAuth

### DIFF
--- a/lang/tr.json
+++ b/lang/tr.json
@@ -1,5 +1,6 @@
 {
     "auth.login": "Giriş",
+    "auth.login.authentik": "Authentik ile Giriş Yap",
     "auth.login.azure": "Microsoft ile Giriş Yap",
     "auth.login.bitbucket": "Bitbucket ile Giriş Yap",
     "auth.login.clerk": "Clerk ile Giriş Yap",
@@ -8,6 +9,7 @@
     "auth.login.gitlab": "GitLab ile Giriş Yap",
     "auth.login.google": "Google ile Giriş Yap",
     "auth.login.infomaniak": "Infomaniak ile Giriş Yap",
+    "auth.login.zitadel": "Zitadel ile Giriş Yap",
     "auth.already_registered": "Zaten kayıtlı mısınız?",
     "auth.confirm_password": "Şifreyi Onayla",
     "auth.forgot_password_link": "Şifrenizi mi unuttunuz?",


### PR DESCRIPTION
## Changes

Adds the two missing Turkish translations in `lang/tr.json` so it reaches
parity with `lang/en.json`:

- `auth.login.authentik` → "Authentik ile Giriş Yap"
- `auth.login.zitadel` → "Zitadel ile Giriş Yap"

Both strings follow the existing "<Provider> ile Giriş Yap" convention used
by every other OAuth provider in tr.json (Microsoft, GitHub, GitLab, Google,
Discord, Bitbucket, Clerk, Infomaniak).

## Issues

- N/A — small language file parity fix.

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Text-only diff (login screen). Renders identically to existing
`auth.login.github`, `auth.login.google`, etc. — no UI screenshot needed.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Anthropic)
- How extensively: Used to spot the en/tr key gap (`array_diff_key` between
  en.json and tr.json) and draft consistent translations following the
  existing convention. Native Turkish speaker reviewed and approved the
  2-line diff before submission.

## Testing

- `jq empty lang/tr.json` → valid JSON
- Key count parity: `lang/en.json` = 42, `lang/tr.json` = 42
- No extra/missing keys vs en.json (`(en keys) - (tr keys) = 0`,
  `(tr keys) - (en keys) = 0`)
- Pattern consistency with existing `auth.login.<provider>` entries

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
