### PR TITLE
feat: add Ollama standalone service template

### DIFF
--- a/templates/compose/ollama.yaml
+++ b/templates/compose/ollama.yaml
@@ -1,0 +1,29 @@
+# documentation: https://ollama.com
+# slogan: Get up and running with large language models locally — run Llama, Mistral, Gemma, and more.
+# category: ai
+# tags: ollama, llm, ai, local, models, llama, mistral, inference
+# logo: svgs/ollama.svg
+# port: 11434
+
+services:
+  ollama:
+    image: ollama/ollama:latest
+    volumes:
+      - ollama-data:/root/.ollama
+    environment:
+      - SERVICE_URL_OLLAMA_11434
+      - OLLAMA_KEEP_ALIVE=${OLLAMA_KEEP_ALIVE:-5m}
+      - OLLAMA_HOST=${OLLAMA_HOST:-0.0.0.0}
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 10s
+      timeout: 30s
+      retries: 5
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities:
+                - gpu


### PR DESCRIPTION
## Changes
- Add standalone Ollama one-click service (without Open WebUI)
- NVIDIA GPU support, configurable keep-alive, healthcheck

## Category
- [x] Adding new one click service

## AI Assistance
- [x] AI was used: Claude assisted with template structure and PR formatting

## Testing
- Official ollama/ollama:latest image, port 11434, healthcheck via ollama list

## Contributor Agreement
> [!IMPORTANT]
> - [x] I have read and understood the contributor guidelines.
> - [x] This is not a duplicate.
> - [x] I have tested all changes.
