### PR TITLE
Prefer IPv6 for standalone Docker networks

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -98,11 +98,11 @@ class InstallDocker
             ]);
             if ($server->isSwarm()) {
                 $command = $command->merge([
-                    'docker network create --attachable --driver overlay coolify-overlay >/dev/null 2>&1 || true',
+                    dockerNetworkCreateCommand('coolify-overlay', isSwarm: true, suppressOutput: true).' 2>&1 || true',
                 ]);
             } else {
                 $command = $command->merge([
-                    'docker network create --attachable coolify >/dev/null 2>&1 || true',
+                    dockerNetworkCreateCommand('coolify', suppressOutput: true).' 2>&1 || true',
                 ]);
                 $command = $command->merge([
                     "echo 'Done!'",

--- a/app/Actions/Service/StartService.php
+++ b/app/Actions/Service/StartService.php
@@ -33,7 +33,7 @@ class StartService
         }
         if ($service->networks()->count() > 0) {
             $commands[] = "echo 'Creating Docker network.'";
-            $commands[] = "docker network inspect $service->uuid >/dev/null 2>&1 || docker network create --attachable $service->uuid";
+            $commands[] = "docker network inspect $service->uuid >/dev/null 2>&1 || ".dockerNetworkCreateCommand($service->uuid);
         }
         $commands[] = 'echo Starting service.';
         $commands[] = "docker compose --project-directory {$workdir} -f {$workdir}/docker-compose.yml --project-name {$service->uuid} up -d --remove-orphans --force-recreate --build";

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -788,7 +788,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             // TODO
         } else {
             $this->execute_remote_command([
-                "docker network inspect '{$networkId}' >/dev/null 2>&1 || docker network create --attachable '{$networkId}' >/dev/null || true",
+                "docker network inspect '{$networkId}' >/dev/null 2>&1 || ".dockerNetworkCreateCommand($networkId, suppressOutput: true).' || true',
                 'hidden' => true,
                 'ignore_errors' => true,
             ], [

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -1406,9 +1406,9 @@ $schema://$host {
             return;
         }
         if ($isSwarm) {
-            return instant_remote_process(['docker network create --attachable --driver overlay coolify-overlay >/dev/null 2>&1 || true'], $this, false);
+            return instant_remote_process([dockerNetworkCreateCommand('coolify-overlay', isSwarm: true, suppressOutput: true).' 2>&1 || true'], $this, false);
         } else {
-            return instant_remote_process(['docker network create coolify --attachable >/dev/null 2>&1 || true'], $this, false);
+            return instant_remote_process([dockerNetworkCreateCommand('coolify', suppressOutput: true).' 2>&1 || true'], $this, false);
         }
     }
 

--- a/app/Models/StandaloneDocker.php
+++ b/app/Models/StandaloneDocker.php
@@ -25,7 +25,7 @@ class StandaloneDocker extends BaseModel
             $server = $newStandaloneDocker->server;
             $safeNetwork = escapeshellarg($newStandaloneDocker->network);
             instant_remote_process([
-                "docker network inspect {$safeNetwork} >/dev/null 2>&1 || docker network create --driver overlay --attachable {$safeNetwork} >/dev/null",
+                "docker network inspect {$safeNetwork} >/dev/null 2>&1 || ".dockerNetworkCreateCommand($newStandaloneDocker->network, suppressOutput: true),
             ], $server, false);
             ConnectProxyToNetworksJob::dispatchSync($server);
         });

--- a/bootstrap/helpers/proxy.php
+++ b/bootstrap/helpers/proxy.php
@@ -21,6 +21,24 @@ function isDockerPredefinedNetwork(string $network): bool
     return in_array($network, ['default', 'host'], true);
 }
 
