### PR TITLE
feat: add WordPress OpenLiteSpeed service template

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -48,6 +48,9 @@ services:
       - -c
       - |
         set -e
+        wp() {
+          php -d memory_limit=512M /usr/local/bin/wp "$@"
+        }
         if [ ! -f /var/www/html/wp-config.php ]; then
           wp core download --path=/var/www/html --allow-root --force
           wp config create \
@@ -59,7 +62,6 @@ services:
             --skip-check \
             --allow-root
           wp config shuffle-salts --path=/var/www/html --allow-root
-          wp plugin install litespeed-cache --path=/var/www/html --allow-root
         fi
         chown -R 1000:1000 /var/www/html
 

--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -1,0 +1,79 @@
+# documentation: https://docs.litespeedtech.com/cloud/docker/ols-wordpress/
+# slogan: WordPress running behind the high-performance OpenLiteSpeed web server.
+# category: cms
+# tags: cms, blog, wordpress, openlitespeed, mariadb
+# logo: svgs/wordpress.svg
+# port: 80
+
+services:
+  wordpress:
+    image: litespeedtech/openlitespeed:latest
+    volumes:
+      - wordpress-files:/var/www/vhosts/localhost/html
+      - openlitespeed-config:/usr/local/lsws/conf
+      - openlitespeed-admin-config:/usr/local/lsws/admin/conf
+      - openlitespeed-logs:/usr/local/lsws/logs
+      - openlitespeed-acme:/root/.acme.sh
+    environment:
+      - SERVICE_URL_WORDPRESS_80
+      - TZ=${TZ:-UTC}
+    depends_on:
+      wordpress-installer:
+        condition: service_completed_successfully
+      mariadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+
+  wordpress-installer:
+    exclude_from_hc: true
+    image: wordpress:cli-php8.3
+    user: root
+    volumes:
+      - wordpress-files:/var/www/html
+    environment:
+      - WORDPRESS_DB_HOST=mariadb
+      - WORDPRESS_DB_USER=$SERVICE_USER_WORDPRESS
+      - WORDPRESS_DB_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+      - WORDPRESS_DB_NAME=wordpress
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    restart: on-failure
+    command:
+      - sh
+      - -c
+      - |
+        set -e
+        if [ ! -f /var/www/html/wp-config.php ]; then
+          wp core download --path=/var/www/html --allow-root --force
+          wp config create \
+            --path=/var/www/html \
+            --dbname="$WORDPRESS_DB_NAME" \
+            --dbuser="$WORDPRESS_DB_USER" \
+            --dbpass="$WORDPRESS_DB_PASSWORD" \
+            --dbhost="$WORDPRESS_DB_HOST" \
+            --skip-check \
+            --allow-root
+          wp config shuffle-salts --path=/var/www/html --allow-root
+          wp plugin install litespeed-cache --path=/var/www/html --allow-root
+        fi
+        chown -R 1000:1000 /var/www/html
+
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
Fixes #8264

/claim #8264

Summary:
- Add a WordPress + OpenLiteSpeed compose template.
- Persist WordPress files, OpenLiteSpeed configuration/log data, ACME data, and MariaDB data.
- Bootstrap WordPress files with WP-CLI after MariaDB is healthy and wire the service URL for Coolify proxy support.
- Keep the template unopinionated by leaving final WordPress site installation to the browser setup flow.

Demo:
- Video: https://gist.githubusercontent.com/SylvainWinning/3faeb3b98ef6e62ed05148a7f7a850bc/raw/69cbdd89a450dd17c1b1d3a5740101185abf83a5/coolify-wordpress-openlitespeed-demo.webm
- Screenshot: https://gist.githubusercontent.com/SylvainWinning/3faeb3b98ef6e62ed05148a7f7a850bc/raw/dc2e5abff04103eb18acdd5a44d1627a6c1d01ed/wordpress-openlitespeed-demo.png

Testing:
- `ruby -e "require 'yaml'; YAML.load_file('templates/compose/wordpress-with-openlitespeed.yaml'); puts 'yaml ok'"`
- `git diff --check`
- Started the compose stack locally with a temporary `8088:80` port mapping and Docker Compose-only compatibility adjustments for the demo.
- Verified `mariadb` healthy, `wordpress` healthy, WP-CLI generated WordPress files and `wp-config.php`, and `curl -I http://localhost:8088` returns `server: LiteSpeed` with a redirect to `/wp-admin/install.php`.

Notes:
- Kept the PR scoped to the source compose template only.
- The local demo file only adds a temporary port mapping because Coolify normally handles routing via `SERVICE_URL_WORDPRESS_80`.
