### PR TITLE
Add Ruflo service template

### DIFF
--- a/public/svgs/ruflo.svg
+++ b/public/svgs/ruflo.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" role="img" aria-label="Ruflo">
+  <title>Ruflo</title>
+  <defs>
+    <linearGradient id="ruflo-bg" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#7C3AED"/>
+      <stop offset="1" stop-color="#0EA5E9"/>
+    </linearGradient>
+    <linearGradient id="ruflo-stroke" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FFFFFF" stop-opacity="0.95"/>
+      <stop offset="1" stop-color="#FFFFFF" stop-opacity="0.75"/>
+    </linearGradient>
+  </defs>
+  <rect x="2" y="2" width="60" height="60" rx="14" fill="url(#ruflo-bg)"/>
+  <!-- Mesh / swarm: 7 nodes connected in a hub-spoke + ring pattern -->
+  <g stroke="url(#ruflo-stroke)" stroke-width="1.6" stroke-linecap="round">
+    <line x1="32" y1="32" x2="32" y2="14"/>
+    <line x1="32" y1="32" x2="48" y2="22"/>
+    <line x1="32" y1="32" x2="50" y2="40"/>
+    <line x1="32" y1="32" x2="40" y2="52"/>
+    <line x1="32" y1="32" x2="22" y2="50"/>
+    <line x1="32" y1="32" x2="14" y2="38"/>
+    <line x1="32" y1="32" x2="18" y2="22"/>
+    <line x1="32" y1="14" x2="48" y2="22"/>
+    <line x1="48" y1="22" x2="50" y2="40"/>
+    <line x1="50" y1="40" x2="40" y2="52"/>
+    <line x1="40" y1="52" x2="22" y2="50"/>
+    <line x1="22" y1="50" x2="14" y2="38"/>
+    <line x1="14" y1="38" x2="18" y2="22"/>
+    <line x1="18" y1="22" x2="32" y2="14"/>
+  </g>
+  <g fill="#FFFFFF">
+    <circle cx="32" cy="32" r="4.5"/>
+    <circle cx="32" cy="14" r="2.6"/>
+    <circle cx="48" cy="22" r="2.6"/>
+    <circle cx="50" cy="40" r="2.6"/>
+    <circle cx="40" cy="52" r="2.6"/>
+    <circle cx="22" cy="50" r="2.6"/>
+    <circle cx="14" cy="38" r="2.6"/>
+    <circle cx="18" cy="22" r="2.6"/>
+  </g>
+</svg>

