### PR TITLE
fix(security): use escapeshellarg in CleanupStaleMultiplexedConnections

### DIFF
--- a/app/Jobs/CleanupStaleMultiplexedConnections.php
+++ b/app/Jobs/CleanupStaleMultiplexedConnections.php
@@ -37,7 +37,7 @@ class CleanupStaleMultiplexedConnections implements ShouldQueue
             }
 
             $muxSocket = "/var/www/html/storage/app/ssh/mux/{$muxFile}";
-            $checkCommand = "ssh -O check -o ControlPath={$muxSocket} {$server->user}@{$server->ip} 2>/dev/null";
+            $checkCommand = "ssh -O check -o ControlPath={$muxSocket} ".escapeshellarg($server->user).'@'.escapeshellarg($server->ip).' 2>/dev/null';
             $checkProcess = Process::run($checkCommand);
 
             if ($checkProcess->exitCode() !== 0) {

--- a/tests/Unit/CleanupStaleMultiplexedConnectionsEscapingTest.php
+++ b/tests/Unit/CleanupStaleMultiplexedConnectionsEscapingTest.php
@@ -1,0 +1,10 @@
+<?php
+
+use App\Jobs\CleanupStaleMultiplexedConnections;
+
+it('has no raw user@ip string interpolation in CleanupStaleMultiplexedConnections', function () {
+    $reflection = new ReflectionClass(CleanupStaleMultiplexedConnections::class);
+    $source = file_get_contents($reflection->getFileName());
+
+    expect($source)->not->toContain('{$server->user}@{$server->ip}');
+});


### PR DESCRIPTION
## Changes

Wrap `$server->user` and `$server->ip` with `escapeshellarg()` in `CleanupStaleMultiplexedConnections::cleanupStaleConnections()` (line 40), matching the pattern used by `SshMultiplexingHelper::escapedUserAtHost()`.

**Before:**
```php
$checkCommand = "ssh -O check -o ControlPath={$muxSocket} {$server->user}@{$server->ip} 2>/dev/null";
```

**After:**
```php
$checkCommand = "ssh -O check -o ControlPath={$muxSocket} ".escapeshellarg($server->user).'@'.escapeshellarg($server->ip).' 2>/dev/null';
```

Every other SSH command path in `SshMultiplexingHelper` uses `escapedUserAtHost()` which calls `escapeshellarg()`. This job was the only one that skipped it. The unescaped interpolation was introduced in commit `42ff7b19a` (Sep 2024, #3454).

## Issues

- Closes #10077

## Category

- [x] Bug fix

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**
- Tools used: Grok
- How extensively: Used for codebase audit and fix identification; all changes reviewed and verified manually

## Testing

Added 1 Pest test in `tests/Unit/CleanupStaleMultiplexedConnectionsEscapingTest.php`:
- Source-level verification that no raw `{$server->user}@{$server->ip}` interpolation exists (same pattern as existing `SshCommandInjectionTest.php:98-103`)
- Red-green verified: test fails without fix, passes with fix

Existing `SshCommandInjectionTest` tests (18 tests, 20 assertions) pass with no regressions.

## Related

- #9175 - `escapeshellarg` for backup commands (merged)
- #9185 - `escapeshellarg` for volume names (merged)
- #8898 - sanitize newlines to prevent RCE (merged)
- #8617 - prevent command injection via base64 (merged)

## Contributor Agreement

> [!IMPORTANT]
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.