### PR TITLE
feat: global deployment page with filters

### DIFF
--- a/app/Livewire/Deployments/Index.php
+++ b/app/Livewire/Deployments/Index.php
@@ -2,7 +2,6 @@
 
 namespace App\Livewire\Deployments;
 
-use App\Enums\ApplicationDeploymentStatus;
 use App\Models\ApplicationDeploymentQueue;
 use App\Models\Project;
 use App\Models\Server;

--- a/app/Livewire/Deployments/Index.php
+++ b/app/Livewire/Deployments/Index.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace App\Livewire\Deployments;
+
+use App\Enums\ApplicationDeploymentStatus;
+use App\Models\ApplicationDeploymentQueue;
+use App\Models\Project;
+use App\Models\Server;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class Index extends Component
+{
+    use WithPagination;
+
+    public ?string $projectFilter = null;
+
+    public ?string $serverFilter = null;
+
+    public ?string $sourceFilter = null;
+
+    public ?string $statusFilter = null;
+
+    public array $projects = [];
+
+    public array $servers = [];
+
+    public array $sources = [];
+
+    protected $queryString = [
+        'projectFilter' => ['except' => ''],
+        'serverFilter' => ['except' => ''],
+        'sourceFilter' => ['except' => ''],
+        'statusFilter' => ['except' => ''],
+    ];
+
+    public function mount()
+    {
+        $teamId = currentTeam()->id;
+
+        $this->projects = Project::ownedByCurrentTeam()
+            ->get()
+            ->map(fn ($p) => ['id' => (string) $p->id, 'name' => $p->name, 'uuid' => $p->uuid])
+            ->values()
+            ->toArray();
+
+        $this->servers = Server::ownedByCurrentTeam()
+            ->get()
+            ->map(fn ($s) => ['id' => (string) $s->id, 'name' => $s->name])
+            ->values()
+            ->toArray();
+
+        $this->sources = ApplicationDeploymentQueue::whereIn('application_id', function ($q) use ($teamId) {
+            $q->select('id')
+                ->from('applications')
+                ->whereIn('environment_id', function ($q2) use ($teamId) {
+                    $q2->select('id')
+                        ->from('environments')
+                        ->whereIn('project_id', function ($q3) use ($teamId) {
+                            $q3->select('id')
+                                ->from('projects')
+                                ->where('team_id', $teamId);
+                        });
+                });
+        })
+            ->whereNotNull('git_type')
+            ->distinct()
+            ->pluck('git_type')
+            ->map(fn ($type) => ['id' => $type, 'name' => ucfirst($type)])
+            ->values()
+            ->toArray();
+    }
+
+    public function updating($property)
+    {
+        if (in_array($property, ['projectFilter', 'serverFilter', 'sourceFilter', 'statusFilter'])) {
+            $this->resetPage();
+        }
+    }
+
+    public function clearFilters()
+    {
+        $this->projectFilter = null;
+        $this->serverFilter = null;
+        $this->sourceFilter = null;
+        $this->statusFilter = null;
+        $this->resetPage();
+    }
+
+    public function render()
+    {
+        $teamId = currentTeam()->id;
+
+        $query = ApplicationDeploymentQueue::query()
+            ->select('application_deployment_queues.*')
+            ->join('applications', 'application_deployment_queues.application_id', '=', 'applications.id')
+            ->join('environments', 'applications.environment_id', '=', 'environments.id')
+            ->join('projects', 'environments.project_id', '=', 'projects.id')
+            ->where('projects.team_id', $teamId);
+
+        if ($this->projectFilter) {
+            $query->where('projects.id', $this->projectFilter);
+        }
+
+        if ($this->serverFilter) {
+            $query->where('application_deployment_queues.server_id', $this->serverFilter);
+        }
+
+        if ($this->sourceFilter) {
+            $query->where('application_deployment_queues.git_type', $this->sourceFilter);
+        }
+
+        if ($this->statusFilter) {
+            $query->where('application_deployment_queues.status', $this->statusFilter);
+        }
+
+        $query->orderBy('application_deployment_queues.created_at', 'desc');
+
+        $deployments = $query->with('application.environment.project')->paginate(25);
+
+        $hasActiveFilters = $this->projectFilter || $this->serverFilter || $this->sourceFilter || $this->statusFilter;
+
+        return view('livewire.deployments.index', [
+            'deployments' => $deployments,
+            'hasActiveFilters' => $hasActiveFilters,
+        ]);
+    }
+}

--- a/resources/views/components/navbar.blade.php
+++ b/resources/views/components/navbar.blade.php
@@ -116,6 +116,16 @@
                         </a>
                     </li>
                     <li>