--- a/templates/compose/ruflo.yaml
+++ b/templates/compose/ruflo.yaml
@@ -1,0 +1,139 @@
+# documentation: https://github.com/ruvnet/ruflo
+# slogan: Multi-agent orchestration for Claude Code with 87 MCP tools, swarm coordination, and a built-in chat UI
+# tags: ai,agents,mcp,claude,llm,orchestration,swarm,chat-ui
+# logo: svgs/ruflo.svg
+# port: 3000
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Ruflo on Coolify v4
+#
+# Mirrors ruflo/docker-compose.yml from upstream (ruvnet/ruflo) and replaces:
+#   • host port bindings  →  ${SERVICE_FQDN_NGINX_3000} (Coolify routes via Traefik)
+#   • bare Mongo          →  authenticated Mongo with ${SERVICE_USER_MONGO} / ${SERVICE_PASSWORD_MONGO}
+#   • build contexts      →  pre-built images at ghcr.io/yashodhank/ruflo-*
+#                            (published by the companion ruvnet/ruflo workflow)
+#
+# Required (set in Coolify env panel):
+#   At least ONE of OPENAI_API_KEY / GOOGLE_API_KEY / OPENROUTER_API_KEY
+#
+# Optional MCP-tool group toggles (all default per upstream defaults):
+#   MCP_GROUP_INTELLIGENCE / _AGENTS / _MEMORY / _DEVTOOLS  (default: true)
+#   MCP_GROUP_SECURITY / _BROWSER / _NEURAL / _AGENTIC_FLOW
+#     / _CLAUDE_CODE / _GEMINI / _CODEX                     (default: false)
+#   ANTHROPIC_API_KEY                                       (required iff MCP_GROUP_CLAUDE_CODE=true)
+#
+# Magic envs resolved by Coolify at deploy time:
+#   ${SERVICE_FQDN_NGINX_3000}   → public HTTPS URL for the chat UI
+#   ${SERVICE_USER_MONGO} / ${SERVICE_PASSWORD_MONGO}
+# ─────────────────────────────────────────────────────────────────────────────
+
+services:
+
+  # ── MongoDB ────────────────────────────────────────────────────────────────
+  mongodb:
+    image: mongo:7
+    restart: unless-stopped
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${SERVICE_USER_MONGO}
+      MONGO_INITDB_ROOT_PASSWORD: ${SERVICE_PASSWORD_MONGO}
+      MONGO_INITDB_DATABASE: ${MONGODB_DB_NAME:-chat-db}
+    volumes:
+      - mongo-data:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping').ok"]
+      interval: 15s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
+  # ── MCP Bridge — OpenAI-compatible MCP gateway ─────────────────────────────
+  mcp-bridge:
+    image: ghcr.io/yashodhank/ruflo-mcp-bridge:${RUFLO_IMAGE_TAG:-latest}
+    restart: unless-stopped
+    environment:
+      PORT: "3001"
+      NODE_ENV: production
+      # ── At least ONE provider key required ─────────────────────────────
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      GOOGLE_API_KEY: ${GOOGLE_API_KEY:-}
+      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+      # ── Optional: Anthropic key (only when MCP_GROUP_CLAUDE_CODE=true) ─
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      # ── Optional backend service URLs ──────────────────────────────────
+      SEARCH_API_URL: ${SEARCH_API_URL:-}
+      RESEARCH_API_URL: ${RESEARCH_API_URL:-}
+      # ── Tool group toggles (mirror upstream defaults) ──────────────────
+      MCP_GROUP_INTELLIGENCE: ${MCP_GROUP_INTELLIGENCE:-true}
+      MCP_GROUP_AGENTS: ${MCP_GROUP_AGENTS:-true}
+      MCP_GROUP_MEMORY: ${MCP_GROUP_MEMORY:-true}
+      MCP_GROUP_DEVTOOLS: ${MCP_GROUP_DEVTOOLS:-true}
+      MCP_GROUP_SECURITY: ${MCP_GROUP_SECURITY:-false}
+      MCP_GROUP_BROWSER: ${MCP_GROUP_BROWSER:-false}
+      MCP_GROUP_NEURAL: ${MCP_GROUP_NEURAL:-false}
+      MCP_GROUP_AGENTIC_FLOW: ${MCP_GROUP_AGENTIC_FLOW:-false}
+      MCP_GROUP_CLAUDE_CODE: ${MCP_GROUP_CLAUDE_CODE:-false}
+      MCP_GROUP_GEMINI: ${MCP_GROUP_GEMINI:-false}
+      MCP_GROUP_CODEX: ${MCP_GROUP_CODEX:-false}
+    volumes:
+      - mcp-bridge-state:/app/.claude-flow
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://localhost:3001/health').then(r => process.exit(r.ok ? 0 : 1))"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  # ── Chat UI — RUVocal SvelteKit fork (HuggingFace chat-ui base) ────────────
+  chat-ui:
+    image: ghcr.io/yashodhank/ruflo-chat-ui:${RUFLO_IMAGE_TAG:-latest}
+    restart: unless-stopped
+    depends_on:
+      mongodb:
+        condition: service_healthy
+      mcp-bridge:
+        condition: service_healthy
+    environment:
+      DOTENV_LOCAL: |
+        MONGODB_URL=mongodb://${SERVICE_USER_MONGO}:${SERVICE_PASSWORD_MONGO}@mongodb:27017/?authSource=admin
+        MONGODB_DB_NAME=${MONGODB_DB_NAME:-chat-db}
+        PUBLIC_APP_NAME=${BRAND_NAME:-RuFlo}
+        PUBLIC_APP_DESCRIPTION=${BRAND_DESCRIPTION:-Enterprise AI Agent Orchestration Platform}
+        PUBLIC_APP_ASSETS=chatui
+        PUBLIC_ORIGIN=${SERVICE_FQDN_NGINX_3000}
+        LLM_SUMMARIZATION=${LLM_SUMMARIZATION:-true}
+        ENABLE_DATA_EXPORT=${ENABLE_DATA_EXPORT:-true}
+        ALLOW_IFRAME=${ALLOW_IFRAME:-true}
+        OPENAI_BASE_URL=http://mcp-bridge:3001
+        OPENAI_API_KEY=${OPENAI_API_KEY:-sk-placeholder}
+        MCP_SERVERS=[{"name":"Core Tools","url":"http://mcp-bridge:3001/mcp/core"},{"name":"Intelligence & Learning","url":"http://mcp-bridge:3001/mcp/intelligence"},{"name":"Agents & Orchestration","url":"http://mcp-bridge:3001/mcp/agents"},{"name":"Memory & Knowledge","url":"http://mcp-bridge:3001/mcp/memory"},{"name":"Dev Tools & Analysis","url":"http://mcp-bridge:3001/mcp/devtools"}]
+        COOKIE_SECURE=${COOKIE_SECURE:-true}
+        COOKIE_SAMESITE=${COOKIE_SAMESITE:-lax}
+        OPENID_PROVIDER_URL=${OPENID_PROVIDER_URL:-}
+        OPENID_CLIENT_ID=${OPENID_CLIENT_ID:-}
+        OPENID_CLIENT_SECRET=${OPENID_CLIENT_SECRET:-}
+        OPENID_SCOPES=${OPENID_SCOPES:-openid profile email}
+        OPENID_NAME_CLAIM=${OPENID_NAME_CLAIM:-name}
+
+  # ── Nginx reverse proxy — primary HTTP entrypoint, brand injection ─────────
+  nginx:
+    image: ghcr.io/yashodhank/ruflo-nginx:${RUFLO_IMAGE_TAG:-latest}
+    restart: unless-stopped
+    depends_on:
+      chat-ui:
+        condition: service_started
+      mcp-bridge:
+        condition: service_healthy
+    environment:
+      SERVICE_FQDN_NGINX_3000: ""
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+volumes:
+  mongo-data:
+    driver: local
+  mcp-bridge-state:
+    driver: local


