### PR TITLE
fix: keep compose loader setup output out of raw yaml

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -1849,6 +1849,13 @@ class Application extends BaseModel
         }
     }
 
+    protected function redirectComposeLoaderOutput(string $command, string $outputLog): string
+    {
+        $escapedOutputLog = escapeshellarg($outputLog);
+
+        return "({$command}) >> {$escapedOutputLog} 2>&1 || { cat {$escapedOutputLog} >&2; exit 1; }";
+    }
+
     public function loadComposeFile($isInit = false, ?string $restoreBaseDirectory = null, ?string $restoreDockerComposeLocation = null)
     {
         // Use provided restore values or capture current values as fallback
@@ -1858,10 +1865,11 @@ class Application extends BaseModel
             return;
         }
         $uuid = new Cuid2;
-        ['commands' => $cloneCommand] = $this->generateGitImportCommands(deployment_uuid: $uuid, only_checkout: true, exec_in_docker: false, custom_base_dir: '.');
+        ['commands' => $cloneCommand] = $this->generateGitImportCommands(deployment_uuid: $uuid, only_checkout: true, exec_in_docker: false, custom_base_dir: 'checkout');
         $workdir = rtrim($this->base_directory, '/');
         $composeFile = $this->docker_compose_location;
         $fileList = collect([".$workdir$composeFile"]);
+        $composeLoaderOutputLog = "/tmp/{$uuid}/compose-loader-output.log";
         $gitRemoteStatus = $this->getGitRemoteStatus(deployment_uuid: $uuid);
         if (! $gitRemoteStatus['is_accessible']) {
             throw new RuntimeException('Failed to read Git source. Please verify repository access and try again.');
@@ -1887,10 +1895,11 @@ class Application extends BaseModel
                 "rm -rf /tmp/{$uuid}",
                 "mkdir -p /tmp/{$uuid}",
                 "cd /tmp/{$uuid}",
-                $cloneCommand,
-                'git sparse-checkout init',
-                "git sparse-checkout set {$fileList->implode(' ')}",
-                'git read-tree -mu HEAD',
+                $this->redirectComposeLoaderOutput($cloneCommand, $composeLoaderOutputLog),
+                'cd checkout',
+                $this->redirectComposeLoaderOutput('git sparse-checkout init', $composeLoaderOutputLog),
+                $this->redirectComposeLoaderOutput("git sparse-checkout set {$fileList->implode(' ')}", $composeLoaderOutputLog),
+                $this->redirectComposeLoaderOutput('git read-tree -mu HEAD', $composeLoaderOutputLog),
                 "cat .$workdir$composeFile",
             ]);
         } else {
@@ -1898,10 +1907,11 @@ class Application extends BaseModel
                 "rm -rf /tmp/{$uuid}",
                 "mkdir -p /tmp/{$uuid}",
                 "cd /tmp/{$uuid}",
-                $cloneCommand,
-                'git sparse-checkout init --cone',
-                "git sparse-checkout set {$fileList->implode(' ')}",
-                'git read-tree -mu HEAD',
+                $this->redirectComposeLoaderOutput($cloneCommand, $composeLoaderOutputLog),
+                'cd checkout',
+                $this->redirectComposeLoaderOutput('git sparse-checkout init --cone', $composeLoaderOutputLog),
+                $this->redirectComposeLoaderOutput("git sparse-checkout set {$fileList->implode(' ')}", $composeLoaderOutputLog),
+                $this->redirectComposeLoaderOutput('git read-tree -mu HEAD', $composeLoaderOutputLog),
                 "cat .$workdir$composeFile",
             ]);
         }

--- a/tests/Unit/ApplicationComposeLoaderOutputTest.php
+++ b/tests/Unit/ApplicationComposeLoaderOutputTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Models\Application;
+
+it('redirects compose loader setup output away from stdout', function () {
+    $application = new class extends Application
+    {
+        public function wrapComposeLoaderCommand(string $command, string $outputLog): string
+        {
+            return $this->redirectComposeLoaderOutput($command, $outputLog);
+        }
+    };
+
+    $wrappedCommand = $application->wrapComposeLoaderCommand(
+        "git clone --no-checkout -b 'main' 'https://github.com/example/repo' 'checkout'",
+        '/tmp/compose-load-test/compose-loader-output.log'
+    );
+
+    expect($wrappedCommand)->toBe(
+        "(git clone --no-checkout -b 'main' 'https://github.com/example/repo' 'checkout') >> '/tmp/compose-load-test/compose-loader-output.log' 2>&1 || { cat '/tmp/compose-load-test/compose-loader-output.log' >&2; exit 1; }"
+    );
+});
+
+it('keeps compose loader setup commands silent before catting the compose file', function () {
+    $source = file_get_contents(__DIR__.'/../../app/Models/Application.php');
+
+    expect($source)
+        ->toContain("custom_base_dir: 'checkout'")
+        ->toContain('$this->redirectComposeLoaderOutput($cloneCommand, $composeLoaderOutputLog)')
+        ->toContain("'cd checkout'")
+        ->toContain('$this->redirectComposeLoaderOutput(\'git sparse-checkout init --cone\', $composeLoaderOutputLog)')
+        ->toContain('"cat .$workdir$composeFile"');
+});


### PR DESCRIPTION
## Changes

- Clone compose-file checkouts into `/tmp/<uuid>/checkout` before sparse checkout.
- Redirect clone and sparse-checkout setup stdout/stderr into a temporary log, replaying that log to stderr only when a setup step fails.
- Keep the final `cat` as the only stdout-producing step, so setup text cannot be saved into `docker_compose_raw`.
- Add focused coverage for the wrapper and command shape.

/claim #5251

## Issues

- Fixes #5251

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Backend-only change. Manual command reproduction after wrapping setup output:

```text
services:
  web:
    image: nginx
```

Failure path exits non-zero with empty stdout and replays setup logs on stderr.

## AI Assistance

- [x] AI was NOT used to create this PR
- [ ] AI was used (please describe below)

## Testing

- `git diff --check`
- PHP 8.4 container syntax checks for `app/Models/Application.php` and `tests/Unit/ApplicationComposeLoaderOutputTest.php`
- PHP 8.4 container: `php vendor/bin/pest tests/Unit/ApplicationComposeLoaderOutputTest.php --compact` after enabling sockets: 2 passed, 6 assertions
- PHP 8.4 container: `php vendor/bin/pint --dirty --format=agent`
- Manual shell checks for success and failure output routing.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
