### PR TITLE
feat: add WordPress OpenLiteSpeed service template

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed-and-mariadb.yaml
+++ b/templates/compose/wordpress-with-openlitespeed-and-mariadb.yaml
@@ -1,0 +1,77 @@
+# documentation: https://github.com/litespeedtech/ols-docker-env
+# slogan: WordPress with OpenLiteSpeed provides a high-performance PHP web server stack for WordPress sites.
+# category: cms
+# tags: cms, blog, content, management, wordpress, openlitespeed, mariadb, php
+# logo: svgs/wordpress.svg
+# port: 80
+
+services:
+  litespeed:
+    image: litespeedtech/openlitespeed:latest
+    volumes:
+      - wordpress-files:/var/www/vhosts/localhost/html
+      - litespeed-conf:/usr/local/lsws/conf
+      - litespeed-admin-conf:/usr/local/lsws/admin/conf
+      - litespeed-logs:/usr/local/lsws/logs
+    environment:
+      - SERVICE_URL_LITESPEED_80
+      - TZ=${TIMEZONE:-UTC}
+    depends_on:
+      wordpress-init:
+        condition: service_completed_successfully
+      mariadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1"]
+      interval: 2s
+      timeout: 10s
+      retries: 10
+
+  wordpress-init:
+    image: litespeedtech/openlitespeed:latest
+    restart: "no"
+    entrypoint: ["/bin/bash", "-lc"]
+    command: |
+      set -e
+      until mysqladmin ping -h "$${WORDPRESS_DB_HOST}" -u"$${WORDPRESS_DB_USER}" -p"$${WORDPRESS_DB_PASSWORD}" --silent; do
+        sleep 2
+      done
+      mkdir -p /var/www/vhosts/localhost/html
+      if [ ! -f /var/www/vhosts/localhost/html/index.php ]; then
+        wp core download --path=/var/www/vhosts/localhost/html --allow-root
+      fi
+      if [ ! -f /var/www/vhosts/localhost/html/wp-config.php ]; then
+        wp config create \
+          --path=/var/www/vhosts/localhost/html \
+          --dbname="$${WORDPRESS_DB_NAME}" \
+          --dbuser="$${WORDPRESS_DB_USER}" \
+          --dbpass="$${WORDPRESS_DB_PASSWORD}" \
+          --dbhost="$${WORDPRESS_DB_HOST}" \
+          --allow-root
+      fi
+      chown -R 994:994 /var/www/vhosts/localhost/html
+    volumes:
+      - wordpress-files:/var/www/vhosts/localhost/html
+    environment:
+      - WORDPRESS_DB_HOST=mariadb
+      - WORDPRESS_DB_NAME=wordpress
+      - WORDPRESS_DB_USER=${SERVICE_USER_WORDPRESS}
+      - WORDPRESS_DB_PASSWORD=${SERVICE_PASSWORD_WORDPRESS}
+    depends_on:
+      mariadb:
+        condition: service_healthy
+
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=${SERVICE_PASSWORD_ROOT}
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=${SERVICE_USER_WORDPRESS}
+      - MYSQL_PASSWORD=${SERVICE_PASSWORD_WORDPRESS}
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
 ## Changes

  Added a new one-click service template for WordPress with OpenLiteSpeed and MariaDB. The template uses the official
  `litespeedtech/openlitespeed` image and persists the WordPress document root, OpenLiteSpeed configuration, admin
  configuration, logs, and MariaDB data.

  The template includes a one-shot `wordpress-init` service that waits for MariaDB, downloads WordPress files when the volume is
  empty, creates `wp-config.php`, and then lets the OpenLiteSpeed container serve the site.

  ## Issues

  - Fixes #8264
  /claim #8264

  ## Category

  - [ ] Bug fix
  - [ ] Improvement
  - [ ] New feature
  - [x] Adding new one click service
  - [ ] Fixing or updating existing one click service

  ## Preview

  This is a compose template-only change, so there is no UI screenshot. The new template is named `wordpress-with-openlitespeed-
  and-mariadb`.

  ## AI Assistance

  - [ ] AI was NOT used to create this PR
  - [x] AI was used (please describe below)

  **If AI was used:**

  - Tools used: OpenAI Codex
  - How extensively: Used to inspect existing service-template patterns, draft the compose template, and run local syntax
  checks. I reviewed the final diff before submitting.

  ## Testing

  - Ran `npx --yes yaml@2.8.1 valid` against the new compose template.
  - Ran local Python YAML checks for the service structure and Coolify magic variables.
  - Docker runtime testing was not available in my local environment.

  ## Contributor Agreement

  > [!IMPORTANT]
  >
  > - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/
  CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
  > - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://
  github.com/coolify/issues) (including closed ones) to ensure this isn't a duplicate.
  > - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they
  will work as expected when a maintainer tests them.