### PR TITLE
feat(ui): add search functionality for environment variables

### DIFF
--- a/app/Livewire/Project/Shared/EnvironmentVariable/All.php
+++ b/app/Livewire/Project/Shared/EnvironmentVariable/All.php
@@ -25,6 +25,8 @@ class All extends Component
 
     public string $view = 'normal';
 
+    public string $search = '';
+
     public bool $is_env_sorting_enabled = false;
 
     public bool $use_build_secrets = false;
@@ -34,6 +36,14 @@ class All extends Component
         'refreshEnvs',
         'environmentVariableDeleted' => 'refreshEnvs',
     ];
+
+    public function updatedSearch()
+    {
+        unset($this->environmentVariables);
+        unset($this->environmentVariablesPreview);
+        unset($this->hardcodedEnvironmentVariables);
+        unset($this->hardcodedEnvironmentVariablesPreview);
+    }
 
     public function mount()
     {
@@ -68,6 +78,10 @@ class All extends Component
         $query = $this->resource->environment_variables()
             ->orderByRaw("CASE WHEN is_required = true AND (value IS NULL OR value = '') THEN 0 ELSE 1 END");
 
+        if ($this->search !== '') {
+            $query->where('key', 'like', "%{$this->search}%");
+        }
+
         if ($this->is_env_sorting_enabled) {
             $query->orderBy('key');
         } else {
@@ -81,6 +95,10 @@ class All extends Component
     {
         $query = $this->resource->environment_variables_preview()
             ->orderByRaw("CASE WHEN is_required = true AND (value IS NULL OR value = '') THEN 0 ELSE 1 END");
+
+        if ($this->search !== '') {
+            $query->where('key', 'like', "%{$this->search}%");
+        }
 
         if ($this->is_env_sorting_enabled) {
             $query->orderBy('key');
@@ -137,6 +155,12 @@ class All extends Component
         $hardcodedVars = $hardcodedVars->filter(function ($var) use ($managedKeys) {
             return ! in_array($var['key'], $managedKeys);
         });
+
+        if ($this->search !== '') {
+            $hardcodedVars = $hardcodedVars->filter(function ($var) {
+                return str($var['key'])->contains($this->search, true);
+            });
+        }
 
         // Apply sorting based on is_env_sorting_enabled
         if ($this->is_env_sorting_enabled) {
@@ -285,6 +309,8 @@ class All extends Component
         // Clear computed property cache to force refresh
         unset($this->environmentVariables);
         unset($this->environmentVariablesPreview);
+        unset($this->hardcodedEnvironmentVariables);
+        unset($this->hardcodedEnvironmentVariablesPreview);
 
         $this->dispatch('success', 'Environment variable added.');
     }
@@ -416,6 +442,8 @@ class All extends Component
         // Clear computed property cache to force refresh
         unset($this->environmentVariables);
         unset($this->environmentVariablesPreview);
+        unset($this->hardcodedEnvironmentVariables);
+        unset($this->hardcodedEnvironmentVariablesPreview);
         $this->getDevView();
     }
 }

--- a/resources/views/livewire/project/shared/environment-variable/all.blade.php
+++ b/resources/views/livewire/project/shared/environment-variable/all.blade.php
@@ -50,12 +50,25 @@
             </div>
             <div class="w-full md:w-96">
                 <div class="relative">
-                    <input type="search" placeholder="Search" wire:model.live.debounce.300ms="search" class="w-full input pl-10" />
+                    <input type="search" placeholder="Search" wire:model.live.debounce.300ms="search"
+                        class="w-full input pl-10" />
                     <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
-                        <svg class="w-4 h-4 dark:text-neutral-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-                        </svg>
+                        <div class="relative w-4 h-4">
+                            <svg wire:loading.remove wire:target="search"
+                                class="absolute inset-0 w-4 h-4 dark:text-neutral-400" fill="none"
+                                stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                    d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                            </svg>
+                            <svg wire:loading wire:target="search"
+                                class="absolute inset-0 w-4 h-4 text-coollabs dark:text-warning animate-spin"
+                                fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor"
+                                    stroke-width="4" />
+                                <path class="opacity-75" fill="currentColor"
+                                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                            </svg>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/resources/views/livewire/project/shared/environment-variable/all.blade.php
+++ b/resources/views/livewire/project/shared/environment-variable/all.blade.php
@@ -43,9 +43,22 @@
         @endif
     </div>
     @if ($view === 'normal')
-        <div>
-            <h3>Production Environment Variables</h3>
-            <div>Environment (secrets) variables for Production.</div>
+        <div class="flex flex-col md:flex-row gap-2 justify-between md:items-center">
+            <div>
+                <h3>Production Environment Variables</h3>
+                <div class="subtitle">Environment (secrets) variables for Production.</div>
+            </div>
+            <div class="w-full md:w-96">
+                <div class="relative">
+                    <input type="search" placeholder="Search" wire:model.live.debounce.300ms="search" class="w-full input pl-10" />
+                    <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+                        <svg class="w-4 h-4 dark:text-neutral-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                        </svg>
+                    </div>
+                </div>
+            </div>
         </div>
         @forelse ($this->environmentVariables as $env)
             <livewire:project.shared.environment-variable.show wire:key="environment-{{ $env->id }}" :env="$env"
@@ -56,8 +69,7 @@
         @if (($resource->type() === 'service' || $resource?->build_pack === 'dockercompose') && $this->hardcodedEnvironmentVariables->isNotEmpty())
             @foreach ($this->hardcodedEnvironmentVariables as $index => $env)
                 <livewire:project.shared.environment-variable.show-hardcoded
-                    wire:key="hardcoded-prod-{{ $env['key'] }}-{{ $env['service_name'] ?? 'default' }}-{{ $index }}"
-                    :env="$env" />
+                    wire:key="hardcoded-prod-{{ $env['key'] }}-{{ $env['service_name'] ?? 'default' }}-{{ $index }}" :env="$env" />
             @endforeach
         @endif
         @if ($resource->type() === 'application' && $resource->environment_variables_preview->count() > 0 && $showPreview)
@@ -88,8 +100,9 @@
                     label="Production Environment Variables"></x-forms.textarea>
 
                 @if ($showPreview)
-                    <x-forms.textarea rows="10" class="whitespace-pre-wrap font-sans" label="Preview Deployments Environment Variables"
-                        id="variablesPreview" wire:model="variablesPreview"></x-forms.textarea>
+                    <x-forms.textarea rows="10" class="whitespace-pre-wrap font-sans"
+                        label="Preview Deployments Environment Variables" id="variablesPreview"
+                        wire:model="variablesPreview"></x-forms.textarea>
                 @endif
 
                 <x-forms.button type="submit" class="btn btn-primary">Save All Environment Variables</x-forms.button>
@@ -98,8 +111,9 @@
                     label="Production Environment Variables" disabled></x-forms.textarea>
 
                 @if ($showPreview)
-                    <x-forms.textarea rows="10" class="whitespace-pre-wrap font-sans" label="Preview Deployments Environment Variables"
-                        id="variablesPreview" wire:model="variablesPreview" disabled></x-forms.textarea>
+                    <x-forms.textarea rows="10" class="whitespace-pre-wrap font-sans"
+                        label="Preview Deployments Environment Variables" id="variablesPreview" wire:model="variablesPreview"
+                        disabled></x-forms.textarea>
                 @endif
             @endcan
         </form>


### PR DESCRIPTION
## Changes

- Added a real-time search input to the Environment Variables page that filters variables by key name
- Search works across production variables, preview deployment variables, and hardcoded Docker Compose variables
- A loading spinner replaces the search icon while the request is in-flight, using the project's design system colors
- Search is debounced at 300ms to avoid excessive requests
- The "Developer view" (bulk editor) is unaffected by search

## Issues

- Fixes #10413

## Category

- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

> Before the changes done
<img width="1303" height="323" alt="Screenshot 2026-05-26 150013" src="https://github.com/user-attachments/assets/9a2c2849-9fe4-49ce-8c58-d2e13b76f422" />


> After the changes done
<img width="1559" height="603" alt="Screenshot 2026-05-26 142229" src="https://github.com/user-attachments/assets/c31fc5f7-b776-46ae-b7c1-78264bf5e7a1" />

## AI Assistance

- [x] AI was NOT used to create this PR
- [ ] AI was used (please describe below)


## Testing

- Navigated to a project resource → Environment Variables tab
- Typed partial key names in the Search box and verified variables filter in real-time
- Confirmed the spinner replaces the search icon during loading and swaps back when complete
- Cleared the search box and confirmed all variables are restored
- Verified preview environment variables are also filtered
- Verified hardcoded Docker Compose variables are also filtered
- Confirmed the Developer view (bulk editor) is unaffected by search

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.

