### PR TITLE
feat: add pgBackRest database backups

### DIFF
--- a/app/Http/Controllers/Api/DatabasesController.php
+++ b/app/Http/Controllers/Api/DatabasesController.php
@@ -18,6 +18,7 @@ use App\Models\Project;
 use App\Models\S3Storage;
 use App\Models\ScheduledDatabaseBackup;
 use App\Models\Server;
+use App\Models\ServiceDatabase;
 use App\Models\StandalonePostgresql;
 use App\Support\ValidationPatterns;
 use Illuminate\Http\JsonResponse;
@@ -641,6 +642,9 @@ class DatabasesController extends Controller
                         'frequency' => ['type' => 'string', 'description' => 'Backup frequency (cron expression or: every_minute, hourly, daily, weekly, monthly, yearly)'],
                         'enabled' => ['type' => 'boolean', 'description' => 'Whether the backup is enabled', 'default' => true],
                         'save_s3' => ['type' => 'boolean', 'description' => 'Whether to save backups to S3', 'default' => false],
+                        'backup_method' => ['type' => 'string', 'enum' => ['dump', 'pgbackrest'], 'description' => 'Backup engine. Use pgbackrest for incremental PostgreSQL backups to S3.', 'default' => 'dump'],
+                        'pgbackrest_backup_type' => ['type' => 'string', 'enum' => ['full', 'diff', 'incr'], 'description' => 'pgBackRest backup type when backup_method is pgbackrest.', 'default' => 'incr'],
+                        'pgbackrest_require_wal_archive' => ['type' => 'boolean', 'description' => 'Require PostgreSQL WAL archive verification for pgBackRest backups. When false, Coolify runs pgBackRest with --archive-check=n if WAL archiving is not configured.', 'default' => true],
                         's3_storage_uuid' => ['type' => 'string', 'description' => 'S3 storage UUID (required if save_s3 is true)'],
                         'databases_to_backup' => ['type' => 'string', 'description' => 'Comma separated list of databases to backup'],
                         'dump_all' => ['type' => 'boolean', 'description' => 'Whether to dump all databases', 'default' => false],
@@ -688,7 +692,7 @@ class DatabasesController extends Controller
     )]
     public function create_backup(Request $request)
     {
-        $backupConfigFields = ['save_s3', 'enabled', 'dump_all', 'frequency', 'databases_to_backup', 'database_backup_retention_amount_locally', 'database_backup_retention_days_locally', 'database_backup_retention_max_storage_locally', 'database_backup_retention_amount_s3', 'database_backup_retention_days_s3', 'database_backup_retention_max_storage_s3', 's3_storage_uuid', 'timeout'];
+        $backupConfigFields = ['save_s3', 'backup_method', 'pgbackrest_backup_type', 'pgbackrest_require_wal_archive', 'enabled', 'dump_all', 'frequency', 'databases_to_backup', 'database_backup_retention_amount_locally', 'database_backup_retention_days_locally', 'database_backup_retention_max_storage_locally', 'database_backup_retention_amount_s3', 'database_backup_retention_days_s3', 'database_backup_retention_max_storage_s3', 's3_storage_uuid', 'timeout'];
 
         $teamId = getTeamIdFromToken();
         if (is_null($teamId)) {
@@ -705,6 +709,9 @@ class DatabasesController extends Controller
             'frequency' => 'required|string',
             'enabled' => 'boolean',
             'save_s3' => 'boolean',
+            'backup_method' => 'string|in:dump,pgbackrest',
+            'pgbackrest_backup_type' => 'string|in:full,diff,incr',
+            'pgbackrest_require_wal_archive' => 'boolean',
             'dump_all' => 'boolean',
             'backup_now' => 'boolean|nullable',
             's3_storage_uuid' => 'string|exists:s3_storages,uuid|nullable',
@@ -805,6 +812,11 @@ class DatabasesController extends Controller
             }
         }
 
+        $pgBackRestValidation = $this->validatePgBackRestBackupConfiguration($database, $backupData);
+        if ($pgBackRestValidation instanceof JsonResponse) {
+            return $pgBackRestValidation;
+        }
+
         // Validate databases_to_backup input
         if (! empty($backupData['databases_to_backup'])) {
             try {
@@ -887,6 +899,9 @@ class DatabasesController extends Controller
                     type: 'object',
                     properties: [
                         'save_s3' => ['type' => 'boolean', 'description' => 'Whether data is saved in s3 or not'],
+                        'backup_method' => ['type' => 'string', 'enum' => ['dump', 'pgbackrest'], 'description' => 'Backup engine. Use pgbackrest for incremental PostgreSQL backups to S3.'],
+                        'pgbackrest_backup_type' => ['type' => 'string', 'enum' => ['full', 'diff', 'incr'], 'description' => 'pgBackRest backup type when backup_method is pgbackrest.'],
+                        'pgbackrest_require_wal_archive' => ['type' => 'boolean', 'description' => 'Require PostgreSQL WAL archive verification for pgBackRest backups. When false, Coolify runs pgBackRest with --archive-check=n if WAL archiving is not configured.'],
                         's3_storage_uuid' => ['type' => 'string', 'description' => 'S3 storage UUID'],
                         'backup_now' => ['type' => 'boolean', 'description' => 'Whether to take a backup now or not'],
                         'enabled' => ['type' => 'boolean', 'description' => 'Whether the backup is enabled or not'],
@@ -929,7 +944,7 @@ class DatabasesController extends Controller
     )]
     public function update_backup(Request $request)
     {
-        $backupConfigFields = ['save_s3', 'enabled', 'dump_all', 'frequency', 'databases_to_backup', 'database_backup_retention_amount_locally', 'database_backup_retention_days_locally', 'database_backup_retention_max_storage_locally', 'database_backup_retention_amount_s3', 'database_backup_retention_days_s3', 'database_backup_retention_max_storage_s3', 's3_storage_uuid', 'timeout'];
+        $backupConfigFields = ['save_s3', 'backup_method', 'pgbackrest_backup_type', 'pgbackrest_require_wal_archive', 'enabled', 'dump_all', 'frequency', 'databases_to_backup', 'database_backup_retention_amount_locally', 'database_backup_retention_days_locally', 'database_backup_retention_max_storage_locally', 'database_backup_retention_amount_s3', 'database_backup_retention_days_s3', 'database_backup_retention_max_storage_s3', 's3_storage_uuid', 'timeout'];
 
         $teamId = getTeamIdFromToken();
         if (is_null($teamId)) {
@@ -945,6 +960,9 @@ class DatabasesController extends Controller
             'backup_now' => 'boolean|nullable',
             'enabled' => 'boolean',
             'dump_all' => 'boolean',
+            'backup_method' => 'string|in:dump,pgbackrest',
+            'pgbackrest_backup_type' => 'string|in:full,diff,incr',
+            'pgbackrest_require_wal_archive' => 'boolean',
             's3_storage_uuid' => 'string|exists:s3_storages,uuid|nullable',
             'databases_to_backup' => 'string|nullable',
             'frequency' => 'string',
@@ -1042,6 +1060,11 @@ class DatabasesController extends Controller
                 ], 422);
             }
             unset($backupData['s3_storage_uuid']);
+        }
+
+        $pgBackRestValidation = $this->validatePgBackRestBackupConfiguration($database, $backupData, $backupConfig);
+        if ($pgBackRestValidation instanceof JsonResponse) {
+            return $pgBackRestValidation;
         }
 
         // Validate databases_to_backup input
@@ -2413,15 +2436,28 @@ class DatabasesController extends Controller
             DB::beginTransaction();
             // Get all executions for this backup configuration
             $executions = $backup->executions()->get();
+            $server = $backup->server();
+            $usesPgBackRest = data_get($backup, 'backup_method') === 'pgbackrest';
+
+            $deletedFilenames = [];
+            if ($usesPgBackRest && $deleteS3 && $backup->s3) {
+                $repositoryPrefix = pgBackRestRepositoryKeyPrefix($backup);
+                if ($repositoryPrefix) {
+                    deleteBackupsS3Prefix($repositoryPrefix, $backup->s3);
+                }
+            }
 
             // Delete all execution files (locally and optionally from S3)
             foreach ($executions as $execution) {
-                if ($execution->filename) {
-                    deleteBackupsLocally($execution->filename, $database->destination->server);
+                if ($execution->filename && ! in_array($execution->filename, $deletedFilenames, true)) {
+                    if (! $usesPgBackRest && $server) {
+                        deleteBackupsLocally($execution->filename, $server);
+                    }
 
-                    if ($deleteS3 && $backup->s3) {
+                    if (! $usesPgBackRest && $deleteS3 && $backup->s3) {
                         deleteBackupsS3($execution->filename, $backup->s3);
                     }
+                    $deletedFilenames[] = $execution->filename;
                 }
 
                 $execution->delete();
@@ -2549,12 +2585,22 @@ class DatabasesController extends Controller
         }
 
         $deleteS3 = $request->boolean('delete_s3', false);
+        $usesPgBackRest = data_get($backup, 'backup_method') === 'pgbackrest';
+        if ($usesPgBackRest && $deleteS3) {
+            return response()->json([
+                'message' => 'A single pgBackRest execution cannot be deleted from S3 because executions share one repository. Delete the scheduled backup with delete_s3=true to remove the repository.',
+            ], 422);
+        }
 
         try {
             if ($execution->filename) {
-                deleteBackupsLocally($execution->filename, $database->destination->server);
+                $server = $backup->server();
 
-                if ($deleteS3 && $backup->s3) {
+                if (! $usesPgBackRest && $server) {
+                    deleteBackupsLocally($execution->filename, $server);
+                }
+
+                if (! $usesPgBackRest && $deleteS3 && $backup->s3) {
                     deleteBackupsS3($execution->filename, $backup->s3);
                 }
             }
@@ -4070,5 +4116,51 @@ class DatabasesController extends Controller
         ]);
 
         return response()->json(['message' => 'Storage deleted.']);
+    }
+
+    private function validatePgBackRestBackupConfiguration($database, array &$backupData, ?ScheduledDatabaseBackup $existingBackup = null): ?JsonResponse
+    {
+        $backupMethod = $backupData['backup_method'] ?? data_get($existingBackup, 'backup_method', 'dump');
+        if ($backupMethod !== 'pgbackrest') {
+            return null;
+        }
+
+        $databaseType = $database instanceof ServiceDatabase ? $database->databaseType() : $database->type();
+        if (! str($databaseType)->contains('postgres')) {
+            return response()->json([
+                'message' => 'Validation failed.',
+                'errors' => ['backup_method' => ['pgBackRest backups are only supported for PostgreSQL databases.']],
+            ], 422);
+        }
+
+        $saveS3 = array_key_exists('save_s3', $backupData) ? (bool) $backupData['save_s3'] : (bool) data_get($existingBackup, 'save_s3', false);
+        $s3StorageId = $backupData['s3_storage_id'] ?? data_get($existingBackup, 's3_storage_id');
+
+        if (! $saveS3 || blank($s3StorageId)) {
+            return response()->json([
+                'message' => 'Validation failed.',
+                'errors' => [
+                    'backup_method' => ['pgBackRest backups require S3 storage because pgBackRest writes an incremental repository instead of a single local dump file.'],
+                    'save_s3' => ['The save_s3 field must be true when backup_method is pgbackrest.'],
+                    's3_storage_uuid' => ['The s3_storage_uuid field is required when backup_method is pgbackrest.'],
+                ],
+            ], 422);
+        }
+
+        $backupData['backup_method'] = 'pgbackrest';
+        $backupData['pgbackrest_backup_type'] = $backupData['pgbackrest_backup_type'] ?? data_get($existingBackup, 'pgbackrest_backup_type', 'incr');
+        $pgBackRestRequireWalArchive = array_key_exists('pgbackrest_require_wal_archive', $backupData)
+            ? $backupData['pgbackrest_require_wal_archive']
+            : data_get($existingBackup, 'pgbackrest_require_wal_archive');
+        $backupData['pgbackrest_require_wal_archive'] = $pgBackRestRequireWalArchive === null ? true : (bool) $pgBackRestRequireWalArchive;
+        $backupData['dump_all'] = true;
+        $backupData['databases_to_backup'] = null;
+        $backupData['disable_local_backup'] = true;
+        $backupData['database_backup_retention_amount_locally'] = 0;
+        $backupData['database_backup_retention_days_locally'] = 0;
+        $backupData['database_backup_retention_max_storage_locally'] = 0;
+        $backupData['database_backup_retention_max_storage_s3'] = 0;
+
+        return null;
     }
 }

--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -65,6 +65,14 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
 
     public ?string $postgres_password = null;
 
+    public ?string $postgres_data_path = null;
+
+    public ?string $postgres_pgdata_path = null;
+
+    public ?string $postgres_uid = null;
+
+    public ?string $postgres_gid = null;
+
     public ?string $mongo_root_username = null;
 
     public ?string $mongo_root_password = null;
@@ -158,6 +166,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                     } else {
                         $databasesToBackup = $this->database->postgres_user;
                     }