+                        <a title="Deployments" {{ wireNavigate() }}
+                            class="{{ request()->is('deployments') ? 'menu-item menu-item-active' : 'menu-item' }}"
+                            href="/deployments">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="menu-item-icon" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3v11.25A2.25 2.25 0 005.25 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0118 16.5h-2.25m-7.5 0h7.5m-7.5 0l-1 3m8.5-3l1 3m0 0l.5 1.5m-.5-1.5h-9.5m0 0l-.5 1.5m.75-9l3-3 2.148 2.148A12.061 12.061 0 0116.5 7.605" />
+                            </svg>
+                            <span class="menu-item-label">Deployments</span>
+                        </a>
+                    </li>
+                    <li>
                         <a title="Projects" {{ wireNavigate() }}
                             class="{{ request()->is('project/*') || request()->is('projects') ? 'menu-item menu-item-active' : 'menu-item' }}"
                             href="/projects">

--- a/resources/views/livewire/deployments/index.blade.php
+++ b/resources/views/livewire/deployments/index.blade.php
@@ -1,0 +1,176 @@
+<div>
+    <x-slot:title>
+        Deployments | Coolify
+    </x-slot>
+    <div class="flex gap-2">
+        <h1>Deployments</h1>
+    </div>
+    <div class="subtitle">All deployments across all your projects.</div>
+
+    <div class="pb-4">
+        <div class="flex flex-wrap items-end gap-2">
+            @if (count($projects) > 1)
+                <x-forms.select wire:model.live="projectFilter" label="Project">
+                    <option value="">All Projects</option>
+                    @foreach ($projects as $project)
+                        <option value="{{ $project['id'] }}">{{ $project['name'] }}</option>
+                    @endforeach
+                </x-forms.select>
+            @endif
+
+            @if (count($servers) > 1)
+                <x-forms.select wire:model.live="serverFilter" label="Server">
+                    <option value="">All Servers</option>
+                    @foreach ($servers as $server)
+                        <option value="{{ $server['id'] }}">{{ $server['name'] }}</option>
+                    @endforeach
+                </x-forms.select>
+            @endif
+
+            @if (count($sources) > 1)
+                <x-forms.select wire:model.live="sourceFilter" label="Source">
+                    <option value="">All Sources</option>
+                    @foreach ($sources as $source)
+                        <option value="{{ $source['id'] }}">{{ $source['name'] }}</option>
+                    @endforeach
+                </x-forms.select>
+            @endif
+
+            <x-forms.select wire:model.live="statusFilter" label="Status">
+                <option value="">All Statuses</option>
+                <option value="queued">Queued</option>
+                <option value="in_progress">In Progress</option>
+                <option value="finished">Success</option>
+                <option value="failed">Failed</option>
+                <option value="cancelled-by-user">Cancelled</option>
+            </x-forms.select>
+
+            @if ($hasActiveFilters)
+                <x-forms.button wire:click="clearFilters">Clear Filters</x-forms.button>
+            @endif
+        </div>
+    </div>
+
+    <div wire:poll.5000ms="$refresh" class="flex flex-col w-full gap-2 pb-10">
+        @forelse ($deployments as $deployment)
+            @php
+                $statusColor = match ($deployment->status) {
+                    'in_progress' => 'border-blue-500/50 border-dashed',
+                    'queued' => 'border-purple-500/50 border-dashed',
+                    'finished' => 'border-success',
+                    'failed' => 'border-error',
+                    'cancelled-by-user' => 'border-white border-dashed',
+                    default => 'border-neutral-300 dark:border-coolgray-200',
+                };
+                $statusText = match ($deployment->status) {
+                    'in_progress' => 'In Progress',
+                    'queued' => 'Queued',
+                    'finished' => 'Success',
+                    'failed' => 'Failed',
+                    'cancelled-by-user' => 'Cancelled',
+                    default => ucfirst($deployment->status),
+                };
+                $statusBadgeBg = match ($deployment->status) {
+                    'in_progress' => 'bg-blue-100/80 text-blue-700 dark:bg-blue-500/20 dark:text-blue-300',
+                    'queued' => 'bg-purple-100/80 text-purple-700 dark:bg-purple-500/20 dark:text-purple-300',
+                    'finished' => 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-200',
+                    'failed' => 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-200',
+                    'cancelled-by-user' => 'bg-gray-100 text-gray-700 dark:bg-gray-600/30 dark:text-gray-300',
+                    default => 'bg-gray-100 text-gray-700 dark:bg-gray-600/30 dark:text-gray-300',
+                };
+                $project = $deployment->application?->environment?->project;
+                $appLink = $deployment->deployment_url
+                    ? $deployment->deployment_url
+                    : ($project && $deployment->application
+                        ? route('project.application.deployment.show', [
+                            'project_uuid' => $project->uuid,
+                            'environment_uuid' => $deployment->application->environment?->uuid,
+                            'application_uuid' => $deployment->application->uuid,
+                            'deployment_uuid' => $deployment->deployment_uuid,
+                        ])
+                        : '#');
+            @endphp
+            <div class="p-2 border-l-2 bg-white dark:bg-coolgray-100 {{ $statusColor }}">
+                <a href="{{ $appLink }}" {{ wireNavigate() }} class="block">
+                    <div class="flex flex-col gap-1">
+                        {{-- Top row: Status badge + Application name + Project/Environment --}}
+                        <div class="flex items-center flex-wrap gap-2">
+                            <span class="px-3 py-1 rounded-md text-xs font-medium shadow-xs {{ $statusBadgeBg }}">
+                                {{ $statusText }}
+                            </span>
+                            <span class="text-sm font-medium dark:text-white">
+                                {{ $deployment->application_name ?? 'Unknown' }}
+                            </span>
+                            @if ($project)
+                                <span class="text-xs text-gray-500 dark:text-gray-400">
+                                    {{ $project->name }}
+                                    @if ($deployment->application?->environment)
+                                        / {{ $deployment->application->environment->name }}
+                                    @endif
+                                </span>
+                            @endif
+                        </div>
+
+                        {{-- Server + Commit + Duration --}}
+                        <div class="flex items-center flex-wrap gap-x-4 gap-y-1 text-xs text-gray-600 dark:text-gray-400">
+                            @if ($deployment->server_name)
+                                <span>Server: {{ $deployment->server_name }}</span>
+                            @endif
+
+                            @if ($deployment->commit)
+                                <span>
+                                    Commit:
+                                    <span class="font-mono">{{ substr($deployment->commit, 0, 7) }}</span>
+                                </span>
+                            @endif
+
+                            @if ($deployment->commit_message)
+                                <span class="truncate max-w-xs">
+                                    {{ Str::before($deployment->commit_message, "\n") }}
+                                </span>
+                            @endif
+
+                            @if ($deployment->git_type)
+                                <span class="bg-gray-200/70 dark:bg-gray-600/20 px-2 py-0.5 rounded-md text-xs text-gray-800 dark:text-gray-100 border border-gray-400/30">
+                                    {{ ucfirst($deployment->git_type) }}
+                                </span>
+                            @endif
+                        </div>
+
+                        {{-- Timing --}}
+                        <div class="flex items-center flex-wrap gap-x-4 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
+                            <span>Started: {{ $deployment->created_at?->format('Y-m-d H:i:s') ?? 'N/A' }}</span>
+                            @php
+                                $duration = $deployment->finished_at
+                                    ? calculateDuration($deployment->created_at, $deployment->finished_at)
+                                    : ($deployment->status === 'in_progress'
+                                        ? calculateDuration($deployment->created_at, now())
+                                        : null);
+                            @endphp
+                            @if ($duration)
+                                <span>Duration: {{ $duration }}</span>
+                            @endif
+                            @if ($deployment->finished_at)
+                                <span>{{ \Carbon\Carbon::parse($deployment->finished_at)->diffForHumans() }}</span>
+                            @elseif($deployment->status === 'in_progress')
+                                <span>Running for: {{ calculateDuration($deployment->created_at, now()) }}</span>
+                            @endif
+                        </div>
+                    </div>
+                </a>
+            </div>
+        @empty
+            <div class="py-8 text-center text-gray-500 dark:text-gray-400">
+                @if ($hasActiveFilters)
+                    No deployments match your filters.
+                @else
+                    No deployments found yet. Start by deploying an application!
+                @endif
+            </div>
+        @endforelse
+
+        <div class="py-4">
+            {{ $deployments->onEachSide(1)->links() }}
+        </div>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\UploadController;
 use App\Livewire\Admin\Index as AdminIndex;
 use App\Livewire\Boarding\Index as BoardingIndex;
 use App\Livewire\Dashboard;
