### PR TITLE
feat(oauth): add generic OIDC provider

### DIFF
--- a/app/Livewire/SettingsOauth.php
+++ b/app/Livewire/SettingsOauth.php
@@ -18,6 +18,7 @@ class SettingsOauth extends Component
             $carry["oauth_settings_map.$setting->provider.redirect_uri"] = 'nullable';
             $carry["oauth_settings_map.$setting->provider.tenant"] = 'nullable';
             $carry["oauth_settings_map.$setting->provider.base_url"] = 'nullable';
+            $carry["oauth_settings_map.$setting->provider.scopes"] = 'nullable|string|max:255';
 
             return $carry;
         }, []);
@@ -38,6 +39,7 @@ class SettingsOauth extends Component
                 'redirect_uri' => $setting->redirect_uri,
                 'tenant' => $setting->tenant,
                 'base_url' => $setting->base_url,
+                'scopes' => $setting->scopes,
             ];
 
             return $carry;
@@ -61,6 +63,7 @@ class SettingsOauth extends Component
                 'redirect_uri' => $oauthData['redirect_uri'],
                 'tenant' => $oauthData['tenant'],
                 'base_url' => $oauthData['base_url'],
+                'scopes' => $oauthData['scopes'] ?? null,
             ]);
 
             if (! $oauth->couldBeEnabled()) {
@@ -79,6 +82,7 @@ class SettingsOauth extends Component
                 'redirect_uri' => $oauth->redirect_uri,
                 'tenant' => $oauth->tenant,
                 'base_url' => $oauth->base_url,
+                'scopes' => $oauth->scopes,
             ];
 
             $this->dispatch('success', 'OAuth settings for '.$oauth->provider.' updated successfully!');
@@ -100,6 +104,7 @@ class SettingsOauth extends Component
                     'redirect_uri' => $settingData['redirect_uri'],
                     'tenant' => $settingData['tenant'],
                     'base_url' => $settingData['base_url'],
+                    'scopes' => $settingData['scopes'] ?? null,
                 ]);
 
                 if ($settingData['enabled'] && ! $oauth->couldBeEnabled()) {
@@ -119,6 +124,7 @@ class SettingsOauth extends Component
                     'redirect_uri' => $oauth->redirect_uri,
                     'tenant' => $oauth->tenant,
                     'base_url' => $oauth->base_url,
+                    'scopes' => $oauth->scopes,
                 ];
             }
 

--- a/app/Models/OauthSetting.php
+++ b/app/Models/OauthSetting.php
@@ -11,7 +11,7 @@ class OauthSetting extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['provider', 'client_id', 'client_secret', 'redirect_uri', 'tenant', 'base_url', 'enabled'];
+    protected $fillable = ['provider', 'client_id', 'client_secret', 'redirect_uri', 'tenant', 'base_url', 'scopes', 'enabled'];
 
     protected function clientSecret(): Attribute
     {
@@ -28,6 +28,7 @@ class OauthSetting extends Model
                 return filled($this->client_id) && filled($this->client_secret) && filled($this->tenant);
             case 'authentik':
             case 'clerk':
+            case 'oidc':
                 return filled($this->client_id) && filled($this->client_secret) && filled($this->base_url);
             default:
                 return filled($this->client_id) && filled($this->client_secret);

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -10,6 +10,7 @@ use SocialiteProviders\Discord\DiscordExtendSocialite;
 use SocialiteProviders\Google\GoogleExtendSocialite;
 use SocialiteProviders\Infomaniak\InfomaniakExtendSocialite;
 use SocialiteProviders\Manager\SocialiteWasCalled;
+use SocialiteProviders\OIDC\OIDCExtendSocialite;
 use SocialiteProviders\Zitadel\ZitadelExtendSocialite;
 
 class EventServiceProvider extends ServiceProvider
@@ -22,6 +23,7 @@ class EventServiceProvider extends ServiceProvider
             DiscordExtendSocialite::class.'@handle',
             GoogleExtendSocialite::class.'@handle',
             InfomaniakExtendSocialite::class.'@handle',
+            OIDCExtendSocialite::class.'@handle',
             ZitadelExtendSocialite::class.'@handle',
         ],
     ];

--- a/bootstrap/helpers/socialite.php
+++ b/bootstrap/helpers/socialite.php
@@ -2,6 +2,12 @@
 
 use App\Models\OauthSetting;
 use Laravel\Socialite\Facades\Socialite;
