### PR TITLE
fix(log-viewer): scope DOM queries to Alpine component root for multi-container logs

### DIFF
--- a/resources/views/livewire/project/shared/get-logs.blade.php
+++ b/resources/views/livewire/project/shared/get-logs.blade.php
@@ -61,7 +61,7 @@
             }
         },
         scrollToBottom() {
-            const logsContainer = document.getElementById('logsContainer');
+            const logsContainer = this.$root.querySelector('#logsContainer');
             if (logsContainer) {
                 this.isScrolling = true;
                 logsContainer.scrollTop = logsContainer.scrollHeight;
@@ -117,7 +117,7 @@
             this.applyColorLogs();
         },
         applyColorLogs() {
-            const logs = document.getElementById('logs');
+            const logs = this.$root.querySelector('#logs');
             if (!logs) return;
             const lines = logs.querySelectorAll('[data-log-line]');
             lines.forEach(line => {
@@ -134,7 +134,7 @@
             if (!selection || selection.isCollapsed || !selection.toString().trim()) {
                 return false;
             }
-            const logsContainer = document.getElementById('logs');
+            const logsContainer = this.$root.querySelector('#logs');
             if (!logsContainer) return false;
             const range = selection.getRangeAt(0);
             return logsContainer.contains(range.commonAncestorContainer);
@@ -144,7 +144,7 @@
             return doc.documentElement.textContent;
         },
         applySearch() {
-            const logs = document.getElementById('logs');
+            const logs = this.$root.querySelector('#logs');
             if (!logs) return;
             const lines = logs.querySelectorAll('[data-log-line]');
             const query = this.searchQuery.trim().toLowerCase();
@@ -200,7 +200,7 @@
             }
         },
         downloadLogs() {
-            const logs = document.getElementById('logs');
+            const logs = this.$root.querySelector('#logs');
             if (!logs) return;
             const visibleLines = logs.querySelectorAll('[data-log-line]:not(.hidden)');
             let content = '';
@@ -243,14 +243,14 @@
 
             // Apply colors after Livewire updates (existing content)
             Livewire.hook('morph.updated', ({ el }) => {
-                if (el.id === 'logs') {
+                if (el.id === 'logs' && this.$root.contains(el)) {
                     applyAfterUpdate();
                 }
             });
 
             // Apply colors after Livewire adds new content (initial load)
             Livewire.hook('morph.added', ({ el }) => {
-                if (el.id === 'logs') {
+                if (el.id === 'logs' && this.$root.contains(el)) {
                     applyAfterUpdate();
                 }
             });


### PR DESCRIPTION
## Fixes

Closes #10207

## What changed

When viewing logs for applications with multiple containers, log-color highlighting, search, download, and auto-scroll only worked on the first container. This happened because all DOM queries used global \document.getElementById()\ which always returned the first matching element on the page.

### Changes in \esources/views/livewire/project/shared/get-logs.blade.php\:

- **applyColorLogs()**: \document.getElementById('logs')\ -> \	his.\.querySelector('#logs')\
- **applySearch()**: \document.getElementById('logs')\ -> \	his.\.querySelector('#logs')\
- **downloadLogs()**: \document.getElementById('logs')\ -> \	his.\.querySelector('#logs')\
- **scrollToBottom()**: \document.getElementById('logsContainer')\ -> \	his.\.querySelector('#logsContainer')\
- **hasActiveLogSelection()**: \document.getElementById('logs')\ -> \	his.\.querySelector('#logs')\
- **init() Livewire hooks**: Added \	his.\.contains(el)\ guard to both \morph.updated\ and \morph.added\ hooks

## How tested

- Verified the Blade file syntax is valid (no PHP/Laravel syntax errors)
- Confirmed all 6 DOM query sites were updated consistently
- The fix follows the exact pattern suggested by the issue reporter who tested a local hotfix and confirmed it resolves the issue

## Limitations/Risks

- This is a client-side only change affecting Alpine.js component behavior
- No backend or database changes
- No new dependencies added