### PR TITLE
[codex] add wordpress openlitespeed service template

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -1,0 +1,72 @@
+# documentation: https://docs.litespeedtech.com/cloud/docker/ols-wordpress/
+# slogan: WordPress served by OpenLiteSpeed with MariaDB.
+# category: cms
+# tags: cms, blog, content, management, wordpress, openlitespeed, litespeed, mariadb
+# logo: svgs/wordpress.svg
+# port: 80
+
+services:
+  wordpress:
+    image: litespeedtech/openlitespeed:latest
+    volumes:
+      - wordpress-files:/var/www/vhosts/localhost/html
+    environment:
+      - SERVICE_URL_WORDPRESS_80
+      - TZ=${TZ:-UTC}
+    depends_on:
+      wordpress-init:
+        condition: service_completed_successfully
+      mariadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1"]
+      interval: 2s
+      timeout: 10s
+      retries: 10
+
+  wordpress-init:
+    exclude_from_hc: true
+    image: wordpress:cli-php8.3
+    restart: no
+    user: "0:0"
+    working_dir: /var/www/html
+    volumes:
+      - wordpress-files:/var/www/html
+    environment:
+      - WORDPRESS_DB_HOST=mariadb
+      - WORDPRESS_DB_USER=${SERVICE_USER_WORDPRESS}
+      - WORDPRESS_DB_PASSWORD=${SERVICE_PASSWORD_WORDPRESS}
+      - WORDPRESS_DB_NAME=${MYSQL_DATABASE:-wordpress}
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    command: >
+      sh -c '
+        set -e;
+        if [ ! -f wp-config.php ]; then
+          wp core download --allow-root &&
+          wp config create
+            --dbname="$${WORDPRESS_DB_NAME}"
+            --dbuser="$${WORDPRESS_DB_USER}"
+            --dbpass="$${WORDPRESS_DB_PASSWORD}"
+            --dbhost="$${WORDPRESS_DB_HOST}"
+            --skip-check
+            --allow-root;
+        fi;
+        chown -R 65534:65534 /var/www/html
+      '
+
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=${SERVICE_PASSWORD_ROOT}
+      - MYSQL_DATABASE=${MYSQL_DATABASE:-wordpress}
+      - MYSQL_USER=${SERVICE_USER_WORDPRESS}
+      - MYSQL_PASSWORD=${SERVICE_PASSWORD_WORDPRESS}
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10

--- a/templates/service-templates-latest.json
+++ b/templates/service-templates-latest.json
@@ -5225,6 +5225,25 @@
         "logo": "svgs/wordpress.svg",
         "minversion": "0.0.0"
     },
