### PR TITLE
Add OAuth-only registration controls

### DIFF
--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\ResetsUserPasswords;
 
 class ResetUserPassword implements ResetsUserPasswords
@@ -17,6 +18,12 @@ class ResetUserPassword implements ResetsUserPasswords
      */
     public function reset(User $user, array $input): void
     {
+        if (instanceSettings()->is_oauth_login_only_enabled && $user->isOauthUser()) {
+            throw ValidationException::withMessages([
+                'email' => __('Password reset is disabled for OAuth users.'),
+            ]);
+        }
+
         Validator::make($input, [
             'password' => ['required', Password::defaults(), 'confirmed'],
         ])->validate();

--- a/app/Actions/Fortify/UpdateUserPassword.php
+++ b/app/Actions/Fortify/UpdateUserPassword.php
@@ -17,6 +17,14 @@ class UpdateUserPassword implements UpdatesUserPasswords
      */
     public function update(User $user, array $input): void
     {
+        if (instanceSettings()->is_oauth_login_only_enabled && $user->isOauthUser()) {
+            $validator = Validator::make([], []);
+            $validator->after(function ($validator) {
+                $validator->errors()->add('password', __('Password changes are disabled for OAuth users.'));
+            });
+            $validator->validateWithBag('updatePassword');
+        }
+
         Validator::make($input, [
             'current_password' => ['required', 'string', 'current_password:web'],
             'password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -78,6 +78,11 @@ class Controller extends BaseController
                 return response()->json(['message' => 'Transactional emails are not active'], 400);
             }
             $request->validate([Fortify::email() => 'required|email']);
+            $user = User::whereEmail($request->input(Fortify::email()))->first();
+            if ($user && instanceSettings()->is_oauth_login_only_enabled && $user->isOauthUser()) {
+                return response()->json(['message' => 'Password reset is disabled for OAuth users.'], 400);
+            }
+
             $status = Password::broker(config('fortify.passwords'))->sendResetLink(
                 $request->only(Fortify::email())
             );

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\OauthSetting;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -10,6 +11,8 @@ class OauthController extends Controller
 {
     public function redirect(string $provider)
     {
+        $this->ensureProviderIsEnabled($provider);
+
         $socialite_provider = get_socialite_provider($provider);
 
         return $socialite_provider->redirect();
@@ -18,18 +21,23 @@ class OauthController extends Controller
     public function callback(string $provider)
     {
         try {
+            $this->ensureProviderIsEnabled($provider);
+
             $oauthUser = get_socialite_provider($provider)->user();
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! $settings->is_oauth_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 
                 $user = User::create([
                     'name' => $oauthUser->name,
                     'email' => $oauthUser->email,
+                    'oauth_provider' => $provider,
                 ]);
+            } elseif ($user->oauth_provider !== $provider) {
+                $user->update(['oauth_provider' => $provider]);
             }
             Auth::login($user);
 
@@ -38,6 +46,15 @@ class OauthController extends Controller
             $errorCode = $e instanceof HttpException ? 'auth.failed' : 'auth.failed.callback';
 
             return redirect()->route('login')->withErrors([__($errorCode)]);
+        }
+    }
+
+    private function ensureProviderIsEnabled(string $provider): void
+    {
+        $oauthSetting = OauthSetting::firstWhere('provider', $provider);
+
+        if (! $oauthSetting?->enabled) {
+            abort(404);
         }
     }
 }

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -16,6 +16,12 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $is_oauth_registration_enabled;
+
+    #[Validate('boolean')]
+    public bool $is_oauth_login_only_enabled;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -41,6 +47,8 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_registration_enabled' => 'boolean',
+            'is_oauth_login_only_enabled' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => ['nullable', 'string', new ValidDnsServers],
@@ -62,6 +70,8 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled ?? false;
+        $this->is_oauth_login_only_enabled = $this->settings->is_oauth_login_only_enabled ?? false;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -142,6 +152,8 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
+            $this->settings->is_oauth_login_only_enabled = $this->is_oauth_login_only_enabled;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -18,6 +18,8 @@ class InstanceSettings extends Model
         'do_not_track',
         'is_auto_update_enabled',
         'is_registration_enabled',
+        'is_oauth_registration_enabled',
+        'is_oauth_login_only_enabled',
         'next_channel',
         'smtp_enabled',
         'smtp_from_address',
@@ -63,6 +65,8 @@ class InstanceSettings extends Model
 
         'allowed_ip_ranges' => 'array',
         'is_auto_update_enabled' => 'boolean',
+        'is_oauth_registration_enabled' => 'boolean',
+        'is_oauth_login_only_enabled' => 'boolean',
         'auto_update_frequency' => 'string',
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -48,6 +48,7 @@ class User extends Authenticatable implements SendsEmail
         'email',
         'password',
         'force_password_reset',
+        'oauth_provider',
         'marketing_emails',
         'pending_email',
         'email_change_code',
@@ -64,6 +65,7 @@ class User extends Authenticatable implements SendsEmail
     protected $casts = [
         'email_verified_at' => 'datetime',
         'force_password_reset' => 'boolean',
+        'oauth_provider' => 'string',
         'show_boarding' => 'boolean',
         'email_change_code_expires_at' => 'datetime',
     ];
@@ -486,5 +488,10 @@ class User extends Authenticatable implements SendsEmail
     public function hasPassword(): bool
     {
         return ! empty($this->password);
+    }
+
+    public function isOauthUser(): bool
+    {
+        return filled($this->oauth_provider);
     }
 }

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -60,20 +60,26 @@ class FortifyServiceProvider extends ServiceProvider
             $settings = instanceSettings();
             $enabled_oauth_providers = OauthSetting::where('enabled', true)->get();
             $users = User::count();
-            if ($users == 0) {
-                // If there are no users, redirect to registration
+            if ($users == 0 && ! $settings->is_oauth_registration_enabled) {
+                // If there are no users, redirect to registration unless OAuth registration is allowed.
                 return redirect()->route('register');
             }
 
             return view('auth.login', [
                 'is_registration_enabled' => $settings->is_registration_enabled,
+                'is_oauth_registration_enabled' => $settings->is_oauth_registration_enabled,
                 'enabled_oauth_providers' => $enabled_oauth_providers,
             ]);
         });
 
         Fortify::authenticateUsing(function (Request $request) {
+            $settings = instanceSettings();
             $email = strtolower($request->email);
             $user = User::where('email', $email)->with('teams')->first();
+            if ($user && $settings->is_oauth_login_only_enabled && $user->isOauthUser()) {
+                return null;
+            }
+
             if (
                 $user &&
                 Hash::check($request->password, $user->password)

--- a/database/migrations/2026_05_11_000001_add_oauth_authentication_settings_to_instance_settings_table.php
+++ b/database/migrations/2026_05_11_000001_add_oauth_authentication_settings_to_instance_settings_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_registration_enabled')->default(false)->after('is_registration_enabled');
+            $table->boolean('is_oauth_login_only_enabled')->default(false)->after('is_oauth_registration_enabled');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn(['is_oauth_registration_enabled', 'is_oauth_login_only_enabled']);
+        });
+    }
+};

