### PR TITLE
fix: fall back when ipv6 docker network creation fails

### DIFF
--- a/bootstrap/helpers/proxy.php
+++ b/bootstrap/helpers/proxy.php
@@ -20,6 +20,16 @@ function isDockerPredefinedNetwork(string $network): bool
     return in_array($network, ['default', 'host'], true);
 }
 
+function dockerNetworkCreateCommand(string $network, bool $overlay = false, bool $suppressOutput = false): string
+{
+    $safe = escapeshellarg($network);
+    $driver = $overlay ? '--driver overlay ' : '';
+    $output = $suppressOutput ? ' >/dev/null' : '';
+    $ipv6Output = $suppressOutput ? ' >/dev/null 2>/dev/null' : ' 2>/dev/null';
+
+    return "(docker network create {$driver}--ipv6 --attachable {$safe}{$ipv6Output} || docker network create {$driver}--attachable {$safe}{$output})";
+}
+
 function collectProxyDockerNetworksByServer(Server $server)
 {
     if (! $server->isFunctional()) {
@@ -108,18 +118,20 @@ function connectProxyToNetworks(Server $server)
     ['networks' => $networks] = collectDockerNetworksByServer($server);
     if ($server->isSwarm()) {
         $commands = $networks->map(function ($network) {
+            $safe = escapeshellarg($network);
             return [
-                "docker network ls --format '{{.Name}}' | grep '^$network$' >/dev/null || docker network create --driver overlay --attachable $network >/dev/null",
-                "docker network connect $network coolify-proxy >/dev/null 2>&1 || true",
-                "echo 'Successfully connected coolify-proxy to $network network.'",
+                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || ".dockerNetworkCreateCommand($network, overlay: true, suppressOutput: true),
+                "docker network connect {$safe} coolify-proxy >/dev/null 2>&1 || true",
+                "echo 'Successfully connected coolify-proxy to {$safe} network.'",
             ];
         });
     } else {
         $commands = $networks->map(function ($network) {
+            $safe = escapeshellarg($network);
             return [
-                "docker network ls --format '{{.Name}}' | grep '^$network$' >/dev/null || docker network create --attachable $network >/dev/null",
-                "docker network connect $network coolify-proxy >/dev/null 2>&1 || true",
-                "echo 'Successfully connected coolify-proxy to $network network.'",
+                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || ".dockerNetworkCreateCommand($network, suppressOutput: true),
+                "docker network connect {$safe} coolify-proxy >/dev/null 2>&1 || true",
+                "echo 'Successfully connected coolify-proxy to {$safe} network.'",
             ];
         });
     }
@@ -140,16 +152,18 @@ function ensureProxyNetworksExist(Server $server)
 
     if ($server->isSwarm()) {
         $commands = $networks->map(function ($network) {
+            $safe = escapeshellarg($network);
             return [
-                "echo 'Ensuring network $network exists...'",
-                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --driver overlay --attachable $network",
+                "echo 'Ensuring network {$safe} exists...'",
+                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || ".dockerNetworkCreateCommand($network, overlay: true),
             ];
         });
     } else {
         $commands = $networks->map(function ($network) {
+            $safe = escapeshellarg($network);
             return [
-                "echo 'Ensuring network $network exists...'",
-                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --attachable $network",
+                "echo 'Ensuring network {$safe} exists...'",
+                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || ".dockerNetworkCreateCommand($network),
             ];
         });
     }

--- a/tests/Unit/ProxyHelperTest.php
+++ b/tests/Unit/ProxyHelperTest.php
@@ -189,3 +189,27 @@ it('identifies none as not predefined (per codebase pattern)', function () {
     // only filters 'default' and 'host', so we maintain consistency
     expect(isDockerPredefinedNetwork('none'))->toBeFalse();
 });
+
+it('creates bridge networks with ipv6 fallback', function () {
+    $command = dockerNetworkCreateCommand('coolify', suppressOutput: true);
+
+    expect($command)
+        ->toContain('docker network create --ipv6 --attachable coolify >/dev/null 2>/dev/null')
+        ->toContain('|| docker network create --attachable coolify >/dev/null');
+});
+
+it('creates overlay networks with ipv6 fallback', function () {
+    $command = dockerNetworkCreateCommand('coolify-overlay', overlay: true);
+
+    expect($command)
+        ->toContain('docker network create --driver overlay --ipv6 --attachable coolify-overlay 2>/dev/null')
+        ->toContain('|| docker network create --driver overlay --attachable coolify-overlay');
+});
+
+it('shell escapes network names in network creation fallback commands', function () {
+    $command = dockerNetworkCreateCommand('custom network', suppressOutput: true);
+
+    expect($command)
+        ->toContain("docker network create --ipv6 --attachable 'custom network' >/dev/null 2>/dev/null")
+        ->toContain("|| docker network create --attachable 'custom network' >/dev/null");
+});


### PR DESCRIPTION
## Changes

- Add a shared Docker network creation helper for Coolify-managed proxy networks.
- Try creating bridge and overlay proxy networks with `--ipv6` first so IPv6 clients can preserve the real client IP through the proxy path.
- Fall back to the current IPv4-only `docker network create` command when the Docker host is not configured for IPv6, avoiding a hard failure for existing installations.
- Reuse the helper in both proxy network connection and pre-compose network creation paths.
- Add unit coverage for bridge, overlay, and shell-escaped network names.

## Issues

- Fixes #3436
- /claim #3436

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not a UI change. The affected output is the generated Docker network command; the new helper produces an IPv6-first command with an IPv4 fallback.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Used to inspect the issue/repo, prepare the focused helper/test patch, and draft this PR. I reviewed the generated shell command behavior and kept the change scoped to the proxy network creation path.

## Testing

- `git diff --check`
- Reviewed the generated command strings in `bootstrap/helpers/proxy.php` and the added expectations in `tests/Unit/ProxyHelperTest.php`.

I could not run the PHP/Pest suite locally in this environment because PHP and Docker are not installed here, so I am leaving the full local-development checkbox below unchecked rather than overstating verification.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
