### PR TITLE
[codex] Add server Docker image management

### DIFF
--- a/app/Actions/Docker/ListServerDockerImages.php
+++ b/app/Actions/Docker/ListServerDockerImages.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Actions\Docker;
+
+use App\Models\Server;
+use Illuminate\Support\Collection;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class ListServerDockerImages
+{
+    use AsAction;
+
+    public function handle(Server $server): Collection
+    {
+        if (! $server->isFunctional()) {
+            return collect([]);
+        }
+
+        $imagesOutput = instant_remote_process([
+            "docker image ls -a --no-trunc --digests --format '{{json .}}'",
+        ], $server, false);
+        $containersOutput = instant_remote_process([
+            "docker ps -a --format '{{json .}}'",
+        ], $server, false);
+        $containers = format_docker_command_output_to_json($containersOutput ?? '');
+
+        return self::normalizeImages(
+            format_docker_command_output_to_json($imagesOutput ?? ''),
+            self::usedImageReferencesFromContainers($containers),
+            $containers
+        );
+    }
+
+    public static function normalizeImages(Collection $images, Collection $usedImages, ?Collection $containers = null): Collection
+    {
+        $usedImages = $usedImages
+            ->map(fn ($image) => trim((string) $image))
+            ->filter()
+            ->unique()
+            ->values();
+        $containers = $containers ?? collect([]);
+
+        return $images
+            ->map(function (array $image) use ($usedImages, $containers) {
+                $repository = self::normalizeDockerValue(data_get($image, 'Repository'));
+                $tag = self::normalizeDockerValue(data_get($image, 'Tag'));
+                $digest = self::normalizeDockerValue(data_get($image, 'Digest'));
+                $id = self::normalizeDockerValue(data_get($image, 'ID'));
+                $reference = self::imageReference($repository, $tag);
+                $references = collect([$id, $reference])
+                    ->when($repository && $digest, fn (Collection $items) => $items->push("{$repository}@{$digest}"))
+                    ->filter()
+                    ->unique()
+                    ->values();
+                $usedBy = self::containersUsingImage($containers, $references);
+
+                return [
+                    'id' => $id,
+                    'repository' => $repository,
+                    'tag' => $tag,
+                    'digest' => $digest,
+                    'reference' => $reference,
+                    'created_at' => self::normalizeDockerValue(data_get($image, 'CreatedAt')),
+                    'created_since' => self::normalizeDockerValue(data_get($image, 'CreatedSince')),
+                    'size' => self::normalizeDockerValue(data_get($image, 'Size')),
+                    'shared_size' => self::normalizeDockerValue(data_get($image, 'SharedSize')),
+                    'unique_size' => self::normalizeDockerValue(data_get($image, 'UniqueSize')),
+                    'virtual_size' => self::normalizeDockerValue(data_get($image, 'VirtualSize')),
+                    'dangling' => ! $repository || ! $tag,
+                    'in_use' => $usedBy->isNotEmpty() || $references->contains(fn ($reference) => $usedImages->contains($reference)),
+                    'containers' => $usedBy->toArray(),
+                ];
+            })
+            ->filter(fn (array $image) => filled(data_get($image, 'id')))
+            ->sortBy([
+                ['repository', 'asc'],
+                ['tag', 'asc'],
+                ['id', 'asc'],
+            ], SORT_NATURAL)
+            ->values();
+    }
+
+    public static function usedImageReferencesFromContainers(Collection $containers): Collection
+    {
+        return $containers
+            ->map(fn (array $container) => data_get($container, 'Image'))
+            ->filter()
+            ->values();
+    }
+
+    public static function imageReference(?string $repository, ?string $tag): ?string
+    {
+        if (! $repository) {
+            return null;
+        }
+
+        if (! $tag) {
+            return $repository;
+        }
+
+        return "{$repository}:{$tag}";
+    }
+
+    private static function normalizeDockerValue(mixed $value): ?string
+    {
+        $value = trim((string) $value);
+
+        if ($value === '' || $value === '<none>') {
+            return null;
+        }
+
+        return $value;
+    }
+
+    private static function containersUsingImage(Collection $containers, Collection $imageReferences): Collection
+    {
+        return $containers
+            ->filter(fn (array $container) => $imageReferences->contains(data_get($container, 'Image')))
+            ->map(fn (array $container) => [
+                'id' => self::normalizeDockerValue(data_get($container, 'ID')),
+                'name' => self::normalizeDockerValue(data_get($container, 'Names')),
+                'state' => self::normalizeDockerValue(data_get($container, 'State')),
+                'status' => self::normalizeDockerValue(data_get($container, 'Status')),
+            ])
+            ->values();
+    }
+}

