### PR TITLE
feat(ui): add collapsible sidebar with tooltip and team menu

### DIFF
--- a/resources/css/utilities.css
+++ b/resources/css/utilities.css
@@ -343,3 +343,12 @@
 @utility log-info {
     @apply bg-blue-500/10 dark:bg-blue-500/15;
 }
+
+@media (min-width: 1024px) {
+    .sidebar-collapsed .menu-item {
+        justify-content: center;
+        padding-left: 0;
+        padding-right: 0;
+        gap: 0;
+    }
+}

--- a/resources/views/components/navbar.blade.php
+++ b/resources/views/components/navbar.blade.php
@@ -1,5 +1,20 @@
-<nav class="flex flex-col flex-1 px-2 bg-white border-r dark:border-coolgray-200 border-neutral-300 dark:bg-base"
+<nav class="flex flex-col flex-1 bg-white border-r dark:border-coolgray-200 border-neutral-300 dark:bg-base"
+    :class="collapsed ? 'lg:px-1 px-2 sidebar-collapsed' : 'px-2'"
+    @mouseover="
+        if (!collapsed) return;
+        const el = $event.target.closest('.menu-item');
+        if (!el) { tooltip.show = false; return; }
+        const text = el.getAttribute('title') || el.getAttribute('aria-label') || '';
+        if (!text) return;
+        const rect = el.getBoundingClientRect();
+        tooltip.text = text;
+        tooltip.x = rect.right + 8;
+        tooltip.y = rect.top + rect.height / 2;
+        tooltip.show = true;
+    "
+    @mouseleave="tooltip.show = false"
     x-data="{
+        tooltip: { text: '', x: 0, y: 0, show: false },
         switchWidth() {
                 if (this.full === 'full') {
                     localStorage.setItem('pageWidth', 'center');
@@ -77,12 +92,22 @@
                 }
             }
     }">
-    <div class="flex lg:pt-6 pt-4 pb-4 pl-2">
-        <div class="flex flex-col w-full">
+    <div class="flex lg:pt-6 pt-4 pb-4 pl-2 items-start gap-2"
+        :class="collapsed ? 'lg:flex-col lg:items-center lg:pl-0 lg:gap-3' : ''">
+        <div class="flex flex-col w-full" :class="collapsed && 'lg:hidden'">
             <a href="/" {{ wireNavigate() }} class="text-2xl font-bold tracking-tight dark:text-white hover:opacity-80 transition-opacity">Coolify</a>
             <x-version />
         </div>
-        <div>
+        <div class="hidden flex-col items-center w-full gap-1"
+            :class="collapsed && 'lg:flex'">
+            <a href="/" {{ wireNavigate() }}
+                class="hover:opacity-80 transition-opacity"
+                title="Coolify">
+                <img src="/coolify-logo.svg" alt="Coolify" class="w-6 h-6" />
+            </a>
+            <x-version class="text-[10px]" />
+        </div>
+        <div :class="collapsed && 'lg:hidden'">
             <!-- Search button that triggers global search modal -->
             <button @click="$dispatch('open-global-search')" type="button" title="Search (Press / or ⌘K)"
                 class="flex items-center gap-1.5 px-2.5 py-1.5 bg-neutral-100 dark:bg-coolgray-100 border border-neutral-300 dark:border-coolgray-200 rounded-md hover:bg-neutral-200 dark:hover:bg-coolgray-200 transition-colors">
@@ -95,9 +120,11 @@
                     class="px-1 py-0.5 text-xs font-semibold text-neutral-500 dark:text-neutral-400 bg-neutral-200 dark:bg-coolgray-200 rounded">/</kbd>
             </button>
         </div>
-        <livewire:settings-dropdown />
+        <div :class="collapsed && 'lg:hidden'">
+            <livewire:settings-dropdown />
+        </div>
     </div>
-    <div class="px-2 pt-2 pb-7">
+    <div class="px-2 pt-2 pb-7" :class="collapsed && 'lg:px-0 lg:pt-0 lg:pb-4 lg:flex lg:justify-center'">
         <livewire:switch-team />
     </div>
     <ul role="list" class="flex flex-col flex-1 gap-y-7">
@@ -112,7 +139,7 @@
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                                     d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
                             </svg>
-                            <span class="menu-item-label">Dashboard</span>
+                            <span class="menu-item-label" :class="collapsed && 'lg:hidden'">Dashboard</span>
                         </a>
                     </li>
                     <li>
