### PR TITLE
Fix/docker compose env var default volume path

### DIFF
--- a/bootstrap/helpers/parsers.php
+++ b/bootstrap/helpers/parsers.php
@@ -122,7 +122,7 @@ function parseDockerVolumeString(string $volumeString): array
 
     // First, check if the source contains an environment variable with default value
     // This needs to be done before counting colons because ${VAR:-value} contains a colon
-    $envVarPattern = '/^\$\{[^}]+:-[^}]*\}/';
+    $envVarPattern = '/^\$\{[^}]+:-[^}]*\}[^:]*/';
     $hasEnvVarWithDefault = false;
     $envVarEndPos = 0;
 
@@ -321,8 +321,9 @@ function parseDockerVolumeString(string $volumeString): array
         // Pattern 2: ${WORD_CHARS}/path/to/file (env var with path concatenation)
         $isSimpleEnvVar = preg_match('/^\$\{[a-zA-Z_][a-zA-Z0-9_]*\}$/', $sourceStr);
         $isEnvVarWithPath = preg_match('/^\$\{[a-zA-Z_][a-zA-Z0-9_]*\}[\/\w\.\-]*$/', $sourceStr);
+        $isEnvVarWithDefault = preg_match('/^\\$\\{[^}]+:-[^}]*\\}[\/\\w\.\\-]*$/', $sourceStr);
 
