### PR TITLE
feat: add OAuth-only registration settings

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -19,7 +19,8 @@ class CreateNewUser implements CreatesNewUsers
     public function create(array $input): User
     {
         $settings = instanceSettings();
-        if (! $settings->is_registration_enabled) {
+        $isFirstUser = User::count() == 0;
+        if (! $isFirstUser && (! $settings->is_registration_enabled || ! $settings->is_password_authentication_enabled)) {
             abort(403);
         }
         Validator::make($input, [
@@ -34,7 +35,7 @@ class CreateNewUser implements CreatesNewUsers
             'password' => ['required', Password::defaults(), 'confirmed'],
         ])->validate();
 
-        if (User::count() == 0) {
+        if ($isFirstUser) {
             // If this is the first user, make them the root user
             // Team is already created in the database/seeders/ProductionSeeder.php
             $user = (new User)->forceFill([

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -27,7 +27,7 @@ class OauthController extends Controller
             $user = User::whereEmail($email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! $settings->is_oauth_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 
@@ -35,6 +35,7 @@ class OauthController extends Controller
                     'name' => $oauthUser->name,
                     'email' => $email,
                 ]);
+                $user->markEmailAsVerified();
             }
             Auth::login($user);
 

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -16,6 +16,12 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $is_oauth_registration_enabled;
+
+    #[Validate('boolean')]
+    public bool $is_password_authentication_enabled;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -44,6 +50,8 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_registration_enabled' => 'boolean',
+            'is_password_authentication_enabled' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => ['nullable', 'string', new ValidDnsServers],
@@ -66,6 +74,8 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled ?? false;
+        $this->is_password_authentication_enabled = $this->settings->is_password_authentication_enabled ?? true;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -147,6 +157,8 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
+            $this->settings->is_password_authentication_enabled = $this->is_password_authentication_enabled;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -18,6 +18,8 @@ class InstanceSettings extends Model
         'do_not_track',
         'is_auto_update_enabled',
         'is_registration_enabled',
+        'is_oauth_registration_enabled',
+        'is_password_authentication_enabled',
         'next_channel',
         'smtp_enabled',
         'smtp_from_address',
@@ -69,6 +71,8 @@ class InstanceSettings extends Model
         'sentinel_token' => 'encrypted',
         'is_wire_navigate_enabled' => 'boolean',
         'is_mcp_server_enabled' => 'boolean',
+        'is_oauth_registration_enabled' => 'boolean',
+        'is_password_authentication_enabled' => 'boolean',
     ];
 
     protected static function booted(): void

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -7,6 +7,7 @@ use App\Actions\Fortify\ResetUserPassword;
 use App\Actions\Fortify\UpdateUserPassword;
 use App\Actions\Fortify\UpdateUserProfileInformation;
 use App\Models\OauthSetting;
+use App\Models\TeamInvitation;
 use App\Models\User;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
@@ -47,7 +48,7 @@ class FortifyServiceProvider extends ServiceProvider
             $isFirstUser = User::count() === 0;
 
             $settings = instanceSettings();
-            if (! $settings->is_registration_enabled) {
+            if (! $isFirstUser && (! $settings->is_registration_enabled || ! $settings->is_password_authentication_enabled)) {
                 return redirect()->route('login');
             }
 
@@ -67,11 +68,16 @@ class FortifyServiceProvider extends ServiceProvider
 
             return view('auth.login', [
                 'is_registration_enabled' => $settings->is_registration_enabled,
+                'is_password_authentication_enabled' => $settings->is_password_authentication_enabled,
                 'enabled_oauth_providers' => $enabled_oauth_providers,
             ]);
         });
 
         Fortify::authenticateUsing(function (Request $request) {
+            if (! instanceSettings()->is_password_authentication_enabled) {
+                return null;
+            }
+
             $email = strtolower($request->email);
             $user = User::where('email', $email)->with('teams')->first();
             if (
@@ -82,7 +88,7 @@ class FortifyServiceProvider extends ServiceProvider
                 $user->save();
 
                 // Check if user has a pending invitation they haven't accepted yet
-                $invitation = \App\Models\TeamInvitation::whereEmail($email)->first();
+                $invitation = TeamInvitation::whereEmail($email)->first();
                 if ($invitation && $invitation->isValid()) {
                     // User is logging in for the first time after being invited
                     // Attach them to the invited team if not already attached

--- a/database/migrations/2026_05_12_000000_add_oauth_only_auth_settings_to_instance_settings.php
+++ b/database/migrations/2026_05_12_000000_add_oauth_only_auth_settings_to_instance_settings.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_registration_enabled')->default(false);
+            $table->boolean('is_password_authentication_enabled')->default(true);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn([
+                'is_oauth_registration_enabled',
+                'is_password_authentication_enabled',
+            ]);
+        });
+    }
+};

--- a/database/schema/testing-schema.sql
+++ b/database/schema/testing-schema.sql
@@ -391,6 +391,8 @@ CREATE TABLE IF NOT EXISTS "instance_settings" (
     "do_not_track" INTEGER DEFAULT false NOT NULL,
     "is_auto_update_enabled" INTEGER DEFAULT true NOT NULL,
     "is_registration_enabled" INTEGER DEFAULT true NOT NULL,
+    "is_oauth_registration_enabled" INTEGER DEFAULT false NOT NULL,
+    "is_password_authentication_enabled" INTEGER DEFAULT true NOT NULL,
     "created_at" TEXT,
     "updated_at" TEXT,
     "next_channel" INTEGER DEFAULT false NOT NULL,
@@ -1752,3 +1754,4 @@ INSERT INTO "migrations" ("id", "migration", "batch") VALUES (311, '2025_12_10_1
 INSERT INTO "migrations" ("id", "migration", "batch") VALUES (312, '2025_12_15_143052_trim_s3_storage_credentials', 312);
 INSERT INTO "migrations" ("id", "migration", "batch") VALUES (313, '2025_12_17_000001_add_is_wire_navigate_enabled_to_instance_settings_table', 313);
 INSERT INTO "migrations" ("id", "migration", "batch") VALUES (314, '2025_12_17_000002_add_restart_tracking_to_standalone_databases', 314);
+INSERT INTO "migrations" ("id", "migration", "batch") VALUES (315, '2026_05_12_000000_add_oauth_only_auth_settings_to_instance_settings', 315);

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -29,33 +29,35 @@
                         </div>
                     @endif
 
-                    <form action="/login" method="POST" class="flex flex-col gap-4">
-                        @csrf
-                        @env('local')
-                            <x-forms.input value="test@example.com" type="email" autocomplete="email" name="email" required
-                                label="{{ __('input.email') }}" />
-                            <x-forms.input value="password" type="password" autocomplete="current-password" name="password"
-                                required label="{{ __('input.password') }}" />
-                        @else
-                            <x-forms.input type="email" name="email" autocomplete="email" required
-                                label="{{ __('input.email') }}" />
-                            <x-forms.input type="password" name="password" autocomplete="current-password" required
-                                label="{{ __('input.password') }}" />
-                        @endenv
+                    @if ($is_password_authentication_enabled)
+                        <form action="/login" method="POST" class="flex flex-col gap-4">
+                            @csrf
+                            @env('local')
+                                <x-forms.input value="test@example.com" type="email" autocomplete="email" name="email" required
+                                    label="{{ __('input.email') }}" />
+                                <x-forms.input value="password" type="password" autocomplete="current-password" name="password"
+                                    required label="{{ __('input.password') }}" />
+                            @else
+                                <x-forms.input type="email" name="email" autocomplete="email" required
+                                    label="{{ __('input.email') }}" />
+                                <x-forms.input type="password" name="password" autocomplete="current-password" required
+                                    label="{{ __('input.password') }}" />
+                            @endenv
 
-                        <div class="flex items-center justify-between">
-                            <a href="/forgot-password"
-                                class="text-sm dark:text-neutral-400 hover:text-coollabs dark:hover:text-warning hover:underline transition-colors">
-                                {{ __('auth.forgot_password_link') }}
-                            </a>
-                        </div>
+                            <div class="flex items-center justify-between">
+                                <a href="/forgot-password"
+                                    class="text-sm dark:text-neutral-400 hover:text-coollabs dark:hover:text-warning hover:underline transition-colors">
+                                    {{ __('auth.forgot_password_link') }}
+                                </a>
+                            </div>
 
-                        <x-forms.button class="w-full justify-center py-3 box-boarding" type="submit" isHighlighted>
-                            {{ __('auth.login') }}
-                        </x-forms.button>
-                    </form>
+                            <x-forms.button class="w-full justify-center py-3 box-boarding" type="submit" isHighlighted>
+                                {{ __('auth.login') }}
+                            </x-forms.button>
+                        </form>
+                    @endif
 
-                    @if ($is_registration_enabled)
+                    @if ($is_registration_enabled && $is_password_authentication_enabled)
                         <div class="relative my-6">
                             <div class="absolute inset-0 flex items-center">
                                 <div class="w-full border-t border-neutral-300 dark:border-coolgray-400"></div>

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -42,6 +42,16 @@
                         </div>
                     @endif
                     <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_registration_enabled"
+                            helper="Allow users who authenticate with a configured OAuth provider to self-register even when password registration is disabled."
+                            label="OAuth Registration Allowed" />
+                    </div>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_password_authentication_enabled"
+                            helper="Allow users to sign in with email and password. Disable this to require OAuth for sign in."
+                            label="Password Authentication" />
+                    </div>
+                    <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"
                             helper="Opt out of anonymous usage tracking. When enabled, this instance will not report to coolify.io's installation count and will not send error reports to help improve Coolify."
                             label="Do Not Track" />

--- a/tests/Feature/OauthOnlyAuthenticationTest.php
+++ b/tests/Feature/OauthOnlyAuthenticationTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use App\Actions\Fortify\CreateNewUser;
+use App\Http\Controllers\OauthController;
+use App\Models\InstanceSettings;
+use App\Models\OauthSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Socialite\Facades\Socialite;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::unguarded(fn () => InstanceSettings::query()->create(['id' => 0]));
+});
+
+function setAuthSettings(bool $passwordAuthentication, bool $passwordRegistration, bool $oauthRegistration = false): void
+{
+    InstanceSettings::query()->update([
+        'is_password_authentication_enabled' => $passwordAuthentication,
+        'is_registration_enabled' => $passwordRegistration,
+        'is_oauth_registration_enabled' => $oauthRegistration,
+    ]);
+}
+
+it('hides password login and registration when password authentication is disabled', function () {
+    $this->withoutVite();
+    $this->withViewErrors([]);
+
+    $html = view('auth.login', [
+        'is_registration_enabled' => true,
+        'is_password_authentication_enabled' => false,
+        'enabled_oauth_providers' => collect(),
+    ])->render();
+
+    expect($html)
+        ->not->toContain('name="password"')
+        ->not->toContain(__('auth.register_now'));
+});
+
+it('rejects password login when password authentication is disabled', function () {
+    User::factory()->create([
+        'email' => 'user@example.com',
+        'password' => Hash::make('password'),
+    ]);
+    setAuthSettings(passwordAuthentication: false, passwordRegistration: true);
+
+    $this->post('/login', [
+        'email' => 'user@example.com',
+        'password' => 'password',
+    ]);
+
+    $this->assertGuest();
+});
+
+it('rejects password registration when password authentication is disabled', function () {
+    User::factory()->create();
+    setAuthSettings(passwordAuthentication: false, passwordRegistration: true);
+
+    (new CreateNewUser)->create([
+        'name' => 'New User',
+        'email' => 'new@example.com',
+        'password' => 'Password1!',
+        'password_confirmation' => 'Password1!',
+    ]);
+})->throws(HttpException::class);
+
+it('allows oauth self-registration when password registration is disabled', function () {
+    setAuthSettings(passwordAuthentication: false, passwordRegistration: false, oauthRegistration: true);
+
+    OauthSetting::create([
+        'provider' => 'github',
+        'enabled' => true,
+        'client_id' => 'client-id',
+        'client_secret' => 'client-secret',
+        'redirect_uri' => route('auth.callback', 'github'),
+    ]);
+
+    $provider = Mockery::mock();
+    $provider->shouldReceive('user')->once()->andReturn((object) [
+        'name' => 'OAuth User',
+        'email' => 'oauth@example.com',
+    ]);
+
+    Socialite::shouldReceive('buildProvider')->once()->andReturn($provider);
+
+    $response = app(OauthController::class)->callback('github');
+
+    expect($response->getTargetUrl())->toBe(url('/'))
+        ->and(auth()->check())->toBeTrue()
+        ->and(User::whereEmail('oauth@example.com')->first())
+        ->password->toBeNull();
+});


### PR DESCRIPTION
## Changes

- Added separate instance settings for OAuth self-registration and password authentication.
- OAuth users can now self-register when general password registration is disabled.
- Admins can disable email/password sign-in and password self-registration to require OAuth-only access.
- Added focused feature coverage for the OAuth-only registration flow.

## Issues

- Fixes #8042

## Category

- [ ] Bug fix
- [x] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Settings page adds two Advanced toggles: OAuth Registration Allowed and Password Authentication.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Used for implementation, test writing, and local verification; changes were reviewed before submission.

## Testing

- Focused OAuth-only authentication feature test passed.
- Pint style check passed for touched PHP files.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
