### PR TITLE
fix: prefer ipv6 for proxy ingress networks

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -98,11 +98,11 @@ class InstallDocker
             ]);
             if ($server->isSwarm()) {
                 $command = $command->merge([
-                    'docker network create --attachable --driver overlay coolify-overlay >/dev/null 2>&1 || true',
+                    dockerNetworkCreateCommand('coolify-overlay', isSwarm: true, suppressOutput: true).' || true',
                 ]);
             } else {
                 $command = $command->merge([
-                    'docker network create --attachable coolify >/dev/null 2>&1 || true',
+                    dockerNetworkCreateCommand('coolify', preferIpv6: true, suppressOutput: true).' || true',
                 ]);
                 $command = $command->merge([
                     "echo 'Done!'",

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -1406,9 +1406,9 @@ $schema://$host {
             return;
         }
         if ($isSwarm) {
-            return instant_remote_process(['docker network create --attachable --driver overlay coolify-overlay >/dev/null 2>&1 || true'], $this, false);
+            return instant_remote_process([dockerNetworkCreateCommand('coolify-overlay', isSwarm: true, suppressOutput: true).' || true'], $this, false);
         } else {
-            return instant_remote_process(['docker network create coolify --attachable >/dev/null 2>&1 || true'], $this, false);
+            return instant_remote_process([dockerNetworkCreateCommand('coolify', preferIpv6: true, suppressOutput: true).' || true'], $this, false);
         }
     }
 

--- a/app/Models/StandaloneDocker.php
+++ b/app/Models/StandaloneDocker.php
@@ -23,9 +23,8 @@ class StandaloneDocker extends BaseModel
         parent::boot();
         static::created(function ($newStandaloneDocker) {
             $server = $newStandaloneDocker->server;
-            $safeNetwork = escapeshellarg($newStandaloneDocker->network);
             instant_remote_process([
-                "docker network inspect {$safeNetwork} >/dev/null 2>&1 || docker network create --driver overlay --attachable {$safeNetwork} >/dev/null",
+                'docker network inspect '.escapeshellarg($newStandaloneDocker->network).' >/dev/null 2>&1 || '.dockerNetworkCreateCommand($newStandaloneDocker->network, preferIpv6: true, suppressOutput: true),
             ], $server, false);
             ConnectProxyToNetworksJob::dispatchSync($server);
         });

--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -149,6 +149,27 @@ function executeInDocker(string $containerId, string $command)
     return "docker exec {$containerId} bash -c '{$escapedCommand}'";
 }
 
