### PR TITLE
fix: retry transient git import failures

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -1314,7 +1314,68 @@ class Application extends BaseModel
             $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && {$sshCommand} git lfs pull";
         }
 
-        return $git_clone_command;
+        return $this->wrapGitImportCommandWithRetry($git_clone_command, $escapedBaseDir);
+    }
+
+    private function wrapGitImportCommandWithRetry(string $git_import_command, string $escapedBaseDir): string
+    {
+        $transientGitFailurePattern = implode('|', [
+            'curl 92',
+            'HTTP/2 stream',
+            'early EOF',
+            'fetch-pack: unexpected disconnect',
+            'invalid index-pack output',
+            'remote end hung up unexpectedly',
+            'connection reset',
+            'Operation timed out',
+        ]);
+
+        $script = <<<'BASH'
+set -o pipefail
+attempt=1
+max_attempts=3
+while true; do
+    if [ "$attempt" -gt 1 ]; then
+        rm -rf -- __COOLIFY_GIT_IMPORT_BASE_DIR__
+    fi
+
+    output_file="$(mktemp)"
+    if { __COOLIFY_GIT_IMPORT_COMMAND__; } >"$output_file" 2>&1; then
+        cat "$output_file"
+        rm -f "$output_file"
+        exit 0
+    fi
+
+    status="$?"
+    cat "$output_file"
+
+    if [ "$attempt" -ge "$max_attempts" ] || ! grep -Eiq __COOLIFY_GIT_TRANSIENT_PATTERN__ "$output_file"; then
+        rm -f "$output_file"
+        exit "$status"
+    fi
+
+    rm -f "$output_file"
+    attempt=$((attempt + 1))
+    echo "Retrying Git import after transient network failure (attempt $attempt/$max_attempts)..."
+    sleep $((attempt * 2))
+done
+BASH;
+
+        $script = str_replace(
+            [
+                '__COOLIFY_GIT_IMPORT_BASE_DIR__',
+                '__COOLIFY_GIT_IMPORT_COMMAND__',
+                '__COOLIFY_GIT_TRANSIENT_PATTERN__',
+            ],
+            [
+                $escapedBaseDir,
+                $git_import_command,
+                escapeshellarg($transientGitFailurePattern),
+            ],
+            $script
+        );
+
+        return 'bash -lc '.escapeshellarg($script);
     }
 
     public function getGitRemoteStatus(string $deployment_uuid)

--- a/tests/Feature/ApplicationRollbackTest.php
+++ b/tests/Feature/ApplicationRollbackTest.php
@@ -72,7 +72,7 @@ describe('Application Rollback', function () {
 
         // escapeshellarg wraps the value in single quotes, neutralizing metacharacters
         expect($result)
-            ->toContain("checkout 'abc123; rm -rf /'")
+            ->toContain("checkout '\\''abc123; rm -rf /'\\''")
             ->not->toContain('checkout abc123; rm -rf /');
     });
 
@@ -142,5 +142,22 @@ describe('Application Rollback', function () {
         expect($result)
             ->toContain('GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" git lfs pull')
             ->not->toContain('-i /root/.ssh/id_rsa');
+    });
+
+    test('setGitImportSettings retries transient git import failures', function () {
+        $result = $this->application->setGitImportSettings(
+            deployment_uuid: 'test-uuid',
+            git_clone_command: 'git clone',
+            public: true,
+        );
+
+        expect($result)
+            ->toContain('bash -lc')
+            ->toContain('max_attempts=3')
+            ->toContain("rm -rf -- '\\''/artifacts/test-uuid'\\''")
+            ->toContain('Retrying Git import after transient network failure')
+            ->toContain('curl 92')
+            ->toContain('early EOF')
+            ->toContain('invalid index-pack output');
     });
 });


### PR DESCRIPTION
## Changes

- Adds a bounded retry wrapper around application Git import commands so transient clone and fetch failures can recover instead of failing the deployment immediately.
- Retries only when command output matches network or packfile failure signatures like HTTP/2 stream errors, early EOF, unexpected disconnects, invalid pack output, connection resets, or timeouts.
- Removes the partial artifact directory before a retry so the next clone starts from a clean path.
- Leaves non-transient failures such as auth, permission, and missing repository errors on the normal fast-fail path.

## Issues

- /claim #5251
- Fixes #5251

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No UI change.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Used to inspect the affected code path, implement the retry wrapper, and run focused local verification. I reviewed the diff and test output before submitting.

## Testing

- PHP syntax checks passed for the changed application model and feature test.
- Pint passed on the changed files.
- Git diff whitespace check passed.
- The focused ApplicationRollbackTest suite passed.
- The local Docker development stack started successfully and the health endpoint returned OK after startup.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.