### PR TITLE
feat: add kubernetes destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ It helps you manage your servers, applications, and databases on your own hardwa
 
 Imagine having the ease of a cloud but with your own servers. That is **Coolify**.
 
+Kubernetes deployment-target work is tracked in [docs/specs/20260518-kubernetes-destination-foundation.md](./docs/specs/20260518-kubernetes-destination-foundation.md). It includes Kubernetes destinations, UI create/edit/select flows, manifest generation, encrypted kubeconfig support, server-side dry-runs, `kubectl apply`, rollout status, restart, and stop-by-scale.
+
 No vendor lock-in, which means that all the configurations for your applications/databases/etc are saved to your server. So, if you decide to stop using Coolify (oh nooo), you could still manage your running resources. You lose the automations and all the magic. 🪄️
 
 For more information, take a look at our landing page at [coolify.io](https://coolify.io).

--- a/app/Actions/Application/StopApplication.php
+++ b/app/Actions/Application/StopApplication.php
@@ -5,6 +5,9 @@ namespace App\Actions\Application;
 use App\Actions\Server\CleanupDocker;
 use App\Events\ServiceStatusChanged;
 use App\Models\Application;
+use App\Models\KubernetesCluster;
+use App\Services\Kubernetes\KubernetesApplicationManifestGenerator;
+use App\Services\Kubernetes\KubernetesKubectlCommandBuilder;
 use Lorisleiva\Actions\Concerns\AsAction;
 
 class StopApplication
@@ -15,6 +18,10 @@ class StopApplication
 
     public function handle(Application $application, bool $previewDeployments = false, bool $dockerCleanup = true)
     {
+        if ($application->destination instanceof KubernetesCluster) {
+            return $this->stopKubernetesApplication($application);
+        }
+
         $servers = collect([$application->destination->server]);
         if ($application?->additional_servers?->count() > 0) {
             $servers = $servers->merge($application->additional_servers);
@@ -65,5 +72,48 @@ class StopApplication
         ]);
 
         ServiceStatusChanged::dispatch($application->environment->project->team->id);
+    }
+
+    private function stopKubernetesApplication(Application $application): ?string
+    {
+        try {
+            $cluster = $application->destination;
+            $server = $cluster->server;
+
+            if (! $server->isFunctional()) {
+                return 'Server is not functional';
+            }
+
+            $builder = new KubernetesKubectlCommandBuilder;
+            $generator = new KubernetesApplicationManifestGenerator;
+            $resourceName = $generator->resourceName($application);
+            $kubeconfigPath = $cluster->effectiveKubeconfigPath();
+            $commands = [
+                'mkdir -p '.escapeshellarg($cluster->configurationDirectory()),
+            ];
+
+            if (filled($cluster->kubeconfig)) {
+                $commands[] = $builder->writeKubeconfig($cluster->storedKubeconfigPath(), $cluster->kubeconfig);
+                $kubeconfigPath = $cluster->storedKubeconfigPath();
+            }
+
+            if (blank($kubeconfigPath)) {
+                return 'Kubernetes kubeconfig is not configured';
+            }
+
+            $commands[] = $builder->scaleDeployment($cluster, $resourceName, 0, $kubeconfigPath);
+            instant_remote_process($commands, $server, throwError: false);
+            $application->update([
+                'status' => 'exited',
+                'restart_count' => 0,
+                'last_restart_at' => null,
+                'last_restart_type' => null,
+            ]);
+            ServiceStatusChanged::dispatch($application->environment->project->team->id);
+
+            return null;
+        } catch (\Exception $e) {
+            return $e->getMessage();
+        }
     }
 }

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -14,11 +14,14 @@ use App\Models\ApplicationPreview;
 use App\Models\EnvironmentVariable;
 use App\Models\GithubApp;
 use App\Models\GitlabApp;
+use App\Models\KubernetesCluster;
 use App\Models\Server;
 use App\Models\StandaloneDocker;
 use App\Models\SwarmDocker;
 use App\Notifications\Application\DeploymentFailed;
 use App\Notifications\Application\DeploymentSuccess;
+use App\Services\Kubernetes\KubernetesApplicationManifestGenerator;
+use App\Services\Kubernetes\KubernetesKubectlCommandBuilder;
 use App\Support\ValidationPatterns;
 use App\Traits\EnvironmentVariableAnalyzer;
 use App\Traits\ExecuteRemoteCommand;
@@ -85,7 +88,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
 
     private GithubApp|GitlabApp|string $source = 'other';
 
-    private StandaloneDocker|SwarmDocker $destination;
+    private StandaloneDocker|SwarmDocker|KubernetesCluster $destination;
 
     // Deploy to Server
     private Server $server;
@@ -189,6 +192,8 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
 
     private Collection|string $build_secrets;
 
+    private bool $helperContainerStarted = false;
+
     public function tags()
     {
         // Do not remove this one, it needs to properly identify which worker is running the job
@@ -229,7 +234,16 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         }
         $this->server = Server::find($this->application_deployment_queue->server_id);
         $this->timeout = $this->server->settings->dynamic_timeout;
-        $this->destination = $this->server->destinations()->where('id', $this->application_deployment_queue->destination_id)->first();
+        if ((int) $this->application->destination_id === (int) $this->application_deployment_queue->destination_id) {
+            $destination = $this->application->destination;
+        } else {
+            $destination = $this->server->destinations()
+                ->first(fn ($destination) => (int) $destination->id === (int) $this->application_deployment_queue->destination_id);
+        }
+        if (! $destination) {
+            throw new DeploymentException('Deployment destination not found.');
+        }
+        $this->destination = $destination;
         $this->server = $this->mainServer = $this->destination->server;
         $this->serverUser = $this->server->user;
         $this->is_this_additional_server = $this->application->additional_servers()->wherePivot('server_id', $this->server->id)->count() > 0;
