### PR TITLE
fix(git): write deploy key to per-deployment path, not root's id_rsa

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -2261,18 +2261,19 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         $private_key = data_get($this->application, 'private_key.private_key');
         if ($private_key) {
             $private_key = base64_encode($private_key);
+            $customSshKeyLocation = "/root/.ssh/id_rsa_coolify_{$this->deployment_uuid}";
             $this->execute_remote_command(
                 [
                     executeInDocker($this->deployment_uuid, 'mkdir -p /root/.ssh'),
                 ],
                 [
-                    executeInDocker($this->deployment_uuid, "echo '{$private_key}' | base64 -d | tee /root/.ssh/id_rsa > /dev/null"),
+                    executeInDocker($this->deployment_uuid, "echo '{$private_key}' | base64 -d | tee {$customSshKeyLocation} > /dev/null"),
                 ],
                 [
-                    executeInDocker($this->deployment_uuid, 'chmod 600 /root/.ssh/id_rsa'),
+                    executeInDocker($this->deployment_uuid, "chmod 600 {$customSshKeyLocation}"),
                 ],
                 [
-                    executeInDocker($this->deployment_uuid, "GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$this->customPort} -o Port={$this->customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /root/.ssh/id_rsa\" git ls-remote {$this->fullRepoUrl} {$lsRemoteRef}"),
+                    executeInDocker($this->deployment_uuid, "GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$this->customPort} -o Port={$this->customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i {$customSshKeyLocation} -o IdentitiesOnly=yes\" git ls-remote {$this->fullRepoUrl} {$lsRemoteRef}"),
                     'hidden' => true,
                     'save' => 'git_commit_sha',
                 ]

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -1343,6 +1343,7 @@ class Application extends BaseModel
         $branch = $this->git_branch;
         ['repository' => $customRepository, 'port' => $customPort] = $this->customRepository();
         $commands = collect([]);
+        $customSshKeyLocation = "/root/.ssh/id_rsa_coolify_{$deployment_uuid}";
         $base_command = 'git ls-remote';
 
         if ($this->deploymentType() === 'source') {
@@ -1396,19 +1397,20 @@ class Application extends BaseModel
                     $private_key = base64_encode($private_key);
                     $gitlabPort = $gitlabSource->custom_port ?? 22;
                     $escapedCustomRepository = str_replace("'", "'\\''", $customRepository);
-                    $base_command = "GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$gitlabPort} -o Port={$gitlabPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /root/.ssh/id_rsa\" {$base_command} '{$escapedCustomRepository}'";
+                    $base_command = "GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$gitlabPort} -o Port={$gitlabPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i {$customSshKeyLocation} -o IdentitiesOnly=yes\" {$base_command} '{$escapedCustomRepository}'";
 
                     if ($exec_in_docker) {
                         $commands = collect([
                             executeInDocker($deployment_uuid, 'mkdir -p /root/.ssh'),
-                            executeInDocker($deployment_uuid, "echo '{$private_key}' | base64 -d | tee /root/.ssh/id_rsa > /dev/null"),
-                            executeInDocker($deployment_uuid, 'chmod 600 /root/.ssh/id_rsa'),
+                            executeInDocker($deployment_uuid, "echo '{$private_key}' | base64 -d | tee {$customSshKeyLocation} > /dev/null"),
+                            executeInDocker($deployment_uuid, "chmod 600 {$customSshKeyLocation}"),
                         ]);
                     } else {
                         $commands = collect([
+                            "trap 'rm -f {$customSshKeyLocation}' EXIT",
                             'mkdir -p /root/.ssh',
-                            "echo '{$private_key}' | base64 -d | tee /root/.ssh/id_rsa > /dev/null",
-                            'chmod 600 /root/.ssh/id_rsa',
+                            "echo '{$private_key}' | base64 -d | tee {$customSshKeyLocation} > /dev/null",
+                            "chmod 600 {$customSshKeyLocation}",
                         ]);
                     }
 
@@ -1454,19 +1456,20 @@ class Application extends BaseModel
             // When used with executeInDocker (which uses bash -c '...'), we need to escape for bash context
             // Replace ' with '\'' to safely escape within single-quoted bash strings
             $escapedCustomRepository = str_replace("'", "'\\''", $customRepository);
-            $base_command = "GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$customPort} -o Port={$customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /root/.ssh/id_rsa\" {$base_command} '{$escapedCustomRepository}'";
+            $base_command = "GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$customPort} -o Port={$customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i {$customSshKeyLocation} -o IdentitiesOnly=yes\" {$base_command} '{$escapedCustomRepository}'";
 
             if ($exec_in_docker) {
                 $commands = collect([
                     executeInDocker($deployment_uuid, 'mkdir -p /root/.ssh'),
-                    executeInDocker($deployment_uuid, "echo '{$private_key}' | base64 -d | tee /root/.ssh/id_rsa > /dev/null"),
-                    executeInDocker($deployment_uuid, 'chmod 600 /root/.ssh/id_rsa'),
+                    executeInDocker($deployment_uuid, "echo '{$private_key}' | base64 -d | tee {$customSshKeyLocation} > /dev/null"),
+                    executeInDocker($deployment_uuid, "chmod 600 {$customSshKeyLocation}"),
                 ]);
             } else {
                 $commands = collect([
+                    "trap 'rm -f {$customSshKeyLocation}' EXIT",
                     'mkdir -p /root/.ssh',
-                    "echo '{$private_key}' | base64 -d | tee /root/.ssh/id_rsa > /dev/null",
-                    'chmod 600 /root/.ssh/id_rsa',
+                    "echo '{$private_key}' | base64 -d | tee {$customSshKeyLocation} > /dev/null",
+                    "chmod 600 {$customSshKeyLocation}",
                 ]);
             }
 
@@ -1507,6 +1510,7 @@ class Application extends BaseModel
         $branch = $this->git_branch;
         ['repository' => $customRepository, 'port' => $customPort] = $this->customRepository();
         $baseDir = $custom_base_dir ?? $this->generateBaseDir($deployment_uuid);
+        $customSshKeyLocation = "/root/.ssh/id_rsa_coolify_{$deployment_uuid}";
 
         // Escape shell arguments for safety to prevent command injection
         $escapedBranch = escapeshellarg($branch);
@@ -1603,7 +1607,7 @@ class Application extends BaseModel
                     $private_key = base64_encode($private_key);
                     $gitlabPort = $gitlabSource->custom_port ?? 22;
                     $escapedCustomRepository = escapeshellarg($customRepository);
-                    $gitlabSshCommand = "GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$gitlabPort} -o Port={$gitlabPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /root/.ssh/id_rsa\"";
+                    $gitlabSshCommand = "GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$gitlabPort} -o Port={$gitlabPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i {$customSshKeyLocation} -o IdentitiesOnly=yes\"";
                     $git_clone_command_base = "{$gitlabSshCommand} {$git_clone_command} {$escapedCustomRepository} {$escapedBaseDir}";
                     if ($only_checkout) {
                         $git_clone_command = $git_clone_command_base;
@@ -1613,14 +1617,15 @@ class Application extends BaseModel
                     if ($exec_in_docker) {
                         $commands = collect([
                             executeInDocker($deployment_uuid, 'mkdir -p /root/.ssh'),
-                            executeInDocker($deployment_uuid, "echo '{$private_key}' | base64 -d | tee /root/.ssh/id_rsa > /dev/null"),
-                            executeInDocker($deployment_uuid, 'chmod 600 /root/.ssh/id_rsa'),
+                            executeInDocker($deployment_uuid, "echo '{$private_key}' | base64 -d | tee {$customSshKeyLocation} > /dev/null"),
+                            executeInDocker($deployment_uuid, "chmod 600 {$customSshKeyLocation}"),
                         ]);
                     } else {
                         $commands = collect([
+                            "trap 'rm -f {$customSshKeyLocation}' EXIT",
                             'mkdir -p /root/.ssh',
-                            "echo '{$private_key}' | base64 -d | tee /root/.ssh/id_rsa > /dev/null",
-                            'chmod 600 /root/.ssh/id_rsa',
+                            "echo '{$private_key}' | base64 -d | tee {$customSshKeyLocation} > /dev/null",
+                            "chmod 600 {$customSshKeyLocation}",
                         ]);
                     }
 
@@ -1631,7 +1636,7 @@ class Application extends BaseModel
                         } else {
                             $commands->push("echo 'Checking out $branch'");
                         }
-                        $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$gitlabPort} -o Port={$gitlabPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /root/.ssh/id_rsa\" git fetch origin $branch && ".$this->buildGitCheckoutCommand($pr_branch_name);
+                        $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$gitlabPort} -o Port={$gitlabPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i {$customSshKeyLocation} -o IdentitiesOnly=yes\" git fetch origin $branch && ".$this->buildGitCheckoutCommand($pr_branch_name);
                     }
 
                     if ($exec_in_docker) {
@@ -1674,7 +1679,7 @@ class Application extends BaseModel
             }
             $private_key = base64_encode($private_key);
             $escapedCustomRepository = escapeshellarg($customRepository);
-            $deployKeySshCommand = "GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$customPort} -o Port={$customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /root/.ssh/id_rsa\"";
+            $deployKeySshCommand = "GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$customPort} -o Port={$customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i {$customSshKeyLocation} -o IdentitiesOnly=yes\"";
             $git_clone_command_base = "{$deployKeySshCommand} {$git_clone_command} {$escapedCustomRepository} {$escapedBaseDir}";
             if ($only_checkout) {
                 $git_clone_command = $git_clone_command_base;
@@ -1684,14 +1689,15 @@ class Application extends BaseModel
             if ($exec_in_docker) {
                 $commands = collect([
                     executeInDocker($deployment_uuid, 'mkdir -p /root/.ssh'),
-                    executeInDocker($deployment_uuid, "echo '{$private_key}' | base64 -d | tee /root/.ssh/id_rsa > /dev/null"),
-                    executeInDocker($deployment_uuid, 'chmod 600 /root/.ssh/id_rsa'),
+                    executeInDocker($deployment_uuid, "echo '{$private_key}' | base64 -d | tee {$customSshKeyLocation} > /dev/null"),
+                    executeInDocker($deployment_uuid, "chmod 600 {$customSshKeyLocation}"),
                 ]);
             } else {
                 $commands = collect([
+                    "trap 'rm -f {$customSshKeyLocation}' EXIT",
                     'mkdir -p /root/.ssh',
-                    "echo '{$private_key}' | base64 -d | tee /root/.ssh/id_rsa > /dev/null",
-                    'chmod 600 /root/.ssh/id_rsa',
+                    "echo '{$private_key}' | base64 -d | tee {$customSshKeyLocation} > /dev/null",
+                    "chmod 600 {$customSshKeyLocation}",
                 ]);
             }
             if ($pull_request_id !== 0) {
@@ -1702,7 +1708,7 @@ class Application extends BaseModel
                     } else {
                         $commands->push("echo 'Checking out $branch'");
                     }
-                    $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$customPort} -o Port={$customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /root/.ssh/id_rsa\" git fetch origin $branch && ".$this->buildGitCheckoutCommand($pr_branch_name);
+                    $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$customPort} -o Port={$customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i {$customSshKeyLocation} -o IdentitiesOnly=yes\" git fetch origin $branch && ".$this->buildGitCheckoutCommand($pr_branch_name);
                 } elseif ($git_type === 'github' || $git_type === 'gitea') {
                     $branch = "pull/{$pull_request_id}/head:$pr_branch_name";
                     if ($exec_in_docker) {
@@ -1710,14 +1716,14 @@ class Application extends BaseModel
                     } else {
                         $commands->push("echo 'Checking out $branch'");
                     }
-                    $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$customPort} -o Port={$customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /root/.ssh/id_rsa\" git fetch origin $branch && ".$this->buildGitCheckoutCommand($pr_branch_name);
+                    $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$customPort} -o Port={$customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i {$customSshKeyLocation} -o IdentitiesOnly=yes\" git fetch origin $branch && ".$this->buildGitCheckoutCommand($pr_branch_name);
                 } elseif ($git_type === 'bitbucket') {
                     if ($exec_in_docker) {
                         $commands->push(executeInDocker($deployment_uuid, "echo 'Checking out $branch'"));
                     } else {
                         $commands->push("echo 'Checking out $branch'");
                     }
-                    $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$customPort} -o Port={$customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /root/.ssh/id_rsa\" ".$this->buildGitCheckoutCommand($commit);
+                    $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$customPort} -o Port={$customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i {$customSshKeyLocation} -o IdentitiesOnly=yes\" ".$this->buildGitCheckoutCommand($commit);
                 }
             }
 
@@ -1747,7 +1753,7 @@ class Application extends BaseModel
                     } else {
                         $commands->push("echo 'Checking out $branch'");
                     }
