### PR TITLE
feat: add WordPress OpenLiteSpeed service template

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -1,0 +1,72 @@
+# documentation: https://docs.litespeedtech.com/cloud/docker/ols-wordpress/
+# slogan: WordPress served by OpenLiteSpeed with MariaDB.
+# category: cms
+# tags: cms, blog, content, management, wordpress, openlitespeed, litespeed, mariadb
+# logo: svgs/wordpress.svg
+# port: 80
+
+services:
+  wordpress:
+    image: litespeedtech/openlitespeed:latest
+    volumes:
+      - wordpress-files:/var/www/vhosts/localhost/html
+    environment:
+      - SERVICE_URL_WORDPRESS_80
+      - TZ=${TZ:-UTC}
+    depends_on:
+      wordpress-init:
+        condition: service_completed_successfully
+      mariadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1"]
+      interval: 2s
+      timeout: 10s
+      retries: 10
+
+  wordpress-init:
+    exclude_from_hc: true
+    image: wordpress:cli-php8.3
+    restart: no
+    user: "0:0"
+    working_dir: /var/www/html
+    volumes:
+      - wordpress-files:/var/www/html
+    environment:
+      - WORDPRESS_DB_HOST=mariadb
+      - WORDPRESS_DB_USER=${SERVICE_USER_WORDPRESS}
+      - WORDPRESS_DB_PASSWORD=${SERVICE_PASSWORD_WORDPRESS}
+      - WORDPRESS_DB_NAME=${MYSQL_DATABASE:-wordpress}
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    command: >
+      sh -c '
+        set -e;
+        if [ ! -f wp-config.php ]; then
+          wp core download --allow-root &&
+          wp config create
+            --dbname="$${WORDPRESS_DB_NAME}"
+            --dbuser="$${WORDPRESS_DB_USER}"
+            --dbpass="$${WORDPRESS_DB_PASSWORD}"
+            --dbhost="$${WORDPRESS_DB_HOST}"
+            --skip-check
+            --allow-root;
+        fi;
+        chown -R 65534:65534 /var/www/html
+      '
+
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=${SERVICE_PASSWORD_ROOT}
+      - MYSQL_DATABASE=${MYSQL_DATABASE:-wordpress}
+      - MYSQL_USER=${SERVICE_USER_WORDPRESS}
+      - MYSQL_PASSWORD=${SERVICE_PASSWORD_WORDPRESS}
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
## Changes

- Added a `wordpress-with-openlitespeed` one click service template.
- The template runs OpenLiteSpeed, initializes WordPress with WP-CLI when `wp-config.php` is missing, and uses MariaDB 11 for storage.
- WordPress files and MariaDB data are persisted with named volumes.

## Issues

- Fixes #8264

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

- Not available. Docker is not installed in my local environment, so I could not capture a live deployment screenshot.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: AI drafted the template and PR text; the generated files and validation output were reviewed before submission.

## Testing

- Parsed `templates/compose/wordpress-with-openlitespeed.yaml` with a local YAML parser.
- Verified the template uses `SERVICE_URL_WORDPRESS_80` for Coolify's generated public endpoint.
- Could not run a live Docker deployment locally because Docker is not available on PATH.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
