### PR TITLE
Add OAuth self-registration controls

### DIFF
--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -5,6 +5,7 @@ namespace App\Actions\Fortify;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Validation\Rules\Password;
 use Laravel\Fortify\Contracts\ResetsUserPasswords;
 
@@ -17,6 +18,12 @@ class ResetUserPassword implements ResetsUserPasswords
      */
     public function reset(User $user, array $input): void
     {
+        if (! $user->is_password_login_enabled) {
+            throw ValidationException::withMessages([
+                'email' => __('Password login is disabled for this account.'),
+            ]);
+        }
+
         Validator::make($input, [
             'password' => ['required', Password::defaults(), 'confirmed'],
         ])->validate();

--- a/app/Actions/Fortify/UpdateUserPassword.php
+++ b/app/Actions/Fortify/UpdateUserPassword.php
@@ -5,6 +5,7 @@ namespace App\Actions\Fortify;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Validation\Rules\Password;
 use Laravel\Fortify\Contracts\UpdatesUserPasswords;
 
@@ -17,6 +18,15 @@ class UpdateUserPassword implements UpdatesUserPasswords
      */
     public function update(User $user, array $input): void
     {
+        if (! $user->is_password_login_enabled) {
+            $exception = ValidationException::withMessages([
+                'current_password' => __('Password login is disabled for this account.'),
+            ]);
+            $exception->errorBag = 'updatePassword';
+
+            throw $exception;
+        }
+
         Validator::make($input, [
             'current_password' => ['required', 'string', 'current_password:web'],
             'password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\OauthSetting;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -19,17 +20,24 @@ class OauthController extends Controller
     {
         try {
             $oauthUser = get_socialite_provider($provider)->user();
-            $user = User::whereEmail($oauthUser->email)->first();
+            $oauthSetting = OauthSetting::firstWhere('provider', $provider);
+            $email = strtolower($oauthUser->email);
+            $user = User::whereEmail($email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! $oauthSetting?->allow_registration) {
                     abort(403, 'Registration is disabled');
                 }
 
                 $user = User::create([
                     'name' => $oauthUser->name,
-                    'email' => $oauthUser->email,
+                    'email' => $email,
                 ]);
+
+                $user->forceFill([
+                    'oauth_provider' => $provider,
+                    'is_password_login_enabled' => ! $oauthSetting?->disable_password_login,
+                ])->save();
             }
             Auth::login($user);
 

--- a/app/Livewire/SettingsOauth.php
+++ b/app/Livewire/SettingsOauth.php
@@ -9,10 +9,28 @@ class SettingsOauth extends Component
 {
     public $oauth_settings_map;
 
+    private function mapOauthSetting(OauthSetting $setting): array
+    {
+        return [
+            'id' => $setting->id,
+            'provider' => $setting->provider,
+            'enabled' => $setting->enabled,
+            'allow_registration' => $setting->allow_registration,
+            'disable_password_login' => $setting->disable_password_login,
+            'client_id' => $setting->client_id,
+            'client_secret' => $setting->client_secret,
+            'redirect_uri' => $setting->redirect_uri,
+            'tenant' => $setting->tenant,
+            'base_url' => $setting->base_url,
+        ];
+    }
+
     protected function rules()
     {
         return OauthSetting::all()->reduce(function ($carry, $setting) {
             $carry["oauth_settings_map.$setting->provider.enabled"] = 'required';
+            $carry["oauth_settings_map.$setting->provider.allow_registration"] = 'required|boolean';
+            $carry["oauth_settings_map.$setting->provider.disable_password_login"] = 'required|boolean';
             $carry["oauth_settings_map.$setting->provider.client_id"] = 'nullable';
             $carry["oauth_settings_map.$setting->provider.client_secret"] = 'nullable';
             $carry["oauth_settings_map.$setting->provider.redirect_uri"] = 'nullable';
@@ -29,16 +47,7 @@ class SettingsOauth extends Component
             return redirect()->route('home');
         }
         $this->oauth_settings_map = OauthSetting::all()->sortBy('provider')->reduce(function ($carry, $setting) {
-            $carry[$setting->provider] = [
-                'id' => $setting->id,
-                'provider' => $setting->provider,
-                'enabled' => $setting->enabled,
-                'client_id' => $setting->client_id,
-                'client_secret' => $setting->client_secret,
-                'redirect_uri' => $setting->redirect_uri,
-                'tenant' => $setting->tenant,
-                'base_url' => $setting->base_url,
-            ];
+            $carry[$setting->provider] = $this->mapOauthSetting($setting);
 
             return $carry;
         }, []);
@@ -56,6 +65,8 @@ class SettingsOauth extends Component
 
             $oauth->fill([
                 'enabled' => $oauthData['enabled'],
+                'allow_registration' => $oauthData['allow_registration'],
+                'disable_password_login' => $oauthData['disable_password_login'],
                 'client_id' => $oauthData['client_id'],
                 'client_secret' => $oauthData['client_secret'],
                 'redirect_uri' => $oauthData['redirect_uri'],
@@ -63,23 +74,14 @@ class SettingsOauth extends Component
                 'base_url' => $oauthData['base_url'],
             ]);
 
-            if (! $oauth->couldBeEnabled()) {
+            if ($oauthData['enabled'] && ! $oauth->couldBeEnabled()) {
                 $oauth->update(['enabled' => false]);
                 throw new \Exception('OAuth settings are not complete for '.$oauth->provider.'.<br/>Please fill in all required fields.');
             }
             $oauth->save();
 
             // Update the array with fresh data
-            $this->oauth_settings_map[$provider] = [
-                'id' => $oauth->id,
-                'provider' => $oauth->provider,
-                'enabled' => $oauth->enabled,
-                'client_id' => $oauth->client_id,
-                'client_secret' => $oauth->client_secret,
-                'redirect_uri' => $oauth->redirect_uri,
-                'tenant' => $oauth->tenant,
-                'base_url' => $oauth->base_url,
-            ];
+            $this->oauth_settings_map[$provider] = $this->mapOauthSetting($oauth);
 
             $this->dispatch('success', 'OAuth settings for '.$oauth->provider.' updated successfully!');
         } else {
@@ -95,6 +97,8 @@ class SettingsOauth extends Component
 
                 $oauth->fill([
                     'enabled' => $settingData['enabled'],
+                    'allow_registration' => $settingData['allow_registration'],
+                    'disable_password_login' => $settingData['disable_password_login'],
                     'client_id' => $settingData['client_id'],
                     'client_secret' => $settingData['client_secret'],
                     'redirect_uri' => $settingData['redirect_uri'],
@@ -110,16 +114,7 @@ class SettingsOauth extends Component
                 $oauth->save();
 
                 // Update the array with fresh data
-                $this->oauth_settings_map[$oauth->provider] = [
-                    'id' => $oauth->id,
-                    'provider' => $oauth->provider,
-                    'enabled' => $oauth->enabled,
-                    'client_id' => $oauth->client_id,
-                    'client_secret' => $oauth->client_secret,
-                    'redirect_uri' => $oauth->redirect_uri,
-                    'tenant' => $oauth->tenant,
-                    'base_url' => $oauth->base_url,
-                ];
+                $this->oauth_settings_map[$oauth->provider] = $this->mapOauthSetting($oauth);
             }
 
             if (! empty($errors)) {

--- a/app/Models/OauthSetting.php
+++ b/app/Models/OauthSetting.php
@@ -11,7 +11,23 @@ class OauthSetting extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['provider', 'client_id', 'client_secret', 'redirect_uri', 'tenant', 'base_url', 'enabled'];
+    protected $fillable = [
+        'provider',
+        'client_id',
+        'client_secret',
+        'redirect_uri',
+        'tenant',
+        'base_url',
+        'enabled',
+        'allow_registration',
+        'disable_password_login',
+    ];
+
+    protected $casts = [
+        'enabled' => 'boolean',
+        'allow_registration' => 'boolean',
+        'disable_password_login' => 'boolean',
+    ];
 
     protected function clientSecret(): Attribute
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -64,6 +64,7 @@ class User extends Authenticatable implements SendsEmail
     protected $casts = [
         'email_verified_at' => 'datetime',
         'force_password_reset' => 'boolean',
+        'is_password_login_enabled' => 'boolean',
         'show_boarding' => 'boolean',
         'email_change_code_expires_at' => 'datetime',
     ];

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -67,6 +67,7 @@ class FortifyServiceProvider extends ServiceProvider
 
             return view('auth.login', [
                 'is_registration_enabled' => $settings->is_registration_enabled,
+                'is_oauth_registration_enabled' => $enabled_oauth_providers->contains('allow_registration', true),
                 'enabled_oauth_providers' => $enabled_oauth_providers,
             ]);
         });
@@ -76,6 +77,8 @@ class FortifyServiceProvider extends ServiceProvider
             $user = User::where('email', $email)->with('teams')->first();
             if (
                 $user &&
+                $user->is_password_login_enabled &&
+                filled($user->password) &&
                 Hash::check($request->password, $user->password)
             ) {
                 $user->updated_at = now();

--- a/database/migrations/2026_05_12_000000_add_oauth_registration_controls.php
+++ b/database/migrations/2026_05_12_000000_add_oauth_registration_controls.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('oauth_settings', function (Blueprint $table) {
+            $table->boolean('allow_registration')->default(false)->after('enabled');
+            $table->boolean('disable_password_login')->default(false)->after('allow_registration');
+        });
+
+        if (DB::table('instance_settings')->where('id', 0)->value('is_registration_enabled')) {
+            DB::table('oauth_settings')->update(['allow_registration' => true]);
+        }
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('oauth_provider')->nullable()->after('email');
+            $table->boolean('is_password_login_enabled')->default(true)->after('password');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['oauth_provider', 'is_password_login_enabled']);
+        });
+
+        Schema::table('oauth_settings', function (Blueprint $table) {
+            $table->dropColumn(['allow_registration', 'disable_password_login']);
+        });
+    }
+};

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -70,7 +70,7 @@
                             class="block w-full text-center py-3 px-4 rounded-lg border border-neutral-300 dark:border-coolgray-400 font-medium hover:border-coollabs dark:hover:border-warning transition-colors">
                             {{ __('auth.register_now') }}
                         </a>
-                    @else
+                    @elseif (! $is_oauth_registration_enabled)
                         <div class="mt-6 text-center text-sm text-neutral-500 dark:text-neutral-400">
                             {{ __('auth.registration_disabled') }}
                         </div>

--- a/resources/views/livewire/settings-oauth.blade.php
+++ b/resources/views/livewire/settings-oauth.blade.php
@@ -17,9 +17,23 @@
             @foreach ($oauth_settings_map as $oauth_setting)
                 <div class="p-4 border dark:border-coolgray-300 border-neutral-200">
                     <h3>{{ ucfirst($oauth_setting['provider']) }}</h3>
-                    <div class="w-32">
-                        <x-forms.checkbox instantSave="instantSave('{{ $oauth_setting['provider'] }}')"
-                            id="oauth_settings_map.{{ $oauth_setting['provider'] }}.enabled" label="Enabled" />
+                    <div class="flex flex-wrap gap-x-6 gap-y-2">
+                        <div class="w-32">
+                            <x-forms.checkbox instantSave="instantSave('{{ $oauth_setting['provider'] }}')"
+                                id="oauth_settings_map.{{ $oauth_setting['provider'] }}.enabled" label="Enabled" />
+                        </div>
+                        <div class="w-56">
+                            <x-forms.checkbox
+                                id="oauth_settings_map.{{ $oauth_setting['provider'] }}.allow_registration"
+                                label="Allow Registration"
+                                helper="Allow this provider to create new users even when password registration is disabled." />
+                        </div>
+                        <div class="w-64">
+                            <x-forms.checkbox
+                                id="oauth_settings_map.{{ $oauth_setting['provider'] }}.disable_password_login"
+                                label="Disable Password Login"
+                                helper="New users created by this provider can only sign in with OAuth." />
+                        </div>
                     </div>
                     <div class="flex flex-col w-full gap-2 xl:flex-row">
                         <x-forms.input id="oauth_settings_map.{{ $oauth_setting['provider'] }}.client_id"

--- a/tests/Feature/OauthAuthenticationTest.php
+++ b/tests/Feature/OauthAuthenticationTest.php
@@ -1,0 +1,114 @@
+<?php
+
+use App\Actions\Fortify\ResetUserPassword;
+use App\Models\InstanceSettings;
+use App\Models\OauthSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
+use Laravel\Socialite\Facades\Socialite;
+
+uses(RefreshDatabase::class);
+
+function createGithubOauthSetting(array $overrides = []): OauthSetting
+{
+    return OauthSetting::create(array_merge([
+        'provider' => 'github',
+        'enabled' => true,
+        'allow_registration' => false,
+        'disable_password_login' => false,
+    ], $overrides));
+}
+
+function mockGithubOauthUser(string $email = 'oauth@example.com', string $name = 'OAuth User'): void
+{
+    $provider = Mockery::mock();
+    $provider->shouldReceive('user')->once()->andReturn((object) [
+        'email' => $email,
+        'name' => $name,
+    ]);
+
+    Socialite::shouldReceive('buildProvider')->once()->andReturn($provider);
+}
+
+beforeEach(function () {
+    InstanceSettings::create([
+        'id' => 0,
+        'is_registration_enabled' => false,
+    ]);
+});
+
+it('allows oauth registration when provider registration is enabled and password registration is disabled', function () {
+    createGithubOauthSetting([
+        'allow_registration' => true,
+        'disable_password_login' => true,
+    ]);
+    mockGithubOauthUser('new-oauth@example.com', 'New OAuth User');
+
+    $response = $this->get(route('auth.callback', 'github'));
+
+    $response->assertRedirect('/');
+    $this->assertAuthenticated();
+
+    $user = User::whereEmail('new-oauth@example.com')->first();
+
+    expect($user)->not->toBeNull()
+        ->and($user->oauth_provider)->toBe('github')
+        ->and($user->is_password_login_enabled)->toBeFalse();
+});
+
+it('blocks oauth registration when both provider and password registration are disabled', function () {
+    createGithubOauthSetting(['allow_registration' => false]);
+    mockGithubOauthUser('blocked-oauth@example.com', 'Blocked OAuth User');
+
+    $response = $this->get(route('auth.callback', 'github'));
+
+    $response->assertRedirect(route('login'));
+    $this->assertGuest();
+    expect(User::whereEmail('blocked-oauth@example.com')->exists())->toBeFalse();
+});
+
+it('keeps existing users able to sign in with oauth when provider registration is disabled', function () {
+    $user = User::factory()->create([
+        'email' => 'existing-oauth@example.com',
+    ]);
+    createGithubOauthSetting(['allow_registration' => false]);
+    mockGithubOauthUser('existing-oauth@example.com', 'Existing OAuth User');
+
+    $response = $this->get(route('auth.callback', 'github'));
+
+    $response->assertRedirect('/');
+    $this->assertAuthenticatedAs($user);
+});
+
+it('does not allow password login for oauth only users', function () {
+    $user = User::factory()->create([
+        'email' => 'oauth-only@example.com',
+        'password' => Hash::make('Password1!'),
+    ]);
+    $user->forceFill([
+        'oauth_provider' => 'github',
+        'is_password_login_enabled' => false,
+    ])->save();
+
+    $response = $this->post('/login', [
+        'email' => 'oauth-only@example.com',
+        'password' => 'Password1!',
+    ]);
+
+    $response->assertRedirect();
+    $this->assertGuest();
+});
+
+it('does not allow oauth only users to create a password by resetting it', function () {
+    $user = User::factory()->create([
+        'oauth_provider' => 'github',
+        'is_password_login_enabled' => false,
+    ]);
+
+    expect(fn () => (new ResetUserPassword)->reset($user, [
+        'password' => 'Password1!',
+        'password_confirmation' => 'Password1!',
+    ]))->toThrow(ValidationException::class);
+});


### PR DESCRIPTION
  ## Summary
  - Adds per-provider OAuth controls for allowing OAuth registration independently of password registration
  - Tracks OAuth-created users and optionally disables password login for them
  - Blocks password login and password reset for OAuth-only users
  - Avoids showing the generic registration-disabled message when OAuth registration is available

  ## Testing
  - Added focused feature coverage in `tests/Feature/OauthAuthenticationTest.php`