### PR TITLE
feat: add OpenLiteSpeed service template

### DIFF
--- a/templates/compose/openlitespeed.yaml
+++ b/templates/compose/openlitespeed.yaml
@@ -1,0 +1,24 @@
+# documentation: https://docs.litespeedtech.com/cloud/docker/openlitespeed/
+# slogan: OpenLiteSpeed is an open-source, high-performance HTTP server with built-in PHP support.
+# category: webserver
+# tags: webserver, php, openlitespeed, litespeed
+# logo: svgs/default.webp
+# port: 80
+
+services:
+  openlitespeed:
+    image: litespeedtech/openlitespeed:1.9.0-lsphp84
+    volumes:
+      - openlitespeed-sites:/var/www/vhosts
+      - openlitespeed-conf:/usr/local/lsws/conf
+      - openlitespeed-admin-conf:/usr/local/lsws/admin/conf
+      - openlitespeed-logs:/usr/local/lsws/logs
+      - openlitespeed-acme:/root/.acme.sh
+    environment:
+      - SERVICE_URL_OPENLITESPEED
+      - TZ=${TZ:-UTC}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1"]
+      interval: 2s
+      timeout: 10s
+      retries: 10

--- a/templates/service-templates-latest.json
+++ b/templates/service-templates-latest.json
@@ -3434,6 +3434,21 @@
         "minversion": "0.0.0",
         "port": "8080"
     },
+    "openlitespeed": {
+        "documentation": "https://docs.litespeedtech.com/cloud/docker/openlitespeed/?utm_source=coolify.io",
+        "slogan": "OpenLiteSpeed is an open-source, high-performance HTTP server with built-in PHP support.",
+        "compose": "c2VydmljZXM6CiAgb3BlbmxpdGVzcGVlZDoKICAgIGltYWdlOiBsaXRlc3BlZWR0ZWNoL29wZW5saXRlc3BlZWQ6MS45LjAtbHNwaHA4NAogICAgdm9sdW1lczoKICAgICAgLSBvcGVubGl0ZXNwZWVkLXNpdGVzOi92YXIvd3d3L3Zob3N0cwogICAgICAtIG9wZW5saXRlc3BlZWQtY29uZjovdXNyL2xvY2FsL2xzd3MvY29uZgogICAgICAtIG9wZW5saXRlc3BlZWQtYWRtaW4tY29uZjovdXNyL2xvY2FsL2xzd3MvYWRtaW4vY29uZgogICAgICAtIG9wZW5saXRlc3BlZWQtbG9nczovdXNyL2xvY2FsL2xzd3MvbG9ncwogICAgICAtIG9wZW5saXRlc3BlZWQtYWNtZTovcm9vdC8uYWNtZS5zaAogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gU0VSVklDRV9VUkxfT1BFTkxJVEVTUEVFRAogICAgICAtIFRaPSR7VFo6LVVUQ30KICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OiBbIkNNRCIsICJjdXJsIiwgIi1mIiwgImh0dHA6Ly8xMjcuMC4wLjEiXQogICAgICBpbnRlcnZhbDogMnMKICAgICAgdGltZW91dDogMTBzCiAgICAgIHJldHJpZXM6IDEwCg==",
+        "tags": [
+            "webserver",
+            "php",
+            "openlitespeed",
+            "litespeed"
+        ],
+        "category": "webserver",
+        "logo": "svgs/default.webp",
+        "minversion": "0.0.0",
+        "port": "80"
+    },
     "openclaw": {
         "documentation": "https://coolify.io/docs/services/openclaw?utm_source=coolify.io",
         "slogan": "AI-powered coding assistant with multi-provider support and browser automation.",

--- a/templates/service-templates.json
+++ b/templates/service-templates.json
@@ -3434,6 +3434,21 @@
         "minversion": "0.0.0",
         "port": "8080"
     },
+    "openlitespeed": {
+        "documentation": "https://docs.litespeedtech.com/cloud/docker/openlitespeed/?utm_source=coolify.io",
+        "slogan": "OpenLiteSpeed is an open-source, high-performance HTTP server with built-in PHP support.",
+        "compose": "c2VydmljZXM6CiAgb3BlbmxpdGVzcGVlZDoKICAgIGltYWdlOiBsaXRlc3BlZWR0ZWNoL29wZW5saXRlc3BlZWQ6MS45LjAtbHNwaHA4NAogICAgdm9sdW1lczoKICAgICAgLSBvcGVubGl0ZXNwZWVkLXNpdGVzOi92YXIvd3d3L3Zob3N0cwogICAgICAtIG9wZW5saXRlc3BlZWQtY29uZjovdXNyL2xvY2FsL2xzd3MvY29uZgogICAgICAtIG9wZW5saXRlc3BlZWQtYWRtaW4tY29uZjovdXNyL2xvY2FsL2xzd3MvYWRtaW4vY29uZgogICAgICAtIG9wZW5saXRlc3BlZWQtbG9nczovdXNyL2xvY2FsL2xzd3MvbG9ncwogICAgICAtIG9wZW5saXRlc3BlZWQtYWNtZTovcm9vdC8uYWNtZS5zaAogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gU0VSVklDRV9GUUROX09QRU5MSVRFU1BFRUQKICAgICAgLSBUWj0ke1RaOi1VVEN9CiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDogWyJDTUQiLCAiY3VybCIsICItZiIsICJodHRwOi8vMTI3LjAuMC4xIl0KICAgICAgaW50ZXJ2YWw6IDJzCiAgICAgIHRpbWVvdXQ6IDEwcwogICAgICByZXRyaWVzOiAxMAo=",
+        "tags": [
+            "webserver",
+            "php",
+            "openlitespeed",
+            "litespeed"
+        ],
+        "category": "webserver",
+        "logo": "svgs/default.webp",
+        "minversion": "0.0.0",
+        "port": "80"
+    },
     "openclaw": {
         "documentation": "https://coolify.io/docs/services/openclaw?utm_source=coolify.io",
         "slogan": "AI-powered coding assistant with multi-provider support and browser automation.",


### PR DESCRIPTION
## What
- Adds an unopinionated OpenLiteSpeed one-click service template.
- Uses the official `litespeedtech/openlitespeed` image with PHP support.
- Persists sites, OpenLiteSpeed config, admin config, logs, and ACME data.
- Updates both generated service template JSON files.

## Why
Closes #8264.
/claim #8264

This follows prior maintainer feedback on #8264 to add OpenLiteSpeed as a reusable standalone service instead of tightly coupling the template to WordPress bootstrap logic. Users can deploy WordPress or other PHP apps on top of the OpenLiteSpeed service data volume.

## Testing
- Parsed `templates/compose/openlitespeed.yaml` with Ruby YAML.
- Parsed both service template JSON files.
- Decoded and parsed the generated base64 compose entries from `service-templates-latest.json` and `service-templates.json`.
- Verified `service-templates-latest.json` uses `SERVICE_URL_OPENLITESPEED` and legacy `service-templates.json` uses `SERVICE_FQDN_OPENLITESPEED`.
- `git diff --check` passed.

I could not run a full Docker deployment locally because Docker is not installed in this environment.
