### PR TITLE
fix(docker): add --network flag support to docker run converter

### DIFF
--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -1016,6 +1016,7 @@ function convertDockerRunToCompose(?string $custom_docker_run_options = null)
         '--gpus' => 'gpus',
         '--hostname' => 'hostname',
         '--entrypoint' => 'entrypoint',
+        '--network' => 'network_mode',
     ]);
     foreach ($matches as $match) {
         $option = $match[1];


### PR DESCRIPTION
## Summary

This pull request fixes Issue #10099 where the `--network=host` flag is silently dropped when converting Docker run commands to Docker Compose format.

## Problem Description

When users specify `--network=host` (or `--network host`) in their custom Docker run options field, the flag is not converted to the Docker Compose equivalent (`network_mode: host`). Instead, it is silently ignored, causing containers to run in the default bridge network instead of the host network.

## Root Cause

The `convertDockerRunToCompose()` function in `bootstrap/helpers/docker.php` maintains a mapping of Docker run flags to their Docker Compose equivalents. However, the `--network` flag was missing from this mapping.

## Solution

Add `'--network' => 'network_mode'` to the `$mapping` collection. The `network_mode` property in Docker Compose supports the `host` value to achieve the same behavior as Docker's `--network=host` flag.

## Changes

- `bootstrap/helpers/docker.php`: Added `--network` to the flag mapping collection

## Testing

The fix maps:
- `--network=host` -> `network_mode: host`
- `--network bridge` -> `network_mode: bridge`
- `--network <custom>` -> `network_mode: <custom>`

## Related Issue

Fixes #10099