### PR TITLE
Add Docker Mailserver service template

### DIFF
--- a/templates/compose/docker-mailserver.yaml
+++ b/templates/compose/docker-mailserver.yaml
@@ -1,0 +1,45 @@
+# documentation: https://docker-mailserver.github.io/docker-mailserver/latest/
+# slogan: Production-ready self-hosted mail server with SMTP, IMAP, antispam, antivirus, and persistent mailbox storage.
+# category: email
+# tags: email,smtp,imap,mailserver,postfix,dovecot,rspamd
+# logo: svgs/default.webp
+# port: 25
+
+services:
+  mailserver:
+    image: ghcr.io/docker-mailserver/docker-mailserver:latest
+    hostname: ${MAIL_HOSTNAME:-mail.example.com}
+    environment:
+      - OVERRIDE_HOSTNAME=${MAIL_HOSTNAME:-mail.example.com}
+      - POSTMASTER_ADDRESS=${POSTMASTER_ADDRESS:-postmaster@example.com}
+      - SSL_TYPE=${SSL_TYPE:-self-signed}
+      - TLS_LEVEL=${TLS_LEVEL:-modern}
+      - ENABLE_RSPAMD=${ENABLE_RSPAMD:-1}
+      - ENABLE_CLAMAV=${ENABLE_CLAMAV:-0}
+      - ENABLE_FAIL2BAN=${ENABLE_FAIL2BAN:-1}
+      - ENABLE_POSTGREY=${ENABLE_POSTGREY:-0}
+      - ONE_DIR=${ONE_DIR:-1}
+      - PERMIT_DOCKER=${PERMIT_DOCKER:-network}
+      - SPOOF_PROTECTION=${SPOOF_PROTECTION:-1}
+      - POSTFIX_MESSAGE_SIZE_LIMIT=${POSTFIX_MESSAGE_SIZE_LIMIT:-10240000}
+      - LOG_LEVEL=${LOG_LEVEL:-info}
+    ports:
+      - "25:25"
+      - "143:143"
+      - "465:465"
+      - "587:587"
+      - "993:993"
+    volumes:
+      - mailserver-mail-data:/var/mail/
+      - mailserver-mail-state:/var/mail-state/
+      - mailserver-mail-logs:/var/log/mail/
+      - mailserver-config:/tmp/docker-mailserver/
+      - mailserver-certs:/etc/letsencrypt/
+      - /etc/localtime:/etc/localtime:ro
+    stop_grace_period: 1m
+    cap_add:
+      - NET_ADMIN
+    healthcheck:
+      test: ["CMD-SHELL", "ss --listening --ipv4 --tcp | grep --silent ':smtp' || exit 1"]
+      timeout: 3s
+      retries: 0

--- a/templates/service-templates-latest.json
+++ b/templates/service-templates-latest.json
@@ -870,6 +870,24 @@
         "logo": "svgs/diun.svg",
         "minversion": "0.0.0"
     },
