### PR TITLE
Add WordPress OpenLiteSpeed service template

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -1,0 +1,61 @@
+# documentation: https://docs.litespeedtech.com/cloud/docker/
+# slogan: Run WordPress on OpenLiteSpeed with MariaDB for a high-performance PHP hosting stack.
+# category: cms
+# tags: cms, blog, content, management, wordpress, openlitespeed, mariadb
+# logo: svgs/wordpress.svg
+
+services:
+  openlitespeed:
+    image: litespeedtech/openlitespeed:1.8.5-lsphp83
+    volumes:
+      - wordpress-files:/var/www/vhosts/localhost/html
+      - openlitespeed-conf:/usr/local/lsws/conf
+      - openlitespeed-admin-conf:/usr/local/lsws/admin/conf
+      - openlitespeed-logs:/usr/local/lsws/logs
+    environment:
+      - SERVICE_URL_OPENLITESPEED_80
+      - WORDPRESS_DB_HOST=mariadb:3306
+      - WORDPRESS_DB_NAME=wordpress
+      - WORDPRESS_DB_USER=$SERVICE_USER_WORDPRESS
+      - WORDPRESS_DB_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    depends_on:
+      - mariadb
+    command:
+      - sh
+      - -c
+      - |
+        until mysqladmin ping -h mariadb -u"$WORDPRESS_DB_USER" -p"$WORDPRESS_DB_PASSWORD" --silent; do
+          sleep 2
+        done
+        cd /var/www/vhosts/localhost/html
+        if [ ! -f wp-load.php ]; then
+          wp core download --allow-root
+        fi
+        if [ ! -f wp-config.php ]; then
+          wp config create \
+            --dbname="$WORDPRESS_DB_NAME" \
+            --dbuser="$WORDPRESS_DB_USER" \
+            --dbpass="$WORDPRESS_DB_PASSWORD" \
+            --dbhost="$WORDPRESS_DB_HOST" \
+            --allow-root
+        fi
+        chown -R nobody:nogroup /var/www/vhosts/localhost/html
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10

--- a/templates/service-templates-latest.json
+++ b/templates/service-templates-latest.json
@@ -5225,6 +5225,23 @@
         "logo": "svgs/wordpress.svg",
         "minversion": "0.0.0"
     },
