### PR TITLE
feat: add OAuth registration controls

### DIFF
--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -27,14 +27,18 @@ class OauthController extends Controller
             $user = User::whereEmail($email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! $settings->is_oauth_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 
                 $user = User::create([
                     'name' => $oauthUser->name,
                     'email' => $email,
+                    'oauth_provider' => $provider,
                 ]);
+            } elseif (! $user->oauth_provider) {
+                $user->oauth_provider = $provider;
+                $user->save();
             }
             Auth::login($user);
 

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -16,6 +16,12 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $is_oauth_registration_enabled;
+
+    #[Validate('boolean')]
+    public bool $is_oauth_password_login_disabled;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -44,6 +50,8 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_registration_enabled' => 'boolean',
+            'is_oauth_password_login_disabled' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => ['nullable', 'string', new ValidDnsServers],
@@ -66,6 +74,8 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled;
+        $this->is_oauth_password_login_disabled = $this->settings->is_oauth_password_login_disabled;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -147,6 +157,8 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
+            $this->settings->is_oauth_password_login_disabled = $this->is_oauth_password_login_disabled;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -18,6 +18,8 @@ class InstanceSettings extends Model
         'do_not_track',
         'is_auto_update_enabled',
         'is_registration_enabled',
+        'is_oauth_registration_enabled',
+        'is_oauth_password_login_disabled',
         'next_channel',
         'smtp_enabled',
         'smtp_from_address',
@@ -64,6 +66,9 @@ class InstanceSettings extends Model
 
         'allowed_ip_ranges' => 'array',
         'is_auto_update_enabled' => 'boolean',
+        'is_registration_enabled' => 'boolean',
+        'is_oauth_registration_enabled' => 'boolean',
+        'is_oauth_password_login_disabled' => 'boolean',
         'auto_update_frequency' => 'string',
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -47,6 +47,7 @@ class User extends Authenticatable implements SendsEmail
         'name',
         'email',
         'password',
+        'oauth_provider',
         'force_password_reset',
         'marketing_emails',
         'pending_email',

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -7,6 +7,7 @@ use App\Actions\Fortify\ResetUserPassword;
 use App\Actions\Fortify\UpdateUserPassword;
 use App\Actions\Fortify\UpdateUserProfileInformation;
 use App\Models\OauthSetting;
+use App\Models\TeamInvitation;
 use App\Models\User;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
@@ -76,13 +77,21 @@ class FortifyServiceProvider extends ServiceProvider
             $user = User::where('email', $email)->with('teams')->first();
             if (
                 $user &&
+                $user->oauth_provider &&
+                instanceSettings()->is_oauth_password_login_disabled
+            ) {
+                return null;
+            }
+
+            if (
+                $user &&
                 Hash::check($request->password, $user->password)
             ) {
                 $user->updated_at = now();
                 $user->save();
 
                 // Check if user has a pending invitation they haven't accepted yet
-                $invitation = \App\Models\TeamInvitation::whereEmail($email)->first();
+                $invitation = TeamInvitation::whereEmail($email)->first();
                 if ($invitation && $invitation->isValid()) {
                     // User is logging in for the first time after being invited
                     // Attach them to the invited team if not already attached

--- a/database/migrations/2026_05_11_000000_add_oauth_registration_settings.php
+++ b/database/migrations/2026_05_11_000000_add_oauth_registration_settings.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_registration_enabled')->default(false);
+            $table->boolean('is_oauth_password_login_disabled')->default(false);
+        });
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('oauth_provider')->nullable()->after('password');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('oauth_provider');
+        });
+
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn([
+                'is_oauth_registration_enabled',
+                'is_oauth_password_login_disabled',
+            ]);
+        });
+    }
+};

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -42,6 +42,16 @@
                         </div>
                     @endif
                     <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_registration_enabled"
+                            helper="Allow new users signing in with a configured OAuth provider to create an account even when password registration is disabled."
+                            label="OAuth Registration Allowed" />
+                    </div>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_password_login_disabled"
+                            helper="Prevent users linked to an OAuth provider from logging in with a password. They must continue using OAuth."
+                            label="Require OAuth Login for OAuth Users" />
+                    </div>
+                    <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"
                             helper="Opt out of anonymous usage tracking. When enabled, this instance will not report to coolify.io's installation count and will not send error reports to help improve Coolify."
                             label="Do Not Track" />

