### PR TITLE
feat(auth): add OAuth-only self-registration

### DIFF
--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\ResetsUserPasswords;
 
 class ResetUserPassword implements ResetsUserPasswords
@@ -17,6 +18,12 @@ class ResetUserPassword implements ResetsUserPasswords
      */
     public function reset(User $user, array $input): void
     {
+        if ($user->isOauthOnly()) {
+            throw ValidationException::withMessages([
+                'email' => __('OAuth accounts cannot set a password. Please sign in with your OAuth provider.'),
+            ]);
+        }
+
         Validator::make($input, [
             'password' => ['required', Password::defaults(), 'confirmed'],
         ])->validate();

--- a/app/Actions/Fortify/UpdateUserPassword.php
+++ b/app/Actions/Fortify/UpdateUserPassword.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\UpdatesUserPasswords;
 
 class UpdateUserPassword implements UpdatesUserPasswords
@@ -17,6 +18,12 @@ class UpdateUserPassword implements UpdatesUserPasswords
      */
     public function update(User $user, array $input): void
     {
+        if ($user->isOauthOnly()) {
+            throw ValidationException::withMessages([
+                'current_password' => __('OAuth accounts cannot set a password. Please sign in with your OAuth provider.'),
+            ])->errorBag('updatePassword');
+        }
+
         Validator::make($input, [
             'current_password' => ['required', 'string', 'current_password:web'],
             'password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\OauthSetting;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -10,6 +11,8 @@ class OauthController extends Controller
 {
     public function redirect(string $provider)
     {
+        $this->ensureProviderEnabled($provider);
+
         $socialite_provider = get_socialite_provider($provider);
 
         return $socialite_provider->redirect();
@@ -18,11 +21,13 @@ class OauthController extends Controller
     public function callback(string $provider)
     {
         try {
+            $this->ensureProviderEnabled($provider);
+
             $oauthUser = get_socialite_provider($provider)->user();
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! $settings->is_oauth_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 
@@ -30,6 +35,7 @@ class OauthController extends Controller
                     'name' => $oauthUser->name,
                     'email' => $oauthUser->email,
                 ]);
+                $user->forceFill(['oauth_provider' => $provider])->save();
             }
             Auth::login($user);
 
@@ -38,6 +44,15 @@ class OauthController extends Controller
             $errorCode = $e instanceof HttpException ? 'auth.failed' : 'auth.failed.callback';
 
             return redirect()->route('login')->withErrors([__($errorCode)]);
+        }
+    }
+
+    private function ensureProviderEnabled(string $provider): void
+    {
+        $oauthSetting = OauthSetting::firstWhere('provider', $provider);
+
+        if (! $oauthSetting?->enabled) {
+            abort(403, 'OAuth provider is disabled');
         }
     }
 }

--- a/app/Livewire/Profile/Index.php
+++ b/app/Livewire/Profile/Index.php
@@ -240,6 +240,12 @@ class Index extends Component
     public function resetPassword()
     {
         try {
+            if (auth()->user()->isOauthOnly()) {
+                $this->dispatch('error', 'OAuth accounts cannot set a password. Please sign in with your OAuth provider.');
+
+                return;
+            }
+
             $this->validate([
                 'current_password' => ['required'],
                 'new_password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Livewire/SettingsOauth.php
+++ b/app/Livewire/SettingsOauth.php
@@ -2,16 +2,21 @@
 
 namespace App\Livewire;
 
+use App\Models\InstanceSettings;
 use App\Models\OauthSetting;
 use Livewire\Component;
 
 class SettingsOauth extends Component
 {
+    public InstanceSettings $settings;
+
     public $oauth_settings_map;
+
+    public bool $is_oauth_registration_enabled;
 
     protected function rules()
     {
-        return OauthSetting::all()->reduce(function ($carry, $setting) {
+        $rules = OauthSetting::all()->reduce(function ($carry, $setting) {
             $carry["oauth_settings_map.$setting->provider.enabled"] = 'required';
             $carry["oauth_settings_map.$setting->provider.client_id"] = 'nullable';
             $carry["oauth_settings_map.$setting->provider.client_secret"] = 'nullable';
@@ -21,6 +26,10 @@ class SettingsOauth extends Component
 
             return $carry;
         }, []);
+
+        $rules['is_oauth_registration_enabled'] = 'boolean';
+
+        return $rules;
     }
 
     public function mount()
@@ -28,6 +37,8 @@ class SettingsOauth extends Component
         if (! isInstanceAdmin()) {
             return redirect()->route('home');
         }
+        $this->settings = instanceSettings();
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled;
         $this->oauth_settings_map = OauthSetting::all()->sortBy('provider')->reduce(function ($carry, $setting) {
             $carry[$setting->provider] = [
                 'id' => $setting->id,
@@ -42,6 +53,12 @@ class SettingsOauth extends Component
 
             return $carry;
         }, []);
+    }
+
+    private function updateInstanceSettings()
+    {
+        $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
+        $this->settings->save();
     }
 
     private function updateOauthSettings(?string $provider = null)
@@ -137,8 +154,21 @@ class SettingsOauth extends Component
         }
     }
 
+    public function instantSaveOauthRegistration()
+    {
+        try {
+            $this->validateOnly('is_oauth_registration_enabled');
+            $this->updateInstanceSettings();
+            $this->dispatch('success', 'OAuth registration settings updated successfully!');
+        } catch (\Exception $e) {
+            return handleError($e, $this);
+        }
+    }
+
     public function submit()
     {
+        $this->validate();
+        $this->updateInstanceSettings();
         $this->updateOauthSettings();
         $this->dispatch('success', 'Instance settings updated successfully!');
     }

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -18,6 +18,7 @@ class InstanceSettings extends Model
         'do_not_track',
         'is_auto_update_enabled',
         'is_registration_enabled',
+        'is_oauth_registration_enabled',
         'next_channel',
         'smtp_enabled',
         'smtp_from_address',
@@ -63,6 +64,8 @@ class InstanceSettings extends Model
 
         'allowed_ip_ranges' => 'array',
         'is_auto_update_enabled' => 'boolean',
+        'is_registration_enabled' => 'boolean',
+        'is_oauth_registration_enabled' => 'boolean',
         'auto_update_frequency' => 'string',
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -487,4 +487,9 @@ class User extends Authenticatable implements SendsEmail
     {
         return ! empty($this->password);
     }
+
+    public function isOauthOnly(): bool
+    {
+        return filled($this->oauth_provider) && ! $this->hasPassword();
+    }
 }

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -76,6 +76,7 @@ class FortifyServiceProvider extends ServiceProvider
             $user = User::where('email', $email)->with('teams')->first();
             if (
                 $user &&
+                $user->hasPassword() &&
                 Hash::check($request->password, $user->password)
             ) {
                 $user->updated_at = now();

--- a/database/migrations/2026_05_11_000000_add_oauth_registration_enabled_to_instance_settings_table.php
+++ b/database/migrations/2026_05_11_000000_add_oauth_registration_enabled_to_instance_settings_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_registration_enabled')->default(false)->after('is_registration_enabled');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn('is_oauth_registration_enabled');
+        });
+    }
+};

--- a/database/migrations/2026_05_11_000001_add_oauth_provider_to_users_table.php
+++ b/database/migrations/2026_05_11_000001_add_oauth_provider_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('oauth_provider')->nullable()->after('password');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('oauth_provider');
+        });
+    }
+};

