### PR TITLE
fix: allow OAuth registration when password signup is disabled

### DIFF
--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -26,11 +26,6 @@ class OauthController extends Controller
             $email = strtolower($email);
             $user = User::whereEmail($email)->first();
             if (! $user) {
-                $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
-                    abort(403, 'Registration is disabled');
-                }
-
                 $user = User::create([
                     'name' => $oauthUser->name,
                     'email' => $email,

--- a/tests/Feature/OauthRegistrationTest.php
+++ b/tests/Feature/OauthRegistrationTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use App\Http\Middleware\CheckForcePasswordReset;
+use App\Http\Middleware\DecideWhatToDoWithUser;
+use App\Models\InstanceSettings;
+use App\Models\OauthSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Once;
+use Laravel\Socialite\Facades\Socialite;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->withoutMiddleware([DecideWhatToDoWithUser::class, CheckForcePasswordReset::class]);
+    Once::flush();
+
+    if (! InstanceSettings::find(0)) {
+        $settings = new InstanceSettings;
+        $settings->id = 0;
+        $settings->saveQuietly();
+    }
+});
+
+test('oauth callback can create a user when general registration is disabled', function () {
+    $this->withoutExceptionHandling();
+    $this->withoutMiddleware();
+
+    config([
+        'cache.default' => 'array',
+        'session.driver' => 'array',
+        'queue.default' => 'sync',
+    ]);
+    Event::fake();
+
+    InstanceSettings::find(0)->update(['is_registration_enabled' => false]);
+
+    OauthSetting::create([
+        'provider' => 'github',
+        'enabled' => true,
+        'client_id' => 'github-client-id',
+        'client_secret' => 'github-client-secret',
+        'redirect_uri' => route('auth.callback', 'github'),
+    ]);
+
+    $provider = Mockery::mock();
+    $provider->shouldReceive('user')->once()->andReturn((object) [
+        'name' => 'OAuth User',
+        'email' => 'oauth-user@example.com',
+    ]);
+
+    Socialite::shouldReceive('buildProvider')->once()->andReturn($provider);
+
+    $response = $this->get(route('auth.callback', 'github'));
+
+    $response->assertRedirect('/');
+    $this->assertDatabaseHas('users', [
+        'email' => 'oauth-user@example.com',
+        'name' => 'OAuth User',
+    ]);
+    expect(auth()->user())->toBeInstanceOf(User::class);
+    expect(auth()->user()->email)->toBe('oauth-user@example.com');
+});


### PR DESCRIPTION
/claim #8042

## Changes

- Allows the OAuth callback to create a user when general password/self-registration is disabled.
- Keeps the regular registration flow controlled by is_registration_enabled.
- This lets admins disable public password signup while still relying on a configured OAuth provider to decide who can access the instance.

## Issues

- Fixes #8042

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A - backend OAuth callback behavior. I verified this with an automated feature test rather than a UI screenshot.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Codex helped prepare the small controller change and the regression test. I reviewed the behavior and verified it locally with the commands below.

## Testing

Added tests/Feature/OauthRegistrationTest.php. The test disables general registration, configures a GitHub OAuth provider, mocks the Socialite user response, calls the OAuth callback, and verifies that the new OAuth user is created and logged in.

```powershell
php artisan test --compact tests\Feature\OauthRegistrationTest.php --colors=never
```

Result:

```text
Tests: 1 passed (7 assertions)
```

```powershell
php vendor\bin\pint --dirty --format agent
```

Result:

```json
{"result":"pass"}
```

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/next/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
