### PR TITLE
fix: allow OAuth signup when registration is disabled

### DIFF
--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\ResetsUserPasswords;
 
 class ResetUserPassword implements ResetsUserPasswords
@@ -17,6 +18,12 @@ class ResetUserPassword implements ResetsUserPasswords
      */
     public function reset(User $user, array $input): void
     {
+        if (instanceSettings()->disable_password_auth_for_oauth_users && $user->isOauthUser()) {
+            throw ValidationException::withMessages([
+                'password' => __('Password authentication is disabled for OAuth users.'),
+            ]);
+        }
+
         Validator::make($input, [
             'password' => ['required', Password::defaults(), 'confirmed'],
         ])->validate();

--- a/app/Actions/Fortify/UpdateUserPassword.php
+++ b/app/Actions/Fortify/UpdateUserPassword.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\UpdatesUserPasswords;
 
 class UpdateUserPassword implements UpdatesUserPasswords
@@ -17,6 +18,12 @@ class UpdateUserPassword implements UpdatesUserPasswords
      */
     public function update(User $user, array $input): void
     {
+        if (instanceSettings()->disable_password_auth_for_oauth_users && $user->isOauthUser()) {
+            throw ValidationException::withMessages([
+                'password' => __('Password authentication is disabled for OAuth users.'),
+            ])->errorBag('updatePassword');
+        }
+
         Validator::make($input, [
             'current_password' => ['required', 'string', 'current_password:web'],
             'password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -26,15 +26,13 @@ class OauthController extends Controller
             $email = strtolower($email);
             $user = User::whereEmail($email)->first();
             if (! $user) {
-                $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
-                    abort(403, 'Registration is disabled');
-                }
-
                 $user = User::create([
                     'name' => $oauthUser->name,
                     'email' => $email,
+                    'is_oauth_user' => true,
                 ]);
+            } elseif (! $user->hasPassword() && ! $user->is_oauth_user) {
+                $user->update(['is_oauth_user' => true]);
             }
             Auth::login($user);
 

--- a/app/Livewire/SettingsOauth.php
+++ b/app/Livewire/SettingsOauth.php
@@ -9,6 +9,8 @@ class SettingsOauth extends Component
 {
     public $oauth_settings_map;
 
+    public bool $disable_password_auth_for_oauth_users = false;
+
     protected function rules()
     {
         return OauthSetting::all()->reduce(function ($carry, $setting) {
@@ -20,7 +22,9 @@ class SettingsOauth extends Component
             $carry["oauth_settings_map.$setting->provider.base_url"] = 'nullable';
 
             return $carry;
-        }, []);
+        }, [
+            'disable_password_auth_for_oauth_users' => 'boolean',
+        ]);
     }
 
     public function mount()
@@ -28,6 +32,7 @@ class SettingsOauth extends Component
         if (! isInstanceAdmin()) {
             return redirect()->route('home');
         }
+        $this->disable_password_auth_for_oauth_users = instanceSettings()->disable_password_auth_for_oauth_users;
         $this->oauth_settings_map = OauthSetting::all()->sortBy('provider')->reduce(function ($carry, $setting) {
             $carry[$setting->provider] = [
                 'id' => $setting->id,
@@ -139,6 +144,10 @@ class SettingsOauth extends Component
 
     public function submit()
     {
+        $settings = instanceSettings();
+        $settings->disable_password_auth_for_oauth_users = $this->disable_password_auth_for_oauth_users;
+        $settings->save();
+
         $this->updateOauthSettings();
         $this->dispatch('success', 'Instance settings updated successfully!');
     }

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -35,6 +35,7 @@ class InstanceSettings extends Model
         'custom_dns_servers',
         'instance_name',
         'is_api_enabled',
+        'disable_password_auth_for_oauth_users',
         'allowed_ips',
         'auto_update_frequency',
         'update_check_frequency',
@@ -62,6 +63,7 @@ class InstanceSettings extends Model
         'resend_enabled' => 'boolean',
         'resend_api_key' => 'encrypted',
 
+        'disable_password_auth_for_oauth_users' => 'boolean',
         'allowed_ip_ranges' => 'array',
         'is_auto_update_enabled' => 'boolean',
         'auto_update_frequency' => 'string',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -48,6 +48,7 @@ class User extends Authenticatable implements SendsEmail
         'email',
         'password',
         'force_password_reset',
+        'is_oauth_user',
         'marketing_emails',
         'pending_email',
         'email_change_code',
@@ -64,6 +65,7 @@ class User extends Authenticatable implements SendsEmail
     protected $casts = [
         'email_verified_at' => 'datetime',
         'force_password_reset' => 'boolean',
+        'is_oauth_user' => 'boolean',
         'show_boarding' => 'boolean',
         'email_change_code_expires_at' => 'datetime',
     ];
@@ -486,5 +488,10 @@ class User extends Authenticatable implements SendsEmail
     public function hasPassword(): bool
     {
         return ! empty($this->password);
+    }
+
+    public function isOauthUser(): bool
+    {
+        return $this->is_oauth_user || ! $this->hasPassword();
     }
 }

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -7,6 +7,7 @@ use App\Actions\Fortify\ResetUserPassword;
 use App\Actions\Fortify\UpdateUserPassword;
 use App\Actions\Fortify\UpdateUserProfileInformation;
 use App\Models\OauthSetting;
+use App\Models\TeamInvitation;
 use App\Models\User;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
@@ -74,6 +75,10 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::authenticateUsing(function (Request $request) {
             $email = strtolower($request->email);
             $user = User::where('email', $email)->with('teams')->first();
+            if ($user && instanceSettings()->disable_password_auth_for_oauth_users && $user->isOauthUser()) {
+                return null;
+            }
+
             if (
                 $user &&
                 Hash::check($request->password, $user->password)
@@ -82,7 +87,7 @@ class FortifyServiceProvider extends ServiceProvider
                 $user->save();
 
                 // Check if user has a pending invitation they haven't accepted yet
-                $invitation = \App\Models\TeamInvitation::whereEmail($email)->first();
+                $invitation = TeamInvitation::whereEmail($email)->first();
                 if ($invitation && $invitation->isValid()) {
                     // User is logging in for the first time after being invited
                     // Attach them to the invited team if not already attached

--- a/database/migrations/2026_05_11_073300_add_disable_password_auth_for_oauth_users_to_instance_settings_table.php
+++ b/database/migrations/2026_05_11_073300_add_disable_password_auth_for_oauth_users_to_instance_settings_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('disable_password_auth_for_oauth_users')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn('disable_password_auth_for_oauth_users');
+        });
+    }
+};

--- a/database/migrations/2026_05_11_073301_add_is_oauth_user_to_users_table.php
+++ b/database/migrations/2026_05_11_073301_add_is_oauth_user_to_users_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('is_oauth_user')->default(false);
+        });
+
+        DB::table('users')
+            ->whereNull('password')
+            ->update(['is_oauth_user' => true]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('is_oauth_user');
+        });
+    }
+};

