### PR TITLE
feat: add public_host config for database resources

### DIFF
--- a/app/Livewire/Project/Database/Clickhouse/General.php
+++ b/app/Livewire/Project/Database/Clickhouse/General.php
@@ -38,6 +38,8 @@ class General extends Component
 
     public mixed $publicPortTimeout = 3600;
 
+    public ?string $publicHost = null;
+
     public ?string $customDockerRunOptions = null;
 
     public ?string $dbUrl = null;
@@ -87,6 +89,7 @@ class General extends Component
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer|min:1|max:65535',
             'publicPortTimeout' => 'nullable|integer|min:1',
+            'publicHost' => 'nullable|string',
             'customDockerRunOptions' => 'nullable|string',
             'dbUrl' => 'nullable|string',
             'dbUrlPublic' => 'nullable|string',
@@ -126,6 +129,7 @@ class General extends Component
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort ?: null;
             $this->database->public_port_timeout = $this->publicPortTimeout ?: null;
+            $this->database->public_host = $this->publicHost;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->save();
@@ -142,6 +146,7 @@ class General extends Component
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
             $this->publicPortTimeout = $this->database->public_port_timeout;
+            $this->publicHost = $this->database->public_host;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->dbUrl = $this->database->internal_db_url;

--- a/app/Livewire/Project/Database/Dragonfly/General.php
+++ b/app/Livewire/Project/Database/Dragonfly/General.php
@@ -38,6 +38,8 @@ class General extends Component
 
     public mixed $publicPortTimeout = 3600;
 
+    public ?string $publicHost = null;
+
     public ?string $customDockerRunOptions = null;
 
     public ?string $dbUrl = null;
@@ -97,6 +99,7 @@ class General extends Component
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer|min:1|max:65535',
             'publicPortTimeout' => 'nullable|integer|min:1',
+            'publicHost' => 'nullable|string',
             'customDockerRunOptions' => 'nullable|string',
             'dbUrl' => 'nullable|string',
             'dbUrlPublic' => 'nullable|string',
@@ -135,6 +138,7 @@ class General extends Component
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort ?: null;
             $this->database->public_port_timeout = $this->publicPortTimeout ?: null;
+            $this->database->public_host = $this->publicHost;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->enable_ssl = $this->enable_ssl;
@@ -151,6 +155,7 @@ class General extends Component
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
             $this->publicPortTimeout = $this->database->public_port_timeout;
+            $this->publicHost = $this->database->public_host;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->enable_ssl = $this->database->enable_ssl;

--- a/app/Livewire/Project/Database/Keydb/General.php
+++ b/app/Livewire/Project/Database/Keydb/General.php
@@ -40,6 +40,8 @@ class General extends Component
 
     public mixed $publicPortTimeout = 3600;
 
+    public ?string $publicHost = null;
+
     public ?string $customDockerRunOptions = null;
 
     public ?string $dbUrl = null;
@@ -100,6 +102,7 @@ class General extends Component
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer|min:1|max:65535',
             'publicPortTimeout' => 'nullable|integer|min:1',
+            'publicHost' => 'nullable|string',
             'customDockerRunOptions' => 'nullable|string',
             'dbUrl' => 'nullable|string',
             'dbUrlPublic' => 'nullable|string',
@@ -141,6 +144,7 @@ class General extends Component
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort ?: null;
             $this->database->public_port_timeout = $this->publicPortTimeout ?: null;
+            $this->database->public_host = $this->publicHost;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->enable_ssl = $this->enable_ssl;
@@ -158,6 +162,7 @@ class General extends Component
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
             $this->publicPortTimeout = $this->database->public_port_timeout;
+            $this->publicHost = $this->database->public_host;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->enable_ssl = $this->database->enable_ssl;

--- a/app/Livewire/Project/Database/Mariadb/General.php
+++ b/app/Livewire/Project/Database/Mariadb/General.php
@@ -46,6 +46,8 @@ class General extends Component
 
     public mixed $publicPortTimeout = 3600;
 
+    public ?string $publicHost = null;
+
     public bool $isLogDrainEnabled = false;
 
     public ?string $customDockerRunOptions = null;
@@ -92,6 +94,7 @@ class General extends Component
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer|min:1|max:65535',
             'publicPortTimeout' => 'nullable|integer|min:1',
