### PR TITLE
fix: gzip-compress compose YAML on deploy transmission to avoid MAX_ARG_STRLEN limit

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -697,9 +697,9 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
 
             $yaml = Yaml::dump(convertToArray($composeFile), 10);
         }
-        $this->docker_compose_base64 = base64_encode($yaml);
+        $this->docker_compose_base64 = base64_encode(gzencode($yaml, 9));
         $this->execute_remote_command([
-            executeInDocker($this->deployment_uuid, "echo '{$this->docker_compose_base64}' | base64 -d | tee {$this->workdir}{$this->docker_compose_location} > /dev/null"),
+            executeInDocker($this->deployment_uuid, "echo '{$this->docker_compose_base64}' | base64 -d | gunzip | tee {$this->workdir}{$this->docker_compose_location} > /dev/null"),
             'hidden' => true,
         ]);
 
@@ -1060,7 +1060,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                     "mkdir -p $mainDir",
                 ],
                 [
-                    "echo '{$this->docker_compose_base64}' | base64 -d | tee $composeFileName > /dev/null",
+                    "echo '{$this->docker_compose_base64}' | base64 -d | gunzip | tee $composeFileName > /dev/null",
                 ],
                 [
                     "echo '{$readme}' > $mainDir/README.md",
@@ -3278,8 +3278,8 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
         }
 
         $this->docker_compose = Yaml::dump($docker_compose, 10);
-        $this->docker_compose_base64 = base64_encode($this->docker_compose);
-        $this->execute_remote_command([executeInDocker($this->deployment_uuid, "echo '{$this->docker_compose_base64}' | base64 -d | tee {$this->workdir}/docker-compose.yaml > /dev/null"), 'hidden' => true]);
+        $this->docker_compose_base64 = base64_encode(gzencode($this->docker_compose, 9));
+        $this->execute_remote_command([executeInDocker($this->deployment_uuid, "echo '{$this->docker_compose_base64}' | base64 -d | gunzip | tee {$this->workdir}/docker-compose.yaml > /dev/null"), 'hidden' => true]);
     }
 
     private function generate_local_persistent_volumes()


### PR DESCRIPTION
## Changes

I hit `proc_open(): posix_spawn() failed: Argument list too long` deploying a self-hosted Sentry stack (~76 services, ~511KB compose after Coolify's `SERVICE_NAME_*` env injection). After digging, the limit isn't `ARG_MAX` — it's `MAX_ARG_STRLEN` (`32 * PAGE_SIZE` = 128KB on 4KB-page systems), a hard-coded kernel constant on the size of any single argv string. Raising stack ulimit doesn't help.

The deploy code base64-encodes the rendered compose and passes it as one argv to `bash -c "echo '<BASE64>' | base64 -d | tee FILE"`. Once the base64 string crosses 128KB, every deploy fails before a single line touches disk.

Fix: wrap the encode in `gzencode($yaml, 9)` and pipe through `gunzip` on the decode side. The compose written to disk is byte-identical (gzip is lossless). In my case the on-the-wire size went from ~682KB base64 to ~16KB base64 — 40x headroom under the limit.

5 changes in `app/Jobs/ApplicationDeploymentJob.php`:
- 2 `base64_encode(...)` → `base64_encode(gzencode(..., 9))`
- 3 `| base64 -d | tee` → `| base64 -d | gunzip | tee`

`gunzip` is in coreutils on every distro the deploy helper would run on, so no new dependencies.

## Issues

- Fixes deploys of any compose where the rendered YAML's base64 exceeds 128KB. Repro: any Sentry self-hosted compose, or any compose with >50 services (Coolify auto-injects `SERVICE_NAME_*` for every service into every service's env, which compounds quadratically).

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Before (deploy log):
```
Deployment failed: The command "timeout 3600 ssh ..." ... 
Error: proc_open(): posix_spawn() failed: Argument list too long
```

After: deploy proceeds, the compose lands on disk identical to the pre-patch output (verified via `diff` on a smaller compose where both paths succeed).

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Opus) for diagnosis (kernel limit identification, code search) and drafting the patch + PR text.
- How extensively: The diagnosis path, the patch itself, and this PR body were AI-assisted. I reviewed every change, applied the patch to my running Coolify instance, and confirmed the previously-failing deploy got past the compose-write step.

## Testing

1. Patched a live Coolify 4.1.0 install.
2. Triggered a deploy whose pre-patch behavior was the `proc_open() ... Argument list too long` failure above.
3. After patch: compose written successfully, deploy progresses past the write step. Verified with `gunzip` round-trip that the on-disk YAML byte-matches what Coolify would have written un-gzipped on a smaller compose.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md).
> - [x] I have searched existing issues and PRs to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify.