### PR TITLE
fix(team): prevent 500 when deleting the current team

### DIFF
--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -361,7 +361,7 @@ function refreshSession(?Team $team = null): void
         }
         if (! $team) {
             // Fall back to any team the user still belongs to.
-            $team = User::find(Auth::id())->teams()->first();
+            $team = User::query()->find(Auth::id())?->teams()->first();
         }
     }
 

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -353,14 +353,30 @@ function showBoarding(): bool
 function refreshSession(?Team $team = null): void
 {
     if (! $team) {
-        if (Auth::user()->currentTeam()) {
-            $team = Team::find(Auth::user()->currentTeam()->id);
-        } else {
-            $team = User::find(Auth::id())->teams->first();
+        $currentTeam = Auth::user()->currentTeam();
+        if ($currentTeam) {
+            // currentTeam() can resolve a stale (just-deleted) team from the
+            // session/cache, so Team::find() may still return null here.
+            $team = Team::find($currentTeam->id);
+        }
+        if (! $team) {
+            // Fall back to any team the user still belongs to.
+            $team = User::find(Auth::id())->teams()->first();
         }
     }
+
     // Clear old cache key format for backwards compatibility
     Cache::forget('team:'.Auth::id());
+
+    if (! $team) {
+        // The user has no team left (e.g. just deleted their current team and
+        // belongs to no other): clear the stale session reference instead of
+        // dereferencing null.
+        session()->forget('currentTeam');
+
+        return;
+    }
+
     // Use new cache key format that includes team ID
     Cache::forget('user:'.Auth::id().':team:'.$team->id);
     Cache::remember('user:'.Auth::id().':team:'.$team->id, 3600, function () use ($team) {


### PR DESCRIPTION
## Changes

The fix of 500 error bug when deleting the team. The reason of the issue was that the team after deletion is gone, but it was cached. So when accessing the deleted team `null` was returned from ` Team::find()`. Then the `null` value was assigned to the non-nullable Team. A `refreshSession()` fallback was made to any team user belongs to.

## Issues

- Fixes #10351

## Category

- [X] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

<img width="1280" height="752" alt="unpatched-2-after" src="https://github.com/user-attachments/assets/37f041a4-1662-4d35-aeec-f5fc830eb215" />

## AI Assistance

- [ ] AI was NOT used to create this PR
- [X] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude code
- How extensively: I assumed the cause of the issue due to stale cached values and then the implementation was done completely by Claude code. Then tested manually

## Testing

The testing was done on a locally deployed Coolify instance
1. Reproduced the 500 on unpatched delete flow above, delete -> 500
2. Applied the fix; repeated the exact flow -> 302 redirect, no 5xx, current team falls back to Root Team.

## Contributor Agreement

> - [X] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [X] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [X] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
