### PR TITLE
Add OAuth-only authentication settings

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -19,7 +19,7 @@ class CreateNewUser implements CreatesNewUsers
     public function create(array $input): User
     {
         $settings = instanceSettings();
-        if (! $settings->is_registration_enabled) {
+        if (! $settings->is_registration_enabled || ! ($settings->is_password_login_enabled ?? true)) {
             abort(403);
         }
         Validator::make($input, [

--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -17,6 +17,10 @@ class ResetUserPassword implements ResetsUserPasswords
      */
     public function reset(User $user, array $input): void
     {
+        if (! (instanceSettings()->is_password_login_enabled ?? true)) {
+            abort(403);
+        }
+
         Validator::make($input, [
             'password' => ['required', Password::defaults(), 'confirmed'],
         ])->validate();

--- a/app/Actions/Fortify/UpdateUserPassword.php
+++ b/app/Actions/Fortify/UpdateUserPassword.php
@@ -17,6 +17,10 @@ class UpdateUserPassword implements UpdatesUserPasswords
      */
     public function update(User $user, array $input): void
     {
+        if (! (instanceSettings()->is_password_login_enabled ?? true)) {
+            abort(403);
+        }
+
         Validator::make($input, [
             'current_password' => ['required', 'string', 'current_password:web'],
             'password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -68,6 +68,10 @@ class Controller extends BaseController
 
     public function forgot_password(Request $request)
     {
+        if (! (instanceSettings()->is_password_login_enabled ?? true)) {
+            abort(403);
+        }
+
         if (is_transactional_emails_enabled()) {
             $arrayOfRequest = $request->only(Fortify::email());
             $request->merge([
@@ -96,6 +100,10 @@ class Controller extends BaseController
 
     public function link()
     {
+        if (! (instanceSettings()->is_password_login_enabled ?? true)) {
+            return redirect()->route('login');
+        }
+
         $token = request()->get('token');
         if ($token) {
             $decrypted = Crypt::decryptString($token);

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -22,7 +22,7 @@ class OauthController extends Controller
             $user = User::whereEmail($oauthUser->email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! ($settings->is_oauth_registration_enabled ?? false)) {
                     abort(403, 'Registration is disabled');
                 }
 

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\Settings;
 
 use App\Models\InstanceSettings;
+use App\Models\OauthSetting;
 use App\Rules\ValidDnsServers;
 use App\Rules\ValidIpOrCidr;
 use Livewire\Attributes\Validate;
@@ -14,6 +15,12 @@ class Advanced extends Component
 
     #[Validate('boolean')]
     public bool $is_registration_enabled;
+
+    #[Validate('boolean')]
+    public bool $is_oauth_registration_enabled;
+
+    #[Validate('boolean')]
+    public bool $is_password_login_enabled;
 
     #[Validate('boolean')]
     public bool $do_not_track;
@@ -41,6 +48,8 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_registration_enabled' => 'boolean',
+            'is_password_login_enabled' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => ['nullable', 'string', new ValidDnsServers],
@@ -62,6 +71,8 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled;
+        $this->is_password_login_enabled = $this->settings->is_password_login_enabled ?? true;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -142,6 +153,8 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
+            $this->settings->is_password_login_enabled = $this->is_password_login_enabled;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;
@@ -166,6 +179,25 @@ class Advanced extends Component
         $this->settings->is_registration_enabled = $this->is_registration_enabled = true;
         $this->settings->save();
         $this->dispatch('success', 'Registration has been enabled.');
+
+        return true;
+    }
+
+    public function togglePasswordLogin($password): bool
+    {
+        if (! verifyPasswordConfirmation($password, $this)) {
+            return false;
+        }
+
+        if (! OauthSetting::where('enabled', true)->exists()) {
+            $this->dispatch('error', 'Enable at least one OAuth provider before disabling password login.');
+
+            return false;
+        }
+
+        $this->settings->is_password_login_enabled = $this->is_password_login_enabled = false;
+        $this->settings->save();
+        $this->dispatch('success', 'Password login has been disabled.');
 
         return true;
     }

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -18,6 +18,8 @@ class InstanceSettings extends Model
         'do_not_track',
         'is_auto_update_enabled',
         'is_registration_enabled',
+        'is_oauth_registration_enabled',
+        'is_password_login_enabled',
         'next_channel',
         'smtp_enabled',
         'smtp_from_address',
@@ -63,6 +65,9 @@ class InstanceSettings extends Model
 
         'allowed_ip_ranges' => 'array',
         'is_auto_update_enabled' => 'boolean',
+        'is_registration_enabled' => 'boolean',
+        'is_oauth_registration_enabled' => 'boolean',
+        'is_password_login_enabled' => 'boolean',
         'auto_update_frequency' => 'string',
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -47,7 +47,7 @@ class FortifyServiceProvider extends ServiceProvider
             $isFirstUser = User::count() === 0;
 
             $settings = instanceSettings();
-            if (! $settings->is_registration_enabled) {
+            if (! $settings->is_registration_enabled || ! ($settings->is_password_login_enabled ?? true)) {
                 return redirect()->route('login');
             }
 
@@ -60,18 +60,23 @@ class FortifyServiceProvider extends ServiceProvider
             $settings = instanceSettings();
             $enabled_oauth_providers = OauthSetting::where('enabled', true)->get();
             $users = User::count();
-            if ($users == 0) {
+            if ($users == 0 && ($settings->is_password_login_enabled ?? true)) {
                 // If there are no users, redirect to registration
                 return redirect()->route('register');
             }
 
             return view('auth.login', [
                 'is_registration_enabled' => $settings->is_registration_enabled,
+                'is_password_login_enabled' => $settings->is_password_login_enabled ?? true,
                 'enabled_oauth_providers' => $enabled_oauth_providers,
             ]);
         });
 
         Fortify::authenticateUsing(function (Request $request) {
+            if (! (instanceSettings()->is_password_login_enabled ?? true)) {
+                return null;
+            }
+
             $email = strtolower($request->email);
             $user = User::where('email', $email)->with('teams')->first();
             if (
@@ -104,9 +109,17 @@ class FortifyServiceProvider extends ServiceProvider
             }
         });
         Fortify::requestPasswordResetLinkView(function () {
+            if (! (instanceSettings()->is_password_login_enabled ?? true)) {
+                return redirect()->route('login');
+            }
+
             return view('auth.forgot-password');
         });
         Fortify::resetPasswordView(function ($request) {
+            if (! (instanceSettings()->is_password_login_enabled ?? true)) {
+                return redirect()->route('login');
+            }
+
             return view('auth.reset-password', ['request' => $request]);
         });
         Fortify::resetUserPasswordsUsing(ResetUserPassword::class);

--- a/database/migrations/2026_05_13_000000_add_oauth_registration_settings_to_instance_settings.php
+++ b/database/migrations/2026_05_13_000000_add_oauth_registration_settings_to_instance_settings.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_registration_enabled')->default(false)->after('is_registration_enabled');
+            $table->boolean('is_password_login_enabled')->default(true)->after('is_oauth_registration_enabled');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn(['is_oauth_registration_enabled', 'is_password_login_enabled']);
+        });
+    }
+};

--- a/database/schema/testing-schema.sql
+++ b/database/schema/testing-schema.sql
@@ -391,6 +391,8 @@ CREATE TABLE IF NOT EXISTS "instance_settings" (
     "do_not_track" INTEGER DEFAULT false NOT NULL,
     "is_auto_update_enabled" INTEGER DEFAULT true NOT NULL,
     "is_registration_enabled" INTEGER DEFAULT true NOT NULL,
+    "is_oauth_registration_enabled" INTEGER DEFAULT false NOT NULL,
+    "is_password_login_enabled" INTEGER DEFAULT true NOT NULL,
     "created_at" TEXT,
     "updated_at" TEXT,
     "next_channel" INTEGER DEFAULT false NOT NULL,
@@ -1752,3 +1754,4 @@ INSERT INTO "migrations" ("id", "migration", "batch") VALUES (311, '2025_12_10_1
 INSERT INTO "migrations" ("id", "migration", "batch") VALUES (312, '2025_12_15_143052_trim_s3_storage_credentials', 312);
 INSERT INTO "migrations" ("id", "migration", "batch") VALUES (313, '2025_12_17_000001_add_is_wire_navigate_enabled_to_instance_settings_table', 313);
 INSERT INTO "migrations" ("id", "migration", "batch") VALUES (314, '2025_12_17_000002_add_restart_tracking_to_standalone_databases', 314);
+INSERT INTO "migrations" ("id", "migration", "batch") VALUES (315, '2026_05_13_000000_add_oauth_registration_settings_to_instance_settings', 315);

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -29,51 +29,55 @@
                         </div>
                     @endif
 
-                    <form action="/login" method="POST" class="flex flex-col gap-4">
-                        @csrf
-                        @env('local')
-                            <x-forms.input value="test@example.com" type="email" autocomplete="email" name="email" required
-                                label="{{ __('input.email') }}" />
-                            <x-forms.input value="password" type="password" autocomplete="current-password" name="password"
-                                required label="{{ __('input.password') }}" />
-                        @else
-                            <x-forms.input type="email" name="email" autocomplete="email" required
-                                label="{{ __('input.email') }}" />
-                            <x-forms.input type="password" name="password" autocomplete="current-password" required
-                                label="{{ __('input.password') }}" />
-                        @endenv
+                    @if ($is_password_login_enabled)
+                        <form action="/login" method="POST" class="flex flex-col gap-4">
+                            @csrf
+                            @env('local')
+                                <x-forms.input value="test@example.com" type="email" autocomplete="email" name="email" required
+                                    label="{{ __('input.email') }}" />
+                                <x-forms.input value="password" type="password" autocomplete="current-password" name="password"
+                                    required label="{{ __('input.password') }}" />
+                            @else
+                                <x-forms.input type="email" name="email" autocomplete="email" required
+                                    label="{{ __('input.email') }}" />
+                                <x-forms.input type="password" name="password" autocomplete="current-password" required
+                                    label="{{ __('input.password') }}" />
+                            @endenv
 
-                        <div class="flex items-center justify-between">
-                            <a href="/forgot-password"
-                                class="text-sm dark:text-neutral-400 hover:text-coollabs dark:hover:text-warning hover:underline transition-colors">
-                                {{ __('auth.forgot_password_link') }}
+                            <div class="flex items-center justify-between">
+                                <a href="/forgot-password"
+                                    class="text-sm dark:text-neutral-400 hover:text-coollabs dark:hover:text-warning hover:underline transition-colors">
+                                    {{ __('auth.forgot_password_link') }}
+                                </a>
+                            </div>
+
+                            <x-forms.button class="w-full justify-center py-3 box-boarding" type="submit" isHighlighted>
+                                {{ __('auth.login') }}
+                            </x-forms.button>
+                        </form>
+                    @endif
+
+                    @if ($is_password_login_enabled)
+                        @if ($is_registration_enabled)
+                            <div class="relative my-6">
+                                <div class="absolute inset-0 flex items-center">
+                                    <div class="w-full border-t border-neutral-300 dark:border-coolgray-400"></div>
+                                </div>
+                                <div class="relative flex justify-center text-sm">
+                                    <span class="px-2 bg-gray-50 dark:bg-base text-neutral-500 dark:text-neutral-400 ">
+                                        Don't have an account?
+                                    </span>
+                                </div>
+                            </div>
+                            <a href="/register"
+                                class="block w-full text-center py-3 px-4 rounded-lg border border-neutral-300 dark:border-coolgray-400 font-medium hover:border-coollabs dark:hover:border-warning transition-colors">
+                                {{ __('auth.register_now') }}
                             </a>
-                        </div>
-
-                        <x-forms.button class="w-full justify-center py-3 box-boarding" type="submit" isHighlighted>
-                            {{ __('auth.login') }}
-                        </x-forms.button>
-                    </form>
-
-                    @if ($is_registration_enabled)
-                        <div class="relative my-6">
-                            <div class="absolute inset-0 flex items-center">
-                                <div class="w-full border-t border-neutral-300 dark:border-coolgray-400"></div>
+                        @else
+                            <div class="mt-6 text-center text-sm text-neutral-500 dark:text-neutral-400">
+                                {{ __('auth.registration_disabled') }}
                             </div>
-                            <div class="relative flex justify-center text-sm">
-                                <span class="px-2 bg-gray-50 dark:bg-base text-neutral-500 dark:text-neutral-400 ">
-                                    Don't have an account?
-                                </span>
-                            </div>
-                        </div>
-                        <a href="/register"
-                            class="block w-full text-center py-3 px-4 rounded-lg border border-neutral-300 dark:border-coolgray-400 font-medium hover:border-coollabs dark:hover:border-warning transition-colors">
-                            {{ __('auth.register_now') }}
-                        </a>
-                    @else
-                        <div class="mt-6 text-center text-sm text-neutral-500 dark:text-neutral-400">
-                            {{ __('auth.registration_disabled') }}
-                        </div>
+                        @endif
                     @endif
 
                     @if ($enabled_oauth_providers->isNotEmpty())

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -42,6 +42,37 @@
                         </div>
                     @endif
                     <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_registration_enabled"
+                            helper="Allow users to self-register with enabled OAuth providers even when password registration is disabled."
+                            label="OAuth Registration Allowed" />
+                    </div>
+                    @if ($is_password_login_enabled)
+                        <div class="flex items-center justify-between gap-2 md:w-96"
+                            wire:key="password-login-enabled">
+                            <label class="flex items-center gap-2">
+                                Password Login
+                                <x-helper
+                                    helper="Allow users to sign in and self-register with email and password. Disabling this makes enabled OAuth providers the only login option.">
+                                </x-helper>
+                            </label>
+                            <x-modal-confirmation title="Disable Password Login?" buttonTitle="Disable" isErrorButton
+                                submitAction="togglePasswordLogin" :actions="[
+                                    'Password login and password registration will be disabled.',
+                                    'Users must sign in with an enabled OAuth provider.',
+                                ]"
+                                warningMessage="Make sure at least one OAuth provider is enabled and your admin account can use it before continuing."
+                                confirmationText="DISABLE PASSWORD LOGIN"
+                                confirmationLabel="Please type the confirmation text to disable password login."
+                                shortConfirmationLabel="Confirmation text" />
+                        </div>
+                    @else
+                        <div class="md:w-96" wire:key="password-login-disabled">
+                            <x-forms.checkbox instantSave id="is_password_login_enabled"
+                                helper="Allow users to sign in and self-register with email and password."
+                                label="Password Login" />
+                        </div>
+                    @endif
+                    <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"
                             helper="Opt out of anonymous usage tracking. When enabled, this instance will not report to coolify.io's installation count and will not send error reports to help improve Coolify."
                             label="Do Not Track" />

--- a/tests/Feature/OauthAuthenticationSettingsTest.php
+++ b/tests/Feature/OauthAuthenticationSettingsTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use App\Models\InstanceSettings;
+use App\Models\OauthSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Socialite\Facades\Socialite;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::create(['id' => 0]);
+});
+
+test('oauth can create users when password registration is disabled but oauth registration is enabled', function () {
+    InstanceSettings::find(0)->update([
+        'is_registration_enabled' => false,
+        'is_oauth_registration_enabled' => true,
+    ]);
+
+    OauthSetting::create([
+        'provider' => 'github',
+        'enabled' => true,
+        'client_id' => 'client-id',
+        'client_secret' => 'client-secret',
+        'redirect_uri' => 'https://coolify.example.com/auth/github/callback',
+    ]);
+
+    $provider = Mockery::mock();
+    $provider->shouldReceive('user')->once()->andReturn((object) [
+        'name' => 'OAuth User',
+        'email' => 'oauth@example.com',
+    ]);
+
+    Socialite::shouldReceive('buildProvider')->once()->andReturn($provider);
+
+    $this->get('/auth/github/callback')
+        ->assertRedirect('/');
+
+    $user = User::whereEmail('oauth@example.com')->first();
+
+    expect($user)->not->toBeNull()
+        ->and($user->hasPassword())->toBeFalse();
+});
+
+test('oauth cannot create users when both registration modes are disabled', function () {
+    InstanceSettings::find(0)->update([
+        'is_registration_enabled' => false,
+        'is_oauth_registration_enabled' => false,
+    ]);
+
+    OauthSetting::create([
+        'provider' => 'github',
+        'enabled' => true,
+        'client_id' => 'client-id',
+        'client_secret' => 'client-secret',
+        'redirect_uri' => 'https://coolify.example.com/auth/github/callback',
+    ]);
+
+    $provider = Mockery::mock();
+    $provider->shouldReceive('user')->once()->andReturn((object) [
+        'name' => 'Blocked User',
+        'email' => 'blocked@example.com',
+    ]);
+
+    Socialite::shouldReceive('buildProvider')->once()->andReturn($provider);
+
+    $this->get('/auth/github/callback')
+        ->assertRedirect(route('login'));
+
+    expect(User::whereEmail('blocked@example.com')->exists())->toBeFalse();
+});
+
+test('password login is rejected when password login is disabled', function () {
+    InstanceSettings::find(0)->update(['is_password_login_enabled' => false]);
+
+    $user = User::factory()->create([
+        'email' => 'password@example.com',
+        'password' => Hash::make('password'),
+    ]);
+
+    $this->post('/login', [
+        'email' => $user->email,
+        'password' => 'password',
+    ])->assertSessionHasErrors();
+
+    $this->assertGuest();
+});
+
+test('password login form and password registration link are hidden when password login is disabled', function () {
+    InstanceSettings::find(0)->update([
+        'is_registration_enabled' => true,
+        'is_password_login_enabled' => false,
+    ]);
+
+    User::factory()->create();
+
+    $this->get('/login')
+        ->assertOk()
+        ->assertDontSee('name="password"', false)
+        ->assertDontSee(__('auth.register_now'));
+});


### PR DESCRIPTION
## Changes

- Add separate instance settings for OAuth self-registration and password login
- Allow enabled OAuth providers to create users when normal password registration is disabled
- Allow admins to disable password login/registration/reset/update/auth-link login for OAuth-only instances
- Add Advanced Settings controls for OAuth registration and password login
- Add focused feature coverage for OAuth registration and disabled password login behavior

## Issues

- Fixes #8042

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A - settings/auth behavior change.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**
- Tools used: OpenAI Codex
- How extensively: Used to inspect the auth/settings code paths and prepare the implementation. Changes were reviewed before submission.

## Testing

- Ran `git diff --check`
- Added `tests/Feature/OauthAuthenticationSettingsTest.php`
- Could not run `php artisan test tests/Feature/OauthAuthenticationSettingsTest.php` in this environment because PHP is not installed locally.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