--- a/tests/Feature/OauthRegistrationSettingsTest.php
+++ b/tests/Feature/OauthRegistrationSettingsTest.php
@@ -1,0 +1,96 @@
+<?php
+
+use App\Http\Controllers\OauthController;
+use App\Models\InstanceSettings;
+use App\Models\OauthSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Socialite\Facades\Socialite;
+
+uses(RefreshDatabase::class);
+
+function fakeOauthProvider(string $email = 'oauth@example.com', string $name = 'OAuth User'): object
+{
+    return new class($email, $name)
+    {
+        public function __construct(private string $email, private string $name) {}
+
+        public function user(): object
+        {
+            return (object) [
+                'email' => $this->email,
+                'name' => $this->name,
+            ];
+        }
+    };
+}
+
+beforeEach(function () {
+    config()->set('app.maintenance.driver', 'file');
+
+    InstanceSettings::unguarded(fn () => InstanceSettings::create(['id' => 0]));
+
+    OauthSetting::create([
+        'provider' => 'github',
+        'enabled' => true,
+        'client_id' => 'client-id',
+        'client_secret' => 'client-secret',
+        'redirect_uri' => 'http://localhost/auth/github/callback',
+    ]);
+});
+
+it('allows oauth registration when password registration is disabled but oauth registration is enabled', function () {
+    $settings = instanceSettings();
+    $settings->is_registration_enabled = false;
+    $settings->is_oauth_registration_enabled = true;
+    $settings->save();
+
+    Socialite::shouldReceive('buildProvider')
+        ->once()
+        ->andReturn(fakeOauthProvider());
+
+    app(OauthController::class)->callback('github');
+
+    $user = User::whereEmail('oauth@example.com')->first();
+
+    expect($user)->not->toBeNull()
+        ->and($user->oauth_provider)->toBe('github')
+        ->and(auth()->check())->toBeTrue();
+});
+
+it('blocks oauth registration when both password and oauth registration are disabled', function () {
+    $settings = instanceSettings();
+    $settings->is_registration_enabled = false;
+    $settings->is_oauth_registration_enabled = false;
+    $settings->save();
+
+    Socialite::shouldReceive('buildProvider')
+        ->once()
+        ->andReturn(fakeOauthProvider());
+
+    app(OauthController::class)->callback('github');
+
+    expect(User::whereEmail('oauth@example.com')->exists())->toBeFalse()
+        ->and(auth()->check())->toBeFalse();
+});
+
+it('blocks password login for users linked to oauth when oauth password login is disabled', function () {
+    $settings = instanceSettings();
+    $settings->is_oauth_password_login_disabled = true;
+    $settings->save();
+
+    $user = User::factory()->create([
+        'email' => 'oauth@example.com',
+        'password' => Hash::make('password'),
+        'oauth_provider' => 'github',
+    ]);
+
+    // Exercise the configured Fortify callback by sending a real login request.
+    $this->post('/login', [
+        'email' => $user->email,
+        'password' => 'password',
+    ])->assertSessionHasErrors();
+
+    expect(auth()->check())->toBeFalse();
+});


### PR DESCRIPTION
Closes #8042
/claim #8042

## Summary

- added separate instance settings for OAuth registration and OAuth-only login behavior
- track the OAuth provider when a user is created or linked through OAuth
- allow OAuth-created users when password registration is disabled but OAuth registration is enabled
- block password login for OAuth-linked users when admins enable the OAuth-only setting
- added feature tests for the new OAuth registration and login restrictions

## Notes

This keeps password registration and OAuth registration as separate controls. It also avoids changing existing provider setup: the new behavior only applies after an OAuth provider is already configured and enabled.

## Testing

- `php -l` against all modified PHP files using `php:8.4-cli`: passed.
- `vendor/bin/pint` against modified PHP files using `php:8.4-cli`: passed; one style issue fixed.
- Focused Pest tests using `php:8.4-cli` with `pdo_pgsql`, `sockets`, and `pcntl` installed in the one-off container:

```text
php vendor/bin/pest tests/Feature/OauthRegistrationSettingsTest.php tests/Feature/OauthControllerTest.php
```

Result:

```text
Tests: 6 passed (33 assertions)
```