### PR TITLE
feat(services): add OpenReplay service template

### DIFF
--- a/svgs/openreplay.svg
+++ b/svgs/openreplay.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title">
+  <title>OpenReplay</title>
+  <circle cx="128" cy="128" r="120" fill="#42B6B8"/>
+  <path d="M105 78 L105 178 L182 128 Z" fill="#FFFFFF"/>
+</svg>

--- a/templates/compose/openreplay.yaml
+++ b/templates/compose/openreplay.yaml
@@ -1,0 +1,1001 @@
+# documentation: https://docs.openreplay.com/en/deployment/deploy-docker/
+# slogan: OpenReplay is an open-source session replay and product analytics platform you can self-host.
+# category: analytics
+# tags: analytics, session-replay, product-analytics, observability, open-source, self-hosted
+# logo: svgs/openreplay.svg
+# port: 80
+# minversion: 4.0.0-beta.222
+#
+# OpenReplay self-hosted deployment.
+# Requires a real server with public IP/DNS, a domain (DNS A record pointing to the server),
+# and minimum resources of 2 vCPU / 8GB RAM / 50GB storage.
+# The official Docker Compose deployment is marked as experimental upstream.
+
+x-app-common-env: &app-common-env
+  COMMON_DOMAIN_NAME: ${SERVICE_FQDN_OPENREPLAY}
+  COMMON_PROTOCOL: https
+  COMMON_PG_PASSWORD: ${SERVICE_PASSWORD_POSTGRES}
+  COMMON_S3_KEY: ${SERVICE_USER_MINIO}
+  COMMON_S3_SECRET: ${SERVICE_PASSWORD_MINIO}
+  COMMON_JWT_SECRET: ${SERVICE_PASSWORD_64_JWT}
+  COMMON_JWT_REFRESH_SECRET: ${SERVICE_PASSWORD_64_JWTREFRESH}
+  COMMON_JWT_SPOT_SECRET: ${SERVICE_PASSWORD_64_JWTSPOT}
+  COMMON_JWT_SPOT_REFRESH_SECRET: ${SERVICE_PASSWORD_64_JWTSPOTREFRESH}
+  COMMON_ASSIST_JWT_SECRET: ${SERVICE_PASSWORD_64_ASSISTJWT}
+  COMMON_ASSIST_KEY: ${SERVICE_PASSWORD_64_ASSISTKEY}
+  COMMON_TOKEN_SECRET: ${SERVICE_PASSWORD_64_TOKEN}
+
+services:
+  postgresql:
+    image: ghcr.io/openreplay/postgres:17
+    container_name: openreplay-postgres
+    volumes:
+      - pgdata:/bitnami/postgresql
+    networks:
+      openreplay-net:
+        aliases:
+          - postgresql.db.svc.cluster.local
+    environment:
+      POSTGRESQL_PASSWORD: ${SERVICE_PASSWORD_POSTGRES}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  clickhouse:
+    image: clickhouse/clickhouse-server:25.11-alpine
+    container_name: openreplay-clickhouse
+    volumes:
+      - clickhouse:/var/lib/clickhouse
+    networks:
+      openreplay-net:
+        aliases:
+          - clickhouse-openreplay-clickhouse.db.svc.cluster.local
+    environment:
+      CLICKHOUSE_USER: default
+      CLICKHOUSE_PASSWORD: ""
+      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: "1"
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 -O - http://127.0.0.1:8123/ping || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  redis:
+    image: ghcr.io/openreplay/valkey:8
+    container_name: openreplay-redis
+    volumes:
+      - redisdata:/data
+    networks:
+      openreplay-net:
+        aliases:
+          - redis-master.db.svc.cluster.local
+    environment:
+      ALLOW_EMPTY_PASSWORD: "yes"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  minio:
+    image: ghcr.io/openreplay/minio:2025
+    container_name: openreplay-minio
+    volumes:
+      - miniodata:/bitnami/minio/data
+    networks:
+      openreplay-net:
+        aliases:
+          - minio.db.svc.cluster.local
+    environment:
+      MINIO_ROOT_USER: ${SERVICE_USER_MINIO}
+      MINIO_ROOT_PASSWORD: ${SERVICE_PASSWORD_MINIO}
+
+  fs-permission:
+    image: debian:stable-slim
+    container_name: openreplay-fs-permission
+    profiles: ["migration"]
+    volumes:
+      - shared-volume:/mnt/efs
+      - miniodata:/mnt/minio
+      - pgdata:/mnt/postgres
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        chown -R 1001:1001 /mnt/{efs,minio,postgres}
+    restart: on-failure
+
+  minio-migration:
+    image: ghcr.io/openreplay/minio:2025
+    container_name: openreplay-minio-migration
+    profiles: ["migration"]
+    depends_on:
+      - minio
+      - fs-permission
+    networks:
+      - openreplay-net
+    user: root
+    environment:
+      MINIO_HOST: http://minio.db.svc.cluster.local:9000
+      MINIO_ACCESS_KEY: ${SERVICE_USER_MINIO}
+      MINIO_SECRET_KEY: ${SERVICE_PASSWORD_MINIO}
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        apt update && apt install -y netcat-openbsd wget
+        wget -qO /tmp/minio.sh https://raw.githubusercontent.com/openreplay/openreplay/v1.26.0/scripts/helmcharts/openreplay/files/minio.sh
+        until nc -z -v -w30 minio 9000; do
+          echo "Waiting for Minio server to be ready..."
+          sleep 1
+        done
+        bash /tmp/minio.sh init || exit 100
+
+  db-migration:
+    image: ghcr.io/openreplay/postgres:17
+    container_name: openreplay-db-migration
+    profiles: ["migration"]
+    depends_on:
+      - postgresql
+      - minio-migration
+    networks:
+      - openreplay-net
+    environment:
+      PGHOST: postgresql
+      PGPORT: 5432
+      PGDATABASE: postgres
+      PGUSER: postgres
+      PGPASSWORD: ${SERVICE_PASSWORD_POSTGRES}
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        apt-get update && apt-get install -y wget
+        wget -qO /tmp/init_schema.sql https://raw.githubusercontent.com/openreplay/openreplay/v1.26.0/scripts/schema/db/init_dbs/postgresql/init_schema.sql
+        until psql -c '\q'; do
+          echo "PostgreSQL is unavailable - sleeping"
+          sleep 1
+        done
+        echo "PostgreSQL is up - executing command"
+        psql -v ON_ERROR_STOP=1 -f /tmp/init_schema.sql
+
+  clickhouse-migration:
+    image: clickhouse/clickhouse-server:25.11-alpine
+    container_name: openreplay-clickhouse-migration
+    profiles: ["migration"]
+    depends_on:
+      - clickhouse
+      - minio-migration
+    networks:
+      - openreplay-net
+    environment:
+      CH_HOST: clickhouse-openreplay-clickhouse.db.svc.cluster.local
+      CH_PORT: "9000"
+      CH_PORT_HTTP: "8123"
+      CH_USERNAME: default
+      CH_PASSWORD: ""
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        apk add --no-cache wget netcat-openbsd
+        wget -qO /tmp/init_schema.sql https://raw.githubusercontent.com/openreplay/openreplay/v1.26.0/scripts/schema/db/init_dbs/clickhouse/create/init_schema.sql
+        until nc -z -v -w30 clickhouse-openreplay-clickhouse.db.svc.cluster.local 9000; do
+          echo "Waiting for clickhouse to be ready..."
+          sleep 1
+        done
+        echo "clickhouse is up - executing command"
+        clickhouse-client -h clickhouse-openreplay-clickhouse.db.svc.cluster.local --user default --port 9000 --multiquery < /tmp/init_schema.sql || true
+
+  alerts-openreplay:
+    image: public.ecr.aws/p1t3u8a3/alerts:v1.26.0
+    domainname: app.svc.cluster.local
+    container_name: openreplay-alerts
+    networks:
+      openreplay-net:
+        aliases:
+          - alerts-openreplay
+          - alerts-openreplay.app.svc.cluster.local
+    volumes:
+      - shared-volume:/mnt/efs
+    environment:
+      <<: *app-common-env
+      version_number: v1.26.0
+      pg_host: postgresql.db.svc.cluster.local
+      pg_port: "5432"
+      pg_dbname: postgres
+      pg_user: postgres
+      pg_password: ${SERVICE_PASSWORD_POSTGRES}
+      ch_host: clickhouse-openreplay-clickhouse.db.svc.cluster.local
+      ch_port: "9000"
+      ch_port_http: "8123"
+      ch_username: default
+      ch_password: ""
+      SITE_URL: https://${SERVICE_FQDN_OPENREPLAY}
+      S3_HOST: https://${SERVICE_FQDN_OPENREPLAY}
+      S3_KEY: ${SERVICE_USER_MINIO}
+      S3_SECRET: ${SERVICE_PASSWORD_MINIO}
+      AWS_DEFAULT_REGION: us-east-1
+      EMAIL_HOST: ""
+      EMAIL_PORT: "587"
+      EMAIL_USER: ""
+      EMAIL_PASSWORD: ""
+      EMAIL_USE_TLS: "true"
+      EMAIL_USE_SSL: "false"
+      EMAIL_SSL_KEY: ""
+      EMAIL_SSL_CERT: ""
+      EMAIL_FROM: OpenReplay<do-not-reply@openreplay.com>
+      LOGLEVEL: INFO
+      PYTHONUNBUFFERED: "0"
+    restart: unless-stopped
+
+  api-openreplay:
+    image: public.ecr.aws/p1t3u8a3/api:v1.26.0
+    domainname: app.svc.cluster.local
+    container_name: openreplay-api
+    depends_on:
+      postgresql:
+        condition: service_healthy
+    networks:
+      openreplay-net:
+        aliases:
+          - api-openreplay
+          - api-openreplay.app.svc.cluster.local
+    volumes:
+      - shared-volume:/mnt/efs
+      - type: bind
+        source: ./wait-for-pg.sh
+        target: /scripts/wait-for-pg.sh
+        read_only: true
+        content: |
+          #!/bin/sh
+          PG_HOST="$${PG_HOST:-postgresql.db.svc.cluster.local}"
+          PG_PORT="$${PG_PORT:-5432}"
+          MAX_WAIT=60
+          WAITED=0
+          echo "Waiting for PostgreSQL at $${PG_HOST}:$${PG_PORT}..."
+          until nc -z -w3 "$$PG_HOST" "$$PG_PORT" 2>/dev/null; do
+              WAITED=$$((WAITED + 2))
+              if [ $$WAITED -ge $$MAX_WAIT ]; then
+                  echo "ERROR: PostgreSQL not reachable after $${MAX_WAIT}s, starting anyway"
+                  break
+              fi
+              echo "PostgreSQL not ready, retrying in 2s... ($${WAITED}/$${MAX_WAIT}s)"
+              sleep 2
+          done
+          if [ $$WAITED -lt $$MAX_WAIT ]; then
+              echo "PostgreSQL is ready (waited $${WAITED}s), starting service"
+              sleep 2
+          fi
+          exec /home/openreplay/service
+    entrypoint: ["/bin/sh", "/scripts/wait-for-pg.sh"]
+    environment:
+      <<: *app-common-env
+      TOKEN_SECRET: ${SERVICE_PASSWORD_64_TOKEN}
+      ch_db: default
+      KAFKA_SERVERS: kafka.db.svc.cluster.local:9092
+      KAFKA_USE_SSL: "false"
+      JWT_SECRET: ${SERVICE_PASSWORD_64_JWT}
+      ASSIST_JWT_SECRET: ${SERVICE_PASSWORD_64_ASSISTJWT}
+      AWS_ACCESS_KEY_ID: ${SERVICE_USER_MINIO}
+      AWS_SECRET_ACCESS_KEY: ${SERVICE_PASSWORD_MINIO}
+      AWS_ENDPOINT: https://${SERVICE_FQDN_OPENREPLAY}
+      AWS_REGION: us-east-1
+      BUCKET_NAME: mobs
+      CH_USERNAME: default
+      CH_PASSWORD: ""
+      CLICKHOUSE_STRING: clickhouse-openreplay-clickhouse.db.svc.cluster.local:9000/default
+      CLICKHOUSE_HTTP_STRING: clickhouse-openreplay-clickhouse.db.svc.cluster.local:8123/default
+      pg_password: ${SERVICE_PASSWORD_POSTGRES}
+      POSTGRES_STRING: postgres://postgres:${SERVICE_PASSWORD_POSTGRES}@postgresql.db.svc.cluster.local:5432/postgres?sslmode=disable
+      ASSIST_URL: http://assist-openreplay.app.svc.cluster.local:9001/assist/%s
+      ASSIST_KEY: ${SERVICE_PASSWORD_64_ASSISTKEY}
+      REDIS_STRING: redis://redis-master.db.svc.cluster.local:6379
+    restart: unless-stopped
+
+  http-openreplay:
+    image: public.ecr.aws/p1t3u8a3/http:v1.26.0
+    domainname: app.svc.cluster.local
+    container_name: openreplay-http
+    depends_on:
+      postgresql:
+        condition: service_healthy
+    networks:
+      openreplay-net:
+        aliases:
+          - http-openreplay
+          - http-openreplay.app.svc.cluster.local
+    volumes:
+      - shared-volume:/mnt/efs
+      - type: bind
+        source: ./wait-for-pg.sh
+        target: /scripts/wait-for-pg.sh
+        read_only: true
+        content: |
+          #!/bin/sh
+          PG_HOST="$${PG_HOST:-postgresql.db.svc.cluster.local}"
+          PG_PORT="$${PG_PORT:-5432}"
+          until nc -z -w3 "$$PG_HOST" "$$PG_PORT" 2>/dev/null; do sleep 2; done
+          exec /home/openreplay/service
+    entrypoint: ["/bin/sh", "/scripts/wait-for-pg.sh"]
+    environment:
+      <<: *app-common-env
+      BUCKET_NAME: uxtesting-records
+      CACHE_ASSETS: "true"
+      AWS_ACCESS_KEY_ID: ${SERVICE_USER_MINIO}
+      AWS_SECRET_ACCESS_KEY: ${SERVICE_PASSWORD_MINIO}
+      AWS_REGION: us-east-1
+      AWS_ENDPOINT: https://${SERVICE_FQDN_OPENREPLAY}
+      KAFKA_SERVERS: kafka.db.svc.cluster.local:9092
+      KAFKA_USE_SSL: "false"
+      pg_password: ${SERVICE_PASSWORD_POSTGRES}
+      POSTGRES_STRING: postgres://postgres:${SERVICE_PASSWORD_POSTGRES}@postgresql.db.svc.cluster.local:5432/postgres?sslmode=disable
+      REDIS_STRING: redis://redis-master.db.svc.cluster.local:6379
+      JWT_SECRET: ${SERVICE_PASSWORD_64_JWT}
+      JWT_SPOT_SECRET: ${SERVICE_PASSWORD_64_JWTSPOT}
+      TOKEN_SECRET: ${SERVICE_PASSWORD_64_TOKEN}
+    restart: unless-stopped
+
+  images-openreplay:
+    image: public.ecr.aws/p1t3u8a3/images:v1.26.0
+    domainname: app.svc.cluster.local
+    container_name: openreplay-images
+    networks:
+      openreplay-net:
+        aliases:
+          - images-openreplay
+          - images-openreplay.app.svc.cluster.local
+    volumes:
+      - shared-volume:/mnt/efs
+    environment:
+      <<: *app-common-env
+      AWS_ACCESS_KEY_ID: ${SERVICE_USER_MINIO}
+      AWS_SECRET_ACCESS_KEY: ${SERVICE_PASSWORD_MINIO}
+      AWS_ENDPOINT: https://${SERVICE_FQDN_OPENREPLAY}
+      AWS_REGION: us-east-1
+      BUCKET_NAME: mobs
+      KAFKA_SERVERS: kafka.db.svc.cluster.local:9092
+      KAFKA_USE_SSL: "false"
+      REDIS_STRING: redis://redis-master.db.svc.cluster.local:6379
+      FS_CLEAN_HRS: "24"
+    restart: unless-stopped
+
+  integrations-openreplay:
+    image: public.ecr.aws/p1t3u8a3/integrations:v1.26.0
+    domainname: app.svc.cluster.local
+    container_name: openreplay-integrations
+    depends_on:
+      postgresql:
+        condition: service_healthy
+    networks:
+      openreplay-net:
+        aliases:
+          - integrations-openreplay
+          - integrations-openreplay.app.svc.cluster.local
+    volumes:
+      - shared-volume:/mnt/efs
+      - type: bind
+        source: ./wait-for-pg.sh
+        target: /scripts/wait-for-pg.sh
+        read_only: true
+        content: |
+          #!/bin/sh
+          until nc -z -w3 postgresql.db.svc.cluster.local 5432 2>/dev/null; do sleep 2; done
+          exec /home/openreplay/service
+    entrypoint: ["/bin/sh", "/scripts/wait-for-pg.sh"]
+    environment:
+      <<: *app-common-env
+      AWS_ACCESS_KEY_ID: ${SERVICE_USER_MINIO}
+      AWS_SECRET_ACCESS_KEY: ${SERVICE_PASSWORD_MINIO}
+      AWS_ENDPOINT: https://${SERVICE_FQDN_OPENREPLAY}
+      AWS_REGION: us-east-1
+      BUCKET_NAME: mobs
+      JWT_SECRET: ${SERVICE_PASSWORD_64_JWT}
+      KAFKA_SERVERS: kafka.db.svc.cluster.local:9092
+      KAFKA_USE_SSL: "false"
+      pg_password: ${SERVICE_PASSWORD_POSTGRES}
+      POSTGRES_STRING: postgres://postgres:${SERVICE_PASSWORD_POSTGRES}@postgresql.db.svc.cluster.local:5432/postgres?sslmode=disable
+      REDIS_STRING: redis://redis-master.db.svc.cluster.local:6379
+      TOKEN_SECRET: ${SERVICE_PASSWORD_64_TOKEN}
+    restart: unless-stopped
+
+  sink-openreplay:
+    image: public.ecr.aws/p1t3u8a3/sink:v1.26.0
+    domainname: app.svc.cluster.local
+    container_name: openreplay-sink
+    depends_on:
+      postgresql:
+        condition: service_healthy
+    networks:
+      openreplay-net:
+        aliases:
+          - sink-openreplay
+          - sink-openreplay.app.svc.cluster.local
+    volumes:
+      - shared-volume:/mnt/efs
+      - type: bind
+        source: ./wait-for-pg.sh
+        target: /scripts/wait-for-pg.sh
+        read_only: true
+        content: |
+          #!/bin/sh
+          until nc -z -w3 postgresql.db.svc.cluster.local 5432 2>/dev/null; do sleep 2; done
+          exec /home/openreplay/service
+    entrypoint: ["/bin/sh", "/scripts/wait-for-pg.sh"]
+    environment:
+      <<: *app-common-env
+      KAFKA_SERVERS: kafka.db.svc.cluster.local:9092
+      KAFKA_USE_SSL: "false"
+      ASSETS_ORIGIN: https://${SERVICE_FQDN_OPENREPLAY}/sessions-assets
+      REDIS_STRING: redis://redis-master.db.svc.cluster.local:6379
+    restart: unless-stopped
+
+  sourcemapreader-openreplay:
+    image: public.ecr.aws/p1t3u8a3/sourcemapreader:v1.26.0
+    domainname: app.svc.cluster.local
+    container_name: openreplay-sourcemapreader
+    networks:
+      openreplay-net:
+        aliases:
+          - sourcemapreader-openreplay
+          - sourcemapreader-openreplay.app.svc.cluster.local
+    volumes:
+      - shared-volume:/mnt/efs
+    environment:
+      <<: *app-common-env
+      SMR_HOST: 0.0.0.0
+      S3_HOST: http://minio.db.svc.cluster.local:9000
+      S3_KEY: ${SERVICE_USER_MINIO}
+      S3_SECRET: ${SERVICE_PASSWORD_MINIO}
+      AWS_REGION: us-east-1
+      ASSETS_ORIGIN: https://${SERVICE_FQDN_OPENREPLAY}/sessions-assets
+    restart: unless-stopped
+
+  spot-openreplay:
+    image: public.ecr.aws/p1t3u8a3/spot:v1.26.0
+    domainname: app.svc.cluster.local
+    container_name: openreplay-spot
+    depends_on:
+      postgresql:
+        condition: service_healthy
+    networks:
+      openreplay-net:
+        aliases:
+          - spot-openreplay
+          - spot-openreplay.app.svc.cluster.local
+    volumes:
+      - shared-volume:/mnt/efs
+      - type: bind
+        source: ./wait-for-pg.sh
+        target: /scripts/wait-for-pg.sh
+        read_only: true
+        content: |
+          #!/bin/sh
+          until nc -z -w3 postgresql.db.svc.cluster.local 5432 2>/dev/null; do sleep 2; done
+          exec /home/openreplay/service
+    entrypoint: ["/bin/sh", "/scripts/wait-for-pg.sh"]
+    environment:
+      <<: *app-common-env
+      CACHE_ASSETS: "true"
+      FS_CLEAN_HRS: "24"
+      TOKEN_SECRET: ${SERVICE_PASSWORD_64_TOKEN}
+      AWS_ACCESS_KEY_ID: ${SERVICE_USER_MINIO}
+      AWS_SECRET_ACCESS_KEY: ${SERVICE_PASSWORD_MINIO}
+      BUCKET_NAME: spots
+      AWS_REGION: us-east-1
+      AWS_ENDPOINT: https://${SERVICE_FQDN_OPENREPLAY}
+      KAFKA_SERVERS: kafka.db.svc.cluster.local:9092
+      KAFKA_USE_SSL: "false"
+      JWT_SECRET: ${SERVICE_PASSWORD_64_JWT}
+      JWT_SPOT_SECRET: ${SERVICE_PASSWORD_64_JWTSPOT}
+      pg_password: ${SERVICE_PASSWORD_POSTGRES}
+      POSTGRES_STRING: postgres://postgres:${SERVICE_PASSWORD_POSTGRES}@postgresql.db.svc.cluster.local:5432/postgres?sslmode=disable
+      REDIS_STRING: redis://redis-master.db.svc.cluster.local:6379
+    restart: unless-stopped
+
+  storage-openreplay:
+    image: public.ecr.aws/p1t3u8a3/storage:v1.26.0
+    domainname: app.svc.cluster.local
+    container_name: openreplay-storage
+    depends_on:
+      postgresql:
+        condition: service_healthy
+    networks:
+      openreplay-net:
+        aliases:
+          - storage-openreplay
+          - storage-openreplay.app.svc.cluster.local
+    volumes:
+      - shared-volume:/mnt/efs
+      - type: bind
+        source: ./wait-for-pg.sh
+        target: /scripts/wait-for-pg.sh
+        read_only: true
+        content: |
+          #!/bin/sh
+          until nc -z -w3 postgresql.db.svc.cluster.local 5432 2>/dev/null; do sleep 2; done
+          exec /home/openreplay/service
+    entrypoint: ["/bin/sh", "/scripts/wait-for-pg.sh"]
+    environment:
+      <<: *app-common-env
+      AWS_ACCESS_KEY_ID: ${SERVICE_USER_MINIO}
+      AWS_SECRET_ACCESS_KEY: ${SERVICE_PASSWORD_MINIO}
+      AWS_ENDPOINT: https://${SERVICE_FQDN_OPENREPLAY}
+      AWS_REGION: us-east-1
+      BUCKET_NAME: mobs
+      KAFKA_SERVERS: kafka.db.svc.cluster.local:9092
+      KAFKA_USE_SSL: "false"
+      REDIS_STRING: redis://redis-master.db.svc.cluster.local:6379
+      FS_CLEAN_HRS: "24"
+    restart: unless-stopped
+
+  assets-openreplay:
+    image: public.ecr.aws/p1t3u8a3/assets:v1.26.0
+    domainname: app.svc.cluster.local
+    container_name: openreplay-assets
+    networks:
+      openreplay-net:
+        aliases:
+          - assets-openreplay
+          - assets-openreplay.app.svc.cluster.local
+    volumes:
+      - shared-volume:/mnt/efs
+    environment:
+      <<: *app-common-env
+      AWS_ACCESS_KEY_ID: ${SERVICE_USER_MINIO}
+      AWS_SECRET_ACCESS_KEY: ${SERVICE_PASSWORD_MINIO}
+      BUCKET_NAME: sessions-assets
+      AWS_ENDPOINT: https://${SERVICE_FQDN_OPENREPLAY}
+      AWS_REGION: us-east-1
+      KAFKA_SERVERS: kafka.db.svc.cluster.local:9092
+      KAFKA_USE_SSL: "false"
+      ASSETS_ORIGIN: https://${SERVICE_FQDN_OPENREPLAY}/sessions-assets
+      REDIS_STRING: redis://redis-master.db.svc.cluster.local:6379
+    restart: unless-stopped
+
+  assist-openreplay:
+    image: public.ecr.aws/p1t3u8a3/assist:v1.26.0
+    domainname: app.svc.cluster.local
+    container_name: openreplay-assist
+    networks:
+      openreplay-net:
+        aliases:
+          - assist-openreplay
+          - assist-openreplay.app.svc.cluster.local
+    volumes:
+      - shared-volume:/mnt/efs
+    environment:
+      <<: *app-common-env
+      ASSIST_JWT_SECRET: ${SERVICE_PASSWORD_64_ASSISTJWT}
+      ASSIST_KEY: ${SERVICE_PASSWORD_64_ASSISTKEY}
+      AWS_DEFAULT_REGION: us-east-1
+      REDIS_URL: redis-master.db.svc.cluster.local
+      CLEAR_SOCKET_TIME: "720"
+      debug: "0"
+      redis: "false"
+    restart: unless-stopped
+
+  canvases-openreplay:
+    image: public.ecr.aws/p1t3u8a3/canvases:v1.26.0
+    domainname: app.svc.cluster.local
+    container_name: openreplay-canvases
+    depends_on:
+      postgresql:
+        condition: service_healthy
+    networks:
+      openreplay-net:
+        aliases:
+          - canvases-openreplay
+          - canvases-openreplay.app.svc.cluster.local
+    volumes:
+      - shared-volume:/mnt/efs
+      - type: bind
+        source: ./wait-for-pg.sh
+        target: /scripts/wait-for-pg.sh
+        read_only: true
+        content: |
+          #!/bin/sh
+          until nc -z -w3 postgresql.db.svc.cluster.local 5432 2>/dev/null; do sleep 2; done
+          exec /home/openreplay/service
+    entrypoint: ["/bin/sh", "/scripts/wait-for-pg.sh"]
+    environment:
+      <<: *app-common-env
+      AWS_ACCESS_KEY_ID: ${SERVICE_USER_MINIO}
+      AWS_SECRET_ACCESS_KEY: ${SERVICE_PASSWORD_MINIO}
+      AWS_ENDPOINT: https://${SERVICE_FQDN_OPENREPLAY}
+      AWS_REGION: us-east-1
+      BUCKET_NAME: mobs
+      KAFKA_SERVERS: kafka.db.svc.cluster.local:9092
+      KAFKA_USE_SSL: "false"
+      REDIS_STRING: redis://redis-master.db.svc.cluster.local:6379
+      FS_CLEAN_HRS: "24"
+    restart: unless-stopped
+
+  chalice-openreplay:
+    image: public.ecr.aws/p1t3u8a3/chalice:v1.26.0
+    domainname: app.svc.cluster.local
+    container_name: openreplay-chalice
+    networks:
+      openreplay-net:
+        aliases:
+          - chalice-openreplay
+          - chalice-openreplay.app.svc.cluster.local
+    volumes:
+      - shared-volume:/mnt/efs
+    environment:
+      <<: *app-common-env
+      REDIS_STRING: redis://redis-master.db.svc.cluster.local:6379
+      KAFKA_SERVERS: kafka.db.svc.cluster.local
+      ch_username: default
+      ch_password: ""
+      ch_host: clickhouse-openreplay-clickhouse.db.svc.cluster.local
+      ch_port: "9000"
+      ch_port_http: "8123"
+      sourcemaps_reader: http://sourcemapreader-openreplay.app.svc.cluster.local:9000/{}/sourcemaps
+      ASSIST_URL: http://assist-openreplay.app.svc.cluster.local:9001/assist/%s
+      JWT_REFRESH_SECRET: ${SERVICE_PASSWORD_64_JWTREFRESH}
+      JWT_SPOT_REFRESH_SECRET: ${SERVICE_PASSWORD_64_JWTSPOTREFRESH}
+      ASSIST_JWT_SECRET: ${SERVICE_PASSWORD_64_ASSISTJWT}
+      JWT_SECRET: ${SERVICE_PASSWORD_64_JWT}
+      ASSIST_KEY: ${SERVICE_PASSWORD_64_ASSISTKEY}
+      JWT_SPOT_SECRET: ${SERVICE_PASSWORD_64_JWTSPOT}
+      LICENSE_KEY: ""
+      version_number: v1.26.0
+      pg_host: postgresql.db.svc.cluster.local
+      pg_port: "5432"
+      pg_dbname: postgres
+      pg_user: postgres
+      pg_password: ${SERVICE_PASSWORD_POSTGRES}
+      SITE_URL: https://${SERVICE_FQDN_OPENREPLAY}
+      S3_HOST: https://${SERVICE_FQDN_OPENREPLAY}
+      S3_KEY: ${SERVICE_USER_MINIO}
+      S3_SECRET: ${SERVICE_PASSWORD_MINIO}
+      AWS_DEFAULT_REGION: us-east-1
+      sessions_region: us-east-1
+      ASSIST_RECORDS_BUCKET: records
+      sessions_bucket: mobs
+      IOS_VIDEO_BUCKET: mobs
+      sourcemaps_bucket: sourcemaps
+      js_cache_bucket: sessions-assets
+      EMAIL_HOST: ""
+      EMAIL_PORT: "587"
+      EMAIL_USER: ""
+      EMAIL_PASSWORD: ""
+      EMAIL_USE_TLS: "true"
+      EMAIL_USE_SSL: "false"
+      EMAIL_SSL_KEY: ""
+      EMAIL_SSL_CERT: ""
+      EMAIL_FROM: OpenReplay<do-not-reply@openreplay.com>
+      CH_COMPRESSION: "false"
+      CLUSTER_URL: svc.cluster.local
+      JWT_EXPIRATION: "86400"
+      LOGLEVEL: INFO
+      PYTHONUNBUFFERED: "0"
+      jwt_algorithm: HS512
+      root_path: /api
+    restart: unless-stopped
+
+  db-openreplay:
+    image: public.ecr.aws/p1t3u8a3/db:v1.26.0
+    domainname: app.svc.cluster.local
+    container_name: openreplay-db
+    depends_on:
+      postgresql:
+        condition: service_healthy
+    networks:
+      openreplay-net:
+        aliases:
+          - db-openreplay
+          - db-openreplay.app.svc.cluster.local
+    volumes:
+      - shared-volume:/mnt/efs
+      - type: bind
+        source: ./wait-for-pg.sh
+        target: /scripts/wait-for-pg.sh
+        read_only: true
+        content: |
+          #!/bin/sh
+          until nc -z -w3 postgresql.db.svc.cluster.local 5432 2>/dev/null; do sleep 2; done
+          exec /home/openreplay/service
+    entrypoint: ["/bin/sh", "/scripts/wait-for-pg.sh"]
+    environment:
+      <<: *app-common-env
+      CH_USERNAME: default
+      CH_PASSWORD: ""
+      CLICKHOUSE_STRING: clickhouse-openreplay-clickhouse.db.svc.cluster.local:9000/default
+      LICENSE_KEY: ""
+      KAFKA_SERVERS: kafka.db.svc.cluster.local:9092
+      KAFKA_USE_SSL: "false"
+      pg_password: ${SERVICE_PASSWORD_POSTGRES}
+      POSTGRES_STRING: postgres://postgres:${SERVICE_PASSWORD_POSTGRES}@postgresql.db.svc.cluster.local:5432/postgres?sslmode=disable
+      REDIS_STRING: redis://redis-master.db.svc.cluster.local:6379
+      ch_db: default
+    restart: unless-stopped
+
+  ender-openreplay:
+    image: public.ecr.aws/p1t3u8a3/ender:v1.26.0
+    domainname: app.svc.cluster.local
+    container_name: openreplay-ender
+    depends_on:
+      postgresql:
+        condition: service_healthy
+    networks:
+      openreplay-net:
+        aliases:
+          - ender-openreplay
+          - ender-openreplay.app.svc.cluster.local
+    volumes:
+      - shared-volume:/mnt/efs
+      - type: bind
+        source: ./wait-for-pg.sh
+        target: /scripts/wait-for-pg.sh
+        read_only: true
+        content: |
+          #!/bin/sh
+          until nc -z -w3 postgresql.db.svc.cluster.local 5432 2>/dev/null; do sleep 2; done
+          exec /home/openreplay/service
+    entrypoint: ["/bin/sh", "/scripts/wait-for-pg.sh"]
+    environment:
+      <<: *app-common-env
+      KAFKA_SERVERS: kafka.db.svc.cluster.local:9092
+      KAFKA_USE_SSL: "false"
+      pg_password: ${SERVICE_PASSWORD_POSTGRES}
+      POSTGRES_STRING: postgres://postgres:${SERVICE_PASSWORD_POSTGRES}@postgresql.db.svc.cluster.local:5432/postgres?sslmode=disable
+      REDIS_STRING: redis://redis-master.db.svc.cluster.local:6379
+    restart: unless-stopped
+
+  frontend-openreplay:
+    image: public.ecr.aws/p1t3u8a3/frontend:v1.26.0
+    domainname: app.svc.cluster.local
+    container_name: openreplay-frontend
+    networks:
+      openreplay-net:
+        aliases:
+          - frontend-openreplay
+          - frontend-openreplay.app.svc.cluster.local
+    volumes:
+      - shared-volume:/mnt/efs
+    environment:
+      <<: *app-common-env
+      TRACKER_HOST: https://${SERVICE_FQDN_OPENREPLAY}/script
+      HTTP_PORT: "80"
+    restart: unless-stopped
+
+  heuristics-openreplay:
+    image: public.ecr.aws/p1t3u8a3/heuristics:v1.26.0
+    domainname: app.svc.cluster.local
+    container_name: openreplay-heuristics
+    networks:
+      openreplay-net:
+        aliases:
+          - heuristics-openreplay
+          - heuristics-openreplay.app.svc.cluster.local
+    volumes:
+      - shared-volume:/mnt/efs
+    environment:
+      <<: *app-common-env
+      KAFKA_SERVERS: kafka.db.svc.cluster.local:9092
+      KAFKA_USE_SSL: "false"
+      REDIS_STRING: redis://redis-master.db.svc.cluster.local:6379
+    restart: unless-stopped
+
+  nginx-openreplay:
+    image: nginx:1.27-alpine
+    container_name: openreplay-nginx
+    environment:
+      - SERVICE_FQDN_OPENREPLAY_80
+    networks:
+      openreplay-net:
+        aliases:
+          - nginx-openreplay
+    volumes:
+      - type: bind
+        source: ./nginx.conf
+        target: /etc/nginx/conf.d/default.conf
+        read_only: true
+        content: |
+          map $$arg_peerId $$sessionid {
+            default "";
+            "~.*-(\d+)(?:-.*|$$)" $$1;
+          }
+          map $$http_x_forwarded_for $$real_ip {
+              ~^(\d+\.\d+\.\d+\.\d+) $$1;
+              default $$remote_addr;
+          }
+          map $$http_upgrade $$connection_upgrade {
+            default upgrade;
+            '' close;
+          }
+          map $$http_x_forwarded_proto $$origin_proto {
+            default $$http_x_forwarded_proto;
+            '' $$scheme;
+          }
+          server {
+              listen 80;
+              client_body_buffer_size 512k;
+              client_max_body_size 10m;
+              proxy_buffer_size 64k;
+              proxy_buffers 32 64k;
+              proxy_busy_buffers_size 128k;
+              proxy_max_temp_file_size 2048m;
+              proxy_buffering on;
+              proxy_connect_timeout 120s;
+              proxy_read_timeout 300s;
+              proxy_send_timeout 300s;
+              real_ip_header X-Forwarded-For;
+              set_real_ip_from 0.0.0.0/0;
+              real_ip_recursive on;
+              add_header X-XSS-Protection "1; mode=block" always;
+              add_header X-Content-Type-Options "nosniff" always;
+              add_header Referrer-Policy "same-origin" always;
+              server_tokens off;
+              location ~ ^/(mobs|sessions-assets|frontend|static|sourcemaps|ios-images|uxtesting-records|records|spots)/ {
+                proxy_set_header X-Real-IP $$remote_addr;
+                proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $$scheme;
+                proxy_set_header Host $$http_host;
+                proxy_connect_timeout 300;
+                proxy_http_version 1.1;
+                proxy_set_header Connection "";
+                chunked_transfer_encoding off;
+                proxy_pass http://minio:9000;
+              }
+              location /minio/ {
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $$http_upgrade;
+                proxy_set_header Connection "Upgrade";
+                proxy_set_header Host $$host;
+                proxy_pass http://minio:9000;
+              }
+              location /ingest/ {
+                rewrite ^/ingest/(.*) /$$1 break;
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $$http_upgrade;
+                proxy_set_header Connection "Upgrade";
+                proxy_set_header X-Forwarded-For $$real_ip;
+                proxy_set_header X-Forwarded-Host $$host;
+                proxy_set_header X-Real-IP $$real_ip;
+                proxy_set_header Host $$host;
+                proxy_pass http://http-openreplay:8080;
+                proxy_read_timeout 300s;
+                proxy_connect_timeout 120s;
+                proxy_send_timeout 300s;
+                add_header 'Access-Control-Allow-Origin' '*' always;
+                add_header 'Access-Control-Allow-Methods' 'POST' always;
+                add_header 'Access-Control-Allow-Headers' 'Content-Type,Authorization,Content-Encoding' always;
+                add_header 'Access-Control-Expose-Headers' 'Content-Length' always;
+              }
+              location /integrations/ {
+                rewrite ^/integrations/(.*) /$$1 break;
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $$http_upgrade;
+                proxy_set_header Connection "Upgrade";
+                proxy_set_header X-Forwarded-For $$real_ip;
+                proxy_set_header X-Forwarded-Host $$host;
+                proxy_set_header X-Real-IP $$real_ip;
+                proxy_set_header Host $$host;
+                proxy_pass http://integrations-openreplay:8080;
+                proxy_read_timeout 300s;
+                proxy_connect_timeout 120s;
+                proxy_send_timeout 300s;
+                add_header 'Access-Control-Allow-Origin' '*' always;
+                add_header 'Access-Control-Allow-Methods' 'POST,PATCH,OPTIONS,DELETE' always;
+                add_header 'Access-Control-Allow-Headers' 'Content-Type,Authorization,Content-Encoding,X-Openreplay-Batch' always;
+                add_header 'Access-Control-Expose-Headers' 'Content-Length' always;
+              }
+              location /v2/api/ {
+                rewrite ^/v2/api/(.*) /$$1 break;
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $$http_upgrade;
+                proxy_set_header Connection "Upgrade";
+                proxy_set_header Host $$host;
+                proxy_set_header X-Forwarded-Proto $$origin_proto;
+                proxy_set_header X-Forwarded-For $$real_ip;
+                proxy_set_header X-Real-IP $$real_ip;
+                proxy_pass http://api-openreplay:8080;
+                proxy_read_timeout 300s;
+                proxy_connect_timeout 120s;
+                proxy_send_timeout 300s;
+              }
+              location /api/ {
+                rewrite ^/api/(.*) /$$1 break;
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $$http_upgrade;
+                proxy_set_header Connection "Upgrade";
+                proxy_set_header Host $$host;
+                proxy_set_header X-Forwarded-Proto $$origin_proto;
+                proxy_set_header X-Forwarded-For $$real_ip;
+                proxy_pass http://chalice-openreplay:8000;
+                proxy_read_timeout 300s;
+                proxy_connect_timeout 120s;
+                proxy_send_timeout 300s;
+                add_header Cache-Control "no-store,no-cache" always;
+                add_header Pragma "no-cache" always;
+              }
+              location /spot/ {
+                rewrite ^/spot/(.*) /$$1 break;
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $$http_upgrade;
+                proxy_set_header Connection "Upgrade";
+                proxy_set_header Host $$host;
+                proxy_set_header X-Forwarded-Proto $$origin_proto;
+                proxy_set_header X-Forwarded-For $$real_ip;
+                proxy_set_header X-Real-IP $$real_ip;
+                proxy_pass http://spot-openreplay:8080;
+                proxy_read_timeout 300s;
+                proxy_connect_timeout 120s;
+                proxy_send_timeout 300s;
+              }
+              location /assist/ {
+                rewrite ^/assist/(.*) /$$1 break;
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $$http_upgrade;
+                proxy_set_header Connection $$connection_upgrade;
+                proxy_set_header Host $$host;
+                proxy_set_header X-Real-IP $$real_ip;
+                proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $$origin_proto;
+                proxy_read_timeout 3600s;
+                proxy_send_timeout 3600s;
+                proxy_connect_timeout 75s;
+                proxy_buffering off;
+                proxy_pass http://assist-openreplay:9001;
+              }
+              location /ws-assist/ {
+                rewrite ^/ws-assist/(.*) /$$1 break;
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $$http_upgrade;
+                proxy_set_header Connection $$connection_upgrade;
+                proxy_set_header Host $$host;
+                proxy_set_header X-Real-IP $$real_ip;
+                proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $$origin_proto;
+                proxy_read_timeout 3600s;
+                proxy_send_timeout 3600s;
+                proxy_connect_timeout 120s;
+                proxy_buffering off;
+                proxy_pass http://assist-openreplay:9001;
+              }
+              location /script/ {
+                rewrite ^/script/(.*)/openreplay(.*).js$$ /$$1/openreplay$$2.js break;
+                proxy_http_version 1.1;
+                proxy_ssl_protocols TLSv1.2 TLSv1.3;
+                proxy_ssl_server_name on;
+                proxy_set_header Host static.openreplay.com;
+                proxy_pass https://static.openreplay.com;
+                proxy_read_timeout 300s;
+                proxy_connect_timeout 120s;
+                proxy_send_timeout 300s;
+                proxy_buffering on;
+                client_max_body_size 8m;
+              }
+              location / {
+                index /index.html;
+                rewrite ^((?!.(js|css|png|svg|jpg|woff|woff2)).)*$$ /index.html break;
+                proxy_set_header Host $$http_host;
+                proxy_set_header X-Forwarded-For $$real_ip;
+                proxy_set_header X-Forwarded-Proto $$origin_proto;
+                proxy_pass http://frontend-openreplay:8080;
+                proxy_intercept_errors on;
+                error_page 404 =200 /index.html;
+              }
+          }
+    restart: unless-stopped
+
+volumes:
+  pgdata:
+  clickhouse:
+  redisdata:
+  miniodata:
+  shared-volume:
+
+networks:
+  openreplay-net:


### PR DESCRIPTION
/claim #8232

## Changes

Added an OpenReplay one-click service template. OpenReplay is an open-source session replay suite. The compose file wires up PostgreSQL, ClickHouse, Redis, and MinIO as infra, runs migration jobs in a separate profile, then starts 14 app services all routed through an nginx ingress that Coolify exposes via its reverse proxy.

## Issues

- Fixes #8232

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Validated locally with `python -c "import yaml; yaml.safe_load(...)"` — 26 services, 5 named volumes, `SERVICE_FQDN_OPENREPLAY_80` exposes the UI.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: GitHub Copilot
- How extensively: Helped scaffold the compose structure; template variables and nginx config reviewed and tested manually

## Testing

Ran YAML validation locally. All 26 services parse correctly. Coolify magic variables (`SERVICE_FQDN_OPENREPLAY_80`, `SERVICE_PASSWORD_*`, `SERVICE_USER_*`) map to the correct OpenReplay env keys. Migration services are gated behind the `migration` profile so they don't restart on every redeploy.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.