### PR TITLE
feat: allow OAuth-only self-registration

### DIFF
--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\ResetsUserPasswords;
 
 class ResetUserPassword implements ResetsUserPasswords
@@ -17,6 +18,12 @@ class ResetUserPassword implements ResetsUserPasswords
      */
     public function reset(User $user, array $input): void
     {
+        if ($user->oauth_provider) {
+            throw ValidationException::withMessages([
+                'password' => __('Password login is disabled for this OAuth account.'),
+            ]);
+        }
+
         Validator::make($input, [
             'password' => ['required', Password::defaults(), 'confirmed'],
         ])->validate();

--- a/app/Actions/Fortify/UpdateUserPassword.php
+++ b/app/Actions/Fortify/UpdateUserPassword.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\UpdatesUserPasswords;
 
 class UpdateUserPassword implements UpdatesUserPasswords
@@ -17,6 +18,12 @@ class UpdateUserPassword implements UpdatesUserPasswords
      */
     public function update(User $user, array $input): void
     {
+        if ($user->oauth_provider) {
+            throw ValidationException::withMessages([
+                'password' => __('Password login is disabled for this OAuth account.'),
+            ])->errorBag('updatePassword');
+        }
+
         Validator::make($input, [
             'current_password' => ['required', 'string', 'current_password:web'],
             'password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\OauthSetting;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -10,6 +11,11 @@ class OauthController extends Controller
 {
     public function redirect(string $provider)
     {
+        $oauthSetting = OauthSetting::firstWhere('provider', $provider);
+        if (! $oauthSetting?->enabled) {
+            abort(403, 'OAuth provider is disabled');
+        }
+
         $socialite_provider = get_socialite_provider($provider);
 
         return $socialite_provider->redirect();
@@ -18,6 +24,11 @@ class OauthController extends Controller
     public function callback(string $provider)
     {
         try {
+            $oauthSetting = OauthSetting::firstWhere('provider', $provider);
+            if (! $oauthSetting?->enabled) {
+                abort(403, 'OAuth provider is disabled');
+            }
+
             $oauthUser = get_socialite_provider($provider)->user();
             $email = trim((string) $oauthUser->email);
             if ($email === '') {
@@ -27,13 +38,16 @@ class OauthController extends Controller
             $user = User::whereEmail($email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! $oauthSetting->allow_registration) {
                     abort(403, 'Registration is disabled');
                 }
 
+                $name = trim((string) ($oauthUser->name ?? ''));
+
                 $user = User::create([
-                    'name' => $oauthUser->name,
+                    'name' => $name !== '' ? $name : str($email)->before('@')->toString(),
                     'email' => $email,
+                    'oauth_provider' => $provider,
                 ]);
             }
             Auth::login($user);

--- a/app/Livewire/SettingsOauth.php
+++ b/app/Livewire/SettingsOauth.php
@@ -18,6 +18,7 @@ class SettingsOauth extends Component
             $carry["oauth_settings_map.$setting->provider.redirect_uri"] = 'nullable';
             $carry["oauth_settings_map.$setting->provider.tenant"] = 'nullable';
             $carry["oauth_settings_map.$setting->provider.base_url"] = 'nullable';
+            $carry["oauth_settings_map.$setting->provider.allow_registration"] = 'boolean';
 
             return $carry;
         }, []);
@@ -38,6 +39,7 @@ class SettingsOauth extends Component
                 'redirect_uri' => $setting->redirect_uri,
                 'tenant' => $setting->tenant,
                 'base_url' => $setting->base_url,
+                'allow_registration' => $setting->allow_registration,
             ];
 
             return $carry;
@@ -61,6 +63,7 @@ class SettingsOauth extends Component
                 'redirect_uri' => $oauthData['redirect_uri'],
                 'tenant' => $oauthData['tenant'],
                 'base_url' => $oauthData['base_url'],
+                'allow_registration' => $oauthData['allow_registration'],
             ]);
 
             if (! $oauth->couldBeEnabled()) {
@@ -79,6 +82,7 @@ class SettingsOauth extends Component
                 'redirect_uri' => $oauth->redirect_uri,
                 'tenant' => $oauth->tenant,
                 'base_url' => $oauth->base_url,
+                'allow_registration' => $oauth->allow_registration,
             ];
 
             $this->dispatch('success', 'OAuth settings for '.$oauth->provider.' updated successfully!');
@@ -100,6 +104,7 @@ class SettingsOauth extends Component
                     'redirect_uri' => $settingData['redirect_uri'],
                     'tenant' => $settingData['tenant'],
                     'base_url' => $settingData['base_url'],
+                    'allow_registration' => $settingData['allow_registration'],
                 ]);
 
                 if ($settingData['enabled'] && ! $oauth->couldBeEnabled()) {
@@ -119,6 +124,7 @@ class SettingsOauth extends Component
                     'redirect_uri' => $oauth->redirect_uri,
                     'tenant' => $oauth->tenant,
                     'base_url' => $oauth->base_url,
+                    'allow_registration' => $oauth->allow_registration,
                 ];
             }
 

