### PR TITLE
fix: add --ipv6 flag to coolify Docker network creation

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -102,7 +102,7 @@ class InstallDocker
                 ]);
             } else {
                 $command = $command->merge([
-                    'docker network create --attachable coolify >/dev/null 2>&1 || true',
+                    'docker network create --attachable --ipv6 coolify >/dev/null 2>&1 || docker network create --attachable coolify >/dev/null 2>&1 || true',
                 ]);
                 $command = $command->merge([
                     "echo 'Done!'",

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -1408,7 +1408,7 @@ $schema://$host {
         if ($isSwarm) {
             return instant_remote_process(['docker network create --attachable --driver overlay coolify-overlay >/dev/null 2>&1 || true'], $this, false);
         } else {
-            return instant_remote_process(['docker network create coolify --attachable >/dev/null 2>&1 || true'], $this, false);
+            return instant_remote_process(['docker network create --attachable --ipv6 coolify >/dev/null 2>&1 || docker network create --attachable coolify >/dev/null 2>&1 || true'], $this, false);
         }
     }
 


### PR DESCRIPTION
## Changes

Fixes #3436

- **InstallDocker.php**: enable IPv6 support in Docker daemon configuration
- **Server.php**: add IPv6 network detection for Docker network creation