### PR TITLE
fix(cleanup): preserve self-hosted server IPs

### DIFF
--- a/app/Console/Commands/CleanupUnreachableServers.php
+++ b/app/Console/Commands/CleanupUnreachableServers.php
@@ -18,9 +18,13 @@ class CleanupUnreachableServers extends Command
         if ($servers->count() > 0) {
             foreach ($servers as $server) {
                 echo "Cleanup unreachable server ($server->id) with name $server->name";
-                $server->update([
-                    'ip' => '1.2.3.4',
-                ]);
+                if (isCloud()) {
+                    $server->update([
+                        'ip' => '1.2.3.4',
+                    ]);
+                } else {
+                    $server->forceDisableServer();
+                }
             }
         }
     }

--- a/tests/Feature/CleanupUnreachableServersTest.php
+++ b/tests/Feature/CleanupUnreachableServersTest.php
@@ -6,7 +6,30 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 
 uses(RefreshDatabase::class);
 
-it('cleans up servers with unreachable_count >= 3 after 7 days', function () {
+it('disables (non-destructively) self-hosted servers with unreachable_count >= 3 after 7 days', function () {
+    config(['constants.coolify.self_hosted' => true]);
+
+    $team = Team::factory()->create();
+    $server = Server::factory()->create([
+        'team_id' => $team->id,
+        'unreachable_count' => 50,
+        'unreachable_notification_sent' => true,
+        'updated_at' => now()->subDays(8),
+    ]);
+
+    $originalIp = (string) $server->ip;
+
+    $this->artisan('cleanup:unreachable-servers')->assertSuccessful();
+
+    $server->refresh();
+    // IP must be preserved — never overwritten on self-hosted.
+    expect($server->ip)->toBe($originalIp);
+    expect($server->settings->force_disabled)->toBeTrue();
+});
+
+it('overwrites the IP with 1.2.3.4 on cloud for servers with unreachable_count >= 3 after 7 days', function () {
+    config(['constants.coolify.self_hosted' => false]);
+
     $team = Team::factory()->create();
     $server = Server::factory()->create([
         'team_id' => $team->id,
@@ -36,6 +59,7 @@ it('does not clean up servers with unreachable_count less than 3', function () {
 
     $server->refresh();
     expect($server->ip)->toBe($originalIp);
+    expect($server->settings->force_disabled)->toBeFalse();
 });
 
 it('does not clean up servers updated within 7 days', function () {
@@ -53,6 +77,7 @@ it('does not clean up servers updated within 7 days', function () {
 
     $server->refresh();
     expect($server->ip)->toBe($originalIp);
+    expect($server->settings->force_disabled)->toBeFalse();
 });
 
 it('does not clean up servers without notification sent', function () {
@@ -70,4 +95,5 @@ it('does not clean up servers without notification sent', function () {
 
     $server->refresh();
     expect($server->ip)->toBe($originalIp);
+    expect($server->settings->force_disabled)->toBeFalse();
 });


### PR DESCRIPTION
## Summary
- Prevents self-hosted unreachable server cleanup from overwriting server IPs with `1.2.3.4`.
- Disables stale unreachable self-hosted servers instead, preserving their configured address for recovery.
- Keeps the existing cloud cleanup behavior and expands test coverage for both cloud and self-hosted paths.

Related: #10471

---

Fixes #10471