### PR TITLE
fix: isolate compose loader git output

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -1868,6 +1868,7 @@ class Application extends BaseModel
         }
         $getGitVersion = instant_remote_process(['git --version'], $this->destination->server, false);
         $gitVersion = str($getGitVersion)->explode(' ')->last();
+        $gitOutputLog = "/tmp/{$uuid}/git-output.log";
 
         if (version_compare($gitVersion, '2.35.1', '<')) {
             $fileList = $fileList->map(function ($file) {
@@ -1887,10 +1888,10 @@ class Application extends BaseModel
                 "rm -rf /tmp/{$uuid}",
                 "mkdir -p /tmp/{$uuid}",
                 "cd /tmp/{$uuid}",
-                $cloneCommand,
-                'git sparse-checkout init',
-                "git sparse-checkout set {$fileList->implode(' ')}",
-                'git read-tree -mu HEAD',
+                $this->silenceRemoteCommandOutput($cloneCommand, $gitOutputLog),
+                $this->silenceRemoteCommandOutput('git sparse-checkout init', $gitOutputLog),
+                $this->silenceRemoteCommandOutput("git sparse-checkout set {$fileList->implode(' ')}", $gitOutputLog),
+                $this->silenceRemoteCommandOutput('git read-tree -mu HEAD', $gitOutputLog),
                 "cat .$workdir$composeFile",
             ]);
         } else {
@@ -1898,10 +1899,10 @@ class Application extends BaseModel
                 "rm -rf /tmp/{$uuid}",
                 "mkdir -p /tmp/{$uuid}",
                 "cd /tmp/{$uuid}",
-                $cloneCommand,
-                'git sparse-checkout init --cone',
-                "git sparse-checkout set {$fileList->implode(' ')}",
-                'git read-tree -mu HEAD',
+                $this->silenceRemoteCommandOutput($cloneCommand, $gitOutputLog),
+                $this->silenceRemoteCommandOutput('git sparse-checkout init --cone', $gitOutputLog),
+                $this->silenceRemoteCommandOutput("git sparse-checkout set {$fileList->implode(' ')}", $gitOutputLog),
+                $this->silenceRemoteCommandOutput('git read-tree -mu HEAD', $gitOutputLog),
                 "cat .$workdir$composeFile",
             ]);
         }
@@ -1977,6 +1978,13 @@ class Application extends BaseModel
 
             throw new RuntimeException("Docker Compose file not found at: $workdir$composeFile (branch: {$this->git_branch})<br><br>Check if you used the right extension (.yaml or .yml) in the compose file name.");
         }
+    }
+
+    private function silenceRemoteCommandOutput(string $command, string $logFile): string
+    {
+        $escapedLogFile = escapeshellarg($logFile);
+
+        return "({$command}) >> {$escapedLogFile} 2>&1 || { cat {$escapedLogFile} >&2; exit 1; }";
     }
 
     public function parseContainerLabels(?ApplicationPreview $preview = null)

--- a/tests/Unit/ApplicationLoadComposeFileOutputIsolationTest.php
+++ b/tests/Unit/ApplicationLoadComposeFileOutputIsolationTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Models\Application;
+
+it('wraps compose loader git commands so only the compose file is written to stdout', function () {
+    $application = new Application;
+    $method = new ReflectionMethod(Application::class, 'silenceRemoteCommandOutput');
+    $method->setAccessible(true);
+
+    $command = $method->invoke(
+        $application,
+        'git clone https://example.com/acme/app.git .',
+        '/tmp/coolify-test/git-output.log'
+    );
+    $escapedLogFile = escapeshellarg('/tmp/coolify-test/git-output.log');
+    $expected = '(git clone https://example.com/acme/app.git .)'
+        ." >> {$escapedLogFile} 2>&1"
+        ." || { cat {$escapedLogFile} >&2; exit 1; }";
+
+    expect($command)
+        ->toBe($expected)
+        ->toContain(">> {$escapedLogFile} 2>&1")
+        ->toContain("cat {$escapedLogFile} >&2");
+});
+
+it('keeps loadComposeFile setup commands silent before cat reads the compose file', function () {
+    $applicationFile = file_get_contents(__DIR__.'/../../app/Models/Application.php');
+    $loadComposeFileStart = strpos($applicationFile, 'public function loadComposeFile');
+    $parseContainerLabelsStart = strpos($applicationFile, 'public function parseContainerLabels');
+    $loadComposeFile = substr($applicationFile, $loadComposeFileStart, $parseContainerLabelsStart - $loadComposeFileStart);
+
+    expect($loadComposeFile)
+        ->toContain('$this->silenceRemoteCommandOutput($cloneCommand, $gitOutputLog)')
+        ->toContain("\$this->silenceRemoteCommandOutput('git sparse-checkout init', \$gitOutputLog)")
+        ->toContain("\$this->silenceRemoteCommandOutput('git sparse-checkout init --cone', \$gitOutputLog)")
+        ->toContain("\$this->silenceRemoteCommandOutput('git read-tree -mu HEAD', \$gitOutputLog)")
+        ->toContain('"cat .$workdir$composeFile"');
+});


### PR DESCRIPTION
## Changes

- Keep the compose loader checkout setup quiet so git clone and sparse-checkout progress cannot be saved before the compose YAML.
- Preserve useful diagnostics by writing setup output to a temporary log and printing that log only when a setup command fails.
- Add focused regression coverage for the command wrapper and compose-loader command sequence.

## Issues

- Fixes #5251
- /claim #5251
- Supersedes closed draft #10277 after correcting the PR template and quality-check metadata.

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No UI change. The regression test demonstrates the failure path directly: setup output is redirected away from captured stdout, and only the compose file read remains as the stdout-producing step.

- [coolify-5251-output-isolation-demo.mp4](https://github.com/emsabiq/coolify/releases/download/pr-10277-demo-video/coolify-5251-output-isolation-demo.mp4)

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex
- How extensively: Used to inspect the issue thread, implement the focused patch, and run local formatting and regression checks before submission.

## Testing

- Dirty-file formatting passed.
- Targeted Pest regression test passed.
- PHP syntax checks for the changed files passed.
- Whitespace check passed.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
