### PR TITLE
fix: keep changelog modal above sidebar toggle

### DIFF
--- a/resources/views/livewire/settings-dropdown.blade.php
+++ b/resources/views/livewire/settings-dropdown.blade.php
@@ -198,7 +198,7 @@
 
     <!-- What's New Modal -->
     @if ($showWhatsNewModal)
-        <div class="fixed inset-0 z-50 flex items-center justify-center py-6 px-4"
+        <div class="fixed inset-0 z-99 flex items-center justify-center py-6 px-4"
             @keydown.escape.window="$wire.closeWhatsNewModal()">
             <!-- Background overlay -->
             <div class="absolute inset-0 w-full h-full bg-black/20 backdrop-blur-xs" wire:click="closeWhatsNewModal">


### PR DESCRIPTION
## Changes

- Raise the What's New modal wrapper from `z-50` to `z-99`.
- This puts the changelog modal on the same stacking layer as the existing modal overlays, so the desktop sidebar collapse button no longer appears above the changelog.

## Issues

- Fixes #10443
- Replaces #10464, which was closed because it targeted the wrong base branch.

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No screenshot/video is attached because this environment cannot start the local Coolify UI: `spin` and `php` are not installed, and Docker Desktop is not running. The issue report includes the broken stacking state; this PR only changes the modal stack level.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Used to inspect the issue, read the contribution rules, make the one-line Blade class change, and run the available checks. The change is limited to the changelog modal z-index.

## Testing

- `git diff --check`
- `npm run build`
- Local UI testing was not run because this machine is missing the Coolify development runtime described in the contribution guide.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
