### PR TITLE
feat: add OAuth-only registration controls

### DIFF
--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\ResetsUserPasswords;
 
 class ResetUserPassword implements ResetsUserPasswords
@@ -17,6 +18,12 @@ class ResetUserPassword implements ResetsUserPasswords
      */
     public function reset(User $user, array $input): void
     {
+        if ($user->cannotUsePasswordLogin()) {
+            throw ValidationException::withMessages([
+                'email' => __('Password login is disabled for OAuth users. Please sign in with your OAuth provider.'),
+            ]);
+        }
+
         Validator::make($input, [
             'password' => ['required', Password::defaults(), 'confirmed'],
         ])->validate();

--- a/app/Actions/Fortify/UpdateUserPassword.php
+++ b/app/Actions/Fortify/UpdateUserPassword.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\UpdatesUserPasswords;
 
 class UpdateUserPassword implements UpdatesUserPasswords
@@ -17,6 +18,12 @@ class UpdateUserPassword implements UpdatesUserPasswords
      */
     public function update(User $user, array $input): void
     {
+        if ($user->cannotUsePasswordLogin()) {
+            throw ValidationException::withMessages([
+                'password' => __('Password login is disabled for OAuth users. Please sign in with your OAuth provider.'),
+            ]);
+        }
+
         Validator::make($input, [
             'current_password' => ['required', 'string', 'current_password:web'],
             'password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -24,17 +24,33 @@ class OauthController extends Controller
                 abort(403, 'OAuth provider did not return an email address');
             }
             $email = strtolower($email);
-            $user = User::whereEmail($email)->first();
+            $oauthId = (string) $oauthUser->id;
+
+            $user = User::where('oauth_provider', $provider)
+                ->where('oauth_id', $oauthId)
+                ->first();
+
+            if (! $user) {
+                $user = User::whereEmail($email)->first();
+            }
+
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! $settings->is_oauth_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 
                 $user = User::create([
                     'name' => $oauthUser->name,
                     'email' => $email,
+                    'oauth_provider' => $provider,
+                    'oauth_id' => $oauthId,
                 ]);
+            } elseif (! $user->isOauthUser()) {
+                $user->forceFill([
+                    'oauth_provider' => $provider,
+                    'oauth_id' => $oauthId,
+                ])->save();
             }
             Auth::login($user);
 

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -16,6 +16,12 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $is_oauth_registration_enabled;
+
+    #[Validate('boolean')]
+    public bool $is_password_login_enabled_for_oauth_users;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -44,6 +50,8 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_registration_enabled' => 'boolean',
+            'is_password_login_enabled_for_oauth_users' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => ['nullable', 'string', new ValidDnsServers],
@@ -66,6 +74,8 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled;
+        $this->is_password_login_enabled_for_oauth_users = $this->settings->is_password_login_enabled_for_oauth_users;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -147,6 +157,8 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
+            $this->settings->is_password_login_enabled_for_oauth_users = $this->is_password_login_enabled_for_oauth_users;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -18,6 +18,8 @@ class InstanceSettings extends Model
         'do_not_track',
         'is_auto_update_enabled',
         'is_registration_enabled',
+        'is_oauth_registration_enabled',
+        'is_password_login_enabled_for_oauth_users',
         'next_channel',
         'smtp_enabled',
         'smtp_from_address',
@@ -64,6 +66,9 @@ class InstanceSettings extends Model
 
         'allowed_ip_ranges' => 'array',
         'is_auto_update_enabled' => 'boolean',
+        'is_registration_enabled' => 'boolean',
+        'is_oauth_registration_enabled' => 'boolean',
+        'is_password_login_enabled_for_oauth_users' => 'boolean',
         'auto_update_frequency' => 'string',
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -47,6 +47,8 @@ class User extends Authenticatable implements SendsEmail
         'name',
         'email',
         'password',
+        'oauth_provider',
+        'oauth_id',
         'force_password_reset',
         'marketing_emails',
         'pending_email',
@@ -486,5 +488,15 @@ class User extends Authenticatable implements SendsEmail
     public function hasPassword(): bool
     {
         return ! empty($this->password);
+    }
+
+    public function isOauthUser(): bool
+    {
+        return filled($this->oauth_provider);
+    }
+
+    public function cannotUsePasswordLogin(): bool
+    {
+        return $this->isOauthUser() && ! instanceSettings()->is_password_login_enabled_for_oauth_users;
     }
 }

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -67,6 +67,7 @@ class FortifyServiceProvider extends ServiceProvider
 
             return view('auth.login', [
                 'is_registration_enabled' => $settings->is_registration_enabled,
+                'is_oauth_registration_enabled' => $settings->is_oauth_registration_enabled,
                 'enabled_oauth_providers' => $enabled_oauth_providers,
             ]);
         });
