### PR TITLE
Add OAuth registration controls

### DIFF
--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -5,6 +5,7 @@ namespace App\Actions\Fortify;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Validation\Rules\Password;
 use Laravel\Fortify\Contracts\ResetsUserPasswords;
 
@@ -17,6 +18,12 @@ class ResetUserPassword implements ResetsUserPasswords
      */
     public function reset(User $user, array $input): void
     {
+        if ($user->isOauthAccount() && ! instanceSettings()->is_oauth_password_login_enabled) {
+            throw ValidationException::withMessages([
+                'email' => __('This account is restricted to OAuth login.'),
+            ]);
+        }
+
         Validator::make($input, [
             'password' => ['required', Password::defaults(), 'confirmed'],
         ])->validate();

--- a/app/Actions/Fortify/UpdateUserPassword.php
+++ b/app/Actions/Fortify/UpdateUserPassword.php
@@ -5,6 +5,7 @@ namespace App\Actions\Fortify;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Validation\Rules\Password;
 use Laravel\Fortify\Contracts\UpdatesUserPasswords;
 
@@ -17,6 +18,12 @@ class UpdateUserPassword implements UpdatesUserPasswords
      */
     public function update(User $user, array $input): void
     {
+        if ($user->isOauthAccount() && ! instanceSettings()->is_oauth_password_login_enabled) {
+            throw ValidationException::withMessages([
+                'password' => __('This account is restricted to OAuth login.'),
+            ]);
+        }
+
         Validator::make($input, [
             'current_password' => ['required', 'string', 'current_password:web'],
             'password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -22,14 +22,19 @@ class OauthController extends Controller
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! $settings->is_oauth_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 
-                $user = User::create([
+                $user = new User([
                     'name' => $oauthUser->name,
                     'email' => $oauthUser->email,
                 ]);
+                $user->oauth_provider = $provider;
+                $user->save();
+            } elseif (! $user->hasPassword() && empty($user->oauth_provider)) {
+                $user->oauth_provider = $provider;
+                $user->save();
             }
             Auth::login($user);
 

--- a/app/Livewire/Profile/Index.php
+++ b/app/Livewire/Profile/Index.php
@@ -32,6 +32,8 @@ class Index extends Component
 
     public bool $show_verification = false;
 
+    public bool $password_management_disabled = false;
+
     public function mount()
     {
         $this->userId = Auth::id();
@@ -43,6 +45,9 @@ class Index extends Component
             $this->new_email = Auth::user()->pending_email;
             $this->show_verification = true;
         }
+
+        $this->password_management_disabled = Auth::user()->isOauthAccount()
+            && ! instanceSettings()->is_oauth_password_login_enabled;
     }
 
     public function submit()
@@ -240,6 +245,12 @@ class Index extends Component
     public function resetPassword()
     {
         try {
+            if ($this->password_management_disabled) {
+                $this->dispatch('error', 'This account is restricted to OAuth login.');
+
+                return;
+            }
+
             $this->validate([
                 'current_password' => ['required'],
                 'new_password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -16,6 +16,12 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $is_oauth_registration_enabled;
+
+    #[Validate('boolean')]
+    public bool $is_oauth_password_login_enabled;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -41,6 +47,8 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_registration_enabled' => 'boolean',
+            'is_oauth_password_login_enabled' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => ['nullable', 'string', new ValidDnsServers],
@@ -62,6 +70,8 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled;
+        $this->is_oauth_password_login_enabled = $this->settings->is_oauth_password_login_enabled;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -142,6 +152,8 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
+            $this->settings->is_oauth_password_login_enabled = $this->is_oauth_password_login_enabled;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -18,6 +18,8 @@ class InstanceSettings extends Model
         'do_not_track',
         'is_auto_update_enabled',
         'is_registration_enabled',
+        'is_oauth_registration_enabled',
+        'is_oauth_password_login_enabled',
         'next_channel',
         'smtp_enabled',
         'smtp_from_address',
@@ -63,6 +65,8 @@ class InstanceSettings extends Model
 
         'allowed_ip_ranges' => 'array',
         'is_auto_update_enabled' => 'boolean',
+        'is_oauth_registration_enabled' => 'boolean',
+        'is_oauth_password_login_enabled' => 'boolean',
         'auto_update_frequency' => 'string',
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -487,4 +487,9 @@ class User extends Authenticatable implements SendsEmail
     {
         return ! empty($this->password);
     }
+
+    public function isOauthAccount(): bool
+    {
+        return ! empty($this->oauth_provider) || ! $this->hasPassword();
+    }
 }

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -67,6 +67,7 @@ class FortifyServiceProvider extends ServiceProvider
 
             return view('auth.login', [
                 'is_registration_enabled' => $settings->is_registration_enabled,
+                'is_oauth_registration_enabled' => $settings->is_oauth_registration_enabled,
                 'enabled_oauth_providers' => $enabled_oauth_providers,
             ]);
         });
@@ -76,6 +77,7 @@ class FortifyServiceProvider extends ServiceProvider
             $user = User::where('email', $email)->with('teams')->first();
             if (
                 $user &&
+                (! $user->isOauthAccount() || instanceSettings()->is_oauth_password_login_enabled) &&
                 Hash::check($request->password, $user->password)
             ) {
                 $user->updated_at = now();

--- a/database/migrations/2026_05_11_000000_add_oauth_registration_settings.php
+++ b/database/migrations/2026_05_11_000000_add_oauth_registration_settings.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! Schema::hasColumn('instance_settings', 'is_oauth_registration_enabled')) {
+            Schema::table('instance_settings', function (Blueprint $table) {
+                $table->boolean('is_oauth_registration_enabled')->default(false);
+            });
+        }
+
+        if (! Schema::hasColumn('instance_settings', 'is_oauth_password_login_enabled')) {
+            Schema::table('instance_settings', function (Blueprint $table) {
+                $table->boolean('is_oauth_password_login_enabled')->default(true);
+            });
+        }
+
+        if (! Schema::hasColumn('users', 'oauth_provider')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->string('oauth_provider')->nullable()->after('password');
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (Schema::hasColumn('users', 'oauth_provider')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->dropColumn('oauth_provider');
+            });
+        }
+
+        if (Schema::hasColumn('instance_settings', 'is_oauth_registration_enabled')) {
+            Schema::table('instance_settings', function (Blueprint $table) {
+                $table->dropColumn('is_oauth_registration_enabled');
+            });
+        }
+
+        if (Schema::hasColumn('instance_settings', 'is_oauth_password_login_enabled')) {
+            Schema::table('instance_settings', function (Blueprint $table) {
+                $table->dropColumn('is_oauth_password_login_enabled');
+            });
+        }
+    }
+};

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -72,7 +72,11 @@
                         </a>
                     @else
                         <div class="mt-6 text-center text-sm text-neutral-500 dark:text-neutral-400">
-                            {{ __('auth.registration_disabled') }}
+                            @if ($is_oauth_registration_enabled && $enabled_oauth_providers->isNotEmpty())
+                                Password registration is disabled.
+                            @else
+                                {{ __('auth.registration_disabled') }}
+                            @endif
                         </div>
                     @endif
 

--- a/resources/views/livewire/profile/index.blade.php
+++ b/resources/views/livewire/profile/index.blade.php
@@ -55,20 +55,27 @@
             </form>
         @endif
     </div>
-    <form wire:submit='resetPassword' class="flex flex-col pt-4">
-        <div class="flex items-center gap-2 pb-2">
-            <h2>Change Password</h2>
-            <x-forms.button type="submit" label="Save">Save</x-forms.button>
-        </div>
-        <div class="text-xs font-bold dark:text-warning pb-2">Resetting the password will logout all sessions.</div>
-        <div class="flex flex-col gap-2">
-            <x-forms.input id="current_password" label="Current Password" required type="password" />
-            <div class="flex gap-2">
-                <x-forms.input id="new_password" label="New Password" required type="password" />
-                <x-forms.input id="new_password_confirmation" label="New Password Again" required type="password" />
+    @if (!$password_management_disabled)
+        <form wire:submit='resetPassword' class="flex flex-col pt-4">
+            <div class="flex items-center gap-2 pb-2">
+                <h2>Change Password</h2>
+                <x-forms.button type="submit" label="Save">Save</x-forms.button>
             </div>
+            <div class="text-xs font-bold dark:text-warning pb-2">Resetting the password will logout all sessions.</div>
+            <div class="flex flex-col gap-2">
+                <x-forms.input id="current_password" label="Current Password" required type="password" />
+                <div class="flex gap-2">
+                    <x-forms.input id="new_password" label="New Password" required type="password" />
+                    <x-forms.input id="new_password_confirmation" label="New Password Again" required type="password" />
+                </div>
+            </div>
+        </form>
+    @else
+        <div class="flex flex-col pt-4">
+            <h2>Change Password</h2>
+            <div class="text-xs font-bold dark:text-warning pb-2">This account is restricted to OAuth login.</div>
         </div>
-    </form>
+    @endif
     <h2 class="py-4">Two-factor Authentication</h2>
     @if (session('status') == 'two-factor-authentication-enabled')
         <div class="mb-4 font-medium">

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -42,6 +42,16 @@
                         </div>
                     @endif
                     <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_registration_enabled"
+                            helper="Allow enabled OAuth providers to create accounts even when password registration is disabled."
+                            label="OAuth Registration Allowed" />
+                    </div>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_password_login_enabled"
+                            helper="Allow accounts created through OAuth to add or use a local password. Disable to keep OAuth-created accounts OAuth-only."
+                            label="OAuth Password Login" />
+                    </div>
+                    <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"
                             helper="Opt out of anonymous usage tracking. When enabled, this instance will not report to coolify.io's installation count and will not send error reports to help improve Coolify."
                             label="Do Not Track" />

--- a/tests/Feature/MassAssignmentProtectionTest.php
+++ b/tests/Feature/MassAssignmentProtectionTest.php
@@ -99,6 +99,7 @@ describe('mass assignment protection', function () {
         expect($user->isFillable('pending_email'))->toBeFalse('pending_email should not be fillable');
         expect($user->isFillable('email_change_code'))->toBeFalse('email_change_code should not be fillable');
         expect($user->isFillable('email_change_code_expires_at'))->toBeFalse('email_change_code_expires_at should not be fillable');
+        expect($user->isFillable('oauth_provider'))->toBeFalse('oauth_provider should not be fillable');
     });
 
     test('User model allows mass assignment of profile fields', function () {

--- a/tests/Feature/OauthRegistrationSettingsTest.php
+++ b/tests/Feature/OauthRegistrationSettingsTest.php
@@ -1,0 +1,108 @@
+<?php
+
+use App\Actions\Fortify\ResetUserPassword;
+use App\Models\InstanceSettings;
+use App\Models\OauthSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
+use Laravel\Socialite\Facades\Socialite;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::unguarded(fn () => InstanceSettings::query()->create([
+        'id' => 0,
+        'is_registration_enabled' => false,
+        'is_oauth_registration_enabled' => false,
+        'is_oauth_password_login_enabled' => true,
+    ]));
+
+    OauthSetting::query()->create([
+        'provider' => 'github',
+        'enabled' => true,
+        'client_id' => 'test-client-id',
+        'client_secret' => 'test-client-secret',
+    ]);
+});
+
+function fakeGithubOauthUser(string $email = 'oauth-user@example.com', string $name = 'OAuth User'): void
+{
+    Socialite::shouldReceive('buildProvider')
+        ->once()
+        ->andReturn(new class($email, $name) {
+            public function __construct(
+                private readonly string $email,
+                private readonly string $name,
+            ) {
+            }
+
+            public function user(): object
+            {
+                return (object) [
+                    'email' => $this->email,
+                    'name' => $this->name,
+                ];
+            }
+        });
+}
+
+it('allows oauth self registration when password registration is disabled', function () {
+    instanceSettings()->update(['is_oauth_registration_enabled' => true]);
+
+    fakeGithubOauthUser();
+
+    $this->get('/auth/github/callback')
+        ->assertRedirect('/');
+
+    $user = User::whereEmail('oauth-user@example.com')->first();
+
+    expect($user)->not->toBeNull()
+        ->and($user->oauth_provider)->toBe('github')
+        ->and($user->password)->toBeNull();
+
+    $this->assertAuthenticatedAs($user);
+});
+
+it('keeps oauth self registration blocked when oauth registration is disabled', function () {
+    fakeGithubOauthUser();
+
+    $this->get('/auth/github/callback')
+        ->assertRedirect(route('login'));
+
+    expect(User::whereEmail('oauth-user@example.com')->exists())->toBeFalse();
+});
+
+it('blocks password login for oauth accounts when oauth password login is disabled', function () {
+    instanceSettings()->update(['is_oauth_password_login_enabled' => false]);
+
+    User::factory()->create([
+        'email' => 'oauth-user@example.com',
+        'password' => Hash::make('password'),
+        'oauth_provider' => 'github',
+    ]);
+
+    $this->post('/login', [
+        'email' => 'oauth-user@example.com',
+        'password' => 'password',
+    ])->assertSessionHasErrors();
+
+    $this->assertGuest();
+});
+
+it('prevents oauth accounts from setting a password when oauth password login is disabled', function () {
+    instanceSettings()->update(['is_oauth_password_login_enabled' => false]);
+
+    $user = User::factory()->create([
+        'password' => null,
+        'oauth_provider' => 'github',
+    ]);
+
+    expect(fn () => (new ResetUserPassword)->reset($user, [
+        'password' => 'Password1!',
+        'password_confirmation' => 'Password1!',
+    ]))->toThrow(ValidationException::class);
+
+    expect($user->fresh()->password)->toBeNull();
+});


### PR DESCRIPTION
## Changes

- Adds separate instance settings for OAuth self-registration and OAuth account password login.
- Allows enabled OAuth providers to create new users when password registration is disabled, if OAuth registration is enabled.
- Tracks OAuth-created accounts through `users.oauth_provider`.
- Blocks password login, password reset, and profile password changes for OAuth accounts when OAuth password login is disabled.
- Adds settings UI controls and focused feature coverage.

## Issue

Closes #8042
/claim #8042

## Testing

- Added `tests/Feature/OauthRegistrationSettingsTest.php`.
- Added mass-assignment coverage for `oauth_provider`.
- `git diff --check`

Could not run the PHP test suite locally because this environment does not have PHP or Composer installed.