+function dockerNetworkCreateCommand(string $network, bool $isSwarm = false, bool $preferIpv6 = true, bool $suppressOutput = false): string
+{
+    $safe = escapeshellarg($network);
+    $outputRedirect = $suppressOutput ? ' >/dev/null' : '';
+
+    if ($isSwarm) {
+        return "docker network create --driver overlay --attachable {$safe}{$outputRedirect}";
+    }
+
+    $fallback = "docker network create --attachable {$safe}{$outputRedirect}";
+
+    if (! $preferIpv6) {
+        return $fallback;
+    }
+
+    return "docker network create --ipv6 --attachable {$safe}{$outputRedirect} 2>/dev/null || {$fallback}";
+}
+
 function collectProxyDockerNetworksByServer(Server $server)
 {
     if (! $server->isFunctional()) {
@@ -111,7 +129,7 @@ function connectProxyToNetworks(Server $server)
         $commands = $networks->map(function ($network) {
             $safe = escapeshellarg($network);
             return [
-                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || docker network create --driver overlay --attachable {$safe} >/dev/null",
+                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || ".dockerNetworkCreateCommand($network, isSwarm: true, suppressOutput: true),
                 "docker network connect {$safe} coolify-proxy >/dev/null 2>&1 || true",
                 "echo 'Successfully connected coolify-proxy to {$safe} network.'",
             ];
@@ -120,7 +138,7 @@ function connectProxyToNetworks(Server $server)
         $commands = $networks->map(function ($network) {
             $safe = escapeshellarg($network);
             return [
-                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || docker network create --attachable {$safe} >/dev/null",
+                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || ".dockerNetworkCreateCommand($network, suppressOutput: true),
                 "docker network connect {$safe} coolify-proxy >/dev/null 2>&1 || true",
                 "echo 'Successfully connected coolify-proxy to {$safe} network.'",
             ];
@@ -146,7 +164,7 @@ function ensureProxyNetworksExist(Server $server)
             $safe = escapeshellarg($network);
             return [
                 "echo 'Ensuring network {$safe} exists...'",
-                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --driver overlay --attachable {$safe}",
+                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || ".dockerNetworkCreateCommand($network, isSwarm: true),
             ];
         });
     } else {
@@ -154,7 +172,7 @@ function ensureProxyNetworksExist(Server $server)
             $safe = escapeshellarg($network);
             return [
                 "echo 'Ensuring network {$safe} exists...'",
-                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --attachable {$safe}",
+                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || ".dockerNetworkCreateCommand($network),
             ];
         });
     }

--- a/tests/Unit/DockerNetworkInjectionTest.php
+++ b/tests/Unit/DockerNetworkInjectionTest.php
@@ -46,3 +46,28 @@ it('SwarmDocker accepts valid network names', function (string $network) {
     'with hyphen' => 'my-network',
     'with underscore' => 'my_network',
 ]);
+
+it('creates standalone docker networks with IPv6 preferred and IPv4 fallback', function () {
+    $command = dockerNetworkCreateCommand('coolify');
+
+    expect($command)
+        ->toContain('docker network create --ipv6 --attachable')
+        ->toContain('2>/dev/null || docker network create --attachable')
+        ->toContain("'coolify'");
+});
+
+it('keeps swarm docker network creation IPv4-only', function () {
+    $command = dockerNetworkCreateCommand('coolify-overlay', isSwarm: true);
+
+    expect($command)
+        ->toBe("docker network create --driver overlay --attachable 'coolify-overlay'")
+        ->not->toContain('--ipv6');
+});
+
+it('can suppress docker network creation output', function () {
+    $command = dockerNetworkCreateCommand('coolify', suppressOutput: true);
+
+    expect($command)
+        ->toContain("docker network create --ipv6 --attachable 'coolify' >/dev/null")
+        ->toContain("|| docker network create --attachable 'coolify' >/dev/null");
+});


### PR DESCRIPTION
## Summary

- add a shared Docker network creation helper
- prefer IPv6-enabled standalone bridge networks with a safe IPv4 fallback
- reuse the helper across install, validation, proxy connection, service startup, application deployment, and destination network creation paths
- keep swarm overlay network creation unchanged

## Why

Closes #3436.

Coolify-created standalone Docker networks were created without IPv6 support. For IPv6 clients, this can leave Traefik/Caddy forwarding proxy-local addresses instead of the original client address in `X-Forwarded-For`.

The new helper tries `docker network create --ipv6 --attachable ...` for standalone networks. If Docker IPv6 support is unavailable, it falls back to the previous IPv4-only command so existing installs do not fail.

## Tests

- `git diff --check`
- Not run: PHP/Pest/Pint are unavailable in this local environment (`php` is not installed and `vendor/` is absent).