### PR TITLE
fix(destination): scope server and network selection to current team

### DIFF
--- a/app/Livewire/Project/Shared/Destination.php
+++ b/app/Livewire/Project/Shared/Destination.php
@@ -110,15 +110,23 @@ class Destination extends Component
 
     public function promote(int $network_id, int $server_id)
     {
-        $main_destination = $this->resource->destination;
-        $this->resource->update([
-            'destination_id' => $network_id,
-            'destination_type' => StandaloneDocker::class,
-        ]);
-        $this->resource->additional_networks()->detach($network_id, ['server_id' => $server_id]);
-        $this->resource->additional_networks()->attach($main_destination->id, ['server_id' => $main_destination->server->id]);
-        $this->refreshServers();
-        $this->resource->refresh();
+        try {
+            $server = Server::ownedByCurrentTeam()->findOrFail($server_id);
+            $network = StandaloneDocker::ownedByCurrentTeam()->findOrFail($network_id);
+            $this->authorize('update', $this->resource);
+
+            $main_destination = $this->resource->destination;
+            $this->resource->update([
+                'destination_id' => $network->id,
+                'destination_type' => StandaloneDocker::class,
+            ]);
+            $this->resource->additional_networks()->detach($network->id, ['server_id' => $server->id]);
+            $this->resource->additional_networks()->attach($main_destination->id, ['server_id' => $main_destination->server->id]);
+            $this->refreshServers();
+            $this->resource->refresh();
+        } catch (\Exception $e) {
+            return handleError($e, $this);
+        }
     }
 
     public function refreshServers()
@@ -130,8 +138,16 @@ class Destination extends Component
 
     public function addServer(int $network_id, int $server_id)
     {
-        $this->resource->additional_networks()->attach($network_id, ['server_id' => $server_id]);
-        $this->dispatch('refresh');
+        try {
+            $server = Server::ownedByCurrentTeam()->findOrFail($server_id);
+            $network = StandaloneDocker::ownedByCurrentTeam()->findOrFail($network_id);
+            $this->authorize('update', $this->resource);
+
+            $this->resource->additional_networks()->attach($network->id, ['server_id' => $server->id]);
+            $this->dispatch('refresh');
+        } catch (\Exception $e) {
+            return handleError($e, $this);
+        }
     }
 
     public function removeServer(int $network_id, int $server_id, $password, $selectedActions = [])

