### PR TITLE
fix: create Docker networks with IPv6 fallback

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -98,11 +98,11 @@ class InstallDocker
             ]);
             if ($server->isSwarm()) {
                 $command = $command->merge([
-                    'docker network create --attachable --driver overlay coolify-overlay >/dev/null 2>&1 || true',
+                    dockerNetworkCreateCommand('coolify-overlay', isSwarm: true, quiet: true).' || true',
                 ]);
             } else {
                 $command = $command->merge([
-                    'docker network create --attachable coolify >/dev/null 2>&1 || true',
+                    dockerNetworkCreateCommand('coolify', quiet: true).' || true',
                 ]);
                 $command = $command->merge([
                     "echo 'Done!'",

--- a/app/Actions/Service/StartService.php
+++ b/app/Actions/Service/StartService.php
@@ -33,7 +33,7 @@ class StartService
         }
         if ($service->networks()->count() > 0) {
             $commands[] = "echo 'Creating Docker network.'";
-            $commands[] = "docker network inspect $service->uuid >/dev/null 2>&1 || docker network create --attachable $service->uuid";
+            $commands[] = dockerNetworkCreateCommand($service->uuid);
         }
         $commands[] = 'echo Starting service.';
         $commands[] = "docker compose --project-directory {$workdir} -f {$workdir}/docker-compose.yml --project-name {$service->uuid} up -d --remove-orphans --force-recreate --build";

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -793,7 +793,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             // TODO
         } else {
             $this->execute_remote_command([
-                "docker network inspect '{$networkId}' >/dev/null 2>&1 || docker network create --attachable '{$networkId}' >/dev/null || true",
+                dockerNetworkCreateCommand($networkId, quiet: true).' || true',
                 'hidden' => true,
                 'ignore_errors' => true,
             ], [

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -1406,9 +1406,9 @@ $schema://$host {
             return;
         }
         if ($isSwarm) {
-            return instant_remote_process(['docker network create --attachable --driver overlay coolify-overlay >/dev/null 2>&1 || true'], $this, false);
+            return instant_remote_process([dockerNetworkCreateCommand('coolify-overlay', isSwarm: true, quiet: true).' || true'], $this, false);
         } else {
-            return instant_remote_process(['docker network create coolify --attachable >/dev/null 2>&1 || true'], $this, false);
+            return instant_remote_process([dockerNetworkCreateCommand('coolify', quiet: true).' || true'], $this, false);
         }
     }
 

--- a/app/Models/StandaloneDocker.php
+++ b/app/Models/StandaloneDocker.php
@@ -23,9 +23,8 @@ class StandaloneDocker extends BaseModel
         parent::boot();
         static::created(function ($newStandaloneDocker) {
             $server = $newStandaloneDocker->server;
-            $safeNetwork = escapeshellarg($newStandaloneDocker->network);
             instant_remote_process([
-                "docker network inspect {$safeNetwork} >/dev/null 2>&1 || docker network create --driver overlay --attachable {$safeNetwork} >/dev/null",
+                dockerNetworkCreateCommand($newStandaloneDocker->network, isSwarm: $server->isSwarm(), quiet: true),
             ], $server, false);
             ConnectProxyToNetworksJob::dispatchSync($server);
         });

--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -127,6 +127,27 @@ function format_docker_envs_to_json($rawOutput)
         return collect([]);
     }
 }
+
+function dockerNetworkCreateCommand(string $network, bool $isSwarm = false, bool $quiet = false): string
+{
+    $safeNetwork = escapeshellarg($network);
+    $redirect = $quiet ? ' >/dev/null 2>&1' : '';
+    $inspect = "docker network inspect {$safeNetwork} >/dev/null 2>&1";
+
+    if ($isSwarm) {
+        return "{$inspect} || docker network create --driver overlay --attachable {$safeNetwork}{$redirect}";
+    }
+
+    $existingNetworkCheck = $inspect;
+    if (! $quiet) {
+        $ipv6Enabled = "[ \"$(docker network inspect --format '{{.EnableIPv6}}' {$safeNetwork} 2>/dev/null)\" = \"true\" ]";
+        $ipv6Warning = "echo 'Existing Docker network does not have IPv6 enabled; recreate it to preserve IPv6 client IPs.' >&2";
+        $existingNetworkCheck = "{$inspect} && ({$ipv6Enabled} || {$ipv6Warning})";
+    }
+
+    return "{$existingNetworkCheck} || docker network create --attachable --ipv6 {$safeNetwork} >/dev/null 2>&1 || {$inspect} || docker network create --attachable {$safeNetwork}{$redirect}";
+}
+
 function checkMinimumDockerEngineVersion($dockerVersion)
 {
     $majorDockerVersion = (int) str($dockerVersion)->before('.')->value();

--- a/bootstrap/helpers/proxy.php
+++ b/bootstrap/helpers/proxy.php
@@ -111,7 +111,7 @@ function connectProxyToNetworks(Server $server)
         $commands = $networks->map(function ($network) {
             $safe = escapeshellarg($network);
             return [
-                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || docker network create --driver overlay --attachable {$safe} >/dev/null",
+                dockerNetworkCreateCommand($network, isSwarm: true, quiet: true),
                 "docker network connect {$safe} coolify-proxy >/dev/null 2>&1 || true",
                 "echo 'Successfully connected coolify-proxy to {$safe} network.'",
             ];
@@ -120,7 +120,7 @@ function connectProxyToNetworks(Server $server)
         $commands = $networks->map(function ($network) {
             $safe = escapeshellarg($network);
             return [
-                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || docker network create --attachable {$safe} >/dev/null",
+                dockerNetworkCreateCommand($network, quiet: true),
                 "docker network connect {$safe} coolify-proxy >/dev/null 2>&1 || true",
                 "echo 'Successfully connected coolify-proxy to {$safe} network.'",
             ];
@@ -146,7 +146,7 @@ function ensureProxyNetworksExist(Server $server)
             $safe = escapeshellarg($network);
             return [
                 "echo 'Ensuring network {$safe} exists...'",
-                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --driver overlay --attachable {$safe}",
+                dockerNetworkCreateCommand($network, isSwarm: true),
             ];
         });
     } else {
@@ -154,7 +154,7 @@ function ensureProxyNetworksExist(Server $server)
             $safe = escapeshellarg($network);
             return [
                 "echo 'Ensuring network {$safe} exists...'",
-                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --attachable {$safe}",
+                dockerNetworkCreateCommand($network),
             ];
         });
     }

