### PR TITLE
fix: enable IPv6 for Docker networks

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -97,12 +97,14 @@ class InstallDocker
                 'systemctl restart docker',
             ]);
             if ($server->isSwarm()) {
+                $createNetworkCommand = dockerNetworkCreateCommand('coolify-overlay', isSwarm: true, enableIpv6: shouldEnableDockerNetworkIpv6($server));
                 $command = $command->merge([
-                    'docker network create --attachable --driver overlay coolify-overlay >/dev/null 2>&1 || true',
+                    "{$createNetworkCommand} >/dev/null 2>&1 || true",
                 ]);
             } else {
+                $createNetworkCommand = dockerNetworkCreateCommand('coolify', enableIpv6: shouldEnableDockerNetworkIpv6($server));
                 $command = $command->merge([
-                    'docker network create --attachable coolify >/dev/null 2>&1 || true',
+                    "{$createNetworkCommand} >/dev/null 2>&1 || true",
                 ]);
                 $command = $command->merge([
                     "echo 'Done!'",

--- a/app/Actions/Service/StartService.php
+++ b/app/Actions/Service/StartService.php
@@ -14,6 +14,7 @@ class StartService
 
     public function handle(Service $service, bool $pullLatestImages = false, bool $stopBeforeStart = false)
     {
+        $server = $service->server;
         $service->parse();
         if ($stopBeforeStart) {
             StopService::run(service: $service, dockerCleanup: false);
@@ -32,8 +33,10 @@ class StartService
             $commands[] = "docker compose --project-directory {$workdir} pull";
         }
         if ($service->networks()->count() > 0) {
+            $safeServiceNetwork = escapeshellarg($service->uuid);
+            $createNetworkCommand = dockerNetworkCreateCommand($service->uuid, enableIpv6: shouldEnableDockerNetworkIpv6($server));
             $commands[] = "echo 'Creating Docker network.'";
-            $commands[] = "docker network inspect $service->uuid >/dev/null 2>&1 || docker network create --attachable $service->uuid";
+            $commands[] = "docker network inspect {$safeServiceNetwork} >/dev/null 2>&1 || {$createNetworkCommand}";
         }
         $commands[] = 'echo Starting service.';
         $commands[] = "docker compose --project-directory {$workdir} -f {$workdir}/docker-compose.yml --project-name {$service->uuid} up -d --remove-orphans --force-recreate --build";
@@ -47,6 +50,6 @@ class StartService
             }
         }
 
-        return remote_process($commands, $service->server, type_uuid: $service->uuid, callEventOnFinish: 'ServiceStatusChanged');
+        return remote_process($commands, $server, type_uuid: $service->uuid, callEventOnFinish: 'ServiceStatusChanged');
     }
 }

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -787,8 +787,9 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         if ($this->server->isSwarm()) {
             // TODO
         } else {
+            $createNetworkCommand = dockerNetworkCreateCommand($networkId, enableIpv6: shouldEnableDockerNetworkIpv6($this->server));
             $this->execute_remote_command([
-                "docker network inspect '{$networkId}' >/dev/null 2>&1 || docker network create --attachable '{$networkId}' >/dev/null || true",
+                "docker network inspect '{$networkId}' >/dev/null 2>&1 || {$createNetworkCommand} >/dev/null || true",
                 'hidden' => true,
                 'ignore_errors' => true,
             ], [

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -1406,9 +1406,13 @@ $schema://$host {
             return;
         }
         if ($isSwarm) {
-            return instant_remote_process(['docker network create --attachable --driver overlay coolify-overlay >/dev/null 2>&1 || true'], $this, false);
+            $createNetworkCommand = dockerNetworkCreateCommand('coolify-overlay', isSwarm: true, enableIpv6: shouldEnableDockerNetworkIpv6($this));
+
+            return instant_remote_process(["{$createNetworkCommand} >/dev/null 2>&1 || true"], $this, false);
         } else {
-            return instant_remote_process(['docker network create coolify --attachable >/dev/null 2>&1 || true'], $this, false);
+            $createNetworkCommand = dockerNetworkCreateCommand('coolify', enableIpv6: shouldEnableDockerNetworkIpv6($this));
+
+            return instant_remote_process(["{$createNetworkCommand} >/dev/null 2>&1 || true"], $this, false);
         }
     }
 

--- a/app/Models/StandaloneDocker.php
+++ b/app/Models/StandaloneDocker.php
@@ -24,8 +24,9 @@ class StandaloneDocker extends BaseModel
         static::created(function ($newStandaloneDocker) {
             $server = $newStandaloneDocker->server;
             $safeNetwork = escapeshellarg($newStandaloneDocker->network);
+            $createNetworkCommand = dockerNetworkCreateCommand($newStandaloneDocker->network, isSwarm: true, enableIpv6: shouldEnableDockerNetworkIpv6($server));
             instant_remote_process([
-                "docker network inspect {$safeNetwork} >/dev/null 2>&1 || docker network create --driver overlay --attachable {$safeNetwork} >/dev/null",
+                "docker network inspect {$safeNetwork} >/dev/null 2>&1 || {$createNetworkCommand} >/dev/null",
             ], $server, false);
             ConnectProxyToNetworksJob::dispatchSync($server);
         });

--- a/bootstrap/helpers/proxy.php
+++ b/bootstrap/helpers/proxy.php
@@ -3,6 +3,7 @@
 use App\Actions\Proxy\SaveProxyConfiguration;
 use App\Enums\ProxyTypes;
 use App\Models\Application;
+use App\Models\InstanceSettings;
 use App\Models\Server;
 use Illuminate\Support\Facades\Log;
 use Symfony\Component\Yaml\Yaml;
@@ -19,6 +20,33 @@ function isDockerPredefinedNetwork(string $network): bool
     // Only filter 'default' and 'host' to match existing codebase patterns
     // See: bootstrap/helpers/parsers.php:891, bootstrap/helpers/shared.php:689,748
     return in_array($network, ['default', 'host'], true);
+}
+
+function shouldEnableDockerNetworkIpv6(Server $server, ?string $instancePublicIpv6 = null): bool
+{
+    if ($instancePublicIpv6 === null && $server->isLocalhost()) {
+        try {
+            $instancePublicIpv6 = data_get(InstanceSettings::get(), 'public_ipv6');
+        } catch (\Throwable) {
+            $instancePublicIpv6 = null;
+        }
+    }
+
+    return ($server->isLocalhost() && filled($instancePublicIpv6))
+        || filter_var($server->ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false;
+}
+
+function dockerNetworkCreateCommand(string $network, bool $isSwarm = false, bool $enableIpv6 = false): string
+{
+    $safe = escapeshellarg($network);
+    $driver = $isSwarm ? '--driver overlay ' : '';
+    $command = "docker network create {$driver}--attachable {$safe}";
+
+    if (! $enableIpv6) {
+        return $command;
+    }
+
+    return "(docker network create {$driver}--ipv6 --attachable {$safe} 2>/dev/null || {$command})";
 }
 
 function collectProxyDockerNetworksByServer(Server $server)
@@ -107,20 +135,25 @@ function collectDockerNetworksByServer(Server $server)
 function connectProxyToNetworks(Server $server)
 {
     ['networks' => $networks] = collectDockerNetworksByServer($server);
+    $enableIpv6 = shouldEnableDockerNetworkIpv6($server);
     if ($server->isSwarm()) {
-        $commands = $networks->map(function ($network) {
+        $commands = $networks->map(function ($network) use ($enableIpv6) {
             $safe = escapeshellarg($network);
+            $createNetworkCommand = dockerNetworkCreateCommand($network, isSwarm: true, enableIpv6: $enableIpv6);
+
             return [
-                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || docker network create --driver overlay --attachable {$safe} >/dev/null",
+                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || {$createNetworkCommand} >/dev/null",
                 "docker network connect {$safe} coolify-proxy >/dev/null 2>&1 || true",
                 "echo 'Successfully connected coolify-proxy to {$safe} network.'",
             ];
         });
     } else {
-        $commands = $networks->map(function ($network) {
+        $commands = $networks->map(function ($network) use ($enableIpv6) {
             $safe = escapeshellarg($network);
+            $createNetworkCommand = dockerNetworkCreateCommand($network, enableIpv6: $enableIpv6);
+
             return [
-                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || docker network create --attachable {$safe} >/dev/null",
+                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || {$createNetworkCommand} >/dev/null",
                 "docker network connect {$safe} coolify-proxy >/dev/null 2>&1 || true",
                 "echo 'Successfully connected coolify-proxy to {$safe} network.'",
             ];
@@ -140,21 +173,26 @@ function connectProxyToNetworks(Server $server)
 function ensureProxyNetworksExist(Server $server)
 {
     ['allNetworks' => $networks] = collectDockerNetworksByServer($server);
+    $enableIpv6 = shouldEnableDockerNetworkIpv6($server);
 
     if ($server->isSwarm()) {
-        $commands = $networks->map(function ($network) {
+        $commands = $networks->map(function ($network) use ($enableIpv6) {
             $safe = escapeshellarg($network);
+            $createNetworkCommand = dockerNetworkCreateCommand($network, isSwarm: true, enableIpv6: $enableIpv6);
+
             return [
                 "echo 'Ensuring network {$safe} exists...'",
-                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --driver overlay --attachable {$safe}",
+                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || {$createNetworkCommand}",
             ];
         });
     } else {
-        $commands = $networks->map(function ($network) {
+        $commands = $networks->map(function ($network) use ($enableIpv6) {
             $safe = escapeshellarg($network);
+            $createNetworkCommand = dockerNetworkCreateCommand($network, enableIpv6: $enableIpv6);
+
             return [
                 "echo 'Ensuring network {$safe} exists...'",
-                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --attachable {$safe}",
+                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || {$createNetworkCommand}",
             ];
         });
     }

--- a/tests/Unit/ProxyHelperTest.php
+++ b/tests/Unit/ProxyHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\Server;
+use App\Models\ServerSetting;
 use Illuminate\Support\Facades\Log;
 
 beforeEach(function () {
@@ -188,4 +190,51 @@ it('identifies none as not predefined (per codebase pattern)', function () {
     // 'none' is technically a Docker predefined network, but existing codebase
     // only filters 'default' and 'host', so we maintain consistency
     expect(isDockerPredefinedNetwork('none'))->toBeFalse();
+});
+
+it('creates standalone proxy networks with ipv6 when requested', function () {
+    $command = dockerNetworkCreateCommand('coolify', isSwarm: false, enableIpv6: true);
+
+    expect($command)
+        ->toContain('docker network create')
+        ->toContain('--attachable')
+        ->toContain('--ipv6')
+        ->toContain('||')
+        ->toContain('coolify');
+});
+
+it('keeps standalone proxy network creation unchanged when ipv6 is not requested', function () {
+    $command = dockerNetworkCreateCommand('coolify', isSwarm: false, enableIpv6: false);
+
+    expect($command)
+        ->toContain('docker network create')
+        ->toContain('--attachable')
+        ->not->toContain('--ipv6')
+        ->toContain('coolify');
+});
+
+it('creates swarm proxy networks with ipv6 when requested', function () {
+    $command = dockerNetworkCreateCommand('coolify-overlay', isSwarm: true, enableIpv6: true);
+
+    expect($command)
+        ->toContain('docker network create')
+        ->toContain('--driver overlay')
+        ->toContain('--attachable')
+        ->toContain('--ipv6')
+        ->toContain('coolify-overlay');
+});
+
+it('enables docker network ipv6 for ipv6 server addresses', function () {
+    $server = new Server(['ip' => '2001:db8::10']);
+    $server->setRelation('settings', new ServerSetting);
+
+    expect(shouldEnableDockerNetworkIpv6($server))->toBeTrue();
+});
+
+it('enables docker network ipv6 when the local instance has a public ipv6 address', function () {
+    $server = new Server(['ip' => '192.0.2.10']);
+    $server->id = 0;
+    $server->setRelation('settings', new ServerSetting);
+
+    expect(shouldEnableDockerNetworkIpv6($server, '2001:db8::20'))->toBeTrue();
 });


### PR DESCRIPTION
Closes #3436

/claim #3436

This updates the Docker network creation paths used by proxy, app deployment, service startup, and server validation so they request IPv6-capable Docker networks when the target server is IPv6, or when the local Coolify instance has a public IPv6 address configured.

The create command first tries `docker network create --ipv6 ...` and falls back to the previous IPv4-only command if Docker rejects IPv6 network creation, so IPv4-only installations keep the existing behavior.

Tested with:
- `php vendor/bin/pest tests/Unit/ProxyHelperTest.php`
- `php vendor/bin/pint --dirty --test`
- `php -l` on the changed PHP files