--- a/database/migrations/2026_05_11_000002_add_oauth_provider_to_users_table.php
+++ b/database/migrations/2026_05_11_000002_add_oauth_provider_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('oauth_provider')->nullable()->after('password');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('oauth_provider');
+        });
+    }
+};

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -70,7 +70,7 @@
                             class="block w-full text-center py-3 px-4 rounded-lg border border-neutral-300 dark:border-coolgray-400 font-medium hover:border-coollabs dark:hover:border-warning transition-colors">
                             {{ __('auth.register_now') }}
                         </a>
-                    @else
+                    @elseif (! $is_oauth_registration_enabled)
                         <div class="mt-6 text-center text-sm text-neutral-500 dark:text-neutral-400">
                             {{ __('auth.registration_disabled') }}
                         </div>

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -41,6 +41,17 @@
                                 shortConfirmationLabel="Confirmation text" />
                         </div>
                     @endif
+                    <h4 class="pt-4">Authentication Settings</h4>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_registration_enabled"
+                            helper="Allow new users to self-register by using an enabled OAuth provider, even when regular password registration is disabled."
+                            label="OAuth Registration Allowed" />
+                    </div>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_login_only_enabled"
+                            helper="Users who have authenticated with an OAuth provider cannot log in with a password or create a password through password reset while this is enabled."
+                            label="OAuth Users Login With OAuth Only" />
+                    </div>
                     <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"
                             helper="Opt out of anonymous usage tracking. When enabled, this instance will not report to coolify.io's installation count and will not send error reports to help improve Coolify."

