### PR TITLE
fix: keep compose loader setup output out of raw compose

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -1859,6 +1859,7 @@ class Application extends BaseModel
         }
         $uuid = new Cuid2;
         ['commands' => $cloneCommand] = $this->generateGitImportCommands(deployment_uuid: $uuid, only_checkout: true, exec_in_docker: false, custom_base_dir: '.');
+        $gitOutputLog = "/tmp/{$uuid}/compose-load.log";
         $workdir = rtrim($this->base_directory, '/');
         $composeFile = $this->docker_compose_location;
         $fileList = collect([".$workdir$composeFile"]);
@@ -1886,22 +1887,24 @@ class Application extends BaseModel
             $commands = collect([
                 "rm -rf /tmp/{$uuid}",
                 "mkdir -p /tmp/{$uuid}",
+                ': > '.escapeshellarg($gitOutputLog),
                 "cd /tmp/{$uuid}",
-                $cloneCommand,
-                'git sparse-checkout init',
-                "git sparse-checkout set {$fileList->implode(' ')}",
-                'git read-tree -mu HEAD',
+                $this->composeFileLoadSetupCommand($cloneCommand, $gitOutputLog),
+                $this->composeFileLoadSetupCommand('git sparse-checkout init', $gitOutputLog),
+                $this->composeFileLoadSetupCommand("git sparse-checkout set {$fileList->implode(' ')}", $gitOutputLog),
+                $this->composeFileLoadSetupCommand('git read-tree -mu HEAD', $gitOutputLog),
                 "cat .$workdir$composeFile",
             ]);
         } else {
             $commands = collect([
                 "rm -rf /tmp/{$uuid}",
                 "mkdir -p /tmp/{$uuid}",
+                ': > '.escapeshellarg($gitOutputLog),
                 "cd /tmp/{$uuid}",
-                $cloneCommand,
-                'git sparse-checkout init --cone',
-                "git sparse-checkout set {$fileList->implode(' ')}",
-                'git read-tree -mu HEAD',
+                $this->composeFileLoadSetupCommand($cloneCommand, $gitOutputLog),
+                $this->composeFileLoadSetupCommand('git sparse-checkout init --cone', $gitOutputLog),
+                $this->composeFileLoadSetupCommand("git sparse-checkout set {$fileList->implode(' ')}", $gitOutputLog),
+                $this->composeFileLoadSetupCommand('git read-tree -mu HEAD', $gitOutputLog),
                 "cat .$workdir$composeFile",
             ]);
         }
@@ -1977,6 +1980,13 @@ class Application extends BaseModel
 
             throw new RuntimeException("Docker Compose file not found at: $workdir$composeFile (branch: {$this->git_branch})<br><br>Check if you used the right extension (.yaml or .yml) in the compose file name.");
         }
+    }
+
+    private function composeFileLoadSetupCommand(string $command, string $gitOutputLog): string
+    {
+        $escapedGitOutputLog = escapeshellarg($gitOutputLog);
+
+        return "{$command} >> {$escapedGitOutputLog} 2>&1 || { cat {$escapedGitOutputLog} >&2; exit 1; }";
     }
 
     public function parseContainerLabels(?ApplicationPreview $preview = null)

--- a/tests/Feature/ApplicationComposeFileLoadTest.php
+++ b/tests/Feature/ApplicationComposeFileLoadTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use App\Models\Application;
+
+describe('Application compose file loading', function () {
+    test('redirects git setup output away from compose file content', function () {
+        $application = new Application;
+        $method = new ReflectionMethod(Application::class, 'composeFileLoadSetupCommand');
+        $method->setAccessible(true);
+
+        $command = $method->invoke($application, 'git clone --no-checkout repo .', '/tmp/coolify-test/compose-load.log');
+
+        expect($command)
+            ->toBe("git clone --no-checkout repo . >> '/tmp/coolify-test/compose-load.log' 2>&1 || { cat '/tmp/coolify-test/compose-load.log' >&2; exit 1; }")
+            ->toContain("cat '/tmp/coolify-test/compose-load.log' >&2");
+    });
+});


### PR DESCRIPTION
## Changes

- Keeps Docker Compose loader clone/sparse-checkout/read-tree output out of the captured compose content.
- Writes setup command output to a temporary `compose-load.log` during `Application::loadComposeFile()`.
- Replays that log to stderr only if a setup step fails, preserving failure diagnostics while keeping successful stdout limited to the final `cat` of the compose file.
- Adds focused coverage for the setup-command wrapper.

## Issues

- /claim #5251
- Fixes #5251

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No UI change. This targets the deterministic Docker Compose corruption path reported in #5251 where setup output such as `Cloning into '.'...` can be captured into `docker_compose_raw`.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Used to inspect the current issue notes, implement the scoped fix, and run focused local verification. I reviewed the diff and test output before submitting.

## Testing

- `php -l app/Models/Application.php`
- `php -l tests/Feature/ApplicationComposeFileLoadTest.php`
- `./vendor/bin/pint --test app/Models/Application.php tests/Feature/ApplicationComposeFileLoadTest.php`
- `APP_ENV=testing ./vendor/bin/pest tests/Feature/ApplicationComposeFileLoadTest.php`
- `APP_ENV=testing ./vendor/bin/pest tests/Feature/ApplicationRollbackTest.php tests/Feature/ApplicationComposeFileLoadTest.php`

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.