### PR TITLE
fix(logs): scope DOM lookups to component root in multi-container log viewer

### DIFF
--- a/resources/views/livewire/project/shared/get-logs.blade.php
+++ b/resources/views/livewire/project/shared/get-logs.blade.php
@@ -61,7 +61,7 @@
             }
         },
         scrollToBottom() {
-            const logsContainer = document.getElementById('logsContainer');
+            const logsContainer = this.$root.querySelector('#logsContainer');
             if (logsContainer) {
                 this.isScrolling = true;
                 logsContainer.scrollTop = logsContainer.scrollHeight;
@@ -117,7 +117,7 @@
             this.applyColorLogs();
         },
         applyColorLogs() {
-            const logs = document.getElementById('logs');
+            const logs = this.$root.querySelector('#logs');
             if (!logs) return;
             const lines = logs.querySelectorAll('[data-log-line]');
             lines.forEach(line => {
@@ -134,7 +134,7 @@
             if (!selection || selection.isCollapsed || !selection.toString().trim()) {
                 return false;
             }
-            const logsContainer = document.getElementById('logs');
+            const logsContainer = this.$root.querySelector('#logs');
             if (!logsContainer) return false;
             const range = selection.getRangeAt(0);
             return logsContainer.contains(range.commonAncestorContainer);
@@ -144,7 +144,7 @@
             return doc.documentElement.textContent;
         },
         applySearch() {
-            const logs = document.getElementById('logs');
+            const logs = this.$root.querySelector('#logs');
             if (!logs) return;
             const lines = logs.querySelectorAll('[data-log-line]');
             const query = this.searchQuery.trim().toLowerCase();
@@ -200,7 +200,7 @@
             }
         },
         downloadLogs() {
-            const logs = document.getElementById('logs');
+            const logs = this.$root.querySelector('#logs');
             if (!logs) return;
             const visibleLines = logs.querySelectorAll('[data-log-line]:not(.hidden)');
             let content = '';
@@ -243,14 +243,14 @@
 
             // Apply colors after Livewire updates (existing content)
             Livewire.hook('morph.updated', ({ el }) => {
-                if (el.id === 'logs') {
+                if (el.id === 'logs' && this.$root.contains(el)) {
                     applyAfterUpdate();
                 }
             });
 
             // Apply colors after Livewire adds new content (initial load)
             Livewire.hook('morph.added', ({ el }) => {
-                if (el.id === 'logs') {
+                if (el.id === 'logs' && this.$root.contains(el)) {
                     applyAfterUpdate();
                 }
             });


### PR DESCRIPTION
## Summary

This pull request fixes Issue #10207 where log level colors only applied to the first container's logs when multiple containers are displayed on the same page.

## Problem Description

When viewing logs for an application with multiple containers, the "Toggle Log Colors" feature only applies log-level background colors to the first container log panel.

## Root Cause

The log viewer component was using global DOM lookups via `document.getElementById()`. When multiple containers render their own log panels, each has its own `#logs` and `#logsContainer` element. Global lookups always return the first matching element.

## Solution

Scope all DOM lookups to the current Alpine/Livewire component root using `this.$root.querySelector()` instead of `document.getElementById()`. Also update Livewire morph hooks to check if the changed element belongs to the current component.

## Changes

- `resources/views/livewire/project/shared/get-logs.blade.php`: Scope DOM lookups to component root

## Testing

Log colors now work correctly for all container panels on the page.

## Related Issue

Fixes #10207