### PR TITLE
fix: add IPv6 fallback for Docker network creation

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -98,11 +98,11 @@ class InstallDocker
             ]);
             if ($server->isSwarm()) {
                 $command = $command->merge([
-                    'docker network create --attachable --driver overlay coolify-overlay >/dev/null 2>&1 || true',
+                    dockerNetworkCreateCommand('coolify-overlay', 'overlay'),
                 ]);
             } else {
                 $command = $command->merge([
-                    'docker network create --attachable coolify >/dev/null 2>&1 || true',
+                    dockerNetworkCreateCommand('coolify'),
                 ]);
                 $command = $command->merge([
                     "echo 'Done!'",

--- a/app/Actions/Service/StartService.php
+++ b/app/Actions/Service/StartService.php
@@ -33,7 +33,7 @@ class StartService
         }
         if ($service->networks()->count() > 0) {
             $commands[] = "echo 'Creating Docker network.'";
-            $commands[] = "docker network inspect $service->uuid >/dev/null 2>&1 || docker network create --attachable $service->uuid";
+            $commands[] = dockerNetworkCreateCommand($service->uuid);
         }
         $commands[] = 'echo Starting service.';
         $commands[] = "docker compose --project-directory {$workdir} -f {$workdir}/docker-compose.yml --project-name {$service->uuid} up -d --remove-orphans --force-recreate --build";

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -775,7 +775,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             // TODO
         } else {
             $this->execute_remote_command([
-                "docker network inspect '{$networkId}' >/dev/null 2>&1 || docker network create --attachable '{$networkId}' >/dev/null || true",
+                dockerNetworkCreateCommand(escapeshellarg($networkId)),
                 'hidden' => true,
                 'ignore_errors' => true,
             ], [

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -1406,9 +1406,9 @@ $schema://$host {
             return;
         }
         if ($isSwarm) {
-            return instant_remote_process(['docker network create --attachable --driver overlay coolify-overlay >/dev/null 2>&1 || true'], $this, false);
+            return instant_remote_process([dockerNetworkCreateCommand('coolify-overlay', 'overlay')], $this, false);
         } else {
-            return instant_remote_process(['docker network create coolify --attachable >/dev/null 2>&1 || true'], $this, false);
+            return instant_remote_process([dockerNetworkCreateCommand('coolify')], $this, false);
         }
     }
 

--- a/app/Models/StandaloneDocker.php
+++ b/app/Models/StandaloneDocker.php
@@ -25,7 +25,7 @@ class StandaloneDocker extends BaseModel
             $server = $newStandaloneDocker->server;
             $safeNetwork = escapeshellarg($newStandaloneDocker->network);
             instant_remote_process([
-                "docker network inspect {$safeNetwork} >/dev/null 2>&1 || docker network create --driver overlay --attachable {$safeNetwork} >/dev/null",
+                dockerNetworkCreateCommand($safeNetwork, $server->isSwarm() ? 'overlay' : 'bridge'),
             ], $server, false);
             ConnectProxyToNetworksJob::dispatchSync($server);
         });

--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -149,6 +149,15 @@ function executeInDocker(string $containerId, string $command)
     return "docker exec {$containerId} bash -c '{$escapedCommand}'";
 }
 
