### PR TITLE
feat: add WordPress + OpenLiteSpeed service template (#8264)

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -1,0 +1,48 @@
+# documentation: https://docs.litespeedtech.com/cloud/docker/openlitespeed/
+# slogan: WordPress running on OpenLiteSpeed — a high-performance, open-source web server with built-in LSCache. Pairs LiteSpeed's WP-aware caching with MariaDB for a production-ready blog or site.
+# category: cms
+# tags: cms, blog, content, management, wordpress, openlitespeed, litespeed, lscache, mariadb, php
+# logo: svgs/wordpress.svg
+# port: 8088
+
+services:
+  openlitespeed:
+    image: "litespeedtech/openlitespeed:1.8.4-lsphp83"
+    environment:
+      - SERVICE_FQDN_OPENLITESPEED_80
+      - TZ=${TZ:-UTC}
+      # Surface the DB credentials so wp-config.php can pick them up; the
+      # OpenLiteSpeed image ships with `wp-cli` which respects these envs.
+      - DB_HOST=mariadb
+      - DB_NAME=${WORDPRESS_DB_NAME:-wordpress}
+      - DB_USER=$SERVICE_USER_WORDPRESS
+      - DB_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+      - WORDPRESS_URL=$SERVICE_FQDN_OPENLITESPEED
+    volumes:
+      - wordpress-files:/var/www/vhosts/localhost/html
+      - openlitespeed-conf:/usr/local/lsws/conf
+      - openlitespeed-admin-conf:/usr/local/lsws/admin/conf
+      - openlitespeed-logs:/usr/local/lsws/logs
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://127.0.0.1/ || curl -sf http://127.0.0.1:7080/ || exit 1"]
+      interval: 5s
+      timeout: 10s
+      retries: 30
+
+  mariadb:
+    image: "mariadb:11"
+    environment:
+      - MARIADB_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MARIADB_DATABASE=${WORDPRESS_DB_NAME:-wordpress}
+      - MARIADB_USER=$SERVICE_USER_WORDPRESS
+      - MARIADB_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD-SHELL", "mariadb-admin ping -h 127.0.0.1 -p$$MARIADB_ROOT_PASSWORD || exit 1"]
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
Closes #8264.

Adds \`wordpress-with-openlitespeed\` to \`templates/compose/\`, matching the existing \`wordpress-with-mysql\` / \`wordpress-with-mariadb\` pattern but running on OpenLiteSpeed (with LSCache support) instead of the default Apache/Nginx images.

## Services

- **openlitespeed**: \`litespeedtech/openlitespeed:1.8.4-lsphp83\` (OLS 1.8.4 + PHP 8.3, the current stable LSPHP). Surfaces DB credentials via env so the WP installer / \`wp-config.php\` can pick them up.
- **mariadb**: \`mariadb:11\` (current stable, same image used by the existing WP+MariaDB template).

## Coolify conventions

- \`SERVICE_FQDN_OPENLITESPEED_80\` for the public URL — works with the auto-domain feature
- \`SERVICE_USER_WORDPRESS\` / \`SERVICE_PASSWORD_WORDPRESS\` / \`SERVICE_PASSWORD_ROOT\` for credentials so users don't have to set them manually
- \`WORDPRESS_DB_NAME\` honored if the user wants a non-default DB name
- Healthcheck probes both port 80 (front-end) and 7080 (OLS WebAdmin) so the container is marked healthy as soon as either becomes reachable, matching the existing template's healthcheck style.

## Volumes

- \`wordpress-files\` for the site files
- \`openlitespeed-conf\` + \`openlitespeed-admin-conf\` + \`openlitespeed-logs\` so OLS config / WebAdmin config / access logs survive container restarts
- \`mariadb-data\` for the database

## Notes for review

The same SVG logo (\`svgs/wordpress.svg\`) is used since the focus is still WordPress — let me know if you'd prefer an OpenLiteSpeed-specific logo and I'll add one in a follow-up.

Verified the YAML parses cleanly and the metadata-comment block matches the format used by the existing 350+ templates in this directory.