### PR TITLE
feat: support OAuth-only authentication

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -19,7 +19,7 @@ class CreateNewUser implements CreatesNewUsers
     public function create(array $input): User
     {
         $settings = instanceSettings();
-        if (! $settings->is_registration_enabled) {
+        if (! $settings->is_registration_enabled || ! $settings->is_password_login_enabled) {
             abort(403);
         }
         Validator::make($input, [

--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -17,6 +17,10 @@ class ResetUserPassword implements ResetsUserPasswords
      */
     public function reset(User $user, array $input): void
     {
+        if (! instanceSettings()->is_password_login_enabled) {
+            abort(403);
+        }
+
         Validator::make($input, [
             'password' => ['required', Password::defaults(), 'confirmed'],
         ])->validate();

--- a/app/Actions/Fortify/UpdateUserPassword.php
+++ b/app/Actions/Fortify/UpdateUserPassword.php
@@ -17,6 +17,10 @@ class UpdateUserPassword implements UpdatesUserPasswords
      */
     public function update(User $user, array $input): void
     {
+        if (! instanceSettings()->is_password_login_enabled) {
+            abort(403);
+        }
+
         Validator::make($input, [
             'current_password' => ['required', 'string', 'current_password:web'],
             'password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -27,15 +27,35 @@ class OauthController extends Controller
             $user = User::whereEmail($email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! $settings->is_oauth_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 
-                $user = User::create([
-                    'name' => $oauthUser->name,
-                    'email' => $email,
-                ]);
+                if (User::count() === 0) {
+                    $user = (new User)->forceFill([
+                        'id' => 0,
+                        'name' => $oauthUser->name,
+                        'email' => $email,
+                    ]);
+                    $user->save();
+                    $settings->is_registration_enabled = false;
+                    $settings->save();
+                } else {
+                    $user = User::create([
+                        'name' => $oauthUser->name,
+                        'email' => $email,
+                    ]);
+                }
+
+                if (isCloud()) {
+                    $user->sendVerificationEmail();
+                } else {
+                    $user->markEmailAsVerified();
+                }
             }
+
+            $team = $user->teams()->first();
+            session(['currentTeam' => $user->currentTeam = $team]);
             Auth::login($user);
 
             return redirect('/');

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -16,6 +16,12 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $is_oauth_registration_enabled;
+
+    #[Validate('boolean')]
+    public bool $is_password_login_enabled;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -44,6 +50,8 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_registration_enabled' => 'boolean',
+            'is_password_login_enabled' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => ['nullable', 'string', new ValidDnsServers],
@@ -66,6 +74,8 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled;
+        $this->is_password_login_enabled = $this->settings->is_password_login_enabled ?? true;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -147,6 +157,8 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
+            $this->settings->is_password_login_enabled = $this->is_password_login_enabled;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -18,6 +18,8 @@ class InstanceSettings extends Model
         'do_not_track',
         'is_auto_update_enabled',
         'is_registration_enabled',
+        'is_oauth_registration_enabled',
+        'is_password_login_enabled',
         'next_channel',
         'smtp_enabled',
         'smtp_from_address',
@@ -64,6 +66,9 @@ class InstanceSettings extends Model
 
         'allowed_ip_ranges' => 'array',
         'is_auto_update_enabled' => 'boolean',
+        'is_registration_enabled' => 'boolean',
+        'is_oauth_registration_enabled' => 'boolean',
+        'is_password_login_enabled' => 'boolean',
         'auto_update_frequency' => 'string',
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -47,7 +47,7 @@ class FortifyServiceProvider extends ServiceProvider
             $isFirstUser = User::count() === 0;
 
             $settings = instanceSettings();
-            if (! $settings->is_registration_enabled) {
+            if (! $settings->is_registration_enabled || ! $settings->is_password_login_enabled) {
                 return redirect()->route('login');
             }
 
@@ -60,18 +60,23 @@ class FortifyServiceProvider extends ServiceProvider
             $settings = instanceSettings();
             $enabled_oauth_providers = OauthSetting::where('enabled', true)->get();
             $users = User::count();
-            if ($users == 0) {
+            if ($users == 0 && $settings->is_registration_enabled && $settings->is_password_login_enabled) {
                 // If there are no users, redirect to registration
                 return redirect()->route('register');
             }
 
             return view('auth.login', [
                 'is_registration_enabled' => $settings->is_registration_enabled,
+                'is_password_login_enabled' => $settings->is_password_login_enabled,
                 'enabled_oauth_providers' => $enabled_oauth_providers,
             ]);
         });
 
         Fortify::authenticateUsing(function (Request $request) {
+            if (! instanceSettings()->is_password_login_enabled) {
+                return null;
+            }
+
             $email = strtolower($request->email);
             $user = User::where('email', $email)->with('teams')->first();
             if (

--- a/database/migrations/2026_05_13_000001_add_oauth_authentication_settings_to_instance_settings.php
+++ b/database/migrations/2026_05_13_000001_add_oauth_authentication_settings_to_instance_settings.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_registration_enabled')->default(false);
+            $table->boolean('is_password_login_enabled')->default(true);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn([
+                'is_oauth_registration_enabled',
+                'is_password_login_enabled',
+            ]);
+        });
+    }
+};

--- a/database/schema/testing-schema.sql
+++ b/database/schema/testing-schema.sql
@@ -391,6 +391,8 @@ CREATE TABLE IF NOT EXISTS "instance_settings" (
     "do_not_track" INTEGER DEFAULT false NOT NULL,
     "is_auto_update_enabled" INTEGER DEFAULT true NOT NULL,
     "is_registration_enabled" INTEGER DEFAULT true NOT NULL,
+    "is_oauth_registration_enabled" INTEGER DEFAULT false NOT NULL,
+    "is_password_login_enabled" INTEGER DEFAULT true NOT NULL,
     "created_at" TEXT,
     "updated_at" TEXT,
     "next_channel" INTEGER DEFAULT false NOT NULL,

--- a/database/seeders/InstanceSettingsSeeder.php
+++ b/database/seeders/InstanceSettingsSeeder.php
@@ -16,6 +16,8 @@ class InstanceSettingsSeeder extends Seeder
         InstanceSettings::create([
             'id' => 0,
             'is_registration_enabled' => true,
+            'is_oauth_registration_enabled' => false,
+            'is_password_login_enabled' => true,
             'is_api_enabled' => isDev(),
             'smtp_enabled' => true,
             'smtp_host' => 'coolify-mail',

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -29,33 +29,35 @@
                         </div>
                     @endif
 
-                    <form action="/login" method="POST" class="flex flex-col gap-4">
-                        @csrf
-                        @env('local')
-                            <x-forms.input value="test@example.com" type="email" autocomplete="email" name="email" required
-                                label="{{ __('input.email') }}" />
-                            <x-forms.input value="password" type="password" autocomplete="current-password" name="password"
-                                required label="{{ __('input.password') }}" />
-                        @else
-                            <x-forms.input type="email" name="email" autocomplete="email" required
-                                label="{{ __('input.email') }}" />
-                            <x-forms.input type="password" name="password" autocomplete="current-password" required
-                                label="{{ __('input.password') }}" />
-                        @endenv
+                    @if ($is_password_login_enabled)
+                        <form action="/login" method="POST" class="flex flex-col gap-4">
+                            @csrf
+                            @env('local')
+                                <x-forms.input value="test@example.com" type="email" autocomplete="email" name="email" required
+                                    label="{{ __('input.email') }}" />
+                                <x-forms.input value="password" type="password" autocomplete="current-password" name="password"
+                                    required label="{{ __('input.password') }}" />
+                            @else
+                                <x-forms.input type="email" name="email" autocomplete="email" required
+                                    label="{{ __('input.email') }}" />
+                                <x-forms.input type="password" name="password" autocomplete="current-password" required
+                                    label="{{ __('input.password') }}" />
+                            @endenv
 
-                        <div class="flex items-center justify-between">
-                            <a href="/forgot-password"
-                                class="text-sm dark:text-neutral-400 hover:text-coollabs dark:hover:text-warning hover:underline transition-colors">
-                                {{ __('auth.forgot_password_link') }}
-                            </a>
-                        </div>
+                            <div class="flex items-center justify-between">
+                                <a href="/forgot-password"
+                                    class="text-sm dark:text-neutral-400 hover:text-coollabs dark:hover:text-warning hover:underline transition-colors">
+                                    {{ __('auth.forgot_password_link') }}
+                                </a>
+                            </div>
 
-                        <x-forms.button class="w-full justify-center py-3 box-boarding" type="submit" isHighlighted>
-                            {{ __('auth.login') }}
-                        </x-forms.button>
-                    </form>
+                            <x-forms.button class="w-full justify-center py-3 box-boarding" type="submit" isHighlighted>
+                                {{ __('auth.login') }}
+                            </x-forms.button>
+                        </form>
+                    @endif
 
-                    @if ($is_registration_enabled)
+                    @if ($is_registration_enabled && $is_password_login_enabled)
                         <div class="relative my-6">
                             <div class="absolute inset-0 flex items-center">
                                 <div class="w-full border-t border-neutral-300 dark:border-coolgray-400"></div>

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -42,6 +42,16 @@
                         </div>
                     @endif
                     <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_registration_enabled"
+                            helper="Allow new users to self-register through enabled OAuth providers even when password registration is disabled."
+                            label="OAuth Registration Allowed" />
+                    </div>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_password_login_enabled"
+                            helper="Allow users to sign in and self-register with passwords. Disable this to require OAuth sign-in."
+                            label="Password Login Allowed" />
+                    </div>
+                    <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"
                             helper="Opt out of anonymous usage tracking. When enabled, this instance will not report to coolify.io's installation count and will not send error reports to help improve Coolify."
                             label="Do Not Track" />

--- a/tests/Feature/OauthAuthenticationSettingsTest.php
+++ b/tests/Feature/OauthAuthenticationSettingsTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use App\Models\InstanceSettings;
+use App\Models\OauthSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Socialite\Facades\Socialite;
+
+uses(RefreshDatabase::class);
+
+function createInstanceSettingsForOauthAuth(array $overrides = []): InstanceSettings
+{
+    return InstanceSettings::create(array_merge([
+        'id' => 0,
+        'is_registration_enabled' => false,
+        'is_oauth_registration_enabled' => false,
+        'is_password_login_enabled' => true,
+    ], $overrides));
+}
+
+function fakeGithubOauthCallback(string $email = 'oauth@example.com', string $name = 'OAuth User'): void
+{
+    OauthSetting::create([
+        'provider' => 'github',
+        'enabled' => true,
+        'client_id' => 'client-id',
+        'client_secret' => 'client-secret',
+    ]);
+
+    $provider = Mockery::mock();
+    $provider->shouldReceive('user')->once()->andReturn((object) [
+        'email' => $email,
+        'name' => $name,
+    ]);
+
+    Socialite::shouldReceive('buildProvider')->once()->andReturn($provider);
+}
+
+it('allows oauth self registration when password registration is disabled but oauth registration is enabled', function () {
+    createInstanceSettingsForOauthAuth([
+        'is_oauth_registration_enabled' => true,
+    ]);
+    fakeGithubOauthCallback();
+
+    $this->get('/auth/github/callback')->assertRedirect('/');
+
+    $user = User::whereEmail('oauth@example.com')->first();
+
+    expect($user)->not->toBeNull()
+        ->and($user->id)->toBe(0)
+        ->and($user->hasPassword())->toBeFalse()
+        ->and(session('currentTeam')->id)->toBe(0);
+});
+
+it('rejects new oauth users when both password and oauth registration are disabled', function () {
+    createInstanceSettingsForOauthAuth();
+    fakeGithubOauthCallback();
+
+    $this->get('/auth/github/callback')
+        ->assertRedirect('/login')
+        ->assertSessionHasErrors();
+
+    expect(User::whereEmail('oauth@example.com')->exists())->toBeFalse();
+});
+
+it('blocks password login when password login is disabled', function () {
+    createInstanceSettingsForOauthAuth([
+        'is_password_login_enabled' => false,
+    ]);
+
+    User::create([
+        'name' => 'Password User',
+        'email' => 'password@example.com',
+        'password' => Hash::make('password'),
+    ]);
+
+    $this->post('/login', [
+        'email' => 'password@example.com',
+        'password' => 'password',
+    ])->assertRedirect('/');
+
+    $this->assertGuest();
+});
+
+it('hides password login and registration controls when password login is disabled', function () {
+    createInstanceSettingsForOauthAuth([
+        'is_registration_enabled' => true,
+        'is_password_login_enabled' => false,
+    ]);
+
+    User::create([
+        'name' => 'Existing User',
+        'email' => 'existing@example.com',
+        'password' => Hash::make('password'),
+    ]);
+
+    $this->get('/login')
+        ->assertSuccessful()
+        ->assertDontSee('name="email"', false)
+        ->assertDontSee('name="password"', false)
+        ->assertDontSee(__('auth.register_now'));
+});


### PR DESCRIPTION
Closes #8042

Adds support for OAuth-only access by separating password registration/login from OAuth self-registration.

Changes:
- Adds instance settings for OAuth self-registration and password login
- Allows OAuth users to self-register when general password registration is disabled
- Blocks password login/register/reset/update when password login is disabled
- Hides password login and password registration controls in OAuth-only mode
- Adds focused feature tests for the new auth settings

Testing:
- Not run locally: PHP is not installed in my environment.
- Ran `git diff --check`.

AI disclosure:
- Implemented with AI assistance. I reviewed the change flow and kept the patch scoped to the auth setting gates.
