### PR TITLE
fix(proxy): allow configuring instance certificate resolver

### DIFF
--- a/app/Livewire/Settings/Index.php
+++ b/app/Livewire/Settings/Index.php
@@ -17,6 +17,9 @@ class Index extends Component
     #[Validate('nullable|string|max:255|url')]
     public ?string $fqdn = null;
 
+    #[Validate(['nullable', 'string', 'max:255', 'regex:/^[A-Za-z0-9_.-]+$/'])]
+    public ?string $instance_domain_certificate_resolver = null;
+
     #[Validate('required|integer|min:1025|max:65535')]
     public int $public_port_min;
 
@@ -49,6 +52,7 @@ class Index extends Component
     protected array $messages = [
         'fqdn.url' => 'Invalid instance URL.',
         'fqdn.max' => 'URL must not exceed 255 characters.',
+        'instance_domain_certificate_resolver.regex' => 'Instance TLS certificate resolver may only contain letters, numbers, _, ., and -.',
         'dev_helper_version.regex' => 'Dev helper version must match Docker tag format (alphanumeric, _, ., -; first char cannot be . or -).',
     ];
 
@@ -67,6 +71,7 @@ class Index extends Component
             $this->server = Server::findOrFail(0);
         }
         $this->fqdn = $this->settings->fqdn;
+        $this->instance_domain_certificate_resolver = $this->settings->instance_domain_certificate_resolver;
         $this->public_port_min = $this->settings->public_port_min;
         $this->public_port_max = $this->settings->public_port_max;
         $this->instance_name = $this->settings->instance_name;
@@ -87,8 +92,10 @@ class Index extends Component
 
     public function instantSave($isSave = true)
     {
+        $this->normalizeInstanceDomainCertificateResolver();
         $this->validate();
         $this->settings->fqdn = $this->fqdn ? trim($this->fqdn) : $this->fqdn;
+        $this->settings->instance_domain_certificate_resolver = $this->instance_domain_certificate_resolver;
         $this->settings->public_port_min = $this->public_port_min;
         $this->settings->public_port_max = $this->public_port_max;
         $this->settings->instance_name = $this->instance_name;
@@ -132,6 +139,7 @@ class Index extends Component
             if ($this->fqdn) {
                 $this->fqdn = trim($this->fqdn);
             }
+            $this->normalizeInstanceDomainCertificateResolver();
 
             $this->validate();
 
@@ -168,6 +176,16 @@ class Index extends Component
         } catch (\Exception $e) {
             return handleError($e, $this);
         }
+    }
+
+    private function normalizeInstanceDomainCertificateResolver(): void
+    {
+        if (is_null($this->instance_domain_certificate_resolver)) {
+            return;
+        }
+
+        $resolver = trim($this->instance_domain_certificate_resolver);
+        $this->instance_domain_certificate_resolver = $resolver === '' ? null : $resolver;
     }
 
     public function buildHelperImage()

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -9,10 +9,15 @@ use Spatie\Url\Url;
 
 class InstanceSettings extends Model
 {
+    public const DEFAULT_INSTANCE_DOMAIN_CERTIFICATE_RESOLVER = 'letsencrypt';
+
+    public const INSTANCE_DOMAIN_CERTIFICATE_RESOLVER_REGEX = '/^[A-Za-z0-9_.-]+$/';
+
     protected $fillable = [
         'public_ipv4',
         'public_ipv6',
         'fqdn',
+        'instance_domain_certificate_resolver',
         'public_port_min',
         'public_port_max',
         'do_not_track',
@@ -96,6 +101,38 @@ class InstanceSettings extends Model
                 }
             }
         );