-                    $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$customPort} -o Port={$customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /root/.ssh/id_rsa\" git fetch origin $branch && ".$this->buildGitCheckoutCommand($pr_branch_name);
+                    $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$customPort} -o Port={$customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i {$customSshKeyLocation} -o IdentitiesOnly=yes\" git fetch origin $branch && ".$this->buildGitCheckoutCommand($pr_branch_name);
                 } elseif ($git_type === 'github' || $git_type === 'gitea') {
                     $branch = "pull/{$pull_request_id}/head:$pr_branch_name";
                     if ($exec_in_docker) {
@@ -1755,14 +1761,14 @@ class Application extends BaseModel
                     } else {
                         $commands->push("echo 'Checking out $branch'");
                     }
-                    $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$customPort} -o Port={$customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /root/.ssh/id_rsa\" git fetch origin $branch && ".$this->buildGitCheckoutCommand($pr_branch_name);
+                    $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$customPort} -o Port={$customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i {$customSshKeyLocation} -o IdentitiesOnly=yes\" git fetch origin $branch && ".$this->buildGitCheckoutCommand($pr_branch_name);
                 } elseif ($git_type === 'bitbucket') {
                     if ($exec_in_docker) {
                         $commands->push(executeInDocker($deployment_uuid, "echo 'Checking out $branch'"));
                     } else {
                         $commands->push("echo 'Checking out $branch'");
                     }
-                    $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$customPort} -o Port={$customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /root/.ssh/id_rsa\" ".$this->buildGitCheckoutCommand($commit);
+                    $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && GIT_SSH_COMMAND=\"ssh -o ConnectTimeout=30 -p {$customPort} -o Port={$customPort} -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i {$customSshKeyLocation} -o IdentitiesOnly=yes\" ".$this->buildGitCheckoutCommand($commit);
                 }
             }
 

