### PR TITLE
feat: improve source management, GitHub App deletion and restart UX

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -1184,6 +1184,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             $this->application_deployment_queue->addLogEntry("Image not found ({$this->production_image_name}). Building new image.");
         }
         if ($this->restart_only) {
+            $this->application_deployment_queue->addLogEntry("Image not found locally or in registry. Falling back to full redeploy to rebuild it.");
             $this->restart_only = false;
             $this->decide_what_to_do();
         }

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -1131,20 +1131,27 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
     {
         $this->application_deployment_queue->addLogEntry("Restarting {$this->customRepository}:{$this->application->git_branch} on {$this->server->name}.");
 
-        // Restart doesn't need the build server — disable it so the helper container
-        // is created on the deployment server with the correct network/flags.
+        $containers = getCurrentApplicationContainerStatus($this->server, $this->application->id, $this->pull_request_id);
+        $runningContainers = $containers->filter(fn ($c) => data_get($c, 'State') === 'running');
+
+        if ($runningContainers->isNotEmpty()) {
+            $names = $runningContainers->map(fn ($c) => data_get($c, 'Names'))->implode(' ');
+            $this->application_deployment_queue->addLogEntry("Restarting container(s): {$names}.");
+            $this->execute_remote_command(["docker restart {$names}"]);
+            $this->application_deployment_queue->addLogEntry('Restart completed.');
+            $this->completeDeployment();
+
+            return;
+        }
+
+        $this->application_deployment_queue->addLogEntry('No running containers found. Attempting to start from existing image.');
         $originalUseBuildServer = $this->use_build_server;
         $this->use_build_server = false;
-
         $this->prepare_builder_image();
         $this->check_git_if_build_needed();
         $this->generate_image_names();
         $this->check_image_locally_or_remotely();
-
-        // Restore before should_skip_build() — it may re-enter decide_what_to_do()
-        // for a full rebuild which needs the build server.
         $this->use_build_server = $originalUseBuildServer;
-
         $this->should_skip_build();
         $this->completeDeployment();
     }
@@ -1184,7 +1191,6 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             $this->application_deployment_queue->addLogEntry("Image not found ({$this->production_image_name}). Building new image.");
         }
         if ($this->restart_only) {
-            $this->application_deployment_queue->addLogEntry("Image not found locally or in registry. Falling back to full redeploy to rebuild it.");
             $this->restart_only = false;
             $this->decide_what_to_do();
         }

--- a/app/Livewire/Project/Application/Source.php
+++ b/app/Livewire/Project/Application/Source.php
@@ -129,6 +129,26 @@ class Source extends Component
         }
     }
 