@@ -76,6 +77,8 @@ class FortifyServiceProvider extends ServiceProvider
             $user = User::where('email', $email)->with('teams')->first();
             if (
                 $user &&
+                ! $user->cannotUsePasswordLogin() &&
+                $user->hasPassword() &&
                 Hash::check($request->password, $user->password)
             ) {
                 $user->updated_at = now();

--- a/database/migrations/2026_05_11_000000_add_oauth_authentication_policy_settings.php
+++ b/database/migrations/2026_05_11_000000_add_oauth_authentication_policy_settings.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_registration_enabled')->default(false)->after('is_registration_enabled');
+            $table->boolean('is_password_login_enabled_for_oauth_users')->default(true)->after('is_oauth_registration_enabled');
+        });
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('oauth_provider')->nullable()->after('password');
+            $table->string('oauth_id')->nullable()->after('oauth_provider');
+            $table->unique(['oauth_provider', 'oauth_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropUnique(['oauth_provider', 'oauth_id']);
+            $table->dropColumn(['oauth_provider', 'oauth_id']);
+        });
+
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn([
+                'is_oauth_registration_enabled',
+                'is_password_login_enabled_for_oauth_users',
+            ]);
+        });
+    }
+};

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -70,7 +70,7 @@
                             class="block w-full text-center py-3 px-4 rounded-lg border border-neutral-300 dark:border-coolgray-400 font-medium hover:border-coollabs dark:hover:border-warning transition-colors">
                             {{ __('auth.register_now') }}
                         </a>
-                    @else
+                    @elseif (! $is_oauth_registration_enabled || $enabled_oauth_providers->isEmpty())
                         <div class="mt-6 text-center text-sm text-neutral-500 dark:text-neutral-400">
                             {{ __('auth.registration_disabled') }}
                         </div>

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -41,6 +41,17 @@
                                 shortConfirmationLabel="Confirmation text" />
                         </div>
                     @endif
+                    <h4 class="pt-4">Authentication Settings</h4>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_registration_enabled"
+                            helper="Allow enabled OAuth providers to create new users even when normal registration is disabled."
+                            label="OAuth Registration Allowed" />
+                    </div>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_password_login_enabled_for_oauth_users"
+                            helper="When disabled, users linked to an OAuth provider must continue signing in with OAuth and cannot use or create a password."
+                            label="Password Login for OAuth Users" />
+                    </div>
                     <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"
                             helper="Opt out of anonymous usage tracking. When enabled, this instance will not report to coolify.io's installation count and will not send error reports to help improve Coolify."

