### PR TITLE
Add WordPress OpenLiteSpeed service template

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -1,0 +1,51 @@
+# documentation: https://docs.litespeedtech.com/cloud/docker/ols-wordpress/
+# slogan: WordPress running on OpenLiteSpeed with MariaDB and LiteSpeed Cache support.
+# category: cms
+# tags: cms, blog, content, management, wordpress, openlitespeed, litespeed, mariadb
+# logo: svgs/wordpress.svg
+# port: 80
+
+services:
+  litespeed:
+    image: litespeedtech/openlitespeed:${OLS_VERSION:-1.8.5}-${PHP_VERSION:-lsphp85}
+    volumes:
+      - litespeed-conf:/usr/local/lsws/conf
+      - litespeed-admin-conf:/usr/local/lsws/admin/conf
+      - litespeed-bin:/usr/local/bin
+      - wordpress-sites:/var/www/vhosts
+      - litespeed-acme:/root/.acme.sh
+      - litespeed-logs:/usr/local/lsws/logs
+    environment:
+      - SERVICE_URL_LITESPEED_80
+      - TZ=${TZ:-UTC}
+      - TimeZone=${TZ:-UTC}
+      - DOMAIN=${SERVICE_FQDN_LITESPEED_80:-localhost}
+      - MYSQL_HOST=mariadb
+      - MYSQL_ROOT_PASSWORD=${SERVICE_PASSWORD_ROOT}
+      - MYSQL_DATABASE=${MYSQL_DATABASE:-wordpress}
+      - MYSQL_USER=${SERVICE_USER_WORDPRESS}
+      - MYSQL_PASSWORD=${SERVICE_PASSWORD_WORDPRESS}
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+
+  mariadb:
+    image: mariadb:11.4
+    command: ["--max-allowed-packet=512M"]
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=${SERVICE_PASSWORD_ROOT}
+      - MYSQL_DATABASE=${MYSQL_DATABASE:-wordpress}
+      - MYSQL_USER=${SERVICE_USER_WORDPRESS}
+      - MYSQL_PASSWORD=${SERVICE_PASSWORD_WORDPRESS}
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10

--- a/templates/service-templates-latest.json
+++ b/templates/service-templates-latest.json
@@ -5223,6 +5223,25 @@
         "logo": "svgs/wordpress.svg",
         "minversion": "0.0.0"
     },
