### PR TITLE
fix(templates): Matrix Synapse registration env vars and validation

### DIFF
--- a/templates/compose/matrix-synapse-with-postgresql.yaml
+++ b/templates/compose/matrix-synapse-with-postgresql.yaml
@@ -143,3 +143,4 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
+

--- a/templates/compose/matrix-synapse-with-postgresql.yaml
+++ b/templates/compose/matrix-synapse-with-postgresql.yaml
@@ -33,8 +33,8 @@ services:
       - -c
       - |
         validate_registration_env() {
-          if [ "${ENABLE_REGISTRATION}" = "true" ]; then
-            if [ "${ENABLE_REGISTRATION_WITHOUT_VERIFICATION}" != "true" ] && [ "${REGISTRATION_REQUIRES_TOKEN}" != "true" ]; then
+          if [ "$${ENABLE_REGISTRATION}" = "true" ]; then
+            if [ "$${ENABLE_REGISTRATION_WITHOUT_VERIFICATION}" != "true" ] && [ "$${REGISTRATION_REQUIRES_TOKEN}" != "true" ]; then
               echo "ERROR: ENABLE_REGISTRATION=true requires ENABLE_REGISTRATION_WITHOUT_VERIFICATION=true or REGISTRATION_REQUIRES_TOKEN=true." >&2
               echo "See Synapse registration docs: https://element-hq.github.io/synapse/latest/usage/configuration/config_documentation.html#registration" >&2
               exit 1
@@ -54,14 +54,6 @@ services:
 
         grep "form_secret" /data/homeserver.yaml \
         | awk '{print $2}' > ./form_secret
-
-        registration_yaml=""
-        if [ "${ENABLE_REGISTRATION}" = "true" ]; then
-          registration_yaml="
-        enable_registration: true
-        enable_registration_without_verification: ${ENABLE_REGISTRATION_WITHOUT_VERIFICATION}
-        registration_requires_token: ${REGISTRATION_REQUIRES_TOKEN}"
-        fi
 
         # Create homeserver.yaml with PostgreSQL
         cat <<EOF > /data/homeserver.yaml
@@ -101,7 +93,14 @@ services:
 
         trusted_key_servers:
           - server_name: "matrix.org"
-        ${registration_yaml}
+        EOF
+
+        [ "$${ENABLE_REGISTRATION}" = "true" ] && ! grep "#registration" /data/homeserver.yaml &>/dev/null \
+        && echo >> /data/homeserver.yaml \
+        && cat <<EOF >> /data/homeserver.yaml
+        enable_registration: true
+        enable_registration_without_verification: $${ENABLE_REGISTRATION_WITHOUT_VERIFICATION}
+        registration_requires_token: $${REGISTRATION_REQUIRES_TOKEN}
         EOF
 
         # Register admin user if provided
@@ -111,12 +110,12 @@ services:
           done
           register_new_matrix_user \
             -a \
-            -u "${SERVICE_USER_ADMIN}" \
-            -p "${SERVICE_PASSWORD_ADMIN}" \
+            -u "$${SERVICE_USER_ADMIN}" \
+            -p "$${SERVICE_PASSWORD_ADMIN}" \
             -c /data/homeserver.yaml \
             http://localhost:8008 &>/dev/null
         }
-        [ -n "${SERVICE_USER_ADMIN}" ] && register_admin &
+        [ -n "$${SERVICE_USER_ADMIN}" ] && register_admin &
 
         /start.py
     healthcheck:

--- a/templates/compose/matrix-synapse-with-postgresql.yaml
+++ b/templates/compose/matrix-synapse-with-postgresql.yaml
@@ -9,6 +9,7 @@
 # - If hosting at matrix.example.org but want user IDs like @user:example.org, set SYNAPSE_SERVER_NAME=example.org
 # - You'll need to set up .well-known delegation at https://example.org/.well-known/matrix/server
 # - See: https://element-hq.github.io/synapse/latest/delegate.html
+# Registration (default false): if ENABLE_REGISTRATION=true, also set ENABLE_REGISTRATION_WITHOUT_VERIFICATION or REGISTRATION_REQUIRES_TOKEN — https://element-hq.github.io/synapse/latest/usage/configuration/config_documentation.html#registration
 
 services:
   synapse:
@@ -18,6 +19,8 @@ services:
       - SYNAPSE_SERVER_NAME=${SYNAPSE_SERVER_NAME:?}
       - SYNAPSE_REPORT_STATS=${SYNAPSE_REPORT_STATS:-no}
       - ENABLE_REGISTRATION=${ENABLE_REGISTRATION:-false}
+      - ENABLE_REGISTRATION_WITHOUT_VERIFICATION=${ENABLE_REGISTRATION_WITHOUT_VERIFICATION:-false}
+      - REGISTRATION_REQUIRES_TOKEN=${REGISTRATION_REQUIRES_TOKEN:-false}
       - SERVICE_USER_ADMIN=${SERVICE_USER_ADMIN}
       - SERVICE_PASSWORD_ADMIN=${SERVICE_PASSWORD_ADMIN}
       - SERVICE_USER_POSTGRESQL=${SERVICE_USER_POSTGRESQL}
@@ -29,6 +32,17 @@ services:
       - /bin/bash
       - -c
       - |
+        validate_registration_env() {
+          if [ "${ENABLE_REGISTRATION}" = "true" ]; then
+            if [ "${ENABLE_REGISTRATION_WITHOUT_VERIFICATION}" != "true" ] && [ "${REGISTRATION_REQUIRES_TOKEN}" != "true" ]; then
+              echo "ERROR: ENABLE_REGISTRATION=true requires ENABLE_REGISTRATION_WITHOUT_VERIFICATION=true or REGISTRATION_REQUIRES_TOKEN=true." >&2
+              echo "See Synapse registration docs: https://element-hq.github.io/synapse/latest/usage/configuration/config_documentation.html#registration" >&2
+              exit 1
+            fi
+          fi
+        }
+        validate_registration_env
+
         ! test -f /data/homeserver.yaml && /start.py generate
 
         # Extract secrets from generated config
@@ -40,6 +54,14 @@ services:
 
         grep "form_secret" /data/homeserver.yaml \
         | awk '{print $2}' > ./form_secret
+
+        registration_yaml=""
+        if [ "${ENABLE_REGISTRATION}" = "true" ]; then
+          registration_yaml="
+        enable_registration: true
+        enable_registration_without_verification: ${ENABLE_REGISTRATION_WITHOUT_VERIFICATION}
+        registration_requires_token: ${REGISTRATION_REQUIRES_TOKEN}"
+        fi
 
         # Create homeserver.yaml with PostgreSQL
         cat <<EOF > /data/homeserver.yaml
@@ -79,12 +101,7 @@ services:
 
         trusted_key_servers:
           - server_name: "matrix.org"
-        EOF
-
-        [ "${ENABLE_REGISTRATION}" = "true" ] && ! grep "#registration" /data/homeserver.yaml &>/dev/null \
-        && echo >> /data/homeserver.yaml \
-        && cat <<EOF >> /data/homeserver.yaml
-        enable_registration: true
+        ${registration_yaml}
         EOF
 
         # Register admin user if provided
@@ -94,8 +111,8 @@ services:
           done
           register_new_matrix_user \
             -a \
-            -u ${SERVICE_USER_ADMIN} \
-            -p ${SERVICE_PASSWORD_ADMIN} \
+            -u "${SERVICE_USER_ADMIN}" \
+            -p "${SERVICE_PASSWORD_ADMIN}" \
             -c /data/homeserver.yaml \
             http://localhost:8008 &>/dev/null
         }

--- a/templates/compose/matrix-synapse-with-sqlite.yaml
+++ b/templates/compose/matrix-synapse-with-sqlite.yaml
@@ -88,3 +88,4 @@ services:
       timeout: 10s
       retries: 5
       start_period: 20s
+

--- a/templates/compose/matrix-synapse-with-sqlite.yaml
+++ b/templates/compose/matrix-synapse-with-sqlite.yaml
@@ -9,6 +9,8 @@
 # - If hosting at matrix.example.org but want user IDs like @user:example.org, set SYNAPSE_SERVER_NAME=example.org
 # - You'll need to set up .well-known delegation at https://example.org/.well-known/matrix/server
 # - See: https://element-hq.github.io/synapse/latest/delegate.html