--- a/tests/Unit/DeployKeyDedicatedPathTest.php
+++ b/tests/Unit/DeployKeyDedicatedPathTest.php
@@ -1,0 +1,112 @@
+<?php
+
+use App\Models\Application;
+use App\Models\ApplicationSetting;
+use App\Models\GitlabApp;
+use App\Models\PrivateKey;
+
+afterEach(function () {
+    Mockery::close();
+});
+
+/**
+ * Git operations authenticate with the SSH key assigned in the UI. Coolify writes that key to a
+ * per-deployment path (/root/.ssh/id_rsa_coolify_<deployment_uuid>) instead of the shared
+ * /root/.ssh/id_rsa, so it can neither overwrite the server root's own key nor race with other
+ * concurrent operations on the same host. `-o IdentitiesOnly=yes` makes ssh offer only that key.
+ * On the host path an EXIT trap removes the key when the shell finishes; the docker path runs in an
+ * ephemeral container, so it needs no cleanup.
+ */
+$keyPath = '/root/.ssh/id_rsa_coolify_test-deployment-uuid';
+
+it('writes a deploy key to a per-deployment path and cleans it up for ls-remote on the host', function () use ($keyPath) {
+    $privateKey = Mockery::mock(PrivateKey::class)->makePartial();
+    $privateKey->shouldReceive('getAttribute')->with('private_key')->andReturn('fake-private-key');
+
+    $application = Mockery::mock(Application::class)->makePartial();
+    $application->git_branch = 'main';
+    $application->shouldReceive('deploymentType')->andReturn('deploy_key');
+    $application->shouldReceive('customRepository')->andReturn(['repository' => 'git@gitlab.com:user/repo.git', 'port' => 22]);
+    $application->shouldReceive('getAttribute')->with('private_key')->andReturn($privateKey);
+
+    $result = $application->generateGitLsRemoteCommands('test-deployment-uuid', false);
+
+    expect($result['commands'])
+        ->toContain("tee {$keyPath}")
+        ->toContain("-i {$keyPath} -o IdentitiesOnly=yes")
+        ->toContain("trap 'rm -f {$keyPath}' EXIT") // removed when the shell exits
+        ->not->toContain('tee /root/.ssh/id_rsa >'); // never overwrites the host root's own key
+});
+
+it('writes a deploy key to a per-deployment path for ls-remote inside docker without a trap', function () use ($keyPath) {
+    $privateKey = Mockery::mock(PrivateKey::class)->makePartial();
+    $privateKey->shouldReceive('getAttribute')->with('private_key')->andReturn('fake-private-key');
+
+    $application = Mockery::mock(Application::class)->makePartial();
+    $application->git_branch = 'main';
+    $application->shouldReceive('deploymentType')->andReturn('deploy_key');
+    $application->shouldReceive('customRepository')->andReturn(['repository' => 'git@gitlab.com:user/repo.git', 'port' => 22]);
+    $application->shouldReceive('getAttribute')->with('private_key')->andReturn($privateKey);
+
+    $result = $application->generateGitLsRemoteCommands('test-deployment-uuid', true);
+
+    expect($result['commands'])
+        ->toContain("tee {$keyPath}")
+        ->toContain("-i {$keyPath} -o IdentitiesOnly=yes")
+        ->not->toContain('trap ') // ephemeral container, no cleanup needed
+        ->not->toContain('tee /root/.ssh/id_rsa >');
+});
+
+it('writes a GitLab source private key to a per-deployment path with cleanup on the host', function () use ($keyPath) {
+    $privateKey = Mockery::mock(PrivateKey::class)->makePartial();
+    $privateKey->shouldReceive('getAttribute')->with('private_key')->andReturn('fake-private-key');
+
+    $gitlabSource = Mockery::mock(GitlabApp::class)->makePartial();
+    $gitlabSource->shouldReceive('getMorphClass')->andReturn(GitlabApp::class);
+    $gitlabSource->shouldReceive('getAttribute')->with('html_url')->andReturn('https://gitlab.com');
+    $gitlabSource->shouldReceive('getAttribute')->with('privateKey')->andReturn($privateKey);
+    $gitlabSource->shouldReceive('getAttribute')->with('private_key_id')->andReturn(1);
+    $gitlabSource->shouldReceive('getAttribute')->with('custom_port')->andReturn(22);
+
+    $application = Mockery::mock(Application::class)->makePartial();
+    $application->git_branch = 'main';
+    $application->shouldReceive('deploymentType')->andReturn('source');
+    $application->shouldReceive('customRepository')->andReturn(['repository' => 'git@gitlab.com:user/repo.git', 'port' => 22]);
+    $application->shouldReceive('getAttribute')->with('source')->andReturn($gitlabSource);
+    $application->source = $gitlabSource;
+
+    $result = $application->generateGitLsRemoteCommands('test-deployment-uuid', false);
+
+    expect($result['commands'])
+        ->toContain("tee {$keyPath}")
+        ->toContain("-i {$keyPath} -o IdentitiesOnly=yes")
+        ->toContain("trap 'rm -f {$keyPath}' EXIT")
+        ->not->toContain('tee /root/.ssh/id_rsa >');
+});
+
+it('writes a deploy key to a per-deployment path and cleans it up when cloning on the host', function () use ($keyPath) {
+    $privateKey = Mockery::mock(PrivateKey::class)->makePartial();
+    $privateKey->shouldReceive('getAttribute')->with('private_key')->andReturn('fake-private-key');
+
+    $settings = Mockery::mock(ApplicationSetting::class)->makePartial();
+    $settings->shouldReceive('getAttribute')->with('is_git_shallow_clone_enabled')->andReturn(false);
+    $settings->shouldReceive('getAttribute')->with('is_git_submodules_enabled')->andReturn(false);
+    $settings->shouldReceive('getAttribute')->with('is_git_lfs_enabled')->andReturn(false);
+
+    $application = Mockery::mock(Application::class)->makePartial();
+    $application->git_branch = 'main';
+    $application->shouldReceive('deploymentType')->andReturn('deploy_key');
+    $application->shouldReceive('customRepository')->andReturn(['repository' => 'git@gitlab.com:user/repo.git', 'port' => 22]);
+    $application->shouldReceive('getAttribute')->with('private_key')->andReturn($privateKey);
+    $application->shouldReceive('getAttribute')->with('settings')->andReturn($settings);
+    $application->shouldReceive('getAttribute')->with('git_commit_sha')->andReturn('HEAD');
+
+    // exec_in_docker = false → the loadComposeFile / host clone path
+    $result = $application->generateGitImportCommands('test-deployment-uuid', 0, null, false);
+
+    expect($result['commands'])
+        ->toContain("tee {$keyPath}")
+        ->toContain("-i {$keyPath} -o IdentitiesOnly=yes")
+        ->toContain("trap 'rm -f {$keyPath}' EXIT")
+        ->not->toContain('tee /root/.ssh/id_rsa >');
+});


