### PR TITLE
fix: keep compose loader stdout clean

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -1868,6 +1868,9 @@ class Application extends BaseModel
         }
         $getGitVersion = instant_remote_process(['git --version'], $this->destination->server, false);
         $gitVersion = str($getGitVersion)->explode(' ')->last();
+        $logFile = escapeshellarg("/tmp/{$uuid}/load-compose-file.log");
+        $quietCloneCommand = $this->muteComposeLoaderCommand($cloneCommand, $logFile);
+        $quietReadTreeCommand = $this->muteComposeLoaderCommand('git read-tree -mu HEAD', $logFile);
 
         if (version_compare($gitVersion, '2.35.1', '<')) {
             $fileList = $fileList->map(function ($file) {
@@ -1883,25 +1886,29 @@ class Application extends BaseModel
 
                 return $paths;
             })->flatten()->unique()->values();
+            $quietSparseCheckoutInitCommand = $this->muteComposeLoaderCommand('git sparse-checkout init', $logFile);
+            $quietSparseCheckoutSetCommand = $this->muteComposeLoaderCommand("git sparse-checkout set {$fileList->implode(' ')}", $logFile);
             $commands = collect([
                 "rm -rf /tmp/{$uuid}",
                 "mkdir -p /tmp/{$uuid}",
                 "cd /tmp/{$uuid}",
-                $cloneCommand,
-                'git sparse-checkout init',
-                "git sparse-checkout set {$fileList->implode(' ')}",
-                'git read-tree -mu HEAD',
+                $quietCloneCommand,
+                $quietSparseCheckoutInitCommand,
+                $quietSparseCheckoutSetCommand,
+                $quietReadTreeCommand,
                 "cat .$workdir$composeFile",
             ]);
         } else {
+            $quietSparseCheckoutInitCommand = $this->muteComposeLoaderCommand('git sparse-checkout init --cone', $logFile);
+            $quietSparseCheckoutSetCommand = $this->muteComposeLoaderCommand("git sparse-checkout set {$fileList->implode(' ')}", $logFile);
             $commands = collect([
                 "rm -rf /tmp/{$uuid}",
                 "mkdir -p /tmp/{$uuid}",
                 "cd /tmp/{$uuid}",
-                $cloneCommand,
-                'git sparse-checkout init --cone',
-                "git sparse-checkout set {$fileList->implode(' ')}",
-                'git read-tree -mu HEAD',
+                $quietCloneCommand,
+                $quietSparseCheckoutInitCommand,
+                $quietSparseCheckoutSetCommand,
+                $quietReadTreeCommand,
                 "cat .$workdir$composeFile",
             ]);
         }
@@ -1977,6 +1984,11 @@ class Application extends BaseModel
 
             throw new RuntimeException("Docker Compose file not found at: $workdir$composeFile (branch: {$this->git_branch})<br><br>Check if you used the right extension (.yaml or .yml) in the compose file name.");
         }
+    }
+
+    protected function muteComposeLoaderCommand(string $command, string $escapedLogFile): string
+    {
+        return "({$command}) > {$escapedLogFile} 2>&1 || { cat {$escapedLogFile} >&2; exit 1; }";
     }
 
     public function parseContainerLabels(?ApplicationPreview $preview = null)

--- a/tests/Unit/ApplicationLoadComposeFileCommandTest.php
+++ b/tests/Unit/ApplicationLoadComposeFileCommandTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use App\Models\Application;
+
+it('keeps compose loader setup output out of stdout', function () {
+    $application = new class extends Application
+    {
+        public function muteForTest(string $command, string $escapedLogFile): string
+        {
+            return $this->muteComposeLoaderCommand($command, $escapedLogFile);
+        }
+    };
+
+    $command = $application->muteForTest('git clone https://example.com/repo.git .', "'/tmp/load-compose-file.log'");
+
+    expect($command)
+        ->toBe("(git clone https://example.com/repo.git .) > '/tmp/load-compose-file.log' 2>&1 || { cat '/tmp/load-compose-file.log' >&2; exit 1; }")
+        ->toContain("> '/tmp/load-compose-file.log' 2>&1")
+        ->toContain("cat '/tmp/load-compose-file.log' >&2")
+        ->toContain('exit 1');
+});


### PR DESCRIPTION
## Changes

- Keep `loadComposeFile()` setup commands out of the captured Docker Compose stdout.
- Send clone, sparse-checkout, and read-tree output to a temporary log file, while preserving that log on stderr if any setup command fails.
- Add a focused regression test for the command wrapper so only the final `cat` step is expected to produce compose content on stdout.

## Issues

- Fixes #5251
- /claim #5251

This addresses the deterministic `docker_compose_raw` corruption described in the latest reproduction notes, where command output such as `Cloning into '.'...` can be saved before the actual compose YAML and later parsed as an empty service map.

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Backend command-output handling only; no UI change.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex
- How extensively: Used for issue/code-path inspection and patch drafting. The final change was reviewed locally and covered with targeted tests.

## Testing

- `php artisan test --compact tests\Unit\ApplicationLoadComposeFileCommandTest.php`
- `php -l app\Models\Application.php`
- `php -l tests\Unit\ApplicationLoadComposeFileCommandTest.php`
- `php vendor\laravel\pint\builds\pint --dirty --test`
- `git diff --check`

Note: tests were run on Windows PHP. Composer install required ignoring `ext-pcntl` and `ext-posix`, which are not available on Windows PHP.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