@@ -127,7 +154,7 @@
                                 <path d="M4 12l8 4l8 -4" />
                                 <path d="M4 16l8 4l8 -4" />
                             </svg>
-                            <span class="menu-item-label">Projects</span>
+                            <span class="menu-item-label" :class="collapsed && 'lg:hidden'">Projects</span>
                         </a>
                     </li>
                     <li>
@@ -145,7 +172,7 @@
                                 <path d="M7 16v.01" />
                                 <path d="M20 15l-2 3h3l-2 3" />
                             </svg>
-                            <span class="menu-item-label">Servers</span>
+                            <span class="menu-item-label" :class="collapsed && 'lg:hidden'">Servers</span>
                         </a>
                     </li>
 
@@ -157,7 +184,7 @@
                                 <path fill="currentColor"
                                     d="m6.793 1.207l.353.354l-.353-.354ZM1.207 6.793l-.353-.354l.353.354Zm0 1.414l.354-.353l-.354.353Zm5.586 5.586l-.354.353l.354-.353Zm1.414 0l-.353-.354l.353.354Zm5.586-5.586l.353.354l-.353-.354Zm0-1.414l-.354.353l.354-.353ZM8.207 1.207l.354-.353l-.354.353ZM6.44.854L.854 6.439l.707.707l5.585-5.585L6.44.854ZM.854 8.56l5.585 5.585l.707-.707l-5.585-5.585l-.707.707Zm7.707 5.585l5.585-5.585l-.707-.707l-5.585 5.585l.707.707Zm5.585-7.707L8.561.854l-.707.707l5.585 5.585l.707-.707Zm0 2.122a1.5 1.5 0 0 0 0-2.122l-.707.707a.5.5 0 0 1 0 .708l.707.707ZM6.44 14.146a1.5 1.5 0 0 0 2.122 0l-.707-.707a.5.5 0 0 1-.708 0l-.707.707ZM.854 6.44a1.5 1.5 0 0 0 0 2.122l.707-.707a.5.5 0 0 1 0-.708L.854 6.44Zm6.292-4.878a.5.5 0 0 1 .708 0L8.56.854a1.5 1.5 0 0 0-2.122 0l.707.707Zm-2 1.293l1 1l.708-.708l-1-1l-.708.708ZM7.5 5a.5.5 0 0 1-.5-.5H6A1.5 1.5 0 0 0 7.5 6V5Zm.5-.5a.5.5 0 0 1-.5.5v1A1.5 1.5 0 0 0 9 4.5H8ZM7.5 4a.5.5 0 0 1 .5.5h1A1.5 1.5 0 0 0 7.5 3v1Zm0-1A1.5 1.5 0 0 0 6 4.5h1a.5.5 0 0 1 .5-.5V3Zm.646 2.854l1.5 1.5l.707-.708l-1.5-1.5l-.707.708ZM10.5 8a.5.5 0 0 1-.5-.5H9A1.5 1.5 0 0 0 10.5 9V8Zm.5-.5a.5.5 0 0 1-.5.5v1A1.5 1.5 0 0 0 12 7.5h-1Zm-.5-.5a.5.5 0 0 1 .5.5h1A1.5 1.5 0 0 0 10.5 6v1Zm0-1A1.5 1.5 0 0 0 9 7.5h1a.5.5 0 0 1 .5-.5V6ZM7 5.5v4h1v-4H7Zm.5 5.5a.5.5 0 0 1-.5-.5H6A1.5 1.5 0 0 0 7.5 12v-1Zm.5-.5a.5.5 0 0 1-.5.5v1A1.5 1.5 0 0 0 9 10.5H8Zm-.5-.5a.5.5 0 0 1 .5.5h1A1.5 1.5 0 0 0 7.5 9v1Zm0-1A1.5 1.5 0 0 0 6 10.5h1a.5.5 0 0 1 .5-.5V9Z" />
                             </svg>
-                            <span class="menu-item-label">Sources</span>
+                            <span class="menu-item-label" :class="collapsed && 'lg:hidden'">Sources</span>
                         </a>
                     </li>
                     <li>