+use Laravel\Socialite\Two\BitbucketProvider;
+use Laravel\Socialite\Two\GithubProvider;
+use Laravel\Socialite\Two\GitlabProvider;
+use SocialiteProviders\Discord\Provider as DiscordProvider;
+use SocialiteProviders\Infomaniak\Provider as InfomaniakProvider;
+use SocialiteProviders\Manager\Config;
 
 function get_socialite_provider(string $provider)
 {
@@ -12,7 +18,7 @@ function get_socialite_provider(string $provider)
     }
 
     if ($provider === 'azure') {
-        $azure_config = new \SocialiteProviders\Manager\Config(
+        $azure_config = new Config(
             $oauth_setting->client_id,
             $oauth_setting->client_secret,
             $oauth_setting->redirect_uri,
@@ -23,7 +29,7 @@ function get_socialite_provider(string $provider)
     }
 
     if ($provider == 'authentik' || $provider == 'clerk') {
-        $authentik_clerk_config = new \SocialiteProviders\Manager\Config(
+        $authentik_clerk_config = new Config(
             $oauth_setting->client_id,
             $oauth_setting->client_secret,
             $oauth_setting->redirect_uri,
@@ -33,8 +39,30 @@ function get_socialite_provider(string $provider)
         return Socialite::driver($provider)->setConfig($authentik_clerk_config);
     }
 
+    if ($provider == 'oidc') {
+        $oidc_scopes = collect(preg_split('/[\s,]+/', (string) $oauth_setting->scopes, -1, PREG_SPLIT_NO_EMPTY))
+            ->filter()
+            ->values()
+            ->all();
+
+        $oidc_config = new Config(
+            $oauth_setting->client_id,
+            $oauth_setting->client_secret,
+            $oauth_setting->redirect_uri,
+            ['base_url' => rtrim((string) $oauth_setting->base_url, '/')],
+        );
+
+        $socialite = Socialite::driver('oidc')->setConfig($oidc_config);
+
+        if (! empty($oidc_scopes)) {
+            $socialite->scopes($oidc_scopes);
+        }
+
+        return $socialite;
+    }
+
     if ($provider == 'zitadel') {
-        $zitadel_config = new \SocialiteProviders\Manager\Config(
+        $zitadel_config = new Config(
             $oauth_setting->client_id,
             $oauth_setting->client_secret,
             $oauth_setting->redirect_uri,
@@ -45,7 +73,7 @@ function get_socialite_provider(string $provider)
     }
 
     if ($provider == 'google') {
-        $google_config = new \SocialiteProviders\Manager\Config(
+        $google_config = new Config(
             $oauth_setting->client_id,
             $oauth_setting->client_secret,
             $oauth_setting->redirect_uri
@@ -63,11 +91,11 @@ function get_socialite_provider(string $provider)
     ];
 
     $provider_class_map = [
-        'bitbucket' => \Laravel\Socialite\Two\BitbucketProvider::class,
-        'discord' => \SocialiteProviders\Discord\Provider::class,
-        'github' => \Laravel\Socialite\Two\GithubProvider::class,
-        'gitlab' => \Laravel\Socialite\Two\GitlabProvider::class,
-        'infomaniak' => \SocialiteProviders\Infomaniak\Provider::class,
+        'bitbucket' => BitbucketProvider::class,
+        'discord' => DiscordProvider::class,
+        'github' => GithubProvider::class,
+        'gitlab' => GitlabProvider::class,
+        'infomaniak' => InfomaniakProvider::class,
     ];
 
     $socialite = Socialite::buildProvider(

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "danharrin/livewire-rate-limiting": "^2.1.0",
         "doctrine/dbal": "^4.4.1",
         "guzzlehttp/guzzle": "^7.10.0",
+        "kovah/laravel-socialite-oidc": "^0.8.0",
         "laravel/fortify": "^1.34.0",
         "laravel/framework": "^12.49.0",
         "laravel/horizon": "^5.43.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "64b77285a7140ce68e83db2659e9a21d",
+    "content-hash": "9063fc5ad023828ca0dce8e8eb21c213",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -1702,6 +1702,74 @@
                 "source": "https://github.com/Jean85/pretty-package-versions/tree/2.1.1"
             },
             "time": "2025-03-19T14:43:43+00:00"
+        },
+        {
+            "name": "kovah/laravel-socialite-oidc",
+            "version": "v0.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Kovah/laravel-socialite-oidc.git",
+                "reference": "cfd9c9a658da97b961d936159c45ca4ed082e62a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Kovah/laravel-socialite-oidc/zipball/cfd9c9a658da97b961d936159c45ca4ed082e62a",
+                "reference": "cfd9c9a658da97b961d936159c45ca4ed082e62a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "firebase/php-jwt": "^6.4|^7.0",
+                "illuminate/http": "^9.0 | ^10.0 | ^11.0 | ^12.0 | ^13.0",
+                "illuminate/support": "^9.0 | ^10.0 | ^11.0 | ^12.0 | ^13.0",
+                "php": "^8.1",
+                "socialiteproviders/manager": "^4.0"
+            },
+            "conflict": {
+                "jp-gauthier/socialiteproviders-oidc": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "SocialiteProviders\\OIDC\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "JPG Dev",
+                    "homepage": "https://jpgdev.com"
+                },
+                {
+                    "name": "Kevin Woblick",
+                    "email": "contact@woblick.dev",
+                    "homepage": "https://woblick.dev",
+                    "role": "Developer"
+                }
+            ],
+            "description": "OpenID Connect OAuth2 Provider for Laravel Socialite",
+            "homepage": "https://github.com/kovah/laravel-socialite-oidc",
+            "keywords": [
+                "laravel",
+                "oauth",
+                "oidc",
+                "provider",
+                "socialite"
+            ],
+            "support": {
+                "issues": "https://github.com/Kovah/laravel-socialite-oidc/issues",
+                "source": "https://github.com/Kovah/laravel-socialite-oidc/tree/v0.8.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/kovah",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-30T09:17:26+00:00"
         },
         {
             "name": "laravel/fortify",

--- a/config/services.php
+++ b/config/services.php
@@ -60,6 +60,14 @@ return [
         'tenant' => env('GOOGLE_TENANT'),
     ],
 
+    'oidc' => [
+        'base_url' => env('OIDC_BASE_URL'),
+        'client_id' => env('OIDC_CLIENT_ID'),
+        'client_secret' => env('OIDC_CLIENT_SECRET'),
+        'redirect' => env('OIDC_REDIRECT_URI'),
+        'scopes' => env('OIDC_SCOPES') ? preg_split('/[\s,]+/', env('OIDC_SCOPES'), -1, PREG_SPLIT_NO_EMPTY) : [],
+    ],
+
     'zitadel' => [
         'client_id' => env('ZITADEL_CLIENT_ID'),
         'client_secret' => env('ZITADEL_CLIENT_SECRET'),

--- a/database/migrations/2026_05_23_000000_add_scopes_to_oauth_settings_table.php
+++ b/database/migrations/2026_05_23_000000_add_scopes_to_oauth_settings_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('oauth_settings', function (Blueprint $table) {
+            $table->string('scopes')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('oauth_settings', function (Blueprint $table) {
+            $table->dropColumn('scopes');
+        });
+    }
+};

--- a/database/seeders/OauthSettingSeeder.php
+++ b/database/seeders/OauthSettingSeeder.php
@@ -24,6 +24,7 @@ class OauthSettingSeeder extends Seeder
                 'google',
                 'authentik',
                 'infomaniak',
+                'oidc',
                 'zitadel',
             ]);
 

--- a/lang/ar.json
+++ b/lang/ar.json
@@ -9,6 +9,7 @@
     "auth.login.gitlab": "تسجيل الدخول باستخدام Gitlab",
     "auth.login.google": "تسجيل الدخول باستخدام Google",
     "auth.login.infomaniak": "تسجيل الدخول باستخدام Infomaniak",
+    "auth.login.oidc": "تسجيل الدخول باستخدام OIDC",
     "auth.already_registered": "هل سبق لك التسجيل؟",
     "auth.confirm_password": "تأكيد كلمة المرور",
     "auth.forgot_password_link": "هل نسيت كلمة المرور؟",

--- a/lang/az.json
+++ b/lang/az.json
@@ -9,6 +9,7 @@
   "auth.login.gitlab": "GitLab ilə daxil ol",
   "auth.login.google": "Google ilə daxil ol",
   "auth.login.infomaniak": "Infomaniak ilə daxil ol",
+  "auth.login.oidc": "OIDC ilə daxil ol",
   "auth.already_registered": "Qeytiyatınız var?",
   "auth.confirm_password": "Şifrəni təsdiqləyin",
   "auth.forgot_password_link": "Şifrəmi unutdum?",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -8,6 +8,7 @@
     "auth.login.gitlab": "Přihlásit se pomocí Gitlabu",
     "auth.login.google": "Přihlásit se pomocí Google",
     "auth.login.infomaniak": "Přihlásit se pomocí Infomaniak",
+    "auth.login.oidc": "Přihlásit se pomocí OIDC",
     "auth.already_registered": "Již jste registrováni?",
     "auth.confirm_password": "Potvrďte heslo",
     "auth.forgot_password_link": "Zapomněli jste heslo?",

--- a/lang/de.json
+++ b/lang/de.json
@@ -8,6 +8,7 @@
     "auth.login.gitlab": "Mit GitLab anmelden",
     "auth.login.google": "Mit Google anmelden",
     "auth.login.infomaniak": "Mit Infomaniak anmelden",
+    "auth.login.oidc": "Mit OIDC anmelden",
     "auth.login.zitadel": "Mit Zitadel anmelden",
     "auth.already_registered": "Bereits registriert?",
     "auth.confirm_password": "Passwort bestätigen",

--- a/lang/en.json
+++ b/lang/en.json
@@ -9,6 +9,7 @@
     "auth.login.gitlab": "Login with Gitlab",
     "auth.login.google": "Login with Google",
     "auth.login.infomaniak": "Login with Infomaniak",
+    "auth.login.oidc": "Login with OIDC",
     "auth.login.zitadel": "Login with Zitadel",
     "auth.already_registered": "Already registered?",
     "auth.confirm_password": "Confirm password",

--- a/lang/es.json
+++ b/lang/es.json
@@ -8,6 +8,7 @@
     "auth.login.gitlab": "Acceder con Gitlab",
     "auth.login.google": "Acceder con Google",
     "auth.login.infomaniak": "Acceder con Infomaniak",
+    "auth.login.oidc": "Acceder con OIDC",
     "auth.already_registered": "¿Ya estás registrado?",
     "auth.confirm_password": "Confirmar contraseña",
     "auth.forgot_password_link": "¿Olvidaste tu contraseña?",

--- a/lang/fa.json
+++ b/lang/fa.json
@@ -8,6 +8,7 @@
     "auth.login.gitlab": "ورود با گیت لب",
     "auth.login.google": "ورود با گوگل",
     "auth.login.infomaniak": "ورود با Infomaniak",
+    "auth.login.oidc": "ورود با OIDC",
     "auth.already_registered": "قبلاً ثبت نام کرده‌اید؟",
     "auth.confirm_password": "تایید رمز عبور",
     "auth.forgot_password_link": "رمز عبور را فراموش کرده‌اید؟",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -9,6 +9,7 @@
     "auth.login.gitlab": "Connexion avec Gitlab",
     "auth.login.google": "Connexion avec Google",
     "auth.login.infomaniak": "Connexion avec Infomaniak",
+    "auth.login.oidc": "Connexion avec OIDC",
     "auth.already_registered": "Déjà enregistré ?",
     "auth.confirm_password": "Confirmer le mot de passe",
     "auth.forgot_password_link": "Mot de passe oublié ?",

--- a/lang/id.json
+++ b/lang/id.json
@@ -9,6 +9,7 @@
     "auth.login.gitlab": "Masuk dengan Gitlab",
     "auth.login.google": "Masuk dengan Google",
     "auth.login.infomaniak": "Masuk dengan Infomaniak",
+    "auth.login.oidc": "Masuk dengan OIDC",
     "auth.already_registered": "Sudah terdaftar?",
     "auth.confirm_password": "Konfirmasi kata sandi",
     "auth.forgot_password_link": "Lupa kata sandi?",

--- a/lang/it.json
+++ b/lang/it.json
@@ -9,6 +9,7 @@
     "auth.login.gitlab": "Accedi con Gitlab",
     "auth.login.google": "Accedi con Google",
     "auth.login.infomaniak": "Accedi con Infomaniak",
+    "auth.login.oidc": "Accedi con OIDC",
     "auth.already_registered": "Già registrato?",
     "auth.confirm_password": "Conferma password",
     "auth.forgot_password_link": "Hai dimenticato la password?",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -8,6 +8,7 @@
     "auth.login.gitlab": "Gitlabでログイン",
     "auth.login.google": "Googleでログイン",
     "auth.login.infomaniak": "Infomaniakでログイン",
+    "auth.login.oidc": "OIDCでログイン",
     "auth.already_registered": "すでに登録済みですか？",
     "auth.confirm_password": "パスワードを確認",
     "auth.forgot_password_link": "パスワードをお忘れですか？",

--- a/lang/no.json
+++ b/lang/no.json
@@ -9,6 +9,7 @@
     "auth.login.gitlab": "Logg inn med Gitlab",
     "auth.login.google": "Logg inn med Google",
     "auth.login.infomaniak": "Logg inn med Infomaniak",
+    "auth.login.oidc": "Logg inn med OIDC",
     "auth.already_registered": "Allerede registrert?",
     "auth.confirm_password": "Bekreft passord",
     "auth.forgot_password_link": "Glemt passord?",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -9,6 +9,7 @@
     "auth.login.gitlab": "Zaloguj się przez Gitlab",
     "auth.login.google": "Zaloguj się przez Google",
     "auth.login.infomaniak": "Zaloguj się przez Infomaniak",
+    "auth.login.oidc": "Zaloguj się przez OIDC",
     "auth.login.zitadel": "Zaloguj się przez Zitadel",
     "auth.already_registered": "Już zarejestrowany?",
     "auth.confirm_password": "Potwierdź hasło",

--- a/lang/pt-br.json
+++ b/lang/pt-br.json
@@ -9,6 +9,7 @@
     "auth.login.gitlab": "Entrar com Gitlab",
     "auth.login.google": "Entrar com Google",
     "auth.login.infomaniak": "Entrar com Infomaniak",
+    "auth.login.oidc": "Entrar com OIDC",
     "auth.login.zitadel": "Entrar com Zitadel",
     "auth.already_registered": "Já tem uma conta?",
     "auth.confirm_password": "Confirmar senha",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -9,6 +9,7 @@
     "auth.login.gitlab": "Entrar com Gitlab",
     "auth.login.google": "Entrar com Google",
     "auth.login.infomaniak": "Entrar com Infomaniak",
+    "auth.login.oidc": "Entrar com OIDC",
     "auth.login.zitadel": "Entrar com Zitadel",
     "auth.already_registered": "Já tem uma conta?",
     "auth.confirm_password": "Confirmar senha",

--- a/lang/ro.json
+++ b/lang/ro.json
@@ -8,6 +8,7 @@
     "auth.login.gitlab": "Autentificare prin Gitlab",
     "auth.login.google": "Autentificare prin Google",
     "auth.login.infomaniak": "Autentificare prin Infomaniak",
+    "auth.login.oidc": "Autentificare prin OIDC",
     "auth.already_registered": "Sunteți deja înregistrat?",
     "auth.confirm_password": "Confirmați parola",
     "auth.forgot_password_link": "Ați uitat parola?",

--- a/lang/tr.json
+++ b/lang/tr.json
@@ -8,6 +8,7 @@
     "auth.login.gitlab": "GitLab ile Giriş Yap",
     "auth.login.google": "Google ile Giriş Yap",
     "auth.login.infomaniak": "Infomaniak ile Giriş Yap",
+    "auth.login.oidc": "OIDC ile Giriş Yap",
     "auth.already_registered": "Zaten kayıtlı mısınız?",
     "auth.confirm_password": "Şifreyi Onayla",
     "auth.forgot_password_link": "Şifrenizi mi unuttunuz?",

--- a/lang/vi.json
+++ b/lang/vi.json
@@ -8,6 +8,7 @@
     "auth.login.gitlab": "Đăng Nhập Bằng Gitlab",
     "auth.login.google": "Đăng Nhập Bằng Google",
     "auth.login.infomaniak": "Đăng Nhập Bằng Infomaniak",
+    "auth.login.oidc": "Đăng Nhập Bằng OIDC",
     "auth.already_registered": "Đã đăng ký?",
     "auth.confirm_password": "Nhập lại mật khẩu",
     "auth.forgot_password_link": "Quên mật khẩu?",

--- a/lang/zh-cn.json
+++ b/lang/zh-cn.json
@@ -9,6 +9,7 @@
     "auth.login.gitlab": "使用 Gitlab 登录",
     "auth.login.google": "使用 Google 登录",
     "auth.login.infomaniak": "使用 Infomaniak 登录",
+    "auth.login.oidc": "使用 OIDC 登录",
     "auth.login.zitadel": "使用 Zitadel 登录",
     "auth.already_registered": "已经注册？",
     "auth.confirm_password": "确认密码",

--- a/lang/zh-tw.json
+++ b/lang/zh-tw.json
@@ -8,6 +8,7 @@
     "auth.login.gitlab": "使用 Gitlab 登入",
     "auth.login.google": "使用 Google 登入",
     "auth.login.infomaniak": "使用 Infomaniak 登入",
+    "auth.login.oidc": "使用 OIDC 登入",
     "auth.already_registered": "已經註冊？",
     "auth.confirm_password": "確認密碼",
     "auth.forgot_password_link": "忘記密碼？",

--- a/resources/views/livewire/settings-oauth.blade.php
+++ b/resources/views/livewire/settings-oauth.blade.php
@@ -16,7 +16,7 @@
         <div class="flex flex-col gap-2 pt-4">
             @foreach ($oauth_settings_map as $oauth_setting)
                 <div class="p-4 border dark:border-coolgray-300 border-neutral-200">
-                    <h3>{{ ucfirst($oauth_setting['provider']) }}</h3>
+                    <h3>{{ $oauth_setting['provider'] == 'oidc' ? 'Generic OIDC' : ucfirst($oauth_setting['provider']) }}</h3>
                     <div class="w-32">
                         <x-forms.checkbox instantSave="instantSave('{{ $oauth_setting['provider'] }}')"
                             id="oauth_settings_map.{{ $oauth_setting['provider'] }}.enabled" label="Enabled" />
@@ -41,9 +41,16 @@
                             $oauth_setting['provider'] == 'authentik' ||
                                 $oauth_setting['provider'] == 'clerk' ||
                                 $oauth_setting['provider'] == 'zitadel' ||
+                                $oauth_setting['provider'] == 'oidc' ||
                                 $oauth_setting['provider'] == 'gitlab')
                             <x-forms.input id="oauth_settings_map.{{ $oauth_setting['provider'] }}.base_url"
-                                label="Base URL" />
+                                label="{{ $oauth_setting['provider'] == 'oidc' ? 'Issuer / Base URL' : 'Base URL' }}"
+                                helper="{{ $oauth_setting['provider'] == 'oidc' ? 'OIDC issuer URL without the /.well-known/openid-configuration suffix.' : '' }}" />
+                        @endif
+                        @if ($oauth_setting['provider'] == 'oidc')
+                            <x-forms.input id="oauth_settings_map.{{ $oauth_setting['provider'] }}.scopes"
+                                label="Scopes"
+                                helper="Optional additional scopes separated by spaces or commas. Defaults include openid, email, and profile." />
                         @endif
                     </div>
                 </div>

--- a/tests/Feature/OauthControllerTest.php
+++ b/tests/Feature/OauthControllerTest.php
@@ -5,6 +5,7 @@ use App\Models\OauthSetting;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Socialite\Facades\Socialite;
+use SocialiteProviders\Manager\Config;
 
 uses(RefreshDatabase::class);
 
@@ -30,7 +31,7 @@ it('logs in an existing user when the oauth provider returns a mixed-case email'
         'email' => 'username@example.edu',
     ]);
 
-    $provider = \Mockery::mock();
+    $provider = Mockery::mock();
     $provider->shouldReceive('setConfig')->once()->andReturnSelf();
     $provider->shouldReceive('with')->once()->with(['hd' => 'example.com'])->andReturnSelf();
     $provider->shouldReceive('user')->once()->andReturn((object) [
@@ -58,7 +59,7 @@ it('rejects oauth logins when the provider does not return an email address', fu
         'is_registration_enabled' => true,
     ]);
 
-    $provider = \Mockery::mock();
+    $provider = Mockery::mock();
     $provider->shouldReceive('setConfig')->once()->andReturnSelf();
     $provider->shouldReceive('with')->once()->with(['hd' => 'example.com'])->andReturnSelf();
     $provider->shouldReceive('user')->once()->andReturn((object) [
@@ -77,3 +78,58 @@ it('rejects oauth logins when the provider does not return an email address', fu
     'null email' => [null],
     'blank email' => ['   '],
 ]);
+
+it('logs in an existing user through the generic oidc provider', function () {
+    config()->set('app.maintenance.driver', 'file');
+
+    $user = User::factory()->create([
+        'email' => 'oidc-user@example.com',
+    ]);
+
+    OauthSetting::create([
+        'provider' => 'oidc',
+        'client_id' => 'oidc-client-id',
+        'client_secret' => 'oidc-client-secret',
+        'redirect_uri' => 'https://coolify.example.com/auth/oidc/callback',
+        'base_url' => 'https://idp.example.com/realms/coolify/',
+        'scopes' => 'groups, roles',
+    ]);
+
+    $provider = Mockery::mock();
+    $provider->shouldReceive('setConfig')->once()->with(Mockery::on(function ($config) {
+        $values = $config instanceof Config ? $config->get() : [];
+
+        return $values['client_id'] === 'oidc-client-id'
+            && $values['client_secret'] === 'oidc-client-secret'
+            && $values['redirect'] === 'https://coolify.example.com/auth/oidc/callback'
+            && $values['base_url'] === 'https://idp.example.com/realms/coolify';
+    }))->andReturnSelf();
+    $provider->shouldReceive('scopes')->once()->with(['groups', 'roles'])->andReturnSelf();
+    $provider->shouldReceive('user')->once()->andReturn((object) [
+        'email' => 'OIDC-User@example.com',
+        'name' => 'OIDC User',
+        'id' => 'oidc-user-id',
+    ]);
+
+    Socialite::shouldReceive('driver')->once()->with('oidc')->andReturn($provider);
+
+    $response = $this->get(route('auth.callback', 'oidc'));
+
+    $response->assertRedirect('/');
+    $this->assertAuthenticatedAs($user);
+    expect(User::count())->toBe(1);
+});
+
+it('requires a base url before oidc can be enabled', function () {
+    $oauthSetting = new OauthSetting([
+        'provider' => 'oidc',
+        'client_id' => 'oidc-client-id',
+        'client_secret' => 'oidc-client-secret',
+    ]);
+
+    expect($oauthSetting->couldBeEnabled())->toBeFalse();
+
+    $oauthSetting->base_url = 'https://idp.example.com/realms/coolify';
+
+    expect($oauthSetting->couldBeEnabled())->toBeTrue();
+});


### PR DESCRIPTION
## Changes

- Adds generic OIDC OAuth provider support for custom providers such as Keycloak, Nextcloud, Authentik, Zitadel, and other compatible identity providers.
- Adds the current OIDC Socialite provider package and registers it with Coolify's existing Socialite provider flow.
- Adds instance settings for the OIDC issuer/base URL and optional extra scopes, plus settings UI fields and login labels.
- Seeds the OIDC provider and stores scope configuration using the existing OAuth settings model.

## Issues

- Relates to #6696
- Based on the idea from the existing OIDC PR, but redone cleanly against the current next branch.

## Category

- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No screenshot included. This is a settings-page form addition and backend OAuth provider wiring; the new Generic OIDC fields appear in Settings > OAuth after the provider is seeded.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex in the contributor's fork.
- How extensively: Used to inspect the current codebase, implement the focused changes, run formatting/tests, and prepare the PR. The implementation was kept aligned with the existing OAuth flow.

## Testing

- docker run --rm -v ${PWD}:/app -w /app composer:2 composer validate --no-check-publish --strict - passed.
- docker run --rm -v ${PWD}:/app -w /app composer:2 php vendor/bin/pint [touched PHP files] - passed after formatting the touched PHP files.
- docker run --rm -v ${PWD}:/app -w /app composer:2 sh -lc "apk add --no-cache postgresql-dev linux-headers >/tmp/apk.log && docker-php-ext-install pdo_pgsql pcntl sockets >/tmp/ext.log && php artisan test tests/Feature/OauthControllerTest.php" - passed, 5 tests and 36 assertions.
- Manual live OIDC-provider testing was not performed because no real IdP credentials were available in this local environment.

## Security

- No secrets committed.
- OIDC config is stored and handled using the existing Coolify OAuth settings patterns.
- Callback and redirect behavior follows the existing OAuth provider flow.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.