+    "wordpress-with-openlitespeed": {
+        "documentation": "https://docs.litespeedtech.com/cloud/docker/ols-wordpress/?utm_source=coolify.io",
+        "slogan": "WordPress served by OpenLiteSpeed with MariaDB.",
+        "compose": "c2VydmljZXM6CiAgd29yZHByZXNzOgogICAgaW1hZ2U6IGxpdGVzcGVlZHRlY2gvb3BlbmxpdGVzcGVlZDpsYXRlc3QKICAgIHZvbHVtZXM6CiAgICAgIC0gd29yZHByZXNzLWZpbGVzOi92YXIvd3d3L3Zob3N0cy9sb2NhbGhvc3QvaHRtbAogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gU0VSVklDRV9VUkxfV09SRFBSRVNTXzgwCiAgICAgIC0gVFo9JHtUWjotVVRDfQogICAgZGVwZW5kc19vbjoKICAgICAgd29yZHByZXNzLWluaXQ6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2NvbXBsZXRlZF9zdWNjZXNzZnVsbHkKICAgICAgbWFyaWFkYjoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfaGVhbHRoeQogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6IFsiQ01EIiwgImN1cmwiLCAiLWYiLCAiaHR0cDovLzEyNy4wLjAuMSJdCiAgICAgIGludGVydmFsOiAycwogICAgICB0aW1lb3V0OiAxMHMKICAgICAgcmV0cmllczogMTAKCiAgd29yZHByZXNzLWluaXQ6CiAgICBleGNsdWRlX2Zyb21faGM6IHRydWUKICAgIGltYWdlOiB3b3JkcHJlc3M6Y2xpLXBocDguMwogICAgcmVzdGFydDogbm8KICAgIHVzZXI6ICIwOjAiCiAgICB3b3JraW5nX2RpcjogL3Zhci93d3cvaHRtbAogICAgdm9sdW1lczoKICAgICAgLSB3b3JkcHJlc3MtZmlsZXM6L3Zhci93d3cvaHRtbAogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gV09SRFBSRVNTX0RCX0hPU1Q9bWFyaWFkYgogICAgICAtIFdPUkRQUkVTU19EQl9VU0VSPSR7U0VSVklDRV9VU0VSX1dPUkRQUkVTU30KICAgICAgLSBXT1JEUFJFU1NfREJfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX1dPUkRQUkVTU30KICAgICAgLSBXT1JEUFJFU1NfREJfTkFNRT0ke01ZU1FMX0RBVEFCQVNFOi13b3JkcHJlc3N9CiAgICBkZXBlbmRzX29uOgogICAgICBtYXJpYWRiOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5CiAgICBjb21tYW5kOiA+CiAgICAgIHNoIC1jICcKICAgICAgICBzZXQgLWU7CiAgICAgICAgaWYgWyAhIC1mIHdwLWNvbmZpZy5waHAgXTsgdGhlbgogICAgICAgICAgd3AgY29yZSBkb3dubG9hZCAtLWFsbG93LXJvb3QgJiYKICAgICAgICAgIHdwIGNvbmZpZyBjcmVhdGUKICAgICAgICAgICAgLS1kYm5hbWU9IiQke1dPUkRQUkVTU19EQl9OQU1FfSIKICAgICAgICAgICAgLS1kYnVzZXI9IiQke1dPUkRQUkVTU19EQl9VU0VSfSIKICAgICAgICAgICAgLS1kYnBhc3M9IiQke1dPUkRQUkVTU19EQl9QQVNTV09SRH0iCiAgICAgICAgICAgIC0tZGJob3N0PSIkJHtXT1JEUFJFU1NfREJfSE9TVH0iCiAgICAgICAgICAgIC0tc2tpcC1jaGVjawogICAgICAgICAgICAtLWFsbG93LXJvb3Q7CiAgICAgICAgZmk7CiAgICAgICAgY2hvd24gLVIgNjU1MzQ6NjU1MzQgL3Zhci93d3cvaHRtbAogICAgICAnCgogIG1hcmlhZGI6CiAgICBpbWFnZTogbWFyaWFkYjoxMQogICAgdm9sdW1lczoKICAgICAgLSBtYXJpYWRiLWRhdGE6L3Zhci9saWIvbXlzcWwKICAgIGVudmlyb25tZW50OgogICAgICAtIE1ZU1FMX1JPT1RfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX1JPT1R9CiAgICAgIC0gTVlTUUxfREFUQUJBU0U9JHtNWVNRTF9EQVRBQkFTRTotd29yZHByZXNzfQogICAgICAtIE1ZU1FMX1VTRVI9JHtTRVJWSUNFX1VTRVJfV09SRFBSRVNTfQogICAgICAtIE1ZU1FMX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9XT1JEUFJFU1N9CiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDogWyJDTUQiLCAiaGVhbHRoY2hlY2suc2giLCAiLS1jb25uZWN0IiwgIi0taW5ub2RiX2luaXRpYWxpemVkIl0KICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAo=",
+        "tags": [
+            "cms",
+            "blog",
+            "content",
+            "management",
+            "wordpress",
+            "openlitespeed",
+            "litespeed",
+            "mariadb"
+        ],
+        "category": "cms",
+        "logo": "svgs/wordpress.svg",
+        "minversion": "0.0.0",
+        "port": "80"
+    },
     "wordpress-without-database": {
         "documentation": "https://wordpress.org?utm_source=coolify.io",
         "slogan": "WordPress is open source software you can use to create a beautiful website, blog, or app.",

--- a/templates/service-templates.json
+++ b/templates/service-templates.json
@@ -5225,6 +5225,25 @@
         "logo": "svgs/wordpress.svg",
         "minversion": "0.0.0"
     },
