### PR TITLE
feat: add WordPress OpenLiteSpeed service template

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -1,0 +1,54 @@
+# documentation: https://github.com/luizeof/dockerpress
+# slogan: WordPress running on OpenLiteSpeed with LiteSpeed Cache and MariaDB.
+# category: cms
+# tags: cms, wordpress, openlitespeed, litespeed, blog, content, management, mariadb
+# logo: svgs/wordpress.svg
+# port: 80
+
+services:
+  wordpress:
+    image: luizeof/dockerpress:latest
+    environment:
+      - SERVICE_URL_WORDPRESS_80
+      - VIRTUAL_HOST=${SERVICE_FQDN_WORDPRESS}
+      - WORDPRESS_DB_HOST=mariadb
+      - WORDPRESS_DB_PORT=3306
+      - WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME:-wordpress}
+      - WORDPRESS_DB_USER=${SERVICE_USER_WORDPRESS}
+      - WORDPRESS_DB_PASSWORD=${SERVICE_PASSWORD_WORDPRESS}
+      - WORDPRESS_DB_PREFIX=${WORDPRESS_DB_PREFIX:-wp_}
+      - MYSQL_ROOT_PASSWORD=${SERVICE_PASSWORD_ROOT}
+      - ADMIN_USER=${SERVICE_USER_ADMIN}
+      - ADMIN_PASS=${SERVICE_PASSWORD_ADMIN}
+      - ADMIN_PASSWORD=${SERVICE_PASSWORD_OPENLITESPEED}
+      - ADMIN_EMAIL=${ADMIN_EMAIL:-admin@example.com}
+      - WP_LOCALE=${WP_LOCALE:-en_US}
+      - WP_DEBUG=${WP_DEBUG:-false}
+      - DISABLE_WP_CRON=${DISABLE_WP_CRON:-false}
+    volumes:
+      - wordpress-files:/var/www/html
+      - openlitespeed-logs:/var/log/litespeed
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1/ || exit 1"]
+      interval: 10s
+      timeout: 20s
+      retries: 10
+      start_period: 60s
+
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=${SERVICE_PASSWORD_ROOT}
+      - MYSQL_DATABASE=${WORDPRESS_DB_NAME:-wordpress}
+      - MYSQL_USER=${SERVICE_USER_WORDPRESS}
+      - MYSQL_PASSWORD=${SERVICE_PASSWORD_WORDPRESS}
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
## Changes

- Adds a WordPress + OpenLiteSpeed one-click service template backed by MariaDB.
- Persists WordPress files, OpenLiteSpeed logs, and MariaDB data in named volumes.
- Uses Coolify service URL/FQDN helpers for proxy and certificate management.
- Provides generated credentials for WordPress, MariaDB, and the OpenLiteSpeed admin password.

## Issues

- Closes #8264
- /claim #8264

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Demo video: https://github.com/michael-schvarcz/coolify/releases/download/coolify-openlitespeed-demo-10091/coolify-openlitespeed-demo-pr-10091.mp4

The recording shows the new WordPress + OpenLiteSpeed compose template, the Coolify service variables it uses, and the local validation results. A full Coolify UI run was not available from this workspace.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Used to inspect existing templates, draft the compose template, and run local validation commands. Human review should focus on image choice and Coolify template conventions.

## Testing

- Parsed `templates/compose/wordpress-with-openlitespeed.yaml` with Ruby YAML.
- Ran `git diff --cached --check` before committing.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.