### PR TITLE
feat: add generic OIDC OAuth provider support

### DIFF
--- a/app/Models/OauthSetting.php
+++ b/app/Models/OauthSetting.php
@@ -28,6 +28,7 @@ class OauthSetting extends Model
                 return filled($this->client_id) && filled($this->client_secret) && filled($this->tenant);
             case 'authentik':
             case 'clerk':
+            case 'oidc':
                 return filled($this->client_id) && filled($this->client_secret) && filled($this->base_url);
             default:
                 return filled($this->client_id) && filled($this->client_secret);

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -10,6 +10,7 @@ use SocialiteProviders\Discord\DiscordExtendSocialite;
 use SocialiteProviders\Google\GoogleExtendSocialite;
 use SocialiteProviders\Infomaniak\InfomaniakExtendSocialite;
 use SocialiteProviders\Manager\SocialiteWasCalled;
+use SocialiteProviders\OIDC\OIDCExtendSocialite;
 use SocialiteProviders\Zitadel\ZitadelExtendSocialite;
 
 class EventServiceProvider extends ServiceProvider
@@ -22,6 +23,7 @@ class EventServiceProvider extends ServiceProvider
             DiscordExtendSocialite::class.'@handle',
             GoogleExtendSocialite::class.'@handle',
             InfomaniakExtendSocialite::class.'@handle',
+            OIDCExtendSocialite::class.'@handle',
             ZitadelExtendSocialite::class.'@handle',
         ],
     ];

--- a/bootstrap/helpers/socialite.php
+++ b/bootstrap/helpers/socialite.php
@@ -33,6 +33,17 @@ function get_socialite_provider(string $provider)
         return Socialite::driver($provider)->setConfig($authentik_clerk_config);
     }
 
+    if ($provider == 'oidc') {
+        $oidc_config = new \SocialiteProviders\Manager\Config(
+            $oauth_setting->client_id,
+            $oauth_setting->client_secret,
+            $oauth_setting->redirect_uri,
+            ['base_url' => $oauth_setting->base_url],
+        );
+
+        return Socialite::driver('oidc')->setConfig($oidc_config);
+    }
+
     if ($provider == 'zitadel') {
         $zitadel_config = new \SocialiteProviders\Manager\Config(
             $oauth_setting->client_id,

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
         "socialiteproviders/google": "^4.1",
         "socialiteproviders/infomaniak": "^4.0",
         "socialiteproviders/microsoft-azure": "^5.2",
+        "socialiteproviders/oidc": "^1.0",
         "socialiteproviders/zitadel": "^4.2",
         "spatie/laravel-activitylog": "^4.11.0",
         "spatie/laravel-data": "^4.19.1",

--- a/config/services.php
+++ b/config/services.php
@@ -67,4 +67,11 @@ return [
         'base_url' => env('ZITADEL_BASE_URL'),
     ],
 
+    'oidc' => [
+        'client_id' => env('OIDC_CLIENT_ID'),
+        'client_secret' => env('OIDC_CLIENT_SECRET'),
+        'redirect' => env('OIDC_REDIRECT_URI'),
+        'base_url' => env('OIDC_BASE_URL'),
+    ],
+
 ];

--- a/database/seeders/OauthSettingSeeder.php
+++ b/database/seeders/OauthSettingSeeder.php
@@ -24,6 +24,7 @@ class OauthSettingSeeder extends Seeder
                 'google',
                 'authentik',
                 'infomaniak',
+                'oidc',
                 'zitadel',
             ]);
 

--- a/lang/de.json
+++ b/lang/de.json
@@ -8,6 +8,7 @@
     "auth.login.gitlab": "Mit GitLab anmelden",
     "auth.login.google": "Mit Google anmelden",
     "auth.login.infomaniak": "Mit Infomaniak anmelden",
+    "auth.login.oidc": "Mit OIDC anmelden",
     "auth.login.zitadel": "Mit Zitadel anmelden",
     "auth.already_registered": "Bereits registriert?",
     "auth.confirm_password": "Passwort bestätigen",

--- a/lang/en.json
+++ b/lang/en.json
@@ -9,6 +9,7 @@
     "auth.login.gitlab": "Login with Gitlab",
     "auth.login.google": "Login with Google",
     "auth.login.infomaniak": "Login with Infomaniak",
+    "auth.login.oidc": "Login with OIDC",
     "auth.login.zitadel": "Login with Zitadel",
     "auth.already_registered": "Already registered?",
     "auth.confirm_password": "Confirm password",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -9,6 +9,7 @@
     "auth.login.gitlab": "Zaloguj się przez Gitlab",
     "auth.login.google": "Zaloguj się przez Google",
     "auth.login.infomaniak": "Zaloguj się przez Infomaniak",
+    "auth.login.oidc": "Zaloguj się przez OIDC",
     "auth.login.zitadel": "Zaloguj się przez Zitadel",
     "auth.already_registered": "Już zarejestrowany?",
     "auth.confirm_password": "Potwierdź hasło",

--- a/resources/views/livewire/settings-oauth.blade.php
+++ b/resources/views/livewire/settings-oauth.blade.php
@@ -40,6 +40,7 @@
                         @if (
                             $oauth_setting['provider'] == 'authentik' ||
                                 $oauth_setting['provider'] == 'clerk' ||
+                                $oauth_setting['provider'] == 'oidc' ||
                                 $oauth_setting['provider'] == 'zitadel' ||
                                 $oauth_setting['provider'] == 'gitlab')
                             <x-forms.input id="oauth_settings_map.{{ $oauth_setting['provider'] }}.base_url"


### PR DESCRIPTION
This PR implements a generic OpenID Connect (OIDC) OAuth provider for Coolify, allowing users to authenticate with any OIDC-compliant identity provider.

## Changes

- **Database**: Added 'oidc' to OauthSettingSeeder providers list
- **Config**: Added OIDC section to services.php with client_id, client_secret, redirect, base_url
- **Composer**: Added socialiteproviders/oidc package dependency
- **Event Provider**: Registered OIDCExtendSocialite event listener
- **Helper**: Added OIDC configuration handler in socialite.php
- **Model**: Added 'oidc' case to couldBeEnabled() requiring client_id, client_secret, base_url
- **UI**: Added base_url input field for OIDC in settings OAuth blade template
- **i18n**: Added "Login with OIDC" translations to en.json, de.json, and pl.json

## Requirements

To enable OIDC, users need to configure:
- Client ID
- Client Secret  
- Base URL (OIDC issuer URL)

## Testing

1. Configure OIDC provider in Settings > OAuth
2. Set Client ID, Client Secret, and Base URL
3. Test login flow

## Related

This is a fresh implementation of generic OIDC support, following the same patterns used by Authentik, Clerk, and Zitadel providers.