### PR TITLE
fix: prefer IPv6 for proxy ingress networks

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -98,11 +98,11 @@ class InstallDocker
             ]);
             if ($server->isSwarm()) {
                 $command = $command->merge([
-                    'docker network create --attachable --driver overlay coolify-overlay >/dev/null 2>&1 || true',
+                    dockerNetworkEnsureCommand('coolify-overlay', isSwarm: true, suppressOutput: true).' || true',
                 ]);
             } else {
                 $command = $command->merge([
-                    'docker network create --attachable coolify >/dev/null 2>&1 || true',
+                    dockerNetworkEnsureCommand('coolify', preferIpv6: true, repairEmptyIpv4Only: true, suppressOutput: true).' || true',
                 ]);
                 $command = $command->merge([
                     "echo 'Done!'",

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -1406,9 +1406,9 @@ $schema://$host {
             return;
         }
         if ($isSwarm) {
-            return instant_remote_process(['docker network create --attachable --driver overlay coolify-overlay >/dev/null 2>&1 || true'], $this, false);
+            return instant_remote_process([dockerNetworkEnsureCommand('coolify-overlay', isSwarm: true, suppressOutput: true).' || true'], $this, false);
         } else {
-            return instant_remote_process(['docker network create coolify --attachable >/dev/null 2>&1 || true'], $this, false);
+            return instant_remote_process([dockerNetworkEnsureCommand('coolify', preferIpv6: true, repairEmptyIpv4Only: true, suppressOutput: true).' || true'], $this, false);
         }
     }
 

--- a/app/Models/StandaloneDocker.php
+++ b/app/Models/StandaloneDocker.php
@@ -23,9 +23,8 @@ class StandaloneDocker extends BaseModel
         parent::boot();
         static::created(function ($newStandaloneDocker) {
             $server = $newStandaloneDocker->server;
-            $safeNetwork = escapeshellarg($newStandaloneDocker->network);
             instant_remote_process([
-                "docker network inspect {$safeNetwork} >/dev/null 2>&1 || docker network create --driver overlay --attachable {$safeNetwork} >/dev/null",
+                dockerNetworkEnsureCommand($newStandaloneDocker->network, preferIpv6: true, repairEmptyIpv4Only: true, suppressOutput: true),
             ], $server, false);
             ConnectProxyToNetworksJob::dispatchSync($server);
         });

--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -149,6 +149,58 @@ function executeInDocker(string $containerId, string $command)
     return "docker exec {$containerId} bash -c '{$escapedCommand}'";
 }
 
+function dockerNetworkExistsCommand(string $network): string
+{
+    $safeNetwork = escapeshellarg($network);
+
+    return "docker network inspect {$safeNetwork} >/dev/null 2>&1";
+}
+
+function dockerNetworkIpv6EnabledCommand(string $network): string
+{
+    $safeNetwork = escapeshellarg($network);
+
+    return "docker network inspect --format '{{.EnableIPv6}}' {$safeNetwork} 2>/dev/null | grep -Fxq true";
+}
+
+function dockerNetworkCreateCommand(string $network, bool $isSwarm = false, bool $preferIpv6 = false, bool $suppressOutput = false): string
+{
+    $safeNetwork = escapeshellarg($network);
+    $outputRedirect = $suppressOutput ? ' >/dev/null 2>&1' : '';
+
+    if ($isSwarm) {
+        return "docker network create --driver overlay --attachable {$safeNetwork}{$outputRedirect}";
+    }
+
+    $plainCreate = "docker network create --attachable {$safeNetwork}{$outputRedirect}";
+
+    if (! $preferIpv6) {
+        return $plainCreate;
+    }
+
+    $ipv6Redirect = $suppressOutput ? ' >/dev/null 2>&1' : ' 2>/dev/null';
+    $ipv6Create = "docker network create --ipv6 --attachable {$safeNetwork}{$ipv6Redirect}";
+
+    return "({$ipv6Create} || {$plainCreate})";
+}
+
+function dockerNetworkEnsureCommand(string $network, bool $isSwarm = false, bool $preferIpv6 = false, bool $repairEmptyIpv4Only = false, bool $suppressOutput = false): string
+{
+    $safeNetwork = escapeshellarg($network);
+    $inspectCommand = dockerNetworkExistsCommand($network);
+    $createCommand = dockerNetworkCreateCommand($network, $isSwarm, $preferIpv6, $suppressOutput);
+
+    if ($isSwarm || ! $preferIpv6 || ! $repairEmptyIpv4Only) {
+        return "{$inspectCommand} || {$createCommand}";
+    }
+
+    $ipv6CheckCommand = dockerNetworkIpv6EnabledCommand($network);
+    $containerCountCommand = "docker network inspect --format '{{len .Containers}}' {$safeNetwork} 2>/dev/null || echo 1";
+    $warning = escapeshellarg("Coolify proxy network {$network} exists without IPv6. Recreate the network during a maintenance window so IPv6 clients keep their real IP in X-Forwarded-For.");
+
+    return "(if ! {$inspectCommand}; then {$createCommand}; elif {$ipv6CheckCommand}; then true; else container_count=\$({$containerCountCommand}); if [ \"\$container_count\" = \"0\" ]; then docker network rm {$safeNetwork} >/dev/null 2>&1 && {$createCommand}; else echo {$warning}; fi; fi)";
+}
+
 function getContainerStatus(Server $server, string $container_id, bool $all_data = false, bool $throwError = false)
 {
     if ($server->isSwarm()) {

--- a/bootstrap/helpers/proxy.php
+++ b/bootstrap/helpers/proxy.php
@@ -36,6 +36,40 @@ function collectProxyDockerNetworksByServer(Server $server)
         return collect(json_decode($network))->keys();
     })->flatten()->unique();
 }
