### PR TITLE
fix(logs): preserve HTML tags in log viewer attributes

### DIFF
--- a/resources/views/livewire/project/shared/get-logs.blade.php
+++ b/resources/views/livewire/project/shared/get-logs.blade.php
@@ -538,11 +538,11 @@
                                         $lineKey = "{$timestamp}.{$microseconds}";
                                     }
                                 @endphp
-                                <div wire:key="{{ $lineKey ?? 'line-' . $index }}" data-log-line data-log-content="{{ $line }}" class="flex gap-2 log-line">
+                                <div wire:key="{{ $lineKey ?? 'line-' . $index }}" data-log-line data-log-content="{!! addslashes($line) !!}" class="flex gap-2 log-line">
                                     @if ($timestamp && $showTimeStamps)
                                         <span class="shrink-0 text-gray-500">{{ $timestamp }}</span>
                                     @endif
-                                    <span data-line-text="{{ $logContent }}" class="whitespace-pre-wrap break-all">{{ $logContent }}</span>
+                                    <span data-line-text="{!! addslashes($logContent) !!}" class="whitespace-pre-wrap break-all">{{ $logContent }}</span>
                                 </div>
                             @endforeach
                         </div>


### PR DESCRIPTION
## Summary

Fixes Issue #10345 where HTML tags are removed before rendering in logs viewer.

## Problem

Applications producing logs with HTML tags like `<div>` show empty content because tags are stripped.

## Root Cause

Blade `{{ }}` syntax escapes HTML for attributes, breaking HTML tag display.

## Solution

Use `{!! addslashes() !!}` to preserve HTML in data attributes while escaping for JavaScript safety.

## Changes

- `resources/views/livewire/project/shared/get-logs.blade.php`: Use `{!! addslashes($line) !!}` for data attributes

## Testing

HTML tags like `<div>A</div>` render correctly with tags visible.

Fixes #10345