### PR TITLE
fix(deploy): persist Railpack Buildx metadata

### DIFF
--- a/app/Actions/Server/CleanupDocker.php
+++ b/app/Actions/Server/CleanupDocker.php
@@ -51,7 +51,7 @@ class CleanupDocker
             'docker container prune -f --filter "label=coolify.managed=true" --filter "label!=coolify.proxy=true" --filter "label!=coolify.type=database" --filter "label!=coolify.type=application" --filter "label!=coolify.type=service"',
             $imagePruneCmd,
             'docker builder prune -af',
-            'BUILDX_CONFIG=$HOME/.docker/buildx docker buildx prune --builder coolify-railpack -af 2>/dev/null || true',
+            "docker run --rm -v $HOME/.docker/buildx:/root/.docker/buildx -v /var/run/docker.sock:/var/run/docker.sock {$helperImageWithVersion} docker buildx prune --builder coolify-railpack -af 2>/dev/null || true",
             "docker images --filter before=$helperImageWithVersion --filter reference=$helperImage | grep $helperImage | awk '{print $3}' | xargs -r docker rmi -f",
             "docker images --filter before=$realtimeImageWithVersion --filter reference=$realtimeImage | grep $realtimeImage | awk '{print $3}' | xargs -r docker rmi -f",
             "docker images --filter before=$helperImageWithoutPrefixVersion --filter reference=$helperImageWithoutPrefix | grep $helperImageWithoutPrefix | awk '{print $3}' | xargs -r docker rmi -f",

--- a/app/Actions/Server/CleanupDocker.php
+++ b/app/Actions/Server/CleanupDocker.php
@@ -51,7 +51,7 @@ class CleanupDocker
             'docker container prune -f --filter "label=coolify.managed=true" --filter "label!=coolify.proxy=true" --filter "label!=coolify.type=database" --filter "label!=coolify.type=application" --filter "label!=coolify.type=service"',
             $imagePruneCmd,
             'docker builder prune -af',
-            'docker buildx prune --builder coolify-railpack -af 2>/dev/null || true',
+            'BUILDX_CONFIG=$HOME/.docker/buildx docker buildx prune --builder coolify-railpack -af 2>/dev/null || true',
             "docker images --filter before=$helperImageWithVersion --filter reference=$helperImage | grep $helperImage | awk '{print $3}' | xargs -r docker rmi -f",
             "docker images --filter before=$realtimeImageWithVersion --filter reference=$realtimeImage | grep $realtimeImage | awk '{print $3}' | xargs -r docker rmi -f",
             "docker images --filter before=$helperImageWithoutPrefixVersion --filter reference=$helperImageWithoutPrefix | grep $helperImageWithoutPrefix | awk '{print $3}' | xargs -r docker rmi -f",

--- a/app/Actions/Server/CleanupDocker.php
+++ b/app/Actions/Server/CleanupDocker.php
@@ -51,7 +51,7 @@ class CleanupDocker
             'docker container prune -f --filter "label=coolify.managed=true" --filter "label!=coolify.proxy=true" --filter "label!=coolify.type=database" --filter "label!=coolify.type=application" --filter "label!=coolify.type=service"',
             $imagePruneCmd,
             'docker builder prune -af',
-            "docker run --rm -v $HOME/.docker/buildx:/root/.docker/buildx -v /var/run/docker.sock:/var/run/docker.sock {$helperImageWithVersion} docker buildx prune --builder coolify-railpack -af 2>/dev/null || true",
+            "docker run --rm -v \$HOME/.docker/buildx:/root/.docker/buildx -v /var/run/docker.sock:/var/run/docker.sock {$helperImageWithVersion} docker buildx prune --builder coolify-railpack -af 2>/dev/null || true",
             "docker images --filter before=$helperImageWithVersion --filter reference=$helperImage | grep $helperImage | awk '{print $3}' | xargs -r docker rmi -f",
             "docker images --filter before=$realtimeImageWithVersion --filter reference=$realtimeImage | grep $realtimeImage | awk '{print $3}' | xargs -r docker rmi -f",
             "docker images --filter before=$helperImageWithoutPrefixVersion --filter reference=$helperImageWithoutPrefix | grep $helperImageWithoutPrefix | awk '{print $3}' | xargs -r docker rmi -f",

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -2129,21 +2129,23 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         $helperImage = "{$helperImage}:".getHelperVersion();
         // Get user home directory
         $this->serverUserHomeDir = instant_remote_process(['echo $HOME'], $this->server);
+        instant_remote_process(["mkdir -p {$this->serverUserHomeDir}/.docker/buildx"], $this->server);
         $this->dockerConfigFileExists = instant_remote_process(["test -f {$this->serverUserHomeDir}/.docker/config.json && echo 'OK' || echo 'NOK'"], $this->server);
 
         $env_flags = $this->generate_docker_env_flags_for_secrets();
