### PR TITLE
feat: add OAuth-only registration controls

### DIFF
--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -5,6 +5,7 @@ namespace App\Actions\Fortify;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Validation\Rules\Password;
 use Laravel\Fortify\Contracts\ResetsUserPasswords;
 
@@ -17,6 +18,12 @@ class ResetUserPassword implements ResetsUserPasswords
      */
     public function reset(User $user, array $input): void
     {
+        if ($user->usesOauthOnlyAuthentication()) {
+            throw ValidationException::withMessages([
+                'email' => 'Password reset is disabled for this account. Please sign in with your OAuth provider.',
+            ]);
+        }
+
         Validator::make($input, [
             'password' => ['required', Password::defaults(), 'confirmed'],
         ])->validate();

--- a/app/Actions/Fortify/UpdateUserPassword.php
+++ b/app/Actions/Fortify/UpdateUserPassword.php
@@ -5,6 +5,7 @@ namespace App\Actions\Fortify;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Validation\Rules\Password;
 use Laravel\Fortify\Contracts\UpdatesUserPasswords;
 
@@ -17,6 +18,15 @@ class UpdateUserPassword implements UpdatesUserPasswords
      */
     public function update(User $user, array $input): void
     {
+        if ($user->usesOauthOnlyAuthentication()) {
+            $exception = ValidationException::withMessages([
+                'current_password' => 'Password login is disabled for this account. Please sign in with your OAuth provider.',
+            ]);
+            $exception->errorBag = 'updatePassword';
+
+            throw $exception;
+        }
+
         Validator::make($input, [
             'current_password' => ['required', 'string', 'current_password:web'],
             'password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -78,6 +78,12 @@ class Controller extends BaseController
                 return response()->json(['message' => 'Transactional emails are not active'], 400);
             }
             $request->validate([Fortify::email() => 'required|email']);
+            $user = User::whereEmail(Str::lower($request->string(Fortify::email())->value()))->first();
+            if ($user && $user->usesOauthOnlyAuthentication()) {
+                return back()->withErrors([
+                    Fortify::email() => 'Password reset is disabled for this account. Please sign in with your OAuth provider.',
+                ]);
+            }
             $status = Password::broker(config('fortify.passwords'))->sendResetLink(
                 $request->only(Fortify::email())
             );

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -51,8 +51,21 @@ class OauthController extends Controller
                         'is_oauth_only' => $settings->is_oauth_only_auth_enabled,
                     ]);
                 }
-            } elseif ($user->oauth_provider === $provider && instanceSettings()->is_oauth_only_auth_enabled && ! $user->is_oauth_only) {
-                $user->update(['is_oauth_only' => true]);
+            } else {
+                $settings = instanceSettings();
+                $updates = [];
+
+                if ($user->oauth_provider !== $provider) {
+                    $updates['oauth_provider'] = $provider;
+                }
+
+                if ($settings->is_oauth_only_auth_enabled && ! $user->is_oauth_only) {
+                    $updates['is_oauth_only'] = true;
+                }
+
+                if ($updates !== []) {
+                    $user->update($updates);
+                }
             }
             Auth::login($user);
 

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -27,14 +27,32 @@ class OauthController extends Controller
             $user = User::whereEmail($email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! $settings->is_oauth_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 
-                $user = User::create([
-                    'name' => $oauthUser->name,
-                    'email' => $email,
-                ]);
+                if (User::count() === 0) {
+                    $user = (new User)->forceFill([
+                        'id' => 0,
+                        'name' => $oauthUser->name,
+                        'email' => $email,
+                        'oauth_provider' => $provider,
+                        'is_oauth_only' => $settings->is_oauth_only_auth_enabled,
+                    ]);
+                    $user->save();
+
+                    $settings->is_registration_enabled = false;
+                    $settings->save();
+                } else {
+                    $user = User::create([
+                        'name' => $oauthUser->name,
+                        'email' => $email,
+                        'oauth_provider' => $provider,
+                        'is_oauth_only' => $settings->is_oauth_only_auth_enabled,
+                    ]);
+                }
+            } elseif ($user->oauth_provider === $provider && instanceSettings()->is_oauth_only_auth_enabled && ! $user->is_oauth_only) {
+                $user->update(['is_oauth_only' => true]);
             }
             Auth::login($user);
 