--- a/tests/Unit/DockerNetworkCreateCommandTest.php
+++ b/tests/Unit/DockerNetworkCreateCommandTest.php
@@ -1,0 +1,40 @@
+<?php
+
+it('builds standalone docker network create commands with ipv6 fallback', function () {
+    $safeNetwork = escapeshellarg('coolify');
+    $inspect = "docker network inspect {$safeNetwork} >/dev/null 2>&1";
+    $ipv6Enabled = "[ \"$(docker network inspect --format '{{.EnableIPv6}}' {$safeNetwork} 2>/dev/null)\" = \"true\" ]";
+    $ipv6Warning = "echo 'Existing Docker network does not have IPv6 enabled; recreate it to preserve IPv6 client IPs.' >&2";
+
+    expect(dockerNetworkCreateCommand('coolify'))->toBe(
+        "{$inspect} && ({$ipv6Enabled} || {$ipv6Warning}) || docker network create --attachable --ipv6 {$safeNetwork} >/dev/null 2>&1 || {$inspect} || docker network create --attachable {$safeNetwork}"
+    );
+});
+
+it('can silence standalone docker network create commands', function () {
+    $safeNetwork = escapeshellarg('coolify');
+    $inspect = "docker network inspect {$safeNetwork} >/dev/null 2>&1";
+
+    expect(dockerNetworkCreateCommand('coolify', quiet: true))->toBe(
+        "{$inspect} || docker network create --attachable --ipv6 {$safeNetwork} >/dev/null 2>&1 || {$inspect} || docker network create --attachable {$safeNetwork} >/dev/null 2>&1"
+    );
+});
+
+it('keeps swarm overlay docker network creation unchanged', function () {
+    $safeNetwork = escapeshellarg('coolify-overlay');
+    $inspect = "docker network inspect {$safeNetwork} >/dev/null 2>&1";
+
+    expect(dockerNetworkCreateCommand('coolify-overlay', isSwarm: true))->toBe(
+        "{$inspect} || docker network create --driver overlay --attachable {$safeNetwork}"
+    )->not->toContain('--ipv6');
+});
+
+it('shell escapes docker network names in create commands', function () {
+    $network = "app's.network";
+    $safeNetwork = escapeshellarg($network);
+
+    expect(dockerNetworkCreateCommand($network))
+        ->toContain("docker network inspect {$safeNetwork}")
+        ->toContain("docker network create --attachable --ipv6 {$safeNetwork}")
+        ->toContain("docker network create --attachable {$safeNetwork}");
+});


### PR DESCRIPTION
## Changes

- Added one helper for Coolify-managed Docker network creation.
- Standalone networks now try IPv6-enabled creation first and fall back to the existing IPv4-only create command when Docker IPv6 is unavailable.
- Reused the helper for proxy, install, validation, application compose, service, and destination network creation paths.
- Existing standalone networks are checked for IPv6 in visible proxy setup paths so operators know when an old network must be recreated.

## Issues

- Fixes #3436
- /claim #3436

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No UI change. This changes the remote Docker commands Coolify generates for managed networks.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Used to inspect related PRs, update the command helper and call sites, add tests, and review the diff.

## Testing

- `git diff --check`
- Searched the codebase to confirm Docker network creation now goes through the shared helper.

I could not run Pest or Pint locally because this runner does not have PHP, Composer, Docker, or Spin installed.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