### PR DESCRIPTION
## Changes

- Coolify wrote the Git deploy/private key to the shared `/root/.ssh/id_rsa` path before
  every Git operation. On servers where root already has its own key pair this overwrote
  root's key and left a mismatched `/root/.ssh/id_rsa.pub`, so OpenSSH offered the wrong
  public key and auth failed with `Permission denied (publickey)`. Two concurrent
  operations on the same server also clobbered each other's key.
- The key is now written to a per-deployment path `/root/.ssh/id_rsa_coolify_<deployment_uuid>`,
  offered with `-o IdentitiesOnly=yes`, and removed on the host via an `EXIT` trap. Root's
  `/root/.ssh/id_rsa` is never touched, the race is gone, and the stale `.pub` problem
  disappears (no sibling `.pub` → ssh derives the key from the private file).

## Issues

https://github.com/coollabsio/coolify/issues/10203

## Category

- [x] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A — backend-only change (no UI). The fix is in the generated SSH/Git commands.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Opus)

- How extensively: AI investigated the root cause, implemented the fix across
  `Application.php` / `ApplicationDeploymentJob.php`, and wrote the unit tests. The
  approach (dedicated per-deployment path, race-condition handling, minimal/surgical
  change) was human-directed and human-reviewed.

## Testing

- Added `tests/Unit/DeployKeyDedicatedPathTest.php` covering both methods
  (`generateGitLsRemoteCommands`, `generateGitImportCommands`) in host and docker modes
  and the GitLab-source path. Tests assert the per-deployment key path, `IdentitiesOnly=yes`,
  the host-side `trap … EXIT` cleanup, and that the bare `/root/.ssh/id_rsa` is never written.
- `php artisan test --filter=DeployKeyDedicatedPath` → all pass; `vendor/bin/pint` clean.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
