### PR TITLE
feat(webhook): support Bitbucket Data Center manual webhooks

### DIFF
--- a/app/Http/Controllers/Webhook/Bitbucket.php
+++ b/app/Http/Controllers/Webhook/Bitbucket.php
@@ -4,88 +4,79 @@ namespace App\Http\Controllers\Webhook;
 
 use App\Actions\Application\CleanupPreviewDeployment;
 use App\Http\Controllers\Controller;
-use App\Http\Controllers\Webhook\Concerns\DetectsSkipDeployCommits;
+use App\Http\Controllers\Webhook\Bitbucket\BitbucketWebhookContext;
+use App\Http\Controllers\Webhook\Bitbucket\BitbucketWebhookVariantRegistry;
 use App\Http\Controllers\Webhook\Concerns\MatchesManualWebhookApplications;
 use App\Models\Application;
 use App\Models\ApplicationPreview;
 use Exception;
+use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\Request;
 use Visus\Cuid2\Cuid2;
 
 class Bitbucket extends Controller
 {
-    use DetectsSkipDeployCommits;
     use MatchesManualWebhookApplications;
 
-    public function manual(Request $request)
+    public function manual(Request $request, ?BitbucketWebhookVariantRegistry $registry = null)
     {
         try {
             $return_payloads = collect([]);
-            $payload = $request->collect();
-            $headers = $request->headers->all();
-            $x_bitbucket_token = data_get($headers, 'x-hub-signature.0', '');
-            $x_bitbucket_event = data_get($headers, 'x-event-key.0', '');
-            $handled_events = collect(['repo:push', 'pullrequest:updated', 'pullrequest:created', 'pullrequest:rejected', 'pullrequest:fulfilled']);
-            if (! $handled_events->contains($x_bitbucket_event)) {
+            $registry ??= new BitbucketWebhookVariantRegistry;
+            $variant = $registry->resolve($request);
+            $raw_bitbucket_event = $variant->eventKey($request);
+
+            if ($raw_bitbucket_event === '' || ! in_array($raw_bitbucket_event, $variant->handledEventKeys(), true)) {
                 return response([
                     'status' => 'failed',
                     'message' => 'Nothing to do. Event not handled.',
                 ]);
             }
-            if ($x_bitbucket_event === 'repo:push') {
-                $branch = data_get($payload, 'push.changes.0.new.name');
-                $full_name = data_get($payload, 'repository.full_name');
-                $commit = data_get($payload, 'push.changes.0.new.target.hash');
-                // Bitbucket webhooks ship up to 5 commits per change. Larger pushes
-                // are evaluated only on the visible 5.
-                $skip_deploy_commits = self::shouldSkipDeploy(
-                    collect(data_get($payload, 'push.changes', []))
-                        ->flatMap(fn ($change) => data_get($change, 'commits', []))
-                        ->pluck('message')
-                        ->filter()
-                        ->values()
-                        ->all()
-                );
 
-                if (! $branch) {
-                    return response([
-                        'status' => 'failed',
-                        'message' => 'Nothing to do. No branch found in the request.',
-                    ]);
-                }
-            }
-            if ($x_bitbucket_event === 'pullrequest:updated' || $x_bitbucket_event === 'pullrequest:created' || $x_bitbucket_event === 'pullrequest:rejected' || $x_bitbucket_event === 'pullrequest:fulfilled') {
-                $branch = data_get($payload, 'pullrequest.destination.branch.name');
-                $base_branch = data_get($payload, 'pullrequest.source.branch.name');
-                $full_name = data_get($payload, 'repository.full_name');
-                $pull_request_id = data_get($payload, 'pullrequest.id');
-                $pull_request_html_url = data_get($payload, 'pullrequest.links.html.href');
-                $pull_request_title = data_get($payload, 'pullrequest.title');
-                $skip_deploy_pr = self::shouldSkipDeployAny([$pull_request_title]);
-                $commit = data_get($payload, 'pullrequest.source.commit.hash');
-            }
-            $full_name = $this->manualWebhookRepositoryFullName($full_name);
-            if ($full_name === null) {
+            $context = $variant->parse($request);
+
+            if ($context === null) {
                 return response([
                     'status' => 'failed',
-                    'message' => 'Nothing to do. Invalid repository.',
+                    'message' => $variant->unhandledBranchMessage($raw_bitbucket_event),
                 ]);
             }
-            $applications = $this->manualWebhookApplications(Application::query()->where('git_branch', $branch), $full_name);
+
+            $applications = Application::query()
+                ->where('git_branch', $context->branch)
+                ->get()
+                ->filter(function (Application $application) use ($context): bool {
+                    foreach ($context->repositoryIdentifiers as $identifier) {
+                        $normalized = $this->normalizeManualWebhookRepositoryPath($identifier);
+                        if ($this->manualWebhookRepositoryMatches($application->git_repository, $normalized)) {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                })
+                ->values();
+
+            $repositoryLabel = $context->repositoryLabel();
+
             if ($applications->isEmpty()) {
                 return response([
                     'status' => 'failed',
-                    'message' => "Nothing to do. No applications found with deploy key set, branch is '$branch' and Git Repository name has $full_name.",
+                    'message' => "Nothing to do. No applications found with deploy key set, branch is '{$context->branch}' and Git Repository name has {$repositoryLabel}.",
                 ]);
             }
+
+            $headers = $request->headers->all();
+            $x_bitbucket_token = data_get($headers, 'x-hub-signature.0', '');
+
             foreach ($applications as $application) {
                 $webhook_secret = data_get($application, 'manual_webhook_secret_bitbucket');
                 if (empty($webhook_secret)) {
                     auditLogWebhookFailure('bitbucket', 'webhook_secret_missing', [
                         'application_uuid' => $application->uuid,
                         'application_name' => $application->name,
-                        'repository' => $full_name ?? null,
-                        'event' => $x_bitbucket_event,
+                        'repository' => $repositoryLabel,
+                        'event' => $raw_bitbucket_event,
                     ]);
                     $return_payloads->push($this->unauthenticatedManualWebhookFailurePayload());
 
@@ -98,8 +89,8 @@ class Bitbucket extends Controller
                     auditLogWebhookFailure('bitbucket', 'malformed_signature', [
                         'application_uuid' => $application->uuid,
                         'application_name' => $application->name,
-                        'repository' => $full_name ?? null,
-                        'event' => $x_bitbucket_event,
+                        'repository' => $repositoryLabel,
+                        'event' => $raw_bitbucket_event,
                     ]);
                     $return_payloads->push($this->unauthenticatedManualWebhookFailurePayload());
 
@@ -111,8 +102,8 @@ class Bitbucket extends Controller
                     auditLogWebhookFailure('bitbucket', 'invalid_signature', [
                         'application_uuid' => $application->uuid,
                         'application_name' => $application->name,
-                        'repository' => $full_name ?? null,
-                        'event' => $x_bitbucket_event,
+                        'repository' => $repositoryLabel,
+                        'event' => $raw_bitbucket_event,
                     ]);
                     $return_payloads->push($this->unauthenticatedManualWebhookFailurePayload());
 
@@ -128,149 +119,193 @@ class Bitbucket extends Controller
 
                     continue;
                 }
-                if ($x_bitbucket_event === 'repo:push') {
-                    if ($application->isDeployable()) {
-                        if ($skip_deploy_commits ?? false) {
-                            $return_payloads->push([
-                                'application' => $application->name,
-                                'status' => 'skipped',
-                                'message' => 'All commits contain [skip cd] or [skip ci]. Skipping deployment.',
-                                'application_uuid' => $application->uuid,
-                                'application_name' => $application->name,
-                            ]);
 
-                            continue;
-                        }
-                        $deployment_uuid = new Cuid2;
-                        $result = queue_application_deployment(
-                            application: $application,
-                            deployment_uuid: $deployment_uuid,
-                            commit: $commit,
-                            force_rebuild: false,
-                            is_webhook: true
-                        );
-                        if ($result['status'] === 'queue_full') {
-                            return response($result['message'], 429)->header('Retry-After', 60);
-                        } elseif ($result['status'] === 'skipped') {
-                            $return_payloads->push([
-                                'application' => $application->name,
-                                'status' => 'skipped',
-                                'message' => $result['message'],
-                            ]);
-                        } else {
-                            auditLog('webhook.deployment.queued', [
-                                'provider' => 'bitbucket',
-                                'mode' => 'manual',
-                                'application_uuid' => $application->uuid,
-                                'application_name' => $application->name,
-                                'deployment_uuid' => $deployment_uuid->toString(),
-                                'commit' => $commit,
-                                'repository' => $full_name ?? null,
-                            ]);
-                            $return_payloads->push([
-                                'application' => $application->name,
-                                'status' => 'success',
-                                'message' => 'Deployment queued.',
-                            ]);
-                        }
-                    } else {
-                        $return_payloads->push([
-                            'application' => $application->name,
-                            'status' => 'failed',
-                            'message' => 'Auto deployment disabled.',
-                        ]);
-                    }
-                }
-                if ($x_bitbucket_event === 'pullrequest:created' || $x_bitbucket_event === 'pullrequest:updated') {
-                    if ($application->isPRDeployable()) {
-                        if ($skip_deploy_pr ?? false) {
-                            $return_payloads->push([
-                                'application' => $application->name,
-                                'status' => 'skipped',
-                                'message' => 'PR title contains [skip cd] or [skip ci]. Skipping preview deployment.',
-                            ]);
-
-                            continue;
-                        }
-                        $deployment_uuid = new Cuid2;
-                        $found = ApplicationPreview::where('application_id', $application->id)->where('pull_request_id', $pull_request_id)->first();
-                        if (! $found) {
-                            if ($application->build_pack === 'dockercompose') {
-                                $pr_app = ApplicationPreview::create([
-                                    'git_type' => 'bitbucket',
-                                    'application_id' => $application->id,
-                                    'pull_request_id' => $pull_request_id,
-                                    'pull_request_html_url' => $pull_request_html_url,
-                                    'docker_compose_domains' => $application->docker_compose_domains,
-                                ]);
-                                $pr_app->generate_preview_fqdn_compose();
-                            } else {
-                                $pr_app = ApplicationPreview::create([
-                                    'git_type' => 'bitbucket',
-                                    'application_id' => $application->id,
-                                    'pull_request_id' => $pull_request_id,
-                                    'pull_request_html_url' => $pull_request_html_url,
-                                ]);
-                                $pr_app->generate_preview_fqdn();
-                            }
-                        }
-                        $result = queue_application_deployment(
-                            application: $application,
-                            pull_request_id: $pull_request_id,
-                            deployment_uuid: $deployment_uuid,
-                            force_rebuild: false,
-                            commit: $commit,
-                            is_webhook: true,
-                            git_type: 'bitbucket'
-                        );
-                        if ($result['status'] === 'queue_full') {
-                            return response($result['message'], 429)->header('Retry-After', 60);
-                        } elseif ($result['status'] === 'skipped') {
-                            $return_payloads->push([
-                                'application' => $application->name,
-                                'status' => 'skipped',
-                                'message' => $result['message'],
-                            ]);
-                        } else {
-                            $return_payloads->push([
-                                'application' => $application->name,
-                                'status' => 'success',
-                                'message' => 'Preview deployment queued.',
-                            ]);
-                        }
-                    } else {
-                        $return_payloads->push([
-                            'application' => $application->name,
-                            'status' => 'failed',
-                            'message' => 'Preview deployments disabled.',
-                        ]);
-                    }
-                }
-                if ($x_bitbucket_event === 'pullrequest:rejected' || $x_bitbucket_event === 'pullrequest:fulfilled') {
-                    $found = ApplicationPreview::where('application_id', $application->id)->where('pull_request_id', $pull_request_id)->first();
-                    if ($found) {
-                        // Use comprehensive cleanup that cancels active deployments,
-                        // kills helper containers, and removes all PR containers
-                        CleanupPreviewDeployment::run($application, $pull_request_id, $found);
-
-                        $return_payloads->push([
-                            'application' => $application->name,
-                            'status' => 'success',
-                            'message' => 'Preview deployment closed.',
-                        ]);
-                    } else {
-                        $return_payloads->push([
-                            'application' => $application->name,
-                            'status' => 'failed',
-                            'message' => 'No preview deployment found.',
-                        ]);
-                    }
-                }
+                $return_payloads->push($this->dispatchBitbucketWebhookAction($application, $context, $repositoryLabel));
             }
 
             return response($return_payloads);
         } catch (Exception $e) {
             return handleError($e);
         }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function dispatchBitbucketWebhookAction(Application $application, BitbucketWebhookContext $context, string $repositoryLabel): array
+    {
+        return match ($context->action) {
+            'push' => $this->handlePush($application, $context, $repositoryLabel),
+            'preview_deploy' => $this->handlePreviewDeploy($application, $context),
+            'preview_close' => $this->handlePreviewClose($application, $context),
+            default => [
+                'application' => $application->name,
+                'status' => 'failed',
+                'message' => 'Nothing to do. Event not handled.',
+            ],
+        };
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function handlePush(Application $application, BitbucketWebhookContext $context, string $repositoryLabel): array
+    {
+        if (! $application->isDeployable()) {
+            return [
+                'application' => $application->name,
+                'status' => 'failed',
+                'message' => 'Auto deployment disabled.',
+            ];
+        }
+
+        if ($context->skipDeployCommits) {
+            return [
+                'application' => $application->name,
+                'status' => 'skipped',
+                'message' => 'All commits contain [skip cd] or [skip ci]. Skipping deployment.',
+                'application_uuid' => $application->uuid,
+                'application_name' => $application->name,
+            ];
+        }
+
+        $deployment_uuid = new Cuid2;
+        $result = queue_application_deployment(
+            application: $application,
+            deployment_uuid: $deployment_uuid,
+            commit: $context->commit,
+            force_rebuild: false,
+            is_webhook: true
+        );
+
+        if ($result['status'] === 'queue_full') {
+            throw new HttpResponseException(response($result['message'], 429)->header('Retry-After', 60));
+        }
+
+        if ($result['status'] === 'skipped') {
+            return [
+                'application' => $application->name,
+                'status' => 'skipped',
+                'message' => $result['message'],
+            ];
+        }
+
+        auditLog('webhook.deployment.queued', [
+            'provider' => 'bitbucket',
+            'mode' => 'manual',
+            'application_uuid' => $application->uuid,
+            'application_name' => $application->name,
+            'deployment_uuid' => $deployment_uuid->toString(),
+            'commit' => $context->commit,
+            'repository' => $repositoryLabel,
+        ]);
+
+        return [
+            'application' => $application->name,
+            'status' => 'success',
+            'message' => 'Deployment queued.',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function handlePreviewDeploy(Application $application, BitbucketWebhookContext $context): array
+    {
+        if (! $application->isPRDeployable()) {
+            return [
+                'application' => $application->name,
+                'status' => 'failed',
+                'message' => 'Preview deployments disabled.',
+            ];
+        }
+
+        if ($context->skipDeployPr) {
+            return [
+                'application' => $application->name,
+                'status' => 'skipped',
+                'message' => 'PR title contains [skip cd] or [skip ci]. Skipping preview deployment.',
+            ];
+        }
+
+        $deployment_uuid = new Cuid2;
+        $found = ApplicationPreview::where('application_id', $application->id)
+            ->where('pull_request_id', $context->pullRequestId)
+            ->first();
+
+        if (! $found) {
+            if ($application->build_pack === 'dockercompose') {
+                $pr_app = ApplicationPreview::create([
+                    'git_type' => 'bitbucket',
+                    'application_id' => $application->id,
+                    'pull_request_id' => $context->pullRequestId,
+                    'pull_request_html_url' => $context->pullRequestHtmlUrl,
+                    'docker_compose_domains' => $application->docker_compose_domains,
+                ]);
+                $pr_app->generate_preview_fqdn_compose();
+            } else {
+                $pr_app = ApplicationPreview::create([
+                    'git_type' => 'bitbucket',
+                    'application_id' => $application->id,
+                    'pull_request_id' => $context->pullRequestId,
+                    'pull_request_html_url' => $context->pullRequestHtmlUrl,
+                ]);
+                $pr_app->generate_preview_fqdn();
+            }
+        }
+
+        $result = queue_application_deployment(
+            application: $application,
+            pull_request_id: $context->pullRequestId,
+            deployment_uuid: $deployment_uuid,
+            force_rebuild: false,
+            commit: $context->commit,
+            is_webhook: true,
+            git_type: 'bitbucket'
+        );
+
+        if ($result['status'] === 'queue_full') {
+            throw new HttpResponseException(response($result['message'], 429)->header('Retry-After', 60));
+        }
+
+        if ($result['status'] === 'skipped') {
+            return [
+                'application' => $application->name,
+                'status' => 'skipped',
+                'message' => $result['message'],
+            ];
+        }
+
+        return [
+            'application' => $application->name,
+            'status' => 'success',
+            'message' => 'Preview deployment queued.',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function handlePreviewClose(Application $application, BitbucketWebhookContext $context): array
+    {
+        $found = ApplicationPreview::where('application_id', $application->id)
+            ->where('pull_request_id', $context->pullRequestId)
+            ->first();
+
+        if (! $found) {
+            return [
+                'application' => $application->name,
+                'status' => 'failed',
+                'message' => 'No preview deployment found.',
+            ];
+        }
+
+        CleanupPreviewDeployment::run($application, $context->pullRequestId, $found);
+
+        return [
+            'application' => $application->name,
+            'status' => 'success',
+            'message' => 'Preview deployment closed.',
+        ];
     }
 }

--- a/app/Http/Controllers/Webhook/Bitbucket/BitbucketCloudWebhookVariant.php
+++ b/app/Http/Controllers/Webhook/Bitbucket/BitbucketCloudWebhookVariant.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Http\Controllers\Webhook\Bitbucket;
+
+use App\Http\Controllers\Webhook\Concerns\DetectsSkipDeployCommits;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+class BitbucketCloudWebhookVariant implements BitbucketWebhookVariant
+{
+    use DetectsSkipDeployCommits;
+
+    public function supports(Request $request): bool
+    {
+        $event = $this->eventKey($request);
+        if ($event !== '' && $this->isCloudEvent($event)) {
+            return true;
+        }
+
+        $payload = $request->collect();
+
+        return filled(data_get($payload, 'repository.full_name'))
+            || filled(data_get($payload, 'push.changes'));
+    }
+
+    public function eventKey(Request $request): string
+    {
+        $header = $request->header('X-Event-Key');
+        if (filled($header)) {
+            return Str::lower($header);
+        }
+
+        return '';
+    }
+
+    public function handledEventKeys(): array
+    {
+        return [
+            'repo:push',
+            'pullrequest:created',
+            'pullrequest:updated',
+            'pullrequest:rejected',
+            'pullrequest:fulfilled',
+        ];
+    }
+
+    public function parse(Request $request): ?BitbucketWebhookContext
+    {
+        $payload = $request->collect();
+        $rawEvent = $this->eventKey($request);
+        $repositoryIdentifiers = BitbucketRepositoryIdentifiers::fromPayload($payload);
+
+        if ($rawEvent === 'repo:push') {
+            $branch = data_get($payload, 'push.changes.0.new.name');
+            $commit = data_get($payload, 'push.changes.0.new.target.hash');
+            $skipDeployCommits = self::shouldSkipDeploy(
+                collect(data_get($payload, 'push.changes', []))
+                    ->flatMap(fn ($change) => data_get($change, 'commits', []))
+                    ->pluck('message')
+                    ->filter()
+                    ->values()
+                    ->all()
+            );
+
+            if (! filled($branch)) {
+                return null;
+            }
+
+            return new BitbucketWebhookContext(
+                rawEvent: $rawEvent,
+                action: 'push',
+                branch: (string) $branch,
+                repositoryIdentifiers: $repositoryIdentifiers,
+                commit: filled($commit) ? (string) $commit : null,
+                skipDeployCommits: $skipDeployCommits,
+            );
+        }
+
+        if (in_array($rawEvent, ['pullrequest:created', 'pullrequest:updated', 'pullrequest:rejected', 'pullrequest:fulfilled'], true)) {
+            $pullRequest = data_get($payload, 'pullrequest');
+            if (! is_array($pullRequest)) {
+                return null;
+            }
+
+            $branch = data_get($pullRequest, 'destination.branch.name');
+            $pullRequestTitle = data_get($pullRequest, 'title');
+            $commit = data_get($pullRequest, 'source.commit.hash');
+            $pullRequestId = data_get($pullRequest, 'id');
+            $pullRequestHtmlUrl = data_get($pullRequest, 'links.html.href');
+
+            if (! filled($branch)) {
+                return null;
+            }
+
+            $action = in_array($rawEvent, ['pullrequest:rejected', 'pullrequest:fulfilled'], true)
+                ? 'preview_close'
+                : 'preview_deploy';
+
+            return new BitbucketWebhookContext(
+                rawEvent: $rawEvent,
+                action: $action,
+                branch: (string) $branch,
+                repositoryIdentifiers: $repositoryIdentifiers,
+                commit: filled($commit) ? (string) $commit : null,
+                skipDeployPr: self::shouldSkipDeployAny([$pullRequestTitle]),
+                pullRequestId: filled($pullRequestId) ? (int) $pullRequestId : null,
+                pullRequestHtmlUrl: filled($pullRequestHtmlUrl) ? (string) $pullRequestHtmlUrl : null,
+            );
+        }
+
+        return null;
+    }
+
+    public function unhandledBranchMessage(string $rawEvent): string
+    {
+        return 'Nothing to do. No branch found in the request.';
+    }
+
+    private function isCloudEvent(string $event): bool
+    {
+        return in_array($event, $this->handledEventKeys(), true);
+    }
+}

--- a/app/Http/Controllers/Webhook/Bitbucket/BitbucketDataCenterWebhookVariant.php
+++ b/app/Http/Controllers/Webhook/Bitbucket/BitbucketDataCenterWebhookVariant.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Http\Controllers\Webhook\Bitbucket;
+
+use App\Http\Controllers\Webhook\Concerns\DetectsSkipDeployCommits;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+class BitbucketDataCenterWebhookVariant implements BitbucketWebhookVariant
+{
+    use DetectsSkipDeployCommits;
+
+    public function supports(Request $request): bool
+    {
+        $event = $this->eventKey($request);
+
+        if ($event !== '' && $this->isDataCenterEvent($event)) {
+            return true;
+        }
+
+        return filled($request->collect()->get('eventKey'));
+    }
+
+    public function eventKey(Request $request): string
+    {
+        $header = $request->header('X-Event-Key');
+        if (filled($header)) {
+            return Str::lower($header);
+        }
+
+        $bodyKey = $request->collect()->get('eventKey');
+        if (filled($bodyKey)) {
+            return Str::lower((string) $bodyKey);
+        }
+
+        return '';
+    }
+
+    public function handledEventKeys(): array
+    {
+        return [
+            'repo:refs_changed',
+            'pr:opened',
+            'pr:from_ref_updated',
+            'pr:modified',
+            'pr:declined',
+            'pr:merged',
+            'pr:deleted',
+        ];
+    }
+
+    public function parse(Request $request): ?BitbucketWebhookContext
+    {
+        $payload = $request->collect();
+        $rawEvent = $this->eventKey($request);
+        $repositoryIdentifiers = BitbucketRepositoryIdentifiers::fromPayload($payload);
+
+        if ($rawEvent === 'repo:refs_changed') {
+            $change = data_get($payload, 'changes.0');
+            if (data_get($change, 'type') !== 'UPDATE') {
+                return null;
+            }
+
+            $branch = data_get($change, 'ref.displayId');
+            $commit = data_get($change, 'toHash');
+
+            if (! filled($branch)) {
+                return null;
+            }
+
+            return new BitbucketWebhookContext(
+                rawEvent: $rawEvent,
+                action: 'push',
+                branch: (string) $branch,
+                repositoryIdentifiers: $repositoryIdentifiers,
+                commit: filled($commit) ? (string) $commit : null,
+            );
+        }
+
+        $action = match ($rawEvent) {
+            'pr:opened', 'pr:from_ref_updated', 'pr:modified' => 'preview_deploy',
+            'pr:declined', 'pr:merged', 'pr:deleted' => 'preview_close',
+            default => null,
+        };
+
+        if ($action === null) {
+            return null;
+        }
+
+        $pullRequest = data_get($payload, 'pullRequest');
+        if (! is_array($pullRequest)) {
+            return null;
+        }
+
+        $branch = data_get($pullRequest, 'toRef.displayId');
+        $pullRequestTitle = data_get($pullRequest, 'title');
+        $commit = data_get($pullRequest, 'fromRef.latestCommit');
+        $pullRequestId = data_get($pullRequest, 'id');
+        $pullRequestHtmlUrl = data_get($pullRequest, 'links.self.0.href');
+
+        if (! filled($branch)) {
+            return null;
+        }
+
+        return new BitbucketWebhookContext(
+            rawEvent: $rawEvent,
+            action: $action,
+            branch: (string) $branch,
+            repositoryIdentifiers: $repositoryIdentifiers,
+            commit: filled($commit) ? (string) $commit : null,
+            skipDeployPr: self::shouldSkipDeployAny([$pullRequestTitle]),
+            pullRequestId: filled($pullRequestId) ? (int) $pullRequestId : null,
+            pullRequestHtmlUrl: filled($pullRequestHtmlUrl) ? (string) $pullRequestHtmlUrl : null,
+        );
+    }
+
+    public function unhandledBranchMessage(string $rawEvent): string
+    {
+        if ($rawEvent === 'repo:refs_changed') {
+            return 'Nothing to do. Ref change is not a branch push update.';
+        }
+
+        return 'Nothing to do. No branch found in the request.';
+    }
+
+    private function isDataCenterEvent(string $event): bool
+    {
+        return in_array($event, $this->handledEventKeys(), true)
+            || str_starts_with($event, 'pr:');
+    }
+}

--- a/app/Http/Controllers/Webhook/Bitbucket/BitbucketRepositoryIdentifiers.php
+++ b/app/Http/Controllers/Webhook/Bitbucket/BitbucketRepositoryIdentifiers.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Controllers\Webhook\Bitbucket;
+
+use Illuminate\Support\Collection;
+
+class BitbucketRepositoryIdentifiers
+{
+    /**
+     * @return array<int, string>
+     */
+    public static function fromPayload(Collection $payload): array
+    {
+        $identifiers = collect();
+
+        $fullName = data_get($payload, 'repository.full_name');
+        if (filled($fullName)) {
+            $identifiers->push($fullName);
+        }
+
+        $repository = data_get($payload, 'repository')
+            ?? data_get($payload, 'pullRequest.toRef.repository')
+            ?? data_get($payload, 'pullRequest.fromRef.repository')
+            ?? data_get($payload, 'pullrequest.toRef.repository')
+            ?? data_get($payload, 'pullrequest.fromRef.repository');
+
+        if (! is_array($repository)) {
+            return $identifiers->unique()->filter()->values()->all();
+        }
+
+        $projectKey = data_get($repository, 'project.key');
+        $slug = data_get($repository, 'slug');
+
+        if (filled($projectKey) && filled($slug)) {
+            $identifiers->push("{$projectKey}/{$slug}");
+            $identifiers->push(strtolower((string) $projectKey).'/'.$slug);
+        }
+
+        if (filled($slug)) {
+            $identifiers->push($slug);
+        }
+
+        foreach (data_get($repository, 'links.clone', []) as $clone) {
+            $href = data_get($clone, 'href');
+            if (! is_string($href) || $href === '') {
+                continue;
+            }
+
+            if (preg_match('#[:/]([^/]+/[^/]+?)(?:\.git)?$#', $href, $matches)) {
+                $identifiers->push($matches[1]);
+            }
+
+            $path = preg_replace('/\.git$/', '', parse_url($href, PHP_URL_PATH) ?? '');
+            $path = trim(str_replace(':', '/', (string) $path), '/');
+            if ($path === '') {
+                continue;
+            }
+
+            $segments = explode('/', $path);
+            if (count($segments) >= 2) {
+                $identifiers->push(implode('/', array_slice($segments, -2)));
+            }
+            $identifiers->push(end($segments));
+        }
+
+        return $identifiers->unique()->filter()->values()->all();
+    }
+}

--- a/app/Http/Controllers/Webhook/Bitbucket/BitbucketWebhookContext.php
+++ b/app/Http/Controllers/Webhook/Bitbucket/BitbucketWebhookContext.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers\Webhook\Bitbucket;
+
+class BitbucketWebhookContext
+{
+    /**
+     * @param  array<int, string>  $repositoryIdentifiers
+     */
+    public function __construct(
+        public readonly string $rawEvent,
+        public readonly string $action,
+        public readonly string $branch,
+        public readonly array $repositoryIdentifiers,
+        public readonly ?string $commit = null,
+        public readonly bool $skipDeployCommits = false,
+        public readonly bool $skipDeployPr = false,
+        public readonly ?int $pullRequestId = null,
+        public readonly ?string $pullRequestHtmlUrl = null,
+    ) {}
+
+    public function repositoryLabel(): string
+    {
+        return implode(', ', $this->repositoryIdentifiers) ?: 'unknown';
+    }
+}

--- a/app/Http/Controllers/Webhook/Bitbucket/BitbucketWebhookVariant.php
+++ b/app/Http/Controllers/Webhook/Bitbucket/BitbucketWebhookVariant.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers\Webhook\Bitbucket;
+
+use Illuminate\Http\Request;
+
+interface BitbucketWebhookVariant
+{
+    public function supports(Request $request): bool;
+
+    public function eventKey(Request $request): string;
+
+    /**
+     * @return array<int, string>
+     */
+    public function handledEventKeys(): array;
+
+    public function parse(Request $request): ?BitbucketWebhookContext;
+
+    public function unhandledBranchMessage(string $rawEvent): string;
+}

--- a/app/Http/Controllers/Webhook/Bitbucket/BitbucketWebhookVariantRegistry.php
+++ b/app/Http/Controllers/Webhook/Bitbucket/BitbucketWebhookVariantRegistry.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers\Webhook\Bitbucket;
+
+use Illuminate\Http\Request;
+
+class BitbucketWebhookVariantRegistry
+{
+    /**
+     * @var array<int, BitbucketWebhookVariant>
+     */
+    private array $variants;
+
+    public function __construct(?BitbucketDataCenterWebhookVariant $dataCenter = null, ?BitbucketCloudWebhookVariant $cloud = null)
+    {
+        $this->variants = [
+            $dataCenter ?? new BitbucketDataCenterWebhookVariant,
+            $cloud ?? new BitbucketCloudWebhookVariant,
+        ];
+    }
+
+    public function resolve(Request $request): BitbucketWebhookVariant
+    {
+        foreach ($this->variants as $variant) {
+            if ($variant->supports($request)) {
+                return $variant;
+            }
+        }
+
+        return $this->variants[array_key_last($this->variants)];
+    }
+}

--- a/tests/Feature/Webhook/WebhookHmacTest.php
+++ b/tests/Feature/Webhook/WebhookHmacTest.php
@@ -240,6 +240,49 @@ describe('Bitbucket Manual Webhook HMAC', function () {
         expect($content)->not->toContain('Invalid signature');
         expect($content)->not->toContain('Webhook secret not configured');
     });
+
+    test('accepts bitbucket data center repo refs changed with valid sha256 hash', function () {
+        $app = createApplicationWithWebhook(
+            repo: '~harrison/fx-data-agents-benchmark-output',
+            branch: 'master',
+            overrides: [
+                'git_repository' => 'ssh://git@code.fineres.com:7999/~harrison/fx-data-agents-benchmark-output.git',
+            ]
+        );
+        $secret = $app->manual_webhook_secret_bitbucket;
+
+        $payload = json_encode([
+            'eventKey' => 'repo:refs_changed',
+            'repository' => [
+                'slug' => 'fx-data-agents-benchmark-output',
+                'project' => ['key' => '~HARRISON'],
+                'links' => [
+                    'clone' => [
+                        ['href' => 'ssh://git@code.fineres.com:7999/~harrison/fx-data-agents-benchmark-output.git'],
+                    ],
+                ],
+            ],
+            'changes' => [[
+                'ref' => ['displayId' => 'master'],
+                'toHash' => '2502c69be7e8570a0fb7a7e2ef1df150433c9549',
+                'type' => 'UPDATE',
+            ]],
+        ]);
+
+        $hmac = hash_hmac('sha256', $payload, $secret);
+
+        $response = $this->call('POST', '/webhooks/source/bitbucket/events/manual', [], [], [], [
+            'HTTP_X-Event-Key' => 'repo:refs_changed',
+            'HTTP_X-Hub-Signature' => "sha256={$hmac}",
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+
+        $response->assertOk();
+        $content = $response->getContent();
+        expect($content)->not->toContain('Invalid signature');
+        expect($content)->not->toContain('Event not handled');
+        expect($content)->not->toContain('No applications found');
+    });
 });
 
 describe('Gitea Manual Webhook HMAC', function () {

--- a/tests/Unit/BitbucketWebhookVariantTest.php
+++ b/tests/Unit/BitbucketWebhookVariantTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use App\Http\Controllers\Webhook\Bitbucket\BitbucketCloudWebhookVariant;
+use App\Http\Controllers\Webhook\Bitbucket\BitbucketDataCenterWebhookVariant;
+use App\Http\Controllers\Webhook\Bitbucket\BitbucketWebhookVariantRegistry;
+use Illuminate\Http\Request;
+
+describe('BitbucketWebhookVariantRegistry', function () {
+    test('resolves data center variant for repo refs changed payload', function () {
+        $request = Request::create('/webhooks/source/bitbucket/events/manual', 'POST', [
+            'eventKey' => 'repo:refs_changed',
+            'repository' => ['slug' => 'repo', 'project' => ['key' => 'PROJ']],
+            'changes' => [[
+                'ref' => ['displayId' => 'master'],
+                'toHash' => 'abc',
+                'type' => 'UPDATE',
+            ]],
+        ]);
+
+        $variant = (new BitbucketWebhookVariantRegistry)->resolve($request);
+
+        expect($variant)->toBeInstanceOf(BitbucketDataCenterWebhookVariant::class);
+    });
+
+    test('resolves cloud variant for repo push payload', function () {
+        $request = Request::create('/webhooks/source/bitbucket/events/manual', 'POST', [
+            'repository' => ['full_name' => 'org/repo'],
+            'push' => ['changes' => [['new' => ['name' => 'main', 'target' => ['hash' => 'abc']]]]],
+        ], [], [], [
+            'HTTP_X-Event-Key' => 'repo:push',
+        ]);
+
+        $variant = (new BitbucketWebhookVariantRegistry)->resolve($request);
+
+        expect($variant)->toBeInstanceOf(BitbucketCloudWebhookVariant::class);
+    });
+});
+
+describe('BitbucketDataCenterWebhookVariant', function () {
+    test('parses repo refs changed payload', function () {
+        $request = Request::create('/webhooks/source/bitbucket/events/manual', 'POST', [
+            'eventKey' => 'repo:refs_changed',
+            'repository' => [
+                'slug' => 'fx-data-agents-benchmark-output',
+                'project' => ['key' => '~HARRISON'],
+                'links' => [
+                    'clone' => [
+                        ['href' => 'ssh://git@code.fineres.com:7999/~harrison/fx-data-agents-benchmark-output.git'],
+                    ],
+                ],
+            ],
+            'changes' => [[
+                'ref' => ['displayId' => 'master'],
+                'toHash' => '2502c69be7e8570a0fb7a7e2ef1df150433c9549',
+                'type' => 'UPDATE',
+            ]],
+        ]);
+
+        $context = (new BitbucketDataCenterWebhookVariant)->parse($request);
+
+        expect($context)->not->toBeNull();
+        expect($context->action)->toBe('push');
+        expect($context->branch)->toBe('master');
+        expect($context->repositoryIdentifiers)->toContain('~harrison/fx-data-agents-benchmark-output');
+    });
+});


### PR DESCRIPTION
## Changes

Self-hosted Bitbucket Data Center sends `repo:refs_changed` on push and `pr:*` for pull requests. Coolify manual webhooks only parsed Bitbucket Cloud (`repo:push`, `pullrequest:*`), so DC instances returned "Event not handled."

This adds a variant registry: Data Center and Cloud parsers produce a shared context (`push`, `preview_deploy`, `preview_close`). Repository matching works without `repository.full_name` (project key + slug, clone URLs). Cloud behavior is unchanged.

Tested with a DC-shaped payload (refs_changed, master branch, SSH clone URL).

## Issues

- Fixes #10430

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A (webhook only).

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Cursor
- How extensively: Drafted implementation; I reviewed DC vs Cloud webhook docs and validated payload fields against our Bitbucket controller.

## Testing

1. `php vendor/bin/pest tests/Unit/BitbucketWebhookVariantTest.php tests/Feature/Webhook/WebhookHmacTest.php --filter=Bitbucket`
2. POST to `/webhooks/source/bitbucket/events/manual` with `X-Event-Key: repo:refs_changed`, DC JSON body, valid `X-Hub-Signature` — expect no "Event not handled" when app repo/branch match.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