+
+function collectProxyIngressDockerNetworksByServer(Server $server)
+{
+    if ($server->isSwarm()) {
+        $networks = collect($server->swarmDockers)->map(function ($docker) {
+            return $docker['network'];
+        });
+
+        if ($networks->count() === 0) {
+            $networks = collect(['coolify-overlay']);
+        }
+    } else {
+        $networks = collect($server->standaloneDockers)->map(function ($docker) {
+            return $docker['network'];
+        });
+
+        if ($networks->count() === 0) {
+            $networks = collect(['coolify']);
+        }
+    }
+
+    return $networks->flatten()->unique()->filter(function ($network) {
+        return ! isDockerPredefinedNetwork($network);
+    });
+}
+
+function shouldCreateProxyNetworkWithIpv6(Server $server, string $network): bool
+{
+    if ($server->isSwarm()) {
+        return false;
+    }
+
+    return collectProxyIngressDockerNetworksByServer($server)->contains($network);
+}
 function collectDockerNetworksByServer(Server $server)
 {
     $allNetworks = collect([]);
@@ -110,17 +144,20 @@ function connectProxyToNetworks(Server $server)
     if ($server->isSwarm()) {
         $commands = $networks->map(function ($network) {
             $safe = escapeshellarg($network);
+
             return [
-                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || docker network create --driver overlay --attachable {$safe} >/dev/null",
+                dockerNetworkEnsureCommand($network, isSwarm: true, suppressOutput: true),
                 "docker network connect {$safe} coolify-proxy >/dev/null 2>&1 || true",
                 "echo 'Successfully connected coolify-proxy to {$safe} network.'",
             ];
         });
     } else {
-        $commands = $networks->map(function ($network) {
+        $commands = $networks->map(function ($network) use ($server) {
             $safe = escapeshellarg($network);
+            $preferIpv6 = shouldCreateProxyNetworkWithIpv6($server, $network);
+
             return [
-                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || docker network create --attachable {$safe} >/dev/null",
+                dockerNetworkEnsureCommand($network, preferIpv6: $preferIpv6, repairEmptyIpv4Only: $preferIpv6, suppressOutput: true),
                 "docker network connect {$safe} coolify-proxy >/dev/null 2>&1 || true",
                 "echo 'Successfully connected coolify-proxy to {$safe} network.'",
             ];
@@ -144,17 +181,20 @@ function ensureProxyNetworksExist(Server $server)
     if ($server->isSwarm()) {
         $commands = $networks->map(function ($network) {
             $safe = escapeshellarg($network);
+
             return [
                 "echo 'Ensuring network {$safe} exists...'",
-                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --driver overlay --attachable {$safe}",
+                dockerNetworkEnsureCommand($network, isSwarm: true),
             ];
         });
     } else {
-        $commands = $networks->map(function ($network) {
+        $commands = $networks->map(function ($network) use ($server) {
             $safe = escapeshellarg($network);
+            $preferIpv6 = shouldCreateProxyNetworkWithIpv6($server, $network);
+
             return [
                 "echo 'Ensuring network {$safe} exists...'",
-                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --attachable {$safe}",
+                dockerNetworkEnsureCommand($network, preferIpv6: $preferIpv6, repairEmptyIpv4Only: $preferIpv6),
             ];
         });
     }
@@ -230,21 +270,7 @@ function generateDefaultProxyConfiguration(Server $server, array $custom_command
     $proxy_path = $server->proxyPath();
     $proxy_type = $server->proxyType();
 
-    if ($server->isSwarm()) {
-        $networks = collect($server->swarmDockers)->map(function ($docker) {
-            return $docker['network'];
-        })->unique();
-        if ($networks->count() === 0) {
-            $networks = collect(['coolify-overlay']);
-        }
-    } else {
-        $networks = collect($server->standaloneDockers)->map(function ($docker) {
-            return $docker['network'];
-        })->unique();
-        if ($networks->count() === 0) {
-            $networks = collect(['coolify']);
-        }
-    }
+    $networks = collectProxyIngressDockerNetworksByServer($server);
 
     $array_of_networks = collect([]);
     $filtered_networks = collect([]);

--- a/tests/Unit/ProxyNetworkCommandTest.php
+++ b/tests/Unit/ProxyNetworkCommandTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use App\Models\Server;
+
+function proxyNetworkCommandTestServer(bool $isSwarm = false, array $standaloneDockers = [], array $swarmDockers = []): Server
+{
+    $server = Mockery::mock(Server::class);
+    $server->shouldReceive('isSwarm')->andReturn($isSwarm);
+    $server->shouldReceive('getSchemalessAttributes')->andReturn([]);
+    $server->shouldReceive('getAttribute')->with('standaloneDockers')->andReturn(collect($standaloneDockers));
+    $server->shouldReceive('getAttribute')->with('swarmDockers')->andReturn(collect($swarmDockers));
+
+    return $server;
+}
+
+it('builds standalone Docker network creation with IPv6 fallback', function () {
+    $command = dockerNetworkCreateCommand('coolify', preferIpv6: true);
+
+    expect($command)->toBe("(docker network create --ipv6 --attachable 'coolify' 2>/dev/null || docker network create --attachable 'coolify')");
+});
+
+it('builds quiet standalone Docker network creation with IPv6 fallback', function () {
+    $command = dockerNetworkCreateCommand('coolify', preferIpv6: true, suppressOutput: true);
+
+    expect($command)->toBe("(docker network create --ipv6 --attachable 'coolify' >/dev/null 2>&1 || docker network create --attachable 'coolify' >/dev/null 2>&1)");
+});
+
+it('does not add IPv6 flags to swarm overlay networks', function () {
+    $command = dockerNetworkCreateCommand('coolify-overlay', isSwarm: true, preferIpv6: true);
+
+    expect($command)
+        ->toBe("docker network create --driver overlay --attachable 'coolify-overlay'")
+        ->not->toContain('--ipv6');
+});
+
+it('repairs an empty existing IPv4-only proxy network and warns when it is in use', function () {
+    $command = dockerNetworkEnsureCommand('coolify', preferIpv6: true, repairEmptyIpv4Only: true, suppressOutput: true);
+
+    expect($command)
+        ->toContain("docker network inspect --format '{{.EnableIPv6}}' 'coolify'")
+        ->toContain("docker network inspect --format '{{len .Containers}}' 'coolify'")
+        ->toContain("docker network rm 'coolify'")
+        ->toContain('exists without IPv6')
+        ->toContain('X-Forwarded-For');
+});
+
+it('uses the default coolify network as a standalone proxy ingress network', function () {
+    $server = proxyNetworkCommandTestServer();
+
+    expect(shouldCreateProxyNetworkWithIpv6($server, 'coolify'))->toBeTrue()
+        ->and(shouldCreateProxyNetworkWithIpv6($server, 'app-network'))->toBeFalse();
+});
+
+it('prefers IPv6 only for standalone networks used by the proxy compose file', function () {
+    $server = proxyNetworkCommandTestServer(standaloneDockers: [
+        ['network' => 'frontend'],
+    ]);
+
+    expect(shouldCreateProxyNetworkWithIpv6($server, 'frontend'))->toBeTrue()
+        ->and(shouldCreateProxyNetworkWithIpv6($server, 'worker'))->toBeFalse();
+});
+
+it('does not request IPv6 for swarm proxy ingress networks', function () {
+    $server = proxyNetworkCommandTestServer(isSwarm: true, swarmDockers: [
+        ['network' => 'coolify-overlay'],
+    ]);
+
+    expect(shouldCreateProxyNetworkWithIpv6($server, 'coolify-overlay'))->toBeFalse();
+});


### PR DESCRIPTION
## Changes

- Creates standalone proxy ingress networks with `--ipv6` first, then falls back to the current non-IPv6 create command when Docker or the host cannot create IPv6 networks.
- Limits IPv6 preference to Coolify-managed standalone proxy ingress networks (`coolify` or configured standalone proxy networks).
- Leaves swarm overlay networks and backend app/service-only networks on the existing behavior.
- Detects existing IPv4-only proxy ingress networks and prints a maintenance-window remediation warning instead of deleting/recreating Docker networks automatically.
- Adds focused unit coverage for command generation, fallback behavior, existing-network warning, default/custom proxy ingress network selection, and swarm exclusion.

## Why this matches #3436

The latest issue discussion narrows the bug to IPv6 clients entering Traefik through a Coolify proxy ingress network that was created IPv4-only. This patch targets that ingress network path without changing unrelated backend networks.

## Demo

Command-generation behavior covered by `tests/Unit/ProxyNetworkCommandTest.php`:

- `dockerNetworkCreateCommand('coolify', preferIpv6: true)` generates `docker network create --ipv6 --attachable 'coolify'` with fallback to the existing plain create command.
- Existing IPv4-only proxy networks inspect `.EnableIPv6` and warn without removing the network automatically.

## Issues

- Fixes #3436

/claim #3436

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Backend-only proxy network command change; no UI preview applies.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Assisted with codebase inspection, patching, and validation; final changes were reviewed before submission.

## Testing

- `git diff --check`
- PHP syntax checks on all changed PHP files

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