@@ -170,7 +197,7 @@
                                     stroke-linejoin="round" stroke-width="2"
                                     d="M9 4L3 8v12l6-3l6 3l6-4V4l-6 3l-6-3zm-2 8.001V12m4 .001V12m3-2l2 2m2 2l-2-2m0 0l2-2m-2 2l-2 2" />
                             </svg>
-                            <span class="menu-item-label">Destinations</span>
+                            <span class="menu-item-label" :class="collapsed && 'lg:hidden'">Destinations</span>
                         </a>
                     </li>
                     <li>
@@ -185,7 +212,7 @@
                                     <path d="M4 12v6a8 3 0 0 0 16 0v-6" />
                                 </g>
                             </svg>
-                            <span class="menu-item-label">S3 Storages</span>
+                            <span class="menu-item-label" :class="collapsed && 'lg:hidden'">S3 Storages</span>
                         </a>
                     </li>
                     <li>
@@ -200,7 +227,7 @@
                                     <path d="M8 16c1.5 0 3-2 4-3.5S14.5 9 16 9" />
                                 </g>
                             </svg>
-                            <span class="menu-item-label">Shared Variables</span>
+                            <span class="menu-item-label" :class="collapsed && 'lg:hidden'">Shared Variables</span>
                         </a>
                     </li>
                     <li>
@@ -212,7 +239,7 @@
                                     stroke-linejoin="round" stroke-width="2"
                                     d="M10 5a2 2 0 1 1 4 0a7 7 0 0 1 4 6v3a4 4 0 0 0 2 3H4a4 4 0 0 0 2-3v-3a7 7 0 0 1 4-6M9 17v1a3 3 0 0 0 6 0v-1" />
                             </svg>
-                            <span class="menu-item-label">Notifications</span>
+                            <span class="menu-item-label" :class="collapsed && 'lg:hidden'">Notifications</span>
                         </a>
                     </li>
                     <li>
@@ -224,7 +251,7 @@
                                     stroke-linejoin="round" stroke-width="2"
                                     d="m16.555 3.843l3.602 3.602a2.877 2.877 0 0 1 0 4.069l-2.643 2.643a2.877 2.877 0 0 1-4.069 0l-.301-.301l-6.558 6.558a2 2 0 0 1-1.239.578L5.172 21H4a1 1 0 0 1-.993-.883L3 20v-1.172a2 2 0 0 1 .467-1.284l.119-.13L4 17h2v-2h2v-2l2.144-2.144l-.301-.301a2.877 2.877 0 0 1 0-4.069l2.643-2.643a2.877 2.877 0 0 1 4.069 0zM15 9h.01" />
                             </svg>
-                            <span class="menu-item-label">Keys & Tokens</span>
+                            <span class="menu-item-label" :class="collapsed && 'lg:hidden'">Keys & Tokens</span>
                         </a>
                     </li>
                     <li>
@@ -239,7 +266,7 @@
                                     <path d="m18 19l1.592-1.592a4.82 4.82 0 0 0 0-6.816L15 6m-8 4h-.01" />
                                 </g>
                             </svg>
-                            <span class="menu-item-label">Tags</span>
+                            <span class="menu-item-label" :class="collapsed && 'lg:hidden'">Tags</span>
                         </a>
                     </li>
                     @can('canAccessTerminal')
@@ -254,7 +281,7 @@
                                     <path d="M5 7l5 5l-5 5" />
                                     <path d="M12 19l7 0" />
                                 </svg>
-                                <span class="menu-item-label">Terminal</span>
+                                <span class="menu-item-label" :class="collapsed && 'lg:hidden'">Terminal</span>
                             </a>
                         </li>
                     @endcan
@@ -270,7 +297,7 @@
                                 <path d="M12 10m-3 0a3 3 0 1 0 6 0a3 3 0 1 0 -6 0" />
                                 <path d="M6.168 18.849a4 4 0 0 1 3.832 -2.849h4a4 4 0 0 1 3.834 2.855" />
                             </svg>
-                            <span class="menu-item-label">Profile</span>
+                            <span class="menu-item-label" :class="collapsed && 'lg:hidden'">Profile</span>
                         </a>
                     </li>
                     <li>
@@ -288,7 +315,7 @@
                                 <path d="M5 5a2 2 0 1 0 4 0a2 2 0 0 0 -4 0" />
                                 <path d="M3 13v-1a2 2 0 0 1 2 -2h2" />
                             </svg>
