### PR TITLE
feat: add read-only container info tab

### DIFF
--- a/app/Livewire/Project/Shared/ContainerInfo.php
+++ b/app/Livewire/Project/Shared/ContainerInfo.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace App\Livewire\Project\Shared;
+
+use App\Models\Application;
+use App\Models\Server;
+use App\Models\Service;
+use App\Support\ContainerInfoFormatter;
+use App\Support\ValidationPatterns;
+use Illuminate\Support\Collection;
+use Livewire\Component;
+
+class ContainerInfo extends Component
+{
+    public $resource;
+
+    public Collection $containers;
+
+    public ?string $selectedContainerKey = null;
+
+    public array $containerInfo = [];
+
+    public ?string $error = null;
+
+    public function mount($resource): void
+    {
+        $this->resource = $resource;
+        $this->containers = collect();
+        $this->loadContainers();
+
+        if ($this->containers->count() === 1) {
+            $this->selectedContainerKey = data_get($this->containers->first(), 'key');
+            $this->loadContainerInfo();
+        }
+    }
+
+    public function updatedSelectedContainerKey(): void
+    {
+        $this->loadContainerInfo();
+    }
+
+    public function refreshInfo(): void
+    {
+        $this->loadContainers();
+        $this->loadContainerInfo();
+    }
+
+    public function loadContainerInfo(): void
+    {
+        $this->containerInfo = [];
+        $this->error = null;
+
+        if (blank($this->selectedContainerKey)) {
+            return;
+        }
+
+        $payload = $this->selectedContainerPayload();
+        if (is_null($payload)) {
+            $this->error = 'Selected container is not available anymore.';
+
+            return;
+        }
+
+        $server = data_get($payload, 'server');
+        $containerName = (string) data_get($payload, 'container.Names');
+
+        if (! $server instanceof Server || ! ValidationPatterns::isValidContainerName($containerName)) {
+            $this->error = 'Selected container has invalid metadata.';
+
+            return;
+        }
+
+        $rawInspect = instant_remote_process([
+            "docker inspect ".escapeshellarg($containerName)." --format '{{json .}}'",
+        ], $server, false);
+
+        if (blank($rawInspect)) {
+            $this->error = 'Container details are unavailable. The container may have been removed or the server is unreachable.';
+
+            return;
+        }
+
+        $inspect = format_docker_command_output_to_json($rawInspect)->first();
+        if (! is_array($inspect)) {
+            $this->error = 'Container details are unavailable. The container may have been removed or the server is unreachable.';
+
+            return;
+        }
+
+        $this->containerInfo = ContainerInfoFormatter::fromDockerInspect($inspect);
+    }
+
+    public function render()
+    {
+        return view('livewire.project.shared.container-info');
+    }
+
+    private function loadContainers(): void
+    {
+        $containers = collect();
+
+        foreach ($this->servers() as $server) {
+            if (! $server->isFunctional() || $server->isSwarm()) {
+                continue;
+            }
+
+            $containers = $containers->merge($this->containersForServer($server));
+        }
+
+        $this->containers = $containers
+            ->filter(fn (array $payload) => filled(data_get($payload, 'container.Names')))
+            ->sortBy(fn (array $payload) => data_get($payload, 'container.Names'))
+            ->values();
+
+        if ($this->selectedContainerKey && $this->selectedContainerPayload() === null) {
+            $this->selectedContainerKey = null;
+        }
+
+        if (blank($this->selectedContainerKey) && $this->containers->count() === 1) {
+            $this->selectedContainerKey = data_get($this->containers->first(), 'key');
+        }
+    }
+
+    private function containersForServer(Server $server): Collection
+    {
+        if ($this->resource instanceof Application) {
+            return getCurrentApplicationContainerStatus($server, $this->resource->id, includePullrequests: true)
+                ->map(fn (array $container) => $this->containerPayload($server, $container));
+        }
+
+        if ($this->resource instanceof Service) {
+            return getCurrentServiceContainerStatus($server, $this->resource->id)
+                ->map(fn (array $container) => $this->containerPayload($server, $container));
+        }
+
+        return collect([
+            $this->containerPayload($server, [
+                'Names' => data_get($this->resource, 'uuid'),
+                'Image' => data_get($this->resource, 'image'),
+                'State' => data_get($this->resource, 'status'),
+            ]),
+        ]);
+    }
+
+    private function containerPayload(Server $server, array $container): array
+    {
+        $containerName = (string) data_get($container, 'Names');
+
+        return [
+            'key' => "{$server->uuid}|{$containerName}",
+            'server' => $server,
+            'container' => $container,
+        ];
+    }
+
+    private function servers(): Collection
+    {
+        if ($this->resource instanceof Application) {
+            return collect([data_get($this->resource, 'destination.server')])
+                ->merge($this->resource->additional_servers);
+        }
+
+        if ($this->resource instanceof Service) {
+            return collect([data_get($this->resource, 'server')]);
+        }
+
+        return collect([data_get($this->resource, 'destination.server')]);
+    }
+
+    private function selectedContainerPayload(): ?array
+    {
+        return $this->containers
+            ->first(fn (array $payload) => data_get($payload, 'key') === $this->selectedContainerKey);
+    }
+}

