### PR TITLE
Add OAuth registration and password controls

### DIFF
--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\ResetsUserPasswords;
 
 class ResetUserPassword implements ResetsUserPasswords
@@ -17,6 +18,12 @@ class ResetUserPassword implements ResetsUserPasswords
      */
     public function reset(User $user, array $input): void
     {
+        if ($user->hasPasswordAuthDisabledByOauth()) {
+            throw ValidationException::withMessages([
+                'email' => __('Password login is disabled for this OAuth account. Please sign in with your OAuth provider.'),
+            ]);
+        }
+
         Validator::make($input, [
             'password' => ['required', Password::defaults(), 'confirmed'],
         ])->validate();

--- a/app/Actions/Fortify/UpdateUserPassword.php
+++ b/app/Actions/Fortify/UpdateUserPassword.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\UpdatesUserPasswords;
 
 class UpdateUserPassword implements UpdatesUserPasswords
@@ -17,6 +18,15 @@ class UpdateUserPassword implements UpdatesUserPasswords
      */
     public function update(User $user, array $input): void
     {
+        if ($user->hasPasswordAuthDisabledByOauth()) {
+            $exception = ValidationException::withMessages([
+                'password' => __('Password login is disabled for this OAuth account. Please sign in with your OAuth provider.'),
+            ]);
+            $exception->errorBag = 'updatePassword';
+
+            throw $exception;
+        }
+
         Validator::make($input, [
             'current_password' => ['required', 'string', 'current_password:web'],
             'password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\OauthSetting;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -18,6 +19,7 @@ class OauthController extends Controller
     public function callback(string $provider)
     {
         try {
+            $oauthSetting = OauthSetting::where('provider', $provider)->where('enabled', true)->firstOrFail();
             $oauthUser = get_socialite_provider($provider)->user();
             $email = trim((string) $oauthUser->email);
             if ($email === '') {
@@ -27,14 +29,20 @@ class OauthController extends Controller
             $user = User::whereEmail($email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! $oauthSetting->is_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 
                 $user = User::create([
                     'name' => $oauthUser->name,
                     'email' => $email,
+                    'oauth_provider' => $provider,
                 ]);
+            } elseif ($user->oauth_provider !== $provider) {
+                $user->forceFill([
+                    'oauth_provider' => $provider,
+                    'force_password_reset' => false,
+                ])->save();
             }
             Auth::login($user);
 

--- a/app/Livewire/SettingsOauth.php
+++ b/app/Livewire/SettingsOauth.php
@@ -18,6 +18,8 @@ class SettingsOauth extends Component
             $carry["oauth_settings_map.$setting->provider.redirect_uri"] = 'nullable';
             $carry["oauth_settings_map.$setting->provider.tenant"] = 'nullable';
             $carry["oauth_settings_map.$setting->provider.base_url"] = 'nullable';
+            $carry["oauth_settings_map.$setting->provider.is_registration_enabled"] = 'boolean';
+            $carry["oauth_settings_map.$setting->provider.disable_password_auth"] = 'boolean';
 
             return $carry;
         }, []);
@@ -38,6 +40,8 @@ class SettingsOauth extends Component
                 'redirect_uri' => $setting->redirect_uri,
                 'tenant' => $setting->tenant,
                 'base_url' => $setting->base_url,
+                'is_registration_enabled' => $setting->is_registration_enabled,
+                'disable_password_auth' => $setting->disable_password_auth,
             ];
 
             return $carry;
@@ -61,6 +65,8 @@ class SettingsOauth extends Component
                 'redirect_uri' => $oauthData['redirect_uri'],
                 'tenant' => $oauthData['tenant'],
                 'base_url' => $oauthData['base_url'],
+                'is_registration_enabled' => $oauthData['is_registration_enabled'],
+                'disable_password_auth' => $oauthData['disable_password_auth'],
             ]);
 
             if (! $oauth->couldBeEnabled()) {
@@ -79,6 +85,8 @@ class SettingsOauth extends Component
                 'redirect_uri' => $oauth->redirect_uri,
                 'tenant' => $oauth->tenant,
                 'base_url' => $oauth->base_url,
+                'is_registration_enabled' => $oauth->is_registration_enabled,
+                'disable_password_auth' => $oauth->disable_password_auth,
             ];
 
             $this->dispatch('success', 'OAuth settings for '.$oauth->provider.' updated successfully!');
@@ -100,6 +108,8 @@ class SettingsOauth extends Component
                     'redirect_uri' => $settingData['redirect_uri'],
                     'tenant' => $settingData['tenant'],
                     'base_url' => $settingData['base_url'],
+                    'is_registration_enabled' => $settingData['is_registration_enabled'],
+                    'disable_password_auth' => $settingData['disable_password_auth'],
                 ]);
 
                 if ($settingData['enabled'] && ! $oauth->couldBeEnabled()) {
@@ -119,6 +129,8 @@ class SettingsOauth extends Component
                     'redirect_uri' => $oauth->redirect_uri,
                     'tenant' => $oauth->tenant,
                     'base_url' => $oauth->base_url,
+                    'is_registration_enabled' => $oauth->is_registration_enabled,
+                    'disable_password_auth' => $oauth->disable_password_auth,
                 ];
             }
 

