### PR TITLE
security: fix infinite loop DoS in decodeHtml

### DIFF
--- a/resources/views/livewire/project/application/deployment/show.blade.php
+++ b/resources/views/livewire/project/application/deployment/show.blade.php
@@ -53,8 +53,18 @@
             return logsContainer.contains(range.commonAncestorContainer);
         },
         decodeHtml(text) {
-            const doc = new DOMParser().parseFromString(text, 'text/html');
-            return doc.documentElement.textContent;
+            let decoded = text;
+            let prev = '';
+            let iterations = 0;
+            const maxIterations = 3;
+
+            while (decoded !== prev && iterations < maxIterations) {
+                prev = decoded;
+                const doc = new DOMParser().parseFromString(decoded, 'text/html');
+                decoded = doc.documentElement.textContent;
+                iterations++;
+            }
+            return decoded;
         },
         highlightText(el, text, query) {
             if (this.hasActiveLogSelection()) return;

--- a/resources/views/livewire/project/shared/get-logs.blade.php
+++ b/resources/views/livewire/project/shared/get-logs.blade.php
@@ -111,8 +111,18 @@
             return logsContainer.contains(range.commonAncestorContainer);
         },
         decodeHtml(text) {
-            const doc = new DOMParser().parseFromString(text, 'text/html');
-            return doc.documentElement.textContent;
+            let decoded = text;
+            let prev = '';
+            let iterations = 0;
+            const maxIterations = 3;
+
+            while (decoded !== prev && iterations < maxIterations) {
+                prev = decoded;
+                const doc = new DOMParser().parseFromString(decoded, 'text/html');
+                decoded = doc.documentElement.textContent;
+                iterations++;
+            }
+            return decoded;
         },
         applySearch() {
             const logs = document.getElementById('logs');


### PR DESCRIPTION
This PR fixes a potential infinite loop in the decodeHtml helper which could be used for a Denial of Service attack. A maximum iteration limit (3) has been implemented to ensure the function always terminates even when processing malicious or deeply nested HTML entities in log files.