-                            <span class="menu-item-label">Teams</span>
+                            <span class="menu-item-label" :class="collapsed && 'lg:hidden'">Teams</span>
                         </a>
                     </li>
                     @if (isCloud() && auth()->user()->isAdmin())
@@ -301,7 +328,7 @@
                                         stroke-linejoin="round" stroke-width="2"
                                         d="M3 8a3 3 0 0 1 3-3h12a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3zm0 2h18M7 15h.01M11 15h2" />
                                 </svg>
-                                <span class="menu-item-label">Subscription</span>
+                                <span class="menu-item-label" :class="collapsed && 'lg:hidden'">Subscription</span>
                             </a>
                         </li>
                     @endif
@@ -319,7 +346,7 @@
                                         d="M10.325 4.317c.426 -1.756 2.924 -1.756 3.35 0a1.724 1.724 0 0 0 2.573 1.066c1.543 -.94 3.31 .826 2.37 2.37a1.724 1.724 0 0 0 1.065 2.572c1.756 .426 1.756 2.924 0 3.35a1.724 1.724 0 0 0 -1.066 2.573c.94 1.543 -.826 3.31 -2.37 2.37a1.724 1.724 0 0 0 -2.572 1.065c-.426 1.756 -2.924 1.756 -3.35 0a1.724 1.724 0 0 0 -2.573 -1.066c-1.543 .94 -3.31 -.826 -2.37 -2.37a1.724 1.724 0 0 0 -1.065 -2.572c-1.756 -.426 -1.756 -2.924 0 -3.35a1.724 1.724 0 0 0 1.066 -2.573c-.94 -1.543 .826 -3.31 2.37 -2.37c1 .608 2.296 .07 2.572 -1.065z" />
                                     <path d="M9 12a3 3 0 1 0 6 0a3 3 0 0 0 -6 0" />
                                 </svg>
-                                <span class="menu-item-label">Settings</span>
+                                <span class="menu-item-label" :class="collapsed && 'lg:hidden'">Settings</span>
                             </a>
                         </li>
                     @endif
@@ -333,7 +360,7 @@
                                         <path fill="currentColor"
                                             d="M177.62 159.6a52 52 0 0 1-34 34a12.2 12.2 0 0 1-3.6.55a12 12 0 0 1-3.6-23.45a28 28 0 0 0 18.32-18.32a12 12 0 0 1 22.9 7.2ZM220 144a92 92 0 0 1-184 0c0-28.81 11.27-58.18 33.48-87.28a12 12 0 0 1 17.9-1.33l19.69 19.11L127 19.89a12 12 0 0 1 18.94-5.12C168.2 33.25 220 82.85 220 144m-24 0c0-41.71-30.61-78.39-52.52-99.29l-20.21 55.4a12 12 0 0 1-19.63 4.5L80.71 82.36C67 103.38 60 124.06 60 144a68 68 0 0 0 136 0" />
                                     </svg>
-                                    <span class="menu-item-label">Admin</span>
+                                    <span class="menu-item-label" :class="collapsed && 'lg:hidden'">Admin</span>
                                 </a>
                             </li>
                         @endif
@@ -341,7 +368,7 @@
                     <div class="flex-1"></div>
                     @if (isInstanceAdmin() && !isCloud())
                         @persist('upgrade')
-                            <li>
+                            <li :class="collapsed && 'lg:hidden'">
                                 <livewire:upgrade />
                             </li>
                         @endpersist
@@ -368,7 +395,7 @@
                                         d="M12 6L8.707 9.293a1 1 0 0 0 0 1.414l.543.543c.69.69 1.81.69 2.5 0l1-1a3.182 3.182 0 0 1 4.5 0l2.25 2.25m-7 3l2 2M15 13l2 2" />
                                 </g>
                             </svg>
-                            <span class="menu-item-label">Sponsor us</span>
+                            <span class="menu-item-label" :class="collapsed && 'lg:hidden'">Sponsor us</span>
                         </a>
                     </li>
                 @endif
@@ -384,7 +411,7 @@
                                     <path fill="currentColor"
                                         d="M140 180a12 12 0 1 1-12-12a12 12 0 0 1 12 12M128 72c-22.06 0-40 16.15-40 36v4a8 8 0 0 0 16 0v-4c0-11 10.77-20 24-20s24 9 24 20s-10.77 20-24 20a8 8 0 0 0-8 8v8a8 8 0 0 0 16 0v-.72c18.24-3.35 32-17.9 32-35.28c0-19.85-17.94-36-40-36m104 56A104 104 0 1 1 128 24a104.11 104.11 0 0 1 104 104m-16 0a88 88 0 1 0-88 88a88.1 88.1 0 0 0 88-88" />
                                 </svg>
