### PR TITLE
feat: add WordPress OpenLiteSpeed service template

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -1,0 +1,57 @@
+# documentation: https://docs.litespeedtech.com/cloud/docker/ols-wordpress/
+# slogan: WordPress running on OpenLiteSpeed with persistent files and MariaDB storage.
+# category: cms
+# tags: cms, blog, content, management, wordpress, openlitespeed, litespeed, mariadb
+# logo: svgs/wordpress.svg
+# port: 80
+
+services:
+  wordpress:
+    image: litespeedtech/openlitespeed:latest
+    environment:
+      - SERVICE_URL_WORDPRESS_80
+      - TZ=${TZ:-UTC}
+    volumes:
+      - wordpress-files:/var/www/vhosts/localhost/html
+      - openlitespeed-logs:/usr/local/lsws/logs
+    depends_on:
+      wordpress-setup:
+        condition: service_completed_successfully
+      mariadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://127.0.0.1:80/ || exit 1"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+
+  wordpress-setup:
+    image: wordpress:cli
+    restart: "no"
+    exclude_from_hc: true
+    volumes:
+      - wordpress-files:/var/www/html
+    environment:
+      - WORDPRESS_DB_HOST=mariadb
+      - WORDPRESS_DB_USER=$SERVICE_USER_WORDPRESS
+      - WORDPRESS_DB_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+      - WORDPRESS_DB_NAME=wordpress
+    command: sh -c "mkdir -p /var/www/html && if [ ! -f /var/www/html/wp-config.php ]; then wp core download --path=/var/www/html --skip-content --force --allow-root && wp config create --path=/var/www/html --dbname=\"$${WORDPRESS_DB_NAME}\" --dbuser=\"$${WORDPRESS_DB_USER}\" --dbpass=\"$${WORDPRESS_DB_PASSWORD}\" --dbhost=\"$${WORDPRESS_DB_HOST}\" --skip-check --allow-root; fi"
+    depends_on:
+      mariadb:
+        condition: service_healthy
+
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10

--- a/templates/service-templates-latest.json
+++ b/templates/service-templates-latest.json
@@ -5225,6 +5225,25 @@
         "logo": "svgs/wordpress.svg",
         "minversion": "0.0.0"
     },
