### PR TITLE
fix(api): correct OpenAPI schema for GET /deployments/applications/{uuid}

### DIFF
--- a/app/Http/Controllers/Api/DeployController.php
+++ b/app/Http/Controllers/Api/DeployController.php
@@ -653,8 +653,19 @@ class DeployController extends Controller
                     new OA\MediaType(
                         mediaType: 'application/json',
                         schema: new OA\Schema(
-                            type: 'array',
-                            items: new OA\Items(ref: '#/components/schemas/Application'),
+                            type: 'object',
+                            properties: [
+                                new OA\Property(
+                                    property: 'count',
+                                    type: 'integer',
+                                    description: 'Total number of deployments for this application.',
+                                ),
+                                new OA\Property(
+                                    property: 'deployments',
+                                    type: 'array',
+                                    items: new OA\Items(ref: '#/components/schemas/ApplicationDeploymentQueue'),
+                                ),
+                            ]
                         )
                     ),
                 ]),


### PR DESCRIPTION
## Summary

The `GET /deployments/applications/{uuid}` endpoint is documented in the OpenAPI schema as returning `Application[]` (an array of Application objects), but the actual implementation in `Application::deployments()` returns an object with the following shape:

```json
{
  "count": 42,
  "deployments": [ /* ApplicationDeploymentQueue[] */ ]
}
```

This mismatch causes:
- API clients that rely on the generated OpenAPI schema to receive an unexpected data structure
- Type-safe SDK generators (e.g. `openapi-fetch`, `openapi-typescript`) to produce incorrect types, requiring workarounds like manual casting

## Changes

- Updated the `#[OA\Get]` annotation on `DeployController::get_application_deployments()` to correctly reflect the actual response shape: an object with a `count` integer and a `deployments` array of `ApplicationDeploymentQueue` items.

## Test plan

- [ ] Regenerate the OpenAPI spec and verify the schema for `GET /deployments/applications/{uuid}` matches the actual API response
- [ ] Confirm existing clients consuming this endpoint are unaffected (the response payload is unchanged — only the documentation is corrected)