### PR TITLE
feat: add global deployments page

### DIFF
--- a/app/Livewire/Deployment/Index.php
+++ b/app/Livewire/Deployment/Index.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Livewire\Deployment;
+
+use App\Models\Application;
+use App\Models\ApplicationDeploymentQueue;
+use Livewire\Attributes\Title;
+use Livewire\Attributes\Url;
+use Livewire\Component;
+
+#[Title('Deployments | Coolify')]
+class Index extends Component
+{
+    #[Url]
+    public string $status = 'all';
+
+    public function render()
+    {
+        $team = auth()->user()->currentTeam();
+
+        $applicationIds = Application::whereHas('environment.project', function ($q) use ($team) {
+            $q->where('team_id', $team->id);
+        })->pluck('id');
+
+        $query = ApplicationDeploymentQueue::whereIn('application_id', $applicationIds)
+            ->orderByDesc('id')
+            ->limit(100);
+
+        if ($this->status !== 'all') {
+            $query->where('status', $this->status);
+        }
+
+        $deployments = $query->get([
+            'id',
+            'application_id',
+            'application_name',
+            'deployment_url',
+            'pull_request_id',
+            'server_name',
+            'server_id',
+            'status',
+            'created_at',
+        ]);
+
+        return view('livewire.deployment.index', [
+            'deployments' => $deployments,
+        ]);
+    }
+}

--- a/resources/views/components/navbar.blade.php
+++ b/resources/views/components/navbar.blade.php
@@ -269,6 +269,21 @@
                             <span class="menu-item-label" :class="collapsed && 'lg:hidden'">Tags</span>
                         </a>
                     </li>
+                    <li>
+                        <a title="Deployments" {{ wireNavigate() }}
+                            class="{{ request()->is('deployments*') ? 'menu-item-active menu-item' : 'menu-item' }}"
+                            href="{{ route('deployments.index') }}">
+                            <svg class="menu-item-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+                                stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round"
+                                stroke-linejoin="round">
+                                <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                                <path d="M4 7h16" />
+                                <path d="M4 12h16" />
+                                <path d="M4 17h10" />
+                            </svg>
+                            <span class="menu-item-label" :class="collapsed && 'lg:hidden'">Deployments</span>
+                        </a>
+                    </li>
                     @can('canAccessTerminal')
                         <li>
                             <a title="Terminal"

--- a/resources/views/livewire/deployment/index.blade.php
+++ b/resources/views/livewire/deployment/index.blade.php
@@ -1,0 +1,45 @@
+<div>
+    <div class="flex items-center justify-between">
+        <div>
+            <h1>Deployments</h1>
+            <div class="subtitle">Recent deployments across your applications.</div>
+        </div>
+        <x-forms.select wire:model.live="status" class="w-48">
+            <option value="all">All statuses</option>
+            <option value="queued">Queued</option>
+            <option value="in_progress">In progress</option>
+            <option value="finished">Finished</option>
+            <option value="failed">Failed</option>
+            <option value="cancelled">Cancelled</option>
+        </x-forms.select>
+    </div>
+
+    <div class="pt-6" wire:poll.5s>
+        @forelse ($deployments as $deployment)
+            <div class="box-without-bg mb-2 flex flex-col gap-2 p-4 lg:flex-row lg:items-center lg:justify-between">
+                <div>
+                    <div class="font-bold">
+                        {{ $deployment->application_name }}
+                    </div>
+                    <div class="text-sm text-neutral-500">
+                        {{ $deployment->server_name }}
+                        @if ($deployment->pull_request_id)
+                            <span>· PR #{{ $deployment->pull_request_id }}</span>
+                        @endif
+                        <span>· {{ $deployment->created_at?->diffForHumans() }}</span>
+                    </div>
+                </div>
+                <div class="flex items-center gap-3">
+                    <span class="text-sm">{{ str($deployment->status)->headline() }}</span>
+                    @if ($deployment->deployment_url)
+                        <a class="text-sm text-warning hover:underline" href="{{ $deployment->deployment_url }}" target="_blank">
+                            View deployment
+                        </a>
+                    @endif
+                </div>
+            </div>
+        @empty
+            <div class="box-without-bg p-4 text-neutral-500">No deployments found.</div>
+        @endforelse
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -80,6 +80,7 @@ use App\Livewire\Storage\Index as StorageIndex;
 use App\Livewire\Storage\Show as StorageShow;
 use App\Livewire\Subscription\Index as SubscriptionIndex;
 use App\Livewire\Subscription\Show as SubscriptionShow;
+use App\Livewire\Deployment\Index as DeploymentGlobalIndex;
 use App\Livewire\Tags\Show as TagsShow;
 use App\Livewire\Team\AdminView as TeamAdminView;
 use App\Livewire\Team\Index as TeamIndex;
@@ -129,6 +130,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::prefix('tags')->group(function () {
         Route::get('/{tagName?}', TagsShow::class)->name('tags.show');
     });
+
+    Route::get('/deployments', DeploymentGlobalIndex::class)->name('deployments.index');
 
     Route::prefix('notifications')->group(function () {
         Route::get('/email', NotificationEmail::class)->name('notifications.email');


### PR DESCRIPTION
## Summary

Adds a global deployments page at `/deployments` for viewing recent deployments across all applications owned by the current team.

## Changes

- Add `App\Livewire\Deployment\Index` Livewire component
- Add `resources/views/livewire/deployment/index.blade.php`
- Add `/deployments` route named `deployments.index`
- Add Deployments sidebar navigation item
- Add status filter via URL parameter
- Auto-refresh the list every 5 seconds with `wire:poll`

## Notes

This is a new PR based on `next` for #7596. Previous attempt #10120 targeted `v4.x`, so I rebuilt it against the current development branch.

Closes #7596
