### PR TITLE
fix: create Docker networks with IPv6 fallback

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -98,11 +98,11 @@ class InstallDocker
             ]);
             if ($server->isSwarm()) {
                 $command = $command->merge([
-                    'docker network create --attachable --driver overlay coolify-overlay >/dev/null 2>&1 || true',
+                    dockerNetworkCreateCommand('coolify-overlay', isSwarm: true, quiet: true).' || true',
                 ]);
             } else {
                 $command = $command->merge([
-                    'docker network create --attachable coolify >/dev/null 2>&1 || true',
+                    dockerNetworkCreateCommand('coolify', quiet: true).' || true',
                 ]);
                 $command = $command->merge([
                     "echo 'Done!'",

--- a/app/Actions/Service/StartService.php
+++ b/app/Actions/Service/StartService.php
@@ -33,7 +33,7 @@ class StartService
         }
         if ($service->networks()->count() > 0) {
             $commands[] = "echo 'Creating Docker network.'";
-            $commands[] = "docker network inspect $service->uuid >/dev/null 2>&1 || docker network create --attachable $service->uuid";
+            $commands[] = "docker network inspect $service->uuid >/dev/null 2>&1 || ".dockerNetworkCreateCommand($service->uuid);
         }
         $commands[] = 'echo Starting service.';
         $commands[] = "docker compose --project-directory {$workdir} -f {$workdir}/docker-compose.yml --project-name {$service->uuid} up -d --remove-orphans --force-recreate --build";

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -793,7 +793,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             // TODO
         } else {
             $this->execute_remote_command([
-                "docker network inspect '{$networkId}' >/dev/null 2>&1 || docker network create --attachable '{$networkId}' >/dev/null || true",
+                "docker network inspect '{$networkId}' >/dev/null 2>&1 || ".dockerNetworkCreateCommand($networkId, quiet: true)." || true",
                 'hidden' => true,
                 'ignore_errors' => true,
             ], [

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -1406,9 +1406,9 @@ $schema://$host {
             return;
         }
         if ($isSwarm) {
-            return instant_remote_process(['docker network create --attachable --driver overlay coolify-overlay >/dev/null 2>&1 || true'], $this, false);
+            return instant_remote_process([dockerNetworkCreateCommand('coolify-overlay', isSwarm: true, quiet: true).' || true'], $this, false);
         } else {
-            return instant_remote_process(['docker network create coolify --attachable >/dev/null 2>&1 || true'], $this, false);
+            return instant_remote_process([dockerNetworkCreateCommand('coolify', quiet: true).' || true'], $this, false);
         }
     }
 

--- a/app/Models/StandaloneDocker.php
+++ b/app/Models/StandaloneDocker.php
@@ -25,7 +25,7 @@ class StandaloneDocker extends BaseModel
             $server = $newStandaloneDocker->server;
             $safeNetwork = escapeshellarg($newStandaloneDocker->network);
             instant_remote_process([
-                "docker network inspect {$safeNetwork} >/dev/null 2>&1 || docker network create --driver overlay --attachable {$safeNetwork} >/dev/null",
+                "docker network inspect {$safeNetwork} >/dev/null 2>&1 || ".dockerNetworkCreateCommand($newStandaloneDocker->network, isSwarm: true, quiet: true),
             ], $server, false);
             ConnectProxyToNetworksJob::dispatchSync($server);
         });

--- a/bootstrap/helpers/proxy.php
+++ b/bootstrap/helpers/proxy.php
@@ -21,6 +21,15 @@ function isDockerPredefinedNetwork(string $network): bool
     return in_array($network, ['default', 'host'], true);
 }
 
