### PR TITLE
feat: add WordPress OpenLiteSpeed service template

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -1,0 +1,57 @@
+# documentation: https://docs.litespeedtech.com/cloud/docker/ols-wordpress/
+# slogan: WordPress running on OpenLiteSpeed with persistent files and MariaDB storage.
+# category: cms
+# tags: cms, blog, content, management, wordpress, openlitespeed, litespeed, mariadb
+# logo: svgs/wordpress.svg
+# port: 80
+
+services:
+  wordpress:
+    image: litespeedtech/openlitespeed:latest
+    environment:
+      - SERVICE_URL_WORDPRESS_80
+      - TZ=${TZ:-UTC}
+    volumes:
+      - wordpress-files:/var/www/vhosts/localhost/html
+      - openlitespeed-logs:/usr/local/lsws/logs
+    depends_on:
+      wordpress-setup:
+        condition: service_completed_successfully
+      mariadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://127.0.0.1:80/ || exit 1"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+
+  wordpress-setup:
+    image: wordpress:cli
+    restart: "no"
+    exclude_from_hc: true
+    volumes:
+      - wordpress-files:/var/www/html
+    environment:
+      - WORDPRESS_DB_HOST=mariadb
+      - WORDPRESS_DB_USER=$SERVICE_USER_WORDPRESS
+      - WORDPRESS_DB_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+      - WORDPRESS_DB_NAME=wordpress
+    command: sh -c "mkdir -p /var/www/html && if [ ! -f /var/www/html/wp-config.php ]; then wp core download --path=/var/www/html --skip-content --force --allow-root && wp config create --path=/var/www/html --dbname=\"$${WORDPRESS_DB_NAME}\" --dbuser=\"$${WORDPRESS_DB_USER}\" --dbpass=\"$${WORDPRESS_DB_PASSWORD}\" --dbhost=\"$${WORDPRESS_DB_HOST}\" --skip-check --allow-root; fi"
+    depends_on:
+      mariadb:
+        condition: service_healthy
+
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
## Changes

- AI-assisted fix via Codex for Algora bounty coolify#8264 ($7.50).
- Adds `wordpress-with-openlitespeed` service template for WordPress on OpenLiteSpeed.
- Uses `litespeedtech/openlitespeed:latest` behind Coolify's built-in proxy on port 80.
- Adds a one-shot `wordpress:cli` setup service that idempotently downloads WordPress and creates `wp-config.php`.
- Persists WordPress files, OpenLiteSpeed logs, and MariaDB data.

## Issues

- Fixes #8264
- /claim #8264

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not included; this is a service-template-only change.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Codex prepared the patch and local validation; the scope and PR submission were human-directed.

## Testing

- Parsed the new YAML service template with a YAML parser.
- Ran git diff --check.
- Confirmed the PR only changes the compose template file; generated catalog files are intentionally left out because the quality workflow blocks them.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.