+# Registration (default false): if ENABLE_REGISTRATION=true, also set ENABLE_REGISTRATION_WITHOUT_VERIFICATION or REGISTRATION_REQUIRES_TOKEN — https://element-hq.github.io/synapse/latest/usage/configuration/config_documentation.html#registration
+# SQLite: registration env vars apply only when homeserver.yaml is first created.
 
 services:
   synapse:
@@ -18,6 +20,8 @@ services:
       - SYNAPSE_SERVER_NAME=${SYNAPSE_SERVER_NAME:?}
       - SYNAPSE_REPORT_STATS=${SYNAPSE_REPORT_STATS:-no}
       - ENABLE_REGISTRATION=${ENABLE_REGISTRATION:-false}
+      - ENABLE_REGISTRATION_WITHOUT_VERIFICATION=${ENABLE_REGISTRATION_WITHOUT_VERIFICATION:-false}
+      - REGISTRATION_REQUIRES_TOKEN=${REGISTRATION_REQUIRES_TOKEN:-false}
       - SERVICE_USER_ADMIN=${SERVICE_USER_ADMIN}
       - SERVICE_PASSWORD_ADMIN=${SERVICE_PASSWORD_ADMIN}
     volumes:
@@ -26,6 +30,17 @@ services:
     command:
       - -c
       - |
+        validate_registration_env() {
+          if [ "${ENABLE_REGISTRATION}" = "true" ]; then
+            if [ "${ENABLE_REGISTRATION_WITHOUT_VERIFICATION}" != "true" ] && [ "${REGISTRATION_REQUIRES_TOKEN}" != "true" ]; then
+              echo "ERROR: ENABLE_REGISTRATION=true requires ENABLE_REGISTRATION_WITHOUT_VERIFICATION=true or REGISTRATION_REQUIRES_TOKEN=true." >&2
+              echo "See Synapse registration docs: https://element-hq.github.io/synapse/latest/usage/configuration/config_documentation.html#registration" >&2
+              exit 1
+            fi
+          fi
+        }
+        validate_registration_env
+
         # Generate config on first run
         if [ ! -f /data/homeserver.yaml ]; then
           # Generate default config using SYNAPSE_SERVER_NAME (permanent, used in user IDs)
@@ -43,8 +58,12 @@ services:
           sed -i '/type: http/a \    x_forwarded: true' /data/homeserver.yaml
 
           # Enable registration if requested
-          if [ "${ENABLE_REGISTRATION}" = "true" ] && ! grep -q "enable_registration" /data/homeserver.yaml; then
-            echo "enable_registration: true" >> /data/homeserver.yaml
+          if [ "${ENABLE_REGISTRATION}" = "true" ]; then
+            cat >> /data/homeserver.yaml <<REGEOF
+        enable_registration: true
+        enable_registration_without_verification: ${ENABLE_REGISTRATION_WITHOUT_VERIFICATION}
+        registration_requires_token: ${REGISTRATION_REQUIRES_TOKEN}
+        REGEOF
           fi
         fi
 

