### PR TITLE
Fix log panel DOM scoping

### DIFF
--- a/resources/views/livewire/project/shared/get-logs.blade.php
+++ b/resources/views/livewire/project/shared/get-logs.blade.php
@@ -60,8 +60,14 @@
                 this.disableFollow();
             }
         },
+        getLogsElement() {
+            return this.$root.querySelector('#logs');
+        },
+        getLogsContainerElement() {
+            return this.$root.querySelector('#logsContainer');
+        },
         scrollToBottom() {
-            const logsContainer = document.getElementById('logsContainer');
+            const logsContainer = this.getLogsContainerElement();
             if (logsContainer) {
                 this.isScrolling = true;
                 logsContainer.scrollTop = logsContainer.scrollHeight;
@@ -117,7 +123,7 @@
             this.applyColorLogs();
         },
         applyColorLogs() {
-            const logs = document.getElementById('logs');
+            const logs = this.getLogsElement();
             if (!logs) return;
             const lines = logs.querySelectorAll('[data-log-line]');
             lines.forEach(line => {
@@ -134,7 +140,7 @@
             if (!selection || selection.isCollapsed || !selection.toString().trim()) {
                 return false;
             }
-            const logsContainer = document.getElementById('logs');
+            const logsContainer = this.getLogsElement();
             if (!logsContainer) return false;
             const range = selection.getRangeAt(0);
             return logsContainer.contains(range.commonAncestorContainer);
@@ -144,7 +150,7 @@
             return doc.documentElement.textContent;
         },
         applySearch() {
-            const logs = document.getElementById('logs');
+            const logs = this.getLogsElement();
             if (!logs) return;
             const lines = logs.querySelectorAll('[data-log-line]');
             const query = this.searchQuery.trim().toLowerCase();
@@ -200,7 +206,7 @@
             }
         },
         downloadLogs() {
-            const logs = document.getElementById('logs');
+            const logs = this.getLogsElement();
             if (!logs) return;
             const visibleLines = logs.querySelectorAll('[data-log-line]:not(.hidden)');
             let content = '';
@@ -243,14 +249,14 @@
 
             // Apply colors after Livewire updates (existing content)
             Livewire.hook('morph.updated', ({ el }) => {
-                if (el.id === 'logs') {
+                if (el.id === 'logs' && this.$root.contains(el)) {
                     applyAfterUpdate();
                 }
             });
 
             // Apply colors after Livewire adds new content (initial load)
             Livewire.hook('morph.added', ({ el }) => {
-                if (el.id === 'logs') {
+                if (el.id === 'logs' && this.$root.contains(el)) {
                     applyAfterUpdate();
                 }
             });


### PR DESCRIPTION
## Summary

- Scope log viewer DOM lookups to the current Alpine component root.
- Keep log coloring, filtering, selection detection, download, and follow-scroll behavior isolated per log panel.
- Scope Livewire morph hooks so updates only reprocess the log panel that owns the changed element.

## Why

Multiple log panels can render on the same page with repeated `logs` and `logsContainer` IDs. The previous global `document.getElementById(...)` lookups only targeted the first matching panel, so color/search/download/follow-scroll behavior could operate on the wrong container.

Fixes #10207.

## Testing

- Verified the touched component no longer uses global `document.getElementById('logs')` or `document.getElementById('logsContainer')`.
- Ran `git diff --check`.

I could not run the PHP/Laravel test suite in this environment because `php` is not installed.