-                                <span class="menu-item-label">Feedback</span>
+                                <span class="menu-item-label" :class="collapsed && 'lg:hidden'">Feedback</span>
                             </div>
                         </x-slot:content>
                         <livewire:help />
@@ -394,15 +421,21 @@
                     <form action="/logout" method="POST">
                         @csrf
                         <button title="Logout" type="submit" class="gap-2 mb-6 menu-item">
-                            <svg class="menu-item-icon mr-1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                            <svg class="menu-item-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                                 <path fill="currentColor"
                                     d="M12 22C6.477 22 2 17.523 2 12S6.477 2 12 2a9.985 9.985 0 0 1 8 4h-2.71a8 8 0 1 0 .001 12h2.71A9.985 9.985 0 0 1 12 22m7-6v-3h-8v-2h8V8l5 4z" />
                             </svg>
-                            <span>Logout</span>
+                            <span :class="collapsed && 'lg:hidden'">Logout</span>
                         </button>
                     </form>
                 </li>
             </ul>
         </li>
     </ul>
+    <div x-show="collapsed && tooltip.show"
+        x-cloak
+        x-transition.opacity.duration.100ms
+        :style="`left: ${tooltip.x}px; top: ${tooltip.y}px;`"
+        class="fixed z-[100] -translate-y-1/2 px-2 py-1 text-xs font-medium rounded-md bg-neutral-900 dark:bg-coolgray-300 text-white whitespace-nowrap pointer-events-none shadow-lg border border-neutral-700 dark:border-coolgray-200"
+        x-text="tooltip.text"></div>
 </nav>

--- a/resources/views/components/navbar.blade.php
+++ b/resources/views/components/navbar.blade.php
@@ -92,8 +92,8 @@
                 }
             }
     }">
-    <div class="flex lg:pt-6 pt-4 pb-4 pl-2 items-start gap-2"
-        :class="collapsed ? 'lg:flex-col lg:items-center lg:pl-0 lg:gap-3' : ''">
+    <div class="flex pt-4 pb-4 pl-2 items-start gap-2"
+        :class="collapsed ? 'lg:flex-col lg:items-center lg:pl-0 lg:gap-3 lg:pt-8' : 'lg:pt-6'">
         <div class="flex flex-col w-full" :class="collapsed && 'lg:hidden'">
             <a href="/" {{ wireNavigate() }} class="text-2xl font-bold tracking-tight dark:text-white hover:opacity-80 transition-opacity">Coolify</a>
             <x-version />

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -10,12 +10,19 @@
         <livewire:deployments-indicator />
         <div x-data="{
             open: false,
+            collapsed: false,
+            pageWidth: 'full',
             init() {
                 this.pageWidth = localStorage.getItem('pageWidth');
                 if (!this.pageWidth) {
                     this.pageWidth = 'full';
                     localStorage.setItem('pageWidth', 'full');
                 }
+                this.collapsed = localStorage.getItem('sidebarCollapsed') === 'true';
+            },
+            toggleSidebar() {
+                this.collapsed = !this.collapsed;
+                localStorage.setItem('sidebarCollapsed', this.collapsed);
             }
         }" x-cloak class="mx-auto dark:text-inherit text-black"
             :class="pageWidth === 'full' ? '' : 'max-w-7xl'">
@@ -40,10 +47,20 @@
                 </div>
             </div>
 
-            <div class="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-56 lg:flex-col min-w-0">
+            <div class="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:flex-col min-w-0 transition-[width] duration-200"
+                :class="collapsed ? 'lg:w-16' : 'lg:w-56'">
                 <div class="flex flex-col overflow-y-auto grow gap-y-5 scrollbar min-w-0">
                     <x-navbar />
                 </div>
