### PR TITLE
Support --dns in custom Docker options

### DIFF
--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -1000,6 +1000,7 @@ function convertDockerRunToCompose(?string $custom_docker_run_options = null)
         '--ulimit',
         '--device',
         '--shm-size',
+        '--dns',
     ]);
     $mapping = collect([
         '--cap-add' => 'cap_add',
@@ -1013,6 +1014,7 @@ function convertDockerRunToCompose(?string $custom_docker_run_options = null)
         '--ip' => 'ip',
         '--ip6' => 'ip6',
         '--shm-size' => 'shm_size',
+        '--dns' => 'dns',
         '--gpus' => 'gpus',
         '--hostname' => 'hostname',
         '--entrypoint' => 'entrypoint',

--- a/tests/Feature/CommandInjectionSecurityTest.php
+++ b/tests/Feature/CommandInjectionSecurityTest.php
@@ -636,6 +636,7 @@ describe('custom_docker_run_options validation', function () {
         '--entrypoint "sh -c \'npm start\'"',
         '--entrypoint "sh -c \'php artisan schedule:work\'"',
         '--hostname "my-host"',
+        '--dns 10.0.0.10 --dns=1.1.1.1',
     ]);
 });
 

--- a/tests/Feature/DockerCustomCommandsTest.php
+++ b/tests/Feature/DockerCustomCommandsTest.php
@@ -46,6 +46,24 @@ test('ConvertIp', function () {
     ]);
 });
 
+test('ConvertDns', function () {
+    $input = '--dns 10.0.0.10 --dns=1.1.1.1';
+    $output = convertDockerRunToCompose($input);
+    expect($output)->toBe([
+        'dns' => ['10.0.0.10', '1.1.1.1'],
+    ]);
+});
+
+test('ConvertDnsWithOtherOptions', function () {
+    $input = '--cap-add=NET_ADMIN --dns 10.0.0.10 --init';
+    $output = convertDockerRunToCompose($input);
+    expect($output)->toBe([
+        'cap_add' => ['NET_ADMIN'],
+        'dns' => ['10.0.0.10'],
+        'init' => true,
+    ]);
+});
+
 test('ConvertPrivilegedAndInit', function () {
     $input = '---privileged --init';
     $output = convertDockerRunToCompose($input);


### PR DESCRIPTION
## Summary
- map custom Docker option `--dns` to Docker Compose `dns`
- support repeated `--dns` values with both space and equals syntax
- add conversion and validation coverage

## Tests
- `php vendor/bin/pest tests/Feature/DockerCustomCommandsTest.php --filter=ConvertDns`
- `php vendor/bin/pest tests/Feature/DockerCustomCommandsTest.php tests/Feature/CommandInjectionSecurityTest.php --filter="ConvertDns|custom_docker_run_options"`

Ran the tests in a `php:8.4-cli` container with `pdo_pgsql`, `sockets`, and `pcntl` extensions installed.