+    "wordpress-with-openlitespeed": {
+        "documentation": "https://docs.litespeedtech.com/cloud/docker/ols-wordpress/?utm_source=coolify.io",
+        "slogan": "WordPress served by OpenLiteSpeed with MariaDB.",
+        "compose": "c2VydmljZXM6CiAgd29yZHByZXNzOgogICAgaW1hZ2U6IGxpdGVzcGVlZHRlY2gvb3BlbmxpdGVzcGVlZDpsYXRlc3QKICAgIHZvbHVtZXM6CiAgICAgIC0gd29yZHByZXNzLWZpbGVzOi92YXIvd3d3L3Zob3N0cy9sb2NhbGhvc3QvaHRtbAogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gU0VSVklDRV9GUUROX1dPUkRQUkVTU184MAogICAgICAtIFRaPSR7VFo6LVVUQ30KICAgIGRlcGVuZHNfb246CiAgICAgIHdvcmRwcmVzcy1pbml0OgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9jb21wbGV0ZWRfc3VjY2Vzc2Z1bGx5CiAgICAgIG1hcmlhZGI6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OiBbIkNNRCIsICJjdXJsIiwgIi1mIiwgImh0dHA6Ly8xMjcuMC4wLjEiXQogICAgICBpbnRlcnZhbDogMnMKICAgICAgdGltZW91dDogMTBzCiAgICAgIHJldHJpZXM6IDEwCgogIHdvcmRwcmVzcy1pbml0OgogICAgZXhjbHVkZV9mcm9tX2hjOiB0cnVlCiAgICBpbWFnZTogd29yZHByZXNzOmNsaS1waHA4LjMKICAgIHJlc3RhcnQ6IG5vCiAgICB1c2VyOiAiMDowIgogICAgd29ya2luZ19kaXI6IC92YXIvd3d3L2h0bWwKICAgIHZvbHVtZXM6CiAgICAgIC0gd29yZHByZXNzLWZpbGVzOi92YXIvd3d3L2h0bWwKICAgIGVudmlyb25tZW50OgogICAgICAtIFdPUkRQUkVTU19EQl9IT1NUPW1hcmlhZGIKICAgICAgLSBXT1JEUFJFU1NfREJfVVNFUj0ke1NFUlZJQ0VfVVNFUl9XT1JEUFJFU1N9CiAgICAgIC0gV09SRFBSRVNTX0RCX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9XT1JEUFJFU1N9CiAgICAgIC0gV09SRFBSRVNTX0RCX05BTUU9JHtNWVNRTF9EQVRBQkFTRTotd29yZHByZXNzfQogICAgZGVwZW5kc19vbjoKICAgICAgbWFyaWFkYjoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfaGVhbHRoeQogICAgY29tbWFuZDogPgogICAgICBzaCAtYyAnCiAgICAgICAgc2V0IC1lOwogICAgICAgIGlmIFsgISAtZiB3cC1jb25maWcucGhwIF07IHRoZW4KICAgICAgICAgIHdwIGNvcmUgZG93bmxvYWQgLS1hbGxvdy1yb290ICYmCiAgICAgICAgICB3cCBjb25maWcgY3JlYXRlCiAgICAgICAgICAgIC0tZGJuYW1lPSIkJHtXT1JEUFJFU1NfREJfTkFNRX0iCiAgICAgICAgICAgIC0tZGJ1c2VyPSIkJHtXT1JEUFJFU1NfREJfVVNFUn0iCiAgICAgICAgICAgIC0tZGJwYXNzPSIkJHtXT1JEUFJFU1NfREJfUEFTU1dPUkR9IgogICAgICAgICAgICAtLWRiaG9zdD0iJCR7V09SRFBSRVNTX0RCX0hPU1R9IgogICAgICAgICAgICAtLXNraXAtY2hlY2sKICAgICAgICAgICAgLS1hbGxvdy1yb290OwogICAgICAgIGZpOwogICAgICAgIGNob3duIC1SIDY1NTM0OjY1NTM0IC92YXIvd3d3L2h0bWwKICAgICAgJwoKICBtYXJpYWRiOgogICAgaW1hZ2U6IG1hcmlhZGI6MTEKICAgIHZvbHVtZXM6CiAgICAgIC0gbWFyaWFkYi1kYXRhOi92YXIvbGliL215c3FsCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBNWVNRTF9ST09UX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9ST09UfQogICAgICAtIE1ZU1FMX0RBVEFCQVNFPSR7TVlTUUxfREFUQUJBU0U6LXdvcmRwcmVzc30KICAgICAgLSBNWVNRTF9VU0VSPSR7U0VSVklDRV9VU0VSX1dPUkRQUkVTU30KICAgICAgLSBNWVNRTF9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfV09SRFBSRVNTfQogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6IFsiQ01EIiwgImhlYWx0aGNoZWNrLnNoIiwgIi0tY29ubmVjdCIsICItLWlubm9kYl9pbml0aWFsaXplZCJdCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAK",
+        "tags": [
+            "cms",
+            "blog",
+            "content",
+            "management",
+            "wordpress",
+            "openlitespeed",
+            "litespeed",
+            "mariadb"
+        ],
+        "category": "cms",
+        "logo": "svgs/wordpress.svg",
+        "minversion": "0.0.0",
+        "port": "80"
+    },
     "wordpress-without-database": {
         "documentation": "https://wordpress.org?utm_source=coolify.io",
         "slogan": "WordPress is open source software you can use to create a beautiful website, blog, or app.",


### PR DESCRIPTION
Closes #8264.

This adds a new `wordpress-with-openlitespeed` service template for running WordPress behind OpenLiteSpeed with MariaDB.

Summary:

- Adds `templates/compose/wordpress-with-openlitespeed.yaml`.
- Persists WordPress files and MariaDB data with named volumes.
- Serves the WordPress volume from OpenLiteSpeed's default document root on port 80.
- Adds a one-shot WP-CLI init service that downloads WordPress and creates `wp-config.php` only when it is missing.
- Updates `templates/service-templates-latest.json` and `templates/service-templates.json` with the service catalog entries.

Validation:

- Parsed the compose YAML successfully with a local YAML parser.
- Parsed the decoded compose payloads from both generated service template JSON entries.
- Confirmed the latest catalog uses `SERVICE_URL_WORDPRESS_80` and the FQDN catalog uses `SERVICE_FQDN_WORDPRESS_80`.

Note: I could not run a live Docker deployment in this local environment because Docker is not available on PATH.
