### PR TITLE
Add container info to resource operations

### DIFF
--- a/app/Livewire/Project/Shared/ContainerInfo.php
+++ b/app/Livewire/Project/Shared/ContainerInfo.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace App\Livewire\Project\Shared;
+
+use App\Models\Application;
+use App\Models\Server;
+use App\Models\Service;
+use App\Models\ServiceApplication;
+use App\Models\ServiceDatabase;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+use Livewire\Component;
+
+class ContainerInfo extends Component
+{
+    public $resource;
+
+    public array $containers = [];
+
+    public ?string $error = null;
+
+    public function mount(mixed $resource): void
+    {
+        $this->resource = $resource;
+        $this->loadContainers();
+    }
+
+    public function loadContainers(): void
+    {
+        $this->containers = [];
+        $this->error = null;
+
+        try {
+            $server = $this->resolveServer();
+            if (! $server) {
+                $this->error = 'No server found for this resource.';
+
+                return;
+            }
+
+            if ($server->isSwarm()) {
+                $this->error = 'Container information is currently available for Docker standalone resources.';
+
+                return;
+            }
+
+            $labels = $this->dockerFilterLabels();
+            if ($labels === []) {
+                $this->error = 'Container information is not available for this resource type.';
+
+                return;
+            }
+
+            $this->containers = $this->inspectContainersByLabels($server, $labels)
+                ->map(fn (array $container) => $this->formatContainer($container))
+                ->values()
+                ->all();
+        } catch (\Throwable $e) {
+            Log::error('Failed to load container information: '.$e->getMessage(), [
+                'resource_type' => $this->resource?->getMorphClass(),
+                'resource_id' => $this->resource?->id,
+            ]);
+
+            $this->error = 'Unable to load container information.';
+        }
+    }
+
+    private function resolveServer(): ?Server
+    {
+        if ($this->resource instanceof ServiceApplication || $this->resource instanceof ServiceDatabase) {
+            return $this->resource->service?->server;
+        }
+
+        return data_get($this->resource, 'server') ?? data_get($this->resource, 'destination.server');
+    }
+
+    private function dockerFilterLabels(): array
+    {
+        if ($this->resource->getMorphClass() === Application::class) {
+            return ["coolify.applicationId={$this->resource->id}"];
+        }
+
+        if ($this->resource->getMorphClass() === Service::class) {
+            return ["coolify.serviceId={$this->resource->id}"];
+        }
+
+        if ($this->resource->getMorphClass() === ServiceApplication::class) {
+            return [
+                "coolify.serviceId={$this->resource->service_id}",
+                "coolify.service.subType=application",
+                "coolify.service.subId={$this->resource->id}",
+            ];
+        }
+
+        if ($this->resource->getMorphClass() === ServiceDatabase::class) {
+            return [
+                "coolify.serviceId={$this->resource->service_id}",
+                "coolify.service.subType=database",
+                "coolify.service.subId={$this->resource->id}",
+            ];
+        }
+
+        if (method_exists($this->resource, 'type') && str($this->resource->type())->startsWith('standalone-')) {
+            return ["com.docker.compose.service={$this->resource->uuid}"];
+        }
+
+        return [];
+    }
+
+    private function inspectContainersByLabels(Server $server, array $labels): Collection
+    {
+        $filters = collect($labels)
+            ->map(fn (string $label) => '--filter '.escapeshellarg("label={$label}"))
+            ->implode(' ');
+
+        $command = "ids=\$(docker container ls -aq {$filters}); if [ -n \"\$ids\" ]; then docker container inspect \$ids --format '{{json .}}'; fi";
+        $output = instant_remote_process([$command], $server, false) ?? '';
+
+        return format_docker_command_output_to_json($output)->filter();
+    }
+
+    private function formatContainer(array $container): array
+    {
+        $labels = data_get($container, 'Config.Labels', []);
+        $status = data_get($container, 'State.Status', 'unknown');
+        $health = data_get($container, 'State.Health.Status');
+
+        return [
+            'id' => data_get($container, 'Id'),
+            'short_id' => substr((string) data_get($container, 'Id'), 0, 12),
+            'name' => ltrim((string) data_get($container, 'Name'), '/'),
+            'image' => data_get($container, 'Config.Image') ?? data_get($container, 'Image'),
+            'compose_service' => data_get($labels, 'com.docker.compose.service')
+                ?? data_get($labels, 'coolify.serviceName')
+                ?? data_get($labels, 'coolify.name'),
+            'status' => $health ? "{$status}:{$health}" : $status,
+            'restart_count' => data_get($container, 'RestartCount', 0),
+            'ports' => $this->formatPorts(data_get($container, 'NetworkSettings.Ports') ?? []),
+            'networks' => $this->formatNetworks(data_get($container, 'NetworkSettings.Networks') ?? []),
+        ];
+    }
+
+    private function formatPorts(array $ports): array
+    {
+        return collect($ports)
+            ->flatMap(function ($bindings, string $containerPort) {
+                if (blank($bindings)) {
+                    return [$containerPort];
+                }
+
+                return collect($bindings)->map(function (array $binding) use ($containerPort) {
+                    $hostIp = data_get($binding, 'HostIp', '0.0.0.0');
+                    $hostPort = data_get($binding, 'HostPort');
+
+                    return "{$hostIp}:{$hostPort}->{$containerPort}";
+                });
+            })
+            ->values()
+            ->all();
+    }
+
+    private function formatNetworks(array $networks): array
+    {
+        return collect($networks)
+            ->map(fn (array $network, string $name) => [
+                'name' => $name,
+                'ip_address' => data_get($network, 'IPAddress'),
+                'gateway' => data_get($network, 'Gateway'),
+            ])
+            ->values()
+            ->all();
+    }
+
+    public function render()
+    {
+        return view('livewire.project.shared.container-info');
+    }
+}

