### PR TITLE
fix(proxy): prefer ipv6-capable networks for ingress

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -102,7 +102,7 @@ class InstallDocker
                 ]);
             } else {
                 $command = $command->merge([
-                    'docker network create --attachable coolify >/dev/null 2>&1 || true',
+                    buildDockerNetworkCreateIfMissingCommand('coolify', preferIpv6: true).' || true',
                 ]);
                 $command = $command->merge([
                     "echo 'Done!'",

--- a/app/Actions/Service/StartService.php
+++ b/app/Actions/Service/StartService.php
@@ -33,7 +33,7 @@ class StartService
         }
         if ($service->networks()->count() > 0) {
             $commands[] = "echo 'Creating Docker network.'";
-            $commands[] = "docker network inspect $service->uuid >/dev/null 2>&1 || docker network create --attachable $service->uuid";
+            $commands[] = buildDockerNetworkCreateIfMissingCommand($service->uuid, preferIpv6: true);
         }
         $commands[] = 'echo Starting service.';
         $commands[] = "docker compose --project-directory {$workdir} -f {$workdir}/docker-compose.yml --project-name {$service->uuid} up -d --remove-orphans --force-recreate --build";

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -788,7 +788,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             // TODO
         } else {
             $this->execute_remote_command([
-                "docker network inspect '{$networkId}' >/dev/null 2>&1 || docker network create --attachable '{$networkId}' >/dev/null || true",
+                buildDockerNetworkCreateIfMissingCommand($networkId, preferIpv6: true)." || true",
                 'hidden' => true,
                 'ignore_errors' => true,
             ], [

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -1408,7 +1408,7 @@ $schema://$host {
         if ($isSwarm) {
             return instant_remote_process(['docker network create --attachable --driver overlay coolify-overlay >/dev/null 2>&1 || true'], $this, false);
         } else {
-            return instant_remote_process(['docker network create coolify --attachable >/dev/null 2>&1 || true'], $this, false);
+            return instant_remote_process([buildDockerNetworkCreateIfMissingCommand('coolify', preferIpv6: true)], $this, false);
         }
     }
 

--- a/app/Models/StandaloneDocker.php
+++ b/app/Models/StandaloneDocker.php
@@ -23,9 +23,8 @@ class StandaloneDocker extends BaseModel
         parent::boot();
         static::created(function ($newStandaloneDocker) {
             $server = $newStandaloneDocker->server;
-            $safeNetwork = escapeshellarg($newStandaloneDocker->network);
             instant_remote_process([
-                "docker network inspect {$safeNetwork} >/dev/null 2>&1 || docker network create --driver overlay --attachable {$safeNetwork} >/dev/null",
+                buildDockerNetworkCreateIfMissingCommand($newStandaloneDocker->network, preferIpv6: true),
             ], $server, false);
             ConnectProxyToNetworksJob::dispatchSync($server);
         });

--- a/bootstrap/helpers/proxy.php
+++ b/bootstrap/helpers/proxy.php
@@ -21,6 +21,22 @@ function isDockerPredefinedNetwork(string $network): bool
     return in_array($network, ['default', 'host'], true);
 }
 
+function buildDockerNetworkCreateIfMissingCommand(string $network, bool $preferIpv6 = false, bool $overlay = false): string
+{
+    $safe = escapeshellarg($network);
+    $baseCreate = $overlay
+        ? "docker network create --driver overlay --attachable {$safe}"
+        : "docker network create --attachable {$safe}";
+
+    if ($preferIpv6 && ! $overlay) {
+        $baseCreate = "docker network create --attachable --ipv6 {$safe} >/dev/null 2>&1 || docker network create --attachable {$safe} >/dev/null 2>&1";
+    } else {
+        $baseCreate .= " >/dev/null 2>&1";
+    }
+
+    return "docker network inspect {$safe} >/dev/null 2>&1 || ({$baseCreate})";
+}
+
 function collectProxyDockerNetworksByServer(Server $server)
 {
     if (! $server->isFunctional()) {
@@ -113,16 +129,16 @@ function connectProxyToNetworks(Server $server)
             return [
                 "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || docker network create --driver overlay --attachable {$safe} >/dev/null",
                 "docker network connect {$safe} coolify-proxy >/dev/null 2>&1 || true",
-                "echo 'Successfully connected coolify-proxy to {$safe} network.'",
+                "echo 'Successfully connected coolify-proxy to {$network} network.'",
             ];
         });
     } else {
         $commands = $networks->map(function ($network) {
             $safe = escapeshellarg($network);
             return [
-                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || docker network create --attachable {$safe} >/dev/null",
+                buildDockerNetworkCreateIfMissingCommand($network, preferIpv6: $network === 'coolify'),
                 "docker network connect {$safe} coolify-proxy >/dev/null 2>&1 || true",
-                "echo 'Successfully connected coolify-proxy to {$safe} network.'",
+                "echo 'Successfully connected coolify-proxy to {$network} network.'",
             ];
         });
     }
@@ -145,16 +161,15 @@ function ensureProxyNetworksExist(Server $server)
         $commands = $networks->map(function ($network) {
             $safe = escapeshellarg($network);
             return [
-                "echo 'Ensuring network {$safe} exists...'",
+                "echo 'Ensuring network {$network} exists...'",
                 "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --driver overlay --attachable {$safe}",
             ];
         });
     } else {
         $commands = $networks->map(function ($network) {
-            $safe = escapeshellarg($network);
             return [
-                "echo 'Ensuring network {$safe} exists...'",
-                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --attachable {$safe}",
+                "echo 'Ensuring network {$network} exists...'",
+                buildDockerNetworkCreateIfMissingCommand($network, preferIpv6: $network === 'coolify'),
             ];
         });
     }

--- a/tests/Unit/ProxyNetworkCreateCommandTest.php
+++ b/tests/Unit/ProxyNetworkCreateCommandTest.php
@@ -1,0 +1,26 @@
+<?php
+
+it('prefers ipv6 with fallback for coolify network', function () {
+    $command = buildDockerNetworkCreateIfMissingCommand('coolify', preferIpv6: true);
+
+    expect($command)
+        ->toContain("docker network inspect 'coolify' >/dev/null 2>&1 ||")
+        ->toContain("docker network create --attachable --ipv6 'coolify'")
+        ->toContain("docker network create --attachable 'coolify'");
+});
+
+it('uses standard create for non-coolify networks', function () {
+    $command = buildDockerNetworkCreateIfMissingCommand('app-network');
+
+    expect($command)
+        ->toContain("docker network inspect 'app-network' >/dev/null 2>&1 || docker network create --attachable 'app-network'")
+        ->not->toContain('--ipv6');
+});
+
+it('keeps overlay creation path unchanged', function () {
+    $command = buildDockerNetworkCreateIfMissingCommand('coolify-overlay', preferIpv6: true, overlay: true);
+
+    expect($command)
+        ->toContain("docker network create --driver overlay --attachable 'coolify-overlay'")
+        ->not->toContain('--ipv6');
+});


### PR DESCRIPTION
/claim #3436

Prefer IPv6 when creating Coolify ingress networks, with IPv4 fallback if the host cannot create IPv6 Docker networks. Reuse the helper across proxy/install/service/app network creation paths and cover the generated command strings with unit tests.