+                <button type="button" @click="toggleSidebar()"
+                    :title="collapsed ? 'Expand sidebar' : 'Collapse sidebar'"
+                    class="absolute top-8 -right-3 z-50 hidden lg:flex items-center justify-center w-6 h-6 rounded-full border bg-white dark:bg-coolgray-100 dark:border-coolgray-200 border-neutral-300 hover:bg-neutral-100 dark:hover:bg-coolgray-200 transition-colors shadow-sm">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 text-neutral-600 dark:text-neutral-300 transition-transform"
+                        :class="collapsed ? '' : 'rotate-180'"
+                        fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+                    </svg>
+                </button>
             </div>
 
             <div
@@ -62,7 +79,7 @@
                 </button>
             </div>
 
-            <main class="lg:pl-56">
+            <main class="transition-[padding] duration-200" :class="collapsed ? 'lg:pl-16' : 'lg:pl-56'">
                 <div class="p-4 sm:px-6 lg:px-8 lg:py-6">
                     {{ $slot }}
                 </div>

--- a/resources/views/livewire/switch-team.blade.php
+++ b/resources/views/livewire/switch-team.blade.php
@@ -1,6 +1,49 @@
-<x-forms.select wire:model.live="selectedTeamId">
-    <option value="default" disabled selected>Switch team</option>
-    @foreach (auth()->user()->teams as $team)
-        <option value="{{ $team->id }}">{{ $team->name }}</option>
-    @endforeach
-</x-forms.select>
+@php
+    $currentTeam = auth()->user()->currentTeam();
+    $teamInitial = strtoupper(mb_substr($currentTeam->name, 0, 1));
+@endphp
+<div>
+    <div :class="collapsed && 'lg:hidden'">
+        <x-forms.select wire:model.live="selectedTeamId">
+            <option value="default" disabled selected>Switch team</option>
+            @foreach (auth()->user()->teams as $team)
+                <option value="{{ $team->id }}">{{ $team->name }}</option>
+            @endforeach
+        </x-forms.select>
+    </div>
+    <div class="hidden"
+        :class="collapsed && 'lg:block'"
+        x-data="{
+            teamOpen: false,
+            teamX: 0,
+            teamY: 0,
+            openTeamMenu(ev) {
+                const rect = ev.currentTarget.getBoundingClientRect();
+                this.teamX = rect.right + 8;
+                this.teamY = rect.top;
+                this.teamOpen = !this.teamOpen;
+            }
+        }">
+        <button @click="openTeamMenu($event)" type="button"
+            title="Team: {{ $currentTeam->name }}"
+            class="flex items-center justify-center w-8 h-8 text-sm font-semibold rounded-md bg-coollabs hover:opacity-80 transition-opacity text-white cursor-pointer">
+            {{ $teamInitial }}
+        </button>
+        <div x-show="teamOpen"
+            @click.outside="teamOpen = false"
+            x-transition.opacity.duration.100ms
+            x-cloak
+            :style="`left: ${teamX}px; top: ${teamY}px;`"
+            class="fixed z-[100] min-w-48 max-h-72 overflow-y-auto bg-white dark:bg-coolgray-100 border border-neutral-300 dark:border-coolgray-200 rounded-md shadow-lg py-1">
+            <div class="px-3 py-1.5 text-xs font-semibold text-neutral-500 dark:text-neutral-400 border-b border-neutral-200 dark:border-coolgray-200">Switch team</div>
+            @foreach (auth()->user()->teams as $team)
+                <button type="button"
+                    wire:click="switch_to({{ $team->id }})"
+                    @click="teamOpen = false"
+                    class="w-full px-3 py-1.5 text-left text-sm hover:bg-neutral-100 dark:hover:bg-coolgray-200 dark:text-white {{ $team->id === $currentTeam->id ? 'font-semibold text-coollabs dark:text-warning' : '' }}">
+                    {{ $team->name }}
+                </button>
+            @endforeach
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary

- Desktop sidebar now collapses to icon-only rail (`lg:w-16`) via toggle button; state persisted in `localStorage`
- Smooth width/padding transition (`duration-200`) on sidebar and main content area
- Collapsed state hides text labels (`menu-item-label`), branding/version, search, settings dropdown, and upgrade widget; icons stay centered via `.sidebar-collapsed .menu-item` utility CSS
- Tooltip portal renders item labels on hover when sidebar is collapsed (fixed-position, follows cursor via `mouseover` delegation)
- `switch-team.blade.php` gains a collapsed variant: shows team initial avatar button; click opens a flyout dropdown positioned relative to the button
- Coolify logo SVG shown in collapsed header in place of text wordmark
