### PR TITLE
fix(stripe): re-throw exceptions in webhook jobs to enable queue retries

### DIFF
--- a/app/Jobs/StripeProcessJob.php
+++ b/app/Jobs/StripeProcessJob.php
@@ -177,6 +177,9 @@ class StripeProcessJob implements ShouldBeEncrypted, ShouldQueue
                                 break;
                             }
                         } catch (\Exception $e) {
+                            send_internal_notification('invoice.payment_failed: Unable to verify payment intent status: '.$e->getMessage());
+                            SubscriptionInvoiceFailedJob::dispatch($team)->delay(now()->addSeconds(60));
+                            break;
                         }
                     }
 
@@ -342,6 +345,8 @@ class StripeProcessJob implements ShouldBeEncrypted, ShouldQueue
             }
         } catch (\Exception $e) {
             send_internal_notification('StripeProcessJob error: '.$e->getMessage());
+
+            throw $e;
         }
     }
 }

--- a/app/Jobs/SubscriptionInvoiceFailedJob.php
+++ b/app/Jobs/SubscriptionInvoiceFailedJob.php
@@ -15,6 +15,10 @@ class SubscriptionInvoiceFailedJob implements ShouldBeEncrypted, ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    public int $tries = 3;
+
+    public array $backoff = [30, 60, 120];
+
     public function __construct(protected Team $team)
     {
         $this->onQueue('high');
@@ -60,6 +64,9 @@ class SubscriptionInvoiceFailedJob implements ShouldBeEncrypted, ShouldQueue
                         }
                     }
                 } catch (\Exception $e) {
+                    send_internal_notification('SubscriptionInvoiceFailedJob: Stripe verification failed, will retry: '.$e->getMessage());
+
+                    throw $e;
                 }
             }
 

--- a/app/Jobs/VerifyStripeSubscriptionStatusJob.php
+++ b/app/Jobs/VerifyStripeSubscriptionStatusJob.php
@@ -99,6 +99,8 @@ class VerifyStripeSubscriptionStatusJob implements ShouldBeEncrypted, ShouldQueu
             send_internal_notification(
                 'VerifyStripeSubscriptionStatusJob failed for subscription ID '.$this->subscription->id.': '.$e->getMessage()
             );
+
+            throw $e;
         }
     }
 }

--- a/tests/Feature/Subscription/StripeErrorHandlingTest.php
+++ b/tests/Feature/Subscription/StripeErrorHandlingTest.php
@@ -1,0 +1,133 @@
+<?php
+
+use App\Jobs\StripeProcessJob;
+use App\Jobs\SubscriptionInvoiceFailedJob;
+use App\Jobs\VerifyStripeSubscriptionStatusJob;
+use App\Models\Subscription;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    config()->set('constants.coolify.self_hosted', false);
+    config()->set('subscription.provider', 'stripe');
+    config()->set('subscription.stripe_api_key', 'sk_test_fake');
+    config()->set('subscription.stripe_excluded_plans', '');
+
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+});
+
+describe('StripeProcessJob re-throws exceptions for queue retry', function () {
+    test('unhandled event type propagates exception instead of swallowing it', function () {
+        $event = [
+            'type' => 'some.unknown.event',
+            'data' => ['object' => []],
+        ];
+
+        $job = new StripeProcessJob($event);
+
+        expect(fn () => $job->handle())->toThrow(\RuntimeException::class, 'Unhandled event type: some.unknown.event');
+    });
+
+    test('missing subscription in invoice.paid propagates exception', function () {
+        $event = [
+            'type' => 'invoice.paid',
+            'data' => [
+                'object' => [
+                    'customer' => 'cus_nonexistent',
+                    'amount_paid' => 1000,
+                    'subscription' => 'sub_123',
+                    'lines' => ['data' => [['plan' => ['id' => 'price_test']]]],
+                ],
+            ],
+        ];
+
+        $job = new StripeProcessJob($event);
+
+        expect(fn () => $job->handle())->toThrow(\RuntimeException::class, 'No subscription found for customer');
+    });
+});
+
+describe('invoice.payment_failed dispatches with delay on Stripe API error', function () {
+    test('Stripe API failure during payment intent verification dispatches delayed job', function () {
+        Queue::fake();
+
+        Subscription::create([
+            'team_id' => $this->team->id,
+            'stripe_subscription_id' => 'sub_test_verify',
+            'stripe_customer_id' => 'cus_test_verify',
+            'stripe_invoice_paid' => false,
+        ]);
+
+        $mockStripe = Mockery::mock(\Stripe\StripeClient::class);
+        $mockPaymentIntents = Mockery::mock();
+        $mockStripe->paymentIntents = $mockPaymentIntents;
+
+        $mockPaymentIntents
+            ->shouldReceive('retrieve')
+            ->with('pi_test_123')
+            ->andThrow(new \Exception('Stripe API unavailable'));
+
+        app()->bind(\Stripe\StripeClient::class, fn () => $mockStripe);
+
+        $event = [
+            'type' => 'invoice.payment_failed',
+            'data' => [
+                'object' => [
+                    'customer' => 'cus_test_verify',
+                    'id' => 'inv_test',
+                    'payment_intent' => 'pi_test_123',
+                ],
+            ],
+        ];
+
+        $job = new StripeProcessJob($event);
+        $job->handle();
+
+        Queue::assertPushed(SubscriptionInvoiceFailedJob::class, function ($job) {
+            return $job->delay instanceof \DateTimeInterface;
+        });
+    });
+});
+
+describe('VerifyStripeSubscriptionStatusJob re-throws for queue retry', function () {
+    test('Stripe API error propagates exception instead of swallowing it', function () {
+        $subscription = Subscription::create([
+            'team_id' => $this->team->id,
+            'stripe_subscription_id' => 'sub_verify_rethrow',
+            'stripe_customer_id' => 'cus_verify_rethrow',
+            'stripe_invoice_paid' => true,
+        ]);
+
+        $job = new VerifyStripeSubscriptionStatusJob($subscription);
+
+        expect(fn () => $job->handle())->toThrow(\Exception::class);
+    });
+});
+
+describe('SubscriptionInvoiceFailedJob re-throws on verification failure', function () {
+    test('Stripe API error during verification propagates instead of sending false email', function () {
+        Subscription::create([
+            'team_id' => $this->team->id,
+            'stripe_subscription_id' => 'sub_inv_fail',
+            'stripe_customer_id' => 'cus_inv_fail',
+            'stripe_invoice_paid' => false,
+        ]);
+
+        $job = new SubscriptionInvoiceFailedJob($this->team);
+
+        expect(fn () => $job->handle())->toThrow(\Exception::class);
+    });
+
+    test('has retry configuration', function () {
+        $job = new SubscriptionInvoiceFailedJob($this->team);
+
+        expect($job->tries)->toBe(3);
+        expect($job->backoff)->toBe([30, 60, 120]);
+    });
+});