+            'publicHost' => 'nullable|string',
             'isLogDrainEnabled' => 'nullable|boolean',
             'customDockerRunOptions' => 'nullable',
             'enableSsl' => 'boolean',
@@ -132,6 +135,7 @@ class General extends Component
         'isPublic' => 'Is Public',
         'publicPort' => 'Public Port',
         'publicPortTimeout' => 'Public Port Timeout',
+        'publicHost' => 'Public Host',
         'customDockerRunOptions' => 'Custom Docker Options',
         'enableSsl' => 'Enable SSL',
     ];
@@ -174,6 +178,7 @@ class General extends Component
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort ?: null;
             $this->database->public_port_timeout = $this->publicPortTimeout ?: null;
+            $this->database->public_host = $this->publicHost;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->enable_ssl = $this->enableSsl;
@@ -194,6 +199,7 @@ class General extends Component
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
             $this->publicPortTimeout = $this->database->public_port_timeout;
+            $this->publicHost = $this->database->public_host;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->enableSsl = $this->database->enable_ssl;

--- a/app/Livewire/Project/Database/Mongodb/General.php
+++ b/app/Livewire/Project/Database/Mongodb/General.php
@@ -44,6 +44,8 @@ class General extends Component
 
     public mixed $publicPortTimeout = 3600;
 
+    public ?string $publicHost = null;
+
     public bool $isLogDrainEnabled = false;
 
     public ?string $customDockerRunOptions = null;
@@ -89,6 +91,7 @@ class General extends Component
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer|min:1|max:65535',
             'publicPortTimeout' => 'nullable|integer|min:1',
+            'publicHost' => 'nullable|string',
             'isLogDrainEnabled' => 'nullable|boolean',
             'customDockerRunOptions' => 'nullable',
             'enableSsl' => 'boolean',
@@ -129,6 +132,7 @@ class General extends Component
         'isPublic' => 'Is Public',
         'publicPort' => 'Public Port',
         'publicPortTimeout' => 'Public Port Timeout',
+        'publicHost' => 'Public Host',
         'customDockerRunOptions' => 'Custom Docker Run Options',
         'enableSsl' => 'Enable SSL',
         'sslMode' => 'SSL Mode',
@@ -171,6 +175,7 @@ class General extends Component
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort ?: null;
             $this->database->public_port_timeout = $this->publicPortTimeout ?: null;
+            $this->database->public_host = $this->publicHost;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->enable_ssl = $this->enableSsl;
@@ -191,6 +196,7 @@ class General extends Component
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
             $this->publicPortTimeout = $this->database->public_port_timeout;
+            $this->publicHost = $this->database->public_host;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->enableSsl = $this->database->enable_ssl;

--- a/app/Livewire/Project/Database/Mysql/General.php
+++ b/app/Livewire/Project/Database/Mysql/General.php
@@ -46,6 +46,8 @@ class General extends Component
 
     public mixed $publicPortTimeout = 3600;
 
+    public ?string $publicHost = null;
+
     public bool $isLogDrainEnabled = false;
 
     public ?string $customDockerRunOptions = null;
@@ -94,6 +96,7 @@ class General extends Component
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer|min:1|max:65535',
             'publicPortTimeout' => 'nullable|integer|min:1',
+            'publicHost' => 'nullable|string',
             'isLogDrainEnabled' => 'nullable|boolean',
             'customDockerRunOptions' => 'nullable',
             'enableSsl' => 'boolean',
@@ -136,6 +139,7 @@ class General extends Component
         'isPublic' => 'Is Public',
         'publicPort' => 'Public Port',
         'publicPortTimeout' => 'Public Port Timeout',
+        'publicHost' => 'Public Host',
         'customDockerRunOptions' => 'Custom Docker Run Options',
         'enableSsl' => 'Enable SSL',
         'sslMode' => 'SSL Mode',
@@ -179,6 +183,7 @@ class General extends Component
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort ?: null;
             $this->database->public_port_timeout = $this->publicPortTimeout ?: null;
+            $this->database->public_host = $this->publicHost;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->enable_ssl = $this->enableSsl;
@@ -200,6 +205,7 @@ class General extends Component
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
             $this->publicPortTimeout = $this->database->public_port_timeout;
+            $this->publicHost = $this->database->public_host;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->enableSsl = $this->database->enable_ssl;

