### PR TITLE
[codex] fix changelog modal stacking

### DIFF
--- a/resources/views/livewire/settings-dropdown.blade.php
+++ b/resources/views/livewire/settings-dropdown.blade.php
@@ -238,7 +238,7 @@
 
     <!-- What's New Modal -->
     @if ($showWhatsNewModal)
-        <div class="fixed inset-0 z-50 flex items-center justify-center py-6 px-4"
+        <div class="fixed inset-0 z-99 flex items-center justify-center py-6 px-4"
             @keydown.escape.window="$wire.closeWhatsNewModal()">
             <!-- Background overlay -->
             <div class="absolute inset-0 w-full h-full bg-black/20 backdrop-blur-xs" wire:click="closeWhatsNewModal">


### PR DESCRIPTION
## Summary
- Raise the What's New / changelog modal overlay from `z-50` to `z-99`.
- Align the changelog overlay with the existing modal stacking layer so the desktop sidebar collapse toggle no longer appears above it.

Fixes #10443.

## Validation
- `git diff --check`
- `npm run build`

Manual browser checks were skipped as requested.