### PR DESCRIPTION
## Changes

Re-throw exceptions after `send_internal_notification()` in `StripeProcessJob`, `VerifyStripeSubscriptionStatusJob`, and `SubscriptionInvoiceFailedJob` so Laravel's queue retry mechanism (`$tries`/`$backoff`) actually works. Add error logging and delayed dispatch in `StripeProcessJob`'s `invoice.payment_failed` handler when Stripe API verification fails, instead of silently falling through to send an immediate failure email. Add `$tries = 3` and `$backoff = [30, 60, 120]` to `SubscriptionInvoiceFailedJob` which previously had no retry configuration.

**What was happening:** Exceptions inside these jobs were caught and logged (via `send_internal_notification`) but never re-thrown. This made `$tries = 3` dead code because Laravel considered every run "successful." Transient Stripe API errors during payment verification caused false "payment failed" emails to be sent to users.

**What this changes:** Exceptions now propagate after notification, enabling queue retries. The `invoice.payment_failed` handler defers its failure notification by 60 seconds when Stripe's API is unreachable, giving the payment time to settle.

The empty catch patterns were introduced in commits `b6ff5f89b9` (Sep 2025) and `37d4d5f98c` (Nov 2024). Related: #9030.

## Issues

- Closes #9984

## Category

- [x] Bug fix

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**
- Tools used: Grok
- How extensively: Used for codebase audit and initial fix identification; all changes reviewed and verified manually

## Testing

Added 6 Pest tests in `tests/Feature/Subscription/StripeErrorHandlingTest.php`:
- `StripeProcessJob` re-throws on unhandled event type
- `StripeProcessJob` re-throws on missing subscription
- `invoice.payment_failed` dispatches delayed job on Stripe API error
- `VerifyStripeSubscriptionStatusJob` re-throws on Stripe API error
- `SubscriptionInvoiceFailedJob` re-throws on verification failure
- `SubscriptionInvoiceFailedJob` has correct retry configuration

All 6 tests pass locally. The 3 pre-existing `VerifyStripeSubscriptionStatusJobTest` tests were already broken on `next` before this change (verified by running them on the unmodified branch); their Mockery bindings do not intercept `new \Stripe\StripeClient()`, and the previous exception-swallowing masked the failure.

## Contributor Agreement

> [!IMPORTANT]
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