--- a/app/Actions/Docker/RemoveServerDockerImage.php
+++ b/app/Actions/Docker/RemoveServerDockerImage.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Actions\Docker;
+
+use App\Models\Server;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class RemoveServerDockerImage
+{
+    use AsAction;
+
+    public function handle(Server $server, string $imageId): string
+    {
+        if (! $server->isFunctional()) {
+            throw new \Exception('Server is not functional.');
+        }
+
+        if (blank($imageId)) {
+            throw new \Exception('Docker image ID is required.');
+        }
+
+        return instant_remote_process([
+            'docker image rm '.escapeshellarg($imageId),
+        ], $server);
+    }
+}

--- a/app/Livewire/Server/DockerImages.php
+++ b/app/Livewire/Server/DockerImages.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Livewire\Server;
+
+use App\Actions\Docker\ListServerDockerImages;
+use App\Actions\Docker\RemoveServerDockerImage;
+use App\Models\Server;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Collection;
+use Livewire\Attributes\Computed;
+use Livewire\Component;
+
+class DockerImages extends Component
+{
+    use AuthorizesRequests;
+
+    public Server $server;
+
+    public array $parameters = [];
+
+    public array $images = [];
+
+    public string $search = '';
+
+    public string $filter = 'all';
+
+    public function mount(string $server_uuid)
+    {
+        try {
+            $this->server = Server::ownedByCurrentTeam()->whereUuid($server_uuid)->firstOrFail();
+            $this->parameters = get_route_parameters();
+            $this->loadImages();
+        } catch (\Throwable) {
+            return redirect()->route('server.index');
+        }
+    }
+
+    #[Computed]
+    public function filteredImages(): Collection
+    {
+        $search = str($this->search)->lower()->trim()->value();
+
+        return collect($this->images)
+            ->when($this->filter === 'used', fn (Collection $images) => $images->where('in_use', true))
+            ->when($this->filter === 'unused', fn (Collection $images) => $images->where('in_use', false))
+            ->when($this->filter === 'dangling', fn (Collection $images) => $images->where('dangling', true))
+            ->when($search !== '', function (Collection $images) use ($search) {
+                return $images->filter(function (array $image) use ($search) {
+                    return collect([
+                        data_get($image, 'reference'),
+                        data_get($image, 'repository'),
+                        data_get($image, 'tag'),
+                        data_get($image, 'digest'),
+                        data_get($image, 'id'),
+                    ])
+                        ->filter()
+                        ->contains(fn (string $value) => str($value)->lower()->contains($search));
+                });
+            })
+            ->values();
+    }
+
+    #[Computed]
+    public function imageSummary(): array
+    {
+        $images = collect($this->images);
+
+        return [
+            'total' => $images->count(),
+            'used' => $images->where('in_use', true)->count(),
+            'unused' => $images->where('in_use', false)->count(),
+            'dangling' => $images->where('dangling', true)->count(),
+        ];
+    }
+
+    public function loadImages()
+    {
+        try {
+            $this->images = ListServerDockerImages::run($this->server)->toArray();
+            $this->dispatch('success', 'Docker images refreshed.');
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function removeImage(string $imageId)
+    {
+        try {
+            $this->authorize('update', $this->server);
+
+            $image = ListServerDockerImages::run($this->server)->firstWhere('id', $imageId);
+            if (! $image) {
+                throw new \Exception('Docker image not found. Refresh the list and try again.');
+            }
+            if (data_get($image, 'in_use')) {
+                throw new \Exception('This image is used by an existing container and cannot be removed here.');
+            }
+
+            RemoveServerDockerImage::run($this->server, $imageId);
+            $this->dispatch('success', 'Docker image removed.');
+            $this->loadImages();
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function render()
+    {
+        return view('livewire.server.docker-images');
+    }
+}

--- a/resources/views/components/server/sidebar.blade.php
+++ b/resources/views/components/server/sidebar.blade.php
@@ -31,6 +31,9 @@
         <a class="sub-menu-item {{ $activeMenu === 'docker-cleanup' ? 'menu-item-active' : '' }}" {{ wireNavigate() }}
             href="{{ route('server.docker-cleanup', ['server_uuid' => $server->uuid]) }}"><span class="menu-item-label">Docker Cleanup</span>
         </a>
+        <a class="sub-menu-item {{ $activeMenu === 'docker-images' ? 'menu-item-active' : '' }}" {{ wireNavigate() }}
+            href="{{ route('server.docker-images', ['server_uuid' => $server->uuid]) }}"><span class="menu-item-label">Docker Images</span>
+        </a>
         <a class="sub-menu-item {{ $activeMenu === 'destinations' ? 'menu-item-active' : '' }}" {{ wireNavigate() }}
             href="{{ route('server.destinations', ['server_uuid' => $server->uuid]) }}"><span class="menu-item-label">Destinations</span>
         </a>

--- a/resources/views/livewire/server/docker-images.blade.php
+++ b/resources/views/livewire/server/docker-images.blade.php
@@ -1,0 +1,125 @@
+<div>
+    <x-slot:title>
+        {{ data_get_str($server, 'name')->limit(10) }} > Docker Images | Coolify
+    </x-slot>
+    <livewire:server.navbar :server="$server" />
+    <div class="flex flex-col h-full gap-8 sm:flex-row">
+        <x-server.sidebar :server="$server" activeMenu="docker-images" />
+        <div class="w-full">
+            <div class="flex flex-col gap-2">
+                <div class="flex items-center gap-2">
+                    <h2>Docker Images</h2>
+                    <x-forms.button wire:click="loadImages">Refresh</x-forms.button>
+                </div>
+                <div>Review local Docker images on this server and remove unused images manually.</div>
+            </div>
+
+            <div class="grid gap-2 py-6 sm:grid-cols-2 xl:grid-cols-4">
+                <div class="box-without-bg">
+                    <div class="text-xs uppercase text-neutral-500">Total</div>
+                    <div class="text-2xl font-semibold">{{ $this->imageSummary['total'] }}</div>
+                </div>
+                <div class="box-without-bg">
+                    <div class="text-xs uppercase text-neutral-500">In use</div>
+                    <div class="text-2xl font-semibold">{{ $this->imageSummary['used'] }}</div>
+                </div>
+                <div class="box-without-bg">
+                    <div class="text-xs uppercase text-neutral-500">Unused</div>
+                    <div class="text-2xl font-semibold">{{ $this->imageSummary['unused'] }}</div>
+                </div>
+                <div class="box-without-bg">
+                    <div class="text-xs uppercase text-neutral-500">Dangling</div>
+                    <div class="text-2xl font-semibold">{{ $this->imageSummary['dangling'] }}</div>
+                </div>
+            </div>
+
+            <div class="flex flex-col gap-2 pb-6 xl:flex-row">
+                <x-forms.input id="search" label="Search" placeholder="Repository, tag, digest, or image ID" />
+                <x-forms.select id="filter" label="Filter">
+                    <option value="all">All images</option>
+                    <option value="used">In use</option>
+                    <option value="unused">Unused</option>
+                    <option value="dangling">Dangling</option>
+                </x-forms.select>
+            </div>
+
+            <div wire:loading wire:target="loadImages,removeImage" class="pb-4">
+                Loading Docker images...
+            </div>
+
+            @if ($this->filteredImages->count() > 0)
+                <div class="overflow-x-auto">
+                    <table class="min-w-full">
+                        <thead>
+                            <tr>
+                                <th class="px-5 py-3 text-xs font-medium text-left uppercase">Repository</th>
+                                <th class="px-5 py-3 text-xs font-medium text-left uppercase">Tag</th>
+                                <th class="px-5 py-3 text-xs font-medium text-left uppercase">Image ID</th>
+                                <th class="px-5 py-3 text-xs font-medium text-left uppercase">Created</th>
+                                <th class="px-5 py-3 text-xs font-medium text-left uppercase">Size</th>
+                                <th class="px-5 py-3 text-xs font-medium text-left uppercase">Status</th>
+                                <th class="px-5 py-3 text-xs font-medium text-left uppercase">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($this->filteredImages as $image)
+                                <tr wire:key="docker-image-{{ data_get($image, 'id') }}">
+                                    <td class="px-5 py-4 text-sm whitespace-nowrap">
+                                        {{ data_get($image, 'repository') ?? '<none>' }}
+                                        @if (data_get($image, 'digest'))
+                                            <div class="text-xs text-neutral-500">{{ data_get($image, 'digest') }}</div>
+                                        @endif
+                                    </td>
+                                    <td class="px-5 py-4 text-sm whitespace-nowrap">
+                                        {{ data_get($image, 'tag') ?? '<none>' }}
+                                    </td>
+                                    <td class="px-5 py-4 font-mono text-xs whitespace-nowrap">
+                                        {{ str(data_get($image, 'id'))->limit(24) }}
+                                    </td>
+                                    <td class="px-5 py-4 text-sm whitespace-nowrap">
+                                        {{ data_get($image, 'created_since') ?? data_get($image, 'created_at') ?? '-' }}
+                                    </td>
+                                    <td class="px-5 py-4 text-sm whitespace-nowrap">
+                                        {{ data_get($image, 'size') ?? '-' }}
+                                    </td>
+                                    <td class="px-5 py-4 text-sm whitespace-nowrap">
+                                        @if (data_get($image, 'in_use'))
+                                            <span class="text-green-500">In use</span>
+                                            @if (count(data_get($image, 'containers', [])) > 0)
+                                                <div class="text-xs text-neutral-500">
+                                                    @foreach (collect(data_get($image, 'containers', []))->take(2) as $container)
+                                                        <div>{{ data_get($container, 'name') }} ({{ data_get($container, 'state') }})</div>
+                                                    @endforeach
+                                                    @if (count(data_get($image, 'containers', [])) > 2)
+                                                        <div>+{{ count(data_get($image, 'containers', [])) - 2 }} more</div>
+                                                    @endif
+                                                </div>
+                                            @endif
+                                        @elseif (data_get($image, 'dangling'))
+                                            <span class="text-warning">Dangling</span>
+                                        @else
+                                            <span>Unused</span>
+                                        @endif
+                                    </td>
+                                    <td class="px-5 py-4 text-sm whitespace-nowrap">
+                                        @if (data_get($image, 'in_use'))
+                                            <x-forms.button disabled isError>Delete</x-forms.button>
+                                        @else
+                                            <x-forms.button isError
+                                                wire:click="removeImage('{{ data_get($image, 'id') }}')"
+                                                wire:confirm="Delete this unused Docker image from the server?">
+                                                Delete
+                                            </x-forms.button>
+                                        @endif
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            @else
+                <div>No Docker images found.</div>
+            @endif
+        </div>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -47,6 +47,7 @@ use App\Livewire\Server\CloudProviderToken\Show as CloudProviderTokenShow;
 use App\Livewire\Server\Delete as DeleteServer;
 use App\Livewire\Server\Destinations as ServerDestinations;
 use App\Livewire\Server\DockerCleanup;
+use App\Livewire\Server\DockerImages;
 use App\Livewire\Server\Index as ServerIndex;
 use App\Livewire\Server\LogDrains;
 use App\Livewire\Server\PrivateKey\Show as PrivateKeyShow;
@@ -293,6 +294,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/proxy/logs', ProxyLogs::class)->name('server.proxy.logs');
         Route::get('/terminal', ExecuteContainerCommand::class)->name('server.command')->middleware('can.access.terminal');
         Route::get('/docker-cleanup', DockerCleanup::class)->name('server.docker-cleanup');
+        Route::get('/docker-images', DockerImages::class)->name('server.docker-images');
         Route::get('/security', fn () => redirect(route('dashboard')))->name('server.security')->middleware('can.update.resource');
         Route::get('/security/patches', Patches::class)->name('server.security.patches')->middleware('can.update.resource');
         Route::get('/security/terminal-access', TerminalAccess::class)->name('server.security.terminal-access')->middleware('can.update.resource');

--- a/tests/Unit/Actions/Docker/ListServerDockerImagesTest.php
+++ b/tests/Unit/Actions/Docker/ListServerDockerImagesTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use App\Actions\Docker\ListServerDockerImages;
+
+it('normalizes docker image output and marks images used by containers', function () {
+    $images = ListServerDockerImages::normalizeImages(collect([
+        [
+            'Repository' => 'ghcr.io/coollabsio/coolify',
+            'Tag' => 'latest',
+            'Digest' => '<none>',
+            'ID' => 'sha256:abc123',
+            'CreatedSince' => '2 days ago',
+            'Size' => '1.2GB',
+        ],
+        [
+            'Repository' => 'redis',
+            'Tag' => '7-alpine',
+            'Digest' => '<none>',
+            'ID' => 'sha256:def456',
+            'CreatedSince' => '4 days ago',
+            'Size' => '42MB',
+        ],
+    ]), collect([
+        'ghcr.io/coollabsio/coolify:latest',
+    ]));
+
+    expect($images)->toHaveCount(2)
+        ->and($images->firstWhere('id', 'sha256:abc123')['in_use'])->toBeTrue()
+        ->and($images->firstWhere('id', 'sha256:def456')['in_use'])->toBeFalse();
+});
+
+it('shows which containers use an image', function () {
+    $containers = collect([
+        [
+            'ID' => 'container123',
+            'Names' => 'coolify',
+            'Image' => 'ghcr.io/coollabsio/coolify:latest',
+            'State' => 'running',
+            'Status' => 'Up 3 minutes',
+        ],
+    ]);
+
+    $images = ListServerDockerImages::normalizeImages(collect([
+        [
+            'Repository' => 'ghcr.io/coollabsio/coolify',
+            'Tag' => 'latest',
+            'ID' => 'sha256:abc123',
+        ],
+    ]), ListServerDockerImages::usedImageReferencesFromContainers($containers), $containers);
+
+    expect($images->first()['containers'])->toMatchArray([
+        [
+            'id' => 'container123',
+            'name' => 'coolify',
+            'state' => 'running',
+            'status' => 'Up 3 minutes',
+        ],
+    ]);
+});
+
+it('marks digest-referenced images as used', function () {
+    $images = ListServerDockerImages::normalizeImages(collect([
+        [
+            'Repository' => 'registry.example.com/app',
+            'Tag' => 'stable',
+            'Digest' => 'sha256:feed',
+            'ID' => 'sha256:123456',
+        ],
+    ]), collect([
+        'registry.example.com/app@sha256:feed',
+    ]));
+
+    expect($images->first()['in_use'])->toBeTrue();
+});
+
+it('treats untagged images as dangling', function () {
+    $images = ListServerDockerImages::normalizeImages(collect([
+        [
+            'Repository' => '<none>',
+            'Tag' => '<none>',
+            'ID' => 'sha256:untagged',
+            'Size' => '18MB',
+        ],
+    ]), collect());
+
+    expect($images->first())->toMatchArray([
+        'dangling' => true,
+        'reference' => null,
+    ]);
+});


### PR DESCRIPTION
/claim #2499

## Summary

Adds a focused server-level Docker Images page that covers the first image-management slice requested in #2499:

- list local Docker images for a server
- mark images that are currently referenced by containers
- show the containers using an image when that data is available
- allow deleting only images that are not currently in use
- add the server route/sidebar entry and unit coverage for image normalization

This intentionally complements the existing registry-credentials work in #7790 instead of duplicating it.

## Validation

- `php -l app/Actions/Docker/ListServerDockerImages.php app/Actions/Docker/RemoveServerDockerImage.php app/Livewire/Server/DockerImages.php tests/Unit/Actions/Docker/ListServerDockerImagesTest.php routes/web.php`
- `./vendor/bin/pest tests/Unit/Actions/Docker/ListServerDockerImagesTest.php`
- `./vendor/bin/pint --dirty --test`
