### PR TITLE
Add OAuth self-registration controls

### DIFF
--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -17,6 +17,10 @@ class ResetUserPassword implements ResetsUserPasswords
      */
     public function reset(User $user, array $input): void
     {
+        if ($user->oauth_only) {
+            abort(403, 'Password login is disabled for this account.');
+        }
+
         Validator::make($input, [
             'password' => ['required', Password::defaults(), 'confirmed'],
         ])->validate();

--- a/app/Actions/Fortify/UpdateUserPassword.php
+++ b/app/Actions/Fortify/UpdateUserPassword.php
@@ -17,6 +17,10 @@ class UpdateUserPassword implements UpdatesUserPasswords
      */
     public function update(User $user, array $input): void
     {
+        if ($user->oauth_only) {
+            abort(403, 'Password login is disabled for this account.');
+        }
+
         Validator::make($input, [
             'current_password' => ['required', 'string', 'current_password:web'],
             'password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\OauthSetting;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -10,6 +11,10 @@ class OauthController extends Controller
 {
     public function redirect(string $provider)
     {
+        OauthSetting::where('provider', $provider)
+            ->where('enabled', true)
+            ->firstOrFail();
+
         $socialite_provider = get_socialite_provider($provider);
 
         return $socialite_provider->redirect();
@@ -18,11 +23,14 @@ class OauthController extends Controller
     public function callback(string $provider)
     {
         try {
+            $oauthSetting = OauthSetting::where('provider', $provider)
+                ->where('enabled', true)
+                ->firstOrFail();
             $oauthUser = get_socialite_provider($provider)->user();
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! $oauthSetting->allow_registration) {
                     abort(403, 'Registration is disabled');
                 }
 
@@ -30,6 +38,12 @@ class OauthController extends Controller
                     'name' => $oauthUser->name,
                     'email' => $oauthUser->email,
                 ]);
+            }
+            if ($oauthSetting->force_oauth_only && ($user->hasPassword() || ! $user->oauth_only)) {
+                $user->forceFill([
+                    'password' => null,
+                    'oauth_only' => true,
+                ])->save();
             }
             Auth::login($user);
 

--- a/app/Livewire/SettingsOauth.php
+++ b/app/Livewire/SettingsOauth.php
@@ -18,6 +18,8 @@ class SettingsOauth extends Component
             $carry["oauth_settings_map.$setting->provider.redirect_uri"] = 'nullable';
             $carry["oauth_settings_map.$setting->provider.tenant"] = 'nullable';
             $carry["oauth_settings_map.$setting->provider.base_url"] = 'nullable';
+            $carry["oauth_settings_map.$setting->provider.allow_registration"] = 'required';
+            $carry["oauth_settings_map.$setting->provider.force_oauth_only"] = 'required';
 
             return $carry;
         }, []);
@@ -38,6 +40,8 @@ class SettingsOauth extends Component
                 'redirect_uri' => $setting->redirect_uri,
                 'tenant' => $setting->tenant,
                 'base_url' => $setting->base_url,
+                'allow_registration' => $setting->allow_registration,
+                'force_oauth_only' => $setting->force_oauth_only,
             ];
 
             return $carry;
@@ -61,6 +65,8 @@ class SettingsOauth extends Component
                 'redirect_uri' => $oauthData['redirect_uri'],
                 'tenant' => $oauthData['tenant'],
                 'base_url' => $oauthData['base_url'],
+                'allow_registration' => $oauthData['allow_registration'],
+                'force_oauth_only' => $oauthData['force_oauth_only'],
             ]);
 
             if (! $oauth->couldBeEnabled()) {
@@ -79,6 +85,8 @@ class SettingsOauth extends Component
                 'redirect_uri' => $oauth->redirect_uri,
                 'tenant' => $oauth->tenant,
                 'base_url' => $oauth->base_url,
+                'allow_registration' => $oauth->allow_registration,
+                'force_oauth_only' => $oauth->force_oauth_only,
             ];
 
             $this->dispatch('success', 'OAuth settings for '.$oauth->provider.' updated successfully!');
