### PR TITLE
fix(docker): use HTTPS for nginx apk repository

### DIFF
--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -38,6 +38,8 @@ RUN apk upgrade --no-cache && \
     mkdir -p /usr/share/keyrings && \
     curl -fSsL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor > /usr/share/keyrings/postgresql.gpg
 
+RUN sed -i 's|http://nginx.org/packages|https://nginx.org/packages|g' /etc/apk/repositories
+
 # Install system dependencies
 RUN apk add --no-cache \
     postgresql${POSTGRES_VERSION}-client \


### PR DESCRIPTION
## Summary

- Updates the development Docker image to rewrite the nginx APK repository URL from HTTP to HTTPS.
- Ensures subsequent `apk add` operations fetch nginx packages over a secure transport.

## Testing

- Not run; PR metadata generated from the provided diff.