### PR TITLE
feat: add DragonflyDB service template

### DIFF
--- a/public/svgs/dragonfly.svg
+++ b/public/svgs/dragonfly.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <circle cx="64" cy="64" r="56" fill="#1A1A2E"/>
+  <text x="64" y="78" text-anchor="middle" font-family="Arial,sans-serif" font-weight="bold" font-size="36" fill="#E94560">DB</text>
+</svg>

--- a/templates/compose/dragonfly.yaml
+++ b/templates/compose/dragonfly.yaml
@@ -1,0 +1,15 @@
+# documentation: https://www.dragonflydb.io
+# slogan: A modern Redis replacement — 25x faster, fully compatible, designed for cloud-native workloads.
+# category: database
+# tags: dragonflydb, redis, cache, key-value, in-memory, database, high-performance
+# logo: svgs/dragonfly.svg
+# port: 6379
+
+services:
+  dragonfly:
+    image: docker.dragonflydb.io/dragonflydb/dragonfly:latest
+    volumes:
+      - dragonfly-data:/data
+    environment:
+      - SERVICE_URL_DRAGONFLY_6379
+    command: dragonfly --logtostderr --requirepass=${DRAGONFLY_PASSWORD:-} --dir /data


### PR DESCRIPTION
## Changes
- Add DragonflyDB one-click service (Redis-compatible, 25x throughput)

## Issues
- N/A

## Category
- [x] Adding new one click service

## Preview
DragonflyDB is a modern Redis replacement designed for cloud-native workloads, offering full Redis API compatibility with significantly higher throughput.

## AI Assistance
- [x] AI was used (please describe below)
- Tools used: Claude
- How extensively: Assisted with template structure

## Testing
- Official docker.dragonflydb.io/dragonflydb/dragonfly:latest image, port 6379, configurable password

## Contributor Agreement
> [!IMPORTANT]
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched existing issues and pull requests to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.