@@ -100,6 +108,8 @@ class SettingsOauth extends Component
                     'redirect_uri' => $settingData['redirect_uri'],
                     'tenant' => $settingData['tenant'],
                     'base_url' => $settingData['base_url'],
+                    'allow_registration' => $settingData['allow_registration'],
+                    'force_oauth_only' => $settingData['force_oauth_only'],
                 ]);
 
                 if ($settingData['enabled'] && ! $oauth->couldBeEnabled()) {
@@ -119,6 +129,8 @@ class SettingsOauth extends Component
                     'redirect_uri' => $oauth->redirect_uri,
                     'tenant' => $oauth->tenant,
                     'base_url' => $oauth->base_url,
+                    'allow_registration' => $oauth->allow_registration,
+                    'force_oauth_only' => $oauth->force_oauth_only,
                 ];
             }
 

--- a/app/Models/OauthSetting.php
+++ b/app/Models/OauthSetting.php
@@ -11,7 +11,23 @@ class OauthSetting extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['provider', 'client_id', 'client_secret', 'redirect_uri', 'tenant', 'base_url', 'enabled'];
+    protected $fillable = [
+        'provider',
+        'client_id',
+        'client_secret',
+        'redirect_uri',
+        'tenant',
+        'base_url',
+        'enabled',
+        'allow_registration',
+        'force_oauth_only',
+    ];
+
+    protected $casts = [
+        'enabled' => 'boolean',
+        'allow_registration' => 'boolean',
+        'force_oauth_only' => 'boolean',
+    ];
 
     protected function clientSecret(): Attribute
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -36,6 +36,7 @@ use OpenApi\Attributes as OA;
         'updated_at' => ['type' => 'string', 'description' => 'The date when the user was updated.'],
         'two_factor_confirmed_at' => ['type' => 'string', 'description' => 'The date when the user two factor was confirmed.'],
         'force_password_reset' => ['type' => 'boolean', 'description' => 'The flag to force the user to reset the password.'],
+        'oauth_only' => ['type' => 'boolean', 'description' => 'The flag to disable password login for OAuth-managed accounts.'],
         'marketing_emails' => ['type' => 'boolean', 'description' => 'The flag to receive marketing emails.'],
     ],
 )]
@@ -48,6 +49,7 @@ class User extends Authenticatable implements SendsEmail
         'email',
         'password',
         'force_password_reset',
+        'oauth_only',
         'marketing_emails',
         'pending_email',
         'email_change_code',
@@ -64,6 +66,7 @@ class User extends Authenticatable implements SendsEmail
     protected $casts = [
         'email_verified_at' => 'datetime',
         'force_password_reset' => 'boolean',
+        'oauth_only' => 'boolean',
         'show_boarding' => 'boolean',
         'email_change_code_expires_at' => 'datetime',
     ];

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -76,6 +76,7 @@ class FortifyServiceProvider extends ServiceProvider
             $user = User::where('email', $email)->with('teams')->first();
             if (
                 $user &&
+                ! $user->oauth_only &&
                 Hash::check($request->password, $user->password)
             ) {
                 $user->updated_at = now();

--- a/database/migrations/2026_05_12_000000_add_oauth_registration_controls_to_oauth_settings_table.php
+++ b/database/migrations/2026_05_12_000000_add_oauth_registration_controls_to_oauth_settings_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('oauth_settings', function (Blueprint $table) {
+            $table->boolean('allow_registration')->default(false)->after('enabled');
+            $table->boolean('force_oauth_only')->default(false)->after('allow_registration');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('oauth_settings', function (Blueprint $table) {
+            $table->dropColumn(['allow_registration', 'force_oauth_only']);
+        });
+    }
+};

--- a/database/migrations/2026_05_12_000001_add_oauth_only_to_users_table.php
+++ b/database/migrations/2026_05_12_000001_add_oauth_only_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('oauth_only')->default(false)->after('force_password_reset');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('oauth_only');
+        });
+    }
+};

--- a/resources/views/livewire/settings-oauth.blade.php
+++ b/resources/views/livewire/settings-oauth.blade.php
@@ -21,6 +21,14 @@
                         <x-forms.checkbox instantSave="instantSave('{{ $oauth_setting['provider'] }}')"
                             id="oauth_settings_map.{{ $oauth_setting['provider'] }}.enabled" label="Enabled" />
                     </div>
