### PR TITLE
fix(api): allow source commit build setting

### DIFF
--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -2365,7 +2365,7 @@ class ApplicationsController extends Controller
         $this->authorize('update', $application);
 
         $server = $application->destination->server;
-        $allowedFields = ['name', 'description', 'is_static', 'is_spa', 'is_auto_deploy_enabled', 'is_force_https_enabled', 'domains', 'git_repository', 'git_branch', 'git_commit_sha', 'docker_registry_image_name', 'docker_registry_image_tag', 'build_pack', 'static_image', 'install_command', 'build_command', 'start_command', 'ports_exposes', 'ports_mappings', 'custom_network_aliases', 'base_directory', 'publish_directory', 'health_check_enabled', 'health_check_type', 'health_check_command', 'health_check_path', 'health_check_port', 'health_check_host', 'health_check_method', 'health_check_return_code', 'health_check_scheme', 'health_check_response_text', 'health_check_interval', 'health_check_timeout', 'health_check_retries', 'health_check_start_period', 'limits_memory', 'limits_memory_swap', 'limits_memory_swappiness', 'limits_memory_reservation', 'limits_cpus', 'limits_cpuset', 'limits_cpu_shares', 'custom_labels', 'custom_docker_run_options', 'post_deployment_command', 'post_deployment_command_container', 'pre_deployment_command', 'pre_deployment_command_container', 'watch_paths', 'manual_webhook_secret_github', 'manual_webhook_secret_gitlab', 'manual_webhook_secret_bitbucket', 'manual_webhook_secret_gitea', 'dockerfile_location', 'dockerfile_target_build', 'docker_compose_location', 'docker_compose_custom_start_command', 'docker_compose_custom_build_command', 'docker_compose_domains', 'redirect', 'instant_deploy', 'use_build_server', 'custom_nginx_configuration', 'is_http_basic_auth_enabled', 'http_basic_auth_username', 'http_basic_auth_password', 'connect_to_docker_network', 'force_domain_override', 'is_container_label_escape_enabled', 'is_preserve_repository_enabled'];
+        $allowedFields = ['name', 'description', 'is_static', 'is_spa', 'is_auto_deploy_enabled', 'is_force_https_enabled', 'domains', 'git_repository', 'git_branch', 'git_commit_sha', 'docker_registry_image_name', 'docker_registry_image_tag', 'build_pack', 'static_image', 'install_command', 'build_command', 'start_command', 'ports_exposes', 'ports_mappings', 'custom_network_aliases', 'base_directory', 'publish_directory', 'health_check_enabled', 'health_check_type', 'health_check_command', 'health_check_path', 'health_check_port', 'health_check_host', 'health_check_method', 'health_check_return_code', 'health_check_scheme', 'health_check_response_text', 'health_check_interval', 'health_check_timeout', 'health_check_retries', 'health_check_start_period', 'limits_memory', 'limits_memory_swap', 'limits_memory_swappiness', 'limits_memory_reservation', 'limits_cpus', 'limits_cpuset', 'limits_cpu_shares', 'custom_labels', 'custom_docker_run_options', 'post_deployment_command', 'post_deployment_command_container', 'pre_deployment_command', 'pre_deployment_command_container', 'watch_paths', 'manual_webhook_secret_github', 'manual_webhook_secret_gitlab', 'manual_webhook_secret_bitbucket', 'manual_webhook_secret_gitea', 'dockerfile_location', 'dockerfile_target_build', 'docker_compose_location', 'docker_compose_custom_start_command', 'docker_compose_custom_build_command', 'docker_compose_domains', 'redirect', 'instant_deploy', 'use_build_server', 'custom_nginx_configuration', 'is_http_basic_auth_enabled', 'http_basic_auth_username', 'http_basic_auth_password', 'connect_to_docker_network', 'force_domain_override', 'is_container_label_escape_enabled', 'is_preserve_repository_enabled', 'include_source_commit_in_build'];
 
         $validationRules = [
             'name' => 'string|max:255',
@@ -2380,6 +2380,7 @@ class ApplicationsController extends Controller
             'is_http_basic_auth_enabled' => 'boolean|nullable',
             'http_basic_auth_username' => 'string',
             'http_basic_auth_password' => 'string',
+            'include_source_commit_in_build' => 'boolean',
         ];
         $validationRules = array_merge(sharedDataApplications(), $validationRules);
         $validationMessages = [
@@ -2616,6 +2617,7 @@ class ApplicationsController extends Controller
         $useBuildServer = $request->use_build_server;
         $isContainerLabelEscapeEnabled = $request->boolean('is_container_label_escape_enabled');
         $isPreserveRepositoryEnabled = $request->boolean('is_preserve_repository_enabled');
+        $includeSourceCommitInBuild = $request->boolean('include_source_commit_in_build');
         if (isset($useBuildServer)) {
             $application->settings->is_build_server_enabled = $useBuildServer;
             $application->settings->save();
@@ -2653,6 +2655,11 @@ class ApplicationsController extends Controller
         if ($request->has('is_preserve_repository_enabled')) {
             $application->settings->is_preserve_repository_enabled = $isPreserveRepositoryEnabled;
             $application->settings->save();
+        }
+        if ($request->has('include_source_commit_in_build')) {
+            $application->settings->include_source_commit_in_build = $includeSourceCommitInBuild;
+            $application->settings->save();
+            $request->offsetUnset('include_source_commit_in_build');
         }
         removeUnnecessaryFieldsFromRequest($request);
 

--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -2660,7 +2660,6 @@ class ApplicationsController extends Controller
         if ($request->has('include_source_commit_in_build')) {
             $application->settings->include_source_commit_in_build = $includeSourceCommitInBuild;
             $application->settings->save();
-            $request->offsetUnset('include_source_commit_in_build');
         }
         removeUnnecessaryFieldsFromRequest($request);
 

--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -2280,6 +2280,7 @@ class ApplicationsController extends Controller
                             'force_domain_override' => ['type' => 'boolean', 'description' => 'Force domain usage even if conflicts are detected. Default is false.'],
                             'is_container_label_escape_enabled' => ['type' => 'boolean', 'default' => true, 'description' => 'Escape special characters in labels. By default, $ (and other chars) is escaped. So if you write $ in the labels, it will be saved as $$. If you want to use env variables inside the labels, turn this off.'],
                             'is_preserve_repository_enabled' => ['type' => 'boolean', 'description' => 'Preserve git repository during application update. If false, the existing repository will be removed and replaced with the new one. If true, the existing repository will be kept and the new one will be ignored. Default is false.'],
+                            'include_source_commit_in_build' => ['type' => 'boolean', 'description' => 'Include source commit information in the build. Default is false.'],
                         ],
                     )
                 ),