--- a/app/Livewire/Project/Database/Postgresql/General.php
+++ b/app/Livewire/Project/Database/Postgresql/General.php
@@ -50,6 +50,8 @@ class General extends Component
 
     public mixed $publicPortTimeout = 3600;
 
+    public ?string $publicHost = null;
+
     public bool $isLogDrainEnabled = false;
 
     public ?string $customDockerRunOptions = null;
@@ -104,6 +106,7 @@ class General extends Component
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer|min:1|max:65535',
             'publicPortTimeout' => 'nullable|integer|min:1',
+            'publicHost' => 'nullable|string',
             'isLogDrainEnabled' => 'nullable|boolean',
             'customDockerRunOptions' => 'nullable',
             'enableSsl' => 'boolean',
@@ -147,6 +150,7 @@ class General extends Component
         'isPublic' => 'Is Public',
         'publicPort' => 'Public Port',
         'publicPortTimeout' => 'Public Port Timeout',
+        'publicHost' => 'Public Host',
         'customDockerRunOptions' => 'Custom Docker Run Options',
         'enableSsl' => 'Enable SSL',
         'sslMode' => 'SSL Mode',
@@ -192,6 +196,7 @@ class General extends Component
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort ?: null;
             $this->database->public_port_timeout = $this->publicPortTimeout ?: null;
+            $this->database->public_host = $this->publicHost;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->enable_ssl = $this->enableSsl;
@@ -215,6 +220,7 @@ class General extends Component
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
             $this->publicPortTimeout = $this->database->public_port_timeout;
+            $this->publicHost = $this->database->public_host;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->enableSsl = $this->database->enable_ssl;

--- a/app/Livewire/Project/Database/Redis/General.php
+++ b/app/Livewire/Project/Database/Redis/General.php
@@ -38,6 +38,8 @@ class General extends Component
 
     public mixed $publicPortTimeout = 3600;
 
+    public ?string $publicHost = null;
+
     public bool $isLogDrainEnabled = false;
 
     public ?string $customDockerRunOptions = null;
@@ -79,6 +81,7 @@ class General extends Component
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer|min:1|max:65535',
             'publicPortTimeout' => 'nullable|integer|min:1',
+            'publicHost' => 'nullable|string',
             'isLogDrainEnabled' => 'nullable|boolean',
             'customDockerRunOptions' => 'nullable',
             'redisUsername' => ValidationPatterns::databaseIdentifierRules(
@@ -119,6 +122,7 @@ class General extends Component
         'isPublic' => 'Is Public',
         'publicPort' => 'Public Port',
         'publicPortTimeout' => 'Public Port Timeout',
+        'publicHost' => 'Public Host',
         'customDockerRunOptions' => 'Custom Docker Options',
         'redisUsername' => 'Redis Username',
         'redisPassword' => 'Redis Password',
@@ -159,6 +163,7 @@ class General extends Component
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort ?: null;
             $this->database->public_port_timeout = $this->publicPortTimeout ?: null;
+            $this->database->public_host = $this->publicHost;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
             $this->database->enable_ssl = $this->enableSsl;
@@ -175,6 +180,7 @@ class General extends Component
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
             $this->publicPortTimeout = $this->database->public_port_timeout;
+            $this->publicHost = $this->database->public_host;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;
             $this->enableSsl = $this->database->enable_ssl;

--- a/app/Livewire/Project/Service/Index.php
+++ b/app/Livewire/Project/Service/Index.php
@@ -55,6 +55,8 @@ class Index extends Component
 
     public mixed $publicPortTimeout = 3600;
 
+    public ?string $publicHost = null;
+
     public bool $isPublic = false;
 
     public bool $isLogDrainEnabled = false;
@@ -93,6 +95,7 @@ class Index extends Component
         'excludeFromStatus' => 'required|boolean',
         'publicPort' => 'nullable|integer|min:1|max:65535',
         'publicPortTimeout' => 'nullable|integer|min:1',
+        'publicHost' => 'nullable|string',
         'isPublic' => 'required|boolean',
         'isLogDrainEnabled' => 'required|boolean',
         // Application-specific rules
@@ -162,6 +165,7 @@ class Index extends Component
             $this->serviceDatabase->exclude_from_status = $this->excludeFromStatus;
             $this->serviceDatabase->public_port = $this->publicPort ?: null;
             $this->serviceDatabase->public_port_timeout = $this->publicPortTimeout ?: null;
+            $this->serviceDatabase->public_host = $this->publicHost;
             $this->serviceDatabase->is_public = $this->isPublic;
             $this->serviceDatabase->is_log_drain_enabled = $this->isLogDrainEnabled;
         } else {
@@ -171,6 +175,7 @@ class Index extends Component
             $this->excludeFromStatus = $this->serviceDatabase->exclude_from_status ?? false;
             $this->publicPort = $this->serviceDatabase->public_port;
             $this->publicPortTimeout = $this->serviceDatabase->public_port_timeout;
+            $this->publicHost = $this->serviceDatabase->public_host;
             $this->isPublic = $this->serviceDatabase->is_public ?? false;
             $this->isLogDrainEnabled = $this->serviceDatabase->is_log_drain_enabled ?? false;
         }