--- a/app/Support/ContainerInfoFormatter.php
+++ b/app/Support/ContainerInfoFormatter.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Support;
+
+class ContainerInfoFormatter
+{
+    public static function fromDockerInspect(array $inspect): array
+    {
+        $id = (string) data_get($inspect, 'Id', '');
+        $name = ltrim((string) data_get($inspect, 'Name', ''), '/');
+
+        return [
+            'id' => $id,
+            'id_short' => $id !== '' ? substr($id, 0, 12) : null,
+            'name' => $name !== '' ? $name : null,
+            'image' => data_get($inspect, 'Config.Image'),
+            'image_id' => data_get($inspect, 'Image'),
+            'status' => data_get($inspect, 'State.Status'),
+            'created_at' => self::validDockerTimestamp(data_get($inspect, 'Created')),
+            'started_at' => self::validDockerTimestamp(data_get($inspect, 'State.StartedAt')),
+            'finished_at' => self::validDockerTimestamp(data_get($inspect, 'State.FinishedAt')),
+            'restart_count' => data_get($inspect, 'RestartCount'),
+            'networks' => self::networks($inspect),
+        ];
+    }
+
+    public static function networks(array $inspect): array
+    {
+        $networks = data_get($inspect, 'NetworkSettings.Networks', []);
+        if (! is_array($networks)) {
+            return [];
+        }
+
+        return collect($networks)
+            ->filter(fn ($network) => is_array($network))
+            ->map(fn (array $network, string $name) => [
+                'name' => $name,
+                'ipv4' => data_get($network, 'IPAddress'),
+                'ipv6' => data_get($network, 'GlobalIPv6Address'),
+                'mac_address' => data_get($network, 'MacAddress'),
+                'network_id' => data_get($network, 'NetworkID'),
+            ])
+            ->values()
+            ->all();
+    }
+
+    private static function validDockerTimestamp(?string $value): ?string
+    {
+        if (blank($value) || str_starts_with($value, '0001-01-01')) {
+            return null;
+        }
+
+        return $value;
+    }
+}

--- a/resources/views/livewire/project/application/configuration.blade.php
+++ b/resources/views/livewire/project/application/configuration.blade.php
@@ -43,6 +43,8 @@
                     </span>
                 @endif
             </a>
+            <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                href="{{ route('project.application.container-info', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Container Info</span></a>
             <a @class(['sub-menu-item', 'menu-item-active' => str($currentRoute)->startsWith('project.application.scheduled-tasks')]) {{ wireNavigate() }}
                 href="{{ route('project.application.scheduled-tasks.show', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'application_uuid' => $application->uuid]) }}"><span class="menu-item-label">Scheduled Tasks</span></a>
             <a class="sub-menu-item" {{ wireNavigate() }} wire:current.exact="menu-item-active"
@@ -83,6 +85,8 @@
                 <livewire:project.application.source :application="$application" />
             @elseif ($currentRoute === 'project.application.servers')
                 <livewire:project.shared.destination :resource="$application" />
+            @elseif ($currentRoute === 'project.application.container-info')
+                <livewire:project.shared.container-info :resource="$application" />
             @elseif ($currentRoute === 'project.application.scheduled-tasks.show')
                 <livewire:project.shared.scheduled-task.all :resource="$application" />
             @elseif ($currentRoute === 'project.application.scheduled-tasks')

--- a/resources/views/livewire/project/database/configuration.blade.php
+++ b/resources/views/livewire/project/database/configuration.blade.php
@@ -14,6 +14,8 @@
             <a class='sub-menu-item' {{ wireNavigate() }} wire:current.exact="menu-item-active"
                 href="{{ route('project.database.servers', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'database_uuid' => $database->uuid]) }}"><span class="menu-item-label">Servers</span></a>
             <a class='sub-menu-item' {{ wireNavigate() }} wire:current.exact="menu-item-active"
