### PR TITLE
feat(auth): add OAuth-only self-registration controls

### DIFF
--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\ResetsUserPasswords;
 
 class ResetUserPassword implements ResetsUserPasswords
@@ -17,6 +18,12 @@ class ResetUserPassword implements ResetsUserPasswords
      */
     public function reset(User $user, array $input): void
     {
+        if (filled($user->oauth_provider) && instanceSettings()->disable_password_auth_for_oauth_users) {
+            throw ValidationException::withMessages([
+                'password' => __('Password authentication is disabled for OAuth users.'),
+            ]);
+        }
+
         Validator::make($input, [
             'password' => ['required', Password::defaults(), 'confirmed'],
         ])->validate();

--- a/app/Actions/Fortify/UpdateUserPassword.php
+++ b/app/Actions/Fortify/UpdateUserPassword.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\UpdatesUserPasswords;
 
 class UpdateUserPassword implements UpdatesUserPasswords
@@ -17,6 +18,12 @@ class UpdateUserPassword implements UpdatesUserPasswords
      */
     public function update(User $user, array $input): void
     {
+        if (filled($user->oauth_provider) && instanceSettings()->disable_password_auth_for_oauth_users) {
+            throw ValidationException::withMessages([
+                'password' => __('Password authentication is disabled for OAuth users.'),
+            ]);
+        }
+
         Validator::make($input, [
             'current_password' => ['required', 'string', 'current_password:web'],
             'password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -27,14 +27,19 @@ class OauthController extends Controller
             $user = User::whereEmail($email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! $settings->is_oauth_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 
                 $user = User::create([
                     'name' => $oauthUser->name,
                     'email' => $email,
+                    'oauth_provider' => $provider,
                 ]);
+            } elseif ($user->oauth_provider !== $provider) {
+                $user->forceFill([
+                    'oauth_provider' => $provider,
+                ])->save();
             }
             Auth::login($user);
 

--- a/app/Livewire/SettingsOauth.php
+++ b/app/Livewire/SettingsOauth.php
@@ -9,9 +9,13 @@ class SettingsOauth extends Component
 {
     public $oauth_settings_map;
 
+    public bool $is_oauth_registration_enabled = false;
+
+    public bool $disable_password_auth_for_oauth_users = false;
+
     protected function rules()
     {
-        return OauthSetting::all()->reduce(function ($carry, $setting) {
+        $rules = OauthSetting::all()->reduce(function ($carry, $setting) {
             $carry["oauth_settings_map.$setting->provider.enabled"] = 'required';
             $carry["oauth_settings_map.$setting->provider.client_id"] = 'nullable';
             $carry["oauth_settings_map.$setting->provider.client_secret"] = 'nullable';
@@ -21,6 +25,11 @@ class SettingsOauth extends Component
 
             return $carry;
         }, []);
+
+        return array_merge($rules, [
+            'is_oauth_registration_enabled' => 'boolean',
+            'disable_password_auth_for_oauth_users' => 'boolean',
+        ]);
     }
 
     public function mount()
@@ -28,6 +37,9 @@ class SettingsOauth extends Component
         if (! isInstanceAdmin()) {
             return redirect()->route('home');
         }
+        $settings = instanceSettings();
+        $this->is_oauth_registration_enabled = $settings->is_oauth_registration_enabled;
+        $this->disable_password_auth_for_oauth_users = $settings->disable_password_auth_for_oauth_users;
         $this->oauth_settings_map = OauthSetting::all()->sortBy('provider')->reduce(function ($carry, $setting) {
             $carry[$setting->provider] = [
                 'id' => $setting->id,
@@ -128,6 +140,14 @@ class SettingsOauth extends Component
         }
     }
 
+    private function updateInstanceSettings(): void
+    {
+        $settings = instanceSettings();
+        $settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
+        $settings->disable_password_auth_for_oauth_users = $this->disable_password_auth_for_oauth_users;
+        $settings->save();
+    }
+
     public function instantSave(string $provider)
     {
         try {
@@ -139,6 +159,7 @@ class SettingsOauth extends Component
 
     public function submit()
     {
+        $this->updateInstanceSettings();
         $this->updateOauthSettings();
         $this->dispatch('success', 'Instance settings updated successfully!');
     }

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -18,6 +18,8 @@ class InstanceSettings extends Model
         'do_not_track',
         'is_auto_update_enabled',
         'is_registration_enabled',
+        'is_oauth_registration_enabled',
+        'disable_password_auth_for_oauth_users',
         'next_channel',
         'smtp_enabled',
         'smtp_from_address',
@@ -64,6 +66,8 @@ class InstanceSettings extends Model
 
         'allowed_ip_ranges' => 'array',
         'is_auto_update_enabled' => 'boolean',
+        'is_oauth_registration_enabled' => 'boolean',
+        'disable_password_auth_for_oauth_users' => 'boolean',
         'auto_update_frequency' => 'string',
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -47,6 +47,7 @@ class User extends Authenticatable implements SendsEmail
         'name',
         'email',
         'password',
+        'oauth_provider',
         'force_password_reset',
         'marketing_emails',
         'pending_email',

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -7,6 +7,7 @@ use App\Actions\Fortify\ResetUserPassword;
 use App\Actions\Fortify\UpdateUserPassword;
 use App\Actions\Fortify\UpdateUserProfileInformation;
 use App\Models\OauthSetting;
+use App\Models\TeamInvitation;
 use App\Models\User;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
@@ -67,6 +68,7 @@ class FortifyServiceProvider extends ServiceProvider
 
             return view('auth.login', [
                 'is_registration_enabled' => $settings->is_registration_enabled,
+                'is_oauth_registration_enabled' => $settings->is_oauth_registration_enabled,
                 'enabled_oauth_providers' => $enabled_oauth_providers,
             ]);
         });
@@ -74,6 +76,10 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::authenticateUsing(function (Request $request) {
             $email = strtolower($request->email);
             $user = User::where('email', $email)->with('teams')->first();
+            if ($user && filled($user->oauth_provider) && instanceSettings()->disable_password_auth_for_oauth_users) {
+                return null;
+            }
+
             if (
                 $user &&
                 Hash::check($request->password, $user->password)
@@ -82,7 +88,7 @@ class FortifyServiceProvider extends ServiceProvider
                 $user->save();
 
                 // Check if user has a pending invitation they haven't accepted yet
-                $invitation = \App\Models\TeamInvitation::whereEmail($email)->first();
+                $invitation = TeamInvitation::whereEmail($email)->first();
                 if ($invitation && $invitation->isValid()) {
                     // User is logging in for the first time after being invited
                     // Attach them to the invited team if not already attached

--- a/database/migrations/2026_05_11_000000_add_oauth_registration_settings_to_instance_settings.php
+++ b/database/migrations/2026_05_11_000000_add_oauth_registration_settings_to_instance_settings.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_registration_enabled')->default(false)->after('is_registration_enabled');
+            $table->boolean('disable_password_auth_for_oauth_users')->default(false)->after('is_oauth_registration_enabled');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn([
+                'is_oauth_registration_enabled',
+                'disable_password_auth_for_oauth_users',
+            ]);
+        });
+    }
+};

--- a/database/migrations/2026_05_11_000001_add_oauth_provider_to_users_table.php
+++ b/database/migrations/2026_05_11_000001_add_oauth_provider_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('oauth_provider')->nullable()->after('password');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('oauth_provider');
+        });
+    }
+};

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -70,7 +70,7 @@
                             class="block w-full text-center py-3 px-4 rounded-lg border border-neutral-300 dark:border-coolgray-400 font-medium hover:border-coollabs dark:hover:border-warning transition-colors">
                             {{ __('auth.register_now') }}
                         </a>
-                    @else
+                    @elseif (!$is_oauth_registration_enabled || $enabled_oauth_providers->isEmpty())
                         <div class="mt-6 text-center text-sm text-neutral-500 dark:text-neutral-400">
                             {{ __('auth.registration_disabled') }}
                         </div>

--- a/resources/views/livewire/settings-oauth.blade.php
+++ b/resources/views/livewire/settings-oauth.blade.php
@@ -13,6 +13,12 @@
             </div>
             <div class="pb-4 ">Custom authentication (OAuth) configurations.</div>
         </div>
+        <div class="flex flex-col gap-2 py-4">
+            <x-forms.checkbox id="is_oauth_registration_enabled" label="Allow OAuth self-registration"
+                helper="Allow new users to create accounts through enabled OAuth providers even when normal registration is disabled." />
+            <x-forms.checkbox id="disable_password_auth_for_oauth_users" label="Disable password auth for OAuth users"
+                helper="Users who sign in through an OAuth provider cannot create or use passwords." />
+        </div>
         <div class="flex flex-col gap-2 pt-4">
             @foreach ($oauth_settings_map as $oauth_setting)
                 <div class="p-4 border dark:border-coolgray-300 border-neutral-200">

--- a/tests/Feature/OauthRegistrationSettingsTest.php
+++ b/tests/Feature/OauthRegistrationSettingsTest.php
@@ -1,0 +1,170 @@
+<?php
+
+use App\Actions\Fortify\ResetUserPassword;
+use App\Actions\Fortify\UpdateUserPassword;
+use App\Livewire\SettingsOauth;
+use App\Models\InstanceSettings;
+use App\Models\OauthSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
+use Laravel\Socialite\Facades\Socialite;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    config([
+        'app.maintenance.store' => 'array',
+        'cache.default' => 'array',
+    ]);
+
+    InstanceSettings::unguarded(function () {
+        InstanceSettings::query()->create([
+            'id' => 0,
+            'is_registration_enabled' => false,
+            'is_oauth_registration_enabled' => false,
+            'disable_password_auth_for_oauth_users' => false,
+        ]);
+    });
+
+    OauthSetting::query()->create([
+        'provider' => 'github',
+        'enabled' => true,
+        'client_id' => 'client-id',
+        'client_secret' => 'client-secret',
+        'redirect_uri' => 'http://localhost/auth/github/callback',
+    ]);
+
+    User::factory()->create([
+        'id' => 0,
+        'email' => 'admin@example.com',
+    ]);
+});
+
+it('allows oauth registration when password registration is disabled', function () {
+    instanceSettings()->update([
+        'is_oauth_registration_enabled' => true,
+    ]);
+
+    Socialite::shouldReceive('buildProvider')
+        ->once()
+        ->andReturn(new class
+        {
+            public function user(): object
+            {
+                return (object) [
+                    'name' => 'OAuth User',
+                    'email' => 'oauth@example.com',
+                ];
+            }
+        });
+
+    $response = $this->get(route('auth.callback', 'github'));
+
+    $response->assertRedirect('/');
+    $this->assertAuthenticated();
+    $this->assertDatabaseHas('users', [
+        'email' => 'oauth@example.com',
+        'oauth_provider' => 'github',
+        'password' => null,
+    ]);
+});
+
+it('keeps oauth registration disabled unless it is explicitly enabled', function () {
+    Socialite::shouldReceive('buildProvider')
+        ->once()
+        ->andReturn(new class
+        {
+            public function user(): object
+            {
+                return (object) [
+                    'name' => 'OAuth User',
+                    'email' => 'oauth@example.com',
+                ];
+            }
+        });
+
+    $response = $this->get(route('auth.callback', 'github'));
+
+    $response->assertRedirect(route('login'));
+    $this->assertGuest();
+    expect(User::whereEmail('oauth@example.com')->exists())->toBeFalse();
+});
+
+it('blocks password login for oauth users when password auth is disabled', function () {
+    instanceSettings()->update([
+        'disable_password_auth_for_oauth_users' => true,
+    ]);
+
+    User::factory()->create([
+        'email' => 'oauth@example.com',
+        'password' => Hash::make('password'),
+        'oauth_provider' => 'github',
+    ]);
+
+    $response = $this->post('/login', [
+        'email' => 'oauth@example.com',
+        'password' => 'password',
+    ]);
+
+    $response->assertSessionHasErrors();
+    $this->assertGuest();
+});
+
+it('blocks password reset for oauth users when password auth is disabled', function () {
+    instanceSettings()->update([
+        'disable_password_auth_for_oauth_users' => true,
+    ]);
+
+    $user = User::factory()->create([
+        'password' => null,
+        'oauth_provider' => 'github',
+    ]);
+
+    expect(fn () => app(ResetUserPassword::class)->reset($user, [
+        'password' => 'Password1!@',
+        'password_confirmation' => 'Password1!@',
+    ]))->toThrow(ValidationException::class);
+
+    expect($user->fresh()->password)->toBeNull();
+});
+
+it('blocks password changes for oauth users when password auth is disabled', function () {
+    instanceSettings()->update([
+        'disable_password_auth_for_oauth_users' => true,
+    ]);
+
+    $user = User::factory()->create([
+        'password' => Hash::make('password'),
+        'oauth_provider' => 'github',
+    ]);
+
+    expect(fn () => app(UpdateUserPassword::class)->update($user, [
+        'current_password' => 'password',
+        'password' => 'Password1!@',
+        'password_confirmation' => 'Password1!@',
+    ]))->toThrow(ValidationException::class);
+
+    expect(Hash::check('password', $user->fresh()->password))->toBeTrue();
+});
+
+it('persists oauth registration controls from the oauth settings page', function () {
+    $admin = User::findOrFail(0);
+
+    $this->actingAs($admin);
+    session(['currentTeam' => ['id' => 0]]);
+
+    Livewire::test(SettingsOauth::class)
+        ->set('is_oauth_registration_enabled', true)
+        ->set('disable_password_auth_for_oauth_users', true)
+        ->call('submit')
+        ->assertDispatched('success');
+
+    $this->assertDatabaseHas('instance_settings', [
+        'id' => 0,
+        'is_oauth_registration_enabled' => true,
+        'disable_password_auth_for_oauth_users' => true,
+    ]);
+});


### PR DESCRIPTION
/claim #8042

## Changes

- Allows instance admins to enable OAuth self-registration while standard email/password registration stays disabled.
- Stores the OAuth provider on users who authenticate through an OAuth provider.
- Adds an instance setting that blocks password login, password reset, and password change flows for OAuth users when enabled.
- Keeps the login page from saying registration is disabled when OAuth self-registration is available.

## Issues

- Fixes #8042

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not included. The change is in authentication/settings behavior and is covered by focused feature tests.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Codex implemented the patch and tests under the account owner's direction. The result was checked with formatting, syntax checks, and focused feature tests.

## Testing

- Ran vendor/bin/pint --dirty --format agent
- Ran php artisan test --compact tests/Feature/OauthRegistrationSettingsTest.php
- Ran docker exec coolify php artisan test --compact tests/Feature/OauthRegistrationSettingsTest.php
- Ran php -l on changed PHP files
- Ran git diff --check HEAD~1 HEAD
- Started the local Coolify development stack with OrbStack and Spin
- Confirmed Coolify containers are healthy and http://localhost:8000 responds by redirecting to /login

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
