### PR TITLE
fix(api): apply private_key_uuid in update_server

### DIFF
--- a/app/Http/Controllers/Api/ServersController.php
+++ b/app/Http/Controllers/Api/ServersController.php
@@ -706,7 +706,15 @@ class ServersController extends Controller
                 return response()->json(['message' => 'Invalid proxy type.'], 422);
             }
         }
-        $server->update($request->only(['name', 'description', 'ip', 'port', 'user']));
+        $updateFields = $request->only(['name', 'description', 'ip', 'port', 'user']);
+        if ($request->filled('private_key_uuid')) {
+            $privateKey = PrivateKey::whereTeamId($teamId)->whereUuid($request->private_key_uuid)->first();
+            if (! $privateKey) {
+                return response()->json(['message' => 'Private key not found.'], 404);
+            }
+            $updateFields['private_key_id'] = $privateKey->id;
+        }
+        $server->update($updateFields);
         if ($request->is_build_server) {
             $server->settings()->update([
                 'is_build_server' => $request->is_build_server,


### PR DESCRIPTION
## Summary

The `PATCH /api/v1/servers/{uuid}` endpoint advertises `private_key_uuid` in its `allowedFields` and validator, but the field is silently dropped from the actual update call. As a result, attaching or rotating a server's SSH key via the API is a no-op — the request returns 201 but `private_key_id` stays unchanged.

## Repro

```bash
# Register a private key
curl -X POST $URL/api/v1/security/keys -H \"Authorization: Bearer $TOKEN\" \
  -d '{\"name\":\"new-key\",\"private_key\":\"...\"}'
# → { \"uuid\": \"NEW_KEY_UUID\" }

# Try to bind it to a server
curl -X PATCH $URL/api/v1/servers/$SERVER_UUID \
  -H \"Authorization: Bearer $TOKEN\" \
  -d '{\"private_key_uuid\":\"NEW_KEY_UUID\"}'
# → 201 { \"uuid\": ... }   (looks like success)

# But the server still has the old key
curl $URL/api/v1/servers/$SERVER_UUID | jq .private_key_id
# → unchanged
```

I hit this while trying to set up SSH for a freshly-installed Coolify instance via the API and had to patch the `servers` table directly in Postgres as a workaround.

## Fix

In `update_server`, resolve `private_key_uuid` to a `PrivateKey` scoped to the caller's team (same pattern as `create_server`) and include `private_key_id` in the update payload. A missing/foreign key returns 404, mirroring the create flow.

## Test plan

- [x] PATCH with valid `private_key_uuid` now updates `private_key_id` on the server row
- [x] PATCH with an unknown UUID returns 404
- [x] PATCH without `private_key_uuid` continues to work and does not clear the existing key
- [x] Other allowed fields (`name`, `ip`, `port`, `user`, ...) still update as before