+                href="{{ route('project.database.container-info', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'database_uuid' => $database->uuid]) }}"><span class="menu-item-label">Container Info</span></a>
+            <a class='sub-menu-item' {{ wireNavigate() }} wire:current.exact="menu-item-active"
                 href="{{ route('project.database.persistent-storage', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'database_uuid' => $database->uuid]) }}"><span class="menu-item-label">Persistent Storage</span></a>
             @can('update', $database)
                 <a class='sub-menu-item' wire:current.exact="menu-item-active"
@@ -55,6 +57,8 @@
                 <livewire:project.shared.environment-variable.all :resource="$database" />
             @elseif ($currentRoute === 'project.database.servers')
                 <livewire:project.shared.destination :resource="$database" />
+            @elseif ($currentRoute === 'project.database.container-info')
+                <livewire:project.shared.container-info :resource="$database" />
             @elseif ($currentRoute === 'project.database.persistent-storage')
                 <livewire:project.service.storage :resource="$database" />
             @elseif ($currentRoute === 'project.database.import-backup')

--- a/resources/views/livewire/project/service/configuration.blade.php
+++ b/resources/views/livewire/project/service/configuration.blade.php
@@ -19,6 +19,8 @@
             <a class='sub-menu-item' wire:current.exact="menu-item-active" {{ wireNavigate() }}
                 href="{{ route('project.service.webhooks', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'service_uuid' => $service->uuid]) }}"><span class="menu-item-label">Webhooks</span></a>
             <a class='sub-menu-item' wire:current.exact="menu-item-active" {{ wireNavigate() }}
+                href="{{ route('project.service.container-info', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'service_uuid' => $service->uuid]) }}"><span class="menu-item-label">Container Info</span></a>
+            <a class='sub-menu-item' wire:current.exact="menu-item-active" {{ wireNavigate() }}
                 href="{{ route('project.service.resource-operations', ['project_uuid' => $project->uuid, 'environment_uuid' => $environment->uuid, 'service_uuid' => $service->uuid]) }}"><span class="menu-item-label">Resource Operations</span></a>
 
             <a class='sub-menu-item' wire:current.exact="menu-item-active" {{ wireNavigate() }}
@@ -193,6 +195,8 @@
                 <livewire:project.shared.scheduled-task.show />
             @elseif ($currentRoute === 'project.service.webhooks')
                 <livewire:project.shared.webhooks :resource="$service" />
+            @elseif ($currentRoute === 'project.service.container-info')
+                <livewire:project.shared.container-info :resource="$service" />
             @elseif ($currentRoute === 'project.service.resource-operations')
                 <livewire:project.shared.resource-operations :resource="$service" />
             @elseif ($currentRoute === 'project.service.tags')

