### PR TITLE
feat: add global deployments page

### DIFF
--- a/app/Livewire/Deployments/Index.php
+++ b/app/Livewire/Deployments/Index.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Livewire\Deployments;
+
+use App\Models\ApplicationDeploymentQueue;
+use App\Models\Server;
+use App\Models\Project;
+use Livewire\Component;
+use Livewire\Attributes\Url;
+
+class Index extends Component
+{
+    #[Url(as: 'project')]
+    public ?string $filterProject = null;
+
+    #[Url(as: 'server')]
+    public ?string $filterServer = null;
+
+    #[Url(as: 'source')]
+    public ?string $filterSource = null;
+
+    #[Url(as: 'status')]
+    public ?string $filterStatus = null;
+
+    public $perPage = 25;
+    public $deployments;
+    public $totalCount;
+    public $hasMorePages = false;
+
+    public $projects;
+    public $servers;
+    public $sources;
+
+    public function mount()
+    {
+        $teamId = currentTeam()->id;
+        $this->servers = Server::ownedByCurrentTeamCached();
+        $this->projects = Project::where('team_id', $teamId)->get();
+        $this->sources = \App\Models\GithubApp::where('team_id', $teamId)
+            ->orWhere('is_system_wide', true)
+            ->get();
+        $this->loadDeployments();
+    }
+
+    public function loadDeployments()
+    {
+        $teamId = currentTeam()->id;
+        $query = ApplicationDeploymentQueue::query()
+            ->with(['application.environment.project'])
+            ->whereHas('application', function ($q) use ($teamId) {
+                $q->whereIn('environment_id', function ($sub) use ($teamId) {
+                    $sub->select('id')
+                        ->from('environments')
+                        ->whereIn('project_id', function ($p) use ($teamId) {
+                            $p->select('id')
+                                ->from('projects')
+                                ->where('team_id', $teamId);
+                        });
+                });
+            });
+
+        if ($this->filterProject) {
+            $query->whereHas('application.environment.project', function ($q) {
+                $q->where('uuid', $this->filterProject);
+            });
+        }
+
+        if ($this->filterServer) {
+            $query->where('server_id', function ($q) {
+                $q->select('id')->from('servers')->where('uuid', $this->filterServer);
+            });
+        }
+
+        if ($this->filterSource) {
+            $query->whereHas('application', function ($q) {
+                $q->where('source_id', $this->filterSource);
+            });
+        }
+
+        if ($this->filterStatus) {
+            $query->where('status', $this->filterStatus);
+        }
+
+        $this->totalCount = $query->count();
+        $deploymentsQuery = $query->orderBy('created_at', 'desc')
+            ->take($this->perPage + 1)
+            ->get();
+
+        $this->hasMorePages = $deploymentsQuery->count() > $this->perPage;
+        $this->deployments = $deploymentsQuery->take($this->perPage);
+    }
+
+    public function updated($property)
+    {
+        if (in_array($property, ['filterProject', 'filterServer', 'filterSource', 'filterStatus'])) {
+            $this->perPage = 25;
+            $this->loadDeployments();
+        }
+    }
+
+    public function clearFilters()
+    {
+        $this->filterProject = null;
+        $this->filterServer = null;
+        $this->filterSource = null;
+        $this->filterStatus = null;
+        $this->perPage = 25;
+        $this->loadDeployments();
+    }
+
+    public function loadMore()
+    {
+        $this->perPage += 25;
+        $this->loadDeployments();
+    }
+
+    public function render()
+    {
+        return view('livewire.deployments.index')
+            ->layout('layouts.app');
+    }
+}

--- a/resources/views/components/navbar.blade.php
+++ b/resources/views/components/navbar.blade.php
@@ -175,7 +175,16 @@
                             <span class="menu-item-label" :class="collapsed && 'lg:hidden'">Servers</span>
                         </a>
                     </li>