--- a/resources/views/livewire/project/shared/container-info.blade.php
+++ b/resources/views/livewire/project/shared/container-info.blade.php
@@ -1,0 +1,83 @@
+<div class="py-8">
+    <div class="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+            <h3>Container Information</h3>
+            <div class="pb-2">Inspect running and stopped containers, exposed ports, and Docker networks for this resource.</div>
+        </div>
+        <x-forms.button wire:click="loadContainers" wire:loading.attr="disabled" wire:target="loadContainers">
+            Refresh
+        </x-forms.button>
+    </div>
+
+    @if ($error)
+        <x-callout type="warning" title="Container information unavailable">
+            {{ $error }}
+        </x-callout>
+    @elseif (count($containers) === 0)
+        <x-callout type="info" title="No containers found">
+            Deploy this resource to see container and network information.
+        </x-callout>
+    @else
+        <div class="overflow-x-auto">
+            <div class="inline-block min-w-full">
+                <div class="overflow-hidden">
+                    <table class="min-w-full">
+                        <thead>
+                            <tr>
+                                <th class="px-5 py-3 text-xs font-medium text-left uppercase">Container</th>
+                                <th class="px-5 py-3 text-xs font-medium text-left uppercase">Image</th>
+                                <th class="px-5 py-3 text-xs font-medium text-left uppercase">Status</th>
+                                <th class="px-5 py-3 text-xs font-medium text-left uppercase">Ports</th>
+                                <th class="px-5 py-3 text-xs font-medium text-left uppercase">Networks</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($containers as $container)
+                                <tr>
+                                    <td class="px-5 py-4 text-sm align-top dark:text-white">
+                                        <div class="font-bold">{{ $container['name'] ?: $container['short_id'] }}</div>
+                                        <div class="text-xs text-neutral-600 dark:text-neutral-400">{{ $container['short_id'] }}</div>
+                                        @if ($container['compose_service'])
+                                            <div class="text-xs text-neutral-600 dark:text-neutral-400">{{ $container['compose_service'] }}</div>
+                                        @endif
+                                    </td>
+                                    <td class="px-5 py-4 text-sm align-top dark:text-white">
+                                        {{ $container['image'] ?: '-' }}
+                                    </td>
+                                    <td class="px-5 py-4 text-sm align-top whitespace-nowrap dark:text-white">
+                                        <div>{{ $container['status'] }}</div>
+                                        <div class="text-xs text-neutral-600 dark:text-neutral-400">
+                                            Restarts: {{ $container['restart_count'] }}
+                                        </div>
+                                    </td>
+                                    <td class="px-5 py-4 text-sm align-top dark:text-white">
+                                        @forelse ($container['ports'] as $port)
+                                            <div>{{ $port }}</div>
+                                        @empty
+                                            -
+                                        @endforelse
+                                    </td>
+                                    <td class="px-5 py-4 text-sm align-top dark:text-white">
+                                        @forelse ($container['networks'] as $network)
+                                            <div class="pb-2">
+                                                <div class="font-medium">{{ $network['name'] }}</div>
+                                                <div class="text-xs text-neutral-600 dark:text-neutral-400">
+                                                    IP: {{ $network['ip_address'] ?: '-' }}
+                                                    @if ($network['gateway'])
+                                                        | Gateway: {{ $network['gateway'] }}
+                                                    @endif
+                                                </div>
+                                            </div>
+                                        @empty
+                                            -
+                                        @endforelse
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/project/shared/resource-operations.blade.php
+++ b/resources/views/livewire/project/shared/resource-operations.blade.php
@@ -1,6 +1,7 @@
 <div>
     <h2>Resource Operations</h2>
     <div>You can easily make different kind of operations on this resource.</div>
+    <livewire:project.shared.container-info :resource="$resource" />
 
     <div x-data="{
         selectedCloneServer: null,


### PR DESCRIPTION
## Changes

- Added a shared ContainerInfo Livewire component to show Docker container details in Resource Operations.
- The component looks up containers by existing Coolify Docker labels and displays container name, short ID, image, status, restart count, exposed ports, and Docker network details.
- Reuses the existing Resource Operations page so the information is available for applications, services, service subresources, and standalone databases.

## Issues

- Fixes #2495

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not available from my local environment. The change adds a Container Information section to the existing Resource Operations page.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Used to help implement the Livewire component and prepare the PR. The changes were reviewed before submission.

## Testing

- Ran `php -l app/Livewire/Project/Shared/ContainerInfo.php`
- Ran `git diff --check`

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.