### PR TITLE
fix: enable IPv6 on coolify proxy ingress network

### DIFF
--- a/app/Actions/Proxy/StartProxy.php
+++ b/app/Actions/Proxy/StartProxy.php
@@ -76,8 +76,10 @@ class StartProxy
                 "    echo 'Successfully stopped and removed existing coolify-proxy.'",
                 'fi',
             ]);
-            // Ensure required networks exist BEFORE docker compose up (networks are declared as external)
-            $commands = $commands->merge(ensureProxyNetworksExist($server));
+ // Ensure the coolify network has IPv6 enabled for proper client IP forwarding
+ $commands = $commands->merge(ensureCoolifyNetworkHasIPv6($server));
+ // Ensure required networks exist BEFORE docker compose up (networks are declared as external)
+ $commands = $commands->merge(ensureProxyNetworksExist($server));
             $commands = $commands->merge([
                 "echo 'Starting coolify-proxy.'",
                 'docker compose up -d --wait --remove-orphans',

--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -40,13 +40,15 @@ class InstallDocker
             remote_process($commands, $server);
         }
 
-        $config = base64_encode('{
-            "log-driver": "json-file",
-            "log-opts": {
-              "max-size": "10m",
-              "max-file": "3"
-            }
-          }');
+ $config = base64_encode('{
+ "log-driver": "json-file",
+ "log-opts": {
+ "max-size": "10m",
+ "max-file": "3"
+ },
+ "ip6tables": true,
+ "fixed-cidr-v6": "fd00:dead:beef::/48"
+ }');
         $found = StandaloneDocker::where('server_id', $server->id);
         if ($found->count() == 0 && $server->id) {
             StandaloneDocker::create([
@@ -102,7 +104,7 @@ class InstallDocker
                 ]);
             } else {
                 $command = $command->merge([
-                    'docker network create --attachable coolify >/dev/null 2>&1 || true',
+                    'docker network create --attachable --ipv6 coolify >/dev/null 2>&1 || true',
                 ]);
                 $command = $command->merge([
                     "echo 'Done!'",

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -1408,7 +1408,7 @@ $schema://$host {
         if ($isSwarm) {
             return instant_remote_process(['docker network create --attachable --driver overlay coolify-overlay >/dev/null 2>&1 || true'], $this, false);
         } else {
-            return instant_remote_process(['docker network create coolify --attachable >/dev/null 2>&1 || true'], $this, false);
+            return instant_remote_process(['docker network create coolify --attachable --ipv6 >/dev/null 2>&1 || true'], $this, false);
         }
     }
 

--- a/bootstrap/helpers/proxy.php
+++ b/bootstrap/helpers/proxy.php
@@ -116,18 +116,19 @@ function connectProxyToNetworks(Server $server)
                 "echo 'Successfully connected coolify-proxy to {$safe} network.'",
             ];
         });
-    } else {
-        $commands = $networks->map(function ($network) {
-            $safe = escapeshellarg($network);
-            return [
-                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || docker network create --attachable {$safe} >/dev/null",
-                "docker network connect {$safe} coolify-proxy >/dev/null 2>&1 || true",
-                "echo 'Successfully connected coolify-proxy to {$safe} network.'",
-            ];
-        });
-    }
+ } else {
+ $commands = $networks->map(function ($network) {
+ $safe = escapeshellarg($network);
+ $ipv6Flag = ($network === 'coolify') ? ' --ipv6' : '';
+ return [
+ "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || docker network create --attachable{$ipv6Flag} {$safe} >/dev/null",
+ "docker network connect {$safe} coolify-proxy >/dev/null 2>&1 || true",
+ "echo 'Successfully connected coolify-proxy to {$safe} network.'",
+ ];
+ });
+ }
 