+use App\Livewire\Deployments\Index as DeploymentsIndex;
 use App\Livewire\Destination\Index as DestinationIndex;
 use App\Livewire\Destination\Show as DestinationShow;
 use App\Livewire\ForcePasswordReset;
@@ -109,6 +110,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
     });
 
     Route::get('/', Dashboard::class)->name('dashboard');
+    Route::get('/deployments', DeploymentsIndex::class)->name('deployments.index');
+
     Route::get('/admin', AdminIndex::class)->name('admin.index');
     Route::get('/onboarding', BoardingIndex::class)->name('onboarding');
 


### PR DESCRIPTION
## Summary
Implements #7596 — New Global Deployment Page

### Changes
- **New Livewire component** `App\Livewire\Deployments\Index` — team-scoped deployment list
  - 4 filters: Project, Server, Source (git_type), Status
  - Filters auto-hide when only 1 option exists
  - `wire:poll.5000ms` for live updates
  - URL-persistent filter state via ``
  - Pagination (25 per page)
- **New Blade template** with color-coded status badges, card layout, commit info, duration, timing
- **Route** `/deployments` added to `routes/web.php`
- **Navbar** link added between Dashboard and Projects

### Testing
- Follows established Coolify Livewire patterns exactly
- Uses eager-loading for `application.environment.project`
- Leverages existing `calculateDuration()` helper

💰 Bounty: #7596 ($50)