+    }
+
+    public function instanceDomainCertificateResolver(): Attribute
+    {
+        return Attribute::make(
+            set: function ($value) {
+                if (is_null($value)) {
+                    return null;
+                }
+
+                $value = trim((string) $value);
+
+                return $value === '' ? null : $value;
+            }
+        );
+    }
+
+    public function getInstanceDomainCertificateResolver(): string
+    {
+        $resolver = $this->instance_domain_certificate_resolver;
+
+        if (! is_string($resolver)) {
+            return self::DEFAULT_INSTANCE_DOMAIN_CERTIFICATE_RESOLVER;
+        }
+
+        $resolver = trim($resolver);
+
+        if ($resolver === '' || ! preg_match(self::INSTANCE_DOMAIN_CERTIFICATE_RESOLVER_REGEX, $resolver)) {
+            return self::DEFAULT_INSTANCE_DOMAIN_CERTIFICATE_RESOLVER;
+        }
+
+        return $resolver;
     }
 
     public function updateCheckFrequency(): Attribute

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -454,115 +454,7 @@ class Server extends BaseModel
                     "rm -f $file",
                 ], $this);
             } else {
-                $url = Url::fromString($settings->fqdn);
-                $host = $url->getHost();
-                $schema = $url->getScheme();
-                $traefik_dynamic_conf = [
-                    'http' => [
-                        'middlewares' => [
-                            'redirect-to-https' => [
-                                'redirectscheme' => [
-                                    'scheme' => 'https',
-                                ],
-                            ],
-                            'gzip' => [
-                                'compress' => true,
-                            ],
-                        ],
-                        'routers' => [
-                            'coolify-http' => [
-                                'middlewares' => [
-                                    0 => 'gzip',
-                                ],
-                                'entryPoints' => [
-                                    0 => 'http',
-                                ],
-                                'service' => 'coolify',
-                                'rule' => "Host(`{$host}`)",
-                            ],
-                            'coolify-realtime-ws' => [
-                                'entryPoints' => [
-                                    0 => 'http',
-                                ],
-                                'service' => 'coolify-realtime',
-                                'rule' => "Host(`{$host}`) && PathPrefix(`/app`)",
-                            ],
-                            'coolify-terminal-ws' => [
-                                'entryPoints' => [
-                                    0 => 'http',
-                                ],
-                                'service' => 'coolify-terminal',
-                                'rule' => "Host(`{$host}`) && PathPrefix(`/terminal/ws`)",
-                            ],
-                        ],
-                        'services' => [
-                            'coolify' => [
-                                'loadBalancer' => [
-                                    'servers' => [
-                                        0 => [
-                                            'url' => 'http://coolify:8080',
-                                        ],
-                                    ],
-                                ],
-                            ],
-                            'coolify-realtime' => [
-                                'loadBalancer' => [
-                                    'servers' => [
-                                        0 => [
-                                            'url' => 'http://coolify-realtime:6001',
-                                        ],
-                                    ],
-                                ],
-                            ],
-                            'coolify-terminal' => [
-                                'loadBalancer' => [
-                                    'servers' => [
-                                        0 => [
-                                            'url' => 'http://coolify-realtime:6002',
-                                        ],
-                                    ],
-                                ],
-                            ],
-                        ],
-                    ],
-                ];
-
-                if ($schema === 'https') {
-                    $traefik_dynamic_conf['http']['routers']['coolify-http']['middlewares'] = [
-                        0 => 'redirect-to-https',
-                    ];
-
-                    $traefik_dynamic_conf['http']['routers']['coolify-https'] = [
-                        'entryPoints' => [
-                            0 => 'https',
-                        ],
-                        'service' => 'coolify',
-                        'rule' => "Host(`{$host}`)",
-                        'tls' => [
-                            'certresolver' => 'letsencrypt',
-                        ],
-                    ];
-                    $traefik_dynamic_conf['http']['routers']['coolify-realtime-wss'] = [
-                        'entryPoints' => [
-                            0 => 'https',
-                        ],
-                        'service' => 'coolify-realtime',
-                        'rule' => "Host(`{$host}`) && PathPrefix(`/app`)",
-                        'tls' => [
-                            'certresolver' => 'letsencrypt',
-                        ],
-                    ];
-                    $traefik_dynamic_conf['http']['routers']['coolify-terminal-wss'] = [
-                        'entryPoints' => [
-                            0 => 'https',
-                        ],
-                        'service' => 'coolify-terminal',
-                        'rule' => "Host(`{$host}`) && PathPrefix(`/terminal/ws`)",
-                        'tls' => [
-                            'certresolver' => 'letsencrypt',
-                        ],
-                    ];
-                }
+                $traefik_dynamic_conf = $this->buildCoolifyTraefikDynamicConfiguration($settings);
                 $yaml = Yaml::dump($traefik_dynamic_conf, 12, 2);
                 $yaml =
                     "# This file is automatically generated by Coolify.\n".
@@ -603,6 +495,123 @@ $schema://$host {
                 $this->reloadCaddy();
             }
         }
