### PR TITLE
feat(templates): add Huly service template

### DIFF
--- a/templates/compose/huly.yaml
+++ b/templates/compose/huly.yaml
@@ -1,36 +1,183 @@
-# ignore: true
-# documentation: https://huly.io/
-# category: cms
+# documentation: https://github.com/hcengineering/huly-selfhost
+# category: productivity
 # slogan: Open Source All-in-One Project Management Platform
-# tags: linear,jira,slack,project,management,notion,motion
-# port: 8080
+# tags: linear,jira,slack,project-management,notion,motion,collaboration
+# port: 80
 
 services:
-  mongodb:
-    image: "mongo:7-jammy"
-    container_name: mongodb
+  huly:
+    image: "nginx:1.21.3"
+    depends_on:
+      - front
+      - account
+      - transactor
+      - collaborator
+      - rekoni
+      - stats
     environment:
-      - PUID=1000
-      - PGID=1000
+      - SERVICE_URL_HULY_80
     volumes:
-      - huly-db:/data/db
+      - type: bind
+        source: ./huly.nginx
+        target: /etc/nginx/conf.d/default.conf
+        content: |
+          server {
+              listen 80;
+              server_name _;
+              client_max_body_size 100M;
+
+              location / {
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+                  proxy_pass http://front:8080;
+              }
+
+              location /_accounts {
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+                  rewrite ^/_accounts(/.*)$ $1 break;
+                  proxy_pass http://account:3000/;
+              }
+
+              location /_collaborator {
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+                  proxy_http_version 1.1;
+                  proxy_set_header Upgrade $http_upgrade;
+                  proxy_set_header Connection "upgrade";
+                  rewrite ^/_collaborator(/.*)$ $1 break;
+                  proxy_pass http://collaborator:3078/;
+              }
+
+              location /_transactor {
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+                  proxy_http_version 1.1;
+                  proxy_set_header Upgrade $http_upgrade;
+                  proxy_set_header Connection "upgrade";
+                  rewrite ^/_transactor(/.*)$ $1 break;
+                  proxy_pass http://transactor:3333/;
+              }
+
+              location ~ ^/eyJ {
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+                  proxy_http_version 1.1;
+                  proxy_set_header Upgrade $http_upgrade;
+                  proxy_set_header Connection "upgrade";
+                  proxy_pass http://transactor:3333;
+              }
+
+              location /_rekoni {
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+                  rewrite ^/_rekoni(/.*)$ $1 break;
+                  proxy_pass http://rekoni:4004/;
+              }
+
+              location /_stats {
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+                  rewrite ^/_stats(/.*)$ $1 break;
+                  proxy_pass http://stats:4900/;
+              }
+          }
+    restart: unless-stopped
+
+  cockroach:
+    image: cockroachdb/cockroach:latest-v24.2
+    command: start-single-node --accept-sql-without-tls
+    environment:
+      - COCKROACH_DATABASE=${CR_DATABASE:-huly}
+      - COCKROACH_USER=$SERVICE_USER_COCKROACH
+      - COCKROACH_PASSWORD=$SERVICE_PASSWORD_COCKROACH
+    volumes:
+      - cr-data:/cockroach/cockroach-data
+      - cr-certs:/cockroach/certs
+      - type: bind
+        source: ./cockroach-init.sh
+        target: /docker-entrypoint-initdb.d/10-huly-grants.sh
+        content: |
+          cockroach sql --certs-dir=/cockroach/certs --host=127.0.0.1:26257 --user=root --database="${COCKROACH_DATABASE}" --execute="GRANT ALL ON SCHEMA public TO \"${COCKROACH_USER}\""
+    restart: unless-stopped
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - cockroach sql --certs-dir=/cockroach/certs --host=127.0.0.1:26257 --user=root --database="$${COCKROACH_DATABASE}" --execute="SHOW GRANTS ON SCHEMA public" | grep -qi "$${COCKROACH_USER}.*ALL"
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  redpanda:
+    image: docker.redpanda.com/redpandadata/redpanda:v24.3.6
+    command:
+      - redpanda
+      - start
+      - --kafka-addr
+      - internal://0.0.0.0:9092,external://0.0.0.0:19092
+      - --advertise-kafka-addr
+      - internal://redpanda:9092,external://localhost:19092
+      - --pandaproxy-addr
+      - internal://0.0.0.0:8082,external://0.0.0.0:18082
+      - --advertise-pandaproxy-addr
+      - internal://redpanda:8082,external://localhost:18082
+      - --schema-registry-addr
+      - internal://0.0.0.0:8081,external://0.0.0.0:18081
+      - --rpc-addr
+      - redpanda:33145
+      - --advertise-rpc-addr
+      - redpanda:33145
+      - --mode
+      - dev-container
+      - --smp
+      - "1"
+      - --default-log-level=info
+    volumes:
+      - redpanda-data:/var/lib/redpanda/data
+    healthcheck:
+      test:
+        - CMD
+        - rpk
+        - cluster
+        - info
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
   minio:
-    image: ghcr.io/coollabsio/minio:RELEASE.2025-10-15T17-29-55Z # Released on 15 October 2025
+    image: minio/minio
     command: server /data --address ":9000" --console-address ":9001"
     volumes:
-      - huly-files:/data      
+      - files:/data
     healthcheck:
-      test: ["CMD", "mc", "ready", "local"]
+      test:
+        - CMD
+        - mc
+        - ready
+        - local
       interval: 5s
-      timeout: 20s
       retries: 10
+    restart: unless-stopped
+
   elastic:
-    image: "elasticsearch:7.14.2"
+    image: elasticsearch:7.14.2
     command: |
       /bin/sh -c "./bin/elasticsearch-plugin list | grep -q ingest-attachment || yes | ./bin/elasticsearch-plugin install --silent ingest-attachment;
       /usr/local/bin/docker-entrypoint.sh eswrapper"
-    volumes:
-      - huly-elastic:/usr/share/elasticsearch/data
     environment:
       - ELASTICSEARCH_PORT_NUMBER=9200
       - BITNAMI_DEBUG=true
@@ -38,86 +185,175 @@ services:
       - ES_JAVA_OPTS=-Xms1024m -Xmx1024m
       - http.cors.enabled=true
       - http.cors.allow-origin=http://localhost:8082
+    volumes:
+      - elastic:/usr/share/elasticsearch/data
     healthcheck:
-      test: curl -s http://127.0.0.1:9200/_cluster/health | grep -vq '"status":"red"'
-      interval: 5s
+      test:
+        - CMD-SHELL
+        - curl -s http://localhost:9200/_cluster/health | grep -vq '"status":"red"'
+      interval: 20s
       retries: 10
-  account:
-    image: hardcoreeng/account:v0.6.246
-    environment:
-      - SERVICE_URL_HULY_3000
-      - SERVER_PORT=3000
-      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
-      - MONGO_URL=mongodb://mongodb:27017
-      - TRANSACTOR_URL=ws://transactor:3333
-      - ENDPOINT_URL=ws://transactor:3333
-      - MINIO_ENDPOINT=minio
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadmin
-      - FRONT_URL=http://front:8080
-      - INIT_WORKSPACE=demo-tracker
-      - MODEL_ENABLED=*
-      - ACCOUNTS_URL=http://localhost:3000
-  front:
-    image: hardcoreeng/front:v0.6.246
-    environment:
-      - SERVICE_URL_HULY_8080
-      - MONGO_URL=mongodb://mongodb:27017
-      - SERVER_PORT=8080
-      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
-      - ACCOUNTS_URL=http://account:3000
-      - REKONI_URL=http://rekoni:4004
-      - CALENDAR_URL=http://localhost:8095
-      - GMAIL_URL=http://localhost:8088
-      - TELEGRAM_URL=http://localhost:8086
-      - UPLOAD_URL=/files
-      - TRANSACTOR_URL=ws://transactor:3333
-      - ELASTIC_URL=http://elastic:9200
-      - COLLABORATOR_URL=ws://collaborator:3078
-      - COLLABORATOR_API_URL=http://collaborator:3078
-      - MINIO_ENDPOINT=minio
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadmin
-      - TITLE=Huly Self Hosted
-      - DEFAULT_LANGUAGE=en
-      - LAST_NAME_FIRST=true
     restart: unless-stopped
