### PR TITLE
fix(realtime): remove axios dependency

### DIFF
--- a/config/constants.php
+++ b/config/constants.php
@@ -4,7 +4,7 @@ return [
     'coolify' => [
         'version' => '4.1.0',
         'helper_version' => '1.0.13',
-        'realtime_version' => '1.0.14',
+        'realtime_version' => '1.0.15',
         'railpack_version' => '0.22.0',
         'self_hosted' => env('SELF_HOSTED', true),
         'autoupdate' => env('AUTOUPDATE'),

--- a/docker/coolify-realtime/Dockerfile
+++ b/docker/coolify-realtime/Dockerfile
@@ -12,8 +12,8 @@ ARG CLOUDFLARED_VERSION
 WORKDIR /terminal
 RUN apk upgrade --no-cache && \
     apk add --no-cache openssh-client make g++ python3 curl
-COPY docker/coolify-realtime/package.json ./
-RUN npm i
+COPY docker/coolify-realtime/package*.json ./
+RUN npm ci
 RUN npm rebuild node-pty --update-binary
 COPY docker/coolify-realtime/soketi-entrypoint.sh /soketi-entrypoint.sh
 COPY docker/coolify-realtime/terminal-server.js /terminal/terminal-server.js

--- a/docker/coolify-realtime/package-lock.json
+++ b/docker/coolify-realtime/package-lock.json
@@ -7,7 +7,6 @@
             "dependencies": {
                 "@xterm/addon-fit": "0.11.0",
                 "@xterm/xterm": "6.0.0",
-                "axios": "1.15.0",
                 "cookie": "1.1.1",
                 "dotenv": "17.3.1",
                 "node-pty": "1.1.0",
@@ -29,48 +28,6 @@
                 "addons/*"
             ]
         },
-        "node_modules/asynckit": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-            "license": "MIT"
-        },
-        "node_modules/axios": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-            "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.11",
-                "form-data": "^4.0.5",
-                "proxy-from-env": "^2.1.0"
-            }
-        },
-        "node_modules/call-bind-apply-helpers": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/combined-stream": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "license": "MIT",
-            "dependencies": {
-                "delayed-stream": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/cookie": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -84,15 +41,6 @@
                 "url": "https://opencollective.com/express"
             }
         },
