### PR TITLE
fix: add IPv6 fallback for Coolify Docker networks

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -102,7 +102,7 @@ class InstallDocker
                 ]);
             } else {
                 $command = $command->merge([
-                    'docker network create --attachable coolify >/dev/null 2>&1 || true',
+                    dockerNetworkCreateCommand('coolify', suppressOutput: true).' || true',
                 ]);
                 $command = $command->merge([
                     "echo 'Done!'",

--- a/app/Actions/Service/StartService.php
+++ b/app/Actions/Service/StartService.php
@@ -33,7 +33,7 @@ class StartService
         }
         if ($service->networks()->count() > 0) {
             $commands[] = "echo 'Creating Docker network.'";
-            $commands[] = "docker network inspect $service->uuid >/dev/null 2>&1 || docker network create --attachable $service->uuid";
+            $commands[] = "docker network inspect $service->uuid >/dev/null 2>&1 || ".dockerNetworkCreateCommand($service->uuid);
         }
         $commands[] = 'echo Starting service.';
         $commands[] = "docker compose --project-directory {$workdir} -f {$workdir}/docker-compose.yml --project-name {$service->uuid} up -d --remove-orphans --force-recreate --build";

--- a/app/Models/StandaloneDocker.php
+++ b/app/Models/StandaloneDocker.php
@@ -25,7 +25,7 @@ class StandaloneDocker extends BaseModel
             $server = $newStandaloneDocker->server;
             $safeNetwork = escapeshellarg($newStandaloneDocker->network);
             instant_remote_process([
-                "docker network inspect {$safeNetwork} >/dev/null 2>&1 || docker network create --driver overlay --attachable {$safeNetwork} >/dev/null",
+                "docker network inspect {$safeNetwork} >/dev/null 2>&1 || ".dockerNetworkCreateCommand($newStandaloneDocker->network, suppressOutput: true),
             ], $server, false);
             ConnectProxyToNetworksJob::dispatchSync($server);
         });

--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -149,6 +149,20 @@ function executeInDocker(string $containerId, string $command)
     return "docker exec {$containerId} bash -c '{$escapedCommand}'";
 }
 
+function dockerNetworkCreateCommand(string $network, bool $isSwarm = false, bool $suppressOutput = false): string
+{
+    $safeNetwork = escapeshellarg($network);
+    $options = $isSwarm ? '--driver overlay --attachable' : '--attachable';
+    $stdoutRedirect = $suppressOutput ? ' >/dev/null' : '';
+    $stderrRedirect = $suppressOutput ? ' 2>&1' : '';
+
+    if ($isSwarm) {
+        return "docker network create {$options} {$safeNetwork}{$stdoutRedirect}{$stderrRedirect}";
+    }
+
+    return "(docker network create --ipv6 {$options} {$safeNetwork}{$stdoutRedirect} 2>/dev/null || docker network create {$options} {$safeNetwork}{$stdoutRedirect}{$stderrRedirect})";
+}
+
 function getContainerStatus(Server $server, string $container_id, bool $all_data = false, bool $throwError = false)
 {
     if ($server->isSwarm()) {

--- a/bootstrap/helpers/proxy.php
+++ b/bootstrap/helpers/proxy.php
@@ -120,7 +120,7 @@ function connectProxyToNetworks(Server $server)
         $commands = $networks->map(function ($network) {
             $safe = escapeshellarg($network);
             return [
-                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || docker network create --attachable {$safe} >/dev/null",
+                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || ".dockerNetworkCreateCommand($network, suppressOutput: true),
                 "docker network connect {$safe} coolify-proxy >/dev/null 2>&1 || true",
                 "echo 'Successfully connected coolify-proxy to {$safe} network.'",
             ];
@@ -154,7 +154,7 @@ function ensureProxyNetworksExist(Server $server)
             $safe = escapeshellarg($network);
             return [
                 "echo 'Ensuring network {$safe} exists...'",
-                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --attachable {$safe}",
+                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || ".dockerNetworkCreateCommand($network),
             ];
         });
     }

--- a/tests/Unit/DockerNetworkCreateCommandTest.php
+++ b/tests/Unit/DockerNetworkCreateCommandTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+
+class DockerNetworkCreateCommandTest extends TestCase
+{
+    public function test_standalone_networks_try_ipv6_then_fall_back_to_ipv4(): void
+    {
+        $command = dockerNetworkCreateCommand('coolify');
+
+        $this->assertSame(
+            "(docker network create --ipv6 --attachable 'coolify' 2>/dev/null || docker network create --attachable 'coolify')",
+            $command
+        );
+    }
+
+    public function test_standalone_networks_can_suppress_output(): void
+    {
+        $command = dockerNetworkCreateCommand('coolify', suppressOutput: true);
+
+        $this->assertSame(
+            "(docker network create --ipv6 --attachable 'coolify' >/dev/null 2>/dev/null || docker network create --attachable 'coolify' >/dev/null 2>&1)",
+            $command
+        );
+    }
+
+    public function test_swarm_networks_keep_existing_overlay_behavior(): void
+    {
+        $command = dockerNetworkCreateCommand('coolify-overlay', isSwarm: true, suppressOutput: true);
+
+        $this->assertSame(
+            "docker network create --driver overlay --attachable 'coolify-overlay' >/dev/null 2>&1",
+            $command
+        );
+    }
+}


### PR DESCRIPTION
/claim #3436

## Summary

Adds a safer Docker network creation helper that attempts IPv6-enabled standalone networks first, then falls back to the existing IPv4-only command when Docker or the host is not configured for IPv6.

## Why

Issue #3436 shows that IPv6 clients can lose the real client IP through Traefik/Caddy when Coolify-created Docker networks are IPv4-only. Simply adding `--ipv6` everywhere can break installs where Docker IPv6 is unavailable, so this keeps existing behavior as a fallback.

## Changes

- Add `dockerNetworkCreateCommand()`
- Use it for standalone proxy, service, install, and destination network creation paths
- Leave swarm overlay behavior unchanged
- Add unit coverage for generated command behavior

## Testing

- Added `tests/Unit/DockerNetworkCreateCommandTest.php`
- Not run locally: PHP CLI is unavailable in this environment