-
+                    <li>
+                        <a title="Deployments" href="/deployments" {{ wireNavigate() }}
+                            class="{{ request()->is('deployments') ? 'menu-item-active menu-item' : 'menu-item' }}">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="menu-item-icon" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 5.25h16.5m-16.5 4.5h16.5m-16.5 4.5h16.5m-16.5 4.5h16.5" />
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 3.75v1.5m7.5 0v-1.5" />
+                            </svg>
+                            <span class="menu-item-label" :class="collapsed && 'lg:hidden'">Deployments</span>
+                        </a>
+                    </li>
                     <li>
                         <a title="Sources" {{ wireNavigate() }}
                             class="{{ request()->is('source*') ? 'menu-item-active menu-item' : 'menu-item' }}"

--- a/resources/views/livewire/deployments/index.blade.php
+++ b/resources/views/livewire/deployments/index.blade.php
@@ -1,0 +1,124 @@
+<div>
+    <x-slot:title>Deployments | Coolify</x-slot>
+
+    <div class="flex items-center justify-between">
+        <h1>Deployments</h1>
+    </div>
+
+    <div class="flex flex-wrap items-center gap-2 pb-4" wire:poll.5000ms="loadDeployments">
+        <x-forms.select wire:model.live="filterProject">
+            <option value="">All Projects</option>
+            @foreach ($projects as $project)
+                <option value="{{ $project->uuid }}">{{ $project->name }}</option>
+            @endforeach
+        </x-forms.select>
+
+        @if ($servers->count() > 1)
+            <x-forms.select wire:model.live="filterServer">
+                <option value="">All Servers</option>
+                @foreach ($servers as $server)
+                    <option value="{{ $server->uuid }}">{{ $server->name }}</option>
+                @endforeach
+            </x-forms.select>
+        @endif
+
+        @if ($sources->count() > 1)
+            <x-forms.select wire:model.live="filterSource">
+                <option value="">All Sources</option>
+                @foreach ($sources as $source)
+                    <option value="{{ $source->id }}">{{ $source->name }}</option>
+                @endforeach
+            </x-forms.select>
+        @endif
+
+        <x-forms.select wire:model.live="filterStatus">
+            <option value="">All Statuses</option>
+            <option value="queued">Queued</option>
+            <option value="in_progress">In Progress</option>
+            <option value="finished">Success</option>
+            <option value="failed">Failed</option>
+            <option value="cancelled-by-user">Cancelled</option>
+        </x-forms.select>
+
+        @if ($filterProject || $filterServer || $filterSource || $filterStatus)
+            <x-forms.button wire:click="clearFilters">Clear Filters</x-forms.button>
+        @endif
+
+        <span class="text-sm text-gray-500 ml-auto">{{ $totalCount }} total</span>
+    </div>
+
+    <div class="flex flex-col gap-2">
+        @forelse ($deployments as $deployment)
+            <a href="{{ $deployment->deployment_url }}" @class([
+                'p-3 border-l-2 bg-white dark:bg-coolgray-100 rounded-lg transition-all hover:shadow-md',
+                'border-blue-500/50' => $deployment->status === 'in_progress',
+                'border-purple-500/50' => $deployment->status === 'queued',
+                'border-red-500' => $deployment->status === 'failed',
+                'border-green-500' => $deployment->status === 'finished',
+                'border-gray-400' => $deployment->status === 'cancelled-by-user',
+            ])>
+                <div class="flex items-center justify-between">
+                    <div class="flex items-center gap-3">
+                        <span @class([
+                            'px-2 py-0.5 rounded text-xs font-medium',
+                            'bg-blue-100 text-blue-700 dark:bg-blue-500/20 dark:text-blue-300' => $deployment->status === 'in_progress',
+                            'bg-purple-100 text-purple-700 dark:bg-purple-500/20 dark:text-purple-300' => $deployment->status === 'queued',
+                            'bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-300' => $deployment->status === 'finished',
+                            'bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-300' => $deployment->status === 'failed',
+                            'bg-gray-100 text-gray-600 dark:bg-gray-500/20 dark:text-gray-300' => $deployment->status === 'cancelled-by-user',
+                        ])>
+                            {{ str_replace(['-', '_'], ' ', ucfirst($deployment->status)) }}
+                        </span>
+                        <span class="font-medium">{{ $deployment->application_name }}</span>
+                    </div>
+                    <div class="text-xs text-gray-500">
+                        {{ $deployment->created_at->diffForHumans() }}
+                    </div>
+                </div>
+                <div class="flex items-center gap-4 mt-1 text-xs text-gray-500">
+                    <span>
+                        {{ data_get($deployment, 'application.environment.project.name') }} /
+                        {{ data_get($deployment, 'application.environment.name') }}
+                    </span>
+                    <span>{{ $deployment->server_name }}</span>
+                    @if ($deployment->commit)
+                        <span>{{ substr($deployment->commit, 0, 7) }}</span>
+                    @endif
+                    @if ($deployment->is_webhook)
+                        <span class="bg-gray-200 dark:bg-coolgray-200 px-1.5 py-0.5 rounded text-xs dark:text-white">Webhook</span>
+                    @elseif ($deployment->rollback)
+                        <span class="bg-gray-200 dark:bg-coolgray-200 px-1.5 py-0.5 rounded text-xs dark:text-white">Rollback</span>
+                    @elseif ($deployment->pull_request_id)
+                        <span class="bg-gray-200 dark:bg-coolgray-200 px-1.5 py-0.5 rounded text-xs dark:text-white">PR #{{ $deployment->pull_request_id }}</span>
+                    @else
+                        <span class="bg-gray-200 dark:bg-coolgray-200 px-1.5 py-0.5 rounded text-xs dark:text-white">Manual</span>
+                    @endif
+                    @if ($deployment->finished_at)
+                        <span>{{ \Carbon\Carbon::parse($deployment->created_at)->diffForHumans(\Carbon\Carbon::parse($deployment->finished_at), true) }}</span>
+                    @elseif ($deployment->status === 'in_progress')
+                        <span class="text-blue-500">Running for {{ \Carbon\Carbon::parse($deployment->created_at)->diffForHumans(now(), true) }}</span>
+                    @endif
+                </div>
+                @if ($deployment->commit_message)
+                    <div class="mt-1 text-xs text-gray-600 dark:text-gray-400 truncate max-w-2xl">
+                        {{ $deployment->commit_message }}
+                    </div>
+                @endif
+            </a>
+        @empty
+            <div class="text-center py-10 text-gray-500">
+                <svg class="mx-auto h-12 w-12 text-gray-300 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4" />
+                </svg>
+                <p class="text-lg font-medium">No deployments found</p>
+                <p class="mt-1">Deploy your first application to see it here.</p>
+            </div>
+        @endforelse
+
+        @if ($hasMorePages)
+            <div class="text-center pt-2">
+                <x-forms.button wire:click="loadMore">Load More</x-forms.button>
+            </div>
+        @endif
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,7 @@ use App\Livewire\Profile\Index as ProfileIndex;
 use App\Livewire\Project\Application\Configuration as ApplicationConfiguration;
 use App\Livewire\Project\Application\Deployment\Index as DeploymentIndex;
 use App\Livewire\Project\Application\Deployment\Show as DeploymentShow;
