### PR TITLE
Add Vultr cloud provider integration

### DIFF
--- a/app/Actions/Server/DeleteServer.php
+++ b/app/Actions/Server/DeleteServer.php
@@ -7,13 +7,14 @@ use App\Models\Server;
 use App\Models\Team;
 use App\Notifications\Server\HetznerDeletionFailed;
 use App\Services\HetznerService;
+use App\Services\VultrService;
 use Lorisleiva\Actions\Concerns\AsAction;
 
 class DeleteServer
 {
     use AsAction;
 
-    public function handle(int $serverId, bool $deleteFromHetzner = false, ?int $hetznerServerId = null, ?int $cloudProviderTokenId = null, ?int $teamId = null)
+    public function handle(int $serverId, bool $deleteFromHetzner = false, ?int $hetznerServerId = null, ?int $cloudProviderTokenId = null, ?int $teamId = null, bool $deleteFromVultr = false, ?string $vultrInstanceId = null)
     {
         $server = Server::withTrashed()->find($serverId);
 
@@ -21,6 +22,14 @@ class DeleteServer
         if ($deleteFromHetzner && ($hetznerServerId || ($server && $server->hetzner_server_id))) {
             $this->deleteFromHetznerById(
                 $hetznerServerId ?? $server->hetzner_server_id,
+                $cloudProviderTokenId ?? $server->cloud_provider_token_id,
+                $teamId ?? $server->team_id
+            );
+        }
+
+        if ($deleteFromVultr && ($vultrInstanceId || ($server && $server->vultr_instance_id))) {
+            $this->deleteFromVultrById(
+                $vultrInstanceId ?? $server->vultr_instance_id,
                 $cloudProviderTokenId ?? $server->cloud_provider_token_id,
                 $teamId ?? $server->team_id
             );
@@ -98,6 +107,52 @@ class DeleteServer
             // Notify the team about the failure
             $team = Team::find($teamId);
             $team?->notify(new HetznerDeletionFailed($hetznerServerId, $teamId, $e->getMessage()));
+        }
+    }
+
+    private function deleteFromVultrById(string $vultrInstanceId, ?int $cloudProviderTokenId, int $teamId): void
+    {
+        try {
+            $token = null;
+
+            if ($cloudProviderTokenId) {
+                $token = CloudProviderToken::find($cloudProviderTokenId);
+            }
+
+            if (! $token) {
+                $token = CloudProviderToken::where('team_id', $teamId)
+                    ->where('provider', 'vultr')
+                    ->first();
+            }
+
+            if (! $token) {
+                ray('No Vultr token found for team, skipping Vultr deletion', [
+                    'team_id' => $teamId,
+                    'vultr_instance_id' => $vultrInstanceId,
+                ]);
+
+                return;
+            }
+
+            $vultrService = new VultrService($token->token);
+            $vultrService->deleteInstance($vultrInstanceId);
+
+            ray('Deleted server from Vultr', [
+                'vultr_instance_id' => $vultrInstanceId,
+                'team_id' => $teamId,
+            ]);
+        } catch (\Throwable $e) {
+            ray('Failed to delete server from Vultr', [
+                'error' => $e->getMessage(),
+                'vultr_instance_id' => $vultrInstanceId,
+                'team_id' => $teamId,
+            ]);
+
+            logger()->error('Failed to delete server from Vultr', [
+                'error' => $e->getMessage(),
+                'vultr_instance_id' => $vultrInstanceId,
+                'team_id' => $teamId,
+            ]);
         }
     }
 }

--- a/app/Actions/Server/ValidateServer.php
+++ b/app/Actions/Server/ValidateServer.php
@@ -28,6 +28,19 @@ class ValidateServer
         $server->update([
             'validation_logs' => null,
         ]);
+        if ($server->vultr_instance_id) {
+            $status = $server->refreshVultrState();
+            if (in_array($status, ['stopped', 'suspended', 'deleted'], true)) {
+                $this->error = $status === 'deleted'
+                    ? 'Vultr instance is deleted or no longer accessible. Relink this server before validating.'
+                    : 'Vultr instance is '.($status ?? 'not running').'. Power it on before validating.';
+                $server->update([
+                    'validation_logs' => $this->error,
+                ]);
+                throw new \Exception($this->error);
+            }
+        }
+
         ['uptime' => $this->uptime, 'error' => $error] = $server->validateConnection();
         if (! $this->uptime) {
             $sanitizedError = htmlspecialchars($error ?? '', ENT_QUOTES, 'UTF-8');

--- a/app/Http/Controllers/Api/CloudProviderTokensController.php
+++ b/app/Http/Controllers/Api/CloudProviderTokensController.php
@@ -37,6 +37,9 @@ class CloudProviderTokensController extends Controller
                 'digitalocean' => Http::withHeaders([
                     'Authorization' => 'Bearer '.$token,
                 ])->timeout(10)->get('https://api.digitalocean.com/v2/account'),
+                'vultr' => Http::withHeaders([
+                    'Authorization' => 'Bearer '.$token,
+                ])->timeout(10)->get('https://api.vultr.com/v2/account'),
                 default => null,
             };
 
@@ -82,7 +85,7 @@ class CloudProviderTokensController extends Controller
                                 properties: [
                                     'uuid' => ['type' => 'string'],
                                     'name' => ['type' => 'string'],
-                                    'provider' => ['type' => 'string', 'enum' => ['hetzner', 'digitalocean']],
+                                    'provider' => ['type' => 'string', 'enum' => ['hetzner', 'digitalocean', 'vultr']],
                                     'team_id' => ['type' => 'integer'],
                                     'servers_count' => ['type' => 'integer'],
                                     'created_at' => ['type' => 'string'],
@@ -199,7 +202,7 @@ class CloudProviderTokensController extends Controller
                     type: 'object',
                     required: ['provider', 'token', 'name'],
                     properties: [
-                        'provider' => ['type' => 'string', 'enum' => ['hetzner', 'digitalocean'], 'example' => 'hetzner', 'description' => 'The cloud provider.'],
+                        'provider' => ['type' => 'string', 'enum' => ['hetzner', 'digitalocean', 'vultr'], 'example' => 'hetzner', 'description' => 'The cloud provider.'],
                         'token' => ['type' => 'string', 'example' => 'your-api-token-here', 'description' => 'The API token for the cloud provider.'],
                         'name' => ['type' => 'string', 'example' => 'My Hetzner Token', 'description' => 'A friendly name for the token.'],
                     ],
@@ -253,7 +256,7 @@ class CloudProviderTokensController extends Controller
         $body = $request->json()->all();
 
         $validator = customApiValidator($body, [
-            'provider' => 'required|string|in:hetzner,digitalocean',
+            'provider' => 'required|string|in:hetzner,digitalocean,vultr',
             'token' => 'required|string',
             'name' => 'required|string|max:255',
         ]);

--- a/app/Http/Controllers/Api/ServersController.php
+++ b/app/Http/Controllers/Api/ServersController.php
@@ -834,7 +834,9 @@ class ServersController extends Controller
             false, // Don't delete from Hetzner via API
             $server->hetzner_server_id,
             $server->cloud_provider_token_id,
-            $server->team_id
+            $server->team_id,
+            false, // Don't delete from Vultr via API
+            $server->vultr_instance_id
         );
 
         auditLog('api.server.deleted', [

--- a/app/Http/Controllers/Api/VultrController.php
+++ b/app/Http/Controllers/Api/VultrController.php
@@ -1,0 +1,311 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Actions\Server\ValidateServer;
+use App\Enums\ProxyTypes;
+use App\Exceptions\RateLimitException;
+use App\Http\Controllers\Controller;
+use App\Models\CloudProviderToken;
+use App\Models\PrivateKey;
+use App\Models\Server;
+use App\Models\Team;
+use App\Rules\ValidCloudInitYaml;
+use App\Rules\ValidHostname;
+use App\Services\VultrService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class VultrController extends Controller
+{
+    private function getCloudProviderTokenUuid(Request $request): ?string
+    {
+        return $request->cloud_provider_token_uuid ?? $request->cloud_provider_token_id;
+    }
+
+    private function getVultrToken(Request $request): CloudProviderToken|JsonResponse
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+
+        $validator = customApiValidator($request->all(), [
+            'cloud_provider_token_uuid' => 'required_without:cloud_provider_token_id|string',
+            'cloud_provider_token_id' => 'required_without:cloud_provider_token_uuid|string',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'message' => 'Validation failed.',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $token = CloudProviderToken::whereTeamId($teamId)
+            ->whereUuid($this->getCloudProviderTokenUuid($request))
+            ->where('provider', 'vultr')
+            ->first();
+
+        if (! $token) {
+            return response()->json(['message' => 'Vultr cloud provider token not found.'], 404);
+        }
+
+        return $token;
+    }
+
+    public function regions(Request $request)
+    {
+        $token = $this->getVultrToken($request);
+        if ($token instanceof JsonResponse) {
+            return $token;
+        }
+
+        try {
+            return response()->json((new VultrService($token->token))->getRegions());
+        } catch (\Throwable) {
+            return response()->json(['message' => 'Failed to fetch Vultr regions.'], 500);
+        }
+    }
+
+    public function plans(Request $request)
+    {
+        $token = $this->getVultrToken($request);
+        if ($token instanceof JsonResponse) {
+            return $token;
+        }
+
+        try {
+            return response()->json((new VultrService($token->token))->getPlans());
+        } catch (\Throwable) {
+            return response()->json(['message' => 'Failed to fetch Vultr plans.'], 500);
+        }
+    }
+
+    public function operatingSystems(Request $request)
+    {
+        $token = $this->getVultrToken($request);
+        if ($token instanceof JsonResponse) {
+            return $token;
+        }
+
+        try {
+            return response()->json((new VultrService($token->token))->getOperatingSystems());
+        } catch (\Throwable) {
+            return response()->json(['message' => 'Failed to fetch Vultr operating systems.'], 500);
+        }
+    }
+
+    public function sshKeys(Request $request)
+    {
+        $token = $this->getVultrToken($request);
+        if ($token instanceof JsonResponse) {
+            return $token;
+        }
+
+        try {
+            return response()->json((new VultrService($token->token))->getSshKeys());
+        } catch (\Throwable) {
+            return response()->json(['message' => 'Failed to fetch Vultr SSH keys.'], 500);
+        }
+    }
+
+    public function createServer(Request $request)
+    {
+        $allowedFields = [
+            'cloud_provider_token_uuid',
+            'cloud_provider_token_id',
+            'region',
+            'plan',
+            'os_id',
+            'name',
+            'private_key_uuid',
+            'enable_ipv6',
+            'disable_public_ipv4',
+            'vultr_ssh_key_ids',
+            'cloud_init_script',
+            'instant_validate',
+        ];
+
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+
+        $return = validateIncomingRequest($request);
+        if ($return instanceof JsonResponse) {
+            return $return;
+        }
+
+        $validator = customApiValidator($request->all(), [
+            'cloud_provider_token_uuid' => 'required_without:cloud_provider_token_id|string',
+            'cloud_provider_token_id' => 'required_without:cloud_provider_token_uuid|string',
+            'region' => 'required|string',
+            'plan' => 'required|string',
+            'os_id' => 'required|integer',
+            'name' => ['nullable', 'string', 'max:253', new ValidHostname],
+            'private_key_uuid' => 'required|string',
+            'enable_ipv6' => 'nullable|boolean',
+            'disable_public_ipv4' => 'nullable|boolean',
+            'vultr_ssh_key_ids' => 'nullable|array',
+            'vultr_ssh_key_ids.*' => 'string',
+            'cloud_init_script' => ['nullable', 'string', new ValidCloudInitYaml],
+            'instant_validate' => 'nullable|boolean',
+        ]);
+
+        $extraFields = array_diff(array_keys($request->all()), $allowedFields);
+        if ($validator->fails() || ! empty($extraFields)) {
+            $errors = $validator->errors();
+            foreach ($extraFields as $field) {
+                $errors->add($field, 'This field is not allowed.');
+            }
+
+            return response()->json([
+                'message' => 'Validation failed.',
+                'errors' => $errors,
+            ], 422);
+        }
+
+        $team = Team::find($teamId);
+        if (Team::serverLimitReached($team)) {
+            return response()->json(['message' => 'Server limit reached for your subscription.'], 400);
+        }
+
+        if (! $request->name) {
+            $request->offsetSet('name', generate_random_name());
+        }
+        if (is_null($request->enable_ipv6)) {
+            $request->offsetSet('enable_ipv6', true);
+        }
+        if (is_null($request->disable_public_ipv4)) {
+            $request->offsetSet('disable_public_ipv4', false);
+        }
+        if (is_null($request->vultr_ssh_key_ids)) {
+            $request->offsetSet('vultr_ssh_key_ids', []);
+        }
+        if (is_null($request->instant_validate)) {
+            $request->offsetSet('instant_validate', false);
+        }
+
+        $token = CloudProviderToken::whereTeamId($teamId)
+            ->whereUuid($this->getCloudProviderTokenUuid($request))
+            ->where('provider', 'vultr')
+            ->first();
+
+        if (! $token) {
+            return response()->json(['message' => 'Vultr cloud provider token not found.'], 404);
+        }
+
+        $privateKey = PrivateKey::whereTeamId($teamId)->whereUuid($request->private_key_uuid)->first();
+        if (! $privateKey) {
+            return response()->json(['message' => 'Private key not found.'], 404);
+        }
+
+        try {
+            $vultrService = new VultrService($token->token);
+            $publicKey = $privateKey->getPublicKey();
+            $existingKey = $this->findMatchingSshKey($vultrService->getSshKeys(), $publicKey);
+
+            if ($existingKey) {
+                $sshKeyId = $existingKey['id'];
+            } else {
+                $uploadedKey = $vultrService->uploadSshKey($privateKey->name, $publicKey);
+                $sshKeyId = $uploadedKey['id'];
+            }
+
+            $normalizedServerName = strtolower(trim($request->name));
+            $sshKeys = array_values(array_unique(array_merge([$sshKeyId], $request->vultr_ssh_key_ids)));
+
+            $params = [
+                'region' => $request->region,
+                'plan' => $request->plan,
+                'os_id' => $request->os_id,
+                'label' => $normalizedServerName,
+                'hostname' => $normalizedServerName,
+                'sshkey_id' => $sshKeys,
+                'enable_ipv6' => $request->enable_ipv6,
+                'disable_public_ipv4' => $request->disable_public_ipv4,
+            ];
+
+            if (! empty($request->cloud_init_script)) {
+                $params['user_data'] = $request->cloud_init_script;
+            }
+
+            $vultrInstance = $vultrService->createInstance($params);
+            $ipAddress = $vultrService->getPublicIp($vultrInstance, $request->disable_public_ipv4, $request->enable_ipv6) ?? '0.0.0.0';
+
+            $server = Server::create([
+                'name' => $normalizedServerName,
+                'ip' => $ipAddress,
+                'user' => 'root',
+                'port' => 22,
+                'team_id' => $teamId,
+                'private_key_id' => $privateKey->id,
+                'cloud_provider_token_id' => $token->id,
+                'vultr_instance_id' => $vultrInstance['id'],
+                'vultr_instance_status' => $vultrInstance['status'] ?? null,
+            ]);
+
+            $vultrInstance = $vultrService->waitForPublicIp($vultrInstance, $request->disable_public_ipv4, $request->enable_ipv6);
+            $assignedIpAddress = $vultrService->getPublicIp($vultrInstance, $request->disable_public_ipv4, $request->enable_ipv6);
+            if ($assignedIpAddress && $assignedIpAddress !== $server->ip) {
+                $ipAddress = $assignedIpAddress;
+                $server->update([
+                    'ip' => $assignedIpAddress,
+                    'vultr_instance_status' => $vultrInstance['status'] ?? $server->vultr_instance_status,
+                ]);
+            }
+
+            $server->proxy->set('status', 'exited');
+            $server->proxy->set('type', ProxyTypes::TRAEFIK->value);
+            $server->save();
+
+            if ($request->instant_validate) {
+                ValidateServer::dispatch($server);
+            }
+
+            auditLog('api.vultr_server.created', [
+                'team_id' => $teamId,
+                'server_uuid' => $server->uuid,
+                'server_name' => $server->name,
+                'vultr_instance_id' => $vultrInstance['id'],
+                'ip' => $ipAddress,
+            ]);
+
+            return response()->json([
+                'uuid' => $server->uuid,
+                'vultr_instance_id' => $vultrInstance['id'],
+                'ip' => $ipAddress,
+            ])->setStatusCode(201);
+        } catch (RateLimitException $e) {
+            $response = response()->json(['message' => $e->getMessage()], 429);
+            if ($e->retryAfter !== null) {
+                $response->header('Retry-After', $e->retryAfter);
+            }
+
+            return $response;
+        } catch (\Throwable) {
+            return response()->json(['message' => 'Failed to create Vultr server.'], 500);
+        }
+    }
+
+    private function findMatchingSshKey(array $sshKeys, string $publicKey): ?array
+    {
+        $normalizedPublicKey = $this->normalizePublicKey($publicKey);
+
+        foreach ($sshKeys as $sshKey) {
+            if ($this->normalizePublicKey($sshKey['ssh_key'] ?? '') === $normalizedPublicKey) {
+                return $sshKey;
+            }
+        }
+
+        return null;
+    }
+
+    private function normalizePublicKey(string $publicKey): string
+    {
+        $parts = preg_split('/\s+/', trim($publicKey));
+
+        return implode(' ', array_slice($parts ?: [], 0, 2));
+    }
+}

--- a/app/Jobs/ServerConnectionCheckJob.php
+++ b/app/Jobs/ServerConnectionCheckJob.php
@@ -67,6 +67,10 @@ class ServerConnectionCheckJob implements ShouldBeEncrypted, ShouldQueue
                 $this->checkHetznerStatus();
             }
 
+            if ($this->server->vultr_instance_id && $this->server->cloudProviderToken) {
+                $this->checkVultrStatus();
+            }
+
             // Temporarily disable mux if requested
             if ($this->disableMux) {
                 $this->disableSshMux();
@@ -184,6 +188,21 @@ class ServerConnectionCheckJob implements ShouldBeEncrypted, ShouldQueue
             }
         }
 
+    }
+
+    private function checkVultrStatus(): void
+    {
+        try {
+            $status = $this->server->refreshVultrState();
+        } catch (\Throwable) {
+            // Silently ignore transient Vultr API errors.
+
+            return;
+        }
+
+        if (in_array($status, ['stopped', 'suspended', 'deleted'], true)) {
+            throw new \Exception('Vultr instance is not running');
+        }
     }
 
     private function checkConnection(): bool

