### PR TITLE
feat: add InfluxDB service template

### DIFF
--- a/public/svgs/influxdb.svg
+++ b/public/svgs/influxdb.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="24" fill="#22ADF6"/>
+  <text x="64" y="84" text-anchor="middle" font-family="monospace" font-weight="bold" font-size="48" fill="#FFF">in</text>
+</svg>

--- a/templates/compose/influxdb.yaml
+++ b/templates/compose/influxdb.yaml
@@ -1,0 +1,26 @@
+# documentation: https://docs.influxdata.com/influxdb
+# slogan: InfluxDB is the open-source time series database for metrics, events, and real-time analytics.
+# category: database
+# tags: influxdb, time-series, metrics, monitoring, iot, analytics
+# logo: svgs/influxdb.svg
+# port: 8086
+
+services:
+  influxdb:
+    image: influxdb:2-alpine
+    volumes:
+      - influxdb-data:/var/lib/influxdb2
+      - influxdb-config:/etc/influxdb2
+    environment:
+      - SERVICE_URL_INFLUXDB_8086
+      - DOCKER_INFLUXDB_INIT_MODE=${INFLUXDB_INIT_MODE:-setup}
+      - DOCKER_INFLUXDB_INIT_USERNAME=${INFLUXDB_ADMIN_USER:-admin}
+      - DOCKER_INFLUXDB_INIT_PASSWORD=${SERVICE_PASSWORD_INFLUXDB:-}
+      - DOCKER_INFLUXDB_INIT_ORG=${INFLUXDB_ORG:-my-org}
+      - DOCKER_INFLUXDB_INIT_BUCKET=${INFLUXDB_BUCKET:-my-bucket}
+      - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=${SERVICE_PASSWORD_INFLUXDB_ADMIN_TOKEN:-}
+    healthcheck:
+      test: ["CMD", "influx", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5


### PR DESCRIPTION
## Changes
- Add InfluxDB v2 one-click service template
- Auto-setup with configurable admin, org, bucket
- Healthcheck via influx ping

## Category
- [x] Adding new one click service

## Contributor Agreement
- [x] Read guidelines
- [x] Not duplicate
- [x] Tested