--- a/resources/views/livewire/profile/index.blade.php
+++ b/resources/views/livewire/profile/index.blade.php
@@ -55,20 +55,30 @@
             </form>
         @endif
     </div>
-    <form wire:submit='resetPassword' class="flex flex-col pt-4">
+    <div class="flex flex-col pt-4">
         <div class="flex items-center gap-2 pb-2">
             <h2>Change Password</h2>
-            <x-forms.button type="submit" label="Save">Save</x-forms.button>
+            @if (!request()->user()->isOauthOnly())
+                <x-forms.button form="change-password-form" type="submit" label="Save">Save</x-forms.button>
+            @endif
         </div>
-        <div class="text-xs font-bold dark:text-warning pb-2">Resetting the password will logout all sessions.</div>
-        <div class="flex flex-col gap-2">
-            <x-forms.input id="current_password" label="Current Password" required type="password" />
-            <div class="flex gap-2">
-                <x-forms.input id="new_password" label="New Password" required type="password" />
-                <x-forms.input id="new_password_confirmation" label="New Password Again" required type="password" />
+        @if (request()->user()->isOauthOnly())
+            <div class="text-xs font-bold dark:text-warning pb-2">
+                Password login is disabled for this OAuth account. Please sign in with your OAuth provider.
             </div>
-        </div>
-    </form>
+        @else
+            <form id="change-password-form" wire:submit='resetPassword'>
+                <div class="text-xs font-bold dark:text-warning pb-2">Resetting the password will logout all sessions.</div>
+                <div class="flex flex-col gap-2">
+                    <x-forms.input id="current_password" label="Current Password" required type="password" />
+                    <div class="flex gap-2">
+                        <x-forms.input id="new_password" label="New Password" required type="password" />
+                        <x-forms.input id="new_password_confirmation" label="New Password Again" required type="password" />
+                    </div>
+                </div>
+            </form>
+        @endif
+    </div>
     <h2 class="py-4">Two-factor Authentication</h2>
     @if (session('status') == 'two-factor-authentication-enabled')
         <div class="mb-4 font-medium">

--- a/resources/views/livewire/settings-oauth.blade.php
+++ b/resources/views/livewire/settings-oauth.blade.php
@@ -13,6 +13,11 @@
             </div>
             <div class="pb-4 ">Custom authentication (OAuth) configurations.</div>
         </div>
