### PR TITLE
feat: persist deployment log timestamp toggle preference in localStorage

### DIFF
--- a/resources/views/livewire/project/application/deployment/show.blade.php
+++ b/resources/views/livewire/project/application/deployment/show.blade.php
@@ -9,7 +9,7 @@
         fullscreen: @entangle('fullscreen'),
         alwaysScroll: {{ $isKeepAliveOn ? 'true' : 'false' }},
         rafId: null,
-        showTimestamps: true,
+        showTimestamps: localStorage.getItem('coolify-deployment-show-timestamps') !== 'false',
         searchQuery: '',
         matchCount: 0,
         deploymentId: '{{ $application_deployment_queue->deployment_uuid ?? 'deployment' }}',
@@ -279,7 +279,7 @@
                                     </div>
                                 </div>
                             </div>
-                            <button title="Toggle Timestamps" x-on:click="showTimestamps = !showTimestamps"
+                            <button title="Toggle Timestamps" x-on:click="showTimestamps = !showTimestamps; localStorage.setItem('coolify-deployment-show-timestamps', showTimestamps)"
                                 :class="showTimestamps ? '!text-warning' : ''"
                                 class="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
                                 <svg class="w-4 h-4" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none"


### PR DESCRIPTION
## Changes

The deployment log view has a clock button to toggle timestamp visibility. Previously, this preference was stored only in Alpine.js memory and reset to `true` on every page reload.

This change persists the user's choice in `localStorage` under the key `coolify-deployment-show-timestamps`, consistent with how other log preferences are already stored (`coolify-color-logs`, `coolify-log-filters`).

Two lines changed in `resources/views/livewire/project/application/deployment/show.blade.php`:
- Initialization reads from `localStorage` (defaults to `true` when the key is absent)
- The toggle button writes the new value to `localStorage` on each click

## Issues

- Fixes #9955

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Toggle off → reload → timestamps remain hidden. Toggle on → reload → timestamps remain visible.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude (AI coding assistant) for suggesting the implementation
- How extensively: AI suggested the two-line change; code was reviewed and tested manually

## Testing

1. Open any deployment log page
2. Click the clock icon to hide timestamps — they disappear
3. Reload the page — timestamps stay hidden
4. Click again to show them — reload — they stay visible
5. Verify `coolify-deployment-show-timestamps` key in DevTools → Application → Local Storage

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.