### PR TITLE
feat(service): add WordPress with OpenLiteSpeed template

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -1,0 +1,41 @@
+# documentation: https://docs.openlitespeed.org/
+# slogan: WordPress with OpenLiteSpeed — a high-performance WordPress stack using the LiteSpeed web server with built-in LSCache support.
+# category: cms
+# tags: cms, blog, wordpress, openlitespeed, litespeed, performance, lscache, cache
+# logo: svgs/wordpress.svg
+# port: 80
+
+services:
+  wordpress:
+    image: litespeedtech/openlitespeed-wordpress:latest
+    volumes:
+      - wordpress-files:/var/www/vhosts/localhost/html
+      - lsws-conf:/usr/local/lsws/conf
+    environment:
+      - SERVICE_URL_WORDPRESS
+      - WORDPRESS_DB_HOST=mariadb
+      - WORDPRESS_DB_USER=$SERVICE_USER_WORDPRESS
+      - WORDPRESS_DB_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+      - WORDPRESS_DB_NAME=wordpress
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:80"]
+      interval: 5s
+      timeout: 10s
+      retries: 10
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_MYSQLROOT
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
Hey! I saw the issue for an OpenLiteSpeed template and figured I'd give it a shot.

## What this does

Adds a WordPress + OpenLiteSpeed template to the one-click services. It uses the official `litespeedtech/openlitespeed-wordpress` image with MariaDB 11, pretty much the same setup as the existing wordpress-with-mariadb template but swapping Apache for OLS.

I went with the official Litespeed image since it already bundles WordPress + OLS together, so no extra wiring needed. The variable naming and database config match the existing WordPress template conventions.

## Why OLS

OpenLiteSpeed is event-driven so it uses less memory than Apache under load, and it has LSCache built in which is nice for WordPress performance. Figured it's a good alternative option to have alongside the Apache-based one.

## Issues

Fixes #8264

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Spin up the template in Coolify, both containers should hit `healthy`. The WordPress setup page should load and response headers should show `server: LiteSpeed`.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

I used an AI agent to help research the template structure and compare against existing Coolify templates. The actual template was written by studying `wordpress-with-mariadb.yaml` and the official OLS Docker image docs. I reviewed and validated everything myself.

## Testing

- YAML passes linting
- Structure matches `wordpress-with-mariadb.yaml` - same variable naming, same db setup, same health checks
- Uses official `litespeedtech/openlitespeed-wordpress:latest` image
- Didn't touch the auto-generated JSON files (learned that from a previous PR)

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
