### PR TITLE
feat(auth): support oauth-only self-registration

### DIFF
--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\ResetsUserPasswords;
 
 class ResetUserPassword implements ResetsUserPasswords
@@ -17,6 +18,12 @@ class ResetUserPassword implements ResetsUserPasswords
      */
     public function reset(User $user, array $input): void
     {
+        if ($user->is_oauth_only) {
+            throw ValidationException::withMessages([
+                'password' => 'Password login is disabled for this account. Use your OAuth provider to sign in.',
+            ]);
+        }
+
         Validator::make($input, [
             'password' => ['required', Password::defaults(), 'confirmed'],
         ])->validate();

--- a/app/Actions/Fortify/UpdateUserPassword.php
+++ b/app/Actions/Fortify/UpdateUserPassword.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\UpdatesUserPasswords;
 
 class UpdateUserPassword implements UpdatesUserPasswords
@@ -17,6 +18,15 @@ class UpdateUserPassword implements UpdatesUserPasswords
      */
     public function update(User $user, array $input): void
     {
+        if ($user->is_oauth_only) {
+            $exception = ValidationException::withMessages([
+                'password' => 'Password login is disabled for this account. Use your OAuth provider to sign in.',
+            ]);
+            $exception->errorBag = 'updatePassword';
+
+            throw $exception;
+        }
+
         Validator::make($input, [
             'current_password' => ['required', 'string', 'current_password:web'],
             'password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -78,6 +78,10 @@ class Controller extends BaseController
                 return response()->json(['message' => 'Transactional emails are not active'], 400);
             }
             $request->validate([Fortify::email() => 'required|email']);
+            $user = User::whereEmail((string) $request->input(Fortify::email()))->first();
+            if ($user?->is_oauth_only) {
+                return app(SuccessfulPasswordResetLinkRequestResponse::class, ['status' => Password::RESET_LINK_SENT]);
+            }
             $status = Password::broker(config('fortify.passwords'))->sendResetLink(
                 $request->only(Fortify::email())
             );

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -26,15 +26,12 @@ class OauthController extends Controller
             $email = strtolower($email);
             $user = User::whereEmail($email)->first();
             if (! $user) {
-                $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
-                    abort(403, 'Registration is disabled');
-                }
-
-                $user = User::create([
+                $user = (new User)->forceFill([
                     'name' => $oauthUser->name,
                     'email' => $email,
+                    'is_oauth_only' => true,
                 ]);
+                $user->save();
             }
             Auth::login($user);
 

--- a/app/Livewire/Profile/Index.php
+++ b/app/Livewire/Profile/Index.php
@@ -240,6 +240,12 @@ class Index extends Component
     public function resetPassword()
     {
         try {
+            if (! auth()->user()->canUsePasswordAuth()) {
+                $this->dispatch('error', 'Password login is disabled for this account. Use your OAuth provider to sign in.');
+
+                return;
+            }
+
             $this->validate([
                 'current_password' => ['required'],
                 'new_password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -34,6 +34,7 @@ use OpenApi\Attributes as OA;
         'email_verified_at' => ['type' => 'string', 'description' => 'The date when the user email was verified.'],
         'created_at' => ['type' => 'string', 'description' => 'The date when the user was created.'],
         'updated_at' => ['type' => 'string', 'description' => 'The date when the user was updated.'],
+        'is_oauth_only' => ['type' => 'boolean', 'description' => 'Whether the account is restricted to OAuth sign-in only.'],
         'two_factor_confirmed_at' => ['type' => 'string', 'description' => 'The date when the user two factor was confirmed.'],
         'force_password_reset' => ['type' => 'boolean', 'description' => 'The flag to force the user to reset the password.'],
         'marketing_emails' => ['type' => 'boolean', 'description' => 'The flag to receive marketing emails.'],
@@ -63,6 +64,7 @@ class User extends Authenticatable implements SendsEmail
 
     protected $casts = [
         'email_verified_at' => 'datetime',
+        'is_oauth_only' => 'boolean',
         'force_password_reset' => 'boolean',
         'show_boarding' => 'boolean',
         'email_change_code_expires_at' => 'datetime',
@@ -486,5 +488,10 @@ class User extends Authenticatable implements SendsEmail
     public function hasPassword(): bool
     {
         return ! empty($this->password);
+    }
+
+    public function canUsePasswordAuth(): bool
+    {
+        return $this->hasPassword() && ! $this->is_oauth_only;
     }
 }

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -76,6 +76,7 @@ class FortifyServiceProvider extends ServiceProvider
             $user = User::where('email', $email)->with('teams')->first();
             if (
                 $user &&
+                $user->canUsePasswordAuth() &&
                 Hash::check($request->password, $user->password)
             ) {
                 $user->updated_at = now();

--- a/database/migrations/2026_05_19_000000_add_is_oauth_only_to_users_table.php
+++ b/database/migrations/2026_05_19_000000_add_is_oauth_only_to_users_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('is_oauth_only')->default(false)->after('password');
+        });
+
+        DB::table('users')
+            ->whereNull('password')
+            ->update(['is_oauth_only' => true]);
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('is_oauth_only');
+        });
+    }
+};

--- a/resources/views/livewire/profile/index.blade.php
+++ b/resources/views/livewire/profile/index.blade.php
@@ -55,20 +55,29 @@
             </form>
         @endif
     </div>
-    <form wire:submit='resetPassword' class="flex flex-col pt-4">
-        <div class="flex items-center gap-2 pb-2">
-            <h2>Change Password</h2>
-            <x-forms.button type="submit" label="Save">Save</x-forms.button>
-        </div>
-        <div class="text-xs font-bold dark:text-warning pb-2">Resetting the password will logout all sessions.</div>
-        <div class="flex flex-col gap-2">
-            <x-forms.input id="current_password" label="Current Password" required type="password" />
-            <div class="flex gap-2">
-                <x-forms.input id="new_password" label="New Password" required type="password" />
-                <x-forms.input id="new_password_confirmation" label="New Password Again" required type="password" />
+    @if (auth()->user()->canUsePasswordAuth())
+        <form wire:submit='resetPassword' class="flex flex-col pt-4">
+            <div class="flex items-center gap-2 pb-2">
+                <h2>Change Password</h2>
+                <x-forms.button type="submit" label="Save">Save</x-forms.button>
+            </div>
+            <div class="text-xs font-bold dark:text-warning pb-2">Resetting the password will logout all sessions.</div>
+            <div class="flex flex-col gap-2">
+                <x-forms.input id="current_password" label="Current Password" required type="password" />
+                <div class="flex gap-2">
+                    <x-forms.input id="new_password" label="New Password" required type="password" />
+                    <x-forms.input id="new_password_confirmation" label="New Password Again" required type="password" />
+                </div>
+            </div>
+        </form>
+    @else
+        <div class="flex flex-col pt-4">
+            <h2 class="pb-2">Change Password</h2>
+            <div class="text-xs font-bold dark:text-warning">
+                This account is managed by an OAuth provider, so local password login is disabled.
             </div>
         </div>
-    </form>
+    @endif
     <h2 class="py-4">Two-factor Authentication</h2>
     @if (session('status') == 'two-factor-authentication-enabled')
         <div class="mb-4 font-medium">

--- a/tests/Feature/OauthControllerTest.php
+++ b/tests/Feature/OauthControllerTest.php
@@ -48,6 +48,32 @@ it('logs in an existing user when the oauth provider returns a mixed-case email'
     expect(User::count())->toBe(1);
 });
 
+it('creates oauth-only users even when general registration is disabled', function () {
+    config()->set('app.maintenance.driver', 'file');
+
+    $provider = \Mockery::mock();
+    $provider->shouldReceive('setConfig')->once()->andReturnSelf();
+    $provider->shouldReceive('with')->once()->with(['hd' => 'example.com'])->andReturnSelf();
+    $provider->shouldReceive('user')->once()->andReturn((object) [
+        'email' => 'new-user@example.edu',
+        'name' => 'Example User',
+        'id' => 'google-user-id',
+    ]);
+
+    Socialite::shouldReceive('driver')->once()->with('google')->andReturn($provider);
+
+    $response = $this->get(route('auth.callback', 'google'));
+
+    $response->assertRedirect('/');
+    $user = User::whereEmail('new-user@example.edu')->first();
+
+    expect($user)
+        ->not->toBeNull()
+        ->and($user->is_oauth_only)->toBeTrue()
+        ->and($user->password)->toBeNull();
+    $this->assertAuthenticatedAs($user);
+});
+
 it('rejects oauth logins when the provider does not return an email address', function (?string $providerEmail) {
     config()->set('app.maintenance.driver', 'file');
     InstanceSettings::firstOrCreate([

--- a/tests/Feature/OauthOnlyPasswordFlowTest.php
+++ b/tests/Feature/OauthOnlyPasswordFlowTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Actions\Fortify\ResetUserPassword;
+use App\Actions\Fortify\UpdateUserPassword;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
+
+uses(RefreshDatabase::class);
+
+it('prevents oauth-only users from creating a password through the reset flow', function () {
+    $newPassword = str_repeat('n', 24);
+
+    $user = User::factory()->create([
+        'password' => null,
+        'is_oauth_only' => true,
+    ]);
+
+    expect(fn () => app(ResetUserPassword::class)->reset($user, [
+        'password' => $newPassword,
+        'password_confirmation' => $newPassword,
+    ]))->toThrow(ValidationException::class);
+});
+
+it('prevents oauth-only users from switching to local password login', function () {
+    $currentPassword = str_repeat('c', 24);
+    $newPassword = str_repeat('n', 24);
+
+    $user = User::factory()->create([
+        'password' => Hash::make($currentPassword),
+        'is_oauth_only' => true,
+    ]);
+
+    expect(fn () => app(UpdateUserPassword::class)->update($user, [
+        'current_password' => $currentPassword,
+        'password' => $newPassword,
+        'password_confirmation' => $newPassword,
+    ]))->toThrow(ValidationException::class);
+});


### PR DESCRIPTION
## Changes

- allow OAuth callbacks to create a new user even when general self-registration is disabled
- add an `is_oauth_only` flag for provider-managed accounts and backfill existing passwordless users into that state
- block local password login, password reset, and profile password changes for OAuth-only accounts
- add focused feature coverage for OAuth signup and OAuth-only password flows

## Issues

- Fixes #8042

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

- N/A for this auth flow change

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex
- How extensively: Used for implementation drafting, test drafting, and local review; changes were then manually checked and adjusted

## Testing

- Added focused feature tests for OAuth signup when self-registration is disabled and for OAuth-only password restrictions
- I could not run the Laravel test suite in this workspace because PHP, Composer, and Docker were not available locally
- Manual verification steps prepared:
  1. disable general self-registration
  2. configure a working OAuth provider
  3. sign in with a new OAuth user and confirm account creation succeeds
  4. confirm the OAuth-only user cannot use email/password login, password reset, or local password changes
  5. confirm an existing non-OAuth user can still use normal password login

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
