### PR TITLE
fix: prevent git clone output in compose content

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -1859,6 +1859,7 @@ class Application extends BaseModel
         }
         $uuid = new Cuid2;
         ['commands' => $cloneCommand] = $this->generateGitImportCommands(deployment_uuid: $uuid, only_checkout: true, exec_in_docker: false, custom_base_dir: '.');
+        $cloneCommand = "{$cloneCommand} >/dev/null";
         $workdir = rtrim($this->base_directory, '/');
         $composeFile = $this->docker_compose_location;
         $fileList = collect([".$workdir$composeFile"]);


### PR DESCRIPTION
Fixes #5251.

`loadComposeFile()` captures remote command output and stores it in `docker_compose_raw`. The sparse-checkout path runs `git clone` before `cat`ing the compose file, so clone progress/status output can be mixed into the captured compose content.

This redirects the clone step stdout to `/dev/null`, keeping the captured output limited to the later `cat .$workdir$composeFile`.

Verification:
- `php -l app/Models/Application.php`

/claim #5251