### PR TITLE
feat: add Cut (self-hosted URL shortener) one-click service

### DIFF
--- a/public/svgs/cut.svg
+++ b/public/svgs/cut.svg
@@ -1,0 +1,10 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Cut logo">
+  <rect width="64" height="64" rx="16" fill="#059669"/>
+  <g transform="translate(14 14) scale(1.5)" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="6" cy="6" r="3"/>
+    <path d="M8.12 8.12 12 12"/>
+    <path d="M20 4 8.12 15.88"/>
+    <circle cx="6" cy="18" r="3"/>
+    <path d="M14.8 14.8 20 20"/>
+  </g>
+</svg>

--- a/templates/compose/cut.yaml
+++ b/templates/compose/cut.yaml
@@ -1,0 +1,42 @@
+# documentation: https://github.com/MendyLanda/cut#-coolify
+# slogan: A tiny, self-hosted URL shortener — short links that are entirely yours.
+# category: productivity
+# tags: url-shortener,links,redis,self-hosted
+# logo: svgs/cut.svg
+# port: 3000
+
+services:
+  cut:
+    image: ghcr.io/mendylanda/cut:latest
+    environment:
+      # Coolify generates the public FQDN and routes it to port 3000. Cut reads
+      # the request host at runtime, so no base-URL variable is needed.
+      - SERVICE_FQDN_CUT_3000
+      # Coolify generates a strong admin password; view or change it in the UI.
+      - ADMIN_PASSWORD=${SERVICE_PASSWORD_ADMIN}
+      # Bundled Redis below (private to the stack, never exposed).
+      - REDIS_URL=redis://redis:6379
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:3000/"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: redis:7-alpine
+    # appendonly = durable across restarts; noeviction because this is Cut's
+    # primary datastore, not a cache (don't drop links under memory pressure).
+    command: redis-server --appendonly yes --maxmemory-policy noeviction
+    volumes:
+      - cut-redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+volumes:
+  cut-redis-data:


### PR DESCRIPTION
## Changes

Adds a one-click service template for Cut, a small self-hosted URL shortener (owner-only admin, per-link passwords, expiries, click limits).

The template runs the published image `ghcr.io/mendylanda/cut` next to a private Redis that stores the links and click counts. Redis uses `--maxmemory-policy noeviction` because it's the datastore here, not a cache, so it shouldn't drop keys under memory pressure. The admin password comes from `SERVICE_PASSWORD_ADMIN`, and `SERVICE_FQDN_CUT_3000` routes the domain to port 3000. Cut reads the request host at runtime, so there's no base URL to set.

Files added:
- `templates/compose/cut.yaml`
- `public/svgs/cut.svg`

## Issues

- Fixes #10477

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

I verified the stack directly with Docker Compose (see Testing). I don't have a live Coolify instance on hand to capture a UI screenshot, so I'm leaving this as a draft until a Coolify-instance deploy + screenshot can be added. Happy to finish that off.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude (via Claude Code)
- How extensively: helped draft the compose template and this description. I reviewed and tested everything before submitting and can explain what each line does and why.

## Testing

Ran the same two-container stack locally (the app image + `redis:7-alpine` with `noeviction`):

- `docker build` of the image succeeds; the container boots and serves `/` and `/admin` (both HTTP 200).
- `GET /api/keepalive` does a real write, and the key then shows up in Redis (`redis-cli KEYS '*'`).
- Confirmed the app picks its Redis-over-TCP backend when `REDIS_URL` is set.

- Deployed screenshot:
<img width="1727" height="1078" alt="SCR-20260531-sjap" src="https://github.com/user-attachments/assets/ecdcaccb-bf91-4327-8130-692d74b084a7" />

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the contributor guidelines.
> - [x] I have searched existing issues and pull requests (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify.