### PR TITLE
fix: add --ipv6 flag to coolify docker network creation

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -102,7 +102,7 @@ class InstallDocker
                 ]);
             } else {
                 $command = $command->merge([
-                    'docker network create --attachable coolify >/dev/null 2>&1 || true',
+                    'docker network create --attachable --ipv6 coolify >/dev/null 2>&1 || docker network create --attachable coolify >/dev/null 2>&1 || true',
                 ]);
                 $command = $command->merge([
                     "echo 'Done!'",

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -1408,7 +1408,7 @@ $schema://$host {
         if ($isSwarm) {
             return instant_remote_process(['docker network create --attachable --driver overlay coolify-overlay >/dev/null 2>&1 || true'], $this, false);
         } else {
-            return instant_remote_process(['docker network create coolify --attachable >/dev/null 2>&1 || true'], $this, false);
+            return instant_remote_process(['docker network create --attachable --ipv6 coolify >/dev/null 2>&1 || docker network create --attachable coolify >/dev/null 2>&1 || true'], $this, false);
         }
     }
 


### PR DESCRIPTION
When the coolify Docker network is created without --ipv6, IPv6 clients connect through Docker internal NAT and lose their real IP address. Traefik/Caddy then see the proxy internal IP (e.g., 172.18.0.1) as X-Forwarded-For instead of the client real IPv6 address.

This fix adds --ipv6 flag to the docker network create command for the coolify network in both InstallDocker and Server model, with a graceful fallback if IPv6 is not available on the Docker daemon.

/claim #3436