+    "docker-mailserver": {
+        "documentation": "https://docker-mailserver.github.io/docker-mailserver/latest/?utm_source=coolify.io",
+        "slogan": "Production-ready self-hosted mail server with SMTP, IMAP, antispam, antivirus, and persistent mailbox storage.",
+        "compose": "c2VydmljZXM6CiAgbWFpbHNlcnZlcjoKICAgIGltYWdlOiBnaGNyLmlvL2RvY2tlci1tYWlsc2VydmVyL2RvY2tlci1tYWlsc2VydmVyOmxhdGVzdAogICAgaG9zdG5hbWU6ICR7TUFJTF9IT1NUTkFNRTotbWFpbC5leGFtcGxlLmNvbX0KICAgIGVudmlyb25tZW50OgogICAgICAtIE9WRVJSSURFX0hPU1ROQU1FPSR7TUFJTF9IT1NUTkFNRTotbWFpbC5leGFtcGxlLmNvbX0KICAgICAgLSBQT1NUTUFTVEVSX0FERFJFU1M9JHtQT1NUTUFTVEVSX0FERFJFU1M6LXBvc3RtYXN0ZXJAZXhhbXBsZS5jb219CiAgICAgIC0gU1NMX1RZUEU9JHtTU0xfVFlQRTotc2VsZi1zaWduZWR9CiAgICAgIC0gVExTX0xFVkVMPSR7VExTX0xFVkVMOi1tb2Rlcm59CiAgICAgIC0gRU5BQkxFX1JTUEFNRD0ke0VOQUJMRV9SU1BBTUQ6LTF9CiAgICAgIC0gRU5BQkxFX0NMQU1BVj0ke0VOQUJMRV9DTEFNQVY6LTB9CiAgICAgIC0gRU5BQkxFX0ZBSUwyQkFOPSR7RU5BQkxFX0ZBSUwyQkFOOi0xfQogICAgICAtIEVOQUJMRV9QT1NUR1JFWT0ke0VOQUJMRV9QT1NUR1JFWTotMH0KICAgICAgLSBPTkVfRElSPSR7T05FX0RJUjotMX0KICAgICAgLSBQRVJNSVRfRE9DS0VSPSR7UEVSTUlUX0RPQ0tFUjotbmV0d29ya30KICAgICAgLSBTUE9PRl9QUk9URUNUSU9OPSR7U1BPT0ZfUFJPVEVDVElPTjotMX0KICAgICAgLSBQT1NURklYX01FU1NBR0VfU0laRV9MSU1JVD0ke1BPU1RGSVhfTUVTU0FHRV9TSVpFX0xJTUlUOi0xMDI0MDAwMH0KICAgICAgLSBMT0dfTEVWRUw9JHtMT0dfTEVWRUw6LWluZm99CiAgICBwb3J0czoKICAgICAgLSAiMjU6MjUiCiAgICAgIC0gIjE0MzoxNDMiCiAgICAgIC0gIjQ2NTo0NjUiCiAgICAgIC0gIjU4Nzo1ODciCiAgICAgIC0gIjk5Mzo5OTMiCiAgICB2b2x1bWVzOgogICAgICAtIG1haWxzZXJ2ZXItbWFpbC1kYXRhOi92YXIvbWFpbC8KICAgICAgLSBtYWlsc2VydmVyLW1haWwtc3RhdGU6L3Zhci9tYWlsLXN0YXRlLwogICAgICAtIG1haWxzZXJ2ZXItbWFpbC1sb2dzOi92YXIvbG9nL21haWwvCiAgICAgIC0gbWFpbHNlcnZlci1jb25maWc6L3RtcC9kb2NrZXItbWFpbHNlcnZlci8KICAgICAgLSBtYWlsc2VydmVyLWNlcnRzOi9ldGMvbGV0c2VuY3J5cHQvCiAgICAgIC0gL2V0Yy9sb2NhbHRpbWU6L2V0Yy9sb2NhbHRpbWU6cm8KICAgIHN0b3BfZ3JhY2VfcGVyaW9kOiAxbQogICAgY2FwX2FkZDoKICAgICAgLSBORVRfQURNSU4KICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OiBbIkNNRC1TSEVMTCIsICJzcyAtLWxpc3RlbmluZyAtLWlwdjQgLS10Y3AgfCBncmVwIC0tc2lsZW50ICc6c210cCcgfHwgZXhpdCAxIl0KICAgICAgdGltZW91dDogM3MKICAgICAgcmV0cmllczogMAo=",
+        "tags": [
+            "email",
+            "smtp",
+            "imap",
+            "mailserver",
+            "postfix",
+            "dovecot",
+            "rspamd"
+        ],
+        "category": "email",
+        "logo": "svgs/default.webp",
+        "minversion": "0.0.0",
+        "port": "25"
+    },
     "docker-registry": {
         "documentation": "https://distribution.github.io/distribution/?utm_source=coolify.io",
         "slogan": "The Docker Registry lets you distribute Docker images.",

--- a/templates/service-templates.json
+++ b/templates/service-templates.json
@@ -870,6 +870,24 @@
         "logo": "svgs/diun.svg",
         "minversion": "0.0.0"
     },
