### PR TITLE
Add WordPress with OpenLiteSpeed service template

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -1,0 +1,79 @@
+# documentation: https://docs.litespeedtech.com/cloud/docker/ols-wordpress/
+# slogan: WordPress running behind the high-performance OpenLiteSpeed web server.
+# category: cms
+# tags: cms, blog, wordpress, openlitespeed, mariadb
+# logo: svgs/wordpress.svg
+# port: 80
+
+services:
+  wordpress:
+    image: litespeedtech/openlitespeed:${OPENLITESPEED_VERSION:-1.8.5-lsphp85}
+    volumes:
+      - wordpress-files:/var/www/vhosts/localhost/html
+      - openlitespeed-conf:/usr/local/lsws/conf
+      - openlitespeed-admin-conf:/usr/local/lsws/admin/conf
+      - openlitespeed-logs:/usr/local/lsws/logs
+    environment:
+      - SERVICE_URL_WORDPRESS_80
+      - TZ=${TIMEZONE:-UTC}
+    depends_on:
+      wordpress-installer:
+        condition: service_completed_successfully
+      mariadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1/"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+
+  wordpress-installer:
+    exclude_from_hc: true
+    image: wordpress:cli-php8.3
+    user: root
+    volumes:
+      - wordpress-files:/var/www/html
+    environment:
+      - WORDPRESS_DB_HOST=mariadb
+      - WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME:-wordpress}
+      - WORDPRESS_DB_USER=${SERVICE_USER_WORDPRESS}
+      - WORDPRESS_DB_PASSWORD=${SERVICE_PASSWORD_WORDPRESS}
+      - WORDPRESS_URL=${SERVICE_URL_WORDPRESS:-http://localhost}
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    restart: on-failure
+    command:
+      - sh
+      - -c
+      - |
+        set -e
+        if [ ! -f /var/www/html/wp-config.php ]; then
+          wp core download --path=/var/www/html --allow-root
+          wp config create \
+            --path=/var/www/html \
+            --dbname="$WORDPRESS_DB_NAME" \
+            --dbuser="$WORDPRESS_DB_USER" \
+            --dbpass="$WORDPRESS_DB_PASSWORD" \
+            --dbhost="$WORDPRESS_DB_HOST" \
+            --skip-check \
+            --allow-root
+          wp config shuffle-salts --path=/var/www/html --allow-root
+          wp plugin install litespeed-cache --path=/var/www/html --allow-root
+        fi
+        chown -R 1000:1000 /var/www/html
+
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=${SERVICE_PASSWORD_MARIADBROOT}
+      - MYSQL_DATABASE=${WORDPRESS_DB_NAME:-wordpress}
+      - MYSQL_USER=${SERVICE_USER_WORDPRESS}
+      - MYSQL_PASSWORD=${SERVICE_PASSWORD_WORDPRESS}
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
## Summary

- Adds a WordPress + OpenLiteSpeed service template.
- Uses MariaDB with persistent storage.
- Adds a one-shot `wordpress-installer` service that downloads WordPress, creates `wp-config.php`, shuffles salts, and installs the LiteSpeed Cache plugin into the shared WordPress volume.
- Exposes the WordPress/OpenLiteSpeed frontend through Coolify's `SERVICE_URL_WORDPRESS_80` proxy integration.

Closes #8264.

## Validation

- Parsed `templates/compose/wordpress-with-openlitespeed.yaml` with Ruby YAML.
- Could not run `docker compose config` locally because Docker is not installed in this environment.