--- a/templates/compose/matrix-synapse-with-sqlite.yaml
+++ b/templates/compose/matrix-synapse-with-sqlite.yaml
@@ -31,8 +31,8 @@ services:
       - -c
       - |
         validate_registration_env() {
-          if [ "${ENABLE_REGISTRATION}" = "true" ]; then
-            if [ "${ENABLE_REGISTRATION_WITHOUT_VERIFICATION}" != "true" ] && [ "${REGISTRATION_REQUIRES_TOKEN}" != "true" ]; then
+          if [ "$${ENABLE_REGISTRATION}" = "true" ]; then
+            if [ "$${ENABLE_REGISTRATION_WITHOUT_VERIFICATION}" != "true" ] && [ "$${REGISTRATION_REQUIRES_TOKEN}" != "true" ]; then
               echo "ERROR: ENABLE_REGISTRATION=true requires ENABLE_REGISTRATION_WITHOUT_VERIFICATION=true or REGISTRATION_REQUIRES_TOKEN=true." >&2
               echo "See Synapse registration docs: https://element-hq.github.io/synapse/latest/usage/configuration/config_documentation.html#registration" >&2
               exit 1
@@ -49,7 +49,7 @@ services:
           # Set public_baseurl to actual deployment URL (may differ from server_name)
           # This allows hosting at matrix.example.org while server_name is example.org
           if ! grep -q "public_baseurl" /data/homeserver.yaml; then
-            sed -i "/^server_name:/a public_baseurl: ${SERVICE_URL_SYNAPSE}/" /data/homeserver.yaml
+            sed -i "/^server_name:/a public_baseurl: $${SERVICE_URL_SYNAPSE}/" /data/homeserver.yaml
           fi
 
           # Configure listener for reverse proxy
@@ -58,24 +58,24 @@ services:
           sed -i '/type: http/a \    x_forwarded: true' /data/homeserver.yaml
 
           # Enable registration if requested
-          if [ "${ENABLE_REGISTRATION}" = "true" ]; then
+          if [ "$${ENABLE_REGISTRATION}" = "true" ]; then
             cat >> /data/homeserver.yaml <<REGEOF
         enable_registration: true
-        enable_registration_without_verification: ${ENABLE_REGISTRATION_WITHOUT_VERIFICATION}
-        registration_requires_token: ${REGISTRATION_REQUIRES_TOKEN}
+        enable_registration_without_verification: $${ENABLE_REGISTRATION_WITHOUT_VERIFICATION}
+        registration_requires_token: $${REGISTRATION_REQUIRES_TOKEN}
         REGEOF
           fi
         fi
 
         # Register admin user if credentials provided
-        if [ -n "${SERVICE_USER_ADMIN}" ] && [ -n "${SERVICE_PASSWORD_ADMIN}" ]; then
+        if [ -n "$${SERVICE_USER_ADMIN}" ] && [ -n "$${SERVICE_PASSWORD_ADMIN}" ]; then
           (
             while ! curl -sf http://localhost:8008/health > /dev/null 2>&1; do
               sleep 2
             done
             register_new_matrix_user -a \
-              -u "${SERVICE_USER_ADMIN}" \
-              -p "${SERVICE_PASSWORD_ADMIN}" \
+              -u "$${SERVICE_USER_ADMIN}" \
+              -p "$${SERVICE_PASSWORD_ADMIN}" \
               -c /data/homeserver.yaml \
               http://localhost:8008 2>/dev/null || true
           ) &


### PR DESCRIPTION
## Changes

- I changed the .yaml configuration for the services to install [matrix](https://matrix.org) as defined here https://coolify.io/docs/services/matrix
- Currently, there is only the env var "ENABLE_REGISTRATION" - however, when setting this to true, I got the following error: 

> You have enabled open registration without any verification. This is a known vector for spam and abuse. If you would like to allow public registration, please consider adding email, captcha, or token-based verification. Otherwise this check can be removed by setting the `enable_registration_without_verification` config option to `true`.

- So I have added two extra env vars "REGISTRATION_REQUIRES_TOKEN" and "ENABLE_REGISTRATION_WITHOUT_VERIFICATION", giving the user more control when deploying synapse.

### How to use

- Invite-only: ENABLE_REGISTRATION=true + REGISTRATION_REQUIRES_TOKEN=true
- Open registration: ENABLE_REGISTRATION=true + ENABLE_REGISTRATION_WITHOUT_VERIFICATION=true
- All three default to false (unchanged behavior when registration is off).

## Issues

- Fixes Synapse crashing when setting `ENABLE_REGISTRATION=true` without additional verification config

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [x] Fixing or updating existing one click service

## Preview

N/A - No UI changes.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Cursor Compose 2.5 Fast
- How extensively: All changes were implemented by Cursor and reviewed by myself with my own eyes.

## Testing

I copied the .yaml config to my own coolify instance and have deployed matrix+postgres as well as matrix+sqlite successfully.

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.