### PR TITLE
feat(api): allow log drain config via PATCH /servers/{uuid}

### DIFF
--- a/app/Http/Controllers/Api/ServersController.php
+++ b/app/Http/Controllers/Api/ServersController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers\Api;
 
 use App\Actions\Server\DeleteServer;
+use App\Actions\Server\StartLogDrain;
+use App\Actions\Server\StopLogDrain;
 use App\Actions\Server\ValidateServer;
 use App\Enums\ProxyStatus;
 use App\Enums\ProxyTypes;
@@ -649,7 +651,7 @@ class ServersController extends Controller
     )]
     public function update_server(Request $request)
     {
-        $allowedFields = ['name', 'description', 'ip', 'port', 'user', 'private_key_uuid', 'is_build_server', 'instant_validate', 'proxy_type', 'concurrent_builds', 'dynamic_timeout', 'deployment_queue_limit', 'server_disk_usage_notification_threshold', 'server_disk_usage_check_frequency', 'connection_timeout'];
+        $allowedFields = ['name', 'description', 'ip', 'port', 'user', 'private_key_uuid', 'is_build_server', 'instant_validate', 'proxy_type', 'concurrent_builds', 'dynamic_timeout', 'deployment_queue_limit', 'server_disk_usage_notification_threshold', 'server_disk_usage_check_frequency', 'connection_timeout', 'is_logdrain_newrelic_enabled', 'is_logdrain_highlight_enabled', 'is_logdrain_axiom_enabled', 'is_logdrain_custom_enabled', 'logdrain_newrelic_license_key', 'logdrain_newrelic_base_uri', 'logdrain_highlight_project_id', 'logdrain_axiom_api_key', 'logdrain_axiom_dataset_name', 'logdrain_custom_config', 'logdrain_custom_config_parser'];
 
         $teamId = getTeamIdFromToken();
         if (is_null($teamId)) {
@@ -676,6 +678,17 @@ class ServersController extends Controller
             'server_disk_usage_notification_threshold' => 'integer|min:1|max:100',
             'server_disk_usage_check_frequency' => 'string',
             'connection_timeout' => 'integer|min:1|max:300',
+            'is_logdrain_newrelic_enabled' => 'boolean|nullable',
+            'is_logdrain_highlight_enabled' => 'boolean|nullable',
+            'is_logdrain_axiom_enabled' => 'boolean|nullable',
+            'is_logdrain_custom_enabled' => 'boolean|nullable',
+            'logdrain_newrelic_license_key' => 'string|nullable',
+            'logdrain_newrelic_base_uri' => 'string|nullable',
+            'logdrain_highlight_project_id' => 'string|nullable',
+            'logdrain_axiom_api_key' => 'string|nullable',
+            'logdrain_axiom_dataset_name' => 'string|nullable',
+            'logdrain_custom_config' => 'string|nullable',
+            'logdrain_custom_config_parser' => 'string|nullable',
         ]);
 
         $extraFields = array_diff(array_keys($request->all()), $allowedFields);
@@ -723,6 +736,15 @@ class ServersController extends Controller
         $advancedSettings = $request->only(['concurrent_builds', 'dynamic_timeout', 'deployment_queue_limit', 'server_disk_usage_notification_threshold', 'server_disk_usage_check_frequency', 'connection_timeout']);
         if (! empty($advancedSettings)) {
             $server->settings()->update(array_filter($advancedSettings, fn ($value) => ! is_null($value)));
+        }
+
+        $logDrainFields = ['is_logdrain_newrelic_enabled', 'is_logdrain_highlight_enabled', 'is_logdrain_axiom_enabled', 'is_logdrain_custom_enabled', 'logdrain_newrelic_license_key', 'logdrain_newrelic_base_uri', 'logdrain_highlight_project_id', 'logdrain_axiom_api_key', 'logdrain_axiom_dataset_name', 'logdrain_custom_config', 'logdrain_custom_config_parser'];
+        $logDrainPayload = $request->only($logDrainFields);
+        if (! empty($logDrainPayload)) {
+            $server->settings()->update($logDrainPayload);
+            $server->refresh();
+            StopLogDrain::run($server);
+            StartLogDrain::run($server);
         }
 
         if ($request->instant_validate) {


### PR DESCRIPTION
## What

Adds the 11 log-drain settings to `update_server` so they can be configured through the public API instead of UI-only.

## Why

Today, `PATCH /api/v1/servers/{uuid}` with any `logdrain_*` or `is_logdrain_*_enabled` field returns:

\`\`\`json
{"message":"Validation failed.","errors":{"is_logdrain_custom_enabled":["This field is not allowed."]}}
\`\`\`

…because the controller hard-codes an `\$allowedFields` allowlist. So infra automation (IaC, scripts, MCP tools) that wants to enable a log drain has to either click through the Livewire form by hand or write directly to `server_settings` and then call `StartLogDrain` over SSH — neither is great.

## What changed

In `app/Http/Controllers/Api/ServersController.php::update_server`:

1. Added the 11 fields (4 enable toggles + 7 config strings) to `\$allowedFields`.
2. Added matching `boolean|nullable` / `string|nullable` validator rules.
3. When any of those fields is present in the payload, persist them to `ServerSetting` and then run `StopLogDrain` + `StartLogDrain` — mirroring exactly what the Livewire form's save action does.

`use` statements for `StartLogDrain` and `StopLogDrain` added at the top of the file.

## Behavior notes

- Only one drain can be active at a time — `StartLogDrain` picks the first enabled type (`newrelic > highlight > axiom > custom`), unchanged from today.
- The Stop+Start pair runs whenever any log-drain field is in the payload, matching UI semantics.
- No new tests added — the existing `update_server` flow has no test coverage in the repo and this PR keeps that scope. Happy to add one in a follow-up if you'd like.

## How tested

Locally against a self-hosted Coolify v4.1.0:

\`\`\`bash
curl -X PATCH https://coolify.example/api/v1/servers/{uuid} \\
  -H "Authorization: Bearer <token>" -H "Content-Type: application/json" \\
  -d '{"is_logdrain_custom_enabled": true, "logdrain_custom_config": "[SERVICE]\nFlush 5\n..."}'
\`\`\`

Returns 201, `coolify-log-drain` container starts with the new config, and a follow-up PATCH with `{"is_logdrain_custom_enabled": false}` tears it down.