### PR TITLE
fix: keep compose clone output out of raw YAML

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -1525,7 +1525,7 @@ class Application extends BaseModel
 
         $git_clone_command = "git clone{$depthFlag}{$submoduleFlags} -b {$escapedBranch}";
         if ($only_checkout) {
-            $git_clone_command = "git clone{$depthFlag}{$submoduleFlags} --no-checkout -b {$escapedBranch}";
+            $git_clone_command = "git clone --quiet{$depthFlag}{$submoduleFlags} --no-checkout -b {$escapedBranch}";
         }
         if ($pull_request_id !== 0) {
             $pr_branch_name = "pr-{$pull_request_id}-coolify";
@@ -1858,7 +1858,7 @@ class Application extends BaseModel
             return;
         }
         $uuid = new Cuid2;
-        ['commands' => $cloneCommand] = $this->generateGitImportCommands(deployment_uuid: $uuid, only_checkout: true, exec_in_docker: false, custom_base_dir: '.');
+        ['commands' => $cloneCommand] = $this->generateGitImportCommands(deployment_uuid: $uuid, only_checkout: true, exec_in_docker: false, custom_base_dir: 'checkout');
         $workdir = rtrim($this->base_directory, '/');
         $composeFile = $this->docker_compose_location;
         $fileList = collect([".$workdir$composeFile"]);
@@ -1888,6 +1888,7 @@ class Application extends BaseModel
                 "mkdir -p /tmp/{$uuid}",
                 "cd /tmp/{$uuid}",
                 $cloneCommand,
+                'cd checkout',
                 'git sparse-checkout init',
                 "git sparse-checkout set {$fileList->implode(' ')}",
                 'git read-tree -mu HEAD',
@@ -1899,6 +1900,7 @@ class Application extends BaseModel
                 "mkdir -p /tmp/{$uuid}",
                 "cd /tmp/{$uuid}",
                 $cloneCommand,
+                'cd checkout',
                 'git sparse-checkout init --cone',
                 "git sparse-checkout set {$fileList->implode(' ')}",
                 'git read-tree -mu HEAD',

--- a/tests/Unit/ApplicationGitImportCommandsTest.php
+++ b/tests/Unit/ApplicationGitImportCommandsTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Models\Application;
+use App\Models\ApplicationSetting;
+use App\Models\GithubApp;
+
+it('uses quiet clone output when loading only checkout files', function () {
+    $source = Mockery::mock(GithubApp::class)->makePartial();
+    $source->html_url = 'https://github.com';
+    $source->is_public = true;
+    $source->shouldReceive('getMorphClass')->andReturn(GithubApp::class);
+
+    $application = Mockery::mock(Application::class)->makePartial();
+    $application->git_branch = 'main';
+    $application->source = $source;
+    $application->settings = new ApplicationSetting([
+        'is_git_shallow_clone_enabled' => false,
+        'is_git_submodules_enabled' => false,
+    ]);
+    $application->shouldReceive('deploymentType')->andReturn('source');
+    $application->shouldReceive('customRepository')->andReturn([
+        'repository' => 'coollabsio/coolify',
+        'port' => 22,
+    ]);
+
+    $result = $application->generateGitImportCommands(
+        deployment_uuid: 'compose-load-test',
+        exec_in_docker: false,
+        only_checkout: true,
+        custom_base_dir: '.'
+    );
+
+    expect($result['commands'])
+        ->toContain('git clone --quiet --no-checkout')
+        ->not->toContain("git clone --no-checkout");
+});
+
+it('loads compose files from a dedicated checkout directory before catting compose content', function () {
+    $source = file_get_contents(app_path('Models/Application.php'));
+
+    expect($source)
+        ->toContain("custom_base_dir: 'checkout'")
+        ->toContain("'cd checkout'")
+        ->toContain('"cat .$workdir$composeFile"');
+});


### PR DESCRIPTION
## What this PR changes

/claim #5251

This fixes the producer-side compose corruption path described in the latest reproduction notes on #5251.

`Application::loadComposeFile()` was cloning directly into the temporary directory whose combined command output is captured and stored as `docker_compose_raw`. Git clone progress such as `Cloning into '.'...` could therefore be prepended to the compose YAML, causing `Yaml::parse()` to fail and downstream compose generation to write `services: {}`.

The change keeps the sparse checkout in `/tmp/<uuid>/checkout`, enters that directory before sparse-checkout/cat, and uses `git clone --quiet` for the `only_checkout` path so successful clone progress cannot become captured compose content.

## Tests

- `git diff --check`
- `docker run --rm -v "${PWD}:/app" -w /app php:8.4-cli php -l app/Models/Application.php`
- `docker run --rm -v "${PWD}:/app" -w /app php:8.4-cli php -l tests/Unit/ApplicationGitImportCommandsTest.php`

I could not run the Pest test suite on the host because PHP/Composer are not installed in this Windows environment. I added focused regression coverage for the generated command path and the compose loader checkout sequence.

## AI disclosure

I used Codex to inspect the issue context, make the patch, and run the validation above.
