### PR TITLE
Enable IPv6 fallback for Docker networks

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -98,11 +98,11 @@ class InstallDocker
             ]);
             if ($server->isSwarm()) {
                 $command = $command->merge([
-                    'docker network create --attachable --driver overlay coolify-overlay >/dev/null 2>&1 || true',
+                    dockerNetworkCreateCommand('coolify-overlay', isSwarm: true, hideOutput: true).' || true',
                 ]);
             } else {
                 $command = $command->merge([
-                    'docker network create --attachable coolify >/dev/null 2>&1 || true',
+                    dockerNetworkCreateCommand('coolify', hideOutput: true).' || true',
                 ]);
                 $command = $command->merge([
                     "echo 'Done!'",

--- a/app/Actions/Service/StartService.php
+++ b/app/Actions/Service/StartService.php
@@ -31,13 +31,14 @@ class StartService
             $commands[] = "echo 'Pulling images.'";
             $commands[] = "docker compose --project-directory {$workdir} pull";
         }
+        $safeNetwork = escapeshellarg($service->uuid);
         if ($service->networks()->count() > 0) {
             $commands[] = "echo 'Creating Docker network.'";
-            $commands[] = "docker network inspect $service->uuid >/dev/null 2>&1 || docker network create --attachable $service->uuid";
+            $commands[] = "docker network inspect {$safeNetwork} >/dev/null 2>&1 || ".dockerNetworkCreateCommand($service->uuid);
         }
         $commands[] = 'echo Starting service.';
         $commands[] = "docker compose --project-directory {$workdir} -f {$workdir}/docker-compose.yml --project-name {$service->uuid} up -d --remove-orphans --force-recreate --build";
-        $commands[] = "docker network connect $service->uuid coolify-proxy >/dev/null 2>&1 || true";
+        $commands[] = "docker network connect {$safeNetwork} coolify-proxy >/dev/null 2>&1 || true";
         if (data_get($service, 'connect_to_docker_network')) {
             $compose = data_get($service, 'docker_compose', []);
             $safeNetwork = escapeshellarg($service->destination->network);

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -774,12 +774,15 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         if ($this->server->isSwarm()) {
             // TODO
         } else {
+            $safeNetworkId = escapeshellarg($networkId);
+            $createNetworkCommand = dockerNetworkCreateCommand($networkId, hideOutput: true);
+
             $this->execute_remote_command([
-                "docker network inspect '{$networkId}' >/dev/null 2>&1 || docker network create --attachable '{$networkId}' >/dev/null || true",
+                "docker network inspect {$safeNetworkId} >/dev/null 2>&1 || {$createNetworkCommand} || true",
                 'hidden' => true,
                 'ignore_errors' => true,
             ], [
-                "docker network connect {$networkId} coolify-proxy >/dev/null 2>&1 || true",
+                "docker network connect {$safeNetworkId} coolify-proxy >/dev/null 2>&1 || true",
                 'hidden' => true,
                 'ignore_errors' => true,
             ]);

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -1428,9 +1428,9 @@ $schema://$host {
             return;
         }
         if ($isSwarm) {
-            return instant_remote_process(['docker network create --attachable --driver overlay coolify-overlay >/dev/null 2>&1 || true'], $this, false);
+            return instant_remote_process([dockerNetworkCreateCommand('coolify-overlay', isSwarm: true, hideOutput: true).' || true'], $this, false);
         } else {
-            return instant_remote_process(['docker network create coolify --attachable >/dev/null 2>&1 || true'], $this, false);
+            return instant_remote_process([dockerNetworkCreateCommand('coolify', hideOutput: true).' || true'], $this, false);
         }
     }
 

--- a/app/Models/StandaloneDocker.php
+++ b/app/Models/StandaloneDocker.php
@@ -25,7 +25,7 @@ class StandaloneDocker extends BaseModel
             $server = $newStandaloneDocker->server;
             $safeNetwork = escapeshellarg($newStandaloneDocker->network);
             instant_remote_process([
-                "docker network inspect {$safeNetwork} >/dev/null 2>&1 || docker network create --driver overlay --attachable {$safeNetwork} >/dev/null",
+                "docker network inspect {$safeNetwork} >/dev/null 2>&1 || ".dockerNetworkCreateCommand($newStandaloneDocker->network, hideOutput: true),
             ], $server, false);
             ConnectProxyToNetworksJob::dispatchSync($server);
         });

--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -86,7 +86,7 @@ function format_docker_command_output_to_json($rawOutput): Collection
         return $outputLines
             ->reject(fn ($line) => empty($line))
             ->map(fn ($outputLine) => json_decode($outputLine, true, flags: JSON_THROW_ON_ERROR));
-    } catch (\Throwable) {
+    } catch (Throwable) {
         return collect([]);
     }
 }
@@ -123,7 +123,7 @@ function format_docker_envs_to_json($rawOutput)
 
             return [$env[0] => $env[1]];
         });
-    } catch (\Throwable) {
+    } catch (Throwable) {
         return collect([]);
     }
 }