--- a/app/Models/OauthSetting.php
+++ b/app/Models/OauthSetting.php
@@ -11,7 +11,21 @@ class OauthSetting extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['provider', 'client_id', 'client_secret', 'redirect_uri', 'tenant', 'base_url', 'enabled'];
+    protected $fillable = [
+        'provider',
+        'client_id',
+        'client_secret',
+        'redirect_uri',
+        'tenant',
+        'base_url',
+        'enabled',
+        'allow_registration',
+    ];
+
+    protected $casts = [
+        'enabled' => 'boolean',
+        'allow_registration' => 'boolean',
+    ];
 
     protected function clientSecret(): Attribute
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -47,6 +47,7 @@ class User extends Authenticatable implements SendsEmail
         'name',
         'email',
         'password',
+        'oauth_provider',
         'force_password_reset',
         'marketing_emails',
         'pending_email',

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -7,6 +7,7 @@ use App\Actions\Fortify\ResetUserPassword;
 use App\Actions\Fortify\UpdateUserPassword;
 use App\Actions\Fortify\UpdateUserProfileInformation;
 use App\Models\OauthSetting;
+use App\Models\TeamInvitation;
 use App\Models\User;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
@@ -76,13 +77,14 @@ class FortifyServiceProvider extends ServiceProvider
             $user = User::where('email', $email)->with('teams')->first();
             if (
                 $user &&
+                ! $user->oauth_provider &&
                 Hash::check($request->password, $user->password)
             ) {
                 $user->updated_at = now();
                 $user->save();
 
                 // Check if user has a pending invitation they haven't accepted yet
-                $invitation = \App\Models\TeamInvitation::whereEmail($email)->first();
+                $invitation = TeamInvitation::whereEmail($email)->first();
                 if ($invitation && $invitation->isValid()) {
                     // User is logging in for the first time after being invited
                     // Attach them to the invited team if not already attached

--- a/database/migrations/2026_05_27_000001_tune_postgres_fillfactor_and_autovacuum.php
+++ b/database/migrations/2026_05_27_000001_tune_postgres_fillfactor_and_autovacuum.php
@@ -7,11 +7,15 @@ return new class extends Migration
 {
     public function up(): void
     {
+        if (DB::getDriverName() !== 'pgsql') {
+            return;
+        }
+
         // Fillfactor < 100 leaves free space per page so Postgres can do HOT
         // (Heap-Only Tuple) in-place updates instead of allocating a new tuple
         // elsewhere. Coolify's hot-update tables churn rows on every Sentinel
         // push / status change; without page-local headroom, non-HOT updates
-        // accumulate dead tuples and bloat the heap (we've seen up to 50× on
+        // accumulate dead tuples and bloat the heap (we've seen up to 50x on
         // cloud). Lower fillfactor on hot-update tables, default on the rest.
         DB::statement('ALTER TABLE applications SET (fillfactor = 70)');
         DB::statement('ALTER TABLE servers SET (fillfactor = 85)');
@@ -28,7 +32,7 @@ return new class extends Migration
         DB::statement('ALTER TABLE standalone_clickhouses SET (fillfactor = 85)');
         DB::statement('ALTER TABLE application_deployment_queues SET (fillfactor = 90)');
 
-        // Autovacuum default kicks in at 20% dead tuples — too lazy for our
+        // Autovacuum default kicks in at 20% dead tuples, too lazy for our
         // churn rate. Trigger at 5% on the highest-write tables to keep heap
         // pages tidy and prevent visibility-map gaps that hurt scan plans.
         DB::statement('ALTER TABLE applications SET (autovacuum_vacuum_scale_factor = 0.05)');
@@ -40,6 +44,10 @@ return new class extends Migration
 
     public function down(): void
     {
+        if (DB::getDriverName() !== 'pgsql') {
+            return;
+        }
+
         DB::statement('ALTER TABLE applications RESET (fillfactor, autovacuum_vacuum_scale_factor)');
         DB::statement('ALTER TABLE servers RESET (fillfactor, autovacuum_vacuum_scale_factor)');
         DB::statement('ALTER TABLE services RESET (fillfactor)');

--- a/database/migrations/2026_05_31_000000_add_allow_registration_to_oauth_settings_table.php
+++ b/database/migrations/2026_05_31_000000_add_allow_registration_to_oauth_settings_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('oauth_settings', function (Blueprint $table) {
+            $table->boolean('allow_registration')->default(false)->after('enabled');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('oauth_settings', function (Blueprint $table) {
+            $table->dropColumn('allow_registration');
+        });
+    }
+};

--- a/database/migrations/2026_05_31_000001_add_oauth_provider_to_users_table.php
+++ b/database/migrations/2026_05_31_000001_add_oauth_provider_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('oauth_provider')->nullable()->after('password');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('oauth_provider');
+        });
+    }
+};

--- a/resources/views/livewire/settings-oauth.blade.php
+++ b/resources/views/livewire/settings-oauth.blade.php
@@ -21,6 +21,12 @@
                         <x-forms.checkbox instantSave="instantSave('{{ $oauth_setting['provider'] }}')"
                             id="oauth_settings_map.{{ $oauth_setting['provider'] }}.enabled" label="Enabled" />
                     </div>
+                    <div class="w-64">
+                        <x-forms.checkbox
+                            helper="Allow new users to create accounts with this provider even when password registration is disabled."
+                            id="oauth_settings_map.{{ $oauth_setting['provider'] }}.allow_registration"
+                            label="Allow Registration" />
+                    </div>
                     <div class="flex flex-col w-full gap-2 xl:flex-row">
                         <x-forms.input id="oauth_settings_map.{{ $oauth_setting['provider'] }}.client_id"
                             label="Client ID" />

--- a/tests/Feature/OauthControllerTest.php
+++ b/tests/Feature/OauthControllerTest.php
@@ -1,15 +1,22 @@
 <?php
 
+use App\Actions\Fortify\ResetUserPassword;
+use App\Actions\Fortify\UpdateUserPassword;
 use App\Models\InstanceSettings;
 use App\Models\OauthSetting;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
 use Laravel\Socialite\Facades\Socialite;
 
 uses(RefreshDatabase::class);
 
 beforeEach(function () {
-    InstanceSettings::create([
+    $this->withoutVite();
+    config()->set('app.maintenance.driver', 'file');
+
+    InstanceSettings::forceCreate([
         'id' => 0,
         'is_registration_enabled' => false,
     ]);
@@ -20,17 +27,16 @@ beforeEach(function () {
         'client_secret' => 'client-secret',
         'redirect_uri' => 'https://coolify.example.com/auth/google/callback',
         'tenant' => 'example.com',
+        'enabled' => true,
     ]);
 });
 
 it('logs in an existing user when the oauth provider returns a mixed-case email', function () {
-    config()->set('app.maintenance.driver', 'file');
-
     $user = User::factory()->create([
         'email' => 'username@example.edu',
     ]);
 
-    $provider = \Mockery::mock();
+    $provider = Mockery::mock();
     $provider->shouldReceive('setConfig')->once()->andReturnSelf();
     $provider->shouldReceive('with')->once()->with(['hd' => 'example.com'])->andReturnSelf();
     $provider->shouldReceive('user')->once()->andReturn((object) [
@@ -48,17 +54,102 @@ it('logs in an existing user when the oauth provider returns a mixed-case email'
     expect(User::count())->toBe(1);
 });
 
+it('creates an oauth user when provider registration is allowed and password registration is disabled', function () {
+    OauthSetting::where('provider', 'google')->update([
+        'allow_registration' => true,
+    ]);
+
+    $provider = Mockery::mock();
+    $provider->shouldReceive('setConfig')->once()->andReturnSelf();
+    $provider->shouldReceive('with')->once()->with(['hd' => 'example.com'])->andReturnSelf();
+    $provider->shouldReceive('user')->once()->andReturn((object) [
+        'email' => 'NewUser@example.edu',
+        'name' => 'New OAuth User',
+        'id' => 'google-user-id',
+    ]);
+
+    Socialite::shouldReceive('driver')->once()->with('google')->andReturn($provider);
+
+    $response = $this->get(route('auth.callback', 'google'));
+
+    $response->assertRedirect('/');
+    $user = User::whereEmail('newuser@example.edu')->first();
+    expect($user)->not->toBeNull()
+        ->and($user->password)->toBeNull()
+        ->and($user->oauth_provider)->toBe('google');
+    $this->assertAuthenticatedAs($user);
+});
+
+it('rejects password login for oauth-only users even if a password exists', function () {
+    User::factory()->create([
+        'email' => 'oauth-only@example.edu',
+        'password' => Hash::make('password'),
+        'oauth_provider' => 'google',
+    ]);
+
+    $response = $this->from('/login')->post('/login', [
+        'email' => 'oauth-only@example.edu',
+        'password' => 'password',
+    ]);
+
+    $response->assertRedirect('/login');
+    $this->assertGuest();
+});
+
+it('rejects password reset and password update for oauth-only users', function () {
+    $user = User::factory()->create([
+        'password' => null,
+        'oauth_provider' => 'google',
+    ]);
+
+    expect(fn () => (new ResetUserPassword)->reset($user, [
+        'password' => 'Password123!',
+        'password_confirmation' => 'Password123!',
+    ]))->toThrow(ValidationException::class);
+
+    expect(fn () => (new UpdateUserPassword)->update($user, [
+        'current_password' => 'password',
+        'password' => 'Password123!',
+        'password_confirmation' => 'Password123!',
+    ]))->toThrow(ValidationException::class);
+
+    expect($user->refresh()->password)->toBeNull();
+});
+
+it('rejects new oauth users when provider registration and password registration are disabled', function () {
+    $provider = Mockery::mock();
+    $provider->shouldReceive('setConfig')->once()->andReturnSelf();
+    $provider->shouldReceive('with')->once()->with(['hd' => 'example.com'])->andReturnSelf();
+    $provider->shouldReceive('user')->once()->andReturn((object) [
+        'email' => 'NewUser@example.edu',
+        'name' => 'New OAuth User',
+        'id' => 'google-user-id',
+    ]);
+
+    Socialite::shouldReceive('driver')->once()->with('google')->andReturn($provider);
+
+    $response = $this->from('/login')->get(route('auth.callback', 'google'));
+
+    $response->assertRedirect('/login');
+    expect(User::whereEmail('newuser@example.edu')->exists())->toBeFalse();
+});
+
+it('rejects oauth redirects when the provider is disabled', function () {
+    OauthSetting::where('provider', 'google')->update([
+        'enabled' => false,
+    ]);
+
+    $response = $this->get(route('auth.redirect', 'google'));
+
+    $response->assertForbidden();
+});
+
 it('rejects oauth logins when the provider does not return an email address', function (?string $providerEmail) {
-    config()->set('app.maintenance.driver', 'file');
-    InstanceSettings::firstOrCreate([
-        'id' => 0,
-    ], [
-        'is_registration_enabled' => false,
-    ])->update([
+    InstanceSettings::query()->findOrFail(0)->update([
         'is_registration_enabled' => true,
     ]);
 
-    $provider = \Mockery::mock();
+    $provider = Mockery::mock();
     $provider->shouldReceive('setConfig')->once()->andReturnSelf();
     $provider->shouldReceive('with')->once()->with(['hd' => 'example.com'])->andReturnSelf();
     $provider->shouldReceive('user')->once()->andReturn((object) [


### PR DESCRIPTION
## Changes

- Added a per-provider OAuth setting that lets admins opt specific providers into self-registration while global password registration stays disabled.
- OAuth-created users are marked with their provider and kept passwordless.
- Password login, password reset, and password update paths now reject OAuth-only users.
- Disabled OAuth providers now fail before redirect/callback handling.
- The Postgres-only fillfactor migration now skips non-Postgres test connections.

## Issues

- Fixes #8042
- Supersedes #10466 because it was auto-closed before the template/body correction and cannot be reopened by the contributor.
- /claim #8042

## Category

- [ ] Bug fix
- [x] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

- Settings > Authentication now shows an "Allow Registration" checkbox for each OAuth provider.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex
- How extensively: Used to implement the patch and run targeted local verification.

## Testing

- vendor/bin/pint --dirty --format agent
- php artisan test tests/Feature/OauthControllerTest.php --compact

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the contributor guidelines. If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched existing issues and pull requests, including closed ones, to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
