### PR TITLE
feat: show application container details on servers tab

### DIFF
--- a/app/Livewire/Project/Shared/Destination.php
+++ b/app/Livewire/Project/Shared/Destination.php
@@ -17,6 +17,8 @@ class Destination extends Component
 
     public Collection $networks;
 
+    public Collection $containerDetails;
+
     public function getListeners()
     {
         $teamId = auth()->user()->currentTeam()->id;
@@ -31,6 +33,7 @@ class Destination extends Component
     public function mount()
     {
         $this->networks = collect([]);
+        $this->containerDetails = collect([]);
         $this->loadData();
     }
 
@@ -53,6 +56,46 @@ class Destination extends Component
             $this->networks = $this->networks->reject(function ($network) {
                 return $this->resource->additional_servers->pluck('id')->contains($network->server->id);
             });
+        }
+
+        $this->loadContainerDetails();
+    }
+
+    private function loadContainerDetails(): void
+    {
+        $this->containerDetails = collect([]);
+
+        if ($this->resource->getMorphClass() !== 'App\Models\Application') {
+            return;
+        }
+
+        $destinations = collect([$this->resource->destination])
+            ->merge($this->resource->additional_networks ?? collect([]))
+            ->filter();
+
+        foreach ($destinations as $destination) {
+            $server = $destination->server;
+
+            if (! $server || ! $server->isFunctional() || $server->isSwarm()) {
+                continue;
+            }
+
+            try {
+                $containers = getCurrentApplicationContainerStatus($server, $this->resource->id)
+                    ->map(fn ($container) => [
+                        'id' => data_get($container, 'ID'),
+                        'name' => data_get($container, 'Names'),
+                        'image' => data_get($container, 'Image'),
+                        'status' => data_get($container, 'Status'),
+                        'networks' => data_get($container, 'Networks'),
+                        'ports' => data_get($container, 'Ports') ?: '-',
+                    ])
+                    ->values();
+
+                $this->containerDetails->put($server->id, $containers);
+            } catch (\Throwable) {
+                $this->containerDetails->put($server->id, collect([]));
+            }
         }
     }
 

--- a/resources/views/livewire/project/shared/destination.blade.php
+++ b/resources/views/livewire/project/shared/destination.blade.php
@@ -20,6 +20,9 @@
                     Network: {{ data_get($resource, 'destination.network') }}
                 </div>
             </div>
+            @include('livewire.project.shared.partials.container-details', [
+                'containers' => $containerDetails->get(data_get($resource, 'destination.server.id'), collect([])),
+            ])
             @if ($resource?->additional_networks?->count() > 0)
                 <div class="flex gap-2">
                     <x-forms.button
@@ -53,6 +56,9 @@
                             </div>
                         </div>
                     </div>
+                    @include('livewire.project.shared.partials.container-details', [
+                        'containers' => $containerDetails->get(data_get($destination, 'server.id'), collect([])),
+                    ])
                     <div class="flex gap-2">
                         <x-forms.button
                             wire:click="redeploy('{{ data_get($destination, 'id') }}','{{ data_get($destination, 'server.id') }}')">Deploy</x-forms.button>

--- a/resources/views/livewire/project/shared/partials/container-details.blade.php
+++ b/resources/views/livewire/project/shared/partials/container-details.blade.php
@@ -1,0 +1,35 @@
+@if ($containers->isNotEmpty())
+    <div class="grid grid-cols-1 gap-2">
+        <h4>Container Details</h4>
+        @foreach ($containers as $container)
+            <div class="grid grid-cols-1 gap-2 p-4 border rounded dark:border-coolgray-300 bg-white dark:bg-coolgray-100">
+                <div class="grid grid-cols-1 gap-2 md:grid-cols-2">
+                    <div>
+                        <div class="text-xs uppercase text-neutral-500">Container ID</div>
+                        <div class="font-mono text-sm break-all">{{ data_get($container, 'id') }}</div>
+                    </div>
+                    <div>
+                        <div class="text-xs uppercase text-neutral-500">Name</div>
+                        <div class="font-mono text-sm break-all">{{ data_get($container, 'name') }}</div>
+                    </div>
+                    <div>
+                        <div class="text-xs uppercase text-neutral-500">Image</div>
+                        <div class="font-mono text-sm break-all">{{ data_get($container, 'image') }}</div>
+                    </div>
+                    <div>
+                        <div class="text-xs uppercase text-neutral-500">Status</div>
+                        <div class="font-mono text-sm break-all">{{ data_get($container, 'status') }}</div>
+                    </div>
+                    <div>
+                        <div class="text-xs uppercase text-neutral-500">Networks</div>
+                        <div class="font-mono text-sm break-all">{{ data_get($container, 'networks') }}</div>
+                    </div>
+                    <div>
+                        <div class="text-xs uppercase text-neutral-500">Ports</div>
+                        <div class="font-mono text-sm break-all">{{ data_get($container, 'ports') }}</div>
+                    </div>
+                </div>
+            </div>
+        @endforeach
+    </div>
+@endif


### PR DESCRIPTION
## Summary
- adds read-only Docker container details to the application Servers tab
- shows container ID, name, image, status, Docker networks, and ports for each deployed application container
- keeps network mutation out of scope and reuses the existing Coolify container lookup helper

## Verification
- `git diff --check`

Could not run PHP/Laravel tests locally because `php` is not installed in this workspace.

/claim #2495