### PR TITLE
fix(api): preserve env var value when PATCH omits it

### DIFF
--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -2904,7 +2904,9 @@ class ApplicationsController extends Controller
         if ($is_preview) {
             $env = $application->environment_variables_preview->where('key', $key)->first();
             if ($env) {
-                $env->value = $request->value;
+                if ($request->has('value')) {
+                    $env->value = $request->value;
+                }
                 if ($env->is_literal != $is_literal) {
                     $env->is_literal = $is_literal;
                 }
@@ -2945,7 +2947,9 @@ class ApplicationsController extends Controller
         } else {
             $env = $application->environment_variables->where('key', $key)->first();
             if ($env) {
-                $env->value = $request->value;
+                if ($request->has('value')) {
+                    $env->value = $request->value;
+                }
                 if ($env->is_literal != $is_literal) {
                     $env->is_literal = $is_literal;
                 }
@@ -3125,7 +3129,9 @@ class ApplicationsController extends Controller
             if ($is_preview) {
                 $env = $application->environment_variables_preview->where('key', $key)->first();
                 if ($env) {
-                    $env->value = $item->get('value');
+                    if ($item->has('value')) {
+                        $env->value = $item->get('value');
+                    }
 
                     if ($env->is_literal != $is_literal) {
                         $env->is_literal = $is_literal;
@@ -3164,7 +3170,9 @@ class ApplicationsController extends Controller
             } else {
                 $env = $application->environment_variables->where('key', $key)->first();
                 if ($env) {
-                    $env->value = $item->get('value');
+                    if ($item->has('value')) {
+                        $env->value = $item->get('value');
+                    }
                     if ($env->is_literal != $is_literal) {
                         $env->is_literal = $is_literal;
                     }


### PR DESCRIPTION
## Fix: Preserve env var value when PATCH omits it

STRAWBERRY

### Problem
Issue #9977: Updating env-var flags via PATCH unintentionally clears the value.

When PATCHing env vars to update flags (e.g., `is_buildtime`), the `value` field was always overwritten - even when omitted from the request. This caused secret values like `NEXTAUTH_SECRET` to be wiped, breaking deployments.

### Solution
Changed `$env->value = $request->value;` to use `$request->has('value')` check, matching the pattern used for all other optional fields (`is_runtime`, `is_buildtime`, `comment`, etc.).

### Changes
**ApplicationsController.php**: Applied fix in 4 places:
1. `update_env_by_uuid()` - is_preview branch (line ~2907)
2. `update_env_by_uuid()` - non-preview branch (line ~2948)  
3. `create_bulk_envs()` - is_preview branch (line ~3132)
4. `create_bulk_envs()` - non-preview branch (line ~3171)

### Testing
```bash
# Before fix: PATCHing {"key":"FOO","is_buildtime":false} would wipe FOO's value
# After fix: Value is preserved when omitted
curl -X PATCH /api/v1/applications/{uuid}/envs \
  -H "Content-Type: application/json" \
  -d '{"key":"FOO","is_buildtime":false}'
# FOO's value is now preserved
```