### PR TITLE
feat: add InfluxDB service template

### DIFF
--- a/public/svgs/dragonfly.svg
+++ b/public/svgs/dragonfly.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <circle cx="64" cy="64" r="56" fill="#1A1A2E"/>
+  <text x="64" y="78" text-anchor="middle" font-family="Arial" font-weight="bold" font-size="36" fill="#E94560">DB</text>
+</svg>

--- a/public/svgs/influxdb.svg
+++ b/public/svgs/influxdb.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="24" fill="#22ADF6"/>
+  <text x="64" y="84" text-anchor="middle" font-family="monospace" font-weight="bold" font-size="48" fill="#FFF">in</text>
+</svg>

--- a/templates/compose/dragonfly.yaml
+++ b/templates/compose/dragonfly.yaml
@@ -1,0 +1,15 @@
+# documentation: https://www.dragonflydb.io
+# slogan: A modern Redis replacement — 25x faster, fully compatible, designed for cloud-native workloads.
+# category: database
+# tags: dragonflydb, redis, cache, key-value, in-memory, database
+# logo: svgs/dragonfly.svg
+# port: 6379
+
+services:
+  dragonfly:
+    image: docker.dragonflydb.io/dragonflydb/dragonfly:latest
+    volumes:
+      - dragonfly-data:/data
+    environment:
+      - SERVICE_URL_DRAGONFLY_6379
+    command: dragonfly --logtostderr --requirepass=${DRAGONFLY_PASSWORD:-} --dir /data

--- a/templates/compose/influxdb.yaml
+++ b/templates/compose/influxdb.yaml
@@ -1,0 +1,26 @@
+# documentation: https://docs.influxdata.com/influxdb
+# slogan: InfluxDB is the open-source time series database for metrics, events, and real-time analytics.
+# category: database
+# tags: influxdb, time-series, metrics, monitoring, iot, analytics
+# logo: svgs/influxdb.svg
+# port: 8086
+
+services:
+  influxdb:
+    image: influxdb:2-alpine
+    volumes:
+      - influxdb-data:/var/lib/influxdb2
+      - influxdb-config:/etc/influxdb2
+    environment:
+      - SERVICE_URL_INFLUXDB_8086
+      - DOCKER_INFLUXDB_INIT_MODE=${INFLUXDB_INIT_MODE:-setup}
+      - DOCKER_INFLUXDB_INIT_USERNAME=${INFLUXDB_ADMIN_USER:-admin}
+      - DOCKER_INFLUXDB_INIT_PASSWORD=${SERVICE_PASSWORD_INFLUXDB:-}
+      - DOCKER_INFLUXDB_INIT_ORG=${INFLUXDB_ORG:-my-org}
+      - DOCKER_INFLUXDB_INIT_BUCKET=${INFLUXDB_BUCKET:-my-bucket}
+      - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=${SERVICE_PASSWORD_INFLUXDB_ADMIN_TOKEN:-}
+    healthcheck:
+      test: ["CMD", "influx", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5


### PR DESCRIPTION
## Changes
- Add InfluxDB v2 one-click service with auto-setup

## Issues
- N/A

## Category
- [x] Adding new one click service

## Preview
InfluxDB is the leading time-series database for metrics, events, and IoT analytics.

## AI Assistance
- [x] AI was used (please describe below)
- Tools used: Claude
- How extensively: Assisted with template structure

## Testing
- Official influxdb:2-alpine image, port 8086, auto-initialization, influx ping healthcheck

## Contributor Agreement
> [!IMPORTANT]
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched existing issues and pull requests to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.