### PR TITLE
feat: add Huly service template

### DIFF
--- a/templates/compose/huly.yaml
+++ b/templates/compose/huly.yaml
@@ -1,36 +1,178 @@
-# ignore: true
-# documentation: https://huly.io/
-# category: cms
-# slogan: Open Source All-in-One Project Management Platform
-# tags: linear,jira,slack,project,management,notion,motion
-# port: 8080
+# documentation: https://github.com/hcengineering/huly-selfhost
+# category: productivity
+# slogan: Open-source all-in-one project management platform
+# tags: huly,project-management,collaboration,linear,jira,notion,slack
+# port: 80
+
+x-huly-common-env: &huly-common-env
+  SERVER_SECRET: $SERVICE_PASSWORD_SECRET
+  DB_URL: postgres://root@cockroach:26257/defaultdb?sslmode=disable
+  STORAGE_CONFIG: minio|minio?accessKey=$SERVICE_USER_MINIO&secretKey=$SERVICE_PASSWORD_MINIO
+  STATS_URL: http://stats:4900
+  QUEUE_CONFIG: redpanda:9092
 
 services:
-  mongodb:
-    image: "mongo:7-jammy"
-    container_name: mongodb
+  nginx:
+    image: nginx:1.29.2
     environment:
-      - PUID=1000
-      - PGID=1000
+      - SERVICE_URL_HULY_80
+    depends_on:
+      - front
+      - account
+      - collaborator
+      - transactor
+      - rekoni
+      - stats
     volumes:
