### PR TITLE
fix: allow OAuth self-registration when signup is disabled

### DIFF
--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\ResetsUserPasswords;
 
 class ResetUserPassword implements ResetsUserPasswords
@@ -17,6 +18,12 @@ class ResetUserPassword implements ResetsUserPasswords
      */
     public function reset(User $user, array $input): void
     {
+        if (! $user->hasPassword()) {
+            throw ValidationException::withMessages([
+                'email' => 'Password reset is not available for OAuth-only accounts.',
+            ]);
+        }
+
         Validator::make($input, [
             'password' => ['required', Password::defaults(), 'confirmed'],
         ])->validate();

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -26,11 +26,6 @@ class OauthController extends Controller
             $email = strtolower($email);
             $user = User::whereEmail($email)->first();
             if (! $user) {
-                $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
-                    abort(403, 'Registration is disabled');
-                }
-
                 $user = User::create([
                     'name' => $oauthUser->name,
                     'email' => $email,

--- a/tests/Feature/OauthRegistrationTest.php
+++ b/tests/Feature/OauthRegistrationTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use App\Actions\Fortify\ResetUserPassword;
+use App\Http\Middleware\CheckForcePasswordReset;
+use App\Http\Middleware\DecideWhatToDoWithUser;
+use App\Models\InstanceSettings;
+use App\Models\OauthSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Once;
+use Illuminate\Validation\ValidationException;
+use Laravel\Socialite\Facades\Socialite;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->withoutMiddleware([CheckForcePasswordReset::class, DecideWhatToDoWithUser::class]);
+    config([
+        'app.maintenance.store' => 'array',
+        'cache.default' => 'array',
+    ]);
+    Once::flush();
+
+    $settings = new InstanceSettings;
+    $settings->id = 0;
+    $settings->is_registration_enabled = false;
+    $settings->saveQuietly();
+});
+
+it('allows oauth users to self-register when general registration is disabled', function () {
+    OauthSetting::create([
+        'provider' => 'github',
+        'enabled' => true,
+        'client_id' => 'github-client-id',
+        'client_secret' => 'github-client-secret',
+    ]);
+
+    $provider = Mockery::mock();
+    $provider->shouldReceive('user')
+        ->once()
+        ->andReturn((object) [
+            'name' => 'OAuth User',
+            'email' => 'oauth@example.com',
+        ]);
+
+    Socialite::shouldReceive('buildProvider')
+        ->once()
+        ->andReturn($provider);
+
+    $this->get(route('auth.callback', 'github'))
+        ->assertRedirect('/');
+
+    $user = User::whereEmail('oauth@example.com')->first();
+
+    expect($user)->not->toBeNull()
+        ->and($user->password)->toBeNull();
+
+    $this->assertAuthenticatedAs($user);
+});
+
+it('does not let oauth-only users create a password through password reset', function () {
+    $user = User::factory()->create([
+        'password' => null,
+    ]);
+
+    expect(fn () => app(ResetUserPassword::class)->reset($user, [
+        'password' => 'Password1!@',
+        'password_confirmation' => 'Password1!@',
+    ]))->toThrow(ValidationException::class);
+
+    expect($user->refresh()->password)->toBeNull();
+});


### PR DESCRIPTION
STRAWBERRY
/claim #8042

## Changes

- Allow enabled OAuth providers to create a user even when regular email/password registration is disabled.
- Keep OAuth-created accounts passwordless by rejecting password reset attempts for users that do not already have a password.
- Add focused feature coverage for OAuth self-registration and the OAuth-only password reset guard.

## Issues

- Fixes #8042

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable. This is a backend authentication flow change with feature-test coverage.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Used to inspect the existing auth flow, prepare the small patch, and run local validation. I reviewed the changed flow and test results before submitting.

## Testing

- `php vendor/bin/pest tests/Feature/OauthRegistrationTest.php`
- `php vendor/bin/pint --dirty --format agent`
- `git diff --check`

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested the affected backend authentication flow with focused local feature tests and I am confident that it will work as expected when a maintainer tests it.