### PR TITLE
Add global deployments page

### DIFF
--- a/app/Livewire/Deployments/Index.php
+++ b/app/Livewire/Deployments/Index.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Livewire\Deployments;
+
+use App\Enums\ApplicationDeploymentStatus;
+use App\Models\ApplicationDeploymentQueue;
+use App\Models\Project;
+use App\Models\Server;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class Index extends Component
+{
+    use WithPagination;
+
+    public ?Collection $projects = null;
+
+    public ?Collection $servers = null;
+
+    public ?string $projectUuid = null;
+
+    public ?string $serverUuid = null;
+
+    public ?string $source = null;
+
+    public ?string $status = null;
+
+    public int $perPage = 25;
+
+    public function mount(): void
+    {
+        $this->projects = Project::whereTeamId(currentTeam()->id)->orderBy('name')->get(['id', 'uuid', 'name']);
+        $this->servers = Server::ownedByCurrentTeamCached()->sortBy('name')->values();
+    }
+
+    public function updated($name): void
+    {
+        if (in_array($name, ['projectUuid', 'serverUuid', 'source', 'status', 'perPage'], true)) {
+            $this->resetPage();
+        }
+    }
+
+    private function deploymentsQuery(bool $applySourceFilter = true): Builder
+    {
+        $teamId = currentTeam()->id;
+
+        $query = ApplicationDeploymentQueue::query()
+            ->with(['application.environment.project'])
+            ->whereHas('application', function (Builder $query) use ($teamId) {
+                $query->whereHas('environment.project', function (Builder $query) use ($teamId) {
+                    $query->where('team_id', $teamId);
+                });
+            })
+            ->orderByDesc('id');
+
+        if ($this->projectUuid) {
+            $projectId = $this->projects?->firstWhere('uuid', $this->projectUuid)?->id;
+            if ($projectId) {
+                $query->whereHas('application.environment', fn (Builder $q) => $q->where('project_id', $projectId));
+            }
+        }
+
+        if ($this->serverUuid) {
+            $serverId = $this->servers?->firstWhere('uuid', $this->serverUuid)?->id;
+            if ($serverId) {
+                $query->where('server_id', $serverId);
+            }
+        }
+
+        if ($applySourceFilter) {
+            if ($this->source === 'webhook') {
+                $query->where('is_webhook', true);
+            } elseif ($this->source === 'api') {
+                $query->where('is_api', true);
+            } elseif ($this->source === 'manual') {
+                $query->where('is_webhook', false)->where('is_api', false);
+            }
+        }
+
+        if ($this->status) {
+            $allowedStatuses = collect(ApplicationDeploymentStatus::cases())->pluck('value')->all();
+            if (in_array($this->status, $allowedStatuses, true)) {
+                $query->where('status', $this->status);
+            }
+        }
+
+        return $query;
+    }
+
+    public function render()
+    {
+        $deployments = $this->deploymentsQuery()->paginate($this->perPage);
+
+        $queryWithoutSource = $this->deploymentsQuery(applySourceFilter: false);
+        $availableSources = collect([
+            'webhook' => 'Webhook',
+            'api' => 'API',
+            'manual' => 'Manual',
+        ])->filter(function ($label, $value) use ($queryWithoutSource) {
+            $query = clone $queryWithoutSource;
+
+            return match ($value) {
+                'webhook' => $query->where('is_webhook', true)->exists(),
+                'api' => $query->where('is_api', true)->exists(),
+                'manual' => $query->where('is_webhook', false)->where('is_api', false)->exists(),
+                default => false,
+            };
+        });
+
+        return view('livewire.deployments.index', [
+            'deployments' => $deployments,
+            'availableSources' => $availableSources,
+            'availableStatuses' => collect(ApplicationDeploymentStatus::cases())->mapWithKeys(fn ($case) => [$case->value => str($case->value)->headline()]),
+        ]);
+    }
+}

--- a/resources/views/components/navbar.blade.php
+++ b/resources/views/components/navbar.blade.php
@@ -188,6 +188,18 @@
                         </a>
                     </li>
                     <li>
+                        <a title="Deployments" {{ wireNavigate() }}
+                            class="{{ request()->is('deployments') ? 'menu-item-active menu-item' : 'menu-item' }}"
+                            href="{{ route('deployments.index') }}">
+                            <svg class="menu-item-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"
+                                    stroke-width="2"
+                                    d="M12 3l7 4v10l-7 4l-7-4V7l7-4Zm0 0v10m0 0l7-4m-7 4L5 9" />
+                            </svg>
+                            <span class="menu-item-label" :class="collapsed && 'lg:hidden'">Deployments</span>
+                        </a>
+                    </li>
+                    <li>
                         <a title="Destinations" {{ wireNavigate() }}
                             class="{{ request()->is('destination*') ? 'menu-item-active menu-item' : 'menu-item' }}"
                             href="{{ route('destination.index') }}">