+    "wordpress-with-openlitespeed": {
+        "documentation": "https://docs.litespeedtech.com/cloud/docker/?utm_source=coolify.io",
+        "slogan": "Run WordPress on OpenLiteSpeed with MariaDB for a high-performance PHP hosting stack.",
+        "compose": "c2VydmljZXM6CiAgb3BlbmxpdGVzcGVlZDoKICAgIGltYWdlOiBsaXRlc3BlZWR0ZWNoL29wZW5saXRlc3BlZWQ6MS44LjUtbHNwaHA4MwogICAgdm9sdW1lczoKICAgIC0gd29yZHByZXNzLWZpbGVzOi92YXIvd3d3L3Zob3N0cy9sb2NhbGhvc3QvaHRtbAogICAgLSBvcGVubGl0ZXNwZWVkLWNvbmY6L3Vzci9sb2NhbC9sc3dzL2NvbmYKICAgIC0gb3BlbmxpdGVzcGVlZC1hZG1pbi1jb25mOi91c3IvbG9jYWwvbHN3cy9hZG1pbi9jb25mCiAgICAtIG9wZW5saXRlc3BlZWQtbG9nczovdXNyL2xvY2FsL2xzd3MvbG9ncwogICAgZW52aXJvbm1lbnQ6CiAgICAtIFNFUlZJQ0VfVVJMX09QRU5MSVRFU1BFRURfODAKICAgIC0gV09SRFBSRVNTX0RCX0hPU1Q9bWFyaWFkYjozMzA2CiAgICAtIFdPUkRQUkVTU19EQl9OQU1FPXdvcmRwcmVzcwogICAgLSBXT1JEUFJFU1NfREJfVVNFUj0kU0VSVklDRV9VU0VSX1dPUkRQUkVTUwogICAgLSBXT1JEUFJFU1NfREJfUEFTU1dPUkQ9JFNFUlZJQ0VfUEFTU1dPUkRfV09SRFBSRVNTCiAgICBkZXBlbmRzX29uOgogICAgLSBtYXJpYWRiCiAgICBjb21tYW5kOgogICAgLSBzaAogICAgLSAiLWMiCiAgICAtIHwKICAgICAgdW50aWwgbXlzcWxhZG1pbiBwaW5nIC1oIG1hcmlhZGIgLXUiJFdPUkRQUkVTU19EQl9VU0VSIiAtcCIkV09SRFBSRVNTX0RCX1BBU1NXT1JEIiAtLXNpbGVudDsgZG8KICAgICAgICBzbGVlcCAyCiAgICAgIGRvbmUKICAgICAgY2QgL3Zhci93d3cvdmhvc3RzL2xvY2FsaG9zdC9odG1sCiAgICAgIGlmIFsgISAtZiB3cC1sb2FkLnBocCBdOyB0aGVuCiAgICAgICAgd3AgY29yZSBkb3dubG9hZCAtLWFsbG93LXJvb3QKICAgICAgZmkKICAgICAgaWYgWyAhIC1mIHdwLWNvbmZpZy5waHAgXTsgdGhlbgogICAgICAgIHdwIGNvbmZpZyBjcmVhdGUgXAogICAgICAgICAgLS1kYm5hbWU9IiRXT1JEUFJFU1NfREJfTkFNRSIgXAogICAgICAgICAgLS1kYnVzZXI9IiRXT1JEUFJFU1NfREJfVVNFUiIgXAogICAgICAgICAgLS1kYnBhc3M9IiRXT1JEUFJFU1NfREJfUEFTU1dPUkQiIFwKICAgICAgICAgIC0tZGJob3N0PSIkV09SRFBSRVNTX0RCX0hPU1QiIFwKICAgICAgICAgIC0tYWxsb3ctcm9vdAogICAgICBmaQogICAgICBjaG93biAtUiBub2JvZHk6bm9ncm91cCAvdmFyL3d3dy92aG9zdHMvbG9jYWxob3N0L2h0bWwKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAtIENNRAogICAgICAtIGN1cmwKICAgICAgLSAiLWYiCiAgICAgIC0gaHR0cDovLzEyNy4wLjAuMQogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCiAgbWFyaWFkYjoKICAgIGltYWdlOiBtYXJpYWRiOjExCiAgICB2b2x1bWVzOgogICAgLSBtYXJpYWRiLWRhdGE6L3Zhci9saWIvbXlzcWwKICAgIGVudmlyb25tZW50OgogICAgLSBNWVNRTF9ST09UX1BBU1NXT1JEPSRTRVJWSUNFX1BBU1NXT1JEX1JPT1QKICAgIC0gTVlTUUxfREFUQUJBU0U9d29yZHByZXNzCiAgICAtIE1ZU1FMX1VTRVI9JFNFUlZJQ0VfVVNFUl9XT1JEUFJFU1MKICAgIC0gTVlTUUxfUEFTU1dPUkQ9JFNFUlZJQ0VfUEFTU1dPUkRfV09SRFBSRVNTCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgLSBDTUQKICAgICAgLSBoZWFsdGhjaGVjay5zaAogICAgICAtICItLWNvbm5lY3QiCiAgICAgIC0gIi0taW5ub2RiX2luaXRpYWxpemVkIgogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCg==",
+        "tags": [
+          "cms",
+          "blog",
+          "content",
+          "management",
+          "wordpress",
+          "openlitespeed",
+          "mariadb"
+        ],
+        "category": "cms",
+        "logo": "svgs/wordpress.svg",
+        "minversion": "0.0.0"
+    },
     "wordpress-without-database": {
         "documentation": "https://wordpress.org?utm_source=coolify.io",
         "slogan": "WordPress is open source software you can use to create a beautiful website, blog, or app.",

--- a/templates/service-templates.json
+++ b/templates/service-templates.json
@@ -5225,6 +5225,23 @@
         "logo": "svgs/wordpress.svg",
         "minversion": "0.0.0"
     },