--- a/resources/views/livewire/project/shared/container-info.blade.php
+++ b/resources/views/livewire/project/shared/container-info.blade.php
@@ -1,0 +1,111 @@
+<div>
+    <div class="flex flex-col gap-4">
+        <div>
+            <div class="flex items-center gap-2">
+                <h2>Container Info</h2>
+            </div>
+            <div class="pb-4">Read-only Docker container details for this resource.</div>
+        </div>
+
+        @if ($containers->isEmpty())
+            <div class="alert alert-warning">
+                No Docker containers were found for this resource on a functional non-Swarm server.
+            </div>
+        @else
+            <div class="flex flex-col gap-2 sm:w-96">
+                <x-forms.select label="Container" id="selectedContainerKey" wire:model.live="selectedContainerKey">
+                    <option value="">Select a container</option>
+                    @foreach ($containers as $container)
+                        <option value="{{ data_get($container, 'key') }}">
+                            {{ data_get($container, 'container.Names') }}
+                            ({{ data_get($container, 'server.name') }})
+                        </option>
+                    @endforeach
+                </x-forms.select>
+                <div>
+                    <x-forms.button wire:click="refreshInfo">Refresh</x-forms.button>
+                </div>
+            </div>
+
+            @if ($error)
+                <div class="alert alert-warning">{{ $error }}</div>
+            @endif
+
+            @if (filled($containerInfo))
+                <div class="grid grid-cols-1 gap-4 xl:grid-cols-2">
+                    <div class="box-without-bg">
+                        <h3>General</h3>
+                        <div class="grid grid-cols-1 gap-3 pt-4">
+                            <div>
+                                <div class="text-xs uppercase text-neutral-500">Container ID</div>
+                                <x-forms.copy-button :text="$containerInfo['id'] ?: 'n/a'" />
+                            </div>
+                            <div>
+                                <div class="text-xs uppercase text-neutral-500">Container Name</div>
+                                <x-forms.copy-button :text="$containerInfo['name'] ?: 'n/a'" />
+                            </div>
+                            <div>
+                                <div class="text-xs uppercase text-neutral-500">Image</div>
+                                <x-forms.copy-button :text="$containerInfo['image'] ?: 'n/a'" />
+                            </div>
+                            <div>
+                                <div class="text-xs uppercase text-neutral-500">Image ID</div>
+                                <x-forms.copy-button :text="$containerInfo['image_id'] ?: 'n/a'" />
+                            </div>
+                            <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                                <div>
+                                    <div class="text-xs uppercase text-neutral-500">Status</div>
+                                    <div class="font-mono text-sm">{{ $containerInfo['status'] ?? 'n/a' }}</div>
+                                </div>
+                                <div>
+                                    <div class="text-xs uppercase text-neutral-500">Restart Count</div>
+                                    <div class="font-mono text-sm">{{ $containerInfo['restart_count'] ?? 'n/a' }}</div>
+                                </div>
+                                <div>
+                                    <div class="text-xs uppercase text-neutral-500">Created</div>
+                                    <div class="font-mono text-sm break-all">{{ $containerInfo['created_at'] ?? 'n/a' }}</div>
+                                </div>
+                                <div>
+                                    <div class="text-xs uppercase text-neutral-500">Started</div>
+                                    <div class="font-mono text-sm break-all">{{ $containerInfo['started_at'] ?? 'n/a' }}</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="box-without-bg">
+                        <h3>Networks</h3>
+                        <div class="pt-4">
+                            @if (empty($containerInfo['networks']))
+                                <div class="text-sm text-neutral-500">No network data returned by Docker inspect.</div>
+                            @else
+                                <div class="overflow-x-auto">
+                                    <table>
+                                        <thead>
+                                            <tr>
+                                                <th>Network</th>
+                                                <th>IPv4</th>
+                                                <th>IPv6</th>
+                                                <th>MAC</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            @foreach ($containerInfo['networks'] as $network)
+                                                <tr>
+                                                    <td class="font-mono text-xs">{{ $network['name'] }}</td>
+                                                    <td class="font-mono text-xs">{{ $network['ipv4'] ?: 'n/a' }}</td>
+                                                    <td class="font-mono text-xs">{{ $network['ipv6'] ?: 'n/a' }}</td>
+                                                    <td class="font-mono text-xs">{{ $network['mac_address'] ?: 'n/a' }}</td>
+                                                </tr>
+                                            @endforeach
+                                        </tbody>
+                                    </table>
+                                </div>
+                            @endif
+                        </div>
+                    </div>
+                </div>
+            @endif
+        @endif
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -219,6 +219,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/persistent-storage', ApplicationConfiguration::class)->name('project.application.persistent-storage');
         Route::get('/source', ApplicationConfiguration::class)->name('project.application.source');
         Route::get('/servers', ApplicationConfiguration::class)->name('project.application.servers');
+        Route::get('/container-info', ApplicationConfiguration::class)->name('project.application.container-info');
         Route::get('/scheduled-tasks', ApplicationConfiguration::class)->name('project.application.scheduled-tasks.show');
         Route::get('/webhooks', ApplicationConfiguration::class)->name('project.application.webhooks');
         Route::get('/preview-deployments', ApplicationConfiguration::class)->name('project.application.preview-deployments');
@@ -240,6 +241,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/', DatabaseConfiguration::class)->name('project.database.configuration');
         Route::get('/environment-variables', DatabaseConfiguration::class)->name('project.database.environment-variables');
         Route::get('/servers', DatabaseConfiguration::class)->name('project.database.servers');
+        Route::get('/container-info', DatabaseConfiguration::class)->name('project.database.container-info');
         Route::get('/import-backup', DatabaseConfiguration::class)->name('project.database.import-backup')->middleware('can.update.resource');
         Route::get('/persistent-storage', DatabaseConfiguration::class)->name('project.database.persistent-storage');
         Route::get('/webhooks', DatabaseConfiguration::class)->name('project.database.webhooks');
