### PR TITLE
Allow OAUTH-only self-registering without general registration

### DIFF
--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -21,11 +21,6 @@ class OauthController extends Controller
             $oauthUser = get_socialite_provider($provider)->user();
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
-                $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
-                    abort(403, 'Registration is disabled');
-                }
-
                 $user = User::create([
                     'name' => $oauthUser->name,
                     'email' => $oauthUser->email,


### PR DESCRIPTION
## Summary

This PR allows users to self-register via OAUTH2 even when general self-registration is disabled.

## Changes

- Removed the `is_registration_enabled` check in `OauthController::callback()`
- OAUTH users can now self-register regardless of the general registration setting
- General registration (email/password) still respects the `is_registration_enabled` setting

## Issue

Fixes #8042

## Testing

- Tested that OAUTH users can self-register when general registration is disabled
- Verified that general registration still respects the `is_registration_enabled` setting