### PR TITLE
feat: support oauth-only self registration

### DIFF
--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -17,6 +17,10 @@ class ResetUserPassword implements ResetsUserPasswords
      */
     public function reset(User $user, array $input): void
     {
+        if ($user->isOauthPasswordAuthDisabled()) {
+            abort(403);
+        }
+
         Validator::make($input, [
             'password' => ['required', Password::defaults(), 'confirmed'],
         ])->validate();

--- a/app/Actions/Fortify/UpdateUserPassword.php
+++ b/app/Actions/Fortify/UpdateUserPassword.php
@@ -17,6 +17,10 @@ class UpdateUserPassword implements UpdatesUserPasswords
      */
     public function update(User $user, array $input): void
     {
+        if ($user->isOauthPasswordAuthDisabled()) {
+            abort(403);
+        }
+
         Validator::make($input, [
             'current_password' => ['required', 'string', 'current_password:web'],
             'password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -78,6 +78,10 @@ class Controller extends BaseController
                 return response()->json(['message' => 'Transactional emails are not active'], 400);
             }
             $request->validate([Fortify::email() => 'required|email']);
+            $user = User::whereEmail($request->input(Fortify::email()))->first();
+            if ($user?->isOauthPasswordAuthDisabled()) {
+                return app(SuccessfulPasswordResetLinkRequestResponse::class, ['status' => Password::RESET_LINK_SENT]);
+            }
             $status = Password::broker(config('fortify.passwords'))->sendResetLink(
                 $request->only(Fortify::email())
             );

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -22,15 +22,20 @@ class OauthController extends Controller
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! $settings->is_oauth_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 
                 $user = User::create([
                     'name' => $oauthUser->name,
                     'email' => $oauthUser->email,
+                    'oauth_provider' => $provider,
                 ]);
+            } elseif (is_null($user->oauth_provider) && ! $user->hasPassword()) {
+                $user->forceFill(['oauth_provider' => $provider])->save();
             }
+            $user->currentTeam = $user->teams->firstWhere('personal_team', true) ?? $user->recreate_personal_team();
+            session(['currentTeam' => $user->currentTeam]);
             Auth::login($user);
 
             return redirect('/');

--- a/app/Livewire/SettingsOauth.php
+++ b/app/Livewire/SettingsOauth.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire;
 
+use App\Models\InstanceSettings;
 use App\Models\OauthSetting;
 use Livewire\Component;
 
@@ -9,8 +10,19 @@ class SettingsOauth extends Component
 {
     public $oauth_settings_map;
 
+    public InstanceSettings $settings;
+
+    public bool $is_oauth_registration_enabled;
+
+    public bool $is_oauth_password_auth_disabled;
+
     protected function rules()
     {
+        $rules = [
+            'is_oauth_registration_enabled' => 'boolean',
+            'is_oauth_password_auth_disabled' => 'boolean',
+        ];
+
         return OauthSetting::all()->reduce(function ($carry, $setting) {
             $carry["oauth_settings_map.$setting->provider.enabled"] = 'required';
             $carry["oauth_settings_map.$setting->provider.client_id"] = 'nullable';
@@ -20,7 +32,7 @@ class SettingsOauth extends Component
             $carry["oauth_settings_map.$setting->provider.base_url"] = 'nullable';
 
             return $carry;
-        }, []);
+        }, $rules);
     }
 
     public function mount()
@@ -28,6 +40,9 @@ class SettingsOauth extends Component
         if (! isInstanceAdmin()) {
             return redirect()->route('home');
         }
+        $this->settings = instanceSettings();
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled;
+        $this->is_oauth_password_auth_disabled = $this->settings->is_oauth_password_auth_disabled;
         $this->oauth_settings_map = OauthSetting::all()->sortBy('provider')->reduce(function ($carry, $setting) {
             $carry[$setting->provider] = [
                 'id' => $setting->id,
@@ -139,7 +154,27 @@ class SettingsOauth extends Component
 
     public function submit()
     {
+        $this->validate();
+        $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
+        $this->settings->is_oauth_password_auth_disabled = $this->is_oauth_password_auth_disabled;
+        $this->settings->save();
         $this->updateOauthSettings();
         $this->dispatch('success', 'Instance settings updated successfully!');
+    }
+
+    public function instantSaveOauthRegistration()
+    {
+        $this->validateOnly('is_oauth_registration_enabled');
+        $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
+        $this->settings->save();
+        $this->dispatch('success', 'OAuth registration setting updated successfully!');
+    }
+
+    public function instantSaveOauthPasswordAuth()
+    {
+        $this->validateOnly('is_oauth_password_auth_disabled');
+        $this->settings->is_oauth_password_auth_disabled = $this->is_oauth_password_auth_disabled;
+        $this->settings->save();
+        $this->dispatch('success', 'OAuth password authentication setting updated successfully!');
     }
 }

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -18,6 +18,8 @@ class InstanceSettings extends Model
         'do_not_track',
         'is_auto_update_enabled',
         'is_registration_enabled',
+        'is_oauth_registration_enabled',
+        'is_oauth_password_auth_disabled',
         'next_channel',
         'smtp_enabled',
         'smtp_from_address',
@@ -63,6 +65,9 @@ class InstanceSettings extends Model
 
         'allowed_ip_ranges' => 'array',
         'is_auto_update_enabled' => 'boolean',
+        'is_registration_enabled' => 'boolean',
+        'is_oauth_registration_enabled' => 'boolean',
+        'is_oauth_password_auth_disabled' => 'boolean',
         'auto_update_frequency' => 'string',
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -52,6 +52,7 @@ class User extends Authenticatable implements SendsEmail
         'pending_email',
         'email_change_code',
         'email_change_code_expires_at',
+        'oauth_provider',
     ];
 
     protected $hidden = [
@@ -486,5 +487,15 @@ class User extends Authenticatable implements SendsEmail
     public function hasPassword(): bool
     {
         return ! empty($this->password);
+    }
+
+    public function isOauthUser(): bool
+    {
+        return ! empty($this->oauth_provider);
+    }
+
+    public function isOauthPasswordAuthDisabled(): bool
+    {
+        return $this->isOauthUser() && (bool) instanceSettings()->is_oauth_password_auth_disabled;
     }
 }

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -74,6 +74,9 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::authenticateUsing(function (Request $request) {
             $email = strtolower($request->email);
             $user = User::where('email', $email)->with('teams')->first();
+            if ($user?->isOauthPasswordAuthDisabled()) {
+                return null;
+            }
             if (
                 $user &&
                 Hash::check($request->password, $user->password)

--- a/database/migrations/2026_05_12_000000_add_oauth_authentication_settings.php
+++ b/database/migrations/2026_05_12_000000_add_oauth_authentication_settings.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_registration_enabled')->default(false);
+            $table->boolean('is_oauth_password_auth_disabled')->default(false);
+        });
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('oauth_provider')->nullable()->after('password');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('oauth_provider');
+        });
+
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn([
+                'is_oauth_registration_enabled',
+                'is_oauth_password_auth_disabled',
+            ]);
+        });
+    }
+};