@@ -140,6 +140,21 @@ function checkMinimumDockerEngineVersion($dockerVersion)
 function escapeShellValue(string $value): string
 {
     return "'".str_replace("'", "'\\''", $value)."'";
+}
+
+function dockerNetworkCreateCommand(string $network, bool $isSwarm = false, bool $hideOutput = false): string
+{
+    $safeNetwork = escapeshellarg($network);
+    $outputRedirect = $hideOutput ? ' >/dev/null 2>&1' : '';
+
+    if ($isSwarm) {
+        return "docker network create --attachable --driver overlay {$safeNetwork}{$outputRedirect}";
+    }
+
+    $createWithIpv6 = "docker network create --attachable --ipv6 {$safeNetwork} >/dev/null 2>&1";
+    $createFallback = "docker network create --attachable {$safeNetwork}{$outputRedirect}";
+
+    return "({$createWithIpv6} || {$createFallback})";
 }
 
 function executeInDocker(string $containerId, string $command)
@@ -255,12 +270,12 @@ function defaultLabels($id, $name, string $projectName, string $resourceName, st
 
 function generateServiceSpecificFqdns(ServiceApplication|Application $resource)
 {
-    if ($resource->getMorphClass() === \App\Models\ServiceApplication::class) {
+    if ($resource->getMorphClass() === ServiceApplication::class) {
         $uuid = data_get($resource, 'uuid');
         $server = data_get($resource, 'service.server');
         $environment_variables = data_get($resource, 'service.environment_variables');
         $type = $resource->serviceType();
-    } elseif ($resource->getMorphClass() === \App\Models\Application::class) {
+    } elseif ($resource->getMorphClass() === Application::class) {
         $uuid = data_get($resource, 'uuid');
         $server = data_get($resource, 'destination.server');
         $environment_variables = data_get($resource, 'environment_variables');
@@ -641,7 +656,7 @@ function fqdnLabelsForTraefik(string $uuid, Collection $domains, bool $is_force_
                     }
                 }
             }
-        } catch (\Throwable) {
+        } catch (Throwable) {
             continue;
         }
     }
@@ -1219,7 +1234,7 @@ function validateComposeFile(string $compose, int $server_id): string|Throwable
     $server = Server::ownedByCurrentTeam()->find($server_id);
     try {
         if (! $server) {
-            throw new \Exception('Server not found');
+            throw new Exception('Server not found');
         }
         $yaml_compose = Yaml::parse($compose);
 
@@ -1235,7 +1250,7 @@ function validateComposeFile(string $compose, int $server_id): string|Throwable
         ], $server);
 
         return 'OK';
