### PR TITLE
fix(git): skip lfs smudge when disabled

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -1295,6 +1295,7 @@ class Application extends BaseModel
         $baseDir = $this->generateBaseDir($deployment_uuid);
         $escapedBaseDir = escapeshellarg($baseDir);
         $isShallowCloneEnabled = $this->settings?->is_git_shallow_clone_enabled ?? false;
+        $isGitLfsEnabled = $this->settings?->is_git_lfs_enabled ?? false;
         $gitCommand = $gitConfigOptions ? "git {$gitConfigOptions}" : 'git';
 
         $resolvedGitSshCommand = $git_ssh_command ?? $gitSshCommand;
@@ -1303,6 +1304,10 @@ class Application extends BaseModel
                 ? $resolvedGitSshCommand
                 : 'GIT_SSH_COMMAND="'.$resolvedGitSshCommand.'"')
             : 'GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"';
+
+        if (! $isGitLfsEnabled) {
+            $git_clone_command = "export GIT_LFS_SKIP_SMUDGE=1 && {$git_clone_command}";
+        }
 
         // Use the explicitly passed commit (e.g. from rollback), falling back to the application's git_commit_sha.
         // Invalid refs will cause the git checkout/fetch command to fail on the remote server.
@@ -1328,7 +1333,7 @@ class Application extends BaseModel
             $submoduleFlags = $isShallowCloneEnabled ? '--depth=1' : '';
             $git_clone_command = "{$git_clone_command} {$gitCommand} submodule sync && {$sshCommand} {$gitCommand} submodule update --init --recursive {$submoduleFlags}; fi";
         }
-        if ($this->settings->is_git_lfs_enabled) {
+        if ($isGitLfsEnabled) {
             $git_clone_command = "{$git_clone_command} && cd {$escapedBaseDir} && {$sshCommand} {$gitCommand} lfs pull";
         }
 

--- a/tests/Feature/ApplicationRollbackTest.php
+++ b/tests/Feature/ApplicationRollbackTest.php
@@ -86,6 +86,35 @@ describe('Application Rollback', function () {
         expect($result)->not->toContain('advice.detachedHead=false checkout');
     });
 
+    test('setGitImportSettings skips git lfs smudge when git lfs is disabled', function () {
+        $this->application->git_commit_sha = 'abc123def456abc123def456abc123def456abc1';
+
+        $result = $this->application->setGitImportSettings(
+            deployment_uuid: 'test-uuid',
+            git_clone_command: 'git clone',
+            public: true,
+        );
+
+        expect($result)
+            ->toStartWith('export GIT_LFS_SKIP_SMUDGE=1 && git clone')
+            ->toContain("checkout 'abc123def456abc123def456abc123def456abc1'")
+            ->not->toContain('git lfs pull');
+    });
+
+    test('setGitImportSettings keeps git lfs smudge enabled when git lfs is enabled', function () {
+        $this->application->settings->is_git_lfs_enabled = true;
+
+        $result = $this->application->setGitImportSettings(
+            deployment_uuid: 'test-uuid',
+            git_clone_command: 'git clone',
+            public: true,
+        );
+
+        expect($result)
+            ->not->toContain('GIT_LFS_SKIP_SMUDGE')
+            ->toContain('git lfs pull');
+    });
+
     test('setGitImportSettings uses provided git_ssh_command for fetch', function () {
         $this->application->settings->is_git_shallow_clone_enabled = true;
         $rollbackCommit = 'abc123def456abc123def456abc123def456abc1';


### PR DESCRIPTION
## Summary
- export GIT_LFS_SKIP_SMUDGE=1 for git import commands when Git LFS is disabled
- keep the existing git lfs pull path unchanged when Git LFS is enabled
- add regression coverage for disabled/enabled LFS command generation

Fixes #10360.

## Validation
- php -l app\\Models\\Application.php
- php -l tests\\Feature\\ApplicationRollbackTest.php
- git diff --check

Could not run php artisan test tests\\Feature\\ApplicationRollbackTest.php --filter lfs locally because this checkout does not have endor/autoload.php.