### PR TITLE
feat(templates): add OpenReplay service template

### DIFF
--- a/templates/compose/openreplay.yaml
+++ b/templates/compose/openreplay.yaml
@@ -1,0 +1,564 @@
+# documentation: https://docs.openreplay.com/en/deployment/deploy-docker/
+# slogan: OpenReplay is an open-source session replay and product analytics platform.
+# category: analytics
+# tags: analytics, session-replay, product-analytics, monitoring, open-source
+# logo: svgs/default.webp
+# port: 80
+
+x-openreplay-common: &openreplay-common
+  COMMON_VERSION: ${OPENREPLAY_VERSION:-v1.23.0}
+  COMMON_PROTOCOL: ${OPENREPLAY_PROTOCOL:-https}
+  COMMON_DOMAIN_NAME: ${SERVICE_FQDN_OPENREPLAY}
+  COMMON_JWT_SECRET: ${SERVICE_PASSWORD_OPENREPLAYJWT}
+  COMMON_JWT_SPOT_SECRET: ${SERVICE_PASSWORD_OPENREPLAYSPOTJWT}
+  COMMON_JWT_REFRESH_SECRET: ${SERVICE_PASSWORD_OPENREPLAYJWTREFRESH}
+  COMMON_JWT_SPOT_REFRESH_SECRET: ${SERVICE_PASSWORD_OPENREPLAYSPOTJWTREFRESH}
+  COMMON_ASSIST_JWT_SECRET: ${SERVICE_PASSWORD_OPENREPLAYASSISTJWT}
+  COMMON_ASSIST_KEY: ${SERVICE_PASSWORD_OPENREPLAYASSISTKEY}
+  COMMON_TOKEN_SECRET: ${SERVICE_PASSWORD_OPENREPLAYTOKEN}
+  COMMON_S3_KEY: ${SERVICE_USER_OPENREPLAYS3}
+  COMMON_S3_SECRET: ${SERVICE_PASSWORD_OPENREPLAYS3}
+  COMMON_PG_PASSWORD: ${SERVICE_PASSWORD_OPENREPLAYPOSTGRES}
+  SITE_URL: ${SERVICE_URL_OPENREPLAY}
+  S3_HOST: ${SERVICE_URL_OPENREPLAY}
+  AWS_ENDPOINT: ${SERVICE_URL_OPENREPLAY}
+  AWS_REGION: us-east-1
+  AWS_DEFAULT_REGION: us-east-1
+  KAFKA_SERVERS: kafka.db.svc.cluster.local:9092
+  KAFKA_USE_SSL: "false"
+  LICENSE_KEY: ""
+  REDIS_STRING: redis://redis-master.db.svc.cluster.local:6379
+  CH_USERNAME: default
+  CH_PASSWORD: ""
+  CLICKHOUSE_STRING: clickhouse-openreplay-clickhouse.db.svc.cluster.local:9000/default
+  CLICKHOUSE_HTTP_STRING: clickhouse-openreplay-clickhouse.db.svc.cluster.local:8123/default
+  POSTGRES_STRING: postgres://postgres:${SERVICE_PASSWORD_OPENREPLAYPOSTGRES}@postgresql.db.svc.cluster.local:5432/postgres?sslmode=disable
+  pg_host: postgresql.db.svc.cluster.local
+  pg_port: "5432"
+  pg_dbname: postgres
+  pg_user: postgres
+  pg_password: ${SERVICE_PASSWORD_OPENREPLAYPOSTGRES}
+  ch_host: clickhouse-openreplay-clickhouse.db.svc.cluster.local
+  ch_port: "9000"
+  ch_port_http: "8123"
+  ch_username: default
+  ch_password: ""
+  version_number: ${OPENREPLAY_VERSION:-v1.23.0}
+  LOGLEVEL: INFO
+  PYTHONUNBUFFERED: "0"
+
+services:
+  postgresql:
+    image: ghcr.io/openreplay/postgres:${POSTGRES_VERSION:-17}
+    volumes:
+      - openreplay-postgres:/bitnami/postgresql
+    networks:
+      openreplay-net:
+        aliases:
+          - postgresql.db.svc.cluster.local
+    environment:
+      POSTGRESQL_PASSWORD: ${SERVICE_PASSWORD_OPENREPLAYPOSTGRES}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  clickhouse:
+    image: clickhouse/clickhouse-server:${CLICKHOUSE_VERSION:-25.11-alpine}
+    volumes:
+      - openreplay-clickhouse:/var/lib/clickhouse
+    networks:
+      openreplay-net:
+        aliases:
+          - clickhouse-openreplay-clickhouse.db.svc.cluster.local
+    environment:
+      CLICKHOUSE_USER: default
+      CLICKHOUSE_PASSWORD: ""
+      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: "1"
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q 0.0.0.0:8123/ping || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: ghcr.io/openreplay/valkey:${REDIS_VERSION:-8}
+    volumes:
+      - openreplay-redis:/data
+    networks:
+      openreplay-net:
+        aliases:
+          - redis-master.db.svc.cluster.local
+    environment:
+      ALLOW_EMPTY_PASSWORD: "yes"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  minio:
+    image: rustfs/rustfs:${RUSTFS_VERSION:-1.0.0-beta.1}
+    volumes:
+      - openreplay-minio:/data
+    networks:
+      openreplay-net:
+        aliases:
+          - minio.db.svc.cluster.local
+    environment:
+      RUSTFS_ACCESS_KEY: ${SERVICE_USER_OPENREPLAYS3}
+      RUSTFS_SECRET_KEY: ${SERVICE_PASSWORD_OPENREPLAYS3}
+      RUSTFS_ADDRESS: 0.0.0.0:9000
+      RUSTFS_CONSOLE_ENABLE: "true"
+      RUSTFS_CONSOLE_ADDRESS: 0.0.0.0:9001
+      RUSTFS_VOLUMES: /data
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z localhost 9000 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  minio-migration:
+    image: minio/mc:latest
+    restart: on-failure
+    depends_on:
+      minio:
+        condition: service_healthy
+    networks:
+      - openreplay-net
+    environment:
+      MINIO_HOST: http://minio.db.svc.cluster.local:9000
+      MINIO_ACCESS_KEY: ${SERVICE_USER_OPENREPLAYS3}
+      MINIO_SECRET_KEY: ${SERVICE_PASSWORD_OPENREPLAYS3}
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        mc alias set minio "$${MINIO_HOST}" "$${MINIO_ACCESS_KEY}" "$${MINIO_SECRET_KEY}"
+        for bucket in mobs sessions-assets static sourcemaps sessions-mobile-assets quickwit vault-data records spots; do
+          mc mb minio/$${bucket} || true
+        done
+        mc policy set download minio/sessions-assets || true
+        mc anonymous set download minio/sessions-assets || true
+
+  db-migration:
+    image: postgres:${POSTGRES_VERSION:-17}-alpine
+    restart: on-failure
+    depends_on:
+      postgresql:
+        condition: service_healthy
+      minio-migration:
+        condition: service_completed_successfully
+    networks:
+      - openreplay-net
+    environment:
+      PGHOST: postgresql.db.svc.cluster.local
+      PGPORT: "5432"
+      PGDATABASE: postgres
+      PGUSER: postgres
+      PGPASSWORD: ${SERVICE_PASSWORD_OPENREPLAYPOSTGRES}
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        wget -O /tmp/init_schema.sql https://raw.githubusercontent.com/openreplay/openreplay/main/scripts/schema/db/init_dbs/postgresql/init_schema.sql
+        psql -v ON_ERROR_STOP=1 -f /tmp/init_schema.sql
+
+  clickhouse-migration:
+    image: clickhouse/clickhouse-server:${CLICKHOUSE_VERSION:-25.11-alpine}
+    restart: on-failure
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+      minio-migration:
+        condition: service_completed_successfully
+    networks:
+      - openreplay-net
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        wget -O /tmp/init_schema.sql https://raw.githubusercontent.com/openreplay/openreplay/main/scripts/schema/db/init_dbs/clickhouse/create/init_schema.sql
+        clickhouse-client -h clickhouse-openreplay-clickhouse.db.svc.cluster.local --user default --port 9000 --multiquery < /tmp/init_schema.sql || true
+
+  alerts-openreplay:
+    image: public.ecr.aws/p1t3u8a3/alerts:${OPENREPLAY_VERSION:-v1.23.0}
+    depends_on:
+      db-migration:
+        condition: service_completed_successfully
+      clickhouse-migration:
+        condition: service_completed_successfully
+    networks:
+      openreplay-net:
+        aliases:
+          - alerts-openreplay
+          - alerts-openreplay.app.svc.cluster.local
+    volumes:
+      - openreplay-shared:/mnt/efs
+    environment:
+      <<: *openreplay-common
+      EMAIL_HOST: ${OPENREPLAY_EMAIL_HOST:-}
+      EMAIL_PORT: ${OPENREPLAY_EMAIL_PORT:-587}
+      EMAIL_USER: ${OPENREPLAY_EMAIL_USER:-}
+      EMAIL_PASSWORD: ${OPENREPLAY_EMAIL_PASSWORD:-}
+      EMAIL_USE_TLS: ${OPENREPLAY_EMAIL_USE_TLS:-true}
+      EMAIL_USE_SSL: ${OPENREPLAY_EMAIL_USE_SSL:-false}
+      EMAIL_FROM: ${OPENREPLAY_EMAIL_FROM:-OpenReplay<do-not-reply@openreplay.com>}
+    restart: unless-stopped
+
+  api-openreplay:
+    image: public.ecr.aws/p1t3u8a3/api:${OPENREPLAY_VERSION:-v1.23.0}
+    depends_on:
+      db-migration:
+        condition: service_completed_successfully
+      clickhouse-migration:
+        condition: service_completed_successfully
+      redis:
+        condition: service_healthy
+    networks:
+      openreplay-net:
+        aliases:
+          - api-openreplay
+          - api-openreplay.app.svc.cluster.local
+    volumes:
+      - openreplay-shared:/mnt/efs
+    environment:
+      <<: *openreplay-common
+      TOKEN_SECRET: ${SERVICE_PASSWORD_OPENREPLAYTOKEN}
+      JWT_SECRET: ${SERVICE_PASSWORD_OPENREPLAYJWT}
+      ASSIST_JWT_SECRET: ${SERVICE_PASSWORD_OPENREPLAYASSISTJWT}
+      AWS_ACCESS_KEY_ID: ${SERVICE_USER_OPENREPLAYS3}
+      AWS_SECRET_ACCESS_KEY: ${SERVICE_PASSWORD_OPENREPLAYS3}
+      BUCKET_NAME: mobs
+      ASSIST_URL: http://assist-openreplay.app.svc.cluster.local:9001/assist/%s
+      ASSIST_KEY: ${SERVICE_PASSWORD_OPENREPLAYASSISTKEY}
+      ch_db: default
+    restart: unless-stopped
+
+  chalice-openreplay:
+    image: public.ecr.aws/p1t3u8a3/chalice:${OPENREPLAY_VERSION:-v1.23.0}
+    depends_on:
+      db-migration:
+        condition: service_completed_successfully
+      clickhouse-migration:
+        condition: service_completed_successfully
+      redis:
+        condition: service_healthy
+    networks:
+      openreplay-net:
+        aliases:
+          - chalice-openreplay
+          - chalice-openreplay.app.svc.cluster.local
+    volumes:
+      - openreplay-shared:/mnt/efs
+    environment:
+      <<: *openreplay-common
+      JWT_REFRESH_SECRET: ${SERVICE_PASSWORD_OPENREPLAYJWTREFRESH}
+      JWT_SPOT_REFRESH_SECRET: ${SERVICE_PASSWORD_OPENREPLAYSPOTJWTREFRESH}
+      JWT_SECRET: ${SERVICE_PASSWORD_OPENREPLAYJWT}
+      JWT_SPOT_SECRET: ${SERVICE_PASSWORD_OPENREPLAYSPOTJWT}
+      ASSIST_JWT_SECRET: ${SERVICE_PASSWORD_OPENREPLAYASSISTJWT}
+      ASSIST_KEY: ${SERVICE_PASSWORD_OPENREPLAYASSISTKEY}
+      ASSIST_URL: http://assist-openreplay.app.svc.cluster.local:9001/assist/%s
+      sourcemaps_reader: http://sourcemapreader-openreplay.app.svc.cluster.local:9000/{}/sourcemaps
+      sessions_region: us-east-1
+      ASSIST_RECORDS_BUCKET: records
+      sessions_bucket: mobs
+      IOS_VIDEO_BUCKET: mobs
+      sourcemaps_bucket: sourcemaps
+      js_cache_bucket: sessions-assets
+      EMAIL_HOST: ${OPENREPLAY_EMAIL_HOST:-}
+      EMAIL_PORT: ${OPENREPLAY_EMAIL_PORT:-587}
+      EMAIL_USER: ${OPENREPLAY_EMAIL_USER:-}
+      EMAIL_PASSWORD: ${OPENREPLAY_EMAIL_PASSWORD:-}
+      EMAIL_USE_TLS: ${OPENREPLAY_EMAIL_USE_TLS:-true}
+      EMAIL_USE_SSL: ${OPENREPLAY_EMAIL_USE_SSL:-false}
+      EMAIL_FROM: ${OPENREPLAY_EMAIL_FROM:-OpenReplay<do-not-reply@openreplay.com>}
+      SCIM_ACCESS_SECRET_KEY: ${SERVICE_PASSWORD_OPENREPLAYSCIMACCESS}
+      SCIM_REFRESH_SECRET_KEY: ${SERVICE_PASSWORD_OPENREPLAYSCIMREFRESH}
+      CH_COMPRESSION: "false"
+      CLUSTER_URL: svc.cluster.local
+      JWT_EXPIRATION: "86400"
+      SAML2_MD_URL: ""
+      SCIM_ACCESS_TOKEN_EXPIRE_SECONDS: "86400"
+      jwt_algorithm: HS512
+      root_path: /api
+    restart: unless-stopped
+
+  http-openreplay:
+    image: public.ecr.aws/p1t3u8a3/http:${OPENREPLAY_VERSION:-v1.23.0}
+    depends_on:
+      api-openreplay:
+        condition: service_started
+    networks:
+      openreplay-net:
+        aliases:
+          - http-openreplay
+          - http-openreplay.app.svc.cluster.local
+    volumes:
+      - openreplay-shared:/mnt/efs
+    environment:
+      <<: *openreplay-common
+      BUCKET_NAME: uxtesting-records
+      CACHE_ASSETS: "true"
+      AWS_ACCESS_KEY_ID: ${SERVICE_USER_OPENREPLAYS3}
+      AWS_SECRET_ACCESS_KEY: ${SERVICE_PASSWORD_OPENREPLAYS3}
+      JWT_SECRET: ${SERVICE_PASSWORD_OPENREPLAYJWT}
+      JWT_SPOT_SECRET: ${SERVICE_PASSWORD_OPENREPLAYSPOTJWT}
+      TOKEN_SECRET: ${SERVICE_PASSWORD_OPENREPLAYTOKEN}
+    restart: unless-stopped
+
+  frontend-openreplay:
+    image: public.ecr.aws/p1t3u8a3/frontend:${OPENREPLAY_VERSION:-v1.23.0}
+    networks:
+      openreplay-net:
+        aliases:
+          - frontend-openreplay
+          - frontend-openreplay.app.svc.cluster.local
+    volumes:
+      - openreplay-shared:/mnt/efs
+    environment:
+      TRACKER_HOST: ${SERVICE_URL_OPENREPLAY}/script
+      HTTP_PORT: "80"
+    restart: unless-stopped
+
+  assist-openreplay:
+    image: public.ecr.aws/p1t3u8a3/assist:${OPENREPLAY_VERSION:-v1.23.0}
+    depends_on:
+      redis:
+        condition: service_healthy
+    networks:
+      openreplay-net:
+        aliases:
+          - assist-openreplay
+          - assist-openreplay.app.svc.cluster.local
+    volumes:
+      - openreplay-shared:/mnt/efs
+    environment:
+      ASSIST_JWT_SECRET: ${SERVICE_PASSWORD_OPENREPLAYASSISTJWT}
+      ASSIST_KEY: ${SERVICE_PASSWORD_OPENREPLAYASSISTKEY}
+      AWS_DEFAULT_REGION: us-east-1
+      REDIS_URL: redis-master.db.svc.cluster.local
+      CLEAR_SOCKET_TIME: "720"
+      debug: "0"
+      redis: "false"
+    restart: unless-stopped
+
+  sourcemapreader-openreplay:
+    image: public.ecr.aws/p1t3u8a3/sourcemapreader:${OPENREPLAY_VERSION:-v1.23.0}
+    networks:
+      openreplay-net:
+        aliases:
+          - sourcemapreader-openreplay
+          - sourcemapreader-openreplay.app.svc.cluster.local
+    volumes:
+      - openreplay-shared:/mnt/efs
+    environment:
+      SMR_HOST: 0.0.0.0
+      S3_HOST: http://minio.db.svc.cluster.local:9000
+      S3_KEY: ${SERVICE_USER_OPENREPLAYS3}
+      S3_SECRET: ${SERVICE_PASSWORD_OPENREPLAYS3}
+      AWS_REGION: us-east-1
+      LICENSE_KEY: ""
+      ASSETS_ORIGIN: ${SERVICE_URL_OPENREPLAY}/sessions-assets
+    restart: unless-stopped
+
+  images-openreplay:
+    image: public.ecr.aws/p1t3u8a3/images:${OPENREPLAY_VERSION:-v1.23.0}
+    networks:
+      openreplay-net:
+        aliases:
+          - images-openreplay
+          - images-openreplay.app.svc.cluster.local
+    volumes:
+      - openreplay-shared:/mnt/efs
+    environment:
+      <<: *openreplay-common
+      AWS_ACCESS_KEY_ID: ${SERVICE_USER_OPENREPLAYS3}
+      AWS_SECRET_ACCESS_KEY: ${SERVICE_PASSWORD_OPENREPLAYS3}
+      BUCKET_NAME: mobs
+      FS_CLEAN_HRS: "24"
+    restart: unless-stopped
+
+  integrations-openreplay:
+    image: public.ecr.aws/p1t3u8a3/integrations:${OPENREPLAY_VERSION:-v1.23.0}
+    networks:
+      openreplay-net:
+        aliases:
+          - integrations-openreplay
+          - integrations-openreplay.app.svc.cluster.local
+    volumes:
+      - openreplay-shared:/mnt/efs
+    environment:
+      <<: *openreplay-common
+      AWS_ACCESS_KEY_ID: ${SERVICE_USER_OPENREPLAYS3}
+      AWS_SECRET_ACCESS_KEY: ${SERVICE_PASSWORD_OPENREPLAYS3}
+      BUCKET_NAME: mobs
+      JWT_SECRET: ${SERVICE_PASSWORD_OPENREPLAYJWT}
+      TOKEN_SECRET: ${SERVICE_PASSWORD_OPENREPLAYTOKEN}
+    restart: unless-stopped
+
+  sink-openreplay:
+    image: public.ecr.aws/p1t3u8a3/sink:${OPENREPLAY_VERSION:-v1.23.0}
+    networks:
+      openreplay-net:
+        aliases:
+          - sink-openreplay
+          - sink-openreplay.app.svc.cluster.local
+    volumes:
+      - openreplay-shared:/mnt/efs
+    environment:
+      <<: *openreplay-common
+      ASSETS_ORIGIN: ${SERVICE_URL_OPENREPLAY}/sessions-assets
+    restart: unless-stopped
+
+  spot-openreplay:
+    image: public.ecr.aws/p1t3u8a3/spot:${OPENREPLAY_VERSION:-v1.23.0}
+    networks:
+      openreplay-net:
+        aliases:
+          - spot-openreplay
+          - spot-openreplay.app.svc.cluster.local
+    volumes:
+      - openreplay-shared:/mnt/efs
+    environment:
+      <<: *openreplay-common
+      CACHE_ASSETS: "true"
+      FS_CLEAN_HRS: "24"
+      TOKEN_SECRET: ${SERVICE_PASSWORD_OPENREPLAYTOKEN}
+      AWS_ACCESS_KEY_ID: ${SERVICE_USER_OPENREPLAYS3}
+      AWS_SECRET_ACCESS_KEY: ${SERVICE_PASSWORD_OPENREPLAYS3}
+      BUCKET_NAME: spots
+      JWT_SECRET: ${SERVICE_PASSWORD_OPENREPLAYJWT}
+      JWT_SPOT_SECRET: ${SERVICE_PASSWORD_OPENREPLAYSPOTJWT}
+    restart: unless-stopped
+
+  storage-openreplay:
+    image: public.ecr.aws/p1t3u8a3/storage:${OPENREPLAY_VERSION:-v1.23.0}
+    networks:
+      openreplay-net:
+        aliases:
+          - storage-openreplay
+          - storage-openreplay.app.svc.cluster.local
+    volumes:
+      - openreplay-shared:/mnt/efs
+    environment:
+      <<: *openreplay-common
+      AWS_ACCESS_KEY_ID: ${SERVICE_USER_OPENREPLAYS3}
+      AWS_SECRET_ACCESS_KEY: ${SERVICE_PASSWORD_OPENREPLAYS3}
+      BUCKET_NAME: mobs
+      FS_CLEAN_HRS: "24"
+    restart: unless-stopped
+
+  assets-openreplay:
+    image: public.ecr.aws/p1t3u8a3/assets:${OPENREPLAY_VERSION:-v1.23.0}
+    networks:
+      openreplay-net:
+        aliases:
+          - assets-openreplay
+          - assets-openreplay.app.svc.cluster.local
+    volumes:
+      - openreplay-shared:/mnt/efs
+    environment:
+      <<: *openreplay-common
+      AWS_ACCESS_KEY_ID: ${SERVICE_USER_OPENREPLAYS3}
+      AWS_SECRET_ACCESS_KEY: ${SERVICE_PASSWORD_OPENREPLAYS3}
+      BUCKET_NAME: sessions-assets
+      ASSETS_ORIGIN: ${SERVICE_URL_OPENREPLAY}/sessions-assets
+    restart: unless-stopped
+
+  canvases-openreplay:
+    image: public.ecr.aws/p1t3u8a3/canvases:${OPENREPLAY_VERSION:-v1.23.0}
+    networks:
+      openreplay-net:
+        aliases:
+          - canvases-openreplay
+          - canvases-openreplay.app.svc.cluster.local
+    volumes:
+      - openreplay-shared:/mnt/efs
+    environment:
+      <<: *openreplay-common
+      AWS_ACCESS_KEY_ID: ${SERVICE_USER_OPENREPLAYS3}
+      AWS_SECRET_ACCESS_KEY: ${SERVICE_PASSWORD_OPENREPLAYS3}
+      BUCKET_NAME: mobs
+      FS_CLEAN_HRS: "24"
+    restart: unless-stopped
+
+  db-openreplay:
+    image: public.ecr.aws/p1t3u8a3/db:${OPENREPLAY_VERSION:-v1.23.0}
+    networks:
+      openreplay-net:
+        aliases:
+          - db-openreplay
+          - db-openreplay.app.svc.cluster.local
+    volumes:
+      - openreplay-shared:/mnt/efs
+    environment:
+      <<: *openreplay-common
+      ch_db: default
+    restart: unless-stopped
+
+  ender-openreplay:
+    image: public.ecr.aws/p1t3u8a3/ender:${OPENREPLAY_VERSION:-v1.23.0}
+    networks:
+      openreplay-net:
+        aliases:
+          - ender-openreplay
+          - ender-openreplay.app.svc.cluster.local
+    volumes:
+      - openreplay-shared:/mnt/efs
+    environment:
+      <<: *openreplay-common
+    restart: unless-stopped
+
+  heuristics-openreplay:
+    image: public.ecr.aws/p1t3u8a3/heuristics:${OPENREPLAY_VERSION:-v1.23.0}
+    networks:
+      openreplay-net:
+        aliases:
+          - heuristics-openreplay
+          - heuristics-openreplay.app.svc.cluster.local
+    volumes:
+      - openreplay-shared:/mnt/efs
+    environment:
+      <<: *openreplay-common
+    restart: unless-stopped
+
+  openreplay:
+    image: nginx:alpine
+    depends_on:
+      frontend-openreplay:
+        condition: service_started
+      http-openreplay:
+        condition: service_started
+      api-openreplay:
+        condition: service_started
+      chalice-openreplay:
+        condition: service_started
+    networks:
+      - openreplay-net
+    environment:
+      - SERVICE_URL_OPENREPLAY_80
+    command:
+      - /bin/sh
+      - -c
+      - |
+        wget -O /etc/nginx/conf.d/default.conf https://raw.githubusercontent.com/openreplay/openreplay/main/scripts/docker-compose/nginx.conf
+        nginx -g 'daemon off;'
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://127.0.0.1/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+volumes:
+  openreplay-postgres:
+  openreplay-clickhouse:
+  openreplay-redis:
+  openreplay-minio:
+  openreplay-shared:
+
+networks:
+  openreplay-net:


### PR DESCRIPTION
/claim #8232

## Changes

- Added an OpenReplay one-click service template based on the upstream Docker Compose deployment.
- Inlined the required OpenReplay environment values so the Coolify template does not depend on external `docker-envs/*.env` files.
- Removed the upstream Caddy service and exposed OpenReplay through Coolify's proxy with `SERVICE_URL_OPENREPLAY_80`.

## Issues

- Fixes #8232

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

I could not record a runtime demo yet because Docker is not available in my local environment.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex
- How extensively: Used to inspect the upstream Docker Compose files, draft the Coolify service template, and run static YAML/diff validation. I reviewed the generated changes before submitting.

## Testing

- Parsed `templates/compose/openreplay.yaml` successfully with a Node YAML parser.
- Ran `git diff --check`.
- Verified the template includes the Coolify public route variable `SERVICE_URL_OPENREPLAY_80`.

Docker runtime testing was not available in my local environment.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.