### PR TITLE
Add WordPress OpenLiteSpeed service template

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -1,0 +1,62 @@
+# documentation: https://docs.litespeedtech.com/cloud/docker/ols-wordpress/
+# slogan: Run WordPress on OpenLiteSpeed with persistent files and MariaDB storage.
+# category: cms
+# tags: cms, blog, content, management, wordpress, openlitespeed, mariadb
+# logo: svgs/wordpress.svg
+# port: 80
+
+services:
+  wordpress:
+    image: litespeedtech/openlitespeed:1.9.0-lsphp83
+    volumes:
+      - wordpress-files:/var/www/vhosts/localhost/html
+      - openlitespeed-conf:/usr/local/lsws/conf
+      - openlitespeed-admin-conf:/usr/local/lsws/admin/conf
+      - openlitespeed-logs:/usr/local/lsws/logs
+    environment:
+      - SERVICE_URL_WORDPRESS_80
+      - WORDPRESS_DB_HOST=mariadb
+      - WORDPRESS_DB_USER=${SERVICE_USER_WORDPRESS}
+      - WORDPRESS_DB_PASSWORD=${SERVICE_PASSWORD_WORDPRESS}
+      - WORDPRESS_DB_NAME=${MARIADB_DATABASE:-wordpress}
+    command:
+      - bash
+      - -lc
+      - |
+        set -e
+        cd /var/www/vhosts/localhost/html
+        if [ ! -f wp-settings.php ]; then
+          wp core download --allow-root
+        fi
+        if [ ! -f wp-config.php ]; then
+          wp config create --allow-root --skip-check \
+            --dbhost="${WORDPRESS_DB_HOST}" \
+            --dbname="${WORDPRESS_DB_NAME}" \
+            --dbuser="${WORDPRESS_DB_USER}" \
+            --dbpass="${WORDPRESS_DB_PASSWORD}"
+        fi
+        chown -R 1000:1000 /var/www/vhosts/localhost/html
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+
+  mariadb:
+    image: mariadb:11.4
+    command: ["--max-allowed-packet=512M"]
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=${SERVICE_PASSWORD_ROOT}
+      - MYSQL_DATABASE=${MARIADB_DATABASE:-wordpress}
+      - MYSQL_USER=${SERVICE_USER_WORDPRESS}
+      - MYSQL_PASSWORD=${SERVICE_PASSWORD_WORDPRESS}
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10

--- a/templates/service-templates-latest.json
+++ b/templates/service-templates-latest.json
@@ -5239,6 +5239,24 @@
         "logo": "svgs/wordpress.svg",
         "minversion": "0.0.0"
     },
