### PR TITLE
fix(template): rename redis to n8n-redis to prevent DNS collision on shared Coolify network

### DIFF
--- a/templates/compose/n8n-with-postgres-and-worker.yaml
+++ b/templates/compose/n8n-with-postgres-and-worker.yaml
@@ -24,10 +24,9 @@ services:
       - DB_POSTGRESDB_SCHEMA=public
       - DB_POSTGRESDB_PASSWORD=$SERVICE_PASSWORD_POSTGRES
       - EXECUTIONS_MODE=queue
-      - QUEUE_BULL_REDIS_HOST=redis
+      - QUEUE_BULL_REDIS_HOST=n8n-redis
       - QUEUE_HEALTH_CHECK_ACTIVE=true
       - N8N_ENCRYPTION_KEY=${SERVICE_PASSWORD_ENCRYPTION}
-      - N8N_RUNNERS_ENABLED=true
       - N8N_RUNNERS_MODE=external
       - N8N_RUNNERS_BROKER_LISTEN_ADDRESS=${N8N_RUNNERS_BROKER_LISTEN_ADDRESS:-0.0.0.0}
       - N8N_RUNNERS_BROKER_PORT=${N8N_RUNNERS_BROKER_PORT:-5679}
@@ -45,7 +44,7 @@ services:
     depends_on:
       postgresql:
         condition: service_healthy
-      redis:
+      n8n-redis:
         condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:5678/healthz"]
@@ -67,10 +66,9 @@ services:
       - DB_POSTGRESDB_SCHEMA=public
       - DB_POSTGRESDB_PASSWORD=$SERVICE_PASSWORD_POSTGRES
       - EXECUTIONS_MODE=queue
-      - QUEUE_BULL_REDIS_HOST=redis
+      - QUEUE_BULL_REDIS_HOST=n8n-redis
       - QUEUE_HEALTH_CHECK_ACTIVE=true
       - N8N_ENCRYPTION_KEY=${SERVICE_PASSWORD_ENCRYPTION}
-      - N8N_RUNNERS_ENABLED=true
       - N8N_RUNNERS_MODE=external
       - N8N_RUNNERS_BROKER_LISTEN_ADDRESS=${N8N_RUNNERS_BROKER_LISTEN_ADDRESS:-0.0.0.0}
       - N8N_RUNNERS_BROKER_PORT=${N8N_RUNNERS_BROKER_PORT:-5679}
@@ -94,7 +92,7 @@ services:
         condition: service_healthy
       postgresql:
         condition: service_healthy
-      redis:
+      n8n-redis:
         condition: service_healthy
 
   postgresql:
@@ -111,10 +109,10 @@ services:
       timeout: 20s
       retries: 10
 
-  redis:
+  n8n-redis:
     image: redis:6-alpine
     volumes:
-      - redis-data:/data
+      - n8n-redis-data:/data
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s
@@ -129,7 +127,8 @@ services:
       - N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT=${N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT:-15}
       - N8N_RUNNERS_MAX_CONCURRENCY=${N8N_RUNNERS_MAX_CONCURRENCY:-5}
     depends_on:
-      - n8n
+      n8n-worker:
+        condition: service_healthy
     healthcheck:
       test:
         - CMD-SHELL


### PR DESCRIPTION
STRAWBERRY

## Changes

Renamed the Redis service from `redis` to `n8n-redis` in the n8n-with-postgres-and-worker template, updated all references in environment variables, depends_on blocks, and the volume name.

Also removed the deprecated `N8N_RUNNERS_ENABLED=true` env var which was removed in n8n 2.x and causes a deprecation warning on every startup. Fixed task-runners depends_on to wait for n8n-worker to be healthy before starting.

## Issues

- Fixes #10210
- Refs #7771

## Category

- [ ] Bug fix
- [x] Fixing or updating existing one click service

## Preview

Verified in production. Before the fix, n8n main connected to the project Redis while n8n worker connected to Coolify internal Redis — all executions queued forever. After renaming to n8n-redis both containers resolve to the same Redis and executions complete normally.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude (root cause diagnosis via /proc/net/tcp inspection), human verified and tested fix in production
- How extensively: Debugging only. The fix is a rename verified working before submitting.

## Testing

Deployed on a Coolify instance with Connect to Predefined Network enabled. Triggered multiple workflow executions — all completed. Worker logs show no WRONGPASS or NOAUTH errors.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.