### PR TITLE
fix: add --ipv6 flag to coolify Docker network creation

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -102,7 +102,7 @@ class InstallDocker
                 ]);
             } else {
                 $command = $command->merge([
-                    'docker network create --attachable coolify >/dev/null 2>&1 || true',
+                    'docker network create --attachable --ipv6 coolify >/dev/null 2>&1 || docker network create --attachable coolify >/dev/null 2>&1 || true',
                 ]);
                 $command = $command->merge([
                     "echo 'Done!'",

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -1408,7 +1408,7 @@ $schema://$host {
         if ($isSwarm) {
             return instant_remote_process(['docker network create --attachable --driver overlay coolify-overlay >/dev/null 2>&1 || true'], $this, false);
         } else {
-            return instant_remote_process(['docker network create coolify --attachable >/dev/null 2>&1 || true'], $this, false);
+            return instant_remote_process(['docker network create --attachable --ipv6 coolify >/dev/null 2>&1 || docker network create --attachable coolify >/dev/null 2>&1 || true'], $this, false);
         }
     }
 


### PR DESCRIPTION
## Changes
- Add --ipv6 flag to Docker network creation in InstallDocker.php and Server.php
- Falls back to IPv4-only network creation if IPv6 is not supported on the host

## Issues
- Fixes #3436

## Category
- [ ] Feature  
- [x] Fix / Improvement

## Preview
N/A

## AI Assistance  
- [x] AI was used

## Testing
- [x] Verified template/service YAML is valid
- [x] Read relevant Coolify documentation

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/next/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.