+    "docker-mailserver": {
+        "documentation": "https://docker-mailserver.github.io/docker-mailserver/latest/?utm_source=coolify.io",
+        "slogan": "Production-ready self-hosted mail server with SMTP, IMAP, antispam, antivirus, and persistent mailbox storage.",
+        "compose": "c2VydmljZXM6CiAgbWFpbHNlcnZlcjoKICAgIGltYWdlOiBnaGNyLmlvL2RvY2tlci1tYWlsc2VydmVyL2RvY2tlci1tYWlsc2VydmVyOmxhdGVzdAogICAgaG9zdG5hbWU6ICR7TUFJTF9IT1NUTkFNRTotbWFpbC5leGFtcGxlLmNvbX0KICAgIGVudmlyb25tZW50OgogICAgICAtIE9WRVJSSURFX0hPU1ROQU1FPSR7TUFJTF9IT1NUTkFNRTotbWFpbC5leGFtcGxlLmNvbX0KICAgICAgLSBQT1NUTUFTVEVSX0FERFJFU1M9JHtQT1NUTUFTVEVSX0FERFJFU1M6LXBvc3RtYXN0ZXJAZXhhbXBsZS5jb219CiAgICAgIC0gU1NMX1RZUEU9JHtTU0xfVFlQRTotc2VsZi1zaWduZWR9CiAgICAgIC0gVExTX0xFVkVMPSR7VExTX0xFVkVMOi1tb2Rlcm59CiAgICAgIC0gRU5BQkxFX1JTUEFNRD0ke0VOQUJMRV9SU1BBTUQ6LTF9CiAgICAgIC0gRU5BQkxFX0NMQU1BVj0ke0VOQUJMRV9DTEFNQVY6LTB9CiAgICAgIC0gRU5BQkxFX0ZBSUwyQkFOPSR7RU5BQkxFX0ZBSUwyQkFOOi0xfQogICAgICAtIEVOQUJMRV9QT1NUR1JFWT0ke0VOQUJMRV9QT1NUR1JFWTotMH0KICAgICAgLSBPTkVfRElSPSR7T05FX0RJUjotMX0KICAgICAgLSBQRVJNSVRfRE9DS0VSPSR7UEVSTUlUX0RPQ0tFUjotbmV0d29ya30KICAgICAgLSBTUE9PRl9QUk9URUNUSU9OPSR7U1BPT0ZfUFJPVEVDVElPTjotMX0KICAgICAgLSBQT1NURklYX01FU1NBR0VfU0laRV9MSU1JVD0ke1BPU1RGSVhfTUVTU0FHRV9TSVpFX0xJTUlUOi0xMDI0MDAwMH0KICAgICAgLSBMT0dfTEVWRUw9JHtMT0dfTEVWRUw6LWluZm99CiAgICBwb3J0czoKICAgICAgLSAiMjU6MjUiCiAgICAgIC0gIjE0MzoxNDMiCiAgICAgIC0gIjQ2NTo0NjUiCiAgICAgIC0gIjU4Nzo1ODciCiAgICAgIC0gIjk5Mzo5OTMiCiAgICB2b2x1bWVzOgogICAgICAtIG1haWxzZXJ2ZXItbWFpbC1kYXRhOi92YXIvbWFpbC8KICAgICAgLSBtYWlsc2VydmVyLW1haWwtc3RhdGU6L3Zhci9tYWlsLXN0YXRlLwogICAgICAtIG1haWxzZXJ2ZXItbWFpbC1sb2dzOi92YXIvbG9nL21haWwvCiAgICAgIC0gbWFpbHNlcnZlci1jb25maWc6L3RtcC9kb2NrZXItbWFpbHNlcnZlci8KICAgICAgLSBtYWlsc2VydmVyLWNlcnRzOi9ldGMvbGV0c2VuY3J5cHQvCiAgICAgIC0gL2V0Yy9sb2NhbHRpbWU6L2V0Yy9sb2NhbHRpbWU6cm8KICAgIHN0b3BfZ3JhY2VfcGVyaW9kOiAxbQogICAgY2FwX2FkZDoKICAgICAgLSBORVRfQURNSU4KICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OiBbIkNNRC1TSEVMTCIsICJzcyAtLWxpc3RlbmluZyAtLWlwdjQgLS10Y3AgfCBncmVwIC0tc2lsZW50ICc6c210cCcgfHwgZXhpdCAxIl0KICAgICAgdGltZW91dDogM3MKICAgICAgcmV0cmllczogMAo=",
+        "tags": [
+            "email",
+            "smtp",
+            "imap",
+            "mailserver",
+            "postfix",
+            "dovecot",
+            "rspamd"
+        ],
+        "category": "email",
+        "logo": "svgs/default.webp",
+        "minversion": "0.0.0",
+        "port": "25"
+    },
     "docker-registry": {
         "documentation": "https://distribution.github.io/distribution/?utm_source=coolify.io",
         "slogan": "The Docker Registry lets you distribute Docker images.",


### PR DESCRIPTION
Closes #8266

## Summary
- add a reusable Docker Mailserver template under the email category
- expose SMTP/IMAP submission ports and persist mailbox data, state, logs, config, and certificate storage
- update the generated service template catalogs so the template is available in Coolify

## Notes
- defaults to self-signed TLS so the container can start before a production certificate is configured
- exposes MAIL_HOSTNAME, POSTMASTER_ADDRESS, SSL_TYPE, and related Docker Mailserver options as Coolify environment variables

## Testing
- php artisan generate:services
- Parsed both service template JSON catalogs with ConvertFrom-Json
- Decoded the generated Docker Mailserver catalog entry and verified the image, persisted certificate volume, and Fail2Ban setting