+    "wordpress-with-openlitespeed": {
+        "documentation": "https://docs.litespeedtech.com/cloud/docker/ols-wordpress/?utm_source=coolify.io",
+        "slogan": "WordPress running on OpenLiteSpeed with persistent files and MariaDB storage.",
+        "compose": "c2VydmljZXM6CiAgd29yZHByZXNzOgogICAgaW1hZ2U6IGxpdGVzcGVlZHRlY2gvb3BlbmxpdGVzcGVlZDpsYXRlc3QKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX1dPUkRQUkVTU184MAogICAgICAtIFRaPSR7VFo6LVVUQ30KICAgIHZvbHVtZXM6CiAgICAgIC0gd29yZHByZXNzLWZpbGVzOi92YXIvd3d3L3Zob3N0cy9sb2NhbGhvc3QvaHRtbAogICAgICAtIG9wZW5saXRlc3BlZWQtbG9nczovdXNyL2xvY2FsL2xzd3MvbG9ncwogICAgZGVwZW5kc19vbjoKICAgICAgd29yZHByZXNzLXNldHVwOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9jb21wbGV0ZWRfc3VjY2Vzc2Z1bGx5CiAgICAgIG1hcmlhZGI6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OiBbIkNNRC1TSEVMTCIsICJjdXJsIC1mIGh0dHA6Ly8xMjcuMC4wLjE6ODAvIHx8IGV4aXQgMSJdCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAKCiAgd29yZHByZXNzLXNldHVwOgogICAgaW1hZ2U6IHdvcmRwcmVzczpjbGkKICAgIHJlc3RhcnQ6ICJubyIKICAgIGV4Y2x1ZGVfZnJvbV9oYzogdHJ1ZQogICAgdm9sdW1lczoKICAgICAgLSB3b3JkcHJlc3MtZmlsZXM6L3Zhci93d3cvaHRtbAogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gV09SRFBSRVNTX0RCX0hPU1Q9bWFyaWFkYgogICAgICAtIFdPUkRQUkVTU19EQl9VU0VSPSRTRVJWSUNFX1VTRVJfV09SRFBSRVNTCiAgICAgIC0gV09SRFBSRVNTX0RCX1BBU1NXT1JEPSRTRVJWSUNFX1BBU1NXT1JEX1dPUkRQUkVTUwogICAgICAtIFdPUkRQUkVTU19EQl9OQU1FPXdvcmRwcmVzcwogICAgY29tbWFuZDogc2ggLWMgIm1rZGlyIC1wIC92YXIvd3d3L2h0bWwgJiYgaWYgWyAhIC1mIC92YXIvd3d3L2h0bWwvd3AtY29uZmlnLnBocCBdOyB0aGVuIHdwIGNvcmUgZG93bmxvYWQgLS1wYXRoPS92YXIvd3d3L2h0bWwgLS1za2lwLWNvbnRlbnQgLS1mb3JjZSAtLWFsbG93LXJvb3QgJiYgd3AgY29uZmlnIGNyZWF0ZSAtLXBhdGg9L3Zhci93d3cvaHRtbCAtLWRibmFtZT1cIiQke1dPUkRQUkVTU19EQl9OQU1FfVwiIC0tZGJ1c2VyPVwiJCR7V09SRFBSRVNTX0RCX1VTRVJ9XCIgLS1kYnBhc3M9XCIkJHtXT1JEUFJFU1NfREJfUEFTU1dPUkR9XCIgLS1kYmhvc3Q9XCIkJHtXT1JEUFJFU1NfREJfSE9TVH1cIiAtLXNraXAtY2hlY2sgLS1hbGxvdy1yb290OyBmaSIKICAgIGRlcGVuZHNfb246CiAgICAgIG1hcmlhZGI6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKCiAgbWFyaWFkYjoKICAgIGltYWdlOiBtYXJpYWRiOjExCiAgICB2b2x1bWVzOgogICAgICAtIG1hcmlhZGItZGF0YTovdmFyL2xpYi9teXNxbAogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gTVlTUUxfUk9PVF9QQVNTV09SRD0kU0VSVklDRV9QQVNTV09SRF9ST09UCiAgICAgIC0gTVlTUUxfREFUQUJBU0U9d29yZHByZXNzCiAgICAgIC0gTVlTUUxfVVNFUj0kU0VSVklDRV9VU0VSX1dPUkRQUkVTUwogICAgICAtIE1ZU1FMX1BBU1NXT1JEPSRTRVJWSUNFX1BBU1NXT1JEX1dPUkRQUkVTUwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6IFsiQ01EIiwgImhlYWx0aGNoZWNrLnNoIiwgIi0tY29ubmVjdCIsICItLWlubm9kYl9pbml0aWFsaXplZCJdCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAK",
+        "tags": [
+            "cms",
+            "blog",
+            "content",
+            "management",
+            "wordpress",
+            "openlitespeed",
+            "litespeed",
+            "mariadb"
+        ],
+        "category": "cms",
+        "logo": "svgs/wordpress.svg",
+        "minversion": "0.0.0",
+        "port": "80"
+    },
     "wordpress-without-database": {
         "documentation": "https://wordpress.org?utm_source=coolify.io",
         "slogan": "WordPress is open source software you can use to create a beautiful website, blog, or app.",

--- a/templates/service-templates.json
+++ b/templates/service-templates.json
@@ -5225,6 +5225,25 @@
         "logo": "svgs/wordpress.svg",
         "minversion": "0.0.0"
     },
