### PR TITLE
fix(templates): use valid hermes-agent image tag in hermes-agent-with-webui

### DIFF
--- a/templates/compose/hermes-agent-with-webui.yaml
+++ b/templates/compose/hermes-agent-with-webui.yaml
@@ -7,7 +7,7 @@
 
 services:
   hermes-agent:
-    image: nousresearch/hermes-agent:sha-273ff5c4a47af4499bbe5e3b1139efd313995554
+    image: nousresearch/hermes-agent:v2026.5.29.2
     command: gateway run
     environment:
       - HERMES_HOME=/home/hermes/.hermes


### PR DESCRIPTION
## Why

The `hermes-agent-with-webui` service template pins a Docker image tag that does not exist:

```yaml
image: nousresearch/hermes-agent:sha-273ff5c4a47af4499bbe5e3b1139efd313995554
```

Deploying the service fails at the image-pull step:

```
Image nousresearch/hermes-agent:sha-273ff5c4a47af4499bbe5e3b1139efd313995554 Error
failed to resolve reference "docker.io/nousresearch/hermes-agent:sha-273ff5c4a47af4499bbe5e3b1139efd313995554": not found
```

The [`nousresearch/hermes-agent`](https://hub.docker.com/r/nousresearch/hermes-agent) repository does not publish `sha-*` tags. It publishes semver-style release tags (`v2026.5.29.2`, `v2026.5.28`, …) plus `latest` and `main`. The pinned SHA tag was never a valid reference, so the template is broken for anyone who deploys it.

## What

Pin the agent image to the current release tag `v2026.5.29.2`, which exists on Docker Hub and lets the template deploy successfully.

```diff
-    image: nousresearch/hermes-agent:sha-273ff5c4a47af4499bbe5e3b1139efd313995554
+    image: nousresearch/hermes-agent:v2026.5.29.2
```

## Note

Coolify serves templates from the compiled `templates/service-templates*.json` (base64-encoded compose), which is regenerated from the `templates/compose/*.yaml` sources. This PR updates the source YAML only — a maintainer regen of the compiled JSON may be needed for the change to reach deployed instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)