### PR TITLE
feat: add Docker Image Management page

### DIFF
--- a/app/Livewire/Server/DockerImages.php
+++ b/app/Livewire/Server/DockerImages.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace App\Livewire\Server;
+
+use App\Models\Server;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Collection;
+use Livewire\Attributes\Computed;
+use Livewire\Component;
+
+class DockerImages extends Component
+{
+    use AuthorizesRequests;
+
+    public Server $server;
+
+    public array $parameters = [];
+
+    public function mount(string $server_uuid)
+    {
+        try {
+            $this->server = Server::ownedByCurrentTeam()->whereUuid($server_uuid)->firstOrFail();
+            $this->parameters = get_route_parameters();
+        } catch (\Throwable) {
+            return redirect()->route('server.index');
+        }
+    }
+
+    #[Computed]
+    public function images(): Collection
+    {
+        try {
+            $raw = instant_remote_process(
+                ["docker images --format '{{json .}}'"],
+                $this->server,
+                false
+            );
+
+            if (! $raw) {
+                return collect();
+            }
+
+            $lines = array_filter(explode("\n", trim($raw)));
+            $images = collect();
+
+            foreach ($lines as $line) {
+                $data = json_decode($line, true);
+                if (! $data || ! isset($data['Repository'])) {
+                    continue;
+                }
+
+                $repoTag = $data['Repository'].':'.$data['Tag'];
+                $imageId = $data['ID'];
+
+                // Check which containers use this image
+                $usedBy = instant_remote_process(
+                    ["docker ps -a --filter ancestor={$repoTag} --format '{{.Names}}' 2>/dev/null || true"],
+                    $this->server,
+                    false
+                );
+
+                $images->push([
+                    'id' => $imageId,
+                    'repository' => $data['Repository'],
+                    'tag' => $data['Tag'],
+                    'size' => $data['Size'] ?? '?',
+                    'created_at' => $data['CreatedAt'] ?? '?',
+                    'repo_tag' => $repoTag,
+                    'used_by' => $usedBy ? array_filter(explode("\n", trim($usedBy))) : [],
+                    'is_dangling' => $data['Repository'] === '<none>' || $data['Tag'] === '<none>',
+                    'is_used' => ! empty($usedBy),
+                ]);
+            }
+
+            return $images;
+        } catch (\Throwable) {
+            return collect();
+        }
+    }
+
+    #[Computed]
+    public function danglingCount(): int
+    {
+        return $this->images->filter(fn ($img) => $img['is_dangling'])->count();
+    }
+
+    #[Computed]
+    public function totalSize(): string
+    {
+        $totalBytes = 0;
+        foreach ($this->images as $img) {
+            $size = $img['size'];
+            if (preg_match('/^(\d+(?:\.\d+)?)\s*(B|KB|MB|GB)$/i', $size, $m)) {
+                $value = (float) $m[1];
+                $unit = strtoupper($m[2]);
+                $multipliers = ['B' => 1, 'KB' => 1024, 'MB' => 1024 ** 2, 'GB' => 1024 ** 3];
+                $totalBytes += $value * ($multipliers[$unit] ?? 1);
+            }
+        }
+
+        if ($totalBytes === 0) {
+            return '0 B';
+        }
+
+        $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+        $i = floor(log($totalBytes, 1024));
+
+        return @round($totalBytes / pow(1024, $i), 1).' '.$units[$i];
+    }
+
+    public function deleteImage(string $repoTag): void
+    {
+        try {
+            $this->authorize('update', $this->server);
+            instant_remote_process(
+                ["docker rmi {$repoTag} 2>/dev/null || docker image rm {$repoTag} 2>/dev/null || true"],
+                $this->server,
+                false
+            );
+            $this->dispatch('success', "Image {$repoTag} deleted.");
+            unset($this->images);
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function pruneDangling(): void
+    {
+        try {
+            $this->authorize('update', $this->server);
+            instant_remote_process(
+                ['docker image prune -af'],
+                $this->server,
+                false
+            );
+            $this->dispatch('success', 'All dangling images pruned.');
+            unset($this->images);
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function pruneAll(): void
+    {
+        try {
+            $this->authorize('update', $this->server);
+            instant_remote_process(
+                ['docker image prune -af && docker builder prune -af'],
+                $this->server,
+                false
+            );
+            $this->dispatch('success', 'All unused images and build cache pruned.');
+            unset($this->images);
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function render()
+    {
+        return view('livewire.server.docker-images');
+    }
+}

--- a/resources/views/components/server/sidebar.blade.php
+++ b/resources/views/components/server/sidebar.blade.php
@@ -31,6 +31,9 @@
         <a class="sub-menu-item {{ $activeMenu === 'docker-cleanup' ? 'menu-item-active' : '' }}" {{ wireNavigate() }}
             href="{{ route('server.docker-cleanup', ['server_uuid' => $server->uuid]) }}"><span class="menu-item-label">Docker Cleanup</span>
         </a>
+        <a class="sub-menu-item {{ $activeMenu === 'docker-images' ? 'menu-item-active' : '' }}" {{ wireNavigate() }}
+            href="{{ route('server.docker-images', ['server_uuid' => $server->uuid]) }}"><span class="menu-item-label">Docker Images</span>
+        </a>
         <a class="sub-menu-item {{ $activeMenu === 'destinations' ? 'menu-item-active' : '' }}" {{ wireNavigate() }}
             href="{{ route('server.destinations', ['server_uuid' => $server->uuid]) }}"><span class="menu-item-label">Destinations</span>
         </a>

--- a/resources/views/livewire/server/docker-images.blade.php
+++ b/resources/views/livewire/server/docker-images.blade.php
@@ -1,0 +1,114 @@
+<div>
+    <x-slot:title>
+        {{ data_get_str($server, 'name')->limit(10) }} > Docker Images | Coolify
+    </x-slot>
+    <livewire:server.navbar :server="$server" />
+    <div x-data="{ activeTab: window.location.hash ? window.location.hash.substring(1) : 'all' }"
+        class="flex flex-col h-full gap-8 sm:flex-row">
+        <x-server.sidebar :server="$server" activeMenu="docker-images" />
+        <div class="w-full">
+            <div class="flex items-center gap-2">
+                <h2>Docker Images</h2>
+                <div class="flex items-center gap-2 ml-auto">
+                    <span class="text-xs text-neutral-500">
+                        {{ $this->images->count() }} images &middot;
+                        {{ $this->danglingCount }} dangling &middot;
+                        {{ $this->totalSize }} total
+                    </span>
+                </div>
+            </div>
+            <div class="mt-1 mb-6">Manage Docker images on your server.</div>
+
+            @if ($this->danglingCount > 0)
+                <x-callout type="warning" title="Unused Images Detected">
+                    <p>{{ $this->danglingCount }} dangling images can be safely removed to free up disk space.</p>
+                    <div class="flex gap-2 mt-2">
+                        <x-modal-confirmation title="Prune Dangling Images?"
+                            buttonTitle="Prune Dangling Images" isHighlightedButton
+                            submitAction="pruneDangling"
+                            :actions="['Permanently deletes all untagged (dangling) images']"
+                            :confirmWithText="false" :confirmWithPassword="false"
+                            step2ButtonText="Prune Dangling Images" />
+                        <x-modal-confirmation title="Prune All Unused Images?"
+                            buttonTitle="Prune All" isDangerButton
+                            submitAction="pruneAll"
+                            :actions="[
+                                'Permanently deletes all unused images',
+                                'Clears build cache',
+                            ]"
+                            :confirmWithText="false" :confirmWithPassword="false"
+                            step2ButtonText="Prune All" />
+                    </div>
+                </x-callout>
+            @endif
+
+            <div class="mt-6">
+                @if ($this->images->isEmpty())
+                    <div class="text-neutral-500 text-sm">No Docker images found on this server.</div>
+                @else
+                    <div class="overflow-x-auto">
+                        <table class="w-full text-sm">
+                            <thead>
+                                <tr class="text-left text-neutral-500 border-b border-neutral-700">
+                                    <th class="pb-2 pr-4">Repository</th>
+                                    <th class="pb-2 pr-4">Tag</th>
+                                    <th class="pb-2 pr-4">Image ID</th>
+                                    <th class="pb-2 pr-4">Size</th>
+                                    <th class="pb-2 pr-4">Created</th>
+                                    <th class="pb-2 pr-4">Used By</th>
+                                    <th class="pb-2 pr-2">Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach ($this->images as $image)
+                                    <tr wire:key="img-{{ md5($image['repo_tag'].$image['id']) }}"
+                                        class="border-b border-neutral-800 hover:bg-neutral-900/50 {{ $image['is_dangling'] ? 'opacity-60' : '' }}">
+                                        <td class="py-2 pr-4 font-mono text-xs max-w-[200px] truncate">
+                                            {{ $image['repository'] }}
+                                        </td>
+                                        <td class="py-2 pr-4">
+                                            <span
+                                                class="px-1.5 py-0.5 text-xs rounded {{ $image['is_dangling'] ? 'bg-red-900/30 text-red-400' : 'bg-neutral-800 text-neutral-300' }}">
+                                                {{ $image['tag'] }}
+                                            </span>
+                                        </td>
+                                        <td class="py-2 pr-4 font-mono text-xs text-neutral-400">
+                                            {{ strlen($image['id']) > 12 ? substr($image['id'], 7, 12) : $image['id'] }}
+                                        </td>
+                                        <td class="py-2 pr-4 text-xs">{{ $image['size'] }}</td>
+                                        <td class="py-2 pr-4 text-xs text-neutral-400">{{ $image['created_at'] }}</td>
+                                        <td class="py-2 pr-4 text-xs max-w-[150px] truncate">
+                                            @if ($image['is_used'])
+                                                <span class="text-emerald-400">{{ count($image['used_by']) }}
+                                                    container(s)</span>
+                                            @else
+                                                <span class="text-neutral-500">Not used</span>
+                                            @endif
+                                        </td>
+                                        <td class="py-2 pr-2">
+                                            @can('update', $server)
+                                                @if (!$image['is_used'])
+                                                    <x-modal-confirmation
+                                                        title="Delete image {{ $image['repo_tag'] }}?"
+                                                        buttonTitle="Delete"
+                                                        isDangerButton
+                                                        submitAction="deleteImage('{{ $image['repo_tag'] }}')"
+                                                        :actions="['This action cannot be undone.']"
+                                                        :confirmWithText="false"
+                                                        :confirmWithPassword="false"
+                                                        step2ButtonText="Delete Image" />
+                                                @else
+                                                    <span class="text-xs text-neutral-600">In use</span>
+                                                @endif
+                                            @endcan
+                                        </td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                @endif
+            </div>
+        </div>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -48,6 +48,7 @@ use App\Livewire\Server\CloudProviderToken\Show as CloudProviderTokenShow;
 use App\Livewire\Server\Delete as DeleteServer;
 use App\Livewire\Server\Destinations as ServerDestinations;
 use App\Livewire\Server\DockerCleanup;
+use App\Livewire\Server\DockerImages;
 use App\Livewire\Server\Index as ServerIndex;
 use App\Livewire\Server\LogDrains;
 use App\Livewire\Server\PrivateKey\Show as PrivateKeyShow;
@@ -294,6 +295,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/proxy/logs', ProxyLogs::class)->name('server.proxy.logs');
         Route::get('/terminal', ExecuteContainerCommand::class)->name('server.command')->middleware('can.access.terminal');
         Route::get('/docker-cleanup', DockerCleanup::class)->name('server.docker-cleanup');
+        Route::get('/docker-images', DockerImages::class)->name('server.docker-images');
         Route::get('/security', fn () => redirect(route('dashboard')))->name('server.security')->middleware('can.update.resource');
         Route::get('/security/patches', Patches::class)->name('server.security.patches')->middleware('can.update.resource');
         Route::get('/security/terminal-access', TerminalAccess::class)->name('server.security.terminal-access')->middleware('can.update.resource');


### PR DESCRIPTION
## Changes

- Add Docker Images management page under server sidebar
- List all images with repository, tag, size, and creation date
- Show which containers are using each image
- Delete individual unused images
- Bulk prune dangling images
- Clear build cache

## Issues

Closes #2499

/claim #2499