### PR TITLE
feat: allow oauth self-registration and restrict to oauth only

### DIFF
--- a/app/Actions/Fortify/UpdateUserPassword.php
+++ b/app/Actions/Fortify/UpdateUserPassword.php
@@ -17,6 +17,9 @@ class UpdateUserPassword implements UpdatesUserPasswords
      */
     public function update(User $user, array $input): void
     {
+        if ($user->force_oauth_only) {
+            throw new \Exception('Password changes are disabled for OAuth only users.');
+        }
         Validator::make($input, [
             'current_password' => ['required', 'string', 'current_password:web'],
             'password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -22,14 +22,21 @@ class OauthController extends Controller
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! $settings->is_oauth_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 
                 $user = User::create([
                     'name' => $oauthUser->name,
                     'email' => $oauthUser->email,
+                    'force_oauth_only' => $settings->is_force_oauth_login_enabled,
                 ]);
+            } else {
+                $settings = instanceSettings();
+                if ($settings->is_force_oauth_login_enabled && ! $user->force_oauth_only) {
+                    $user->force_oauth_only = true;
+                    $user->save();
+                }
             }
             Auth::login($user);
 

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -14,6 +14,8 @@ class Advanced extends Component
 
     #[Validate('boolean')]
     public bool $is_registration_enabled;
+    public bool $is_oauth_registration_enabled;
+    public bool $is_force_oauth_login_enabled;
 
     #[Validate('boolean')]
     public bool $do_not_track;
@@ -41,6 +43,8 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_registration_enabled' => 'boolean',
+            'is_force_oauth_login_enabled' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => ['nullable', 'string', new ValidDnsServers],
@@ -62,6 +66,8 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled;
+        $this->is_force_oauth_login_enabled = $this->settings->is_force_oauth_login_enabled;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -142,6 +148,8 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
+            $this->settings->is_force_oauth_login_enabled = $this->is_force_oauth_login_enabled;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -44,6 +44,8 @@ class InstanceSettings extends Model
         'disable_two_step_confirmation',
         'is_sponsorship_popup_enabled',
         'dev_helper_version',
+        'is_force_oauth_login_enabled',
+        'is_oauth_registration_enabled',
         'is_wire_navigate_enabled',
     ];
 
@@ -67,6 +69,8 @@ class InstanceSettings extends Model
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',
         'is_wire_navigate_enabled' => 'boolean',
+        'is_force_oauth_login_enabled' => 'boolean',
+        'is_oauth_registration_enabled' => 'boolean',
     ];
 
     protected static function booted(): void

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -52,6 +52,7 @@ class User extends Authenticatable implements SendsEmail
         'pending_email',
         'email_change_code',
         'email_change_code_expires_at',
+        'force_oauth_only',
     ];
 
     protected $hidden = [
@@ -66,6 +67,7 @@ class User extends Authenticatable implements SendsEmail
         'force_password_reset' => 'boolean',
         'show_boarding' => 'boolean',
         'email_change_code_expires_at' => 'datetime',
+        'force_oauth_only' => 'boolean',
     ];
 
     /**

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -74,6 +74,9 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::authenticateUsing(function (Request $request) {
             $email = strtolower($request->email);
             $user = User::where('email', $email)->with('teams')->first();
+            if ($user && $user->force_oauth_only) {
+                return null;
+            }
             if (
                 $user &&
                 Hash::check($request->password, $user->password)

--- a/database/migrations/2026_05_12_000000_add_oauth_registration_settings_to_instance_settings.php
+++ b/database/migrations/2026_05_12_000000_add_oauth_registration_settings_to_instance_settings.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $code) {
+            $code->boolean('is_oauth_registration_enabled')->default(true);
+            $code->boolean('is_force_oauth_login_enabled')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $code) {
+            $code->dropColumn('is_oauth_registration_enabled');
+            $code->dropColumn('is_force_oauth_login_enabled');
+        });
+    }
+};

--- a/database/migrations/2026_05_12_000001_add_force_oauth_only_to_users_table.php
+++ b/database/migrations/2026_05_12_000001_add_force_oauth_only_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $code) {
+            $code->boolean('force_oauth_only')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $code) {
+            $code->dropColumn('force_oauth_only');
+        });
+    }
+};

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -42,6 +42,16 @@
                         </div>
                     @endif
                     <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_registration_enabled"
+                            helper="Allow users to self-register with OAuth2 (Github, Gitlab, etc.) even if general registration is disabled."
+                            label="OAuth2 Registration Allowed" />
+                    </div>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_force_oauth_login_enabled"
+                            helper="Restrict users who register via OAuth2 to only use OAuth2 for login. This blocks them from setting or using a local password."
+                            label="Force OAuth2 Login" />
+                    </div>
+                    <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"
                             helper="Opt out of anonymous usage tracking. When enabled, this instance will not report to coolify.io's installation count and will not send error reports to help improve Coolify."
                             label="Do Not Track" />


### PR DESCRIPTION
This enhancement allows users to self-register via OAuth and provides an option to restrict registration to OAuth only for better security.