### PR TITLE
feat(service): add PayloadCMS service template

### DIFF
--- a/public/svgs/payloadcms.svg
+++ b/public/svgs/payloadcms.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128">
+  <rect width="128" height="128" rx="24" fill="#000000"/>
+  <text x="64" y="78" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle">P</text>
+  <text x="64" y="108" font-family="Arial,sans-serif" font-size="16" font-weight="bold" fill="#AAAAAA" text-anchor="middle">CMS</text>
+</svg>

--- a/templates/compose/payloadcms.yaml
+++ b/templates/compose/payloadcms.yaml
@@ -1,0 +1,33 @@
+# documentation: https://payloadcms.com/docs/production/deployment#docker
+# slogan: The open-source, Next.js, headless CMS.
+# category: cms
+# tags: cms,payload,nextjs,headless,api,payloadcms
+# logo: svgs/payloadcms.svg
+# port: 3000
+
+services:
+  payload:
+    image: payloadcms/payload:latest
+    restart: unless-stopped
+    environment:
+      - SERVICE_URL_PAYLOAD_3000
+      - PAYLOAD_SECRET=${SERVICE_PASSWORD_64_PAYLOAD}
+      - DATABASE_URI=postgres://${SERVICE_USER_POSTGRES}:${SERVICE_PASSWORD_POSTGRES}@postgres:5432/${POSTGRES_DB:-payload}
+      - PAYLOAD_PUBLIC_SERVER_URL=${SERVICE_URL_PAYLOAD}
+    depends_on:
+      postgres:
+        condition: service_healthy
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    volumes:
+      - payload-postgres-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=${SERVICE_USER_POSTGRES}
+      - POSTGRES_PASSWORD=${SERVICE_PASSWORD_POSTGRES}
+      - POSTGRES_DB=${POSTGRES_DB:-payload}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
+      interval: 2s
+      timeout: 10s
+      retries: 15

--- a/templates/service-templates-latest.json
+++ b/templates/service-templates-latest.json
@@ -3684,6 +3684,23 @@
         "minversion": "0.0.0",
         "port": "80"
     },
+    "payloadcms": {
+        "documentation": "https://payloadcms.com/docs/production/deployment#docker?utm_source=coolify.io",
+        "slogan": "The open-source, Next.js, headless CMS.",
+        "compose": "c2VydmljZXM6CiAgcGF5bG9hZDoKICAgIGltYWdlOiAncGF5bG9hZGNtcy9wYXlsb2FkOmxhdGVzdCcKICAgIHJlc3RhcnQ6IHVubGVzcy1zdG9wcGVkCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX1VSTF9QQVlMT0FEXzMwMDAKICAgICAgLSAnUEFZTE9BRF9TRUNSRVQ9JHtTRVJWSUNFX1BBU1NXT1JEXzY0X1BBWUxPQUR9JwogICAgICAtICdEQVRBQkFTRV9VUkk9cG9zdGdyZXM6Ly8ke1NFUlZJQ0VfVVNFUl9QT1NUR1JFU306JHtTRVJWSUNFX1BBU1NXT1JEX1BPU1RHUkVTfUBwb3N0Z3Jlczo1NDMyLyR7UE9TVEdSRVNfREI6LXBheWxvYWR9JwogICAgICAtICdQQVlMT0FEX1BVQkxJQ19TRVJWRVJfVVJMPSR7U0VSVklDRV9VUkxfUEFZTE9BRH0nCiAgICBkZXBlbmRzX29uOgogICAgICBwb3N0Z3JlczoKICAgICAgICBjb25kaXRpb246IHNlcnZpY2VfaGVhbHRoeQogIHBvc3RncmVzOgogICAgaW1hZ2U6ICdwb3N0Z3JlczoxNi1hbHBpbmUnCiAgICByZXN0YXJ0OiB1bmxlc3Mtc3RvcHBlZAogICAgdm9sdW1lczoKICAgICAgLSAncGF5bG9hZC1wb3N0Z3Jlcy1kYXRhOi92YXIvbGliL3Bvc3RncmVzcWwvZGF0YScKICAgIGVudmlyb25tZW50OgogICAgICAtICdQT1NUR1JFU19VU0VSPSR7U0VSVklDRV9VU0VSX1BPU1RHUkVTfScKICAgICAgLSAnUE9TVEdSRVNfUEFTU1dPUkQ9JHtTRVJWSUNFX1BBU1NXT1JEX1BPU1RHUkVTfScKICAgICAgLSAnUE9TVEdSRVNfREI9JHtQT1NUR1JFU19EQjotcGF5bG9hZH0nCiAgICBoZWFsdGhjaGVjazoKICAgICAgdGVzdDoKICAgICAgICAtIENNRC1TSEVMTAogICAgICAgIC0gJ3BnX2lzcmVhZHkgLWQgJCR7UE9TVEdSRVNfREJ9IC1VICQke1BPU1RHUkVTX1VTRVJ9JwogICAgICBpbnRlcnZhbDogMnMKICAgICAgdGltZW91dDogMTBzCiAgICAgIHJldHJpZXM6IDE1Cg==",
+        "tags": [
+            "cms",
+            "payload",
+            "nextjs",
+            "headless",
+            "api",
+            "payloadcms"
+        ],
+        "category": "cms",
+        "logo": "svgs/payloadcms.svg",
+        "minversion": "0.0.0",
+        "port": "3000"
+    },
     "paymenter": {
         "documentation": "https://paymenter.org/docs/guides/docker?utm_source=coolify.io",
         "slogan": "Open-Source Billing, Built for Hosting",

--- a/templates/service-templates.json
+++ b/templates/service-templates.json
@@ -3684,6 +3684,23 @@
         "minversion": "0.0.0",
         "port": "80"
     },