@@ -302,34 +316,36 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         try {
             // Make sure the private key is stored in the filesystem
             $this->server->privateKey->storeInFileSystem();
-            // Generate custom host<->ip mapping
-            $safeNetwork = escapeshellarg($this->destination->network);
-            $allContainers = instant_remote_process(["docker network inspect {$safeNetwork} -f '{{json .Containers}}' "], $this->server);
+            if (! ($this->destination instanceof KubernetesCluster)) {
+                // Generate custom host<->ip mapping
+                $safeNetwork = escapeshellarg($this->destination->network);
+                $allContainers = instant_remote_process(["docker network inspect {$safeNetwork} -f '{{json .Containers}}' "], $this->server);
 
-            if (! is_null($allContainers)) {
-                $allContainers = format_docker_command_output_to_json($allContainers);
-                $ips = collect([]);
-                if (count($allContainers) > 0) {
-                    $allContainers = $allContainers[0];
-                    $allContainers = collect($allContainers)->sort()->values();
-                    foreach ($allContainers as $container) {
-                        $containerName = data_get($container, 'Name');
-                        if ($containerName === 'coolify-proxy') {
-                            continue;
-                        }
-                        if (preg_match('/-(\d{12})/', $containerName)) {
-                            continue;
-                        }
-                        $containerIp = data_get($container, 'IPv4Address');
-                        if ($containerName && $containerIp) {
-                            $containerIp = str($containerIp)->before('/');
-                            $ips->put($containerName, $containerIp->value());
+                if (! is_null($allContainers)) {
+                    $allContainers = format_docker_command_output_to_json($allContainers);
+                    $ips = collect([]);
+                    if (count($allContainers) > 0) {
+                        $allContainers = $allContainers[0];
+                        $allContainers = collect($allContainers)->sort()->values();
+                        foreach ($allContainers as $container) {
+                            $containerName = data_get($container, 'Name');
+                            if ($containerName === 'coolify-proxy') {
+                                continue;
+                            }
+                            if (preg_match('/-(\d{12})/', $containerName)) {
+                                continue;
+                            }
+                            $containerIp = data_get($container, 'IPv4Address');
+                            if ($containerName && $containerIp) {
+                                $containerIp = str($containerIp)->before('/');
+                                $ips->put($containerName, $containerIp->value());
+                            }
                         }
                     }
+                    $this->addHosts = $ips->map(function ($ip, $name) {
+                        return "--add-host $name:$ip";
+                    })->implode(' ');
                 }
-                $this->addHosts = $ips->map(function ($ip, $name) {
-                    return "--add-host $name:$ip";
-                })->implode(' ');
             }
 
             if ($this->application->dockerfile_target_build) {
@@ -390,8 +406,10 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             }
 
             try {
-                $this->application_deployment_queue->addLogEntry("Gracefully shutting down build container: {$this->deployment_uuid}");
-                $this->graceful_shutdown_container($this->deployment_uuid, skipRemove: true);
+                if ($this->helperContainerStarted) {
+                    $this->application_deployment_queue->addLogEntry("Gracefully shutting down build container: {$this->deployment_uuid}");
+                    $this->graceful_shutdown_container($this->deployment_uuid, skipRemove: true);
+                }
             } catch (Exception $e) {
                 // Log but don't fail - container cleanup errors are expected when container is already gone
                 \Log::warning('Failed to shutdown container '.$this->deployment_uuid.': '.$e->getMessage());
@@ -516,7 +534,9 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
 
         // Then handle side effects - these should not fail the deployment
         try {
-            GetContainersStatus::dispatch($this->server);
+            if (! ($this->destination instanceof KubernetesCluster)) {
+                GetContainersStatus::dispatch($this->server);
+            }
         } catch (Exception $e) {
             \Log::warning('Failed to dispatch GetContainersStatus for deployment '.$this->deployment_uuid.': '.$e->getMessage());
         }
@@ -532,7 +552,11 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         }
 
         try {
-            $this->run_post_deployment_command();
+            if (! ($this->destination instanceof KubernetesCluster)) {
+                $this->run_post_deployment_command();
+            } elseif (filled($this->application->post_deployment_command)) {
+                $this->application_deployment_queue->addLogEntry('Post-deployment command skipped for Kubernetes destinations.');
+            }
         } catch (Exception $e) {
             \Log::warning('Post deployment command failed for '.$this->deployment_uuid.': '.$e->getMessage());
         }
@@ -581,6 +605,12 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
 
         $this->application_deployment_queue->addLogEntry("Starting deployment of {$displayName} to {$this->server->name}.");
         $this->generate_image_names();
+        if ($this->destination instanceof KubernetesCluster) {
+            $this->rolling_update();
+
+            return;
+        }
+
         $this->prepare_builder_image();
         $this->generate_compose_file();
 
@@ -1197,6 +1227,13 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
 
     private function just_restart()
     {
+        if ($this->destination instanceof KubernetesCluster) {
+            $this->restart_kubernetes_deployment();
+            $this->completeDeployment();
+
+            return;
+        }
+
         $this->application_deployment_queue->addLogEntry("Restarting {$this->customRepository}:{$this->application->git_branch} on {$this->server->name}.");
 
         // Restart doesn't need the build server — disable it so the helper container
@@ -1215,6 +1252,36 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
 
         $this->should_skip_build();
         $this->completeDeployment();
+    }
+
+    private function restart_kubernetes_deployment(): void
+    {
+        $cluster = $this->destination;
+        $builder = new KubernetesKubectlCommandBuilder;
+        $generator = new KubernetesApplicationManifestGenerator;
+        $resourceName = $generator->resourceName($this->application);
+        $kubeconfigPath = $cluster->effectiveKubeconfigPath();
+        $commands = [
+            ['command' => 'mkdir -p '.escapeshellarg($cluster->configurationDirectory()), 'hidden' => true],
+        ];
+
+        if (filled($cluster->kubeconfig)) {
+            $commands[] = ['command' => $builder->writeKubeconfig($cluster->storedKubeconfigPath(), $cluster->kubeconfig), 'hidden' => true];
+            $kubeconfigPath = $cluster->storedKubeconfigPath();
+        }
+
+        if (blank($kubeconfigPath)) {
+            throw new DeploymentException('Kubernetes kubeconfig is not configured.');
+        }
+
+        $this->server = $this->mainServer;
+        $this->application_deployment_queue->addLogEntry("Restarting Kubernetes deployment {$resourceName}.");
+        $this->execute_remote_command(
+            ...array_merge($commands, [
+                ['command' => $builder->rolloutRestart($cluster, $resourceName, $kubeconfigPath), 'type' => 'stdout'],
+                ['command' => $builder->rolloutStatus($cluster, $resourceName, $this->timeout, $kubeconfigPath), 'type' => 'stdout'],
+            ])
+        );
     }
 
     private function should_skip_build()
@@ -1879,6 +1946,12 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
     {
         try {
             $this->checkForCancellation();
+            if ($this->destination instanceof KubernetesCluster) {
+                $this->deploy_to_kubernetes();
+
+                return;
+            }
+
             if ($this->server->isSwarm()) {
                 $this->application_deployment_queue->addLogEntry('Rolling update started.');
                 $this->execute_remote_command(
@@ -1924,6 +1997,89 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         } catch (Exception $e) {
             throw new DeploymentException('Rolling update failed ('.get_class($e).'): '.$e->getMessage(), $e->getCode(), $e);
         }
+    }
+
+    private function deploy_to_kubernetes(): void
+    {
+        if ($this->application->build_pack === 'dockercompose') {
+            throw new DeploymentException('Kubernetes destinations do not support Docker Compose applications yet.');
+        }
+
+        if ($this->application->persistentStorages()->count() > 0) {
+            throw new DeploymentException('Kubernetes destinations do not support Coolify persistent storage volumes yet.');
+        }
+
+        if ($this->build_pack !== 'dockerimage' && blank($this->application->docker_registry_image_name)) {
+            throw new DeploymentException('Kubernetes build deployments require a Docker registry image name.');
+        }
+
+        $this->server = $this->mainServer;
+        $cluster = $this->destination;
+        if (! ($cluster instanceof KubernetesCluster)) {
+            throw new DeploymentException('Invalid Kubernetes destination.');
+        }
+
+        $builder = new KubernetesKubectlCommandBuilder;
+        $generator = new KubernetesApplicationManifestGenerator;
+        $resourceName = $generator->resourceName($this->application);
+        $manifestDirectory = "{$this->configuration_dir}/kubernetes";
+        $manifestPath = "{$manifestDirectory}/manifest-{$this->deployment_uuid}.yaml";
+        $kubeconfigPath = $cluster->effectiveKubeconfigPath();
+        $manifestYaml = $generator->toYaml($this->application, [
+            'namespace' => $cluster->namespace,
+            'ingress_class' => $cluster->ingress_class,
+            'service_type' => $cluster->service_type,
+            'replicas' => $cluster->replicas,
+            'autoscaling' => $cluster->autoscaling_enabled,
+            'min_replicas' => $cluster->min_replicas,
+            'max_replicas' => $cluster->max_replicas,
+            'target_cpu_utilization_percentage' => $cluster->target_cpu_utilization_percentage,
+            'image' => $this->production_image_name,
+            'deployment_uuid' => $this->deployment_uuid,
+            'environment' => $this->kubernetesRuntimeEnvironment(),
+        ]);
+
+        $commands = [
+            ['command' => 'mkdir -p '.escapeshellarg($manifestDirectory), 'hidden' => true],
+            ['command' => 'mkdir -p '.escapeshellarg($cluster->configurationDirectory()), 'hidden' => true],
+            ['command' => $builder->writeManifest($manifestPath, $manifestYaml), 'hidden' => true],
+        ];
+
+        if (filled($cluster->kubeconfig)) {
+            $commands[] = ['command' => $builder->writeKubeconfig($cluster->storedKubeconfigPath(), $cluster->kubeconfig), 'hidden' => true];
+            $kubeconfigPath = $cluster->storedKubeconfigPath();
+        }
+
+        if (blank($kubeconfigPath)) {
+            throw new DeploymentException('Kubernetes kubeconfig is not configured.');
+        }
+
+        $this->application_deployment_queue->addLogEntry('----------------------------------------');
+        $this->application_deployment_queue->addLogEntry("Applying Kubernetes manifests to namespace {$cluster->namespace}.");
+        $this->execute_remote_command(
+            ...array_merge($commands, [
+                ['command' => $builder->version($cluster, $kubeconfigPath), 'hidden' => true],
+                ['command' => $builder->serverSideDryRun($cluster, $manifestPath, $kubeconfigPath), 'hidden' => true],
+                ['command' => $builder->apply($cluster, $manifestPath, $kubeconfigPath), 'type' => 'stdout'],
+                ['command' => $builder->rolloutStatus($cluster, $resourceName, $this->timeout, $kubeconfigPath), 'type' => 'stdout'],
+            ])
+        );
+        $this->application->update(['status' => 'running']);
+        $this->application_deployment_queue->addLogEntry('Kubernetes rollout completed.');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function kubernetesRuntimeEnvironment(): array
+    {
+        return $this->generate_runtime_environment_variables()
+            ->mapWithKeys(function (string $line) {
+                [$key, $value] = array_pad(explode('=', $line, 2), 2, '');
+
+                return [$key => $value];
+            })
+            ->toArray();
     }
 
     private function health_check()
@@ -2112,12 +2268,14 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             }
             $runCommand = "docker run -d --name {$this->deployment_uuid} {$env_flags} --rm -v {$this->serverUserHomeDir}/.docker/config.json:/root/.docker/config.json:ro -v /var/run/docker.sock:/var/run/docker.sock {$helperImage}";
         } else {
+            $networkOption = '';
+            if (! ($this->destination instanceof KubernetesCluster)) {
+                $networkOption = ' --network '.escapeshellarg($this->destination->network);
+            }
             if ($this->dockerConfigFileExists === 'OK') {
-                $safeNetwork = escapeshellarg($this->destination->network);
-                $runCommand = "docker run -d --network {$safeNetwork} --name {$this->deployment_uuid} {$env_flags} --rm -v {$this->serverUserHomeDir}/.docker/config.json:/root/.docker/config.json:ro -v /var/run/docker.sock:/var/run/docker.sock {$helperImage}";
+                $runCommand = "docker run -d{$networkOption} --name {$this->deployment_uuid} {$env_flags} --rm -v {$this->serverUserHomeDir}/.docker/config.json:/root/.docker/config.json:ro -v /var/run/docker.sock:/var/run/docker.sock {$helperImage}";
             } else {
-                $safeNetwork = escapeshellarg($this->destination->network);
-                $runCommand = "docker run -d --network {$safeNetwork} --name {$this->deployment_uuid} {$env_flags} --rm -v /var/run/docker.sock:/var/run/docker.sock {$helperImage}";
+                $runCommand = "docker run -d{$networkOption} --name {$this->deployment_uuid} {$env_flags} --rm -v /var/run/docker.sock:/var/run/docker.sock {$helperImage}";
             }
         }
         if ($firstTry) {
@@ -2136,6 +2294,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                 'command' => executeInDocker($this->deployment_uuid, "mkdir -p {$this->basedir}"),
             ],
         );
+        $this->helperContainerStarted = true;
         $this->run_pre_deployment_command();
     }
 
@@ -3042,6 +3201,12 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
 
     private function generate_compose_file()
     {
+        if ($this->destination instanceof KubernetesCluster) {
+            $this->prepare_kubernetes_build_context();
+
+            return;
+        }
+
         $this->checkForCancellation();
         $this->create_workdir();
         $ports = $this->application->main_port();
@@ -3280,6 +3445,22 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
         $this->docker_compose = Yaml::dump($docker_compose, 10);
         $this->docker_compose_base64 = base64_encode($this->docker_compose);
         $this->execute_remote_command([executeInDocker($this->deployment_uuid, "echo '{$this->docker_compose_base64}' | base64 -d | tee {$this->workdir}/docker-compose.yaml > /dev/null"), 'hidden' => true]);
+    }
+
+    private function prepare_kubernetes_build_context(): void
+    {
+        $this->checkForCancellation();
+        $this->create_workdir();
+
+        if ($this->application->build_pack === 'dockerfile' || $this->application->dockerfile) {
+            $this->execute_remote_command([
+                executeInDocker($this->deployment_uuid, "cat {$this->workdir}{$this->dockerfile_location}"),
+                'hidden' => true,
+                'save' => 'dockerfile_from_repo',
+                'ignore_errors' => true,
+            ]);
+            $this->application->parseHealthcheckFromDockerfile($this->saved_outputs->get('dockerfile_from_repo'));
+        }
     }
 
     private function generate_local_persistent_volumes()
@@ -4259,6 +4440,10 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
 
     private function modify_dockerfiles_for_compose($composeFile)
     {
+        if ($this->destination instanceof KubernetesCluster) {
+            return;
+        }
+
         if ($this->application->build_pack !== 'dockercompose') {
             return;
         }
@@ -4820,6 +5005,10 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
             $this->application_deployment_queue->addLogEntry("  {$traceLine}", 'stderr', hidden: true);
         }
         $this->application_deployment_queue->addLogEntry('========================================', 'stderr');
+
+        if ($this->destination instanceof KubernetesCluster) {
+            return;
+        }
 
         if ($this->application->build_pack !== 'dockercompose') {
             $code = $exception->getCode();

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -4440,7 +4440,7 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
 
     private function modify_dockerfiles_for_compose($composeFile)
     {
-        if ($this->destination instanceof KubernetesCluster) {
+        if (isset($this->destination) && $this->destination instanceof KubernetesCluster) {
             return;
         }
 
@@ -5006,7 +5006,7 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
         }
         $this->application_deployment_queue->addLogEntry('========================================', 'stderr');
 
-        if ($this->destination instanceof KubernetesCluster) {
+        if (isset($this->destination) && $this->destination instanceof KubernetesCluster) {
             return;
         }
 

--- a/app/Livewire/Destination/New/Kubernetes.php
+++ b/app/Livewire/Destination/New/Kubernetes.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace App\Livewire\Destination\New;
+
+use App\Models\KubernetesCluster;
+use App\Models\Server;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Validation\ValidationException;
+use Livewire\Attributes\Locked;
+use Livewire\Attributes\Validate;
+use Livewire\Component;
+use Visus\Cuid2\Cuid2;
+
+class Kubernetes extends Component
+{
+    use AuthorizesRequests;
+
+    #[Locked]
+    public $servers;
+
+    #[Locked]
+    public Server $selectedServer;
+
+    #[Validate(['required', 'string', 'max:255'])]
+    public string $name;
+
+    #[Validate(['required', 'string', 'max:63', 'regex:/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/'])]
+    public string $namespace = 'default';
+
+    #[Validate(['nullable', 'string', 'max:255'])]
+    public string $context = '';
+
+    #[Validate(['nullable', 'string', 'max:1024'])]
+    public string $kubeconfigPath = '';
+
+    #[Validate(['nullable', 'string'])]
+    public string $kubeconfig = '';
+
+    #[Validate(['required', 'string', 'max:63', 'regex:/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/'])]
+    public string $ingressClass = 'traefik';
+
+    #[Validate(['required', 'string', 'in:ClusterIP,NodePort,LoadBalancer'])]
+    public string $serviceType = 'ClusterIP';
+
+    #[Validate(['required', 'integer', 'min:1', 'max:100'])]
+    public int $replicas = 1;
+
+    #[Validate(['required', 'boolean'])]
+    public bool $autoscalingEnabled = false;
+
+    #[Validate(['required', 'integer', 'min:1', 'max:100'])]
+    public int $minReplicas = 1;
+
+    #[Validate(['required', 'integer', 'min:1', 'max:100'])]
+    public int $maxReplicas = 3;
+
+    #[Validate(['required', 'integer', 'min:1', 'max:100'])]
+    public int $targetCpuUtilizationPercentage = 70;
+
+    #[Validate(['required', 'string'])]
+    public string $serverId;
+
+    public function mount(?string $server_id = null): void
+    {
+        $this->servers = Server::isUsable()->get();
+        $foundServer = $server_id ? $this->servers->find($server_id) : $this->servers->first();
+
+        if (! $foundServer) {
+            throw new \Exception('Server not found.');
+        }
+
+        $this->selectedServer = $foundServer;
+        $this->serverId = $this->selectedServer->id;
+        $this->generateName();
+    }
+
+    public function updatedServerId(): void
+    {
+        $this->selectedServer = $this->servers->find($this->serverId);
+        $this->generateName();
+    }
+
+    public function generateName(): void
+    {
+        $name = data_get($this->selectedServer, 'name', new Cuid2);
+        $this->name = str("{$name}-kubernetes")->kebab();
+    }
+
+    public function submit()
+    {
+        try {
+            $this->authorize('create', KubernetesCluster::class);
+            $this->validate();
+
+            if (blank($this->kubeconfigPath) && blank($this->kubeconfig)) {
+                throw ValidationException::withMessages([
+                    'kubeconfigPath' => 'Provide a kubeconfig path or paste kubeconfig content.',
+                ]);
+            }
+            if ($this->autoscalingEnabled && $this->maxReplicas < $this->minReplicas) {
+                throw ValidationException::withMessages([
+                    'maxReplicas' => 'Max replicas must be greater than or equal to min replicas.',
+                ]);
+            }
+
+            $found = $this->selectedServer->kubernetesClusters()->where('name', $this->name)->first();
+
+            if ($found) {
+                throw ValidationException::withMessages([
+                    'name' => 'A Kubernetes destination with this name already exists on this server.',
+                ]);
+            }
+
+            $cluster = KubernetesCluster::create([
+                'name' => $this->name,
+                'namespace' => $this->namespace,
+                'context' => blank($this->context) ? null : $this->context,
+                'kubeconfig_path' => blank($this->kubeconfigPath) ? null : $this->kubeconfigPath,
+                'kubeconfig' => blank($this->kubeconfig) ? null : $this->kubeconfig,
+                'ingress_class' => $this->ingressClass,
+                'service_type' => $this->serviceType,
+                'replicas' => $this->replicas,
+                'autoscaling_enabled' => $this->autoscalingEnabled,
+                'min_replicas' => $this->minReplicas,
+                'max_replicas' => $this->maxReplicas,
+                'target_cpu_utilization_percentage' => $this->targetCpuUtilizationPercentage,
+                'server_id' => $this->selectedServer->id,
+            ]);
+
+            redirectRoute($this, 'destination.show', [$cluster->uuid]);
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+}

--- a/app/Livewire/Destination/Show.php
+++ b/app/Livewire/Destination/Show.php
@@ -2,10 +2,12 @@
 
 namespace App\Livewire\Destination;
 
+use App\Models\KubernetesCluster;
 use App\Models\StandaloneDocker;
+use App\Services\Kubernetes\KubernetesKubectlCommandBuilder;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Locked;
-use Livewire\Attributes\Validate;
 use Livewire\Component;
 
 class Show extends Component
@@ -15,14 +17,61 @@ class Show extends Component
     #[Locked]
     public $destination;
 
-    #[Validate(['string', 'required'])]
-    public string $name;
+    public string $name = '';
 
-    #[Validate(['string', 'required', 'max:255', 'regex:/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/'])]
-    public string $network;
+    public string $network = '';
 
-    #[Validate(['string', 'required'])]
-    public string $serverIp;
+    public string $serverIp = '';
+
+    public string $namespace = 'default';
+
+    public string $context = '';
+
+    public string $kubeconfigPath = '';
+
+    public string $kubeconfig = '';
+
+    public string $ingressClass = 'traefik';
+
+    public string $serviceType = 'ClusterIP';
+
+    public int $replicas = 1;
+
+    public bool $autoscalingEnabled = false;
+
+    public int $minReplicas = 1;
+
+    public int $maxReplicas = 3;
+
+    public int $targetCpuUtilizationPercentage = 70;
+
+    public function rules(): array
+    {
+        $rules = [
+            'name' => ['string', 'required'],
+            'serverIp' => ['string', 'required'],
+        ];
+
+        if ($this->destination instanceof KubernetesCluster) {
+            return $rules + [
+                'namespace' => ['required', 'string', 'max:63', 'regex:/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/'],
+                'context' => ['nullable', 'string', 'max:255'],
+                'kubeconfigPath' => ['nullable', 'string', 'max:1024'],
+                'kubeconfig' => ['nullable', 'string'],
+                'ingressClass' => ['required', 'string', 'max:63', 'regex:/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/'],
+                'serviceType' => ['required', 'string', 'in:ClusterIP,NodePort,LoadBalancer'],
+                'replicas' => ['required', 'integer', 'min:1', 'max:100'],
+                'autoscalingEnabled' => ['required', 'boolean'],
+                'minReplicas' => ['required', 'integer', 'min:1', 'max:100'],
+                'maxReplicas' => ['required', 'integer', 'min:1', 'max:100'],
+                'targetCpuUtilizationPercentage' => ['required', 'integer', 'min:1', 'max:100'],
+            ];
+        }
+
+        return $rules + [
+            'network' => ['string', 'required', 'max:255', 'regex:/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/'],
+        ];
+    }
 
     public function mount(string $destination_uuid)
     {
@@ -43,13 +92,50 @@ class Show extends Component
         if ($toModel) {
             $this->validate();
             $this->destination->name = $this->name;
-            $this->destination->network = $this->network;
-            $this->destination->server->ip = $this->serverIp;
+
+            if ($this->destination instanceof KubernetesCluster) {
+                if ($this->autoscalingEnabled && $this->maxReplicas < $this->minReplicas) {
+                    throw ValidationException::withMessages([
+                        'maxReplicas' => 'Max replicas must be greater than or equal to min replicas.',
+                    ]);
+                }
+
+                $this->destination->namespace = $this->namespace;
+                $this->destination->context = blank($this->context) ? null : $this->context;
+                $this->destination->kubeconfig_path = blank($this->kubeconfigPath) ? null : $this->kubeconfigPath;
+                $this->destination->kubeconfig = blank($this->kubeconfig) ? null : $this->kubeconfig;
+                $this->destination->ingress_class = $this->ingressClass;
+                $this->destination->service_type = $this->serviceType;
+                $this->destination->replicas = $this->replicas;
+                $this->destination->autoscaling_enabled = $this->autoscalingEnabled;
+                $this->destination->min_replicas = $this->minReplicas;
+                $this->destination->max_replicas = $this->maxReplicas;
+                $this->destination->target_cpu_utilization_percentage = $this->targetCpuUtilizationPercentage;
+            } else {
+                $this->destination->network = $this->network;
+                $this->destination->server->ip = $this->serverIp;
+            }
+
             $this->destination->save();
         } else {
             $this->name = $this->destination->name;
-            $this->network = $this->destination->network;
             $this->serverIp = $this->destination->server->ip;
+
+            if ($this->destination instanceof KubernetesCluster) {
+                $this->namespace = $this->destination->namespace;
+                $this->context = $this->destination->context ?? '';
+                $this->kubeconfigPath = $this->destination->kubeconfig_path ?? '';
+                $this->kubeconfig = $this->destination->kubeconfig ?? '';
+                $this->ingressClass = $this->destination->ingress_class;
+                $this->serviceType = $this->destination->service_type;
+                $this->replicas = $this->destination->replicas;
+                $this->autoscalingEnabled = $this->destination->autoscaling_enabled;
+                $this->minReplicas = $this->destination->min_replicas;
+                $this->maxReplicas = $this->destination->max_replicas;
+                $this->targetCpuUtilizationPercentage = $this->destination->target_cpu_utilization_percentage;
+            } else {
+                $this->network = $this->destination->network;
+            }
         }
     }
 
@@ -65,10 +151,51 @@ class Show extends Component
         }
     }
 
+    public function testConnection()
+    {
+        try {
+            $this->authorize('update', $this->destination);
+
+            if (! ($this->destination instanceof KubernetesCluster)) {
+                return;
+            }
+
+            $this->syncData(true);
+            $this->destination->refresh();
+
+            $builder = new KubernetesKubectlCommandBuilder;
+            $commands = [
+                'mkdir -p '.escapeshellarg($this->destination->configurationDirectory()),
+            ];
+            $kubeconfigPath = $this->destination->effectiveKubeconfigPath();
+
+            if (filled($this->destination->kubeconfig)) {
+                $commands[] = $builder->writeKubeconfig($this->destination->storedKubeconfigPath(), $this->destination->kubeconfig);
+                $kubeconfigPath = $this->destination->storedKubeconfigPath();
+            }
+
+            if (blank($kubeconfigPath)) {
+                $this->dispatch('error', 'Kubeconfig is required.');
+
+                return;
+            }
+
+            $commands[] = $builder->version($this->destination, $kubeconfigPath);
+            instant_remote_process($commands, $this->destination->server);
+            $this->dispatch('success', 'Kubernetes connection verified.');
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
     public function delete()
     {
         try {
             $this->authorize('delete', $this->destination);
+
+            if ($this->destination instanceof KubernetesCluster && $this->destination->attachedTo()) {
+                return $this->dispatch('error', 'You must delete all resources before deleting this destination.');
+            }
 
             if ($this->destination->getMorphClass() === StandaloneDocker::class) {
                 if ($this->destination->attachedTo()) {

--- a/app/Livewire/Project/Application/Heading.php
+++ b/app/Livewire/Project/Application/Heading.php
@@ -5,6 +5,7 @@ namespace App\Livewire\Project\Application;
 use App\Actions\Application\StopApplication;
 use App\Actions\Docker\GetContainersStatus;
 use App\Models\Application;
+use App\Models\KubernetesCluster;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Livewire\Component;
 use Visus\Cuid2\Cuid2;
@@ -51,6 +52,12 @@ class Heading extends Component
 
     public function checkStatus()
     {
+        if ($this->application->destination instanceof KubernetesCluster) {
+            $this->dispatch('success', 'Kubernetes status is updated during deployments.');
+
+            return;
+        }
+
         if ($this->application->destination->server->isFunctional()) {
             GetContainersStatus::dispatch($this->application->destination->server);
         } else {
@@ -81,6 +88,21 @@ class Heading extends Component
         }
         if ($this->application->destination->server->isSwarm() && str($this->application->docker_registry_image_name)->isEmpty()) {
             $this->dispatch('error', 'Failed to deploy.', 'To deploy to a Swarm cluster you must set a Docker image name first.');
+
+            return;
+        }
+        if ($this->application->destination instanceof KubernetesCluster && $this->application->build_pack === 'dockercompose') {
+            $this->dispatch('error', 'Failed to deploy.', 'Kubernetes destinations do not support Docker Compose applications yet.');
+
+            return;
+        }
+        if ($this->application->destination instanceof KubernetesCluster && $this->application->persistentStorages()->count() > 0) {
+            $this->dispatch('error', 'Failed to deploy.', 'Kubernetes destinations do not support Coolify persistent storage volumes yet.');
+
+            return;
+        }
+        if ($this->application->destination instanceof KubernetesCluster && $this->application->build_pack !== 'dockerimage' && str($this->application->docker_registry_image_name)->isEmpty()) {
+            $this->dispatch('error', 'Failed to deploy.', 'To deploy built applications to Kubernetes you must set a Docker image name first.');
 
             return;
         }
@@ -137,6 +159,16 @@ class Heading extends Component
     {
         $this->authorize('deploy', $this->application);
 
+        if ($this->application->destination instanceof KubernetesCluster && $this->application->build_pack === 'dockercompose') {
+            $this->dispatch('error', 'Failed to deploy.', 'Kubernetes destinations do not support Docker Compose applications yet.');
+
+            return;
+        }
+        if ($this->application->destination instanceof KubernetesCluster && $this->application->build_pack !== 'dockerimage' && str($this->application->docker_registry_image_name)->isEmpty()) {
+            $this->dispatch('error', 'Failed to deploy.', 'To deploy built applications to Kubernetes you must set a Docker image name first.');
+
+            return;
+        }
         if ($this->application->additional_servers->count() > 0 && str($this->application->docker_registry_image_name)->isEmpty()) {
             $this->dispatch('error', 'Failed to deploy', 'Before deploying to multiple servers, you must first set a Docker image in the General tab.<br>More information here: <a target="_blank" class="underline" href="https://coolify.io/docs/knowledge-base/server/multiple-servers">documentation</a>');
 

--- a/app/Livewire/Project/New/Select.php
+++ b/app/Livewire/Project/New/Select.php
@@ -29,6 +29,8 @@ class Select extends Component
 
     public ?Collection $swarmDockers;
 
+    public ?Collection $kubernetesClusters;
+
     public array $parameters;
 
     public Collection|array $services = [];
@@ -329,11 +331,12 @@ class Select extends Component
         $this->server = $server;
         $this->standaloneDockers = $server->standaloneDockers;
         $this->swarmDockers = $server->swarmDockers;
-        $count = count($this->standaloneDockers) + count($this->swarmDockers);
+        $this->kubernetesClusters = $this->isDatabase ? collect([]) : $server->kubernetesClusters;
+        $count = count($this->standaloneDockers) + count($this->swarmDockers) + count($this->kubernetesClusters);
         if ($count === 1) {
-            $docker = $this->standaloneDockers->first() ?? $this->swarmDockers->first();
-            if ($docker) {
-                $this->setDestination($docker->uuid);
+            $destination = $this->standaloneDockers->first() ?? $this->swarmDockers->first() ?? $this->kubernetesClusters->first();
+            if ($destination) {
+                $this->setDestination($destination->uuid);
 
                 return $this->whatToDoNext();
             }

--- a/app/Livewire/Project/Resource/Create.php
+++ b/app/Livewire/Project/Resource/Create.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\Project\Resource;
 
 use App\Models\EnvironmentVariable;
+use App\Models\KubernetesCluster;
 use App\Models\Service;
 use Livewire\Component;
 
@@ -34,6 +35,13 @@ class Create extends Component
                 return redirect()->route('dashboard');
             }
             $services = get_service_templates();
+
+            if ($destination instanceof KubernetesCluster && (in_array($type, DATABASE_TYPES) || $type->startsWith('one-click-service-') || $type->startsWith('docker-compose-empty'))) {
+                return redirect()->route('project.resource.create', [
+                    'project_uuid' => $project->uuid,
+                    'environment_uuid' => $environment->uuid,
+                ]);
+            }
 
             if (in_array($type, DATABASE_TYPES)) {
                 if ($type->value() === 'postgresql') {

--- a/app/Livewire/Project/Shared/Destination.php
+++ b/app/Livewire/Project/Shared/Destination.php
@@ -5,6 +5,7 @@ namespace App\Livewire\Project\Shared;
 use App\Actions\Application\StopApplicationOneServer;
 use App\Actions\Docker\GetContainersStatus;
 use App\Events\ApplicationStatusChanged;
+use App\Models\KubernetesCluster;
 use App\Models\Server;
 use App\Models\StandaloneDocker;
 use Illuminate\Support\Collection;
@@ -36,6 +37,12 @@ class Destination extends Component
 
     public function loadData()
     {
+        if ($this->resource->destination instanceof KubernetesCluster) {
+            $this->networks = collect([]);
+
+            return;
+        }
+
         $all_networks = collect([]);
         $all_networks = $all_networks->push($this->resource->destination);
         $all_networks = $all_networks->merge($this->resource->additional_networks);

--- a/app/Models/KubernetesCluster.php
+++ b/app/Models/KubernetesCluster.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\HasSafeStringAttribute;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Support\Collection;
+
+class KubernetesCluster extends BaseModel
+{
+    use HasFactory;
+    use HasSafeStringAttribute;
+
+    protected $fillable = [
+        'server_id',
+        'name',
+        'namespace',
+        'context',
+        'kubeconfig_path',
+        'kubeconfig',
+        'ingress_class',
+        'service_type',
+        'replicas',
+        'autoscaling_enabled',
+        'min_replicas',
+        'max_replicas',
+        'target_cpu_utilization_percentage',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'kubeconfig' => 'encrypted',
+            'replicas' => 'integer',
+            'autoscaling_enabled' => 'boolean',
+            'min_replicas' => 'integer',
+            'max_replicas' => 'integer',
+            'target_cpu_utilization_percentage' => 'integer',
+        ];
+    }
+
+    public function applications(): MorphMany
+    {
+        return $this->morphMany(Application::class, 'destination');
+    }
+
+    public function server(): BelongsTo
+    {
+        return $this->belongsTo(Server::class);
+    }
+
+    public static function ownedByCurrentTeam(): Builder
+    {
+        return static::whereHas('server', fn ($q) => $q->whereTeamId(currentTeam()->id));
+    }
+
+    public static function ownedByCurrentTeamAPI(int $teamId): Builder
+    {
+        return static::whereHas('server', fn ($q) => $q->whereTeamId($teamId));
+    }
+
+    /**
+     * Get the server attribute using identity map caching.
+     */
+    public function getServerAttribute(): ?Server
+    {
+        if ($this->relationLoaded('server')) {
+            return $this->getRelation('server');
+        }
+
+        $server = Server::findCached($this->server_id);
+
+        if ($server) {
+            $this->setRelation('server', $server);
+        }
+
+        return $server;
+    }
+
+    public function services(): Collection
+    {
+        return collect();
+    }
+
+    public function databases(): Collection
+    {
+        return collect();
+    }
+
+    public function attachedTo(): bool
+    {
+        return $this->applications?->count() > 0;
+    }
+
+    public function configurationDirectory(): string
+    {
+        return base_configuration_dir()."/kubernetes/{$this->uuid}";
+    }
+
+    public function storedKubeconfigPath(): string
+    {
+        return $this->configurationDirectory().'/kubeconfig';
+    }
+
+    public function effectiveKubeconfigPath(): ?string
+    {
+        if (filled($this->kubeconfig)) {
+            return $this->storedKubeconfigPath();
+        }
+
+        return $this->kubeconfig_path;
+    }
+}

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -23,6 +23,7 @@ use App\Traits\HasSafeStringAttribute;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
@@ -313,7 +314,7 @@ class Server extends BaseModel
         $teamId = currentTeam()->id;
         $selectArray = collect($select)->concat(['id']);
 
-        return Server::whereTeamId($teamId)->with('settings', 'swarmDockers', 'standaloneDockers')->select($selectArray->all())->orderBy('name');
+        return Server::whereTeamId($teamId)->with('settings', 'swarmDockers', 'standaloneDockers', 'kubernetesClusters')->select($selectArray->all())->orderBy('name');
     }
 
     /**
@@ -994,8 +995,9 @@ $schema://$host {
     {
         $standalone_docker = $this->hasMany(StandaloneDocker::class)->get();
         $swarm_docker = $this->hasMany(SwarmDocker::class)->get();
+        $kubernetes_clusters = $this->hasMany(KubernetesCluster::class)->get();
 
-        return $standalone_docker->concat($swarm_docker);
+        return $standalone_docker->concat($swarm_docker)->concat($kubernetes_clusters);
     }
 
     public function standaloneDockers()
@@ -1006,6 +1008,11 @@ $schema://$host {
     public function swarmDockers()
     {
         return $this->hasMany(SwarmDocker::class);
+    }
+
+    public function kubernetesClusters(): HasMany
+    {
+        return $this->hasMany(KubernetesCluster::class);
     }
 
     public function privateKey()

--- a/app/Policies/KubernetesClusterPolicy.php
+++ b/app/Policies/KubernetesClusterPolicy.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\KubernetesCluster;
+use App\Models\User;
+
+class KubernetesClusterPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    public function view(User $user, KubernetesCluster $kubernetesCluster): bool
+    {
+        return $user->teams->contains('id', $kubernetesCluster->server->team_id);
+    }
+
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    public function update(User $user, KubernetesCluster $kubernetesCluster): bool
+    {
+        return $user->teams->contains('id', $kubernetesCluster->server->team_id);
+    }
+
+    public function delete(User $user, KubernetesCluster $kubernetesCluster): bool
+    {
+        return $user->teams->contains('id', $kubernetesCluster->server->team_id);
+    }
+
+    public function restore(User $user, KubernetesCluster $kubernetesCluster): bool
+    {
+        return false;
+    }
+
+    public function forceDelete(User $user, KubernetesCluster $kubernetesCluster): bool
+    {
+        return false;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -19,6 +19,7 @@ class AuthServiceProvider extends ServiceProvider
         \App\Models\PrivateKey::class => \App\Policies\PrivateKeyPolicy::class,
         \App\Models\StandaloneDocker::class => \App\Policies\StandaloneDockerPolicy::class,
         \App\Models\SwarmDocker::class => \App\Policies\SwarmDockerPolicy::class,
+        \App\Models\KubernetesCluster::class => \App\Policies\KubernetesClusterPolicy::class,
         \App\Models\Application::class => \App\Policies\ApplicationPolicy::class,
         \App\Models\ApplicationPreview::class => \App\Policies\ApplicationPreviewPolicy::class,
         \App\Models\ApplicationSetting::class => \App\Policies\ApplicationSettingPolicy::class,

--- a/app/Services/Kubernetes/KubernetesApplicationManifestGenerator.php
+++ b/app/Services/Kubernetes/KubernetesApplicationManifestGenerator.php
@@ -1,0 +1,410 @@
+<?php
+
+namespace App\Services\Kubernetes;
+
+use App\Models\Application;
+use InvalidArgumentException;
+use Symfony\Component\Yaml\Yaml;
+
+class KubernetesApplicationManifestGenerator
+{
+    /**
+     * @param  array{namespace?: string, ingress_class?: string, service_type?: string, replicas?: int, min_replicas?: int, max_replicas?: int, autoscaling?: bool, target_cpu_utilization_percentage?: int, image?: string, environment?: array<string, string>, deployment_uuid?: string}  $options
+     * @return array<int, array<string, mixed>>
+     */
+    public function generate(Application $application, array $options = []): array
+    {
+        $name = $this->resourceName($application);
+        $namespace = $this->namespace($options['namespace'] ?? null);
+        $port = $this->containerPort($application);
+        $labels = $this->labels($application, $name);
+
+        $resources = [];
+        $secret = $this->secret($name, $namespace, $labels, $options);
+
+        if ($secret !== null) {
+            $resources[] = $secret;
+        }
+
+        $resources[] = $this->deployment($application, $name, $namespace, $port, $labels, $options, $secret !== null);
+        $resources[] = $this->service($name, $namespace, $port, $labels, $options);
+
+        $ingress = $this->ingress($application, $name, $namespace, $labels, $options);
+
+        if ($ingress !== null) {
+            $resources[] = $ingress;
+        }
+
+        if (($options['autoscaling'] ?? false) === true) {
+            $resources[] = $this->horizontalPodAutoscaler($name, $namespace, $labels, $options);
+        }
+
+        return $resources;
+    }
+
+    /**
+     * @param  array{namespace?: string, ingress_class?: string, service_type?: string, replicas?: int, min_replicas?: int, max_replicas?: int, autoscaling?: bool, target_cpu_utilization_percentage?: int, image?: string, environment?: array<string, string>, deployment_uuid?: string}  $options
+     */
+    public function toYaml(Application $application, array $options = []): string
+    {
+        return collect($this->generate($application, $options))
+            ->map(fn (array $resource) => Yaml::dump($resource, 10, 2, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK))
+            ->implode("---\n");
+    }
+
+    public function resourceName(Application $application): string
+    {
+        $name = str($application->name ?: 'application')
+            ->lower()
+            ->replaceMatches('/[^a-z0-9-]+/', '-')
+            ->replaceMatches('/-+/', '-')
+            ->trim('-')
+            ->toString();
+
+        if ($name === '') {
+            $name = 'application';
+        }
+
+        $suffix = substr((string) $application->uuid, 0, 8);
+        $name = substr($name, 0, 54 - strlen($suffix));
+
+        return trim($name, '-').'-'.$suffix;
+    }
+
+    /**
+     * @param  array<string, string>  $labels
+     * @param  array{replicas?: int, image?: string, deployment_uuid?: string}  $options
+     * @return array<string, mixed>
+     */
+    private function deployment(Application $application, string $name, string $namespace, int $port, array $labels, array $options, bool $hasSecret): array
+    {
+        $container = [
+            'name' => 'application',
+            'image' => $this->image($application, $options),
+            'ports' => [
+                [
+                    'name' => 'http',
+                    'containerPort' => $port,
+                    'protocol' => 'TCP',
+                ],
+            ],
+        ];
+
+        if ($hasSecret) {
+            $container['envFrom'] = [
+                [
+                    'secretRef' => [
+                        'name' => $this->secretName($name),
+                    ],
+                ],
+            ];
+        }
+
+        $healthCheck = $this->httpHealthCheck($application, $port);
+
+        if ($healthCheck !== null) {
+            $container['readinessProbe'] = $healthCheck;
+            $container['livenessProbe'] = $healthCheck;
+        }
+
+        $resources = $this->resources($application);
+
+        if ($resources !== []) {
+            $container['resources'] = $resources;
+        }
+
+        $templateMetadata = [
+            'labels' => $labels,
+        ];
+
+        if (filled($options['deployment_uuid'] ?? null)) {
+            $templateMetadata['annotations'] = [
+                'coolify.io/deployment-uuid' => $options['deployment_uuid'],
+            ];
+        }
+
+        return [
+            'apiVersion' => 'apps/v1',
+            'kind' => 'Deployment',
+            'metadata' => [
+                'name' => $name,
+                'namespace' => $namespace,
+                'labels' => $labels,
+            ],
+            'spec' => [
+                'replicas' => (int) ($options['replicas'] ?? 1),
+                'revisionHistoryLimit' => 3,
+                'strategy' => [
+                    'type' => 'RollingUpdate',
+                    'rollingUpdate' => [
+                        'maxUnavailable' => 0,
+                        'maxSurge' => 1,
+                    ],
+                ],
+                'selector' => [
+                    'matchLabels' => [
+                        'app.kubernetes.io/name' => $name,
+                        'app.kubernetes.io/managed-by' => 'coolify',
+                    ],
+                ],
+                'template' => [
+                    'metadata' => $templateMetadata,
+                    'spec' => [
+                        'containers' => [$container],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, string>  $labels
+     * @param  array{environment?: array<string, string>}  $options
+     * @return array<string, mixed>|null
+     */
+    private function secret(string $name, string $namespace, array $labels, array $options): ?array
+    {
+        $environment = collect($options['environment'] ?? [])
+            ->filter(fn ($value, $key) => preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', (string) $key) === 1)
+            ->map(fn ($value) => base64_encode((string) $value));
+
+        if ($environment->isEmpty()) {
+            return null;
+        }
+
+        return [
+            'apiVersion' => 'v1',
+            'kind' => 'Secret',
+            'metadata' => [
+                'name' => $this->secretName($name),
+                'namespace' => $namespace,
+                'labels' => $labels,
+            ],
+            'type' => 'Opaque',
+            'data' => $environment->toArray(),
+        ];
+    }
+
+    /**
+     * @param  array<string, string>  $labels
+     * @param  array{service_type?: string}  $options
+     * @return array<string, mixed>
+     */
+    private function service(string $name, string $namespace, int $port, array $labels, array $options): array
+    {
+        return [
+            'apiVersion' => 'v1',
+            'kind' => 'Service',
+            'metadata' => [
+                'name' => $name,
+                'namespace' => $namespace,
+                'labels' => $labels,
+            ],
+            'spec' => [
+                'type' => $options['service_type'] ?? 'ClusterIP',
+                'selector' => [
+                    'app.kubernetes.io/name' => $name,
+                    'app.kubernetes.io/managed-by' => 'coolify',
+                ],
+                'ports' => [
+                    [
+                        'name' => 'http',
+                        'protocol' => 'TCP',
+                        'port' => 80,
+                        'targetPort' => $port,
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, string>  $labels
+     * @param  array{ingress_class?: string}  $options
+     * @return array<string, mixed>|null
+     */
+    private function ingress(Application $application, string $name, string $namespace, array $labels, array $options): ?array
+    {
+        $host = $this->host($application);
+
+        if ($host === null) {
+            return null;
+        }
+
+        return [
+            'apiVersion' => 'networking.k8s.io/v1',
+            'kind' => 'Ingress',
+            'metadata' => [
+                'name' => $name,
+                'namespace' => $namespace,
+                'labels' => $labels,
+            ],
+            'spec' => [
+                'ingressClassName' => $options['ingress_class'] ?? 'traefik',
+                'rules' => [
+                    [
+                        'host' => $host,
+                        'http' => [
+                            'paths' => [
+                                [
+                                    'path' => '/',
+                                    'pathType' => 'Prefix',
+                                    'backend' => [
+                                        'service' => [
+                                            'name' => $name,
+                                            'port' => [
+                                                'number' => 80,
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, string>  $labels
+     * @param  array{min_replicas?: int, max_replicas?: int, target_cpu_utilization_percentage?: int}  $options
+     * @return array<string, mixed>
+     */
+    private function horizontalPodAutoscaler(string $name, string $namespace, array $labels, array $options): array
+    {
+        return [
+            'apiVersion' => 'autoscaling/v2',
+            'kind' => 'HorizontalPodAutoscaler',
+            'metadata' => [
+                'name' => $name,
+                'namespace' => $namespace,
+                'labels' => $labels,
+            ],
+            'spec' => [
+                'scaleTargetRef' => [
+                    'apiVersion' => 'apps/v1',
+                    'kind' => 'Deployment',
+                    'name' => $name,
+                ],
+                'minReplicas' => (int) ($options['min_replicas'] ?? 1),
+                'maxReplicas' => (int) ($options['max_replicas'] ?? 3),
+                'metrics' => [
+                    [
+                        'type' => 'Resource',
+                        'resource' => [
+                            'name' => 'cpu',
+                            'target' => [
+                                'type' => 'Utilization',
+                                'averageUtilization' => (int) ($options['target_cpu_utilization_percentage'] ?? 70),
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function httpHealthCheck(Application $application, int $port): ?array
+    {
+        if (! $application->health_check_enabled || $application->health_check_type === 'cmd') {
+            return null;
+        }
+
+        return [
+            'httpGet' => [
+                'path' => $application->health_check_path ?: '/',
+                'port' => (int) ($application->health_check_port ?: $port),
+                'scheme' => strtoupper($application->health_check_scheme ?: 'HTTP'),
+            ],
+            'periodSeconds' => (int) ($application->health_check_interval ?: 30),
+            'timeoutSeconds' => (int) ($application->health_check_timeout ?: 5),
+            'failureThreshold' => (int) ($application->health_check_retries ?: 3),
+            'initialDelaySeconds' => (int) ($application->health_check_start_period ?: 10),
+        ];
+    }
+
+    /**
+     * @return array<string, array<string, string>>
+     */
+    private function resources(Application $application): array
+    {
+        $limits = array_filter([
+            'memory' => $application->limits_memory ?: null,
+            'cpu' => $application->limits_cpus ?: null,
+        ]);
+
+        $requests = array_filter([
+            'memory' => $application->limits_memory_reservation ?: null,
+        ]);
+
+        return array_filter([
+            'limits' => $limits,
+            'requests' => $requests,
+        ]);
+    }
+
+    private function image(Application $application, array $options): string
+    {
+        if (filled($options['image'] ?? null)) {
+            return $options['image'];
+        }
+
+        if (! $application->docker_registry_image_name) {
+            throw new InvalidArgumentException('Kubernetes deployments require docker_registry_image_name.');
+        }
+
+        if (! $application->docker_registry_image_tag) {
+            return $application->docker_registry_image_name;
+        }
+
+        return $application->docker_registry_image_name.':'.$application->docker_registry_image_tag;
+    }
+
+    private function containerPort(Application $application): int
+    {
+        $ports = collect(preg_split('/[\s,]+/', (string) $application->ports_exposes))
+            ->map(fn (string $port) => trim($port))
+            ->filter(fn (string $port) => is_numeric($port) && (int) $port > 0)
+            ->values();
+
+        return (int) ($ports->first() ?: 3000);
+    }
+
+    private function host(Application $application): ?string
+    {
+        $fqdn = trim(explode(',', (string) $application->fqdn)[0]);
+
+        if ($fqdn === '') {
+            return null;
+        }
+
+        return parse_url($fqdn, PHP_URL_HOST) ?: $fqdn;
+    }
+
+    private function namespace(?string $namespace): string
+    {
+        return $namespace ?: 'default';
+    }
+
+    private function secretName(string $name): string
+    {
+        return "{$name}-env";
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function labels(Application $application, string $name): array
+    {
+        return [
+            'app.kubernetes.io/name' => $name,
+            'app.kubernetes.io/managed-by' => 'coolify',
+            'app.kubernetes.io/component' => 'application',
+            'coolify.io/application-uuid' => (string) $application->uuid,
+        ];
+    }
+}

--- a/app/Services/Kubernetes/KubernetesKubectlCommandBuilder.php
+++ b/app/Services/Kubernetes/KubernetesKubectlCommandBuilder.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Services\Kubernetes;
+
+use App\Models\KubernetesCluster;
+
+class KubernetesKubectlCommandBuilder
+{
+    public function version(KubernetesCluster $cluster, ?string $kubeconfigPath = null): string
+    {
+        return $this->base($cluster, $kubeconfigPath).' version --output=yaml';
+    }
+
+    public function apply(KubernetesCluster $cluster, string $manifestPath, ?string $kubeconfigPath = null): string
+    {
+        return $this->base($cluster, $kubeconfigPath).' apply -f '.escapeshellarg($manifestPath);
+    }
+
+    public function serverSideDryRun(KubernetesCluster $cluster, string $manifestPath, ?string $kubeconfigPath = null): string
+    {
+        return $this->apply($cluster, $manifestPath, $kubeconfigPath).' --dry-run=server';
+    }
+
+    public function rolloutStatus(KubernetesCluster $cluster, string $deploymentName, int $timeoutSeconds = 300, ?string $kubeconfigPath = null): string
+    {
+        return $this->base($cluster, $kubeconfigPath).' rollout status '.escapeshellarg("deployment/{$deploymentName}").' --timeout='.((int) $timeoutSeconds).'s';
+    }
+
+    public function rolloutRestart(KubernetesCluster $cluster, string $deploymentName, ?string $kubeconfigPath = null): string
+    {
+        return $this->base($cluster, $kubeconfigPath).' rollout restart '.escapeshellarg("deployment/{$deploymentName}");
+    }
+
+    public function scaleDeployment(KubernetesCluster $cluster, string $deploymentName, int $replicas, ?string $kubeconfigPath = null): string
+    {
+        return $this->base($cluster, $kubeconfigPath).' scale '.escapeshellarg("deployment/{$deploymentName}").' --replicas='.((int) $replicas);
+    }
+
+    public function writeManifest(string $manifestPath, string $manifestYaml): string
+    {
+        return $this->writeFile($manifestPath, $manifestYaml);
+    }
+
+    public function writeKubeconfig(string $kubeconfigPath, string $kubeconfig): string
+    {
+        return $this->writeFile($kubeconfigPath, $kubeconfig).' && chmod 600 '.escapeshellarg($kubeconfigPath);
+    }
+
+    public function writeFile(string $path, string $contents): string
+    {
+        return 'printf %s '.escapeshellarg(base64_encode($contents)).' | base64 -d > '.escapeshellarg($path);
+    }
+
+    private function base(KubernetesCluster $cluster, ?string $kubeconfigPath = null): string
+    {
+        $command = 'kubectl';
+
+        $effectiveKubeconfigPath = $kubeconfigPath ?: $cluster->effectiveKubeconfigPath();
+
+        if ($effectiveKubeconfigPath) {
+            $command .= ' --kubeconfig='.escapeshellarg($effectiveKubeconfigPath);
+        }
+
+        if ($cluster->context) {
+            $command .= ' --context='.escapeshellarg($cluster->context);
+        }
+
+        if ($cluster->namespace) {
+            $command .= ' --namespace='.escapeshellarg($cluster->namespace);
+        }
+
+        return $command;
+    }
+}

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -10,6 +10,7 @@ use App\Models\EnvironmentVariable;
 use App\Models\GithubApp;
 use App\Models\GitlabApp;
 use App\Models\InstanceSettings;
+use App\Models\KubernetesCluster;
 use App\Models\LocalFileVolume;
 use App\Models\LocalPersistentVolume;
 use App\Models\Server;
@@ -328,14 +329,15 @@ function currentTeam()
     return Auth::user()?->currentTeam() ?? null;
 }
 
-function find_destination_for_current_team(?string $uuid): StandaloneDocker|SwarmDocker|null
+function find_destination_for_current_team(?string $uuid): StandaloneDocker|SwarmDocker|KubernetesCluster|null
 {
     if (blank($uuid) || ! currentTeam()) {
         return null;
     }
 
     return StandaloneDocker::ownedByCurrentTeam()->where('uuid', $uuid)->first()
-        ?? SwarmDocker::ownedByCurrentTeam()->where('uuid', $uuid)->first();
+        ?? SwarmDocker::ownedByCurrentTeam()->where('uuid', $uuid)->first()
+        ?? KubernetesCluster::ownedByCurrentTeam()->where('uuid', $uuid)->first();
 }
 
 function showBoarding(): bool

--- a/database/factories/KubernetesClusterFactory.php
+++ b/database/factories/KubernetesClusterFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class KubernetesClusterFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'uuid' => fake()->uuid(),
+            'name' => fake()->unique()->word(),
+            'namespace' => 'default',
+            'context' => null,
+            'kubeconfig_path' => null,
+            'kubeconfig' => null,
+            'ingress_class' => 'traefik',
+            'service_type' => 'ClusterIP',
+            'replicas' => 1,
+            'autoscaling_enabled' => false,
+            'min_replicas' => 1,
+            'max_replicas' => 3,
+            'target_cpu_utilization_percentage' => 70,
+            'server_id' => 1,
+        ];
+    }
+}

--- a/database/migrations/2026_05_18_000000_create_kubernetes_clusters_table.php
+++ b/database/migrations/2026_05_18_000000_create_kubernetes_clusters_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('kubernetes_clusters', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('uuid')->unique();
+            $table->string('namespace')->default('default');
+            $table->string('context')->nullable();
+            $table->string('kubeconfig_path')->nullable();
+            $table->longText('kubeconfig')->nullable();
+            $table->string('ingress_class')->default('traefik');
+            $table->string('service_type')->default('ClusterIP');
+            $table->unsignedInteger('replicas')->default(1);
+            $table->boolean('autoscaling_enabled')->default(false);
+            $table->unsignedInteger('min_replicas')->default(1);
+            $table->unsignedInteger('max_replicas')->default(3);
+            $table->unsignedInteger('target_cpu_utilization_percentage')->default(70);
+
+            $table->foreignId('server_id');
+            $table->unique(['server_id', 'name']);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('kubernetes_clusters');
+    }
+};

--- a/docs/specs/20260518-kubernetes-destination-foundation.md
+++ b/docs/specs/20260518-kubernetes-destination-foundation.md
@@ -1,0 +1,146 @@
+---
+title: Kubernetes Destination Deployment
+status: implemented
+date: 2026-05-18
+owners:
+    - coolify
+related:
+    - https://github.com/coollabsio/coolify/issues/2390
+    - https://github.com/coollabsio/coolify/discussions/2455
+    - https://github.com/coollabsio/coolify/issues/5685
+---
+
+# Kubernetes Destination Deployment
+
+## Summary
+
+Coolify now has a Kubernetes destination path that mirrors the existing `StandaloneDocker` and `SwarmDocker` polymorphic destination shape, exposes UI for cluster configuration, and deploys application manifests with `kubectl`.
+
+This foundation targets the deploy-to-Kubernetes path from [coollabsio/coolify#2390](https://github.com/coollabsio/coolify/issues/2390). It does not solve running Coolify itself inside Kubernetes, which remains a separate Helm/GitOps concern tracked in [discussion #2455](https://github.com/coollabsio/coolify/discussions/2455).
+
+## Goals
+
+- Add a first-class `KubernetesCluster` destination model.
+- Generate Kubernetes-native manifests from a Coolify application image configuration.
+- Support production SaaS primitives: Deployment, Service, Ingress, Secret-backed runtime env, probes, resource limits, rolling updates, and optional HorizontalPodAutoscaler.
+- Keep deployment execution explicit through generated `kubectl` commands over the existing SSH execution host.
+- Validate generated manifests with unit tests, `kubectl --dry-run=client`, and server-side dry-run in the deployment job.
+
+## Non-Goals
+
+- No automatic K3s installation flow.
+- No Docker Compose to Kubernetes conversion.
+- No database, service template, or persistent volume translation.
+- No Helm chart for running Coolify itself inside Kubernetes.
+
+## Research Inputs
+
+- [Full Kubernetes support with autoscale](https://github.com/coollabsio/coolify/issues/2390) is the canonical feature request. The most concrete community PoC uses a `KubernetesCluster` model, manifest generation, and `kubectl apply`.
+- [Kubernetes Helm Chart for GitOps Deployments](https://github.com/coollabsio/coolify/discussions/2455) asks for Coolify itself to run in Kubernetes. A maintainer/contributor comment notes that Coolify's Docker dependency makes this a different, harder problem.
+- [Coolify v5.x](https://github.com/coollabsio/coolify/issues/5685) frames scaling as core product work, with discussion around simple production scalability.
+- Kubernetes docs used for API targets: [Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/), [Services](https://kubernetes.io/docs/concepts/services-networking/service/), [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/), [Horizontal Pod Autoscaling](https://kubernetes.io/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/), and [kubeconfig](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/).
+
+## Data Model
+
+`kubernetes_clusters` stores connection metadata for a Kubernetes destination owned through a Coolify `Server`.
+
+| Field                               | Purpose                                                              |
+| ----------------------------------- | -------------------------------------------------------------------- |
+| `server_id`                         | Keeps current team ownership and SSH execution boundaries.           |
+| `name`                              | Human-readable destination name.                                     |
+| `namespace`                         | Default namespace for generated resources.                           |
+| `context`                           | Optional kubeconfig context.                                         |
+| `kubeconfig_path`                   | Optional path on the execution host.                                 |
+| `kubeconfig`                        | Optional encrypted kubeconfig content written to the execution host. |
+| `ingress_class`                     | Default Ingress class, initially `traefik`.                          |
+| `service_type`                      | Default Service type, initially `ClusterIP`.                         |
+| `replicas`                          | Deployment replica count.                                            |
+| `autoscaling_enabled`               | Enables an HPA manifest.                                             |
+| `min_replicas` / `max_replicas`     | HPA scaling bounds.                                                  |
+| `target_cpu_utilization_percentage` | HPA CPU target.                                                      |
+
+```mermaid
+erDiagram
+    SERVERS ||--o{ STANDALONE_DOCKERS : owns
+    SERVERS ||--o{ SWARM_DOCKERS : owns
+    SERVERS ||--o{ KUBERNETES_CLUSTERS : owns
+    KUBERNETES_CLUSTERS ||--o{ APPLICATIONS : destination
+    STANDALONE_DOCKERS ||--o{ APPLICATIONS : destination
+    SWARM_DOCKERS ||--o{ APPLICATIONS : destination
+```
+
+The diagram shows the destination parity goal: Kubernetes clusters sit beside existing Docker destinations and use the same polymorphic application destination pattern.
+
+## Manifest Flow
+
+```mermaid
+flowchart LR
+    A["Coolify Application"] --> B["KubernetesApplicationManifestGenerator"]
+    B --> C["Secret when runtime env exists"]
+    B --> D["Deployment"]
+    B --> E["Service"]
+    B --> F["Ingress when fqdn exists"]
+    B --> G["HorizontalPodAutoscaler when enabled"]
+    C --> H["kubectl apply"]
+    D --> H
+    E --> H
+    F --> H
+    G --> H
+```
+
+The generator converts a Coolify application into Kubernetes resources. Docker Image applications use the configured image directly. Git, Dockerfile, Nixpacks, Railpack, and static builds must have a registry image name so the built image can be pushed before Kubernetes pulls it.
+
+## Deployment Semantics
+
+The first supported workload shape is stateless web application deployment:
+
+- `Secret` uses `v1` and stores runtime environment variables for `envFrom`.
+- `Deployment` uses `apps/v1`, `revisionHistoryLimit: 3`, rolling-update strategy, stable Coolify labels, image name/tag, exposed container port, HTTP probes, and resource settings.
+- `Service` uses `v1`, defaults to `ClusterIP`, and routes public port `80` to the application container port.
+- `Ingress` uses `networking.k8s.io/v1` and is emitted only when `fqdn` exists.
+- `HorizontalPodAutoscaler` uses `autoscaling/v2` and is opt-in through destination UI.
+- Stop scales the Deployment to `0`. Restart runs `kubectl rollout restart` for restart-only deployments.
+
+```mermaid
+sequenceDiagram
+    participant Coolify
+    participant Generator
+    participant Host as SSH Host
+    participant API as Kubernetes API
+    Coolify->>Generator: Application + cluster options
+    Generator-->>Coolify: YAML documents
+    Coolify->>Host: write kubeconfig when encrypted content exists
+    Coolify->>Host: write manifest
+    Coolify->>Host: kubectl apply --dry-run=server
+    Coolify->>Host: kubectl apply -f manifest
+    Coolify->>Host: kubectl rollout status
+    Host->>API: apply resources
+    API-->>Host: accepted or validation error
+```
+
+The diagram shows the intended execution path. This keeps Coolify's current SSH execution model intact while introducing Kubernetes as the backend API.
+
+## Operational Notes
+
+- Server-side dry-run is the production deployment validation before apply.
+- Status reconciliation must allow Kubernetes eventual consistency. The community PoC reported a false-failure race and solved it with a grace window.
+- Ingress must stay controller-agnostic. `ingress_class` should default to Traefik for Coolify parity but remain configurable.
+- Compose/service/database support should be separate follow-up work. Static Compose conversion alone is not enough for production because volumes, secrets, health checks, lifecycle hooks, and status all need Coolify semantics.
+
+## Test Plan
+
+- Unit tests assert Secret, Deployment, Service, Ingress, HPA, probes, resources, host parsing, image overrides, and image requirements.
+- Unit tests assert escaped `kubectl` command construction, manifest writes, kubeconfig writes, and rollout commands.
+- Manifest YAML is parsed and checked with `kubectl apply --dry-run=client --validate=false`.
+- Manual cluster validation should use:
+
+```bash
+kubectl --kubeconfig <path-to-kubeconfig> version --output=yaml
+kubectl --kubeconfig <path-to-kubeconfig> apply --dry-run=server -f <manifest>
+```
+
+## Follow-Up Work
+
+- Add status reconciliation from Deployment, ReplicaSet, Pod, Service, and Ingress state.
+- Add persistent volume support before enabling stateful service templates.
+- Decide whether K3s bootstrap belongs in core or as a separate installation action.

--- a/resources/views/components/modal-input.blade.php
+++ b/resources/views/components/modal-input.blade.php
@@ -36,7 +36,7 @@
     <template x-teleport="body">
         <div x-show="modalOpen"
             x-init="$watch('modalOpen', value => { if(value) { $nextTick(() => { const firstInput = $el.querySelector('input, textarea, select'); firstInput?.focus(); }) } })"
-            class="fixed top-0 left-0 z-99 flex items-center justify-center w-screen h-screen p-4">
+            class="fixed top-0 left-0 z-99 flex items-center justify-center w-screen h-dvh p-2 sm:p-4">
             <div x-show="modalOpen" x-transition:enter="ease-out duration-100" x-transition:enter-start="opacity-0"
                 x-transition:enter-end="opacity-100" x-transition:leave="ease-in duration-100"
                 x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0"
@@ -49,18 +49,20 @@
                 x-transition:leave="ease-in duration-100"
                 x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
                 x-transition:leave-end="opacity-0 -translate-y-2 sm:scale-95"
-                class="relative flex flex-col w-full max-h-[calc(100vh-2rem)] min-h-0 border rounded-sm drop-shadow-sm lg:w-auto lg:min-w-2xl lg:max-w-4xl bg-white border-neutral-200 dark:bg-base dark:border-coolgray-300">
-                <div class="flex items-center justify-between py-6 px-6 shrink-0">
-                    <h3 class="text-2xl font-bold">{{ $title }}</h3>
+                class="relative flex flex-col w-full max-h-[calc(100dvh-1rem)] min-h-0 border rounded-sm drop-shadow-sm sm:max-h-[calc(100dvh-2rem)] lg:w-auto lg:min-w-2xl lg:max-w-4xl bg-white border-neutral-200 dark:bg-base dark:border-coolgray-300">
+                <div
+                    class="sticky top-0 z-10 flex items-center justify-between gap-4 px-4 py-4 border-b sm:px-6 sm:py-5 shrink-0 bg-white border-neutral-200 dark:bg-base dark:border-coolgray-300">
+                    <h3 class="text-xl font-bold leading-tight sm:text-2xl">{{ $title }}</h3>
                     <button @click="modalOpen=false"
-                        class="absolute top-0 right-0 flex items-center justify-center w-8 h-8 mt-5 mr-5 rounded-full dark:text-white hover:bg-neutral-100 dark:hover:bg-coolgray-300 outline-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coollabs dark:focus-visible:ring-warning focus-visible:ring-offset-2 dark:focus-visible:ring-offset-base">
+                        class="flex items-center justify-center w-8 h-8 rounded-full shrink-0 dark:text-white hover:bg-neutral-100 dark:hover:bg-coolgray-300 outline-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coollabs dark:focus-visible:ring-warning focus-visible:ring-offset-2 dark:focus-visible:ring-offset-base">
                         <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
                             stroke-width="1.5" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
                         </svg>
                     </button>
                 </div>
-                <div class="relative flex items-start justify-center w-full min-h-0 px-6 pb-6 overflow-y-auto">
+                <div
+                    class="relative flex items-start justify-center w-full min-h-0 px-4 py-4 overflow-y-auto overscroll-contain sm:px-6 sm:py-6">
                     {{ $slot }}
                 </div>
             </div>

--- a/resources/views/components/modal-input.blade.php
+++ b/resources/views/components/modal-input.blade.php
@@ -49,7 +49,7 @@
                 x-transition:leave="ease-in duration-100"
                 x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
                 x-transition:leave-end="opacity-0 -translate-y-2 sm:scale-95"
-                class="relative w-full lg:w-auto lg:min-w-2xl lg:max-w-4xl border rounded-sm drop-shadow-sm bg-white border-neutral-200 dark:bg-base dark:border-coolgray-300 flex flex-col">
+                class="relative flex flex-col w-full max-h-[calc(100vh-2rem)] min-h-0 border rounded-sm drop-shadow-sm lg:w-auto lg:min-w-2xl lg:max-w-4xl bg-white border-neutral-200 dark:bg-base dark:border-coolgray-300">
                 <div class="flex items-center justify-between py-6 px-6 shrink-0">
                     <h3 class="text-2xl font-bold">{{ $title }}</h3>
                     <button @click="modalOpen=false"
@@ -60,7 +60,7 @@
                         </svg>
                     </button>
                 </div>
-                <div class="relative flex items-center justify-center w-auto px-6 pb-6">
+                <div class="relative flex items-start justify-center w-full min-h-0 px-6 pb-6 overflow-y-auto">
                     {{ $slot }}
                 </div>
             </div>

--- a/resources/views/livewire/destination/index.blade.php
+++ b/resources/views/livewire/destination/index.blade.php
@@ -6,17 +6,11 @@
         <h1>Destinations</h1>
         @if ($servers->count() > 0)
             @can('createAnyResource')
-                <x-modal-input buttonTitle="+ Add" title="New Destination">
-                    <div class="flex flex-col gap-8">
-                        <div>
-                            <h3 class="pb-2">Docker</h3>
-                            <livewire:destination.new.docker />
-                        </div>
-                        <div>
-                            <h3 class="pb-2">Kubernetes</h3>
-                            <livewire:destination.new.kubernetes />
-                        </div>
-                    </div>
+                <x-modal-input buttonTitle="+ Docker" title="New Docker Destination">
+                    <livewire:destination.new.docker />
+                </x-modal-input>
+                <x-modal-input buttonTitle="+ Kubernetes" title="New Kubernetes Destination">
+                    <livewire:destination.new.kubernetes />
                 </x-modal-input>
             @endcan
         @endif

--- a/resources/views/livewire/destination/index.blade.php
+++ b/resources/views/livewire/destination/index.blade.php
@@ -7,7 +7,16 @@
         @if ($servers->count() > 0)
             @can('createAnyResource')
                 <x-modal-input buttonTitle="+ Add" title="New Destination">
-                    <livewire:destination.new.docker />
+                    <div class="flex flex-col gap-8">
+                        <div>
+                            <h3 class="pb-2">Docker</h3>
+                            <livewire:destination.new.docker />
+                        </div>
+                        <div>
+                            <h3 class="pb-2">Kubernetes</h3>
+                            <livewire:destination.new.kubernetes />
+                        </div>
+                    </div>
                 </x-modal-input>
             @endcan
         @endif
@@ -34,6 +43,16 @@
                                 <x-deprecated-badge />
                             </div>
                             <div class="box-description">server: {{ $destination->server->name }}</div>
+                        </div>
+                    </a>
+                @endif
+                @if ($destination->getMorphClass() === 'App\Models\KubernetesCluster')
+                    <a class="coolbox group" {{ wireNavigate() }}
+                        href="{{ route('destination.show', ['destination_uuid' => data_get($destination, 'uuid')]) }}">
+                        <div class="flex flex-col mx-6">
+                            <div class="box-title">{{ $destination->name }}</div>
+                            <div class="box-description">Namespace: {{ $destination->namespace }}</div>
+                            <div class="box-description">Server: {{ $destination->server->name }}</div>
                         </div>
                     </a>
                 @endif

--- a/resources/views/livewire/destination/new/kubernetes.blade.php
+++ b/resources/views/livewire/destination/new/kubernetes.blade.php
@@ -1,0 +1,44 @@
+@can('createAnyResource')
+    <div class="w-full">
+        <form class="flex flex-col gap-4" wire:submit='submit'>
+            <div class="flex gap-2">
+                <x-forms.input id="name" label="Name" required />
+                <x-forms.input id="namespace" label="Namespace" required />
+            </div>
+            <div class="flex gap-2">
+                <x-forms.input id="ingressClass" label="Ingress Class" required />
+                <x-forms.select id="serviceType" label="Service Type" required>
+                    <option value="ClusterIP">ClusterIP</option>
+                    <option value="NodePort">NodePort</option>
+                    <option value="LoadBalancer">LoadBalancer</option>
+                </x-forms.select>
+            </div>
+            <div class="flex gap-2">
+                <x-forms.input id="replicas" label="Replicas" type="number" min="1" max="100" required />
+                <x-forms.input id="minReplicas" label="Min Replicas" type="number" min="1" max="100" required />
+                <x-forms.input id="maxReplicas" label="Max Replicas" type="number" min="1" max="100" required />
+            </div>
+            <div class="flex gap-2">
+                <x-forms.checkbox id="autoscalingEnabled" label="Autoscaling" />
+                <x-forms.input id="targetCpuUtilizationPercentage" label="Target CPU %" type="number" min="1"
+                    max="100" required />
+            </div>
+            <x-forms.input id="context" label="Context" />
+            <x-forms.input id="kubeconfigPath" label="Kubeconfig Path" />
+            <x-forms.textarea id="kubeconfig" label="Kubeconfig" rows="10" spellcheck="false" />
+            <x-forms.select id="serverId" label="Select a server" required wire:change="generateName">
+                <option disabled>Select a server</option>
+                @foreach ($servers as $server)
+                    <option value="{{ $server->id }}">{{ $server->name }}</option>
+                @endforeach
+            </x-forms.select>
+            <x-forms.button type="submit">
+                Continue
+            </x-forms.button>
+        </form>
+    </div>
+@else
+    <x-callout type="warning" title="Permission Required">
+        You don't have permission to create new destinations. Please contact your team administrator for access.
+    </x-callout>
+@endcan

--- a/resources/views/livewire/destination/show.blade.php
+++ b/resources/views/livewire/destination/show.blade.php
@@ -4,9 +4,13 @@
             <h1>Destination</h1>
             <x-forms.button canGate="update" :canResource="$destination" wire:click.prevent='submit'
                 type="submit">Save</x-forms.button>
+            @if ($destination->getMorphClass() === 'App\Models\KubernetesCluster')
+                <x-forms.button canGate="update" :canResource="$destination" wire:click.prevent='testConnection'>Test
+                    Connection</x-forms.button>
+            @endif
             @if ($network !== 'coolify')
                 <x-modal-confirmation title="Confirm Destination Deletion?" buttonTitle="Delete Destination" isErrorButton
-                    submitAction="delete" :actions="['This will delete the selected destination/network.']" confirmationText="{{ $destination->name }}"
+                    submitAction="delete" :actions="['This will delete the selected destination.']" confirmationText="{{ $destination->name }}"
                     confirmationLabel="Please confirm the execution of the actions by entering the Destination Name below"
                     shortConfirmationLabel="Destination Name" :confirmWithPassword="false" step2ButtonText="Permanently Delete" 
                     canGate="delete" :canResource="$destination" />
@@ -15,10 +19,12 @@
 
         @if ($destination->getMorphClass() === 'App\Models\StandaloneDocker')
             <div class="subtitle ">A simple Docker network.</div>
-        @else
+        @elseif ($destination->getMorphClass() === 'App\Models\SwarmDocker')
             <div class="subtitle flex items-center gap-2">A swarm Docker network.
                 <x-deprecated-badge />
             </div>
+        @else
+            <div class="subtitle">A Kubernetes cluster namespace.</div>
         @endif
         <div class="flex gap-2">
             <x-forms.input canGate="update" :canResource="$destination" id="name" label="Name" />
@@ -27,5 +33,38 @@
                 <x-forms.input id="network" label="Docker Network" readonly />
             @endif
         </div>
+        @if ($destination->getMorphClass() === 'App\Models\KubernetesCluster')
+            <div class="flex gap-2 pt-4">
+                <x-forms.input canGate="update" :canResource="$destination" id="namespace" label="Namespace" required />
+                <x-forms.input canGate="update" :canResource="$destination" id="ingressClass" label="Ingress Class" required />
+                <x-forms.select canGate="update" :canResource="$destination" id="serviceType" label="Service Type" required>
+                    <option value="ClusterIP">ClusterIP</option>
+                    <option value="NodePort">NodePort</option>
+                    <option value="LoadBalancer">LoadBalancer</option>
+                </x-forms.select>
+            </div>
+            <div class="flex gap-2 pt-4">
+                <x-forms.input canGate="update" :canResource="$destination" id="replicas" label="Replicas"
+                    type="number" min="1" max="100" required />
+                <x-forms.input canGate="update" :canResource="$destination" id="minReplicas" label="Min Replicas"
+                    type="number" min="1" max="100" required />
+                <x-forms.input canGate="update" :canResource="$destination" id="maxReplicas" label="Max Replicas"
+                    type="number" min="1" max="100" required />
+            </div>
+            <div class="flex gap-2 pt-4">
+                <x-forms.checkbox canGate="update" :canResource="$destination" id="autoscalingEnabled"
+                    label="Autoscaling" />
+                <x-forms.input canGate="update" :canResource="$destination" id="targetCpuUtilizationPercentage"
+                    label="Target CPU %" type="number" min="1" max="100" required />
+            </div>
+            <div class="flex gap-2 pt-4">
+                <x-forms.input canGate="update" :canResource="$destination" id="context" label="Context" />
+                <x-forms.input canGate="update" :canResource="$destination" id="kubeconfigPath" label="Kubeconfig Path" />
+            </div>
+            <div class="pt-4">
+                <x-forms.textarea canGate="update" :canResource="$destination" id="kubeconfig" label="Kubeconfig"
+                    rows="12" spellcheck="false" />
+            </div>
+        @endif
     </form>
 </div>

--- a/resources/views/livewire/project/application/destination.blade.php
+++ b/resources/views/livewire/project/application/destination.blade.php
@@ -3,6 +3,11 @@
     <div class="">The destination server / network where your application will be deployed to.</div>
     <div class="py-4 ">
         <p>Server: {{ data_get($destination, 'server.name') }}</p>
-        <p>Destination Network: {{ $destination->network }}</p>
+        @if ($destination->getMorphClass() === 'App\Models\KubernetesCluster')
+            <p>Namespace: {{ $destination->namespace }}</p>
+            <p>Ingress Class: {{ $destination->ingress_class }}</p>
+        @else
+            <p>Destination Network: {{ $destination->network }}</p>
+        @endif
     </div>
 </div>

--- a/resources/views/livewire/project/new/select.blade.php
+++ b/resources/views/livewire/project/new/select.blade.php
@@ -469,6 +469,17 @@
                         </div>
                     </div>
                 @endforeach
+                @foreach ($kubernetesClusters ?? [] as $kubernetesCluster)
+                    <div class="w-full coolbox group" wire:click="setDestination('{{ $kubernetesCluster->uuid }}')">
+                        <div class="flex flex-col mx-6">
+                            <div class="box-title">
+                                Kubernetes <span class="text-xs">({{ $kubernetesCluster->name }})</span>
+                            </div>
+                            <div class="box-description">
+                                Namespace: {{ $kubernetesCluster->namespace }}</div>
+                        </div>
+                    </div>
+                @endforeach
             @endif
         </div>
     @endif

--- a/resources/views/livewire/project/shared/destination.blade.php
+++ b/resources/views/livewire/project/shared/destination.blade.php
@@ -17,7 +17,11 @@
                     Server: {{ data_get($resource, 'destination.server.name') }}
                 </div>
                 <div class="box-description">
-                    Network: {{ data_get($resource, 'destination.network') }}
+                    @if ($resource->destination->getMorphClass() === 'App\Models\KubernetesCluster')
+                        Namespace: {{ data_get($resource, 'destination.namespace') }}
+                    @else
+                        Network: {{ data_get($resource, 'destination.network') }}
+                    @endif
                 </div>
             </div>
             @if ($resource?->additional_networks?->count() > 0)

--- a/resources/views/livewire/server/destinations.blade.php
+++ b/resources/views/livewire/server/destinations.blade.php
@@ -11,7 +11,16 @@
                     <h2>Destinations</h2>
                     @can('update', $server)
                         <x-modal-input buttonTitle="+ Add" title="New Destination">
-                            <livewire:destination.new.docker :server_id="$server->id" />
+                            <div class="flex flex-col gap-8">
+                                <div>
+                                    <h3 class="pb-2">Docker</h3>
+                                    <livewire:destination.new.docker :server_id="$server->id" />
+                                </div>
+                                <div>
+                                    <h3 class="pb-2">Kubernetes</h3>
+                                    <livewire:destination.new.kubernetes :server_id="$server->id" />
+                                </div>
+                            </div>
                         </x-modal-input>
                     @endcan
                     <x-forms.button canGate="update" :canResource="$server" isHighlighted wire:click='scan'>Scan for Destinations</x-forms.button>
@@ -27,6 +36,11 @@
                     @foreach ($server->swarmDockers as $docker)
                         <a href="{{ route('destination.show', ['destination_uuid' => data_get($docker, 'uuid')]) }}" {{ wireNavigate() }}>
                             <x-forms.button>{{ data_get($docker, 'network') }} </x-forms.button>
+                        </a>
+                    @endforeach
+                    @foreach ($server->kubernetesClusters as $cluster)
+                        <a href="{{ route('destination.show', ['destination_uuid' => data_get($cluster, 'uuid')]) }}" {{ wireNavigate() }}>
+                            <x-forms.button>{{ data_get($cluster, 'namespace') }} </x-forms.button>
                         </a>
                     @endforeach
                 </div>

--- a/resources/views/livewire/server/destinations.blade.php
+++ b/resources/views/livewire/server/destinations.blade.php
@@ -10,17 +10,11 @@
                 <div class="flex items-end gap-2">
                     <h2>Destinations</h2>
                     @can('update', $server)
-                        <x-modal-input buttonTitle="+ Add" title="New Destination">
-                            <div class="flex flex-col gap-8">
-                                <div>
-                                    <h3 class="pb-2">Docker</h3>
-                                    <livewire:destination.new.docker :server_id="$server->id" />
-                                </div>
-                                <div>
-                                    <h3 class="pb-2">Kubernetes</h3>
-                                    <livewire:destination.new.kubernetes :server_id="$server->id" />
-                                </div>
-                            </div>
+                        <x-modal-input buttonTitle="+ Docker" title="New Docker Destination">
+                            <livewire:destination.new.docker :server_id="$server->id" />
+                        </x-modal-input>
+                        <x-modal-input buttonTitle="+ Kubernetes" title="New Kubernetes Destination">
+                            <livewire:destination.new.kubernetes :server_id="$server->id" />
                         </x-modal-input>
                     @endcan
                     <x-forms.button canGate="update" :canResource="$server" isHighlighted wire:click='scan'>Scan for Destinations</x-forms.button>

--- a/tests/Unit/KubernetesApplicationManifestGeneratorTest.php
+++ b/tests/Unit/KubernetesApplicationManifestGeneratorTest.php
@@ -1,0 +1,144 @@
+<?php
+
+use App\Models\Application;
+use App\Services\Kubernetes\KubernetesApplicationManifestGenerator;
+use Symfony\Component\Yaml\Yaml;
+
+function kubernetesApplication(array $attributes = []): Application
+{
+    return new Application(array_merge([
+        'name' => 'Customer API',
+        'uuid' => 'ckv4a1b2c3d4e5f6g7h8i9j0',
+        'fqdn' => 'https://api.example.com',
+        'docker_registry_image_name' => 'registry.example.com/customer/api',
+        'docker_registry_image_tag' => '2026.05.18',
+        'ports_exposes' => '8080',
+        'health_check_enabled' => true,
+        'health_check_path' => '/health',
+        'health_check_scheme' => 'HTTP',
+        'health_check_interval' => 15,
+        'health_check_timeout' => 3,
+        'health_check_retries' => 4,
+        'health_check_start_period' => 20,
+        'limits_memory' => '512Mi',
+        'limits_memory_reservation' => '256Mi',
+        'limits_cpus' => '500m',
+    ], $attributes));
+}
+
+it('generates deployment service ingress and hpa manifests', function () {
+    $generator = new KubernetesApplicationManifestGenerator;
+
+    $resources = $generator->generate(kubernetesApplication(), [
+        'namespace' => 'coolify-production',
+        'ingress_class' => 'nginx',
+        'autoscaling' => true,
+        'min_replicas' => 2,
+        'max_replicas' => 10,
+        'target_cpu_utilization_percentage' => 65,
+    ]);
+
+    expect($resources)->toHaveCount(4);
+    expect(array_column($resources, 'kind'))->toBe(['Deployment', 'Service', 'Ingress', 'HorizontalPodAutoscaler']);
+
+    $deployment = $resources[0];
+    $container = $deployment['spec']['template']['spec']['containers'][0];
+
+    expect($deployment['metadata']['name'])->toBe('customer-api-ckv4a1b2');
+    expect($deployment['metadata']['namespace'])->toBe('coolify-production');
+    expect($container['image'])->toBe('registry.example.com/customer/api:2026.05.18');
+    expect($container['ports'][0]['containerPort'])->toBe(8080);
+    expect($container['readinessProbe']['httpGet']['path'])->toBe('/health');
+    expect($container['resources']['limits'])->toBe([
+        'memory' => '512Mi',
+        'cpu' => '500m',
+    ]);
+
+    $service = $resources[1];
+    expect($service['spec']['ports'][0])->toMatchArray([
+        'port' => 80,
+        'targetPort' => 8080,
+    ]);
+
+    $ingress = $resources[2];
+    expect($ingress['spec']['ingressClassName'])->toBe('nginx');
+    expect($ingress['spec']['rules'][0]['host'])->toBe('api.example.com');
+
+    $hpa = $resources[3];
+    expect($hpa['spec']['minReplicas'])->toBe(2);
+    expect($hpa['spec']['maxReplicas'])->toBe(10);
+    expect($hpa['spec']['metrics'][0]['resource']['target']['averageUtilization'])->toBe(65);
+});
+
+it('omits ingress and probes when application configuration does not need them', function () {
+    $generator = new KubernetesApplicationManifestGenerator;
+
+    $resources = $generator->generate(kubernetesApplication([
+        'fqdn' => null,
+        'health_check_enabled' => false,
+    ]));
+
+    expect(array_column($resources, 'kind'))->toBe(['Deployment', 'Service']);
+    expect($resources[0]['spec']['template']['spec']['containers'][0])
+        ->not->toHaveKeys(['readinessProbe', 'livenessProbe']);
+});
+
+it('adds runtime environment variables through an opaque secret', function () {
+    $generator = new KubernetesApplicationManifestGenerator;
+
+    $resources = $generator->generate(kubernetesApplication(), [
+        'image' => 'registry.example.com/customer/api@sha256:abc123',
+        'deployment_uuid' => 'deployment-123',
+        'environment' => [
+            'APP_ENV' => 'production',
+            'INVALID-KEY' => 'ignored',
+        ],
+    ]);
+
+    expect(array_column($resources, 'kind'))->toBe(['Secret', 'Deployment', 'Service', 'Ingress']);
+    expect($resources[0]['data'])->toBe([
+        'APP_ENV' => base64_encode('production'),
+    ]);
+    expect($resources[1]['spec']['template']['spec']['containers'][0]['image'])
+        ->toBe('registry.example.com/customer/api@sha256:abc123');
+    expect($resources[1]['spec']['template']['spec']['containers'][0]['envFrom'][0]['secretRef']['name'])
+        ->toBe('customer-api-ckv4a1b2-env');
+    expect($resources[1]['spec']['template']['metadata']['annotations']['coolify.io/deployment-uuid'])
+        ->toBe('deployment-123');
+});
+
+it('throws when no registry image is configured', function () {
+    $generator = new KubernetesApplicationManifestGenerator;
+
+    expect(fn () => $generator->generate(kubernetesApplication([
+        'docker_registry_image_name' => null,
+    ])))->toThrow(InvalidArgumentException::class, 'docker_registry_image_name');
+});
+
+it('exports yaml accepted by kubectl client dry run', function () {
+    $kubectl = trim((string) shell_exec('command -v kubectl 2>/dev/null'));
+
+    if ($kubectl === '') {
+        $this->markTestSkipped('kubectl is not installed.');
+    }
+
+    $generator = new KubernetesApplicationManifestGenerator;
+    $yaml = $generator->toYaml(kubernetesApplication(), [
+        'namespace' => 'default',
+        'autoscaling' => true,
+    ]);
+
+    foreach (explode("---\n", $yaml) as $document) {
+        expect(Yaml::parse($document))->toBeArray();
+    }
+
+    $path = tempnam(sys_get_temp_dir(), 'coolify-k8s-').'.yaml';
+    file_put_contents($path, $yaml);
+
+    $output = [];
+    $exitCode = 0;
+    exec(escapeshellcmd($kubectl).' apply --dry-run=client --validate=false -f '.escapeshellarg($path).' 2>&1', $output, $exitCode);
+    unlink($path);
+
+    expect($exitCode)->toBe(0, implode("\n", $output));
+});

--- a/tests/Unit/KubernetesKubectlCommandBuilderTest.php
+++ b/tests/Unit/KubernetesKubectlCommandBuilderTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Models\KubernetesCluster;
+use App\Services\Kubernetes\KubernetesKubectlCommandBuilder;
+
+it('builds escaped kubectl commands for a cluster destination', function () {
+    $cluster = new KubernetesCluster([
+        'namespace' => 'production',
+        'context' => 'iad-prod',
+        'kubeconfig_path' => '/data/coolify/kubernetes/iad prod.yaml',
+    ]);
+
+    $builder = new KubernetesKubectlCommandBuilder;
+
+    expect($builder->serverSideDryRun($cluster, '/data/coolify/app manifests/api.yaml'))
+        ->toBe("kubectl --kubeconfig='/data/coolify/kubernetes/iad prod.yaml' --context='iad-prod' --namespace='production' apply -f '/data/coolify/app manifests/api.yaml' --dry-run=server");
+
+    expect($builder->rolloutStatus($cluster, 'customer-api', 120))
+        ->toBe("kubectl --kubeconfig='/data/coolify/kubernetes/iad prod.yaml' --context='iad-prod' --namespace='production' rollout status 'deployment/customer-api' --timeout=120s");
+});
+
+it('builds a base64 manifest write command', function () {
+    $builder = new KubernetesKubectlCommandBuilder;
+
+    expect($builder->writeManifest('/tmp/app.yaml', "kind: Service\n"))
+        ->toBe("printf %s 'a2luZDogU2VydmljZQo=' | base64 -d > '/tmp/app.yaml'");
+    expect($builder->writeKubeconfig('/tmp/kubeconfig', "apiVersion: v1\n"))
+        ->toBe("printf %s 'YXBpVmVyc2lvbjogdjEK' | base64 -d > '/tmp/kubeconfig' && chmod 600 '/tmp/kubeconfig'");
+});


### PR DESCRIPTION
## Changes

- Adds Kubernetes destinations beside existing Docker destinations.
- Adds create, edit, and select UI for pasted kubeconfig and kubeconfig path modes.
- Generates Deployment, Service, optional Ingress, Secret, and HPA manifests for stateless app deployments.
- Deploys through existing SSH execution using kubectl dry-run, apply, rollout status, restart, and stop by scale.
- Adds unit coverage and a spec doc for the initial scope.

## Issues

- Fixes https://github.com/coollabsio/coolify/issues/2390
- Related: https://github.com/coollabsio/coolify/issues/45
- Claim: /claim #2390

## Category

- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Local Coolify dev instance tested against a real Kubernetes cluster with two destinations:
- pasted kubeconfig
- kubeconfig path

Both connected through Coolify remote execution. A Docker image app using nginx deployed successfully: Deployment 1/1 available, Pod Running, Service ClusterIP.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Assisted implementation, tests, and local verification. Changes were reviewed and tested before submission.

## Testing

Passed:
- Pint dirty formatter
- Kubernetes unit tests
- deployment failure logging regression test
- Blade view cache
- browser smoke for low-height Kubernetes modal
- real Kubernetes smoke deploy with both kubeconfig modes

Known local caveat: full suite still fails in unrelated existing unit tests outside this Kubernetes path.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this is not a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