+        <div class="pb-4 md:w-96">
+            <x-forms.checkbox instantSave="instantSaveOauthRegistration" id="is_oauth_registration_enabled"
+                helper="Allow users who authenticate with an enabled OAuth provider to create an account even when regular registration is disabled. OAuth-created accounts cannot create or use passwords."
+                label="OAuth Registration Allowed" />
+        </div>
         <div class="flex flex-col gap-2 pt-4">
             @foreach ($oauth_settings_map as $oauth_setting)
                 <div class="p-4 border dark:border-coolgray-300 border-neutral-200">

--- a/tests/Feature/MassAssignmentProtectionTest.php
+++ b/tests/Feature/MassAssignmentProtectionTest.php
@@ -94,6 +94,7 @@ describe('mass assignment protection', function () {
         expect($user->isFillable('id'))->toBeFalse('User id should not be fillable');
         expect($user->isFillable('email_verified_at'))->toBeFalse('email_verified_at should not be fillable');
         expect($user->isFillable('remember_token'))->toBeFalse('remember_token should not be fillable');
+        expect($user->isFillable('oauth_provider'))->toBeFalse('oauth_provider should not be fillable');
         expect($user->isFillable('two_factor_secret'))->toBeFalse('two_factor_secret should not be fillable');
         expect($user->isFillable('two_factor_recovery_codes'))->toBeFalse('two_factor_recovery_codes should not be fillable');
         expect($user->isFillable('pending_email'))->toBeFalse('pending_email should not be fillable');

--- a/tests/Feature/OauthRegistrationTest.php
+++ b/tests/Feature/OauthRegistrationTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use App\Actions\Fortify\ResetUserPassword;
+use App\Models\InstanceSettings;
+use App\Models\OauthSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Validation\ValidationException;
+use Laravel\Socialite\Facades\Socialite;
+use Laravel\Socialite\Two\User as SocialiteUser;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::create([
+        'id' => 0,
+        'is_registration_enabled' => false,
+        'is_oauth_registration_enabled' => false,
+    ]);
+
+    OauthSetting::create([
+        'provider' => 'github',
+        'enabled' => true,
+        'client_id' => 'client-id',
+        'client_secret' => 'client-secret',
+    ]);
+});
+
+function fakeGithubOauthUser(string $email = 'oauth@example.com'): void
+{
+    $provider = Mockery::mock();
+    $provider->shouldReceive('user')->once()->andReturn((new SocialiteUser)->map([
+        'id' => 'github-123',
+        'name' => 'OAuth User',
+        'email' => $email,
+    ]));
+
+    Socialite::shouldReceive('buildProvider')->once()->andReturn($provider);
+}
+
+it('blocks oauth self-registration when regular and oauth registration are disabled', function () {
+    fakeGithubOauthUser();
+
+    $this->get(route('auth.callback', 'github'))
+        ->assertRedirect(route('login'));
+
+    $this->assertGuest();
+    $this->assertDatabaseMissing('users', [
+        'email' => 'oauth@example.com',
+    ]);
+});
+
+it('allows oauth self-registration when regular registration is disabled but oauth registration is enabled', function () {
+    instanceSettings()->update([
+        'is_oauth_registration_enabled' => true,
+    ]);
+
+    fakeGithubOauthUser();
+
+    $this->get(route('auth.callback', 'github'))
+        ->assertRedirect('/');
+
+    $this->assertAuthenticated();
+    $this->assertDatabaseHas('users', [
+        'name' => 'OAuth User',
+        'email' => 'oauth@example.com',
+        'password' => null,
+        'oauth_provider' => 'github',
+    ]);
+});
+
+it('does not authenticate oauth-only users with password credentials', function () {
+    User::factory()->create([
+        'email' => 'oauth@example.com',
+        'password' => null,
+        'oauth_provider' => 'github',
+    ]);
+
+    $this->post('/login', [
+        'email' => 'oauth@example.com',
+        'password' => 'Password1!',
+    ])->assertSessionHasErrors();
+
+    $this->assertGuest();
+});
+
+it('prevents oauth-only users from setting a password through password reset', function () {
+    $user = User::factory()->create([
+        'password' => null,
+        'oauth_provider' => 'github',
+    ]);
+
+    app(ResetUserPassword::class)->reset($user, [
+        'password' => 'Password1!',
+        'password_confirmation' => 'Password1!',
+    ]);
+})->throws(ValidationException::class);


### PR DESCRIPTION
## Changes

- Adds an independent instance setting that allows OAuth self-registration while password registration remains disabled.
- Records the provider for users created through OAuth and treats those accounts as OAuth-only while they have no password.
- Blocks OAuth-only accounts from password login, password reset, and profile password changes.
- Adds focused feature coverage for OAuth registration policy and password blocking.

## Issues

- Fixes #8042
- /claim #8042

## Category

- [ ] Bug fix
- [x] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No demo video yet. Local app startup is blocked in this workspace because PHP and Composer are not installed and Docker Desktop's daemon is unavailable.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: implementation and test draft were produced with AI assistance and reviewed via local diffs.

## Testing

- git diff --cached --check
- Not run locally: Pint and PHP feature tests, because PHP and Composer are unavailable and Docker Desktop is not running.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the contributor guidelines. If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched existing issues and pull requests (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