+    "wordpress-with-openlitespeed": {
+        "documentation": "https://docs.litespeedtech.com/cloud/docker/ols-wordpress/?utm_source=coolify.io",
+        "slogan": "WordPress running on OpenLiteSpeed with MariaDB and LiteSpeed Cache support.",
+        "compose": "c2VydmljZXM6CiAgbGl0ZXNwZWVkOgogICAgaW1hZ2U6IGxpdGVzcGVlZHRlY2gvb3BlbmxpdGVzcGVlZDoke09MU19WRVJTSU9OOi0xLjguNX0tJHtQSFBfVkVSU0lPTjotbHNwaHA4NX0KICAgIHZvbHVtZXM6CiAgICAtIGxpdGVzcGVlZC1jb25mOi91c3IvbG9jYWwvbHN3cy9jb25mCiAgICAtIGxpdGVzcGVlZC1hZG1pbi1jb25mOi91c3IvbG9jYWwvbHN3cy9hZG1pbi9jb25mCiAgICAtIGxpdGVzcGVlZC1iaW46L3Vzci9sb2NhbC9iaW4KICAgIC0gd29yZHByZXNzLXNpdGVzOi92YXIvd3d3L3Zob3N0cwogICAgLSBsaXRlc3BlZWQtYWNtZTovcm9vdC8uYWNtZS5zaAogICAgLSBsaXRlc3BlZWQtbG9nczovdXNyL2xvY2FsL2xzd3MvbG9ncwogICAgZW52aXJvbm1lbnQ6CiAgICAtIFNFUlZJQ0VfVVJMX0xJVEVTUEVFRF84MAogICAgLSBUWj0ke1RaOi1VVEN9CiAgICAtIFRpbWVab25lPSR7VFo6LVVUQ30KICAgIC0gRE9NQUlOPSR7U0VSVklDRV9GUUROX0xJVEVTUEVFRF84MDotbG9jYWxob3N0fQogICAgLSBNWVNRTF9IT1NUPW1hcmlhZGIKICAgIC0gTVlTUUxfUk9PVF9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfUk9PVH0KICAgIC0gTVlTUUxfREFUQUJBU0U9JHtNWVNRTF9EQVRBQkFTRTotd29yZHByZXNzfQogICAgLSBNWVNRTF9VU0VSPSR7U0VSVklDRV9VU0VSX1dPUkRQUkVTU30KICAgIC0gTVlTUUxfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX1dPUkRQUkVTU30KICAgIGRlcGVuZHNfb246CiAgICAgIG1hcmlhZGI6CiAgICAgICAgY29uZGl0aW9uOiBzZXJ2aWNlX2hlYWx0aHkKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAtIENNRAogICAgICAtIGN1cmwKICAgICAgLSAiLWYiCiAgICAgIC0gaHR0cDovLzEyNy4wLjAuMQogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCiAgbWFyaWFkYjoKICAgIGltYWdlOiBtYXJpYWRiOjExLjQKICAgIGNvbW1hbmQ6CiAgICAtICItLW1heC1hbGxvd2VkLXBhY2tldD01MTJNIgogICAgdm9sdW1lczoKICAgIC0gbWFyaWFkYi1kYXRhOi92YXIvbGliL215c3FsCiAgICBlbnZpcm9ubWVudDoKICAgIC0gTVlTUUxfUk9PVF9QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfUk9PVH0KICAgIC0gTVlTUUxfREFUQUJBU0U9JHtNWVNRTF9EQVRBQkFTRTotd29yZHByZXNzfQogICAgLSBNWVNRTF9VU0VSPSR7U0VSVklDRV9VU0VSX1dPUkRQUkVTU30KICAgIC0gTVlTUUxfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX1dPUkRQUkVTU30KICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAtIENNRAogICAgICAtIGhlYWx0aGNoZWNrLnNoCiAgICAgIC0gIi0tY29ubmVjdCIKICAgICAgLSAiLS1pbm5vZGJfaW5pdGlhbGl6ZWQiCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiAyMHMKICAgICAgcmV0cmllczogMTAK",
+        "tags": [
+            "cms",
+            "blog",
+            "content",
+            "management",
+            "wordpress",
+            "openlitespeed",
+            "litespeed",
+            "mariadb"
+        ],
+        "category": "cms",
+        "logo": "svgs/wordpress.svg",
+        "minversion": "0.0.0",
+        "port": "80"
+    },
     "wordpress-without-database": {
         "documentation": "https://wordpress.org?utm_source=coolify.io",
         "slogan": "WordPress is open source software you can use to create a beautiful website, blog, or app.",

--- a/templates/service-templates.json
+++ b/templates/service-templates.json
@@ -5223,6 +5223,25 @@
         "logo": "svgs/wordpress.svg",
         "minversion": "0.0.0"
     },