-    } catch (\Throwable $e) {
+    } catch (Throwable $e) {
         return $e->getMessage();
     } finally {
         if (filled($server)) {
@@ -1351,10 +1366,10 @@ function escapeBashDoubleQuoted(?string $value): string
  * Generate Docker build arguments from environment variables collection
  * Returns only keys (no values) since values are sourced from environment via export
  *
- * @param  \Illuminate\Support\Collection|array  $variables  Collection of variables with 'key', 'value', and optionally 'is_multiline'
- * @return \Illuminate\Support\Collection Collection of formatted --build-arg strings (keys only)
+ * @param  Collection|array  $variables  Collection of variables with 'key', 'value', and optionally 'is_multiline'
+ * @return Collection Collection of formatted --build-arg strings (keys only)
  */
-function generateDockerBuildArgs($variables): \Illuminate\Support\Collection
+function generateDockerBuildArgs($variables): Collection
 {
     $variables = collect($variables);
 
@@ -1369,7 +1384,7 @@ function generateDockerBuildArgs($variables): \Illuminate\Support\Collection
 /**
  * Generate Docker environment flags from environment variables collection
  *
- * @param  \Illuminate\Support\Collection|array  $variables  Collection of variables with 'key', 'value', and optionally 'is_multiline'
+ * @param  Collection|array  $variables  Collection of variables with 'key', 'value', and optionally 'is_multiline'
  * @return string Space-separated environment flags
  */
 function generateDockerEnvFlags($variables): string

--- a/bootstrap/helpers/proxy.php
+++ b/bootstrap/helpers/proxy.php
@@ -4,6 +4,7 @@ use App\Actions\Proxy\SaveProxyConfiguration;
 use App\Enums\ProxyTypes;
 use App\Models\Application;
 use App\Models\Server;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
 use Symfony\Component\Yaml\Yaml;
 
@@ -110,8 +111,10 @@ function connectProxyToNetworks(Server $server)
     if ($server->isSwarm()) {
         $commands = $networks->map(function ($network) {
             $safe = escapeshellarg($network);
+            $createNetworkCommand = dockerNetworkCreateCommand($network, isSwarm: true);
+
             return [
-                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || docker network create --driver overlay --attachable {$safe} >/dev/null",
+                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || {$createNetworkCommand} >/dev/null",
                 "docker network connect {$safe} coolify-proxy >/dev/null 2>&1 || true",
                 "echo 'Successfully connected coolify-proxy to {$safe} network.'",
             ];
@@ -119,8 +122,10 @@ function connectProxyToNetworks(Server $server)
     } else {
         $commands = $networks->map(function ($network) {
             $safe = escapeshellarg($network);
+            $createNetworkCommand = dockerNetworkCreateCommand($network, hideOutput: true);
+
             return [
-                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || docker network create --attachable {$safe} >/dev/null",
+                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || {$createNetworkCommand}",
                 "docker network connect {$safe} coolify-proxy >/dev/null 2>&1 || true",
                 "echo 'Successfully connected coolify-proxy to {$safe} network.'",
             ];
@@ -135,7 +140,7 @@ function connectProxyToNetworks(Server $server)
  * This must be called BEFORE docker compose up since the compose file declares networks as external.
  *
  * @param  Server  $server  The server to ensure networks on
- * @return \Illuminate\Support\Collection Commands to create networks if they don't exist
+ * @return Collection Commands to create networks if they don't exist
  */
 function ensureProxyNetworksExist(Server $server)
 {
@@ -144,17 +149,21 @@ function ensureProxyNetworksExist(Server $server)
     if ($server->isSwarm()) {
         $commands = $networks->map(function ($network) {
             $safe = escapeshellarg($network);
+            $createNetworkCommand = dockerNetworkCreateCommand($network, isSwarm: true);
+
             return [
                 "echo 'Ensuring network {$safe} exists...'",
-                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --driver overlay --attachable {$safe}",
+                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || {$createNetworkCommand}",
             ];
         });
     } else {
         $commands = $networks->map(function ($network) {
             $safe = escapeshellarg($network);
+            $createNetworkCommand = dockerNetworkCreateCommand($network);
+
             return [
                 "echo 'Ensuring network {$safe} exists...'",
-                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --attachable {$safe}",
+                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || {$createNetworkCommand}",
             ];
         });
     }
@@ -211,7 +220,7 @@ function extractCustomProxyCommands(Server $server, string $existing_config): ar
                 $custom_commands[] = $command;
             }
         }
-    } catch (\Exception $e) {
+    } catch (Exception $e) {
         // If we can't parse the config, return empty array
         // Silently fail to avoid breaking the proxy regeneration
     }
@@ -432,7 +441,7 @@ function getExactTraefikVersionFromContainer(Server $server): ?string
         Log::debug("getExactTraefikVersionFromContainer: Server '{$server->name}' (ID: {$server->id}) - Could not detect exact version");
 
         return null;
-    } catch (\Exception $e) {
+    } catch (Exception $e) {
         Log::error("getExactTraefikVersionFromContainer: Server '{$server->name}' (ID: {$server->id}) - Error: ".$e->getMessage());
 
         return null;
@@ -479,7 +488,7 @@ function getTraefikVersionFromDockerCompose(Server $server): ?string
         Log::debug("getTraefikVersionFromDockerCompose: Server '{$server->name}' (ID: {$server->id}) - Image format doesn't match expected pattern: {$image}");
 
         return null;
-    } catch (\Exception $e) {
+    } catch (Exception $e) {
         Log::error("getTraefikVersionFromDockerCompose: Server '{$server->name}' (ID: {$server->id}) - Error: ".$e->getMessage());
 
         return null;

--- a/tests/Unit/DockerNetworkCreateCommandTest.php
+++ b/tests/Unit/DockerNetworkCreateCommandTest.php
@@ -1,0 +1,26 @@
+<?php
+
+it('builds standalone Docker network create commands with IPv6 fallback', function () {
+    $command = dockerNetworkCreateCommand('coolify', hideOutput: true);
+
+    expect($command)->toBe("(docker network create --attachable --ipv6 'coolify' >/dev/null 2>&1 || docker network create --attachable 'coolify' >/dev/null 2>&1)");
+});
+
+it('can leave fallback Docker network create output visible', function () {
+    $command = dockerNetworkCreateCommand('app-network');
+
+    expect($command)->toBe("(docker network create --attachable --ipv6 'app-network' >/dev/null 2>&1 || docker network create --attachable 'app-network')");
+});
+
+it('keeps swarm Docker network create commands on overlay networks', function () {
+    $command = dockerNetworkCreateCommand('coolify-overlay', isSwarm: true, hideOutput: true);
+
+    expect($command)->toBe("docker network create --attachable --driver overlay 'coolify-overlay' >/dev/null 2>&1");
+    expect($command)->not->toContain('--ipv6');
+});
+
+it('escapes Docker network names in create commands', function () {
+    $command = dockerNetworkCreateCommand("team's-network", hideOutput: true);
+
+    expect($command)->toContain("'team'\\''s-network'");
+});


### PR DESCRIPTION
Fixes #3436

/claim #3436

## Summary
- Add a Docker network creation helper that enables IPv6 for standalone attachable networks with a safe IPv4-only fallback.
- Reuse the helper across proxy, deployment, service, Docker install, and standalone Docker network creation paths.
- Add unit coverage for IPv6/fallback command generation and Swarm overlay behavior.

## Tests
- vendor/bin/pint --dirty --format agent
- vendor/bin/pest tests/Unit/DockerNetworkCreateCommandTest.php tests/Unit/DockerNetworkInjectionTest.php tests/Unit/ProxyHelperTest.php