### PR TITLE
Add OAuth-only registration controls

### DIFF
--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -5,6 +5,7 @@ namespace App\Actions\Fortify;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Validation\Rules\Password;
 use Laravel\Fortify\Contracts\ResetsUserPasswords;
 
@@ -17,6 +18,12 @@ class ResetUserPassword implements ResetsUserPasswords
      */
     public function reset(User $user, array $input): void
     {
+        if (! $user->canUsePasswordAuthentication()) {
+            throw ValidationException::withMessages([
+                'password' => __('Password changes are disabled for OAuth users.'),
+            ]);
+        }
+
         Validator::make($input, [
             'password' => ['required', Password::defaults(), 'confirmed'],
         ])->validate();

--- a/app/Actions/Fortify/UpdateUserPassword.php
+++ b/app/Actions/Fortify/UpdateUserPassword.php
@@ -5,6 +5,7 @@ namespace App\Actions\Fortify;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Validation\Rules\Password;
 use Laravel\Fortify\Contracts\UpdatesUserPasswords;
 
@@ -17,6 +18,12 @@ class UpdateUserPassword implements UpdatesUserPasswords
      */
     public function update(User $user, array $input): void
     {
+        if (! $user->canUsePasswordAuthentication()) {
+            throw ValidationException::withMessages([
+                'password' => __('Password changes are disabled for OAuth users.'),
+            ]);
+        }
+
         Validator::make($input, [
             'current_password' => ['required', 'string', 'current_password:web'],
             'password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -22,13 +22,18 @@ class OauthController extends Controller
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! $settings->is_oauth_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 
                 $user = User::create([
                     'name' => $oauthUser->name,
                     'email' => $oauthUser->email,
+                    'oauth_provider' => $provider,
+                ]);
+            } elseif (! $user->oauth_provider) {
+                $user->update([
+                    'oauth_provider' => $provider,
                 ]);
             }
             Auth::login($user);

--- a/app/Livewire/Profile/Index.php
+++ b/app/Livewire/Profile/Index.php
@@ -240,6 +240,12 @@ class Index extends Component
     public function resetPassword()
     {
         try {
+            if (! auth()->user()->canUsePasswordAuthentication()) {
+                $this->dispatch('error', 'Password changes are disabled for OAuth users.');
+
+                return;
+            }
+
             $this->validate([
                 'current_password' => ['required'],
                 'new_password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -16,6 +16,12 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $is_oauth_registration_enabled;
+
+    #[Validate('boolean')]
+    public bool $is_oauth_password_login_enabled;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -41,6 +47,8 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_registration_enabled' => 'boolean',
+            'is_oauth_password_login_enabled' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => ['nullable', 'string', new ValidDnsServers],
@@ -62,6 +70,8 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled;
+        $this->is_oauth_password_login_enabled = $this->settings->is_oauth_password_login_enabled;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -142,6 +152,8 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
+            $this->settings->is_oauth_password_login_enabled = $this->is_oauth_password_login_enabled;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;
@@ -166,6 +178,19 @@ class Advanced extends Component
         $this->settings->is_registration_enabled = $this->is_registration_enabled = true;
         $this->settings->save();
         $this->dispatch('success', 'Registration has been enabled.');
+
+        return true;
+    }
+
+    public function toggleOauthRegistration($password): bool
+    {
+        if (! verifyPasswordConfirmation($password, $this)) {
+            return false;
+        }
+
+        $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled = true;
+        $this->settings->save();
+        $this->dispatch('success', 'OAuth registration has been enabled.');
 
         return true;
     }

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -18,6 +18,8 @@ class InstanceSettings extends Model
         'do_not_track',
         'is_auto_update_enabled',
         'is_registration_enabled',
+        'is_oauth_registration_enabled',
+        'is_oauth_password_login_enabled',
         'next_channel',
         'smtp_enabled',
         'smtp_from_address',
@@ -63,6 +65,9 @@ class InstanceSettings extends Model
 
         'allowed_ip_ranges' => 'array',
         'is_auto_update_enabled' => 'boolean',
+        'is_registration_enabled' => 'boolean',
+        'is_oauth_registration_enabled' => 'boolean',
+        'is_oauth_password_login_enabled' => 'boolean',
         'auto_update_frequency' => 'string',
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -31,6 +31,7 @@ use OpenApi\Attributes as OA;
         'id' => ['type' => 'integer', 'description' => 'The user identifier in the database.'],
         'name' => ['type' => 'string', 'description' => 'The user name.'],
         'email' => ['type' => 'string', 'description' => 'The user email.'],
+        'oauth_provider' => ['type' => 'string', 'description' => 'The OAuth provider used to create the user.'],
         'email_verified_at' => ['type' => 'string', 'description' => 'The date when the user email was verified.'],
         'created_at' => ['type' => 'string', 'description' => 'The date when the user was created.'],
         'updated_at' => ['type' => 'string', 'description' => 'The date when the user was updated.'],
@@ -47,6 +48,7 @@ class User extends Authenticatable implements SendsEmail
         'name',
         'email',
         'password',
+        'oauth_provider',
         'force_password_reset',
         'marketing_emails',
         'pending_email',
@@ -486,5 +488,19 @@ class User extends Authenticatable implements SendsEmail
     public function hasPassword(): bool
     {
         return ! empty($this->password);
+    }
+
+    public function isOauthUser(): bool
+    {
+        return ! empty($this->oauth_provider);
+    }
+
+    public function canUsePasswordAuthentication(): bool
+    {
+        if (! $this->isOauthUser() && $this->hasPassword()) {
+            return true;
+        }
+
+        return instanceSettings()->is_oauth_password_login_enabled ?? true;
     }
 }

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -76,6 +76,7 @@ class FortifyServiceProvider extends ServiceProvider
             $user = User::where('email', $email)->with('teams')->first();
             if (
                 $user &&
+                $user->canUsePasswordAuthentication() &&
                 Hash::check($request->password, $user->password)
             ) {
                 $user->updated_at = now();

--- a/database/migrations/2026_05_12_000000_add_oauth_registration_settings.php
+++ b/database/migrations/2026_05_12_000000_add_oauth_registration_settings.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! Schema::hasColumn('instance_settings', 'is_oauth_registration_enabled')) {
+            Schema::table('instance_settings', function (Blueprint $table) {
+                $table->boolean('is_oauth_registration_enabled')->default(false)->after('is_registration_enabled');
+            });
+        }
+
+        if (! Schema::hasColumn('instance_settings', 'is_oauth_password_login_enabled')) {
+            Schema::table('instance_settings', function (Blueprint $table) {
+                $table->boolean('is_oauth_password_login_enabled')->default(true)->after('is_oauth_registration_enabled');
+            });
+        }
+
+        if (! Schema::hasColumn('users', 'oauth_provider')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->string('oauth_provider')->nullable()->after('email');
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (Schema::hasColumn('users', 'oauth_provider')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->dropColumn('oauth_provider');
+            });
+        }
+
+        if (Schema::hasColumn('instance_settings', 'is_oauth_password_login_enabled')) {
+            Schema::table('instance_settings', function (Blueprint $table) {
+                $table->dropColumn('is_oauth_password_login_enabled');
+            });
+        }
+
+        if (Schema::hasColumn('instance_settings', 'is_oauth_registration_enabled')) {
+            Schema::table('instance_settings', function (Blueprint $table) {
+                $table->dropColumn('is_oauth_registration_enabled');
+            });
+        }
+    }
+};

--- a/resources/views/livewire/profile/index.blade.php
+++ b/resources/views/livewire/profile/index.blade.php
@@ -55,20 +55,27 @@
             </form>
         @endif
     </div>
-    <form wire:submit='resetPassword' class="flex flex-col pt-4">
-        <div class="flex items-center gap-2 pb-2">
-            <h2>Change Password</h2>
-            <x-forms.button type="submit" label="Save">Save</x-forms.button>
-        </div>
-        <div class="text-xs font-bold dark:text-warning pb-2">Resetting the password will logout all sessions.</div>
-        <div class="flex flex-col gap-2">
-            <x-forms.input id="current_password" label="Current Password" required type="password" />
-            <div class="flex gap-2">
-                <x-forms.input id="new_password" label="New Password" required type="password" />
-                <x-forms.input id="new_password_confirmation" label="New Password Again" required type="password" />
+    @if (auth()->user()->canUsePasswordAuthentication())
+        <form wire:submit='resetPassword' class="flex flex-col pt-4">
+            <div class="flex items-center gap-2 pb-2">
+                <h2>Change Password</h2>
+                <x-forms.button type="submit" label="Save">Save</x-forms.button>
             </div>
+            <div class="text-xs font-bold dark:text-warning pb-2">Resetting the password will logout all sessions.</div>
+            <div class="flex flex-col gap-2">
+                <x-forms.input id="current_password" label="Current Password" required type="password" />
+                <div class="flex gap-2">
+                    <x-forms.input id="new_password" label="New Password" required type="password" />
+                    <x-forms.input id="new_password_confirmation" label="New Password Again" required type="password" />
+                </div>
+            </div>
+        </form>
+    @else
+        <div class="flex flex-col pt-4">
+            <h2 class="pb-2">Change Password</h2>
+            <div class="text-xs font-bold dark:text-warning">Password changes are disabled for OAuth users.</div>
         </div>
-    </form>
+    @endif
     <h2 class="py-4">Two-factor Authentication</h2>
     @if (session('status') == 'two-factor-authentication-enabled')
         <div class="mb-4 font-medium">

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -41,6 +41,36 @@
                                 shortConfirmationLabel="Confirmation text" />
                         </div>
                     @endif
+                    @if ($is_oauth_registration_enabled)
+                        <div class="md:w-96" wire:key="oauth-registration-enabled">
+                            <x-forms.checkbox instantSave id="is_oauth_registration_enabled"
+                                helper="Allow enabled OAuth providers to create new user accounts even when regular registration is disabled."
+                                label="OAuth Registration Allowed" />
+                        </div>
+                    @else
+                        <div class="flex items-center justify-between gap-2 md:w-96"
+                            wire:key="oauth-registration-disabled">
+                            <label class="flex items-center gap-2">
+                                OAuth Registration Allowed
+                                <x-helper
+                                    helper="Allow enabled OAuth providers to create new user accounts even when regular registration is disabled.">
+                                </x-helper>
+                            </label>
+                            <x-modal-confirmation title="Enable OAuth Registration?" buttonTitle="Enable" isErrorButton
+                                submitAction="toggleOauthRegistration" :actions="[
+                                    'Enables registration through configured OAuth providers',
+                                ]"
+                                warningMessage="Enabling OAuth registration allows anyone accepted by a configured OAuth provider to create an account on this instance."
+                                confirmationText="ENABLE OAUTH REGISTRATION"
+                                confirmationLabel="Please type the confirmation text to enable OAuth registration."
+                                shortConfirmationLabel="Confirmation text" />
+                        </div>
+                    @endif
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_password_login_enabled"
+                            helper="Allow OAuth users to sign in with, create, or reset a local password. Disable this to keep OAuth-created users restricted to OAuth sign-in."
+                            label="Allow Passwords for OAuth Users" />
+                    </div>
                     <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"
                             helper="Opt out of anonymous usage tracking. When enabled, this instance will not report to coolify.io's installation count and will not send error reports to help improve Coolify."

--- a/tests/Feature/ModelFillableCreationTest.php
+++ b/tests/Feature/ModelFillableCreationTest.php
@@ -48,6 +48,7 @@ it('creates User with all fillable attributes', function () {
         'name' => 'Test User',
         'email' => 'fillable-test@example.com',
         'password' => bcrypt('password123'),
+        'oauth_provider' => 'github',
         'force_password_reset' => true,
         'marketing_emails' => false,
         'pending_email' => 'newemail@example.com',
@@ -58,6 +59,7 @@ it('creates User with all fillable attributes', function () {
     expect($user->exists)->toBeTrue();
     expect($user->name)->toBe('Test User');
     expect($user->email)->toBe('fillable-test@example.com');
+    expect($user->oauth_provider)->toBe('github');
     expect($user->force_password_reset)->toBeTrue();
     expect($user->marketing_emails)->toBeFalse();
     expect($user->pending_email)->toBe('newemail@example.com');

--- a/tests/Feature/OauthRegistrationSettingsTest.php
+++ b/tests/Feature/OauthRegistrationSettingsTest.php
@@ -1,0 +1,137 @@
+<?php
+
+use App\Actions\Fortify\ResetUserPassword;
+use App\Actions\Fortify\UpdateUserPassword;
+use App\Models\InstanceSettings;
+use App\Models\OauthSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Once;
+use Illuminate\Validation\ValidationException;
+use Laravel\Socialite\Facades\Socialite;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Once::flush();
+});
+
+function createOauthRegistrationTestSettings(array $overrides = []): InstanceSettings
+{
+    return InstanceSettings::create(array_merge([
+        'id' => 0,
+        'is_registration_enabled' => false,
+        'is_oauth_registration_enabled' => false,
+        'is_oauth_password_login_enabled' => true,
+    ], $overrides));
+}
+
+function fakeGithubOauthRegistrationTestUser(string $email = 'oauth@example.com'): void
+{
+    OauthSetting::create([
+        'provider' => 'github',
+        'client_id' => 'client-id',
+        'client_secret' => 'client-secret',
+        'redirect_uri' => route('auth.callback', 'github'),
+        'enabled' => true,
+    ]);
+
+    $provider = Mockery::mock();
+    $provider->shouldReceive('user')->once()->andReturn((object) [
+        'name' => 'OAuth User',
+        'email' => $email,
+    ]);
+
+    Socialite::shouldReceive('buildProvider')->once()->andReturn($provider);
+}
+
+it('allows oauth self registration when regular registration is disabled and oauth registration is enabled', function () {
+    createOauthRegistrationTestSettings([
+        'is_oauth_registration_enabled' => true,
+    ]);
+    fakeGithubOauthRegistrationTestUser();
+
+    $response = $this->get(route('auth.callback', 'github'));
+
+    $response->assertRedirect('/');
+
+    $user = User::where('email', 'oauth@example.com')->firstOrFail();
+    expect($user->oauth_provider)->toBe('github');
+    $this->assertAuthenticatedAs($user);
+});
+
+it('blocks oauth self registration when both registration modes are disabled', function () {
+    createOauthRegistrationTestSettings();
+    fakeGithubOauthRegistrationTestUser();
+
+    $response = $this->get(route('auth.callback', 'github'));
+
+    $response->assertRedirect(route('login'));
+    expect(User::where('email', 'oauth@example.com')->exists())->toBeFalse();
+});
+
+it('marks existing users as oauth users after a successful oauth login', function () {
+    createOauthRegistrationTestSettings();
+    fakeGithubOauthRegistrationTestUser();
+
+    $user = User::factory()->create([
+        'email' => 'oauth@example.com',
+        'password' => Hash::make('password'),
+        'oauth_provider' => null,
+    ]);
+
+    $response = $this->get(route('auth.callback', 'github'));
+
+    $response->assertRedirect('/');
+    expect($user->refresh()->oauth_provider)->toBe('github');
+});
+
+it('blocks password resets and password updates for oauth users when password auth is disabled', function () {
+    createOauthRegistrationTestSettings([
+        'is_oauth_password_login_enabled' => false,
+    ]);
+
+    $user = User::factory()->create([
+        'password' => Hash::make('password'),
+        'oauth_provider' => 'github',
+    ]);
+
+    expect($user->canUsePasswordAuthentication())->toBeFalse();
+
+    expect(fn () => (new ResetUserPassword)->reset($user, [
+        'password' => 'new-password',
+        'password_confirmation' => 'new-password',
+    ]))->toThrow(ValidationException::class);
+
+    expect(fn () => (new UpdateUserPassword)->update($user, []))
+        ->toThrow(ValidationException::class);
+});
+
+it('keeps password authentication available for regular users when oauth password auth is disabled', function () {
+    createOauthRegistrationTestSettings([
+        'is_oauth_password_login_enabled' => false,
+    ]);
+
+    $user = User::factory()->create([
+        'password' => Hash::make('password'),
+    ]);
+
+    expect($user->isOauthUser())->toBeFalse();
+    expect($user->canUsePasswordAuthentication())->toBeTrue();
+});
+
+it('applies oauth password restrictions to legacy passwordless users', function () {
+    createOauthRegistrationTestSettings([
+        'is_oauth_password_login_enabled' => false,
+    ]);
+
+    $user = User::factory()->create([
+        'password' => null,
+        'oauth_provider' => null,
+    ]);
+
+    expect($user->isOauthUser())->toBeFalse();
+    expect($user->hasPassword())->toBeFalse();
+    expect($user->canUsePasswordAuthentication())->toBeFalse();
+});


### PR DESCRIPTION
Fixes #8042

## Summary
- Add a separate OAuth registration setting so enabled OAuth providers can create accounts when regular registration is disabled.
- Track the OAuth provider on users and optionally block password login, password reset, and password changes for OAuth-linked/passwordless users.
- Add Advanced settings controls and profile messaging for the OAuth password restriction.
- Add feature coverage for OAuth registration and password restriction behavior.

## Testing
- Not run locally: this Codex workspace has no php/composer/vendor install, and the local Docker daemon is unavailable.
- Added tests in `tests/Feature/OauthRegistrationSettingsTest.php`.