+        $buildxMetadataVolume = "-v {$this->serverUserHomeDir}/.docker/buildx:/root/.docker/buildx";
         if ($this->use_build_server) {
             if ($this->dockerConfigFileExists === 'NOK') {
                 throw new DeploymentException('Docker config file (~/.docker/config.json) not found on the build server. Please run "docker login" to login to the docker registry on the server.');
             }
-            $runCommand = "docker run -d --name {$this->deployment_uuid} {$env_flags} --rm -v {$this->serverUserHomeDir}/.docker/config.json:/root/.docker/config.json:ro -v /var/run/docker.sock:/var/run/docker.sock {$helperImage}";
+            $runCommand = "docker run -d --name {$this->deployment_uuid} {$env_flags} --rm -v {$this->serverUserHomeDir}/.docker/config.json:/root/.docker/config.json:ro {$buildxMetadataVolume} -v /var/run/docker.sock:/var/run/docker.sock {$helperImage}";
         } else {
             if ($this->dockerConfigFileExists === 'OK') {
                 $safeNetwork = escapeshellarg($this->destination->network);
-                $runCommand = "docker run -d --network {$safeNetwork} --name {$this->deployment_uuid} {$env_flags} --rm -v {$this->serverUserHomeDir}/.docker/config.json:/root/.docker/config.json:ro -v /var/run/docker.sock:/var/run/docker.sock {$helperImage}";
+                $runCommand = "docker run -d --network {$safeNetwork} --name {$this->deployment_uuid} {$env_flags} --rm -v {$this->serverUserHomeDir}/.docker/config.json:/root/.docker/config.json:ro {$buildxMetadataVolume} -v /var/run/docker.sock:/var/run/docker.sock {$helperImage}";
             } else {
                 $safeNetwork = escapeshellarg($this->destination->network);
-                $runCommand = "docker run -d --network {$safeNetwork} --name {$this->deployment_uuid} {$env_flags} --rm -v /var/run/docker.sock:/var/run/docker.sock {$helperImage}";
+                $runCommand = "docker run -d --network {$safeNetwork} --name {$this->deployment_uuid} {$env_flags} --rm {$buildxMetadataVolume} -v /var/run/docker.sock:/var/run/docker.sock {$helperImage}";
             }
         }
         if ($firstTry) {

--- a/tests/Unit/Actions/Server/CleanupDockerTest.php
+++ b/tests/Unit/Actions/Server/CleanupDockerTest.php
@@ -451,7 +451,8 @@ it('uses persisted buildx metadata when pruning the railpack builder', function 
     $sourceFile = file_get_contents(__DIR__.'/../../../../app/Actions/Server/CleanupDocker.php');
 
     expect($sourceFile)
-        ->toContain('BUILDX_CONFIG=$HOME/.docker/buildx docker buildx prune --builder coolify-railpack -af')
+        ->toContain('docker run --rm -v $HOME/.docker/buildx:/root/.docker/buildx')
+        ->toContain('docker buildx prune --builder coolify-railpack -af')
         ->not->toContain('--buildkitd-flags');
 });
 

--- a/tests/Unit/Actions/Server/CleanupDockerTest.php
+++ b/tests/Unit/Actions/Server/CleanupDockerTest.php
@@ -447,6 +447,14 @@ it('container prune excludes persistent resource types', function () {
     expect($sourceFile)->toContain('label=coolify.managed=true');
 });
 
+it('uses persisted buildx metadata when pruning the railpack builder', function () {
+    $sourceFile = file_get_contents(__DIR__.'/../../../../app/Actions/Server/CleanupDocker.php');
+
+    expect($sourceFile)
+        ->toContain('BUILDX_CONFIG=$HOME/.docker/buildx docker buildx prune --builder coolify-railpack -af')
+        ->not->toContain('--buildkitd-flags');
+});
+
 it('preserves build image for currently running tag', function () {
     $images = collect([
         ['repository' => 'app-uuid', 'tag' => 'commit1', 'created_at' => '2024-01-01 10:00:00', 'image_ref' => 'app-uuid:commit1'],

--- a/tests/Unit/Actions/Server/CleanupDockerTest.php
+++ b/tests/Unit/Actions/Server/CleanupDockerTest.php
@@ -451,7 +451,7 @@ it('uses persisted buildx metadata when pruning the railpack builder', function 
     $sourceFile = file_get_contents(__DIR__.'/../../../../app/Actions/Server/CleanupDocker.php');
 
     expect($sourceFile)
-        ->toContain('docker run --rm -v $HOME/.docker/buildx:/root/.docker/buildx')
+        ->toContain('docker run --rm -v \\$HOME/.docker/buildx:/root/.docker/buildx')
         ->toContain('docker buildx prune --builder coolify-railpack -af')
         ->not->toContain('--buildkitd-flags');
 });

--- a/tests/Unit/ApplicationDeploymentRailpackBuildxMetadataTest.php
+++ b/tests/Unit/ApplicationDeploymentRailpackBuildxMetadataTest.php
@@ -1,0 +1,11 @@
+<?php
+
+it('persists buildx metadata between the helper container and host cleanup', function () {
+    $sourceFile = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
+
+    expect($sourceFile)
+        ->toContain('mkdir -p {$this->serverUserHomeDir}/.docker/buildx')
+        ->toContain('-v {$this->serverUserHomeDir}/.docker/buildx:/root/.docker/buildx');
+
+    expect(substr_count($sourceFile, '{$buildxMetadataVolume} -v /var/run/docker.sock:/var/run/docker.sock'))->toBe(3);
+});


### PR DESCRIPTION
## Summary
- Persist Railpack Buildx metadata on the host so the `coolify-railpack` builder remains discoverable across helper container runs.
- Use the persisted Buildx config during Docker cleanup so Railpack builder cache pruning can reclaim BuildKit storage.
- Add tests covering the persisted metadata mount and Railpack cleanup prune command.

fixes #10507

---

Fixes #10507