### PR TITLE
fix: block fork PRs when public deployments are disabled

### DIFF
--- a/app/Http/Controllers/Webhook/Github.php
+++ b/app/Http/Controllers/Webhook/Github.php
@@ -62,6 +62,7 @@ class Github extends Controller
                 $before_sha = data_get($payload, 'before');
                 $after_sha = data_get($payload, 'after', data_get($payload, 'pull_request.head.sha'));
                 $author_association = data_get($payload, 'pull_request.author_association');
+                $is_fork = data_get($payload, 'pull_request.head.repo.fork', false);
             }
             if (! in_array($x_github_event, ['push', 'pull_request'])) {
                 return response("Nothing to do. Event '$x_github_event' is not supported.");
@@ -222,6 +223,7 @@ class Github extends Controller
                             commitSha: data_get($payload, 'pull_request.head.sha', 'HEAD'),
                             authorAssociation: $author_association,
                             fullName: $full_name,
+                            isFork: $is_fork ?? false,
                         );
 
                         $return_payloads->push([
@@ -303,6 +305,7 @@ class Github extends Controller
                 $before_sha = data_get($payload, 'before');
                 $after_sha = data_get($payload, 'after', data_get($payload, 'pull_request.head.sha'));
                 $author_association = data_get($payload, 'pull_request.author_association');
+                $is_fork = data_get($payload, 'pull_request.head.repo.fork', false);
             }
             if (! in_array($x_github_event, ['push', 'pull_request'])) {
                 return response("Nothing to do. Event '$x_github_event' is not supported.");
@@ -434,6 +437,7 @@ class Github extends Controller
                             commitSha: data_get($payload, 'pull_request.head.sha', 'HEAD'),
                             authorAssociation: $author_association,
                             fullName: $full_name,
+                            isFork: $is_fork ?? false,
                         );
 
                         $return_payloads->push([

--- a/app/Jobs/ProcessGithubPullRequestWebhook.php
+++ b/app/Jobs/ProcessGithubPullRequestWebhook.php
@@ -39,6 +39,7 @@ class ProcessGithubPullRequestWebhook implements ShouldBeEncrypted, ShouldQueue
         public string $commitSha,
         public ?string $authorAssociation,
         public string $fullName,
+        public bool $isFork = false,
     ) {
         $this->onQueue('high');
     }
@@ -92,6 +93,11 @@ class ProcessGithubPullRequestWebhook implements ShouldBeEncrypted, ShouldQueue
 
         // Check if PR deployments from public contributors are restricted
         if (! $application->settings->is_pr_deployments_public_enabled) {
+            // Forks should never be allowed when public deployments are disabled
+            // even if the author has a trusted association, since the code runs from the fork
+            if ($this->isFork) {
+                return;
+            }
             $trustedAssociations = ['OWNER', 'MEMBER', 'COLLABORATOR', 'CONTRIBUTOR'];
             if (! in_array($this->authorAssociation, $trustedAssociations)) {
                 return;


### PR DESCRIPTION
## Fix: Block Fork PRs When Public Deployments Are Disabled

STRAWBERRY

### Problem
Issue #10342: Preview builds are triggered for first-time contributors even when \`Allow Public PR Deployments\` flag is enabled.

The current code only checks `author_association` to determine if a PR should be allowed. However, GitHub's `CONTRIBUTOR` association can be assigned to users who haven't contributed any commits - they may have simply commented on issues or had other activity.

Forks from untrusted users can run malicious code in the Coolify environment, creating a security risk.

### Solution
Added fork detection using GitHub's `pull_request.head.repo.fork` field. When public deployments are disabled (`is_pr_deployments_public_enabled = false`), fork PRs are now blocked entirely, regardless of the author's association.

### Changes
1. **ProcessGithubPullRequestWebhook.php**: Added `$isFork` parameter and early return for forks when public deployments are disabled
2. **Github.php**: Extract `pull_request.head.repo.fork` from webhook payload and pass to job in both `manual()` and `normal()` webhook handlers

### Security
This ensures that even if a malicious user somehow gets a trusted association, their fork PRs will still be blocked when public deployments are disabled, protecting the Coolify deployment environment.