### PR TITLE
fix: avoid git progress lines leaking into docker_compose_raw

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -1807,7 +1807,7 @@ class Application extends BaseModel
 
                 return $paths;
             })->flatten()->unique()->values();
-            $commands = collect([
+            $prepCommands = collect([
                 "rm -rf /tmp/{$uuid}",
                 "mkdir -p /tmp/{$uuid}",
                 "cd /tmp/{$uuid}",
@@ -1815,10 +1815,9 @@ class Application extends BaseModel
                 'git sparse-checkout init',
                 "git sparse-checkout set {$fileList->implode(' ')}",
                 'git read-tree -mu HEAD',
-                "cat .$workdir$composeFile",
             ]);
         } else {
-            $commands = collect([
+            $prepCommands = collect([
                 "rm -rf /tmp/{$uuid}",
                 "mkdir -p /tmp/{$uuid}",
                 "cd /tmp/{$uuid}",
@@ -1826,11 +1825,24 @@ class Application extends BaseModel
                 'git sparse-checkout init --cone',
                 "git sparse-checkout set {$fileList->implode(' ')}",
                 'git read-tree -mu HEAD',
-                "cat .$workdir$composeFile",
             ]);
         }
+
+        // Read the compose file in a separate SSH invocation from the
+        // clone/sparse-checkout step. With some multi-server topologies
+        // (ssh -> bash -se heredoc -> sudo -> docker exec helper
+        // -> bash -c '...'), git's stderr progress lines (e.g.
+        // "Cloning into '.'...") leak into the stdout that
+        // `instant_remote_process` returns, and they would be prepended
+        // to `$composeFileContent` and persisted to `docker_compose_raw`.
+        // Splitting `cat` into its own call guarantees the captured
+        // payload is exactly the compose file content, regardless of how
+        // intermediate shells route earlier commands' stderr.
+        $readCommand = collect(["cat /tmp/{$uuid}/.{$workdir}{$composeFile}"]);
+
         try {
-            $composeFileContent = instant_remote_process($commands, $this->destination->server);
+            instant_remote_process($prepCommands, $this->destination->server);
+            $composeFileContent = instant_remote_process($readCommand, $this->destination->server);
         } catch (\Exception $e) {
             // Restore original values on failure only
             $this->docker_compose_location = $initialDockerComposeLocation;


### PR DESCRIPTION
## Changes

Splits the helper that reads an application's compose file into two separate remote process invocations so the captured stdout for the compose file content cannot pick up stderr leaked by earlier git commands in the same pipeline.

Before: one pipeline running clone, sparse-checkout and the final compose-file read. The captured stdout is reused as the persisted compose. On some multi-server transports, git progress lines such as "Cloning into '.'..." end up on stdout and contaminate the stored payload.

After: a prep call that runs clone plus sparse-checkout (output discarded), followed by a read call that runs only the compose-file read. The read call's stdout is the file content by construction. The error-handling block (mapping low-level errors to the existing user-facing messages), the cleanup of the temp directory, and the pre-2.35.1 git branch are all preserved.

## Issues

- Fixes #10219

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable. The change is server-side; the only user-visible effect is that the compose editor no longer shows a stray progress line as the first line of the stored compose after a deploy.

## AI Assistance

- [x] AI was NOT used to create this PR
- [ ] AI was used (please describe below)

## Testing

Reproduction and end-to-end validation are in the linked issue. Locally: PHP lint clean on the modified file; Pint preset is Laravel and the introduced lines follow the surrounding indentation and quoting style; the existing try/catch/finally still maps the standard error strings to the same RuntimeException messages.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the contributor guidelines.
> - [x] I have searched existing issues and pull requests to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
