### PR TITLE
Prefer IPv6 for standalone proxy networks

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -102,7 +102,7 @@ class InstallDocker
                 ]);
             } else {
                 $command = $command->merge([
-                    'docker network create --attachable coolify >/dev/null 2>&1 || true',
+                    dockerCreateAttachableStandaloneNetworkCommand('coolify', true) . ' || true',
                 ]);
                 $command = $command->merge([
                     "echo 'Done!'",

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -1408,7 +1408,7 @@ $schema://$host {
         if ($isSwarm) {
             return instant_remote_process(['docker network create --attachable --driver overlay coolify-overlay >/dev/null 2>&1 || true'], $this, false);
         } else {
-            return instant_remote_process(['docker network create coolify --attachable >/dev/null 2>&1 || true'], $this, false);
+            return instant_remote_process([dockerCreateAttachableStandaloneNetworkCommand('coolify', true) . ' || true'], $this, false);
         }
     }
 

--- a/bootstrap/helpers/proxy.php
+++ b/bootstrap/helpers/proxy.php
@@ -21,6 +21,15 @@ function isDockerPredefinedNetwork(string $network): bool
     return in_array($network, ['default', 'host'], true);
 }
 
+function dockerCreateAttachableStandaloneNetworkCommand(string $network, bool $quiet = false): string
+{
+    $safe = escapeshellarg($network);
+    $ipv6Output = $quiet ? ' >/dev/null 2>&1' : ' 2>/dev/null';
+    $fallbackOutput = $quiet ? ' >/dev/null 2>&1' : '';
+
+    return "docker network create --ipv6 --attachable {$safe}{$ipv6Output} || docker network create --attachable {$safe}{$fallbackOutput}";
+}
+
 function collectProxyDockerNetworksByServer(Server $server)
 {
     if (! $server->isFunctional()) {
@@ -119,8 +128,10 @@ function connectProxyToNetworks(Server $server)
     } else {
         $commands = $networks->map(function ($network) {
             $safe = escapeshellarg($network);
+            $createNetwork = dockerCreateAttachableStandaloneNetworkCommand($network, true);
+
             return [
-                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || docker network create --attachable {$safe} >/dev/null",
+                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || {$createNetwork}",
                 "docker network connect {$safe} coolify-proxy >/dev/null 2>&1 || true",
                 "echo 'Successfully connected coolify-proxy to {$safe} network.'",
             ];
@@ -152,9 +163,11 @@ function ensureProxyNetworksExist(Server $server)
     } else {
         $commands = $networks->map(function ($network) {
             $safe = escapeshellarg($network);
+            $createNetwork = dockerCreateAttachableStandaloneNetworkCommand($network);
+
             return [
                 "echo 'Ensuring network {$safe} exists...'",
-                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --attachable {$safe}",
+                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || {$createNetwork}",
             ];
         });
     }

--- a/tests/Unit/ProxyHelperTest.php
+++ b/tests/Unit/ProxyHelperTest.php
@@ -189,3 +189,21 @@ it('identifies none as not predefined (per codebase pattern)', function () {
     // only filters 'default' and 'host', so we maintain consistency
     expect(isDockerPredefinedNetwork('none'))->toBeFalse();
 });
+
+it('creates standalone docker networks with ipv6 fallback', function () {
+    $safe = escapeshellarg('coolify');
+    $command = dockerCreateAttachableStandaloneNetworkCommand('coolify');
+    $expected = "docker network create --ipv6 --attachable {$safe} 2>/dev/null"
+        . " || docker network create --attachable {$safe}";
+
+    expect($command)->toBe($expected);
+});
+
+it('can silence standalone docker network creation attempts', function () {
+    $safe = escapeshellarg('coolify');
+    $command = dockerCreateAttachableStandaloneNetworkCommand('coolify', true);
+    $expected = "docker network create --ipv6 --attachable {$safe} >/dev/null 2>&1"
+        . " || docker network create --attachable {$safe} >/dev/null 2>&1";
+
+    expect($command)->toBe($expected);
+});


### PR DESCRIPTION


## Changes

- Added a shared helper for standalone Docker network creation that tries to create IPv6-capable attachable networks first.
- Falls back to the existing IPv4-only Docker network creation command when IPv6 is unavailable on the host.
- Reused the helper for standalone proxy network setup and default `coolify` network validation/install paths.
- Added unit coverage for the generated Docker network creation command.

## Issues

- Fixes #3436

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No UI changes. This is a Docker network command-generation fix.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: AI-assisted implementation with manual review before the submission.

## Testing

- Ran `git diff --check`.

Not run:
- `php artisan test tests/Unit/ProxyHelperTest.php`, because PHP is not installed in my local environment.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.