--- a/app/Models/ServiceDatabase.php
+++ b/app/Models/ServiceDatabase.php
@@ -21,6 +21,7 @@ class ServiceDatabase extends BaseModel
         'exclude_from_status',
         'image',
         'public_port',
+        'public_host',
         'is_public',
         'is_log_drain_enabled',
         'is_include_timestamps',
@@ -143,8 +144,9 @@ class ServiceDatabase extends BaseModel
         if ($this->service->server->isLocalhost() || isDev()) {
             $realIp = base_ip();
         }
+        $host = $this->public_host ?: $realIp;
 
-        return "{$realIp}:{$port}";
+        return "{$host}:{$port}";
     }
 
     public function team()

--- a/app/Models/StandaloneClickhouse.php
+++ b/app/Models/StandaloneClickhouse.php
@@ -25,6 +25,7 @@ class StandaloneClickhouse extends BaseModel
         'image',
         'is_public',
         'public_port',
+        'public_host',
         'ports_mappings',
         'limits_memory',
         'limits_memory_swap',
@@ -298,11 +299,12 @@ class StandaloneClickhouse extends BaseModel
                     if (empty($serverIp)) {
                         return null;
                     }
+                    $host = $this->public_host ?: $serverIp;
                     $encodedUser = rawurlencode($this->clickhouse_admin_user);
                     $encodedPass = rawurlencode($this->clickhouse_admin_password);
                     $database = $this->clickhouse_db ?? 'default';
 
-                    return "clickhouse://{$encodedUser}:{$encodedPass}@{$serverIp}:{$this->public_port}/{$database}";
+                    return "clickhouse://{$encodedUser}:{$encodedPass}@{$host}:{$this->public_port}/{$database}";
                 }
 
                 return null;

--- a/app/Models/StandaloneDragonfly.php
+++ b/app/Models/StandaloneDragonfly.php
@@ -24,6 +24,7 @@ class StandaloneDragonfly extends BaseModel
         'image',
         'is_public',
         'public_port',
+        'public_host',
         'ports_mappings',
         'limits_memory',
         'limits_memory_swap',
@@ -302,9 +303,10 @@ class StandaloneDragonfly extends BaseModel
                     if (empty($serverIp)) {
                         return null;
                     }
+                    $host = $this->public_host ?: $serverIp;
                     $scheme = $this->enable_ssl ? 'rediss' : 'redis';
                     $encodedPass = rawurlencode($this->dragonfly_password);
