### PR TITLE
docs: clarify Supabase MCP private access

### DIFF
--- a/templates/compose/supabase.yaml
+++ b/templates/compose/supabase.yaml
@@ -426,7 +426,7 @@ services:
                     status_code: 403
                     message: "Access is forbidden."
 
-            ## MCP endpoint - local access
+            ## MCP endpoint - private/local access only
             - name: mcp
               _comment: 'MCP: /mcp -> http://supabase-studio:3000/api/mcp (local access)'
               url: http://supabase-studio:3000/api/mcp
@@ -441,10 +441,12 @@ services:
                   config:
                     status_code: 403
                     message: "Access is forbidden."
-                # Enable local access (danger zone!)
+                # Enable private access only (danger zone!)
                 # 1. Comment out the 'request-termination' section above
                 # 2. Uncomment the entire section below, including 'deny'
-                # 3. Add your local IPs to the 'allow' list
+                # 3. Add only your private tunnel, WireGuard, or Docker gateway IPs to 'allow'
+                # 4. Keep one tunnel/local port per Supabase instance to avoid connecting to the wrong project
+                # See the Supabase service documentation for the complete MCP workaround guide.
                 #- name: cors
                 #- name: ip-restriction
                 #  config:


### PR DESCRIPTION
## Changes

- Clarified that the Supabase MCP Kong route should only be enabled for private/local access.
- Added safety notes for private tunnel, WireGuard, and Docker gateway allowlists.
- Added a note that multiple Supabase instances should use separate tunnel/local ports to avoid connecting MCP clients to the wrong project.

This is a companion PR for the full documentation workaround in https://github.com/coollabsio/coolify-docs/pull/596.

/claim #7458

## Issues

- Related to #7458

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Comment-only template guidance change; no UI preview is applicable.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Used to inspect the Supabase template and draft the small wording change, with manual review before submission.

## Testing

- `git diff --check`

I did not run a local Coolify instance because this only changes comments in the Supabase service template.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
