### PR TITLE
feat: support --dns custom Docker option

### DIFF
--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -1000,6 +1000,7 @@ function convertDockerRunToCompose(?string $custom_docker_run_options = null)
         '--ulimit',
         '--device',
         '--shm-size',
+        '--dns',
     ]);
     $mapping = collect([
         '--cap-add' => 'cap_add',
@@ -1013,6 +1014,7 @@ function convertDockerRunToCompose(?string $custom_docker_run_options = null)
         '--ip' => 'ip',
         '--ip6' => 'ip6',
         '--shm-size' => 'shm_size',
+        '--dns' => 'dns',
         '--gpus' => 'gpus',
         '--hostname' => 'hostname',
         '--entrypoint' => 'entrypoint',

--- a/tests/Feature/CommandInjectionSecurityTest.php
+++ b/tests/Feature/CommandInjectionSecurityTest.php
@@ -733,6 +733,7 @@ describe('custom_docker_run_options validation', function () {
         '--entrypoint "sh -c \'npm start\'"',
         '--entrypoint "sh -c \'php artisan schedule:work\'"',
         '--hostname "my-host"',
+        '--dns 10.0.0.10 --dns=1.1.1.1',
     ]);
 });
 

--- a/tests/Feature/DockerCustomCommandsTest.php
+++ b/tests/Feature/DockerCustomCommandsTest.php
@@ -46,6 +46,24 @@ test('ConvertIp', function () {
     ]);
 });
 
+test('ConvertDns', function () {
+    $input = '--dns 10.0.0.10 --dns=1.1.1.1';
+    $output = convertDockerRunToCompose($input);
+    expect($output)->toBe([
+        'dns' => ['10.0.0.10', '1.1.1.1'],
+    ]);
+});
+
+test('ConvertDnsWithOtherOptions', function () {
+    $input = '--cap-add=NET_ADMIN --dns 10.0.0.10 --init';
+    $output = convertDockerRunToCompose($input);
+    expect($output)->toBe([
+        'cap_add' => ['NET_ADMIN'],
+        'dns' => ['10.0.0.10'],
+        'init' => true,
+    ]);
+});
+
 test('ConvertPrivilegedAndInit', function () {
     $input = '---privileged --init';
     $output = convertDockerRunToCompose($input);


### PR DESCRIPTION
## Changes

- Add support for `--dns` in custom Docker options by mapping it to Docker Compose `dns`.
- Support repeated DNS servers with both `--dns value` and `--dns=value` syntax.
- Add conversion and validation coverage for the new option.

## Issues

- Replaces closed PR #10514, which targeted the wrong branch and missed the current PR template.

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No UI changes. This affects generated Docker Compose output for Docker Image app deployments using custom Docker options.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenCode
- How extensively: Used to inspect the option conversion path, make the small code/test change, and run focused tests. Human reviewed the change before submission.

## Testing

- `php vendor/bin/pest tests/Feature/DockerCustomCommandsTest.php --filter=ConvertDns`
- `php vendor/bin/pest tests/Feature/DockerCustomCommandsTest.php tests/Feature/CommandInjectionSecurityTest.php --filter="ConvertDns|custom_docker_run_options"`

The focused tests were run in a `php:8.4-cli` container with `pdo_pgsql`, `sockets`, and `pcntl` installed.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.