### PR TITLE
feat(service): add WordPress OpenLiteSpeed template

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -1,0 +1,73 @@
+# documentation: https://docs.litespeedtech.com/cloud/docker/ols-wordpress/
+# slogan: WordPress served by OpenLiteSpeed with a persistent MariaDB database.
+# category: cms
+# tags: cms, blog, content, management, wordpress, openlitespeed, mariadb
+# logo: svgs/wordpress.svg
+# port: 80
+
+services:
+  wordpress:
+    image: litespeedtech/openlitespeed:${OPENLITESPEED_VERSION:-1.9.0-lsphp83}
+    environment:
+      - SERVICE_URL_WORDPRESS_80
+      - TZ=${TZ:-UTC}
+    volumes:
+      - wordpress-files:/var/www/vhosts/localhost/html
+      - openlitespeed-config:/usr/local/lsws/conf
+      - openlitespeed-admin-config:/usr/local/lsws/admin/conf
+      - openlitespeed-logs:/usr/local/lsws/logs
+    depends_on:
+      mariadb:
+        condition: service_healthy
+      wordpress-init:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1"]
+      interval: 5s
+      timeout: 20s
+      retries: 12
+
+  wordpress-init:
+    image: wordpress:cli-php8.3
+    restart: "no"
+    exclude_from_hc: true
+    volumes:
+      - wordpress-files:/var/www/html
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    environment:
+      - WORDPRESS_DB_HOST=mariadb:3306
+      - WORDPRESS_DB_NAME=wordpress
+      - WORDPRESS_DB_USER=$SERVICE_USER_WORDPRESS
+      - WORDPRESS_DB_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    command:
+      - sh
+      - -c
+      - |
+        set -eu
+        if [ ! -f wp-config.php ]; then
+          wp core download --force --allow-root
+          wp config create \
+            --dbname="$${WORDPRESS_DB_NAME}" \
+            --dbuser="$${WORDPRESS_DB_USER}" \
+            --dbpass="$${WORDPRESS_DB_PASSWORD}" \
+            --dbhost="$${WORDPRESS_DB_HOST}" \
+            --skip-check \
+            --allow-root
+        fi
+
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
STRAWBERRY

## Changes

- Adds a new `wordpress-with-openlitespeed` one-click service template.
- Uses the official `litespeedtech/openlitespeed` image instead of the non-existent `openlitespeed-wordpress` image used in a previously rejected attempt.
- Adds a one-shot `wordpress-init` service with `wordpress:cli-php8.3` to place WordPress files and generate `wp-config.php` in a persistent volume before OpenLiteSpeed serves the site.
- Adds persistent volumes for WordPress files, OpenLiteSpeed config/admin config/logs, and MariaDB data.

## Issues

- Fixes #8264
- /claim #8264

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No screenshot attached. This change adds a Docker Compose service template only.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Used to inspect existing Coolify service templates, compare prior rejected attempts, and prepare the Compose template. The template was checked against the repo's existing one-click service patterns and LiteSpeed documentation.

## Testing

- Parsed `templates/compose/wordpress-with-openlitespeed.yaml` with PyYAML.
- Verified required Coolify service-template metadata: `documentation`, `slogan`, `category`, `tags`, `logo`, and `port`.
- Verified required services exist: `wordpress`, `wordpress-init`, and `mariadb`.
- Verified `SERVICE_URL_WORDPRESS_80` is present for Coolify proxy integration.
- Ran `git diff --check` successfully.
- Could not run a local Coolify Docker instance in this environment because Docker, PHP, and Composer are not installed.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.

## Notes

- No authentication, payment, database migration, deployment, or security-sensitive configuration changes were made.
- No secrets, credentials, production data, or security-sensitive information were accessed.