-      - huly-db:/data/db
+      - type: bind
+        source: ./nginx/huly.conf
+        target: /etc/nginx/conf.d/default.conf
+        read_only: true
+        content: |
+          server {
+              listen 80;
+              server_name _;
+              client_max_body_size 100M;
+
+              location / {
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+                  proxy_pass http://front:8080;
+              }
+
+              location /_accounts {
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+                  rewrite ^/_accounts(/.*)$ $1 break;
+                  proxy_pass http://account:3000/;
+              }
+
+              location /_collaborator {
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+                  proxy_http_version 1.1;
+                  proxy_set_header Upgrade $http_upgrade;
+                  proxy_set_header Connection "upgrade";
+                  rewrite ^/_collaborator(/.*)$ $1 break;
+                  proxy_pass http://collaborator:3078/;
+              }
+
+              location /_transactor {
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+                  proxy_http_version 1.1;
+                  proxy_set_header Upgrade $http_upgrade;
+                  proxy_set_header Connection "upgrade";
+                  rewrite ^/_transactor(/.*)$ $1 break;
+                  proxy_pass http://transactor:3333/;
+              }
+
+              location ~ ^/eyJ {
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+                  proxy_http_version 1.1;
+                  proxy_set_header Upgrade $http_upgrade;
+                  proxy_set_header Connection "upgrade";
+                  proxy_pass http://transactor:3333;
+              }
+
+              location /_rekoni {
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+                  rewrite ^/_rekoni(/.*)$ $1 break;
+                  proxy_pass http://rekoni:4004/;
+              }
+
+              location /_stats {
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+                  rewrite ^/_stats(/.*)$ $1 break;
+                  proxy_pass http://stats:4900/;
+              }
+          }
+    healthcheck:
+      test: ["CMD", "nginx", "-t"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  cockroach:
+    image: cockroachdb/cockroach:v24.2.10
+    command: start-single-node --accept-sql-without-tls
+    volumes:
+      - cr-data:/cockroach/cockroach-data
+      - cr-certs:/cockroach/certs
+    healthcheck:
+      test: ["CMD", "cockroach", "sql", "--insecure", "--host=127.0.0.1:26257", "--execute=SELECT 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  redpanda:
+    image: docker.redpanda.com/redpandadata/redpanda:v24.3.6
+    command:
+      - redpanda
+      - start
+      - --kafka-addr
+      - internal://0.0.0.0:9092,external://0.0.0.0:19092
+      - --advertise-kafka-addr
+      - internal://redpanda:9092,external://localhost:19092
+      - --pandaproxy-addr
+      - internal://0.0.0.0:8082,external://0.0.0.0:18082
+      - --advertise-pandaproxy-addr
+      - internal://redpanda:8082,external://localhost:18082
+      - --schema-registry-addr
+      - internal://0.0.0.0:8081,external://0.0.0.0:18081
+      - --rpc-addr
+      - redpanda:33145
+      - --advertise-rpc-addr
+      - redpanda:33145
+      - --mode
+      - dev-container
+      - --smp
+      - "1"
+      - --default-log-level=info
+    volumes:
+      - redpanda:/var/lib/redpanda/data
+    healthcheck:
+      test: ["CMD", "rpk", "cluster", "info"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
   minio:
-    image: ghcr.io/coollabsio/minio:RELEASE.2025-10-15T17-29-55Z # Released on 15 October 2025
+    image: ghcr.io/coollabsio/minio:RELEASE.2025-10-15T17-29-55Z
     command: server /data --address ":9000" --console-address ":9001"
+    environment:
+      - MINIO_ROOT_USER=$SERVICE_USER_MINIO
+      - MINIO_ROOT_PASSWORD=$SERVICE_PASSWORD_MINIO
     volumes:
-      - huly-files:/data      
+      - files:/data
     healthcheck:
       test: ["CMD", "mc", "ready", "local"]
       interval: 5s
       timeout: 20s
       retries: 10
+
   elastic:
-    image: "elasticsearch:7.14.2"
+    image: elasticsearch:7.14.2
     command: |
       /bin/sh -c "./bin/elasticsearch-plugin list | grep -q ingest-attachment || yes | ./bin/elasticsearch-plugin install --silent ingest-attachment;
       /usr/local/bin/docker-entrypoint.sh eswrapper"
-    volumes:
-      - huly-elastic:/usr/share/elasticsearch/data
     environment:
       - ELASTICSEARCH_PORT_NUMBER=9200
       - BITNAMI_DEBUG=true
@@ -38,86 +180,136 @@ services:
       - ES_JAVA_OPTS=-Xms1024m -Xmx1024m
       - http.cors.enabled=true
       - http.cors.allow-origin=http://localhost:8082
+    volumes:
+      - elastic:/usr/share/elasticsearch/data
     healthcheck:
-      test: curl -s http://127.0.0.1:9200/_cluster/health | grep -vq '"status":"red"'
-      interval: 5s
+      test: ["CMD-SHELL", "curl -s http://localhost:9200/_cluster/health | grep -vq '\"status\":\"red\"'"]
+      interval: 20s
+      timeout: 5s
       retries: 10
-  account:
-    image: hardcoreeng/account:v0.6.246
-    environment:
-      - SERVICE_URL_HULY_3000
-      - SERVER_PORT=3000
-      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
-      - MONGO_URL=mongodb://mongodb:27017
-      - TRANSACTOR_URL=ws://transactor:3333
-      - ENDPOINT_URL=ws://transactor:3333
-      - MINIO_ENDPOINT=minio
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadmin
-      - FRONT_URL=http://front:8080
-      - INIT_WORKSPACE=demo-tracker
-      - MODEL_ENABLED=*
-      - ACCOUNTS_URL=http://localhost:3000
-  front:
-    image: hardcoreeng/front:v0.6.246
-    environment:
-      - SERVICE_URL_HULY_8080
-      - MONGO_URL=mongodb://mongodb:27017
-      - SERVER_PORT=8080
-      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
-      - ACCOUNTS_URL=http://account:3000
-      - REKONI_URL=http://rekoni:4004
-      - CALENDAR_URL=http://localhost:8095
-      - GMAIL_URL=http://localhost:8088
-      - TELEGRAM_URL=http://localhost:8086
-      - UPLOAD_URL=/files
-      - TRANSACTOR_URL=ws://transactor:3333
-      - ELASTIC_URL=http://elastic:9200
-      - COLLABORATOR_URL=ws://collaborator:3078
-      - COLLABORATOR_API_URL=http://collaborator:3078
-      - MINIO_ENDPOINT=minio
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadmin
-      - TITLE=Huly Self Hosted
-      - DEFAULT_LANGUAGE=en
-      - LAST_NAME_FIRST=true
-    restart: unless-stopped
-  collaborator:
-    image: hardcoreeng/collaborator:v0.6.246
-    environment:
-      - COLLABORATOR_PORT=3078
-      - SECRET=secret
-      - ACCOUNTS_URL=http://account:3000
-      - TRANSACTOR_URL=ws://transactor:3333
-      - UPLOAD_URL=/files
-      - MONGO_URL=mongodb://mongodb:27017
-      - MINIO_ENDPOINT=minio
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadmin
-  transactor:
-    image: hardcoreeng/transactor:v0.6.246
-    environment:
-      - SERVER_PORT=3333
-      - ELASTIC_INDEX_NAME=huly
-      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
-      - SERVER_CURSOR_MAXTIMEMS=30000
-      - ELASTIC_URL=http://elastic:9200
-      - MONGO_URL=mongodb://mongodb:27017
-      - METRICS_CONSOLE=false
-      - METRICS_FILE=metrics.txt
-      - MINIO_ENDPOINT=minio
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadmin
-      - REKONI_URL=http://rekoni:4004
-      - FRONT_URL=http://localhost:8087
-      - SERVER_PROVIDER=ws
-      - ACCOUNTS_URL=http://account:3000
-      - LAST_NAME_FIRST=true
-      - UPLOAD_URL=/files
-    restart: unless-stopped
+
   rekoni:
-    image: hardcoreeng/rekoni-service:latest
+    image: hardcoreeng/rekoni-service:${HULY_VERSION:-v0.7.423}
+    environment:
+      - SECRET=$SERVICE_PASSWORD_SECRET
     deploy:
       resources:
         limits:
           memory: 500M
+
+  transactor:
+    image: hardcoreeng/transactor:${HULY_VERSION:-v0.7.423}
+    environment:
+      <<: *huly-common-env
+      SERVER_PORT: 3333
+      FRONT_URL: ${SERVICE_URL_HULY}
+      ACCOUNTS_URL: http://account:3000
+      FULLTEXT_URL: http://fulltext:4700
+      LAST_NAME_FIRST: ${LAST_NAME_FIRST:-true}
+    depends_on:
+      - cockroach
+      - redpanda
+      - minio
+      - fulltext
+
+  collaborator:
+    image: hardcoreeng/collaborator:${HULY_VERSION:-v0.7.423}
+    environment:
+      - COLLABORATOR_PORT=3078
+      - SECRET=$SERVICE_PASSWORD_SECRET
+      - ACCOUNTS_URL=http://account:3000
+      - STATS_URL=http://stats:4900
+      - STORAGE_CONFIG=minio|minio?accessKey=$SERVICE_USER_MINIO&secretKey=$SERVICE_PASSWORD_MINIO
+    depends_on:
+      - account
+      - minio
+
+  account:
+    image: hardcoreeng/account:${HULY_VERSION:-v0.7.423}
+    environment:
+      <<: *huly-common-env
+      SERVER_PORT: 3000
+      TRANSACTOR_URL: ws://transactor:3333;wss://${SERVICE_FQDN_HULY}/_transactor
+      FRONT_URL: ${SERVICE_URL_HULY}
+      STATS_URL: ${SERVICE_URL_HULY}/_stats
+      MODEL_ENABLED: "*"
+      ACCOUNTS_URL: ${SERVICE_URL_HULY}/_accounts
+      ACCOUNT_PORT: 3000
+    depends_on:
+      - cockroach
+      - redpanda
+      - minio
+      - transactor
+
+  workspace:
+    image: hardcoreeng/workspace:${HULY_VERSION:-v0.7.423}
+    environment:
+      <<: *huly-common-env
+      TRANSACTOR_URL: ws://transactor:3333;wss://${SERVICE_FQDN_HULY}/_transactor
+      MODEL_ENABLED: "*"
+      ACCOUNTS_URL: http://account:3000
+      ACCOUNTS_DB_URL: postgres://root@cockroach:26257/defaultdb?sslmode=disable
+    depends_on:
+      - cockroach
+      - redpanda
+      - minio
+      - account
+      - transactor
+
+  front:
+    image: hardcoreeng/front:${HULY_VERSION:-v0.7.423}
+    environment:
+      - SERVER_PORT=8080
+      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
+      - LOVE_ENDPOINT=${SERVICE_URL_HULY}/_love
+      - ACCOUNTS_URL=${SERVICE_URL_HULY}/_accounts
+      - ACCOUNTS_URL_INTERNAL=http://account:3000
+      - REKONI_URL=${SERVICE_URL_HULY}/_rekoni
+      - CALENDAR_URL=${SERVICE_URL_HULY}/_calendar
+      - GMAIL_URL=${SERVICE_URL_HULY}/_gmail
+      - TELEGRAM_URL=${SERVICE_URL_HULY}/_telegram
+      - STATS_URL=${SERVICE_URL_HULY}/_stats
+      - UPLOAD_URL=/files
+      - ELASTIC_URL=http://elastic:9200
+      - COLLABORATOR_URL=wss://${SERVICE_FQDN_HULY}/_collaborator
+      - STORAGE_CONFIG=minio|minio?accessKey=$SERVICE_USER_MINIO&secretKey=$SERVICE_PASSWORD_MINIO
+      - TITLE=${TITLE:-Huly Self Host}
+      - DEFAULT_LANGUAGE=${DEFAULT_LANGUAGE:-en}
+      - LAST_NAME_FIRST=${LAST_NAME_FIRST:-true}
+      - DESKTOP_UPDATES_CHANNEL=${DESKTOP_CHANNEL:-0.7.423}
+      - DISABLED_FEATURES=auto-translate,mailboxes
+    depends_on:
+      - account
+      - collaborator
+      - elastic
+      - minio
+      - rekoni
+      - transactor
+
+  fulltext:
+    image: hardcoreeng/fulltext:${HULY_VERSION:-v0.7.423}
+    environment:
+      <<: *huly-common-env
+      FULLTEXT_DB_URL: http://elastic:9200
+      ELASTIC_INDEX_NAME: huly_storage_index
+      REKONI_URL: http://rekoni:4004
+      ACCOUNTS_URL: http://account:3000
+    depends_on:
+      - cockroach
+      - elastic
+      - minio
+      - redpanda
+      - rekoni
+
+  stats:
+    image: hardcoreeng/stats:${HULY_VERSION:-v0.7.423}
+    environment:
+      - PORT=4900
+      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
+
+volumes:
+  cr-certs:
+  cr-data:
+  elastic:
+  files:
+  redpanda:


### PR DESCRIPTION
## Changes

- Adds a Coolify one-click service template for Huly self-hosted.
- Replaces the ignored legacy Huly compose with the current Huly v0.7.423 service stack from hcengineering/huly-selfhost.
- Adds the nginx reverse proxy configuration needed to serve Huly's frontend, account, collaborator, transactor, rekoni, and stats routes from one Coolify service URL.

/claim #2543

## Issues

- Fixes #2543

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Runtime preview is not attached yet. Huly's upstream self-host docs require at least 2 vCPU and 8 GB RAM, so I validated the template locally at compose level first and can provide a VPS demo if requested by maintainers.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex
- How extensively: Used to inspect upstream Huly self-host compose, adapt it to Coolify's service template format, and run validation commands. I reviewed the generated changes before submitting.

## Testing

- Parsed `templates/compose/huly.yaml` as YAML.
- Ran `docker compose config --quiet` after removing Coolify's custom `content` bind-mount field, which Docker Compose itself does not understand.
- Ran `git diff --check`.
- Confirmed this PR only changes `templates/compose/huly.yaml`; generated service template JSON files are intentionally left untouched because PR quality rules block them.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.