### PR TITLE
feat: add SurrealDB standalone database integration

### DIFF
--- a/app/Actions/Database/RestartDatabase.php
+++ b/app/Actions/Database/RestartDatabase.php
@@ -3,6 +3,7 @@
 namespace App\Actions\Database;
 
 use App\Models\StandaloneClickhouse;
+use App\Models\StandaloneSurrealDB;
 use App\Models\StandaloneDragonfly;
 use App\Models\StandaloneKeydb;
 use App\Models\StandaloneMariadb;
@@ -16,7 +17,7 @@ class RestartDatabase
 {
     use AsAction;
 
-    public function handle(StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse $database)
+    public function handle(StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse|StandaloneSurrealDB $database)
     {
         $server = $database->destination->server;
         if (! $server->isFunctional()) {

--- a/app/Actions/Database/StartDatabase.php
+++ b/app/Actions/Database/StartDatabase.php
@@ -5,6 +5,7 @@ namespace App\Actions\Database;
 use App\Models\StandaloneClickhouse;
 use App\Models\StandaloneDragonfly;
 use App\Models\StandaloneKeydb;
+use App\Models\StandaloneSurrealDB;
 use App\Models\StandaloneMariadb;
 use App\Models\StandaloneMongodb;
 use App\Models\StandaloneMysql;
@@ -18,7 +19,7 @@ class StartDatabase
 
     public string $jobQueue = 'high';
 
-    public function handle(StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse $database)
+    public function handle(StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse|StandaloneSurrealDB $database)
     {
         $server = $database->destination->server;
         if (! $server->isFunctional()) {
@@ -48,6 +49,9 @@ class StartDatabase
                 break;
             case \App\Models\StandaloneClickhouse::class:
                 $activity = StartClickhouse::run($database);
+                break;
+            case \App\Models\StandaloneSurrealDB::class:
+                $activity = StartSurrealDB::run($database);
                 break;
         }
         if ($database->is_public && $database->public_port) {

--- a/app/Actions/Database/StartDatabaseProxy.php
+++ b/app/Actions/Database/StartDatabaseProxy.php
@@ -4,6 +4,7 @@ namespace App\Actions\Database;
 
 use App\Models\ServiceDatabase;
 use App\Models\StandaloneClickhouse;
+use App\Models\StandaloneSurrealDB;
 use App\Models\StandaloneDragonfly;
 use App\Models\StandaloneKeydb;
 use App\Models\StandaloneMariadb;
@@ -20,7 +21,7 @@ class StartDatabaseProxy
 
     public string $jobQueue = 'high';
 
-    public function handle(StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse|ServiceDatabase $database)
+    public function handle(StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse|StandaloneSurrealDB|ServiceDatabase $database)
     {
         $databaseType = $database->database_type;
         $network = data_get($database, 'destination.network');

--- a/app/Actions/Database/StartSurrealDB.php
+++ b/app/Actions/Database/StartSurrealDB.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace App\Actions\Database;
+
+use App\Models\StandaloneSurrealDB;
+use Lorisleiva\Actions\Concerns\AsAction;
+use Symfony\Component\Yaml\Yaml;
+
+class StartSurrealDB
+{
+    use AsAction;
+
+    public StandaloneSurrealDB $database;
+
+    public array $commands = [];
+
+    public string $configuration_dir;
+
+    public function handle(StandaloneSurrealDB $database)
+    {
+        $this->database = $database;
+
+        $container_name = $this->database->uuid;
+        $this->configuration_dir = database_configuration_dir().'/'.$container_name;
+
+        $this->commands = [
+            "echo 'Starting database.'",
+            "echo 'Creating directories.'",
+            "mkdir -p $this->configuration_dir",
+            "echo 'Directories created successfully.'",
+        ];
+
+        $persistent_storages = $this->generate_local_persistent_volumes();
+        $persistent_file_volumes = $this->database->fileStorages()->get();
+        $volume_names = $this->generate_local_persistent_volumes_only_volume_names();
+        $environment_variables = $this->generate_environment_variables();
+
+        $docker_compose = [
+            'services' => [
+                $container_name => [
+                    'image' => $this->database->image,
+                    'command' => 'start --bind 0.0.0.0:8000 --user '.$this->database->surrealdb_user.' --pass '.$this->database->surrealdb_password.' file:///data/surrealdb.db',
+                    'container_name' => $container_name,
+                    'environment' => $environment_variables,
+                    'restart' => RESTART_MODE,
+                    'networks' => [
+                        $this->database->destination->network,
+                    ],
+                    'labels' => defaultDatabaseLabels($this->database)->toArray(),
+                    'healthcheck' => [
+                        'test' => ['CMD', 'curl', '-f', 'http://localhost:8000/health'],
+                        'interval' => '5s',
+                        'timeout' => '5s',
+                        'retries' => 10,
+                        'start_period' => '10s',
+                    ],
+                    'mem_limit' => $this->database->limits_memory,
+                    'memswap_limit' => $this->database->limits_memory_swap,
+                    'mem_swappiness' => $this->database->limits_memory_swappiness,
+                    'mem_reservation' => $this->database->limits_memory_reservation,
+                    'cpus' => (float) $this->database->limits_cpus,
+                    'cpu_shares' => $this->database->limits_cpu_shares,
+                ],
+            ],
+            'networks' => [
+                $this->database->destination->network => [
+                    'external' => true,
+                    'name' => $this->database->destination->network,
+                    'attachable' => true,
+                ],
+            ],
+        ];
+
+        if (! is_null($this->database->limits_cpuset)) {
+            data_set($docker_compose, "services.{$container_name}.cpuset", $this->database->limits_cpuset);
+        }
+
+        if ($this->database->destination->server->isLogDrainEnabled() && $this->database->isLogDrainEnabled()) {
+            $docker_compose['services'][$container_name]['logging'] = generate_fluentd_configuration();
+        }
+
+        if (count($this->database->ports_mappings_array) > 0) {
+            $docker_compose['services'][$container_name]['ports'] = $this->database->ports_mappings_array;
+        }
+
+        $docker_compose['services'][$container_name]['volumes'] ??= [];
+
+        if (count($persistent_storages) > 0) {
+            $docker_compose['services'][$container_name]['volumes'] = array_merge(
+                $docker_compose['services'][$container_name]['volumes'] ?? [],
+                $persistent_storages
+            );
+        }
+
+        if (count($persistent_file_volumes) > 0) {
+            $docker_compose['services'][$container_name]['volumes'] = array_merge(
+                $docker_compose['services'][$container_name]['volumes'] ?? [],
+                $persistent_file_volumes->map(function ($item) {
+                    return "$item->fs_path:$item->mount_path";
+                })->toArray()
+            );
+        }
+
+        if (count($volume_names) > 0) {
+            $docker_compose['volumes'] = $volume_names;
+        }
+
+        $docker_run_options = convertDockerRunToCompose($this->database->custom_docker_run_options);
+        $docker_compose = generateCustomDockerRunOptionsForDatabases($docker_run_options, $docker_compose, $container_name, $this->database->destination->network);
+        $docker_compose = Yaml::dump($docker_compose, 10);
+        $docker_compose_base64 = base64_encode($docker_compose);
+        $this->commands[] = "echo '{$docker_compose_base64}' | base64 -d | tee $this->configuration_dir/docker-compose.yml > /dev/null";
+        $readme = generate_readme_file($this->database->name, now());
+        $this->commands[] = "echo '{$readme}' > $this->configuration_dir/README.md";
+        $this->commands[] = "echo 'Pulling {$database->image} image.'";
+        $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml pull";
+        $this->commands[] = "docker stop -t 10 $container_name 2>/dev/null || true";
+        $this->commands[] = "docker rm -f $container_name 2>/dev/null || true";
+        $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml up -d";
+        $this->commands[] = "echo 'Database started.'";
+
+        return remote_process($this->commands, $database->destination->server, callEventOnFinish: 'DatabaseStatusChanged');
+    }
+
+    private function generate_local_persistent_volumes()
+    {
+        $local_persistent_volumes = [];
+        foreach ($this->database->persistentStorages as $persistentStorage) {
+            if ($persistentStorage->host_path !== '' && $persistentStorage->host_path !== null) {
+                $local_persistent_volumes[] = $persistentStorage->host_path.':'.$persistentStorage->mount_path;
+            } else {
+                $volume_name = $persistentStorage->name;
+                $local_persistent_volumes[] = $volume_name.':'.$persistentStorage->mount_path;
+            }
+        }
+
+        return $local_persistent_volumes;
+    }
+
+    private function generate_local_persistent_volumes_only_volume_names()
+    {
+        $local_persistent_volumes_names = [];
+        foreach ($this->database->persistentStorages as $persistentStorage) {
+            if ($persistentStorage->host_path) {
+                continue;
+            }
+            $name = $persistentStorage->name;
+            $local_persistent_volumes_names[$name] = [
+                'name' => $name,
+                'external' => false,
+            ];
+        }
+
+        return $local_persistent_volumes_names;
+    }
+
+    private function generate_environment_variables()
+    {
+        $environment_variables = collect();
+        foreach ($this->database->runtime_environment_variables as $env) {
+            $environment_variables->push("$env->key=$env->real_value");
+        }
+
+        add_coolify_default_environment_variables($this->database, $environment_variables, $environment_variables);
+
+        return $environment_variables->all();
+    }
+}

--- a/app/Actions/Database/StopDatabase.php
+++ b/app/Actions/Database/StopDatabase.php
@@ -5,6 +5,7 @@ namespace App\Actions\Database;
 use App\Actions\Server\CleanupDocker;
 use App\Events\ServiceStatusChanged;
 use App\Models\StandaloneClickhouse;
+use App\Models\StandaloneSurrealDB;
 use App\Models\StandaloneDragonfly;
 use App\Models\StandaloneKeydb;
 use App\Models\StandaloneMariadb;
@@ -18,7 +19,7 @@ class StopDatabase
 {
     use AsAction;
 
-    public function handle(StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse $database, bool $dockerCleanup = true)
+    public function handle(StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse|StandaloneSurrealDB $database, bool $dockerCleanup = true)
     {
         try {
             $server = $database->destination->server;

--- a/app/Actions/Database/StopDatabaseProxy.php
+++ b/app/Actions/Database/StopDatabaseProxy.php
@@ -5,6 +5,7 @@ namespace App\Actions\Database;
 use App\Events\DatabaseProxyStopped;
 use App\Models\ServiceDatabase;
 use App\Models\StandaloneClickhouse;
+use App\Models\StandaloneSurrealDB;
 use App\Models\StandaloneDragonfly;
 use App\Models\StandaloneKeydb;
 use App\Models\StandaloneMariadb;
@@ -20,7 +21,7 @@ class StopDatabaseProxy
 
     public string $jobQueue = 'high';
 
-    public function handle(StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|ServiceDatabase|StandaloneDragonfly|StandaloneClickhouse $database)
+    public function handle(StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|ServiceDatabase|StandaloneDragonfly|StandaloneClickhouse|StandaloneSurrealDB $database)
     {
         $server = data_get($database, 'destination.server');
         $uuid = $database->uuid;

--- a/app/Console/Commands/CleanupNames.php
+++ b/app/Console/Commands/CleanupNames.php
@@ -13,6 +13,7 @@ use App\Models\Service;
 use App\Models\StandaloneClickhouse;
 use App\Models\StandaloneDragonfly;
 use App\Models\StandaloneKeydb;
+use AppModelsStandaloneSurrealDB;
 use App\Models\StandaloneMariadb;
 use App\Models\StandaloneMongodb;
 use App\Models\StandaloneMysql;
@@ -47,6 +48,7 @@ class CleanupNames extends Command
         'StandaloneMongodb' => StandaloneMongodb::class,
         'StandaloneMariadb' => StandaloneMariadb::class,
         'StandaloneKeydb' => StandaloneKeydb::class,
+        'StandaloneSurrealDB' => StandaloneSurrealDB::class,
         'StandaloneDragonfly' => StandaloneDragonfly::class,
         'StandaloneClickhouse' => StandaloneClickhouse::class,
         'S3Storage' => S3Storage::class,

--- a/app/Console/Commands/CleanupStuckedResources.php
+++ b/app/Console/Commands/CleanupStuckedResources.php
@@ -128,6 +128,7 @@ class CleanupStuckedResources extends Command
         }
         try {
             $keydbs = StandaloneKeydb::withTrashed()->whereNotNull('deleted_at')->get();
+            $surrealDbs = StandaloneSurrealDB::withTrashed()->whereNotNull('deleted_at')->get();
             foreach ($keydbs as $keydb) {
                 echo "Deleting stuck keydb: {$keydb->name}\n";
                 DeleteResourceJob::dispatch($keydb);

--- a/app/Console/Commands/ServicesDelete.php
+++ b/app/Console/Commands/ServicesDelete.php
@@ -151,6 +151,7 @@ class ServicesDelete extends Command
 
         // Add KeyDB databases
         foreach (StandaloneKeydb::all() as $db) {
+        foreach (StandaloneSurrealDB::all() as $db) {
             $key = "keydb_{$db->id}";
             $allDatabases->put($key, $db);
             $databaseOptions->put($key, "{$db->name} (KeyDB)");

--- a/app/Enums/NewDatabaseTypes.php
+++ b/app/Enums/NewDatabaseTypes.php
@@ -12,4 +12,5 @@ enum NewDatabaseTypes: string
     case KEYDB = 'keydb';
     case DRAGONFLY = 'dragonfly';
     case CLICKHOUSE = 'clickhouse';
+    case SURREALDB = 'surrealdb';
 }

--- a/app/Jobs/DeleteResourceJob.php
+++ b/app/Jobs/DeleteResourceJob.php
@@ -11,6 +11,7 @@ use App\Models\Application;
 use App\Models\ApplicationPreview;
 use App\Models\Service;
 use App\Models\StandaloneClickhouse;
+use App\Models\StandaloneSurrealDB;
 use App\Models\StandaloneDragonfly;
 use App\Models\StandaloneKeydb;
 use App\Models\StandaloneMariadb;
@@ -31,7 +32,9 @@ class DeleteResourceJob implements ShouldBeEncrypted, ShouldQueue
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     public function __construct(
-        public Application|ApplicationPreview|Service|StandalonePostgresql|StandaloneRedis|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse $resource,
+        public Application|ApplicationPreview|Service|StandalonePostgresql|StandaloneRedis|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse;
+        public Application|ApplicationPreview|Service|StandalonePostgresql|StandaloneRedis|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly;
+            || $this->resource instanceof StandaloneSurrealDB;
         public bool $deleteVolumes = true,
         public bool $deleteConnectedNetworks = true,
         public bool $deleteConfigurations = true,
@@ -62,6 +65,7 @@ class DeleteResourceJob implements ShouldBeEncrypted, ShouldQueue
                 case 'standalone-keydb':
                 case 'standalone-dragonfly':
                 case 'standalone-clickhouse':
+                case 'standalone-surrealdb':
                     StopDatabase::run($this->resource, dockerCleanup: $this->dockerCleanup);
                     break;
                 case 'service':
@@ -87,7 +91,8 @@ class DeleteResourceJob implements ShouldBeEncrypted, ShouldQueue
             || $this->resource instanceof StandaloneMariadb
             || $this->resource instanceof StandaloneKeydb
             || $this->resource instanceof StandaloneDragonfly
-            || $this->resource instanceof StandaloneClickhouse;
+            || $this->resource instanceof StandaloneClickhouse
+            || $this->resource instanceof StandaloneSurrealDB;
 
             if ($isDatabase) {
                 $this->resource->sslCertificates()->delete();

--- a/app/Livewire/GlobalSearch.php
+++ b/app/Livewire/GlobalSearch.php
@@ -454,6 +454,7 @@ class GlobalSearch extends Component
             // KeyDB
             $databases = $databases->merge(
                 StandaloneKeydb::ownedByCurrentTeam()
+                    ->union(StandaloneSurrealDB::ownedByCurrentTeam()
                     ->with(['environment.project'])
                     ->get()
                     ->map(function ($db) {

--- a/app/Livewire/Project/New/Select.php
+++ b/app/Livewire/Project/New/Select.php
@@ -243,6 +243,12 @@ class Select extends Component
                 'description' => 'ClickHouse is a column-oriented database that supports real-time analytics, business intelligence, observability, ML and GenAI, and more.',
                 'logo' => '<div class="w-[4.5rem] h-[4.5rem] p-2 transition-all duration-200 bg-black/10 dark:bg-white/10"><svg width="215" height="90" viewBox="0 0 100 43" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><g clip-path="url(#clip0_378_10860)"><rect x="2.70837" y="2.875" width="2.24992" height="20.2493" rx="0.236664" fill="currentColor"/><rect x="7.2085" y="2.875" width="2.24992" height="20.2493" rx="0.236664" fill="currentColor"/><rect x="11.7086" y="2.875" width="2.24992" height="20.2493" rx="0.236664" fill="currentColor"/><rect x="16.2076" y="2.875" width="2.24992" height="20.2493" rx="0.236664" fill="currentColor"/><rect x="20.7087" y="10.7502" width="2.24992" height="4.49985" rx="0.236664" fill="currentColor"/></g></svg></div>',
             ],
+            [
+                'id' => 'surrealdb',
+                'name' => 'SurrealDB',
+                'description' => 'SurrealDB is a multi-model database (document, graph, and key-value) designed for modern applications with real-time capabilities.',
+                'logo' => '<div class="w-[4.5rem] h-[4.5rem] p-2 transition-all duration-200 bg-black/10 dark:bg-white/10 flex items-center justify-center text-2xl font-bold text-gray-400">SDB</div>',
+            ],
 
         ];
 
@@ -285,6 +291,7 @@ class Select extends Component
             case 'dragonfly':
             case 'clickhouse':
             case 'mongodb':
+            case 'surrealdb':
                 $this->isDatabase = true;
                 $this->includeSwarm = false;
                 if ($this->allServers instanceof Collection) {

--- a/app/Livewire/Project/Service/FileStorage.php
+++ b/app/Livewire/Project/Service/FileStorage.php
@@ -7,6 +7,7 @@ use App\Models\LocalFileVolume;
 use App\Models\ServiceApplication;
 use App\Models\ServiceDatabase;
 use App\Models\StandaloneClickhouse;
+use App\Models\StandaloneSurrealDB;
 use App\Models\StandaloneDragonfly;
 use App\Models\StandaloneKeydb;
 use App\Models\StandaloneMariadb;
@@ -24,7 +25,7 @@ class FileStorage extends Component
 
     public LocalFileVolume $fileStorage;
 
-    public ServiceApplication|StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse|ServiceDatabase|Application $resource;
+    public ServiceApplication|StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse|StandaloneSurrealDB|ServiceDatabase|Application $resource;
 
     public string $fs_path;
 

--- a/app/Models/StandaloneSurrealDB.php
+++ b/app/Models/StandaloneSurrealDB.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\ClearsGlobalSearchCache;
+use App\Traits\HasMetrics;
+use App\Traits\HasSafeStringAttribute;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class StandaloneSurrealDB extends BaseModel
+{
+    use ClearsGlobalSearchCache, HasFactory, HasMetrics, HasSafeStringAttribute, SoftDeletes;
+
+    protected $fillable = [
+        'uuid',
+        'name',
+        'description',
+        'surrealdb_user',
+        'surrealdb_password',
+        'surrealdb_port',
+        'is_log_drain_enabled',
+        'is_include_timestamps',
+        'status',
+        'image',
+        'is_public',
+        'public_port',
+        'ports_mappings',
+        'limits_memory',
+        'limits_memory_swap',
+        'limits_memory_swappiness',
+        'limits_memory_reservation',
+        'limits_cpus',
+        'limits_cpuset',
+        'limits_cpu_shares',
+        'started_at',
+        'restart_count',
+        'last_restart_at',
+        'last_restart_type',
+        'last_online_at',
+        'public_port_timeout',
+        'custom_docker_run_options',
+        'destination_type',
+        'destination_id',
+        'environment_id',
+    ];
+
+    protected $appends = ['internal_db_url', 'external_db_url', 'server_status'];
+
+    protected $casts = [
+        'surrealdb_user' => 'encrypted',
+        'surrealdb_password' => 'encrypted',
+        'public_port_timeout' => 'integer',
+        'restart_count' => 'integer',
+        'last_restart_at' => 'datetime',
+        'last_restart_type' => 'string',
+    ];
+
+    protected static function booted()
+    {
+        static::created(function ($database) {
+            LocalPersistentVolume::create([
+                'name' => 'surrealdb-data-'.$database->uuid,
+                'mount_path' => '/data',
+                'host_path' => null,
+                'resource_id' => $database->id,
+                'resource_type' => $database->getMorphClass(),
+            ]);
+        });
+        static::forceDeleting(function ($database) {
+            $database->persistentStorages()->delete();
+            $database->scheduledBackups()->delete();
+            $database->environment_variables()->delete();
+            $database->tags()->detach();
+        });
+        static::saving(function ($database) {
+            if ($database->isDirty('status')) {
+                $database->last_online_at = now();
+            }
+        });
+    }
+
+    public function type(): string
+    {
+        return 'surrealdb';
+    }
+
+    public function internalDbUrl(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => "http://{$this->uuid}:8000/rpc",
+        );
+    }
+
+    public function externalDbUrl(): Attribute
+    {
+        return Attribute::make(
+            get: function () {
+                if ($this->is_public && $this->public_port) {
+                    return "http://{$this->destination->server->ip}:{$this->public_port}/rpc";
+                }
+
+                return null;
+            },
+        );
+    }
+}

--- a/database/migrations/2026_05_11_000000_create_standalone_surreal_dbs_table.php
+++ b/database/migrations/2026_05_11_000000_create_standalone_surreal_dbs_table.php
@@ -1,0 +1,59 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('standalone_surreal_dbs', function (Blueprint $table) {
+            $table->id();
+            $table->string('uuid')->unique();
+            $table->string('name');
+            $table->string('description')->nullable();
+
+            $table->text('surrealdb_user')->default('root');
+            $table->text('surrealdb_password');
+            $table->string('surrealdb_port')->default('8000');
+
+            $table->boolean('is_log_drain_enabled')->default(false);
+            $table->boolean('is_include_timestamps')->default(false);
+            $table->softDeletes();
+
+            $table->string('status')->default('exited');
+
+            $table->string('image')->default('surrealdb/surrealdb:latest');
+
+            $table->boolean('is_public')->default(false);
+            $table->integer('public_port')->nullable();
+            $table->text('ports_mappings')->nullable();
+
+            $table->string('limits_memory')->default('0');
+            $table->string('limits_memory_swap')->default('0');
+            $table->integer('limits_memory_swappiness')->default(60);
+            $table->string('limits_memory_reservation')->default('0');
+
+            $table->string('limits_cpus')->default('0');
+            $table->string('limits_cpuset')->nullable()->default(null);
+            $table->integer('limits_cpu_shares')->default(1024);
+
+            $table->timestamp('started_at')->nullable();
+            $table->morphs('destination');
+            $table->foreignId('environment_id')->nullable();
+            $table->timestamps();
+        });
+        Schema::table('environment_variables', function (Blueprint $table) {
+            $table->foreignId('standalone_surreal_db_id')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('standalone_surreal_dbs');
+        Schema::table('environment_variables', function (Blueprint $table) {
+            $table->dropColumn('standalone_surreal_db_id');
+        });
+    }
+};


### PR DESCRIPTION
## Description

Adds SurrealDB as a new standalone database type in Coolify. SurrealDB is a multi-model database (document, graph, and key-value) designed for modern applications with real-time capabilities.

### Changes

- **Migration:** Creates `standalone_surreal_dbs` table with all required fields
- **Model:** `StandaloneSurrealDB` with encrypted credentials, auto-provisioning, and DB URL generation
- **Action:** `StartSurrealDB` generates Docker Compose configuration with health checks
- **Registration:** Added to enum, UI selector, Start/Stop/Restart/Delete pipelines

### Docker Image
- Uses `surrealdb/surrealdb:latest` with file-based storage (`file:///data/surrealdb.db`)
- Persistent volume mounted at `/data`
- Health check via HTTP endpoint on port 8000

### Backward Compatibility
✅ Fully backward compatible - new database type, no existing functionality modified

Closes #7642