-                    $url = "{$scheme}://:{$encodedPass}@{$serverIp}:{$this->public_port}/0";
+                    $url = "{$scheme}://:{$encodedPass}@{$host}:{$this->public_port}/0";
 
                     if ($this->enable_ssl && $this->ssl_mode === 'verify-ca') {
                         $url .= '?cacert=/etc/ssl/certs/coolify-ca.crt';

--- a/app/Models/StandaloneKeydb.php
+++ b/app/Models/StandaloneKeydb.php
@@ -25,6 +25,7 @@ class StandaloneKeydb extends BaseModel
         'image',
         'is_public',
         'public_port',
+        'public_host',
         'ports_mappings',
         'limits_memory',
         'limits_memory_swap',
@@ -303,9 +304,10 @@ class StandaloneKeydb extends BaseModel
                     if (empty($serverIp)) {
                         return null;
                     }
+                    $host = $this->public_host ?: $serverIp;
                     $scheme = $this->enable_ssl ? 'rediss' : 'redis';
                     $encodedPass = rawurlencode($this->keydb_password);
-                    $url = "{$scheme}://:{$encodedPass}@{$serverIp}:{$this->public_port}/0";
+                    $url = "{$scheme}://:{$encodedPass}@{$host}:{$this->public_port}/0";
 
                     if ($this->enable_ssl && $this->ssl_mode === 'verify-ca') {
                         $url .= '?cacert=/etc/ssl/certs/coolify-ca.crt';

--- a/app/Models/StandaloneMariadb.php
+++ b/app/Models/StandaloneMariadb.php
@@ -27,6 +27,7 @@ class StandaloneMariadb extends BaseModel
         'image',
         'is_public',
         'public_port',
+        'public_host',
         'ports_mappings',
         'limits_memory',
         'limits_memory_swap',
@@ -295,10 +296,11 @@ class StandaloneMariadb extends BaseModel
                     if (empty($serverIp)) {
                         return null;
                     }
+                    $host = $this->public_host ?: $serverIp;
                     $encodedUser = rawurlencode($this->mariadb_user);
                     $encodedPass = rawurlencode($this->mariadb_password);
 
-                    return "mysql://{$encodedUser}:{$encodedPass}@{$serverIp}:{$this->public_port}/{$this->mariadb_database}";
+                    return "mysql://{$encodedUser}:{$encodedPass}@{$host}:{$this->public_port}/{$this->mariadb_database}";
                 }
 
                 return null;

--- a/app/Models/StandaloneMongodb.php
+++ b/app/Models/StandaloneMongodb.php
@@ -25,6 +25,7 @@ class StandaloneMongodb extends BaseModel
         'image',
         'is_public',
         'public_port',
+        'public_host',
         'ports_mappings',
         'limits_memory',
         'limits_memory_swap',
@@ -329,9 +330,10 @@ class StandaloneMongodb extends BaseModel
                     if (empty($serverIp)) {
                         return null;
                     }
+                    $host = $this->public_host ?: $serverIp;
                     $encodedUser = rawurlencode($this->mongo_initdb_root_username);
                     $encodedPass = rawurlencode($this->mongo_initdb_root_password);
-                    $url = "mongodb://{$encodedUser}:{$encodedPass}@{$serverIp}:{$this->public_port}/?directConnection=true";
+                    $url = "mongodb://{$encodedUser}:{$encodedPass}@{$host}:{$this->public_port}/?directConnection=true";
                     if ($this->enable_ssl) {
                         $url .= '&tls=true&tlsCAFile=/etc/mongo/certs/ca.pem';
                         if (in_array($this->ssl_mode, ['verify-full'])) {

--- a/app/Models/StandaloneMysql.php
+++ b/app/Models/StandaloneMysql.php
@@ -26,6 +26,7 @@ class StandaloneMysql extends BaseModel
         'image',
         'is_public',
         'public_port',
+        'public_host',
         'ports_mappings',
         'limits_memory',
         'limits_memory_swap',
@@ -309,9 +310,10 @@ class StandaloneMysql extends BaseModel
                     if (empty($serverIp)) {
                         return null;
                     }
+                    $host = $this->public_host ?: $serverIp;
                     $encodedUser = rawurlencode($this->mysql_user);
                     $encodedPass = rawurlencode($this->mysql_password);
-                    $url = "mysql://{$encodedUser}:{$encodedPass}@{$serverIp}:{$this->public_port}/{$this->mysql_database}";
+                    $url = "mysql://{$encodedUser}:{$encodedPass}@{$host}:{$this->public_port}/{$this->mysql_database}";
                     if ($this->enable_ssl) {
                         $url .= "?ssl-mode={$this->ssl_mode}";
                         if (in_array($this->ssl_mode, ['VERIFY_CA', 'VERIFY_IDENTITY'])) {

--- a/app/Models/StandalonePostgresql.php
+++ b/app/Models/StandalonePostgresql.php
@@ -28,6 +28,7 @@ class StandalonePostgresql extends BaseModel
         'image',
         'is_public',
         'public_port',
+        'public_host',
         'ports_mappings',
         'limits_memory',
         'limits_memory_swap',
@@ -320,9 +321,10 @@ class StandalonePostgresql extends BaseModel
                     if (empty($serverIp)) {
                         return null;
                     }
+                    $host = $this->public_host ?: $serverIp;
                     $encodedUser = rawurlencode($this->postgres_user);
                     $encodedPass = rawurlencode($this->postgres_password);
-                    $url = "postgres://{$encodedUser}:{$encodedPass}@{$serverIp}:{$this->public_port}/{$this->postgres_db}";
+                    $url = "postgres://{$encodedUser}:{$encodedPass}@{$host}:{$this->public_port}/{$this->postgres_db}";
                     if ($this->enable_ssl) {
                         $url .= "?sslmode={$this->ssl_mode}";
                         if (in_array($this->ssl_mode, ['verify-ca', 'verify-full'])) {

--- a/app/Models/StandaloneRedis.php
+++ b/app/Models/StandaloneRedis.php
@@ -22,6 +22,7 @@ class StandaloneRedis extends BaseModel
         'image',
         'is_public',
         'public_port',
+        'public_host',
         'ports_mappings',
         'limits_memory',
         'limits_memory_swap',
@@ -309,11 +310,12 @@ class StandaloneRedis extends BaseModel
                     if (empty($serverIp)) {
                         return null;
                     }
+                    $host = $this->public_host ?: $serverIp;
                     $redis_version = $this->getRedisVersion();
                     $username_part = version_compare($redis_version, '6.0', '>=') ? rawurlencode($this->redis_username).':' : '';
                     $encodedPass = rawurlencode($this->redis_password);
                     $scheme = $this->enable_ssl ? 'rediss' : 'redis';
-                    $url = "{$scheme}://{$username_part}{$encodedPass}@{$serverIp}:{$this->public_port}/0";
+                    $url = "{$scheme}://{$username_part}{$encodedPass}@{$host}:{$this->public_port}/0";
 
                     if ($this->enable_ssl && $this->ssl_mode === 'verify-ca') {
                         $url .= '?cacert=/etc/ssl/certs/coolify-ca.crt';

--- a/database/migrations/2026_05_08_000000_add_public_host_to_databases.php
+++ b/database/migrations/2026_05_08_000000_add_public_host_to_databases.php
@@ -1,0 +1,60 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $tables = [
+            'standalone_postgresqls',
+            'standalone_mysqls',
+            'standalone_mariadbs',
+            'standalone_redis',
+            'standalone_mongodbs',
+            'standalone_clickhouses',
+            'standalone_keydbs',
+            'standalone_dragonflies',
+            'service_databases',
+        ];
+
+        foreach ($tables as $table) {
+            if (Schema::hasTable($table) && !Schema::hasColumn($table, 'public_host')) {
+                Schema::table($table, function (Blueprint $table) {
+                    $table->string('public_host')->nullable()->after('public_port');
+                });
+            }
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $tables = [
+            'standalone_postgresqls',
+            'standalone_mysqls',
+            'standalone_mariadbs',
+            'standalone_redis',
+            'standalone_mongodbs',
+            'standalone_clickhouses',
+            'standalone_keydbs',
+            'standalone_dragonflies',
+            'service_databases',
+        ];
+
+        foreach ($tables as $table) {
+            if (Schema::hasTable($table) && Schema::hasColumn($table, 'public_host')) {
+                Schema::table($table, function (Blueprint $table) {
+                    $table->dropColumn('public_host');
+                });
+            }
+        }
+    }
+};

--- a/resources/views/livewire/project/database/clickhouse/general.blade.php
+++ b/resources/views/livewire/project/database/clickhouse/general.blade.php
@@ -78,6 +78,8 @@
             <div class="flex flex-col gap-2">
             <x-forms.input type="number" placeholder="5432" disabled="{{ $isPublic }}" id="publicPort" label="Public Port"
                 canGate="update" :canResource="$database" />
+            <x-forms.input placeholder="your-domain.com" disabled="{{ $isPublic }}" id="publicHost"
+                label="Public Host" helper="Custom hostname for the external connection URL. If empty, the server IP is used." canGate="update" :canResource="$database" />
             <x-forms.input type="number" placeholder="3600" disabled="{{ $isPublic }}" id="publicPortTimeout"
                 label="Proxy Timeout (seconds)" helper="Timeout for the public TCP proxy connection in seconds. Default: 3600 (1 hour)." canGate="update" :canResource="$database" />
             </div>

--- a/resources/views/livewire/project/database/dragonfly/general.blade.php
+++ b/resources/views/livewire/project/database/dragonfly/general.blade.php
@@ -116,6 +116,8 @@
             <div class="flex flex-col gap-2">
                 <x-forms.input type="number" placeholder="5432" disabled="{{ $isPublic }}" id="publicPort" label="Public Port"
                     canGate="update" :canResource="$database" />
+                <x-forms.input placeholder="your-domain.com" disabled="{{ $isPublic }}" id="publicHost"
+                    label="Public Host" helper="Custom hostname for the external connection URL. If empty, the server IP is used." canGate="update" :canResource="$database" />
                 <x-forms.input type="number" placeholder="3600" disabled="{{ $isPublic }}" id="publicPortTimeout"
                     label="Proxy Timeout (seconds)" helper="Timeout for the public TCP proxy connection in seconds. Default: 3600 (1 hour)." canGate="update" :canResource="$database" />
             </div>

--- a/resources/views/livewire/project/database/keydb/general.blade.php
+++ b/resources/views/livewire/project/database/keydb/general.blade.php
@@ -116,6 +116,8 @@
             <div class="flex flex-col gap-2">
                 <x-forms.input type="number" placeholder="5432" disabled="{{ $isPublic }}" id="publicPort" label="Public Port"
                     canGate="update" :canResource="$database" />
+                <x-forms.input placeholder="your-domain.com" disabled="{{ $isPublic }}" id="publicHost"
+                    label="Public Host" helper="Custom hostname for the external connection URL. If empty, the server IP is used." canGate="update" :canResource="$database" />
                 <x-forms.input type="number" placeholder="3600" disabled="{{ $isPublic }}" id="publicPortTimeout"
                     label="Proxy Timeout (seconds)" helper="Timeout for the public TCP proxy connection in seconds. Default: 3600 (1 hour)." canGate="update" :canResource="$database" />
         <x-forms.textarea

--- a/resources/views/livewire/project/database/mariadb/general.blade.php
+++ b/resources/views/livewire/project/database/mariadb/general.blade.php
@@ -140,6 +140,8 @@
             <div class="flex flex-col gap-2">
             <x-forms.input type="number" placeholder="5432" disabled="{{ $isPublic }}"
                 id="publicPort" label="Public Port" canGate="update" :canResource="$database" />
+            <x-forms.input placeholder="your-domain.com" disabled="{{ $isPublic }}" id="publicHost"
+                label="Public Host" helper="Custom hostname for the external connection URL. If empty, the server IP is used." canGate="update" :canResource="$database" />
             <x-forms.input type="number" placeholder="3600" disabled="{{ $isPublic }}" id="publicPortTimeout"
                 label="Proxy Timeout (seconds)" helper="Timeout for the public TCP proxy connection in seconds. Default: 3600 (1 hour)." canGate="update" :canResource="$database" />
             </div>

--- a/resources/views/livewire/project/database/mongodb/general.blade.php
+++ b/resources/views/livewire/project/database/mongodb/general.blade.php
@@ -154,6 +154,8 @@
                 <div class="flex flex-col gap-2">
                 <x-forms.input type="number" placeholder="5432" disabled="{{ $isPublic }}"
                     id="publicPort" label="Public Port" canGate="update" :canResource="$database" />
+                <x-forms.input placeholder="your-domain.com" disabled="{{ $isPublic }}" id="publicHost"
+                    label="Public Host" helper="Custom hostname for the external connection URL. If empty, the server IP is used." canGate="update" :canResource="$database" />
                 <x-forms.input type="number" placeholder="3600" disabled="{{ $isPublic }}" id="publicPortTimeout"
                     label="Proxy Timeout (seconds)" helper="Timeout for the public TCP proxy connection in seconds. Default: 3600 (1 hour)." canGate="update" :canResource="$database" />
                 </div>

--- a/resources/views/livewire/project/database/mysql/general.blade.php
+++ b/resources/views/livewire/project/database/mysql/general.blade.php
@@ -156,6 +156,8 @@
             <div class="flex flex-col gap-2">
             <x-forms.input type="number" placeholder="5432" disabled="{{ $isPublic }}"
                 id="publicPort" label="Public Port" canGate="update" :canResource="$database" />
+            <x-forms.input placeholder="your-domain.com" disabled="{{ $isPublic }}" id="publicHost"
+                label="Public Host" helper="Custom hostname for the external connection URL. If empty, the server IP is used." canGate="update" :canResource="$database" />
             <x-forms.input type="number" placeholder="3600" disabled="{{ $isPublic }}" id="publicPortTimeout"
                 label="Proxy Timeout (seconds)" helper="Timeout for the public TCP proxy connection in seconds. Default: 3600 (1 hour)." canGate="update" :canResource="$database" />
             </div>

--- a/resources/views/livewire/project/database/postgresql/general.blade.php
+++ b/resources/views/livewire/project/database/postgresql/general.blade.php
@@ -166,6 +166,8 @@
                     <div class="flex flex-col gap-2">
                         <x-forms.input type="number" placeholder="5432" disabled="{{ $isPublic }}" id="publicPort"
                             label="Public Port" canGate="update" :canResource="$database" />
+                        <x-forms.input placeholder="your-domain.com" disabled="{{ $isPublic }}" id="publicHost"
+                            label="Public Host" helper="Custom hostname for the external connection URL. If empty, the server IP is used." canGate="update" :canResource="$database" />
                         <x-forms.input type="number" placeholder="3600" disabled="{{ $isPublic }}" id="publicPortTimeout"
                             label="Proxy Timeout (seconds)" helper="Timeout for the public TCP proxy connection in seconds. Default: 3600 (1 hour)." canGate="update" :canResource="$database" />
                     </div>

--- a/resources/views/livewire/project/database/redis/general.blade.php
+++ b/resources/views/livewire/project/database/redis/general.blade.php
@@ -135,6 +135,8 @@
             <div class="flex flex-col gap-2">
                 <x-forms.input type="number" placeholder="5432" disabled="{{ $isPublic }}"
                     id="publicPort" label="Public Port" canGate="update" :canResource="$database" />
+                <x-forms.input placeholder="your-domain.com" disabled="{{ $isPublic }}" id="publicHost"
+                    label="Public Host" helper="Custom hostname for the external connection URL. If empty, the server IP is used." canGate="update" :canResource="$database" />
                 <x-forms.input type="number" placeholder="3600" disabled="{{ $isPublic }}" id="publicPortTimeout"
                     label="Proxy Timeout (seconds)" helper="Timeout for the public TCP proxy connection in seconds. Default: 3600 (1 hour)." canGate="update" :canResource="$database" />
             </div>

--- a/resources/views/livewire/project/service/index.blade.php
+++ b/resources/views/livewire/project/service/index.blade.php
@@ -252,6 +252,9 @@
                                 </div>
                                 <x-forms.input type="number" canGate="update" :canResource="$serviceDatabase" placeholder="5432"
                                     disabled="{{ $serviceDatabase->is_public }}" id="publicPort" label="Public Port" />
+                                <x-forms.input canGate="update" :canResource="$serviceDatabase" placeholder="your-domain.com"
+                                    disabled="{{ $serviceDatabase->is_public }}" id="publicHost" label="Public Host"
+                                    helper="Custom hostname for the external connection URL. If empty, the server IP is used." />
                                 @if ($db_url_public)
                                     <x-forms.input label="Database IP:PORT (public)"
                                         helper="Your credentials are available in your environment variables." type="password"


### PR DESCRIPTION
## Changes

Add a nullable `public_host` string field to all 9 database resource tables. When set, the external connection URL uses this custom hostname instead of the server IP. This allows users to point public database connections through a custom domain or proxy.

- Migration adds `public_host` column to: standalone_postgresqls, standalone_mysqls, standalone_mariadbs, standalone_redis, standalone_mongodbs, standalone_clickhouses, standalone_keydbs, standalone_dragonflies, service_databases
- Each model now uses `public_host ?: serverIp` in `externalDbUrl()` / `getServiceDatabaseUrl()`
- Each Livewire component syncs the new `publicHost` property
- Each Blade template adds a "Public Host" input in the proxy section

## Issues

- Closes #2377

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: AI coding assistant for code generation
- How extensively: AI assisted with writing the repetitive model/Livewire/Blade changes across 9 database types

## Testing

Tested by verifying the migration creates the column correctly, models reference `public_host` in fillable and external URL generation, Livewire components sync the property, and Blade templates render the input field. The fallback to server IP is preserved when `public_host` is null.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.

/claim #2377