-  collaborator:
-    image: hardcoreeng/collaborator:v0.6.246
-    environment:
-      - COLLABORATOR_PORT=3078
-      - SECRET=secret
-      - ACCOUNTS_URL=http://account:3000
-      - TRANSACTOR_URL=ws://transactor:3333
-      - UPLOAD_URL=/files
-      - MONGO_URL=mongodb://mongodb:27017
-      - MINIO_ENDPOINT=minio
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadmin
-  transactor:
-    image: hardcoreeng/transactor:v0.6.246
-    environment:
-      - SERVER_PORT=3333
-      - ELASTIC_INDEX_NAME=huly
-      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
-      - SERVER_CURSOR_MAXTIMEMS=30000
-      - ELASTIC_URL=http://elastic:9200
-      - MONGO_URL=mongodb://mongodb:27017
-      - METRICS_CONSOLE=false
-      - METRICS_FILE=metrics.txt
-      - MINIO_ENDPOINT=minio
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadmin
-      - REKONI_URL=http://rekoni:4004
-      - FRONT_URL=http://localhost:8087
-      - SERVER_PROVIDER=ws
-      - ACCOUNTS_URL=http://account:3000
-      - LAST_NAME_FIRST=true
-      - UPLOAD_URL=/files
-    restart: unless-stopped
+
   rekoni:
-    image: hardcoreeng/rekoni-service:latest
+    image: hardcoreeng/rekoni-service:${HULY_VERSION:-v0.7.423}
+    environment:
+      - SECRET=$SERVICE_PASSWORD_SECRET
+      - STATS_URL=http://stats:4900
     deploy:
       resources:
         limits:
           memory: 500M
