### PR TITLE
feat(templates): add WordPress OpenLiteSpeed service

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -1,0 +1,85 @@
+# documentation: https://docs.litespeedtech.com/cloud/docker/openlitespeed/
+# slogan: WordPress with OpenLiteSpeed and MariaDB for a fast self-hosted CMS stack.
+# category: cms
+# tags: cms, blog, content, management, wordpress, openlitespeed, litespeed, mariadb
+# logo: svgs/wordpress.svg
+# port: 80
+
+services:
+  wordpress:
+    image: litespeedtech/openlitespeed:1.8.5-lsphp85
+    volumes:
+      - wordpress-files:/var/www/vhosts/localhost/html
+      - openlitespeed-conf:/usr/local/lsws/conf
+      - openlitespeed-admin-conf:/usr/local/lsws/admin/conf
+      - openlitespeed-logs:/usr/local/lsws/logs
+    environment:
+      - SERVICE_URL_WORDPRESS_80
+      - WORDPRESS_DB_HOST=mariadb
+      - WORDPRESS_DB_NAME=wordpress
+      - WORDPRESS_DB_USER=$SERVICE_USER_WORDPRESS
+      - WORDPRESS_DB_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    command:
+      - /bin/sh
+      - -c
+      - |
+        set -e
+        DOCROOT=/var/www/vhosts/localhost/html
+        mkdir -p "$$DOCROOT"
+        if [ ! -f "$$DOCROOT/wp-load.php" ]; then
+          wp core download --allow-root --path="$$DOCROOT"
+        fi
+        if [ ! -f "$$DOCROOT/wp-config.php" ]; then
+          wp config create --allow-root --path="$$DOCROOT" \
+            --dbname="$${WORDPRESS_DB_NAME}" \
+            --dbuser="$${WORDPRESS_DB_USER}" \
+            --dbpass="$${WORDPRESS_DB_PASSWORD}" \
+            --dbhost="$${WORDPRESS_DB_HOST}" \
+            --skip-check
+        fi
+        if [ ! -f "$$DOCROOT/.htaccess" ]; then
+          cat > "$$DOCROOT/.htaccess" <<'EOF'
+        # BEGIN WordPress
+        <IfModule mod_rewrite.c>
+        RewriteEngine On
+        RewriteBase /
+        RewriteRule ^index\.php$ - [L]
+        RewriteCond %{REQUEST_FILENAME} !-f
+        RewriteCond %{REQUEST_FILENAME} !-d
+        RewriteRule . /index.php [L]
+        </IfModule>
+        # END WordPress
+        EOF
+        fi
+        chown -R nobody:nogroup /var/www/vhosts/localhost
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1"]
+      interval: 5s
+      timeout: 20s
+      retries: 20
+      start_period: 60s
+
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+
+volumes:
+  wordpress-files:
+  openlitespeed-conf:
+  openlitespeed-admin-conf:
+  openlitespeed-logs:
+  mariadb-data:


### PR DESCRIPTION
## Changes

- Added a WordPress + OpenLiteSpeed service template using the official LiteSpeed image and MariaDB.
- Mounted WordPress files, OpenLiteSpeed config/logs, and database data on named volumes so data survives restarts.
- Exposed port 80 through Coolify's normal service URL handling and initialized WordPress/wp-config.php on first start.

## Issues

- Fixes #8264
- /claim #8264

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not included; this is a service template change.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex
- How extensively: Used to draft the service template and run local checks.

## Testing

- Parsed `templates/compose/wordpress-with-openlitespeed.yaml` with PyYAML.
- Ran shell syntax validation for the WordPress init command with Git Bash `bash -n`.
- Ran `docker compose -f templates\compose\wordpress-with-openlitespeed.yaml config`.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.