+use App\Livewire\Deployments\Index as DeploymentsIndex;
 use App\Livewire\Project\CloneMe as ProjectCloneMe;
 use App\Livewire\Project\Database\Backup\Execution as DatabaseBackupExecution;
 use App\Livewire\Project\Database\Backup\Index as DatabaseBackupIndex;
@@ -201,6 +202,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     });
 
     Route::get('/projects', ProjectIndex::class)->name('project.index');
+    Route::get('/deployments', DeploymentsIndex::class)->name('deployments.index');
     Route::prefix('project/{project_uuid}')->group(function () {
         Route::get('/', ProjectShow::class)->name('project.show');
         Route::get('/edit', ProjectEdit::class)->name('project.edit')->middleware('can.update.resource');


### PR DESCRIPTION
## Changes

Added a new global Deployments page accessible from the sidebar. The page shows all past deployments across all applications with filters for project, server, source, and status. Filters support shareable URLs and hide single-option dropdowns per the issue requirements.

## Issues

- Fixes #7596

## Category

- [ ] New feature

## Preview



## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: AI assistant
- How extensively: Implementation details provided by AI

## Testing

Tested locally by verifying the /deployments route loads and displays deployments for the current team. Verified all filters work individually and in combination. Verified server/source filters hide when only one option exists. Verified pagination with Load More button. Verified empty state renders when no deployments exist.

## Contributor Agreement

> [!IMPORTANT]
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this is not a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.