### PR TITLE
feat: add WordPress OpenLiteSpeed service template

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -1,0 +1,80 @@
+# documentation: https://openlitespeed.org/
+# slogan: WordPress running on OpenLiteSpeed with LSCache support.
+# category: cms
+# tags: cms, blog, content, management, wordpress, openlitespeed, lscache, mariadb
+# logo: svgs/wordpress.svg
+# port: 80
+
+services:
+  wordpress:
+    image: litespeedtech/openlitespeed:latest
+    environment:
+      - SERVICE_URL_WORDPRESS_80
+      - WORDPRESS_DB_HOST=mariadb
+      - WORDPRESS_DB_NAME=${MARIADB_DATABASE:-wordpress}
+      - WORDPRESS_DB_USER=${SERVICE_USER_WORDPRESS}
+      - WORDPRESS_DB_PASSWORD=${SERVICE_PASSWORD_WORDPRESS}
+      - WORDPRESS_ADMIN_USER=${SERVICE_USER_WORDPRESSADMIN}
+      - WORDPRESS_ADMIN_PASSWORD=${SERVICE_PASSWORD_WORDPRESSADMIN}
+      - WORDPRESS_ADMIN_EMAIL=${WORDPRESS_ADMIN_EMAIL:-admin@example.com}
+      - WORDPRESS_SITE_TITLE=${WORDPRESS_SITE_TITLE:-WordPress on OpenLiteSpeed}
+    entrypoint:
+      - /bin/bash
+      - -lc
+      - |
+        set -e
+        WORDPRESS_PATH=/var/www/vhosts/localhost/html
+        mkdir -p "$$WORDPRESS_PATH"
+        if ! wp core is-installed --path="$$WORDPRESS_PATH" --allow-root >/dev/null 2>&1; then
+          find "$$WORDPRESS_PATH" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+          wp core download --path="$$WORDPRESS_PATH" --allow-root
+          wp config create \
+            --path="$$WORDPRESS_PATH" \
+            --dbname="$${WORDPRESS_DB_NAME}" \
+            --dbuser="$${WORDPRESS_DB_USER}" \
+            --dbpass="$${WORDPRESS_DB_PASSWORD}" \
+            --dbhost="$${WORDPRESS_DB_HOST}" \
+            --skip-check \
+            --allow-root
+          wp core install \
+            --path="$$WORDPRESS_PATH" \
+            --url="$${SERVICE_URL_WORDPRESS_80:-http://localhost}" \
+            --title="$${WORDPRESS_SITE_TITLE}" \
+            --admin_user="$${WORDPRESS_ADMIN_USER}" \
+            --admin_password="$${WORDPRESS_ADMIN_PASSWORD}" \
+            --admin_email="$${WORDPRESS_ADMIN_EMAIL}" \
+            --skip-email \
+            --allow-root
+          wp plugin install litespeed-cache --activate --path="$$WORDPRESS_PATH" --allow-root
+        fi
+        chown -R 994:994 "$$WORDPRESS_PATH"
+        exec /entrypoint.sh
+    volumes:
+      - wordpress-files:/var/www/vhosts/localhost/html
+      - openlitespeed-conf:/usr/local/lsws/conf
+      - openlitespeed-admin-conf:/usr/local/lsws/admin/conf
+      - openlitespeed-logs:/usr/local/lsws/logs
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 90s
+
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=${SERVICE_PASSWORD_ROOT}
+      - MYSQL_DATABASE=${MARIADB_DATABASE:-wordpress}
+      - MYSQL_USER=${SERVICE_USER_WORDPRESS}
+      - MYSQL_PASSWORD=${SERVICE_PASSWORD_WORDPRESS}
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
## Changes

- Adds a `wordpress-with-openlitespeed` one-click service template.
- Uses the official `litespeedtech/openlitespeed` image with MariaDB 11.
- Bootstraps WordPress through WP-CLI on first start, using Coolify-generated database and admin credentials.
- Persists the WordPress document root, OpenLiteSpeed config/admin config/logs, and MariaDB data.
- Installs and activates the LiteSpeed Cache plugin during first boot.

## Issues

- Fixes coollabsio/coolify#8264
- /claim #8264

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

New service template only. I validated the template syntax and Compose expansion locally. A full Coolify UI screenshot should be added after deploying the service in a local Coolify instance.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex
- How extensively: Used to inspect existing Coolify service template conventions, draft the compose template, and run local syntax checks. The final change was reviewed against existing templates and OpenLiteSpeed Docker behavior.

## Testing

- Parsed `templates/compose/wordpress-with-openlitespeed.yaml` with Ruby YAML.
- Ran `docker compose config --quiet` against the template with top-level named volumes added for validation.
- Confirmed the PR only adds `templates/compose/wordpress-with-openlitespeed.yaml` and does not touch generated `service-templates*.json` files.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
