### PR TITLE
Add OAuth-only registration controls

### DIFF
--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -17,6 +17,10 @@ class ResetUserPassword implements ResetsUserPasswords
      */
     public function reset(User $user, array $input): void
     {
+        if ($user->hasPasswordAuthenticationDisabled()) {
+            abort(403);
+        }
+
         Validator::make($input, [
             'password' => ['required', Password::defaults(), 'confirmed'],
         ])->validate();

--- a/app/Actions/Fortify/UpdateUserPassword.php
+++ b/app/Actions/Fortify/UpdateUserPassword.php
@@ -17,6 +17,10 @@ class UpdateUserPassword implements UpdatesUserPasswords
      */
     public function update(User $user, array $input): void
     {
+        if ($user->hasPasswordAuthenticationDisabled()) {
+            abort(403);
+        }
+
         Validator::make($input, [
             'current_password' => ['required', 'string', 'current_password:web'],
             'password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -78,6 +78,10 @@ class Controller extends BaseController
                 return response()->json(['message' => 'Transactional emails are not active'], 400);
             }
             $request->validate([Fortify::email() => 'required|email']);
+            $user = User::whereEmail($request->input(Fortify::email()))->first();
+            if ($user?->hasPasswordAuthenticationDisabled()) {
+                return app(SuccessfulPasswordResetLinkRequestResponse::class, ['status' => Password::RESET_LINK_SENT]);
+            }
             $status = Password::broker(config('fortify.passwords'))->sendResetLink(
                 $request->only(Fortify::email())
             );

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\OauthSetting;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -19,17 +20,21 @@ class OauthController extends Controller
     {
         try {
             $oauthUser = get_socialite_provider($provider)->user();
+            $oauthSetting = OauthSetting::firstWhere('provider', $provider);
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! $oauthSetting?->is_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 
                 $user = User::create([
                     'name' => $oauthUser->name,
                     'email' => $oauthUser->email,
+                    'oauth_provider' => $provider,
                 ]);
+            } elseif (blank($user->oauth_provider) && $oauthSetting?->is_password_login_disabled) {
+                $user->forceFill(['oauth_provider' => $provider])->save();
             }
             Auth::login($user);
 

--- a/app/Livewire/SettingsOauth.php
+++ b/app/Livewire/SettingsOauth.php
@@ -13,6 +13,8 @@ class SettingsOauth extends Component
     {
         return OauthSetting::all()->reduce(function ($carry, $setting) {
             $carry["oauth_settings_map.$setting->provider.enabled"] = 'required';
+            $carry["oauth_settings_map.$setting->provider.is_registration_enabled"] = 'required';
+            $carry["oauth_settings_map.$setting->provider.is_password_login_disabled"] = 'required';
             $carry["oauth_settings_map.$setting->provider.client_id"] = 'nullable';
             $carry["oauth_settings_map.$setting->provider.client_secret"] = 'nullable';
             $carry["oauth_settings_map.$setting->provider.redirect_uri"] = 'nullable';
@@ -33,6 +35,8 @@ class SettingsOauth extends Component
                 'id' => $setting->id,
                 'provider' => $setting->provider,
                 'enabled' => $setting->enabled,
+                'is_registration_enabled' => $setting->is_registration_enabled,
+                'is_password_login_disabled' => $setting->is_password_login_disabled,
                 'client_id' => $setting->client_id,
                 'client_secret' => $setting->client_secret,
                 'redirect_uri' => $setting->redirect_uri,
@@ -56,6 +60,8 @@ class SettingsOauth extends Component
 
             $oauth->fill([
                 'enabled' => $oauthData['enabled'],
+                'is_registration_enabled' => $oauthData['is_registration_enabled'],
+                'is_password_login_disabled' => $oauthData['is_password_login_disabled'],
                 'client_id' => $oauthData['client_id'],
                 'client_secret' => $oauthData['client_secret'],
                 'redirect_uri' => $oauthData['redirect_uri'],
@@ -74,6 +80,8 @@ class SettingsOauth extends Component
                 'id' => $oauth->id,
                 'provider' => $oauth->provider,
                 'enabled' => $oauth->enabled,
+                'is_registration_enabled' => $oauth->is_registration_enabled,
+                'is_password_login_disabled' => $oauth->is_password_login_disabled,
                 'client_id' => $oauth->client_id,
                 'client_secret' => $oauth->client_secret,
                 'redirect_uri' => $oauth->redirect_uri,
@@ -95,6 +103,8 @@ class SettingsOauth extends Component
 
                 $oauth->fill([
                     'enabled' => $settingData['enabled'],
+                    'is_registration_enabled' => $settingData['is_registration_enabled'],
+                    'is_password_login_disabled' => $settingData['is_password_login_disabled'],
                     'client_id' => $settingData['client_id'],
                     'client_secret' => $settingData['client_secret'],
                     'redirect_uri' => $settingData['redirect_uri'],
@@ -114,6 +124,8 @@ class SettingsOauth extends Component
                     'id' => $oauth->id,
                     'provider' => $oauth->provider,
                     'enabled' => $oauth->enabled,
+                    'is_registration_enabled' => $oauth->is_registration_enabled,
+                    'is_password_login_disabled' => $oauth->is_password_login_disabled,
                     'client_id' => $oauth->client_id,
                     'client_secret' => $oauth->client_secret,
                     'redirect_uri' => $oauth->redirect_uri,

--- a/app/Models/OauthSetting.php
+++ b/app/Models/OauthSetting.php
@@ -11,7 +11,23 @@ class OauthSetting extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['provider', 'client_id', 'client_secret', 'redirect_uri', 'tenant', 'base_url', 'enabled'];
+    protected $fillable = [
+        'provider',
+        'client_id',
+        'client_secret',
+        'redirect_uri',
+        'tenant',
+        'base_url',
+        'enabled',
+        'is_registration_enabled',
+        'is_password_login_disabled',
+    ];
+
+    protected $casts = [
+        'enabled' => 'boolean',
+        'is_registration_enabled' => 'boolean',
+        'is_password_login_disabled' => 'boolean',
+    ];
 
     protected function clientSecret(): Attribute
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -47,6 +47,7 @@ class User extends Authenticatable implements SendsEmail
         'name',
         'email',
         'password',
+        'oauth_provider',
         'force_password_reset',
         'marketing_emails',
         'pending_email',
@@ -486,5 +487,16 @@ class User extends Authenticatable implements SendsEmail
     public function hasPassword(): bool
     {
         return ! empty($this->password);
+    }
+
+    public function hasPasswordAuthenticationDisabled(): bool
+    {
+        if (blank($this->oauth_provider)) {
+            return false;
+        }
+
+        return OauthSetting::where('provider', $this->oauth_provider)
+            ->where('is_password_login_disabled', true)
+            ->exists();
     }
 }

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -76,6 +76,7 @@ class FortifyServiceProvider extends ServiceProvider
             $user = User::where('email', $email)->with('teams')->first();
             if (
                 $user &&
+                ! $user->hasPasswordAuthenticationDisabled() &&
                 Hash::check($request->password, $user->password)
             ) {
                 $user->updated_at = now();

--- a/database/migrations/2026_05_12_000000_add_oauth_registration_controls.php
+++ b/database/migrations/2026_05_12_000000_add_oauth_registration_controls.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('oauth_settings', function (Blueprint $table) {
+            $table->boolean('is_registration_enabled')->default(false)->after('enabled');
+            $table->boolean('is_password_login_disabled')->default(false)->after('is_registration_enabled');
+        });
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('oauth_provider')->nullable()->after('password')->index();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropIndex(['oauth_provider']);
+            $table->dropColumn('oauth_provider');
+        });
+
+        Schema::table('oauth_settings', function (Blueprint $table) {
+            $table->dropColumn([
+                'is_registration_enabled',
+                'is_password_login_disabled',
+            ]);
+        });
+    }
+};

--- a/resources/views/livewire/settings-oauth.blade.php
+++ b/resources/views/livewire/settings-oauth.blade.php
@@ -21,6 +21,15 @@
                         <x-forms.checkbox instantSave="instantSave('{{ $oauth_setting['provider'] }}')"
                             id="oauth_settings_map.{{ $oauth_setting['provider'] }}.enabled" label="Enabled" />
                     </div>
+                    <div class="flex flex-col gap-1 pb-2">
+                        <x-forms.checkbox id="oauth_settings_map.{{ $oauth_setting['provider'] }}.is_registration_enabled"
+                            label="Allow OAuth registration"
+                            helper="Allow new users to sign up with this provider even when general registration is disabled." />
+                        <x-forms.checkbox
+                            id="oauth_settings_map.{{ $oauth_setting['provider'] }}.is_password_login_disabled"
+                            label="Disable password login for OAuth users"
+                            helper="Users created through this provider cannot create or use a password while this option is enabled." />
+                    </div>
                     <div class="flex flex-col w-full gap-2 xl:flex-row">
                         <x-forms.input id="oauth_settings_map.{{ $oauth_setting['provider'] }}.client_id"
                             label="Client ID" />

--- a/tests/Feature/OauthRegistrationTest.php
+++ b/tests/Feature/OauthRegistrationTest.php
@@ -1,0 +1,115 @@
+<?php
+
+use App\Actions\Fortify\ResetUserPassword;
+use App\Actions\Fortify\UpdateUserPassword;
+use App\Models\InstanceSettings;
+use App\Models\OauthSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Socialite\Facades\Socialite;
+use Laravel\Socialite\Two\GithubProvider;
+use Laravel\Socialite\Two\User as SocialiteUser;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::create([
+        'id' => 0,
+        'is_registration_enabled' => false,
+    ]);
+});
+
+function fakeGithubOauthUser(string $email = 'oauth@example.com'): void
+{
+    $provider = Mockery::mock();
+    $provider->shouldReceive('user')
+        ->once()
+        ->andReturn((new SocialiteUser)->map([
+            'id' => 'github-123',
+            'name' => 'OAuth User',
+            'email' => $email,
+        ]));
+
+    Socialite::shouldReceive('buildProvider')
+        ->once()
+        ->with(GithubProvider::class, Mockery::type('array'))
+        ->andReturn($provider);
+}
+
+function createGithubOauthSetting(array $attributes = []): OauthSetting
+{
+    return OauthSetting::create(array_merge([
+        'provider' => 'github',
+        'enabled' => true,
+        'client_id' => 'client-id',
+        'client_secret' => 'client-secret',
+        'redirect_uri' => 'https://coolify.test/auth/github/callback',
+    ], $attributes));
+}
+
+it('keeps oauth self registration disabled by default when registration is disabled', function () {
+    createGithubOauthSetting();
+    fakeGithubOauthUser();
+
+    $this->get(route('auth.callback', 'github'))
+        ->assertRedirect(route('login'));
+
+    expect(User::whereEmail('oauth@example.com')->exists())->toBeFalse();
+});
+
+it('allows enabled oauth providers to self register when registration is disabled', function () {
+    createGithubOauthSetting(['is_registration_enabled' => true]);
+    fakeGithubOauthUser();
+
+    $this->get(route('auth.callback', 'github'))
+        ->assertRedirect('/');
+
+    $user = User::whereEmail('oauth@example.com')->firstOrFail();
+
+    expect($user->oauth_provider)->toBe('github');
+    expect($user->password)->toBeNull();
+    $this->assertAuthenticatedAs($user);
+});
+
+it('blocks password authentication and password creation for oauth-only users', function () {
+    createGithubOauthSetting([
+        'is_registration_enabled' => true,
+        'is_password_login_disabled' => true,
+    ]);
+
+    $user = User::factory()->create([
+        'email' => 'oauth@example.com',
+        'password' => bcrypt('password'),
+        'oauth_provider' => 'github',
+    ]);
+
+    $this->post('/login', [
+        'email' => 'oauth@example.com',
+        'password' => 'password',
+    ])->assertRedirect();
+    $this->assertGuest();
+
+    app(ResetUserPassword::class)->reset($user, [
+        'password' => 'NewPassword1!',
+        'password_confirmation' => 'NewPassword1!',
+    ]);
+})->throws(Symfony\Component\HttpKernel\Exception\HttpException::class);
+
+it('blocks password updates for oauth-only users', function () {
+    createGithubOauthSetting([
+        'is_registration_enabled' => true,
+        'is_password_login_disabled' => true,
+    ]);
+
+    $user = User::factory()->create([
+        'email' => 'oauth@example.com',
+        'password' => bcrypt('password'),
+        'oauth_provider' => 'github',
+    ]);
+
+    app(UpdateUserPassword::class)->update($user, [
+        'current_password' => 'password',
+        'password' => 'NewPassword1!',
+        'password_confirmation' => 'NewPassword1!',
+    ]);
+})->throws(Symfony\Component\HttpKernel\Exception\HttpException::class);


### PR DESCRIPTION
I added provider-level OAuth settings so an admin can allow OAuth signups even when normal registration is disabled. I also added an option to keep users created through a provider from using or creating passwords.

Fixes #8042