+    "payloadcms": {
+        "documentation": "https://payloadcms.com/docs/production/deployment#docker?utm_source=coolify.io",
+        "slogan": "The open-source, Next.js, headless CMS.",
+        "compose": "c2VydmljZXM6CiAgcGF5bG9hZDoKICAgIGltYWdlOiAncGF5bG9hZGNtcy9wYXlsb2FkOmxhdGVzdCcKICAgIHJlc3RhcnQ6IHVubGVzcy1zdG9wcGVkCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSBTRVJWSUNFX0ZRRE5fUEFZTE9BRF8zMDAwCiAgICAgIC0gJ1BBWUxPQURfU0VDUkVUPSR7U0VSVklDRV9QQVNTV09SRF82NF9QQVlMT0FEfScKICAgICAgLSAnREFUQUJBU0VfVVJJPXBvc3RncmVzOi8vJHtTRVJWSUNFX1VTRVJfUE9TVEdSRVN9OiR7U0VSVklDRV9QQVNTV09SRF9QT1NUR1JFU31AcG9zdGdyZXM6NTQzMi8ke1BPU1RHUkVTX0RCOi1wYXlsb2FkfScKICAgICAgLSAnUEFZTE9BRF9QVUJMSUNfU0VSVkVSX1VSTD0ke1NFUlZJQ0VfRlFETl9QQVlMT0FEfScKICAgIGRlcGVuZHNfb246CiAgICAgIHBvc3RncmVzOgogICAgICAgIGNvbmRpdGlvbjogc2VydmljZV9oZWFsdGh5CiAgcG9zdGdyZXM6CiAgICBpbWFnZTogJ3Bvc3RncmVzOjE2LWFscGluZScKICAgIHJlc3RhcnQ6IHVubGVzcy1zdG9wcGVkCiAgICB2b2x1bWVzOgogICAgICAtICdwYXlsb2FkLXBvc3RncmVzLWRhdGE6L3Zhci9saWIvcG9zdGdyZXNxbC9kYXRhJwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gJ1BPU1RHUkVTX1VTRVI9JHtTRVJWSUNFX1VTRVJfUE9TVEdSRVN9JwogICAgICAtICdQT1NUR1JFU19QQVNTV09SRD0ke1NFUlZJQ0VfUEFTU1dPUkRfUE9TVEdSRVN9JwogICAgICAtICdQT1NUR1JFU19EQj0ke1BPU1RHUkVTX0RCOi1wYXlsb2FkfScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ELVNIRUxMCiAgICAgICAgLSAncGdfaXNyZWFkeSAtZCAkJHtQT1NUR1JFU19EQn0gLVUgJCR7UE9TVEdSRVNfVVNFUn0nCiAgICAgIGludGVydmFsOiAycwogICAgICB0aW1lb3V0OiAxMHMKICAgICAgcmV0cmllczogMTUK",
+        "tags": [
+            "cms",
+            "payload",
+            "nextjs",
+            "headless",
+            "api",
+            "payloadcms"
+        ],
+        "category": "cms",
+        "logo": "svgs/payloadcms.svg",
+        "minversion": "0.0.0",
+        "port": "3000"
+    },
     "paymenter": {
         "documentation": "https://paymenter.org/docs/guides/docker?utm_source=coolify.io",
         "slogan": "Open-Source Billing, Built for Hosting",


### PR DESCRIPTION
Add one-click PayloadCMS service template with PostgreSQL.

PayloadCMS is a Next.js-based headless CMS with a customizable admin UI.

Includes:
- payload service with auto-generated secret
- PostgreSQL database with healthcheck
- persistent volume for database data
- logo and template metadata

/claim #2346