### PR TITLE
feat: add Huly service template

### DIFF
--- a/templates/compose/huly.yaml
+++ b/templates/compose/huly.yaml
@@ -1,123 +1,306 @@
-# ignore: true
-# documentation: https://huly.io/
-# category: cms
+# documentation: https://github.com/hcengineering/huly-selfhost
+# category: productivity
 # slogan: Open Source All-in-One Project Management Platform
-# tags: linear,jira,slack,project,management,notion,motion
-# port: 8080
+# tags: huly,linear,jira,slack,notion,project-management,productivity,self-hosted
+# port: 80
+
+x-huly-database: &huly-database
+  CR_DATABASE: ${CR_DATABASE:-defaultdb}
+  CR_USERNAME: ${CR_USERNAME:-selfhost}
+  CR_DB_URL: postgres://${CR_USERNAME:-selfhost}:${SERVICE_PASSWORD_64_COCKROACH}@cockroach:26257/${CR_DATABASE:-defaultdb}
+
+x-huly-storage: &huly-storage
+  STORAGE_CONFIG: minio|minio?accessKey=minioadmin&secretKey=minioadmin
+
+x-huly-common: &huly-common
+  SERVER_SECRET: ${SERVICE_HEX_64_HULY}
+  STATS_URL: http://stats:4900
+  QUEUE_CONFIG: redpanda:9092
 
 services:
-  mongodb:
-    image: "mongo:7-jammy"
-    container_name: mongodb
+  nginx:
+    image: nginx:1.29.2
     environment:
-      - PUID=1000
-      - PGID=1000
+      - SERVICE_URL_HULY_80
     volumes:
-      - huly-db:/data/db
+      - type: bind
+        source: ./nginx/default.conf
+        target: /etc/nginx/conf.d/default.conf
+        read_only: true
+        content: |
+          server {
+              listen 80;
+              server_name _;
+              client_max_body_size 100M;
+
+              location / {
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+                  proxy_pass http://front:8080;
+              }
+
+              location /_accounts {
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+
+                  rewrite ^/_accounts(/.*)$ $1 break;
+                  proxy_pass http://account:3000/;
+              }
+
+              location /_collaborator {
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+
+                  proxy_http_version 1.1;
+                  proxy_set_header Upgrade $http_upgrade;
+                  proxy_set_header Connection "upgrade";
+                  rewrite ^/_collaborator(/.*)$ $1 break;
+                  proxy_pass http://collaborator:3078/;
+              }
+
+              location /_transactor {
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+
+                  proxy_http_version 1.1;
+                  proxy_set_header Upgrade $http_upgrade;
+                  proxy_set_header Connection "upgrade";
+                  rewrite ^/_transactor(/.*)$ $1 break;
+                  proxy_pass http://transactor:3333/;
+              }
+
+              location ~ ^/eyJ {
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+
+                  proxy_http_version 1.1;
+                  proxy_set_header Upgrade $http_upgrade;
+                  proxy_set_header Connection "upgrade";
+                  proxy_pass http://transactor:3333;
+              }
+
+              location /_rekoni {
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+
+                  rewrite ^/_rekoni(/.*)$ $1 break;
+                  proxy_pass http://rekoni:4004/;
+              }
+
+              location /_stats {
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+
+                  rewrite ^/_stats(/.*)$ $1 break;
+                  proxy_pass http://stats:4900/;
+              }
+          }
+    depends_on:
+      - account
+      - collaborator
+      - front
+      - rekoni
+      - stats
+      - transactor
+    healthcheck:
+      test: ["CMD", "nginx", "-t"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  cockroach:
+    image: cockroachdb/cockroach:latest-v24.2
+    command: start-single-node --accept-sql-without-tls
+    environment:
+      <<: *huly-database
+      COCKROACH_DATABASE: ${CR_DATABASE:-defaultdb}
+      COCKROACH_USER: ${CR_USERNAME:-selfhost}
+      COCKROACH_PASSWORD: ${SERVICE_PASSWORD_64_COCKROACH}
+    volumes:
+      - huly-cr-data:/cockroach/cockroach-data
+      - huly-cr-certs:/cockroach/certs
+    healthcheck:
+      test: ["CMD", "cockroach", "sql", "--insecure", "--host=127.0.0.1:26257", "--execute=SELECT 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  redpanda:
+    image: docker.redpanda.com/redpandadata/redpanda:v24.3.6
+    command:
+      - redpanda
+      - start
+      - --kafka-addr
+      - internal://0.0.0.0:9092,external://0.0.0.0:19092
+      - --advertise-kafka-addr
+      - internal://redpanda:9092,external://localhost:19092
+      - --pandaproxy-addr
+      - internal://0.0.0.0:8082,external://0.0.0.0:18082
+      - --advertise-pandaproxy-addr
+      - internal://redpanda:8082,external://localhost:18082
+      - --schema-registry-addr
+      - internal://0.0.0.0:8081,external://0.0.0.0:18081
+      - --rpc-addr
+      - redpanda:33145
+      - --advertise-rpc-addr
+      - redpanda:33145
+      - --mode
+      - dev-container
+      - --smp
+      - "1"
+      - --default-log-level=info
+    environment:
+      REDPANDA_SUPERUSER_USERNAME: ${REDPANDA_ADMIN_USER:-superadmin}
+      REDPANDA_SUPERUSER_PASSWORD: ${SERVICE_PASSWORD_64_REDPANDA}
+    volumes:
+      - huly-redpanda:/var/lib/redpanda/data
+    healthcheck:
+      test: ["CMD", "rpk", "cluster", "info", "-X", "user=${REDPANDA_ADMIN_USER:-superadmin}", "-X", "pass=${SERVICE_PASSWORD_64_REDPANDA}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
   minio:
-    image: ghcr.io/coollabsio/minio:RELEASE.2025-10-15T17-29-55Z # Released on 15 October 2025
+    image: minio/minio
     command: server /data --address ":9000" --console-address ":9001"
     volumes:
-      - huly-files:/data      
+      - huly-files:/data
     healthcheck:
       test: ["CMD", "mc", "ready", "local"]
       interval: 5s
       timeout: 20s
       retries: 10
+
   elastic:
-    image: "elasticsearch:7.14.2"
+    image: elasticsearch:7.14.2
     command: |
       /bin/sh -c "./bin/elasticsearch-plugin list | grep -q ingest-attachment || yes | ./bin/elasticsearch-plugin install --silent ingest-attachment;
       /usr/local/bin/docker-entrypoint.sh eswrapper"
+    environment:
+      ELASTICSEARCH_PORT_NUMBER: "9200"
+      BITNAMI_DEBUG: "true"
+      discovery.type: single-node
+      ES_JAVA_OPTS: -Xms1024m -Xmx1024m
+      http.cors.enabled: "true"
+      http.cors.allow-origin: http://localhost:8082
     volumes:
       - huly-elastic:/usr/share/elasticsearch/data
-    environment:
-      - ELASTICSEARCH_PORT_NUMBER=9200
-      - BITNAMI_DEBUG=true
-      - discovery.type=single-node
-      - ES_JAVA_OPTS=-Xms1024m -Xmx1024m
-      - http.cors.enabled=true
-      - http.cors.allow-origin=http://localhost:8082
     healthcheck:
-      test: curl -s http://127.0.0.1:9200/_cluster/health | grep -vq '"status":"red"'
-      interval: 5s
+      test: curl -s http://localhost:9200/_cluster/health | grep -vq '"status":"red"'
+      interval: 20s
       retries: 10
-  account:
-    image: hardcoreeng/account:v0.6.246
-    environment:
-      - SERVICE_URL_HULY_3000
-      - SERVER_PORT=3000
-      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
-      - MONGO_URL=mongodb://mongodb:27017
-      - TRANSACTOR_URL=ws://transactor:3333
-      - ENDPOINT_URL=ws://transactor:3333
-      - MINIO_ENDPOINT=minio
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadmin
-      - FRONT_URL=http://front:8080
-      - INIT_WORKSPACE=demo-tracker
-      - MODEL_ENABLED=*
-      - ACCOUNTS_URL=http://localhost:3000
-  front:
-    image: hardcoreeng/front:v0.6.246
-    environment:
-      - SERVICE_URL_HULY_8080
-      - MONGO_URL=mongodb://mongodb:27017
-      - SERVER_PORT=8080
-      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
-      - ACCOUNTS_URL=http://account:3000
-      - REKONI_URL=http://rekoni:4004
-      - CALENDAR_URL=http://localhost:8095
-      - GMAIL_URL=http://localhost:8088
-      - TELEGRAM_URL=http://localhost:8086
-      - UPLOAD_URL=/files
-      - TRANSACTOR_URL=ws://transactor:3333
-      - ELASTIC_URL=http://elastic:9200
-      - COLLABORATOR_URL=ws://collaborator:3078
-      - COLLABORATOR_API_URL=http://collaborator:3078
-      - MINIO_ENDPOINT=minio
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadmin
-      - TITLE=Huly Self Hosted
-      - DEFAULT_LANGUAGE=en
-      - LAST_NAME_FIRST=true
-    restart: unless-stopped
-  collaborator:
-    image: hardcoreeng/collaborator:v0.6.246
-    environment:
-      - COLLABORATOR_PORT=3078
-      - SECRET=secret
-      - ACCOUNTS_URL=http://account:3000
-      - TRANSACTOR_URL=ws://transactor:3333
-      - UPLOAD_URL=/files
-      - MONGO_URL=mongodb://mongodb:27017
-      - MINIO_ENDPOINT=minio
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadmin
-  transactor:
-    image: hardcoreeng/transactor:v0.6.246
-    environment:
-      - SERVER_PORT=3333
-      - ELASTIC_INDEX_NAME=huly
-      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
-      - SERVER_CURSOR_MAXTIMEMS=30000
-      - ELASTIC_URL=http://elastic:9200
-      - MONGO_URL=mongodb://mongodb:27017
-      - METRICS_CONSOLE=false
-      - METRICS_FILE=metrics.txt
-      - MINIO_ENDPOINT=minio
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadmin
-      - REKONI_URL=http://rekoni:4004
-      - FRONT_URL=http://localhost:8087
-      - SERVER_PROVIDER=ws
-      - ACCOUNTS_URL=http://account:3000
-      - LAST_NAME_FIRST=true
-      - UPLOAD_URL=/files
-    restart: unless-stopped
+
   rekoni:
-    image: hardcoreeng/rekoni-service:latest
+    image: hardcoreeng/rekoni-service:${HULY_VERSION:-v0.7.423}
+    environment:
+      SECRET: ${SERVICE_HEX_64_HULY}
     deploy:
       resources:
         limits:
           memory: 500M
+
+  transactor:
+    image: hardcoreeng/transactor:${HULY_VERSION:-v0.7.423}
+    environment:
+      <<: [*huly-common, *huly-database, *huly-storage]
+      SERVER_PORT: "3333"
+      FRONT_URL: ${SERVICE_URL_HULY}
+      ACCOUNTS_URL: http://account:3000
+      FULLTEXT_URL: http://fulltext:4700
+      LAST_NAME_FIRST: ${LAST_NAME_FIRST:-true}
+
+  collaborator:
+    image: hardcoreeng/collaborator:${HULY_VERSION:-v0.7.423}
+    environment:
+      <<: [*huly-common, *huly-storage]
+      COLLABORATOR_PORT: "3078"
+      SECRET: ${SERVICE_HEX_64_HULY}
+      ACCOUNTS_URL: http://account:3000
+
+  account:
+    image: hardcoreeng/account:${HULY_VERSION:-v0.7.423}
+    environment:
+      <<: [*huly-common, *huly-database, *huly-storage]
+      SERVER_PORT: "3000"
+      TRANSACTOR_URL: ws://transactor:3333;${HULY_WS_PROTOCOL:-wss}://${SERVICE_FQDN_HULY}/_transactor
+      FRONT_URL: ${SERVICE_URL_HULY}
+      STATS_URL: ${SERVICE_URL_HULY}/_stats
+      MODEL_ENABLED: "*"
+      ACCOUNTS_URL: ${SERVICE_URL_HULY}/_accounts
+      ACCOUNT_PORT: "3000"
+
+  workspace:
+    image: hardcoreeng/workspace:${HULY_VERSION:-v0.7.423}
+    environment:
+      <<: [*huly-common, *huly-database, *huly-storage]
+      TRANSACTOR_URL: ws://transactor:3333;${HULY_WS_PROTOCOL:-wss}://${SERVICE_FQDN_HULY}/_transactor
+      MODEL_ENABLED: "*"
+      ACCOUNTS_URL: http://account:3000
+      ACCOUNTS_DB_URL: postgres://${CR_USERNAME:-selfhost}:${SERVICE_PASSWORD_64_COCKROACH}@cockroach:26257/${CR_DATABASE:-defaultdb}
+    depends_on:
+      cockroach:
+        condition: service_healthy
+      redpanda:
+        condition: service_healthy
+
+  front:
+    image: hardcoreeng/front:${HULY_VERSION:-v0.7.423}
+    environment:
+      <<: *huly-storage
+      SERVER_PORT: "8080"
+      SERVER_SECRET: ${SERVICE_HEX_64_HULY}
+      LOVE_ENDPOINT: ${SERVICE_URL_HULY}/_love
+      ACCOUNTS_URL: ${SERVICE_URL_HULY}/_accounts
+      ACCOUNTS_URL_INTERNAL: http://account:3000
+      REKONI_URL: ${SERVICE_URL_HULY}/_rekoni
+      CALENDAR_URL: ${SERVICE_URL_HULY}/_calendar
+      GMAIL_URL: ${SERVICE_URL_HULY}/_gmail
+      TELEGRAM_URL: ${SERVICE_URL_HULY}/_telegram
+      STATS_URL: ${SERVICE_URL_HULY}/_stats
+      UPLOAD_URL: /files
+      ELASTIC_URL: http://elastic:9200
+      COLLABORATOR_URL: ${HULY_WS_PROTOCOL:-wss}://${SERVICE_FQDN_HULY}/_collaborator
+      TITLE: ${TITLE:-Huly Self Host}
+      DEFAULT_LANGUAGE: ${DEFAULT_LANGUAGE:-en}
+      LAST_NAME_FIRST: ${LAST_NAME_FIRST:-true}
+      DESKTOP_UPDATES_CHANNEL: ${DESKTOP_CHANNEL:-0.7.423}
+      DISABLED_FEATURES: auto-translate,mailboxes
+
+  fulltext:
+    image: hardcoreeng/fulltext:${HULY_VERSION:-v0.7.423}
+    environment:
+      <<: [*huly-common, *huly-database, *huly-storage]
+      FULLTEXT_DB_URL: http://elastic:9200
+      ELASTIC_INDEX_NAME: huly_storage_index
+      REKONI_URL: http://rekoni:4004
+      ACCOUNTS_URL: http://account:3000
+
+  stats:
+    image: hardcoreeng/stats:${HULY_VERSION:-v0.7.423}
+    environment:
+      PORT: "4900"
+      SERVER_SECRET: ${SERVICE_HEX_64_HULY}
+
+  kvs:
+    image: hardcoreeng/hulykvs:${HULY_VERSION:-v0.7.423}
+    environment:
+      HULY_DB_CONNECTION: postgres://${CR_USERNAME:-selfhost}:${SERVICE_PASSWORD_64_COCKROACH}@cockroach:26257/${CR_DATABASE:-defaultdb}
+      HULY_TOKEN_SECRET: ${SERVICE_HEX_64_HULY}
+    depends_on:
+      cockroach:
+        condition: service_healthy


### PR DESCRIPTION
## Changes

- Adds a current Huly one-click service template based on the official self-host Docker Compose stack.
- Includes the required app, database, object storage, search, queue, and supporting services.
- Uses Coolify-generated variables for the public URL and secrets.
- Leaves generated service template JSON files untouched because this repository blocks direct edits to those files.

## Issues

- Fixes #2543
- /claim #2543

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable: this is a service template addition.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Codex prepared the patch and validation steps.

## Testing

- `git diff --check`
- Parsed the Huly compose template and confirmed the expected services exist.

Not run locally: Docker Compose runtime validation, because Docker is not installed on this machine.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.