--- a/app/Livewire/Profile/Index.php
+++ b/app/Livewire/Profile/Index.php
@@ -32,11 +32,14 @@ class Index extends Component
 
     public bool $show_verification = false;
 
+    public bool $uses_oauth_only_authentication = false;
+
     public function mount()
     {
         $this->userId = Auth::id();
         $this->name = Auth::user()->name;
         $this->email = Auth::user()->email;
+        $this->uses_oauth_only_authentication = Auth::user()->usesOauthOnlyAuthentication();
 
         // Check if there's a pending email change
         if (Auth::user()->hasEmailChangeRequest()) {
@@ -240,6 +243,12 @@ class Index extends Component
     public function resetPassword()
     {
         try {
+            if (auth()->user()->usesOauthOnlyAuthentication()) {
+                $this->dispatch('error', 'Password login is disabled for this account. Please sign in with your OAuth provider.');
+
+                return;
+            }
+
             $this->validate([
                 'current_password' => ['required'],
                 'new_password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -16,6 +16,12 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $is_oauth_registration_enabled;
+
+    #[Validate('boolean')]
+    public bool $is_oauth_only_auth_enabled;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -44,6 +50,8 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_registration_enabled' => 'boolean',
+            'is_oauth_only_auth_enabled' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => ['nullable', 'string', new ValidDnsServers],
@@ -66,6 +74,8 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled;
+        $this->is_oauth_only_auth_enabled = $this->settings->is_oauth_only_auth_enabled;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -147,6 +157,8 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
+            $this->settings->is_oauth_only_auth_enabled = $this->is_oauth_only_auth_enabled;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -18,6 +18,8 @@ class InstanceSettings extends Model
         'do_not_track',
         'is_auto_update_enabled',
         'is_registration_enabled',
+        'is_oauth_registration_enabled',
+        'is_oauth_only_auth_enabled',
         'next_channel',
         'smtp_enabled',
         'smtp_from_address',
@@ -64,6 +66,8 @@ class InstanceSettings extends Model
 
         'allowed_ip_ranges' => 'array',
         'is_auto_update_enabled' => 'boolean',
+        'is_oauth_registration_enabled' => 'boolean',
+        'is_oauth_only_auth_enabled' => 'boolean',
         'auto_update_frequency' => 'string',
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -46,9 +46,11 @@ class User extends Authenticatable implements SendsEmail
     protected $fillable = [
         'name',
         'email',
+        'oauth_provider',
         'password',
         'force_password_reset',
         'marketing_emails',
+        'is_oauth_only',
         'pending_email',
         'email_change_code',
         'email_change_code_expires_at',
@@ -64,6 +66,7 @@ class User extends Authenticatable implements SendsEmail
     protected $casts = [
         'email_verified_at' => 'datetime',
         'force_password_reset' => 'boolean',
+        'is_oauth_only' => 'boolean',
         'show_boarding' => 'boolean',
         'email_change_code_expires_at' => 'datetime',
     ];
@@ -486,5 +489,20 @@ class User extends Authenticatable implements SendsEmail
     public function hasPassword(): bool
     {
         return ! empty($this->password);
+    }
+
+    public function isOauthUser(): bool
+    {
+        return filled($this->oauth_provider);
+    }
+
+    public function usesOauthOnlyAuthentication(): bool
+    {
+        return $this->isOauthUser() && ($this->is_oauth_only || ! $this->hasPassword());
+    }
+
+    public function canUsePasswordAuthentication(): bool
+    {
+        return ! $this->usesOauthOnlyAuthentication();
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -498,11 +498,11 @@ class User extends Authenticatable implements SendsEmail
 
     public function usesOauthOnlyAuthentication(): bool
     {
-        return $this->isOauthUser() && ($this->is_oauth_only || ! $this->hasPassword());
+        return $this->is_oauth_only;
     }
 
     public function canUsePasswordAuthentication(): bool
     {
-        return ! $this->usesOauthOnlyAuthentication();
+        return ! $this->usesOauthOnlyAuthentication() && $this->hasPassword();
     }
 }

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -61,12 +61,15 @@ class FortifyServiceProvider extends ServiceProvider
             $enabled_oauth_providers = OauthSetting::where('enabled', true)->get();
             $users = User::count();
             if ($users == 0) {
-                // If there are no users, redirect to registration
-                return redirect()->route('register');
+                // If there are no users, prefer password registration when enabled.
+                if ($settings->is_registration_enabled) {
+                    return redirect()->route('register');
+                }
             }
 
             return view('auth.login', [
                 'is_registration_enabled' => $settings->is_registration_enabled,
+                'is_oauth_registration_enabled' => $settings->is_oauth_registration_enabled,
                 'enabled_oauth_providers' => $enabled_oauth_providers,
             ]);
         });
@@ -76,6 +79,7 @@ class FortifyServiceProvider extends ServiceProvider
             $user = User::where('email', $email)->with('teams')->first();
             if (
                 $user &&
+                $user->canUsePasswordAuthentication() &&
                 Hash::check($request->password, $user->password)
             ) {
                 $user->updated_at = now();

--- a/database/migrations/2026_05_11_235000_add_oauth_auth_controls.php
+++ b/database/migrations/2026_05_11_235000_add_oauth_auth_controls.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_registration_enabled')->default(false)->after('is_registration_enabled');
+            $table->boolean('is_oauth_only_auth_enabled')->default(false)->after('is_oauth_registration_enabled');
+        });
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('oauth_provider')->nullable()->after('email');
+            $table->boolean('is_oauth_only')->default(false)->after('oauth_provider');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['oauth_provider', 'is_oauth_only']);
+        });
+
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn(['is_oauth_registration_enabled', 'is_oauth_only_auth_enabled']);
+        });
+    }
+};