+    }
+
+    protected function buildCoolifyTraefikDynamicConfiguration(InstanceSettings $settings): array
+    {
+        $url = Url::fromString($settings->fqdn);
+        $host = $url->getHost();
+        $schema = $url->getScheme();
+        $traefik_dynamic_conf = [
+            'http' => [
+                'middlewares' => [
+                    'redirect-to-https' => [
+                        'redirectscheme' => [
+                            'scheme' => 'https',
+                        ],
+                    ],
+                    'gzip' => [
+                        'compress' => true,
+                    ],
+                ],
+                'routers' => [
+                    'coolify-http' => [
+                        'middlewares' => [
+                            0 => 'gzip',
+                        ],
+                        'entryPoints' => [
+                            0 => 'http',
+                        ],
+                        'service' => 'coolify',
+                        'rule' => "Host(`{$host}`)",
+                    ],
+                    'coolify-realtime-ws' => [
+                        'entryPoints' => [
+                            0 => 'http',
+                        ],
+                        'service' => 'coolify-realtime',
+                        'rule' => "Host(`{$host}`) && PathPrefix(`/app`)",
+                    ],
+                    'coolify-terminal-ws' => [
+                        'entryPoints' => [
+                            0 => 'http',
+                        ],
+                        'service' => 'coolify-terminal',
+                        'rule' => "Host(`{$host}`) && PathPrefix(`/terminal/ws`)",
+                    ],
+                ],
+                'services' => [
+                    'coolify' => [
+                        'loadBalancer' => [
+                            'servers' => [
+                                0 => [
+                                    'url' => 'http://coolify:8080',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'coolify-realtime' => [
+                        'loadBalancer' => [
+                            'servers' => [
+                                0 => [
+                                    'url' => 'http://coolify-realtime:6001',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'coolify-terminal' => [
+                        'loadBalancer' => [
+                            'servers' => [
+                                0 => [
+                                    'url' => 'http://coolify-realtime:6002',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        if ($schema === 'https') {
+            $certificateResolver = $settings->getInstanceDomainCertificateResolver();
+
+            $traefik_dynamic_conf['http']['routers']['coolify-http']['middlewares'] = [
+                0 => 'redirect-to-https',
+            ];
+
+            $traefik_dynamic_conf['http']['routers']['coolify-https'] = [
+                'entryPoints' => [
+                    0 => 'https',
+                ],
+                'service' => 'coolify',
+                'rule' => "Host(`{$host}`)",
+                'tls' => [
+                    'certresolver' => $certificateResolver,
+                ],
+            ];
+            $traefik_dynamic_conf['http']['routers']['coolify-realtime-wss'] = [
+                'entryPoints' => [
+                    0 => 'https',
+                ],
+                'service' => 'coolify-realtime',
+                'rule' => "Host(`{$host}`) && PathPrefix(`/app`)",
+                'tls' => [
+                    'certresolver' => $certificateResolver,
+                ],
+            ];
+            $traefik_dynamic_conf['http']['routers']['coolify-terminal-wss'] = [
+                'entryPoints' => [
+                    0 => 'https',
+                ],
+                'service' => 'coolify-terminal',
+                'rule' => "Host(`{$host}`) && PathPrefix(`/terminal/ws`)",
+                'tls' => [
+                    'certresolver' => $certificateResolver,
+                ],
+            ];
+        }
+
+        return $traefik_dynamic_conf;
     }
 
     public function reloadCaddy()

--- a/database/migrations/2026_05_17_000000_add_instance_domain_certificate_resolver_to_instance_settings_table.php
+++ b/database/migrations/2026_05_17_000000_add_instance_domain_certificate_resolver_to_instance_settings_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! Schema::hasColumn('instance_settings', 'instance_domain_certificate_resolver')) {
+            Schema::table('instance_settings', function (Blueprint $table) {
+                $table->string('instance_domain_certificate_resolver')->nullable()->after('fqdn');
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (Schema::hasColumn('instance_settings', 'instance_domain_certificate_resolver')) {
+            Schema::table('instance_settings', function (Blueprint $table) {
+                $table->dropColumn('instance_domain_certificate_resolver');
+            });
+        }
+    }
+};

--- a/resources/views/livewire/settings/index.blade.php
+++ b/resources/views/livewire/settings/index.blade.php
@@ -23,6 +23,9 @@
                                 <span class='dark:text-warning text-coollabs'>Important: </span>
                                 If you want the dashboard to be accessible over HTTPS, you must include <b>https://</b> at the start of the URL. Without it, the dashboard will use HTTP and won’t be secured."
                                 placeholder="https://coolify.yourdomain.com" />
+                            <x-forms.input canGate="update" :canResource="$settings" id="instance_domain_certificate_resolver" label="Instance TLS certificate resolver"
+                                helper="Traefik certificate resolver used for the Coolify instance domain. Defaults to <code>letsencrypt</code>."
+                                placeholder="letsencrypt" />
                             <x-forms.input canGate="update" :canResource="$settings" id="instance_name" label="Name" placeholder="Coolify"
                                 helper="Custom name for your Coolify instance, shown in the URL." />
                             <div class="w-full" x-data="{

--- a/tests/Feature/InstanceDomainCertificateResolverTest.php
+++ b/tests/Feature/InstanceDomainCertificateResolverTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use App\Models\InstanceSettings;
+use App\Models\Server;
+
+function coolifyControlPlaneCertificateResolvers(?string $resolver): array
+{
+    $settings = new InstanceSettings;
+    $settings->fqdn = 'https://infra.example.com';
+    $settings->instance_domain_certificate_resolver = $resolver;
+
+    $server = new class extends Server
+    {
+        public function buildCoolifyTraefikDynamicConfigurationForTest(InstanceSettings $settings): array
+        {
+            return $this->buildCoolifyTraefikDynamicConfiguration($settings);
+        }
+    };
+
+    $routers = $server->buildCoolifyTraefikDynamicConfigurationForTest($settings)['http']['routers'];
+
+    return [
+        'coolify-https' => $routers['coolify-https']['tls']['certresolver'],
+        'coolify-realtime-wss' => $routers['coolify-realtime-wss']['tls']['certresolver'],
+        'coolify-terminal-wss' => $routers['coolify-terminal-wss']['tls']['certresolver'],
+    ];
+}
+
+it('uses letsencrypt for Coolify control-plane HTTPS routers by default', function () {
+    expect(coolifyControlPlaneCertificateResolvers(null))->toBe([
+        'coolify-https' => 'letsencrypt',
+        'coolify-realtime-wss' => 'letsencrypt',
+        'coolify-terminal-wss' => 'letsencrypt',
+    ]);
+});
+
+it('uses configured resolver for all Coolify control-plane HTTPS routers', function () {
+    expect(coolifyControlPlaneCertificateResolvers('letsencrypt-http'))->toBe([
+        'coolify-https' => 'letsencrypt-http',
+        'coolify-realtime-wss' => 'letsencrypt-http',
+        'coolify-terminal-wss' => 'letsencrypt-http',
+    ]);
+});
+
+it('falls back to letsencrypt for unsafe Coolify control-plane resolver values', function () {
+    expect(coolifyControlPlaneCertificateResolvers("letsencrypt-http\nmalicious: true"))->toBe([
+        'coolify-https' => 'letsencrypt',
+        'coolify-realtime-wss' => 'letsencrypt',
+        'coolify-terminal-wss' => 'letsencrypt',
+    ]);
+});


### PR DESCRIPTION
## Changes

- Adds a nullable instance-domain certificate resolver setting with validation and a General settings field.
- Uses the configured resolver for Coolify's own HTTPS and WSS control-plane routers.
- Keeps backward compatibility by falling back to letsencrypt when the setting is empty or unsafe.
- Adds focused tests for default, custom, and unsafe resolver values in the generated control-plane router config.

## Issues

- Fixes #10261
- Related discussion #10263

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable. This adds one field to the existing instance General settings form.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenCode with GPT-5.5.
- How extensively: AI assisted with implementation, tests, and PR text. I reviewed the code, test output, and generated config behavior before submitting.

## Testing

- php artisan test --compact tests/Feature/InstanceDomainCertificateResolverTest.php
- php artisan test --compact tests/Feature/DevHelperVersionValidationTest.php
- COMPOSE_CMD=docker-compose ./vendor/bin/spin up -d
- COMPOSE_CMD=docker-compose ./vendor/bin/spin exec coolify php artisan migrate --seed --force
- COMPOSE_CMD=docker-compose ./vendor/bin/spin exec coolify php artisan test --compact tests/Feature/InstanceDomainCertificateResolverTest.php
- curl -fsS --max-time 20 http://localhost:8000/api/health
- curl -I --max-time 20 http://localhost:8000
- ./vendor/bin/pint --test on the touched PHP files
- git diff --check

The local development instance was started successfully after generating a local app key and setting the local database host for this Lima Docker environment. The app health endpoint returned OK and the web route redirected to the login page.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