--- a/app/Livewire/Security/CloudProviderTokenForm.php
+++ b/app/Livewire/Security/CloudProviderTokenForm.php
@@ -27,7 +27,7 @@ class CloudProviderTokenForm extends Component
     protected function rules(): array
     {
         return [
-            'provider' => 'required|string|in:hetzner,digitalocean',
+            'provider' => 'required|string|in:hetzner,digitalocean,vultr',
             'token' => 'required|string',
             'name' => 'required|string|max:255',
         ];
@@ -50,13 +50,25 @@ class CloudProviderTokenForm extends Component
                 $response = Http::withHeaders([
                     'Authorization' => 'Bearer '.$token,
                 ])->timeout(10)->get('https://api.hetzner.cloud/v1/servers');
-                ray($response);
 
                 return $response->successful();
             }
 
-            // Add other providers here in the future
-            // if ($provider === 'digitalocean') { ... }
+            if ($provider === 'digitalocean') {
+                $response = Http::withHeaders([
+                    'Authorization' => 'Bearer '.$token,
+                ])->timeout(10)->get('https://api.digitalocean.com/v2/account');
+
+                return $response->successful();
+            }
+
+            if ($provider === 'vultr') {
+                $response = Http::withHeaders([
+                    'Authorization' => 'Bearer '.$token,
+                ])->timeout(10)->get('https://api.vultr.com/v2/account');
+
+                return $response->successful();
+            }
 
             return false;
         } catch (\Throwable $e) {

--- a/app/Livewire/Security/CloudProviderTokens.php
+++ b/app/Livewire/Security/CloudProviderTokens.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Security;
 
 use App\Models\CloudProviderToken;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Facades\Http;
 use Livewire\Component;
 
 class CloudProviderTokens extends Component
@@ -50,6 +51,13 @@ class CloudProviderTokens extends Component
                 } else {
                     $this->dispatch('error', 'DigitalOcean token validation failed. Please check the token.');
                 }
+            } elseif ($token->provider === 'vultr') {
+                $isValid = $this->validateVultrToken($token->token);
+                if ($isValid) {
+                    $this->dispatch('success', 'Vultr token is valid.');
+                } else {
+                    $this->dispatch('error', 'Vultr token validation failed. Please check the token.');
+                }
             } else {
                 $this->dispatch('error', 'Unknown provider.');
             }
