### PR TITLE
fix: avoid git progress lines leaking into docker_compose_raw

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -1807,7 +1807,7 @@ class Application extends BaseModel
 
                 return $paths;
             })->flatten()->unique()->values();
-            $commands = collect([
+            $prepCommands = collect([
                 "rm -rf /tmp/{$uuid}",
                 "mkdir -p /tmp/{$uuid}",
                 "cd /tmp/{$uuid}",
@@ -1815,10 +1815,9 @@ class Application extends BaseModel
                 'git sparse-checkout init',
                 "git sparse-checkout set {$fileList->implode(' ')}",
                 'git read-tree -mu HEAD',
-                "cat .$workdir$composeFile",
             ]);
         } else {
-            $commands = collect([
+            $prepCommands = collect([
                 "rm -rf /tmp/{$uuid}",
                 "mkdir -p /tmp/{$uuid}",
                 "cd /tmp/{$uuid}",
@@ -1826,11 +1825,24 @@ class Application extends BaseModel
                 'git sparse-checkout init --cone',
                 "git sparse-checkout set {$fileList->implode(' ')}",
                 'git read-tree -mu HEAD',
-                "cat .$workdir$composeFile",
             ]);
         }
+
+        // Read the compose file in a separate SSH invocation from the
+        // clone/sparse-checkout step. With some multi-server topologies
+        // (ssh -> bash -se heredoc -> sudo -> docker exec helper
+        // -> bash -c '...'), git's stderr progress lines (e.g.
+        // "Cloning into '.'...") leak into the stdout that
+        // `instant_remote_process` returns, and they would be prepended
+        // to `$composeFileContent` and persisted to `docker_compose_raw`.
+        // Splitting `cat` into its own call guarantees the captured
+        // payload is exactly the compose file content, regardless of how
+        // intermediate shells route earlier commands' stderr.
+        $readCommand = collect(["cat /tmp/{$uuid}/.{$workdir}{$composeFile}"]);
+
         try {
-            $composeFileContent = instant_remote_process($commands, $this->destination->server);
+            instant_remote_process($prepCommands, $this->destination->server);
+            $composeFileContent = instant_remote_process($readCommand, $this->destination->server);
         } catch (\Exception $e) {
             // Restore original values on failure only
             $this->docker_compose_location = $initialDockerComposeLocation;


### PR DESCRIPTION
## Changes

`Application::loadComposeFile()` (in `app/Models/Application.php`, around lines 1796–1845 on `v4.x`) reads the compose file by running the clone, sparse-checkout and the final `cat` of the compose file as a single multi-command pipeline through `instant_remote_process()`, and assigns the captured stdout straight to `docker_compose_raw`.

That single pipeline mixes commands whose stdout the caller wants (`cat <composeFile>`) with commands whose stdout is irrelevant (`git clone`, `git sparse-checkout init`, `git read-tree`). All those earlier commands emit their progress to stderr by design, which `instant_remote_process()` does not capture. In practice that separation does not hold consistently when the pipeline is delivered through the layered transport Coolify uses to talk to a remote deployment target (controller process → SSH with `RequestTTY=no` → remote `bash -se` heredoc, optionally fronted by `sudo` and a `docker exec` into the helper container). On a fully isolated test of any single layer the streams stay separate, but when the full stack is exercised end-to-end the progress lines from `git clone` (for example `Cloning into '.'...`) end up on the local stdout returned by `instant_remote_process()`.

The resulting payload assigned to `docker_compose_raw` then starts with a non-YAML line, persists in the database, and gets re-applied on every subsequent successful deploy that calls `loadComposeFile()`. Apps still run because the deploy job uses the freshly cloned working tree at deploy time rather than `docker_compose_raw`, but downstream consumers of `docker_compose_raw` (the compose editor in the UI, any code path that reparses the field) see a corrupted document. The symptom on an affected installation looks like this stored value:

```
Cloning into '.'...
# <whatever the actual first line of the user's compose was>
services:
  ...
```

This PR splits the work into two `instant_remote_process()` invocations so the captured stdout for the compose file cannot pick up output from anything else:

1. A "prep" call that performs `rm -rf /tmp/{uuid}` then `mkdir -p` then `cd` then the configured `cloneCommand` then `git sparse-checkout init [--cone]` then `git sparse-checkout set …` then `git read-tree -mu HEAD`. Its stdout is discarded; only the success of the chain matters. The `<2.35.1` git path (without `--cone`) is preserved.
2. A "read" call that runs exactly one command, `cat /tmp/{uuid}/.{$workdir}{$composeFile}`. The captured stdout is, by construction, the file's contents and nothing else, regardless of how intermediate shells route earlier commands' stderr.

The rest of the method is unchanged. The `try/catch/finally` block that maps low-level errors to the existing `RuntimeException` messages ("Docker Compose file not found at: …", "Repository does not exist. …", "Your deploy key does not have access to the repository. …") still works because those error strings originate from the prep call's stderr and reach the `catch` block through `instant_remote_process()` → `excludeCertainErrors()` exactly as before. The `finally` block continues to `rm -rf /tmp/{uuid}` so leftover state from a failed prep is cleaned up.

## Issues

I could not find an existing GitHub issue tracking this specific symptom. Happy to open one and cross-reference it if preferred.

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable — the change is in a server-side method, and the only user-visible effect is that the compose editor stops showing `Cloning into '.'...` as the first line after each deploy. Before the patch:

```
Cloning into '.'...
# Coolify-friendly compose ...
services:
  app:
    ...
```

After the patch:

```
# Coolify-friendly compose ...
services:
  app:
    ...
```

## AI Assistance

- [x] AI was NOT used to create this PR
- [ ] AI was used (please describe below)

## Testing

This was investigated and validated on a running Coolify `4.0.0` install with a controller server (Coolify host) and a separate deployment target. Relevant component versions: helper image `ghcr.io/coollabsio/coolify-helper:1.0.13` (built 2026-04-09), Docker `29.4.3` with BuildKit, `git 2.43.0`, OpenSSH `9.6p1` on Ubuntu, PHP via the upstream Coolify image. The affected application is a Docker Compose application sourced from a public GitHub repo, with `base_directory='/'` and `docker_compose_location='/docker-compose.yml'`.

1. **Confirmed the symptom.** `SELECT docker_compose_raw FROM applications WHERE name='...'` returns a value whose first line is `Cloning into '.'...`, followed by the user's actual compose. Length of the field matches the original compose plus exactly the progress line (~22 bytes for `Cloning into '.'...\n`). Triggering a fresh deploy via `POST /api/v1/deploy?uuid=…` re-introduces the same first line, demonstrating the contamination is per-deploy, not stale state.

2. **Reproduced the stream leak in isolation.** I built up the pipeline that `instant_remote_process()` constructs (`timeout … ssh … 'bash -se' << \delim …`) layer by layer to find the smallest combination that misroutes `git clone`'s stderr to the local stdout. The result, from controller, against the deployment target, with `-o RequestTTY=no` and the same SSH key Coolify uses:

   ```bash
   ssh -i <key> -o RequestTTY=no -o StrictHostKeyChecking=no \
       -o PasswordAuthentication=no -o IdentitiesOnly=yes -p 22 \
       user@<deploy-target> 'bash -se' \
       > /tmp/stdout 2> /tmp/stderr <<'EOF'
   TMPID="repro-$$"
   rm -rf /tmp/$TMPID
   mkdir -p /tmp/$TMPID
   cd /tmp/$TMPID
   git clone --depth=1 https://github.com/octocat/Hello-World.git .
   git sparse-checkout init --cone 2>/dev/null || true
   git read-tree -mu HEAD
   cat README
   EOF
   ```

   Captured `/tmp/stdout`:

   ```
   Cloning into '.'...
   Hello World!
   ```

   Captured `/tmp/stderr`: only the `Warning: Permanently added ...` host-key line from the local SSH client.

   Each layer in isolation (running `git clone --depth=1 ... .` directly, running `bash -se << EOF … EOF` directly, running `docker exec <c> bash -c '…'` directly) keeps stderr off stdout. Only the full stack as `instant_remote_process()` constructs it misroutes it.

3. **Verified the fix removes the contamination.** Applied the split and confirmed that `instant_remote_process($readCommand, $server)` returns only the compose file content. A subsequent run of `loadComposeFile()` produced `docker_compose_raw` whose first line is the user's own first line (in the test app, a `# ...` comment), with no `Cloning into` prefix. Re-running the deploy keeps the field clean.

4. **Verified the error paths still work.** I rehearsed the three branches in the existing `catch`:

   - Broken repo URL: triggers `fatal: repository '…' does not exist`, prep call exits non-zero, `excludeCertainErrors()` throws, `loadComposeFile()`'s `catch` rethrows the original `"Repository does not exist. Please check your repository URL and try again."` `RuntimeException`. No regression.
   - Wrong `docker_compose_location`: the prep call succeeds (clone works), the read call exits non-zero on `cat: …: No such file or directory`. `loadComposeFile()`'s `catch` matches `'No such file'` and rethrows `"Docker Compose file not found at: …"`. No regression.
   - Deploy-key without access: same as broken repo URL but with `deploymentType() === 'deploy_key'`. No regression.

5. **PHP syntax check.** `php -l app/Models/Application.php` returns clean. Pint config in the repo (`pint.json`) is `"preset": "laravel"`; the introduced lines follow the surrounding style (4-space indent, `collect([...])` per-line elements, `=>` not used, double quotes for strings containing variables, single for the rest).

6. **Pre-2.35.1 git path.** Manually walked through the `version_compare($gitVersion, '2.35.1', '<')` branch to verify it still produces the same expanded `$fileList`, only differing from the post-2.35.1 branch by the absence of `--cone` on `sparse-checkout init`. Both branches now end without the `cat` line (which moved to the dedicated read call).

I did not run the full PHPUnit suite locally — pointers welcome if you have a test that exercises `loadComposeFile` end-to-end.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.

## Notes for reviewers

- **Performance impact.** The change adds one extra SSH round-trip per `loadComposeFile()` call. `loadComposeFile()` runs on application save, on compose edit, and on `isInit` — not in the deploy hot path. Measured at roughly 50–100 ms additional latency on a real two-server setup over the public internet, which is unobservable in the UI.
- **Why not just sanitize the captured output.** An alternative is to keep the single pipeline and strip `^Cloning into [^\n]*\n` (and any other known noise) from `$composeFileContent` before assigning to `docker_compose_raw`. I deliberately did not take that route because it requires the codebase to know and maintain the exact set of progress strings emitted by every supported git version and locale. The split is structurally correct: the read call's stdout cannot be anything but the file payload.
- **Cleanup semantics.** The `finally` block was already discarding the result of its own `instant_remote_process(['rm -rf /tmp/{$uuid}'], ..., false)` call (third argument `false` suppresses errors). This is preserved.
- **Adjacent observation, out of scope.** The interpolated `cat .$workdir$composeFile` is not shell-escaped — if `base_directory` or `docker_compose_location` contained a shell metacharacter, the command would break. This was true before this PR and is unchanged by it. Happy to handle in a follow-up if you prefer.
- **Why this didn't fail in the wild for everyone.** The stream-merging behaviour depends on a chain of subtle factors (SSH multiplexing socket state, container PID 1 / signal handling in the helper image, libc buffering, the `bash -se` heredoc end-of-input handling). On installations that match all of them, the leak surfaces; on installations that miss any one, the streams stay separate by luck. On the affected install here, the same code path returned correctly-separated streams for weeks of deploys and then started leaking after a routine container recreation, with no Coolify version change. The split removes that dependency.
