### PR TITLE
fix(templates): authentik_worker chowns mounted folders to UID 1000 allowing authentik service to read/boot

### DIFF
--- a/templates/compose/authentik.yaml
+++ b/templates/compose/authentik.yaml
@@ -35,7 +35,8 @@ services:
   authentik-worker:
     image: ghcr.io/goauthentik/server:${AUTHENTIK_TAG:-2025.10.3}
     restart: unless-stopped
-    command: worker
+    entrypoint: ["/bin/bash", "-c"]
+    command: ["chown -R 1000:1000 /media /certs /templates && exec dumb-init -- ak worker"]
     environment:
       - AUTHENTIK_POSTGRESQL__HOST=${POSTGRES_HOST:-postgresql}
       - AUTHENTIK_POSTGRESQL__USER=${SERVICE_USER_POSTGRESQL}


### PR DESCRIPTION
## Changes
**Adds**: **entrypoint** & **command** to the authentik-worker service (in authentik service compose file) which chowns (to 1000:1000):
- /media
- /certs
- /templates

Does this before executing 'dumb-init -- ak worker' 

**Why needed**: Coolify provisions/attaches templates (and media & certs) folders as 9999:0 which authentik attempts to run as UID 1000 which results in the server throwing 'PermissionError: [Errno 13] Permission denied: /templates/if/error.html'... This renders a HTTP 500 server error when attempting to visit service URL of the service. As such, authentik_worker should but doesnt own these folders..

## Issues
- Fixes #10512

## Category
- [x] Fixing or updating existing one click service

## Preview
**Before**: visiting service URL returns HTTP 500 (shows server error) and docker logs show of server and worker services show PermissionError (Error 13)
**After**: templates (and other folders) is now owned by 1000:1000... the service loads normally, the error is gone, and ownership persists across redeploys

## AI Assistance
- [x] AI was NOT used to create this PR
- [ ] AI was used (please describe below)

**If AI was used:**
- Tools used: 
- How extensively: 

## Testing
- Reproduced on a live authentik deployment.. stock template gave HTTP 500 with PermissionError shared above...  templates (and other folders) verified as showing it is owned by 9999
- After change verified to show ownership by 1000 and confirmed to persist through re-deployment

## Contributor Agreement
> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.