--- a/bootstrap/helpers/api.php
+++ b/bootstrap/helpers/api.php
@@ -203,5 +203,6 @@ function removeUnnecessaryFieldsFromRequest(Request $request)
     $request->offsetUnset('autogenerate_domain');
     $request->offsetUnset('is_container_label_escape_enabled');
     $request->offsetUnset('is_preserve_repository_enabled');
+    $request->offsetUnset('include_source_commit_in_build');
     $request->offsetUnset('docker_compose_raw');
 }

--- a/tests/Feature/Api/ApplicationSourceCommitSettingApiTest.php
+++ b/tests/Feature/Api/ApplicationSourceCommitSettingApiTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\InstanceSettings;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::unguarded(fn () => InstanceSettings::firstOrCreate(['id' => 0]));
+
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+    session(['currentTeam' => $this->team]);
+
+    $plainTextToken = Str::random(40);
+    $token = $this->user->tokens()->create([
+        'name' => 'source-commit-api-test-'.Str::random(6),
+        'token' => hash('sha256', $plainTextToken),
+        'abilities' => ['*'],
+        'team_id' => $this->team->id,
+    ]);
+    $this->bearerToken = $token->getKey().'|'.$plainTextToken;
+
+    $this->server = Server::factory()->create(['team_id' => $this->team->id]);
+    $this->destination = StandaloneDocker::where('server_id', $this->server->id)->first();
+    $this->project = Project::factory()->create(['team_id' => $this->team->id]);
+    $this->environment = Environment::factory()->create(['project_id' => $this->project->id]);
+    $this->application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => $this->destination->getMorphClass(),
+    ]);
+});
+
+function sourceCommitSettingApiHeaders(string $bearerToken): array
+{
+    return [
+        'Authorization' => 'Bearer '.$bearerToken,
+        'Content-Type' => 'application/json',
+    ];
+}
+
+describe('PATCH /api/v1/applications/{uuid} include_source_commit_in_build', function () {
+    test('updates the application setting through the API', function () {
+        expect((bool) $this->application->settings->include_source_commit_in_build)->toBeFalse();
+
+        $this->withHeaders(sourceCommitSettingApiHeaders($this->bearerToken))
+            ->patchJson("/api/v1/applications/{$this->application->uuid}", [
+                'include_source_commit_in_build' => true,
+            ])
+            ->assertOk();
+
+        expect((bool) $this->application->fresh()->settings->include_source_commit_in_build)->toBeTrue();
+
+        $this->withHeaders(sourceCommitSettingApiHeaders($this->bearerToken))
+            ->patchJson("/api/v1/applications/{$this->application->uuid}", [
+                'include_source_commit_in_build' => false,
+            ])
+            ->assertOk();
+
+        expect((bool) $this->application->fresh()->settings->include_source_commit_in_build)->toBeFalse();
+    });
+
+    test('rejects non boolean values', function () {
+        $this->withHeaders(sourceCommitSettingApiHeaders($this->bearerToken))
+            ->patchJson("/api/v1/applications/{$this->application->uuid}", [
+                'include_source_commit_in_build' => 'not-a-boolean',
+            ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('include_source_commit_in_build');
+    });
+});


### PR DESCRIPTION
## Changes

- Allow PATCH /api/v1/applications/{uuid} to accept include_source_commit_in_build.
- Persist the value on the related ApplicationSetting instead of treating it as an Application field.
- Add API regression coverage for enabling/disabling the setting and rejecting non-boolean values.

## Issues

- Fixes #10280

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable for this API validation/settings fix.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex
- How extensively: used for repository search, patch preparation, and regression test preparation.

## Testing

- Ran php -l app/Http/Controllers/Api/ApplicationsController.php.
- Ran php -l tests/Feature/Api/ApplicationSourceCommitSettingApiTest.php.
- Ran git diff --check.
- Attempted php artisan test tests/Feature/Api/ApplicationSourceCommitSettingApiTest.php, but this local checkout has no vendor/autoload.php, so PHPUnit could not start.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.


fix #10280