### PR TITLE
feat: add read-only container info view for service stack items

### DIFF
--- a/app/Livewire/Project/Service/Index.php
+++ b/app/Livewire/Project/Service/Index.php
@@ -8,6 +8,7 @@ use App\Models\Server;
 use App\Models\Service;
 use App\Models\ServiceApplication;
 use App\Models\ServiceDatabase;
+use App\Support\ContainerInfoPresenter;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
@@ -84,6 +85,10 @@ class Index extends Component
 
     public bool $isStripprefixEnabled = false;
 
+    public ?array $containerInfo = null;
+
+    public ?string $containerInfoError = null;
+
     protected $listeners = ['generateDockerCompose', 'refreshScheduledBackups' => '$refresh', 'refreshFileStorages'];
 
     protected $rules = [
@@ -131,6 +136,9 @@ class Index extends Component
                 $this->resourceType = 'database';
                 $this->serviceDatabase->getFilesFromServer();
                 $this->initializeDatabaseProperties();
+            }
+            if ($this->currentRoute === 'project.service.index.info') {
+                $this->loadContainerInfo();
             }
             $this->s3s = currentTeam()->s3s;
         } catch (\Throwable $e) {
@@ -558,5 +566,33 @@ class Index extends Component
     public function render()
     {
         return view('livewire.project.service.index');
+    }
+
+    private function loadContainerInfo(): void
+    {
+        $containerName = $this->resourceType === 'application'
+            ? "{$this->serviceApplication->name}-{$this->service->uuid}"
+            : "{$this->serviceDatabase->name}-{$this->service->uuid}";
+
+        $server = $this->resourceType === 'application'
+            ? $this->serviceApplication->service->destination->server
+            : $this->serviceDatabase->service->destination->server;
+
+        $inspect = getContainerStatus($server, $containerName, true, false);
+
+        if (! is_array($inspect)) {
+            $this->containerInfoError = 'Live container metadata is unavailable right now. The container may not exist yet or the server is unreachable.';
+            $this->containerInfo = [
+                'container_id' => $containerName,
+                'container_name' => $containerName,
+                'status' => is_string($inspect) ? $inspect : null,
+                'restart_count' => 0,
+                'networks' => [],
+            ];
+
+            return;
+        }
+
+        $this->containerInfo = ContainerInfoPresenter::fromInspect($inspect, $containerName);
     }
 }

