### PR TITLE
fix: prevent git clone noise from corrupting docker_compose_raw

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -1859,6 +1859,7 @@ class Application extends BaseModel
         }
         $uuid = new Cuid2;
         ['commands' => $cloneCommand] = $this->generateGitImportCommands(deployment_uuid: $uuid, only_checkout: true, exec_in_docker: false, custom_base_dir: '.');
+        $quietCloneCommand = preg_replace('/^git clone\b/', 'git clone --quiet', $cloneCommand) ?? $cloneCommand;
         $workdir = rtrim($this->base_directory, '/');
         $composeFile = $this->docker_compose_location;
         $fileList = collect([".$workdir$composeFile"]);
@@ -1887,7 +1888,7 @@ class Application extends BaseModel
                 "rm -rf /tmp/{$uuid}",
                 "mkdir -p /tmp/{$uuid}",
                 "cd /tmp/{$uuid}",
-                $cloneCommand,
+                $quietCloneCommand,
                 'git sparse-checkout init',
                 "git sparse-checkout set {$fileList->implode(' ')}",
                 'git read-tree -mu HEAD',
@@ -1898,7 +1899,7 @@ class Application extends BaseModel
                 "rm -rf /tmp/{$uuid}",
                 "mkdir -p /tmp/{$uuid}",
                 "cd /tmp/{$uuid}",
-                $cloneCommand,
+                $quietCloneCommand,
                 'git sparse-checkout init --cone',
                 "git sparse-checkout set {$fileList->implode(' ')}",
                 'git read-tree -mu HEAD',

--- a/tests/Unit/ApplicationComposeLoadCommandOutputTest.php
+++ b/tests/Unit/ApplicationComposeLoadCommandOutputTest.php
@@ -1,0 +1,10 @@
+<?php
+
+it('ensures loadComposeFile uses quiet clone to avoid polluting compose output', function () {
+    $applicationModel = file_get_contents(__DIR__.'/../../app/Models/Application.php');
+
+    expect($applicationModel)
+        ->toContain("$quietCloneCommand = preg_replace('/^git clone\\b/', 'git clone --quiet', \$cloneCommand) ?? \$cloneCommand;")
+        ->toContain('$quietCloneCommand,')
+        ->toContain("cat .$workdir$composeFile");
+});


### PR DESCRIPTION
Fixes the compose-loader output contamination in `Application::loadComposeFile()` for Docker Compose applications.

### What changed
- Use quiet clone in the compose load path (`git clone --quiet`) so clone progress lines are not captured as compose content.
- Keep existing command flow and error semantics unchanged otherwise.
- Add a focused unit regression test that locks in quiet clone usage for compose loading.

### Why
Issue #5251 shows deterministic cases where non-YAML git output (e.g. `Cloning into ...`) pollutes `docker_compose_raw`, causing parser failure and downstream `services: {}` deployments. This patch prevents clone noise from being emitted into the captured compose content.

### Validation
- Static/unit regression coverage added: `tests/Unit/ApplicationComposeLoadCommandOutputTest.php`.
- Local full test run was not possible in this environment because dependencies are not installed (`./vendor/bin/pest` missing).

/claim #5251