### PR TITLE
feat: add Ollama standalone service template

### DIFF
--- a/templates/compose/ollama.yaml
+++ b/templates/compose/ollama.yaml
@@ -1,0 +1,29 @@
+# documentation: https://ollama.com
+# slogan: Get up and running with large language models locally — run Llama, Mistral, Gemma, and more.
+# category: ai
+# tags: ollama, llm, ai, local, models, llama, mistral, inference
+# logo: svgs/ollama.svg
+# port: 11434
+
+services:
+  ollama:
+    image: ollama/ollama:latest
+    volumes:
+      - ollama-data:/root/.ollama
+    environment:
+      - SERVICE_URL_OLLAMA_11434
+      - OLLAMA_KEEP_ALIVE=${OLLAMA_KEEP_ALIVE:-5m}
+      - OLLAMA_HOST=${OLLAMA_HOST:-0.0.0.0}
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 10s
+      timeout: 30s
+      retries: 5
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities:
+                - gpu


### PR DESCRIPTION
## Changes
- Add standalone Ollama one-click service (without Open WebUI)
- NVIDIA GPU support, configurable keep-alive

## Issues
- N/A

## Category
- [x] Adding new one click service

## Preview
Standalone Ollama for users who want LLM inference without Open WebUI, or plan to use their own frontend.

## AI Assistance
- [x] AI was used (please describe below)
- Tools used: Claude
- How extensively: Assisted with template structure

## Testing
- Official ollama/ollama:latest image
- Port 11434, healthcheck via ollama list
- GPU deploy block for NVIDIA

## Contributor Agreement
> [!IMPORTANT]
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched existing issues and pull requests to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.