--- a/tests/Feature/CrossTeamDestinationAttachTest.php
+++ b/tests/Feature/CrossTeamDestinationAttachTest.php
@@ -1,0 +1,124 @@
+<?php
+
+use App\Livewire\Project\Shared\Destination;
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\InstanceSettings;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Queue::fake();
+
+    InstanceSettings::unguarded(fn () => InstanceSettings::query()->create(['id' => 0]));
+
+    // Attacker: Team A
+    $this->userA = User::factory()->create();
+    $this->teamA = Team::factory()->create();
+    $this->userA->teams()->attach($this->teamA, ['role' => 'owner']);
+
+    $this->serverA = Server::factory()->create(['team_id' => $this->teamA->id]);
+    $this->projectA = Project::factory()->create(['team_id' => $this->teamA->id]);
+    $this->environmentA = Environment::factory()->create(['project_id' => $this->projectA->id]);
+    $this->destinationA = StandaloneDocker::factory()->create([
+        'server_id' => $this->serverA->id,
+        'name' => 'dest-a-'.fake()->unique()->word(),
+        'network' => 'coolify-a-'.fake()->unique()->word(),
+    ]);
+
+    $this->applicationA = Application::factory()->create([
+        'environment_id' => $this->environmentA->id,
+        'destination_id' => $this->destinationA->id,
+        'destination_type' => StandaloneDocker::class,
+    ]);
+
+    // A second usable destination on Team A's own server, used for positive-path tests.
+    $this->serverA2 = Server::factory()->create(['team_id' => $this->teamA->id]);
+    $this->destinationA2 = StandaloneDocker::factory()->create([
+        'server_id' => $this->serverA2->id,
+        'name' => 'dest-a2-'.fake()->unique()->word(),
+        'network' => 'coolify-a2-'.fake()->unique()->word(),
+    ]);
+
+    // Victim: Team B
+    $this->userB = User::factory()->create();
+    $this->teamB = Team::factory()->create();
+    $this->userB->teams()->attach($this->teamB, ['role' => 'owner']);
+
+    $this->serverB = Server::factory()->create(['team_id' => $this->teamB->id]);
+    $this->destinationB = StandaloneDocker::factory()->create([
+        'server_id' => $this->serverB->id,
+        'name' => 'dest-b-'.fake()->unique()->word(),
+        'network' => 'coolify-b-'.fake()->unique()->word(),
+    ]);
+
+    // Act as attacker (Team A)
+    $this->actingAs($this->userA);
+    session(['currentTeam' => $this->teamA]);
+});
+
+describe('Destination::addServer GHSA-j395-3pqh-9r5g', function () {
+    test('cannot attach another team\'s server + network to own application', function () {
+        try {
+            Livewire::test(Destination::class, ['resource' => $this->applicationA])
+                ->call('addServer', $this->destinationB->id, $this->serverB->id);
+        } catch (Throwable $e) {
+            // handleError on ModelNotFoundException calls abort(404); pivot assertion is source of truth.
+        }
+
+        expect($this->applicationA->fresh()->additional_networks)->toHaveCount(0);
+        expect($this->applicationA->fresh()->additional_servers)->toHaveCount(0);
+    });
+
+    test('cannot attach own network paired with another team\'s server', function () {
+        try {
+            Livewire::test(Destination::class, ['resource' => $this->applicationA])
+                ->call('addServer', $this->destinationA2->id, $this->serverB->id);
+        } catch (Throwable $e) {
+        }
+
+        expect($this->applicationA->fresh()->additional_networks)->toHaveCount(0);
+    });
+
+    test('cannot attach another team\'s network paired with own server', function () {
+        try {
+            Livewire::test(Destination::class, ['resource' => $this->applicationA])
+                ->call('addServer', $this->destinationB->id, $this->serverA2->id);
+        } catch (Throwable $e) {
+        }
+
+        expect($this->applicationA->fresh()->additional_networks)->toHaveCount(0);
+    });
+
+    test('can attach own team\'s server + network to own application', function () {
+        Livewire::test(Destination::class, ['resource' => $this->applicationA])
+            ->call('addServer', $this->destinationA2->id, $this->serverA2->id);
+
+        $additional = $this->applicationA->fresh()->additional_networks;
+        expect($additional)->toHaveCount(1);
+        expect($additional->first()->id)->toBe($this->destinationA2->id);
+        expect($additional->first()->pivot->server_id)->toBe($this->serverA2->id);
+    });
+});
+
+describe('Destination::promote GHSA-j395-3pqh-9r5g', function () {
+    test('cannot promote another team\'s network as the application\'s main destination', function () {
+        $originalDestinationId = $this->applicationA->destination_id;
+
+        try {
+            Livewire::test(Destination::class, ['resource' => $this->applicationA])
+                ->call('promote', $this->destinationB->id, $this->serverB->id);
+        } catch (Throwable $e) {
+        }
+
+        expect($this->applicationA->fresh()->destination_id)->toBe($originalDestinationId);
+    });
+});


### PR DESCRIPTION
## Changes

`Project\Shared\Destination::addServer()` and `::promote()` accepted `network_id`/`server_id` from the client and passed them directly into `additional_networks()->attach()` / the resource `update()` without resolving them against the current team or authorizing the action.

Both methods now:

- Resolve the server via `Server::ownedByCurrentTeam()->findOrFail($server_id)` and the network via `StandaloneDocker::ownedByCurrentTeam()->findOrFail($network_id)`.
- Call `$this->authorize('update', $this->resource)`.
- Pass the validated model IDs (not the raw client input) into `attach()`/`detach()`/`update()`.
- Route failures through `handleError()`, matching the sibling `removeServer()` method.

## Issues

- N/A

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Opus 4.7)
- How extensively: Used to locate the affected methods, apply the team-scoping pattern already used by sibling methods, and author the Pest regression test. All code reviewed before commit.

## Testing

- New Pest feature test `CrossTeamDestinationAttachTest` covers `addServer` and `promote` with same-team and other-team `server_id`/`network_id` inputs, asserting the team-scoped paths behave correctly and the same-team positive path still attaches.
- Run with: `php artisan test --compact --filter=CrossTeamDestinationAttachTest`

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md).
> - [x] I have searched existing issues and pull requests to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)