### PR TITLE
feat: add WordPress OpenLiteSpeed service template

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -1,0 +1,51 @@
+# documentation: https://docs.litespeedtech.com/cloud/docker/ols-wordpress/
+# slogan: WordPress running on OpenLiteSpeed with MariaDB and LiteSpeed Cache support.
+# category: cms
+# tags: cms, blog, content, management, wordpress, openlitespeed, litespeed, mariadb
+# logo: svgs/wordpress.svg
+# port: 80
+
+services:
+  litespeed:
+    image: litespeedtech/openlitespeed:${OLS_VERSION:-1.8.5}-${PHP_VERSION:-lsphp85}
+    volumes:
+      - litespeed-conf:/usr/local/lsws/conf
+      - litespeed-admin-conf:/usr/local/lsws/admin/conf
+      - litespeed-bin:/usr/local/bin
+      - wordpress-sites:/var/www/vhosts
+      - litespeed-acme:/root/.acme.sh
+      - litespeed-logs:/usr/local/lsws/logs
+    environment:
+      - SERVICE_URL_LITESPEED_80
+      - TZ=${TZ:-UTC}
+      - TimeZone=${TZ:-UTC}
+      - DOMAIN=${SERVICE_FQDN_LITESPEED_80:-localhost}
+      - MYSQL_HOST=mariadb
+      - MYSQL_ROOT_PASSWORD=${SERVICE_PASSWORD_ROOT}
+      - MYSQL_DATABASE=${MYSQL_DATABASE:-wordpress}
+      - MYSQL_USER=${SERVICE_USER_WORDPRESS}
+      - MYSQL_PASSWORD=${SERVICE_PASSWORD_WORDPRESS}
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+
+  mariadb:
+    image: mariadb:11.4
+    command: ["--max-allowed-packet=512M"]
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=${SERVICE_PASSWORD_ROOT}
+      - MYSQL_DATABASE=${MYSQL_DATABASE:-wordpress}
+      - MYSQL_USER=${SERVICE_USER_WORDPRESS}
+      - MYSQL_PASSWORD=${SERVICE_PASSWORD_WORDPRESS}
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
## Changes

- Added a one-click WordPress + OpenLiteSpeed + MariaDB service template.
- Kept the generated service template JSON files untouched because this repository blocks direct edits to generated template indexes.

## Issues

- Fixes coollabsio/coolify#8264
- /claim #8264
- Reopening after the first PR targeted `v4.x`; this version targets `next` and only changes the source compose template.

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not available in this environment.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Used to inspect existing service template patterns and prepare the compose template; human account owner should review before merge.

## Testing

- Parsed `templates/compose/wordpress-with-openlitespeed.yaml` with Ruby YAML.
- Ran `git diff --check`.
- Did not run a live Coolify deployment because this environment does not have the PHP/composer Coolify runtime configured.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