### PR DESCRIPTION
# Add Ruflo service template

## Summary

Adds a one-click service template for [Ruflo](https://github.com/ruvnet/ruflo)
— enterprise multi-agent orchestration for Claude Code with ~200 MCP tools
across 11 toggleable groups, a self-hosted chat UI, and an
OpenAI-compatible MCP bridge (45k+ ⭐, MIT, actively maintained by @ruvnet).

The template mirrors upstream's `ruflo/docker-compose.yml` 1:1 and replaces
host-port bindings with Coolify's `SERVICE_FQDN_*`, swaps bare Mongo for
authenticated Mongo with `SERVICE_USER_*` / `SERVICE_PASSWORD_*`, and pulls
pre-built images from GHCR (published by a companion PR at
`ruvnet/ruflo`) instead of build contexts.

## Files

| Path | Purpose |
|---|---|
| `templates/compose/ruflo.yaml` | The compose template — 4 services (mongodb, mcp-bridge, chat-ui, nginx), 2 named volumes, full upstream env-var coverage. |
| `public/svgs/ruflo.svg` | 64×64 logo — gradient + mesh swarm motif. |
| `docs/services/ruflo.md` | Service docs in standard frontmatter format. |

## Why this template is useful

- **Mirrors upstream architecture** — chat-ui + mcp-bridge + nginx +
  mongodb, exactly as upstream documents in `ruflo/.env.example` and
  `ruflo/docker-compose.yml`. No re-architecting.
- **Magic-env first** — `SERVICE_FQDN_NGINX_3000` for the public chat URL,
  `SERVICE_USER_MONGO` / `SERVICE_PASSWORD_MONGO` auto-generated for DB
  auth. Users only ever paste a provider API key.
- **All 11 MCP_GROUP_\* toggles exposed** — every tool group from the
  upstream `.env.example` is a tunable env in Coolify's panel, with
  defaults that match upstream.
- **Healthchecks preserved** — every healthcheck from upstream is kept
  verbatim so Traefik routing and the Coolify deploy status remain
  accurate.

## Eligibility

Per [coolify.io/docs/get-started/contribute/service](https://coolify.io/docs/get-started/contribute/service),
the source project needs ≥1,000 GitHub stars. Ruflo currently has 45,735+ ⭐.

## Image dependency

The template pulls these images:

```
ghcr.io/yashodhank/ruflo-mcp-bridge:${RUFLO_IMAGE_TAG:-latest}
ghcr.io/yashodhank/ruflo-chat-ui:${RUFLO_IMAGE_TAG:-latest}
ghcr.io/yashodhank/ruflo-nginx:${RUFLO_IMAGE_TAG:-latest}
mongo:7
```

These are published by an automated weekly snapshot workflow at
[`yashodhank/ruflo-coolify-contribution`](https://github.com/yashodhank/ruflo-coolify-contribution/blob/main/.github/workflows/build-ruflo-images.yml)
which builds the four Dockerfiles already in the upstream `ruvnet/ruflo`
tree (multi-arch, `linux/amd64` + `linux/arm64`) and publishes them to
GHCR. A companion PR at
[`ruvnet/ruflo#1829`](https://github.com/ruvnet/ruflo/pull/1829) ships
the same workflow upstream so the canonical namespace becomes
`ghcr.io/ruvnet/ruflo-*`. Once that PR merges, this template's image
refs can be swapped to upstream's namespace.

This means the template deploys cleanly today on any Coolify v4
instance — no waiting for an upstream merge, no local build step.

## Required user input

Just **one** of these provider keys in Coolify's env panel:

```
OPENAI_API_KEY=...    # or
GOOGLE_API_KEY=...    # or
OPENROUTER_API_KEY=...
```

Everything else (FQDN, Mongo creds, MCP-group defaults, brand strings,
cookie config) auto-generates or has a sensible default.

## Tested

- `docker compose -f templates/compose/ruflo.yaml --env-file .env config -q`
  passes
- `docker compose ... config` resolves all magic envs into concrete values
  and produces correct internal service references
  (`http://mcp-bridge:3001`, `mongodb://${user}:${pw}@mongodb:27017/...`)
- The template does **not** include `ports:` for any service — Coolify's
  Traefik routes via `SERVICE_FQDN_NGINX_3000`

## Open items

1. **Logo** — SVG follows a gradient + mesh swarm motif. Happy to swap for
   an upstream-provided asset if maintainers prefer.
2. **Per-service FQDNs** — the MCP bridge is internal-only by default;
   the docs explain how forks can add `SERVICE_FQDN_MCP_BRIDGE_3001` to
   expose it on its own subdomain.

## Out of scope

- No changes to Coolify core
- No modifications to other templates
- No Helm chart (separate effort)