### PR TITLE
feat: add OAuth-only authentication settings

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -19,7 +19,10 @@ class CreateNewUser implements CreatesNewUsers
     public function create(array $input): User
     {
         $settings = instanceSettings();
-        if (! $settings->is_registration_enabled) {
+        if (
+            User::count() > 0 &&
+            (! $settings->is_registration_enabled || ! ($settings->is_password_authentication_enabled ?? true))
+        ) {
             abort(403);
         }
         Validator::make($input, [

--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -17,6 +17,10 @@ class ResetUserPassword implements ResetsUserPasswords
      */
     public function reset(User $user, array $input): void
     {
+        if (! (instanceSettings()->is_password_authentication_enabled ?? true)) {
+            abort(403);
+        }
+
         Validator::make($input, [
             'password' => ['required', Password::defaults(), 'confirmed'],
         ])->validate();

--- a/app/Actions/Fortify/UpdateUserPassword.php
+++ b/app/Actions/Fortify/UpdateUserPassword.php
@@ -17,6 +17,10 @@ class UpdateUserPassword implements UpdatesUserPasswords
      */
     public function update(User $user, array $input): void
     {
+        if (! (instanceSettings()->is_password_authentication_enabled ?? true)) {
+            abort(403);
+        }
+
         Validator::make($input, [
             'current_password' => ['required', 'string', 'current_password:web'],
             'password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -68,6 +68,10 @@ class Controller extends BaseController
 
     public function forgot_password(Request $request)
     {
+        if (! (instanceSettings()->is_password_authentication_enabled ?? true)) {
+            return response()->json(['message' => 'Password authentication is disabled.'], 403);
+        }
+
         if (is_transactional_emails_enabled()) {
             $arrayOfRequest = $request->only(Fortify::email());
             $request->merge([
@@ -96,6 +100,10 @@ class Controller extends BaseController
 
     public function link()
     {
+        if (! (instanceSettings()->is_password_authentication_enabled ?? true)) {
+            return redirect()->route('login')->with('error', 'Password authentication is disabled.');
+        }
+
         $token = request()->get('token');
         if ($token) {
             $decrypted = Crypt::decryptString($token);

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -27,7 +27,7 @@ class OauthController extends Controller
             $user = User::whereEmail($email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! ($settings->is_oauth_registration_enabled ?? false)) {
                     abort(403, 'Registration is disabled');
                 }
 

--- a/app/Livewire/ForcePasswordReset.php
+++ b/app/Livewire/ForcePasswordReset.php
@@ -40,6 +40,10 @@ class ForcePasswordReset extends Component
 
     public function submit()
     {
+        if (! (instanceSettings()->is_password_authentication_enabled ?? true)) {
+            abort(403);
+        }
+
         if (auth()->user()->force_password_reset === false) {
             return redirect()->route('dashboard');
         }

--- a/app/Livewire/Profile/Index.php
+++ b/app/Livewire/Profile/Index.php
@@ -240,6 +240,10 @@ class Index extends Component
     public function resetPassword()
     {
         try {
+            if (! (instanceSettings()->is_password_authentication_enabled ?? true)) {
+                abort(403);
+            }
+
             $this->validate([
                 'current_password' => ['required'],
                 'new_password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\Settings;
 
 use App\Models\InstanceSettings;
+use App\Models\OauthSetting;
 use App\Rules\ValidDnsServers;
 use App\Rules\ValidIpOrCidr;
 use Livewire\Attributes\Validate;
@@ -14,6 +15,12 @@ class Advanced extends Component
 
     #[Validate('boolean')]
     public bool $is_registration_enabled;
+
+    #[Validate('boolean')]
+    public bool $is_oauth_registration_enabled;
+
+    #[Validate('boolean')]
+    public bool $is_password_authentication_enabled;
 
     #[Validate('boolean')]
     public bool $do_not_track;
@@ -44,6 +51,8 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_registration_enabled' => 'boolean',
+            'is_password_authentication_enabled' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => ['nullable', 'string', new ValidDnsServers],
@@ -66,6 +75,8 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled ?? false;
+        $this->is_password_authentication_enabled = $this->settings->is_password_authentication_enabled ?? true;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -146,7 +157,20 @@ class Advanced extends Component
     public function instantSave()
     {
         try {
+            if (
+                ! $this->is_password_authentication_enabled &&
+                ($this->settings->is_password_authentication_enabled ?? true) &&
+                OauthSetting::where('enabled', true)->doesntExist()
+            ) {
+                $this->is_password_authentication_enabled = $this->settings->is_password_authentication_enabled ?? true;
+                $this->dispatch('error', 'Enable at least one OAuth provider before disabling password authentication.');
+
+                return;
+            }
+
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
+            $this->settings->is_password_authentication_enabled = $this->is_password_authentication_enabled;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/app/Livewire/SettingsOauth.php
+++ b/app/Livewire/SettingsOauth.php
@@ -9,6 +9,26 @@ class SettingsOauth extends Component
 {
     public $oauth_settings_map;
 
+    private function oauthDataCouldBeEnabled(array $settingData): bool
+    {
+        if (! ($settingData['enabled'] ?? false)) {
+            return false;
+        }
+
+        return match ($settingData['provider']) {
+            'azure' => filled($settingData['client_id']) && filled($settingData['client_secret']) && filled($settingData['tenant']),
+            'authentik', 'clerk' => filled($settingData['client_id']) && filled($settingData['client_secret']) && filled($settingData['base_url']),
+            default => filled($settingData['client_id']) && filled($settingData['client_secret']),
+        };
+    }
+
+    private function hasEnabledOauthProviderInMap(): bool
+    {
+        return collect($this->oauth_settings_map)->contains(
+            fn ($settingData) => $this->oauthDataCouldBeEnabled($settingData)
+        );
+    }
+
     protected function rules()
     {
         return OauthSetting::all()->reduce(function ($carry, $setting) {
@@ -46,6 +66,19 @@ class SettingsOauth extends Component
 
     private function updateOauthSettings(?string $provider = null)
     {
+        if (
+            ! (instanceSettings()->is_password_authentication_enabled ?? true) &&
+            ! $this->hasEnabledOauthProviderInMap()
+        ) {
+            if ($provider) {
+                $this->oauth_settings_map[$provider]['enabled'] = true;
+            }
+
+            $this->dispatch('error', 'At least one OAuth provider must remain enabled while password authentication is disabled.');
+
+            return;
+        }
+
         if ($provider) {
             $oauthData = $this->oauth_settings_map[$provider];
             $oauth = OauthSetting::find($oauthData['id']);

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -18,6 +18,8 @@ class InstanceSettings extends Model
         'do_not_track',
         'is_auto_update_enabled',
         'is_registration_enabled',
+        'is_oauth_registration_enabled',
+        'is_password_authentication_enabled',
         'next_channel',
         'smtp_enabled',
         'smtp_from_address',
@@ -59,6 +61,9 @@ class InstanceSettings extends Model
         'smtp_password' => 'encrypted',
         'smtp_timeout' => 'integer',
 
+        'is_registration_enabled' => 'boolean',
+        'is_oauth_registration_enabled' => 'boolean',
+        'is_password_authentication_enabled' => 'boolean',
         'resend_enabled' => 'boolean',
         'resend_api_key' => 'encrypted',
 

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -7,6 +7,7 @@ use App\Actions\Fortify\ResetUserPassword;
 use App\Actions\Fortify\UpdateUserPassword;
 use App\Actions\Fortify\UpdateUserProfileInformation;
 use App\Models\OauthSetting;
+use App\Models\TeamInvitation;
 use App\Models\User;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
@@ -47,7 +48,10 @@ class FortifyServiceProvider extends ServiceProvider
             $isFirstUser = User::count() === 0;
 
             $settings = instanceSettings();
-            if (! $settings->is_registration_enabled) {
+            if (
+                ! $isFirstUser &&
+                (! $settings->is_registration_enabled || ! ($settings->is_password_authentication_enabled ?? true))
+            ) {
                 return redirect()->route('login');
             }
 
@@ -67,11 +71,17 @@ class FortifyServiceProvider extends ServiceProvider
 
             return view('auth.login', [
                 'is_registration_enabled' => $settings->is_registration_enabled,
+                'is_oauth_registration_enabled' => $settings->is_oauth_registration_enabled ?? false,
+                'is_password_authentication_enabled' => $settings->is_password_authentication_enabled ?? true,
                 'enabled_oauth_providers' => $enabled_oauth_providers,
             ]);
         });
 
         Fortify::authenticateUsing(function (Request $request) {
+            if (! (instanceSettings()->is_password_authentication_enabled ?? true)) {
+                return null;
+            }
+
             $email = strtolower($request->email);
             $user = User::where('email', $email)->with('teams')->first();
             if (
@@ -82,7 +92,7 @@ class FortifyServiceProvider extends ServiceProvider
                 $user->save();
 
                 // Check if user has a pending invitation they haven't accepted yet
-                $invitation = \App\Models\TeamInvitation::whereEmail($email)->first();
+                $invitation = TeamInvitation::whereEmail($email)->first();
                 if ($invitation && $invitation->isValid()) {
                     // User is logging in for the first time after being invited
                     // Attach them to the invited team if not already attached

--- a/database/migrations/2026_05_12_000000_add_oauth_registration_and_password_authentication_settings.php
+++ b/database/migrations/2026_05_12_000000_add_oauth_registration_and_password_authentication_settings.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_registration_enabled')->default(false)->after('is_registration_enabled');
+            $table->boolean('is_password_authentication_enabled')->default(true)->after('is_oauth_registration_enabled');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn([
+                'is_oauth_registration_enabled',
+                'is_password_authentication_enabled',
+            ]);
+        });
+    }
+};

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -29,33 +29,39 @@
                         </div>
                     @endif
 
-                    <form action="/login" method="POST" class="flex flex-col gap-4">
-                        @csrf
-                        @env('local')
-                            <x-forms.input value="test@example.com" type="email" autocomplete="email" name="email" required
-                                label="{{ __('input.email') }}" />
-                            <x-forms.input value="password" type="password" autocomplete="current-password" name="password"
-                                required label="{{ __('input.password') }}" />
-                        @else
-                            <x-forms.input type="email" name="email" autocomplete="email" required
-                                label="{{ __('input.email') }}" />
-                            <x-forms.input type="password" name="password" autocomplete="current-password" required
-                                label="{{ __('input.password') }}" />
-                        @endenv
+                    @if ($is_password_authentication_enabled)
+                        <form action="/login" method="POST" class="flex flex-col gap-4">
+                            @csrf
+                            @env('local')
+                                <x-forms.input value="test@example.com" type="email" autocomplete="email" name="email"
+                                    required label="{{ __('input.email') }}" />
+                                <x-forms.input value="password" type="password" autocomplete="current-password"
+                                    name="password" required label="{{ __('input.password') }}" />
+                            @else
+                                <x-forms.input type="email" name="email" autocomplete="email" required
+                                    label="{{ __('input.email') }}" />
+                                <x-forms.input type="password" name="password" autocomplete="current-password" required
+                                    label="{{ __('input.password') }}" />
+                            @endenv
 
-                        <div class="flex items-center justify-between">
-                            <a href="/forgot-password"
-                                class="text-sm dark:text-neutral-400 hover:text-coollabs dark:hover:text-warning hover:underline transition-colors">
-                                {{ __('auth.forgot_password_link') }}
-                            </a>
+                            <div class="flex items-center justify-between">
+                                <a href="/forgot-password"
+                                    class="text-sm dark:text-neutral-400 hover:text-coollabs dark:hover:text-warning hover:underline transition-colors">
+                                    {{ __('auth.forgot_password_link') }}
+                                </a>
+                            </div>
+
+                            <x-forms.button class="w-full justify-center py-3 box-boarding" type="submit" isHighlighted>
+                                {{ __('auth.login') }}
+                            </x-forms.button>
+                        </form>
+                    @else
+                        <div class="mt-6 text-center text-sm text-neutral-500 dark:text-neutral-400">
+                            Password authentication is disabled.
                         </div>
+                    @endif
 
-                        <x-forms.button class="w-full justify-center py-3 box-boarding" type="submit" isHighlighted>
-                            {{ __('auth.login') }}
-                        </x-forms.button>
-                    </form>
-
-                    @if ($is_registration_enabled)
+                    @if ($is_registration_enabled && $is_password_authentication_enabled)
                         <div class="relative my-6">
                             <div class="absolute inset-0 flex items-center">
                                 <div class="w-full border-t border-neutral-300 dark:border-coolgray-400"></div>
@@ -70,7 +76,7 @@
                             class="block w-full text-center py-3 px-4 rounded-lg border border-neutral-300 dark:border-coolgray-400 font-medium hover:border-coollabs dark:hover:border-warning transition-colors">
                             {{ __('auth.register_now') }}
                         </a>
-                    @else
+                    @elseif ($is_password_authentication_enabled && (! ($is_oauth_registration_enabled ?? false) || $enabled_oauth_providers->isEmpty()))
                         <div class="mt-6 text-center text-sm text-neutral-500 dark:text-neutral-400">
                             {{ __('auth.registration_disabled') }}
                         </div>

--- a/resources/views/livewire/profile/index.blade.php
+++ b/resources/views/livewire/profile/index.blade.php
@@ -55,20 +55,22 @@
             </form>
         @endif
     </div>
-    <form wire:submit='resetPassword' class="flex flex-col pt-4">
-        <div class="flex items-center gap-2 pb-2">
-            <h2>Change Password</h2>
-            <x-forms.button type="submit" label="Save">Save</x-forms.button>
-        </div>
-        <div class="text-xs font-bold dark:text-warning pb-2">Resetting the password will logout all sessions.</div>
-        <div class="flex flex-col gap-2">
-            <x-forms.input id="current_password" label="Current Password" required type="password" />
-            <div class="flex gap-2">
-                <x-forms.input id="new_password" label="New Password" required type="password" />
-                <x-forms.input id="new_password_confirmation" label="New Password Again" required type="password" />
+    @if (instanceSettings()->is_password_authentication_enabled ?? true)
+        <form wire:submit='resetPassword' class="flex flex-col pt-4">
+            <div class="flex items-center gap-2 pb-2">
+                <h2>Change Password</h2>
+                <x-forms.button type="submit" label="Save">Save</x-forms.button>
             </div>
-        </div>
-    </form>
+            <div class="text-xs font-bold dark:text-warning pb-2">Resetting the password will logout all sessions.</div>
+            <div class="flex flex-col gap-2">
+                <x-forms.input id="current_password" label="Current Password" required type="password" />
+                <div class="flex gap-2">
+                    <x-forms.input id="new_password" label="New Password" required type="password" />
+                    <x-forms.input id="new_password_confirmation" label="New Password Again" required type="password" />
+                </div>
+            </div>
+        </form>
+    @endif
     <h2 class="py-4">Two-factor Authentication</h2>
     @if (session('status') == 'two-factor-authentication-enabled')
         <div class="mb-4 font-medium">

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -19,28 +19,37 @@
                     @if ($is_registration_enabled)
                         <div class="md:w-96" wire:key="registration-enabled">
                             <x-forms.checkbox instantSave id="is_registration_enabled"
-                                helper="Allow users to self-register. If disabled, only administrators can create accounts."
-                                label="Registration Allowed" />
+                                helper="Allow users to self-register with email and password."
+                                label="Password Registration Allowed" />
                         </div>
                     @else
                         <div class="flex items-center justify-between gap-2 md:w-96"
                             wire:key="registration-disabled">
                             <label class="flex items-center gap-2">
-                                Registration Allowed
-                                <x-helper
-                                    helper="Allow users to self-register. If disabled, only administrators can create accounts.">
+                                Password Registration Allowed
+                                <x-helper helper="Allow users to self-register with email and password.">
                                 </x-helper>
                             </label>
-                            <x-modal-confirmation title="Enable Registration?" buttonTitle="Enable" isErrorButton
+                            <x-modal-confirmation title="Enable Password Registration?" buttonTitle="Enable" isErrorButton
                                 submitAction="toggleRegistration" :actions="[
-                                    'Enables registration for everyone',
+                                    'Enables email/password registration for everyone',
                                 ]"
-                                warningMessage="Enabling registration allows anyone to create an account on this instance. Make sure you understand the implications before proceeding."
+                                warningMessage="Enabling password registration allows anyone to create an account on this instance with email and password. Make sure you understand the implications before proceeding."
                                 confirmationText="ENABLE REGISTRATION"
-                                confirmationLabel="Please type the confirmation text to enable registration."
+                                confirmationLabel="Please type the confirmation text to enable password registration."
                                 shortConfirmationLabel="Confirmation text" />
                         </div>
                     @endif
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_registration_enabled"
+                            helper="Allow users to self-register through enabled OAuth providers, even when password registration is disabled."
+                            label="OAuth Registration Allowed" />
+                    </div>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_password_authentication_enabled"
+                            helper="Allow email/password login, password registration, and password reset. Disable this only after configuring OAuth access."
+                            label="Password Authentication Allowed" />
+                    </div>
                     <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"
                             helper="Opt out of anonymous usage tracking. When enabled, this instance will not report to coolify.io's installation count and will not send error reports to help improve Coolify."

--- a/tests/Feature/OauthControllerTest.php
+++ b/tests/Feature/OauthControllerTest.php
@@ -3,16 +3,21 @@
 use App\Models\InstanceSettings;
 use App\Models\OauthSetting;
 use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Socialite\Facades\Socialite;
 
 uses(RefreshDatabase::class);
 
 beforeEach(function () {
-    InstanceSettings::create([
-        'id' => 0,
-        'is_registration_enabled' => false,
-    ]);
+    Model::unguarded(function () {
+        InstanceSettings::create([
+            'id' => 0,
+            'is_registration_enabled' => false,
+            'is_oauth_registration_enabled' => false,
+            'is_password_authentication_enabled' => true,
+        ]);
+    });
 
     OauthSetting::create([
         'provider' => 'google',
@@ -30,7 +35,7 @@ it('logs in an existing user when the oauth provider returns a mixed-case email'
         'email' => 'username@example.edu',
     ]);
 
-    $provider = \Mockery::mock();
+    $provider = Mockery::mock();
     $provider->shouldReceive('setConfig')->once()->andReturnSelf();
     $provider->shouldReceive('with')->once()->with(['hd' => 'example.com'])->andReturnSelf();
     $provider->shouldReceive('user')->once()->andReturn((object) [
@@ -58,7 +63,7 @@ it('rejects oauth logins when the provider does not return an email address', fu
         'is_registration_enabled' => true,
     ]);
 
-    $provider = \Mockery::mock();
+    $provider = Mockery::mock();
     $provider->shouldReceive('setConfig')->once()->andReturnSelf();
     $provider->shouldReceive('with')->once()->with(['hd' => 'example.com'])->andReturnSelf();
     $provider->shouldReceive('user')->once()->andReturn((object) [
@@ -77,3 +82,51 @@ it('rejects oauth logins when the provider does not return an email address', fu
     'null email' => [null],
     'blank email' => ['   '],
 ]);
+
+it('allows oauth self-registration when only oauth registration is enabled', function () {
+    config()->set('app.maintenance.driver', 'file');
+    InstanceSettings::find(0)->update([
+        'is_registration_enabled' => false,
+        'is_oauth_registration_enabled' => true,
+    ]);
+
+    $provider = Mockery::mock();
+    $provider->shouldReceive('setConfig')->once()->andReturnSelf();
+    $provider->shouldReceive('with')->once()->with(['hd' => 'example.com'])->andReturnSelf();
+    $provider->shouldReceive('user')->once()->andReturn((object) [
+        'email' => 'NewUser@example.edu',
+        'name' => 'New OAuth User',
+        'id' => 'google-user-id',
+    ]);
+
+    Socialite::shouldReceive('driver')->once()->with('google')->andReturn($provider);
+
+    $response = $this->get(route('auth.callback', 'google'));
+
+    $response->assertRedirect('/');
+    $user = User::whereEmail('newuser@example.edu')->first();
+    expect($user)->not->toBeNull()
+        ->and($user->password)->toBeNull();
+    $this->assertAuthenticatedAs($user);
+});
+
+it('rejects oauth self-registration when both registration modes are disabled', function () {
+    config()->set('app.maintenance.driver', 'file');
+
+    $provider = Mockery::mock();
+    $provider->shouldReceive('setConfig')->once()->andReturnSelf();
+    $provider->shouldReceive('with')->once()->with(['hd' => 'example.com'])->andReturnSelf();
+    $provider->shouldReceive('user')->once()->andReturn((object) [
+        'email' => 'BlockedUser@example.edu',
+        'name' => 'Blocked OAuth User',
+        'id' => 'google-user-id',
+    ]);
+
+    Socialite::shouldReceive('driver')->once()->with('google')->andReturn($provider);
+
+    $response = $this->from('/login')->get(route('auth.callback', 'google'));
+
+    $response->assertRedirect('/login');
+    expect(User::whereEmail('blockeduser@example.edu')->exists())->toBeFalse();
+    $this->assertGuest();
+});

--- a/tests/Feature/PasswordAuthenticationSettingsTest.php
+++ b/tests/Feature/PasswordAuthenticationSettingsTest.php
@@ -1,0 +1,131 @@
+<?php
+
+use App\Http\Middleware\CheckForcePasswordReset;
+use App\Http\Middleware\DecideWhatToDoWithUser;
+use App\Livewire\Settings\Advanced;
+use App\Livewire\SettingsOauth;
+use App\Models\InstanceSettings;
+use App\Models\OauthSetting;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Once;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->withoutMiddleware([DecideWhatToDoWithUser::class, CheckForcePasswordReset::class]);
+    $this->withoutVite();
+    config()->set('app.maintenance.driver', 'file');
+    Once::flush();
+    Model::unguarded(function () {
+        InstanceSettings::create([
+            'id' => 0,
+            'is_registration_enabled' => true,
+            'is_oauth_registration_enabled' => false,
+            'is_password_authentication_enabled' => false,
+        ]);
+    });
+});
+
+it('blocks password login when password authentication is disabled', function () {
+    $user = User::factory()->create([
+        'email' => 'password-user@example.com',
+        'password' => Hash::make('password'),
+    ]);
+
+    $this->from('/login')->post('/login', [
+        'email' => $user->email,
+        'password' => 'password',
+    ])->assertRedirect('/login');
+
+    $this->assertGuest();
+});
+
+it('blocks password registration when password authentication is disabled', function () {
+    User::factory()->create();
+
+    $this->post('/register', [
+        'name' => 'Password User',
+        'email' => 'new-password-user@example.com',
+        'password' => 'Password1!',
+        'password_confirmation' => 'Password1!',
+    ])->assertForbidden();
+
+    expect(User::whereEmail('new-password-user@example.com')->exists())->toBeFalse();
+});
+
+it('allows the first root user to register with a password even when password authentication is disabled', function () {
+    $this->get('/register')->assertOk();
+
+    $this->post('/register', [
+        'name' => 'Root User',
+        'email' => 'root-user@example.com',
+        'password' => 'Password1!',
+        'password_confirmation' => 'Password1!',
+    ])->assertRedirect(route('settings.index'));
+
+    $user = User::whereEmail('root-user@example.com')->first();
+    expect($user)->not->toBeNull()
+        ->and($user->id)->toBe(0)
+        ->and($user->password)->not->toBeNull();
+});
+
+it('keeps password authentication enabled when no oauth provider is enabled', function () {
+    InstanceSettings::find(0)->update([
+        'is_password_authentication_enabled' => true,
+    ]);
+    Once::flush();
+
+    Model::unguarded(function () {
+        $rootTeam = Team::factory()->create([
+            'id' => 0,
+            'name' => 'Root Team',
+            'personal_team' => false,
+        ]);
+        $admin = User::factory()->create();
+        $rootTeam->members()->attach($admin->id, ['role' => 'admin']);
+
+        $this->actingAs($admin);
+        session(['currentTeam' => ['id' => $rootTeam->id]]);
+    });
+
+    Livewire::test(Advanced::class)
+        ->set('is_password_authentication_enabled', false)
+        ->call('instantSave')
+        ->assertDispatched('error');
+
+    expect(InstanceSettings::find(0)->is_password_authentication_enabled)->toBeTrue();
+});
+
+it('keeps the last oauth provider enabled when password authentication is disabled', function () {
+    OauthSetting::create([
+        'provider' => 'github',
+        'enabled' => true,
+        'client_id' => 'github-client-id',
+        'client_secret' => 'github-client-secret',
+    ]);
+
+    Model::unguarded(function () {
+        $rootTeam = Team::factory()->create([
+            'id' => 0,
+            'name' => 'Root Team',
+            'personal_team' => false,
+        ]);
+        $admin = User::factory()->create();
+        $rootTeam->members()->attach($admin->id, ['role' => 'admin']);
+
+        $this->actingAs($admin);
+        session(['currentTeam' => ['id' => $rootTeam->id]]);
+    });
+
+    Livewire::test(SettingsOauth::class)
+        ->set('oauth_settings_map.github.enabled', false)
+        ->call('instantSave', 'github')
+        ->assertDispatched('error');
+
+    expect((bool) OauthSetting::where('provider', 'github')->first()->enabled)->toBeTrue();
+});


### PR DESCRIPTION
## Changes

- Add separate instance settings for OAuth self-registration and password authentication.
- Allow OAuth users to self-register when OAuth registration is enabled, even if password registration is disabled.
- Hide and block email/password login, password registration, password reset, forced password reset, and profile password changes when password authentication is disabled.
- Prevent disabling password authentication unless at least one OAuth provider is enabled, and prevent disabling the last OAuth provider while password authentication is off.
- Keep first root-user password registration available so initial setup is not blocked.

## Issues

- Fixes #8042
- /claim #8042

## Category

- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not included; this changes authentication and settings flows. The behavior is covered by feature tests.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: AI assisted with implementation and test writing; the changes were reviewed and verified locally.

## Testing

- Composer dependencies installed locally with PHP 8.4 for test execution.
- vendor/bin/pest tests/Feature/OauthControllerTest.php tests/Feature/PasswordAuthenticationSettingsTest.php
- vendor/bin/pint --dirty --test
- git diff --check
- Common credential pattern scan on changed PHP and Blade files
- Not run: full Spin/Docker Coolify development instance; Docker and Spin are not available on this Windows machine.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.