--- a/resources/views/livewire/deployments/index.blade.php
+++ b/resources/views/livewire/deployments/index.blade.php
@@ -1,0 +1,144 @@
+<div>
+    <x-slot:title>Deployments | Coolify</x-slot>
+    <h1>Deployments</h1>
+
+    <div class="flex flex-col gap-2 pb-10" wire:poll.5000ms>
+        <div class="flex flex-col gap-2 xl:flex-row xl:items-end">
+            @if ($projects?->count() > 1)
+                <x-forms.select id="projectUuid" label="Project" wire:model.live="projectUuid">
+                    <option value="">All projects</option>
+                    @foreach ($projects as $project)
+                        <option value="{{ $project->uuid }}">{{ $project->name }}</option>
+                    @endforeach
+                </x-forms.select>
+            @endif
+
+            @if ($servers?->count() > 1)
+                <x-forms.select id="serverUuid" label="Server" wire:model.live="serverUuid">
+                    <option value="">All servers</option>
+                    @foreach ($servers as $server)
+                        <option value="{{ $server->uuid }}">{{ $server->name }}</option>
+                    @endforeach
+                </x-forms.select>
+            @endif
+
+            @if (($availableSources?->count() ?? 0) > 1)
+                <x-forms.select id="source" label="Source" wire:model.live="source">
+                    <option value="">All sources</option>
+                    @foreach ($availableSources as $value => $label)
+                        <option value="{{ $value }}">{{ $label }}</option>
+                    @endforeach
+                </x-forms.select>
+            @endif
+
+            <x-forms.select id="status" label="Status" wire:model.live="status">
+                <option value="">All statuses</option>
+                @foreach ($availableStatuses as $value => $label)
+                    <option value="{{ $value }}">{{ $label }}</option>
+                @endforeach
+            </x-forms.select>
+
+            <x-forms.select id="perPage" label="Per page" wire:model.live="perPage">
+                <option value="10">10</option>
+                <option value="25">25</option>
+                <option value="50">50</option>
+                <option value="100">100</option>
+            </x-forms.select>
+        </div>
+
+        <div class="flex flex-col gap-2">
+            @forelse ($deployments as $deployment)
+                @php
+                    $application = $deployment->application;
+                @endphp
+                <div @class([
+                    'p-2 border-l-2 bg-white dark:bg-coolgray-100',
+                    'border-blue-500/50 border-dashed' => data_get($deployment, 'status') === 'in_progress',
+                    'border-purple-500/50 border-dashed' => data_get($deployment, 'status') === 'queued',
+                    'border-white border-dashed' => data_get($deployment, 'status') === 'cancelled-by-user',
+                    'border-error' => data_get($deployment, 'status') === 'failed',
+                    'border-success' => data_get($deployment, 'status') === 'finished',
+                ])>
+                    <a href="{{ data_get($deployment, 'deployment_url') }}" {{ wireNavigate() }} class="block">
+                        <div class="flex flex-col">
+                            <div class="flex items-center gap-2 mb-2">
+                                <span @class([
+                                    'px-3 py-1 rounded-md text-xs font-medium shadow-xs',
+                                    'bg-blue-100/80 text-blue-700 dark:bg-blue-500/20 dark:text-blue-300' =>
+                                        data_get($deployment, 'status') === 'in_progress',
+                                    'bg-purple-100/80 text-purple-700 dark:bg-purple-500/20 dark:text-purple-300' =>
+                                        data_get($deployment, 'status') === 'queued',
+                                    'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-200' =>
+                                        data_get($deployment, 'status') === 'failed',
+                                    'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-200' =>
+                                        data_get($deployment, 'status') === 'finished',
+                                    'bg-gray-100 text-gray-700 dark:bg-gray-600/30 dark:text-gray-300' =>
+                                        data_get($deployment, 'status') === 'cancelled-by-user',
+                                ])>
+                                    @php
+                                        $statusText = match (data_get($deployment, 'status')) {
+                                            'finished' => 'Success',
+                                            'in_progress' => 'In Progress',
+                                            'cancelled-by-user' => 'Cancelled',
+                                            'queued' => 'Queued',
+                                            default => ucfirst(data_get($deployment, 'status')),
+                                        };
+                                    @endphp
+                                    {{ $statusText }}
+                                </span>
+                                @if (data_get($deployment, 'server_name'))
+                                    <span class="text-xs text-gray-600 dark:text-gray-400">
+                                        {{ data_get($deployment, 'server_name') }}
+                                    </span>
+                                @endif
+                            </div>
+
+                            <div class="flex flex-col gap-1">
+                                <div class="text-sm font-medium text-gray-900 dark:text-gray-100">
+                                    {{ data_get($deployment, 'application_name') }}
+                                    @if ($application?->project())
+                                        <span class="text-gray-600 dark:text-gray-400 font-normal">
+                                            — {{ $application->project()->name }}
+                                        </span>
+                                    @endif
+                                </div>
+
+                                <div class="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-400">
+                                    @if (data_get($deployment, 'commit'))
+                                        <span class="font-mono">{{ Str::limit(data_get($deployment, 'commit'), 12, '') }}</span>
+                                    @endif
+                                    <span class="bg-gray-200/70 dark:bg-gray-600/20 px-2 py-0.5 rounded-md text-xs text-gray-800 dark:text-gray-100 border border-gray-400/30">
+                                        @if (data_get($deployment, 'is_webhook'))
+                                            Webhook
+                                            @if (data_get($deployment, 'pull_request_id'))
+                                                | Pull Request #{{ data_get($deployment, 'pull_request_id') }}
+                                            @endif
+                                        @elseif (data_get($deployment, 'pull_request_id'))
+                                            Pull Request #{{ data_get($deployment, 'pull_request_id') }}
+                                        @elseif (data_get($deployment, 'rollback') === true)
+                                            Rollback
+                                        @elseif (data_get($deployment, 'is_api'))
+                                            API
+                                        @else
+                                            Manual
+                                        @endif
+                                    </span>
+                                    <span class="text-gray-500 dark:text-gray-500">
+                                        {{ optional(data_get($deployment, 'created_at'))->diffForHumans() }}
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+            @empty
+                <div>No deployments found.</div>
+            @endforelse
+        </div>
+
+        <div>
+            {{ $deployments->links() }}
+        </div>
+    </div>
+</div>
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use App\Livewire\Boarding\Index as BoardingIndex;
 use App\Livewire\Dashboard;
 use App\Livewire\Destination\Index as DestinationIndex;
 use App\Livewire\Destination\Show as DestinationShow;