+function dockerNetworkCreateCommand(string $network, bool $isSwarm = false, bool $preferIpv6 = false, bool $suppressOutput = false): string
+{
+    $safeNetwork = escapeshellarg($network);
+    $outputRedirect = $suppressOutput ? ' >/dev/null 2>&1' : '';
+
+    if ($isSwarm) {
+        return "docker network create --driver overlay --attachable {$safeNetwork}{$outputRedirect}";
+    }
+
+    $plainCreate = "docker network create --attachable {$safeNetwork}{$outputRedirect}";
+
+    if (! $preferIpv6) {
+        return $plainCreate;
+    }
+
+    $ipv6Redirect = $suppressOutput ? ' >/dev/null 2>&1' : ' 2>/dev/null';
+    $ipv6Create = "docker network create --ipv6 --attachable {$safeNetwork}{$ipv6Redirect}";
+
+    return "({$ipv6Create} || {$plainCreate})";
+}
+
 function getContainerStatus(Server $server, string $container_id, bool $all_data = false, bool $throwError = false)
 {
     if ($server->isSwarm()) {

--- a/bootstrap/helpers/proxy.php
+++ b/bootstrap/helpers/proxy.php
@@ -21,6 +21,40 @@ function isDockerPredefinedNetwork(string $network): bool
     return in_array($network, ['default', 'host'], true);
 }
 
+function collectProxyIngressDockerNetworksByServer(Server $server)
+{
+    if ($server->isSwarm()) {
+        $networks = collect($server->swarmDockers)->map(function ($docker) {
+            return $docker['network'];
+        });
+
+        if ($networks->count() === 0) {
+            $networks = collect(['coolify-overlay']);
+        }
+    } else {
+        $networks = collect($server->standaloneDockers)->map(function ($docker) {
+            return $docker['network'];
+        });
+
+        if ($networks->count() === 0) {
+            $networks = collect(['coolify']);
+        }
+    }
+
+    return $networks->flatten()->unique()->filter(function ($network) {
+        return ! isDockerPredefinedNetwork($network);
+    });
+}
+
+function shouldCreateProxyNetworkWithIpv6(Server $server, string $network): bool
+{
+    if ($server->isSwarm()) {
+        return false;
+    }
+
+    return collectProxyIngressDockerNetworksByServer($server)->contains($network);
+}
+
 function collectProxyDockerNetworksByServer(Server $server)
 {
     if (! $server->isFunctional()) {
@@ -110,17 +144,19 @@ function connectProxyToNetworks(Server $server)
     if ($server->isSwarm()) {
         $commands = $networks->map(function ($network) {
             $safe = escapeshellarg($network);
+
             return [
-                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || docker network create --driver overlay --attachable {$safe} >/dev/null",
+                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || ".dockerNetworkCreateCommand($network, isSwarm: true, suppressOutput: true),
                 "docker network connect {$safe} coolify-proxy >/dev/null 2>&1 || true",
                 "echo 'Successfully connected coolify-proxy to {$safe} network.'",
             ];
         });
     } else {
-        $commands = $networks->map(function ($network) {
+        $commands = $networks->map(function ($network) use ($server) {
             $safe = escapeshellarg($network);
+
             return [
-                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || docker network create --attachable {$safe} >/dev/null",
+                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || ".dockerNetworkCreateCommand($network, preferIpv6: shouldCreateProxyNetworkWithIpv6($server, $network), suppressOutput: true),
                 "docker network connect {$safe} coolify-proxy >/dev/null 2>&1 || true",
                 "echo 'Successfully connected coolify-proxy to {$safe} network.'",
             ];
@@ -144,17 +180,19 @@ function ensureProxyNetworksExist(Server $server)
     if ($server->isSwarm()) {
         $commands = $networks->map(function ($network) {
             $safe = escapeshellarg($network);
+
             return [
                 "echo 'Ensuring network {$safe} exists...'",
-                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --driver overlay --attachable {$safe}",
+                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || ".dockerNetworkCreateCommand($network, isSwarm: true),
             ];
         });
     } else {
-        $commands = $networks->map(function ($network) {
+        $commands = $networks->map(function ($network) use ($server) {
             $safe = escapeshellarg($network);
+
             return [
                 "echo 'Ensuring network {$safe} exists...'",
-                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --attachable {$safe}",
+                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || ".dockerNetworkCreateCommand($network, preferIpv6: shouldCreateProxyNetworkWithIpv6($server, $network)),
             ];
         });
     }
@@ -230,21 +268,7 @@ function generateDefaultProxyConfiguration(Server $server, array $custom_command
     $proxy_path = $server->proxyPath();
     $proxy_type = $server->proxyType();
 
-    if ($server->isSwarm()) {
-        $networks = collect($server->swarmDockers)->map(function ($docker) {
-            return $docker['network'];
-        })->unique();
-        if ($networks->count() === 0) {
-            $networks = collect(['coolify-overlay']);
-        }
-    } else {
-        $networks = collect($server->standaloneDockers)->map(function ($docker) {
-            return $docker['network'];
-        })->unique();
-        if ($networks->count() === 0) {
-            $networks = collect(['coolify']);
-        }
-    }
+    $networks = collectProxyIngressDockerNetworksByServer($server);
 
     $array_of_networks = collect([]);
     $filtered_networks = collect([]);

--- a/tests/Unit/ProxyDockerNetworkCreateCommandTest.php
+++ b/tests/Unit/ProxyDockerNetworkCreateCommandTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use App\Models\Server;
+
+function mockProxyNetworkServer(bool $isSwarm = false, array $standaloneDockers = [], array $swarmDockers = []): Server
+{
+    $server = Mockery::mock(Server::class);
+    $server->shouldReceive('isSwarm')->andReturn($isSwarm);
+    $server->shouldReceive('getSchemalessAttributes')->andReturn([]);
+    $server->shouldReceive('getAttribute')->with('standaloneDockers')->andReturn(collect($standaloneDockers));
+    $server->shouldReceive('getAttribute')->with('swarmDockers')->andReturn(collect($swarmDockers));
+
+    return $server;
+}
+
+it('can prefer ipv6 for standalone proxy networks while keeping a plain fallback', function () {
+    $command = dockerNetworkCreateCommand('coolify', preferIpv6: true);
+
+    expect($command)->toBe("(docker network create --ipv6 --attachable 'coolify' 2>/dev/null || docker network create --attachable 'coolify')");
+});
+
+it('keeps plain standalone network creation when ipv6 is not requested', function () {
+    $command = dockerNetworkCreateCommand('app-network');
+
+    expect($command)->toBe("docker network create --attachable 'app-network'");
+});
+
+it('prefers ipv6 only for standalone networks used by the proxy compose file', function () {
+    $server = mockProxyNetworkServer(standaloneDockers: [
+        ['network' => 'coolify'],
+    ]);
+
+    expect(shouldCreateProxyNetworkWithIpv6($server, 'coolify'))->toBeTrue()
+        ->and(shouldCreateProxyNetworkWithIpv6($server, 'application-uuid'))->toBeFalse();
+});
+
+it('uses the default coolify network as the standalone proxy network when no destinations exist', function () {
+    $server = mockProxyNetworkServer();
+
+    expect(shouldCreateProxyNetworkWithIpv6($server, 'coolify'))->toBeTrue()
+        ->and(shouldCreateProxyNetworkWithIpv6($server, 'preview-network'))->toBeFalse();
+});
+
+it('does not request ipv6 for swarm overlay proxy networks', function () {
+    $server = mockProxyNetworkServer(isSwarm: true, swarmDockers: [
+        ['network' => 'coolify-overlay'],
+    ]);
+
+    expect(shouldCreateProxyNetworkWithIpv6($server, 'coolify-overlay'))->toBeFalse();
+
+    $command = dockerNetworkCreateCommand('coolify-overlay', isSwarm: true, preferIpv6: true);
+
+    expect($command)
+        ->toBe("docker network create --driver overlay --attachable 'coolify-overlay'")
+        ->not->toContain('--ipv6');
+});


### PR DESCRIPTION
## Changes

- Added a shared Docker network create helper that can prefer IPv6 for standalone bridge networks, then fall back to the existing create command.
- Applied IPv6 preference only to proxy ingress networks: the default coolify network and custom standalone destination networks used by the proxy compose file.
- Kept app/service backend networks on the existing create path and left swarm overlay networks unchanged.
- Reused the same helper when validating or installing the default network and when creating a standalone destination network.

## Issues

- Fixes #3436

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No UI change. I verified the helper against Docker 29.4 by creating a temporary IPv6 network, inspecting EnableIPv6=true, and removing it.

## Testing

- ./vendor/bin/pest tests/Unit/ProxyHelperTest.php tests/Unit/DockerNetworkInjectionTest.php tests/Unit/ProxyDockerNetworkCreateCommandTest.php --compact
- php -l on the changed PHP files
- git diff --check
- local Docker create/inspect/remove check

/claim #3436

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the contributor guidelines. If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched existing issues and pull requests, including closed ones, to ensure this is not a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance and I am confident that they will work as expected when a maintainer tests them.