### PR TITLE
fix: preserve application env values on partial updates

### DIFF
--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -3085,22 +3085,23 @@ class ApplicationsController extends Controller
             ], 422);
         }
         $is_preview = $request->is_preview ?? false;
-        $is_literal = $request->is_literal ?? false;
         $key = str($request->key)->trim()->replace(' ', '_')->value;
         if ($is_preview) {
             $env = $application->environment_variables_preview->where('key', $key)->first();
             if ($env) {
-                $env->value = $request->value;
-                if ($env->is_literal != $is_literal) {
-                    $env->is_literal = $is_literal;
+                if ($request->has('value')) {
+                    $env->value = $request->value;
+                }
+                if ($request->has('is_literal') && $env->is_literal != $request->is_literal) {
+                    $env->is_literal = $request->is_literal;
                 }
                 if ($env->is_preview != $is_preview) {
                     $env->is_preview = $is_preview;
                 }
-                if ($env->is_multiline != $request->is_multiline) {
+                if ($request->has('is_multiline') && $env->is_multiline != $request->is_multiline) {
                     $env->is_multiline = $request->is_multiline;
                 }
-                if ($env->is_shown_once != $request->is_shown_once) {
+                if ($request->has('is_shown_once') && $env->is_shown_once != $request->is_shown_once) {
                     $env->is_shown_once = $request->is_shown_once;
                 }
                 if ($request->has('is_runtime') && $env->is_runtime != $request->is_runtime) {
@@ -3131,17 +3132,19 @@ class ApplicationsController extends Controller
         } else {
             $env = $application->environment_variables->where('key', $key)->first();
             if ($env) {
-                $env->value = $request->value;
-                if ($env->is_literal != $is_literal) {
-                    $env->is_literal = $is_literal;
+                if ($request->has('value')) {
+                    $env->value = $request->value;
+                }
+                if ($request->has('is_literal') && $env->is_literal != $request->is_literal) {
+                    $env->is_literal = $request->is_literal;
                 }
                 if ($env->is_preview != $is_preview) {
                     $env->is_preview = $is_preview;
                 }
-                if ($env->is_multiline != $request->is_multiline) {
+                if ($request->has('is_multiline') && $env->is_multiline != $request->is_multiline) {
                     $env->is_multiline = $request->is_multiline;
                 }
-                if ($env->is_shown_once != $request->is_shown_once) {
+                if ($request->has('is_shown_once') && $env->is_shown_once != $request->is_shown_once) {
                     $env->is_shown_once = $request->is_shown_once;
                 }
                 if ($request->has('is_runtime') && $env->is_runtime != $request->is_runtime) {
@@ -3311,15 +3314,17 @@ class ApplicationsController extends Controller
             if ($is_preview) {
                 $env = $application->environment_variables_preview->where('key', $key)->first();
                 if ($env) {
-                    $env->value = $item->get('value');
-
-                    if ($env->is_literal != $is_literal) {
-                        $env->is_literal = $is_literal;
+                    if ($item->has('value')) {
+                        $env->value = $item->get('value');
                     }
-                    if ($env->is_multiline != $item->get('is_multiline')) {
+
+                    if ($item->has('is_literal') && $env->is_literal != $item->get('is_literal')) {
+                        $env->is_literal = $item->get('is_literal');
+                    }
+                    if ($item->has('is_multiline') && $env->is_multiline != $item->get('is_multiline')) {
                         $env->is_multiline = $item->get('is_multiline');
                     }
-                    if ($env->is_shown_once != $item->get('is_shown_once')) {
+                    if ($item->has('is_shown_once') && $env->is_shown_once != $item->get('is_shown_once')) {
                         $env->is_shown_once = $item->get('is_shown_once');
                     }
                     if ($item->has('is_runtime') && $env->is_runtime != $item->get('is_runtime')) {
@@ -3350,14 +3355,16 @@ class ApplicationsController extends Controller
             } else {
                 $env = $application->environment_variables->where('key', $key)->first();
                 if ($env) {
-                    $env->value = $item->get('value');
-                    if ($env->is_literal != $is_literal) {
-                        $env->is_literal = $is_literal;
+                    if ($item->has('value')) {
+                        $env->value = $item->get('value');
                     }
-                    if ($env->is_multiline != $item->get('is_multiline')) {
+                    if ($item->has('is_literal') && $env->is_literal != $item->get('is_literal')) {
+                        $env->is_literal = $item->get('is_literal');
+                    }
+                    if ($item->has('is_multiline') && $env->is_multiline != $item->get('is_multiline')) {
                         $env->is_multiline = $item->get('is_multiline');
                     }
-                    if ($env->is_shown_once != $item->get('is_shown_once')) {
+                    if ($item->has('is_shown_once') && $env->is_shown_once != $item->get('is_shown_once')) {
                         $env->is_shown_once = $item->get('is_shown_once');
                     }
                     if ($item->has('is_runtime') && $env->is_runtime != $item->get('is_runtime')) {

--- a/tests/Feature/EnvironmentVariableBulkCommentApiTest.php
+++ b/tests/Feature/EnvironmentVariableBulkCommentApiTest.php
@@ -15,7 +15,8 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 uses(RefreshDatabase::class);
 
 beforeEach(function () {
-    InstanceSettings::updateOrCreate(['id' => 0]);
+    InstanceSettings::unguarded(fn () => InstanceSettings::query()->updateOrCreate(['id' => 0]));
+    config(['app.maintenance.driver' => 'file']);
 
     $this->team = Team::factory()->create();
     $this->user = User::factory()->create();
@@ -150,6 +151,53 @@ describe('PATCH /api/v1/applications/{uuid}/envs/bulk', function () {
 
         expect($env->value)->toBe('new-secret');
         expect($env->comment)->toBe('Keep this comment');
+    });
+
+    test('preserves existing application env value when omitted in bulk update', function () {
+        $application = Application::factory()->create([
+            'environment_id' => $this->environment->id,
+            'destination_id' => $this->destination->id,
+            'destination_type' => $this->destination->getMorphClass(),
+        ]);
+
+        $env = EnvironmentVariable::create([
+            'key' => 'NEXTAUTH_SECRET',
+            'value' => 'stored-secret',
+            'comment' => 'Old comment',
+            'resourceable_type' => Application::class,
+            'resourceable_id' => $application->id,
+            'is_preview' => false,
+            'is_literal' => true,
+            'is_multiline' => true,
+            'is_shown_once' => true,
+            'is_runtime' => true,
+            'is_buildtime' => true,
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->patchJson("/api/v1/applications/{$application->uuid}/envs/bulk", [
+            'data' => [
+                [
+                    'key' => 'NEXTAUTH_SECRET',
+                    'is_buildtime' => false,
+                    'comment' => 'Updated comment',
+                ],
+            ],
+        ]);
+
+        $response->assertStatus(201);
+
+        $env->refresh();
+
+        expect($env->value)->toBe('stored-secret');
+        expect((bool) $env->is_buildtime)->toBeFalse();
+        expect((bool) $env->is_runtime)->toBeTrue();
+        expect((bool) $env->is_literal)->toBeTrue();
+        expect((bool) $env->is_multiline)->toBeTrue();
+        expect((bool) $env->is_shown_once)->toBeTrue();
+        expect($env->comment)->toBe('Updated comment');
     });
 
     test('rejects comment exceeding 256 characters', function () {

--- a/tests/Feature/EnvironmentVariableUpdateApiTest.php
+++ b/tests/Feature/EnvironmentVariableUpdateApiTest.php
@@ -15,7 +15,8 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 uses(RefreshDatabase::class);
 
 beforeEach(function () {
-    InstanceSettings::updateOrCreate(['id' => 0]);
+    InstanceSettings::unguarded(fn () => InstanceSettings::query()->updateOrCreate(['id' => 0]));
+    config(['app.maintenance.driver' => 'file']);
 
     $this->team = Team::factory()->create();
     $this->user = User::factory()->create();
@@ -187,6 +188,86 @@ describe('PATCH /api/v1/applications/{uuid}/envs', function () {
         ]);
         $response->assertJsonFragment(['key' => 'APP_IMAGE_TAG']);
         $response->assertJsonMissing(['message' => 'Environment variable updated.']);
+    });
+
+    test('preserves existing value and omitted flags when updating application env flags', function () {
+        $application = Application::factory()->create([
+            'environment_id' => $this->environment->id,
+            'destination_id' => $this->destination->id,
+            'destination_type' => $this->destination->getMorphClass(),
+        ]);
+
+        $env = EnvironmentVariable::create([
+            'key' => 'NEXTAUTH_SECRET',
+            'value' => 'stored-secret',
+            'resourceable_type' => Application::class,
+            'resourceable_id' => $application->id,
+            'is_preview' => false,
+            'is_literal' => true,
+            'is_multiline' => true,
+            'is_shown_once' => true,
+            'is_runtime' => true,
+            'is_buildtime' => true,
+            'comment' => 'Existing comment',
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->patchJson("/api/v1/applications/{$application->uuid}/envs", [
+            'key' => 'NEXTAUTH_SECRET',
+            'is_buildtime' => false,
+        ]);
+
+        $response->assertStatus(201);
+
+        $env->refresh();
+
+        expect($env->value)->toBe('stored-secret');
+        expect((bool) $env->is_buildtime)->toBeFalse();
+        expect((bool) $env->is_runtime)->toBeTrue();
+        expect((bool) $env->is_literal)->toBeTrue();
+        expect((bool) $env->is_multiline)->toBeTrue();
+        expect((bool) $env->is_shown_once)->toBeTrue();
+        expect($env->comment)->toBe('Existing comment');
+    });
+
+    test('preserves existing preview value when updating application preview env flags', function () {
+        $application = Application::factory()->create([
+            'environment_id' => $this->environment->id,
+            'destination_id' => $this->destination->id,
+            'destination_type' => $this->destination->getMorphClass(),
+        ]);
+
+        $env = EnvironmentVariable::create([
+            'key' => 'PREVIEW_SECRET',
+            'value' => 'preview-secret',
+            'resourceable_type' => Application::class,
+            'resourceable_id' => $application->id,
+            'is_preview' => true,
+            'is_literal' => true,
+            'is_runtime' => true,
+            'is_buildtime' => true,
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->patchJson("/api/v1/applications/{$application->uuid}/envs", [
+            'key' => 'PREVIEW_SECRET',
+            'is_preview' => true,
+            'is_runtime' => false,
+        ]);
+
+        $response->assertStatus(201);
+
+        $env->refresh();
+
+        expect($env->value)->toBe('preview-secret');
+        expect((bool) $env->is_preview)->toBeTrue();
+        expect((bool) $env->is_runtime)->toBeFalse();
+        expect((bool) $env->is_buildtime)->toBeTrue();
+        expect((bool) $env->is_literal)->toBeTrue();
     });
 
     test('returns 404 when environment variable does not exist', function () {


### PR DESCRIPTION
## Changes

- Preserve existing application env values when PATCH `/api/v1/applications/{uuid}/envs` omits `value`.
- Apply the same partial-update behavior to bulk app env updates and omitted optional flags so flag-only updates do not reset unrelated fields.
- Add feature coverage for production, preview, and bulk app env updates.

## Issues

- Fixes #9977

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

API-only bug fix; no UI changes.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenClaw for code editing and Docker-based verification.
- How extensively: Assisted implementation and test drafting; changes were reviewed before submission.

## Testing

- `git diff --check`
- Docker `php -l` for changed PHP files
- Docker Pint `--test` for changed files
- Docker `composer validate --no-check-publish --no-interaction`
- Docker Pest: `tests/Feature/EnvironmentVariableUpdateApiTest.php` and `tests/Feature/EnvironmentVariableBulkCommentApiTest.php` — 18 passed / 66 assertions

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