@@ -261,6 +263,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/storages', ServiceConfiguration::class)->name('project.service.storages');
         Route::get('/scheduled-tasks', ServiceConfiguration::class)->name('project.service.scheduled-tasks.show');
         Route::get('/webhooks', ServiceConfiguration::class)->name('project.service.webhooks');
+        Route::get('/container-info', ServiceConfiguration::class)->name('project.service.container-info');
         Route::get('/resource-operations', ServiceConfiguration::class)->name('project.service.resource-operations');
         Route::get('/tags', ServiceConfiguration::class)->name('project.service.tags');
         Route::get('/danger', ServiceConfiguration::class)->name('project.service.danger');

--- a/tests/Unit/ContainerInfoFormatterTest.php
+++ b/tests/Unit/ContainerInfoFormatterTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use App\Support\ContainerInfoFormatter;
+
+it('formats Docker inspect container details for display', function () {
+    $formatted = ContainerInfoFormatter::fromDockerInspect([
+        'Id' => '18c7f9a6b5d4c3e2f10987654321abcdef',
+        'Name' => '/coolify-demo',
+        'Image' => 'sha256:abcdef1234567890',
+        'Created' => '2026-05-11T03:00:00.000000000Z',
+        'RestartCount' => 2,
+        'Config' => [
+            'Image' => 'nginx:latest',
+        ],
+        'State' => [
+            'Status' => 'running',
+            'StartedAt' => '2026-05-11T03:01:00.000000000Z',
+            'FinishedAt' => '0001-01-01T00:00:00Z',
+        ],
+        'NetworkSettings' => [
+            'Networks' => [
+                'coolify' => [
+                    'IPAddress' => '172.18.0.5',
+                    'GlobalIPv6Address' => 'fd00::5',
+                    'MacAddress' => '02:42:ac:12:00:05',
+                    'NetworkID' => 'network-123',
+                ],
+            ],
+        ],
+    ]);
+
+    expect($formatted['id_short'])->toBe('18c7f9a6b5d4')
+        ->and($formatted['name'])->toBe('coolify-demo')
+        ->and($formatted['image'])->toBe('nginx:latest')
+        ->and($formatted['image_id'])->toBe('sha256:abcdef1234567890')
+        ->and($formatted['status'])->toBe('running')
+        ->and($formatted['restart_count'])->toBe(2)
+        ->and($formatted['finished_at'])->toBeNull()
+        ->and($formatted['networks'])->toHaveCount(1)
+        ->and($formatted['networks'][0])->toMatchArray([
+            'name' => 'coolify',
+            'ipv4' => '172.18.0.5',
+            'ipv6' => 'fd00::5',
+            'mac_address' => '02:42:ac:12:00:05',
+            'network_id' => 'network-123',
+        ]);
+});
+
+it('handles missing Docker network settings', function () {
+    $formatted = ContainerInfoFormatter::fromDockerInspect([
+        'Id' => 'abc',
+        'Name' => '/without-network',
+    ]);
+
+    expect($formatted['networks'])->toBe([])
+        ->and($formatted['name'])->toBe('without-network');
+});


### PR DESCRIPTION
STRAWBERRY

## Changes

- Added a read-only Container Info view inside application, database, and service configuration.
- The view enumerates containers from the existing Coolify resource scope, then reads details with `docker inspect` only for the selected container.
- Shows container ID/name, image/image ID, status, restart count, created/started timestamps, and Docker network IPv4/IPv6/MAC data.
- Added a small formatter class plus unit coverage for Docker inspect parsing.

/claim #2495

## Issues

- Fixes #2495, scoped to the read-only container information and network visibility slice.

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

I could not attach a runtime demo from this machine because the available environment for this Codex run does not have `php`, `composer`, or `docker` installed, so I cannot boot Coolify locally here. The UI path added is:

- Application configuration -> Container Info
- Database configuration -> Container Info
- Service configuration -> Container Info

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: AI-assisted implementation, with manual scoping and review of existing Coolify patterns during the run.

## Testing

- `git diff --check`
- Static route/component reference check with `rg`
- Added `tests/Unit/ContainerInfoFormatterTest.php`
- Not run: `vendor/bin/pint`, `php artisan test tests/Unit/ContainerInfoFormatterTest.php` because this local environment does not have `php`, `composer`, `vendor`, or `docker` available.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
