### PR TITLE
feat: support OAuth-only registration

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -22,6 +22,9 @@ class CreateNewUser implements CreatesNewUsers
         if (! $settings->is_registration_enabled) {
             abort(403);
         }
+        if ($settings->is_password_authentication_disabled && User::count() > 0) {
+            abort(403, 'Password authentication is disabled');
+        }
         Validator::make($input, [
             'name' => ['required', 'string', 'max:255'],
             'email' => [

--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -17,6 +17,10 @@ class ResetUserPassword implements ResetsUserPasswords
      */
     public function reset(User $user, array $input): void
     {
+        if (instanceSettings()->is_password_authentication_disabled && $user->id !== 0) {
+            abort(403, 'Password authentication is disabled');
+        }
+
         Validator::make($input, [
             'password' => ['required', Password::defaults(), 'confirmed'],
         ])->validate();

--- a/app/Actions/Fortify/UpdateUserPassword.php
+++ b/app/Actions/Fortify/UpdateUserPassword.php
@@ -17,6 +17,10 @@ class UpdateUserPassword implements UpdatesUserPasswords
      */
     public function update(User $user, array $input): void
     {
+        if (instanceSettings()->is_password_authentication_disabled && $user->id !== 0) {
+            abort(403, 'Password authentication is disabled');
+        }
+
         Validator::make($input, [
             'current_password' => ['required', 'string', 'current_password:web'],
             'password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -27,7 +27,7 @@ class OauthController extends Controller
             $user = User::whereEmail($email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! $settings->is_oauth_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -16,6 +16,12 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $is_oauth_registration_enabled;
+
+    #[Validate('boolean')]
+    public bool $is_password_authentication_disabled;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -44,6 +50,8 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_registration_enabled' => 'boolean',
+            'is_password_authentication_disabled' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => ['nullable', 'string', new ValidDnsServers],
@@ -66,6 +74,8 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled;
+        $this->is_password_authentication_disabled = $this->settings->is_password_authentication_disabled;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -147,6 +157,8 @@ class Advanced extends Component
     {
         try {
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
+            $this->settings->is_password_authentication_disabled = $this->is_password_authentication_disabled;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -18,6 +18,8 @@ class InstanceSettings extends Model
         'do_not_track',
         'is_auto_update_enabled',
         'is_registration_enabled',
+        'is_oauth_registration_enabled',
+        'is_password_authentication_disabled',
         'next_channel',
         'smtp_enabled',
         'smtp_from_address',
@@ -64,6 +66,9 @@ class InstanceSettings extends Model
 
         'allowed_ip_ranges' => 'array',
         'is_auto_update_enabled' => 'boolean',
+        'is_registration_enabled' => 'boolean',
+        'is_oauth_registration_enabled' => 'boolean',
+        'is_password_authentication_disabled' => 'boolean',
         'auto_update_frequency' => 'string',
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -7,6 +7,7 @@ use App\Actions\Fortify\ResetUserPassword;
 use App\Actions\Fortify\UpdateUserPassword;
 use App\Actions\Fortify\UpdateUserProfileInformation;
 use App\Models\OauthSetting;
+use App\Models\TeamInvitation;
 use App\Models\User;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
@@ -76,13 +77,14 @@ class FortifyServiceProvider extends ServiceProvider
             $user = User::where('email', $email)->with('teams')->first();
             if (
                 $user &&
+                (! instanceSettings()->is_password_authentication_disabled || $user->id === 0) &&
                 Hash::check($request->password, $user->password)
             ) {
                 $user->updated_at = now();
                 $user->save();
 
                 // Check if user has a pending invitation they haven't accepted yet
-                $invitation = \App\Models\TeamInvitation::whereEmail($email)->first();
+                $invitation = TeamInvitation::whereEmail($email)->first();
                 if ($invitation && $invitation->isValid()) {
                     // User is logging in for the first time after being invited
                     // Attach them to the invited team if not already attached

--- a/database/migrations/2026_05_20_000000_add_oauth_auth_settings_to_instance_settings_table.php
+++ b/database/migrations/2026_05_20_000000_add_oauth_auth_settings_to_instance_settings_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_registration_enabled')->default(false);
+            $table->boolean('is_password_authentication_disabled')->default(false);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn([
+                'is_oauth_registration_enabled',
+                'is_password_authentication_disabled',
+            ]);
+        });
+    }
+};

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -42,6 +42,16 @@
                         </div>
                     @endif
                     <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_oauth_registration_enabled"
+                            helper="Allow new users to self-register through enabled OAuth providers even when password registration is disabled."
+                            label="OAuth Registration Allowed" />
+                    </div>
+                    <div class="md:w-96">
+                        <x-forms.checkbox instantSave id="is_password_authentication_disabled"
+                            helper="Disable password login for non-root users. OAuth users still authenticate through enabled OAuth providers."
+                            label="Disable Password Login" />
+                    </div>
+                    <div class="md:w-96">
                         <x-forms.checkbox instantSave id="do_not_track"
                             helper="Opt out of anonymous usage tracking. When enabled, this instance will not report to coolify.io's installation count and will not send error reports to help improve Coolify."
                             label="Do Not Track" />

--- a/tests/Feature/OauthControllerTest.php
+++ b/tests/Feature/OauthControllerTest.php
@@ -1,17 +1,24 @@
 <?php
 
+use App\Actions\Fortify\CreateNewUser;
+use App\Actions\Fortify\ResetUserPassword;
+use App\Actions\Fortify\UpdateUserPassword;
 use App\Models\InstanceSettings;
 use App\Models\OauthSetting;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
 use Laravel\Socialite\Facades\Socialite;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 uses(RefreshDatabase::class);
 
 beforeEach(function () {
-    InstanceSettings::create([
+    InstanceSettings::forceCreate([
         'id' => 0,
         'is_registration_enabled' => false,
+        'is_oauth_registration_enabled' => false,
+        'is_password_authentication_disabled' => false,
     ]);
 
     OauthSetting::create([
@@ -23,6 +30,20 @@ beforeEach(function () {
     ]);
 });
 
+function mockGoogleOauthUser(?string $email = 'username@example.edu'): void
+{
+    $provider = Mockery::mock();
+    $provider->shouldReceive('setConfig')->once()->andReturnSelf();
+    $provider->shouldReceive('with')->once()->with(['hd' => 'example.com'])->andReturnSelf();
+    $provider->shouldReceive('user')->once()->andReturn((object) [
+        'email' => $email,
+        'name' => 'Example User',
+        'id' => 'google-user-id',
+    ]);
+
+    Socialite::shouldReceive('driver')->once()->with('google')->andReturn($provider);
+}
+
 it('logs in an existing user when the oauth provider returns a mixed-case email', function () {
     config()->set('app.maintenance.driver', 'file');
 
@@ -30,7 +51,7 @@ it('logs in an existing user when the oauth provider returns a mixed-case email'
         'email' => 'username@example.edu',
     ]);
 
-    $provider = \Mockery::mock();
+    $provider = Mockery::mock();
     $provider->shouldReceive('setConfig')->once()->andReturnSelf();
     $provider->shouldReceive('with')->once()->with(['hd' => 'example.com'])->andReturnSelf();
     $provider->shouldReceive('user')->once()->andReturn((object) [
@@ -48,6 +69,107 @@ it('logs in an existing user when the oauth provider returns a mixed-case email'
     expect(User::count())->toBe(1);
 });
 
+it('allows oauth self-registration when password registration is disabled', function () {
+    config()->set('app.maintenance.driver', 'file');
+    InstanceSettings::findOrFail(0)->update([
+        'is_registration_enabled' => false,
+        'is_oauth_registration_enabled' => true,
+    ]);
+    mockGoogleOauthUser('NewUser@example.edu');
+
+    $response = $this->get(route('auth.callback', 'google'));
+
+    $response->assertRedirect('/');
+    $user = User::whereEmail('newuser@example.edu')->first();
+    expect($user)->not->toBeNull()
+        ->and($user->password)->toBeNull();
+    $this->assertAuthenticatedAs($user);
+});
+
+it('rejects oauth self-registration when both registration modes are disabled', function () {
+    config()->set('app.maintenance.driver', 'file');
+    mockGoogleOauthUser('newuser@example.edu');
+
+    $response = $this->from('/login')->get(route('auth.callback', 'google'));
+
+    $response->assertRedirect('/login');
+    expect(User::count())->toBe(0);
+});
+
+it('blocks password login for non-root users when password authentication is disabled', function () {
+    config()->set('app.maintenance.driver', 'file');
+    InstanceSettings::findOrFail(0)->update([
+        'is_password_authentication_disabled' => true,
+    ]);
+    User::factory()->create([
+        'email' => 'user@example.edu',
+        'password' => Hash::make('Password1!'),
+    ]);
+
+    $response = $this->post('/login', [
+        'email' => 'user@example.edu',
+        'password' => 'Password1!',
+    ]);
+
+    $response->assertRedirect('/');
+    $this->assertGuest();
+});
+
+it('keeps root password login available when password authentication is disabled', function () {
+    config()->set('app.maintenance.driver', 'file');
+    InstanceSettings::findOrFail(0)->update([
+        'is_password_authentication_disabled' => true,
+    ]);
+    $root = User::factory()->create([
+        'id' => 0,
+        'email' => 'root@example.edu',
+        'password' => Hash::make('Password1!'),
+    ]);
+
+    $response = $this->post('/login', [
+        'email' => 'root@example.edu',
+        'password' => 'Password1!',
+    ]);
+
+    $response->assertRedirect('/');
+    $this->assertAuthenticatedAs($root);
+});
+
+it('blocks new password users when password authentication is disabled', function () {
+    InstanceSettings::findOrFail(0)->update([
+        'is_registration_enabled' => true,
+        'is_password_authentication_disabled' => true,
+    ]);
+    User::factory()->create();
+
+    expect(fn () => (new CreateNewUser)->create([
+        'name' => 'Password User',
+        'email' => 'password-user@example.edu',
+        'password' => 'Password1!',
+        'password_confirmation' => 'Password1!',
+    ]))->toThrow(HttpException::class);
+});
+
+it('blocks password creation for non-root users when password authentication is disabled', function () {
+    InstanceSettings::findOrFail(0)->update([
+        'is_password_authentication_disabled' => true,
+    ]);
+    $user = User::factory()->create([
+        'password' => null,
+    ]);
+
+    expect(fn () => (new ResetUserPassword)->reset($user, [
+        'password' => 'Password1!',
+        'password_confirmation' => 'Password1!',
+    ]))->toThrow(HttpException::class);
+
+    expect(fn () => (new UpdateUserPassword)->update($user, [
+        'current_password' => 'Password1!',
+        'password' => 'NewPassword1!',
+        'password_confirmation' => 'NewPassword1!',
+    ]))->toThrow(HttpException::class);
+});
+
 it('rejects oauth logins when the provider does not return an email address', function (?string $providerEmail) {
     config()->set('app.maintenance.driver', 'file');
     InstanceSettings::firstOrCreate([
@@ -57,17 +179,7 @@ it('rejects oauth logins when the provider does not return an email address', fu
     ])->update([
         'is_registration_enabled' => true,
     ]);
-
-    $provider = \Mockery::mock();
-    $provider->shouldReceive('setConfig')->once()->andReturnSelf();
-    $provider->shouldReceive('with')->once()->with(['hd' => 'example.com'])->andReturnSelf();
-    $provider->shouldReceive('user')->once()->andReturn((object) [
-        'email' => $providerEmail,
-        'name' => 'Example User',
-        'id' => 'google-user-id',
-    ]);
-
-    Socialite::shouldReceive('driver')->once()->with('google')->andReturn($provider);
+    mockGoogleOauthUser($providerEmail);
 
     $response = $this->from('/login')->get(route('auth.callback', 'google'));
 


### PR DESCRIPTION
## Changes

- Adds separate instance settings for OAuth self-registration and disabling password authentication.
- Allows enabled OAuth providers to create passwordless users when regular password registration is disabled.
- Blocks non-root password login, password registration, password reset, and password updates when password authentication is disabled while preserving root password access for recovery.
- Adds regression coverage for OAuth-only registration and password-auth disable behavior.

## Issues

- Fixes #8042
- /claim #8042

## Testing

- `vendor/bin/pint --test` on the changed PHP files
- `php artisan test tests/Feature/OauthControllerTest.php --compact`
- Full Spin dev stack was not run because this local Docker install lacks buildx; the focused PHP container tests cover the changed auth paths.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/next/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested the changed auth behavior thoroughly with focused feature tests in a local PHP container. A full Spin instance could not be started because this Docker install lacks buildx.
>
 I verified the affected behavior with focused Laravel feature tests in a PHP container with the required extensions.