### PR TITLE
Prefer IPv6 when creating Docker networks

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -98,11 +98,11 @@ class InstallDocker
             ]);
             if ($server->isSwarm()) {
                 $command = $command->merge([
-                    'docker network create --attachable --driver overlay coolify-overlay >/dev/null 2>&1 || true',
+                    dockerNetworkCreateCommand('coolify-overlay', 'overlay', preferIpv6: false).' 2>&1 || true',
                 ]);
             } else {
                 $command = $command->merge([
-                    'docker network create --attachable coolify >/dev/null 2>&1 || true',
+                    dockerNetworkCreateCommand('coolify').' 2>&1 || true',
                 ]);
                 $command = $command->merge([
                     "echo 'Done!'",

--- a/app/Actions/Service/StartService.php
+++ b/app/Actions/Service/StartService.php
@@ -33,7 +33,8 @@ class StartService
         }
         if ($service->networks()->count() > 0) {
             $commands[] = "echo 'Creating Docker network.'";
-            $commands[] = "docker network inspect $service->uuid >/dev/null 2>&1 || docker network create --attachable $service->uuid";
+            $safeNetwork = escapeshellarg($service->uuid);
+            $commands[] = "docker network inspect {$safeNetwork} >/dev/null 2>&1 || ".dockerNetworkCreateCommand($safeNetwork);
         }
         $commands[] = 'echo Starting service.';
         $commands[] = "docker compose --project-directory {$workdir} -f {$workdir}/docker-compose.yml --project-name {$service->uuid} up -d --remove-orphans --force-recreate --build";

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -788,7 +788,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             // TODO
         } else {
             $this->execute_remote_command([
-                "docker network inspect '{$networkId}' >/dev/null 2>&1 || docker network create --attachable '{$networkId}' >/dev/null || true",
+                "docker network inspect '{$networkId}' >/dev/null 2>&1 || ".dockerNetworkCreateCommand("'{$networkId}'").' || true',
                 'hidden' => true,
                 'ignore_errors' => true,
             ], [

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -1406,9 +1406,9 @@ $schema://$host {
             return;
         }
         if ($isSwarm) {
-            return instant_remote_process(['docker network create --attachable --driver overlay coolify-overlay >/dev/null 2>&1 || true'], $this, false);
+            return instant_remote_process([dockerNetworkCreateCommand('coolify-overlay', 'overlay', preferIpv6: false).' 2>&1 || true'], $this, false);
         } else {
-            return instant_remote_process(['docker network create coolify --attachable >/dev/null 2>&1 || true'], $this, false);
+            return instant_remote_process([dockerNetworkCreateCommand('coolify').' 2>&1 || true'], $this, false);
         }
     }
 

--- a/app/Models/StandaloneDocker.php
+++ b/app/Models/StandaloneDocker.php
@@ -25,7 +25,7 @@ class StandaloneDocker extends BaseModel
             $server = $newStandaloneDocker->server;
             $safeNetwork = escapeshellarg($newStandaloneDocker->network);
             instant_remote_process([
-                "docker network inspect {$safeNetwork} >/dev/null 2>&1 || docker network create --driver overlay --attachable {$safeNetwork} >/dev/null",
+                "docker network inspect {$safeNetwork} >/dev/null 2>&1 || ".dockerNetworkCreateCommand($safeNetwork, 'overlay', preferIpv6: false),
             ], $server, false);
             ConnectProxyToNetworksJob::dispatchSync($server);
         });

--- a/bootstrap/helpers/proxy.php
+++ b/bootstrap/helpers/proxy.php
@@ -21,6 +21,20 @@ function isDockerPredefinedNetwork(string $network): bool
     return in_array($network, ['default', 'host'], true);
 }
 
+function dockerNetworkCreateCommand(string $network, ?string $driver = null, bool $preferIpv6 = true): string
+{
+    $driverOption = $driver ? "--driver {$driver} " : '';
+    $create = "docker network create {$driverOption}--attachable {$network}";
+
+    if (! $preferIpv6) {
+        return "{$create} >/dev/null";
+    }
+
+    $createWithIpv6 = "docker network create {$driverOption}--attachable --ipv6 {$network}";
+
+    return "({$createWithIpv6} >/dev/null 2>&1 || {$create} >/dev/null)";
+}
+
 function collectProxyDockerNetworksByServer(Server $server)
 {
     if (! $server->isFunctional()) {
@@ -110,8 +124,10 @@ function connectProxyToNetworks(Server $server)
     if ($server->isSwarm()) {
         $commands = $networks->map(function ($network) {
             $safe = escapeshellarg($network);
+            $createCommand = dockerNetworkCreateCommand($safe, 'overlay', preferIpv6: false);
+
             return [
-                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || docker network create --driver overlay --attachable {$safe} >/dev/null",
+                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || {$createCommand}",
                 "docker network connect {$safe} coolify-proxy >/dev/null 2>&1 || true",
                 "echo 'Successfully connected coolify-proxy to {$safe} network.'",
             ];
@@ -119,8 +135,10 @@ function connectProxyToNetworks(Server $server)
     } else {
         $commands = $networks->map(function ($network) {
             $safe = escapeshellarg($network);
+            $createCommand = dockerNetworkCreateCommand($safe);
+
             return [
-                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || docker network create --attachable {$safe} >/dev/null",
+                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || {$createCommand}",
                 "docker network connect {$safe} coolify-proxy >/dev/null 2>&1 || true",
                 "echo 'Successfully connected coolify-proxy to {$safe} network.'",
             ];
@@ -144,17 +162,21 @@ function ensureProxyNetworksExist(Server $server)
     if ($server->isSwarm()) {
         $commands = $networks->map(function ($network) {
             $safe = escapeshellarg($network);
+            $createCommand = dockerNetworkCreateCommand($safe, 'overlay', preferIpv6: false);
+
             return [
                 "echo 'Ensuring network {$safe} exists...'",
-                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --driver overlay --attachable {$safe}",
+                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || {$createCommand}",
             ];
         });
     } else {
         $commands = $networks->map(function ($network) {
             $safe = escapeshellarg($network);
+            $createCommand = dockerNetworkCreateCommand($safe);
+
             return [
                 "echo 'Ensuring network {$safe} exists...'",
-                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --attachable {$safe}",
+                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || {$createCommand}",
             ];
         });
     }

--- a/tests/Unit/DockerNetworkCreateCommandTest.php
+++ b/tests/Unit/DockerNetworkCreateCommandTest.php
@@ -1,0 +1,15 @@
+<?php
+
+test('docker network create command prefers ipv6 and falls back to plain network creation', function () {
+    $command = dockerNetworkCreateCommand('coolify');
+
+    expect($command)
+        ->toBe('(docker network create --attachable --ipv6 coolify >/dev/null 2>&1 || docker network create --attachable coolify >/dev/null)');
+});
+
+test('docker network create command can skip ipv6 for overlay networks', function () {
+    $command = dockerNetworkCreateCommand('coolify-overlay', 'overlay', preferIpv6: false);
+
+    expect($command)
+        ->toBe('docker network create --driver overlay --attachable coolify-overlay >/dev/null');
+});


### PR DESCRIPTION
STRAWBERRY

## Summary
- add a shared Docker network creation helper that prefers --ipv6 for standalone networks and falls back to plain network creation
- use the helper across Coolify network/proxy creation paths
- add unit coverage for the command generation

Fixes #3436

## Testing
- git diff --check
- PHP tests were not run locally because PHP is not installed in this environment
