### PR TITLE
fix(template): rename redis service to n8n-redis to prevent DNS collision with Coolify's internal Redis

### DIFF
--- a/templates/compose/n8n-with-postgres-and-worker.yaml
+++ b/templates/compose/n8n-with-postgres-and-worker.yaml
@@ -1,139 +1,131 @@
-# documentation: https://n8n.io
-# slogan: n8n is an extendable workflow automation tool with queue mode and workers.
-# category: automation
-# tags: n8n,workflow,automation,open,source,low,code,queue,worker,scalable
-# logo: svgs/n8n.png
-# port: 5678
-
 services:
-  n8n:
-    image: n8nio/n8n:2.10.4
-    environment:
-      - SERVICE_URL_N8N_5678
-      - N8N_EDITOR_BASE_URL=${SERVICE_URL_N8N}
-      - WEBHOOK_URL=${SERVICE_URL_N8N}
-      - N8N_HOST=${SERVICE_URL_N8N}
-      - N8N_PROTOCOL=${N8N_PROTOCOL:-https}
-      - GENERIC_TIMEZONE=${GENERIC_TIMEZONE:-UTC}
-      - TZ=${TZ:-UTC}
-      - DB_TYPE=postgresdb
-      - DB_POSTGRESDB_DATABASE=${POSTGRES_DB:-n8n}
-      - DB_POSTGRESDB_HOST=postgresql
-      - DB_POSTGRESDB_PORT=5432
-      - DB_POSTGRESDB_USER=$SERVICE_USER_POSTGRES
-      - DB_POSTGRESDB_SCHEMA=public
-      - DB_POSTGRESDB_PASSWORD=$SERVICE_PASSWORD_POSTGRES
-      - EXECUTIONS_MODE=queue
-      - QUEUE_BULL_REDIS_HOST=redis
-      - QUEUE_HEALTH_CHECK_ACTIVE=true
-      - N8N_ENCRYPTION_KEY=${SERVICE_PASSWORD_ENCRYPTION}
-      - N8N_RUNNERS_ENABLED=true
-      - N8N_RUNNERS_MODE=external
-      - N8N_RUNNERS_BROKER_LISTEN_ADDRESS=${N8N_RUNNERS_BROKER_LISTEN_ADDRESS:-0.0.0.0}
-      - N8N_RUNNERS_BROKER_PORT=${N8N_RUNNERS_BROKER_PORT:-5679}
-      - N8N_RUNNERS_AUTH_TOKEN=$SERVICE_PASSWORD_N8N
-      - N8N_NATIVE_PYTHON_RUNNER=${N8N_NATIVE_PYTHON_RUNNER:-true}
-      - N8N_RUNNERS_MAX_CONCURRENCY=${N8N_RUNNERS_MAX_CONCURRENCY:-5}
-      - OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS=true
-      - N8N_BLOCK_ENV_ACCESS_IN_NODE=${N8N_BLOCK_ENV_ACCESS_IN_NODE:-true}
-      - N8N_GIT_NODE_DISABLE_BARE_REPOS=${N8N_GIT_NODE_DISABLE_BARE_REPOS:-true}
-      - N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS=${N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS:-true}
-      - N8N_PROXY_HOPS=${N8N_PROXY_HOPS:-1}
-      - N8N_SKIP_AUTH_ON_OAUTH_CALLBACK=${N8N_SKIP_AUTH_ON_OAUTH_CALLBACK:-false}
-    volumes:
-      - n8n-data:/home/node/.n8n
-    depends_on:
-      postgresql:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-    healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:5678/healthz"]
-      interval: 5s
-      timeout: 20s
-      retries: 10
+     n8n:
+       image: n8nio/n8n:2.10.4
+       environment:
+         - SERVICE_URL_N8N_5678
+         - N8N_EDITOR_BASE_URL=${SERVICE_URL_N8N}
+         - WEBHOOK_URL=${SERVICE_URL_N8N}
+         - N8N_HOST=${SERVICE_URL_N8N}
+         - N8N_PROTOCOL=${N8N_PROTOCOL:-https}
+         - GENERIC_TIMEZONE=${GENERIC_TIMEZONE:-UTC}
+         - TZ=${TZ:-UTC}
+         - DB_TYPE=postgresdb
+         - DB_POSTGRESDB_DATABASE=${POSTGRES_DB:-n8n}
+         - DB_POSTGRESDB_HOST=postgresql
+         - DB_POSTGRESDB_PORT=5432
+         - DB_POSTGRESDB_USER=$SERVICE_USER_POSTGRES
+         - DB_POSTGRESDB_SCHEMA=public
+         - DB_POSTGRESDB_PASSWORD=$SERVICE_PASSWORD_POSTGRES
+         - EXECUTIONS_MODE=queue
+         - QUEUE_BULL_REDIS_HOST=n8n-redis
+         - QUEUE_HEALTH_CHECK_ACTIVE=true
+         - N8N_ENCRYPTION_KEY=${SERVICE_PASSWORD_ENCRYPTION}
+         - N8N_RUNNERS_MODE=external
+         - N8N_RUNNERS_BROKER_LISTEN_ADDRESS=${N8N_RUNNERS_BROKER_LISTEN_ADDRESS:-0.0.0.0}
+         - N8N_RUNNERS_BROKER_PORT=${N8N_RUNNERS_BROKER_PORT:-5679}
+         - N8N_RUNNERS_AUTH_TOKEN=$SERVICE_PASSWORD_N8N
+         - N8N_NATIVE_PYTHON_RUNNER=${N8N_NATIVE_PYTHON_RUNNER:-true}
+         - N8N_RUNNERS_MAX_CONCURRENCY=${N8N_RUNNERS_MAX_CONCURRENCY:-5}
+         - OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS=true
+         - N8N_BLOCK_ENV_ACCESS_IN_NODE=${N8N_BLOCK_ENV_ACCESS_IN_NODE:-true}
+         - N8N_GIT_NODE_DISABLE_BARE_REPOS=${N8N_GIT_NODE_DISABLE_BARE_REPOS:-true}
+         - N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS=${N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS:-true}
+         - N8N_PROXY_HOPS=${N8N_PROXY_HOPS:-1}
+         - N8N_SKIP_AUTH_ON_OAUTH_CALLBACK=${N8N_SKIP_AUTH_ON_OAUTH_CALLBACK:-false}
+       volumes:
+         - n8n-data:/home/node/.n8n
+       depends_on:
+         postgresql:
+           condition: service_healthy
+         n8n-redis:
+           condition: service_healthy
+       healthcheck:
+         test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:5678/healthz"]
+         interval: 5s
+         timeout: 20s
+         retries: 10
 