+    "wordpress-with-openlitespeed": {
+        "documentation": "https://docs.litespeedtech.com/cloud/docker/ols-wordpress/?utm_source=coolify.io",
+        "slogan": "WordPress running on OpenLiteSpeed with MariaDB and LiteSpeed Cache support.",
+        "compose": "c2VydmljZXM6CiAgbGl0ZXNwZWVkOgogICAgaW1hZ2U6IGxpdGVzcGVlZHRlY2gvb3BlbmxpdGVzcGVlZDoke09MU19WRVJTSU9OOi0xLjguNX0tJHtQSFBfVkVSU0lPTjotbHNwaHA4NX0KICAgIHZvbHVtZXM6CiAgICAtIGxpdGVzcGVlZC1jb25mOi91c3IvbG9jYWwvbHN3cy9jb25mCiAgICAtIGxpdGVzcGVlZC1hZG1pbi1jb25mOi91c3IvbG9jYWwvbHN3cy9hZG1pbi9jb25mCiAgICAtIGxpdGVzcGVlZC1iaW46L3Vzci9sb2NhbC9iaW4KICAgIC0gd29yZHByZXNzLXNpdGVzOi92YXIvd3d3L3Zob3N0cwogICAgLSBsaXRlc3BlZWQtYWNtZTovcm9vdC8uYWNtZS5zaAogICAgLSBsaXRlc3BlZWQtbG9nczovdXNyL2xvY2FsL2xzd3MvbG9ncwogICAgZW52aXJvbm1lbnQ6CiAgICAtIFNFUlZJQ0VfRlFETl9MSVRFU1BFRURfODAKICAgIC0gVFo9JHtUWjotVVRDfQogICAgLSBUaW1lWm9uZT0ke1RaOi1VVEN9CiAgICAtIERPTUFJTj0ke1NFUlZJQ0VfRlFETl9MSVRFU1BFRURfODA6LWxvY2FsaG9zdH0KICAgIC0gTVlTUUxfSE9TVD1tYXJpYWRiCiAgICAtIE1ZU1FMX1JPT1RfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX1JPT1R9CiAgICAtIE1ZU1FMX0RBVEFCQVNFPSR7TVlTUUxfREFUQUJBU0U6LXdvcmRwcmVzc30KICAgIC0gTVlTUUxfVVNFUj0ke1NFUlZJQ0VfVVNFUl9XT1JEUFJFU1N9CiAgICAtIE1ZU1FMX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9XT1JEUFJFU1N9CiAgICBkZXBlbmRzX29uOgogICAgICBtYXJpYWRiOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5CiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgLSBDTUQKICAgICAgLSBjdXJsCiAgICAgIC0gIi1mIgogICAgICAtIGh0dHA6Ly8xMjcuMC4wLjEKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDIwcwogICAgICByZXRyaWVzOiAxMAogIG1hcmlhZGI6CiAgICBpbWFnZTogbWFyaWFkYjoxMS40CiAgICBjb21tYW5kOgogICAgLSAiLS1tYXgtYWxsb3dlZC1wYWNrZXQ9NTEyTSIKICAgIHZvbHVtZXM6CiAgICAtIG1hcmlhZGItZGF0YTovdmFyL2xpYi9teXNxbAogICAgZW52aXJvbm1lbnQ6CiAgICAtIE1ZU1FMX1JPT1RfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX1JPT1R9CiAgICAtIE1ZU1FMX0RBVEFCQVNFPSR7TVlTUUxfREFUQUJBU0U6LXdvcmRwcmVzc30KICAgIC0gTVlTUUxfVVNFUj0ke1NFUlZJQ0VfVVNFUl9XT1JEUFJFU1N9CiAgICAtIE1ZU1FMX1BBU1NXT1JEPSR7U0VSVklDRV9QQVNTV09SRF9XT1JEUFJFU1N9CiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgLSBDTUQKICAgICAgLSBoZWFsdGhjaGVjay5zaAogICAgICAtICItLWNvbm5lY3QiCiAgICAgIC0gIi0taW5ub2RiX2luaXRpYWxpemVkIgogICAgICBpbnRlcnZhbDogNXMKICAgICAgdGltZW91dDogMjBzCiAgICAgIHJldHJpZXM6IDEwCg==",
+        "tags": [
+            "cms",
+            "blog",
+            "content",
+            "management",
+            "wordpress",
+            "openlitespeed",
+            "litespeed",
+            "mariadb"
+        ],
+        "category": "cms",
+        "logo": "svgs/wordpress.svg",
+        "minversion": "0.0.0",
+        "port": "80"
+    },
     "wordpress-without-database": {
         "documentation": "https://wordpress.org?utm_source=coolify.io",
         "slogan": "WordPress is open source software you can use to create a beautiful website, blog, or app.",


### PR DESCRIPTION
## Summary
- Add a WordPress + OpenLiteSpeed + MariaDB one-click service template
- Register the template in both generated service template JSON files
- Use the existing WordPress logo/category and Coolify service URL/FQDN conventions

Fixes #8264

## Verification
- ruby -ryaml parsed templates/compose/wordpress-with-openlitespeed.yaml
- ruby -rjson parsed templates/service-templates-latest.json and templates/service-templates.json
- verified generated entries exist and the FQDN template uses SERVICE_FQDN_LITESPEED_80
- git diff --check

## Notes
- I could not run php artisan generate:services or a live Coolify deployment in this environment because PHP/composer are not installed here.