### PR TITLE
docs: add Supabase MCP workaround guidance

### DIFF
--- a/templates/compose/supabase-mcp.md
+++ b/templates/compose/supabase-mcp.md
@@ -1,0 +1,58 @@
+# Supabase MCP with Coolify
+
+This is the supported workaround for using the self-hosted Supabase MCP endpoint with Coolify without exposing it publicly.
+
+Supabase Studio serves the self-hosted MCP endpoint internally at `/api/mcp`. The Supabase guidance is to keep that route denied from the Internet and reach it only through a VPN or SSH tunnel. The Coolify Supabase template follows that model:
+
+- `/api/mcp` is blocked directly by Kong.
+- `/mcp` is routed to `supabase-studio:3000/api/mcp`.
+- `/mcp` is also blocked until an operator explicitly enables an IP allowlist.
+
+## Enable access for one Coolify Supabase service
+
+1. Open the generated `volumes/api/kong.yml` for the Supabase service.
+2. Keep the `mcp-blocker` route for `/api/mcp` enabled.
+3. In the `mcp` service plugin list, comment out the `request-termination` plugin.
+4. Uncomment the `cors` and `ip-restriction` plugins.
+5. Add only trusted source IPs to `config.allow`.
+6. Restart the `supabase-kong` service.
+
+To use an SSH tunnel, first find the Docker bridge gateway IP that Kong sees:
+
+```bash
+docker inspect <kong-container> --format '{{range .NetworkSettings.Networks}}{{println .Gateway}}{{end}}'
+```
+
+Add that gateway IP to the `allow` list, then create a tunnel to the Coolify host:
+
+```bash
+ssh -L localhost:8080:localhost:8000 user@your-coolify-host
+```
+
+Configure the MCP client with the tunneled endpoint:
+
+```json
+{
+  "mcpServers": {
+    "supabase-self-hosted": {
+      "url": "http://localhost:8080/mcp"
+    }
+  }
+}
+```
+
+## Multiple Supabase services
+
+Configure each Coolify Supabase service separately. Do not expose one shared public `/mcp` route for all instances.
+
+- Use one tunnel, VPN route, or domain per Supabase service.
+- Edit the `volumes/api/kong.yml` generated for that service only.
+- Keep direct `/api/mcp` access blocked for every service.
+- Add only the tunnel or VPN source IPs that must reach that specific instance.
+
+## Troubleshooting
+
+- A `403` from `/mcp` means the default block is still active or the source IP is not allowlisted.
+- A `404` usually means the request is not reaching the Supabase Kong service or the path is not `/mcp`.
+- If the client connects through SSH but is denied, allowlist the Docker bridge gateway IP rather than the public client IP.
+- Restart `supabase-kong` after changing the generated Kong configuration.

--- a/templates/compose/supabase.yaml
+++ b/templates/compose/supabase.yaml
@@ -1,4 +1,4 @@
-# documentation: https://supabase.io
+# documentation: https://supabase.com/docs/guides/self-hosting
 # slogan: The open source Firebase alternative.
 # category: backend
 # tags: firebase, alternative, open-source
@@ -426,9 +426,29 @@ services:
                     status_code: 403
                     message: "Access is forbidden."
 
-            ## MCP endpoint - local access
+            ## MCP endpoint - local or VPN access
+            ##
+            ## Supabase Studio exposes MCP internally at /api/mcp, but Supabase
+            ## recommends keeping self-hosted MCP off the public Internet because
+            ## it does not provide OAuth 2.1 authentication. Coolify exposes it
+            ## through Kong at /mcp only after an explicit allowlist is configured.
+            ##
+            ## Safe setup:
+            ## 1. Keep /api/mcp blocked. Do not expose Studio directly.
+            ## 2. Create an SSH tunnel or connect through a VPN to this Coolify host.
+            ## 3. Find the Docker bridge gateway IP seen by Kong, then add that IP
+            ##    to the allow list below:
+            ##    docker inspect <kong-container> --format '{{range .NetworkSettings.Networks}}{{println .Gateway}}{{end}}'
+            ## 4. Comment out the request-termination plugin below, uncomment cors
+            ##    and ip-restriction, add only trusted tunnel/VPN source IPs, then
+            ##    restart the supabase-kong service.
+            ## 5. Configure the MCP client URL as http://localhost:<tunnel-port>/mcp.
+            ##
+            ## For multiple Supabase services, repeat the same change in each
+            ## service's generated volumes/api/kong.yml and use a separate tunnel
+            ## or domain per instance so routes never share public /mcp access.
             - name: mcp
-              _comment: 'MCP: /mcp -> http://supabase-studio:3000/api/mcp (local access)'
+              _comment: 'MCP: /mcp -> http://supabase-studio:3000/api/mcp (local/VPN access only)'
               url: http://supabase-studio:3000/api/mcp
               routes:
                 - name: mcp


### PR DESCRIPTION
## Summary
- updates the Supabase service documentation link to the current self-hosting docs
- documents the safe Coolify/Supabase MCP workaround directly in the template comments
- adds a focused `templates/compose/supabase-mcp.md` guide for enabling `/mcp` through an SSH tunnel or VPN without exposing `/api/mcp`

## Verification
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file("templates/compose/supabase.yaml"); puts "supabase.yaml parsed"'`

/claim #7458