-        if (! $isSimpleEnvVar && ! $isEnvVarWithPath) {
+        if (! $isSimpleEnvVar && ! $isEnvVarWithPath && ! $isEnvVarWithDefault) {
             try {
                 validateShellSafePath($sourceStr, 'volume source');
             } catch (Exception $e) {

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -1315,7 +1315,7 @@ function getTopLevelNetworks(Service|Application $resource)
 }
 function sourceIsLocal(Stringable $source)
 {
-    if ($source->startsWith('./') || $source->startsWith('/') || $source->startsWith('~') || $source->startsWith('..') || $source->startsWith('~/') || $source->startsWith('../')) {
+    if ($source->startsWith('./') || $source->startsWith('/') || $source->startsWith('~') || $source->startsWith('..') || $source->startsWith('~/') || $source->startsWith('../') || $source->startsWith('$')) {
         return true;
     }
 

--- a/tests/Unit/ParseDockerVolumeStringTest.php
+++ b/tests/Unit/ParseDockerVolumeStringTest.php
@@ -86,6 +86,28 @@ test('parses volumes with environment variables', function () {
     expect($result['mode']->value())->toBe('ro');
 });
 
+test('parses env var with default and path suffix outside braces', function () {
+    // ${BASE_DIR:-$PWD}/data:/app/data — the /data suffix is OUTSIDE the braces.
+    // Coolify must preserve the full source (including /data) so Docker Compose
+    // can resolve the variable and append the suffix at runtime.
+    $result = parseDockerVolumeString('${BASE_DIR:-$PWD}/data:/app/data');
+    expect($result['source']->value())->toBe('${BASE_DIR:-$PWD}/data');
+    expect($result['target']->value())->toBe('/app/data');
+    expect($result['mode'])->toBeNull();
+
+    // With a servers sub-path
+    $result = parseDockerVolumeString('${BASE_DIR:-$PWD}/servers:/app/servers');
+    expect($result['source']->value())->toBe('${BASE_DIR:-$PWD}/servers');
+    expect($result['target']->value())->toBe('/app/servers');
+    expect($result['mode'])->toBeNull();
+
+    // With a mode flag
+    $result = parseDockerVolumeString('${BASE_DIR:-/opt/app}/config:/app/config:ro');
+    expect($result['source']->value())->toBe('${BASE_DIR:-/opt/app}/config');
+    expect($result['target']->value())->toBe('/app/config');
+    expect($result['mode']->value())->toBe('ro');
+});
+
 test('parses Windows paths', function () {
     // Windows absolute path
     $result = parseDockerVolumeString('C:/Users/data:/data');

--- a/tests/Unit/PreviewDeploymentBindMountTest.php
+++ b/tests/Unit/PreviewDeploymentBindMountTest.php
@@ -70,6 +70,13 @@ describe('sourceIsLocal', function () {
     it('returns false for named volumes', function () {
         expect(sourceIsLocal(str('myvolume')))->toBeFalse();
     });
+
+    it('detects env-var-with-default sources as local', function () {
+        // ${BASE_DIR:-$PWD}/data starts with $ and is a bind-mount path, not a named volume
+        expect(sourceIsLocal(str('${BASE_DIR:-$PWD}/data')))->toBeTrue();
+        expect(sourceIsLocal(str('${BASE_DIR:-/opt/app}/servers')))->toBeTrue();
+        expect(sourceIsLocal(str('${VOLUMES_PATH}/mysql')))->toBeTrue();
+    });
 });
 
 describe('replaceLocalSource', function () {

--- a/tests/Unit/VolumeSecurityTest.php
+++ b/tests/Unit/VolumeSecurityTest.php
@@ -142,6 +142,29 @@ test('parseDockerVolumeString accepts environment variables with safe defaults',
     }
 });
 
+test('parseDockerVolumeString accepts env var with default and path suffix outside braces', function () {
+    // Pattern: ${VAR:-default}/sub-path:/container-path
+    // The /sub-path suffix sits OUTSIDE the ${...} braces. Docker Compose handles
+    // the variable substitution; Coolify must not strip the suffix or reject the source.
+    $volumes = [
+        '${BASE_DIR:-$PWD}/data:/app/data',
+        '${BASE_DIR:-$PWD}/servers:/app/servers',
+        '${BASE_DIR:-/opt/app}/config:/app/config:ro',
+        '${DATA_DIR:-/home/user}/db:/var/lib/db',
+    ];
+
+    foreach ($volumes as $volume) {
+        $result = parseDockerVolumeString($volume);
+        expect($result)->toBeArray();
+        expect($result['source'])->not->toBeNull();
+    }
+
+    // Verify source is preserved verbatim (not truncated at the closing brace)
+    $result = parseDockerVolumeString('${BASE_DIR:-$PWD}/data:/app/data');
+    expect($result['source']->value())->toBe('${BASE_DIR:-$PWD}/data');
+    expect($result['target']->value())->toBe('/app/data');
+});
+
 test('parseDockerVolumeString rejects injection in target path', function () {
     // While target paths are less dangerous, we should still validate them
     $maliciousVolumes = [


### PR DESCRIPTION
## Changes

<!-- Describe what changes were made and why in your own words. This "Changes" section must be human-written and not AI-generated. -->

This docker-compose failed parsing and Claude figured out why.
https://github.com/Ketbome/minepanel/blob/main/docker-compose.yml

The changes work locally and make sense. I have not compiled against them on my coolify instance - patches only.

The root cause being that evals in the docker compose were not supported like 
`- BASE_DIR=${BASE_DIR:-$PWD}`


The copilot summary (as I could not write it more clearly):

```
1. parsers.php: parseDockerVolumeString() regex $envVarPattern only matched ${VAR:-default} but dropped the /path suffix that follows. Extended pattern from /^\$\{[^}]+:-[^}]*\}/ to include [^:]* to capture the full source path.

2. parsers.php: security check in parseDockerVolumeString() blocked ${VAR:-default}/path with 'forbidden character ${'. Added $isEnvVarWithDefault pattern to skip validation for ${VAR:-default}/optional/path sources (mirrors existing $isEnvVarWithPath allowance).

3. shared.php: sourceIsLocal() only recognised bind-mount sources starting with ./, /, ~, or ... Sources starting with $ (env var substitution) were misclassified as named volumes, producing names like rlybfy3i19n3bpqrazy6yxgg_pwd instead of bind mounts. Added startsWith('$') to the local-source check.
```

If those patches break purposefully implemented security by not-allowing evals, feel free to close and I am just gonna repatch my server after updates 👍 

I am too unaware of coolify docker-compose parsing to know whether these regex changes may break existing patterns. With these minor changes I would doubt it though.

Tests run after minor changes and also added coverage.

## Issues

<!-- Link related issues or discussions. If reopening a closed PR, explain why it should be reconsidered. -->

- Fixes

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

<!-- Screenshot or short video showing your changes in action. Mandatory for new features. -->

## AI Assistance

<!-- AI-assisted PRs that are human reviewed are welcome, just let us know so we can review appropriately. -->

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used:
Claude Sonnet on Github Copilot Local

- How extensively:

Performed debugging, patching php files through ssh and sep, checking container logs and finally figuring out, why the deploy was failing and finally successfully patching my coolify installation.

Took quite a while, first patching inside the running containers before the php, but quite impressive sill. 

I could not have done it myself, likely eventually hardcoding the docker compose.

## Testing

Patches works on my machine lol

Also added some coverage in a second commit.

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
