### PR TITLE
feat(auth): add OAuth-only authentication settings

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -19,7 +19,7 @@ class CreateNewUser implements CreatesNewUsers
     public function create(array $input): User
     {
         $settings = instanceSettings();
-        if (! $settings->is_registration_enabled) {
+        if (! $settings->is_registration_enabled || $settings->is_password_auth_disabled) {
             abort(403);
         }
         Validator::make($input, [

--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -17,6 +17,10 @@ class ResetUserPassword implements ResetsUserPasswords
      */
     public function reset(User $user, array $input): void
     {
+        if (instanceSettings()->is_password_auth_disabled) {
+            abort(403);
+        }
+
         Validator::make($input, [
             'password' => ['required', Password::defaults(), 'confirmed'],
         ])->validate();

--- a/app/Actions/Fortify/UpdateUserPassword.php
+++ b/app/Actions/Fortify/UpdateUserPassword.php
@@ -17,6 +17,10 @@ class UpdateUserPassword implements UpdatesUserPasswords
      */
     public function update(User $user, array $input): void
     {
+        if (instanceSettings()->is_password_auth_disabled) {
+            abort(403);
+        }
+
         Validator::make($input, [
             'current_password' => ['required', 'string', 'current_password:web'],
             'password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -27,8 +27,8 @@ class OauthController extends Controller
             $user = User::whereEmail($email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
-                    abort(403, 'Registration is disabled');
+                if (! $settings->is_registration_enabled && ! $settings->is_oauth_registration_enabled) {
+                    abort(403, 'OAuth registration is disabled');
                 }
 
                 $user = User::create([

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -16,6 +16,12 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $is_oauth_registration_enabled;
+
+    #[Validate('boolean')]
+    public bool $is_password_auth_disabled;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -44,6 +50,8 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_registration_enabled' => 'boolean',
+            'is_password_auth_disabled' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => ['nullable', 'string', new ValidDnsServers],
@@ -66,6 +74,8 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled;
+        $this->is_password_auth_disabled = $this->settings->is_password_auth_disabled;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -147,6 +157,8 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
+            $this->settings->is_password_auth_disabled = $this->is_password_auth_disabled;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -18,6 +18,8 @@ class InstanceSettings extends Model
         'do_not_track',
         'is_auto_update_enabled',
         'is_registration_enabled',
+        'is_oauth_registration_enabled',
+        'is_password_auth_disabled',
         'next_channel',
         'smtp_enabled',
         'smtp_from_address',
@@ -64,6 +66,9 @@ class InstanceSettings extends Model
 
         'allowed_ip_ranges' => 'array',
         'is_auto_update_enabled' => 'boolean',
+        'is_registration_enabled' => 'boolean',
+        'is_oauth_registration_enabled' => 'boolean',
+        'is_password_auth_disabled' => 'boolean',
         'auto_update_frequency' => 'string',
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -47,7 +47,7 @@ class FortifyServiceProvider extends ServiceProvider
             $isFirstUser = User::count() === 0;
 
             $settings = instanceSettings();
-            if (! $settings->is_registration_enabled) {
+            if (! $settings->is_registration_enabled || $settings->is_password_auth_disabled) {
                 return redirect()->route('login');
             }
 
@@ -67,11 +67,16 @@ class FortifyServiceProvider extends ServiceProvider
 
             return view('auth.login', [
                 'is_registration_enabled' => $settings->is_registration_enabled,
+                'is_password_auth_disabled' => $settings->is_password_auth_disabled,
                 'enabled_oauth_providers' => $enabled_oauth_providers,
             ]);
         });
 
         Fortify::authenticateUsing(function (Request $request) {
+            if (instanceSettings()->is_password_auth_disabled) {
+                return null;
+            }
+
             $email = strtolower($request->email);
             $user = User::where('email', $email)->with('teams')->first();
             if (

--- a/database/migrations/2026_05_12_000000_add_oauth_auth_settings_to_instance_settings.php
+++ b/database/migrations/2026_05_12_000000_add_oauth_auth_settings_to_instance_settings.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_registration_enabled')->default(false);
+            $table->boolean('is_password_auth_disabled')->default(false);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn([
+                'is_oauth_registration_enabled',
+                'is_password_auth_disabled',
+            ]);
+        });
+    }
+};

--- a/database/schema/testing-schema.sql
+++ b/database/schema/testing-schema.sql
@@ -391,6 +391,8 @@ CREATE TABLE IF NOT EXISTS "instance_settings" (
     "do_not_track" INTEGER DEFAULT false NOT NULL,
     "is_auto_update_enabled" INTEGER DEFAULT true NOT NULL,
     "is_registration_enabled" INTEGER DEFAULT true NOT NULL,
+    "is_oauth_registration_enabled" INTEGER DEFAULT false NOT NULL,
+    "is_password_auth_disabled" INTEGER DEFAULT false NOT NULL,
     "created_at" TEXT,
     "updated_at" TEXT,
     "next_channel" INTEGER DEFAULT false NOT NULL,

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -29,33 +29,39 @@
                         </div>
                     @endif
 
-                    <form action="/login" method="POST" class="flex flex-col gap-4">
-                        @csrf
-                        @env('local')
-                            <x-forms.input value="test@example.com" type="email" autocomplete="email" name="email" required
-                                label="{{ __('input.email') }}" />
-                            <x-forms.input value="password" type="password" autocomplete="current-password" name="password"
-                                required label="{{ __('input.password') }}" />
-                        @else
-                            <x-forms.input type="email" name="email" autocomplete="email" required
-                                label="{{ __('input.email') }}" />
-                            <x-forms.input type="password" name="password" autocomplete="current-password" required
-                                label="{{ __('input.password') }}" />
-                        @endenv
+                    @if (! $is_password_auth_disabled)
+                        <form action="/login" method="POST" class="flex flex-col gap-4">
+                            @csrf
+                            @env('local')
+                                <x-forms.input value="test@example.com" type="email" autocomplete="email" name="email" required
+                                    label="{{ __('input.email') }}" />
+                                <x-forms.input value="password" type="password" autocomplete="current-password" name="password"
+                                    required label="{{ __('input.password') }}" />
+                            @else
+                                <x-forms.input type="email" name="email" autocomplete="email" required
+                                    label="{{ __('input.email') }}" />
+                                <x-forms.input type="password" name="password" autocomplete="current-password" required
+                                    label="{{ __('input.password') }}" />
+                            @endenv
 
-                        <div class="flex items-center justify-between">
-                            <a href="/forgot-password"
-                                class="text-sm dark:text-neutral-400 hover:text-coollabs dark:hover:text-warning hover:underline transition-colors">
-                                {{ __('auth.forgot_password_link') }}
-                            </a>
+                            <div class="flex items-center justify-between">
+                                <a href="/forgot-password"
+                                    class="text-sm dark:text-neutral-400 hover:text-coollabs dark:hover:text-warning hover:underline transition-colors">
+                                    {{ __('auth.forgot_password_link') }}
+                                </a>
+                            </div>
+
+                            <x-forms.button class="w-full justify-center py-3 box-boarding" type="submit" isHighlighted>
+                                {{ __('auth.login') }}
+                            </x-forms.button>
+                        </form>
+                    @else
+                        <div class="mb-6 p-4 bg-warning/10 border border-warning rounded-lg">
+                            <p class="text-sm text-warning">Password login is disabled. Continue with an OAuth provider.</p>
                         </div>
+                    @endif
 
-                        <x-forms.button class="w-full justify-center py-3 box-boarding" type="submit" isHighlighted>
-                            {{ __('auth.login') }}
-                        </x-forms.button>
-                    </form>
-
-                    @if ($is_registration_enabled)
+                    @if ($is_registration_enabled && ! $is_password_auth_disabled)
                         <div class="relative my-6">
                             <div class="absolute inset-0 flex items-center">
                                 <div class="w-full border-t border-neutral-300 dark:border-coolgray-400"></div>

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -41,6 +41,17 @@
                                 shortConfirmationLabel="Confirmation text" />
                         </div>
                     @endif
+                    <h4 class="pt-4">Authentication Settings</h4>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_registration_enabled"
+                            helper="Allow new users to self-register through enabled OAuth providers even when general password registration is disabled."
+                            label="OAuth Registration Allowed" />
+                    </div>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_password_auth_disabled"
+                            helper="Disable password login, password resets, and password changes. Users must sign in through an enabled OAuth provider."
+                            label="OAuth Only Login" />
+                    </div>
                     <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"
                             helper="Opt out of anonymous usage tracking. When enabled, this instance will not report to coolify.io's installation count and will not send error reports to help improve Coolify."

--- a/tests/Feature/OauthAuthSettingsTest.php
+++ b/tests/Feature/OauthAuthSettingsTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use App\Actions\Fortify\CreateNewUser;
+use App\Livewire\Settings\Advanced;
+use App\Models\InstanceSettings;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Once;
+use Livewire\Livewire;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::create(['id' => 0]);
+});
+
+test('password login can be disabled for oauth only instances', function () {
+    instanceSettings()->update(['is_password_auth_disabled' => true]);
+    Once::flush();
+
+    User::factory()->create([
+        'id' => 0,
+        'email' => 'test@example.com',
+        'password' => Hash::make('password'),
+    ]);
+
+    $this->post('/login', [
+        'email' => 'test@example.com',
+        'password' => 'password',
+    ])->assertSessionHasErrors();
+
+    $this->assertGuest();
+});
+
+test('password registration is unavailable when oauth only login is enabled', function () {
+    instanceSettings()->update([
+        'is_registration_enabled' => true,
+        'is_password_auth_disabled' => true,
+    ]);
+    Once::flush();
+
+    $this->get('/register')->assertRedirect(route('login'));
+
+    app(CreateNewUser::class)->create([
+        'name' => 'Test User',
+        'email' => 'test@example.com',
+        'password' => 'Password1!@',
+        'password_confirmation' => 'Password1!@',
+    ]);
+})->throws(HttpException::class);
+
+test('advanced settings can enable oauth registration separately from password registration', function () {
+    $rootTeam = Team::find(0) ?? Team::factory()->create(['id' => 0]);
+    $user = User::factory()->create();
+    $rootTeam->members()->attach($user->id, ['role' => 'admin']);
+
+    $this->actingAs($user);
+    session(['currentTeam' => ['id' => $rootTeam->id]]);
+
+    Livewire::test(Advanced::class)
+        ->set('is_registration_enabled', false)
+        ->set('is_oauth_registration_enabled', true)
+        ->set('is_password_auth_disabled', true)
+        ->call('instantSave')
+        ->assertDispatched('success');
+
+    $settings = instanceSettings()->fresh();
+
+    expect($settings->is_registration_enabled)->toBeFalse()
+        ->and($settings->is_oauth_registration_enabled)->toBeTrue()
+        ->and($settings->is_password_auth_disabled)->toBeTrue();
+});


### PR DESCRIPTION
## Changes

- Added separate instance settings for OAuth self-registration and OAuth-only login.
- OAuth callback can now create users when password registration is disabled but OAuth registration is enabled.
- OAuth-only mode disables password login, password registration, password reset, and password changes.
- Added Advanced settings controls and feature tests for the new auth settings.

## Issues

- Fixes #8042
- Replaces #10144, which was closed by the PR quality bot because it targeted `v4.x` and did not use the PR template.

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No preview available from this environment. The UI change is limited to two checkboxes under Advanced > Authentication Settings.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex
- How extensively: AI helped prepare the patch, inspect the existing auth flow, and draft tests. The submitted changes are intentionally scoped to the requested OAuth registration/authentication settings.

## Testing

- `git diff --check origin/next..HEAD`
- Could not run Pest locally because PHP and Composer are not available in this environment.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