--- a/resources/views/livewire/settings-oauth.blade.php
+++ b/resources/views/livewire/settings-oauth.blade.php
@@ -13,6 +13,14 @@
             </div>
             <div class="pb-4 ">Custom authentication (OAuth) configurations.</div>
         </div>
+        <div class="flex flex-col gap-2 pb-4 md:w-96">
+            <x-forms.checkbox instantSave="instantSaveOauthRegistration" id="is_oauth_registration_enabled"
+                label="OAuth Registration Allowed"
+                helper="Allow users to create accounts by signing in with an enabled OAuth provider even when general registration is disabled." />
+            <x-forms.checkbox instantSave="instantSaveOauthPasswordAuth" id="is_oauth_password_auth_disabled"
+                label="OAuth Accounts Only"
+                helper="Prevent OAuth-created users from using password login, password reset, or password changes." />
+        </div>
         <div class="flex flex-col gap-2 pt-4">
             @foreach ($oauth_settings_map as $oauth_setting)
                 <div class="p-4 border dark:border-coolgray-300 border-neutral-200">

--- a/tests/Feature/OauthAuthenticationSettingsTest.php
+++ b/tests/Feature/OauthAuthenticationSettingsTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use App\Actions\Fortify\ResetUserPassword;
+use App\Models\InstanceSettings;
+use App\Models\OauthSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Socialite\Facades\Socialite;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::unguarded(function () {
+        InstanceSettings::query()->create([
+            'id' => 0,
+            'is_registration_enabled' => false,
+            'is_oauth_registration_enabled' => false,
+            'is_oauth_password_auth_disabled' => false,
+        ]);
+    });
+
+    OauthSetting::query()->create([
+        'provider' => 'github',
+        'enabled' => true,
+        'client_id' => 'client-id',
+        'client_secret' => 'client-secret',
+        'redirect_uri' => 'http://coolify.test/auth/github/callback',
+    ]);
+});
+
+it('allows oauth self registration when regular registration is disabled', function () {
+    instanceSettings()->update(['is_oauth_registration_enabled' => true]);
+
+    $provider = Mockery::mock();
+    $provider->shouldReceive('user')->once()->andReturn((object) [
+        'name' => 'OAuth User',
+        'email' => 'oauth@example.com',
+    ]);
+
+    Socialite::shouldReceive('buildProvider')->once()->andReturn($provider);
+
+    $this->get(route('auth.callback', 'github'))->assertRedirect('/');
+
+    $user = User::whereEmail('oauth@example.com')->first();
+
+    expect($user)->not->toBeNull()
+        ->and($user->oauth_provider)->toBe('github')
+        ->and($user->password)->toBeNull();
+});
+
+it('blocks password login for oauth users when oauth-only mode is enabled', function () {
+    instanceSettings()->update(['is_oauth_password_auth_disabled' => true]);
+
+    User::factory()->create([
+        'email' => 'oauth@example.com',
+        'password' => Hash::make('password'),
+        'oauth_provider' => 'github',
+    ]);
+
+    $this->post('/login', [
+        'email' => 'oauth@example.com',
+        'password' => 'password',
+    ])->assertSessionHasErrors('email');
+});
+
+it('blocks password reset for oauth users when oauth-only mode is enabled', function () {
+    instanceSettings()->update(['is_oauth_password_auth_disabled' => true]);
+
+    $user = User::factory()->create([
+        'oauth_provider' => 'github',
+    ]);
+
+    (new ResetUserPassword)->reset($user, [
+        'password' => 'Password1!@',
+        'password_confirmation' => 'Password1!@',
+    ]);
+})->throws(Symfony\Component\HttpKernel\Exception\HttpException::class);


### PR DESCRIPTION
STRAWBERRY

## Changes

- Added separate OAuth registration settings so OAuth users can self-register even when regular registration is disabled.
- Added an OAuth-only mode that prevents OAuth-created accounts from using password login, password reset, or password changes.
- Stored the OAuth provider on newly created OAuth users.
- Added feature tests for OAuth registration and OAuth-only password restrictions.

## Issues

- Fixes #8042

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No UI screenshot yet. This adds two settings to the Authentication settings page:
- OAuth Registration Allowed
- OAuth Accounts Only

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Used to inspect the codebase, implement the first patch, and add tests. I reviewed the changes before submitting.

## Testing

- Ran PHP syntax checks on the changed PHP files.
- Added `tests/Feature/OauthAuthenticationSettingsTest.php`.
- Could not run the full Pest suite locally because my local PHP version is 8.2.12, while this project requires PHP ^8.4.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