--- a/app/Models/OauthSetting.php
+++ b/app/Models/OauthSetting.php
@@ -11,7 +11,23 @@ class OauthSetting extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['provider', 'client_id', 'client_secret', 'redirect_uri', 'tenant', 'base_url', 'enabled'];
+    protected $fillable = [
+        'provider',
+        'client_id',
+        'client_secret',
+        'redirect_uri',
+        'tenant',
+        'base_url',
+        'enabled',
+        'is_registration_enabled',
+        'disable_password_auth',
+    ];
+
+    protected $casts = [
+        'enabled' => 'boolean',
+        'is_registration_enabled' => 'boolean',
+        'disable_password_auth' => 'boolean',
+    ];
 
     protected function clientSecret(): Attribute
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -49,6 +49,7 @@ class User extends Authenticatable implements SendsEmail
         'password',
         'force_password_reset',
         'marketing_emails',
+        'oauth_provider',
         'pending_email',
         'email_change_code',
         'email_change_code_expires_at',
@@ -486,5 +487,16 @@ class User extends Authenticatable implements SendsEmail
     public function hasPassword(): bool
     {
         return ! empty($this->password);
+    }
+
+    public function hasPasswordAuthDisabledByOauth(): bool
+    {
+        if (blank($this->oauth_provider)) {
+            return false;
+        }
+
+        return OauthSetting::where('provider', $this->oauth_provider)
+            ->where('disable_password_auth', true)
+            ->exists();
     }
 }

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -7,6 +7,7 @@ use App\Actions\Fortify\ResetUserPassword;
 use App\Actions\Fortify\UpdateUserPassword;
 use App\Actions\Fortify\UpdateUserProfileInformation;
 use App\Models\OauthSetting;
+use App\Models\TeamInvitation;
 use App\Models\User;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
@@ -76,13 +77,14 @@ class FortifyServiceProvider extends ServiceProvider
             $user = User::where('email', $email)->with('teams')->first();
             if (
                 $user &&
+                ! $user->hasPasswordAuthDisabledByOauth() &&
                 Hash::check($request->password, $user->password)
             ) {
                 $user->updated_at = now();
                 $user->save();
 
                 // Check if user has a pending invitation they haven't accepted yet
-                $invitation = \App\Models\TeamInvitation::whereEmail($email)->first();
+                $invitation = TeamInvitation::whereEmail($email)->first();
                 if ($invitation && $invitation->isValid()) {
                     // User is logging in for the first time after being invited
                     // Attach them to the invited team if not already attached

--- a/database/migrations/2026_05_11_000000_add_oauth_registration_and_password_controls.php
+++ b/database/migrations/2026_05_11_000000_add_oauth_registration_and_password_controls.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('oauth_settings', function (Blueprint $table) {
+            $table->boolean('is_registration_enabled')->default(false);
+            $table->boolean('disable_password_auth')->default(false);
+        });
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('oauth_provider')->nullable()->index();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropIndex(['oauth_provider']);
+            $table->dropColumn('oauth_provider');
+        });
+
+        Schema::table('oauth_settings', function (Blueprint $table) {
+            $table->dropColumn(['is_registration_enabled', 'disable_password_auth']);
+        });
+    }
+};

--- a/resources/views/livewire/settings-oauth.blade.php
+++ b/resources/views/livewire/settings-oauth.blade.php
@@ -21,6 +21,16 @@
                         <x-forms.checkbox instantSave="instantSave('{{ $oauth_setting['provider'] }}')"
                             id="oauth_settings_map.{{ $oauth_setting['provider'] }}.enabled" label="Enabled" />
                     </div>
+                    <div class="grid gap-2 pb-2 md:grid-cols-2">
+                        <x-forms.checkbox instantSave="instantSave('{{ $oauth_setting['provider'] }}')"
+                            id="oauth_settings_map.{{ $oauth_setting['provider'] }}.is_registration_enabled"
+                            label="Allow OAuth self-registration"
+                            helper="Allow new users from this provider to sign up even when password registration is disabled." />
+                        <x-forms.checkbox instantSave="instantSave('{{ $oauth_setting['provider'] }}')"
+                            id="oauth_settings_map.{{ $oauth_setting['provider'] }}.disable_password_auth"
+                            label="Disable password login for OAuth users"
+                            helper="Users who sign in with this provider must continue using OAuth and cannot set or use a password." />
+                    </div>
                     <div class="flex flex-col w-full gap-2 xl:flex-row">
                         <x-forms.input id="oauth_settings_map.{{ $oauth_setting['provider'] }}.client_id"
                             label="Client ID" />

