### PR TITLE
fix(database): preserve docker exec restore commands

### DIFF
--- a/bootstrap/helpers/sudo.php
+++ b/bootstrap/helpers/sudo.php
@@ -20,6 +20,10 @@ function shouldChangeOwnership(string $path): bool
 
     return $isCoolifyPath;
 }
+function runsShellCommandInsideDockerExec(string $line): bool
+{
+    return preg_match('/^\s*(sudo\s+)?docker\s+exec\b.*\b(?:sh|bash)\s+-[a-zA-Z]*c\b/', $line) === 1;
+}
 function parseCommandsByLineForSudo(Collection $commands, Server $server): array
 {
     $commands = $commands->map(function ($line) {
@@ -90,6 +94,10 @@ function parseCommandsByLineForSudo(Collection $commands, Server $server): array
 
     $commands = $commands->map(function ($line) {
         $line = str($line);
+
+        if (runsShellCommandInsideDockerExec($line->value())) {
+            return $line->value();
+        }
 
         // Detect complex piped commands that should be wrapped in bash -c
         $isComplexPipeCommand = (

--- a/tests/Unit/ParseCommandsByLineForSudoTest.php
+++ b/tests/Unit/ParseCommandsByLineForSudoTest.php
@@ -277,6 +277,17 @@ test('handles command with mixed operators and subshells', function () {
     expect($result[0])->toBe('sudo docker ps || sudo echo $(sudo date)');
 });
 
+test('does not inject sudo into docker exec shell commands', function () {
+    $commands = collect([
+        "docker exec postgres sh -c '/tmp/restore_database.sh && rm -f /tmp/restore.sql /tmp/restore_database.sh'",
+    ]);
+
+    $result = parseCommandsByLineForSudo($commands, $this->server);
+
+    expect($result[0])->toBe("sudo docker exec postgres sh -c '/tmp/restore_database.sh && rm -f /tmp/restore.sql /tmp/restore_database.sh'");
+    expect($result[0])->not->toContain('&& sudo rm -f');
+});
+
 test('handles whitespace-only commands gracefully', function () {
     $commands = collect([
         '   ',


### PR DESCRIPTION
## Changes

- Preserve Docker exec shell command bodies when Coolify adds host sudo for non-root servers.
- Keep host Docker access elevated while avoiding sudo inside database containers during restore cleanup.
- Add a regression test for restore-style cleanup commands.

## Issues

- Fixes #9949

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable; this is backend command handling.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

If AI was used:

- Tools used: Codex
- How extensively: Used for repository search, patch drafting, and validation planning. I reviewed the issue, diff, and command behavior before submitting.

## Testing

- PHP syntax check passed for the changed helper and regression test.
- Whitespace check passed with git diff --check.
- Pest and Pint could not be run in this checkout because vendor dependencies are not installed.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the contributor guidelines. If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched existing issues and pull requests, including closed ones, to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.