### PR TITLE
fix: capture scheduled task stderr output

### DIFF
--- a/app/Jobs/ScheduledTaskJob.php
+++ b/app/Jobs/ScheduledTaskJob.php
@@ -142,7 +142,7 @@ class ScheduledTaskJob implements ShouldBeEncrypted, ShouldQueue
                     $exec = "docker exec {$containerName} {$cmd}";
                     // Disable SSH multiplexing to prevent race conditions when multiple tasks run concurrently
                     // See: https://github.com/coollabsio/coolify/issues/6736
-                    $this->task_output = instant_remote_process([$exec], $this->server, true, false, $this->timeout, disableMultiplexing: true);
+                    $this->task_output = instant_remote_process([$exec], $this->server, true, false, $this->timeout, disableMultiplexing: true, includeErrorOutput: true);
                     $this->task_log->update([
                         'status' => 'success',
                         'message' => $this->task_output,

--- a/bootstrap/helpers/remoteProcess.php
+++ b/bootstrap/helpers/remoteProcess.php
@@ -136,7 +136,7 @@ function instant_remote_process_with_timeout(Collection|array $command, Server $
     );
 }
 
-function instant_remote_process(Collection|array $command, Server $server, bool $throwError = true, bool $no_sudo = false, ?int $timeout = null, bool $disableMultiplexing = false): ?string
+function instant_remote_process(Collection|array $command, Server $server, bool $throwError = true, bool $no_sudo = false, ?int $timeout = null, bool $disableMultiplexing = false, bool $includeErrorOutput = false): ?string
 {
     $command = $command instanceof Collection ? $command->toArray() : $command;
 
@@ -147,11 +147,16 @@ function instant_remote_process(Collection|array $command, Server $server, bool 
     $effectiveTimeout = $timeout ?? config('constants.ssh.command_timeout');
 
     return SshRetryHandler::retry(
-        function () use ($server, $command_string, $effectiveTimeout, $disableMultiplexing) {
+        function () use ($server, $command_string, $effectiveTimeout, $disableMultiplexing, $includeErrorOutput) {
             $sshCommand = SshMultiplexingHelper::generateSshCommand($server, $command_string, $disableMultiplexing);
             $process = Process::timeout($effectiveTimeout)->run($sshCommand);
 
             $output = trim($process->output());
+            if ($includeErrorOutput) {
+                $output = collect([$output, trim($process->errorOutput())])
+                    ->filter(fn ($stream) => $stream !== '')
+                    ->implode(PHP_EOL);
+            }
             $exitCode = $process->exitCode();
 
             if ($exitCode !== 0) {

--- a/tests/Feature/ScheduledTaskJobOutputTest.php
+++ b/tests/Feature/ScheduledTaskJobOutputTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use App\Events\ScheduledTaskDone;
+use App\Jobs\ScheduledTaskJob;
+use App\Models\Application;
+use App\Models\InstanceSettings;
+use App\Models\PrivateKey;
+use App\Models\Project;
+use App\Models\ScheduledTask;
+use App\Models\ScheduledTaskExecution;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Facades\Storage;
+
+uses(RefreshDatabase::class);
+
+function scheduledTaskJobOutputPrivateKey(): string
+{
+    return "-----BEGIN OPENSSH PRIVATE KEY-----\n".
+        "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW\n".
+        "QyNTUxOQAAACBbhpqHhqv6aI67Mj9abM3DVbmcfYhZAhC7ca4d9UCevAAAAJi/QySHv0Mk\n".
+        "hwAAAAtzc2gtZWQyNTUxOQAAACBbhpqHhqv6aI67Mj9abM3DVbmcfYhZAhC7ca4d9UCevA\n".
+        "AAAECBQw4jg1WRT2IGHMncCiZhURCts2s24HoDS0thHnnRKVuGmoeGq/pojrsyP1pszcNV\n".
+        "uZx9iFkCELtxrh31QJ68AAAAEXNhaWxANzZmZjY2ZDJlMmRkAQIDBA==\n".
+        '-----END OPENSSH PRIVATE KEY-----';
+}
+
+it('stores stderr from successful scheduled task executions', function () {
+    Event::fake([ScheduledTaskDone::class]);
+    Notification::fake();
+    Process::fake();
+    Storage::fake('ssh-keys');
+    InstanceSettings::unguarded(fn () => InstanceSettings::query()->firstOrCreate(['id' => 0]));
+
+    $team = Team::factory()->create();
+    $privateKey = PrivateKey::create([
+        'name' => 'scheduled-task-output-key',
+        'private_key' => scheduledTaskJobOutputPrivateKey(),
+        'team_id' => $team->id,
+    ]);
+    Storage::disk('ssh-keys')->put("ssh_key@{$privateKey->uuid}", $privateKey->private_key);
+
+    $server = Server::factory()->create([
+        'team_id' => $team->id,
+        'private_key_id' => $privateKey->id,
+    ]);
+    $destination = StandaloneDocker::where('server_id', $server->id)->first();
+    $project = Project::factory()->create(['team_id' => $team->id]);
+    $environment = $project->environments()->first();
+    $application = Application::factory()->create([
+        'environment_id' => $environment->id,
+        'destination_id' => $destination->id,
+        'destination_type' => $destination->getMorphClass(),
+    ]);
+    $task = ScheduledTask::factory()->create([
+        'application_id' => $application->id,
+        'team_id' => $team->id,
+        'command' => 'echo logging to stdout; echo logging to stderr >&2',
+    ]);
+
+    $containerName = 'scheduled-task-container';
+    $containerOutput = json_encode([
+        'Names' => "/{$containerName}",
+        'Labels' => "coolify.applicationId={$application->id}",
+    ]).PHP_EOL;
+
+    Process::fake(function ($process) use ($application, $containerName, $containerOutput) {
+        if (str_contains($process->command, "label=coolify.applicationId={$application->id}")) {
+            return Process::result(output: $containerOutput);
+        }
+
+        if (str_contains($process->command, "docker exec {$containerName}")) {
+            return Process::result(
+                output: "logging to stdout\n",
+                errorOutput: "logging to stderr\n",
+            );
+        }
+
+        return Process::result();
+    });
+
+    (new ScheduledTaskJob($task))->handle();
+
+    $execution = ScheduledTaskExecution::where('scheduled_task_id', $task->id)->first();
+
+    expect($execution)->not->toBeNull()
+        ->and($execution->status)->toBe('success')
+        ->and($execution->message)->toContain('logging to stdout')
+        ->and($execution->message)->toContain('logging to stderr');
+});


### PR DESCRIPTION
<!-- STRAWBERRY -->

## Changes

- Capture stderr along with stdout when a scheduled task command exits successfully.
- Keep `instant_remote_process` unchanged by default by adding an explicit `includeErrorOutput` option for callers that need both streams.
- Add regression coverage for a successful scheduled task that writes to both stdout and stderr.

## Issues

- Fixes #10107

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A - backend scheduled-task log handling change.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: AI assistance for code drafting and test iteration.
- How extensively: Used to help implement and refine the change; I reviewed the code path and verified the behavior with focused tests.

## Testing

- `vendor/bin/pint bootstrap/helpers/remoteProcess.php app/Jobs/ScheduledTaskJob.php tests/Feature/ScheduledTaskJobOutputTest.php`
- `php -l bootstrap/helpers/remoteProcess.php`
- `php -l app/Jobs/ScheduledTaskJob.php`
- `php -l tests/Feature/ScheduledTaskJobOutputTest.php`
- `vendor/bin/pest tests/Feature/ScheduledTaskJobOutputTest.php --colors=never`
- `vendor/bin/pest tests/Feature/ScheduledTaskJobOutputTest.php tests/Feature/ScheduledTaskServerTest.php tests/Feature/ScheduledLogsCommandInputTest.php --colors=never`
- `git diff --check`

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
