### PR TITLE
feat: surrealdb standalone database

### DIFF
--- a/app/Actions/Database/RestartDatabase.php
+++ b/app/Actions/Database/RestartDatabase.php
@@ -5,6 +5,7 @@ namespace App\Actions\Database;
 use App\Models\StandaloneClickhouse;
 use App\Models\StandaloneDragonfly;
 use App\Models\StandaloneKeydb;
+use App\Models\StandaloneSurrealDB;
 use App\Models\StandaloneMariadb;
 use App\Models\StandaloneMongodb;
 use App\Models\StandaloneMysql;
@@ -16,7 +17,7 @@ class RestartDatabase
 {
     use AsAction;
 
-    public function handle(StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse $database)
+    public function handle(StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse|StandaloneSurrealDB $database)
     {
         $server = $database->destination->server;
         if (! $server->isFunctional()) {

--- a/app/Actions/Database/StartDatabase.php
+++ b/app/Actions/Database/StartDatabase.php
@@ -18,7 +18,7 @@ class StartDatabase
 
     public string $jobQueue = 'high';
 
-    public function handle(StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse $database)
+    public function handle(StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse|StandaloneSurrealDB $database)
     {
         $server = $database->destination->server;
         if (! $server->isFunctional()) {
@@ -47,6 +47,9 @@ class StartDatabase
                 $activity = StartDragonfly::run($database);
                 break;
             case \App\Models\StandaloneClickhouse::class:
+            case AppModelsStandaloneSurrealDB::class:
+                $activity = StartSurrealDB::run($database);
+                break;
                 $activity = StartClickhouse::run($database);
                 break;
         }

--- a/app/Actions/Database/StartDatabaseProxy.php
+++ b/app/Actions/Database/StartDatabaseProxy.php
@@ -6,6 +6,7 @@ use App\Models\ServiceDatabase;
 use App\Models\StandaloneClickhouse;
 use App\Models\StandaloneDragonfly;
 use App\Models\StandaloneKeydb;
+use App\Models\StandaloneSurrealDB;
 use App\Models\StandaloneMariadb;
 use App\Models\StandaloneMongodb;
 use App\Models\StandaloneMysql;
@@ -20,7 +21,7 @@ class StartDatabaseProxy
 
     public string $jobQueue = 'high';
 
-    public function handle(StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse|ServiceDatabase $database)
+    public function handle(StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse|StandaloneSurrealDB|ServiceDatabase $database)
     {
         $databaseType = $database->database_type;
         $network = data_get($database, 'destination.network');

--- a/app/Actions/Database/StartSurrealDB.php
+++ b/app/Actions/Database/StartSurrealDB.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace App\Actions\Database;
+
+use App\Models\StandaloneSurrealDB;
+use Lorisleiva\Actions\Concerns\AsAction;
+use Symfony\Component\Yaml\Yaml;
+
+class StartSurrealDB
+{
+    use AsAction;
+
+    public StandaloneSurrealDB $database;
+
+    public array $commands = [];
+
+    public string $configuration_dir;
+
+    public function handle(StandaloneSurrealDB $database)
+    {
+        $this->database = $database;
+
+        $container_name = $this->database->uuid;
+        $this->configuration_dir = database_configuration_dir().'/'.$container_name;
+
+        $this->commands = [
+            "echo 'Starting database.'",
+            "echo 'Creating directories.'",
+            "mkdir -p $this->configuration_dir",
+            "echo 'Directories created successfully.'",
+        ];
+
+        $persistent_storages = $this->generate_local_persistent_volumes();
+        $persistent_file_volumes = $this->database->fileStorages()->get();
+        $volume_names = $this->generate_local_persistent_volumes_only_volume_names();
+        $environment_variables = $this->generate_environment_variables();
+
+        $docker_compose = [
+            'services' => [
+                $container_name => [
+                    'image' => $this->database->image,
+                    'command' => 'start --bind 0.0.0.0:8000 --user '.$this->database->surrealdb_user.' --pass '.$this->database->surrealdb_password.' file:///data/surrealdb.db',
+                    'container_name' => $container_name,
+                    'environment' => $environment_variables,
+                    'restart' => RESTART_MODE,
+                    'networks' => [
+                        $this->database->destination->network,
+                    ],
+                    'labels' => defaultDatabaseLabels($this->database)->toArray(),
+                    'healthcheck' => [
+                        'test' => ['CMD', 'curl', '-f', 'http://localhost:8000/health'],
+                        'interval' => '5s',
+                        'timeout' => '5s',
+                        'retries' => 10,
+                        'start_period' => '10s',
+                    ],
+                    'mem_limit' => $this->database->limits_memory,
+                    'memswap_limit' => $this->database->limits_memory_swap,
+                    'mem_swappiness' => $this->database->limits_memory_swappiness,
+                    'mem_reservation' => $this->database->limits_memory_reservation,
+                    'cpus' => (float) $this->database->limits_cpus,
+                    'cpu_shares' => $this->database->limits_cpu_shares,
+                ],
+            ],
+            'networks' => [
+                $this->database->destination->network => [
+                    'external' => true,
+                    'name' => $this->database->destination->network,
+                    'attachable' => true,
+                ],
+            ],
+        ];
+
+        if (! is_null($this->database->limits_cpuset)) {
+            data_set($docker_compose, "services.{$container_name}.cpuset", $this->database->limits_cpuset);
+        }
+
+        // log drain
+        if ($this->database->destination->server->isLogDrainEnabled() && $this->database->isLogDrainEnabled()) {
+            $docker_compose['services'][$container_name]['logging'] = generate_fluentd_configuration();
+        }
+
+        if (count($this->database->ports_mappings_array) > 0) {
+            $docker_compose['services'][$container_name]['ports'] = $this->database->ports_mappings_array;
+        }
+
+        $docker_compose['services'][$container_name]['volumes'] ??= [];
+
+        if (count($persistent_storages) > 0) {
+            $docker_compose['services'][$container_name]['volumes'] = array_merge(
+                $docker_compose['services'][$container_name]['volumes'] ?? [],
+                $persistent_storages
+            );
+        }
+
+        if (count($persistent_file_volumes) > 0) {
+            $docker_compose['services'][$container_name]['volumes'] = array_merge(
+                $docker_compose['services'][$container_name]['volumes'] ?? [],
+                $persistent_file_volumes->map(fn ($item) => "$item->fs_path:$item->mount_path")->toArray()
+            );
+        }
+
+        if (count($volume_names) > 0) {
+            $docker_compose['volumes'] = $volume_names;
+        }
+
+        $docker_run_options = convertDockerRunToCompose($this->database->custom_docker_run_options);
+        $docker_compose = generateCustomDockerRunOptionsForDatabases($docker_run_options, $docker_compose, $container_name, $this->database->destination->network);
+        $docker_compose = Yaml::dump($docker_compose, 10);
+        $docker_compose_base64 = base64_encode($docker_compose);
+        $this->commands[] = "echo '{$docker_compose_base64}' | base64 -d | tee $this->configuration_dir/docker-compose.yml > /dev/null";
+        $readme = generate_readme_file($this->database->name, now());
+        $this->commands[] = "echo '{$readme}' > $this->configuration_dir/README.md";
+        $this->commands[] = "echo 'Pulling {$database->image} image.'";
+        $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml pull";
+        $this->commands[] = "docker stop -t 10 $container_name 2>/dev/null || true";
+        $this->commands[] = "docker rm -f $container_name 2>/dev/null || true";
+        $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml up -d";
+        $this->commands[] = "echo 'Database started.'";
+
+        return remote_process($this->commands, $database->destination->server, callEventOnFinish: 'DatabaseStatusChanged');
+    }
+
+    private function generate_local_persistent_volumes()
+    {
+        $volumes = [];
+        foreach ($this->database->persistentStorages as $storage) {
+            if ($storage->host_path !== '' && $storage->host_path !== null) {
+                $volumes[] = $storage->host_path.':'.$storage->mount_path;
+            } else {
+                $volumes[] = $storage->name.':'.$storage->mount_path;
+            }
+        }
+
+        return $volumes;
+    }
+
+    private function generate_local_persistent_volumes_only_volume_names()
+    {
+        $names = [];
+        foreach ($this->database->persistentStorages as $storage) {
+            if ($storage->host_path) {
+                continue;
+            }
+            $names[$storage->name] = [
+                'name' => $storage->name,
+                'external' => false,
+            ];
+        }
+
+        return $names;
+    }
+
+    private function generate_environment_variables()
+    {
+        $envs = collect();
+        foreach ($this->database->runtime_environment_variables as $env) {
+            $envs->push("$env->key=$env->real_value");
+        }
+
+        add_coolify_default_environment_variables($this->database, $envs, $envs);
+
+        return $envs->all();
+    }
+}

--- a/app/Actions/Database/StopDatabase.php
+++ b/app/Actions/Database/StopDatabase.php
@@ -7,6 +7,7 @@ use App\Events\ServiceStatusChanged;
 use App\Models\StandaloneClickhouse;
 use App\Models\StandaloneDragonfly;
 use App\Models\StandaloneKeydb;
+use App\Models\StandaloneSurrealDB;
 use App\Models\StandaloneMariadb;
 use App\Models\StandaloneMongodb;
 use App\Models\StandaloneMysql;
@@ -18,7 +19,7 @@ class StopDatabase
 {
     use AsAction;
 
-    public function handle(StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse $database, bool $dockerCleanup = true)
+    public function handle(StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse|StandaloneSurrealDB $database, bool $dockerCleanup = true)
     {
         try {
             $server = $database->destination->server;

--- a/app/Actions/Database/StopDatabaseProxy.php
+++ b/app/Actions/Database/StopDatabaseProxy.php
@@ -7,6 +7,7 @@ use App\Models\ServiceDatabase;
 use App\Models\StandaloneClickhouse;
 use App\Models\StandaloneDragonfly;
 use App\Models\StandaloneKeydb;
+use App\Models\StandaloneSurrealDB;
 use App\Models\StandaloneMariadb;
 use App\Models\StandaloneMongodb;
 use App\Models\StandaloneMysql;
@@ -20,7 +21,7 @@ class StopDatabaseProxy
 
     public string $jobQueue = 'high';
 
-    public function handle(StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|ServiceDatabase|StandaloneDragonfly|StandaloneClickhouse $database)
+    public function handle(StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|ServiceDatabase|StandaloneDragonfly|StandaloneClickhouse|StandaloneSurrealDB $database)
     {
         $server = data_get($database, 'destination.server');
         $uuid = $database->uuid;

--- a/app/Console/Commands/CleanupNames.php
+++ b/app/Console/Commands/CleanupNames.php
@@ -47,6 +47,7 @@ class CleanupNames extends Command
         'StandaloneMongodb' => StandaloneMongodb::class,
         'StandaloneMariadb' => StandaloneMariadb::class,
         'StandaloneKeydb' => StandaloneKeydb::class,
+        'StandaloneSurrealDB' => StandaloneSurrealDB::class,
         'StandaloneDragonfly' => StandaloneDragonfly::class,
         'StandaloneClickhouse' => StandaloneClickhouse::class,
         'S3Storage' => S3Storage::class,

--- a/app/Enums/NewDatabaseTypes.php
+++ b/app/Enums/NewDatabaseTypes.php
@@ -12,4 +12,5 @@ enum NewDatabaseTypes: string
     case KEYDB = 'keydb';
     case DRAGONFLY = 'dragonfly';
     case CLICKHOUSE = 'clickhouse';
+    case SURREALDB = 'surrealdb';
 }

--- a/app/Jobs/DeleteResourceJob.php
+++ b/app/Jobs/DeleteResourceJob.php
@@ -13,6 +13,7 @@ use App\Models\Service;
 use App\Models\StandaloneClickhouse;
 use App\Models\StandaloneDragonfly;
 use App\Models\StandaloneKeydb;
+use App\Models\StandaloneSurrealDB;
 use App\Models\StandaloneMariadb;
 use App\Models\StandaloneMongodb;
 use App\Models\StandaloneMysql;
@@ -31,7 +32,7 @@ class DeleteResourceJob implements ShouldBeEncrypted, ShouldQueue
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     public function __construct(
-        public Application|ApplicationPreview|Service|StandalonePostgresql|StandaloneRedis|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse $resource,
+        public Application|ApplicationPreview|Service|StandalonePostgresql|StandaloneRedis|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse|StandaloneSurrealDB $resource,
         public bool $deleteVolumes = true,
         public bool $deleteConnectedNetworks = true,
         public bool $deleteConfigurations = true,
@@ -62,6 +63,7 @@ class DeleteResourceJob implements ShouldBeEncrypted, ShouldQueue
                 case 'standalone-keydb':
                 case 'standalone-dragonfly':
                 case 'standalone-clickhouse':
+                case 'standalone-surrealdb':
                     StopDatabase::run($this->resource, dockerCleanup: $this->dockerCleanup);
                     break;
                 case 'service':
@@ -87,7 +89,8 @@ class DeleteResourceJob implements ShouldBeEncrypted, ShouldQueue
             || $this->resource instanceof StandaloneMariadb
             || $this->resource instanceof StandaloneKeydb
             || $this->resource instanceof StandaloneDragonfly
-            || $this->resource instanceof StandaloneClickhouse;
+            || $this->resource instanceof StandaloneClickhouse
+            || $this->resource instanceof StandaloneSurrealDB;
 
             if ($isDatabase) {
                 $this->resource->sslCertificates()->delete();

--- a/app/Livewire/Project/New/Select.php
+++ b/app/Livewire/Project/New/Select.php
@@ -243,6 +243,12 @@ class Select extends Component
                 'description' => 'ClickHouse is a column-oriented database that supports real-time analytics, business intelligence, observability, ML and GenAI, and more.',
                 'logo' => '<div class="w-[4.5rem] h-[4.5rem] p-2 transition-all duration-200 bg-black/10 dark:bg-white/10"><svg width="215" height="90" viewBox="0 0 100 43" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><g clip-path="url(#clip0_378_10860)"><rect x="2.70837" y="2.875" width="2.24992" height="20.2493" rx="0.236664" fill="currentColor"/><rect x="7.2085" y="2.875" width="2.24992" height="20.2493" rx="0.236664" fill="currentColor"/><rect x="11.7086" y="2.875" width="2.24992" height="20.2493" rx="0.236664" fill="currentColor"/><rect x="16.2076" y="2.875" width="2.24992" height="20.2493" rx="0.236664" fill="currentColor"/><rect x="20.7087" y="10.7502" width="2.24992" height="4.49985" rx="0.236664" fill="currentColor"/></g></svg></div>',
             ],
+            [
+                'id' => 'surrealdb',
+                'name' => 'SurrealDB',
+                'description' => 'SurrealDB is a multi-model database (document, graph, and key-value) designed for modern applications with real-time capabilities.',
+                'logo' => '<div class="w-[4.5rem] h-[4.5rem] p-2 transition-all duration-200 bg-black/10 dark:bg-white/10 flex items-center justify-center text-2xl font-bold text-gray-400">SDB</div>',
+            ],
 
         ];
 
@@ -285,6 +291,7 @@ class Select extends Component
             case 'dragonfly':
             case 'clickhouse':
             case 'mongodb':
+            case 'surrealdb':
                 $this->isDatabase = true;
                 $this->includeSwarm = false;
                 if ($this->allServers instanceof Collection) {

--- a/app/Livewire/Project/Service/FileStorage.php
+++ b/app/Livewire/Project/Service/FileStorage.php
@@ -9,6 +9,7 @@ use App\Models\ServiceDatabase;
 use App\Models\StandaloneClickhouse;
 use App\Models\StandaloneDragonfly;
 use App\Models\StandaloneKeydb;
+use App\Models\StandaloneSurrealDB;
 use App\Models\StandaloneMariadb;
 use App\Models\StandaloneMongodb;
 use App\Models\StandaloneMysql;
@@ -24,7 +25,7 @@ class FileStorage extends Component
 
     public LocalFileVolume $fileStorage;
 
-    public ServiceApplication|StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse|ServiceDatabase|Application $resource;
+    public ServiceApplication|StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse|StandaloneSurrealDB|ServiceDatabase|Application $resource;
 
     public string $fs_path;
 

--- a/app/Models/StandaloneSurrealDB.php
+++ b/app/Models/StandaloneSurrealDB.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\ClearsGlobalSearchCache;
+use App\Traits\HasMetrics;
+use App\Traits\HasSafeStringAttribute;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class StandaloneSurrealDB extends BaseModel
+{
+    use ClearsGlobalSearchCache, HasFactory, HasMetrics, HasSafeStringAttribute, SoftDeletes;
+
+    protected $fillable = [
+        'uuid',
+        'name',
+        'description',
+        'surrealdb_user',
+        'surrealdb_password',
+        'surrealdb_port',
+        'is_log_drain_enabled',
+        'is_include_timestamps',
+        'status',
+        'image',
+        'is_public',
+        'public_port',
+        'ports_mappings',
+        'limits_memory',
+        'limits_memory_swap',
+        'limits_memory_swappiness',
+        'limits_memory_reservation',
+        'limits_cpus',
+        'limits_cpuset',
+        'limits_cpu_shares',
+        'started_at',
+        'restart_count',
+        'last_restart_at',
+        'last_restart_type',
+        'last_online_at',
+        'public_port_timeout',
+        'custom_docker_run_options',
+        'destination_type',
+        'destination_id',
+        'environment_id',
+    ];
+
+    protected $appends = ['internal_db_url', 'external_db_url', 'server_status'];
+
+    protected $casts = [
+        'surrealdb_user' => 'encrypted',
+        'surrealdb_password' => 'encrypted',
+        'public_port_timeout' => 'integer',
+        'restart_count' => 'integer',
+        'last_restart_at' => 'datetime',
+        'last_online_at' => 'datetime',
+    ];
+
+    protected static function booted()
+    {
+        static::created(function ($db) {
+            LocalPersistentVolume::create([
+                'name' => 'surrealdb-data-'.$db->uuid,
+                'mount_path' => '/data',
+                'host_path' => null,
+                'resource_id' => $db->id,
+                'resource_type' => $db->getMorphClass(),
+            ]);
+        });
+        static::forceDeleting(function ($db) {
+            $db->persistentStorages()->delete();
+            $db->scheduledBackups()->delete();
+            $db->environment_variables()->delete();
+            $db->tags()->detach();
+        });
+    }
+
+    public function type(): string
+    {
+        return 'surrealdb';
+    }
+
+    public function internalDbUrl(): Attribute
+    {
+        return new Attribute(
+            get: fn () => "http://{$this->uuid}:8000/rpc",
+        );
+    }
+
+    public function externalDbUrl(): Attribute
+    {
+        return new Attribute(
+            get: function () {
+                if ($this->is_public && $this->public_port) {
+                    return "http://{$this->destination->server->ip}:{$this->public_port}/rpc";
+                }
+
+                return null;
+            },
+        );
+    }
+}


### PR DESCRIPTION
adds surrealdb as a new standalone database type. includes migration, model, start action, and wiring into the existing database pipeline.

closes #7642