### PR TITLE
docs: clarify Supabase MCP private access

### DIFF
--- a/templates/compose/supabase.yaml
+++ b/templates/compose/supabase.yaml
@@ -426,7 +426,7 @@ services:
                     status_code: 403
                     message: "Access is forbidden."
 
-            ## MCP endpoint - local access
+            ## MCP endpoint - private/local access only
             - name: mcp
               _comment: 'MCP: /mcp -> http://supabase-studio:3000/api/mcp (local access)'
               url: http://supabase-studio:3000/api/mcp
@@ -441,10 +441,12 @@ services:
                   config:
                     status_code: 403
                     message: "Access is forbidden."
-                # Enable local access (danger zone!)
+                # Enable private access only (danger zone!)
                 # 1. Comment out the 'request-termination' section above
                 # 2. Uncomment the entire section below, including 'deny'
-                # 3. Add your local IPs to the 'allow' list
+                # 3. Add only your private tunnel, WireGuard, or Docker gateway IPs to 'allow'
+                # 4. Keep one tunnel/local port per Supabase instance to avoid connecting to the wrong project
+                # See the Supabase service documentation for the complete MCP workaround guide.
                 #- name: cors
                 #- name: ip-restriction
                 #  config:


### PR DESCRIPTION
## Summary

- Clarifies that the Supabase MCP Kong route should only be enabled for private/local access.
- Adds safety notes for private tunnel, WireGuard, and Docker gateway allowlists.
- Notes that multiple Supabase instances should use separate tunnel/local ports to avoid connecting MCP clients to the wrong project.

This is a companion PR for the full documentation workaround in https://github.com/coollabsio/coolify-docs/pull/596.

/claim #7458

## Checks

- `git diff --check`