--- a/tests/Feature/OauthAuthenticationPolicyTest.php
+++ b/tests/Feature/OauthAuthenticationPolicyTest.php
@@ -1,0 +1,126 @@
+<?php
+
+use App\Http\Middleware\CheckForcePasswordReset;
+use App\Http\Middleware\DecideWhatToDoWithUser;
+use App\Models\InstanceSettings;
+use App\Models\OauthSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Once;
+use Laravel\Socialite\Facades\Socialite;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->withoutMiddleware([DecideWhatToDoWithUser::class, CheckForcePasswordReset::class]);
+    Once::flush();
+
+    InstanceSettings::forceCreate([
+        'id' => 0,
+        'is_registration_enabled' => false,
+        'is_oauth_registration_enabled' => false,
+        'is_password_login_enabled_for_oauth_users' => true,
+    ]);
+});
+
+function createOauthAuthenticationPolicySetting(): void
+{
+    OauthSetting::create([
+        'provider' => 'github',
+        'enabled' => true,
+        'client_id' => 'client-id',
+        'client_secret' => 'client-secret',
+        'redirect_uri' => route('auth.callback', 'github'),
+    ]);
+}
+
+function fakeOauthAuthenticationPolicyUser(
+    string $email = 'oauth@example.com',
+    string $id = 'oauth-user-id',
+    string $name = 'OAuth User'
+): void
+{
+    Socialite::shouldReceive('buildProvider')->andReturn(new class($email, $id, $name)
+    {
+        public function __construct(
+            private string $email,
+            private string $id,
+            private string $name,
+        ) {}
+
+        public function user(): object
+        {
+            return (object) [
+                'id' => $this->id,
+                'name' => $this->name,
+                'email' => $this->email,
+            ];
+        }
+    });
+}
+
+test('oauth callback can create a user when oauth registration is enabled and normal registration is disabled', function () {
+    createOauthAuthenticationPolicySetting();
+    fakeOauthAuthenticationPolicyUser();
+
+    instanceSettings()->forceFill([
+        'is_registration_enabled' => false,
+        'is_oauth_registration_enabled' => true,
+    ])->save();
+
+    $this->get(route('auth.callback', 'github'))->assertRedirect('/');
+
+    $user = User::whereEmail('oauth@example.com')->first();
+
+    expect($user)->not->toBeNull()
+        ->and($user->oauth_provider)->toBe('github')
+        ->and($user->oauth_id)->toBe('oauth-user-id')
+        ->and($user->hasPassword())->toBeFalse();
+});
+
+test('oauth callback does not create a user when all registration paths are disabled', function () {
+    createOauthAuthenticationPolicySetting();
+    fakeOauthAuthenticationPolicyUser();
+
+    $this->get(route('auth.callback', 'github'))->assertRedirect(route('login'));
+
+    expect(User::whereEmail('oauth@example.com')->exists())->toBeFalse();
+});
+
+test('oauth callback matches an existing linked user by provider id before email', function () {
+    createOauthAuthenticationPolicySetting();
+    fakeOauthAuthenticationPolicyUser(email: 'changed@example.com');
+
+    $user = User::factory()->create([
+        'email' => 'original@example.com',
+        'oauth_provider' => 'github',
+        'oauth_id' => 'oauth-user-id',
+    ]);
+
+    $this->get(route('auth.callback', 'github'))->assertRedirect('/');
+
+    $this->assertAuthenticatedAs($user->fresh());
+
+    expect(User::count())->toBe(1);
+});
+
+test('password login can be disabled for users linked to an oauth provider', function () {
+    instanceSettings()->forceFill([
+        'is_password_login_enabled_for_oauth_users' => false,
+    ])->save();
+
+    $user = User::factory()->create([
+        'email' => 'oauth-password@example.com',
+        'password' => Hash::make('password'),
+        'oauth_provider' => 'github',
+        'oauth_id' => 'oauth-user-id',
+    ]);
+
+    $this->post('/login', [
+        'email' => $user->email,
+        'password' => 'password',
+    ]);
+
+    $this->assertGuest();
+});


### PR DESCRIPTION
## Changes

- Adds separate instance settings for OAuth self-registration and password login for OAuth-linked users.
- Allows OAuth-created users when normal password self-registration is disabled, while preserving the disabled-registration path when both settings are off.
- Stores OAuth provider/id on users, links existing email users on OAuth login, and blocks password login/reset/update when OAuth password login is disabled.
- Adds Advanced settings toggles, login-page copy, and feature tests for the new auth policy behavior.

## Issues

- Related to #8042
- Bounty claim is omitted while this is draft; the demo video and local Coolify validation should be attached before marking ready.

## Category

- [ ] Bug fix
- [x] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Draft PR: preview video not attached yet. The visible change is two toggles in Settings > Advanced plus updated login-page messaging.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Implementation assistance and review before maintainer/human validation.

## Testing

- `git diff --check origin/next...HEAD`
- Not run: PHP/Pest suite and local Coolify instance validation, because this checkout lacks PHP, Composer, and installed dependencies.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [ ] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.