+                    $this->database->postgres_db = $databasesToBackup;
                     $this->postgres_password = $envs->filter(function ($env) {
                         return str($env)->startsWith('POSTGRES_PASSWORD=');
                     })->first();
@@ -260,6 +269,9 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                 $this->container_name = $this->database->uuid;
                 $this->directory_name = $databaseName.'-'.$this->container_name;
                 $databaseType = $this->database->type();
+                if (str($databaseType)->contains('postgres')) {
+                    $this->postgres_password = data_get($this->database, 'postgres_password');
+                }
                 $databasesToBackup = data_get($this->backup, 'databases_to_backup');
             }
             if (blank($databasesToBackup)) {
@@ -305,6 +317,10 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                 $ip = Str::slug($this->server->ip);
                 $this->backup_dir = backup_dir().'/coolify'."/coolify-db-$ip";
             }
+            $usesPgBackRest = $this->usesPgBackRest($databaseType);
+            if ($usesPgBackRest) {
+                $databasesToBackup = ['postgres-cluster'];
+            }
             foreach ($databasesToBackup as $database) {
                 // Generate unique UUID for each database backup execution
                 $attempts = 0;
@@ -324,11 +340,17 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                 // Step 1: Create local backup
                 try {
                     if (str($databaseType)->contains('postgres')) {
-                        $this->backup_file = "/pg-dump-$database-".Carbon::now()->timestamp.'.dmp';
-                        if ($this->backup->dump_all) {
-                            $this->backup_file = '/pg-dump-all-'.Carbon::now()->timestamp.'.gz';
+                        if ($usesPgBackRest) {
+                            $stanza = $this->pgBackRestStanzaName();
+                            $this->backup_file = '/pgbackrest-'.$stanza.'-'.Carbon::now()->timestamp;
+                            $this->backup_location = $this->pgBackRestRepositoryKeyPrefix($stanza);
+                        } else {
+                            $this->backup_file = "/pg-dump-$database-".Carbon::now()->timestamp.'.dmp';
+                            if ($this->backup->dump_all) {
+                                $this->backup_file = '/pg-dump-all-'.Carbon::now()->timestamp.'.gz';
+                            }
+                            $this->backup_location = $this->backup_dir.$this->backup_file;
                         }
-                        $this->backup_location = $this->backup_dir.$this->backup_file;
                         $this->backup_log = ScheduledDatabaseBackupExecution::create([
                             'uuid' => $this->backup_log_uuid,
                             'database_name' => $database,
@@ -336,7 +358,11 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                             'scheduled_database_backup_id' => $this->backup->id,
                             'local_storage_deleted' => false,
                         ]);
-                        $this->backup_standalone_postgresql($database);
+                        if ($usesPgBackRest) {
+                            $this->backup_standalone_postgresql_pgbackrest($stanza);
+                        } else {
+                            $this->backup_standalone_postgresql($database);
+                        }
                     } elseif (str($databaseType)->contains('mongo')) {
                         if ($database === '*') {
                             $database = 'all';
@@ -390,10 +416,10 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                         throw new \Exception('Unsupported database type');
                     }
 
-                    $size = $this->calculate_size();
+                    $size = $usesPgBackRest ? $this->calculate_pgbackrest_size() : $this->calculate_size();
 
                     // Verify local backup succeeded
-                    if ($size > 0) {
+                    if ($usesPgBackRest || $size > 0) {
                         $localBackupSucceeded = true;
                     } else {
                         throw new \Exception('Local backup file is empty or was not created');
@@ -423,8 +449,8 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                 }
 
                 // Step 2: Upload to S3 if enabled (independent of local backup)
-                $localStorageDeleted = false;
-                if ($this->backup->save_s3 && $localBackupSucceeded) {
+                $localStorageDeleted = $usesPgBackRest;
+                if (! $usesPgBackRest && $this->backup->save_s3 && $localBackupSucceeded) {
                     try {
                         $this->upload_to_s3();
 
@@ -474,7 +500,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
                     }
                 }
             }
-            if ($this->backup_log && $this->backup_log->status === 'success') {
+            if ($this->backup_log && $this->backup_log->status === 'success' && ! $usesPgBackRest) {
                 removeOldBackups($this->backup);
             }
         } catch (Throwable $e) {
@@ -594,6 +620,384 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
         }
     }
 
+    private function backup_standalone_postgresql_pgbackrest(string $stanza): void
+    {
+        if (! $this->backup->save_s3) {
+            throw new \Exception('pgBackRest backups require S3 storage because pgBackRest writes an incremental repository instead of a single local dump file.');
+        }
+
+        if (is_null($this->s3)) {
+            throw new \Exception('S3 storage configuration is required for pgBackRest backups.');
+        }
+
+        $remoteEnvFile = null;
+        try {
+            $this->s3->testConnection(shouldSave: true);
+            $this->postgres_data_path = $this->discoverPostgresDataPathOnHost();
+            instant_remote_process(['mkdir -p '.escapeshellarg($this->backup_dir)], $this->server, true, false, $this->timeout, disableMultiplexing: true);
+
+            $archiveCheckEnabled = $this->pgBackRestArchiveCheckEnabled();
+            $requiresWalArchive = $this->pgBackRestRequiresWalArchive();
+            if (! $archiveCheckEnabled && $requiresWalArchive) {
+                throw new \Exception('pgBackRest WAL archive verification is required for this backup, but PostgreSQL is not configured with archive_mode=on and archive_command using pgbackrest archive-push. Configure WAL archiving or disable WAL archive verification for this schedule to run pgBackRest with --archive-check=n.');
+            }
+            $archiveCheckWarning = $archiveCheckEnabled ? null : 'Warning: PostgreSQL WAL archiving is not configured for pgBackRest on this database, so Coolify ran pgBackRest with --archive-check=n. Configure archive_mode=on and archive_command=pgbackrest archive-push for WAL-verified/PITR backups.';
+            $remoteEnvFile = $this->pgBackRestUploadEnvFile();
+
+            $commands = [];
+            $commands[] = 'docker rm -f '.escapeshellarg('pgbackrest-of-'.$this->backup_log_uuid).' >/dev/null 2>&1 || true';
+
+            $stanzaCreate = $this->pgBackRestDockerCommand($stanza, 'stanza-create', [], $remoteEnvFile);
+            $stanzaInfo = $this->pgBackRestDockerCommand($stanza, 'info', [], $remoteEnvFile);
+            $backupOptions = [
+                '--type='.escapeshellarg($this->pgBackRestBackupType()),
+                '--start-fast=y',
+                '--expire-auto=n',
+            ];
+            if (! $archiveCheckEnabled) {
+                $backupOptions[] = '--archive-check=n';
+            }
+            $backup = $this->pgBackRestDockerCommand($stanza, 'backup', $backupOptions, $remoteEnvFile);
+
+            $commands[] = "($stanzaCreate) || ($stanzaInfo)";
+            if ($archiveCheckEnabled) {
+                $commands[] = $this->pgBackRestDockerCommand($stanza, 'check', [], $remoteEnvFile);
+            }
+            $commands[] = $backup;
+
+            $this->backup_output = instant_remote_process($commands, $this->server, true, false, $this->timeout, disableMultiplexing: true);
+            $this->backup_output = trim($this->backup_output);
+
+            $expireWarning = null;
+            if (! empty($this->pgBackRestRetentionOptions())) {
+                try {
+                    $expireOutput = instant_remote_process([$this->pgBackRestDockerCommand($stanza, 'expire', $this->pgBackRestRetentionOptions(), $remoteEnvFile)], $this->server, true, false, $this->timeout, disableMultiplexing: true);
+                    $expireOutput = trim($expireOutput);
+                    if ($expireOutput !== '') {
+                        $this->backup_output = $this->backup_output === '' ? $expireOutput : $this->backup_output."\n".$expireOutput;
+                    }
+                } catch (Throwable $expireException) {
+                    $expireWarning = 'Warning: pgBackRest backup completed but retention expire failed: '.$expireException->getMessage();
+                    Log::channel('scheduled-errors')->warning('pgBackRest expire failed after successful backup', [
+                        'backup_id' => $this->backup->uuid,
+                        'error' => $expireException->getMessage(),
+                    ]);
+                }
+            }
+
+            foreach ([$archiveCheckWarning, $expireWarning] as $warning) {
+                if ($warning) {
+                    $this->backup_output = $this->backup_output === '' ? $warning : $warning."\n\n".$this->backup_output;
+                }
+            }
+            if ($this->backup_output === '') {
+                $this->backup_output = 'pgBackRest backup completed successfully.';
+            }
+            $this->s3_uploaded = true;
+        } catch (Throwable $e) {
+            $this->s3_uploaded = false;
+            $this->add_to_error_output($e->getMessage());
+            throw $e;
+        } finally {
+            if ($remoteEnvFile) {
+                try {
+                    $this->pgBackRestCleanupRemoteEnvFile($remoteEnvFile);
+                } catch (Throwable $cleanupException) {
+                    Log::channel('scheduled-errors')->warning('Unable to remove temporary pgBackRest environment file', [
+                        'backup_id' => $this->backup->uuid,
+                        'error' => $cleanupException->getMessage(),
+                    ]);
+                }
+            }
+        }
+    }
+
+    private function usesPgBackRest(string $databaseType): bool
+    {
+        return str($databaseType)->contains('postgres') && data_get($this->backup, 'backup_method', 'dump') === 'pgbackrest';
+    }
+
+    private function pgBackRestStanzaName(): string
+    {
+        $stanza = Str::of('coolify-'.$this->backup->uuid)
+            ->replaceMatches('/[^A-Za-z0-9_-]/', '-')
+            ->lower()
+            ->limit(63, '')
+            ->value();
+
+        validateShellSafePath($stanza, 'pgBackRest stanza');
+
+        return $stanza;
+    }
+
+    private function pgBackRestBackupType(): string
+    {
+        $type = data_get($this->backup, 'pgbackrest_backup_type', 'incr');
+
+        return in_array($type, ['full', 'diff', 'incr'], true) ? $type : 'incr';
+    }
+
+    private function pgBackRestRepositoryPath(string $stanza): string
+    {
+        return '/'.trim($this->backup_dir, '/').'/pgbackrest/'.$stanza;
+    }
+
+    private function pgBackRestRepositoryKeyPrefix(string $stanza): string
+    {
+        return trim($this->pgBackRestRepositoryPath($stanza), '/').'/';
+    }
+
+    private function pgBackRestDockerCommand(string $stanza, string $command, array $extraOptions, string $envFilePath): string
+    {
+        $network = data_get($this->backup, 'database_type') === ServiceDatabase::class
+            ? $this->database->service->destination->network
+            : $this->database->destination->network;
+
+        $dockerName = escapeshellarg('pgbackrest-of-'.$this->backup_log_uuid);
+        $safeNetwork = escapeshellarg($network);
+        $image = escapeshellarg(config('constants.coolify.pgbackrest_image'));
+        $pgDataPath = $this->postgres_pgdata_path ?: '/var/lib/postgresql/data';
+        $dataVolume = escapeshellarg($this->postgres_data_path.':'.$pgDataPath.':ro');
+        $envFile = ' --env-file '.escapeshellarg($envFilePath);
+
+        $options = array_merge($this->pgBackRestBaseOptions($stanza), $extraOptions);
+
+        return "docker run --rm --network {$safeNetwork} --name {$dockerName}{$envFile} -v {$dataVolume} {$image} pgbackrest ".implode(' ', $options).' '.$command;
+    }
+
+    private function pgBackRestUploadEnvFile(): string
+    {
+        $remoteEnvDirectory = $this->pgBackRestRemoteEnvDirectory();
+        $remoteEnvFile = $this->pgBackRestRemoteEnvFilePath();
+
+        $localEnvDirectory = storage_path('app/pgbackrest-env');
+        if (! is_dir($localEnvDirectory) && ! mkdir($localEnvDirectory, 0700, true) && ! is_dir($localEnvDirectory)) {
+            throw new \Exception('Unable to create local temporary directory for pgBackRest environment file.');
+        }
+
+        $localEnvFile = tempnam($localEnvDirectory, 'pgbackrest-');
+        if ($localEnvFile === false) {
+            throw new \Exception('Unable to create local temporary pgBackRest environment file.');
+        }
+
+        try {
+            $bytesWritten = file_put_contents($localEnvFile, $this->pgBackRestEnvFileContents());
+            if ($bytesWritten === false) {
+                throw new \Exception('Unable to write local temporary pgBackRest environment file.');
+            }
+            chmod($localEnvFile, 0600);
+            instant_remote_process(['mkdir -m 700 '.escapeshellarg($remoteEnvDirectory)], $this->server, true, true, $this->timeout, disableMultiplexing: true);
+            instant_scp($localEnvFile, $remoteEnvFile, $this->server);
+            instant_remote_process(['chmod 600 '.escapeshellarg($remoteEnvFile)], $this->server, true, true, $this->timeout, disableMultiplexing: true);
+        } catch (Throwable $e) {
+            try {
+                $this->pgBackRestCleanupRemoteEnvFile($remoteEnvFile);
+            } catch (Throwable) {
+            }
+            throw $e;
+        } finally {
+            if (file_exists($localEnvFile)) {
+                unlink($localEnvFile);
+            }
+        }
+
+        return $remoteEnvFile;
+    }
+
+    private function pgBackRestRemoteEnvDirectory(): string
+    {
+        if (blank($this->backup_log_uuid)) {
+            throw new \Exception('Missing pgBackRest backup execution UUID for temporary environment file.');
+        }
+
+        $directory = '/tmp/coolify-pgbackrest-'.$this->backup_log_uuid;
+        validateShellSafePath($directory, 'pgBackRest environment directory path');
+
+        return $directory;
+    }
+
+    private function pgBackRestRemoteEnvFilePath(): string
+    {
+        $path = $this->pgBackRestRemoteEnvDirectory().'/pgbackrest.env';
+        validateShellSafePath($path, 'pgBackRest environment file path');
+
+        return $path;
+    }
+
+    private function pgBackRestCleanupRemoteEnvFile(string $remoteEnvFile): void
+    {
+        validateShellSafePath($remoteEnvFile, 'pgBackRest environment file path');
+        $remoteEnvDirectory = dirname($remoteEnvFile);
+        validateShellSafePath($remoteEnvDirectory, 'pgBackRest environment directory path');
+
+        instant_remote_process([
+            'rm -f '.escapeshellarg($remoteEnvFile).' && rmdir '.escapeshellarg($remoteEnvDirectory).' 2>/dev/null || true',
+        ], $this->server, false, true, $this->timeout, disableMultiplexing: true);
+    }
+
+    private function pgBackRestEnvFileContents(): string
+    {
+        $lines = array_filter([
+            $this->pgBackRestEnvFileLine('PGHOST', $this->container_name),
+            $this->pgBackRestEnvFileLine('PGPORT', '5432'),
+            $this->postgres_password ? $this->pgBackRestEnvFileLine('PGPASSWORD', $this->postgres_password) : null,
+            filled($this->postgres_uid) && ctype_digit($this->postgres_uid) ? $this->pgBackRestEnvFileLine('BACKREST_UID', $this->postgres_uid) : null,
+            filled($this->postgres_gid) && ctype_digit($this->postgres_gid) ? $this->pgBackRestEnvFileLine('BACKREST_GID', $this->postgres_gid) : null,
+            $this->pgBackRestEnvFileLine('PGBACKREST_REPO1_S3_KEY', $this->s3->key),
+            $this->pgBackRestEnvFileLine('PGBACKREST_REPO1_S3_KEY_SECRET', $this->s3->secret),
+        ]);
+
+        return implode("\n", $lines)."\n";
+    }
+
+    private function pgBackRestEnvFileLine(string $key, ?string $value): string
+    {
+        if (! preg_match('/^[A-Z0-9_]+$/', $key)) {
+            throw new \Exception('Invalid pgBackRest environment variable name.');
+        }
+
+        $value = (string) $value;
+        if (str_contains($value, "\0") || str_contains($value, "\n") || str_contains($value, "\r")) {
+            throw new \Exception("pgBackRest environment value for {$key} contains unsupported control characters.");
+        }
+
+        return "{$key}={$value}";
+    }
+
+    private function pgBackRestBaseOptions(string $stanza): array
+    {
+        $database = data_get($this->database, 'postgres_db') ?: 'postgres';
+        $username = data_get($this->database, 'postgres_user') ?: 'postgres';
+        $pgDataPath = $this->postgres_pgdata_path ?: '/var/lib/postgresql/data';
+
+        return [
+            '--stanza='.escapeshellarg($stanza),
+            '--pg1-path='.escapeshellarg($pgDataPath),
+            '--pg1-user='.escapeshellarg($username),
+            '--pg1-database='.escapeshellarg($database),
+            '--repo1-type=s3',
+            '--repo1-path='.escapeshellarg($this->pgBackRestRepositoryPath($stanza)),
+            '--repo1-s3-bucket='.escapeshellarg($this->s3->bucket),
+            '--repo1-s3-endpoint='.escapeshellarg($this->normalizedS3Endpoint()),
+            '--repo1-s3-region='.escapeshellarg($this->s3->region ?: 'us-east-1'),
+            '--repo1-s3-uri-style=path',
+            '--log-level-console=info',
+            '--process-max=2',
+        ];
+    }
+
+    private function pgBackRestRetentionOptions(): array
+    {
+        $retentionAmount = (int) data_get($this->backup, 'database_backup_retention_amount_s3', 0);
+        $retentionDays = (int) data_get($this->backup, 'database_backup_retention_days_s3', 0);
+
+        if ($retentionAmount > 0) {
+            return [
+                '--repo1-retention-full='.escapeshellarg((string) $retentionAmount),
+                '--repo1-retention-full-type=count',
+            ];
+        }
+
+        if ($retentionDays > 0) {
+            return [
+                '--repo1-retention-full='.escapeshellarg((string) $retentionDays),
+                '--repo1-retention-full-type=time',
+            ];
+        }
+
+        return [];
+    }
+
+    private function pgBackRestArchiveCheckEnabled(): bool
+    {
+        $archiveMode = strtolower($this->postgresPsqlValue('SHOW archive_mode;'));
+        $archiveCommand = strtolower($this->postgresPsqlValue('SHOW archive_command;'));
+
+        return in_array($archiveMode, ['on', 'always'], true)
+            && str_contains($archiveCommand, 'pgbackrest')
+            && str_contains($archiveCommand, 'archive-push');
+    }
+
+    private function pgBackRestRequiresWalArchive(): bool
+    {
+        $value = data_get($this->backup, 'pgbackrest_require_wal_archive');
+
+        return $value === null ? true : (bool) $value;
+    }
+
+    private function postgresPsqlValue(string $sql): string
+    {
+        return trim(instant_remote_process([$this->postgresPsqlCommand($sql).' 2>/dev/null || true'], $this->server, false, false, null, disableMultiplexing: true));
+    }
+
+    private function postgresPsqlCommand(string $sql): string
+    {
+        $container = escapeshellarg($this->container_name);
+        $username = escapeshellarg(data_get($this->database, 'postgres_user') ?: 'postgres');
+        $database = escapeshellarg(data_get($this->database, 'postgres_db') ?: 'postgres');
+        $command = 'export PGPASSWORD="${PGPASSWORD:-${POSTGRES_PASSWORD:-}}"; exec psql -tA -v ON_ERROR_STOP=1 -U '.$username.' -d '.$database.' -c '.escapeshellarg($sql);
+
+        return "docker exec {$container} sh -lc ".escapeshellarg($command);
+    }
+
+    private function discoverPostgresDataPathOnHost(): string
+    {
+        $container = escapeshellarg($this->container_name);
+        $pgData = $this->postgresPsqlValue('SHOW data_directory;');
+        if ($pgData === '') {
+            $pgData = trim(instant_remote_process(["docker exec {$container} printenv PGDATA || true"], $this->server, false, false, null, disableMultiplexing: true));
+        }
+        if ($pgData === '') {
+            $pgData = '/var/lib/postgresql/data';
+        }
+        $this->postgres_pgdata_path = rtrim($pgData, '/');
+        $this->postgres_uid = trim(instant_remote_process(["docker exec {$container} sh -lc 'id -u postgres 2>/dev/null || id -u'"], $this->server, false, false, null, disableMultiplexing: true));
+        $this->postgres_gid = trim(instant_remote_process(["docker exec {$container} sh -lc 'id -g postgres 2>/dev/null || id -g'"], $this->server, false, false, null, disableMultiplexing: true));
+
+        $mounts = instant_remote_process(["docker inspect --format '{{range .Mounts}}{{printf \"%s|%s\\n\" .Destination .Source}}{{end}}' {$container}"], $this->server, true, false, null, disableMultiplexing: true);
+        $bestDestination = null;
+        $bestSource = null;
+
+        foreach (explode("\n", trim($mounts)) as $line) {
+            if (! str_contains($line, '|')) {
+                continue;
+            }
+            [$destination, $source] = array_pad(explode('|', $line, 2), 2, null);
+            $destination = rtrim((string) $destination, '/');
+            $source = rtrim((string) $source, '/');
+            if ($destination === '' || $source === '') {
+                continue;
+            }
+            if ($this->postgres_pgdata_path === $destination || str_starts_with($this->postgres_pgdata_path, $destination.'/')) {
+                if ($bestDestination === null || strlen($destination) > strlen($bestDestination)) {
+                    $bestDestination = $destination;
+                    $bestSource = $source;
+                }
+            }
+        }
+
+        if ($bestDestination === null || $bestSource === null) {
+            throw new \Exception("Unable to find a Docker volume or bind mount for PostgreSQL PGDATA path {$pgData}. pgBackRest requires access to the database data directory.");
+        }
+
+        $relative = ltrim(substr($this->postgres_pgdata_path, strlen($bestDestination)), '/');
+
+        return $bestSource.($relative ? '/'.$relative : '');
+    }
+
+    private function normalizedS3Endpoint(): string
+    {
+        $endpoint = (string) $this->s3->endpoint;
+        $host = parse_url($endpoint, PHP_URL_HOST);
+        $port = parse_url($endpoint, PHP_URL_PORT);
+
+        if ($host) {
+            return $host.($port ? ':'.$port : '');
+        }
+
+        return rtrim(preg_replace('#^https?://#', '', $endpoint), '/');
+    }
+
     private function backup_standalone_mysql(string $database): void
     {
         try {
@@ -662,7 +1066,12 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
 
     private function calculate_size()
     {
-        return instant_remote_process(["du -b $this->backup_location | cut -f1"], $this->server, false, false, null, disableMultiplexing: true);
+        return instant_remote_process(['du -sb '.escapeshellarg($this->backup_location).' | cut -f1'], $this->server, false, false, null, disableMultiplexing: true);
+    }
+
+    private function calculate_pgbackrest_size(): int
+    {
+        return 0;
     }
 
     private function upload_to_s3(): void

--- a/app/Livewire/Project/Database/BackupEdit.php
+++ b/app/Livewire/Project/Database/BackupEdit.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\Project\Database;
 
 use App\Models\ScheduledDatabaseBackup;
+use App\Models\ServiceDatabase;
 use Exception;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Livewire\Attributes\Locked;
@@ -63,6 +64,15 @@ class BackupEdit extends Component
     #[Validate(['required', 'boolean'])]
     public bool $saveS3 = false;
 
+    #[Validate(['required', 'string', 'in:dump,pgbackrest'])]
+    public string $backupMethod = 'dump';
+
+    #[Validate(['required', 'string', 'in:full,diff,incr'])]
+    public string $pgBackRestBackupType = 'incr';
+
+    #[Validate(['required', 'boolean'])]
+    public bool $pgBackRestRequireWalArchive = true;
+
     #[Validate(['required', 'boolean'])]
     public bool $disableLocalBackup = false;
 
@@ -78,11 +88,15 @@ class BackupEdit extends Component
     #[Validate(['required', 'int', 'min:60', 'max:36000'])]
     public int|string $timeout = 3600;
 
+    public bool $isPostgres = false;
+
     public function mount()
     {
         try {
             $this->authorize('view', $this->backup->database);
             $this->parameters = get_route_parameters();
+            $this->s3s = currentTeam()->s3s;
+            $this->isPostgres = $this->isPostgresDatabase();
             $this->syncData();
         } catch (Exception $e) {
             return handleError($e, $this);
@@ -101,12 +115,15 @@ class BackupEdit extends Component
             $this->backup->database_backup_retention_days_s3 = $this->databaseBackupRetentionDaysS3;
             $this->backup->database_backup_retention_max_storage_s3 = $this->databaseBackupRetentionMaxStorageS3;
             $this->backup->save_s3 = $this->saveS3;
+            $this->backup->backup_method = $this->backupMethod;
+            $this->backup->pgbackrest_backup_type = $this->pgBackRestBackupType;
+            $this->backup->pgbackrest_require_wal_archive = $this->pgBackRestRequireWalArchive;
             $this->backup->disable_local_backup = $this->disableLocalBackup;
             $this->backup->s3_storage_id = $this->s3StorageId;
 
             // Validate databases_to_backup to prevent command injection
             // Handles all formats including MongoDB's "db:col1,col2|db2:col3"
-            if (filled($this->databasesToBackup)) {
+            if ($this->backupMethod !== 'pgbackrest' && filled($this->databasesToBackup)) {
                 validateDatabasesBackupInput($this->databasesToBackup);
             }
 
@@ -126,6 +143,9 @@ class BackupEdit extends Component
             $this->databaseBackupRetentionDaysS3 = $this->backup->database_backup_retention_days_s3;
             $this->databaseBackupRetentionMaxStorageS3 = $this->backup->database_backup_retention_max_storage_s3;
             $this->saveS3 = $this->backup->save_s3;
+            $this->backupMethod = $this->backup->backup_method ?? 'dump';
+            $this->pgBackRestBackupType = $this->backup->pgbackrest_backup_type ?? 'incr';
+            $this->pgBackRestRequireWalArchive = $this->backup->pgbackrest_require_wal_archive ?? true;
             $this->disableLocalBackup = $this->backup->disable_local_backup ?? false;
             $this->s3StorageId = $this->backup->s3_storage_id;
             $this->databasesToBackup = $this->backup->databases_to_backup;
@@ -144,10 +164,18 @@ class BackupEdit extends Component
 
         try {
             $server = null;
-            if ($this->backup->database instanceof \App\Models\ServiceDatabase) {
+            if ($this->backup->database instanceof ServiceDatabase) {
                 $server = $this->backup->database->service->destination->server;
             } elseif ($this->backup->database->destination && $this->backup->database->destination->server) {
                 $server = $this->backup->database->destination->server;
+            }
+
+            $usesPgBackRest = data_get($this->backup, 'backup_method') === 'pgbackrest';
+            if ($usesPgBackRest && $this->delete_associated_backups_s3 && $this->backup->s3) {
+                $repositoryPrefix = pgBackRestRepositoryKeyPrefix($this->backup);
+                if ($repositoryPrefix) {
+                    deleteBackupsS3Prefix($repositoryPrefix, $this->backup->s3);
+                }
             }
 
             $filenames = $this->backup->executions()
@@ -156,21 +184,23 @@ class BackupEdit extends Component
                 ->where('scheduled_database_backup_id', $this->backup->id)
                 ->pluck('filename')
                 ->filter()
+                ->unique()
+                ->values()
                 ->all();
 
             if (! empty($filenames)) {
-                if ($this->delete_associated_backups_locally && $server) {
+                if (! $usesPgBackRest && $this->delete_associated_backups_locally && $server) {
                     deleteBackupsLocally($filenames, $server);
                 }
 
-                if ($this->delete_associated_backups_s3 && $this->backup->s3) {
+                if (! $usesPgBackRest && $this->delete_associated_backups_s3 && $this->backup->s3) {
                     deleteBackupsS3($filenames, $this->backup->s3);
                 }
             }
 
             $this->backup->delete();
 
-            if ($this->backup->database->getMorphClass() === \App\Models\ServiceDatabase::class) {
+            if ($this->backup->database->getMorphClass() === ServiceDatabase::class) {
                 $serviceDatabase = $this->backup->database;
 
                 return redirect()->route('project.service.database.backups', [
@@ -182,7 +212,7 @@ class BackupEdit extends Component
             } else {
                 return redirect()->route('project.database.backup.index', $this->parameters);
             }
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->dispatch('error', 'Failed to delete backup: '.$e->getMessage());
 
             return handleError($e, $this);
@@ -201,10 +231,38 @@ class BackupEdit extends Component
         }
     }
 
+    public function updatedBackupMethod(string $value): void
+    {
+        if ($value === 'pgbackrest') {
+            $this->saveS3 = true;
+            $this->disableLocalBackup = true;
+            $this->dumpAll = true;
+            $this->databasesToBackup = null;
+            $this->databaseBackupRetentionAmountLocally = 0;
+            $this->databaseBackupRetentionDaysLocally = 0;
+            $this->databaseBackupRetentionMaxStorageLocally = 0;
+            $this->databaseBackupRetentionMaxStorageS3 = 0;
+            if (blank($this->s3StorageId) && $this->s3s->count() > 0) {
+                $this->s3StorageId = $this->s3s->first()->id;
+            }
+        }
+    }
+
+    public function updatedSaveS3(bool $value): void
+    {
+        if ($this->backupMethod === 'pgbackrest' && ! $value) {
+            $this->saveS3 = true;
+        }
+    }
+
     private function customValidate()
     {
         if (! is_numeric($this->backup->s3_storage_id)) {
             $this->backup->s3_storage_id = null;
+        }
+
+        if (filled($this->backup->s3_storage_id) && ! $this->selectedS3StorageBelongsToCurrentTeam()) {
+            throw new Exception('The selected S3 storage is invalid for this team.');
         }
 
         // Validate that disable_local_backup can only be true when S3 backup is enabled
@@ -212,9 +270,25 @@ class BackupEdit extends Component
             $this->backup->disable_local_backup = $this->disableLocalBackup = false;
         }
 
+        if ($this->backup->backup_method === 'pgbackrest') {
+            if (! $this->isPostgresDatabase()) {
+                throw new Exception('pgBackRest backups are only supported for PostgreSQL databases.');
+            }
+            if (! $this->backup->save_s3 || blank($this->backup->s3_storage_id)) {
+                throw new Exception('pgBackRest backups require S3 storage.');
+            }
+            $this->backup->disable_local_backup = $this->disableLocalBackup = true;
+            $this->backup->dump_all = $this->dumpAll = true;
+            $this->backup->databases_to_backup = $this->databasesToBackup = null;
+            $this->backup->database_backup_retention_amount_locally = $this->databaseBackupRetentionAmountLocally = 0;
+            $this->backup->database_backup_retention_days_locally = $this->databaseBackupRetentionDaysLocally = 0;
+            $this->backup->database_backup_retention_max_storage_locally = $this->databaseBackupRetentionMaxStorageLocally = 0;
+            $this->backup->database_backup_retention_max_storage_s3 = $this->databaseBackupRetentionMaxStorageS3 = 0;
+        }
+
         $isValid = validate_cron_expression($this->backup->frequency);
         if (! $isValid) {
-            throw new \Exception('Invalid Cron / Human expression');
+            throw new Exception('Invalid Cron / Human expression');
         }
         $this->validate();
     }
@@ -231,14 +305,38 @@ class BackupEdit extends Component
         }
     }
 
+    private function selectedS3StorageBelongsToCurrentTeam(): bool
+    {
+        if (blank($this->s3StorageId)) {
+            return false;
+        }
+
+        return currentTeam()->s3s()->whereKey($this->s3StorageId)->exists();
+    }
+
+    private function isPostgresDatabase(): bool
+    {
+        $databaseType = $this->backup->database instanceof ServiceDatabase
+            ? $this->backup->database->databaseType()
+            : $this->backup->database->type();
+
+        return str($databaseType)->contains('postgres');
+    }
+
     public function render()
     {
+        $checkboxes = [
+            ['id' => 'delete_associated_backups_s3', 'label' => $this->backupMethod === 'pgbackrest'
+                ? 'The pgBackRest repository for this backup job will be permanently deleted from the selected S3 Storage.'
+                : 'All backups will be permanently deleted (associated with this backup job) from the selected S3 Storage.'],
+        ];
+
+        if ($this->backupMethod !== 'pgbackrest') {
+            array_unshift($checkboxes, ['id' => 'delete_associated_backups_locally', 'label' => __('database.delete_backups_locally')]);
+        }
+
         return view('livewire.project.database.backup-edit', [
-            'checkboxes' => [
-                ['id' => 'delete_associated_backups_locally', 'label' => __('database.delete_backups_locally')],
-                ['id' => 'delete_associated_backups_s3', 'label' => 'All backups will be permanently deleted (associated with this backup job) from the selected S3 Storage.'],
-                // ['id' => 'delete_associated_backups_sftp', 'label' => 'All backups associated with this backup job from this database will be permanently deleted from the selected SFTP Storage.']
-            ],
+            'checkboxes' => $checkboxes,
         ]);
     }
 }

--- a/app/Livewire/Project/Database/BackupExecutions.php
+++ b/app/Livewire/Project/Database/BackupExecutions.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\Project\Database;
 
 use App\Models\ScheduledDatabaseBackup;
+use App\Models\ServiceDatabase;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Component;
@@ -78,15 +79,24 @@ class BackupExecutions extends Component
             return;
         }
 
-        $server = $execution->scheduledDatabaseBackup->database->getMorphClass() === \App\Models\ServiceDatabase::class
+        $server = $execution->scheduledDatabaseBackup->database->getMorphClass() === ServiceDatabase::class
             ? $execution->scheduledDatabaseBackup->database->service->destination->server
             : $execution->scheduledDatabaseBackup->database->destination->server;
 
         try {
-            if ($execution->filename) {
-                deleteBackupsLocally($execution->filename, $server);
+            $usesPgBackRest = data_get($execution->scheduledDatabaseBackup, 'backup_method') === 'pgbackrest';
+            if ($usesPgBackRest && $this->delete_backup_s3) {
+                $this->dispatch('error', 'A single pgBackRest execution cannot be deleted from S3 because executions share one repository. Delete the scheduled backup and choose the S3 repository option to remove it.');
 
-                if ($this->delete_backup_s3 && $execution->scheduledDatabaseBackup->s3) {
+                return true;
+            }
+
+            if ($execution->filename) {
+                if (! $usesPgBackRest) {
+                    deleteBackupsLocally($execution->filename, $server);
+                }
+
+                if (! $usesPgBackRest && $this->delete_backup_s3 && $execution->scheduledDatabaseBackup->s3) {
                     deleteBackupsS3($execution->filename, $execution->scheduledDatabaseBackup->s3);
                 }
             }
@@ -185,7 +195,7 @@ class BackupExecutions extends Component
         if ($this->database) {
             $server = null;
 
-            if ($this->database instanceof \App\Models\ServiceDatabase) {
+            if ($this->database instanceof ServiceDatabase) {
                 $server = $this->database->service->destination->server;
             } elseif ($this->database->destination && $this->database->destination->server) {
                 $server = $this->database->destination->server;

--- a/app/Livewire/Project/Database/CreateScheduledBackup.php
+++ b/app/Livewire/Project/Database/CreateScheduledBackup.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\Project\Database;
 
 use App\Models\ScheduledDatabaseBackup;
+use App\Models\ServiceDatabase;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Collection;
 use Livewire\Attributes\Locked;
@@ -19,10 +20,21 @@ class CreateScheduledBackup extends Component
     #[Validate(['required', 'boolean'])]
     public bool $saveToS3 = false;
 
+    #[Validate(['required', 'string', 'in:dump,pgbackrest'])]
+    public string $backupMethod = 'dump';
+
+    #[Validate(['required', 'string', 'in:full,diff,incr'])]
+    public string $pgBackRestBackupType = 'incr';
+
+    #[Validate(['required', 'boolean'])]
+    public bool $pgBackRestRequireWalArchive = true;
+
     #[Locked]
     public $database;
 
     public bool $enabled = true;
+
+    public bool $isPostgres = false;
 
     #[Validate(['nullable', 'integer'])]
     public ?int $s3StorageId = null;
@@ -36,6 +48,7 @@ class CreateScheduledBackup extends Component
             if ($this->definedS3s->count() > 0) {
                 $this->s3StorageId = $this->definedS3s->first()->id;
             }
+            $this->isPostgres = $this->isPostgresDatabase();
         } catch (\Throwable $e) {
             return handleError($e, $this);
         }
@@ -55,17 +68,43 @@ class CreateScheduledBackup extends Component
                 return;
             }
 
+            if ($this->backupMethod === 'pgbackrest') {
+                if (! $this->isPostgresDatabase()) {
+                    $this->dispatch('error', 'pgBackRest backups are only supported for PostgreSQL databases.');
+
+                    return;
+                }
+                if (! $this->saveToS3 || blank($this->s3StorageId)) {
+                    $this->dispatch('error', 'pgBackRest backups require S3 storage.');
+
+                    return;
+                }
+            }
+
+            if (filled($this->s3StorageId) && ! $this->selectedS3StorageBelongsToCurrentTeam()) {
+                $this->dispatch('error', 'The selected S3 storage is invalid for this team.');
+
+                return;
+            }
+
             $payload = [
                 'enabled' => true,
                 'frequency' => $this->frequency,
                 'save_s3' => $this->saveToS3,
+                'backup_method' => $this->backupMethod,
+                'pgbackrest_backup_type' => $this->pgBackRestBackupType,
+                'pgbackrest_require_wal_archive' => $this->pgBackRestRequireWalArchive,
                 's3_storage_id' => $this->s3StorageId,
                 'database_id' => $this->database->id,
                 'database_type' => $this->database->getMorphClass(),
                 'team_id' => currentTeam()->id,
             ];
 
-            if ($this->database->type() === 'standalone-postgresql') {
+            if ($this->backupMethod === 'pgbackrest') {
+                $payload['dump_all'] = true;
+                $payload['databases_to_backup'] = null;
+                $payload['disable_local_backup'] = true;
+            } elseif ($this->database->type() === 'standalone-postgresql') {
                 $payload['databases_to_backup'] = $this->database->postgres_db;
             } elseif ($this->database->type() === 'standalone-mysql') {
                 $payload['databases_to_backup'] = $this->database->mysql_database;
@@ -74,7 +113,7 @@ class CreateScheduledBackup extends Component
             }
 
             $databaseBackup = ScheduledDatabaseBackup::create($payload);
-            if ($this->database->getMorphClass() === \App\Models\ServiceDatabase::class) {
+            if ($this->database->getMorphClass() === ServiceDatabase::class) {
                 $this->dispatch('refreshScheduledBackups', $databaseBackup->id);
             } else {
                 $this->dispatch('refreshScheduledBackups');
@@ -85,5 +124,40 @@ class CreateScheduledBackup extends Component
         } finally {
             $this->frequency = '';
         }
+    }
+
+    public function updatedBackupMethod(string $value): void
+    {
+        if ($value === 'pgbackrest') {
+            $this->saveToS3 = true;
+            if (blank($this->s3StorageId) && $this->definedS3s->count() > 0) {
+                $this->s3StorageId = $this->definedS3s->first()->id;
+            }
+        }
+    }
+
+    public function updatedSaveToS3(bool $value): void
+    {
+        if ($this->backupMethod === 'pgbackrest' && ! $value) {
+            $this->saveToS3 = true;
+        }
+    }
+
+    private function selectedS3StorageBelongsToCurrentTeam(): bool
+    {
+        if (blank($this->s3StorageId)) {
+            return false;
+        }
+
+        return currentTeam()->s3s()->whereKey($this->s3StorageId)->exists();
+    }
+
+    private function isPostgresDatabase(): bool
+    {
+        $databaseType = $this->database instanceof ServiceDatabase
+            ? $this->database->databaseType()
+            : $this->database->type();
+
+        return str($databaseType)->contains('postgres');
     }
 }

--- a/app/Models/ScheduledDatabaseBackup.php
+++ b/app/Models/ScheduledDatabaseBackup.php
@@ -13,6 +13,11 @@ class ScheduledDatabaseBackup extends BaseModel
         return [
             'database_backup_retention_max_storage_locally' => 'float',
             'database_backup_retention_max_storage_s3' => 'float',
+            'save_s3' => 'boolean',
+            'enabled' => 'boolean',
+            'dump_all' => 'boolean',
+            'disable_local_backup' => 'boolean',
+            'pgbackrest_require_wal_archive' => 'boolean',
         ];
     }
 
@@ -22,6 +27,9 @@ class ScheduledDatabaseBackup extends BaseModel
         'description',
         'enabled',
         'save_s3',
+        'backup_method',
+        'pgbackrest_backup_type',
+        'pgbackrest_require_wal_archive',
         'frequency',
         'database_backup_retention_amount_locally',
         'database_type',

--- a/bootstrap/helpers/databases.php
+++ b/bootstrap/helpers/databases.php
@@ -2,6 +2,7 @@
 
 use App\Models\EnvironmentVariable;
 use App\Models\S3Storage;
+use App\Models\ScheduledDatabaseBackup;
 use App\Models\Server;
 use App\Models\ServiceDatabase;
 use App\Models\StandaloneClickhouse;
@@ -188,7 +189,14 @@ function deleteBackupsLocally(string|array|null $filenames, Server $server): voi
     if (is_string($filenames)) {
         $filenames = [$filenames];
     }
-    $quotedFiles = array_map(fn ($file) => "\"$file\"", $filenames);
+    $filenames = collect($filenames)
+        ->filter(fn ($file) => is_string($file) && str_starts_with($file, '/'))
+        ->values()
+        ->all();
+    if (empty($filenames)) {
+        return;
+    }
+    $quotedFiles = array_map(fn ($file) => escapeshellarg($file), $filenames);
     instant_remote_process(['rm -f '.implode(' ', $quotedFiles)], $server, throwError: false);
 
     $foldersToCheck = collect($filenames)->map(fn ($file) => dirname($file))->unique();
@@ -218,6 +226,71 @@ function deleteBackupsS3(string|array|null $filenames, S3Storage $s3): void
     $disk->delete($filenames);
 }
 
+function deleteBackupsS3Prefix(?string $prefix, S3Storage $s3): void
+{
+    if (blank($prefix) || ! $s3) {
+        return;
+    }
+
+    $prefix = trim($prefix);
+    $backupBase = trim(backup_dir(), '/').'/';
+    if (
+        ! str_starts_with($prefix, $backupBase) ||
+        ! str_ends_with($prefix, '/') ||
+        ! preg_match('#/pgbackrest/coolify-[A-Za-z0-9_-]+/$#', $prefix) ||
+        str_contains($prefix, '..')
+    ) {
+        throw new InvalidArgumentException('Invalid pgBackRest S3 repository prefix.');
+    }
+
+    $disk = Storage::build([
+        'driver' => 's3',
+        'key' => $s3->key,
+        'secret' => $s3->secret,
+        'region' => $s3->region,
+        'bucket' => $s3->bucket,
+        'endpoint' => $s3->endpoint,
+        'use_path_style_endpoint' => true,
+        'aws_url' => $s3->awsUrl(),
+    ]);
+
+    $disk->deleteDirectory(rtrim($prefix, '/'));
+}
+
+function pgBackRestRepositoryKeyPrefix(ScheduledDatabaseBackup $backup): ?string
+{
+    $database = $backup->database;
+    $team = $backup->team;
+    if (! $database || ! $team) {
+        return null;
+    }
+
+    $stanza = Str::of('coolify-'.$backup->uuid)
+        ->replaceMatches('/[^A-Za-z0-9_-]/', '-')
+        ->lower()
+        ->limit(63, '')
+        ->value();
+
+    if ($database instanceof ServiceDatabase) {
+        $serviceUuid = $database->service->uuid;
+        $serviceName = str($database->service->name)->slug();
+        $containerName = "{$database->name}-$serviceUuid";
+        $directoryName = $serviceName.'-'.$containerName;
+    } else {
+        $containerName = $database->uuid;
+        $directoryName = str($database->name)->slug()->value().'-'.$containerName;
+    }
+
+    $backupDir = backup_dir().'/databases/'.str($team->name)->slug().'-'.$team->id.'/'.$directoryName;
+    if ($database->name === 'coolify-db') {
+        $server = $backup->server();
+        $ip = Str::slug($server?->ip ?? 'unknown');
+        $backupDir = backup_dir().'/coolify'."/coolify-db-$ip";
+    }
+
+    return trim($backupDir, '/').'/pgbackrest/'.$stanza.'/';
+}
+
 function deleteEmptyBackupFolder($folderPath, Server $server): void
 {
     $escapedPath = escapeshellarg($folderPath);
@@ -237,6 +310,10 @@ function deleteEmptyBackupFolder($folderPath, Server $server): void
 function removeOldBackups($backup): void
 {
     try {
+        if (data_get($backup, 'backup_method') === 'pgbackrest') {
+            return;
+        }
+
         if ($backup->executions) {
             // Delete old local backups (only if local backup is NOT disabled)
             // Note: When disable_local_backup is enabled, each execution already marks its own

--- a/config/constants.php
+++ b/config/constants.php
@@ -10,6 +10,7 @@ return [
         'base_config_path' => env('BASE_CONFIG_PATH', '/data/coolify'),
         'registry_url' => env('REGISTRY_URL', 'ghcr.io'),
         'helper_image' => env('HELPER_IMAGE', env('REGISTRY_URL', 'ghcr.io').'/coollabsio/coolify-helper'),
+        'pgbackrest_image' => env('PGBACKREST_IMAGE', 'docker.io/woblerr/pgbackrest@sha256:c85089eaa46a12b1b158886a6f1fff98101ca28be4927c67b4e3431ce79c0d19'),
         'realtime_image' => env('REALTIME_IMAGE', env('REGISTRY_URL', 'ghcr.io').'/coollabsio/coolify-realtime'),
         'is_windows_docker_desktop' => env('IS_WINDOWS_DOCKER_DESKTOP', false),
         'cdn_url' => env('CDN_URL', 'https://cdn.coollabs.io'),

--- a/database/migrations/2026_05_11_000000_add_pgbackrest_to_scheduled_database_backups_table.php
+++ b/database/migrations/2026_05_11_000000_add_pgbackrest_to_scheduled_database_backups_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('scheduled_database_backups', function (Blueprint $table) {
+            if (! Schema::hasColumn('scheduled_database_backups', 'backup_method')) {
+                $table->string('backup_method')->default('dump')->after('save_s3');
+            }
+            if (! Schema::hasColumn('scheduled_database_backups', 'pgbackrest_backup_type')) {
+                $table->string('pgbackrest_backup_type')->default('incr')->after('backup_method');
+            }
+            if (! Schema::hasColumn('scheduled_database_backups', 'pgbackrest_require_wal_archive')) {
+                $table->boolean('pgbackrest_require_wal_archive')->default(true)->after('pgbackrest_backup_type');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('scheduled_database_backups', function (Blueprint $table) {
+            if (Schema::hasColumn('scheduled_database_backups', 'pgbackrest_require_wal_archive')) {
+                $table->dropColumn('pgbackrest_require_wal_archive');
+            }
+            if (Schema::hasColumn('scheduled_database_backups', 'pgbackrest_backup_type')) {
+                $table->dropColumn('pgbackrest_backup_type');
+            }
+            if (Schema::hasColumn('scheduled_database_backups', 'backup_method')) {
+                $table->dropColumn('backup_method');
+            }
+        });
+    }
+};

--- a/resources/views/livewire/project/database/backup-edit.blade.php
+++ b/resources/views/livewire/project/database/backup-edit.blade.php
@@ -21,12 +21,15 @@
     <div class="w-64 pb-2">
         <x-forms.checkbox instantSave label="Backup Enabled" id="backupEnabled" />
         @if ($s3s->count() > 0)
-            <x-forms.checkbox instantSave label="S3 Enabled" id="saveS3" />
+            <x-forms.checkbox instantSave label="S3 Enabled" id="saveS3" :disabled="$backupMethod === 'pgbackrest'" />
         @else
             <x-forms.checkbox instantSave helper="No validated S3 storage available." label="S3 Enabled" id="saveS3"
                 disabled />
         @endif
-        @if ($backup->save_s3)
+        @if ($backupMethod === 'pgbackrest')
+            <x-forms.checkbox disabled label="Disable Local Backup" id="disableLocalBackup"
+                helper="pgBackRest writes directly to an incremental S3 repository, so there is no local dump file to keep." />
+        @elseif ($backup->save_s3)
             <x-forms.checkbox instantSave label="Disable Local Backup" id="disableLocalBackup"
                 helper="When enabled, backup files will be deleted from local storage immediately after uploading to S3. This requires S3 backup to be enabled." />
         @else
@@ -34,7 +37,7 @@
                 helper="When enabled, backup files will be deleted from local storage immediately after uploading to S3. This requires S3 backup to be enabled." />
         @endif
     </div>
-    @if ($backup->save_s3)
+    @if ($saveS3 || $backupMethod === 'pgbackrest')
         <div class="pb-6">
             <x-forms.select id="s3StorageId" label="S3 Storage" required>
                 <option value="default" disabled>Select a S3 storage</option>
@@ -46,12 +49,34 @@
     @endif
     <div class="flex flex-col gap-2">
         <h3>Settings</h3>
+        @if ($isPostgres)
+            <div class="flex gap-2">
+                <x-forms.select id="backupMethod" label="Backup Method" wire:model.live="backupMethod" wire:change="instantSave"
+                    helper="pgBackRest stores incremental PostgreSQL backups in S3 and is recommended for large databases.">
+                    <option value="dump">pg_dump</option>
+                    <option value="pgbackrest">pgBackRest (incremental, S3 required)</option>
+                </x-forms.select>
+                @if ($backupMethod === 'pgbackrest')
+                    <x-forms.select id="pgBackRestBackupType" label="pgBackRest Backup Type" wire:model.live="pgBackRestBackupType" wire:change="instantSave"
+                        helper="Use incr for scheduled incremental backups. pgBackRest will create a full backup automatically when needed.">
+                        <option value="incr">Incremental</option>
+                        <option value="diff">Differential</option>
+                        <option value="full">Full</option>
+                    </x-forms.select>
+                    <x-forms.checkbox id="pgBackRestRequireWalArchive" label="Require WAL archive verification" instantSave
+                        helper="Recommended. Requires archive_mode=on and archive_command using pgbackrest archive-push. If disabled, Coolify may run pgBackRest with --archive-check=n when WAL archiving is not configured." />
+                @endif
+            </div>
+            @if ($backupMethod === 'pgbackrest')
+                <div class="text-xs text-warning">pgBackRest backs up the whole PostgreSQL cluster and manages retention with pgBackRest expire. Database selection and local retention are disabled for this method. WAL archive verification is strongly recommended for recoverable/PITR-safe backups.</div>
+            @endif
+        @endif
         <div class="flex gap-2 flex-col ">
             @if ($backup->database_type === 'App\Models\StandalonePostgresql' && $backup->database_id !== 0)
                 <div class="w-48">
-                    <x-forms.checkbox label="Backup All Databases" id="dumpAll" instantSave />
+                    <x-forms.checkbox label="Backup All Databases" id="dumpAll" instantSave :disabled="$backupMethod === 'pgbackrest'" />
                 </div>
-                @if (!$backup->dump_all)
+                @if (!$backup->dump_all && $backupMethod !== 'pgbackrest')
                     <x-forms.input label="Databases To Backup"
                         helper="Comma separated list of databases to backup. Empty will include the default one."
                         id="databasesToBackup" />
@@ -96,22 +121,24 @@
         </div>
 
         <div class="flex gap-6 flex-col">
-            <div>
-                <h4 class="mb-3 font-medium">Local Backup Retention</h4>
-                <div class="flex gap-2">
-                    <x-forms.input label="Number of backups to keep" id="databaseBackupRetentionAmountLocally"
-                        type="number" min="0"
-                        helper="Keeps only the specified number of most recent backups on the server. Set to 0 for unlimited backups." required />
-                    <x-forms.input label="Days to keep backups" id="databaseBackupRetentionDaysLocally" type="number"
-                        min="0"
-                        helper="Automatically removes backups older than the specified number of days. Set to 0 for no time limit." required />
-                    <x-forms.input label="Maximum storage (GB)" id="databaseBackupRetentionMaxStorageLocally"
-                        type="number" min="0" step="any"
-                        helper="When total size of all backups in the current backup job exceeds this limit in GB, the oldest backups will be removed. Decimal values are supported (e.g. 0.001 for 1MB). Set to 0 for unlimited storage." required />
+            @if ($backupMethod !== 'pgbackrest')
+                <div>
+                    <h4 class="mb-3 font-medium">Local Backup Retention</h4>
+                    <div class="flex gap-2">
+                        <x-forms.input label="Number of backups to keep" id="databaseBackupRetentionAmountLocally"
+                            type="number" min="0"
+                            helper="Keeps only the specified number of most recent backups on the server. Set to 0 for unlimited backups." required />
+                        <x-forms.input label="Days to keep backups" id="databaseBackupRetentionDaysLocally" type="number"
+                            min="0"
+                            helper="Automatically removes backups older than the specified number of days. Set to 0 for no time limit." required />
+                        <x-forms.input label="Maximum storage (GB)" id="databaseBackupRetentionMaxStorageLocally"
+                            type="number" min="0" step="any"
+                            helper="When total size of all backups in the current backup job exceeds this limit in GB, the oldest backups will be removed. Decimal values are supported (e.g. 0.001 for 1MB). Set to 0 for unlimited storage." required />
+                    </div>
                 </div>
-            </div>
+            @endif
 
-            @if ($backup->save_s3)
+            @if ($saveS3 || $backupMethod === 'pgbackrest')
                 <div>
                     <h4 class="mb-3 font-medium">S3 Storage Retention</h4>
                     <div class="flex gap-2">
@@ -121,10 +148,15 @@
                         <x-forms.input label="Days to keep backups" id="databaseBackupRetentionDaysS3" type="number"
                             min="0"
                             helper="Automatically removes S3 backups older than the specified number of days. Set to 0 for no time limit." required />
-                        <x-forms.input label="Maximum storage (GB)" id="databaseBackupRetentionMaxStorageS3"
-                            type="number" min="0" step="any"
-                            helper="When total size of all backups in the current backup job exceeds this limit in GB, the oldest backups will be removed. Decimal values are supported (e.g. 0.5 for 500MB). Set to 0 for unlimited storage." required />
+                        @if ($backupMethod !== 'pgbackrest')
+                            <x-forms.input label="Maximum storage (GB)" id="databaseBackupRetentionMaxStorageS3"
+                                type="number" min="0" step="any"
+                                helper="When total size of all backups in the current backup job exceeds this limit in GB, the oldest backups will be removed. Decimal values are supported (e.g. 0.5 for 500MB). Set to 0 for unlimited storage." required />
+                        @endif
                     </div>
+                    @if ($backupMethod === 'pgbackrest')
+                        <div class="mt-2 text-xs text-neutral-500">pgBackRest retention supports count and time policies through pgbackrest expire. Maximum storage cleanup is not applied to pgBackRest repositories.</div>
+                    @endif
                 </div>
             @endif
         </div>

--- a/resources/views/livewire/project/database/backup-executions.blade.php
+++ b/resources/views/livewire/project/database/backup-executions.blade.php
@@ -155,9 +155,11 @@
                         </div>
                     @endif
                     <div class="flex gap-2 mt-4">
-                        @if (data_get($execution, 'status') === 'success')
+                        @if (data_get($execution, 'status') === 'success' && data_get($backup, 'backup_method') !== 'pgbackrest')
                             <x-forms.button class="dark:hover:bg-coolgray-400"
                                 x-on:click="download_file('{{ data_get($execution, 'id') }}')">Download</x-forms.button>
+                        @elseif (data_get($execution, 'status') === 'success' && data_get($backup, 'backup_method') === 'pgbackrest')
+                            <span class="text-xs text-warning">pgBackRest backups are stored as an S3 repository and cannot be downloaded as a single dump file.</span>
                         @endif
                         @php
                             $executionCheckboxes = [];
@@ -167,7 +169,7 @@
                                 $deleteActions[] = 'This backup will be permanently deleted from local storage.';
                             }
 
-                            if (data_get($execution, 's3_uploaded') === true && !data_get($execution, 's3_storage_deleted', false)) {
+                            if (data_get($backup, 'backup_method') !== 'pgbackrest' && data_get($execution, 's3_uploaded') === true && !data_get($execution, 's3_storage_deleted', false)) {
                                 $executionCheckboxes[] = ['id' => 'delete_backup_s3', 'label' => 'Delete the selected backup permanently from S3 Storage'];
                             }
 

--- a/resources/views/livewire/project/database/create-scheduled-backup.blade.php
+++ b/resources/views/livewire/project/database/create-scheduled-backup.blade.php
@@ -2,12 +2,33 @@
     <x-forms.input placeholder="0 0 * * * or daily" id="frequency"
         helper="You can use every_minute, hourly, daily, weekly, monthly, yearly or a cron expression." label="Frequency"
         required />
+    @if ($isPostgres)
+        <x-forms.select id="backupMethod" label="Backup Method" wire:model.live="backupMethod"
+            helper="pgBackRest stores incremental PostgreSQL backups in S3 and is recommended for large databases.">
+            <option value="dump">pg_dump</option>
+            <option value="pgbackrest">pgBackRest (incremental, S3 required)</option>
+        </x-forms.select>
+        @if ($backupMethod === 'pgbackrest')
+            <div class="text-xs text-warning">pgBackRest backs up the whole PostgreSQL cluster. WAL archive verification is strongly recommended for recoverable/PITR-safe backups.</div>
+            <x-forms.select id="pgBackRestBackupType" label="pgBackRest Backup Type" wire:model.live="pgBackRestBackupType"
+                helper="Use incr for scheduled incremental backups. pgBackRest will create a full backup automatically when needed.">
+                <option value="incr">Incremental</option>
+                <option value="diff">Differential</option>
+                <option value="full">Full</option>
+            </x-forms.select>
+            <x-forms.checkbox wire:model.live="pgBackRestRequireWalArchive" label="Require WAL archive verification"
+                helper="Recommended. Requires archive_mode=on and archive_command using pgbackrest archive-push. If disabled, Coolify may run pgBackRest with --archive-check=n when WAL archiving is not configured." />
+        @endif
+    @endif
     <h2>S3</h2>
     @if ($definedS3s->count() === 0)
         <div class="text-red-500">No validated S3 Storages found.</div>
     @else
-        <x-forms.checkbox wire:model.live="saveToS3" label="Save to S3" />
-        @if ($saveToS3)
+        <x-forms.checkbox wire:model.live="saveToS3" label="Save to S3" :disabled="$backupMethod === 'pgbackrest'" />
+        @if ($backupMethod === 'pgbackrest')
+            <div class="text-xs text-warning">pgBackRest requires S3 because it writes an incremental repository instead of a single local dump file.</div>
+        @endif
+        @if ($saveToS3 || $backupMethod === 'pgbackrest')
             <x-forms.select id="s3StorageId" label="Select a S3 Storage">
                 @foreach ($definedS3s as $s3)
                     <option value="{{ $s3->id }}">{{ $s3->name }}</option>

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,7 +33,6 @@ use App\Livewire\Project\Service\DatabaseBackups as ServiceDatabaseBackups;
 use App\Livewire\Project\Service\Index as ServiceIndex;
 use App\Livewire\Project\Shared\ExecuteContainerCommand;
 use App\Livewire\Project\Shared\Logs;
-use App\Livewire\Project\Shared\ScheduledTask\Show as ScheduledTaskShow;
 use App\Livewire\Project\Show as ProjectShow;
 use App\Livewire\Security\ApiTokens;
 use App\Livewire\Security\CloudInitScripts;
@@ -349,6 +348,9 @@ Route::middleware(['auth'])->group(function () {
                 }
             }
             $filename = data_get($execution, 'filename');
+            if (data_get($execution->scheduledDatabaseBackup, 'backup_method') === 'pgbackrest') {
+                return response()->json(['message' => 'pgBackRest backups are stored as an S3 repository and cannot be downloaded as a single dump file.'], 404);
+            }
             if ($execution->scheduledDatabaseBackup->database->getMorphClass() === ServiceDatabase::class) {
                 $server = $execution->scheduledDatabaseBackup->database->service->destination->server;
             } else {

--- a/tests/Feature/DatabaseBackupCreationApiTest.php
+++ b/tests/Feature/DatabaseBackupCreationApiTest.php
@@ -1,21 +1,27 @@
 <?php
 
+use App\Livewire\Project\Database\BackupEdit;
+use App\Livewire\Project\Database\CreateScheduledBackup;
 use App\Models\Environment;
 use App\Models\InstanceSettings;
 use App\Models\Project;
 use App\Models\S3Storage;
 use App\Models\ScheduledDatabaseBackup;
+use App\Models\ScheduledDatabaseBackupExecution;
 use App\Models\Server;
 use App\Models\StandaloneDocker;
+use App\Models\StandaloneMysql;
 use App\Models\StandalonePostgresql;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
 
 uses(RefreshDatabase::class);
 
 beforeEach(function () {
-    InstanceSettings::updateOrCreate(['id' => 0]);
+    InstanceSettings::unguarded(fn () => InstanceSettings::query()->updateOrCreate(['id' => 0]));
+    config(['app.maintenance.driver' => 'file']);
 
     $this->team = Team::factory()->create();
     $this->user = User::factory()->create();
@@ -42,7 +48,7 @@ beforeEach(function () {
         'destination_type' => $this->destination->getMorphClass(),
     ]);
 
-    $this->s3Storage = S3Storage::create([
+    $this->s3Storage = S3Storage::unguarded(fn () => S3Storage::create([
         'name' => 'test-s3',
         'region' => 'us-east-1',
         'key' => 'test-key',
@@ -51,7 +57,103 @@ beforeEach(function () {
         'endpoint' => 'https://s3.example.com',
         'team_id' => $this->team->id,
         'is_usable' => true,
-    ]);
+    ]));
+});
+
+describe('Livewire database backup S3 storage validation', function () {
+    test('create backup rejects tampered s3 storage id from another team', function () {
+        $otherTeam = Team::factory()->create();
+        $otherS3 = S3Storage::unguarded(fn () => S3Storage::create([
+            'name' => 'other-s3-livewire',
+            'region' => 'us-east-1',
+            'key' => 'other-key',
+            'secret' => 'other-secret',
+            'bucket' => 'other-bucket',
+            'endpoint' => 'https://s3.example.com',
+            'team_id' => $otherTeam->id,
+            'is_usable' => true,
+        ]));
+
+        Livewire::actingAs($this->user)
+            ->test(CreateScheduledBackup::class, ['database' => $this->database])
+            ->set('frequency', '0 2 * * 0')
+            ->set('saveToS3', true)
+            ->set('s3StorageId', $otherS3->id)
+            ->call('submit')
+            ->assertDispatched('error', 'The selected S3 storage is invalid for this team.');
+
+        expect(ScheduledDatabaseBackup::where('s3_storage_id', $otherS3->id)->exists())->toBeFalse();
+    });
+
+    test('create backup rejects tampered s3 storage id even when s3 is disabled', function () {
+        $otherTeam = Team::factory()->create();
+        $otherS3 = S3Storage::unguarded(fn () => S3Storage::create([
+            'name' => 'other-s3-disabled-livewire',
+            'region' => 'us-east-1',
+            'key' => 'other-key',
+            'secret' => 'other-secret',
+            'bucket' => 'other-bucket',
+            'endpoint' => 'https://s3.example.com',
+            'team_id' => $otherTeam->id,
+            'is_usable' => true,
+        ]));
+
+        Livewire::actingAs($this->user)
+            ->test(CreateScheduledBackup::class, ['database' => $this->database])
+            ->set('frequency', '0 2 * * 0')
+            ->set('saveToS3', false)
+            ->set('s3StorageId', $otherS3->id)
+            ->call('submit')
+            ->assertDispatched('error', 'The selected S3 storage is invalid for this team.');
+
+        expect(ScheduledDatabaseBackup::where('s3_storage_id', $otherS3->id)->exists())->toBeFalse();
+    });
+
+    test('edit backup rejects tampered s3 storage id from another team', function () {
+        $otherTeam = Team::factory()->create();
+        $otherS3 = S3Storage::unguarded(fn () => S3Storage::create([
+            'name' => 'other-s3-edit-livewire',
+            'region' => 'us-east-1',
+            'key' => 'other-key',
+            'secret' => 'other-secret',
+            'bucket' => 'other-bucket',
+            'endpoint' => 'https://s3.example.com',
+            'team_id' => $otherTeam->id,
+            'is_usable' => true,
+        ]));
+
+        $backup = ScheduledDatabaseBackup::create([
+            'frequency' => 'daily',
+            'enabled' => true,
+            'save_s3' => true,
+            's3_storage_id' => $this->s3Storage->id,
+            'database_id' => $this->database->id,
+            'database_type' => $this->database->getMorphClass(),
+            'team_id' => $this->team->id,
+            'database_backup_retention_amount_locally' => 0,
+            'database_backup_retention_days_locally' => 0,
+            'database_backup_retention_max_storage_locally' => 0,
+            'database_backup_retention_amount_s3' => 0,
+            'database_backup_retention_days_s3' => 0,
+            'database_backup_retention_max_storage_s3' => 0,
+            'backup_method' => 'dump',
+            'pgbackrest_backup_type' => 'incr',
+            'pgbackrest_require_wal_archive' => true,
+            'disable_local_backup' => false,
+            'dump_all' => false,
+            'timeout' => 3600,
+        ]);
+
+        Livewire::actingAs($this->user)
+            ->test(BackupEdit::class, ['backup' => $backup])
+            ->set('s3StorageId', $otherS3->id)
+            ->set('saveS3', true)
+            ->call('instantSave')
+            ->assertDispatched('error', 'The selected S3 storage is invalid for this team.');
+
+        $backup->refresh();
+        expect($backup->s3_storage_id)->toBe($this->s3Storage->id);
+    });
 });
 
 describe('POST /api/v1/databases/{uuid}/backups', function () {
@@ -76,6 +178,79 @@ describe('POST /api/v1/databases/{uuid}/backups', function () {
         expect($backup->team_id)->toBe($this->team->id);
     });
 
+    test('creates pgbackrest postgres backup via API token', function () {
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->postJson("/api/v1/databases/{$this->database->uuid}/backups", [
+            'frequency' => '0 2 * * 0',
+            'save_s3' => true,
+            's3_storage_uuid' => $this->s3Storage->uuid,
+            'backup_method' => 'pgbackrest',
+            'pgbackrest_backup_type' => 'incr',
+            'enabled' => true,
+            'database_backup_retention_amount_locally' => 5,
+            'database_backup_retention_max_storage_s3' => 10,
+        ]);
+
+        $response->assertStatus(201);
+
+        $backup = ScheduledDatabaseBackup::where('uuid', $response->json('uuid'))->first();
+        expect($backup)->not->toBeNull();
+        expect($backup->backup_method)->toBe('pgbackrest');
+        expect($backup->pgbackrest_backup_type)->toBe('incr');
+        expect($backup->pgbackrest_require_wal_archive)->toBeTrue();
+        expect($backup->save_s3)->toBeTrue();
+        expect($backup->s3_storage_id)->toBe($this->s3Storage->id);
+        expect($backup->disable_local_backup)->toBeTrue();
+        expect($backup->dump_all)->toBeTrue();
+        expect($backup->databases_to_backup)->toBeNull();
+        expect($backup->database_backup_retention_amount_locally)->toBe(0);
+        expect((float) $backup->database_backup_retention_max_storage_s3)->toBe(0.0);
+    });
+
+    test('rejects pgbackrest backup without s3 storage', function () {
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->postJson("/api/v1/databases/{$this->database->uuid}/backups", [
+            'frequency' => 'daily',
+            'backup_method' => 'pgbackrest',
+            'pgbackrest_backup_type' => 'incr',
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['backup_method', 'save_s3', 's3_storage_uuid']);
+    });
+
+    test('rejects pgbackrest backup for non postgres database', function () {
+        $mysql = StandaloneMysql::create([
+            'name' => 'test-mysql',
+            'image' => 'mysql:8',
+            'mysql_root_password' => 'password',
+            'mysql_user' => 'mysql',
+            'mysql_password' => 'password',
+            'mysql_database' => 'testdb',
+            'environment_id' => $this->environment->id,
+            'destination_id' => $this->destination->id,
+            'destination_type' => $this->destination->getMorphClass(),
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->postJson("/api/v1/databases/{$mysql->uuid}/backups", [
+            'frequency' => 'daily',
+            'save_s3' => true,
+            's3_storage_uuid' => $this->s3Storage->uuid,
+            'backup_method' => 'pgbackrest',
+            'pgbackrest_backup_type' => 'incr',
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['backup_method']);
+    });
+
     test('creates backup without s3 storage', function () {
         $response = $this->withHeaders([
             'Authorization' => 'Bearer '.$this->bearerToken,
@@ -90,7 +265,7 @@ describe('POST /api/v1/databases/{uuid}/backups', function () {
 
     test('rejects s3_storage_uuid from another team', function () {
         $otherTeam = Team::factory()->create();
-        $otherS3 = S3Storage::create([
+        $otherS3 = S3Storage::unguarded(fn () => S3Storage::create([
             'name' => 'other-s3',
             'region' => 'us-east-1',
             'key' => 'other-key',
@@ -99,7 +274,7 @@ describe('POST /api/v1/databases/{uuid}/backups', function () {
             'endpoint' => 'https://s3.example.com',
             'team_id' => $otherTeam->id,
             'is_usable' => true,
-        ]);
+        ]));
 
         $response = $this->withHeaders([
             'Authorization' => 'Bearer '.$this->bearerToken,
@@ -172,9 +347,41 @@ describe('PATCH /api/v1/databases/{uuid}/backups/{scheduled_backup_uuid}', funct
         expect($backup->save_s3)->toBeTrue();
     });
 
+    test('updates backup to use pgbackrest via API token', function () {
+        $backup = ScheduledDatabaseBackup::create([
+            'frequency' => 'daily',
+            'enabled' => true,
+            'database_id' => $this->database->id,
+            'database_type' => $this->database->getMorphClass(),
+            'team_id' => $this->team->id,
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->patchJson("/api/v1/databases/{$this->database->uuid}/backups/{$backup->uuid}", [
+            'save_s3' => true,
+            's3_storage_uuid' => $this->s3Storage->uuid,
+            'backup_method' => 'pgbackrest',
+            'pgbackrest_backup_type' => 'diff',
+            'pgbackrest_require_wal_archive' => false,
+        ]);
+
+        $response->assertStatus(200);
+        $backup->refresh();
+        expect($backup->backup_method)->toBe('pgbackrest');
+        expect($backup->pgbackrest_backup_type)->toBe('diff');
+        expect($backup->pgbackrest_require_wal_archive)->toBeFalse();
+        expect($backup->s3_storage_id)->toBe($this->s3Storage->id);
+        expect($backup->save_s3)->toBeTrue();
+        expect($backup->disable_local_backup)->toBeTrue();
+        expect($backup->dump_all)->toBeTrue();
+        expect($backup->databases_to_backup)->toBeNull();
+    });
+
     test('rejects s3_storage_uuid from another team on update', function () {
         $otherTeam = Team::factory()->create();
-        $otherS3 = S3Storage::create([
+        $otherS3 = S3Storage::unguarded(fn () => S3Storage::create([
             'name' => 'other-s3',
             'region' => 'us-east-1',
             'key' => 'other-key',
@@ -183,7 +390,7 @@ describe('PATCH /api/v1/databases/{uuid}/backups/{scheduled_backup_uuid}', funct
             'endpoint' => 'https://s3.example.com',
             'team_id' => $otherTeam->id,
             'is_usable' => true,
-        ]);
+        ]));
 
         $backup = ScheduledDatabaseBackup::create([
             'frequency' => 'daily',
@@ -203,5 +410,39 @@ describe('PATCH /api/v1/databases/{uuid}/backups/{scheduled_backup_uuid}', funct
 
         $response->assertStatus(422);
         $response->assertJsonValidationErrors(['s3_storage_uuid']);
+    });
+
+});
+
+describe('DELETE /api/v1/databases/{uuid}/backups/{scheduled_backup_uuid}/executions/{execution_uuid}', function () {
+    test('rejects deleting a single pgbackrest execution from s3', function () {
+        $backup = ScheduledDatabaseBackup::create([
+            'frequency' => 'daily',
+            'enabled' => true,
+            'save_s3' => true,
+            's3_storage_id' => $this->s3Storage->id,
+            'backup_method' => 'pgbackrest',
+            'database_id' => $this->database->id,
+            'database_type' => $this->database->getMorphClass(),
+            'team_id' => $this->team->id,
+        ]);
+
+        $execution = ScheduledDatabaseBackupExecution::create([
+            'database_name' => 'postgres-cluster',
+            'filename' => 'data/coolify/backups/databases/team/db/pgbackrest/coolify-backup/',
+            'scheduled_database_backup_id' => $backup->id,
+            'status' => 'success',
+            's3_uploaded' => true,
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->deleteJson("/api/v1/databases/{$this->database->uuid}/backups/{$backup->uuid}/executions/{$execution->uuid}", [
+            'delete_s3' => true,
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonPath('message', 'A single pgBackRest execution cannot be deleted from S3 because executions share one repository. Delete the scheduled backup with delete_s3=true to remove the repository.');
     });
 });

--- a/tests/Feature/DatabaseBackupJobTest.php
+++ b/tests/Feature/DatabaseBackupJobTest.php
@@ -4,14 +4,30 @@ use App\Jobs\DatabaseBackupJob;
 use App\Models\S3Storage;
 use App\Models\ScheduledDatabaseBackup;
 use App\Models\ScheduledDatabaseBackupExecution;
+use App\Models\StandaloneDocker;
+use App\Models\StandalonePostgresql;
 use App\Models\Team;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
 
 uses(RefreshDatabase::class);
 
+test('pgbackrest default image is digest pinned', function () {
+    $image = config('constants.coolify.pgbackrest_image');
+
+    expect($image)->toContain('@sha256:');
+    expect($image)->not->toEndWith(':latest');
+});
+
 test('scheduled_database_backup_executions table has s3_uploaded column', function () {
     expect(Schema::hasColumn('scheduled_database_backup_executions', 's3_uploaded'))->toBeTrue();
+});
+
+test('scheduled_database_backups table has pgbackrest configuration columns', function () {
+    expect(Schema::hasColumn('scheduled_database_backups', 'backup_method'))->toBeTrue();
+    expect(Schema::hasColumn('scheduled_database_backups', 'pgbackrest_backup_type'))->toBeTrue();
+    expect(Schema::hasColumn('scheduled_database_backups', 'pgbackrest_require_wal_archive'))->toBeTrue();
 });
 
 test('s3_uploaded column is nullable', function () {
@@ -38,6 +54,260 @@ test('scheduled database backup execution model casts storage deletion fields co
     expect($casts['local_storage_deleted'])->toBe('boolean');
     expect($casts)->toHaveKey('s3_storage_deleted');
     expect($casts['s3_storage_deleted'])->toBe('boolean');
+});
+
+test('scheduled database backup model casts boolean fields correctly', function () {
+    $model = new ScheduledDatabaseBackup;
+    $casts = $model->getCasts();
+
+    expect($casts)->toHaveKey('save_s3');
+    expect($casts['save_s3'])->toBe('boolean');
+    expect($casts)->toHaveKey('disable_local_backup');
+    expect($casts['disable_local_backup'])->toBe('boolean');
+    expect($casts)->toHaveKey('pgbackrest_require_wal_archive');
+    expect($casts['pgbackrest_require_wal_archive'])->toBe('boolean');
+});
+
+test('pgbackrest base options use mounted pgdata path and s3 repository', function () {
+    $backup = ScheduledDatabaseBackup::make([
+        'uuid' => 'test-backup-uuid',
+        'frequency' => '0 0 * * *',
+        'backup_method' => 'pgbackrest',
+        'pgbackrest_backup_type' => 'incr',
+        'save_s3' => true,
+    ]);
+
+    $job = new DatabaseBackupJob($backup);
+    $job->backup_dir = '/data/coolify/backups/databases/test-team/test-db';
+    $job->postgres_pgdata_path = '/var/lib/postgresql/data/pgdata';
+    $job->database = new StandalonePostgresql([
+        'postgres_user' => 'postgres',
+        'postgres_db' => 'app',
+    ]);
+    $job->s3 = new S3Storage([
+        'bucket' => 'test-bucket',
+        'endpoint' => 'https://s3.example.com',
+        'region' => 'us-east-1',
+        'key' => 'test-key',
+        'secret' => 'test-secret',
+    ]);
+
+    $reflection = new ReflectionClass($job);
+    $method = $reflection->getMethod('pgBackRestBaseOptions');
+    $options = $method->invoke($job, 'coolify-test');
+
+    expect($options)->toContain("--pg1-path='/var/lib/postgresql/data/pgdata'");
+    expect($options)->not->toContain("--pg1-host='postgres-container'");
+    expect($options)->toContain('--repo1-type=s3');
+    expect($options)->toContain("--repo1-path='/data/coolify/backups/databases/test-team/test-db/pgbackrest/coolify-test'");
+    expect($options)->toContain("--repo1-s3-bucket='test-bucket'");
+    expect($options)->not->toContain("--repo1-s3-key='test-key'");
+    expect($options)->not->toContain("--repo1-s3-key-secret='test-secret'");
+});
+
+test('pgbackrest requires wal archive verification by default and allows explicit opt out', function () {
+    $reflection = new ReflectionClass(DatabaseBackupJob::class);
+    $method = $reflection->getMethod('pgBackRestRequiresWalArchive');
+
+    $defaultJob = new DatabaseBackupJob(ScheduledDatabaseBackup::make([
+        'backup_method' => 'pgbackrest',
+    ]));
+    expect($method->invoke($defaultJob))->toBeTrue();
+
+    $optOutJob = new DatabaseBackupJob(ScheduledDatabaseBackup::make([
+        'backup_method' => 'pgbackrest',
+        'pgbackrest_require_wal_archive' => false,
+    ]));
+    expect($method->invoke($optOutJob))->toBeFalse();
+});
+
+test('pgbackrest docker command uses env file without exposing secret values', function () {
+    $backup = ScheduledDatabaseBackup::make([
+        'uuid' => 'test-backup-uuid',
+        'frequency' => '0 0 * * *',
+        'backup_method' => 'pgbackrest',
+        'pgbackrest_backup_type' => 'incr',
+        'save_s3' => true,
+    ]);
+
+    $job = new DatabaseBackupJob($backup);
+    $job->backup_dir = '/data/coolify/backups/databases/test-team/test-db';
+    $job->backup_log_uuid = 'test-log-uuid';
+    $job->postgres_data_path = '/var/lib/docker/volumes/test/_data';
+    $job->postgres_pgdata_path = '/var/lib/postgresql/data';
+    $job->container_name = 'postgres-container';
+    $job->postgres_password = 'postgres-secret';
+    $job->postgres_uid = '999';
+    $job->postgres_gid = '999';
+    $job->database = new StandalonePostgresql([
+        'postgres_user' => 'postgres',
+        'postgres_db' => 'app',
+    ]);
+    $job->database->setRelation('destination', new StandaloneDocker([
+        'network' => 'coolify-test-network',
+    ]));
+    $job->s3 = new S3Storage([
+        'bucket' => 'test-bucket',
+        'endpoint' => 'https://s3.example.com',
+        'region' => 'us-east-1',
+        'key' => 'test-key',
+        'secret' => 'test-secret',
+    ]);
+
+    $reflection = new ReflectionClass($job);
+    $envPathMethod = $reflection->getMethod('pgBackRestRemoteEnvFilePath');
+    $envPath = $envPathMethod->invoke($job);
+
+    expect($envPath)->toBe('/tmp/coolify-pgbackrest-test-log-uuid/pgbackrest.env');
+
+    $commandMethod = $reflection->getMethod('pgBackRestDockerCommand');
+    $command = $commandMethod->invoke($job, 'coolify-test', 'backup', ['--archive-check=n'], $envPath);
+
+    expect($command)->toContain("--env-file '/tmp/coolify-pgbackrest-test-log-uuid/pgbackrest.env'");
+    expect($command)->toContain('--archive-check=n');
+    expect($command)->not->toContain('test-key');
+    expect($command)->not->toContain('test-secret');
+    expect($command)->not->toContain('postgres-secret');
+    expect($command)->not->toContain('--repo1-s3-key');
+    expect($command)->not->toContain('--repo1-s3-key-secret');
+
+    $psqlCommandMethod = $reflection->getMethod('postgresPsqlCommand');
+    $psqlCommand = $psqlCommandMethod->invoke($job, 'SHOW archive_mode;');
+
+    expect($psqlCommand)->toContain('POSTGRES_PASSWORD');
+    expect($psqlCommand)->not->toContain('postgres-secret');
+
+    $envMethod = $reflection->getMethod('pgBackRestEnvFileContents');
+    $env = $envMethod->invoke($job);
+
+    expect($env)->toContain('PGHOST=postgres-container');
+    expect($env)->toContain('PGPORT=5432');
+    expect($env)->toContain('PGPASSWORD=postgres-secret');
+    expect($env)->toContain('BACKREST_UID=999');
+    expect($env)->toContain('BACKREST_GID=999');
+    expect($env)->toContain('PGBACKREST_REPO1_S3_KEY=test-key');
+    expect($env)->toContain('PGBACKREST_REPO1_S3_KEY_SECRET=test-secret');
+});
+
+test('pgbackrest env file rejects injected variables and invalid names', function () {
+    $job = new DatabaseBackupJob(ScheduledDatabaseBackup::make([
+        'backup_method' => 'pgbackrest',
+        'save_s3' => true,
+    ]));
+    $job->container_name = 'postgres-container';
+    $job->postgres_password = "safe-password\nPGBACKREST_REPO1_S3_KEY_SECRET=injected";
+    $job->s3 = new S3Storage([
+        'key' => 'test-key',
+        'secret' => 'test-secret',
+    ]);
+
+    $reflection = new ReflectionClass($job);
+    $contentsMethod = $reflection->getMethod('pgBackRestEnvFileContents');
+    $lineMethod = $reflection->getMethod('pgBackRestEnvFileLine');
+
+    expect(fn () => $contentsMethod->invoke($job))
+        ->toThrow(Exception::class, 'contains unsupported control characters');
+
+    expect(fn () => $lineMethod->invoke($job, 'BAD-NAME', 'value'))
+        ->toThrow(Exception::class, 'Invalid pgBackRest environment variable name.');
+});
+
+test('deleteBackupsS3 deletes only explicit objects, not directory prefixes', function () {
+    $s3 = S3Storage::unguarded(fn () => new S3Storage([
+        'region' => 'us-east-1',
+        'key' => 'test-key',
+        'secret' => 'test-secret',
+        'bucket' => 'test-bucket',
+        'endpoint' => 'https://s3.example.com',
+    ]));
+
+    $disk = new class
+    {
+        public array $deleted = [];
+
+        public int $deleteDirectoryCalls = 0;
+
+        public function delete($paths): bool
+        {
+            $this->deleted = (array) $paths;
+
+            return true;
+        }
+
+        public function deleteDirectory($directory): bool
+        {
+            $this->deleteDirectoryCalls++;
+
+            return true;
+        }
+    };
+
+    Storage::shouldReceive('build')->once()->andReturn($disk);
+
+    deleteBackupsS3('data/coolify/backups/team/db/pgbackrest/coolify-backup/', $s3);
+
+    expect($disk->deleted)->toBe(['data/coolify/backups/team/db/pgbackrest/coolify-backup/']);
+    expect($disk->deleteDirectoryCalls)->toBe(0);
+});
+
+test('deleteBackupsS3Prefix only accepts scoped pgbackrest repository prefixes', function () {
+    $s3 = S3Storage::unguarded(fn () => new S3Storage([
+        'region' => 'us-east-1',
+        'key' => 'test-key',
+        'secret' => 'test-secret',
+        'bucket' => 'test-bucket',
+        'endpoint' => 'https://s3.example.com',
+    ]));
+
+    foreach ([
+        'data/coolify/backups/team/db/',
+        'data/coolify/backups/team/db/pgbackrest/not-coolify/',
+        'tmp/backups/team/db/pgbackrest/coolify-backup/',
+        'data/coolify/backups/team/../db/pgbackrest/coolify-backup/',
+        'data/coolify/backups/team/db/pgbackrest/coolify-backup',
+    ] as $prefix) {
+        expect(fn () => deleteBackupsS3Prefix($prefix, $s3))
+            ->toThrow(InvalidArgumentException::class, 'Invalid pgBackRest S3 repository prefix.');
+    }
+
+    $disk = new class
+    {
+        public ?string $deletedDirectory = null;
+
+        public function deleteDirectory($directory): bool
+        {
+            $this->deletedDirectory = $directory;
+
+            return true;
+        }
+    };
+
+    Storage::shouldReceive('build')->once()->andReturn($disk);
+
+    deleteBackupsS3Prefix('data/coolify/backups/team/db/pgbackrest/coolify-backup/', $s3);
+
+    expect($disk->deletedDirectory)->toBe('data/coolify/backups/team/db/pgbackrest/coolify-backup');
+});
+
+test('pgbackrest repository key prefix can be derived without execution filenames', function () {
+    $team = Team::factory()->create([
+        'name' => 'Test Team',
+    ]);
+
+    $database = new StandalonePostgresql([
+        'uuid' => 'postgres-uuid',
+        'name' => 'Main PostgreSQL',
+    ]);
+
+    $backup = ScheduledDatabaseBackup::make([
+        'uuid' => 'backup-uuid',
+        'backup_method' => 'pgbackrest',
+        'team_id' => $team->id,
+    ]);
+    $backup->setRelation('team', $team);
+    $backup->setRelation('database', $database);
+
+    expect(pgBackRestRepositoryKeyPrefix($backup))->toBe('data/coolify/backups/databases/test-team-'.$team->id.'/main-postgresql-postgres-uuid/pgbackrest/coolify-backup-uuid/');
 });
 
 test('upload_to_s3 throws exception and disables s3 when storage is null', function () {
@@ -69,7 +339,7 @@ test('upload_to_s3 throws exception and disables s3 when storage is null', funct
 test('deleting s3 storage disables s3 on linked backups', function () {
     $team = Team::factory()->create();
 
-    $s3 = S3Storage::create([
+    $s3 = S3Storage::unguarded(fn () => S3Storage::create([
         'name' => 'Test S3',
         'region' => 'us-east-1',
         'key' => 'test-key',
@@ -77,7 +347,7 @@ test('deleting s3 storage disables s3 on linked backups', function () {
         'bucket' => 'test-bucket',
         'endpoint' => 'https://s3.example.com',
         'team_id' => $team->id,
-    ]);
+    ]));
 
     $backup1 = ScheduledDatabaseBackup::create([
         'frequency' => '0 0 * * *',
@@ -157,7 +427,7 @@ test('failed method does not overwrite successful backup status', function () {
     $log->refresh();
     expect($log->status)->toBe('success');
     expect($log->message)->toBe('Backup completed successfully');
-    expect($log->size)->toBe(1024);
+    expect((int) $log->size)->toBe(1024);
 });
 
 test('failed method updates status when backup was not successful', function () {
@@ -199,7 +469,7 @@ test('failed method updates status when backup was not successful', function () 
 test('s3 storage has scheduled backups relationship', function () {
     $team = Team::factory()->create();
 
-    $s3 = S3Storage::create([
+    $s3 = S3Storage::unguarded(fn () => S3Storage::create([
         'name' => 'Test S3',
         'region' => 'us-east-1',
         'key' => 'test-key',
@@ -207,7 +477,7 @@ test('s3 storage has scheduled backups relationship', function () {
         'bucket' => 'test-bucket',
         'endpoint' => 'https://s3.example.com',
         'team_id' => $team->id,
-    ]);
+    ]));
 
     ScheduledDatabaseBackup::create([
         'frequency' => '0 0 * * *',

--- a/tests/Unit/DatabaseBackupSecurityTest.php
+++ b/tests/Unit/DatabaseBackupSecurityTest.php
@@ -182,7 +182,7 @@ test('escapeshellarg neutralizes command injection in mariadb password', functio
     $escaped = escapeshellarg($maliciousPassword);
 
     // Single quotes in the value get escaped as '\''
-    expect($escaped)->toBe("'pass'\\'''; whoami; echo '\\'''");
+    expect($escaped)->toBe("'pass'\\''; whoami; echo '\\'''");
     $command = "docker exec container mariadb-dump -u root -p$escaped db";
     // Verify the command doesn't contain an unescaped semicolon outside quotes
     expect($command)->toContain("-p'pass'");


### PR DESCRIPTION
## Changes

- Adds pgBackRest as an S3-backed PostgreSQL backup method for scheduled database backups.
- Supports full, differential, and incremental pgBackRest backup types with WAL archive verification enabled by default.
- Restricts pgBackRest to PostgreSQL whole-cluster backups with S3 storage, and disables incompatible local dump retention paths.
- Uses a temporary remote Docker env file for pgBackRest credentials instead of embedding secrets in command strings.
- Adds API, Livewire, model, migration, route, helper, UI, and test coverage for the new backup method.

## Issues

- Relates to #7423
- Existing pgBackRest issues and closed PRs were searched before updating this PR.

## Category

- [ ] Bug fix
- [x] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not attached. The change is primarily backup workflow/configuration behavior; coverage is provided through API, Livewire, unit, feature, and Docker smoke tests.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenClaw/Codex
- How extensively: Implementation assistance, security review, test iteration, and PR preparation under human direction.

## Testing

- `git diff --check`
- PHP lint for changed PHP files
- Pint `--test` for changed files
- `composer validate --no-check-publish --no-interaction`
- Docker pgBackRest digest image smoke: `pgBackRest 2.58.0`
- Relevant Pest suite: 100 tests / 259 assertions passed

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
