### PR TITLE
feat(oauth): add generic OIDC provider support

### DIFF
--- a/app/Models/OauthSetting.php
+++ b/app/Models/OauthSetting.php
@@ -28,6 +28,7 @@ class OauthSetting extends Model
                 return filled($this->client_id) && filled($this->client_secret) && filled($this->tenant);
             case 'authentik':
             case 'clerk':
+            case 'oidc':
                 return filled($this->client_id) && filled($this->client_secret) && filled($this->base_url);
             default:
                 return filled($this->client_id) && filled($this->client_secret);

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -10,6 +10,7 @@ use SocialiteProviders\Discord\DiscordExtendSocialite;
 use SocialiteProviders\Google\GoogleExtendSocialite;
 use SocialiteProviders\Infomaniak\InfomaniakExtendSocialite;
 use SocialiteProviders\Manager\SocialiteWasCalled;
+use SocialiteProviders\OIDC\OIDCExtendSocialite;
 use SocialiteProviders\Zitadel\ZitadelExtendSocialite;
 
 class EventServiceProvider extends ServiceProvider
@@ -22,6 +23,7 @@ class EventServiceProvider extends ServiceProvider
             DiscordExtendSocialite::class.'@handle',
             GoogleExtendSocialite::class.'@handle',
             InfomaniakExtendSocialite::class.'@handle',
+            OIDCExtendSocialite::class.'@handle',
             ZitadelExtendSocialite::class.'@handle',
         ],
     ];

--- a/bootstrap/helpers/socialite.php
+++ b/bootstrap/helpers/socialite.php
@@ -2,6 +2,11 @@
 
 use App\Models\OauthSetting;
 use Laravel\Socialite\Facades\Socialite;