+    restart: unless-stopped
+
+  transactor:
+    image: hardcoreeng/transactor:${HULY_VERSION:-v0.7.423}
+    environment:
+      - SERVER_PORT=3333
+      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
+      - DB_URL=postgres://$SERVICE_USER_COCKROACH:$SERVICE_PASSWORD_COCKROACH@cockroach:26257/${CR_DATABASE:-huly}
+      - STORAGE_CONFIG=minio|minio?accessKey=minioadmin&secretKey=minioadmin
+      - FRONT_URL=$SERVICE_URL_HULY_80
+      - ACCOUNTS_URL=http://account:3000
+      - FULLTEXT_URL=http://fulltext:4700
+      - STATS_URL=http://stats:4900
+      - LAST_NAME_FIRST=${LAST_NAME_FIRST:-true}
+      - QUEUE_CONFIG=redpanda:9092
+    depends_on:
+      cockroach:
+        condition: service_healthy
+      redpanda:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+      elastic:
+        condition: service_healthy
+    restart: unless-stopped
+
+  collaborator:
+    image: hardcoreeng/collaborator:${HULY_VERSION:-v0.7.423}
+    environment:
+      - COLLABORATOR_PORT=3078
+      - SECRET=$SERVICE_PASSWORD_SECRET
+      - ACCOUNTS_URL=http://account:3000
+      - STATS_URL=http://stats:4900
+      - STORAGE_CONFIG=minio|minio?accessKey=minioadmin&secretKey=minioadmin
+    depends_on:
+      - account
+      - stats
+    restart: unless-stopped
+
+  account:
+    image: hardcoreeng/account:${HULY_VERSION:-v0.7.423}
+    environment:
+      - SERVER_PORT=3000
+      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
+      - DB_URL=postgres://$SERVICE_USER_COCKROACH:$SERVICE_PASSWORD_COCKROACH@cockroach:26257/${CR_DATABASE:-huly}
+      - TRANSACTOR_URL=ws://transactor:3333;wss://${SERVICE_URL_HULY}/_transactor
+      - STORAGE_CONFIG=minio|minio?accessKey=minioadmin&secretKey=minioadmin
+      - FRONT_URL=$SERVICE_URL_HULY_80
+      - STATS_URL=http://stats:4900
+      - MODEL_ENABLED=*
+      - ACCOUNTS_URL=$SERVICE_URL_HULY_80/_accounts
+      - ACCOUNT_PORT=3000
+      - QUEUE_CONFIG=redpanda:9092
+    depends_on:
+      cockroach:
+        condition: service_healthy
+      redpanda:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+    restart: unless-stopped
+
+  workspace:
+    image: hardcoreeng/workspace:${HULY_VERSION:-v0.7.423}
+    environment:
+      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
+      - DB_URL=postgres://$SERVICE_USER_COCKROACH:$SERVICE_PASSWORD_COCKROACH@cockroach:26257/${CR_DATABASE:-huly}
+      - TRANSACTOR_URL=ws://transactor:3333;wss://${SERVICE_URL_HULY}/_transactor
+      - STORAGE_CONFIG=minio|minio?accessKey=minioadmin&secretKey=minioadmin
+      - MODEL_ENABLED=*
+      - ACCOUNTS_URL=http://account:3000
+      - STATS_URL=http://stats:4900
+      - QUEUE_CONFIG=redpanda:9092
+      - ACCOUNTS_DB_URL=postgres://$SERVICE_USER_COCKROACH:$SERVICE_PASSWORD_COCKROACH@cockroach:26257/${CR_DATABASE:-huly}
+    depends_on:
+      - account
+      - transactor
+    restart: unless-stopped
+
+  front:
+    image: hardcoreeng/front:${HULY_VERSION:-v0.7.423}
+    environment:
+      - SERVER_PORT=8080
+      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
+      - LOVE_ENDPOINT=$SERVICE_URL_HULY_80/_love
+      - ACCOUNTS_URL=$SERVICE_URL_HULY_80/_accounts
+      - ACCOUNTS_URL_INTERNAL=http://account:3000
+      - REKONI_URL=$SERVICE_URL_HULY_80/_rekoni
+      - CALENDAR_URL=$SERVICE_URL_HULY_80/_calendar
+      - GMAIL_URL=$SERVICE_URL_HULY_80/_gmail
+      - TELEGRAM_URL=$SERVICE_URL_HULY_80/_telegram
+      - STATS_URL=http://stats:4900
+      - UPLOAD_URL=/files
+      - ELASTIC_URL=http://elastic:9200
+      - COLLABORATOR_URL=wss://${SERVICE_URL_HULY}/_collaborator
+      - STORAGE_CONFIG=minio|minio?accessKey=minioadmin&secretKey=minioadmin
+      - TITLE=${TITLE:-Huly Self Host}
+      - DEFAULT_LANGUAGE=${DEFAULT_LANGUAGE:-en}
+      - LAST_NAME_FIRST=${LAST_NAME_FIRST:-true}
+      - DESKTOP_UPDATES_CHANNEL=${DESKTOP_CHANNEL:-0.7.423}
+      - DISABLED_FEATURES=auto-translate,mailboxes
+    depends_on:
+      - account
+      - collaborator
+      - transactor
+      - fulltext
+      - stats
+    restart: unless-stopped
+
+  fulltext:
+    image: hardcoreeng/fulltext:${HULY_VERSION:-v0.7.423}
+    environment:
+      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
+      - DB_URL=postgres://$SERVICE_USER_COCKROACH:$SERVICE_PASSWORD_COCKROACH@cockroach:26257/${CR_DATABASE:-huly}
+      - FULLTEXT_DB_URL=http://elastic:9200
+      - ELASTIC_INDEX_NAME=huly_storage_index
+      - STORAGE_CONFIG=minio|minio?accessKey=minioadmin&secretKey=minioadmin
+      - REKONI_URL=http://rekoni:4004
+      - ACCOUNTS_URL=http://account:3000
+      - STATS_URL=http://stats:4900
+      - QUEUE_CONFIG=redpanda:9092
+    depends_on:
+      cockroach:
+        condition: service_healthy
+      elastic:
+        condition: service_healthy
+      redpanda:
+        condition: service_healthy
+    restart: unless-stopped
+
+  stats:
+    image: hardcoreeng/stats:${HULY_VERSION:-v0.7.423}
+    environment:
+      - PORT=4900
+      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
+    restart: unless-stopped
+
+  kvs:
+    image: hardcoreeng/hulykvs:${HULY_VERSION:-v0.7.423}
+    environment:
+      - HULY_DB_CONNECTION=postgres://$SERVICE_USER_COCKROACH:$SERVICE_PASSWORD_COCKROACH@cockroach:26257/${CR_DATABASE:-huly}
+      - HULY_TOKEN_SECRET=$SERVICE_PASSWORD_SECRET
+    depends_on:
+      cockroach:
+        condition: service_healthy
+    restart: unless-stopped
+
+volumes:
+  elastic:
+  files:
+  cr-data:
+  cr-certs:
+  redpanda-data:


