### PR TITLE
fix: prefer IPv6 for standalone proxy networks with fallback

### DIFF
--- a/bootstrap/helpers/proxy.php
+++ b/bootstrap/helpers/proxy.php
@@ -105,6 +105,31 @@ function collectDockerNetworksByServer(Server $server)
         'allNetworks' => $allNetworks,
     ];
 }
+
+function createStandaloneProxyNetworkCommand(string $network, bool $quiet = false): string
+{
+    $safe = escapeshellarg($network);
+    $firstRedirect = $quiet ? ' >/dev/null 2>&1' : ' 2>/dev/null';
+    $fallbackRedirect = $quiet ? ' >/dev/null' : '';
+
+    return "docker network create --ipv6 --attachable {$safe}{$firstRedirect} || docker network create --attachable {$safe}{$fallbackRedirect}";
+}
+
+function warnIfStandaloneProxyNetworkIsIpv4OnlyCommand(string $network): string
+{
+    $safe = escapeshellarg($network);
+    $message = escapeshellarg("Warning: Docker network {$network} is IPv4-only. Recreate it with IPv6 enabled to preserve real IPv6 client IPs in X-Forwarded-For.");
+
+    return "if [ \"$(docker network inspect -f '{{.EnableIPv6}}' {$safe} 2>/dev/null)\" = 'false' ]; then echo {$message}; fi";
+}
+
+function ensureStandaloneProxyNetworkCommand(string $network, bool $quiet = false): string
+{
+    $safe = escapeshellarg($network);
+
+    return "if docker network ls --format '{{.Name}}' | grep -qxF -- {$safe}; then ".warnIfStandaloneProxyNetworkIsIpv4OnlyCommand($network).'; else '.createStandaloneProxyNetworkCommand($network, $quiet).'; fi';
+}
+
 function connectProxyToNetworks(Server $server)
 {
     ['networks' => $networks] = collectDockerNetworksByServer($server);
@@ -123,7 +148,7 @@ function connectProxyToNetworks(Server $server)
             $safe = escapeshellarg($network);
 
             return [
-                "docker network ls --format '{{.Name}}' | grep '^{$network}$' >/dev/null || docker network create --attachable {$safe} >/dev/null",
+                ensureStandaloneProxyNetworkCommand($network, true),
                 "docker network connect {$safe} coolify-proxy >/dev/null 2>&1 || true",
                 "echo 'Successfully connected coolify-proxy to {$safe} network.'",
             ];
@@ -159,7 +184,7 @@ function ensureProxyNetworksExist(Server $server)
 
             return [
                 "echo 'Ensuring network {$safe} exists...'",
-                "docker network ls --format '{{.Name}}' | grep -q '^{$network}$' || docker network create --attachable {$safe}",
+                ensureStandaloneProxyNetworkCommand($network),
             ];
         });
     }

--- a/tests/Unit/ProxyHelperTest.php
+++ b/tests/Unit/ProxyHelperTest.php
@@ -189,3 +189,40 @@ it('identifies none as not predefined (per codebase pattern)', function () {
     // only filters 'default' and 'host', so we maintain consistency
     expect(isDockerPredefinedNetwork('none'))->toBeFalse();
 });
+
+it('creates standalone proxy networks with ipv6 first and ipv4 fallback', function () {
+    $command = createStandaloneProxyNetworkCommand('coolify');
+
+    expect($command)
+        ->toContain("docker network create --ipv6 --attachable 'coolify'")
+        ->toContain("|| docker network create --attachable 'coolify'")
+        ->toContain('2>/dev/null');
+});
+
+it('keeps standalone proxy network creation quiet when requested', function () {
+    $command = createStandaloneProxyNetworkCommand('coolify', quiet: true);
+
+    expect($command)
+        ->toContain("docker network create --ipv6 --attachable 'coolify' >/dev/null 2>&1")
+        ->toContain("|| docker network create --attachable 'coolify' >/dev/null");
+});
+
+it('warns when an existing standalone proxy network is ipv4 only', function () {
+    $command = warnIfStandaloneProxyNetworkIsIpv4OnlyCommand('coolify');
+
+    expect($command)
+        ->toContain("docker network inspect -f '{{.EnableIPv6}}' 'coolify'")
+        ->toContain("= 'false'")
+        ->toContain('IPv4-only')
+        ->toContain('X-Forwarded-For');
+});
+
+it('ensures standalone proxy networks without failing hosts that do not support ipv6', function () {
+    $command = ensureStandaloneProxyNetworkCommand('coolify');
+
+    expect($command)
+        ->toStartWith("if docker network ls --format '{{.Name}}' | grep -qxF -- 'coolify'; then")
+        ->toContain("docker network create --ipv6 --attachable 'coolify'")
+        ->toContain("|| docker network create --attachable 'coolify'")
+        ->toEndWith('fi');
+});


### PR DESCRIPTION
## Changes

- Prefer IPv6 when creating standalone Coolify-managed proxy networks, with a fallback to the existing IPv4-only command when Docker or the host cannot create IPv6 networks.
- Warn when an existing standalone proxy network is IPv4-only so affected installs are not silently left unchanged.
- Leave swarm overlay network creation unchanged.
- Add focused helper tests for the generated Docker network commands.

## Issues

- Fixes #3436
- /claim #3436
- This supersedes my closed PR #10553 after updating the body to match the required PR template.

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Backend command-generation change only. No UI preview.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex
- How extensively: Used to inspect the issue/code path, edit the focused helper commands/tests, and draft the PR. I reviewed the generated commands and verification output.

## Testing

- `php -l bootstrap/helpers/proxy.php`
- `php -l tests/Unit/ProxyHelperTest.php`
- `php -r 'require "bootstrap/helpers/proxy.php"; echo createStandaloneProxyNetworkCommand("coolify"), PHP_EOL, ensureStandaloneProxyNetworkCommand("coolify"), PHP_EOL;'`
- `git diff --check`

I added Pest assertions in `tests/Unit/ProxyHelperTest.php`, but could not run the Pest file locally because `composer install --no-interaction --prefer-dist --no-progress --no-scripts` stalled before creating `vendor/bin/pest`. Docker is not available in this local environment, so Docker behavior was verified at command-generation level.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
