### PR TITLE
fix: prevent null deref when deleting current team

### DIFF
--- a/app/Livewire/NavbarDeleteTeam.php
+++ b/app/Livewire/NavbarDeleteTeam.php
@@ -22,7 +22,13 @@ class NavbarDeleteTeam extends Component
         }
 
         $currentTeam = currentTeam();
-        $currentTeam->delete();
+
+        // Get the user's first remaining team BEFORE deleting (so currentTeam() doesn't return null)
+        $user = Auth::user();
+        $newTeam = $user->teams()->where('teams.id', '!=', $currentTeam->id)->first();
+        if ($newTeam) {
+            $user->forceFill(['currentTeam_id' => $newTeam->id])->save();
+        }
 
         $currentTeam->members->each(function ($user) use ($currentTeam) {
             if ($user->id === Auth::id()) {
@@ -35,7 +41,9 @@ class NavbarDeleteTeam extends Component
             }
         });
 
-        refreshSession();
+        $currentTeam->delete();
+
+        refreshSession($newTeam);
 
         return redirectRoute($this, 'team.index');
     }

--- a/app/Livewire/Team/Index.php
+++ b/app/Livewire/Team/Index.php
@@ -97,7 +97,13 @@ class Index extends Component
     {
         $currentTeam = currentTeam();
         $this->authorize('delete', $currentTeam);
-        $currentTeam->delete();
+
+        // Get the user's first remaining team BEFORE deleting (so currentTeam() doesn't return null)
+        $user = Auth::user();
+        $newTeam = $user->teams()->where('teams.id', '!=', $currentTeam->id)->first();
+        if ($newTeam) {
+            $user->forceFill(['currentTeam_id' => $newTeam->id])->save();
+        }
 
         $currentTeam->members->each(function ($user) use ($currentTeam) {
             if ($user->id === Auth::id()) {
@@ -110,7 +116,9 @@ class Index extends Component
             }
         });
 
-        refreshSession();
+        $currentTeam->delete();
+
+        refreshSession($newTeam);
 
         return redirect()->route('team.index');
     }


### PR DESCRIPTION
## Fix: Prevent null deref when deleting current team

STRAWBERRY

### Problem
Issue #10351: Deleting the current team returns HTTP 500 (null deref in refreshSession).

When deleting the current team:
1. After deletion, `currentTeam()` returns null since the team no longer exists
2. `refreshSession()` tries to find the team by its now-deleted ID
3. `Team::find()` returns null
4. Accessing `$team->id` throws "Attempt to read property id on null"

### Solution
Instead of calling `refreshSession()` with no argument (which causes it to look up the deleted team), we:
1. Find a new team for the user BEFORE deleting the current team
2. Set `currentTeam_id` on the user model immediately
3. Pass the new team to `refreshSession()`

### Changes
1. **NavbarDeleteTeam.php**: Find replacement team and set `currentTeam_id` before deletion
2. **Team/Index.php**: Same fix applied

### Testing
Steps to reproduce (should now work):
1. Create a second (non-personal) team - it becomes your current team
2. Open Teams -> General -> Danger Zone for that team
3. Click Delete, type the team name to confirm, click "Permanently Delete"
4. Should redirect to team.index without HTTP 500 error