+    "wordpress-with-openlitespeed": {
+        "documentation": "https://docs.litespeedtech.com/cloud/docker/ols-wordpress/?utm_source=coolify.io",
+        "slogan": "Run WordPress on OpenLiteSpeed with persistent files and MariaDB storage.",
+        "compose": "c2VydmljZXM6CiAgd29yZHByZXNzOgogICAgaW1hZ2U6IGxpdGVzcGVlZHRlY2gvb3BlbmxpdGVzcGVlZDoxLjkuMC1sc3BocDgzCiAgICB2b2x1bWVzOgogICAgICAtIHdvcmRwcmVzcy1maWxlczovdmFyL3d3dy92aG9zdHMvbG9jYWxob3N0L2h0bWwKICAgICAgLSBvcGVubGl0ZXNwZWVkLWNvbmY6L3Vzci9sb2NhbC9sc3dzL2NvbmYKICAgICAgLSBvcGVubGl0ZXNwZWVkLWFkbWluLWNvbmY6L3Vzci9sb2NhbC9sc3dzL2FkbWluL2NvbmYKICAgICAgLSBvcGVubGl0ZXNwZWVkLWxvZ3M6L3Vzci9sb2NhbC9sc3dzL2xvZ3MKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfVVJMX1dPUkRQUkVTU184MAogICAgICAtIFdPUkRQUkVTU19EQl9IT1NUPW1hcmlhZGIKICAgICAgLSBXT1JEUFJFU1NfREJfVVNFUj0ke1NFUlZJQ0VfVVNFUl9XT1JEUFJFU1N9CiAgICAgIC0gV09SRFBSRVNTX0RCX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9XT1JEUFJFU1N9CiAgICAgIC0gV09SRFBSRVNTX0RCX05BTUU9JHtNQVJJQURCX0RBVEFCQVNFOi13b3JkcHJlc3N9CiAgICBjb21tYW5kOgogICAgICAtIGJhc2gKICAgICAgLSAtbGMKICAgICAgLSB8CiAgICAgICAgc2V0IC1lCiAgICAgICAgY2QgL3Zhci93d3cvdmhvc3RzL2xvY2FsaG9zdC9odG1sCiAgICAgICAgaWYgWyAhIC1mIHdwLXNldHRpbmdzLnBocCBdOyB0aGVuCiAgICAgICAgICB3cCBjb3JlIGRvd25sb2FkIC0tYWxsb3ctcm9vdAogICAgICAgIGZpCiAgICAgICAgaWYgWyAhIC1mIHdwLWNvbmZpZy5waHAgXTsgdGhlbgogICAgICAgICAgd3AgY29uZmlnIGNyZWF0ZSAtLWFsbG93LXJvb3QgLS1za2lwLWNoZWNrIFwKICAgICAgICAgICAgLS1kYmhvc3Q9IiR7V09SRFBSRVNTX0RCX0hPU1R9IiBcCiAgICAgICAgICAgIC0tZGJuYW1lPSIke1dPUkRQUkVTU19EQl9OQU1FfSIgXAogICAgICAgICAgICAtLWRidXNlcj0iJHtXT1JEUFJFU1NfREJfVVNFUn0iIFwKICAgICAgICAgICAgLS1kYnBhc3M9IiR7V09SRFBSRVNTX0RCX1BBU1NXT1JEfSIKICAgICAgICBmaQogICAgICAgIGNob3duIC1SIDEwMDA6MTAwMCAvdmFyL3d3dy92aG9zdHMvbG9jYWxob3N0L2h0bWwKICAgIGRlcGVuZHNfb246CiAgICAgIG1hcmlhZGI6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OiBbIkNNRCIsICJjdXJsIiwgIi1mIiwgImh0dHA6Ly8xMjcuMC4wLjEiXQogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCgogIG1hcmlhZGI6CiAgICBpbWFnZTogbWFyaWFkYjoxMS40CiAgICBjb21tYW5kOiBbIi0tbWF4LWFsbG93ZWQtcGFja2V0PTUxMk0iXQogICAgdm9sdW1lczoKICAgICAgLSBtYXJpYWRiLWRhdGE6L3Zhci9saWIvbXlzcWwKICAgIGVudmlyb25tZW50OgogICAgICAtIE1ZU1FMX1JPT1RfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX1JPT1R9CiAgICAgIC0gTVlTUUxfREFUQUJBU0U9JHtNQVJJQURCX0RBVEFCQVNFOi13b3JkcHJlc3N9CiAgICAgIC0gTVlTUUxfVVNFUj0ke1NFUlZJQ0VfVVNFUl9XT1JEUFJFU1N9CiAgICAgIC0gTVlTUUxfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX1dPUkRQUkVTU30KICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OiBbIkNNRCIsICJoZWFsdGhjaGVjay5zaCIsICItLWNvbm5lY3QiLCAiLS1pbm5vZGJfaW5pdGlhbGl6ZWQiXQogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCg==",
+        "tags": [
+            "cms",
+            "blog",
+            "content",
+            "management",
+            "wordpress",
+            "openlitespeed",
+            "mariadb"
+        ],
+        "category": "cms",
+        "logo": "svgs/wordpress.svg",
+        "minversion": "0.0.0",
+        "port": "80"
+    },
     "yamtrack-with-postgresql": {
         "documentation": "https://github.com/FuzzyGrim/Yamtrack/wiki?utm_source=coolify.io",
         "slogan": "Yamtrack is a self hosted media tracker for movies, tv shows, anime, manga, video games and books.",

--- a/templates/service-templates.json
+++ b/templates/service-templates.json
@@ -5239,6 +5239,24 @@
         "logo": "svgs/wordpress.svg",
         "minversion": "0.0.0"
     },
