### PR TITLE
fix: stop leaking all env vars across containers in Docker Compose deployments

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -662,14 +662,6 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             }
         } else {
             $composeFile = $this->application->parse(pull_request_id: $this->pull_request_id, preview_id: data_get($this->preview, 'id'), commit: $this->commit);
-            // Always add .env file to services
-            $services = collect(data_get($composeFile, 'services', []));
-            $services = $services->map(function ($service, $name) {
-                $service['env_file'] = ['.env'];
-
-                return $service;
-            });
-            $composeFile['services'] = $services->toArray();
             if (empty($composeFile)) {
                 $this->application_deployment_queue->addLogEntry('Failed to parse docker-compose file.');
                 $this->fail('Failed to parse docker-compose file.');
@@ -1393,7 +1385,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         // Handle empty environment variables
         if ($environment_variables->isEmpty()) {
             // For Docker Compose and Docker Image, we need to create an empty .env file
-            // because we always reference it in the compose file
+            // because docker compose --env-file requires the file to exist for variable interpolation
             if ($this->build_pack === 'dockercompose' || $this->build_pack === 'dockerimage') {
                 $this->application_deployment_queue->addLogEntry('Creating empty .env file (no environment variables defined).');
 

--- a/bootstrap/helpers/parsers.php
+++ b/bootstrap/helpers/parsers.php
@@ -1417,15 +1417,15 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
         if ($depends_on->count() > 0) {
             $payload['depends_on'] = $depends_on;
         }
-        // Auto-inject .env file so Coolify environment variables are available inside containers
-        // This makes Applications behave consistently with manual .env file usage
+        // Preserve explicitly declared env_file entries from the user's compose file.
+        // Do not auto-inject the global .env so each container only sees its own secrets.
         $existingEnvFiles = data_get($service, 'env_file');
-        $envFiles = collect(is_null($existingEnvFiles) ? [] : (is_array($existingEnvFiles) ? $existingEnvFiles : [$existingEnvFiles]))
-            ->push('.env')
-            ->unique()
-            ->values();
-
-        $payload['env_file'] = $envFiles;
+        if (! is_null($existingEnvFiles)) {
+            $envFiles = collect(is_array($existingEnvFiles) ? $existingEnvFiles : [$existingEnvFiles])
+                ->unique()
+                ->values();
+            $payload['env_file'] = $envFiles;
+        }
 
         // Inject commit-based image tag for services with build directive (for rollback support)
         // Only inject if service has build but no explicit image defined

--- a/tests/Unit/ApplicationDeploymentEmptyEnvTest.php
+++ b/tests/Unit/ApplicationDeploymentEmptyEnvTest.php
@@ -3,16 +3,15 @@
 /**
  * Test to verify that empty .env files are created for build packs that require them.
  *
- * This test verifies the fix for the issue where deploying a Docker image without
- * environment variables would fail because Docker Compose expects a .env file
- * when env_file: ['.env'] is specified in the compose file.
+ * Both 'dockerimage' and 'dockercompose' build packs need the .env file to exist:
+ *  - 'dockerimage': uses env_file: ['.env'] in its generated single-container compose file.
+ *  - 'dockercompose': passes --env-file .env to docker compose for variable interpolation.
  *
- * The fix ensures that for 'dockerimage' and 'dockercompose' build packs,
- * an empty .env file is created even when there are no environment variables defined.
+ * The fix ensures that for both build packs an empty .env file is created even when
+ * there are no environment variables defined, so docker compose does not fail.
  */
 it('determines which build packs require empty .env file creation', function () {
-    // Build packs that set env_file: ['.env'] in the generated compose file
-    // and thus require an empty .env file even when no environment variables are defined
+    // Build packs that need the .env file to exist (for env_file: or --env-file interpolation)
     $buildPacksRequiringEnvFile = ['dockerimage', 'dockercompose'];
 
     // Build packs that don't use env_file in the compose file

--- a/tests/Unit/ComposeEnvFileIsolationTest.php
+++ b/tests/Unit/ComposeEnvFileIsolationTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Tests to verify that environment variables are NOT automatically shared across all
+ * containers in a Docker Compose project.
+ *
+ * Before the fix, Coolify injected `env_file: ['.env']` into every service, causing
+ * every container to receive all environment variables from the entire project. This
+ * is a security issue because secrets intended for one service leak to all others.
+ *
+ * The correct Docker Compose behaviour:
+ *  - `.env` is used only for variable interpolation via --env-file flag.
+ *  - Runtime environment variables must be explicitly declared per service.
+ *
+ * See: https://github.com/coollabsio/coolify/issues/7655
+ */
+
+it('ensures applicationParser does not auto-inject global .env into every service', function () {
+    $parsersFile = file_get_contents(__DIR__.'/../../bootstrap/helpers/parsers.php');
+
+    // Extract only the applicationParser function body
+    $start = strpos($parsersFile, 'function applicationParser(');
+    $serviceParserStart = strpos($parsersFile, 'function serviceParser(');
+    $applicationParserContent = substr($parsersFile, $start, $serviceParserStart - $start);
+
+    // The parser must NOT push '.env' into every service's env_file unconditionally
+    expect($applicationParserContent)->not->toContain("->push('.env')");
+
+    // The parser must NOT always assign env_file for every service
+    expect($applicationParserContent)->not->toContain("'env_file'] = \$envFiles");
+});
+
+it('ensures applicationParser preserves explicitly declared env_file entries', function () {
+    $parsersFile = file_get_contents(__DIR__.'/../../bootstrap/helpers/parsers.php');
+
+    // Extract only the applicationParser function body
+    $start = strpos($parsersFile, 'function applicationParser(');
+    $serviceParserStart = strpos($parsersFile, 'function serviceParser(');
+    $applicationParserContent = substr($parsersFile, $start, $serviceParserStart - $start);
+
+    // The parser must still read existing env_file entries from the user's compose file
+    expect($applicationParserContent)->toContain("data_get(\$service, 'env_file')");
+
+    // And must only set env_file when the user has explicitly declared it
+    expect($applicationParserContent)->toContain('if (! is_null($existingEnvFiles))');
+});
+
+it('ensures ApplicationDeploymentJob does not forcibly override env_file for all services', function () {
+    $jobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
+
+    // Extract the deploy_docker_compose_buildpack method
+    $start = strpos($jobFile, 'private function deploy_docker_compose_buildpack()');
+    $nextMethod = strpos($jobFile, 'private function ', $start + 1);
+    $methodContent = substr($jobFile, $start, $nextMethod - $start);
+
+    // The deployment method must NOT iterate over services to set env_file = ['.env']
+    expect($methodContent)->not->toContain("\$service['env_file'] = ['.env']");
+
+    // The deployment method must NOT forcibly rewrite env_file for parsed services
+    expect($methodContent)->not->toContain("'env_file'] = ['.env']");
+});
+
+it('ensures .env file is still created for docker compose interpolation', function () {
+    $jobFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
+
+    // Extract save_runtime_environment_variables method
+    $start = strpos($jobFile, 'private function save_runtime_environment_variables()');
+    $nextMethod = strpos($jobFile, 'private function ', $start + 1);
+    $methodContent = substr($jobFile, $start, $nextMethod - $start);
+
+    // The .env file must still be created for dockercompose (needed for --env-file interpolation)
+    expect($methodContent)->toContain("'dockercompose'");
+    expect($methodContent)->toContain("touch");
+});


### PR DESCRIPTION
## Summary

Fixes the security issue where **all** environment variables from a Docker Compose project were injected into **every** container, regardless of which service they belonged to.

- Removes the loop in `deploy_docker_compose_buildpack()` that overwrote `env_file` with `['.env']` for every service after parsing.
- Removes the unconditional `.env` push inside `applicationParser()`, replacing it with logic that only preserves `env_file` entries the user explicitly declared in their compose file.
- Single-container deployments (`dockerimage`, `dockerfile`, etc.) are **not affected** — `generate_compose_file()` still uses `env_file: ['.env']` there, since there is only one service.

### Root cause

Docker Compose semantics are clear:

- `.env` → used for **variable interpolation** in the compose YAML (`${VAR}` substitution), passed via `--env-file` flag.
- `env_file:` in the YAML → injects all listed file contents as **runtime** environment variables into that specific container.

Coolify was auto-injecting `env_file: ['.env']` into every service after parsing, which turned interpolation variables into runtime variables for all containers. This means:

- A `postgres` service could read `OPENAI_API_KEY` set for the `app` service.
- A `redis` service could read `POSTGRES_PASSWORD`.
- A compromised container could access credentials from all other containers.

### After the fix

- Each service only receives the environment variables explicitly declared in its own `environment:` section (and any `env_file:` entries the user explicitly wrote).
- The `.env` file is still created and passed via `--env-file` for compose-level variable interpolation.
- Users who want to share a variable across services can still do so by explicitly adding `env_file: ['.env']` to each service in their compose file, or by declaring the variable in each service's `environment:` section.

## Test plan

- [x] `tests/Unit/ComposeEnvFileIsolationTest.php` — new tests verifying `applicationParser()` and `deploy_docker_compose_buildpack()` no longer auto-inject `.env` into all services.
- [x] `tests/Unit/ApplicationDeploymentEmptyEnvTest.php` — existing tests still pass; updated comments to reflect that the `.env` file is still required for `--env-file` interpolation.
- [x] Manual verification: parsed compose YAML for a multi-service project no longer contains `env_file: ['.env']` on services that don't declare it.

/claim #7655