### PR TITLE
fix(api): add missing status and server_status fields to Service OpenAPI schema

### DIFF
--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -40,6 +40,8 @@ use Visus\Cuid2\Cuid2;
         'created_at' => ['type' => 'string', 'description' => 'The date and time when the service was created.'],
         'updated_at' => ['type' => 'string', 'description' => 'The date and time when the service was last updated.'],
         'deleted_at' => ['type' => 'string', 'description' => 'The date and time when the service was deleted.'],
+        'status' => ['type' => 'string', 'description' => 'The aggregate status of the service. Format: "{status}:{health}" (e.g. "running:healthy", "exited:unhealthy"). Computed from all service components.'],
+        'server_status' => ['type' => 'boolean', 'description' => 'Whether the server hosting this service is reachable.'],
     ],
 )]
 class Service extends BaseModel


### PR DESCRIPTION
## Summary

The `Service` model declares both `status` and `server_status` in its `$appends` array, which means these fields are **always present** in every API response for services. However, neither field was documented in the OpenAPI schema (`#[OA\Schema]` on the `Service` model).

This causes:
- API clients relying on the generated schema to be unaware of these fields
- Type-safe SDK generators (e.g. `openapi-fetch`, `openapi-typescript`) to not include them in the generated types, even though they are always returned

## Field details

- **`status`** — Aggregate status of all service components. Format: `"{status}:{health}"` (e.g. `"running:healthy"`, `"exited:unhealthy"`). Computed via `Service::getStatusAttribute()`.
- **`server_status`** — Boolean indicating whether the server hosting this service is currently reachable.

## Changes

Added both fields to the `properties` array in the `#[OA\Schema]` attribute on `Service.php`.

## Test plan

- [ ] Regenerate the OpenAPI spec and verify both `status` and `server_status` appear in the `Service` schema
- [ ] Confirm the types and descriptions match the actual values returned by the API