+function dockerNetworkCreateCommand(string $network, bool $isSwarm = false, bool $quiet = false): string
+{
+    $safe = escapeshellarg($network);
+    $driver = $isSwarm ? '--driver overlay ' : '';
+    $fallbackOutput = $quiet ? ' >/dev/null 2>&1' : '';
+
+    return "docker network create --ipv6 {$driver}--attachable {$safe} >/dev/null 2>&1 || docker network create {$driver}--attachable {$safe}{$fallbackOutput}";
+}
+
 function collectProxyDockerNetworksByServer(Server $server)
 {
     if (! $server->isFunctional()) {
@@ -111,7 +120,7 @@ function connectProxyToNetworks(Server $server)
         $commands = $networks->map(function ($network) {
             $safe = escapeshellarg($network);
             return [
-                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || docker network create --driver overlay --attachable {$safe} >/dev/null",
+                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || ".dockerNetworkCreateCommand($network, isSwarm: true, quiet: true),
                 "docker network connect {$safe} coolify-proxy >/dev/null 2>&1 || true",
                 "echo 'Successfully connected coolify-proxy to {$safe} network.'",
             ];
@@ -120,7 +129,7 @@ function connectProxyToNetworks(Server $server)
         $commands = $networks->map(function ($network) {
             $safe = escapeshellarg($network);
             return [
-                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || docker network create --attachable {$safe} >/dev/null",
+                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || ".dockerNetworkCreateCommand($network, quiet: true),
                 "docker network connect {$safe} coolify-proxy >/dev/null 2>&1 || true",
                 "echo 'Successfully connected coolify-proxy to {$safe} network.'",
             ];
@@ -146,7 +155,7 @@ function ensureProxyNetworksExist(Server $server)
             $safe = escapeshellarg($network);
             return [
                 "echo 'Ensuring network {$safe} exists...'",
-                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --driver overlay --attachable {$safe}",
+                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || ".dockerNetworkCreateCommand($network, isSwarm: true),
             ];
         });
     } else {
@@ -154,7 +163,7 @@ function ensureProxyNetworksExist(Server $server)
             $safe = escapeshellarg($network);
             return [
                 "echo 'Ensuring network {$safe} exists...'",
-                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --attachable {$safe}",
+                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || ".dockerNetworkCreateCommand($network),
             ];
         });
     }

--- a/tests/Unit/ProxyHelperTest.php
+++ b/tests/Unit/ProxyHelperTest.php
@@ -189,3 +189,34 @@ it('identifies none as not predefined (per codebase pattern)', function () {
     // only filters 'default' and 'host', so we maintain consistency
     expect(isDockerPredefinedNetwork('none'))->toBeFalse();
 });
+
+
+it('builds standalone network create commands with IPv6 fallback', function () {
+    $command = dockerNetworkCreateCommand('coolify');
+
+    expect($command)
+        ->toContain('docker network create --ipv6 --attachable coolify >/dev/null 2>&1')
+        ->toContain('|| docker network create --attachable coolify');
+});
+
+it('builds swarm overlay network create commands with IPv6 fallback', function () {
+    $command = dockerNetworkCreateCommand('coolify-overlay', isSwarm: true);
+
+    expect($command)
+        ->toContain('docker network create --ipv6 --driver overlay --attachable coolify-overlay >/dev/null 2>&1')
+        ->toContain('|| docker network create --driver overlay --attachable coolify-overlay');
+});
+
+it('can silence the fallback network create command', function () {
+    $command = dockerNetworkCreateCommand('coolify', quiet: true);
+
+    expect($command)->toEndWith('|| docker network create --attachable coolify >/dev/null 2>&1');
+});
+
+it('shell escapes network names in network create commands', function () {
+    $command = dockerNetworkCreateCommand('app network');
+
+    expect($command)
+        ->toContain("docker network create --ipv6 --attachable 'app network'")
+        ->toContain("|| docker network create --attachable 'app network'");
+});


### PR DESCRIPTION
## Changes

- Added a shared Docker network creation helper that tries `--ipv6` first and falls back to the current IPv4-only create command when IPv6 is unavailable.
- Reused the helper for proxy, install/validation, standalone destination, application deployment, and service network creation paths.
- Added focused unit coverage for standalone, swarm overlay, quiet fallback, and shell-escaped network command generation.

## Issues

- Fixes #3436
- /claim #3436

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Command-level change; no UI preview. The generated commands now attempt IPv6-enabled network creation first, then fall back to the existing IPv4-only create path when unsupported.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex
- How extensively: Used to inspect the issue and code paths, make the patch, and run verification.

## Testing

- Parsed changed PHP files with `php-parser`: `bootstrap/helpers/proxy.php`, `app/Models/StandaloneDocker.php`, `app/Models/Server.php`, `app/Jobs/ApplicationDeploymentJob.php`, `app/Actions/Service/StartService.php`, `app/Actions/Server/InstallDocker.php`, `tests/Unit/ProxyHelperTest.php`.
- Searched for `docker network create` and confirmed the touched network creation paths now go through `dockerNetworkCreateCommand`.

I could not run the full Pest suite in this runner because PHP/Composer are not installed and the Docker daemon is not running.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.