@@ -61,7 +69,7 @@ class CloudProviderTokens extends Component
     private function validateHetznerToken(string $token): bool
     {
         try {
-            $response = \Illuminate\Support\Facades\Http::withToken($token)
+            $response = Http::withToken($token)
                 ->timeout(10)
                 ->get('https://api.hetzner.cloud/v1/servers?per_page=1');
 
@@ -74,9 +82,22 @@ class CloudProviderTokens extends Component
     private function validateDigitalOceanToken(string $token): bool
     {
         try {
-            $response = \Illuminate\Support\Facades\Http::withToken($token)
+            $response = Http::withToken($token)
                 ->timeout(10)
                 ->get('https://api.digitalocean.com/v2/account');
+
+            return $response->successful();
+        } catch (\Throwable $e) {
+            return false;
+        }
+    }
+
+    private function validateVultrToken(string $token): bool
+    {
+        try {
+            $response = Http::withToken($token)
+                ->timeout(10)
+                ->get('https://api.vultr.com/v2/account');
 
             return $response->successful();
         } catch (\Throwable $e) {

--- a/app/Livewire/Server/CloudProviderToken/Show.php
+++ b/app/Livewire/Server/CloudProviderToken/Show.php
@@ -5,6 +5,7 @@ namespace App\Livewire\Server\CloudProviderToken;
 use App\Models\CloudProviderToken;
 use App\Models\Server;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Facades\Http;
 use Livewire\Component;
 
 class Show extends Component
@@ -16,6 +17,10 @@ class Show extends Component
     public $cloudProviderTokens = [];
 
     public $parameters = [];
+
+    public string $provider = 'hetzner';
+
+    public string $providerName = 'Hetzner';
 
     public function mount(string $server_uuid)
     {
@@ -36,8 +41,11 @@ class Show extends Component
 
     public function loadTokens()
     {
+        $this->provider = $this->server->vultr_instance_id ? 'vultr' : 'hetzner';
+        $this->providerName = $this->provider === 'vultr' ? 'Vultr' : 'Hetzner';
+
         $this->cloudProviderTokens = CloudProviderToken::ownedByCurrentTeam()
-            ->where('provider', 'hetzner')
+            ->where('provider', $this->provider)
             ->get();
     }
 
@@ -67,7 +75,7 @@ class Show extends Component
 
             $this->server->cloudProviderToken()->associate($ownedToken);
             $this->server->save();
-            $this->dispatch('success', 'Hetzner token updated successfully.');
+            $this->dispatch('success', "{$this->providerName} token updated successfully.");
             $this->dispatch('refreshServerShow');
         } catch (\Exception $e) {
             $this->server->refresh();
@@ -78,10 +86,13 @@ class Show extends Component
     private function validateTokenForServer(CloudProviderToken $token): array
     {
         try {
-            // First, validate the token itself
-            $response = \Illuminate\Support\Facades\Http::withHeaders([
+            $endpoint = $token->provider === 'vultr'
+                ? 'https://api.vultr.com/v2/account'
+                : 'https://api.hetzner.cloud/v1/servers';
+
+            $response = Http::withHeaders([
                 'Authorization' => 'Bearer '.$token->token,
-            ])->timeout(10)->get('https://api.hetzner.cloud/v1/servers');
+            ])->timeout(10)->get($endpoint);
 
             if (! $response->successful()) {
                 return [
@@ -90,9 +101,8 @@ class Show extends Component
                 ];
             }
 
-            // Check if this token can access the specific Hetzner server
             if ($this->server->hetzner_server_id) {
-                $serverResponse = \Illuminate\Support\Facades\Http::withHeaders([
+                $serverResponse = Http::withHeaders([
                     'Authorization' => 'Bearer '.$token->token,
                 ])->timeout(10)->get("https://api.hetzner.cloud/v1/servers/{$this->server->hetzner_server_id}");
 
@@ -100,6 +110,19 @@ class Show extends Component
                     return [
                         'valid' => false,
                         'error' => 'This token cannot access this server. It may belong to a different Hetzner project.',
+                    ];
+                }
+            }
+
+            if ($this->server->vultr_instance_id) {
+                $serverResponse = Http::withHeaders([
+                    'Authorization' => 'Bearer '.$token->token,
+                ])->timeout(10)->get("https://api.vultr.com/v2/instances/{$this->server->vultr_instance_id}");
+
+                if (! $serverResponse->successful()) {
+                    return [
+                        'valid' => false,
+                        'error' => 'This token cannot access this instance. It may belong to a different Vultr account.',
                     ];
                 }
             }
@@ -118,19 +141,23 @@ class Show extends Component
         try {
             $token = $this->server->cloudProviderToken;
             if (! $token) {
-                $this->dispatch('error', 'No Hetzner token is associated with this server.');
+                $this->dispatch('error', "No {$this->providerName} token is associated with this server.");
 
                 return;
             }
 
-            $response = \Illuminate\Support\Facades\Http::withHeaders([
+            $endpoint = $token->provider === 'vultr'
+                ? 'https://api.vultr.com/v2/account'
+                : 'https://api.hetzner.cloud/v1/servers';
+
+            $response = Http::withHeaders([
                 'Authorization' => 'Bearer '.$token->token,
-            ])->timeout(10)->get('https://api.hetzner.cloud/v1/servers');
+            ])->timeout(10)->get($endpoint);
 
             if ($response->successful()) {
-                $this->dispatch('success', 'Hetzner token is valid and working.');
+                $this->dispatch('success', "{$this->providerName} token is valid and working.");
             } else {
-                $this->dispatch('error', 'Hetzner token is invalid or has insufficient permissions.');
+                $this->dispatch('error', "{$this->providerName} token is invalid or has insufficient permissions.");
             }
         } catch (\Throwable $e) {
             return handleError($e, $this);

--- a/app/Livewire/Server/Delete.php
+++ b/app/Livewire/Server/Delete.php
@@ -16,6 +16,8 @@ class Delete extends Component
 
     public bool $delete_from_hetzner = false;
 
+    public bool $delete_from_vultr = false;
+
     public bool $force_delete_resources = false;
 
     public function mount(string $server_uuid)
@@ -35,6 +37,7 @@ class Delete extends Component
 
         if (! empty($selectedActions)) {
             $this->delete_from_hetzner = in_array('delete_from_hetzner', $selectedActions);
+            $this->delete_from_vultr = in_array('delete_from_vultr', $selectedActions);
             $this->force_delete_resources = in_array('force_delete_resources', $selectedActions);
         }
         try {
@@ -57,7 +60,9 @@ class Delete extends Component
                 $this->delete_from_hetzner,
                 $this->server->hetzner_server_id,
                 $this->server->cloud_provider_token_id,
-                $this->server->team_id
+                $this->server->team_id,
+                $this->delete_from_vultr,
+                $this->server->vultr_instance_id
             );
 
             return redirectRoute($this, 'server.index');
@@ -84,6 +89,14 @@ class Delete extends Component
                 'id' => 'delete_from_hetzner',
                 'label' => 'Also delete server from Hetzner Cloud',
                 'default_warning' => 'The actual server on Hetzner Cloud will NOT be deleted.',
+            ];
+        }
+
+        if ($this->server->vultr_instance_id) {
+            $checkboxes[] = [
+                'id' => 'delete_from_vultr',
+                'label' => 'Also delete server from Vultr',
+                'default_warning' => 'The actual server on Vultr will NOT be deleted.',
             ];
         }
 

--- a/app/Livewire/Server/New/ByVultr.php
+++ b/app/Livewire/Server/New/ByVultr.php
@@ -1,0 +1,417 @@
+<?php
+
+namespace App\Livewire\Server\New;
+
+use App\Enums\ProxyTypes;
+use App\Models\CloudInitScript;
+use App\Models\CloudProviderToken;
+use App\Models\PrivateKey;
+use App\Models\Server;
+use App\Models\Team;
+use App\Rules\ValidCloudInitYaml;
+use App\Rules\ValidHostname;
+use App\Services\VultrService;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Collection;
+use Livewire\Attributes\Locked;
+use Livewire\Component;
+
+class ByVultr extends Component
+{
+    use AuthorizesRequests;
+
+    public int $current_step = 1;
+
+    #[Locked]
+    public Collection $available_tokens;
+
+    #[Locked]
+    public $private_keys;
+
+    #[Locked]
+    public $limit_reached;
+
+    public ?int $selected_token_id = null;
+
+    public array $regions = [];
+
+    public array $plans = [];
+
+    public array $operatingSystems = [];
+
+    public array $vultrSshKeys = [];
+
+    public ?string $selected_region = null;
+
+    public ?string $selected_plan = null;
+
+    public ?int $selected_os_id = null;
+
+    public array $selectedVultrSshKeyIds = [];
+
+    public string $server_name = '';
+
+    public ?int $private_key_id = null;
+
+    public bool $loading_data = false;
+
+    public bool $enable_ipv6 = true;
+
+    public bool $disable_public_ipv4 = false;
+
+    public ?string $cloud_init_script = null;
+
+    public bool $save_cloud_init_script = false;
+
+    public ?string $cloud_init_script_name = null;
+
+    public ?int $selected_cloud_init_script_id = null;
+
+    #[Locked]
+    public Collection $saved_cloud_init_scripts;
+
+    public bool $from_onboarding = false;
+
+    public function mount(): void
+    {
+        $this->authorize('viewAny', CloudProviderToken::class);
+        $this->loadTokens();
+        $this->loadSavedCloudInitScripts();
+        $this->server_name = generate_random_name();
+        $this->private_keys = PrivateKey::ownedAndOnlySShKeys()->where('id', '!=', 0)->get();
+
+        if ($this->private_keys->count() > 0) {
+            $this->private_key_id = $this->private_keys->first()->id;
+        }
+    }
+
+    public function getListeners(): array
+    {
+        return [
+            'tokenAdded' => 'handleTokenAdded',
+            'privateKeyCreated' => 'handlePrivateKeyCreated',
+            'modalClosed' => 'resetSelection',
+        ];
+    }
+
+    public function loadTokens(): void
+    {
+        $this->available_tokens = CloudProviderToken::ownedByCurrentTeam()
+            ->where('provider', 'vultr')
+            ->get();
+    }
+
+    public function loadSavedCloudInitScripts(): void
+    {
+        $this->saved_cloud_init_scripts = CloudInitScript::ownedByCurrentTeam()->get();
+    }
+
+    public function resetSelection(): void
+    {
+        $this->selected_token_id = null;
+        $this->current_step = 1;
+        $this->cloud_init_script = null;
+        $this->save_cloud_init_script = false;
+        $this->cloud_init_script_name = null;
+        $this->selected_cloud_init_script_id = null;
+    }
+
+    public function handleTokenAdded($tokenId): void
+    {
+        $this->loadTokens();
+        $this->selected_token_id = $tokenId;
+        $this->nextStep();
+    }
+
+    public function handlePrivateKeyCreated($keyId): void
+    {
+        $this->private_keys = PrivateKey::ownedAndOnlySShKeys()->where('id', '!=', 0)->get();
+        $this->private_key_id = $keyId;
+        $this->resetErrorBag('private_key_id');
+    }
+
+    protected function rules(): array
+    {
+        $rules = [
+            'selected_token_id' => 'required|integer|exists:cloud_provider_tokens,id',
+        ];
+
+        if ($this->current_step === 2) {
+            $rules = array_merge($rules, [
+                'server_name' => ['required', 'string', 'max:253', new ValidHostname],
+                'selected_region' => 'required|string',
+                'selected_plan' => 'required|string',
+                'selected_os_id' => 'required|integer',
+                'private_key_id' => 'required|integer|exists:private_keys,id,team_id,'.currentTeam()->id,
+                'selectedVultrSshKeyIds' => 'nullable|array',
+                'selectedVultrSshKeyIds.*' => 'string',
+                'enable_ipv6' => 'required|boolean',
+                'disable_public_ipv4' => 'required|boolean',
+                'cloud_init_script' => ['nullable', 'string', new ValidCloudInitYaml],
+                'save_cloud_init_script' => 'boolean',
+                'cloud_init_script_name' => 'nullable|string|max:255',
+                'selected_cloud_init_script_id' => 'nullable|integer|exists:cloud_init_scripts,id',
+            ]);
+        }
+
+        return $rules;
+    }
+
+    protected function messages(): array
+    {
+        return [
+            'selected_token_id.required' => 'Please select a Vultr token.',
+            'selected_token_id.exists' => 'Selected token not found.',
+        ];
+    }
+
+    public function selectToken(int $tokenId): void
+    {
+        $this->selected_token_id = $tokenId;
+    }
+
+    public function nextStep(): mixed
+    {
+        $this->validate([
+            'selected_token_id' => 'required|integer|exists:cloud_provider_tokens,id',
+        ]);
+
+        try {
+            $vultrToken = $this->getVultrToken();
+
+            if (! $vultrToken) {
+                return $this->dispatch('error', 'Please select a valid Vultr token.');
+            }
+
+            $this->loadVultrData($vultrToken);
+            $this->current_step = 2;
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+
+        return null;
+    }
+
+    public function previousStep(): void
+    {
+        $this->current_step = 1;
+    }
+
+    public function updatedSelectedRegion(): void
+    {
+        $this->selected_plan = null;
+    }
+
+    public function updatedSelectedCloudInitScriptId($value): void
+    {
+        if ($value) {
+            $script = CloudInitScript::ownedByCurrentTeam()->findOrFail($value);
+            $this->cloud_init_script = $script->script;
+            $this->cloud_init_script_name = $script->name;
+        }
+    }
+
+    public function clearCloudInitScript(): void
+    {
+        $this->selected_cloud_init_script_id = null;
+        $this->cloud_init_script = '';
+        $this->cloud_init_script_name = '';
+        $this->save_cloud_init_script = false;
+    }
+
+    public function getAvailablePlansProperty(): array
+    {
+        if (! $this->selected_region) {
+            return $this->plans;
+        }
+
+        return collect($this->plans)
+            ->filter(function ($plan) {
+                $locations = $plan['locations'] ?? [];
+
+                return empty($locations) || in_array($this->selected_region, $locations);
+            })
+            ->values()
+            ->toArray();
+    }
+
+    public function getSelectedServerPriceProperty(): ?string
+    {
+        if (! $this->selected_plan) {
+            return null;
+        }
+
+        $plan = collect($this->plans)->firstWhere('id', $this->selected_plan);
+        $monthlyCost = $plan['monthly_cost'] ?? null;
+
+        if ($monthlyCost === null) {
+            return null;
+        }
+
+        return '$'.number_format((float) $monthlyCost, 2);
+    }
+
+    private function getVultrToken(): string
+    {
+        if ($this->selected_token_id) {
+            $token = $this->available_tokens->firstWhere('id', $this->selected_token_id);
+
+            return $token ? $token->token : '';
+        }
+
+        return '';
+    }
+
+    private function loadVultrData(string $token): void
+    {
+        $this->loading_data = true;
+
+        try {
+            $vultrService = new VultrService($token);
+
+            $this->regions = collect($vultrService->getRegions())
+                ->sortBy('id')
+                ->values()
+                ->toArray();
+
+            $this->plans = collect($vultrService->getPlans())
+                ->sortBy('monthly_cost')
+                ->values()
+                ->toArray();
+
+            $this->operatingSystems = collect($vultrService->getOperatingSystems())
+                ->sortBy('name')
+                ->values()
+                ->toArray();
+
+            $this->vultrSshKeys = $vultrService->getSshKeys();
+            $this->loading_data = false;
+        } catch (\Throwable $e) {
+            $this->loading_data = false;
+            throw $e;
+        }
+    }
+
+    private function createVultrServer(string $token): array
+    {
+        $vultrService = new VultrService($token);
+        $privateKey = PrivateKey::ownedByCurrentTeam()->findOrFail($this->private_key_id);
+        $publicKey = $privateKey->getPublicKey();
+        $existingKey = $this->findMatchingSshKey($vultrService->getSshKeys(), $publicKey);
+
+        if ($existingKey) {
+            $sshKeyId = $existingKey['id'];
+        } else {
+            $uploadedKey = $vultrService->uploadSshKey($privateKey->name, $publicKey);
+            $sshKeyId = $uploadedKey['id'];
+        }
+
+        $sshKeys = array_values(array_unique(array_merge([$sshKeyId], $this->selectedVultrSshKeyIds)));
+        $normalizedServerName = strtolower(trim($this->server_name));
+
+        $params = [
+            'region' => $this->selected_region,
+            'plan' => $this->selected_plan,
+            'os_id' => $this->selected_os_id,
+            'label' => $normalizedServerName,
+            'hostname' => $normalizedServerName,
+            'sshkey_id' => $sshKeys,
+            'enable_ipv6' => $this->enable_ipv6,
+            'disable_public_ipv4' => $this->disable_public_ipv4,
+        ];
+
+        if (! empty($this->cloud_init_script)) {
+            $params['user_data'] = $this->cloud_init_script;
+        }
+
+        return $vultrService->createInstance($params);
+    }
+
+    public function submit(): mixed
+    {
+        $this->validate();
+
+        try {
+            $this->authorize('create', Server::class);
+
+            if (Team::serverLimitReached()) {
+                return $this->dispatch('error', 'You have reached the server limit for your subscription.');
+            }
+
+            if ($this->save_cloud_init_script && ! empty($this->cloud_init_script) && ! empty($this->cloud_init_script_name)) {
+                $this->authorize('create', CloudInitScript::class);
+
+                CloudInitScript::create([
+                    'team_id' => currentTeam()->id,
+                    'name' => $this->cloud_init_script_name,
+                    'script' => $this->cloud_init_script,
+                ]);
+            }
+
+            $vultrService = new VultrService($this->getVultrToken());
+            $vultrInstance = $this->createVultrServer($this->getVultrToken());
+            $ipAddress = $vultrService->getPublicIp($vultrInstance, $this->disable_public_ipv4, $this->enable_ipv6) ?? '0.0.0.0';
+
+            $server = Server::create([
+                'name' => strtolower(trim($this->server_name)),
+                'ip' => $ipAddress,
+                'user' => 'root',
+                'port' => 22,
+                'team_id' => currentTeam()->id,
+                'private_key_id' => $this->private_key_id,
+                'cloud_provider_token_id' => $this->selected_token_id,
+                'vultr_instance_id' => $vultrInstance['id'],
+                'vultr_instance_status' => $vultrInstance['status'] ?? null,
+            ]);
+
+            $vultrInstance = $vultrService->waitForPublicIp($vultrInstance, $this->disable_public_ipv4, $this->enable_ipv6);
+            $assignedIpAddress = $vultrService->getPublicIp($vultrInstance, $this->disable_public_ipv4, $this->enable_ipv6);
+            if ($assignedIpAddress && $assignedIpAddress !== $server->ip) {
+                $server->update([
+                    'ip' => $assignedIpAddress,
+                    'vultr_instance_status' => $vultrInstance['status'] ?? $server->vultr_instance_status,
+                ]);
+            }
+
+            $server->proxy->set('status', 'exited');
+            $server->proxy->set('type', ProxyTypes::TRAEFIK->value);
+            $server->save();
+
+            if ($this->from_onboarding) {
+                currentTeam()->update([
+                    'show_boarding' => false,
+                ]);
+                refreshSession();
+            }
+
+            return redirectRoute($this, 'server.show', [$server->uuid]);
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function render()
+    {
+        return view('livewire.server.new.by-vultr');
+    }
+
+    private function findMatchingSshKey(array $sshKeys, string $publicKey): ?array
+    {
+        $normalizedPublicKey = $this->normalizePublicKey($publicKey);
+
+        foreach ($sshKeys as $sshKey) {
+            if ($this->normalizePublicKey($sshKey['ssh_key'] ?? '') === $normalizedPublicKey) {
+                return $sshKey;
+            }
+        }
+
+        return null;
+    }
+
+    private function normalizePublicKey(string $publicKey): string
+    {
+        $parts = preg_split('/\s+/', trim($publicKey));
+
+        return implode(' ', array_slice($parts ?: [], 0, 2));
+    }
+}

--- a/app/Livewire/Server/Show.php
+++ b/app/Livewire/Server/Show.php
@@ -9,6 +9,7 @@ use App\Models\CloudProviderToken;
 use App\Models\Server;
 use App\Rules\ValidServerIp;
 use App\Services\HetznerService;
+use App\Services\VultrService;
 use App\Support\ValidationPatterns;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Collection;
@@ -75,7 +76,11 @@ class Show extends Component
 
     public ?string $hetznerServerStatus = null;
 
+    public ?string $vultrInstanceStatus = null;
+
     public bool $hetznerServerManuallyStarted = false;
+
+    public bool $vultrInstanceManuallyStarted = false;
 
     public bool $isValidating = false;
 
@@ -91,6 +96,18 @@ class Show extends Component
     public ?string $hetznerSearchError = null;
 
     public bool $hetznerNoMatchFound = false;
+
+    public Collection $availableVultrTokens;
+
+    public ?int $selectedVultrTokenId = null;
+
+    public ?string $manualVultrInstanceId = null;
+
+    public ?array $matchedVultrInstance = null;
+
+    public ?string $vultrSearchError = null;
+
+    public bool $vultrNoMatchFound = false;
 
     public function getListeners()
     {
@@ -172,10 +189,12 @@ class Show extends Component
             }
             // Load saved Hetzner status and validation state
             $this->hetznerServerStatus = $this->server->hetzner_server_status;
+            $this->vultrInstanceStatus = $this->server->vultr_instance_status;
             $this->isValidating = $this->server->is_validating ?? false;
 
-            // Load Hetzner tokens for linking
+            // Load cloud provider tokens for linking
             $this->loadHetznerTokens();
+            $this->loadVultrTokens();
 
         } catch (\Throwable $e) {
             return handleError($e, $this);
@@ -286,6 +305,22 @@ class Show extends Component
     {
         try {
             $this->authorize('update', $this->server);
+            if ($this->server->vultr_instance_id) {
+                $status = $this->server->refreshVultrState();
+                $this->server->refresh();
+                $this->vultrInstanceStatus = $this->server->vultr_instance_status;
+                $this->ip = $this->server->ip;
+
+                if (in_array($status, ['stopped', 'suspended', 'deleted'], true)) {
+                    $message = $status === 'deleted'
+                        ? 'Vultr instance is deleted or no longer accessible. Relink this server before validating.'
+                        : 'Vultr instance is '.($status ?? 'not running').'. Power it on before validating.';
+                    $this->dispatch('error', $message);
+
+                    return;
+                }
+            }
+
             $this->validationLogs = $this->server->validation_logs = null;
             $this->server->save();
             $this->dispatch('init', $install);
@@ -450,6 +485,27 @@ class Show extends Component
         }
     }
 
+    public function checkVultrInstanceStatus(bool $manual = false)
+    {
+        try {
+            if (! $this->server->vultr_instance_id || ! $this->server->cloudProviderToken) {
+                $this->dispatch('error', 'This server is not associated with a Vultr instance or token.');
+
+                return;
+            }
+
+            $this->vultrInstanceStatus = $this->server->refreshVultrState();
+            $this->server->refresh();
+            $this->ip = $this->server->ip;
+
+            if ($manual) {
+                $this->dispatch('success', 'Instance status refreshed: '.ucfirst($this->vultrInstanceStatus ?? 'unknown'));
+            }
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
     public function handleServerValidated($event = null)
     {
         // Check if event is for this server
@@ -466,6 +522,7 @@ class Show extends Component
 
         // Reload Hetzner tokens in case the linking section should now be shown
         $this->loadHetznerTokens();
+        $this->loadVultrTokens();
 
         $this->dispatch('refreshServerShow');
         $this->dispatch('refreshServer');
@@ -487,6 +544,27 @@ class Show extends Component
             $this->server->update(['hetzner_server_status' => 'starting']);
             $this->hetznerServerManuallyStarted = true; // Set flag to trigger auto-validation when running
             $this->dispatch('success', 'Hetzner server is starting...');
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function startVultrInstance()
+    {
+        try {
+            if (! $this->server->vultr_instance_id || ! $this->server->cloudProviderToken) {
+                $this->dispatch('error', 'This server is not associated with a Vultr instance or token.');
+
+                return;
+            }
+
+            $vultrService = new VultrService($this->server->cloudProviderToken->token);
+            $vultrService->startInstance($this->server->vultr_instance_id);
+
+            $this->vultrInstanceStatus = 'starting';
+            $this->server->update(['vultr_instance_status' => 'starting']);
+            $this->vultrInstanceManuallyStarted = true;
+            $this->dispatch('success', 'Vultr instance is starting...');
         } catch (\Throwable $e) {
             return handleError($e, $this);
         }
@@ -522,6 +600,13 @@ class Show extends Component
     {
         $this->availableHetznerTokens = CloudProviderToken::ownedByCurrentTeam()
             ->where('provider', 'hetzner')
+            ->get();
+    }
+
+    public function loadVultrTokens(): void
+    {
+        $this->availableVultrTokens = CloudProviderToken::ownedByCurrentTeam()
+            ->where('provider', 'vultr')
             ->get();
     }
 
@@ -646,6 +731,130 @@ class Show extends Component
             $this->hetznerSearchError = null;
 
             $this->dispatch('success', 'Server successfully linked to Hetzner Cloud!');
+            $this->dispatch('refreshServerShow');
+        } catch (\Throwable $e) {
+            return handleError($e, $this);
+        }
+    }
+
+    public function searchVultrInstance(): void
+    {
+        $this->vultrSearchError = null;
+        $this->vultrNoMatchFound = false;
+        $this->matchedVultrInstance = null;
+
+        if (! $this->selectedVultrTokenId) {
+            $this->vultrSearchError = 'Please select a Vultr token.';
+
+            return;
+        }
+
+        try {
+            $this->authorize('update', $this->server);
+
+            $token = $this->availableVultrTokens->firstWhere('id', $this->selectedVultrTokenId);
+            if (! $token) {
+                $this->vultrSearchError = 'Invalid token selected.';
+
+                return;
+            }
+
+            $vultrService = new VultrService($token->token);
+            $matched = $vultrService->findInstanceByIp($this->server->ip);
+
+            if ($matched) {
+                $this->matchedVultrInstance = $matched;
+            } else {
+                $this->vultrNoMatchFound = true;
+            }
+        } catch (\Throwable $e) {
+            $this->vultrSearchError = 'Failed to search Vultr instances: '.$e->getMessage();
+        }
+    }
+
+    public function searchVultrInstanceById(): void
+    {
+        $this->vultrSearchError = null;
+        $this->vultrNoMatchFound = false;
+        $this->matchedVultrInstance = null;
+
+        if (! $this->selectedVultrTokenId) {
+            $this->vultrSearchError = 'Please select a Vultr token first.';
+
+            return;
+        }
+
+        if (! $this->manualVultrInstanceId) {
+            $this->vultrSearchError = 'Please enter a Vultr Instance ID.';
+
+            return;
+        }
+
+        try {
+            $this->authorize('update', $this->server);
+
+            $token = $this->availableVultrTokens->firstWhere('id', $this->selectedVultrTokenId);
+            if (! $token) {
+                $this->vultrSearchError = 'Invalid token selected.';
+
+                return;
+            }
+
+            $vultrService = new VultrService($token->token);
+            $instanceData = $vultrService->getInstance($this->manualVultrInstanceId);
+
+            if (! empty($instanceData)) {
+                $this->matchedVultrInstance = $instanceData;
+            } else {
+                $this->vultrNoMatchFound = true;
+            }
+        } catch (\Throwable $e) {
+            $this->vultrSearchError = 'Failed to fetch Vultr instance: '.$e->getMessage();
+        }
+    }
+
+    public function linkToVultr()
+    {
+        if (! $this->matchedVultrInstance) {
+            $this->dispatch('error', 'No Vultr instance selected.');
+
+            return;
+        }
+
+        try {
+            $this->authorize('update', $this->server);
+
+            $token = $this->availableVultrTokens->firstWhere('id', $this->selectedVultrTokenId);
+            if (! $token) {
+                $this->dispatch('error', 'Invalid token selected.');
+
+                return;
+            }
+
+            $vultrService = new VultrService($token->token);
+            $instanceData = $vultrService->getInstance($this->matchedVultrInstance['id']);
+
+            if (empty($instanceData)) {
+                $this->dispatch('error', 'Could not find Vultr instance with ID: '.$this->matchedVultrInstance['id']);
+
+                return;
+            }
+
+            $this->server->update([
+                'cloud_provider_token_id' => $this->selectedVultrTokenId,
+                'vultr_instance_id' => $this->matchedVultrInstance['id'],
+                'vultr_instance_status' => $instanceData['status'] ?? null,
+            ]);
+
+            $this->vultrInstanceStatus = $instanceData['status'] ?? null;
+
+            $this->matchedVultrInstance = null;
+            $this->selectedVultrTokenId = null;
+            $this->manualVultrInstanceId = null;
+            $this->vultrNoMatchFound = false;
+            $this->vultrSearchError = null;
+
+            $this->dispatch('success', 'Server successfully linked to Vultr!');
             $this->dispatch('refreshServerShow');
         } catch (\Throwable $e) {
             return handleError($e, $this);

--- a/app/Livewire/Server/ValidateAndInstall.php
+++ b/app/Livewire/Server/ValidateAndInstall.php
@@ -87,6 +87,22 @@ class ValidateAndInstall extends Component
     public function validateConnection()
     {
         $this->authorize('update', $this->server);
+        if ($this->server->vultr_instance_id) {
+            $status = $this->server->refreshVultrState();
+            $this->server->refresh();
+
+            if (in_array($status, ['stopped', 'suspended', 'deleted'], true)) {
+                $this->error = $status === 'deleted'
+                    ? 'Vultr instance is deleted or no longer accessible. Relink this server before validating.'
+                    : 'Vultr instance is '.($status ?? 'not running').'. Power it on before validating.';
+                $this->server->update([
+                    'validation_logs' => $this->error,
+                ]);
+
+                return;
+            }
+        }
+
         ['uptime' => $this->uptime, 'error' => $error] = $this->server->validateConnection();
         if (! $this->uptime) {
             $sanitizedError = htmlspecialchars($error ?? '', ENT_QUOTES, 'UTF-8');

--- a/app/Models/CloudProviderToken.php
+++ b/app/Models/CloudProviderToken.php
@@ -2,8 +2,12 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
 class CloudProviderToken extends BaseModel
 {
+    use HasFactory;
+
     protected $fillable = [
         'team_id',
         'provider',

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -17,6 +17,7 @@ use App\Livewire\Server\Proxy;
 use App\Notifications\Server\Reachable;
 use App\Notifications\Server\Unreachable;
 use App\Services\ConfigurationRepository;
+use App\Services\VultrService;
 use App\Traits\ClearsGlobalSearchCache;
 use App\Traits\HasMetrics;
 use App\Traits\HasSafeStringAttribute;
@@ -269,7 +270,10 @@ class Server extends BaseModel
         'team_id',
         'hetzner_server_id',
         'hetzner_server_status',
+        'vultr_instance_id',
+        'vultr_instance_status',
         'is_validating',
+        'validation_logs',
         'detected_traefik_version',
         'traefik_outdated_info',
         'server_metadata',
@@ -288,6 +292,51 @@ class Server extends BaseModel
     public function type()
     {
         return 'server';
+    }
+
+    public function refreshVultrState(): ?string
+    {
+        if (! $this->vultr_instance_id || ! $this->cloudProviderToken) {
+            return null;
+        }
+
+        $vultrService = new VultrService($this->cloudProviderToken->token);
+        try {
+            $instance = $vultrService->getInstance($this->vultr_instance_id);
+        } catch (\Throwable $e) {
+            if ((int) $e->getCode() !== 404) {
+                throw $e;
+            }
+
+            if ($this->vultr_instance_status !== 'deleted') {
+                $this->update(['vultr_instance_status' => 'deleted']);
+                $this->forceFill(['vultr_instance_status' => 'deleted']);
+            }
+
+            return 'deleted';
+        }
+
+        $status = ($instance['power_status'] ?? null) === 'stopped'
+            ? 'stopped'
+            : ($instance['status'] ?? null);
+        $publicIp = $vultrService->getPublicIp($instance);
+
+        $updates = [];
+        if ($this->vultr_instance_status !== $status) {
+            $updates['vultr_instance_status'] = $status;
+        }
+
+        $hasPlaceholderIp = blank($this->ip) || in_array($this->ip, ['0.0.0.0', '::'], true);
+        if ($hasPlaceholderIp && $publicIp) {
+            $updates['ip'] = $publicIp;
+        }
+
+        if (! empty($updates)) {
+            $this->update($updates);
+            $this->forceFill($updates);
+        }
+
+        return $status;
     }
 
     protected function isCoolifyHost(): Attribute

--- a/app/Services/VultrService.php
+++ b/app/Services/VultrService.php
@@ -31,7 +31,7 @@ class VultrService
             throw new \Exception('Vultr API error: '.$response->json('error', 'Unknown error'), $response->status());
         }
 
-        return $response->json();
+        return $response->json() ?? [];
     }
 
     private function requestPaginated(string $endpoint, string $resourceKey, array $data = []): array

--- a/app/Services/VultrService.php
+++ b/app/Services/VultrService.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace App\Services;
+
+use App\Exceptions\RateLimitException;
+use Illuminate\Support\Facades\Http;
+
+class VultrService
+{
+    private string $baseUrl = 'https://api.vultr.com/v2';
+
+    public function __construct(private string $token) {}
+
+    private function request(string $method, string $endpoint, array $data = []): array
+    {
+        $response = Http::withHeaders([
+            'Authorization' => 'Bearer '.$this->token,
+        ])
+            ->timeout(30)
+            ->retry(3, fn (int $attempt) => $attempt * 100)
+            ->{$method}($this->baseUrl.$endpoint, $data);
+
+        if (! $response->successful()) {
+            if ($response->status() === 429) {
+                throw new RateLimitException(
+                    'Rate limit exceeded. Please try again later.',
+                    $response->header('Retry-After') !== null ? (int) $response->header('Retry-After') : null
+                );
+            }
+
+            throw new \Exception('Vultr API error: '.$response->json('error', 'Unknown error'), $response->status());
+        }
+
+        return $response->json();
+    }
+
+    private function requestPaginated(string $endpoint, string $resourceKey, array $data = []): array
+    {
+        $allResults = [];
+        $cursor = null;
+
+        do {
+            $query = $data;
+            $query['per_page'] = 100;
+
+            if ($cursor !== null) {
+                $query['cursor'] = $cursor;
+            }
+
+            $response = $this->request('get', $endpoint, $query);
+
+            if (isset($response[$resourceKey])) {
+                $allResults = array_merge($allResults, $response[$resourceKey]);
+            }
+
+            $next = $response['meta']['links']['next'] ?? null;
+            $cursor = $this->cursorFromNextLink($next);
+        } while ($cursor !== null);
+
+        return $allResults;
+    }
+
+    private function cursorFromNextLink(?string $next): ?string
+    {
+        if (blank($next)) {
+            return null;
+        }
+
+        parse_str((string) parse_url($next, PHP_URL_QUERY), $query);
+
+        return $query['cursor'] ?? null;
+    }
+
+    public function getRegions(): array
+    {
+        return $this->requestPaginated('/regions', 'regions');
+    }
+
+    public function getPlans(): array
+    {
+        return $this->requestPaginated('/plans', 'plans');
+    }
+
+    public function getOperatingSystems(): array
+    {
+        return $this->requestPaginated('/os', 'os');
+    }
+
+    public function getSshKeys(): array
+    {
+        return $this->requestPaginated('/ssh-keys', 'ssh_keys');
+    }
+
+    public function uploadSshKey(string $name, string $publicKey): array
+    {
+        $response = $this->request('post', '/ssh-keys', [
+            'name' => $name,
+            'ssh_key' => $publicKey,
+        ]);
+
+        return $response['ssh_key'] ?? [];
+    }
+
+    public function createInstance(array $params): array
+    {
+        if (! empty($params['user_data'])) {
+            $params['user_data'] = base64_encode($params['user_data']);
+        }
+
+        $response = $this->request('post', '/instances', $params);
+
+        return $response['instance'] ?? [];
+    }
+
+    public function waitForPublicIp(array $instance, bool $disablePublicIpv4 = false, bool $enableIpv6 = true, int $attempts = 6, int $sleepMilliseconds = 1000): array
+    {
+        if ($this->getPublicIp($instance, $disablePublicIpv4, $enableIpv6) || empty($instance['id'])) {
+            return $instance;
+        }
+
+        for ($attempt = 0; $attempt < $attempts; $attempt++) {
+            usleep($sleepMilliseconds * 1000);
+
+            $instance = $this->getInstance($instance['id']);
+
+            if ($this->getPublicIp($instance, $disablePublicIpv4, $enableIpv6)) {
+                return $instance;
+            }
+        }
+
+        return $instance;
+    }
+
+    public function getPublicIp(array $instance, bool $disablePublicIpv4 = false, bool $enableIpv6 = true): ?string
+    {
+        $ipv4 = $instance['main_ip'] ?? null;
+        if (! $disablePublicIpv4 && $this->isUsableIp($ipv4)) {
+            return $ipv4;
+        }
+
+        $ipv6 = $instance['v6_main_ip'] ?? null;
+        if ($enableIpv6 && $this->isUsableIp($ipv6)) {
+            return $ipv6;
+        }
+
+        return null;
+    }
+
+    private function isUsableIp(?string $ip): bool
+    {
+        return ! blank($ip) && ! in_array($ip, ['0.0.0.0', '::'], true);
+    }
+
+    public function getInstance(string $instanceId): array
+    {
+        $response = $this->request('get', "/instances/{$instanceId}");
+
+        return $response['instance'] ?? [];
+    }
+
+    public function startInstance(string $instanceId): array
+    {
+        return $this->request('post', "/instances/{$instanceId}/start");
+    }
+
+    public function deleteInstance(string $instanceId): void
+    {
+        $this->request('delete', "/instances/{$instanceId}");
+    }
+
+    public function getInstances(): array
+    {
+        return $this->requestPaginated('/instances', 'instances');
+    }
+
+    public function findInstanceByIp(string $ip): ?array
+    {
+        foreach ($this->getInstances() as $instance) {
+            if (($instance['main_ip'] ?? null) === $ip || ($instance['v6_main_ip'] ?? null) === $ip) {
+                return $instance;
+            }
+        }
+
+        return null;
+    }
+}

--- a/database/factories/CloudProviderTokenFactory.php
+++ b/database/factories/CloudProviderTokenFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\CloudProviderToken;
+use App\Models\Team;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<CloudProviderToken>
+ */
+class CloudProviderTokenFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'team_id' => Team::factory(),
+            'provider' => 'hetzner',
+            'token' => 'test-cloud-provider-token',
+            'name' => fake()->words(3, true),
+        ];
+    }
+}

--- a/database/migrations/2026_06_01_210459_add_vultr_instance_fields_to_servers_table.php
+++ b/database/migrations/2026_06_01_210459_add_vultr_instance_fields_to_servers_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! Schema::hasColumn('servers', 'vultr_instance_id')) {
+            Schema::table('servers', function (Blueprint $table) {
+                $table->string('vultr_instance_id')->nullable()->after('hetzner_server_status');
+            });
+        }
+
+        if (! Schema::hasColumn('servers', 'vultr_instance_status')) {
+            Schema::table('servers', function (Blueprint $table) {
+                $table->string('vultr_instance_status')->nullable()->after('vultr_instance_id');
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (Schema::hasColumn('servers', 'vultr_instance_status')) {
+            Schema::table('servers', function (Blueprint $table) {
+                $table->dropColumn('vultr_instance_status');
+            });
+        }
+
+        if (Schema::hasColumn('servers', 'vultr_instance_id')) {
+            Schema::table('servers', function (Blueprint $table) {
+                $table->dropColumn('vultr_instance_id');
+            });
+        }
+    }
+};

--- a/resources/views/components/server/sidebar.blade.php
+++ b/resources/views/components/server/sidebar.blade.php
@@ -14,10 +14,10 @@
     <a class="sub-menu-item {{ $activeMenu === 'private-key' ? 'menu-item-active' : '' }}" {{ wireNavigate() }}
         href="{{ route('server.private-key', ['server_uuid' => $server->uuid]) }}"><span class="menu-item-label">Private Key</span>
     </a>
-    @if ($server->hetzner_server_id)
+    @if ($server->hetzner_server_id || $server->vultr_instance_id)
         <a class="sub-menu-item {{ $activeMenu === 'cloud-provider-token' ? 'menu-item-active' : '' }}"
             {{ wireNavigate() }}
-            href="{{ route('server.cloud-provider-token', ['server_uuid' => $server->uuid]) }}"><span class="menu-item-label">Hetzner Token</span>
+            href="{{ route('server.cloud-provider-token', ['server_uuid' => $server->uuid]) }}"><span class="menu-item-label">Cloud Token</span>
         </a>
     @endif
     <a class="sub-menu-item {{ $activeMenu === 'ca-certificate' ? 'menu-item-active' : '' }}" {{ wireNavigate() }}

--- a/resources/views/livewire/boarding/index.blade.php
+++ b/resources/views/livewire/boarding/index.blade.php
@@ -193,6 +193,30 @@
                                         </x-slot:content>
                                         <livewire:server.new.by-hetzner :limit_reached="false" :from_onboarding="true" />
                                     </x-modal-input>
+                                    <x-modal-input title="Connect a Vultr Server" isFullWidth>
+                                        <x-slot:content>
+                                            <div
+                                                class="group relative box-without-bg cursor-pointer hover:border-coollabs transition-all duration-200 p-6 h-full min-h-[210px]">
+                                                <div class="flex flex-col gap-4 text-left">
+                                                    <div class="flex items-center justify-between">
+                                                        <svg class="size-10" viewBox="0 0 200 200"
+                                                            xmlns="http://www.w3.org/2000/svg">
+                                                            <rect width="200" height="200" fill="#007BFC" rx="8" />
+                                                            <path d="M42 46 H73 L100 127 L127 46 H158 L114 154 H86 Z"
+                                                                fill="white" />
+                                                        </svg>
+                                                    </div>
+                                                    <div>
+                                                        <h3 class="text-xl font-bold mb-2">Vultr Cloud</h3>
+                                                        <p class="text-sm dark:text-neutral-400">
+                                                            Deploy servers directly from your Vultr account.
+                                                        </p>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </x-slot:content>
+                                        <livewire:server.new.by-vultr :limit_reached="false" :from_onboarding="true" />
+                                    </x-modal-input>
                                 @endif
                             @endcan
                         </div>

--- a/resources/views/livewire/security/cloud-provider-token-form.blade.php
+++ b/resources/views/livewire/security/cloud-provider-token-form.blade.php
@@ -6,6 +6,7 @@
                 <x-forms.select required id="provider" label="Provider">
                     <option value="hetzner">Hetzner</option>
                     <option value="digitalocean">DigitalOcean</option>
+                    <option value="vultr">Vultr</option>
                 </x-forms.select>
             @else
                 <input type="hidden" wire:model="provider" />
@@ -20,7 +21,7 @@
             @if (auth()->user()->currentTeam()->cloudProviderTokens->where('provider', $provider)->isEmpty())
                 <div class="text-sm text-neutral-500 dark:text-neutral-400">
                     Create an API token in the <a
-                        href='{{ $provider === 'hetzner' ? 'https://console.hetzner.com/projects' : '#' }}'
+                        href='{{ $provider === 'hetzner' ? 'https://console.hetzner.com/projects' : ($provider === 'vultr' ? 'https://my.vultr.com/settings/#settingsapi' : '#') }}'
                         target='_blank' class='underline dark:text-white'>{{ ucfirst($provider) }} Console</a> → choose
                     Project → Security → API Tokens.
                     @if ($provider === 'hetzner')
@@ -42,6 +43,7 @@
                     <x-forms.select required id="provider" label="Provider" disabled>
                         <option value="hetzner" selected>Hetzner</option>
                         <option value="digitalocean">DigitalOcean</option>
+                        <option value="vultr">Vultr</option>
                     </x-forms.select>
                 </div>
                 <div class="flex-1 min-w-64">

--- a/resources/views/livewire/server/cloud-provider-token/show.blade.php
+++ b/resources/views/livewire/server/cloud-provider-token/show.blade.php
@@ -1,17 +1,17 @@
 <div>
     <x-slot:title>
-        {{ data_get_str($server, 'name')->limit(10) }} > Hetzner Token | Coolify
+        {{ data_get_str($server, 'name')->limit(10) }} > Cloud Token | Coolify
     </x-slot>
     <livewire:server.navbar :server="$server" />
     <div class="flex flex-col h-full gap-8 sm:flex-row">
         <x-server.sidebar :server="$server" activeMenu="cloud-provider-token" />
         <div class="w-full">
-            @if ($server->hetzner_server_id)
+            @if ($server->hetzner_server_id || $server->vultr_instance_id)
                 <div class="flex items-end gap-2">
-                    <h2>Hetzner Token</h2>
+                    <h2>{{ $providerName }} Token</h2>
                     @can('create', App\Models\CloudProviderToken::class)
-                        <x-modal-input buttonTitle="+ Add" title="Add Hetzner Token">
-                            <livewire:security.cloud-provider-token-form :modal_mode="true" provider="hetzner" />
+                        <x-modal-input buttonTitle="+ Add" title="Add {{ $providerName }} Token">
+                            <livewire:security.cloud-provider-token-form :modal_mode="true" :provider="$provider" />
                         </x-modal-input>
                     @endcan
                     <x-forms.button canGate="update" :canResource="$server" isHighlighted
@@ -19,7 +19,7 @@
                         Validate token
                     </x-forms.button>
                 </div>
-                <div class="pb-4">Change your server's Hetzner token.</div>
+                <div class="pb-4">Change your server's {{ $providerName }} token.</div>
                 <div class="grid xl:grid-cols-2 grid-cols-1 gap-2">
                     @forelse ($cloudProviderTokens as $token)
                         <div
@@ -42,17 +42,17 @@
                             @endif
                         </div>
                     @empty
-                        <div>No Hetzner tokens found. </div>
+                        <div>No {{ $providerName }} tokens found. </div>
                     @endforelse
                 </div>
             @else
                 <div class="flex items-end gap-2">
-                    <h2>Hetzner Token</h2>
+                    <h2>Cloud Token</h2>
                 </div>
-                <div class="pb-4">This server was not created through Hetzner Cloud integration.</div>
+                <div class="pb-4">This server was not created through a supported cloud provider integration.</div>
                 <div class="p-4 border rounded-md dark:border-coolgray-300 dark:bg-coolgray-100">
                     <p class="dark:text-neutral-400">
-                        Only servers created through Hetzner Cloud can have their tokens managed here.
+                        Only servers created through a supported cloud provider can have their tokens managed here.
                     </p>
                 </div>
             @endif

--- a/resources/views/livewire/server/create.blade.php
+++ b/resources/views/livewire/server/create.blade.php
@@ -23,6 +23,29 @@
                 </x-modal-input>
             </div>
 
+            <div>
+                <x-modal-input title="Connect a Vultr Server">
+                    <x-slot:content>
+                        <div class="relative gap-2 cursor-pointer coolbox group">
+                            <div class="flex items-center gap-4 mx-6">
+                                <svg class="w-10 h-10 flex-shrink-0" viewBox="0 0 200 200"
+                                    xmlns="http://www.w3.org/2000/svg">
+                                    <rect width="200" height="200" fill="#007BFC" rx="8" />
+                                    <path d="M42 46 H73 L100 127 L127 46 H158 L114 154 H86 Z" fill="white" />
+                                </svg>
+                                <div class="flex flex-col justify-center flex-1">
+                                    <div class="box-title">Connect a Vultr Server</div>
+                                    <div class="box-description">
+                                        Deploy servers directly from your Vultr account
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </x-slot:content>
+                    <livewire:server.new.by-vultr :private_keys="$private_keys" :limit_reached="$limit_reached" />
+                </x-modal-input>
+            </div>
+
             <div class="border-t dark:border-coolgray-300 my-4"></div>
         @endcan
 

--- a/resources/views/livewire/server/new/by-vultr.blade.php
+++ b/resources/views/livewire/server/new/by-vultr.blade.php
@@ -1,0 +1,192 @@
+<div class="w-full">
+    @if ($limit_reached)
+        <x-limit-reached name="servers" />
+    @else
+        @if ($current_step === 1)
+            <div class="flex flex-col w-full gap-4">
+                @if ($available_tokens->count() > 0)
+                    <div class="flex gap-2">
+                        <div class="flex-1">
+                            <x-forms.select label="Select Vultr Token" id="selected_token_id"
+                                wire:change="selectToken($event.target.value)" required>
+                                <option value="">Select a saved token...</option>
+                                @foreach ($available_tokens as $token)
+                                    <option value="{{ $token->id }}">
+                                        {{ $token->name ?? 'Vultr Token' }}
+                                    </option>
+                                @endforeach
+                            </x-forms.select>
+                        </div>
+                        <div class="flex items-end">
+                            <x-forms.button canGate="create" :canResource="App\Models\Server::class" wire:click="nextStep"
+                                :disabled="!$selected_token_id">
+                                Continue
+                            </x-forms.button>
+                        </div>
+                    </div>
+
+                    <div class="text-center text-sm dark:text-neutral-500">OR</div>
+                @endif
+
+                <x-modal-input isFullWidth
+                    buttonTitle="{{ $available_tokens->count() > 0 ? '+ Add New Token' : 'Add Vultr Token' }}"
+                    title="Add Vultr Token">
+                    <livewire:security.cloud-provider-token-form :modal_mode="true" provider="vultr" />
+                </x-modal-input>
+            </div>
+        @elseif ($current_step === 2)
+            @if ($loading_data)
+                <div class="flex items-center justify-center py-8">
+                    <div class="text-center">
+                        <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto"></div>
+                        <p class="mt-4 text-sm dark:text-neutral-400">Loading Vultr data...</p>
+                    </div>
+                </div>
+            @else
+                <form class="flex flex-col w-full gap-2" wire:submit='submit'>
+                    <div>
+                        <x-forms.input id="server_name" label="Server Name" helper="A friendly name for your server." />
+                    </div>
+
+                    <div>
+                        <x-forms.select label="Region" id="selected_region" wire:model.live="selected_region" required>
+                            <option value="">Select a region...</option>
+                            @foreach ($regions as $region)
+                                <option value="{{ $region['id'] }}">
+                                    {{ $region['city'] ?? $region['id'] }} - {{ $region['country'] ?? $region['id'] }}
+                                </option>
+                            @endforeach
+                        </x-forms.select>
+                    </div>
+
+                    <div>
+                        <x-forms.select label="Plan" id="selected_plan" wire:model.live="selected_plan"
+                            helper="Learn more about <a class='inline-block underline dark:text-white' href='https://www.vultr.com/products/cloud-compute/' target='_blank'>Vultr plans</a>"
+                            required :disabled="!$selected_region">
+                            <option value="">
+                                {{ $selected_region ? 'Select a plan...' : 'Select a region first' }}
+                            </option>
+                            @foreach ($this->availablePlans as $plan)
+                                <option value="{{ $plan['id'] }}">
+                                    {{ $plan['id'] }} -
+                                    {{ $plan['vcpu_count'] ?? '?' }} vCPU,
+                                    {{ isset($plan['ram']) ? number_format($plan['ram'] / 1024, 1) : '?' }}GB RAM,
+                                    {{ $plan['disk'] ?? '?' }}GB
+                                    @if (isset($plan['monthly_cost']))
+                                        - ${{ number_format((float) $plan['monthly_cost'], 2) }}/mo
+                                    @endif
+                                </option>
+                            @endforeach
+                        </x-forms.select>
+                    </div>
+
+                    <div>
+                        <x-forms.select label="Operating System" id="selected_os_id" required>
+                            <option value="">Select an operating system...</option>
+                            @foreach ($operatingSystems as $operatingSystem)
+                                <option value="{{ $operatingSystem['id'] }}">
+                                    {{ $operatingSystem['name'] }}
+                                </option>
+                            @endforeach
+                        </x-forms.select>
+                    </div>
+
+                    <div>
+                        @if ($private_keys->count() === 0)
+                            <div class="flex flex-col gap-2">
+                                <label class="flex gap-1 items-center mb-1 text-sm font-medium">
+                                    Private Key
+                                    <x-highlighted text="*" />
+                                </label>
+                                <div
+                                    class="p-4 border border-warning-500 dark:border-warning-600 rounded bg-warning-50 dark:bg-warning-900/10">
+                                    <p class="text-sm mb-3 text-neutral-700 dark:text-neutral-300">
+                                        No private keys found. You need to create a private key to continue.
+                                    </p>
+                                    <x-modal-input buttonTitle="Create New Private Key" title="New Private Key"
+                                        isHighlightedButton>
+                                        <livewire:security.private-key.create :modal_mode="true" from="server" />
+                                    </x-modal-input>
+                                </div>
+                            </div>
+                        @else
+                            <x-forms.select label="Private Key" id="private_key_id" required>
+                                <option value="">Select a private key...</option>
+                                @foreach ($private_keys as $key)
+                                    <option value="{{ $key->id }}">
+                                        {{ $key->name }}
+                                    </option>
+                                @endforeach
+                            </x-forms.select>
+                            <p class="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
+                                This SSH key will be automatically added to your Vultr account and used to access the
+                                server.
+                            </p>
+                        @endif
+                    </div>
+
+                    <div>
+                        <x-forms.datalist label="Additional SSH Keys (from Vultr)" id="selectedVultrSshKeyIds"
+                            helper="Select existing SSH keys from your Vultr account to add to this server. The Coolify SSH key will be automatically added."
+                            :multiple="true" :disabled="count($vultrSshKeys) === 0" :placeholder="count($vultrSshKeys) > 0 ? 'Search and select SSH keys...' : 'No SSH keys found in Vultr account'">
+                            @foreach ($vultrSshKeys as $sshKey)
+                                <option value="{{ $sshKey['id'] }}">
+                                    {{ $sshKey['name'] }} - {{ substr($sshKey['id'], 0, 20) }}
+                                </option>
+                            @endforeach
+                        </x-forms.datalist>
+                    </div>
+
+                    <div class="flex flex-col gap-2">
+                        <label class="text-sm font-medium">Network Configuration</label>
+                        <div class="flex gap-4">
+                            <x-forms.checkbox id="enable_ipv6" label="Enable IPv6"
+                                helper="Enable public IPv6 address for this server" />
+                            <x-forms.checkbox id="disable_public_ipv4" label="Disable public IPv4"
+                                helper="Disable the default public IPv4 address" />
+                        </div>
+                    </div>
+
+                    <div class="flex flex-col gap-2">
+                        <div class="flex justify-between items-center gap-2">
+                            <label class="text-sm font-medium w-32">Cloud-Init Script</label>
+                            @if ($saved_cloud_init_scripts->count() > 0)
+                                <div class="flex items-center gap-2 flex-1">
+                                    <x-forms.select wire:model.live="selected_cloud_init_script_id" label="" helper="">
+                                        <option value="">Load saved script...</option>
+                                        @foreach ($saved_cloud_init_scripts as $script)
+                                            <option value="{{ $script->id }}">{{ $script->name }}</option>
+                                        @endforeach
+                                    </x-forms.select>
+                                    <x-forms.button type="button" wire:click="clearCloudInitScript">
+                                        Clear
+                                    </x-forms.button>
+                                </div>
+                            @endif
+                        </div>
+                        <x-forms.textarea id="cloud_init_script" label=""
+                            helper="Add a cloud-init script to run when the server is created. Coolify sends it to Vultr as user data."
+                            rows="8" />
+
+                        <div class="flex items-center gap-2">
+                            <x-forms.checkbox id="save_cloud_init_script" label="Save this script for later use" />
+                            <div class="flex-1">
+                                <x-forms.input id="cloud_init_script_name" label="" placeholder="Script name..." />
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="flex gap-2 justify-between">
+                        <x-forms.button type="button" wire:click="previousStep">
+                            Back
+                        </x-forms.button>
+                        <x-forms.button isHighlighted canGate="create" :canResource="App\Models\Server::class"
+                            type="submit" :disabled="!$private_key_id">
+                            Buy & Create Server{{ $this->selectedServerPrice ? ' (' . $this->selectedServerPrice . '/mo)' : '' }}
+                        </x-forms.button>
+                    </div>
+                </form>
+            @endif
+        @endif
+    @endif
+</div>

--- a/resources/views/livewire/server/show.blade.php
+++ b/resources/views/livewire/server/show.blade.php
@@ -1,4 +1,5 @@
-<div x-data x-init="@if ($server->hetzner_server_id && $server->cloudProviderToken && !$hetznerServerStatus) $wire.checkHetznerServerStatus() @endif">
+<div x-data
+    x-init="@if ($server->hetzner_server_id && $server->cloudProviderToken && !$hetznerServerStatus) $wire.checkHetznerServerStatus(); @endif @if ($server->vultr_instance_id && $server->cloudProviderToken) $wire.checkVultrInstanceStatus(); @endif">
     <x-slot:title>
         {{ data_get_str($server, 'name')->limit(10) }} > General | Coolify
     </x-slot>
@@ -78,6 +79,74 @@
                             </x-forms.button>
                         @endif
                     @endif
+                    @if ($server->vultr_instance_id)
+                        <div class="flex items-center">
+                            <div @class([
+                                'flex items-center gap-1.5 px-2 py-1 text-xs font-semibold rounded transition-all',
+                                'bg-white dark:bg-coolgray-100 dark:text-white',
+                            ])
+                                @if (in_array($vultrInstanceStatus, ['pending', 'starting'])) wire:poll.5s="checkVultrInstanceStatus" @endif>
+                                <svg class="w-4 h-4" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+                                    <rect width="200" height="200" fill="#007BFC" rx="8" />
+                                    <path d="M42 46 H73 L100 127 L127 46 H158 L114 154 H86 Z" fill="white" />
+                                </svg>
+                                @if ($vultrInstanceStatus)
+                                    <span class="pl-1.5">
+                                        @if (in_array($vultrInstanceStatus, ['pending', 'starting']))
+                                            <svg class="inline animate-spin h-3 w-3 mr-1 text-coollabs dark:text-warning-500"
+                                                xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                                                <circle class="opacity-25" cx="12" cy="12" r="10"
+                                                    stroke="currentColor" stroke-width="4"></circle>
+                                                <path class="opacity-75" fill="currentColor"
+                                                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z">
+                                                </path>
+                                            </svg>
+                                        @endif
+                                        <span @class([
+                                            'text-green-500' => $vultrInstanceStatus === 'active',
+                                            'text-red-500' => in_array($vultrInstanceStatus, ['stopped', 'suspended', 'deleted']),
+                                        ])>
+                                            {{ ucfirst($vultrInstanceStatus) }}
+                                        </span>
+                                    </span>
+                                @else
+                                    <span class="pl-1.5">
+                                        <svg class="inline animate-spin h-3 w-3 mr-1 text-coollabs dark:text-warning-500"
+                                            xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                                            <circle class="opacity-25" cx="12" cy="12" r="10"
+                                                stroke="currentColor" stroke-width="4"></circle>
+                                            <path class="opacity-75" fill="currentColor"
+                                                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z">
+                                            </path>
+                                        </svg>
+                                        <span>Checking status...</span>
+                                    </span>
+                                @endif
+                            </div>
+                            <button wire:loading.remove wire:target="checkVultrInstanceStatus" title="Refresh Status"
+                                wire:click.prevent='checkVultrInstanceStatus(true)'
+                                class="mx-1 dark:hover:fill-white fill-black dark:fill-warning">
+                                <svg class="w-4 h-4" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                    <path
+                                        d="M12 2a10.016 10.016 0 0 0-7 2.877V3a1 1 0 1 0-2 0v4.5a1 1 0 0 0 1 1h4.5a1 1 0 0 0 0-2H6.218A7.98 7.98 0 0 1 20 12a1 1 0 0 0 2 0A10.012 10.012 0 0 0 12 2zm7.989 13.5h-4.5a1 1 0 0 0 0 2h2.293A7.98 7.98 0 0 1 4 12a1 1 0 0 0-2 0a9.986 9.986 0 0 0 16.989 7.133V21a1 1 0 0 0 2 0v-4.5a1 1 0 0 0-1-1z" />
+                                </svg>
+                            </button>
+                            <button wire:loading wire:target="checkVultrInstanceStatus" title="Refreshing Status"
+                                class="mx-1 dark:hover:fill-white fill-black dark:fill-warning">
+                                <svg class="w-4 h-4 animate-spin" viewBox="0 0 24 24"
+                                    xmlns="http://www.w3.org/2000/svg">
+                                    <path
+                                        d="M12 2a10.016 10.016 0 0 0-7 2.877V3a1 1 0 1 0-2 0v4.5a1 1 0 0 0 1 1h4.5a1 1 0 0 0 0-2H6.218A7.98 7.98 0 0 1 20 12a1 1 0 0 0 2 0A10.012 10.012 0 0 0 12 2zm7.989 13.5h-4.5a1 1 0 0 0 0 2h2.293A7.98 7.98 0 0 1 4 12a1 1 0 0 0-2 0a9.986 9.986 0 0 0 16.989 7.133V21a1 1 0 0 0 2 0v-4.5a1 1 0 0 0-1-1z" />
+                                </svg>
+                            </button>
+                        </div>
+                        @if ($server->cloudProviderToken && !$server->isFunctional() && $vultrInstanceStatus === 'stopped')
+                            <x-forms.button wire:click.prevent='startVultrInstance' isHighlighted canGate="update"
+                                :canResource="$server">
+                                Power On
+                            </x-forms.button>
+                        @endif
+                    @endif
                     @if ($isValidating)
                         <div
                             class="flex items-center gap-1.5 px-2 py-1 text-xs font-semibold rounded bg-warning-100 dark:bg-warning-900/30 text-warning-700 dark:text-warning-400">
@@ -134,7 +203,8 @@
                     (!$isReachable || !$isUsable) &&
                         $server->id !== 0 &&
                         !$isValidating &&
-                        !in_array($hetznerServerStatus, ['initializing', 'starting', 'stopping', 'off']))
+                        !in_array($hetznerServerStatus, ['initializing', 'starting', 'stopping', 'off']) &&
+                        !in_array($vultrInstanceStatus, ['pending', 'starting', 'stopped', 'suspended', 'deleted']))
                     <x-slide-over closeWithX fullScreen>
                         <x-slot:title>Validate & configure</x-slot:title>
                         <x-slot:content>
@@ -417,6 +487,82 @@
                                 <div><span class="font-medium">Type:</span> {{ data_get($matchedHetznerServer, 'server_type.name', 'Unknown') }}</div>
                             </div>
                             <x-forms.button wire:click="linkToHetzner" isHighlighted canGate="update" :canResource="$server">
+                                Link This Server
+                            </x-forms.button>
+                        </div>
+                    @endif
+                </div>
+            @endif
+            @if (!$server->vultr_instance_id && $availableVultrTokens->isNotEmpty())
+                <div class="pt-6">
+                    <h3>Link to Vultr</h3>
+                    <p class="pb-4 text-sm dark:text-neutral-400">
+                        Link this server to a Vultr instance to enable power controls and status monitoring.
+                    </p>
+
+                    <div class="flex flex-wrap gap-4 items-end">
+                        <div class="w-72">
+                            <x-forms.select wire:model="selectedVultrTokenId" label="Vultr Token"
+                                canGate="update" :canResource="$server">
+                                <option value="">Select a token...</option>
+                                @foreach ($availableVultrTokens as $token)
+                                    <option value="{{ $token->id }}">{{ $token->name }}</option>
+                                @endforeach
+                            </x-forms.select>
+                        </div>
+                        <div class="w-72">
+                            <x-forms.input wire:model="manualVultrInstanceId"
+                                label="Instance ID"
+                                placeholder="e.g., 6d4b..."
+                                helper="Enter the Vultr Instance ID from your Vultr dashboard"
+                                canGate="update" :canResource="$server" />
+                        </div>
+                        <x-forms.button wire:click="searchVultrInstanceById"
+                            wire:loading.attr="disabled"
+                            canGate="update" :canResource="$server">
+                            <span wire:loading.remove wire:target="searchVultrInstanceById">Search by ID</span>
+                            <span wire:loading wire:target="searchVultrInstanceById">Searching...</span>
+                        </x-forms.button>
+                        <div class="self-end pb-2 text-sm dark:text-neutral-500">OR</div>
+                        <x-forms.button wire:click="searchVultrInstance"
+                            wire:loading.attr="disabled"
+                            canGate="update" :canResource="$server">
+                            <span wire:loading.remove wire:target="searchVultrInstance">Search by IP</span>
+                            <span wire:loading wire:target="searchVultrInstance">Searching...</span>
+                        </x-forms.button>
+                    </div>
+
+                    @if ($vultrSearchError)
+                        <div class="mt-4 p-4 border border-red-500 rounded-md bg-red-50 dark:bg-red-900/20">
+                            <p class="text-red-600 dark:text-red-400">{{ $vultrSearchError }}</p>
+                        </div>
+                    @endif
+
+                    @if ($vultrNoMatchFound)
+                        <div class="mt-4 p-4 border border-yellow-500 rounded-md bg-yellow-50 dark:bg-yellow-900/20">
+                            <p class="text-yellow-600 dark:text-yellow-400">
+                                @if ($manualVultrInstanceId)
+                                    No Vultr instance found with ID: {{ $manualVultrInstanceId }}
+                                @else
+                                    No Vultr instance found matching IP: {{ $server->ip }}
+                                @endif
+                            </p>
+                            <p class="text-sm dark:text-neutral-400 mt-1">
+                                Try a different token, enter the Instance ID manually, or verify the details are correct.
+                            </p>
+                        </div>
+                    @endif
+
+                    @if ($matchedVultrInstance)
+                        <div class="mt-4 p-4 border border-green-500 rounded-md bg-green-50 dark:bg-green-900/20">
+                            <h4 class="font-semibold text-green-700 dark:text-green-400 mb-2">Match Found!</h4>
+                            <div class="grid grid-cols-2 gap-2 text-sm mb-4">
+                                <div><span class="font-medium">Name:</span> {{ $matchedVultrInstance['label'] ?? $matchedVultrInstance['hostname'] ?? 'Unknown' }}</div>
+                                <div><span class="font-medium">ID:</span> {{ $matchedVultrInstance['id'] }}</div>
+                                <div><span class="font-medium">Status:</span> {{ ucfirst($matchedVultrInstance['status'] ?? 'unknown') }}</div>
+                                <div><span class="font-medium">Plan:</span> {{ $matchedVultrInstance['plan'] ?? 'Unknown' }}</div>
+                            </div>
+                            <x-forms.button wire:click="linkToVultr" isHighlighted canGate="update" :canResource="$server">
                                 Link This Server
                             </x-forms.button>
                         </div>

--- a/resources/views/livewire/server/show.blade.php
+++ b/resources/views/livewire/server/show.blade.php
@@ -140,7 +140,7 @@
                                 </svg>
                             </button>
                         </div>
-                        @if ($server->cloudProviderToken && !$server->isFunctional() && $vultrInstanceStatus === 'stopped')
+                        @if ($server->cloudProviderToken && $vultrInstanceStatus === 'stopped')
                             <x-forms.button wire:click.prevent='startVultrInstance' isHighlighted canGate="update"
                                 :canResource="$server">
                                 Power On

--- a/routes/api.php
+++ b/routes/api.php
@@ -15,6 +15,7 @@ use App\Http\Controllers\Api\SentinelController;
 use App\Http\Controllers\Api\ServersController;
 use App\Http\Controllers\Api\ServicesController;
 use App\Http\Controllers\Api\TeamController;
+use App\Http\Controllers\Api\VultrController;
 use App\Http\Middleware\ApiAllowed;
 use Illuminate\Support\Facades\Route;
 
@@ -97,6 +98,12 @@ Route::group([
     Route::get('/hetzner/images', [HetznerController::class, 'images'])->middleware(['api.ability:read']);
     Route::get('/hetzner/ssh-keys', [HetznerController::class, 'sshKeys'])->middleware(['api.ability:read']);
     Route::post('/servers/hetzner', [HetznerController::class, 'createServer'])->middleware(['api.ability:write']);
+
+    Route::get('/vultr/regions', [VultrController::class, 'regions'])->middleware(['api.ability:read']);
+    Route::get('/vultr/plans', [VultrController::class, 'plans'])->middleware(['api.ability:read']);
+    Route::get('/vultr/os', [VultrController::class, 'operatingSystems'])->middleware(['api.ability:read']);
+    Route::get('/vultr/ssh-keys', [VultrController::class, 'sshKeys'])->middleware(['api.ability:read']);
+    Route::post('/servers/vultr', [VultrController::class, 'createServer'])->middleware(['api.ability:write']);
 
     Route::get('/resources', [ResourcesController::class, 'resources'])->middleware(['api.ability:read']);
 

--- a/tests/Feature/CloudProviderTokenApiTest.php
+++ b/tests/Feature/CloudProviderTokenApiTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\CloudProviderToken;
+use App\Models\InstanceSettings;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -9,6 +10,17 @@ use Illuminate\Support\Facades\Http;
 uses(RefreshDatabase::class);
 
 beforeEach(function () {
+    config([
+        'app.maintenance.driver' => 'file',
+        'cache.default' => 'array',
+        'session.driver' => 'array',
+    ]);
+
+    InstanceSettings::unguarded(fn () => InstanceSettings::query()->create([
+        'id' => 0,
+        'is_api_enabled' => true,
+    ]));
+
     // Create a team with owner
     $this->team = Team::factory()->create();
     $this->user = User::factory()->create();
@@ -159,6 +171,30 @@ describe('POST /api/v1/cloud-tokens', function () {
         $response->assertJsonStructure(['uuid']);
     });
 
+    test('creates a Vultr cloud provider token', function () {
+        Http::fake([
+            'https://api.vultr.com/v2/account' => Http::response([], 200),
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->postJson('/api/v1/cloud-tokens', [
+            'provider' => 'vultr',
+            'token' => 'test-vultr-token',
+            'name' => 'My Vultr Token',
+        ]);
+
+        $response->assertStatus(201);
+        $response->assertJsonStructure(['uuid']);
+
+        $this->assertDatabaseHas('cloud_provider_tokens', [
+            'team_id' => $this->team->id,
+            'provider' => 'vultr',
+            'name' => 'My Vultr Token',
+        ]);
+    });
+
     test('validates provider is required', function () {
         $response = $this->withHeaders([
             'Authorization' => 'Bearer '.$this->bearerToken,
@@ -198,7 +234,7 @@ describe('POST /api/v1/cloud-tokens', function () {
         $response->assertJsonValidationErrors(['name']);
     });
 
-    test('validates provider must be hetzner or digitalocean', function () {
+    test('validates provider must be hetzner digitalocean or vultr', function () {
         $response = $this->withHeaders([
             'Authorization' => 'Bearer '.$this->bearerToken,
             'Content-Type' => 'application/json',
@@ -285,8 +321,7 @@ describe('PATCH /api/v1/cloud-tokens/{uuid}', function () {
             'Content-Type' => 'application/json',
         ])->patchJson("/api/v1/cloud-tokens/{$token->uuid}", []);
 
-        $response->assertStatus(422);
-        $response->assertJsonValidationErrors(['name']);
+        $response->assertStatus(400);
     });
 
     test('cannot update token from another team', function () {
@@ -400,6 +435,25 @@ describe('POST /api/v1/cloud-tokens/{uuid}/validate', function () {
 
         Http::fake([
             'https://api.digitalocean.com/v2/account' => Http::response([], 200),
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->postJson("/api/v1/cloud-tokens/{$token->uuid}/validate");
+
+        $response->assertStatus(200);
+        $response->assertJson(['valid' => true, 'message' => 'Token is valid.']);
+    });
+
+    test('validates a valid Vultr token', function () {
+        $token = CloudProviderToken::factory()->create([
+            'team_id' => $this->team->id,
+            'provider' => 'vultr',
+        ]);
+
+        Http::fake([
+            'https://api.vultr.com/v2/account' => Http::response([], 200),
         ]);
 
         $response = $this->withHeaders([

--- a/tests/Feature/VultrApiTest.php
+++ b/tests/Feature/VultrApiTest.php
@@ -1,0 +1,374 @@
+<?php
+
+use App\Models\CloudProviderToken;
+use App\Models\InstanceSettings;
+use App\Models\PrivateKey;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    config([
+        'app.maintenance.driver' => 'file',
+        'cache.default' => 'array',
+        'session.driver' => 'array',
+    ]);
+
+    InstanceSettings::unguarded(fn () => InstanceSettings::query()->create([
+        'id' => 0,
+        'is_api_enabled' => true,
+    ]));
+
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+
+    session(['currentTeam' => $this->team]);
+    $this->token = $this->user->createToken('test-token', ['*']);
+    $this->bearerToken = $this->token->plainTextToken;
+
+    $this->vultrToken = CloudProviderToken::create([
+        'team_id' => $this->team->id,
+        'provider' => 'vultr',
+        'token' => 'test-vultr-api-token',
+        'name' => 'Test Vultr Token',
+    ]);
+
+    $this->privateKey = PrivateKey::create([
+        'team_id' => $this->team->id,
+        'name' => 'Test Private Key',
+        'description' => 'Test private key',
+        'private_key' => testPrivateKey(),
+    ]);
+});
+
+function testPrivateKey(): string
+{
+    return <<<'KEY'
+-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACBbhpqHhqv6aI67Mj9abM3DVbmcfYhZAhC7ca4d9UCevAAAAJi/QySHv0Mk
+hwAAAAtzc2gtZWQyNTUxOQAAACBbhpqHhqv6aI67Mj9abM3DVbmcfYhZAhC7ca4d9UCevA
+AAAECBQw4jg1WRT2IGHMncCiZhURCts2s24HoDS0thHnnRKVuGmoeGq/pojrsyP1pszcNV
+uZx9iFkCELtxrh31QJ68AAAAEXNhaWxANzZmZjY2ZDJlMmRkAQIDBA==
+-----END OPENSSH PRIVATE KEY-----
+KEY;
+}
+
+function testPublicKey(): string
+{
+    return 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFuGmoeGq/pojrsyP1pszcNVuZx9iFkCELtxrh31QJ68';
+}
+
+describe('GET /api/v1/vultr/regions', function () {
+    test('gets Vultr regions', function () {
+        Http::fake([
+            'https://api.vultr.com/v2/regions*' => Http::response([
+                'regions' => [
+                    ['id' => 'ewr', 'city' => 'New Jersey', 'country' => 'US'],
+                    ['id' => 'ams', 'city' => 'Amsterdam', 'country' => 'NL'],
+                ],
+                'meta' => ['links' => ['next' => null]],
+            ], 200),
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->getJson('/api/v1/vultr/regions?cloud_provider_token_id='.$this->vultrToken->uuid);
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(2);
+        $response->assertJsonFragment(['id' => 'ewr']);
+    });
+
+    test('requires cloud_provider_token_id parameter', function () {
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->getJson('/api/v1/vultr/regions');
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['cloud_provider_token_id']);
+    });
+});
+
+describe('GET /api/v1/vultr/plans', function () {
+    test('gets Vultr plans', function () {
+        Http::fake([
+            'https://api.vultr.com/v2/plans*' => Http::response([
+                'plans' => [
+                    ['id' => 'vc2-1c-1gb', 'vcpu_count' => 1, 'ram' => 1024, 'disk' => 25],
+                    ['id' => 'vc2-2c-2gb', 'vcpu_count' => 2, 'ram' => 2048, 'disk' => 55],
+                ],
+                'meta' => ['links' => ['next' => null]],
+            ], 200),
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->getJson('/api/v1/vultr/plans?cloud_provider_token_uuid='.$this->vultrToken->uuid);
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(2);
+        $response->assertJsonFragment(['id' => 'vc2-1c-1gb']);
+    });
+});
+
+describe('GET /api/v1/vultr/os', function () {
+    test('gets Vultr operating systems', function () {
+        Http::fake([
+            'https://api.vultr.com/v2/os*' => Http::response([
+                'os' => [
+                    ['id' => 2284, 'name' => 'Ubuntu 24.04 LTS x64'],
+                    ['id' => 2136, 'name' => 'Debian 12 x64'],
+                ],
+                'meta' => ['links' => ['next' => null]],
+            ], 200),
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->getJson('/api/v1/vultr/os?cloud_provider_token_id='.$this->vultrToken->uuid);
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(2);
+        $response->assertJsonFragment(['name' => 'Ubuntu 24.04 LTS x64']);
+    });
+});
+
+describe('GET /api/v1/vultr/ssh-keys', function () {
+    test('gets Vultr SSH keys', function () {
+        Http::fake([
+            'https://api.vultr.com/v2/ssh-keys*' => Http::response([
+                'ssh_keys' => [
+                    ['id' => 'key-1', 'name' => 'my-key', 'ssh_key' => testPublicKey()],
+                    ['id' => 'key-2', 'name' => 'another-key', 'ssh_key' => 'ssh-ed25519 AAAAother'],
+                ],
+                'meta' => ['links' => ['next' => null]],
+            ], 200),
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->getJson('/api/v1/vultr/ssh-keys?cloud_provider_token_id='.$this->vultrToken->uuid);
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(2);
+        $response->assertJsonFragment(['name' => 'my-key']);
+    });
+});
+
+describe('POST /api/v1/servers/vultr', function () {
+    test('creates a Vultr server', function () {
+        Http::fake([
+            'https://api.vultr.com/v2/ssh-keys' => Http::response([
+                'ssh_key' => ['id' => 'key-1', 'ssh_key' => testPublicKey()],
+            ], 201),
+            'https://api.vultr.com/v2/ssh-keys*' => Http::response([
+                'ssh_keys' => [],
+                'meta' => ['links' => ['next' => null]],
+            ], 200),
+            'https://api.vultr.com/v2/instances' => Http::response([
+                'instance' => [
+                    'id' => 'instance-1',
+                    'label' => 'test-server',
+                    'main_ip' => '1.2.3.4',
+                    'v6_main_ip' => '2001:db8::1',
+                    'status' => 'pending',
+                ],
+            ], 202),
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->postJson('/api/v1/servers/vultr', [
+            'cloud_provider_token_id' => $this->vultrToken->uuid,
+            'region' => 'ewr',
+            'plan' => 'vc2-1c-1gb',
+            'os_id' => 2284,
+            'name' => 'test-server',
+            'private_key_uuid' => $this->privateKey->uuid,
+            'enable_ipv6' => true,
+            'cloud_init_script' => "#cloud-config\npackages:\n  - curl",
+        ]);
+
+        $response->assertStatus(201);
+        $response->assertJsonStructure(['uuid', 'vultr_instance_id', 'ip']);
+        $response->assertJsonFragment(['vultr_instance_id' => 'instance-1', 'ip' => '1.2.3.4']);
+
+        $this->assertDatabaseHas('servers', [
+            'name' => 'test-server',
+            'ip' => '1.2.3.4',
+            'team_id' => $this->team->id,
+            'vultr_instance_id' => 'instance-1',
+            'vultr_instance_status' => 'pending',
+        ]);
+
+        Http::assertSent(function ($request) {
+            return $request->url() === 'https://api.vultr.com/v2/instances'
+                && $request['region'] === 'ewr'
+                && $request['plan'] === 'vc2-1c-1gb'
+                && $request['os_id'] === 2284
+                && $request['sshkey_id'] === ['key-1']
+                && $request['user_data'] === base64_encode("#cloud-config\npackages:\n  - curl");
+        });
+    });
+
+    test('waits for Vultr to assign a real public IP when creation returns placeholder IP', function () {
+        Http::fake([
+            'https://api.vultr.com/v2/ssh-keys' => Http::response([
+                'ssh_key' => ['id' => 'key-1', 'ssh_key' => testPublicKey()],
+            ], 201),
+            'https://api.vultr.com/v2/ssh-keys*' => Http::response([
+                'ssh_keys' => [],
+                'meta' => ['links' => ['next' => null]],
+            ], 200),
+            'https://api.vultr.com/v2/instances' => Http::response([
+                'instance' => [
+                    'id' => 'instance-1',
+                    'main_ip' => '0.0.0.0',
+                    'status' => 'pending',
+                ],
+            ], 202),
+            'https://api.vultr.com/v2/instances/instance-1' => Http::response([
+                'instance' => [
+                    'id' => 'instance-1',
+                    'main_ip' => '1.2.3.4',
+                    'status' => 'active',
+                ],
+            ], 200),
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->postJson('/api/v1/servers/vultr', [
+            'cloud_provider_token_id' => $this->vultrToken->uuid,
+            'region' => 'ewr',
+            'plan' => 'vc2-1c-1gb',
+            'os_id' => 2284,
+            'name' => 'test-server',
+            'private_key_uuid' => $this->privateKey->uuid,
+        ]);
+
+        $response->assertStatus(201);
+        $response->assertJsonFragment(['ip' => '1.2.3.4']);
+
+        $this->assertDatabaseHas('servers', [
+            'name' => 'test-server',
+            'ip' => '1.2.3.4',
+            'vultr_instance_status' => 'active',
+        ]);
+    });
+
+    test('reuses existing matching Vultr SSH key', function () {
+        Http::fake([
+            'https://api.vultr.com/v2/ssh-keys*' => Http::response([
+                'ssh_keys' => [
+                    ['id' => 'existing-key', 'name' => 'Existing', 'ssh_key' => testPublicKey().' comment'],
+                ],
+                'meta' => ['links' => ['next' => null]],
+            ], 200),
+            'https://api.vultr.com/v2/instances' => Http::response([
+                'instance' => [
+                    'id' => 'instance-1',
+                    'main_ip' => '1.2.3.4',
+                    'status' => 'pending',
+                ],
+            ], 202),
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->postJson('/api/v1/servers/vultr', [
+            'cloud_provider_token_id' => $this->vultrToken->uuid,
+            'region' => 'ewr',
+            'plan' => 'vc2-1c-1gb',
+            'os_id' => 2284,
+            'name' => 'test-server',
+            'private_key_uuid' => $this->privateKey->uuid,
+        ]);
+
+        $response->assertStatus(201);
+
+        Http::assertNotSent(function ($request) {
+            return $request->url() === 'https://api.vultr.com/v2/ssh-keys'
+                && $request->method() === 'POST';
+        });
+        Http::assertSent(function ($request) {
+            return $request->url() === 'https://api.vultr.com/v2/instances'
+                && $request['sshkey_id'] === ['existing-key'];
+        });
+    });
+
+    test('validates required fields', function () {
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->postJson('/api/v1/servers/vultr', []);
+
+        $response->assertStatus(400);
+    });
+
+    test('returns 404 for non-existent Vultr token', function () {
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->postJson('/api/v1/servers/vultr', [
+            'cloud_provider_token_id' => 'non-existent-uuid',
+            'region' => 'ewr',
+            'plan' => 'vc2-1c-1gb',
+            'os_id' => 2284,
+            'private_key_uuid' => $this->privateKey->uuid,
+        ]);
+
+        $response->assertStatus(404);
+        $response->assertJson(['message' => 'Vultr cloud provider token not found.']);
+    });
+
+    test('uses IPv6 when public IPv4 is disabled', function () {
+        Http::fake([
+            'https://api.vultr.com/v2/ssh-keys' => Http::response([
+                'ssh_key' => ['id' => 'key-1', 'ssh_key' => testPublicKey()],
+            ], 201),
+            'https://api.vultr.com/v2/ssh-keys*' => Http::response([
+                'ssh_keys' => [],
+                'meta' => ['links' => ['next' => null]],
+            ], 200),
+            'https://api.vultr.com/v2/instances' => Http::response([
+                'instance' => [
+                    'id' => 'instance-1',
+                    'main_ip' => '',
+                    'v6_main_ip' => '2001:db8::1',
+                    'status' => 'pending',
+                ],
+            ], 202),
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->postJson('/api/v1/servers/vultr', [
+            'cloud_provider_token_id' => $this->vultrToken->uuid,
+            'region' => 'ewr',
+            'plan' => 'vc2-1c-1gb',
+            'os_id' => 2284,
+            'name' => 'test-server',
+            'private_key_uuid' => $this->privateKey->uuid,
+            'enable_ipv6' => true,
+            'disable_public_ipv4' => true,
+        ]);
+
+        $response->assertStatus(201);
+        $response->assertJsonFragment(['ip' => '2001:db8::1']);
+    });
+});

--- a/tests/Feature/VultrServerCreationTest.php
+++ b/tests/Feature/VultrServerCreationTest.php
@@ -1,0 +1,135 @@
+<?php
+
+use App\Livewire\Server\New\ByVultr;
+use App\Models\CloudProviderToken;
+use App\Models\InstanceSettings;
+use App\Models\PrivateKey;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    config([
+        'app.maintenance.driver' => 'file',
+        'cache.default' => 'array',
+        'session.driver' => 'array',
+    ]);
+
+    InstanceSettings::unguarded(fn () => InstanceSettings::query()->create([
+        'id' => 0,
+        'is_api_enabled' => true,
+    ]));
+
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+
+    $this->actingAs($this->user);
+    session(['currentTeam' => $this->team]);
+
+    $this->vultrToken = CloudProviderToken::create([
+        'team_id' => $this->team->id,
+        'provider' => 'vultr',
+        'token' => 'test-vultr-token',
+        'name' => 'Test Vultr Token',
+    ]);
+
+    $this->privateKey = PrivateKey::create([
+        'team_id' => $this->team->id,
+        'name' => 'Test Private Key',
+        'description' => 'Test private key',
+        'private_key' => vultrLivewireTestPrivateKey(),
+    ]);
+});
+
+function vultrLivewireTestPrivateKey(): string
+{
+    return <<<'KEY'
+-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACBbhpqHhqv6aI67Mj9abM3DVbmcfYhZAhC7ca4d9UCevAAAAJi/QySHv0Mk
+hwAAAAtzc2gtZWQyNTUxOQAAACBbhpqHhqv6aI67Mj9abM3DVbmcfYhZAhC7ca4d9UCevA
+AAAECBQw4jg1WRT2IGHMncCiZhURCts2s24HoDS0thHnnRKVuGmoeGq/pojrsyP1pszcNV
+uZx9iFkCELtxrh31QJ68AAAAEXNhaWxANzZmZjY2ZDJlMmRkAQIDBA==
+-----END OPENSSH PRIVATE KEY-----
+KEY;
+}
+
+function vultrLivewireTestPublicKey(): string
+{
+    return 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFuGmoeGq/pojrsyP1pszcNVuZx9iFkCELtxrh31QJ68';
+}
+
+it('creates a Vultr server through the Livewire flow', function () {
+    Http::fake([
+        'https://api.vultr.com/v2/regions*' => Http::response([
+            'regions' => [
+                ['id' => 'ewr', 'city' => 'New Jersey', 'country' => 'US'],
+            ],
+            'meta' => ['links' => ['next' => null]],
+        ], 200),
+        'https://api.vultr.com/v2/plans*' => Http::response([
+            'plans' => [
+                ['id' => 'vc2-1c-1gb', 'vcpu_count' => 1, 'ram' => 1024, 'disk' => 25, 'monthly_cost' => 6, 'locations' => ['ewr']],
+            ],
+            'meta' => ['links' => ['next' => null]],
+        ], 200),
+        'https://api.vultr.com/v2/os*' => Http::response([
+            'os' => [
+                ['id' => 2284, 'name' => 'Ubuntu 24.04 LTS x64'],
+            ],
+            'meta' => ['links' => ['next' => null]],
+        ], 200),
+        'https://api.vultr.com/v2/ssh-keys' => Http::response([
+            'ssh_key' => ['id' => 'key-1', 'ssh_key' => vultrLivewireTestPublicKey()],
+        ], 201),
+        'https://api.vultr.com/v2/ssh-keys*' => Http::response([
+            'ssh_keys' => [],
+            'meta' => ['links' => ['next' => null]],
+        ], 200),
+        'https://api.vultr.com/v2/instances' => Http::response([
+            'instance' => [
+                'id' => 'instance-1',
+                'label' => 'test-vultr-server',
+                'main_ip' => '1.2.3.4',
+                'v6_main_ip' => '2001:db8::1',
+                'status' => 'pending',
+            ],
+        ], 202),
+    ]);
+
+    Livewire::test(ByVultr::class)
+        ->set('selected_token_id', $this->vultrToken->id)
+        ->call('nextStep')
+        ->assertSet('current_step', 2)
+        ->set('server_name', 'test-vultr-server')
+        ->set('selected_region', 'ewr')
+        ->set('selected_plan', 'vc2-1c-1gb')
+        ->set('selected_os_id', 2284)
+        ->set('private_key_id', $this->privateKey->id)
+        ->set('enable_ipv6', true)
+        ->set('cloud_init_script', "#cloud-config\npackages:\n  - curl")
+        ->call('submit');
+
+    $this->assertDatabaseHas('servers', [
+        'name' => 'test-vultr-server',
+        'ip' => '1.2.3.4',
+        'team_id' => $this->team->id,
+        'cloud_provider_token_id' => $this->vultrToken->id,
+        'vultr_instance_id' => 'instance-1',
+        'vultr_instance_status' => 'pending',
+    ]);
+
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.vultr.com/v2/instances'
+            && $request['region'] === 'ewr'
+            && $request['plan'] === 'vc2-1c-1gb'
+            && $request['os_id'] === 2284
+            && $request['sshkey_id'] === ['key-1']
+            && $request['user_data'] === base64_encode("#cloud-config\npackages:\n  - curl");
+    });
+});

--- a/tests/Feature/VultrServerLifecycleTest.php
+++ b/tests/Feature/VultrServerLifecycleTest.php
@@ -1,0 +1,296 @@
+<?php
+
+use App\Actions\Server\ValidateServer as ValidateServerAction;
+use App\Livewire\Server\Show;
+use App\Livewire\Server\ValidateAndInstall;
+use App\Models\CloudProviderToken;
+use App\Models\InstanceSettings;
+use App\Models\PrivateKey;
+use App\Models\Server;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    config([
+        'app.maintenance.driver' => 'file',
+        'cache.default' => 'array',
+        'session.driver' => 'array',
+    ]);
+
+    InstanceSettings::unguarded(fn () => InstanceSettings::query()->create([
+        'id' => 0,
+        'is_api_enabled' => true,
+    ]));
+
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+
+    $this->actingAs($this->user);
+    session(['currentTeam' => $this->team]);
+
+    $this->privateKey = PrivateKey::create([
+        'team_id' => $this->team->id,
+        'name' => 'Test Private Key',
+        'description' => 'Test private key',
+        'private_key' => vultrLifecycleTestPrivateKey(),
+    ]);
+
+    $this->vultrToken = CloudProviderToken::create([
+        'team_id' => $this->team->id,
+        'provider' => 'vultr',
+        'token' => 'test-vultr-token',
+        'name' => 'Test Vultr Token',
+    ]);
+
+    $this->server = Server::factory()->create([
+        'team_id' => $this->team->id,
+        'private_key_id' => $this->privateKey->id,
+        'cloud_provider_token_id' => $this->vultrToken->id,
+        'vultr_instance_id' => 'instance-1',
+        'vultr_instance_status' => 'pending',
+        'ip' => '1.2.3.4',
+    ]);
+});
+
+function vultrLifecycleTestPrivateKey(): string
+{
+    return <<<'KEY'
+-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACBbhpqHhqv6aI67Mj9abM3DVbmcfYhZAhC7ca4d9UCevAAAAJi/QySHv0Mk
+hwAAAAtzc2gtZWQyNTUxOQAAACBbhpqHhqv6aI67Mj9abM3DVbmcfYhZAhC7ca4d9UCevA
+AAAECBQw4jg1WRT2IGHMncCiZhURCts2s24HoDS0thHnnRKVuGmoeGq/pojrsyP1pszcNV
+uZx9iFkCELtxrh31QJ68AAAAEXNhaWxANzZmZjY2ZDJlMmRkAQIDBA==
+-----END OPENSSH PRIVATE KEY-----
+KEY;
+}
+
+it('refreshes Vultr instance status', function () {
+    Http::fake([
+        'https://api.vultr.com/v2/instances/instance-1' => Http::response([
+            'instance' => [
+                'id' => 'instance-1',
+                'status' => 'active',
+            ],
+        ], 200),
+    ]);
+
+    Livewire::test(Show::class, ['server_uuid' => $this->server->uuid])
+        ->call('checkVultrInstanceStatus', true)
+        ->assertSet('vultrInstanceStatus', 'active');
+
+    $this->assertDatabaseHas('servers', [
+        'id' => $this->server->id,
+        'vultr_instance_status' => 'active',
+    ]);
+});
+
+it('refreshes Vultr status on server page load even when cached status is active', function () {
+    $this->server->update(['vultr_instance_status' => 'active']);
+
+    Livewire::test(Show::class, ['server_uuid' => $this->server->uuid])
+        ->assertSee('$wire.checkVultrInstanceStatus();', false);
+});
+
+it('updates placeholder server IP when Vultr status refresh returns assigned public IP', function () {
+    $this->server->update(['ip' => '0.0.0.0']);
+
+    Http::fake([
+        'https://api.vultr.com/v2/instances/instance-1' => Http::response([
+            'instance' => [
+                'id' => 'instance-1',
+                'status' => 'active',
+                'main_ip' => '9.8.7.6',
+            ],
+        ], 200),
+    ]);
+
+    Livewire::test(Show::class, ['server_uuid' => $this->server->uuid])
+        ->call('checkVultrInstanceStatus', true)
+        ->assertSet('ip', '9.8.7.6');
+
+    $this->assertDatabaseHas('servers', [
+        'id' => $this->server->id,
+        'ip' => '9.8.7.6',
+        'vultr_instance_status' => 'active',
+    ]);
+});
+
+it('does not overwrite an established server IP during Vultr status refresh', function () {
+    Http::fake([
+        'https://api.vultr.com/v2/instances/instance-1' => Http::response([
+            'instance' => [
+                'id' => 'instance-1',
+                'status' => 'active',
+                'main_ip' => '9.8.7.6',
+            ],
+        ], 200),
+    ]);
+
+    Livewire::test(Show::class, ['server_uuid' => $this->server->uuid])
+        ->call('checkVultrInstanceStatus', true)
+        ->assertSet('ip', '1.2.3.4')
+        ->assertSet('vultrInstanceStatus', 'active');
+
+    $this->assertDatabaseHas('servers', [
+        'id' => $this->server->id,
+        'ip' => '1.2.3.4',
+        'vultr_instance_status' => 'active',
+    ]);
+});
+
+it('blocks server page validation when Vultr instance is stopped', function () {
+    Http::fake([
+        'https://api.vultr.com/v2/instances/instance-1' => Http::response([
+            'instance' => [
+                'id' => 'instance-1',
+                'status' => 'active',
+                'power_status' => 'stopped',
+                'main_ip' => '1.2.3.4',
+            ],
+        ], 200),
+    ]);
+
+    Livewire::test(Show::class, ['server_uuid' => $this->server->uuid])
+        ->call('validateServer')
+        ->assertSet('vultrInstanceStatus', 'stopped')
+        ->assertDispatched('error', 'Vultr instance is stopped. Power it on before validating.')
+        ->assertNotDispatched('init');
+
+    $this->assertDatabaseHas('servers', [
+        'id' => $this->server->id,
+        'vultr_instance_status' => 'stopped',
+    ]);
+
+    expect($this->server->fresh()->validation_logs)->toBeNull();
+});
+
+it('marks missing Vultr instances as deleted before validation', function () {
+    Http::fake([
+        'https://api.vultr.com/v2/instances/instance-1' => Http::response([
+            'error' => 'instance not found',
+        ], 404),
+    ]);
+
+    Livewire::test(Show::class, ['server_uuid' => $this->server->uuid])
+        ->call('validateServer')
+        ->assertSet('vultrInstanceStatus', 'deleted')
+        ->assertDispatched('error', 'Vultr instance is deleted or no longer accessible. Relink this server before validating.')
+        ->assertNotDispatched('init');
+
+    $this->assertDatabaseHas('servers', [
+        'id' => $this->server->id,
+        'vultr_instance_status' => 'deleted',
+    ]);
+});
+
+it('blocks validation modal connection checks when Vultr instance is stopped', function () {
+    Http::fake([
+        'https://api.vultr.com/v2/instances/instance-1' => Http::response([
+            'instance' => [
+                'id' => 'instance-1',
+                'status' => 'active',
+                'power_status' => 'stopped',
+                'main_ip' => '1.2.3.4',
+            ],
+        ], 200),
+    ]);
+
+    Livewire::test(ValidateAndInstall::class, ['server' => $this->server])
+        ->call('validateConnection')
+        ->assertSet('error', 'Vultr instance is stopped. Power it on before validating.')
+        ->assertNotDispatched('validateOS');
+
+    $this->assertDatabaseHas('servers', [
+        'id' => $this->server->id,
+        'vultr_instance_status' => 'stopped',
+        'validation_logs' => 'Vultr instance is stopped. Power it on before validating.',
+    ]);
+});
+
+it('blocks action validation when Vultr instance is stopped', function () {
+    Http::fake([
+        'https://api.vultr.com/v2/instances/instance-1' => Http::response([
+            'instance' => [
+                'id' => 'instance-1',
+                'status' => 'active',
+                'power_status' => 'stopped',
+                'main_ip' => '1.2.3.4',
+            ],
+        ], 200),
+    ]);
+
+    expect(fn () => ValidateServerAction::run($this->server))
+        ->toThrow(Exception::class, 'Vultr instance is stopped. Power it on before validating.');
+
+    $this->assertDatabaseHas('servers', [
+        'id' => $this->server->id,
+        'vultr_instance_status' => 'stopped',
+        'validation_logs' => 'Vultr instance is stopped. Power it on before validating.',
+    ]);
+});
+
+it('starts a Vultr instance', function () {
+    Http::fake([
+        'https://api.vultr.com/v2/instances/instance-1/start' => Http::response([], 204),
+    ]);
+
+    Livewire::test(Show::class, ['server_uuid' => $this->server->uuid])
+        ->call('startVultrInstance')
+        ->assertSet('vultrInstanceStatus', 'starting');
+
+    $this->assertDatabaseHas('servers', [
+        'id' => $this->server->id,
+        'vultr_instance_status' => 'starting',
+    ]);
+
+    Http::assertSent(fn ($request) => $request->url() === 'https://api.vultr.com/v2/instances/instance-1/start');
+});
+
+it('links a server to Vultr by matching IP', function () {
+    $unlinkedServer = Server::factory()->create([
+        'team_id' => $this->team->id,
+        'private_key_id' => $this->privateKey->id,
+        'ip' => '5.6.7.8',
+    ]);
+
+    Http::fake([
+        'https://api.vultr.com/v2/instances?per_page=100' => Http::response([
+            'instances' => [
+                [
+                    'id' => 'instance-2',
+                    'label' => 'matched-server',
+                    'main_ip' => '5.6.7.8',
+                    'status' => 'active',
+                    'plan' => 'vc2-1c-1gb',
+                ],
+            ],
+            'meta' => ['links' => ['next' => null]],
+        ], 200),
+        'https://api.vultr.com/v2/instances/instance-2' => Http::response([
+            'instance' => [
+                'id' => 'instance-2',
+                'status' => 'active',
+            ],
+        ], 200),
+    ]);
+
+    Livewire::test(Show::class, ['server_uuid' => $unlinkedServer->uuid])
+        ->set('selectedVultrTokenId', $this->vultrToken->id)
+        ->call('searchVultrInstance')
+        ->assertSet('matchedVultrInstance.id', 'instance-2')
+        ->call('linkToVultr');
+
+    $this->assertDatabaseHas('servers', [
+        'id' => $unlinkedServer->id,
+        'cloud_provider_token_id' => $this->vultrToken->id,
+        'vultr_instance_id' => 'instance-2',
+        'vultr_instance_status' => 'active',
+    ]);
+});

--- a/tests/Feature/VultrServerLifecycleTest.php
+++ b/tests/Feature/VultrServerLifecycleTest.php
@@ -236,6 +236,23 @@ it('blocks action validation when Vultr instance is stopped', function () {
     ]);
 });
 
+it('shows Vultr power on button when stopped even if server was previously functional', function () {
+    $this->server->update([
+        'ip' => '1.2.3.5',
+        'vultr_instance_status' => 'stopped',
+    ]);
+    $this->server->settings->update([
+        'is_reachable' => true,
+        'is_usable' => true,
+        'force_disabled' => false,
+    ]);
+
+    expect($this->server->fresh()->isFunctional())->toBeTrue();
+
+    Livewire::test(Show::class, ['server_uuid' => $this->server->uuid])
+        ->assertSee('Power On');
+});
+
 it('starts a Vultr instance', function () {
     Http::fake([
         'https://api.vultr.com/v2/instances/instance-1/start' => Http::response([], 204),

--- a/tests/Unit/ServerBackoffTest.php
+++ b/tests/Unit/ServerBackoffTest.php
@@ -127,6 +127,37 @@ describe('shouldSkipDueToBackoff', function () {
 });
 
 describe('ServerConnectionCheckJob unreachable_count', function () {
+    it('marks Vultr servers unreachable when provider status is unavailable', function () {
+        Event::fake([ServerReachabilityChanged::class]);
+
+        $settings = Mockery::mock();
+        $settings->is_reachable = true;
+        $settings->force_disabled = false;
+        $settings->shouldReceive('update')
+            ->with(['is_reachable' => false, 'is_usable' => false])
+            ->once();
+
+        $server = Mockery::mock(Server::class)->makePartial()->shouldAllowMockingProtectedMethods();
+        $server->shouldReceive('getAttribute')->andReturnUsing(fn (string $key) => match ($key) {
+            'settings' => $settings,
+            'unreachable_notification_sent' => false,
+            'vultr_instance_id' => 'instance-1',
+            'cloudProviderToken' => (object) ['token' => 'test-token'],
+            'id' => 1,
+            'name' => 'test-server',
+            'unreachable_count' => 1,
+            default => null,
+        });
+        $server->shouldReceive('refreshVultrState')->once()->andReturn('stopped');
+        $server->shouldReceive('increment')->with('unreachable_count')->once();
+        $server->id = 1;
+        $server->name = 'test-server';
+        $server->uuid = 'server-uuid';
+
+        $job = new ServerConnectionCheckJob($server);
+        $job->handle();
+    });
+
     it('increments unreachable_count on timeout', function () {
         Event::fake([ServerReachabilityChanged::class]);
 

--- a/tests/Unit/VultrDeleteServerTest.php
+++ b/tests/Unit/VultrDeleteServerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use App\Actions\Server\DeleteServer;
+use App\Models\CloudProviderToken;
+use App\Models\InstanceSettings;
+use App\Models\PrivateKey;
+use App\Models\Server;
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+beforeEach(function () {
+    config([
+        'cache.default' => 'array',
+        'session.driver' => 'array',
+    ]);
+
+    InstanceSettings::unguarded(fn () => InstanceSettings::query()->create([
+        'id' => 0,
+        'is_api_enabled' => true,
+    ]));
+
+    $this->team = Team::factory()->create();
+    session(['currentTeam' => $this->team]);
+
+    $this->privateKey = PrivateKey::create([
+        'team_id' => $this->team->id,
+        'name' => 'Test Private Key',
+        'description' => 'Test private key',
+        'private_key' => vultrDeleteTestPrivateKey(),
+    ]);
+
+    $this->vultrToken = CloudProviderToken::create([
+        'team_id' => $this->team->id,
+        'provider' => 'vultr',
+        'token' => 'test-vultr-token',
+        'name' => 'Test Vultr Token',
+    ]);
+});
+
+function vultrDeleteTestPrivateKey(): string
+{
+    return <<<'KEY'
+-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACBbhpqHhqv6aI67Mj9abM3DVbmcfYhZAhC7ca4d9UCevAAAAJi/QySHv0Mk
+hwAAAAtzc2gtZWQyNTUxOQAAACBbhpqHhqv6aI67Mj9abM3DVbmcfYhZAhC7ca4d9UCevA
+AAAECBQw4jg1WRT2IGHMncCiZhURCts2s24HoDS0thHnnRKVuGmoeGq/pojrsyP1pszcNV
+uZx9iFkCELtxrh31QJ68AAAAEXNhaWxANzZmZjY2ZDJlMmRkAQIDBA==
+-----END OPENSSH PRIVATE KEY-----
+KEY;
+}
+
+it('deletes a Vultr instance when requested', function () {
+    Http::fake([
+        'https://api.vultr.com/v2/instances/instance-1' => Http::response([], 204),
+    ]);
+
+    $server = Server::factory()->create([
+        'team_id' => $this->team->id,
+        'private_key_id' => $this->privateKey->id,
+        'cloud_provider_token_id' => $this->vultrToken->id,
+        'vultr_instance_id' => 'instance-1',
+    ]);
+
+    $server->delete();
+
+    DeleteServer::run(
+        serverId: $server->id,
+        cloudProviderTokenId: $this->vultrToken->id,
+        teamId: $this->team->id,
+        deleteFromVultr: true,
+        vultrInstanceId: 'instance-1'
+    );
+
+    Http::assertSent(fn ($request) => $request->method() === 'DELETE'
+        && $request->url() === 'https://api.vultr.com/v2/instances/instance-1');
+
+    expect(Server::withTrashed()->find($server->id))->toBeNull();
+});

--- a/tests/Unit/VultrServiceTest.php
+++ b/tests/Unit/VultrServiceTest.php
@@ -136,3 +136,17 @@ it('finds an instance by IPv4 or IPv6', function () {
         ->and($service->findInstanceByIp('2001:db8::1')['id'])->toBe('instance-1')
         ->and($service->findInstanceByIp('1.2.3.4'))->toBeNull();
 });
+
+it('handles empty successful responses from Vultr API', function () {
+    Http::fake([
+        'https://api.vultr.com/v2/instances/instance-1/start' => Http::response(null, 204),
+        'https://api.vultr.com/v2/instances/instance-1' => Http::response(null, 204),
+    ]);
+
+    $service = new VultrService('fake-token');
+
+    expect($service->startInstance('instance-1'))->toBe([]);
+    $service->deleteInstance('instance-1');
+
+    Http::assertSentCount(2);
+});

--- a/tests/Unit/VultrServiceTest.php
+++ b/tests/Unit/VultrServiceTest.php
@@ -1,0 +1,138 @@
+<?php
+
+use App\Services\VultrService;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+beforeEach(function () {
+    Http::preventStrayRequests();
+});
+
+it('gets instances from Vultr API', function () {
+    Http::fake([
+        'https://api.vultr.com/v2/instances*' => Http::response([
+            'instances' => [
+                [
+                    'id' => 'instance-1',
+                    'label' => 'test-server-1',
+                    'status' => 'active',
+                    'main_ip' => '123.45.67.89',
+                    'v6_main_ip' => '2001:db8::1',
+                ],
+                [
+                    'id' => 'instance-2',
+                    'label' => 'test-server-2',
+                    'status' => 'stopped',
+                    'main_ip' => '98.76.54.32',
+                    'v6_main_ip' => '2001:db8::2',
+                ],
+            ],
+            'meta' => ['links' => ['next' => null]],
+        ], 200),
+    ]);
+
+    $service = new VultrService('fake-token');
+    $instances = $service->getInstances();
+
+    expect($instances)->toBeArray()
+        ->and($instances)->toHaveCount(2)
+        ->and($instances[0]['id'])->toBe('instance-1')
+        ->and($instances[1]['id'])->toBe('instance-2');
+});
+
+it('follows cursor pagination', function () {
+    Http::fake([
+        'https://api.vultr.com/v2/regions?per_page=100' => Http::response([
+            'regions' => [
+                ['id' => 'ewr', 'city' => 'New Jersey'],
+            ],
+            'meta' => [
+                'links' => [
+                    'next' => 'https://api.vultr.com/v2/regions?cursor=next-cursor',
+                ],
+            ],
+        ], 200),
+        'https://api.vultr.com/v2/regions?per_page=100&cursor=next-cursor' => Http::response([
+            'regions' => [
+                ['id' => 'ams', 'city' => 'Amsterdam'],
+            ],
+            'meta' => ['links' => ['next' => null]],
+        ], 200),
+    ]);
+
+    $service = new VultrService('fake-token');
+    $regions = $service->getRegions();
+
+    expect($regions)->toHaveCount(2)
+        ->and($regions[0]['id'])->toBe('ewr')
+        ->and($regions[1]['id'])->toBe('ams');
+});
+
+it('base64 encodes user data when creating an instance', function () {
+    Http::fake([
+        'https://api.vultr.com/v2/instances' => Http::response([
+            'instance' => [
+                'id' => 'instance-1',
+                'main_ip' => '123.45.67.89',
+                'status' => 'pending',
+            ],
+        ], 202),
+    ]);
+
+    $service = new VultrService('fake-token');
+    $service->createInstance([
+        'region' => 'ewr',
+        'plan' => 'vc2-1c-1gb',
+        'os_id' => 2284,
+        'user_data' => "#cloud-config\npackages:\n  - curl",
+    ]);
+
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.vultr.com/v2/instances'
+            && $request['user_data'] === base64_encode("#cloud-config\npackages:\n  - curl");
+    });
+});
+
+it('waits for Vultr to replace placeholder public IP', function () {
+    Http::fake([
+        'https://api.vultr.com/v2/instances/instance-1' => Http::response([
+            'instance' => [
+                'id' => 'instance-1',
+                'main_ip' => '123.45.67.89',
+                'status' => 'active',
+            ],
+        ], 200),
+    ]);
+
+    $service = new VultrService('fake-token');
+    $instance = $service->waitForPublicIp([
+        'id' => 'instance-1',
+        'main_ip' => '0.0.0.0',
+        'status' => 'pending',
+    ], sleepMilliseconds: 0);
+
+    expect($service->getPublicIp($instance))->toBe('123.45.67.89');
+});
+
+it('finds an instance by IPv4 or IPv6', function () {
+    Http::fake([
+        'https://api.vultr.com/v2/instances*' => Http::response([
+            'instances' => [
+                [
+                    'id' => 'instance-1',
+                    'main_ip' => '123.45.67.89',
+                    'v6_main_ip' => '2001:db8::1',
+                ],
+            ],
+            'meta' => ['links' => ['next' => null]],
+        ], 200),
+    ]);
+
+    $service = new VultrService('fake-token');
+
+    expect($service->findInstanceByIp('123.45.67.89')['id'])->toBe('instance-1')
+        ->and($service->findInstanceByIp('2001:db8::1')['id'])->toBe('instance-1')
+        ->and($service->findInstanceByIp('1.2.3.4'))->toBeNull();
+});


### PR DESCRIPTION
## What changed

  Adds Vultr as a cloud provider integration alongside Hetzner.

  This includes:

  - Vultr cloud provider token validation
  - Vultr API service for regions, plans, OS images, SSH keys, instances, start/delete, and
  instance lookup
  - API endpoints for Vultr metadata and server provisioning
  - Server creation flow from Vultr in the UI
  - Onboarding and server create page entries for Vultr
  - Immediate Coolify server record creation after Vultr instance provisioning to avoid
  orphaned VPS creation if the modal/request is interrupted
  - Status and power-state tracking for Vultr instances
  - Correct handling of Vultr `power_status=stopped`, even when Vultr `status=active`
  - Server detail page status refresh on load
  - Power-on action for stopped Vultr instances
  - Validation preflight that blocks SSH validation when a Vultr instance is stopped,
  suspended, or deleted
  - Existing server linking to Vultr by IP or instance ID
  - Cloud provider token management for Vultr-linked servers
  - Optional Vultr instance deletion when deleting a server
  - Background reachability checks that respect Vultr stopped/deleted states

  ## Testing

  Manual end-to-end testing completed:

  - Connected a Vultr API token
  - Created a Vultr server from Coolify
  - Validated the server and installed Docker
  - Deployed an application
  - Stopped the proxy
  - Deleted the proxy
  - Stopped the VPS in Vultr and verified Coolify detects the stopped state
  - Verified validation no longer waits for SSH timeout when the Vultr VPS is stopped

  Automated tests:

  ```bash
  vendor/bin/pint --dirty --format agent
  php artisan test --compact tests/Feature/VultrServerLifecycleTest.php tests/Feature/
  VultrServerCreationTest.php tests/Feature/VultrApiTest.php tests/Unit/VultrServiceTest.php
  tests/Unit/VultrDeleteServerTest.php tests/Feature/CloudProviderTokenApiTest.php tests/Unit/
  ServerBackoffTest.php
```

  ## Notes

  Vultr reports stopped VPS instances with status=active and power_status=stopped, so the
  integration uses power_status for stopped-state decisions.

<img width="712" height="255" alt="image" src="https://github.com/user-attachments/assets/b991b764-dbb0-4734-967b-097087137e27" />

<img width="675" height="869" alt="image" src="https://github.com/user-attachments/assets/53bc1857-4dda-4f03-a303-d2d739350478" />

<img width="1677" height="548" alt="image" src="https://github.com/user-attachments/assets/85edebda-651d-428b-966d-700ab6cf2d44" />

<img width="1677" height="548" alt="image" src="https://github.com/user-attachments/assets/02286fc8-709c-40e5-a614-2bc44d417f91" />

<img width="1911" height="572" alt="image" src="https://github.com/user-attachments/assets/93279141-e173-4696-b2ac-da2242682882" />

