### PR TITLE
feat: add WordPress OpenLiteSpeed service template

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -15,18 +15,35 @@ services:
       - openlitespeed-logs:/usr/local/lsws/logs
     environment:
       - SERVICE_URL_WORDPRESS_80
+    depends_on:
+      wordpress-installer:
+        condition: service_completed_successfully
+      mariadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+
+  wordpress-installer:
+    image: litespeedtech/openlitespeed:1.9.0-lsphp83
+    volumes:
+      - wordpress-files:/var/www/vhosts/localhost/html
+    environment:
       - WORDPRESS_DB_HOST=mariadb
       - WORDPRESS_DB_USER=${SERVICE_USER_WORDPRESS}
       - WORDPRESS_DB_PASSWORD=${SERVICE_PASSWORD_WORDPRESS}
       - WORDPRESS_DB_NAME=${MARIADB_DATABASE:-wordpress}
-    command:
+    entrypoint:
       - bash
       - -lc
+    command:
       - |
         set -e
         cd /var/www/vhosts/localhost/html
         if [ ! -f wp-settings.php ]; then
-          wp core download --allow-root
+          wp core download --version=6.9.4 --allow-root
         fi
         if [ ! -f wp-config.php ]; then
           wp config create --allow-root --skip-check \
@@ -39,11 +56,7 @@ services:
     depends_on:
       mariadb:
         condition: service_healthy
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1"]
-      interval: 5s
-      timeout: 20s
-      retries: 10
+    restart: "no"
 
   mariadb:
     image: mariadb:11.4

--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -1,0 +1,62 @@
+# documentation: https://docs.litespeedtech.com/cloud/docker/ols-wordpress/
+# slogan: Run WordPress on OpenLiteSpeed with persistent files and MariaDB storage.
+# category: cms
+# tags: cms, blog, content, management, wordpress, openlitespeed, mariadb
+# logo: svgs/wordpress.svg
+# port: 80
+
+services:
+  wordpress:
+    image: litespeedtech/openlitespeed:1.9.0-lsphp83
+    volumes:
+      - wordpress-files:/var/www/vhosts/localhost/html
+      - openlitespeed-conf:/usr/local/lsws/conf
+      - openlitespeed-admin-conf:/usr/local/lsws/admin/conf
+      - openlitespeed-logs:/usr/local/lsws/logs
+    environment:
+      - SERVICE_URL_WORDPRESS_80
+      - WORDPRESS_DB_HOST=mariadb
+      - WORDPRESS_DB_USER=${SERVICE_USER_WORDPRESS}
+      - WORDPRESS_DB_PASSWORD=${SERVICE_PASSWORD_WORDPRESS}
+      - WORDPRESS_DB_NAME=${MARIADB_DATABASE:-wordpress}
+    command:
+      - bash
+      - -lc
+      - |
+        set -e
+        cd /var/www/vhosts/localhost/html
+        if [ ! -f wp-settings.php ]; then
+          wp core download --allow-root
+        fi
+        if [ ! -f wp-config.php ]; then
+          wp config create --allow-root --skip-check \
+            --dbhost="${WORDPRESS_DB_HOST}" \
+            --dbname="${WORDPRESS_DB_NAME}" \
+            --dbuser="${WORDPRESS_DB_USER}" \
+            --dbpass="${WORDPRESS_DB_PASSWORD}"
+        fi
+        chown -R 1000:1000 /var/www/vhosts/localhost/html
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+
+  mariadb:
+    image: mariadb:11.4
+    command: ["--max-allowed-packet=512M"]
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=${SERVICE_PASSWORD_ROOT}
+      - MYSQL_DATABASE=${MARIADB_DATABASE:-wordpress}
+      - MYSQL_USER=${SERVICE_USER_WORDPRESS}
+      - MYSQL_PASSWORD=${SERVICE_PASSWORD_WORDPRESS}
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
## Changes

- Add a WordPress with OpenLiteSpeed one-click service template backed by MariaDB.
- Keep the OpenLiteSpeed runtime service on the image default entrypoint.
- Move WordPress bootstrap into an idempotent one-shot installer service.

## Issues

- Fixes #8264
- /claim #8264

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Demo video: https://github.com/fisher-byte/coolify/releases/download/coolify-openlitespeed-demo-v3/openlitespeed-template-demo.mp4

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

Tools used: Codex
How extensively: Used to inspect prior PR feedback, harden the compose template, and run validation.

## Testing

- Parsed the compose YAML with Ruby/Psych.
- Ran `git diff --check`.
- Verified the OpenLiteSpeed image entrypoint and `/usr/bin/wp` via Docker Registry metadata/layers.
- Confirmed WordPress latest version is `6.9.4` via the official WordPress version API.
- Could not run Docker Compose smoke testing because Docker/PHP installation was blocked by Homebrew network errors.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