-  n8n-worker:
-    image: n8nio/n8n:2.10.4
-    command: worker
-    environment:
-      - GENERIC_TIMEZONE=${GENERIC_TIMEZONE:-UTC}
-      - TZ=${TZ:-UTC}
-      - DB_TYPE=postgresdb
-      - DB_POSTGRESDB_DATABASE=${POSTGRES_DB:-n8n}
-      - DB_POSTGRESDB_HOST=postgresql
-      - DB_POSTGRESDB_PORT=5432
-      - DB_POSTGRESDB_USER=$SERVICE_USER_POSTGRES
-      - DB_POSTGRESDB_SCHEMA=public
-      - DB_POSTGRESDB_PASSWORD=$SERVICE_PASSWORD_POSTGRES
-      - EXECUTIONS_MODE=queue
-      - QUEUE_BULL_REDIS_HOST=redis
-      - QUEUE_HEALTH_CHECK_ACTIVE=true
-      - N8N_ENCRYPTION_KEY=${SERVICE_PASSWORD_ENCRYPTION}
-      - N8N_RUNNERS_ENABLED=true
-      - N8N_RUNNERS_MODE=external
-      - N8N_RUNNERS_BROKER_LISTEN_ADDRESS=${N8N_RUNNERS_BROKER_LISTEN_ADDRESS:-0.0.0.0}
-      - N8N_RUNNERS_BROKER_PORT=${N8N_RUNNERS_BROKER_PORT:-5679}
-      - N8N_RUNNERS_AUTH_TOKEN=$SERVICE_PASSWORD_N8N
-      - N8N_NATIVE_PYTHON_RUNNER=${N8N_NATIVE_PYTHON_RUNNER:-true}
-      - N8N_RUNNERS_MAX_CONCURRENCY=${N8N_RUNNERS_MAX_CONCURRENCY:-5}
-      - N8N_BLOCK_ENV_ACCESS_IN_NODE=${N8N_BLOCK_ENV_ACCESS_IN_NODE:-true}
-      - N8N_GIT_NODE_DISABLE_BARE_REPOS=${N8N_GIT_NODE_DISABLE_BARE_REPOS:-true}
-      - N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS=${N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS:-true}
-      - N8N_PROXY_HOPS=${N8N_PROXY_HOPS:-1}
-      - N8N_SKIP_AUTH_ON_OAUTH_CALLBACK=${N8N_SKIP_AUTH_ON_OAUTH_CALLBACK:-false}
-    volumes:
-      - n8n-data:/home/node/.n8n
-    healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:5678/healthz"]
-      interval: 5s
-      timeout: 20s
-      retries: 10
-    depends_on:
-      n8n:
-        condition: service_healthy
-      postgresql:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
+     n8n-worker:
+       image: n8nio/n8n:2.10.4
+       command: worker
+       environment:
+         - GENERIC_TIMEZONE=${GENERIC_TIMEZONE:-UTC}
+         - TZ=${TZ:-UTC}
+         - DB_TYPE=postgresdb
+         - DB_POSTGRESDB_DATABASE=${POSTGRES_DB:-n8n}
+         - DB_POSTGRESDB_HOST=postgresql
+         - DB_POSTGRESDB_PORT=5432
+         - DB_POSTGRESDB_USER=$SERVICE_USER_POSTGRES
+         - DB_POSTGRESDB_SCHEMA=public
+         - DB_POSTGRESDB_PASSWORD=$SERVICE_PASSWORD_POSTGRES
+         - EXECUTIONS_MODE=queue
+         - QUEUE_BULL_REDIS_HOST=n8n-redis
+         - QUEUE_HEALTH_CHECK_ACTIVE=true
+         - N8N_ENCRYPTION_KEY=${SERVICE_PASSWORD_ENCRYPTION}
+         - N8N_RUNNERS_MODE=external
+         - N8N_RUNNERS_BROKER_LISTEN_ADDRESS=${N8N_RUNNERS_BROKER_LISTEN_ADDRESS:-0.0.0.0}
+         - N8N_RUNNERS_BROKER_PORT=${N8N_RUNNERS_BROKER_PORT:-5679}
+         - N8N_RUNNERS_AUTH_TOKEN=$SERVICE_PASSWORD_N8N
+         - N8N_NATIVE_PYTHON_RUNNER=${N8N_NATIVE_PYTHON_RUNNER:-true}
+         - N8N_RUNNERS_MAX_CONCURRENCY=${N8N_RUNNERS_MAX_CONCURRENCY:-5}
+         - N8N_BLOCK_ENV_ACCESS_IN_NODE=${N8N_BLOCK_ENV_ACCESS_IN_NODE:-true}
+         - N8N_GIT_NODE_DISABLE_BARE_REPOS=${N8N_GIT_NODE_DISABLE_BARE_REPOS:-true}
+         - N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS=${N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS:-true}
+         - N8N_PROXY_HOPS=${N8N_PROXY_HOPS:-1}
+         - N8N_SKIP_AUTH_ON_OAUTH_CALLBACK=${N8N_SKIP_AUTH_ON_OAUTH_CALLBACK:-false}
+       volumes:
+         - n8n-data:/home/node/.n8n
+       healthcheck:
+         test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:5678/healthz"]
+         interval: 5s
+         timeout: 20s
+         retries: 10
+       depends_on:
+         n8n:
+           condition: service_healthy
+         postgresql:
+           condition: service_healthy
+         n8n-redis:
+           condition: service_healthy
 
