### PR TITLE
fix(service): limit Grafana extra fields to Grafana images

### DIFF
--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -626,7 +626,7 @@ class Service extends BaseModel
                     }
                     $fields->put('Unleash', $data->toArray());
                     break;
-                case $image->contains('grafana'):
+                case $this->isGrafanaImage($image->toString()):
                     $data = collect([]);
                     $admin_password = $this->environment_variables()->where('key', 'SERVICE_PASSWORD_GRAFANA')->first();
                     $data = $data->merge([
@@ -1378,6 +1378,15 @@ class Service extends BaseModel
         });
 
         return $fields;
+    }
+
+    private function isGrafanaImage(string $image): bool
+    {
+        return in_array($image, [
+            'grafana/grafana',
+            'grafana/grafana-oss',
+            'grafana/grafana-enterprise',
+        ], true);
     }
 
     public function saveExtraFields($fields)

--- a/tests/Feature/ServiceExtraFieldsTest.php
+++ b/tests/Feature/ServiceExtraFieldsTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Models\Environment;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\Service;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function serviceExtraFieldsTestServiceWithApplicationImage(string $image): Service
+{
+    $team = Team::factory()->create();
+    $project = Project::factory()->create(['team_id' => $team->id]);
+    $environment = Environment::factory()->create(['project_id' => $project->id]);
+    $server = Server::factory()->create();
+    $destination = StandaloneDocker::factory()->create(['server_id' => $server->id]);
+
+    $service = Service::factory()->create([
+        'environment_id' => $environment->id,
+        'server_id' => $server->id,
+        'destination_id' => $destination->id,
+        'destination_type' => StandaloneDocker::class,
+    ]);
+
+    $service->applications()->create([
+        'name' => 'app',
+        'image' => $image,
+    ]);
+
+    return $service;
+}
+
+it('only adds Grafana extra fields for Grafana server images', function (string $image, bool $shouldHaveGrafanaFields) {
+    $fields = serviceExtraFieldsTestServiceWithApplicationImage($image)->extraFields();
+
+    expect($fields->has('Grafana'))->toBe($shouldHaveGrafanaFields);
+})->with([
+    'grafana oss' => ['grafana/grafana-oss:latest', true],
+    'grafana enterprise' => ['grafana/grafana-enterprise:latest', true],
+    'grafana default' => ['grafana/grafana:latest', true],
+    'loki' => ['grafana/loki:latest', false],
+    'promtail' => ['grafana/promtail:latest', false],
+    'tempo' => ['grafana/tempo:latest', false],
+]);


### PR DESCRIPTION
## Summary
- limit Grafana-specific extra fields to Grafana server images only
- keep `grafana/grafana`, `grafana/grafana-oss`, and `grafana/grafana-enterprise` supported
- add regression coverage so `grafana/loki`, `grafana/promtail`, and `grafana/tempo` do not receive Grafana admin fields

Fixes #10556

## Tests
- `php -l app\Models\Service.php`
- `php -l tests\Feature\ServiceExtraFieldsTest.php`
- `git diff --check`

Could not run the feature test locally because this checkout does not have `vendor/autoload.php` installed.