### PR TITLE
fix: allow OAuth self-registration when password registration is disabled

### DIFF
--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\ResetsUserPasswords;
 
 class ResetUserPassword implements ResetsUserPasswords
@@ -17,6 +18,12 @@ class ResetUserPassword implements ResetsUserPasswords
      */
     public function reset(User $user, array $input): void
     {
+        if (! $user->hasPassword()) {
+            throw ValidationException::withMessages([
+                'email' => 'Password reset is unavailable for accounts created through OAuth.',
+            ]);
+        }
+
         Validator::make($input, [
             'password' => ['required', Password::defaults(), 'confirmed'],
         ])->validate();

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -26,11 +26,6 @@ class OauthController extends Controller
             $email = strtolower($email);
             $user = User::whereEmail($email)->first();
             if (! $user) {
-                $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
-                    abort(403, 'Registration is disabled');
-                }
-
                 $user = User::create([
                     'name' => $oauthUser->name,
                     'email' => $email,

--- a/tests/Feature/OauthRegistrationTest.php
+++ b/tests/Feature/OauthRegistrationTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use App\Actions\Fortify\ResetUserPassword;
+use App\Models\InstanceSettings;
+use App\Models\OauthSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Validation\ValidationException;
+use Laravel\Socialite\Facades\Socialite;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    config([
+        'app.maintenance.store' => 'array',
+        'cache.default' => 'array',
+        'queue.default' => 'sync',
+        'session.driver' => 'array',
+    ]);
+
+    InstanceSettings::unguarded(function () {
+        InstanceSettings::query()->create([
+            'id' => 0,
+            'is_registration_enabled' => false,
+        ]);
+    });
+});
+
+it('allows oauth users to self register when password registration is disabled', function () {
+    User::factory()->create(['email' => 'admin@example.com']);
+
+    OauthSetting::create([
+        'provider' => 'github',
+        'enabled' => true,
+        'client_id' => 'github-client-id',
+        'client_secret' => 'github-client-secret',
+        'redirect_uri' => route('auth.callback', 'github'),
+    ]);
+
+    $provider = Mockery::mock();
+    $provider->shouldReceive('user')->once()->andReturn((object) [
+        'name' => 'OAuth User',
+        'email' => 'oauth-user@example.com',
+    ]);
+
+    Socialite::shouldReceive('buildProvider')->once()->andReturn($provider);
+
+    $this->get(route('auth.callback', 'github'))
+        ->assertRedirect('/');
+
+    $user = User::whereEmail('oauth-user@example.com')->firstOrFail();
+
+    $this->assertAuthenticatedAs($user);
+    expect($user->name)->toBe('OAuth User')
+        ->and($user->password)->toBeNull();
+});
+
+it('prevents password reset from creating passwords for oauth-only users', function () {
+    $user = User::factory()->create([
+        'email' => 'oauth-user@example.com',
+        'password' => null,
+    ]);
+
+    expect(fn () => (new ResetUserPassword)->reset($user, [
+        'password' => 'StrongPassword1!',
+        'password_confirmation' => 'StrongPassword1!',
+    ]))->toThrow(ValidationException::class);
+
+    expect($user->refresh()->password)->toBeNull();
+});


### PR DESCRIPTION
## Changes

- Allow OAuth callback to create a new user when password registration is disabled.
- Keep password reset unavailable for OAuth-only users without a password.
- Add feature tests for OAuth self-registration and password reset blocking.

## Issues

- Fixes #8042

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A. Backend authentication flow change covered by feature tests.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Used to inspect the auth flow, prepare the patch, and run local verification. Human operator reviewed and submitted the PR.

## Testing

- vendor/bin/pint --dirty --format agent
- php artisan test tests/Feature/OauthRegistrationTest.php --compact

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the contributor guidelines. If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched existing issues and pull requests, including closed ones, to ensure this is not a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.