-  postgresql:
-    image: postgres:16-alpine
-    volumes:
-      - postgresql-data:/var/lib/postgresql/data
-    environment:
-      - POSTGRES_USER=$SERVICE_USER_POSTGRES
-      - POSTGRES_PASSWORD=$SERVICE_PASSWORD_POSTGRES
-      - POSTGRES_DB=${POSTGRES_DB:-n8n}
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
-      interval: 5s
-      timeout: 20s
-      retries: 10
+     postgresql:
+       image: postgres:16-alpine
+       volumes:
+         - postgresql-data:/var/lib/postgresql/data
+       environment:
+         - POSTGRES_USER=$SERVICE_USER_POSTGRES
+         - POSTGRES_PASSWORD=$SERVICE_PASSWORD_POSTGRES
+         - POSTGRES_DB=${POSTGRES_DB:-n8n}
+       healthcheck:
+         test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+         interval: 5s
+         timeout: 20s
+         retries: 10
 
-  redis:
-    image: redis:6-alpine
-    volumes:
-      - redis-data:/data
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 5s
-      timeout: 5s
-      retries: 10
+     n8n-redis:
+       image: redis:6-alpine
+       volumes:
+         - n8n-redis-data:/data
+       healthcheck:
+         test: ["CMD", "redis-cli", "ping"]
+         interval: 5s
+         timeout: 5s
+         retries: 10
 