+    "wordpress-with-openlitespeed": {
+        "documentation": "https://docs.litespeedtech.com/cloud/docker/ols-wordpress/?utm_source=coolify.io",
+        "slogan": "WordPress running on OpenLiteSpeed with persistent files and MariaDB storage.",
+        "compose": "c2VydmljZXM6CiAgd29yZHByZXNzOgogICAgaW1hZ2U6IGxpdGVzcGVlZHRlY2gvb3BlbmxpdGVzcGVlZDpsYXRlc3QKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9XT1JEUFJFU1NfODAKICAgICAgLSBUWj0ke1RaOi1VVEN9CiAgICB2b2x1bWVzOgogICAgICAtIHdvcmRwcmVzcy1maWxlczovdmFyL3d3dy92aG9zdHMvbG9jYWxob3N0L2h0bWwKICAgICAgLSBvcGVubGl0ZXNwZWVkLWxvZ3M6L3Vzci9sb2NhbC9sc3dzL2xvZ3MKICAgIGRlcGVuZHNfb246CiAgICAgIHdvcmRwcmVzcy1zZXR1cDoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfY29tcGxldGVkX3N1Y2Nlc3NmdWxseQogICAgICBtYXJpYWRiOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5CiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDogWyJDTUQtU0hFTEwiLCAiY3VybCAtZiBodHRwOi8vMTI3LjAuMC4xOjgwLyB8fCBleGl0IDEiXQogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCgogIHdvcmRwcmVzcy1zZXR1cDoKICAgIGltYWdlOiB3b3JkcHJlc3M6Y2xpCiAgICByZXN0YXJ0OiAibm8iCiAgICBleGNsdWRlX2Zyb21faGM6IHRydWUKICAgIHZvbHVtZXM6CiAgICAgIC0gd29yZHByZXNzLWZpbGVzOi92YXIvd3d3L2h0bWwKICAgIGVudmlyb25tZW50OgogICAgICAtIFdPUkRQUkVTU19EQl9IT1NUPW1hcmlhZGIKICAgICAgLSBXT1JEUFJFU1NfREJfVVNFUj0kU0VSVklDRV9VU0VSX1dPUkRQUkVTUwogICAgICAtIFdPUkRQUkVTU19EQl9QQVNTV09SRD0kU0VSVklDRV9QQVNTV09SRF9XT1JEUFJFU1MKICAgICAgLSBXT1JEUFJFU1NfREJfTkFNRT13b3JkcHJlc3MKICAgIGNvbW1hbmQ6IHNoIC1jICJta2RpciAtcCAvdmFyL3d3dy9odG1sICYmIGlmIFsgISAtZiAvdmFyL3d3dy9odG1sL3dwLWNvbmZpZy5waHAgXTsgdGhlbiB3cCBjb3JlIGRvd25sb2FkIC0tcGF0aD0vdmFyL3d3dy9odG1sIC0tc2tpcC1jb250ZW50IC0tZm9yY2UgLS1hbGxvdy1yb290ICYmIHdwIGNvbmZpZyBjcmVhdGUgLS1wYXRoPS92YXIvd3d3L2h0bWwgLS1kYm5hbWU9XCIkJHtXT1JEUFJFU1NfREJfTkFNRX1cIiAtLWRidXNlcj1cIiQke1dPUkRQUkVTU19EQl9VU0VSfVwiIC0tZGJwYXNzPVwiJCR7V09SRFBSRVNTX0RCX1BBU1NXT1JEfVwiIC0tZGJob3N0PVwiJCR7V09SRFBSRVNTX0RCX0hPU1R9XCIgLS1za2lwLWNoZWNrIC0tYWxsb3ctcm9vdDsgZmkiCiAgICBkZXBlbmRzX29uOgogICAgICBtYXJpYWRiOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5CgogIG1hcmlhZGI6CiAgICBpbWFnZTogbWFyaWFkYjoxMQogICAgdm9sdW1lczoKICAgICAgLSBtYXJpYWRiLWRhdGE6L3Zhci9saWIvbXlzcWwKICAgIGVudmlyb25tZW50OgogICAgICAtIE1ZU1FMX1JPT1RfUEFTU1dPUkQ9JFNFUlZJQ0VfUEFTU1dPUkRfUk9PVAogICAgICAtIE1ZU1FMX0RBVEFCQVNFPXdvcmRwcmVzcwogICAgICAtIE1ZU1FMX1VTRVI9JFNFUlZJQ0VfVVNFUl9XT1JEUFJFU1MKICAgICAgLSBNWVNRTF9QQVNTV09SRD0kU0VSVklDRV9QQVNTV09SRF9XT1JEUFJFU1MKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OiBbIkNNRCIsICJoZWFsdGhjaGVjay5zaCIsICItLWNvbm5lY3QiLCAiLS1pbm5vZGJfaW5pdGlhbGl6ZWQiXQogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCg==",
+        "tags": [
+            "cms",
+            "blog",
+            "content",
+            "management",
+            "wordpress",
+            "openlitespeed",
+            "litespeed",
+            "mariadb"
+        ],
+        "category": "cms",
+        "logo": "svgs/wordpress.svg",
+        "minversion": "0.0.0",
+        "port": "80"
+    },
     "wordpress-without-database": {
         "documentation": "https://wordpress.org?utm_source=coolify.io",
         "slogan": "WordPress is open source software you can use to create a beautiful website, blog, or app.",


### PR DESCRIPTION
AI-assisted fix via Codex for Algora bounty coolify#8264 ($7.50). Closes #8264.

## Summary
- Adds a `wordpress-with-openlitespeed` service template.
- Uses `litespeedtech/openlitespeed:latest` behind Coolify's built-in proxy on port 80.
- Adds a one-shot `wordpress:cli` setup service that idempotently downloads WordPress and creates `wp-config.php`.
- Persists WordPress files, OpenLiteSpeed logs, and MariaDB data.
- Updates both generated service template catalogs.

## Verification
- Parsed the new YAML service template with a YAML parser.
- Parsed both generated JSON catalogs.
- Decoded and parsed the new base64 compose entry in both catalogs.
- Verified `service-templates-latest.json` uses `SERVICE_URL_WORDPRESS_80`.
- Verified `service-templates.json` uses `SERVICE_FQDN_WORDPRESS_80`.