### PR TITLE
fix: create proxy networks with IPv6 fallback

### DIFF
--- a/bootstrap/helpers/proxy.php
+++ b/bootstrap/helpers/proxy.php
@@ -104,6 +104,16 @@ function collectDockerNetworksByServer(Server $server)
         'allNetworks' => $allNetworks,
     ];
 }
+
+function dockerNetworkCreateCommand(string $safeNetwork, bool $isSwarm = false, bool $quiet = false): string
+{
+    $driver = $isSwarm ? '--driver overlay ' : '';
+    $redirect = $quiet ? ' >/dev/null' : '';
+    $ipv6Redirect = $quiet ? ' >/dev/null 2>&1' : ' 2>/dev/null';
+
+    return "(docker network create {$driver}--attachable --ipv6 {$safeNetwork}{$ipv6Redirect} || docker network create {$driver}--attachable {$safeNetwork}{$redirect})";
+}
+
 function connectProxyToNetworks(Server $server)
 {
     ['networks' => $networks] = collectDockerNetworksByServer($server);
@@ -111,7 +121,7 @@ function connectProxyToNetworks(Server $server)
         $commands = $networks->map(function ($network) {
             $safe = escapeshellarg($network);
             return [
-                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || docker network create --driver overlay --attachable {$safe} >/dev/null",
+                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || " . dockerNetworkCreateCommand($safe, true, true),
                 "docker network connect {$safe} coolify-proxy >/dev/null 2>&1 || true",
                 "echo 'Successfully connected coolify-proxy to {$safe} network.'",
             ];
@@ -120,7 +130,7 @@ function connectProxyToNetworks(Server $server)
         $commands = $networks->map(function ($network) {
             $safe = escapeshellarg($network);
             return [
-                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || docker network create --attachable {$safe} >/dev/null",
+                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || " . dockerNetworkCreateCommand($safe, false, true),
                 "docker network connect {$safe} coolify-proxy >/dev/null 2>&1 || true",
                 "echo 'Successfully connected coolify-proxy to {$safe} network.'",
             ];
@@ -146,7 +156,7 @@ function ensureProxyNetworksExist(Server $server)
             $safe = escapeshellarg($network);
             return [
                 "echo 'Ensuring network {$safe} exists...'",
-                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --driver overlay --attachable {$safe}",
+                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || " . dockerNetworkCreateCommand($safe, true),
             ];
         });
     } else {
@@ -154,7 +164,7 @@ function ensureProxyNetworksExist(Server $server)
             $safe = escapeshellarg($network);
             return [
                 "echo 'Ensuring network {$safe} exists...'",
-                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --attachable {$safe}",
+                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || " . dockerNetworkCreateCommand($safe),
             ];
         });
     }

--- a/tests/Unit/ProxyDockerNetworkCreateCommandTest.php
+++ b/tests/Unit/ProxyDockerNetworkCreateCommandTest.php
@@ -1,0 +1,26 @@
+<?php
+
+test('docker network creation tries ipv6 before falling back to ipv4', function () {
+    $command = dockerNetworkCreateCommand("'coolify'");
+
+    expect($command)
+        ->toContain('docker network create --attachable --ipv6')
+        ->toContain("docker network create --attachable 'coolify'")
+        ->toContain('||');
+});
+
+test('swarm network creation preserves overlay driver in ipv6 and fallback commands', function () {
+    $command = dockerNetworkCreateCommand("'coolify-overlay'", true);
+
+    expect($command)
+        ->toContain("docker network create --driver overlay --attachable --ipv6 'coolify-overlay'")
+        ->toContain("docker network create --driver overlay --attachable 'coolify-overlay'");
+});
+
+test('quiet network creation suppresses the ipv6 probe output', function () {
+    $command = dockerNetworkCreateCommand("'coolify'", false, true);
+
+    expect($command)
+        ->toContain("docker network create --attachable --ipv6 'coolify' >/dev/null 2>&1")
+        ->toContain("docker network create --attachable 'coolify' >/dev/null");
+});


### PR DESCRIPTION
Fixes #3436

/claim #3436

## Changes

- Makes Coolify-created proxy networks try IPv6-enabled Docker network creation first.
- Falls back to the current IPv4-only Docker network creation command when Docker or the host does not support IPv6.
- Applies the safer IPv6-first/fallback behavior to both proxy network ensure and proxy network connect paths, for standalone and swarm servers.
- Adds focused unit coverage for the generated Docker network creation command.

This is intentionally different from only appending `--ipv6`: it avoids breaking hosts where Docker IPv6 is not configured while still allowing IPv6-capable installations to preserve real IPv6 client forwarding instead of collapsing to the proxy gateway IP.

## Testing

- `git diff --check` passed locally.
- Could not run PHP/Pest/Pint in this environment because PHP and Composer dependencies are not installed here.