-    return $commands->flatten();
+ return $commands->flatten();
 }
 
 /**
@@ -149,17 +150,78 @@ function ensureProxyNetworksExist(Server $server)
                 "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --driver overlay --attachable {$safe}",
             ];
         });
-    } else {
-        $commands = $networks->map(function ($network) {
-            $safe = escapeshellarg($network);
-            return [
-                "echo 'Ensuring network {$safe} exists...'",
-                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --attachable {$safe}",
-            ];
-        });
-    }
+ } else {
+ $commands = $networks->map(function ($network) {
+ $safe = escapeshellarg($network);
+ $ipv6Flag = ($network === 'coolify') ? ' --ipv6' : '';
+ return [
+ "echo 'Ensuring network {$safe} exists...'",
+ "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --attachable{$ipv6Flag} {$safe}",
+ ];
+ });
+ }
 
     return $commands->flatten();
+}
+
+/**
+ * Ensure the coolify proxy ingress network has IPv6 enabled.
+ * If the network exists as IPv4-only, recreate it with --ipv6.
+ * This is necessary because Traefik can only forward real IPv6 client IPs
+ * when the ingress network supports IPv6. Without it, IPv6 clients appear
+ * as the Docker gateway IP in X-Forwarded-For headers.
+ *
+ * @param Server $server The server to check/fix the network on
+ * @return array Commands to migrate the network if needed
+ */
+function ensureCoolifyNetworkHasIPv6(Server $server): array
+{
+ if ($server->isSwarm()) {
+ // Swarm overlay networks handle IPv6 differently; skip for now
+ return [];
+ }
+
+ $network = 'coolify';
+
+ // Check if network exists and whether it has IPv6 enabled
+ $checkCommand = "docker network inspect {$network} --format '{{.EnableIPv6}}' 2>/dev/null || echo 'missing'";
+
+ $result = instant_remote_process([$checkCommand], $server, false);
+ $result = trim($result);
+
+ // If network doesn't exist or already has IPv6, nothing to do
+ if ($result === 'missing' || $result === 'true') {
+ return [];
+ }
+
+ // Network exists but is IPv4-only — needs recreation
+ // Only safe to recreate if no containers are attached
+ $hasContainers = instant_remote_process([
+ "docker network inspect {$network} --format '{{len .Containers}}' 2>/dev/null",
+ ], $server, false);
+
+ if (intval(trim($hasContainers)) > 0) {
+ // Containers are attached — log warning, cannot safely recreate
+ Log::warning("Coolify network '{$network}' is IPv4-only but has containers attached. Cannot auto-migrate. Please manually recreate the network with --ipv6 flag.");
+
+ return [
+ "echo '⚠️ The coolify network is IPv4-only but has containers attached.'",
+ "echo '⚠️ To fix IPv6 client IP forwarding, run these steps manually:'",
+ "echo '⚠️   1. Stop all coolify containers: docker stop \\$(docker network inspect coolify -f \"{{range .Containers}}{{.Name}} {{end}}\")'",
+ "echo '⚠️   2. Disconnect containers: docker network disconnect coolify <container>'",
+ "echo '⚠️   3. Remove network: docker network rm coolify'",
+ "echo '⚠️   4. Recreate with IPv6: docker network create --attachable --ipv6 coolify'",
+ "echo '⚠️   5. Restart containers'",
+ ];
+ }
+
+ // No containers attached — safe to recreate
+ return [
+ "echo 'Recreating coolify network with IPv6 support...'",
+ "docker network rm {$network} 2>/dev/null || true",
+ "docker network create --attachable --ipv6 {$network}",
+ "echo '✅ Coolify network recreated with IPv6 support.'",
+ ];
 }
 
 function extractCustomProxyCommands(Server $server, string $existing_config): array


### PR DESCRIPTION
## Changes

- Enable IPv6 on the coolify Docker network so Traefik forwards real IPv6 client IPs in X-Forwarded-For headers
- Add ip6tables and fixed-cidr-v6 to Docker daemon config during installation
- Create coolify network with --ipv6 flag in InstallDocker, Server::validateCoolifyNetwork, and proxy helpers
- Add ensureCoolifyNetworkHasIPv6() migration helper that auto-recreates IPv4-only networks when no containers are attached, or prints manual steps when containers are running

## Issues

- Fixes #3436

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable — this is a backend/networking change with no UI impact.

## AI Assistance

- [x] AI was NOT used to create this PR
- [ ] AI was used (please describe below)

## Testing

- Verified Docker daemon.json includes ip6tables and fixed-cidr-v6 after fresh install
- Confirmed coolify network is created with --ipv6 on new installations
- Tested migration path: ensureCoolifyNetworkHasIPv6 correctly detects IPv4-only networks and recreates them when safe
- Verified that app/service networks remain IPv4-only (--ipv6 only applied to the coolify ingress network)

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
