### PR TITLE
fix(webhooks): match ssh repos with custom users

### DIFF
--- a/app/Http/Controllers/Webhook/Concerns/MatchesManualWebhookApplications.php
+++ b/app/Http/Controllers/Webhook/Concerns/MatchesManualWebhookApplications.php
@@ -79,7 +79,7 @@ trait MatchesManualWebhookApplications
 
         if (is_array($parts) && isset($parts['scheme'])) {
             $path = data_get($parts, 'path');
-        } elseif (Str::startsWith($gitRepository, 'git@') && str_contains($gitRepository, ':')) {
+        } elseif (preg_match('/\A[A-Za-z0-9_.-]+@[^:\s]+:.+\z/', $gitRepository)) {
             $path = Str::after($gitRepository, ':');
             // scp-style SSH URLs embed a custom port as "git@host:2222/owner/repo".
             // Strip the leading numeric port segment so the path matches the webhook

--- a/tests/Unit/ManualWebhookRepositoryMatchTest.php
+++ b/tests/Unit/ManualWebhookRepositoryMatchTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Http\Controllers\Webhook\Concerns\MatchesManualWebhookApplications;
+
+function manualWebhookRepositoryPath(?string $repository): ?string
+{
+    $matcher = new class
+    {
+        use MatchesManualWebhookApplications;
+
+        public function canonical(?string $repository): ?string
+        {
+            return $this->canonicalManualWebhookRepository($repository);
+        }
+    };
+
+    return $matcher->canonical($repository);
+}
+
+it('normalizes scp-style ssh repositories with non-git users', function () {
+    expect(manualWebhookRepositoryPath('gitea@git.example.com:Test/Repo.git'))->toBe('Test/Repo')
+        ->and(manualWebhookRepositoryPath('forgejo@git.example.com:2222/Test/Repo.git'))->toBe('Test/Repo');
+});


### PR DESCRIPTION
## Summary
- support scp-style SSH repository URLs with users other than `git` in manual webhook matching
- keep custom-port stripping for URLs like `user@host:2222/owner/repo.git`
- add a unit regression test for `gitea@...` and another non-`git` SSH user

Fixes #10560

## Tests
- `php -l app\Http\Controllers\Webhook\Concerns\MatchesManualWebhookApplications.php`
- `php -l tests\Unit\ManualWebhookRepositoryMatchTest.php`
- `git diff --check`

Could not run the unit test locally because this checkout does not have `vendor/autoload.php` installed.