### PR TITLE
feat: add Stalwart mail service template

### DIFF
--- a/templates/compose/stalwart.yaml
+++ b/templates/compose/stalwart.yaml
@@ -1,0 +1,26 @@
+# documentation: https://stalw.art/docs/install/platform/docker/
+# slogan: Stalwart is an all-in-one mail and collaboration server with WebUI administration, SMTP, IMAP, JMAP, CalDAV, CardDAV, and WebDAV support.
+# category: email
+# tags: email,smtp,imap,jmap,caldav,carddav,webdav,mail-server
+# port: 8080
+
+services:
+  stalwart:
+    image: stalwartlabs/stalwart:v0.16
+    volumes:
+      - stalwart-etc:/etc/stalwart
+      - stalwart-data:/var/lib/stalwart
+    ports:
+      - "25:25"
+      - "465:465"
+      - "587:587"
+      - "143:143"
+      - "993:993"
+      - "4190:4190"
+      - "110:110"
+      - "995:995"
+    environment:
+      - SERVICE_URL_STALWART_8080
+      - STALWART_PUBLIC_URL=${SERVICE_URL_STALWART}
+      - STALWART_RECOVERY_ADMIN=${STALWART_RECOVERY_ADMIN:-admin:${SERVICE_PASSWORD_ADMIN}}
+      - TZ=${TZ:-UTC}


### PR DESCRIPTION
## Changes

- Add a new Stalwart mail server one-click service template.
- Persist Stalwart configuration and data using named volumes.
- Expose the common mail service ports for SMTP, submission, IMAP, POP3, and ManageSieve.
- Wire the Stalwart admin/setup UI through Coolify using `SERVICE_URL_STALWART_8080` and `STALWART_PUBLIC_URL`.

## Issues

- Fixes #8266

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No screenshot/video included. This is a compose service template addition; I could not run Docker in my local environment to capture a live Coolify preview.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex, GitHub search, local shell/git.
- How extensively: AI helped research the service choice, draft the compose template, run local static validation, and prepare this PR. I reviewed the final diff and validation output before submission.

## Testing

- `ruby -e 'require "yaml"; YAML.load_file("templates/compose/stalwart.yaml"); puts "yaml ok"'`
- `git diff --check HEAD~1 HEAD`

Docker runtime testing was not possible because the Docker daemon was not running in my environment.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
