### PR TITLE
feat: add WordPress OpenLiteSpeed service template

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -1,0 +1,71 @@
+# documentation: https://openlitespeed.org
+# slogan: Run WordPress with the high-performance OpenLiteSpeed web server and MariaDB.
+# category: cms
+# tags: cms,blog,content,management,wordpress,openlitespeed,mariadb
+# logo: svgs/wordpress.svg
+# port: 80
+
+services:
+  openlitespeed:
+    image: litespeedtech/openlitespeed:1.8.5-lsphp85
+    volumes:
+      - wordpress-files:/var/www/vhosts/localhost/html
+      - openlitespeed-conf:/usr/local/lsws/conf
+      - openlitespeed-admin-conf:/usr/local/lsws/admin/conf
+      - openlitespeed-logs:/usr/local/lsws/logs
+    environment:
+      - SERVICE_URL_OPENLITESPEED_80
+      - TZ=${TZ:-UTC}
+    depends_on:
+      wordpress-init:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+
+  wordpress-init:
+    exclude_from_hc: true
+    image: wordpress:cli-php8.3
+    user: "33:33"
+    volumes:
+      - wordpress-files:/var/www/html
+    environment:
+      - WORDPRESS_DB_HOST=mariadb
+      - WORDPRESS_DB_USER=$SERVICE_USER_WORDPRESS
+      - WORDPRESS_DB_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+      - WORDPRESS_DB_NAME=wordpress
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    command:
+      - sh
+      - -c
+      - |
+        if [ ! -f wp-includes/version.php ]; then
+          wp core download
+        fi
+        if [ ! -f wp-config.php ]; then
+          wp config create \
+            --dbname="$WORDPRESS_DB_NAME" \
+            --dbuser="$WORDPRESS_DB_USER" \
+            --dbpass="$WORDPRESS_DB_PASSWORD" \
+            --dbhost="$WORDPRESS_DB_HOST" \
+            --skip-check
+        fi
+
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
## Changes
- Adds a WordPress + OpenLiteSpeed one-click service template backed by MariaDB.
- Uses an OpenLiteSpeed service for HTTP traffic and a one-shot WordPress CLI init service to populate the shared WordPress files volume and create wp-config.php.
- Persists WordPress files, OpenLiteSpeed config/logs, and MariaDB data in named volumes.

## Issues
- Fixes #8264

## Category
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview
Not attached. I could not run a full Coolify development instance in this environment because Docker/Spin/PHP/Composer are unavailable here.

## AI Assistance
- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**
- Tools used: OpenAI Codex
- How extensively: Used to inspect existing service template patterns, draft the compose template, and validate the YAML structure. I reviewed the final diff before submitting.

## Testing
- Parsed the new compose template with Ruby YAML loader:
  `ruby -e "require 'yaml'; YAML.load_file('templates/compose/wordpress-with-openlitespeed.yaml'); puts 'YAML parsed'"`
- Ran staged diff whitespace validation:
  `git diff --cached --check`
- I was not able to run `php artisan generate:services` or a full local Coolify instance because this machine does not have PHP/Composer/Docker/Spin installed.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/next/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
