### PR TITLE
feat: add global deployments page (#7596)

### DIFF
--- a/app/Livewire/Deployments/Index.php
+++ b/app/Livewire/Deployments/Index.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace App\Livewire\Deployments;
+
+use App\Models\ApplicationDeploymentQueue;
+use App\Models\Server;
+use Illuminate\Support\Collection;
+use Livewire\Component;
+
+class Index extends Component
+{
+    public Collection $deployments;
+
+    public Collection $servers;
+
+    public Collection $projects;
+
+    public Collection $sources;
+
+    public string $status = '';
+
+    public string $serverId = '';
+
+    public string $projectUuid = '';
+
+    public string $source = '';
+
+    public int $deploymentsCount = 0;
+
+    protected $queryString = [
+        'status' => ['except' => ''],
+        'serverId' => ['except' => '', 'as' => 'server'],
+        'projectUuid' => ['except' => '', 'as' => 'project'],
+        'source' => ['except' => ''],
+    ];
+
+    public function getListeners()
+    {
+        $teamId = auth()->user()->currentTeam()->id;
+
+        return [
+            "echo-private:team.{$teamId},ServiceChecked" => 'loadDeployments',
+        ];
+    }
+
+    public function mount()
+    {
+        $this->servers = currentTeam()->servers()->orderBy('name')->get();
+        $this->projects = currentTeam()->projects()->orderBy('name')->get();
+        $this->sources = collect(['manual', 'webhook', 'api', 'rollback', 'pull-request']);
+        $this->loadDeployments();
+    }
+
+    public function updated()
+    {
+        $this->loadDeployments();
+    }
+
+    public function clearFilters()
+    {
+        $this->status = '';
+        $this->serverId = '';
+        $this->projectUuid = '';
+        $this->source = '';
+        $this->loadDeployments();
+    }
+
+    public function loadDeployments()
+    {
+        $query = ApplicationDeploymentQueue::query()
+            ->with('application.environment.project')
+            ->whereHas('application.environment.project', function ($query) {
+                $query->where('team_id', currentTeam()->id);
+            })
+            ->latest();
+
+        if ($this->status !== '') {
+            $query->where('status', $this->status);
+        }
+
+        if ($this->serverId !== '') {
+            $query->where('server_id', $this->serverId);
+        }
+
+        if ($this->projectUuid !== '') {
+            $query->whereHas('application.environment.project', function ($query) {
+                $query->where('uuid', $this->projectUuid);
+            });
+        }
+
+        if ($this->source !== '') {
+            match ($this->source) {
+                'webhook' => $query->where('is_webhook', true),
+                'api' => $query->where('is_api', true),
+                'rollback' => $query->where('rollback', true),
+                'pull-request' => $query->whereNotNull('pull_request_id'),
+                'manual' => $query
+                    ->where(function ($query) {
+                        $query->where('is_webhook', false)->orWhereNull('is_webhook');
+                    })
+                    ->where(function ($query) {
+                        $query->where('is_api', false)->orWhereNull('is_api');
+                    })
+                    ->where(function ($query) {
+                        $query->where('rollback', false)->orWhereNull('rollback');
+                    })
+                    ->whereNull('pull_request_id'),
+                default => null,
+            };
+        }
+
+        $this->deploymentsCount = $query->count();
+        $this->deployments = $query->limit(50)->get();
+    }
+
+    public function deploymentUrl(ApplicationDeploymentQueue $deployment): ?string
+    {
+        $application = $deployment->application;
+        $project = $application?->environment?->project;
+        $environment = $application?->environment;
+
+        if (! $application || ! $project || ! $environment) {
+            return null;
+        }
+
+        return route('project.application.deployment.show', [
+            'project_uuid' => $project->uuid,
+            'environment_uuid' => $environment->uuid,
+            'application_uuid' => $application->uuid,
+            'deployment_uuid' => $deployment->deployment_uuid,
+        ]);
+    }
+
+    public function render()
+    {
+        return view('livewire.deployments.index');
+    }
+}

--- a/resources/views/components/navbar.blade.php
+++ b/resources/views/components/navbar.blade.php
@@ -105,8 +105,19 @@
             <ul role="list" class="flex flex-col h-full space-y-1.5">
                 @if (isSubscribed() || !isCloud())
                     <li>
+                        <a title="Deployments" href="{{ route('deployments.index') }}" {{ wireNavigate() }}
+                            class="{{ request()->is('deployments') ? 'menu-item-active menu-item' : 'menu-item' }}">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="menu-item-icon" fill="none" viewBox="0 0 24 24"
+                                stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                    d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" />
+                            </svg>
+                            <span class="menu-item-label">Deployments</span>
+                        </a>
+                    </li>
+                    <li>
                         <a title="Dashboard" href="/" {{ wireNavigate() }}
-                            class="{{ request()->is('/') ? 'menu-item-active menu-item' : 'menu-item' }}">
+                            class="{{ request()->is('/') && !request()->is('deployments') ? 'menu-item-active menu-item' : 'menu-item' }}">
                             <svg xmlns="http://www.w3.org/2000/svg" class="menu-item-icon" fill="none" viewBox="0 0 24 24"
                                 stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"

--- a/resources/views/livewire/deployments/index.blade.php
+++ b/resources/views/livewire/deployments/index.blade.php
@@ -1,0 +1,152 @@
+<div>
+    <x-slot:title>Deployments | Coolify</x-slot>
+    <h1>Deployments</h1>
+
+    <div class="flex flex-col gap-4 pb-10" wire:poll.5000ms="loadDeployments">
+        <div class="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+            <div>
+                <h2>All deployments <span class="text-xs">({{ $deploymentsCount }})</span></h2>
+                <p class="text-xs text-gray-500 dark:text-gray-400">Latest 50 deployments across team. Auto-refresh every 5s.</p>
+            </div>
+            <div class="flex gap-2">
+                <x-forms.button type="button" wire:click="clearFilters">Clear filters</x-forms.button>
+            </div>
+        </div>
+
+        <div class="grid gap-3 md:grid-cols-4">
+            <div>
+                <x-forms.select wire:model.live="status" id="status" label="Status">
+                    <option value="">All statuses</option>
+                    <option value="queued">Queued</option>
+                    <option value="in_progress">In Progress</option>
+                    <option value="finished">Finished</option>
+                    <option value="failed">Failed</option>
+                    <option value="cancelled-by-user">Cancelled</option>
+                </x-forms.select>
+            </div>
+            @if ($servers->count() > 1)
+            <div>
+                <x-forms.select wire:model.live="serverId" id="serverId" label="Server">
+                    <option value="">All servers</option>
+                    @foreach ($servers as $server)
+                        <option value="{{ $server->id }}">{{ $server->name }}</option>
+                    @endforeach
+                </x-forms.select>
+            </div>
+            @endif
+            @if ($projects->count() > 1)
+            <div>
+                <x-forms.select wire:model.live="projectUuid" id="projectUuid" label="Project">
+                    <option value="">All projects</option>
+                    @foreach ($projects as $project)
+                        <option value="{{ $project->uuid }}">{{ $project->name }}</option>
+                    @endforeach
+                </x-forms.select>
+            </div>
+            @endif
+            <div>
+                <x-forms.select wire:model.live="source" id="source" label="Source">
+                    <option value="">All sources</option>
+                    <option value="manual">Manual</option>
+                    <option value="webhook">Webhook</option>
+                    <option value="api">API</option>
+                    <option value="rollback">Rollback</option>
+                    <option value="pull-request">Pull Request</option>
+                </x-forms.select>
+            </div>
+        </div>
+
+        @forelse ($deployments as $deployment)
+            @php
+                $application = $deployment->application;
+                $project = $application?->environment?->project;
+                $deploymentUrl = $this->deploymentUrl($deployment);
+                $statusText = match (data_get($deployment, 'status')) {
+                    'finished' => 'Success',
+                    'in_progress' => 'In Progress',
+                    'cancelled-by-user' => 'Cancelled',
+                    'queued' => 'Queued',
+                    default => ucfirst(data_get($deployment, 'status')),
+                };
+            @endphp
+            <div @class([
+                'p-3 border-l-2 bg-white dark:bg-coolgray-100 rounded-r-md',
+                'border-blue-500/50 border-dashed' => data_get($deployment, 'status') === 'in_progress',
+                'border-purple-500/50 border-dashed' => data_get($deployment, 'status') === 'queued',
+                'border-white border-dashed' => data_get($deployment, 'status') === 'cancelled-by-user',
+                'border-error' => data_get($deployment, 'status') === 'failed',
+                'border-success' => data_get($deployment, 'status') === 'finished',
+            ])>
+                <div class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                    <div class="min-w-0 flex-1">
+                        <div class="flex flex-wrap items-center gap-2 mb-2">
+                            <span @class([
+                                'px-3 py-1 rounded-md text-xs font-medium shadow-xs',
+                                'bg-blue-100/80 text-blue-700 dark:bg-blue-500/20 dark:text-blue-300' => data_get($deployment, 'status') === 'in_progress',
+                                'bg-purple-100/80 text-purple-700 dark:bg-purple-500/20 dark:text-purple-300' => data_get($deployment, 'status') === 'queued',
+                                'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-200' => data_get($deployment, 'status') === 'failed',
+                                'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-200' => data_get($deployment, 'status') === 'finished',
+                                'bg-gray-100 text-gray-700 dark:bg-gray-600/30 dark:text-gray-300' => data_get($deployment, 'status') === 'cancelled-by-user',
+                            ])>{{ $statusText }}</span>
+
+                            @if ($deployment->pull_request_id)
+                                <span class="bg-gray-200/70 dark:bg-gray-600/20 px-2 py-0.5 rounded-md text-xs text-gray-800 dark:text-gray-100 border border-gray-400/30">PR #{{ $deployment->pull_request_id }}</span>
+                            @endif
+
+                            @if ($deployment->rollback)
+                                <span class="bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-200 px-2 py-0.5 rounded-md text-xs">Rollback</span>
+                            @elseif ($deployment->is_api)
+                                <span class="bg-gray-200/70 dark:bg-gray-600/20 px-2 py-0.5 rounded-md text-xs text-gray-800 dark:text-gray-100 border border-gray-400/30">API</span>
+                            @elseif ($deployment->is_webhook)
+                                <span class="bg-gray-200/70 dark:bg-gray-600/20 px-2 py-0.5 rounded-md text-xs text-gray-800 dark:text-gray-100 border border-gray-400/30">Webhook</span>
+                            @else
+                                <span class="bg-gray-200/70 dark:bg-gray-600/20 px-2 py-0.5 rounded-md text-xs text-gray-800 dark:text-gray-100 border border-gray-400/30">Manual</span>
+                            @endif
+                        </div>
+
+                        <div class="font-medium truncate">{{ $application?->name ?? $deployment->application_name ?? 'Unknown application' }}</div>
+                        <div class="text-sm text-gray-600 dark:text-gray-400 truncate">
+                            Project: {{ $project?->name ?? 'Unknown project' }}
+                        </div>
+                        @if ($deployment->server_name)
+                            <div class="text-sm text-gray-600 dark:text-gray-400 truncate">
+                                Server: {{ $deployment->server_name }}
+                            </div>
+                        @endif
+                        <div class="text-sm text-gray-600 dark:text-gray-400">
+                            Started: {{ $deployment->created_at?->diffForHumans() }}
+                            @if ($deployment->finished_at)
+                                <span class="mx-1">•</span>
+                                Duration: {{ calculateDuration($deployment->created_at, $deployment->finished_at) }}
+                            @endif
+                        </div>
+
+                        @if ($deployment->commit)
+                            <div class="text-sm text-gray-600 dark:text-gray-400 mt-2 break-all">
+                                Commit:
+                                @if ($application)
+                                    <a href="{{ $application->gitCommitLink($deployment->commit) }}" target="_blank" class="underline">
+                                        {{ substr($deployment->commit, 0, 7) }}
+                                    </a>
+                                @else
+                                    <span>{{ substr($deployment->commit, 0, 7) }}</span>
+                                @endif
+                                @if ($deployment->commitMessage())
+                                    <span class="text-gray-500">— {{ Str::before($deployment->commitMessage(), "\n") }}</span>
+                                @endif
+                            </div>
+                        @endif
+                    </div>
+
+                    @if ($deploymentUrl)
+                        <div class="shrink-0">
+                            <a href="{{ $deploymentUrl }}" {{ wireNavigate() }} class="text-sm underline text-primary dark:text-white">Open logs</a>
+                        </div>
+                    @endif
+                </div>
+            </div>
+        @empty
+            <div>No deployments found</div>
+        @endforelse
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\UploadController;
 use App\Livewire\Admin\Index as AdminIndex;
 use App\Livewire\Boarding\Index as BoardingIndex;
 use App\Livewire\Dashboard;
+use App\Livewire\Deployments\Index as DeploymentsIndex;
 use App\Livewire\Destination\Index as DestinationIndex;
 use App\Livewire\Destination\Show as DestinationShow;
 use App\Livewire\ForcePasswordReset;
@@ -109,6 +110,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     });
 
     Route::get('/', Dashboard::class)->name('dashboard');
+    Route::get('/deployments', DeploymentsIndex::class)->name('deployments.index');
     Route::get('/admin', AdminIndex::class)->name('admin.index');
     Route::get('/onboarding', BoardingIndex::class)->name('onboarding');
 


### PR DESCRIPTION
## Summary
- Add a new global deployments page accessible via the sidebar
- Show latest 50 deployments across all projects and servers
- Implement filtering by:
  - Status (Queued, In Progress, Success, Failed, Cancelled)
  - Server (dynamic list based on team servers)
  - Project (dynamic list based on team projects)
  - Source (Manual, Webhook, API, Rollback, Pull Request)
- Implement auto-refresh every 5 seconds using Livewire polling
- Design follows Vercel-inspired layout per issue request
- Smart filter visibility: hide Server/Project filters if team has only one item

Closes #7596

Submitted via Algora bounty hunting workflow.