### PR DESCRIPTION
## Changes

- Replaces the ignored Huly draft template with a current one-click service template based on `hcengineering/huly-selfhost`.
- Adds the required Huly services: nginx entrypoint, CockroachDB, Redpanda, MinIO, Elasticsearch, account, front, transactor, workspace, fulltext, collaborator, rekoni, stats, and kvs.
- Adds persistent volumes, Coolify-managed URL/secrets, internal service URLs, and health-gated startup for the stateful dependencies.
- Adds a Cockroach init script so the Huly user has schema privileges before application services start.

## Issues

- Fixes #2543

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [x] Fixing or updating existing one click service

## Preview

Service template only. The public entrypoint is the Huly web UI through the `huly` nginx service on port 80.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex for repository inspection, template drafting, and validation command execution.
- How extensively: AI assisted with implementation and checks; I reviewed the generated template, compared it against the upstream Huly self-host compose, and validated it in Docker before submission.

## Testing

- Ran `git diff --check`.
- Extracted Coolify `content:` blocks to files and ran `docker compose config`.
- Started the full extracted stack with sample Coolify environment values.
- Confirmed Cockroach, Redpanda, MinIO, and Elasticsearch healthchecks passed.
- Confirmed nginx config with `nginx -t`.
- Confirmed internal `http://huly/` returned HTTP 200.
- Confirmed `/_accounts` routed to the account service.
- Checked service logs after startup for recurring errors.
- Validated through the Coolify dev UI on 2026-05-12:
  - Regenerated the local dev service catalog from `templates/compose/huly.yaml`.
  - Confirmed Huly appears in the one-click Services list.
  - Created a Huly service resource in the UI and confirmed Coolify generated the service stack and deployment files.
  - Started the exact Coolify-generated compose stack in the dev testing host.
  - Confirmed all generated Huly containers started: huly, cockroach, redpanda, minio, elastic, rekoni, transactor, collaborator, account, workspace, front, fulltext, stats, and kvs.
  - Confirmed generated nginx returned `HTTP/1.1 200 OK` for `/` and `/_accounts` routed to account with expected `HTTP/1.1 405 Method Not Allowed` for GET.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested the service template locally by extracting Coolify's generated files and running the resulting Docker Compose stack, and I am confident that it will work as expected when a maintainer tests it.
