### PR TITLE
Fix Huly service template

### DIFF
--- a/templates/compose/huly.yaml
+++ b/templates/compose/huly.yaml
@@ -1,4 +1,3 @@
-# ignore: true
 # documentation: https://huly.io/
 # category: cms
 # slogan: Open Source All-in-One Project Management Platform
@@ -8,7 +7,6 @@
 services:
   mongodb:
     image: "mongo:7-jammy"
-    container_name: mongodb
     environment:
       - PUID=1000
       - PGID=1000
@@ -121,3 +119,8 @@ services:
       resources:
         limits:
           memory: 500M
+
+volumes:
+  huly-db:
+  huly-files:
+  huly-elastic:


### PR DESCRIPTION
Fixes #2543

This enables the existing Huly service template by removing the ignore flag and fixing the compose definition.

Changes:
- Unhide the Huly template so it can be generated into the service templates list
- Remove the hard-coded MongoDB container name
- Declare the missing named volumes used by MongoDB, MinIO, and Elasticsearch

Validation:
- Ran `docker compose -f templates/compose/huly.yaml config`