+use App\Livewire\Deployments\Index as DeploymentsIndex;
 use App\Livewire\ForcePasswordReset;
 use App\Livewire\Notifications\Discord as NotificationDiscord;
 use App\Livewire\Notifications\Email as NotificationEmail;
@@ -312,6 +313,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
 });
 
 Route::middleware(['auth'])->group(function () {
+    Route::get('/deployments', DeploymentsIndex::class)->name('deployments.index');
     Route::get('/sources', function () {
         $sources = currentTeam()->sources();
 

--- a/tests/Feature/DeploymentsPageTest.php
+++ b/tests/Feature/DeploymentsPageTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use App\Models\Application;
+use App\Models\ApplicationDeploymentQueue;
+use App\Models\Environment;
+use App\Models\InstanceSettings;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->team = Team::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+
+    InstanceSettings::unguarded(function () {
+        InstanceSettings::query()->create([
+            'id' => 0,
+            'is_registration_enabled' => true,
+        ]);
+    });
+
+    $this->actingAs($this->user);
+    session(['currentTeam' => $this->team]);
+
+    $this->server = Server::factory()->create(['team_id' => $this->team->id, 'name' => 'server-a']);
+    $this->destination = StandaloneDocker::query()->where('server_id', $this->server->id)->firstOrFail();
+    $this->project = Project::factory()->create(['team_id' => $this->team->id, 'name' => 'project-a']);
+    $this->environment = Environment::factory()->create(['project_id' => $this->project->id]);
+    $this->application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => $this->destination->getMorphClass(),
+        'name' => 'app-a',
+        'status' => 'running',
+    ]);
+
+    ApplicationDeploymentQueue::query()->create([
+        'application_id' => $this->application->id,
+        'deployment_uuid' => (string) Str::uuid(),
+        'commit' => 'deadbeef',
+        'status' => 'finished',
+        'server_id' => $this->server->id,
+        'application_name' => $this->application->name,
+        'server_name' => $this->server->name,
+        'deployment_url' => '/fake/deployment/url',
+        'is_webhook' => false,
+        'is_api' => false,
+        'pull_request_id' => 0,
+        'force_rebuild' => false,
+        'restart_only' => false,
+        'only_this_server' => false,
+        'rollback' => false,
+    ]);
+});
+
+it('renders the global deployments page', function () {
+    $this->withoutVite();
+
+    $response = $this->get(route('deployments.index'));
+
+    $response->assertSuccessful();
+    $response->assertSee('Deployments');
+    $response->assertSee('app-a');
+    $response->assertSee('project-a');
+    $response->assertSee('server-a');
+});


### PR DESCRIPTION
Implements a global /deployments page with filters (project/server/source/status) and pagination, plus a sidebar link.

Fixes #7596