### PR TITLE
feat: add NATS service template

### DIFF
--- a/public/svgs/nats.svg
+++ b/public/svgs/nats.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="24" fill="#233B6E"/>
+  <text x="64" y="82" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-weight="bold" font-size="52" fill="#4DD0E1">N</text>
+</svg>

--- a/public/svgs/nats.svg
+++ b/public/svgs/nats.svg
@@ -1,4 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
-  <rect width="128" height="128" rx="24" fill="#233B6E"/>
-  <text x="64" y="82" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-weight="bold" font-size="52" fill="#4DD0E1">N</text>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" role="img" viewBox="2.42 -0.33 280.40 289.90"><style>svg {enable-background:new 0 0 288 288}</style><style>.st3{fill:#375c93}.st4{fill:#8dc63f}</style><path fill="#34a574" d="M142.8 5.3h134.7v109.2H142.8z"/><path fill="#27aae1" d="M8.1 5.3h134.7v109.2H8.1z"/><path d="M142.8 114.6h134.7v109.2H142.8z" class="st4"/><path d="M8.1 114.6h134.7v109.2H8.1z" class="st3"/><path d="M123 223.2l65.9 61v-61z" class="st4"/><path d="M142.8 223.2l.7 19.2-21.1-19.7z" class="st3"/><path fill="#fff" d="M198.6 146.5V56.1h32.2V173H182L83.5 81v92.1H51.2v-117h50.5l96.9 90.4z"/></svg>

--- a/templates/compose/nats.yaml
+++ b/templates/compose/nats.yaml
@@ -1,0 +1,16 @@
+# documentation: https://docs.nats.io
+# slogan: High-performance cloud native messaging system — connective technology for modern distributed systems.
+# category: infrastructure
+# tags: nats, messaging, pubsub, jetstream, microservices, cloud-native, cncf, streaming
+# logo: svgs/nats.svg
+# port: 8222
+
+services:
+  nats:
+    image: nats:latest
+    command: --jetstream --store_dir /data
+    volumes:
+      - nats-data:/data
+    environment:
+      - SERVICE_URL_NATS_4222
+      - SERVICE_URL_NATS_8222


### PR DESCRIPTION
## Changes
- Add NATS one-click service template (official nats:latest image)
- JetStream enabled for persistent streaming
- Client port 4222 + monitoring port 8222
- Persistent volume for JetStream data

## Issues
- N/A

## Category
- [x] Adding new one click service

## AI Assistance
- [x] AI was used (please describe below)
- Tools used: Claude
- How extensively: Assisted with Docker configuration and PR formatting

## Testing
- Validated YAML syntax
- Official nats:latest Docker image
- Default JetStream command with persistent store

## Contributor Agreement
> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.