--- a/app/Support/ContainerInfoPresenter.php
+++ b/app/Support/ContainerInfoPresenter.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Support;
+
+use Carbon\Carbon;
+
+class ContainerInfoPresenter
+{
+    public static function fromInspect(array $inspect, string $fallbackContainerName): array
+    {
+        $networks = collect(data_get($inspect, 'NetworkSettings.Networks', []))
+            ->map(function ($network, string $networkName) {
+                return [
+                    'name' => $networkName,
+                    'ipv4' => data_get($network, 'IPAddress') ?: null,
+                    'ipv6' => data_get($network, 'GlobalIPv6Address') ?: null,
+                    'mac' => data_get($network, 'MacAddress') ?: null,
+                    'gateway' => data_get($network, 'Gateway') ?: null,
+                ];
+            })
+            ->values()
+            ->all();
+
+        return [
+            'container_id' => data_get($inspect, 'Id') ?: $fallbackContainerName,
+            'container_name' => ltrim((string) data_get($inspect, 'Name', $fallbackContainerName), '/'),
+            'hostname' => data_get($inspect, 'Config.Hostname') ?: null,
+            'status' => data_get($inspect, 'State.Status') ?: null,
+            'image_reference' => data_get($inspect, 'Config.Image') ?: null,
+            'image_hash' => data_get($inspect, 'Image') ?: null,
+            'image_digest' => data_get($inspect, 'RepoDigests.0') ?: null,
+            'created_at' => self::formatDate(data_get($inspect, 'Created')),
+            'started_at' => self::formatDate(data_get($inspect, 'State.StartedAt')),
+            'restart_count' => (int) (data_get($inspect, 'RestartCount') ?? data_get($inspect, 'State.RestartCount') ?? 0),
+            'networks' => $networks,
+        ];
+    }
+
+    private static function formatDate(?string $value): ?array
+    {
+        if (blank($value) || str_starts_with($value, '0001-01-01')) {
+            return null;
+        }
+
+        try {
+            $date = Carbon::parse($value);
+
+            return [
+                'iso' => $date->toIso8601String(),
+                'display' => $date->format('Y-m-d H:i:s T'),
+                'human' => $date->diffForHumans(),
+            ];
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+}

--- a/resources/views/components/service-database/sidebar.blade.php
+++ b/resources/views/components/service-database/sidebar.blade.php
@@ -17,6 +17,8 @@
     <a class="sub-menu-item" wire:current.exact="menu-item-active" {{ wireNavigate() }}
         href="{{ route('project.service.index', $parameters) }}"><span class="menu-item-label">General</span></a>
     <a class="sub-menu-item" wire:current.exact="menu-item-active" {{ wireNavigate() }}
+        href="{{ route('project.service.index.info', $parameters) }}"><span class="menu-item-label">Container Info</span></a>
+    <a class="sub-menu-item" wire:current.exact="menu-item-active" {{ wireNavigate() }}
         href="{{ route('project.service.index.advanced', $parameters) }}"><span class="menu-item-label">Advanced</span></a>
     @if ($serviceDatabase?->isBackupSolutionAvailable() || $serviceDatabase?->is_migrated)
         <a class="sub-menu-item" wire:current.exact="menu-item-active" {{ wireNavigate() }}

--- a/resources/views/livewire/project/service/index.blade.php
+++ b/resources/views/livewire/project/service/index.blade.php
@@ -17,6 +17,8 @@
                 <a class="sub-menu-item" wire:current.exact="menu-item-active" {{ wireNavigate() }}
                     href="{{ route('project.service.index', $parameters) }}"><span class="menu-item-label">General</span></a>
                 <a class="sub-menu-item" wire:current.exact="menu-item-active" {{ wireNavigate() }}
+                    href="{{ route('project.service.index.info', $parameters) }}"><span class="menu-item-label">Container Info</span></a>
+                <a class="sub-menu-item" wire:current.exact="menu-item-active" {{ wireNavigate() }}
                     href="{{ route('project.service.index.advanced', $parameters) }}"><span class="menu-item-label">Advanced</span></a>
             </div>
         @endif
@@ -26,7 +28,12 @@
                     {{ data_get_str($service, 'name')->limit(10) }} >
                     {{ data_get_str($serviceApplication, 'name')->limit(10) }} | Coolify
                 </x-slot>
-                @if ($currentRoute === 'project.service.index.advanced')
+                @if ($currentRoute === 'project.service.index.info')
+                    @include('livewire.project.service.partials.container-info', [
+                        'containerInfo' => $containerInfo,
+                        'containerInfoError' => $containerInfoError,
+                    ])
+                @elseif ($currentRoute === 'project.service.index.advanced')
                     <h2>Advanced</h2>
                     <div class="w-full sm:w-96 flex flex-col gap-1 pt-4">
                         @if (str($serviceApplication->image)->contains('pocketbase'))
@@ -184,6 +191,11 @@
                 </x-slot>
                 @if ($currentRoute === 'project.service.database.import')
                     <livewire:project.database.import :resource="$serviceDatabase" :key="'import-' . $serviceDatabase->uuid" />
+                @elseif ($currentRoute === 'project.service.index.info')
+                    @include('livewire.project.service.partials.container-info', [
+                        'containerInfo' => $containerInfo,
+                        'containerInfoError' => $containerInfoError,
+                    ])
                 @elseif ($currentRoute === 'project.service.index.advanced')
                     <h2>Advanced</h2>
                     <div class="w-full sm:w-96 flex flex-col gap-1 pt-4">

--- a/resources/views/livewire/project/service/partials/container-info.blade.php
+++ b/resources/views/livewire/project/service/partials/container-info.blade.php
@@ -1,0 +1,127 @@
+@php
+    $containerInfo = $containerInfo ?? [];
+    $networks = data_get($containerInfo, 'networks', []);
+@endphp
+
+<div class="flex flex-col gap-6">
+    <div>
+        <h2>Container Info</h2>
+        <div class="text-sm text-neutral-500">
+            Live container metadata pulled from the current server.
+        </div>
+    </div>
+
+    @if ($containerInfoError)
+        <x-callout type="warning" title="Container metadata unavailable">
+            {{ $containerInfoError }}
+        </x-callout>
+    @endif
+
+    <div class="grid gap-6 xl:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">
+        <div class="flex flex-col gap-4">
+            <div class="box-without-bg-without-border dark:bg-coolgray-100 bg-white">
+                <h3 class="pb-4">Runtime</h3>
+                <div class="grid gap-4 sm:grid-cols-2">
+                    <div class="sm:col-span-2">
+                        <div class="pb-2 text-xs uppercase text-neutral-500">Container ID</div>
+                        <x-forms.copy-button :text="data_get($containerInfo, 'container_id', 'Unavailable')" />
+                    </div>
+                    <div class="sm:col-span-2">
+                        <div class="pb-2 text-xs uppercase text-neutral-500">Container Name</div>
+                        <x-forms.copy-button :text="data_get($containerInfo, 'container_name', 'Unavailable')" />
+                    </div>
+                    <div>
+                        <div class="pb-1 text-xs uppercase text-neutral-500">Status</div>
+                        <div>{{ str(data_get($containerInfo, 'status', 'unknown'))->headline() }}</div>
+                    </div>
+                    <div>
+                        <div class="pb-1 text-xs uppercase text-neutral-500">Restart Count</div>
+                        <div>{{ data_get($containerInfo, 'restart_count', 0) }}</div>
+                    </div>
+                    <div>
+                        <div class="pb-1 text-xs uppercase text-neutral-500">Created</div>
+                        @if (data_get($containerInfo, 'created_at'))
+                            <div>{{ data_get($containerInfo, 'created_at.display') }}</div>
+                            <div class="text-xs text-neutral-500">{{ data_get($containerInfo, 'created_at.human') }}</div>
+                        @else
+                            <div class="text-neutral-500">Unavailable</div>
+                        @endif
+                    </div>
+                    <div>
+                        <div class="pb-1 text-xs uppercase text-neutral-500">Started</div>
+                        @if (data_get($containerInfo, 'started_at'))
+                            <div>{{ data_get($containerInfo, 'started_at.display') }}</div>
+                            <div class="text-xs text-neutral-500">{{ data_get($containerInfo, 'started_at.human') }}</div>
+                        @else
+                            <div class="text-neutral-500">Unavailable</div>
+                        @endif
+                    </div>
+                    <div class="sm:col-span-2">
+                        <div class="pb-2 text-xs uppercase text-neutral-500">Image Reference</div>
+                        <x-forms.copy-button :text="data_get($containerInfo, 'image_reference', 'Unavailable')" />
+                    </div>
+                    <div class="sm:col-span-2">
+                        <div class="pb-2 text-xs uppercase text-neutral-500">Image Hash</div>
+                        <x-forms.copy-button :text="data_get($containerInfo, 'image_hash', 'Unavailable')" />
+                    </div>
+                    @if (data_get($containerInfo, 'image_digest'))
+                        <div class="sm:col-span-2">
+                            <div class="pb-2 text-xs uppercase text-neutral-500">Image Digest</div>
+                            <x-forms.copy-button :text="data_get($containerInfo, 'image_digest')" />
+                        </div>
+                    @endif
+                    @if (data_get($containerInfo, 'hostname'))
+                        <div class="sm:col-span-2">
+                            <div class="pb-2 text-xs uppercase text-neutral-500">Hostname</div>
+                            <x-forms.copy-button :text="data_get($containerInfo, 'hostname')" />
+                        </div>
+                    @endif
+                </div>
+            </div>
+        </div>
+
+        <div class="flex flex-col gap-4">
+            <div class="box-without-bg-without-border dark:bg-coolgray-100 bg-white">
+                <div class="flex items-center justify-between pb-4">
+                    <h3>Networks</h3>
+                    <div class="text-xs text-neutral-500">
+                        {{ count($networks) }} attached
+                    </div>
+                </div>
+                @if (empty($networks))
+                    <div class="text-sm text-neutral-500">
+                        No network metadata is available for this container right now.
+                    </div>
+                @else
+                    <div class="flex flex-col gap-4">
+                        @foreach ($networks as $network)
+                            <div class="rounded-sm border border-neutral-200 p-4 dark:border-coolgray-300">
+                                <div class="pb-3 font-medium">{{ data_get($network, 'name') }}</div>
+                                <div class="grid gap-4">
+                                    <div>
+                                        <div class="pb-2 text-xs uppercase text-neutral-500">IPv4</div>
+                                        <x-forms.copy-button :text="data_get($network, 'ipv4', 'Unavailable')" />
+                                    </div>
+                                    <div>
+                                        <div class="pb-2 text-xs uppercase text-neutral-500">IPv6</div>
+                                        <x-forms.copy-button :text="data_get($network, 'ipv6', 'Unavailable')" />
+                                    </div>
+                                    <div>
+                                        <div class="pb-2 text-xs uppercase text-neutral-500">MAC Address</div>
+                                        <x-forms.copy-button :text="data_get($network, 'mac', 'Unavailable')" />
+                                    </div>
+                                    @if (data_get($network, 'gateway'))
+                                        <div>
+                                            <div class="pb-2 text-xs uppercase text-neutral-500">Gateway</div>
+                                            <x-forms.copy-button :text="data_get($network, 'gateway')" />
+                                        </div>
+                                    @endif
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                @endif
+            </div>
+        </div>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -267,6 +267,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/terminal', ExecuteContainerCommand::class)->name('project.service.command')->middleware('can.access.terminal');
         Route::get('/{stack_service_uuid}/backups', ServiceDatabaseBackups::class)->name('project.service.database.backups');
         Route::get('/{stack_service_uuid}/import', ServiceIndex::class)->name('project.service.database.import')->middleware('can.update.resource');
+        Route::get('/{stack_service_uuid}/info', ServiceIndex::class)->name('project.service.index.info');
         Route::get('/{stack_service_uuid}/advanced', ServiceIndex::class)->name('project.service.index.advanced');
         Route::get('/{stack_service_uuid}', ServiceIndex::class)->name('project.service.index');
         Route::get('/tasks/{task_uuid}', ServiceConfiguration::class)->name('project.service.scheduled-tasks');

--- a/tests/Unit/ContainerInfoPresenterTest.php
+++ b/tests/Unit/ContainerInfoPresenterTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use App\Support\ContainerInfoPresenter;
+
+it('formats docker inspect payload into container info metadata', function () {
+    $inspect = [
+        'Id' => 'abcdef1234567890',
+        'Name' => '/coolify-demo-container',
+        'Config' => [
+            'Image' => 'ghcr.io/example/demo:latest',
+            'Hostname' => 'coolify-demo-container',
+        ],
+        'Image' => 'sha256:1234abcd',
+        'RepoDigests' => [
+            'ghcr.io/example/demo@sha256:beefcafe',
+        ],
+        'Created' => '2026-05-13T04:00:00Z',
+        'State' => [
+            'Status' => 'running',
+            'StartedAt' => '2026-05-13T04:05:00Z',
+        ],
+        'RestartCount' => 3,
+        'NetworkSettings' => [
+            'Networks' => [
+                'coolify' => [
+                    'IPAddress' => '172.18.0.9',
+                    'GlobalIPv6Address' => 'fd00::9',
+                    'MacAddress' => '02:42:ac:12:00:09',
+                    'Gateway' => '172.18.0.1',
+                ],
+            ],
+        ],
+    ];
+
+    $result = ContainerInfoPresenter::fromInspect($inspect, 'fallback-container');
+
+    expect($result['container_id'])->toBe('abcdef1234567890')
+        ->and($result['container_name'])->toBe('coolify-demo-container')
+        ->and($result['image_reference'])->toBe('ghcr.io/example/demo:latest')
+        ->and($result['image_hash'])->toBe('sha256:1234abcd')
+        ->and($result['image_digest'])->toBe('ghcr.io/example/demo@sha256:beefcafe')
+        ->and($result['hostname'])->toBe('coolify-demo-container')
+        ->and($result['status'])->toBe('running')
+        ->and($result['restart_count'])->toBe(3)
+        ->and($result['created_at']['iso'])->toBe('2026-05-13T04:00:00+00:00')
+        ->and($result['started_at']['iso'])->toBe('2026-05-13T04:05:00+00:00')
+        ->and($result['networks'])->toHaveCount(1)
+        ->and($result['networks'][0]['name'])->toBe('coolify')
+        ->and($result['networks'][0]['ipv4'])->toBe('172.18.0.9')
+        ->and($result['networks'][0]['ipv6'])->toBe('fd00::9')
+        ->and($result['networks'][0]['mac'])->toBe('02:42:ac:12:00:09')
+        ->and($result['networks'][0]['gateway'])->toBe('172.18.0.1');
+});
+
+it('treats missing docker dates as unavailable', function () {
+    $result = ContainerInfoPresenter::fromInspect([
+        'Name' => '/fallback-container',
+        'State' => [
+            'Status' => 'created',
+            'StartedAt' => '0001-01-01T00:00:00Z',
+        ],
+        'Created' => null,
+        'NetworkSettings' => [
+            'Networks' => [],
+        ],
+    ], 'fallback-container');
+
+    expect($result['container_name'])->toBe('fallback-container')
+        ->and($result['created_at'])->toBeNull()
+        ->and($result['started_at'])->toBeNull()
+        ->and($result['networks'])->toBeArray()
+        ->and($result['networks'])->toHaveCount(0);
+});


### PR DESCRIPTION
/claim #2495

This is a focused first slice for #2495: a read-only Container Info view on individual service application and service database pages.

Scope in this PR:
- add a new `Container Info` route/tab for service stack items
- pull live `docker inspect` metadata from the resource server
- display container ID, runtime container name, image reference/hash/digest, status, created/started timestamps, restart count, and per-network IPv4/IPv6/MAC/gateway data
- keep network mutation out of scope for now so the change stays reviewable and low-risk

Validation completed locally:
- `php -l app/Support/ContainerInfoPresenter.php`
- `php -l app/Livewire/Project/Service/Index.php`
- `php -l routes/web.php`
- `./vendor/bin/pest tests/Unit/ContainerInfoPresenterTest.php`
- `git diff --check`

Demo video:
- pending before ready-for-review; opening as draft first to share the implementation slice and get early direction if needed

AI assistance disclosure:
- AI-assisted implementation, manually reviewed before submission.