--- a/tests/Feature/OauthRegistrationTest.php
+++ b/tests/Feature/OauthRegistrationTest.php
@@ -1,0 +1,132 @@
+<?php
+
+use App\Http\Middleware\CheckForcePasswordReset;
+use App\Http\Middleware\DecideWhatToDoWithUser;
+use App\Models\InstanceSettings;
+use App\Models\OauthSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Redis;
+use Illuminate\Support\Once;
+use Laravel\Socialite\Facades\Socialite;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    config([
+        'cache.default' => 'array',
+        'cache.stores.redis' => config('cache.stores.array'),
+    ]);
+    Cache::setDefaultDriver('array');
+
+    Redis::swap(new class
+    {
+        public function connection(): self
+        {
+            return $this;
+        }
+
+        public function __call(string $name, array $arguments): mixed
+        {
+            return null;
+        }
+    });
+
+    InstanceSettings::query()->insert([
+        'id' => 0,
+        'is_registration_enabled' => false,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+    Once::flush();
+});
+
+function fakeOauthUser(string $email = 'oauth@example.com', string $name = 'OAuth User'): void
+{
+    $provider = new class($email, $name)
+    {
+        public function __construct(private string $email, private string $name) {}
+
+        public function setConfig(mixed $config = null): self
+        {
+            return $this;
+        }
+
+        public function with(array $parameters = []): self
+        {
+            return $this;
+        }
+
+        public function user(): object
+        {
+            return (object) [
+                'email' => $this->email,
+                'name' => $this->name,
+            ];
+        }
+    };
+
+    Socialite::shouldReceive('driver')->with('google')->andReturn($provider);
+}
+
+function createGoogleOauthSetting(array $overrides = []): OauthSetting
+{
+    return OauthSetting::query()->create(array_merge([
+        'provider' => 'google',
+        'enabled' => true,
+        'client_id' => 'client-id',
+        'client_secret' => 'client-secret',
+        'redirect_uri' => 'https://coolify.test/auth/google/callback',
+        'is_registration_enabled' => false,
+        'disable_password_auth' => false,
+    ], $overrides));
+}
+
+it('allows oauth self-registration when password registration is disabled for the instance', function () {
+    $this->withoutMiddleware([CheckForcePasswordReset::class, DecideWhatToDoWithUser::class]);
+
+    createGoogleOauthSetting(['is_registration_enabled' => true]);
+    fakeOauthUser();
+
+    $this->get(route('auth.callback', 'google'))
+        ->assertRedirect('/');
+
+    $user = User::where('email', 'oauth@example.com')->first();
+
+    expect($user)->not->toBeNull()
+        ->and($user->oauth_provider)->toBe('google')
+        ->and($user->password)->toBeNull()
+        ->and(auth()->id())->toBe($user->id);
+});
+
+it('blocks oauth self-registration when both instance and provider registration are disabled', function () {
+    $this->withoutMiddleware([CheckForcePasswordReset::class, DecideWhatToDoWithUser::class]);
+
+    createGoogleOauthSetting(['is_registration_enabled' => false]);
+    fakeOauthUser();
+
+    $this->get(route('auth.callback', 'google'))
+        ->assertRedirect(route('login'));
+
+    expect(User::where('email', 'oauth@example.com')->exists())->toBeFalse()
+        ->and(auth()->check())->toBeFalse();
+});
+
+it('blocks password login for users tied to an oauth-only provider', function () {
+    createGoogleOauthSetting(['disable_password_auth' => true]);
+
+    User::factory()->create([
+        'email' => 'oauth-password@example.com',
+        'password' => Hash::make('Password123!'),
+        'oauth_provider' => 'google',
+    ]);
+
+    $this->post('/login', [
+        'email' => 'oauth-password@example.com',
+        'password' => 'Password123!',
+    ])->assertSessionHasErrors();
+
+    expect(auth()->check())->toBeFalse();
+});


### PR DESCRIPTION
## Summary
- add per-provider OAuth self-registration controls
- add optional password-auth disabling for users associated with OAuth providers
- store the OAuth provider on users and prevent password reset/update when password auth is disabled
- add coverage for OAuth self-registration and OAuth-only password login blocking

Fixes #8042
/claim #8042

## Tests
- `APP_ENV=testing php artisan test --compact tests\Feature\OauthRegistrationTest.php`
- `php vendor\bin\pint --dirty`
- `git diff --check`

## Demo
- Demo video pending. I can add one if maintainers need it before review.