-  task-runners:
-    image: n8nio/runners:2.10.4
-    environment:
-      - N8N_RUNNERS_TASK_BROKER_URI=${N8N_RUNNERS_TASK_BROKER_URI:-http://n8n-worker:5679}
-      - N8N_RUNNERS_AUTH_TOKEN=$SERVICE_PASSWORD_N8N
-      - N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT=${N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT:-15}
-      - N8N_RUNNERS_MAX_CONCURRENCY=${N8N_RUNNERS_MAX_CONCURRENCY:-5}
-    depends_on:
-      - n8n
-    healthcheck:
-      test:
-        - CMD-SHELL
-        - 'wget -qO- http://127.0.0.1:5680/healthz'
-      interval: 5s
-      timeout: 20s
-      retries: 10
+     task-runners:
+       image: n8nio/runners:2.10.4
+       environment:
+         - N8N_RUNNERS_TASK_BROKER_URI=${N8N_RUNNERS_TASK_BROKER_URI:-http://n8n-worker:5679}
+         - N8N_RUNNERS_AUTH_TOKEN=$SERVICE_PASSWORD_N8N
+         - N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT=${N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT:-15}
+         - N8N_RUNNERS_MAX_CONCURRENCY=${N8N_RUNNERS_MAX_CONCURRENCY:-5}
+       depends_on:
+         n8n-worker:
+           condition: service_healthy
+       healthcheck:
+         test:
+           - CMD-SHELL
+           - 'wget -qO- http://127.0.0.1:5680/healthz'
+         interval: 5s
+         timeout: 20s
+         retries: 10


### PR DESCRIPTION
   ## Problem

   When "Connect to Predefined Network" is enabled, the n8n-worker resolves
   `QUEUE_BULL_REDIS_HOST=redis` to Coolify's own internal Redis (on the shared
   `coolify` network) instead of the project's Redis instance.

   This causes:
   - `NOAUTH Authentication required` / `WRONGPASS` errors
   - n8n-worker crash loop
   - All executions stuck in "queued" / "executing" state permanently
   - Silent data loss (queued jobs never execute)

   ## Root Cause

   Docker DNS resolves the hostname `redis` to the first matching container on
   any connected network. Coolify's own Redis is also named `redis` on the shared
   `coolify` network. When a service is on both `n8n_network` and `coolify`, DNS
   resolution is non-deterministic — main may resolve to one Redis, worker to another.

   **Evidence (from production debugging):**
 ```

 n8n main  → Redis 10.0.8.3:6379  ✅ (project Redis, has queue)
 n8n worker → Redis 10.0.1.3:6379 ❌ (Coolify internal Redis, empty)