### PR TITLE
fix: silence git setup commands in loadComposeFile to prevent compose corruption

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -1886,7 +1886,7 @@ class Application extends BaseModel
 
                 return $paths;
             })->flatten()->unique()->values();
-            $commands = collect([
+            $setupCommands = collect([
                 "rm -rf /tmp/{$uuid}",
                 "mkdir -p /tmp/{$uuid}",
                 "cd /tmp/{$uuid}",
@@ -1894,10 +1894,14 @@ class Application extends BaseModel
                 'git sparse-checkout init',
                 "git sparse-checkout set {$fileList->implode(' ')}",
                 'git read-tree -mu HEAD',
+            ]);
+            $commands = collect([
+                "({$setupCommands->implode(' && ')}) > /dev/null",
+                "cd /tmp/{$uuid}",
                 "cat .$workdir$composeFile",
             ]);
         } else {
-            $commands = collect([
+            $setupCommands = collect([
                 "rm -rf /tmp/{$uuid}",
                 "mkdir -p /tmp/{$uuid}",
                 "cd /tmp/{$uuid}",
@@ -1905,6 +1909,10 @@ class Application extends BaseModel
                 'git sparse-checkout init --cone',
                 "git sparse-checkout set {$fileList->implode(' ')}",
                 'git read-tree -mu HEAD',
+            ]);
+            $commands = collect([
+                "({$setupCommands->implode(' && ')}) > /dev/null",
+                "cd /tmp/{$uuid}",
                 "cat .$workdir$composeFile",
             ]);
         }


### PR DESCRIPTION
### Description
When loading a Docker Compose file from Git, the Git setup commands (`git clone`, `git sparse-checkout`, `git read-tree`) run sequentially and their combined standard output is captured by `instant_remote_process`.
If any of these commands print messages to standard output, it pollutes the YAML content saved to the database. This leads to silent parsing errors, saving an empty compose structure (`services: {}`) and causing deployments to fail with `no service selected`.

### Solution
Group the Git setup commands inside a subshell `(...)` and redirect their stdout to `/dev/null`. This ensures only the output of the final `cat` command is captured, preventing any pollution of the compose file contents.

/claim #5251
