### PR TITLE
Add team deployment history page with filters

### DIFF
--- a/app/Livewire/Deployments/Index.php
+++ b/app/Livewire/Deployments/Index.php
@@ -1,0 +1,277 @@
+<?php
+
+namespace App\Livewire\Deployments;
+
+use App\Enums\ApplicationDeploymentStatus;
+use App\Models\Application;
+use App\Models\ApplicationDeploymentQueue;
+use App\Models\Project;
+use App\Models\Server;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class Index extends Component
+{
+    use WithPagination;
+
+    public string $project = 'all';
+
+    public string $server = 'all';
+
+    public string $source = 'all';
+
+    public string $status = 'all';
+
+    public int $perPage = 20;
+
+    protected $queryString = [
+        'project' => ['except' => 'all'],
+        'server' => ['except' => 'all'],
+        'source' => ['except' => 'all'],
+        'status' => ['except' => 'all'],
+    ];
+
+    public function updatingProject(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatingServer(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatingSource(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatingStatus(): void
+    {
+        $this->resetPage();
+    }
+
+    public function clearFilters(): void
+    {
+        $this->project = 'all';
+        $this->server = 'all';
+        $this->source = 'all';
+        $this->status = 'all';
+        $this->resetPage();
+    }
+
+    public function getListeners(): array
+    {
+        $teamId = auth()->user()->currentTeam()->id;
+
+        return [
+            "echo-private:team.{$teamId},ServiceChecked" => '$refresh',
+        ];
+    }
+
+    public function projectOptions(): Collection
+    {
+        return Project::ownedByCurrentTeam()
+            ->whereHas('applications.deployment_queue')
+            ->get(['id', 'name']);
+    }
+
+    public function serverOptions(): Collection
+    {
+        return Server::ownedByCurrentTeam(['id', 'name'])
+            ->whereHas('settings')
+            ->whereHas('teamDeployments')
+            ->get(['id', 'name']);
+    }
+
+    public function sourceOptions(): Collection
+    {
+        return Application::ownedByCurrentTeam()
+            ->whereHas('deployment_queue')
+            ->with('source')
+            ->get(['id', 'source_id', 'source_type', 'git_repository'])
+            ->map(fn (Application $application) => [
+                'value' => $this->sourceFilterValue($application->source_type, $application->source_id),
+                'label' => $this->sourceFilterLabel($application),
+            ])
+            ->unique('value')
+            ->sortBy('label')
+            ->values();
+    }
+
+    public function statusOptions(): Collection
+    {
+        return collect(ApplicationDeploymentStatus::cases())
+            ->map(fn (ApplicationDeploymentStatus $status) => [
+                'value' => $status->value,
+                'label' => $this->statusLabel($status->value),
+            ]);
+    }
+
+    public function deployments(): LengthAwarePaginator
+    {
+        return $this->deploymentQuery()
+            ->latest('created_at')
+            ->paginate($this->perPage);
+    }
+
+    public function hasActiveFilters(): bool
+    {
+        return $this->project !== 'all'
+            || $this->server !== 'all'
+            || $this->source !== 'all'
+            || $this->status !== 'all';
+    }
+
+    public function showServerFilter(): bool
+    {
+        return $this->serverOptions()->count() > 1;
+    }
+
+    public function showSourceFilter(): bool
+    {
+        return $this->sourceOptions()->count() > 1;
+    }
+
+    public function statusLabel(?string $status): string
+    {
+        return match ($status) {
+            ApplicationDeploymentStatus::FINISHED->value => 'Done',
+            ApplicationDeploymentStatus::IN_PROGRESS->value => 'Pending',
+            ApplicationDeploymentStatus::QUEUED->value => 'Queued',
+            ApplicationDeploymentStatus::FAILED->value => 'Failed',
+            ApplicationDeploymentStatus::CANCELLED_BY_USER->value => 'Cancelled',
+            default => str($status ?? 'unknown')->headline()->toString(),
+        };
+    }
+
+    public function deploymentType(ApplicationDeploymentQueue $deployment): string
+    {
+        if ($deployment->is_webhook) {
+            return $deployment->pull_request_id ? "Webhook PR #{$deployment->pull_request_id}" : 'Webhook';
+        }
+
+        if ($deployment->pull_request_id) {
+            return "Pull Request #{$deployment->pull_request_id}";
+        }
+
+        if ($deployment->rollback) {
+            return 'Rollback';
+        }
+
+        if ($deployment->is_api) {
+            return 'API';
+        }
+
+        return 'Manual';
+    }
+
+    public function deploymentUrl(ApplicationDeploymentQueue $deployment): ?string
+    {
+        if ($deployment->deployment_url) {
+            return $deployment->deployment_url;
+        }
+
+        $application = $deployment->application;
+        $environment = $application?->environment;
+        $project = $environment?->project;
+
+        if (! $application || ! $environment || ! $project) {
+            return null;
+        }
+
+        return route('project.application.deployment.show', [
+            'project_uuid' => $project->uuid,
+            'environment_uuid' => $environment->uuid,
+            'application_uuid' => $application->uuid,
+            'deployment_uuid' => $deployment->deployment_uuid,
+        ]);
+    }
+
+    public function sourceName(?Application $application): string
+    {
+        if (! $application) {
+            return 'Unknown source';
+        }
+
+        return $this->sourceFilterLabel($application);
+    }
+
+    private function deploymentQuery(): Builder
+    {
+        $serverIds = Server::ownedByCurrentTeam(['id'])->pluck('id');
+
+        return ApplicationDeploymentQueue::query()
+            ->with(['application.environment.project', 'application.source'])
+            ->whereIn('server_id', $serverIds)
+            ->when($this->project !== 'all', function (Builder $query) {
+                $query->whereHas('application.environment.project', function (Builder $query) {
+                    $query->where('id', $this->project);
+                });
+            })
+            ->when($this->server !== 'all', function (Builder $query) {
+                $query->where('server_id', $this->server);
+            })
+            ->when($this->source !== 'all', function (Builder $query) {
+                if ($this->source === 'public-git') {
+                    $query->whereHas('application', function (Builder $query) {
+                        $query->whereNull('source_type')->whereNull('source_id');
+                    });
+
+                    return;
+                }
+
+                $sourceParts = explode(':', $this->source, 2);
+
+                if (count($sourceParts) !== 2) {
+                    $query->whereRaw('1 = 0');
+
+                    return;
+                }
+
+                [$sourceType, $sourceId] = $sourceParts;
+
+                $query->whereHas('application', function (Builder $query) use ($sourceType, $sourceId) {
+                    $query->where('source_type', $sourceType)->where('source_id', $sourceId);
+                });
+            })
+            ->when($this->status !== 'all', function (Builder $query) {
+                $query->where('status', $this->status);
+            });
+    }
+
+    private function sourceFilterValue(?string $sourceType, ?int $sourceId): string
+    {
+        if (! $sourceType || ! $sourceId) {
+            return 'public-git';
+        }
+
+        return "{$sourceType}:{$sourceId}";
+    }
+
+    private function sourceFilterLabel(Application $application): string
+    {
+        if (! $application->source_type || ! $application->source_id) {
+            return 'Public Git';
+        }
+
+        $sourceType = str(class_basename($application->source_type))->headline()->toString();
+        $sourceName = $application->source?->name;
+
+        return $sourceName ? "{$sourceName} ({$sourceType})" : $sourceType;
+    }
+
+    public function render()
+    {
+        return view('livewire.deployments.index', [
+            'deployments' => $this->deployments(),
+            'projects' => $this->projectOptions(),
+            'servers' => $this->serverOptions(),
+            'sources' => $this->sourceOptions(),
+            'statuses' => $this->statusOptions(),
+        ]);
+    }
+}

--- a/app/Livewire/Deployments/Index.php
+++ b/app/Livewire/Deployments/Index.php
@@ -10,6 +10,7 @@ use App\Models\Server;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Livewire\Component;
 use Livewire\WithPagination;
 
@@ -74,9 +75,20 @@ class Index extends Component
 
     public function projectOptions(): Collection
     {
-        return Project::ownedByCurrentTeam()
-            ->whereHas('applications.deployment_queue')
-            ->get(['id', 'name']);
+        $serverIds = $this->currentTeamServerIds();
+
+        return Project::query()
+            ->select('projects.id', 'projects.name')
+            ->join('environments', 'environments.project_id', '=', 'projects.id')
+            ->join('applications', 'applications.environment_id', '=', 'environments.id')
+            ->join('application_deployment_queues', function ($join) {
+                $join->on(DB::raw($this->castDeploymentApplicationId()), '=', 'applications.id');
+            })
+            ->where('projects.team_id', currentTeam()->id)
+            ->whereIn('application_deployment_queues.server_id', $serverIds)
+            ->distinct()
+            ->orderBy('projects.name')
+            ->get();
     }
 
     public function serverOptions(): Collection
@@ -90,7 +102,12 @@ class Index extends Component
     public function sourceOptions(): Collection
     {
         return Application::ownedByCurrentTeam()
-            ->whereHas('deployment_queue')
+            ->whereExists(function ($query) {
+                $query->selectRaw('1')
+                    ->from('application_deployment_queues')
+                    ->whereRaw($this->deploymentApplicationMatchesApplication())
+                    ->whereIn('application_deployment_queues.server_id', $this->currentTeamServerIds());
+            })
             ->with('source')
             ->get(['id', 'source_id', 'source_type', 'git_repository'])
             ->map(fn (Application $application) => [
@@ -202,14 +219,18 @@ class Index extends Component
 
     private function deploymentQuery(): Builder
     {
-        $serverIds = Server::ownedByCurrentTeam(['id'])->pluck('id');
+        $serverIds = $this->currentTeamServerIds();
 
         return ApplicationDeploymentQueue::query()
             ->with(['application.environment.project', 'application.source'])
             ->whereIn('server_id', $serverIds)
             ->when($this->project !== 'all', function (Builder $query) {
-                $query->whereHas('application.environment.project', function (Builder $query) {
-                    $query->where('id', $this->project);
+                $query->whereExists(function ($query) {
+                    $query->selectRaw('1')
+                        ->from('applications')
+                        ->join('environments', 'environments.id', '=', 'applications.environment_id')
+                        ->whereRaw($this->deploymentApplicationMatchesApplication())
+                        ->where('environments.project_id', $this->project);
                 });
             })
             ->when($this->server !== 'all', function (Builder $query) {
@@ -217,8 +238,12 @@ class Index extends Component
             })
             ->when($this->source !== 'all', function (Builder $query) {
                 if ($this->source === 'public-git') {
-                    $query->whereHas('application', function (Builder $query) {
-                        $query->whereNull('source_type')->whereNull('source_id');
+                    $query->whereExists(function ($query) {
+                        $query->selectRaw('1')
+                            ->from('applications')
+                            ->whereRaw($this->deploymentApplicationMatchesApplication())
+                            ->whereNull('applications.source_type')
+                            ->whereNull('applications.source_id');
                     });
 
                     return;
@@ -234,13 +259,38 @@ class Index extends Component
 
                 [$sourceType, $sourceId] = $sourceParts;
 
-                $query->whereHas('application', function (Builder $query) use ($sourceType, $sourceId) {
-                    $query->where('source_type', $sourceType)->where('source_id', $sourceId);
+                $query->whereExists(function ($query) use ($sourceType, $sourceId) {
+                    $query->selectRaw('1')
+                        ->from('applications')
+                        ->whereRaw($this->deploymentApplicationMatchesApplication())
+                        ->where('applications.source_type', $sourceType)
+                        ->where('applications.source_id', $sourceId);
                 });
             })
             ->when($this->status !== 'all', function (Builder $query) {
                 $query->where('status', $this->status);
             });
+    }
+
+    private function currentTeamServerIds(): Collection
+    {
+        return Server::ownedByCurrentTeam(['id'])->pluck('id');
+    }
+
+    private function deploymentApplicationMatchesApplication(): string
+    {
+        return $this->castDeploymentApplicationId().' = applications.id';
+    }
+
+    private function castDeploymentApplicationId(): string
+    {
+        $column = 'application_deployment_queues.application_id';
+
+        return match (DB::connection()->getDriverName()) {
+            'pgsql' => "CAST({$column} AS BIGINT)",
+            'mysql', 'mariadb' => "CAST({$column} AS UNSIGNED)",
+            default => "CAST({$column} AS INTEGER)",
+        };
     }
 
     private function sourceFilterValue(?string $sourceType, ?int $sourceId): string

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -336,6 +336,11 @@ class Server extends BaseModel
         return $this->hasOne(ServerSetting::class);
     }
 
+    public function teamDeployments()
+    {
+        return $this->hasMany(ApplicationDeploymentQueue::class);
+    }
+
     public function dockerCleanupExecutions()
     {
         return $this->hasMany(DockerCleanupExecution::class);

--- a/resources/views/components/navbar.blade.php
+++ b/resources/views/components/navbar.blade.php
@@ -158,6 +158,23 @@
                         </a>
                     </li>
                     <li>
+                        <a title="Deployments" {{ wireNavigate() }}
+                            class="{{ request()->is('deployments*') ? 'menu-item menu-item-active' : 'menu-item' }}"
+                            href="{{ route('deployments.index') }}">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="menu-item-icon" viewBox="0 0 24 24"
+                                stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round"
+                                stroke-linejoin="round">
+                                <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                                <path d="M4 5h16" />
+                                <path d="M4 12h16" />
+                                <path d="M4 19h16" />
+                                <path d="M8 5v14" />
+                                <path d="M16 5v14" />
+                            </svg>
+                            <span class="menu-item-label" :class="collapsed && 'lg:hidden'">Deployments</span>
+                        </a>
+                    </li>
+                    <li>
                         <a title="Servers" {{ wireNavigate() }}
                             class="{{ request()->is('server/*') || request()->is('servers') ? 'menu-item menu-item-active' : 'menu-item' }}"
                             href="/servers">

--- a/resources/views/livewire/deployments/index.blade.php
+++ b/resources/views/livewire/deployments/index.blade.php
@@ -1,0 +1,139 @@
+<div>
+    <x-slot:title>Deployments | Coolify</x-slot>
+
+    <div class="flex flex-col gap-6" @if (!$deployments->currentPage() || $deployments->currentPage() === 1) wire:poll.5000ms @endif>
+        <div>
+            <h1>Deployments</h1>
+            <div class="subtitle">Deployment history across your current team.</div>
+        </div>
+
+        <div class="rounded-sm border border-neutral-200 bg-white p-4 dark:border-coolgray-300 dark:bg-coolgray-100">
+            <div class="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
+                <x-forms.select id="project" label="Project">
+                    <option value="all">All projects</option>
+                    @foreach ($projects as $projectOption)
+                        <option value="{{ $projectOption->id }}">{{ $projectOption->name }}</option>
+                    @endforeach
+                </x-forms.select>
+
+                @if ($this->showServerFilter())
+                    <x-forms.select id="server" label="Server">
+                        <option value="all">All servers</option>
+                        @foreach ($servers as $serverOption)
+                            <option value="{{ $serverOption->id }}">{{ $serverOption->name }}</option>
+                        @endforeach
+                    </x-forms.select>
+                @endif
+
+                @if ($this->showSourceFilter())
+                    <x-forms.select id="source" label="Source">
+                        <option value="all">All sources</option>
+                        @foreach ($sources as $sourceOption)
+                            <option value="{{ $sourceOption['value'] }}">{{ $sourceOption['label'] }}</option>
+                        @endforeach
+                    </x-forms.select>
+                @endif
+
+                <x-forms.select id="status" label="Status">
+                    <option value="all">All statuses</option>
+                    @foreach ($statuses as $statusOption)
+                        <option value="{{ $statusOption['value'] }}">{{ $statusOption['label'] }}</option>
+                    @endforeach
+                </x-forms.select>
+            </div>
+
+            @if ($this->hasActiveFilters())
+                <div class="mt-3 flex justify-end">
+                    <x-forms.button wire:click="clearFilters">Clear filters</x-forms.button>
+                </div>
+            @endif
+        </div>
+
+        <div class="overflow-hidden rounded-sm border border-neutral-200 bg-white dark:border-coolgray-300 dark:bg-coolgray-100">
+            <div class="grid grid-cols-[minmax(0,1fr)_7rem] gap-3 border-b border-neutral-200 px-4 py-2 text-xs font-bold uppercase text-neutral-500 dark:border-coolgray-300 dark:text-neutral-400 md:grid-cols-[minmax(12rem,1.4fr)_minmax(10rem,1fr)_minmax(8rem,0.9fr)_minmax(7rem,0.8fr)_8rem]">
+                <div>Application</div>
+                <div class="hidden md:block">Project</div>
+                <div class="hidden md:block">Server</div>
+                <div class="hidden md:block">Source</div>
+                <div class="text-right md:text-left">Status</div>
+            </div>
+
+            <div class="divide-y divide-neutral-200 dark:divide-coolgray-300">
+                @forelse ($deployments as $deployment)
+                    @php
+                        $deploymentUrl = $this->deploymentUrl($deployment);
+                        $application = $deployment->application;
+                        $environment = $application?->environment;
+                        $project = $environment?->project;
+                    @endphp
+                    <a href="{{ $deploymentUrl ?? '#' }}" @if ($deploymentUrl) {{ wireNavigate() }} @endif
+                        @class([
+                            'grid grid-cols-[minmax(0,1fr)_7rem] gap-3 px-4 py-3 transition-colors md:grid-cols-[minmax(12rem,1.4fr)_minmax(10rem,1fr)_minmax(8rem,0.9fr)_minmax(7rem,0.8fr)_8rem]',
+                            'hover:bg-neutral-50 dark:hover:bg-coolgray-200' => $deploymentUrl,
+                            'cursor-default opacity-75' => !$deploymentUrl,
+                        ])>
+                        <div class="min-w-0">
+                            <div class="flex min-w-0 items-center gap-2">
+                                <span class="truncate font-medium text-black dark:text-white">
+                                    {{ $deployment->application_name ?? $application?->name ?? 'Unknown application' }}
+                                </span>
+                                @if ($deployment->pull_request_id)
+                                    <span class="inline-flex h-5 items-center rounded-sm border border-neutral-200 bg-neutral-100 px-1.5 text-xs font-medium text-black dark:border-coolgray-300 dark:bg-coolgray-200 dark:text-white">
+                                        PR #{{ $deployment->pull_request_id }}
+                                    </span>
+                                @endif
+                            </div>
+                            <div class="mt-1 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs text-neutral-500 dark:text-neutral-400">
+                                <span>{{ $this->deploymentType($deployment) }}</span>
+                                @if ($deployment->commit)
+                                    <span class="font-mono">{{ str($deployment->commit)->limit(7, '') }}</span>
+                                @endif
+                                <span>{{ formatDateInServerTimezone($deployment->created_at, $application?->destination?->server) }}</span>
+                            </div>
+                            @if ($deployment->commitMessage())
+                                <div class="mt-1 truncate text-xs text-neutral-600 dark:text-neutral-400">
+                                    {{ Str::before($deployment->commitMessage(), "\n") }}
+                                </div>
+                            @endif
+                        </div>
+
+                        <div class="hidden min-w-0 text-sm md:block">
+                            <div class="truncate text-black dark:text-white">{{ $project?->name ?? 'Unknown project' }}</div>
+                            <div class="truncate text-xs text-neutral-500 dark:text-neutral-400">{{ $environment?->name }}</div>
+                        </div>
+
+                        <div class="hidden min-w-0 text-sm md:block">
+                            <div class="truncate text-black dark:text-white">{{ $deployment->server_name ?? 'Unknown server' }}</div>
+                        </div>
+
+                        <div class="hidden min-w-0 text-sm md:block">
+                            <div class="truncate text-neutral-600 dark:text-neutral-400">{{ $this->sourceName($application) }}</div>
+                        </div>
+
+                        <div class="flex justify-end md:justify-start">
+                            <span @class([
+                                'inline-flex h-5 max-w-full items-center rounded-sm border px-1.5 text-xs font-medium leading-4',
+                                'border-green-200 bg-green-50 text-green-800 dark:border-green-900 dark:bg-green-950/30 dark:text-green-300' => $deployment->status === 'finished',
+                                'border-yellow-300 bg-yellow-50 text-yellow-900 dark:border-yellow-800 dark:bg-yellow-950/30 dark:text-yellow-200' => in_array($deployment->status, ['queued', 'in_progress'], true),
+                                'border-red-300 bg-red-50 text-red-800 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300' => $deployment->status === 'failed',
+                                'border-neutral-200 bg-neutral-100 text-black dark:border-coolgray-300 dark:bg-coolgray-200 dark:text-white' => $deployment->status === 'cancelled-by-user',
+                            ])>
+                                {{ $this->statusLabel($deployment->status) }}
+                            </span>
+                        </div>
+                    </a>
+                @empty
+                    <div class="px-4 py-10 text-center text-sm text-neutral-500 dark:text-neutral-400">
+                        No deployments found.
+                    </div>
+                @endforelse
+            </div>
+        </div>
+
+        @if ($deployments->hasPages())
+            <div>
+                {{ $deployments->links() }}
+            </div>
+        @endif
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\UploadController;
 use App\Livewire\Admin\Index as AdminIndex;
 use App\Livewire\Boarding\Index as BoardingIndex;
 use App\Livewire\Dashboard;
+use App\Livewire\Deployments\Index as DeploymentsIndex;
 use App\Livewire\Destination\Index as DestinationIndex;
 use App\Livewire\Destination\Show as DestinationShow;
 use App\Livewire\ForcePasswordReset;
@@ -109,6 +110,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     });
 
     Route::get('/', Dashboard::class)->name('dashboard');
+    Route::get('/deployments', DeploymentsIndex::class)->name('deployments.index');
     Route::get('/admin', AdminIndex::class)->name('admin.index');
     Route::get('/onboarding', BoardingIndex::class)->name('onboarding');
 

--- a/tests/Feature/DeploymentsPageTest.php
+++ b/tests/Feature/DeploymentsPageTest.php
@@ -1,0 +1,156 @@
+<?php
+
+use App\Enums\ApplicationDeploymentStatus;
+use App\Livewire\Deployments\Index;
+use App\Models\Application;
+use App\Models\ApplicationDeploymentQueue;
+use App\Models\Environment;
+use App\Models\GithubApp;
+use App\Models\InstanceSettings;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Visus\Cuid2\Cuid2;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->team = Team::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+
+    InstanceSettings::unguarded(function () {
+        InstanceSettings::query()->create([
+            'id' => 0,
+            'is_registration_enabled' => true,
+        ]);
+    });
+
+    $this->actingAs($this->user);
+    session(['currentTeam' => $this->team]);
+
+    config([
+        'app.maintenance.driver' => 'file',
+        'cache.default' => 'array',
+    ]);
+
+    $this->withoutVite();
+});
+
+it('shows team-wide deployments from the sidebar page without leaking other teams', function () {
+    [$application, $server, $project] = createDeploymentPageApplication($this->team, 'Checkout API');
+    [$otherApplication, $otherServer] = createDeploymentPageApplication(Team::factory()->create(), 'Other Team API');
+
+    ApplicationDeploymentQueue::create([
+        'application_id' => $application->id,
+        'application_name' => $application->name,
+        'server_id' => $server->id,
+        'server_name' => $server->name,
+        'deployment_uuid' => 'current-team-deployment',
+        'deployment_url' => "/project/{$project->uuid}/environment/{$application->environment->uuid}/application/{$application->uuid}/deployment/current-team-deployment",
+        'commit' => '1234567890abcdef',
+        'status' => ApplicationDeploymentStatus::FINISHED->value,
+        'finished_at' => now(),
+    ]);
+
+    ApplicationDeploymentQueue::create([
+        'application_id' => $otherApplication->id,
+        'application_name' => $otherApplication->name,
+        'server_id' => $otherServer->id,
+        'server_name' => $otherServer->name,
+        'deployment_uuid' => 'other-team-deployment',
+        'status' => ApplicationDeploymentStatus::FAILED->value,
+    ]);
+
+    $response = $this->get(route('deployments.index'));
+
+    $response->assertSuccessful();
+    $response->assertSee('Deployments');
+    $response->assertSee('Checkout API');
+    $response->assertSee('Done');
+    $response->assertSee('current-team-deployment');
+    $response->assertDontSee('Other Team API');
+    $response->assertDontSee('other-team-deployment');
+});
+
+it('filters deployments by project server source and status', function () {
+    $source = GithubApp::query()->create([
+        'uuid' => (string) new Cuid2,
+        'name' => 'Production GitHub',
+        'api_url' => 'https://api.github.com',
+        'html_url' => 'https://github.com',
+        'team_id' => $this->team->id,
+    ]);
+
+    [$application, $server, $project] = createDeploymentPageApplication($this->team, 'Filtered API', [
+        'source_id' => $source->id,
+        'source_type' => GithubApp::class,
+    ]);
+
+    [$otherApplication, $otherServer] = createDeploymentPageApplication($this->team, 'Unfiltered API');
+
+    ApplicationDeploymentQueue::create([
+        'application_id' => $application->id,
+        'application_name' => $application->name,
+        'server_id' => $server->id,
+        'server_name' => $server->name,
+        'deployment_uuid' => 'matching-deployment',
+        'commit' => 'abcdef1234567890',
+        'status' => ApplicationDeploymentStatus::QUEUED->value,
+    ]);
+
+    ApplicationDeploymentQueue::create([
+        'application_id' => $otherApplication->id,
+        'application_name' => $otherApplication->name,
+        'server_id' => $otherServer->id,
+        'server_name' => $otherServer->name,
+        'deployment_uuid' => 'non-matching-deployment',
+        'status' => ApplicationDeploymentStatus::FINISHED->value,
+    ]);
+
+    Livewire::test(Index::class)
+        ->set('project', (string) $project->id)
+        ->set('server', (string) $server->id)
+        ->set('source', GithubApp::class.':'.$source->id)
+        ->set('status', ApplicationDeploymentStatus::QUEUED->value)
+        ->assertSee('Filtered API')
+        ->assertSee('matching-deployment')
+        ->assertSee('Production GitHub')
+        ->assertSee('Queued')
+        ->assertDontSee('Unfiltered API')
+        ->assertDontSee('non-matching-deployment');
+});
+
+it('adds deployments to the main sidebar navigation', function () {
+    $navbar = file_get_contents(resource_path('views/components/navbar.blade.php'));
+    $routes = file_get_contents(base_path('routes/web.php'));
+
+    expect($routes)
+        ->toContain("Route::get('/deployments', DeploymentsIndex::class)->name('deployments.index')");
+
+    expect($navbar)
+        ->toContain('Deployments')
+        ->toContain("route('deployments.index')")
+        ->toContain("request()->is('deployments*')");
+});
+
+function createDeploymentPageApplication(Team $team, string $applicationName, array $overrides = []): array
+{
+    $server = Server::factory()->create(['team_id' => $team->id]);
+    $destination = StandaloneDocker::query()->where('server_id', $server->id)->firstOrFail();
+    $project = Project::factory()->create(['team_id' => $team->id]);
+    $environment = Environment::factory()->create(['project_id' => $project->id]);
+    $application = Application::factory()->create(array_merge([
+        'name' => $applicationName,
+        'environment_id' => $environment->id,
+        'destination_id' => $destination->id,
+        'destination_type' => $destination->getMorphClass(),
+        'status' => 'running',
+    ], $overrides));
+
+    return [$application->load('environment.project'), $server, $project];
+}

--- a/tests/Feature/DeploymentsPageTest.php
+++ b/tests/Feature/DeploymentsPageTest.php
@@ -125,6 +125,52 @@ it('filters deployments by project server source and status', function () {
         ->assertDontSee('non-matching-deployment');
 });
 
+it('hides server and source filters until there are multiple options', function () {
+    [$application, $server] = createDeploymentPageApplication($this->team, 'Only Option API');
+
+    ApplicationDeploymentQueue::create([
+        'application_id' => $application->id,
+        'application_name' => $application->name,
+        'server_id' => $server->id,
+        'server_name' => $server->name,
+        'deployment_uuid' => 'only-option-deployment',
+        'status' => ApplicationDeploymentStatus::FINISHED->value,
+    ]);
+
+    Livewire::test(Index::class)
+        ->assertSee('Only Option API')
+        ->assertDontSee('wire:model=server', false)
+        ->assertDontSee('wire:model=source', false);
+
+    $source = GithubApp::query()->create([
+        'uuid' => (string) new Cuid2,
+        'name' => 'Production GitHub',
+        'api_url' => 'https://api.github.com',
+        'html_url' => 'https://github.com',
+        'team_id' => $this->team->id,
+    ]);
+
+    [$secondApplication, $secondServer] = createDeploymentPageApplication($this->team, 'Second Option API', [
+        'source_id' => $source->id,
+        'source_type' => GithubApp::class,
+    ]);
+
+    ApplicationDeploymentQueue::create([
+        'application_id' => $secondApplication->id,
+        'application_name' => $secondApplication->name,
+        'server_id' => $secondServer->id,
+        'server_name' => $secondServer->name,
+        'deployment_uuid' => 'second-option-deployment',
+        'status' => ApplicationDeploymentStatus::QUEUED->value,
+    ]);
+
+    Livewire::test(Index::class)
+        ->assertSee('Only Option API')
+        ->assertSee('Second Option API')
+        ->assertSee('wire:model=server', false)
+        ->assertSee('wire:model=source', false);
+});
+
 it('adds deployments to the main sidebar navigation', function () {
     $navbar = file_get_contents(resource_path('views/components/navbar.blade.php'));
     $routes = file_get_contents(base_path('routes/web.php'));


### PR DESCRIPTION
/claim #7596

Demo: attached `deployments-page-demo.webm`.

## Summary
- Add a top-level Deployments page and sidebar link.
- Show current-team deployment history across applications with links back to deployment logs.
- Add filters for project, server, source, and status, while hiding server/source filters when there is only one option.
- Refresh the first deployments page periodically so queued and pending deployments update without manual reloads.
- Use PostgreSQL-safe deployment/application filtering for the existing deployment queue schema.

## Tests
- `php artisan test --compact tests/Feature/DeploymentsPageTest.php`
- `vendor/bin/pint --dirty --format agent`
- `npm run build`
- PostgreSQL-backed browser smoke for `/deployments`