### PR TITLE
Add configurable Supabase MCP access

### DIFF
--- a/templates/compose/supabase.yaml
+++ b/templates/compose/supabase.yaml
@@ -44,6 +44,9 @@ services:
       - 'KONG_STORAGE_READ_TIMEOUT=${KONG_STORAGE_READ_TIMEOUT:-3600}'
       - 'KONG_STORAGE_REQUEST_BUFFERING=${KONG_STORAGE_REQUEST_BUFFERING:-false}'
       - 'KONG_STORAGE_RESPONSE_BUFFERING=${KONG_STORAGE_RESPONSE_BUFFERING:-false}'
+      # Supabase MCP is blocked by default. Enable only for private VPN, WireGuard, or SSH tunnel source IPs.
+      - SUPABASE_MCP_ENABLED=${SUPABASE_MCP_ENABLED:-false}
+      - SUPABASE_MCP_IP_ALLOWLIST=${SUPABASE_MCP_IP_ALLOWLIST:-127.0.0.1,::1}
     volumes:
       - type: bind
         source: ./volumes/api/kong-entrypoint.sh
@@ -59,6 +62,43 @@ services:
           else
               export LUA_AUTH_EXPR="\$((headers.authorization ~= nil and headers.authorization:sub(1, 10) ~= 'Bearer sb_' and headers.authorization) or headers.apikey)"
               export LUA_RT_WS_EXPR="\$(query_params.apikey)"
+          fi
+
+          build_mcp_allowlist() {
+              local allowlist="${SUPABASE_MCP_IP_ALLOWLIST:-127.0.0.1,::1}"
+              local yaml=""
+              IFS=',' read -ra ips <<< "$allowlist"
+
+              for ip in "${ips[@]}"; do
+                  ip="$(echo "$ip" | xargs)"
+                  if [ -n "$ip" ]; then
+                      yaml="${yaml}
+          - \"$ip\""
+                  fi
+              done
+
+              if [ -z "$yaml" ]; then
+                  yaml='
+          - "127.0.0.1"
+          - "::1"'
+              fi
+
+              printf '%s' "$yaml"
+          }
+
+          if [ "$SUPABASE_MCP_ENABLED" = "true" ]; then
+              export SUPABASE_MCP_PLUGINS="plugins:
+    - name: cors
+    - name: ip-restriction
+      config:
+        allow:$(build_mcp_allowlist)
+        deny: []"
+          else
+              export SUPABASE_MCP_PLUGINS='plugins:
+    - name: request-termination
+      config:
+        status_code: 403
+        message: "Supabase MCP access is disabled."'
           fi
 
           awk '{
@@ -368,6 +408,17 @@ services:
                     - /functions/v1/
               plugins:
                 - name: cors
+
+            ## MCP endpoint
+            - name: mcp
+              _comment: 'MCP: /mcp -> http://supabase-studio:3000/api/mcp. SUPABASE_MCP_IP_ALLOWLIST controls access from VPN, WireGuard, or SSH tunnel client IPs.'
+              url: http://supabase-studio:3000/api/mcp
+              routes:
+                - name: mcp
+                  strip_path: true
+                  paths:
+                    - /mcp
+              $SUPABASE_MCP_PLUGINS
 
             ## OAuth 2.0 Authorization Server Metadata (RFC 8414)
             - name: well-known-oauth

--- a/tests/Unit/SupabaseMcpTemplateTest.php
+++ b/tests/Unit/SupabaseMcpTemplateTest.php
@@ -1,0 +1,13 @@
+<?php
+
+it('keeps Supabase MCP blocked by default and configurable for private access', function () {
+    $template = file_get_contents(__DIR__.'/../../templates/compose/supabase.yaml');
+
+    expect($template)
+        ->toContain('SUPABASE_MCP_ENABLED=${SUPABASE_MCP_ENABLED:-false}')
+        ->toContain('SUPABASE_MCP_IP_ALLOWLIST=${SUPABASE_MCP_IP_ALLOWLIST:-127.0.0.1,::1}')
+        ->toContain('export SUPABASE_MCP_PLUGINS=')
+        ->toContain('url: http://supabase-studio:3000/api/mcp')
+        ->toContain('message: "Supabase MCP access is disabled."')
+        ->toContain('SUPABASE_MCP_IP_ALLOWLIST controls access from VPN, WireGuard, or SSH tunnel client IPs.');
+});


### PR DESCRIPTION
## Summary
- Add disabled-by-default Supabase MCP route in the Supabase Kong template.
- Gate MCP access behind SUPABASE_MCP_ENABLED and SUPABASE_MCP_IP_ALLOWLIST for private VPN/WireGuard/SSH-tunnel access.
- Add a unit test that verifies the template keeps MCP blocked by default and exposes the private-access controls.

Fixes #7458

## Test Plan
- C:\Users\vietkq\AppData\Local\codex-tools\php84\php.exe -l tests\Unit\SupabaseMcpTemplateTest.php
- vendor\bin\pest tests\Unit\SupabaseMcpTemplateTest.php
- vendor\bin\pint --test tests\Unit\SupabaseMcpTemplateTest.php
- git diff --check

Notes: ran with portable PHP 8.4.21 on Windows; Composer install required --ignore-platform-req for Windows-only missing pcntl/posix extensions.