### PR TITLE
fix: keep compose file clone output out of raw yaml

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -1447,9 +1447,10 @@ class Application extends BaseModel
             }
         }
 
-        $git_clone_command = "git clone{$depthFlag}{$submoduleFlags} -b {$escapedBranch}";
+        $quietFlag = $only_checkout ? ' --quiet' : '';
+        $git_clone_command = "git clone{$quietFlag}{$depthFlag}{$submoduleFlags} -b {$escapedBranch}";
         if ($only_checkout) {
-            $git_clone_command = "git clone{$depthFlag}{$submoduleFlags} --no-checkout -b {$escapedBranch}";
+            $git_clone_command = "git clone{$quietFlag}{$depthFlag}{$submoduleFlags} --no-checkout -b {$escapedBranch}";
         }
         if ($pull_request_id !== 0) {
             $pr_branch_name = "pr-{$pull_request_id}-coolify";
@@ -1783,6 +1784,7 @@ class Application extends BaseModel
         }
         $uuid = new Cuid2;
         ['commands' => $cloneCommand] = $this->generateGitImportCommands(deployment_uuid: $uuid, only_checkout: true, exec_in_docker: false, custom_base_dir: '.');
+        $cloneCommand = "{$cloneCommand} 1>&2";
         $workdir = rtrim($this->base_directory, '/');
         $composeFile = $this->docker_compose_location;
         $fileList = collect([".$workdir$composeFile"]);

--- a/tests/Unit/ApplicationGitImportCommandsTest.php
+++ b/tests/Unit/ApplicationGitImportCommandsTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Models\Application;
+use App\Models\ApplicationSetting;
+
+function applicationWithGitSettings(): Application
+{
+    $application = new Application;
+    $application->git_repository = 'https://github.com/example/repo';
+    $application->git_branch = 'main';
+
+    $settings = new ApplicationSetting;
+    $settings->is_git_submodules_enabled = false;
+    $settings->is_git_shallow_clone_enabled = false;
+    $application->setRelation('settings', $settings);
+
+    return $application;
+}
+
+it('uses quiet clone output when only checking out a compose file', function () {
+    $application = applicationWithGitSettings();
+
+    $result = $application->generateGitImportCommands(
+        deployment_uuid: 'test-deployment',
+        exec_in_docker: false,
+        only_checkout: true,
+        custom_base_dir: '.',
+    );
+
+    expect($result['commands'])
+        ->toContain('git clone --quiet --no-checkout -b')
+        ->toContain("'https://github.com/example/repo' '.'");
+});
+
+it('keeps normal deployment clone output unchanged', function () {
+    $application = applicationWithGitSettings();
+
+    $result = $application->generateGitImportCommands(
+        deployment_uuid: 'test-deployment',
+        exec_in_docker: false,
+        only_checkout: false,
+    );
+
+    expect($result['commands'])
+        ->toContain('git clone -b')
+        ->not->toContain('git clone --quiet');
+});


### PR DESCRIPTION
## Changes

- Prevent compose-file loading from saving git clone/setup chatter into `docker_compose_raw`.
- Use `git clone --quiet --no-checkout` for the temporary compose checkout path.
- Redirect clone stdout to stderr before the final `cat`, so `instant_remote_process()` captures only the compose YAML on stdout.
- Add focused coverage for the generated compose checkout clone command.

## Issues

- Fixes #5251
- /claim #5251

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No UI change. Local shell smoke test showed `git clone --quiet --no-checkout` produced `clone_stdout_length=0`, and the captured compose content started with `services:`.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex
- How extensively: Used to trace the compose load path, make the small patch, and write the focused regression test. I reviewed the changed lines and issue context before submitting.

## Testing

- `git diff --check`
- Local shell smoke test for the clone/cat behavior described above
- Not run: Pest/PHP test suite. This environment does not have PHP, Composer, Docker, or Spin installed.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.