--- a/database/seeders/InstanceSettingsSeeder.php
+++ b/database/seeders/InstanceSettingsSeeder.php
@@ -16,6 +16,8 @@ class InstanceSettingsSeeder extends Seeder
         InstanceSettings::create([
             'id' => 0,
             'is_registration_enabled' => true,
+            'is_oauth_registration_enabled' => false,
+            'is_oauth_only_auth_enabled' => false,
             'is_api_enabled' => isDev(),
             'smtp_enabled' => true,
             'smtp_host' => 'coolify-mail',

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -72,7 +72,11 @@
                         </a>
                     @else
                         <div class="mt-6 text-center text-sm text-neutral-500 dark:text-neutral-400">
-                            {{ __('auth.registration_disabled') }}
+                            @if ($is_oauth_registration_enabled && $enabled_oauth_providers->isNotEmpty())
+                                Password registration is disabled. Use one of the OAuth providers below to sign in or create an account.
+                            @else
+                                {{ __('auth.registration_disabled') }}
+                            @endif
                         </div>
                     @endif
 

--- a/resources/views/livewire/profile/index.blade.php
+++ b/resources/views/livewire/profile/index.blade.php
@@ -55,20 +55,31 @@
             </form>
         @endif
     </div>
-    <form wire:submit='resetPassword' class="flex flex-col pt-4">
-        <div class="flex items-center gap-2 pb-2">
-            <h2>Change Password</h2>
-            <x-forms.button type="submit" label="Save">Save</x-forms.button>
-        </div>
-        <div class="text-xs font-bold dark:text-warning pb-2">Resetting the password will logout all sessions.</div>
-        <div class="flex flex-col gap-2">
-            <x-forms.input id="current_password" label="Current Password" required type="password" />
-            <div class="flex gap-2">
-                <x-forms.input id="new_password" label="New Password" required type="password" />
-                <x-forms.input id="new_password_confirmation" label="New Password Again" required type="password" />
+    @if ($uses_oauth_only_authentication)
+        <div class="flex flex-col pt-4">
+            <div class="flex items-center gap-2 pb-2">
+                <h2>Change Password</h2>
+            </div>
+            <div class="text-sm text-neutral-500 dark:text-neutral-400">
+                Password login is disabled for this account. Please continue signing in with your OAuth provider.
             </div>
         </div>
-    </form>
+    @else
+        <form wire:submit='resetPassword' class="flex flex-col pt-4">
+            <div class="flex items-center gap-2 pb-2">
+                <h2>Change Password</h2>
+                <x-forms.button type="submit" label="Save">Save</x-forms.button>
+            </div>
+            <div class="text-xs font-bold dark:text-warning pb-2">Resetting the password will logout all sessions.</div>
+            <div class="flex flex-col gap-2">
+                <x-forms.input id="current_password" label="Current Password" required type="password" />
+                <div class="flex gap-2">
+                    <x-forms.input id="new_password" label="New Password" required type="password" />
+                    <x-forms.input id="new_password_confirmation" label="New Password Again" required type="password" />
+                </div>
+            </div>
+        </form>
+    @endif
     <h2 class="py-4">Two-factor Authentication</h2>
     @if (session('status') == 'two-factor-authentication-enabled')
         <div class="mb-4 font-medium">

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -42,6 +42,16 @@
                         </div>
                     @endif
                     <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_registration_enabled"
+                            helper="Allow new users to create accounts through enabled OAuth providers even when password-based self-registration is disabled."
+                            label="OAuth Registration Allowed" />
+                    </div>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_only_auth_enabled"
+                            helper="Require newly created OAuth users to keep using OAuth only. This blocks password resets and local password logins for OAuth-created accounts."
+                            label="OAuth-only Accounts" />
+                    </div>
+                    <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"
                             helper="Opt out of anonymous usage tracking. When enabled, this instance will not report to coolify.io's installation count and will not send error reports to help improve Coolify."
                             label="Do Not Track" />

--- a/tests/Feature/OauthAuthenticationPolicyTest.php
+++ b/tests/Feature/OauthAuthenticationPolicyTest.php
@@ -12,10 +12,14 @@ uses(RefreshDatabase::class);
 
 beforeEach(function () {
     Once::flush();
+    config([
+        'app.maintenance.driver' => 'file',
+        'cache.default' => 'array',
+    ]);
 
-    InstanceSettings::updateOrCreate([
-        'id' => 0,
-    ], [
+    $settings = new InstanceSettings;
+    $settings->id = 0;
+    $settings->forceFill([
         'is_registration_enabled' => false,
         'is_oauth_registration_enabled' => true,
         'is_oauth_only_auth_enabled' => true,
@@ -26,6 +30,7 @@ beforeEach(function () {
         'smtp_from_address' => 'noreply@example.com',
         'smtp_from_name' => 'Coolify',
     ]);
+    $settings->saveQuietly();
 
     OauthSetting::create([
         'provider' => 'google',
@@ -61,7 +66,7 @@ it('allows oauth self registration when password registration is disabled', func
         ->and($user->oauth_provider)->toBe('google')
         ->and($user->is_oauth_only)->toBeTrue()
         ->and($user->password)->toBeNull()
-        ->and(InstanceSettings::find(0)?->is_registration_enabled)->toBeFalse();
+        ->and(InstanceSettings::find(0)?->is_registration_enabled)->toBeFalsy();
 });
 
 it('blocks oauth self registration when oauth registration is also disabled', function () {

--- a/tests/Feature/OauthAuthenticationPolicyTest.php
+++ b/tests/Feature/OauthAuthenticationPolicyTest.php
@@ -1,0 +1,98 @@
+<?php
+
+use App\Models\InstanceSettings;
+use App\Models\OauthSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Once;
+use Laravel\Socialite\Facades\Socialite;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Once::flush();
+
+    InstanceSettings::updateOrCreate([
+        'id' => 0,
+    ], [
+        'is_registration_enabled' => false,
+        'is_oauth_registration_enabled' => true,
+        'is_oauth_only_auth_enabled' => true,
+        'smtp_enabled' => true,
+        'smtp_host' => 'smtp.example.com',
+        'smtp_port' => 587,
+        'smtp_encryption' => 'tls',
+        'smtp_from_address' => 'noreply@example.com',
+        'smtp_from_name' => 'Coolify',
+    ]);
+
+    OauthSetting::create([
+        'provider' => 'google',
+        'enabled' => true,
+        'client_id' => 'google-client-id',
+        'client_secret' => 'google-client-secret',
+    ]);
+});
+
+function fakeGoogleOauthUser(string $email, string $name): void
+{
+    $provider = Mockery::mock();
+    $provider->shouldReceive('setConfig')->once()->andReturnSelf();
+    $provider->shouldReceive('with')->once()->andReturnSelf();
+    $provider->shouldReceive('user')->once()->andReturn((object) [
+        'email' => $email,
+        'name' => $name,
+    ]);
+
+    Socialite::shouldReceive('driver')->once()->with('google')->andReturn($provider);
+}
+
+it('allows oauth self registration when password registration is disabled', function () {
+    fakeGoogleOauthUser('root@example.com', 'Root User');
+
+    $this->get(route('auth.callback', 'google'))
+        ->assertRedirect('/');
+
+    $user = User::find(0);
+
+    expect($user)->not->toBeNull()
+        ->and($user->email)->toBe('root@example.com')
+        ->and($user->oauth_provider)->toBe('google')
+        ->and($user->is_oauth_only)->toBeTrue()
+        ->and($user->password)->toBeNull()
+        ->and(InstanceSettings::find(0)?->is_registration_enabled)->toBeFalse();
+});
+
+it('blocks oauth self registration when oauth registration is also disabled', function () {
+    InstanceSettings::find(0)?->update([
+        'is_oauth_registration_enabled' => false,
+    ]);
+
+    fakeGoogleOauthUser('blocked@example.com', 'Blocked User');
+
+    $this->from(route('login'))
+        ->get(route('auth.callback', 'google'))
+        ->assertRedirect(route('login'))
+        ->assertSessionHasErrors();
+
+    expect(User::count())->toBe(0);
+});
+
+it('blocks password reset for oauth only accounts', function () {
+    $user = User::factory()->create([
+        'email' => 'oauth-only@example.com',
+        'password' => null,
+        'oauth_provider' => 'google',
+        'is_oauth_only' => true,
+    ]);
+
+    Password::shouldReceive('broker')->never();
+
+    $this->from('/forgot-password')
+        ->post(route('password.forgot'), [
+            'email' => $user->email,
+        ])
+        ->assertRedirect('/forgot-password')
+        ->assertSessionHasErrors('email');
+});

--- a/tests/Feature/OauthAuthenticationPolicyTest.php
+++ b/tests/Feature/OauthAuthenticationPolicyTest.php
@@ -3,6 +3,7 @@
 use App\Models\InstanceSettings;
 use App\Models\OauthSetting;
 use App\Models\User;
+use Illuminate\Contracts\Auth\PasswordBroker;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Once;
@@ -100,4 +101,28 @@ it('blocks password reset for oauth only accounts', function () {
         ])
         ->assertRedirect('/forgot-password')
         ->assertSessionHasErrors('email');
+});
+
+it('allows password reset for oauth accounts when oauth only mode is disabled', function () {
+    $user = User::factory()->create([
+        'email' => 'oauth-password@example.com',
+        'password' => null,
+        'oauth_provider' => 'google',
+        'is_oauth_only' => false,
+    ]);
+
+    $broker = Mockery::mock(PasswordBroker::class);
+    $broker->shouldReceive('sendResetLink')
+        ->once()
+        ->with(['email' => $user->email])
+        ->andReturn(Password::RESET_LINK_SENT);
+
+    Password::shouldReceive('broker')
+        ->once()
+        ->with(config('fortify.passwords'))
+        ->andReturn($broker);
+
+    $this->post(route('password.forgot'), [
+        'email' => $user->email,
+    ])->assertSessionHas('status');
 });


### PR DESCRIPTION
## Changes

- Added separate settings for OAuth self-registration and OAuth-only account behavior.
- Allowed OAuth signups while password registration is disabled when OAuth registration is enabled.
- Added OAuth provider tracking so OAuth-created accounts can be restricted from password login, password reset, and password changes when OAuth-only mode is enabled.
- Preserved root user setup when the first account is created through OAuth.
- Added feature tests covering OAuth registration and password policy behavior.

## Issues

- Fixes #8042

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A. This change affects authentication and instance settings behavior and is covered by feature tests.

## AI Assistance

- [x] AI was NOT used to create this PR
- [ ] AI was used (please describe below)

## Testing

- `php artisan test --compact tests/Feature/OauthAuthenticationPolicyTest.php`
- `vendor/bin/pint --dirty --format agent`

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.