+    public function switchToPublic()
+    {
+        try {
+            $this->authorize('update', $this->application);
+            $this->application->update([
+                'source_id' => null,
+                'source_type' => null,
+                'private_key_id' => null,
+            ]);
+            $this->application->refresh();
+            $this->syncData(false);
+            $this->privateKeyId = null;
+            $this->privateKeyName = null;
+            $this->getSources();
+            $this->dispatch('success', 'Switched to public repository.');
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
     public function changeSource($sourceId, $sourceType)
     {
 

--- a/app/Livewire/Source/Github/Change.php
+++ b/app/Livewire/Source/Github/Change.php
@@ -373,13 +373,6 @@ class Change extends Component
     {
         try {
             $this->authorize('delete', $this->github_app);
-
-            if ($this->github_app->applications->isNotEmpty()) {
-                $this->dispatch('error', 'This source is being used by an application. Please delete all applications first.');
-                $this->github_app->makeVisible('client_secret')->makeVisible('webhook_secret');
-
-                return;
-            }
             $this->github_app->delete();
 
             return redirect()->route('source.all');

--- a/app/Models/GithubApp.php
+++ b/app/Models/GithubApp.php
@@ -44,14 +44,12 @@ class GithubApp extends BaseModel
     protected static function booted(): void
     {
         static::deleting(function (GithubApp $github_app) {
-            $applications_count = Application::where('source_id', $github_app->id)->count();
-            if ($applications_count > 0) {
-                throw new \Exception('You cannot delete this GitHub App because it is in use by '.$applications_count.' application(s). Delete them first.');
-            }
+            Application::where('source_id', $github_app->id)
+                ->where('source_type', $github_app->getMorphClass())
+                ->update(['source_id' => null, 'source_type' => null]);
 
             $privateKey = $github_app->privateKey;
             if ($privateKey) {
-                // Check if key is used by anything EXCEPT this GitHub app
                 $isUsedElsewhere = $privateKey->servers()->exists()
                     || $privateKey->applications()->exists()
                     || $privateKey->githubApps()->where('id', '!=', $github_app->id)->exists()
@@ -59,7 +57,6 @@ class GithubApp extends BaseModel
 
                 if (! $isUsedElsewhere) {
                     $privateKey->delete();
-                } else {
                 }
             }
         });

--- a/resources/views/livewire/project/application/heading.blade.php
+++ b/resources/views/livewire/project/application/heading.blade.php
@@ -55,8 +55,8 @@
                                         Update Service
                                     </div>
                                 @else
-                                    <div class="dropdown-item dropdown-item-touch" wire:click='restart'>
-                                        Restart
+                                    <div class="dropdown-item dropdown-item-touch" wire:click='restart' title="Restart without git pull or rebuild">
+                                        Restart (no rebuild)
                                     </div>
                                 @endif
                             @endif

--- a/resources/views/livewire/project/application/source.blade.php
+++ b/resources/views/livewire/project/application/source.blade.php
@@ -64,6 +64,23 @@
                 <div class="pt-4">
                     <h3 class="pb-2">Change Git Source</h3>
                     <div class="grid grid-cols-1 gap-2">
+                        @if ($application->source_id)
+                            <div>
+                                <x-modal-confirmation title="Switch to Public Repository"
+                                    :actions="['The application will no longer use a GitHub App or deploy key.', 'Make sure the repository is publicly accessible before redeploying.']"
+                                    :buttonFullWidth="true"
+                                    submitAction="switchToPublic"
+                                    :confirmWithText="false" :confirmWithPassword="false"
+                                    step2ButtonText="Switch to Public">
+                                    <x-slot:customButton>
+                                        <div class="flex items-center gap-2">
+                                            <div class="box-title">Public Repository</div>
+                                            <div class="box-description">No GitHub App or deploy key</div>
+                                        </div>
+                                    </x-slot:customButton>
+                                </x-modal-confirmation>
+                            </div>
+                        @endif
                         @forelse ($sources as $source)
                             <div wire:key="{{ $source->name }}">
                                 <x-modal-confirmation title="Change Git Source" :actions="['Change git source to ' . $source->name]" :buttonFullWidth="true"
@@ -88,7 +105,9 @@
                                 </x-modal-confirmation>
                             </div>
                         @empty
-                            <div>No other sources found</div>
+                            @if (!$application->source_id)
+                                <div>No other sources found</div>
+                            @endif
                         @endforelse
                     </div>
                 </div>

--- a/resources/views/livewire/source/github/change.blade.php
+++ b/resources/views/livewire/source/github/change.blade.php
@@ -8,20 +8,21 @@
                         <x-forms.button canGate="update" :canResource="$github_app" type="submit">Save</x-forms.button>
                     @endif
                     @can('delete', $github_app)
-                        @if ($applications->count() > 0)
-                            <x-modal-confirmation title="Confirm GitHub App Deletion?" isErrorButton buttonTitle="Delete"
-                                submitAction="delete" :actions="['The selected GitHub App will be permanently deleted.']" confirmationText="{{ data_get($github_app, 'name') }}"
-                                confirmationLabel="Please confirm the execution of the actions by entering the GitHub App Name below"
-                                shortConfirmationLabel="GitHub App Name" :confirmWithPassword="false"
-                                step2ButtonText="Permanently Delete" />
-                        @else
-                            <x-modal-confirmation title="Confirm GitHub App Deletion?" isErrorButton buttonTitle="Delete"
-                                submitAction="delete" :actions="['The selected GitHub App will be permanently deleted.']"
-                                confirmationLabel="Please confirm the execution of the actions by entering the GitHub App Name below"
-                                shortConfirmationLabel="GitHub App Name"
-                                confirmationText="{{ data_get($github_app, 'name') }}" :confirmWithPassword="false"
-                                step2ButtonText="Permanently Delete" />
-                        @endif
+                        @php
+                            $deleteActions = ['The selected GitHub App will be permanently deleted.'];
+                            if ($applications->count() > 0) {
+                                $deleteActions[] = $applications->count() . ' application(s) will be disconnected from their source and will need to be reconfigured:';
+                                foreach ($applications as $linkedApp) {
+                                    $deleteActions[] = '→ ' . $linkedApp->name;
+                                }
+                            }
+                        @endphp
+                        <x-modal-confirmation title="Confirm GitHub App Deletion?" isErrorButton buttonTitle="Delete"
+                            submitAction="delete" :actions="$deleteActions"
+                            confirmationText="{{ data_get($github_app, 'name') }}"
+                            confirmationLabel="Please confirm the execution of the actions by entering the GitHub App Name below"
+                            shortConfirmationLabel="GitHub App Name" :confirmWithPassword="false"
+                            step2ButtonText="Permanently Delete" />
                     @endcan
                 </div>
             </div>
@@ -208,8 +209,18 @@
             <h1>GitHub App</h1>
             <div class="flex gap-2">
                 @can('delete', $github_app)
+                    @php
+                        $deleteActions = ['The selected GitHub App will be permanently deleted.'];
+                        if ($applications->count() > 0) {
+                            $deleteActions[] = $applications->count() . ' application(s) will be disconnected from their source and will need to be reconfigured:';
+                            foreach ($applications as $linkedApp) {
+                                $deleteActions[] = '→ ' . $linkedApp->name;
+                            }
+                        }
+                    @endphp
                     <x-modal-confirmation title="Confirm GitHub App Deletion?" isErrorButton buttonTitle="Delete"
-                        submitAction="delete" :actions="['The selected GitHub App will be permanently deleted.']" confirmationText="{{ data_get($github_app, 'name') }}"
+                        submitAction="delete" :actions="$deleteActions"
+                        confirmationText="{{ data_get($github_app, 'name') }}"
                         confirmationLabel="Please confirm the execution of the actions by entering the GitHub App Name below"
                         shortConfirmationLabel="GitHub App Name" :confirmWithPassword="false"
                         step2ButtonText="Permanently Delete" />


### PR DESCRIPTION
## Summary

Addresses three UX issues around source management and application lifecycle.

### #10225 — Allow changing source type for deployed applications

- Added `switchToPublic()` action in `Source` Livewire component that clears `source_id`, `source_type` and `private_key_id`
- Added a **Public Repository** button in the _Change Git Source_ section, visible only when the app currently uses a GitHub App source

### #10227 — Allow deleting a GitHub App even when linked to applications

- Removed the hard block in `GithubApp::booted()` — linked applications are disconnected cleanly before deletion
- Removed the early return error in `Change::delete()`
- Deletion modals now list the affected applications before confirming

### #10226 — True restart without git pull or rebuild

- Rewrote `just_restart()` to first check for running containers via `getCurrentApplicationContainerStatus()`
- If containers are running: calls `docker restart {names}` directly — zero git interaction, zero image lookup
- If no containers are running: falls back to the existing image-based start path (unchanged behavior)

## Test plan

- [ ] App using GitHub App: verify "Public Repository" button appears and switches correctly
- [ ] GitHub App with linked apps: verify modal lists affected apps and deletion succeeds
- [ ] Running app: click Restart → logs show `docker restart` with no git operations
- [ ] Stopped app: click Restart → fallback to image-based start works as before

Closes #10225, #10226, #10227