### PR TITLE
feat: add WordPress OpenLiteSpeed service template

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -1,0 +1,48 @@
+# documentation: https://docs.litespeedtech.com/cloud/docker/
+# slogan: A high-performance WordPress stack powered by OpenLiteSpeed and MariaDB.
+# category: cms
+# tags: cms, blog, content, management, wordpress, openlitespeed, mariadb
+# logo: svgs/wordpress.svg
+# port: 80
+
+services:
+  wordpress:
+    image: litespeedtech/openlitespeed:latest
+    volumes:
+      - wordpress-sites:/var/www/vhosts/
+      - wordpress-conf:/usr/local/lsws/conf
+      - wordpress-admin-conf:/usr/local/lsws/admin/conf
+      - wordpress-bin:/usr/local/bin
+      - wordpress-acme:/root/.acme.sh/
+      - wordpress-logs:/usr/local/lsws/logs
+    environment:
+      - SERVICE_URL_WORDPRESS
+      - TZ=${TIMEZONE:-UTC}
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+      - DOMAIN=${SERVICE_FQDN_WORDPRESS}
+    depends_on:
+      mysql:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+  mysql:
+    image: mariadb:11
+    command: ["--max-allowed-packet=512M"]
+    volumes:
+      - mysql-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
## Changes

- Added a new one-click service template for WordPress with OpenLiteSpeed and MariaDB.
- Uses the official `litespeedtech/openlitespeed` image with persistent volumes for sites, config, admin config, ACME data, and logs.
- Adds MariaDB 11 with Coolify-generated database credentials and a health check.
- Keeps `templates/service-templates*.json` untouched because the PR quality workflow blocks changes to generated template bundles.

## Issues

- Fixes #8264

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not available from this environment.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Used to inspect existing service templates, draft the new compose template, and run static checks. The change should still be reviewed and runtime-tested by a maintainer.

## Testing

- Confirmed the change is limited to `templates/compose/wordpress-with-openlitespeed.yaml`.
- Confirmed no generated `templates/service-templates*.json` files were modified.
- Ran a static check for tabs, final newline, `SERVICE_URL_WORDPRESS`, `SERVICE_FQDN_WORDPRESS`, and `# port: 80`.
- Could not run a full local Coolify deployment here because Docker, PHP, and Composer are not available in this environment.