+                    <div class="flex flex-col gap-2 py-2 md:flex-row md:gap-6">
+                        <x-forms.checkbox instantSave="instantSave('{{ $oauth_setting['provider'] }}')"
+                            id="oauth_settings_map.{{ $oauth_setting['provider'] }}.allow_registration"
+                            label="Allow OAuth registration" />
+                        <x-forms.checkbox instantSave="instantSave('{{ $oauth_setting['provider'] }}')"
+                            id="oauth_settings_map.{{ $oauth_setting['provider'] }}.force_oauth_only"
+                            label="OAuth-only accounts" />
+                    </div>
                     <div class="flex flex-col w-full gap-2 xl:flex-row">
                         <x-forms.input id="oauth_settings_map.{{ $oauth_setting['provider'] }}.client_id"
                             label="Client ID" />

--- a/tests/Feature/ModelFillableCreationTest.php
+++ b/tests/Feature/ModelFillableCreationTest.php
@@ -6,6 +6,7 @@ use App\Models\ApplicationSetting;
 use App\Models\CloudProviderToken;
 use App\Models\Environment;
 use App\Models\GithubApp;
+use App\Models\OauthSetting;
 use App\Models\Project;
 use App\Models\ProjectSetting;
 use App\Models\ScheduledDatabaseBackup;
@@ -49,6 +50,7 @@ it('creates User with all fillable attributes', function () {
         'email' => 'fillable-test@example.com',
         'password' => bcrypt('password123'),
         'force_password_reset' => true,
+        'oauth_only' => true,
         'marketing_emails' => false,
         'pending_email' => 'newemail@example.com',
         'email_change_code' => 'ABC123',
@@ -59,10 +61,30 @@ it('creates User with all fillable attributes', function () {
     expect($user->name)->toBe('Test User');
     expect($user->email)->toBe('fillable-test@example.com');
     expect($user->force_password_reset)->toBeTrue();
+    expect($user->oauth_only)->toBeTrue();
     expect($user->marketing_emails)->toBeFalse();
     expect($user->pending_email)->toBe('newemail@example.com');
     expect($user->email_change_code)->toBe('ABC123');
     expect($user->email_change_code_expires_at)->not->toBeNull();
+});
+
+it('creates OauthSetting with all fillable attributes', function () {
+    $setting = OauthSetting::create([
+        'provider' => 'test-provider',
+        'client_id' => 'client-id',
+        'client_secret' => 'client-secret',
+        'redirect_uri' => 'https://example.com/callback',
+        'tenant' => 'example.com',
+        'base_url' => 'https://auth.example.com',
+        'enabled' => true,
+        'allow_registration' => true,
+        'force_oauth_only' => true,
+    ]);
+
+    expect($setting->exists)->toBeTrue();
+    expect($setting->enabled)->toBeTrue();
+    expect($setting->allow_registration)->toBeTrue();
+    expect($setting->force_oauth_only)->toBeTrue();
 });
 
 it('creates Server with all fillable attributes', function () {


### PR DESCRIPTION
Closes #8042

## Summary
- add per-provider OAuth settings for allowing OAuth registration while general registration is disabled
- add an OAuth-only account mode that removes password auth for users signing in through that provider
- block password login, reset, and password updates for OAuth-only users
- expose the new controls in the OAuth settings page and cover fillable model attributes

## Testing
- git diff --check
- php vendor/bin/pint --test app/Actions/Fortify/ResetUserPassword.php app/Actions/Fortify/UpdateUserPassword.php app/Http/Controllers/OauthController.php app/Livewire/SettingsOauth.php app/Models/OauthSetting.php app/Models/User.php app/Providers/FortifyServiceProvider.php database/migrations/2026_05_12_000000_add_oauth_registration_controls_to_oauth_settings_table.php database/migrations/2026_05_12_000001_add_oauth_only_to_users_table.php tests/Feature/ModelFillableCreationTest.php
- php vendor/bin/pest tests/Feature/ModelFillableCreationTest.php --filter='OauthSetting|User'