+function dockerNetworkCreateCommand(string $network, string $driver = 'bridge'): string
+{
+    $driverOption = $driver === 'bridge' ? '' : " --driver {$driver}";
+    $createWithIpv6 = "docker network create{$driverOption} --attachable --ipv6 {$network}";
+    $createWithoutIpv6 = "docker network create{$driverOption} --attachable {$network}";
+
+    return "docker network inspect {$network} >/dev/null 2>&1 || {$createWithIpv6} >/dev/null 2>&1 || {$createWithoutIpv6} >/dev/null 2>&1 || true";
+}
+
 function getContainerStatus(Server $server, string $container_id, bool $all_data = false, bool $throwError = false)
 {
     if ($server->isSwarm()) {

--- a/bootstrap/helpers/proxy.php
+++ b/bootstrap/helpers/proxy.php
@@ -111,7 +111,7 @@ function connectProxyToNetworks(Server $server)
         $commands = $networks->map(function ($network) {
             $safe = escapeshellarg($network);
             return [
-                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || docker network create --driver overlay --attachable {$safe} >/dev/null",
+                dockerNetworkCreateCommand($safe, 'overlay'),
                 "docker network connect {$safe} coolify-proxy >/dev/null 2>&1 || true",
                 "echo 'Successfully connected coolify-proxy to {$safe} network.'",
             ];
@@ -120,7 +120,7 @@ function connectProxyToNetworks(Server $server)
         $commands = $networks->map(function ($network) {
             $safe = escapeshellarg($network);
             return [
-                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || docker network create --attachable {$safe} >/dev/null",
+                dockerNetworkCreateCommand($safe),
                 "docker network connect {$safe} coolify-proxy >/dev/null 2>&1 || true",
                 "echo 'Successfully connected coolify-proxy to {$safe} network.'",
             ];
@@ -146,7 +146,7 @@ function ensureProxyNetworksExist(Server $server)
             $safe = escapeshellarg($network);
             return [
                 "echo 'Ensuring network {$safe} exists...'",
-                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --driver overlay --attachable {$safe}",
+                dockerNetworkCreateCommand($safe, 'overlay'),
             ];
         });
     } else {
@@ -154,7 +154,7 @@ function ensureProxyNetworksExist(Server $server)
             $safe = escapeshellarg($network);
             return [
                 "echo 'Ensuring network {$safe} exists...'",
-                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --attachable {$safe}",
+                dockerNetworkCreateCommand($safe),
             ];
         });
     }

--- a/tests/Unit/DockerNetworkCreateCommandTest.php
+++ b/tests/Unit/DockerNetworkCreateCommandTest.php
@@ -1,0 +1,19 @@
+<?php
+
+it('creates bridge networks with IPv6 and falls back to IPv4-only networks', function () {
+    $command = dockerNetworkCreateCommand('coolify');
+
+    expect($command)
+        ->toContain('docker network inspect coolify >/dev/null 2>&1')
+        ->toContain('docker network create --attachable --ipv6 coolify >/dev/null 2>&1')
+        ->toContain('docker network create --attachable coolify >/dev/null 2>&1 || true');
+});
+
+it('creates overlay networks with IPv6 and falls back to IPv4-only networks', function () {
+    $command = dockerNetworkCreateCommand("'coolify-overlay'", 'overlay');
+
+    expect($command)
+        ->toContain("docker network inspect 'coolify-overlay' >/dev/null 2>&1")
+        ->toContain("docker network create --driver overlay --attachable --ipv6 'coolify-overlay' >/dev/null 2>&1")
+        ->toContain("docker network create --driver overlay --attachable 'coolify-overlay' >/dev/null 2>&1 || true");
+});


### PR DESCRIPTION
## Changes

- Adds a shared `dockerNetworkCreateCommand()` helper for Coolify-managed Docker networks.
- The helper first attempts `docker network create --ipv6` and falls back to the existing IPv4-only network creation path when Docker IPv6 is not enabled on the host.
- Reuses the helper for Coolify network validation/install, application deployments, service startup, standalone Docker destination creation, and proxy network setup.
- Adds unit coverage for bridge and overlay network command generation.

## Issues

- Fixes #3436
- Replaces closed PR #10038, which targeted `v4.x` instead of the required `next` branch.

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

This is a backend Docker network command-generation change. No UI preview applies.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: AI assisted with repository inspection, implementation, and drafting. The change was reviewed against Coolify's existing Docker network creation paths and contributor requirements before submission.

## Testing

- Added `tests/Unit/DockerNetworkCreateCommandTest.php`.
- Ran `git diff --check`.
- Searched remaining `docker network create` call sites. The remaining direct call is in `scripts/upgrade.sh`, where IPv6 fallback behavior already exists.
- I could not run the full Pest/Pint suite locally because PHP/composer dependencies are not installed in this environment.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