+    "wordpress-with-openlitespeed": {
+        "documentation": "https://docs.litespeedtech.com/cloud/docker/?utm_source=coolify.io",
+        "slogan": "Run WordPress on OpenLiteSpeed with MariaDB for a high-performance PHP hosting stack.",
+        "compose": "c2VydmljZXM6CiAgb3BlbmxpdGVzcGVlZDoKICAgIGltYWdlOiBsaXRlc3BlZWR0ZWNoL29wZW5saXRlc3BlZWQ6MS44LjUtbHNwaHA4MwogICAgdm9sdW1lczoKICAgIC0gd29yZHByZXNzLWZpbGVzOi92YXIvd3d3L3Zob3N0cy9sb2NhbGhvc3QvaHRtbAogICAgLSBvcGVubGl0ZXNwZWVkLWNvbmY6L3Vzci9sb2NhbC9sc3dzL2NvbmYKICAgIC0gb3BlbmxpdGVzcGVlZC1hZG1pbi1jb25mOi91c3IvbG9jYWwvbHN3cy9hZG1pbi9jb25mCiAgICAtIG9wZW5saXRlc3BlZWQtbG9nczovdXNyL2xvY2FsL2xzd3MvbG9ncwogICAgZW52aXJvbm1lbnQ6CiAgICAtIFNFUlZJQ0VfRlFETl9PUEVOTElURVNQRUVEXzgwCiAgICAtIFdPUkRQUkVTU19EQl9IT1NUPW1hcmlhZGI6MzMwNgogICAgLSBXT1JEUFJFU1NfREJfTkFNRT13b3JkcHJlc3MKICAgIC0gV09SRFBSRVNTX0RCX1VTRVI9JFNFUlZJQ0VfVVNFUl9XT1JEUFJFU1MKICAgIC0gV09SRFBSRVNTX0RCX1BBU1NXT1JEPSRTRVJWSUNFX1BBU1NXT1JEX1dPUkRQUkVTUwogICAgZGVwZW5kc19vbjoKICAgIC0gbWFyaWFkYgogICAgY29tbWFuZDoKICAgIC0gc2gKICAgIC0gIi1jIgogICAgLSB8CiAgICAgIHVudGlsIG15c3FsYWRtaW4gcGluZyAtaCBtYXJpYWRiIC11IiRXT1JEUFJFU1NfREJfVVNFUiIgLXAiJFdPUkRQUkVTU19EQl9QQVNTV09SRCIgLS1zaWxlbnQ7IGRvCiAgICAgICAgc2xlZXAgMgogICAgICBkb25lCiAgICAgIGNkIC92YXIvd3d3L3Zob3N0cy9sb2NhbGhvc3QvaHRtbAogICAgICBpZiBbICEgLWYgd3AtbG9hZC5waHAgXTsgdGhlbgogICAgICAgIHdwIGNvcmUgZG93bmxvYWQgLS1hbGxvdy1yb290CiAgICAgIGZpCiAgICAgIGlmIFsgISAtZiB3cC1jb25maWcucGhwIF07IHRoZW4KICAgICAgICB3cCBjb25maWcgY3JlYXRlIFwKICAgICAgICAgIC0tZGJuYW1lPSIkV09SRFBSRVNTX0RCX05BTUUiIFwKICAgICAgICAgIC0tZGJ1c2VyPSIkV09SRFBSRVNTX0RCX1VTRVIiIFwKICAgICAgICAgIC0tZGJwYXNzPSIkV09SRFBSRVNTX0RCX1BBU1NXT1JEIiBcCiAgICAgICAgICAtLWRiaG9zdD0iJFdPUkRQUkVTU19EQl9IT1NUIiBcCiAgICAgICAgICAtLWFsbG93LXJvb3QKICAgICAgZmkKICAgICAgY2hvd24gLVIgbm9ib2R5Om5vZ3JvdXAgL3Zhci93d3cvdmhvc3RzL2xvY2FsaG9zdC9odG1sCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgLSBDTUQKICAgICAgLSBjdXJsCiAgICAgIC0gIi1mIgogICAgICAtIGh0dHA6Ly8xMjcuMC4wLjEKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogIG1hcmlhZGI6CiAgICBpbWFnZTogbWFyaWFkYjoxMQogICAgdm9sdW1lczoKICAgIC0gbWFyaWFkYi1kYXRhOi92YXIvbGliL215c3FsCiAgICBlbnZpcm9ubWVudDoKICAgIC0gTVlTUUxfUk9PVF9QQVNTV09SRD0kU0VSVklDRV9QQVNTV09SRF9ST09UCiAgICAtIE1ZU1FMX0RBVEFCQVNFPXdvcmRwcmVzcwogICAgLSBNWVNRTF9VU0VSPSRTRVJWSUNFX1VTRVJfV09SRFBSRVNTCiAgICAtIE1ZU1FMX1BBU1NXT1JEPSRTRVJWSUNFX1BBU1NXT1JEX1dPUkRQUkVTUwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgIC0gQ01ECiAgICAgIC0gaGVhbHRoY2hlY2suc2gKICAgICAgLSAiLS1jb25uZWN0IgogICAgICAtICItLWlubm9kYl9pbml0aWFsaXplZCIKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAo=",
+        "tags": [
+          "cms",
+          "blog",
+          "content",
+          "management",
+          "wordpress",
+          "openlitespeed",
+          "mariadb"
+        ],
+        "category": "cms",
+        "logo": "svgs/wordpress.svg",
+        "minversion": "0.0.0"
+    },
     "wordpress-without-database": {
         "documentation": "https://wordpress.org?utm_source=coolify.io",
         "slogan": "WordPress is open source software you can use to create a beautiful website, blog, or app.",


### PR DESCRIPTION
STRAWBERRY

## Changes

- Adds a WordPress + OpenLiteSpeed one-click service template backed by MariaDB.
- Persists WordPress files, OpenLiteSpeed config, admin config, logs, and MariaDB data through named volumes.
- On first start, the OpenLiteSpeed service waits for MariaDB, downloads WordPress with wp-cli, and creates `wp-config.php` with generated Coolify credentials.
- Adds the generated service metadata entries for both `service-templates-latest.json` and `service-templates.json`.

## Issues

- Fixes #8264

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not available from this environment.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Used to inspect existing service template patterns, add the template, and validate YAML/JSON structure.

## Testing

- Parsed `templates/compose/wordpress-with-openlitespeed.yaml` with Ruby YAML.
- Parsed `templates/service-templates-latest.json` and `templates/service-templates.json` with Ruby JSON.
- Verified the generated latest template keeps `SERVICE_URL_OPENLITESPEED_80`.
- Verified the generated FQDN template converts it to `SERVICE_FQDN_OPENLITESPEED_80`.
- Ran `git diff --check`.
- Could not run `php artisan generate:services` because PHP/Composer are not installed in this environment.
- Could not run `docker compose config` or boot the stack because Docker is not installed in this environment.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