--- a/tests/Feature/OauthAuthenticationSettingsTest.php
+++ b/tests/Feature/OauthAuthenticationSettingsTest.php
@@ -1,0 +1,108 @@
+<?php
+
+use App\Actions\Fortify\ResetUserPassword;
+use App\Actions\Fortify\UpdateUserPassword;
+use App\Models\InstanceSettings;
+use App\Models\OauthSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
+use Laravel\Socialite\Facades\Socialite;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::create([
+        'id' => 0,
+        'is_registration_enabled' => false,
+        'is_oauth_registration_enabled' => false,
+        'is_oauth_login_only_enabled' => false,
+        'smtp_enabled' => true,
+    ]);
+
+    OauthSetting::create([
+        'provider' => 'github',
+        'enabled' => true,
+        'client_id' => 'client-id',
+        'client_secret' => 'client-secret',
+        'redirect_uri' => route('auth.callback', 'github'),
+    ]);
+});
+
+function mockOauthUser(string $email = 'oauth-user@example.com', string $name = 'OAuth User'): void
+{
+    Socialite::shouldReceive('buildProvider')
+        ->once()
+        ->andReturn(new class($email, $name)
+        {
+            public function __construct(private string $email, private string $name) {}
+
+            public function user(): object
+            {
+                return (object) [
+                    'email' => $this->email,
+                    'name' => $this->name,
+                ];
+            }
+        });
+}
+
+it('allows oauth self registration when regular registration is disabled', function () {
+    InstanceSettings::get()->update(['is_oauth_registration_enabled' => true]);
+    mockOauthUser();
+
+    $response = $this->get(route('auth.callback', 'github'));
+
+    $response->assertRedirect('/');
+    $this->assertAuthenticated();
+
+    $user = User::whereEmail('oauth-user@example.com')->firstOrFail();
+    expect($user->oauth_provider)->toBe('github');
+});
+
+it('keeps oauth self registration blocked when neither registration path is enabled', function () {
+    mockOauthUser('blocked@example.com');
+
+    $response = $this->get(route('auth.callback', 'github'));
+
+    $response->assertRedirect(route('login'));
+    $this->assertGuest();
+    expect(User::whereEmail('blocked@example.com')->exists())->toBeFalse();
+});
+
+it('blocks password login for oauth users when oauth login only is enabled', function () {
+    InstanceSettings::get()->update(['is_oauth_login_only_enabled' => true]);
+    $user = User::factory()->create([
+        'email' => 'oauth-user@example.com',
+        'password' => Hash::make('password'),
+        'oauth_provider' => 'github',
+    ]);
+
+    $response = $this->post('/login', [
+        'email' => $user->email,
+        'password' => 'password',
+    ]);
+
+    $response->assertSessionHasErrors();
+    $this->assertGuest();
+});
+
+it('blocks password creation and password changes for oauth users when oauth login only is enabled', function () {
+    InstanceSettings::get()->update(['is_oauth_login_only_enabled' => true]);
+    $user = User::factory()->create([
+        'password' => null,
+        'oauth_provider' => 'github',
+    ]);
+
+    expect(fn () => app(ResetUserPassword::class)->reset($user, [
+        'password' => 'New-password-123!',
+        'password_confirmation' => 'New-password-123!',
+    ]))->toThrow(ValidationException::class);
+
+    expect(fn () => app(UpdateUserPassword::class)->update($user, [
+        'current_password' => 'password',
+        'password' => 'New-password-123!',
+        'password_confirmation' => 'New-password-123!',
+    ]))->toThrow(ValidationException::class);
+});


### PR DESCRIPTION
## Summary

Implements OAuth-only self-registration controls for #8042.

This adds separate instance-level settings so administrators can:

- allow users to self-register through enabled OAuth providers even when regular password registration is disabled
- require users who have authenticated with OAuth to keep using OAuth instead of password login/password reset flows

## Changes

- Added `is_oauth_registration_enabled` and `is_oauth_login_only_enabled` instance settings
- Added `oauth_provider` tracking on users created or linked through OAuth
- Updated OAuth callback registration checks
- Blocks password login, password reset, and password updates for OAuth users when OAuth-only mode is enabled
- Exposes the two new settings in Advanced settings
- Adjusts the login view so OAuth-only registration does not show the regular registration disabled message as the only available path
- Adds feature coverage for OAuth registration and OAuth-only password restrictions

## Testing

- Added `tests/Feature/OauthAuthenticationSettingsTest.php`
- Not run locally: this environment does not have PHP/Composer installed, so I could not execute the Laravel test suite here.