--- a/resources/views/livewire/settings-oauth.blade.php
+++ b/resources/views/livewire/settings-oauth.blade.php
@@ -13,6 +13,11 @@
             </div>
             <div class="pb-4 ">Custom authentication (OAuth) configurations.</div>
         </div>
+        <div class="md:w-96">
+            <x-forms.checkbox id="disable_password_auth_for_oauth_users"
+                helper="When enabled, users created through OAuth without a password cannot create a local password through the password reset flow."
+                label="Disable password login for OAuth users" />
+        </div>
         <div class="flex flex-col gap-2 pt-4">
             @foreach ($oauth_settings_map as $oauth_setting)
                 <div class="p-4 border dark:border-coolgray-300 border-neutral-200">

--- a/tests/Feature/OauthRegistrationPolicyTest.php
+++ b/tests/Feature/OauthRegistrationPolicyTest.php
@@ -1,0 +1,133 @@
+<?php
+
+use App\Actions\Fortify\ResetUserPassword;
+use App\Http\Middleware\PreventRequestsDuringMaintenance;
+use App\Models\InstanceSettings;
+use App\Models\OauthSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Once;
+use Illuminate\Validation\ValidationException;
+use Laravel\Socialite\Facades\Socialite;
+use Laravel\Socialite\Two\User as SocialiteUser;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Once::flush();
+    $this->withoutMiddleware(PreventRequestsDuringMaintenance::class);
+});
+
+function createGoogleOauthSetting(): void
+{
+    OauthSetting::create([
+        'provider' => 'google',
+        'enabled' => true,
+        'client_id' => 'google-client-id',
+        'client_secret' => 'google-client-secret',
+        'redirect_uri' => route('auth.callback', 'google'),
+    ]);
+}
+
+function fakeGoogleOauthUser(string $email = 'oauth@example.com', string $name = 'OAuth User'): void
+{
+    $socialiteUser = new SocialiteUser;
+    $socialiteUser->map([
+        'email' => $email,
+        'name' => $name,
+    ]);
+
+    $provider = Mockery::mock();
+    $provider->shouldReceive('setConfig')->once()->andReturnSelf();
+    $provider->shouldReceive('with')->once()->with(['hd' => null])->andReturnSelf();
+    $provider->shouldReceive('user')->once()->andReturn($socialiteUser);
+
+    Socialite::shouldReceive('driver')->once()->with('google')->andReturn($provider);
+}
+
+it('allows oauth callback to create new users when regular registration is disabled', function () {
+    InstanceSettings::unguarded(function () {
+        InstanceSettings::create([
+            'id' => 0,
+            'is_registration_enabled' => false,
+        ]);
+    });
+    User::factory()->create();
+    createGoogleOauthSetting();
+    fakeGoogleOauthUser();
+
+    $response = $this->get(route('auth.callback', 'google'));
+
+    $response->assertRedirect('/');
+    $this->assertAuthenticated();
+
+    $user = User::whereEmail('oauth@example.com')->first();
+
+    expect($user)->not->toBeNull()
+        ->and($user->name)->toBe('OAuth User')
+        ->and($user->is_oauth_user)->toBeTrue()
+        ->and($user->hasPassword())->toBeFalse();
+});
+
+it('prevents oauth users from creating a password when password auth is disabled for oauth users', function () {
+    InstanceSettings::unguarded(function () {
+        InstanceSettings::create([
+            'id' => 0,
+            'disable_password_auth_for_oauth_users' => true,
+        ]);
+    });
+    $user = User::factory()->create([
+        'is_oauth_user' => true,
+        'password' => null,
+    ]);
+
+    expect(fn () => app(ResetUserPassword::class)->reset($user, [
+        'password' => 'Password123!',
+        'password_confirmation' => 'Password123!',
+    ]))->toThrow(ValidationException::class);
+
+    expect($user->fresh()->password)->toBeNull();
+});
+
+it('allows oauth users to create a password when password auth is enabled for oauth users', function () {
+    InstanceSettings::unguarded(function () {
+        InstanceSettings::create([
+            'id' => 0,
+            'disable_password_auth_for_oauth_users' => false,
+        ]);
+    });
+    $user = User::factory()->create([
+        'is_oauth_user' => true,
+        'password' => null,
+    ]);
+
+    app(ResetUserPassword::class)->reset($user, [
+        'password' => 'Password123!',
+        'password_confirmation' => 'Password123!',
+    ]);
+
+    expect($user->fresh()->hasPassword())->toBeTrue();
+});
+
+it('rejects password login for oauth users when password auth is disabled for oauth users', function () {
+    InstanceSettings::unguarded(function () {
+        InstanceSettings::create([
+            'id' => 0,
+            'disable_password_auth_for_oauth_users' => true,
+        ]);
+    });
+    $user = User::factory()->create([
+        'email' => 'oauth-with-password@example.com',
+        'is_oauth_user' => true,
+        'password' => Hash::make('Password123!'),
+    ]);
+
+    $response = $this->post('/login', [
+        'email' => $user->email,
+        'password' => 'Password123!',
+    ]);
+
+    $response->assertSessionHasErrors();
+    $this->assertGuest();
+});


### PR DESCRIPTION
## Changes

- Allow configured OAuth callbacks to create new users even when regular self-registration is disabled.
- Add an OAuth authentication setting for disabling password auth for OAuth-created users.
- Track OAuth-created users and block password login, reset, and update paths when that setting is enabled.
- Backfill existing users without a password as OAuth users.

## Issues

- Fixes #8042
- /claim #8042

## Category

- [x] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A - backend/authentication settings change covered by feature tests.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex
- How extensively: Implementation and tests were prepared with Codex and verified locally.

## Testing

- `vendor/bin/pint --dirty --format agent`
- `php artisan test --compact tests/Feature/OauthRegistrationPolicyTest.php`

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.