### PR TITLE
feat: add SurrealDB standalone database

### DIFF
--- a/app/Actions/Database/RestartDatabase.php
+++ b/app/Actions/Database/RestartDatabase.php
@@ -10,13 +10,14 @@ use App\Models\StandaloneMongodb;
 use App\Models\StandaloneMysql;
 use App\Models\StandalonePostgresql;
 use App\Models\StandaloneRedis;
+use App\Models\StandaloneSurrealdb;
 use Lorisleiva\Actions\Concerns\AsAction;
 
 class RestartDatabase
 {
     use AsAction;
 
-    public function handle(StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse $database)
+    public function handle(StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse|StandaloneSurrealdb $database)
     {
         $server = $database->destination->server;
         if (! $server->isFunctional()) {

--- a/app/Actions/Database/StartDatabase.php
+++ b/app/Actions/Database/StartDatabase.php
@@ -10,6 +10,7 @@ use App\Models\StandaloneMongodb;
 use App\Models\StandaloneMysql;
 use App\Models\StandalonePostgresql;
 use App\Models\StandaloneRedis;
+use App\Models\StandaloneSurrealdb;
 use Lorisleiva\Actions\Concerns\AsAction;
 
 class StartDatabase
@@ -18,7 +19,7 @@ class StartDatabase
 
     public string $jobQueue = 'high';
 
-    public function handle(StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse $database)
+    public function handle(StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse|StandaloneSurrealdb $database)
     {
         $server = $database->destination->server;
         if (! $server->isFunctional()) {
@@ -48,6 +49,9 @@ class StartDatabase
                 break;
             case \App\Models\StandaloneClickhouse::class:
                 $activity = StartClickhouse::run($database);
+                break;
+            case \App\Models\StandaloneSurrealdb::class:
+                $activity = StartSurrealdb::run($database);
                 break;
         }
         if ($database->is_public && $database->public_port) {

--- a/app/Actions/Database/StartSurrealdb.php
+++ b/app/Actions/Database/StartSurrealdb.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace App\Actions\Database;
+
+use App\Models\StandaloneSurrealdb;
+use Lorisleiva\Actions\Concerns\AsAction;
+use Symfony\Component\Yaml\Yaml;
+
+class StartSurrealdb
+{
+    use AsAction;
+
+    public StandaloneSurrealdb $database;
+
+    public array $commands = [];
+
+    public string $configuration_dir;
+
+    public function handle(StandaloneSurrealdb $database)
+    {
+        $this->database = $database;
+        $container_name = $this->database->uuid;
+        $this->configuration_dir = database_configuration_dir().'/'.$container_name;
+        if (isDev()) {
+            $this->configuration_dir = '/var/lib/docker/volumes/coolify_dev_coolify_data/_data/databases/'.$container_name;
+        }
+
+        $this->commands = [
+            "echo 'Starting SurrealDB.'",
+            "echo 'Creating directories.'",
+            "mkdir -p $this->configuration_dir",
+            "echo 'Directories created successfully.'",
+        ];
+
+        $persistent_storages = $this->generate_local_persistent_volumes();
+        $volume_names = $this->generate_local_persistent_volumes_only_volume_names();
+        $environment_variables = $this->generate_environment_variables();
+
+        $backend = 'surrealkv://data';
+        if ($this->database->storage_backend === 'memory') {
+            $backend = 'memory';
+        } elseif ($this->database->storage_backend === 'file') {
+            $backend = 'file://data';
+        } elseif ($this->database->storage_backend === 'rocksdb') {
+            $backend = 'rocksdb://data';
+        } elseif ($this->database->storage_backend === 'tikv') {
+            $backend = 'tikv://'.$this->database->tikv_endpoint;
+        }
+
+        $command = [
+            'start',
+            '--user',
+            (string) $this->database->surreal_user,
+            '--pass',
+            (string) $this->database->surreal_password,
+            $backend,
+        ];
+
+        if ($this->database->surreal_auth !== 'unauthenticated') {
+            $command[] = '--auth';
+        }
+
+        $docker_compose = [
+            'services' => [
+                $container_name => [
+                    'image' => $this->database->image,
+                    'container_name' => $container_name,
+                    'command' => $command,
+                    'environment' => $environment_variables,
+                    'restart' => RESTART_MODE,
+                    'networks' => [
+                        $this->database->destination->network,
+                    ],
+                    'labels' => defaultDatabaseLabels($this->database)->toArray(),
+                    'healthcheck' => [
+                        'test' => ['CMD', 'curl', '-f', 'http://localhost:8000/health'],
+                        'interval' => '5s',
+                        'timeout' => '5s',
+                        'retries' => 10,
+                        'start_period' => '5s',
+                    ],
+                    'mem_limit' => $this->database->limits_memory,
+                    'memswap_limit' => $this->database->limits_memory_swap,
+                    'mem_swappiness' => $this->database->limits_memory_swappiness,
+                    'mem_reservation' => $this->database->limits_memory_reservation,
+                    'cpus' => (float) $this->database->limits_cpus,
+                    'cpu_shares' => $this->database->limits_cpu_shares,
+                ],
+            ],
+            'networks' => [
+                $this->database->destination->network => [
+                    'external' => true,
+                    'name' => $this->database->destination->network,
+                    'attachable' => true,
+                ],
+            ],
+        ];
+
+        if (filled($this->database->limits_cpuset)) {
+            data_set($docker_compose, "services.{$container_name}.cpuset", $this->database->limits_cpuset);
+        }
+
+        if ($this->database->destination->server->isLogDrainEnabled() && $this->database->isLogDrainEnabled()) {
+            $docker_compose['services'][$container_name]['logging'] = generate_fluentd_configuration();
+        }
+
+        if (count($this->database->ports_mappings_array) > 0) {
+            $docker_compose['services'][$container_name]['ports'] = $this->database->ports_mappings_array;
+        } else {
+            $docker_compose['services'][$container_name]['ports'] = ['8000:8000'];
+        }
+
+        $docker_compose['services'][$container_name]['volumes'] ??= [];
+
+        if (count($persistent_storages) > 0) {
+            $docker_compose['services'][$container_name]['volumes'] = array_merge(
+                $docker_compose['services'][$container_name]['volumes'],
+                $persistent_storages
+            );
+        }
+
+        if (count($volume_names) > 0) {
+            $docker_compose['volumes'] = $volume_names;
+        }
+
+        // Add custom docker run options
+        $docker_run_options = convertDockerRunToCompose($this->database->custom_docker_run_options);
+        $docker_compose = generateCustomDockerRunOptionsForDatabases($docker_run_options, $docker_compose, $container_name, $this->database->destination->network);
+
+        $docker_compose = Yaml::dump($docker_compose, 10);
+        $docker_compose_base64 = base64_encode($docker_compose);
+        $this->commands[] = "echo '{$docker_compose_base64}' | base64 -d | tee $this->configuration_dir/docker-compose.yml > /dev/null";
+        $this->commands[] = "echo 'Pulling {$database->image} image.'";
+        $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml pull";
+        $this->commands[] = "docker stop -t 10 $container_name 2>/dev/null || true";
+        $this->commands[] = "docker rm -f $container_name 2>/dev/null || true";
+        $this->commands[] = "docker compose -f $this->configuration_dir/docker-compose.yml up -d";
+        $this->commands[] = "echo 'Database started.'";
+
+        return remote_process($this->commands, $database->destination->server, callEventOnFinish: 'DatabaseStatusChanged');
+    }
+
+    private function generate_local_persistent_volumes()
+    {
+        $local_persistent_volumes = [];
+        foreach ($this->database->persistentStorages as $persistentStorage) {
+            if ($persistentStorage->host_path !== '' && $persistentStorage->host_path !== null) {
+                $local_persistent_volumes[] = $persistentStorage->host_path.':'.$persistentStorage->mount_path;
+            } else {
+                $volume_name = $persistentStorage->name;
+                $local_persistent_volumes[] = $volume_name.':'.$persistentStorage->mount_path;
+            }
+        }
+
+        return $local_persistent_volumes;
+    }
+
+    private function generate_local_persistent_volumes_only_volume_names()
+    {
+        $local_persistent_volumes_names = [];
+        foreach ($this->database->persistentStorages as $persistentStorage) {
+            if ($persistentStorage->host_path) {
+                continue;
+            }
+            $name = $persistentStorage->name;
+            $local_persistent_volumes_names[$name] = [
+                'name' => $name,
+                'external' => false,
+            ];
+        }
+
+        return $local_persistent_volumes_names;
+    }
+
+    private function generate_environment_variables()
+    {
+        $environment_variables = collect();
+        foreach ($this->database->runtime_environment_variables as $env) {
+            $environment_variables->push("$env->key=$env->real_value");
+        }
+
+        if ($environment_variables->filter(fn ($env) => str($env)->contains('SURREAL_USER'))->isEmpty()) {
+            $environment_variables->push("SURREAL_USER={$this->database->surreal_user}");
+        }
+
+        if ($environment_variables->filter(fn ($env) => str($env)->contains('SURREAL_PASS'))->isEmpty()) {
+            $environment_variables->push("SURREAL_PASS={$this->database->surreal_password}");
+        }
+
+        add_coolify_default_environment_variables($this->database, $environment_variables, $environment_variables);
+
+        return $environment_variables->all();
+    }
+}

--- a/app/Actions/Database/StopDatabase.php
+++ b/app/Actions/Database/StopDatabase.php
@@ -12,13 +12,14 @@ use App\Models\StandaloneMongodb;
 use App\Models\StandaloneMysql;
 use App\Models\StandalonePostgresql;
 use App\Models\StandaloneRedis;
+use App\Models\StandaloneSurrealdb;
 use Lorisleiva\Actions\Concerns\AsAction;
 
 class StopDatabase
 {
     use AsAction;
 
-    public function handle(StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse $database, bool $dockerCleanup = true)
+    public function handle(StandaloneRedis|StandalonePostgresql|StandaloneMongodb|StandaloneMysql|StandaloneMariadb|StandaloneKeydb|StandaloneDragonfly|StandaloneClickhouse|StandaloneSurrealdb $database, bool $dockerCleanup = true)
     {
         try {
             $server = $database->destination->server;

--- a/app/Livewire/Project/Database/Import.php
+++ b/app/Livewire/Project/Database/Import.php
@@ -362,7 +362,8 @@ EOD;
             $resource->getMorphClass() === \App\Models\StandaloneRedis::class ||
             $resource->getMorphClass() === \App\Models\StandaloneKeydb::class ||
             $resource->getMorphClass() === \App\Models\StandaloneDragonfly::class ||
-            $resource->getMorphClass() === \App\Models\StandaloneClickhouse::class
+            $resource->getMorphClass() === \App\Models\StandaloneClickhouse::class ||
+            $resource->getMorphClass() === \App\Models\StandaloneSurrealdb::class
         ) {
             $this->unsupported = true;
         }

--- a/app/Livewire/Project/Database/Surrealdb/General.php
+++ b/app/Livewire/Project/Database/Surrealdb/General.php
@@ -1,0 +1,248 @@
+<?php
+
+namespace App\Livewire\Project\Database\Surrealdb;
+
+use App\Actions\Database\StartDatabaseProxy;
+use App\Actions\Database\StopDatabaseProxy;
+use App\Models\Server;
+use App\Models\StandaloneSurrealdb;
+use App\Support\ValidationPatterns;
+use Exception;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Component;
+
+class General extends Component
+{
+    use AuthorizesRequests;
+
+    public ?Server $server = null;
+
+    public StandaloneSurrealdb $database;
+
+    public string $name;
+
+    public ?string $description = null;
+
+    public string $surrealUser;
+
+    public string $surrealPassword;
+
+    public string $surrealAuth;
+
+    public string $storageBackend;
+
+    public ?string $tikvEndpoint = null;
+
+    public string $image;
+
+    public ?string $portsMappings = null;
+
+    public ?bool $isPublic = null;
+
+    public mixed $publicPort = null;
+
+    public mixed $publicPortTimeout = 3600;
+
+    public ?string $customDockerRunOptions = null;
+
+    public ?string $dbUrl = null;
+
+    public ?string $dbUrlPublic = null;
+
+    public bool $isLogDrainEnabled = false;
+
+    public function getListeners()
+    {
+        $teamId = Auth::user()->currentTeam()->id;
+
+        return [
+            "echo-private:team.{$teamId},DatabaseProxyStopped" => 'databaseProxyStopped',
+        ];
+    }
+
+    public function mount()
+    {
+        try {
+            $this->authorize('view', $this->database);
+            $this->syncData();
+            $this->server = data_get($this->database, 'destination.server');
+            if (! $this->server) {
+                $this->dispatch('error', 'Database destination server is not configured.');
+
+                return;
+            }
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    protected function rules(): array
+    {
+        return [
+            'name' => ValidationPatterns::nameRules(),
+            'description' => ValidationPatterns::descriptionRules(),
+            'surrealUser' => ValidationPatterns::databaseIdentifierRules(
+                enforcePattern: $this->surrealUser !== $this->database->surreal_user,
+            ),
+            'surrealPassword' => ValidationPatterns::databasePasswordRules(
+                enforcePattern: $this->surrealPassword !== $this->database->surreal_password,
+            ),
+            'surrealAuth' => 'required|string',
+            'storageBackend' => 'required|string',
+            'tikvEndpoint' => 'nullable|string',
+            'image' => 'required|string',
+            'portsMappings' => ValidationPatterns::portMappingRules(),
+            'isPublic' => 'nullable|boolean',
+            'publicPort' => 'nullable|integer|min:1|max:65535',
+            'publicPortTimeout' => 'nullable|integer|min:1',
+            'customDockerRunOptions' => 'nullable|string',
+            'dbUrl' => 'nullable|string',
+            'dbUrlPublic' => 'nullable|string',
+            'isLogDrainEnabled' => 'nullable|boolean',
+        ];
+    }
+
+    protected function messages(): array
+    {
+        return array_merge(
+            ValidationPatterns::combinedMessages(),
+            ValidationPatterns::portMappingMessages(),
+            [
+                ...ValidationPatterns::databaseIdentifierMessages('surrealUser', 'User'),
+                ...ValidationPatterns::databasePasswordMessages('surrealPassword', 'Password'),
+                'image.required' => 'The Docker Image field is required.',
+                'image.string' => 'The Docker Image must be a string.',
+                'publicPort.integer' => 'The Public Port must be an integer.',
+                'publicPort.min' => 'The Public Port must be at least 1.',
+                'publicPort.max' => 'The Public Port must not exceed 65535.',
+                'publicPortTimeout.integer' => 'The Public Port Timeout must be an integer.',
+                'publicPortTimeout.min' => 'The Public Port Timeout must be at least 1.',
+            ]
+        );
+    }
+
+    public function syncData(bool $toModel = false)
+    {
+        if ($toModel) {
+            $this->validate();
+            $this->database->name = $this->name;
+            $this->database->description = $this->description;
+            $this->database->surreal_user = $this->surrealUser;
+            $this->database->surreal_password = $this->surrealPassword;
+            $this->database->surreal_auth = $this->surrealAuth;
+            $this->database->storage_backend = $this->storageBackend;
+            $this->database->tikv_endpoint = $this->tikvEndpoint;
+            $this->database->image = $this->image;
+            $this->database->ports_mappings = $this->portsMappings;
+            $this->database->is_public = $this->isPublic;
+            $this->database->public_port = $this->publicPort ?: null;
+            $this->database->public_port_timeout = $this->publicPortTimeout ?: null;
+            $this->database->custom_docker_run_options = $this->customDockerRunOptions;
+            $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
+            $this->database->save();
+
+            $this->dbUrl = $this->database->internal_db_url;
+            $this->dbUrlPublic = $this->database->external_db_url;
+        } else {
+            $this->name = $this->database->name;
+            $this->description = $this->database->description;
+            $this->surrealUser = $this->database->surreal_user;
+            $this->surrealPassword = $this->database->surreal_password;
+            $this->surrealAuth = $this->database->surreal_auth;
+            $this->storageBackend = $this->database->storage_backend;
+            $this->tikvEndpoint = $this->database->tikv_endpoint;
+            $this->image = $this->database->image;
+            $this->portsMappings = $this->database->ports_mappings;
+            $this->isPublic = $this->database->is_public;
+            $this->publicPort = $this->database->public_port;
+            $this->publicPortTimeout = $this->database->public_port_timeout;
+            $this->customDockerRunOptions = $this->database->custom_docker_run_options;
+            $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
+            $this->dbUrl = $this->database->internal_db_url;
+            $this->dbUrlPublic = $this->database->external_db_url;
+        }
+    }
+
+    public function instantSaveAdvanced()
+    {
+        try {
+            $this->authorize('update', $this->database);
+
+            if (! $this->server->isLogDrainEnabled()) {
+                $this->isLogDrainEnabled = false;
+                $this->dispatch('error', 'Log drain is not enabled on the server. Please enable it first.');
+
+                return;
+            }
+            $this->syncData(true);
+
+            $this->dispatch('success', 'Database updated.');
+            $this->dispatch('success', 'You need to restart the service for the changes to take effect.');
+        } catch (Exception $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function instantSave()
+    {
+        try {
+            $this->authorize('update', $this->database);
+
+            if ($this->isPublic && ! $this->publicPort) {
+                $this->dispatch('error', 'Public port is required.');
+                $this->isPublic = false;
+
+                return;
+            }
+            if ($this->isPublic && ! str($this->database->status)->startsWith('running')) {
+                $this->dispatch('error', 'Database must be started to be publicly accessible.');
+                $this->isPublic = false;
+
+                return;
+            }
+            $this->syncData(true);
+            if ($this->isPublic) {
+                StartDatabaseProxy::run($this->database);
+                $this->dispatch('success', 'Database is now publicly accessible.');
+            } else {
+                StopDatabaseProxy::run($this->database);
+                $this->dispatch('success', 'Database is no longer publicly accessible.');
+            }
+        } catch (\Throwable $e) {
+            $this->isPublic = ! $this->isPublic;
+            $this->syncData(true);
+
+            return handleError($e, $this);
+        }
+    }
+
+    public function databaseProxyStopped()
+    {
+        $this->syncData();
+    }
+
+    public function submit()
+    {
+        try {
+            $this->authorize('update', $this->database);
+
+            if ($this->portsMappings) {
+                $this->portsMappings = str($this->portsMappings)->replace(' ', '')->trim()->toString();
+            }
+            if (str($this->publicPort)->isEmpty()) {
+                $this->publicPort = null;
+            }
+            $this->syncData(true);
+            $this->dispatch('success', 'Database updated.');
+        } catch (Exception $e) {
+            return handleError($e, $this);
+        } finally {
+            if (is_null($this->database->config_hash)) {
+                $this->database->isConfigurationChanged(true);
+            } else {
+                $this->dispatch('configurationChanged');
+            }
+        }
+    }
+}

--- a/app/Livewire/Project/New/Select.php
+++ b/app/Livewire/Project/New/Select.php
@@ -243,6 +243,12 @@ class Select extends Component
                 'description' => 'ClickHouse is a column-oriented database that supports real-time analytics, business intelligence, observability, ML and GenAI, and more.',
                 'logo' => '<div class="w-[4.5rem] h-[4.5rem] p-2 transition-all duration-200 bg-black/10 dark:bg-white/10"><svg width="215" height="90" viewBox="0 0 100 43" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><g clip-path="url(#clip0_378_10860)"><rect x="2.70837" y="2.875" width="2.24992" height="20.2493" rx="0.236664" fill="currentColor"/><rect x="7.2085" y="2.875" width="2.24992" height="20.2493" rx="0.236664" fill="currentColor"/><rect x="11.7086" y="2.875" width="2.24992" height="20.2493" rx="0.236664" fill="currentColor"/><rect x="16.2076" y="2.875" width="2.24992" height="20.2493" rx="0.236664" fill="currentColor"/><rect x="20.7087" y="10.7502" width="2.24992" height="4.49985" rx="0.236664" fill="currentColor"/></g></svg></div>',
             ],
+            [
+                'id' => 'surrealdb',
+                'name' => 'SurrealDB',
+                'description' => 'SurrealDB is an end-to-end cloud-native database for initial-stage startups to enterprise-level businesses.',
+                'logo' => '<div class="w-[4.5rem] h-[4.5rem] p-2 transition-all duration-200 bg-black/10 dark:bg-white/10"><svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M50 0C22.3858 0 0 22.3858 0 50C0 77.6142 22.3858 100 50 100C77.6142 100 100 77.6142 100 50C100 22.3858 77.6142 0 50 0ZM50 90C27.9086 90 10 72.0914 10 50C10 27.9086 27.9086 10 50 10C72.0914 10 90 27.9086 90 50C90 72.0914 72.0914 90 50 90ZM65 40C65 48.2843 58.2843 55 50 55C41.7157 55 35 48.2843 35 40C35 31.7157 41.7157 25 50 25C58.2843 25 65 31.7157 65 40ZM50 75C35 75 25 65 25 50H35C35 60 40 65 50 65C60 65 65 60 65 50H75C75 65 65 75 50 75Z" fill="currentColor"/></svg></div>',
+            ],
 
         ];
 
@@ -284,6 +290,7 @@ class Select extends Component
             case 'keydb':
             case 'dragonfly':
             case 'clickhouse':
+            case 'surrealdb':
             case 'mongodb':
                 $this->isDatabase = true;
                 $this->includeSwarm = false;

--- a/app/Livewire/Project/Resource/Create.php
+++ b/app/Livewire/Project/Resource/Create.php
@@ -63,6 +63,8 @@ class Create extends Component
                     $database = create_standalone_dragonfly($environment->id, $destination);
                 } elseif ($type->value() === 'clickhouse') {
                     $database = create_standalone_clickhouse($environment->id, $destination);
+                } elseif ($type->value() === 'surrealdb') {
+                    $database = create_standalone_surrealdb($environment->id, $destination);
                 }
 
                 return redirect()->route('project.database.configuration', [

--- a/app/Livewire/Project/Resource/Index.php
+++ b/app/Livewire/Project/Resource/Index.php
@@ -37,6 +37,8 @@ class Index extends Component
 
     protected Collection $clickhouses;
 
+    protected Collection $surrealdb;
+
     protected Collection $services;
 
     public function mount(): void
@@ -70,6 +72,7 @@ class Index extends Component
                 'keydbs:id,uuid,name,environment_id',
                 'dragonflies:id,uuid,name,environment_id',
                 'clickhouses:id,uuid,name,environment_id',
+                'standalone_surrealdb:id,uuid,name,environment_id',
             ])
             ->get();
 
@@ -81,6 +84,7 @@ class Index extends Component
             'keydbs',
             'dragonflies',
             'clickhouses',
+            'standalone_surrealdb',
             'mariadbs',
             'mongodbs',
             'services',
@@ -114,6 +118,7 @@ class Index extends Component
             'keydbs' => 'keydbs',
             'dragonflies' => 'dragonflies',
             'clickhouses' => 'clickhouses',
+            'surrealdb' => 'standalone_surrealdb',
         ];
 
         foreach ($databaseTypes as $property => $relation) {
@@ -160,6 +165,7 @@ class Index extends Component
             'keydbs' => $this->keydbs,
             'dragonflies' => $this->dragonflies,
             'clickhouses' => $this->clickhouses,
+            'surrealdb' => $this->surrealdb,
             'services' => $this->services,
             'applicationsJs' => $this->toSearchableArray($this->applications),
             'postgresqlsJs' => $this->toSearchableArray($this->postgresqls),
@@ -170,6 +176,7 @@ class Index extends Component
             'keydbsJs' => $this->toSearchableArray($this->keydbs),
             'dragonfliesJs' => $this->toSearchableArray($this->dragonflies),
             'clickhousesJs' => $this->toSearchableArray($this->clickhouses),
+            'surrealdbJs' => $this->toSearchableArray($this->surrealdb),
             'servicesJs' => $this->toSearchableArray($this->services),
         ]);
     }

--- a/app/Livewire/Project/Shared/Danger.php
+++ b/app/Livewire/Project/Shared/Danger.php
@@ -73,7 +73,9 @@ class Danger extends Component
             'standalone-mariadb',
             'standalone-keydb',
             'standalone-dragonfly',
-            'standalone-clickhouse' => $this->resource->name ?? 'Database',
+            'standalone-clickhouse',
+            'standalone-surrealdb' => $this->resource->name ?? 'Database',
+
             'service' => $this->resource->name ?? 'Service',
             'service-application' => $this->resource->name ?? 'Service Application',
             'service-database' => $this->resource->name ?? 'Service Database',

--- a/app/Models/Environment.php
+++ b/app/Models/Environment.php
@@ -106,12 +106,18 @@ class Environment extends BaseModel
         return $this->hasMany(StandaloneDragonfly::class);
     }
 
-    public function clickhouses()
+    public function standalone_clickhouses()
     {
         return $this->hasMany(StandaloneClickhouse::class);
     }
 
+    public function standalone_surrealdb()
+    {
+        return $this->hasMany(StandaloneSurrealdb::class);
+    }
+
     public function databases()
+
     {
         $postgresqls = $this->postgresqls;
         $redis = $this->redis;
@@ -121,8 +127,9 @@ class Environment extends BaseModel
         $keydbs = $this->keydbs;
         $dragonflies = $this->dragonflies;
         $clickhouses = $this->clickhouses;
+        $surrealdb = $this->standalone_surrealdb;
 
-        return $postgresqls->concat($redis)->concat($mongodbs)->concat($mysqls)->concat($mariadbs)->concat($keydbs)->concat($dragonflies)->concat($clickhouses);
+        return $postgresqls->concat($redis)->concat($mongodbs)->concat($mysqls)->concat($mariadbs)->concat($keydbs)->concat($dragonflies)->concat($clickhouses)->concat($surrealdb);
     }
 
     public function project()

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -136,30 +136,37 @@ class Project extends BaseModel
     {
         return $this->hasManyThrough(StandaloneMysql::class, Environment::class);
     }
+public function clickhouses()
+{
+    return $this->hasManyThrough(StandaloneClickhouse::class, Environment::class);
+}
 
-    public function mariadbs()
-    {
-        return $this->hasManyThrough(StandaloneMariadb::class, Environment::class);
-    }
+public function surrealdb()
+{
+    return $this->hasManyThrough(StandaloneSurrealdb::class, Environment::class);
+}
 
-    public function isEmpty()
-    {
-        return $this->applications()->count() == 0 &&
-            $this->redis()->count() == 0 &&
-            $this->postgresqls()->count() == 0 &&
-            $this->mysqls()->count() == 0 &&
-            $this->keydbs()->count() == 0 &&
-            $this->dragonflies()->count() == 0 &&
-            $this->clickhouses()->count() == 0 &&
-            $this->mariadbs()->count() == 0 &&
-            $this->mongodbs()->count() == 0 &&
-            $this->services()->count() == 0;
-    }
+public function mongodbs()
+...
+public function isEmpty()
+{
+    return $this->applications()->count() == 0 &&
+        $this->redis()->count() == 0 &&
+        $this->postgresqls()->count() == 0 &&
+        $this->mysqls()->count() == 0 &&
+        $this->keydbs()->count() == 0 &&
+        $this->dragonflies()->count() == 0 &&
+        $this->clickhouses()->count() == 0 &&
+        $this->surrealdb()->count() == 0 &&
+        $this->mariadbs()->count() == 0 &&
+        $this->mongodbs()->count() == 0 &&
+        $this->services()->count() == 0;
+}
 
-    public function databases()
-    {
-        return $this->postgresqls()->get()->merge($this->redis()->get())->merge($this->mongodbs()->get())->merge($this->mysqls()->get())->merge($this->mariadbs()->get())->merge($this->keydbs()->get())->merge($this->dragonflies()->get())->merge($this->clickhouses()->get());
-    }
+public function databases()
+{
+    return $this->postgresqls()->get()->merge($this->redis()->get())->merge($this->mongodbs()->get())->merge($this->mysqls()->get())->merge($this->mariadbs()->get())->merge($this->keydbs()->get())->merge($this->dragonflies()->get())->merge($this->clickhouses()->get())->merge($this->surrealdb()->get());
+}
 
     public function navigateTo()
     {

--- a/app/Models/StandaloneDocker.php
+++ b/app/Models/StandaloneDocker.php
@@ -85,6 +85,11 @@ class StandaloneDocker extends BaseModel
         return $this->morphMany(StandaloneClickhouse::class, 'destination');
     }
 
+    public function surrealdb()
+    {
+        return $this->morphMany(StandaloneSurrealdb::class, 'destination');
+    }
+
     public function server()
     {
         return $this->belongsTo(Server::class);

--- a/app/Models/StandaloneSurrealdb.php
+++ b/app/Models/StandaloneSurrealdb.php
@@ -1,0 +1,344 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\ClearsGlobalSearchCache;
+use App\Traits\HasMetrics;
+use App\Traits\HasSafeStringAttribute;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class StandaloneSurrealdb extends BaseModel
+{
+    use ClearsGlobalSearchCache, HasFactory, HasMetrics, HasSafeStringAttribute, SoftDeletes;
+
+    protected $table = 'standalone_surrealdb';
+
+    protected $fillable = [
+        'uuid',
+        'name',
+        'description',
+        'surreal_user',
+        'surreal_password',
+        'surreal_auth',
+        'storage_backend',
+        'tikv_endpoint',
+        'status',
+        'image',
+        'is_public',
+        'public_port',
+        'ports_mappings',
+        'limits_memory',
+        'limits_memory_swap',
+        'limits_memory_swappiness',
+        'limits_memory_reservation',
+        'limits_cpus',
+        'limits_cpuset',
+        'limits_cpu_shares',
+        'started_at',
+        'restart_count',
+        'last_restart_at',
+        'last_restart_type',
+        'last_online_at',
+        'public_port_timeout',
+        'is_log_drain_enabled',
+        'is_include_timestamps',
+        'custom_docker_run_options',
+        'config_hash',
+        'destination_type',
+        'destination_id',
+        'environment_id',
+    ];
+
+    protected $appends = ['internal_db_url', 'external_db_url', 'database_type', 'server_status'];
+
+    protected $casts = [
+        'surreal_password' => 'encrypted',
+        'public_port_timeout' => 'integer',
+        'restart_count' => 'integer',
+        'last_restart_at' => 'datetime',
+        'last_restart_type' => 'string',
+    ];
+
+    protected static function booted()
+    {
+        static::created(function ($database) {
+            LocalPersistentVolume::create([
+                'name' => 'surreal-data-'.$database->uuid,
+                'mount_path' => '/data',
+                'host_path' => null,
+                'resource_id' => $database->id,
+                'resource_type' => $database->getMorphClass(),
+            ]);
+        });
+        static::forceDeleting(function ($database) {
+            $database->persistentStorages()->delete();
+            $database->scheduledBackups()->delete();
+            $database->environment_variables()->delete();
+            $database->tags()->detach();
+        });
+        static::saving(function ($database) {
+            if ($database->isDirty('status')) {
+                $database->last_online_at = now();
+            }
+        });
+    }
+
+    public static function ownedByCurrentTeam()
+    {
+        return StandaloneSurrealdb::whereRelation('environment.project.team', 'id', currentTeam()->id)->orderBy('name');
+    }
+
+    public static function ownedByCurrentTeamCached()
+    {
+        return once(function () {
+            return StandaloneSurrealdb::ownedByCurrentTeam()->get();
+        });
+    }
+
+    public function workdir()
+    {
+        return database_configuration_dir()."/{$this->uuid}";
+    }
+
+    protected function serverStatus(): Attribute
+    {
+        return Attribute::make(
+            get: function () {
+                return $this->destination->server->isFunctional();
+            }
+        );
+    }
+
+    public function deleteConfigurations()
+    {
+        $server = data_get($this, 'destination.server');
+        $workdir = $this->workdir();
+        if (str($workdir)->endsWith($this->uuid)) {
+            instant_remote_process(['rm -rf '.$this->workdir()], $server, false);
+        }
+    }
+
+    public function deleteVolumes()
+    {
+        $persistentStorages = $this->persistentStorages()->get() ?? collect();
+        if ($persistentStorages->count() === 0) {
+            return;
+        }
+        $server = data_get($this, 'destination.server');
+        foreach ($persistentStorages as $storage) {
+            instant_remote_process(['docker volume rm -f '.escapeshellarg($storage->name)], $server, false);
+        }
+    }
+
+    public function isConfigurationChanged(bool $save = false)
+    {
+        $newConfigHash = $this->image.$this->ports_mappings.$this->storage_backend.$this->tikv_endpoint;
+        $newConfigHash .= json_encode($this->environment_variables()->get('value')->sort());
+        $newConfigHash = md5($newConfigHash);
+        $oldConfigHash = data_get($this, 'config_hash');
+        if ($oldConfigHash === null) {
+            if ($save) {
+                $this->config_hash = $newConfigHash;
+                $this->save();
+            }
+
+            return true;
+        }
+        if ($oldConfigHash === $newConfigHash) {
+            return false;
+        } else {
+            if ($save) {
+                $this->config_hash = $newConfigHash;
+                $this->save();
+            }
+
+            return true;
+        }
+    }
+
+    public function isRunning()
+    {
+        return (bool) str($this->status)->contains('running');
+    }
+
+    public function isExited()
+    {
+        return (bool) str($this->status)->startsWith('exited');
+    }
+
+    public function realStatus()
+    {
+        return $this->getRawOriginal('status');
+    }
+
+    public function status(): Attribute
+    {
+        return Attribute::make(
+            set: function ($value) {
+                if (str($value)->contains('(')) {
+                    $status = str($value)->before('(')->trim()->value();
+                    $health = str($value)->after('(')->before(')')->trim()->value() ?? 'unhealthy';
+                } elseif (str($value)->contains(':')) {
+                    $status = str($value)->before(':')->trim()->value();
+                    $health = str($value)->after(':')->trim()->value() ?? 'unhealthy';
+                } else {
+                    $status = $value;
+                    $health = 'unhealthy';
+                }
+
+                return "$status:$health";
+            },
+            get: function ($value) {
+                if (str($value)->contains('(')) {
+                    $status = str($value)->before('(')->trim()->value();
+                    $health = str($value)->after('(')->before(')')->trim()->value() ?? 'unhealthy';
+                } elseif (str($value)->contains(':')) {
+                    $status = str($value)->before(':')->trim()->value();
+                    $health = str($value)->after(':')->trim()->value() ?? 'unhealthy';
+                } else {
+                    $status = $value;
+                    $health = 'unhealthy';
+                }
+
+                return "$status:$health";
+            },
+        );
+    }
+
+    public function tags()
+    {
+        return $this->morphToMany(Tag::class, 'taggable');
+    }
+
+    public function project()
+    {
+        return data_get($this, 'environment.project');
+    }
+
+    public function link()
+    {
+        if (data_get($this, 'environment.project.uuid')) {
+            return route('project.database.configuration', [
+                'project_uuid' => data_get($this, 'environment.project.uuid'),
+                'environment_uuid' => data_get($this, 'environment.uuid'),
+                'database_uuid' => data_get($this, 'uuid'),
+            ]);
+        }
+
+        return null;
+    }
+
+    public function isLogDrainEnabled()
+    {
+        return data_get($this, 'is_log_drain_enabled', false);
+    }
+
+    public function portsMappings(): Attribute
+    {
+        return Attribute::make(
+            set: fn ($value) => $value === '' ? null : $value,
+        );
+    }
+
+    public function portsMappingsArray(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => is_null($this->ports_mappings)
+                ? []
+                : explode(',', $this->ports_mappings),
+
+        );
+    }
+
+    public function team()
+    {
+        return data_get($this, 'environment.project.team');
+    }
+
+    public function databaseType(): Attribute
+    {
+        return new Attribute(
+            get: fn () => $this->type(),
+        );
+    }
+
+    public function type(): string
+    {
+        return 'standalone-surrealdb';
+    }
+
+    protected function internalDbUrl(): Attribute
+    {
+        return new Attribute(
+            get: function () {
+                $url = "http://{$this->uuid}:8000";
+                return $url;
+            },
+        );
+    }
+
+    protected function externalDbUrl(): Attribute
+    {
+        return new Attribute(
+            get: function () {
+                if ($this->is_public && $this->public_port) {
+                    $serverIp = $this->destination->server->getIp;
+                    if (empty($serverIp)) {
+                        return null;
+                    }
+                    $url = "http://{$serverIp}:{$this->public_port}";
+                    return $url;
+                }
+
+                return null;
+            }
+        );
+    }
+
+    public function environment()
+    {
+        return $this->belongsTo(Environment::class);
+    }
+
+    public function persistentStorages()
+    {
+        return $this->morphMany(LocalPersistentVolume::class, 'resource');
+    }
+
+    public function fileStorages()
+    {
+        return $this->morphMany(LocalFileVolume::class, 'resource');
+    }
+
+    public function sslCertificates()
+    {
+        return $this->morphMany(SslCertificate::class, 'resource');
+    }
+
+    public function destination()
+    {
+        return $this->morphTo();
+    }
+
+    public function runtime_environment_variables()
+    {
+        return $this->morphMany(EnvironmentVariable::class, 'resourceable');
+    }
+
+    public function scheduledBackups()
+    {
+        return $this->morphMany(ScheduledDatabaseBackup::class, 'database');
+    }
+
+    public function environment_variables()
+    {
+        return $this->morphMany(EnvironmentVariable::class, 'resourceable');
+    }
+
+    public function isBackupSolutionAvailable()
+    {
+        return false; // Backup for SurrealDB is tricky, let's keep it false for now
+    }
+}

--- a/app/Models/SwarmDocker.php
+++ b/app/Models/SwarmDocker.php
@@ -51,6 +51,11 @@ class SwarmDocker extends BaseModel
         return $this->morphMany(StandaloneClickhouse::class, 'destination');
     }
 
+    public function surrealdb()
+    {
+        return $this->morphMany(StandaloneSurrealdb::class, 'destination');
+    }
+
     public function mongodbs()
     {
         return $this->morphMany(StandaloneMongodb::class, 'destination');

--- a/app/Policies/ResourceCreatePolicy.php
+++ b/app/Policies/ResourceCreatePolicy.php
@@ -12,6 +12,7 @@ use App\Models\StandaloneMongodb;
 use App\Models\StandaloneMysql;
 use App\Models\StandalonePostgresql;
 use App\Models\StandaloneRedis;
+use App\Models\StandaloneSurrealdb;
 use App\Models\User;
 
 class ResourceCreatePolicy
@@ -28,6 +29,7 @@ class ResourceCreatePolicy
         StandaloneKeydb::class,
         StandaloneDragonfly::class,
         StandaloneClickhouse::class,
+        StandaloneSurrealdb::class,
         Service::class,
         Application::class,
         GithubApp::class,

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -38,6 +38,8 @@ class AuthServiceProvider extends ServiceProvider
         \App\Models\StandaloneKeydb::class => \App\Policies\DatabasePolicy::class,
         \App\Models\StandaloneDragonfly::class => \App\Policies\DatabasePolicy::class,
         \App\Models\StandaloneClickhouse::class => \App\Policies\DatabasePolicy::class,
+        \App\Models\StandaloneSurrealdb::class => \App\Policies\DatabasePolicy::class,
+        ];
 
         // Notification policies - all use the shared NotificationPolicy
         \App\Models\EmailNotificationSettings::class => \App\Policies\NotificationPolicy::class,

--- a/bootstrap/helpers/constants.php
+++ b/bootstrap/helpers/constants.php
@@ -1,7 +1,7 @@
 <?php
 
 const REDACTED = '<REDACTED>';
-const DATABASE_TYPES = ['postgresql', 'redis', 'mongodb', 'mysql', 'mariadb', 'keydb', 'dragonfly', 'clickhouse'];
+const DATABASE_TYPES = ['postgresql', 'redis', 'mongodb', 'mysql', 'mariadb', 'keydb', 'dragonfly', 'clickhouse', 'surrealdb'];
 const VALID_CRON_STRINGS = [
     'every_minute' => '* * * * *',
     'hourly' => '0 * * * *',

--- a/bootstrap/helpers/databases.php
+++ b/bootstrap/helpers/databases.php
@@ -13,6 +13,7 @@ use App\Models\StandaloneMongodb;
 use App\Models\StandaloneMysql;
 use App\Models\StandalonePostgresql;
 use App\Models\StandaloneRedis;
+use App\Models\StandaloneSurrealdb;
 use App\Models\SwarmDocker;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Storage;
@@ -178,9 +179,27 @@ function create_standalone_clickhouse($environment_id, StandaloneDocker|SwarmDoc
     $database->save();
 
     return $database;
-}
+    }
 
-function deleteBackupsLocally(string|array|null $filenames, Server $server): void
+    function create_standalone_surrealdb($environment_id, StandaloneDocker|SwarmDocker $destination, ?array $otherData = null): StandaloneSurrealdb
+    {
+    $database = new StandaloneSurrealdb;
+    $database->uuid = (new Cuid2);
+    $database->name = 'surrealdb-database-'.$database->uuid;
+    $database->surreal_password = Str::password(length: 64, symbols: false);
+    $database->environment_id = $environment_id;
+    $database->destination_id = $destination->id;
+    $database->destination_type = $destination->getMorphClass();
+    if ($otherData) {
+        $database->fill($otherData);
+    }
+    $database->save();
+
+    return $database;
+    }
+
+    function deleteBackupsLocally
+(string|array|null $filenames, Server $server): void
 {
     if (empty($filenames)) {
         return;

--- a/database/migrations/2026_05_18_100000_create_standalone_surrealdb_table.php
+++ b/database/migrations/2026_05_18_100000_create_standalone_surrealdb_table.php
@@ -1,0 +1,62 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('standalone_surrealdb', function (Blueprint $blueprint) {
+            $blueprint->id();
+            $blueprint->string('uuid')->unique();
+            $blueprint->string('name');
+            $blueprint->string('description')->nullable();
+            $blueprint->string('surreal_user')->default('root');
+            $blueprint->string('surreal_password')->nullable();
+            $blueprint->string('surreal_auth')->default('unauthenticated'); // unauthenticated, namespace, database, root
+            $blueprint->string('storage_backend')->default('surrealkv'); // memory, file, surrealkv, tikv, rocksdb
+            $blueprint->string('tikv_endpoint')->nullable();
+            $blueprint->string('status')->default('exited:unhealthy');
+            $blueprint->string('image')->default('surrealdb/surrealdb:latest');
+            $blueprint->boolean('is_public')->default(false);
+            $blueprint->integer('public_port')->nullable();
+            $blueprint->string('ports_mappings')->nullable();
+            $blueprint->string('limits_memory')->default('0');
+            $blueprint->string('limits_memory_swap')->default('0');
+            $blueprint->integer('limits_memory_swappiness')->default(60);
+            $blueprint->string('limits_memory_reservation')->default('0');
+            $blueprint->string('limits_cpus')->default('0');
+            $blueprint->string('limits_cpuset')->nullable();
+            $blueprint->integer('limits_cpu_shares')->default(1024);
+            $blueprint->dateTime('started_at')->nullable();
+            $blueprint->integer('restart_count')->default(0);
+            $blueprint->dateTime('last_restart_at')->nullable();
+            $blueprint->string('last_restart_type')->nullable();
+            $blueprint->dateTime('last_online_at')->nullable();
+            $blueprint->integer('public_port_timeout')->default(5000);
+            $blueprint->boolean('is_log_drain_enabled')->default(false);
+            $blueprint->boolean('is_include_timestamps')->default(false);
+            $blueprint->string('custom_docker_run_options')->nullable();
+            $blueprint->string('config_hash')->nullable();
+
+            $blueprint->string('destination_type');
+            $blueprint->integer('destination_id');
+            $blueprint->foreignId('environment_id')->constrained()->onDelete('cascade');
+            $blueprint->softDeletes();
+            $blueprint->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('standalone_surrealdb');
+    }
+};

--- a/resources/views/livewire/project/database/configuration.blade.php
+++ b/resources/views/livewire/project/database/configuration.blade.php
@@ -50,6 +50,8 @@
                     <livewire:project.database.dragonfly.general :database="$database" />
                 @elseif ($database->type() === 'standalone-clickhouse')
                     <livewire:project.database.clickhouse.general :database="$database" />
+                @elseif ($database->type() === 'standalone-surrealdb')
+                    <livewire:project.database.surrealdb.general :database="$database" />
                 @endif
             @elseif ($currentRoute === 'project.database.environment-variables')
                 <livewire:project.shared.environment-variable.all :resource="$database" />

--- a/resources/views/livewire/project/database/surrealdb/general.blade.php
+++ b/resources/views/livewire/project/database/surrealdb/general.blade.php
@@ -1,0 +1,110 @@
+<div>
+    <form wire:submit="submit" class="flex flex-col gap-2">
+        <div class="flex items-center gap-2">
+            <h2>General</h2>
+            <x-forms.button type="submit" canGate="update" :canResource="$database">
+                Save
+            </x-forms.button>
+        </div>
+        <div class="flex gap-2">
+            <x-forms.input label="Name" id="name" canGate="update" :canResource="$database" />
+            <x-forms.input label="Description" id="description" canGate="update" :canResource="$database" />
+            <x-forms.input label="Image" id="image" required canGate="update" :canResource="$database"
+                helper="For all available images, check here:<br><br><a target='_blank' href='https://hub.docker.com/r/surrealdb/surrealdb/'>https://hub.docker.com/r/surrealdb/surrealdb/</a>" />
+        </div>
+
+        <div class="flex gap-2">
+            <x-forms.select label="Storage Backend" id="storageBackend" required canGate="update" :canResource="$database">
+                <option value="surrealkv">SurrealKV (Default)</option>
+                <option value="memory">Memory (Ephemeral)</option>
+                <option value="file">File (Persisted)</option>
+                <option value="tikv">TiKV (Distributed)</option>
+                <option value="rocksdb">RocksDB (Experimental)</option>
+            </x-forms.select>
+            @if ($storageBackend === 'tikv')
+                <x-forms.input label="TiKV Endpoint" id="tikvEndpoint" placeholder="127.0.0.1:2379" required canGate="update" :canResource="$database" />
+            @endif
+        </div>
+
+        <div class="flex gap-2">
+            <x-forms.select label="Authentication Mode" id="surrealAuth" required canGate="update" :canResource="$database">
+                <option value="unauthenticated">Unauthenticated</option>
+                <option value="root">Root Authentication</option>
+            </x-forms.select>
+        </div>
+
+        @if ($database->started_at)
+            <div class="flex gap-2">
+                <x-forms.input label="Initial Username" id="surrealUser" placeholder="If empty: root"
+                    readonly helper="You can only change this in the database." canGate="update" :canResource="$database" />
+                <x-forms.input label="Initial Password" id="surrealPassword" type="password" required readonly
+                    helper="You can only change this in the database." canGate="update" :canResource="$database" />
+            </div>
+        @else
+            <div class=" dark:text-warning">Please verify these values. You can only modify them before the initial
+                start. After that, you need to modify it in the database.
+            </div>
+            <div class="flex gap-2">
+                <x-forms.input label="Username" id="surrealUser" required canGate="update" :canResource="$database" />
+                <x-forms.input label="Password" id="surrealPassword" type="password" required canGate="update"
+                    :canResource="$database" />
+            </div>
+        @endif
+        <x-forms.input
+            helper="You can add custom docker run options that will be used when your container is started.<br>Note: Not all options are supported, as they could mess up Coolify's automation and could cause bad experience for users.<br><br>Check the <a class='underline dark:text-white' href='https://coolify.io/docs/knowledge-base/docker/custom-commands'>docs.</a>"
+            placeholder="--cap-add SYS_ADMIN --device=/dev/fuse --security-opt apparmor:unconfined --ulimit nofile=1024:1024 --tmpfs /run:rw,noexec,nosuid,size=65536k"
+            id="customDockerRunOptions" label="Custom Docker Options" canGate="update" :canResource="$database" />
+        <div class="flex flex-col gap-2">
+            <h3 class="py-2">Network</h3>
+            <div class="flex items-end gap-2">
+                <x-forms.input placeholder="8000:8000" id="portsMappings" label="Ports Mappings"
+                    helper="A comma separated list of ports you would like to map to the host system.<br><span class='inline-block font-bold dark:text-warning'>Example</span>8000:8000"
+                    canGate="update" :canResource="$database" />
+            </div>
+            <x-forms.input label="SurrealDB URL (internal)"
+                helper="Internal URL reachable by other services in the same network."
+                readonly wire:model="dbUrl" canGate="update" :canResource="$database" />
+            @if ($dbUrlPublic)
+                <x-forms.input label="SurrealDB URL (public)"
+                    helper="Publicly reachable URL."
+                    readonly wire:model="dbUrlPublic" canGate="update" :canResource="$database" />
+            @else
+                <x-forms.input label="SurrealDB URL (public)"
+                    readonly value="Starting the database will generate this if Publicly Available is checked." canGate="update" :canResource="$database" />
+            @endif
+        </div>
+            <div class="flex flex-col py-2 w-64">
+                <div class="flex items-center gap-2 pb-2">
+                    <div class="flex items-center">
+                        <h3>Proxy</h3>
+                        <x-loading wire:loading wire:target="instantSave" />
+                    </div>
+                    @if ($isPublic)
+                        <x-slide-over fullScreen>
+                            <x-slot:title>Proxy Logs</x-slot:title>
+                            <x-slot:content>
+                                <livewire:project.shared.get-logs :server="$server" :resource="$database"
+                                    container="{{ data_get($database, 'uuid') }}-proxy" :collapsible="false" lazy />
+                            </x-slot:content>
+                            <x-forms.button disabled="{{ !$isPublic }}"
+                                @click="slideOverOpen=true">Logs</x-forms.button>
+                        </x-slide-over>
+                    @endif
+                </div>
+                <x-forms.checkbox instantSave id="isPublic" label="Make it publicly available" canGate="update"
+                    :canResource="$database" />
+            </div>
+            <div class="flex flex-col gap-2">
+            <x-forms.input type="number" placeholder="8000" disabled="{{ $isPublic }}" id="publicPort" label="Public Port"
+                canGate="update" :canResource="$database" />
+            <x-forms.input type="number" placeholder="3600" disabled="{{ $isPublic }}" id="publicPortTimeout"
+                label="Proxy Timeout (seconds)" helper="Timeout for the public TCP proxy connection in seconds. Default: 3600 (1 hour)." canGate="update" :canResource="$database" />
+            </div>
+    </form>
+    <h3 class="pt-4">Advanced</h3>
+    <div class="w-64">
+        <x-forms.checkbox helper="Drain logs to your configured log drain endpoint in your Server settings."
+            instantSave="instantSaveAdvanced" id="isLogDrainEnabled" label="Drain Logs" canGate="update"
+            :canResource="$database" />
+    </div>
+</div>

--- a/resources/views/livewire/project/resource/index.blade.php
+++ b/resources/views/livewire/project/resource/index.blade.php
@@ -404,6 +404,7 @@
             keydbs: @js($keydbsJs),
             dragonflies: @js($dragonfliesJs),
             clickhouses: @js($clickhousesJs),
+            surrealdb: @js($surrealdbJs),
             services: @js($servicesJs),
             filterAndSort(items) {
                 if (this.search === '') {
@@ -430,6 +431,7 @@
                     this.keydbs,
                     this.dragonflies,
                     this.clickhouses,
+                    this.surrealdb,
                 ].flatMap((items) => this.filterAndSort(items))
             },
             get filteredServices() {


### PR DESCRIPTION
This PR addresses bounty #7642:
- Added 'StandaloneSurrealdb' model with support for various storage backends (surrealkv, tikv, rocksdb).
- Created migration for 'standalone_surrealdb' table.
- Implemented 'StartSurrealdb' action following existing patterns.
- Created full Livewire management interface for SurrealDB settings.
- Added SurrealDB to all resource index and creation flows.
/claim #7642