+use Laravel\Socialite\Two\BitbucketProvider;
+use Laravel\Socialite\Two\GithubProvider;
+use Laravel\Socialite\Two\GitlabProvider;
+use SocialiteProviders\Discord\Provider;
+use SocialiteProviders\Manager\Config;
 
 function get_socialite_provider(string $provider)
 {
@@ -12,7 +17,7 @@ function get_socialite_provider(string $provider)
     }
 
     if ($provider === 'azure') {
-        $azure_config = new \SocialiteProviders\Manager\Config(
+        $azure_config = new Config(
             $oauth_setting->client_id,
             $oauth_setting->client_secret,
             $oauth_setting->redirect_uri,
@@ -22,30 +27,19 @@ function get_socialite_provider(string $provider)
         return Socialite::driver('azure')->setConfig($azure_config);
     }
 
-    if ($provider == 'authentik' || $provider == 'clerk') {
-        $authentik_clerk_config = new \SocialiteProviders\Manager\Config(
+    if (in_array($provider, ['authentik', 'clerk', 'oidc', 'zitadel'], true)) {
+        $base_url_config = new Config(
             $oauth_setting->client_id,
             $oauth_setting->client_secret,
             $oauth_setting->redirect_uri,
             ['base_url' => $oauth_setting->base_url],
         );
 
-        return Socialite::driver($provider)->setConfig($authentik_clerk_config);
-    }
-
-    if ($provider == 'zitadel') {
-        $zitadel_config = new \SocialiteProviders\Manager\Config(
-            $oauth_setting->client_id,
-            $oauth_setting->client_secret,
-            $oauth_setting->redirect_uri,
-            ['base_url' => $oauth_setting->base_url],
-        );
-
-        return Socialite::driver('zitadel')->setConfig($zitadel_config);
+        return Socialite::driver($provider)->setConfig($base_url_config);
     }
 
     if ($provider == 'google') {
-        $google_config = new \SocialiteProviders\Manager\Config(
+        $google_config = new Config(
             $oauth_setting->client_id,
             $oauth_setting->client_secret,
             $oauth_setting->redirect_uri
@@ -63,11 +57,11 @@ function get_socialite_provider(string $provider)
     ];
 
     $provider_class_map = [
-        'bitbucket' => \Laravel\Socialite\Two\BitbucketProvider::class,
-        'discord' => \SocialiteProviders\Discord\Provider::class,
-        'github' => \Laravel\Socialite\Two\GithubProvider::class,
-        'gitlab' => \Laravel\Socialite\Two\GitlabProvider::class,
-        'infomaniak' => \SocialiteProviders\Infomaniak\Provider::class,
+        'bitbucket' => BitbucketProvider::class,
+        'discord' => Provider::class,
+        'github' => GithubProvider::class,
+        'gitlab' => GitlabProvider::class,
+        'infomaniak' => SocialiteProviders\Infomaniak\Provider::class,
     ];
 
     $socialite = Socialite::buildProvider(

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "danharrin/livewire-rate-limiting": "^2.1.0",
         "doctrine/dbal": "^4.4.1",
         "guzzlehttp/guzzle": "^7.10.0",
+        "kovah/laravel-socialite-oidc": "^0.8",
         "laravel/fortify": "^1.34.0",
         "laravel/framework": "^12.49.0",
         "laravel/horizon": "^5.43.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "64b77285a7140ce68e83db2659e9a21d",
+    "content-hash": "1fa943039d9573b41da76a8777fea65f",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -1702,6 +1702,74 @@
                 "source": "https://github.com/Jean85/pretty-package-versions/tree/2.1.1"
             },
             "time": "2025-03-19T14:43:43+00:00"
+        },
+        {
+            "name": "kovah/laravel-socialite-oidc",
+            "version": "v0.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Kovah/laravel-socialite-oidc.git",
+                "reference": "cfd9c9a658da97b961d936159c45ca4ed082e62a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Kovah/laravel-socialite-oidc/zipball/cfd9c9a658da97b961d936159c45ca4ed082e62a",
+                "reference": "cfd9c9a658da97b961d936159c45ca4ed082e62a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "firebase/php-jwt": "^6.4|^7.0",
+                "illuminate/http": "^9.0 | ^10.0 | ^11.0 | ^12.0 | ^13.0",
+                "illuminate/support": "^9.0 | ^10.0 | ^11.0 | ^12.0 | ^13.0",
+                "php": "^8.1",
+                "socialiteproviders/manager": "^4.0"
+            },
+            "conflict": {
+                "jp-gauthier/socialiteproviders-oidc": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "SocialiteProviders\\OIDC\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "JPG Dev",
+                    "homepage": "https://jpgdev.com"
+                },
+                {
+                    "name": "Kevin Woblick",
+                    "email": "contact@woblick.dev",
+                    "homepage": "https://woblick.dev",
+                    "role": "Developer"
+                }
+            ],
+            "description": "OpenID Connect OAuth2 Provider for Laravel Socialite",
+            "homepage": "https://github.com/kovah/laravel-socialite-oidc",
+            "keywords": [
+                "laravel",
+                "oauth",
+                "oidc",
+                "provider",
+                "socialite"
+            ],
+            "support": {
+                "issues": "https://github.com/Kovah/laravel-socialite-oidc/issues",
+                "source": "https://github.com/Kovah/laravel-socialite-oidc/tree/v0.8.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/kovah",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-30T09:17:26+00:00"
         },
         {
             "name": "laravel/fortify",
@@ -18072,5 +18140,5 @@
         "php": "^8.4"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/config/services.php
+++ b/config/services.php
@@ -67,4 +67,11 @@ return [
         'base_url' => env('ZITADEL_BASE_URL'),
     ],
 
+    'oidc' => [
+        'client_id' => env('OIDC_CLIENT_ID'),
+        'client_secret' => env('OIDC_CLIENT_SECRET'),
+        'redirect' => env('OIDC_REDIRECT_URI'),
+        'base_url' => env('OIDC_BASE_URL'),
+    ],
+
 ];

--- a/database/seeders/OauthSettingSeeder.php
+++ b/database/seeders/OauthSettingSeeder.php
@@ -25,6 +25,7 @@ class OauthSettingSeeder extends Seeder
                 'authentik',
                 'infomaniak',
                 'zitadel',
+                'oidc',
             ]);
 
             $isOauthSeeded = OauthSetting::count() > 0;

--- a/resources/views/livewire/settings-oauth.blade.php
+++ b/resources/views/livewire/settings-oauth.blade.php
@@ -40,6 +40,7 @@
                         @if (
                             $oauth_setting['provider'] == 'authentik' ||
                                 $oauth_setting['provider'] == 'clerk' ||
+                                $oauth_setting['provider'] == 'oidc' ||
                                 $oauth_setting['provider'] == 'zitadel' ||
                                 $oauth_setting['provider'] == 'gitlab')
                             <x-forms.input id="oauth_settings_map.{{ $oauth_setting['provider'] }}.base_url"


### PR DESCRIPTION
/claim #6696

## Changes
- Add generic OIDC as a configurable OAuth provider.
- Register the OIDC Socialite provider and dependency.
- Seed the provider and expose its Base URL field in OAuth settings.
- Require Base URL before OIDC can be enabled.

## Issues
- Alternative implementation for #6696 against the current next branch.

## Category
- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview
- Not included. This change adds a provider option and configuration field in the existing OAuth settings screen.

## AI Assistance
- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**
- Tools used: OpenAI Codex
- How extensively: Used to draft the implementation and run local validation checks.

## Testing
- Composer dependency update for the OIDC Socialite provider succeeded.
- PHP syntax checks passed for touched application files.
- Pint dirty check passed.
- Whitespace diff check passed.

I could not run the OAuth feature test locally because this checkout fails while bootstrapping with: Call to a member function connection() on null.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.