-        "node_modules/delayed-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
         "node_modules/dotenv": {
             "version": "17.3.1",
             "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
@@ -103,228 +51,6 @@
             },
             "funding": {
                 "url": "https://dotenvx.com"
-            }
-        },
-        "node_modules/dunder-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "gopd": "^1.2.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-define-property": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-errors": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-set-tostringtag": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.6",
-                "has-tostringtag": "^1.0.2",
-                "hasown": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/follow-redirects": {
-            "version": "1.16.0",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/RubenVerborgh"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=4.0"
-            },
-            "peerDependenciesMeta": {
-                "debug": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-            "license": "MIT",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/function-bind": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/get-intrinsic": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.2",
-                "es-define-property": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "es-object-atoms": "^1.1.1",
-                "function-bind": "^1.1.2",
-                "get-proto": "^1.0.1",
-                "gopd": "^1.2.0",
-                "has-symbols": "^1.1.0",
-                "hasown": "^2.0.2",
-                "math-intrinsics": "^1.1.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/get-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-            "license": "MIT",
-            "dependencies": {
-                "dunder-proto": "^1.0.1",
-                "es-object-atoms": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/gopd": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-symbols": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-tostringtag": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-            "license": "MIT",
-            "dependencies": {
-                "has-symbols": "^1.0.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-            "license": "MIT",
-            "dependencies": {
-                "function-bind": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/math-intrinsics": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/mime-db": {
-            "version": "1.52.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/mime-types": {
-            "version": "2.1.35",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-            "license": "MIT",
-            "dependencies": {
-                "mime-db": "1.52.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
             }
         },
         "node_modules/node-addon-api": {
@@ -341,15 +67,6 @@
             "license": "MIT",
             "dependencies": {
                 "node-addon-api": "^7.1.0"
-            }
-        },
-        "node_modules/proxy-from-env": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/ws": {

--- a/docker/coolify-realtime/package.json
+++ b/docker/coolify-realtime/package.json
@@ -5,7 +5,6 @@
         "@xterm/addon-fit": "0.11.0",
         "@xterm/xterm": "6.0.0",
         "cookie": "1.1.1",
-        "axios": "1.15.0",
         "dotenv": "17.3.1",
         "node-pty": "1.1.0",
         "ws": "8.19.0"

--- a/docker/coolify-realtime/terminal-server.js
+++ b/docker/coolify-realtime/terminal-server.js
@@ -1,7 +1,6 @@
 import { WebSocketServer } from 'ws';
 import http from 'http';
 import pty from 'node-pty';
-import axios from 'axios';
 import cookie from 'cookie';
 import 'dotenv/config';
 import {
@@ -12,9 +11,60 @@ import {
     isAuthorizedTargetHost,
 } from './terminal-utils.js';
 
+async function postToCoolify(path, headers) {
+    return new Promise((resolve, reject) => {
+        const request = http.request({
+            hostname: 'coolify',
+            port: 8080,
+            path,
+            method: 'POST',
+            headers,
+        }, (response) => {
+            let responseText = '';
+
+            response.setEncoding('utf8');
+            response.on('data', (chunk) => {
+                responseText += chunk;
+            });
+            response.on('end', () => {
+                try {
+                    resolve({
+                        status: response.statusCode ?? 0,
+                        data: parseResponseData(response.headers['content-type'], responseText),
+                    });
+                } catch (error) {
+                    reject(error);
+                }
+            });
+        });
+
+        request.on('error', reject);
+        request.end();
+    });
+}
+
+function parseResponseData(contentType = '', responseText = '') {
+    if (responseText === '') {
+        return null;
+    }
+
+    if (contentType.includes('application/json')) {
+        return JSON.parse(responseText);
+    }
+
+    return responseText;
+}
+
+function createHttpError(response) {
+    const error = new Error(`Request failed with status code ${response.status}`);
+    error.response = response;
+
+    return error;
+}
+
 const userSessions = new Map();
-const terminalDebugEnabled = ['local', 'development'].includes(
-    String(process.env.APP_ENV || process.env.NODE_ENV || '').toLowerCase()
+const terminalDebugEnabled = ['1', 'true', 'yes'].includes(
+    String(process.env.TERMINAL_DEBUG || '').toLowerCase()
 );
 
 function logTerminal(level, message, context = {}) {
@@ -74,11 +124,9 @@ const verifyClient = async (info, callback) => {
 
     try {
         // Authenticate with Laravel backend
-        const response = await axios.post(`http://coolify:8080/terminal/auth`, null, {
-            headers: {
-                'Cookie': `${sessionCookieName}=${laravelSession}`,
-                'X-XSRF-TOKEN': xsrfToken
-            },
+        const response = await postToCoolify('/terminal/auth', {
+            'Cookie': `${sessionCookieName}=${laravelSession}`,
+            'X-XSRF-TOKEN': xsrfToken
         });
 
         if (response.status === 200) {
@@ -161,12 +209,15 @@ wss.on('connection', async (ws, req) => {
     }
 
     try {
-        const response = await axios.post(`http://coolify:8080/terminal/auth/ips`, null, {
-            headers: {
-                'Cookie': `${sessionCookieName}=${laravelSession}`,
-                'X-XSRF-TOKEN': xsrfToken
-            },
+        const response = await postToCoolify('/terminal/auth/ips', {
+            'Cookie': `${sessionCookieName}=${laravelSession}`,
+            'X-XSRF-TOKEN': xsrfToken
         });
+
+        if (response.status !== 200) {
+            throw createHttpError(response);
+        }
+
         userSession.authorizedIPs = response.data.ipAddresses || [];
         logTerminal('log', 'Fetched authorized terminal hosts for websocket session.', {
             ...connectionContext,

--- a/other/nightly/docker-compose.prod.yml
+++ b/other/nightly/docker-compose.prod.yml
@@ -60,7 +60,7 @@ services:
       retries: 10
       timeout: 2s
   soketi:
-    image: '${REGISTRY_URL:-ghcr.io}/coollabsio/coolify-realtime:1.0.14'
+    image: '${REGISTRY_URL:-ghcr.io}/coollabsio/coolify-realtime:1.0.15'
     ports:
       - "${SOKETI_PORT:-6001}:6001"
       - "6002:6002"

--- a/other/nightly/docker-compose.windows.yml
+++ b/other/nightly/docker-compose.windows.yml
@@ -96,7 +96,7 @@ services:
       retries: 10
       timeout: 2s
   soketi:
-    image: 'ghcr.io/coollabsio/coolify-realtime:1.0.14'
+    image: 'ghcr.io/coollabsio/coolify-realtime:1.0.15'
     pull_policy: always
     container_name: coolify-realtime
     restart: always

--- a/other/nightly/versions.json
+++ b/other/nightly/versions.json
@@ -10,7 +10,7 @@
             "version": "1.0.13"
         },
         "realtime": {
-            "version": "1.0.14"
+            "version": "1.0.15"
         },
         "sentinel": {
             "version": "0.0.21"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
             "devDependencies": {
                 "@tailwindcss/postcss": "4.1.18",
                 "@vitejs/plugin-vue": "6.0.3",
-                "axios": "1.15.0",
                 "laravel-echo": "2.2.7",
                 "laravel-vite-plugin": "2.0.1",
                 "postcss": "8.5.6",
@@ -1466,39 +1465,6 @@
             "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
             "license": "MIT"
         },
-        "node_modules/asynckit": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/axios": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-            "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.11",
-                "form-data": "^4.0.5",
-                "proxy-from-env": "^2.1.0"
-            }
-        },
-        "node_modules/call-bind-apply-helpers": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/clsx": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -1516,19 +1482,6 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/combined-stream": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "delayed-stream": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
             }
         },
         "node_modules/cssesc": {
@@ -1567,16 +1520,6 @@
                 }
             }
         },
-        "node_modules/delayed-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
         "node_modules/denque": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
@@ -1594,21 +1537,6 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/dunder-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "gopd": "^1.2.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
             }
         },
         "node_modules/engine.io-client": {
@@ -1662,55 +1590,6 @@
             },
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
-            }
-        },
-        "node_modules/es-define-property": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-errors": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-set-tostringtag": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.6",
-                "has-tostringtag": "^1.0.2",
-                "hasown": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
             }
         },
         "node_modules/esbuild": {
@@ -1780,44 +1659,6 @@
                 }
             }
         },
-        "node_modules/follow-redirects": {
-            "version": "1.16.0",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/RubenVerborgh"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=4.0"
-            },
-            "peerDependenciesMeta": {
-                "debug": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/fsevents": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1833,116 +1674,12 @@
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
-        "node_modules/function-bind": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/get-intrinsic": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.2",
-                "es-define-property": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "es-object-atoms": "^1.1.1",
-                "function-bind": "^1.1.2",
-                "get-proto": "^1.0.1",
-                "gopd": "^1.2.0",
-                "has-symbols": "^1.1.0",
-                "hasown": "^2.0.2",
-                "math-intrinsics": "^1.1.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/get-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "dunder-proto": "^1.0.1",
-                "es-object-atoms": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/gopd": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/has-symbols": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-tostringtag": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-symbols": "^1.0.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "function-bind": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
         },
         "node_modules/ioredis": {
             "version": "5.6.1",
@@ -2313,39 +2050,6 @@
                 "@jridgewell/sourcemap-codec": "^1.5.5"
             }
         },
-        "node_modules/math-intrinsics": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/mime-db": {
-            "version": "1.52.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/mime-types": {
-            "version": "2.1.35",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mime-db": "1.52.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
         "node_modules/mini-svg-data-uri": {
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
@@ -2498,16 +2202,6 @@
             },
             "peerDependencies": {
                 "react": ">=16.0.0"
-            }
-        },
-        "node_modules/proxy-from-env": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/pusher-js": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "devDependencies": {
         "@tailwindcss/postcss": "4.1.18",
         "@vitejs/plugin-vue": "6.0.3",
-        "axios": "1.15.0",
         "laravel-echo": "2.2.7",
         "laravel-vite-plugin": "2.0.1",
         "postcss": "8.5.6",

--- a/versions.json
+++ b/versions.json
@@ -10,7 +10,7 @@
             "version": "1.0.13"
         },
         "realtime": {
-            "version": "1.0.14"
+            "version": "1.0.15"
         },
         "sentinel": {
             "version": "0.0.21"


### PR DESCRIPTION
## Summary
- Remove `axios` from the root and realtime package manifests
- Replace realtime terminal auth requests with Node's native `http` client, including response parsing and non-200 error handling.
- Switch the realtime Docker build to `npm ci` with lockfile copying for reproducible installs.
- Bump the Coolify realtime image/version references from `1.0.14` to `1.0.15`.