+    "wordpress-with-openlitespeed": {
+        "documentation": "https://docs.litespeedtech.com/cloud/docker/ols-wordpress/?utm_source=coolify.io",
+        "slogan": "Run WordPress on OpenLiteSpeed with persistent files and MariaDB storage.",
+        "compose": "c2VydmljZXM6CiAgd29yZHByZXNzOgogICAgaW1hZ2U6IGxpdGVzcGVlZHRlY2gvb3BlbmxpdGVzcGVlZDoxLjkuMC1sc3BocDgzCiAgICB2b2x1bWVzOgogICAgICAtIHdvcmRwcmVzcy1maWxlczovdmFyL3d3dy92aG9zdHMvbG9jYWxob3N0L2h0bWwKICAgICAgLSBvcGVubGl0ZXNwZWVkLWNvbmY6L3Vzci9sb2NhbC9sc3dzL2NvbmYKICAgICAgLSBvcGVubGl0ZXNwZWVkLWFkbWluLWNvbmY6L3Vzci9sb2NhbC9sc3dzL2FkbWluL2NvbmYKICAgICAgLSBvcGVubGl0ZXNwZWVkLWxvZ3M6L3Vzci9sb2NhbC9sc3dzL2xvZ3MKICAgIGVudmlyb25tZW50OgogICAgICAtIFNFUlZJQ0VfRlFETl9XT1JEUFJFU1NfODAKICAgICAgLSBXT1JEUFJFU1NfREJfSE9TVD1tYXJpYWRiCiAgICAgIC0gV09SRFBSRVNTX0RCX1VTRVI9JHtTRVJWSUNFX1VTRVJfV09SRFBSRVNTfQogICAgICAtIFdPUkRQUkVTU19EQl9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfV09SRFBSRVNTfQogICAgICAtIFdPUkRQUkVTU19EQl9OQU1FPSR7TUFSSUFEQl9EQVRBQkFTRTotd29yZHByZXNzfQogICAgY29tbWFuZDoKICAgICAgLSBiYXNoCiAgICAgIC0gLWxjCiAgICAgIC0gfAogICAgICAgIHNldCAtZQogICAgICAgIGNkIC92YXIvd3d3L3Zob3N0cy9sb2NhbGhvc3QvaHRtbAogICAgICAgIGlmIFsgISAtZiB3cC1zZXR0aW5ncy5waHAgXTsgdGhlbgogICAgICAgICAgd3AgY29yZSBkb3dubG9hZCAtLWFsbG93LXJvb3QKICAgICAgICBmaQogICAgICAgIGlmIFsgISAtZiB3cC1jb25maWcucGhwIF07IHRoZW4KICAgICAgICAgIHdwIGNvbmZpZyBjcmVhdGUgLS1hbGxvdy1yb290IC0tc2tpcC1jaGVjayBcCiAgICAgICAgICAgIC0tZGJob3N0PSIke1dPUkRQUkVTU19EQl9IT1NUfSIgXAogICAgICAgICAgICAtLWRibmFtZT0iJHtXT1JEUFJFU1NfREJfTkFNRX0iIFwKICAgICAgICAgICAgLS1kYnVzZXI9IiR7V09SRFBSRVNTX0RCX1VTRVJ9IiBcCiAgICAgICAgICAgIC0tZGJwYXNzPSIke1dPUkRQUkVTU19EQl9QQVNTV09SRH0iCiAgICAgICAgZmkKICAgICAgICBjaG93biAtUiAxMDAwOjEwMDAgL3Zhci93d3cvdmhvc3RzL2xvY2FsaG9zdC9odG1sCiAgICBkZXBlbmRzX29uOgogICAgICBtYXJpYWRiOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5CiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDogWyJDTUQiLCAiY3VybCIsICItZiIsICJodHRwOi8vMTI3LjAuMC4xIl0KICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAoKICBtYXJpYWRiOgogICAgaW1hZ2U6IG1hcmlhZGI6MTEuNAogICAgY29tbWFuZDogWyItLW1heC1hbGxvd2VkLXBhY2tldD01MTJNIl0KICAgIHZvbHVtZXM6CiAgICAgIC0gbWFyaWFkYi1kYXRhOi92YXIvbGliL215c3FsCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBNWVNRTF9ST09UX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9ST09UfQogICAgICAtIE1ZU1FMX0RBVEFCQVNFPSR7TUFSSUFEQl9EQVRBQkFTRTotd29yZHByZXNzfQogICAgICAtIE1ZU1FMX1VTRVI9JHtTRVJWSUNFX1VTRVJfV09SRFBSRVNTfQogICAgICAtIE1ZU1FMX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9XT1JEUFJFU1N9CiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDogWyJDTUQiLCAiaGVhbHRoY2hlY2suc2giLCAiLS1jb25uZWN0IiwgIi0taW5ub2RiX2luaXRpYWxpemVkIl0KICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAo=",
+        "tags": [
+            "cms",
+            "blog",
+            "content",
+            "management",
+            "wordpress",
+            "openlitespeed",
+            "mariadb"
+        ],
+        "category": "cms",
+        "logo": "svgs/wordpress.svg",
+        "minversion": "0.0.0",
+        "port": "80"
+    },
     "yamtrack-with-postgresql": {
         "documentation": "https://github.com/FuzzyGrim/Yamtrack/wiki?utm_source=coolify.io",
         "slogan": "Yamtrack is a self hosted media tracker for movies, tv shows, anime, manga, video games and books.",


### PR DESCRIPTION
## Summary
- Add a one-click WordPress + OpenLiteSpeed service template backed by MariaDB.
- Persist WordPress files, OpenLiteSpeed config/logs, and database data with named volumes.
- Update generated service template indexes for both latest and FQDN variants.

Closes #8264

## Validation
- Parsed the new compose YAML with Ruby/Psych.
- Parsed both generated JSON indexes and decoded the new template compose payloads.
- Verified `service-templates-latest.json` uses `SERVICE_URL_WORDPRESS_80` and `service-templates.json` uses `SERVICE_FQDN_WORDPRESS_80`.

Note: I could not run the Laravel generator or container smoke test locally because this environment has no `php` or `docker` binary.