### PR TITLE
Allow OAuth signup when password registration is disabled

### DIFF
--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\ResetsUserPasswords;
 
 class ResetUserPassword implements ResetsUserPasswords
@@ -17,6 +18,12 @@ class ResetUserPassword implements ResetsUserPasswords
      */
     public function reset(User $user, array $input): void
     {
+        if (! $user->hasPassword()) {
+            throw ValidationException::withMessages([
+                'password' => __('OAuth users cannot set a password. Please sign in with your OAuth provider.'),
+            ]);
+        }
+
         Validator::make($input, [
             'password' => ['required', Password::defaults(), 'confirmed'],
         ])->validate();

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -26,15 +26,7 @@ class OauthController extends Controller
             $email = strtolower($email);
             $user = User::whereEmail($email)->first();
             if (! $user) {
-                $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
-                    abort(403, 'Registration is disabled');
-                }
-
-                $user = User::create([
-                    'name' => $oauthUser->name,
-                    'email' => $email,
-                ]);
+                $user = $this->createUserFromOauth($oauthUser->name, $email);
             }
             Auth::login($user);
 
@@ -44,5 +36,29 @@ class OauthController extends Controller
 
             return redirect()->route('login')->withErrors([__($errorCode)]);
         }
+    }
+
+    private function createUserFromOauth(?string $name, string $email): User
+    {
+        $userData = [
+            'name' => filled($name) ? $name : $email,
+            'email' => $email,
+        ];
+
+        if (User::count() === 0) {
+            $user = (new User)->forceFill([
+                'id' => 0,
+                ...$userData,
+            ]);
+            $user->save();
+
+            $settings = instanceSettings();
+            $settings->is_registration_enabled = false;
+            $settings->save();
+
+            return $user;
+        }
+
+        return User::create($userData);
     }
 }

--- a/tests/Feature/OauthControllerTest.php
+++ b/tests/Feature/OauthControllerTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use App\Actions\Fortify\ResetUserPassword;
 use App\Models\InstanceSettings;
 use App\Models\OauthSetting;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Validation\ValidationException;
 use Laravel\Socialite\Facades\Socialite;
 
 uses(RefreshDatabase::class);
@@ -47,6 +49,46 @@ it('logs in an existing user when the oauth provider returns a mixed-case email'
     $this->assertAuthenticatedAs($user);
     expect(User::count())->toBe(1);
 });
+
+it('creates and logs in a new oauth user when password registration is disabled', function () {
+    config()->set('app.maintenance.driver', 'file');
+
+    User::factory()->create([
+        'email' => 'admin@example.edu',
+    ]);
+
+    $provider = \Mockery::mock();
+    $provider->shouldReceive('setConfig')->once()->andReturnSelf();
+    $provider->shouldReceive('with')->once()->with(['hd' => 'example.com'])->andReturnSelf();
+    $provider->shouldReceive('user')->once()->andReturn((object) [
+        'email' => 'NewUser@example.edu',
+        'name' => 'New OAuth User',
+        'id' => 'google-user-id',
+    ]);
+
+    Socialite::shouldReceive('driver')->once()->with('google')->andReturn($provider);
+
+    $response = $this->get(route('auth.callback', 'google'));
+
+    $response->assertRedirect('/');
+    $user = User::whereEmail('newuser@example.edu')->first();
+
+    expect($user)->not->toBeNull()
+        ->and($user->password)->toBeNull();
+    $this->assertAuthenticatedAs($user);
+    expect(User::count())->toBe(2);
+});
+
+it('prevents oauth-only users from setting a password through reset', function () {
+    $user = User::factory()->create([
+        'password' => null,
+    ]);
+
+    app(ResetUserPassword::class)->reset($user, [
+        'password' => 'Password1!@',
+        'password_confirmation' => 'Password1!@',
+    ]);
+})->throws(ValidationException::class);
 
 it('rejects oauth logins when the provider does not return an email address', function (?string $providerEmail) {
     config()->set('app.maintenance.driver', 'file');


### PR DESCRIPTION
Fixes #8042

## Summary
- allow OAuth callbacks to create passwordless users even when normal registration is disabled
- keep the first OAuth-created user compatible with the existing root user/team flow
- prevent passwordless OAuth users from adding a password through the reset-password flow

## Tests
- Added coverage in tests/Feature/OauthControllerTest.php for disabled-registration OAuth signup and OAuth-only password reset blocking.
- Not run locally: PHP/vendor dependencies are not installed in this environment.