### PR TITLE
fix(git): persist deploy key base directory

### DIFF
--- a/app/Livewire/Project/New/GithubPrivateRepositoryDeployKey.php
+++ b/app/Livewire/Project/New/GithubPrivateRepositoryDeployKey.php
@@ -35,7 +35,7 @@ class GithubPrivateRepositoryDeployKey extends Component
     public ?string $publish_directory = null;
 
     // In case of docker compose
-    public ?string $base_directory = null;
+    public ?string $base_directory = '/';
 
     public ?string $docker_compose_location = '/docker-compose.yaml';
     // End of docker compose
@@ -65,6 +65,7 @@ class GithubPrivateRepositoryDeployKey extends Component
             'is_static' => 'required|boolean',
             'publish_directory' => 'nullable|string',
             'build_pack' => 'required|string',
+            'base_directory' => ValidationPatterns::directoryPathRules(),
             'docker_compose_location' => ValidationPatterns::filePathRules(),
         ];
     }
@@ -76,6 +77,7 @@ class GithubPrivateRepositoryDeployKey extends Component
         'is_static' => 'Is static',
         'publish_directory' => 'Publish directory',
         'build_pack' => 'Build pack',
+        'base_directory' => 'Base directory',
     ];
 
     public function mount()
@@ -176,9 +178,9 @@ class GithubPrivateRepositoryDeployKey extends Component
             if ($this->build_pack === 'dockerfile' || $this->build_pack === 'dockerimage') {
                 $application_init['health_check_enabled'] = false;
             }
+            $application_init['base_directory'] = $this->base_directory ?: '/';
             if ($this->build_pack === 'dockercompose') {
                 $application_init['docker_compose_location'] = $this->docker_compose_location;
-                $application_init['base_directory'] = $this->base_directory;
             }
             $application = Application::create($application_init);
             $application->settings->is_static = $this->is_static;

--- a/tests/Feature/TeamScopedDestinationTest.php
+++ b/tests/Feature/TeamScopedDestinationTest.php
@@ -11,6 +11,7 @@ use App\Livewire\Project\New\SimpleDockerfile;
 use App\Models\Application;
 use App\Models\Environment;
 use App\Models\InstanceSettings;
+use App\Models\PrivateKey;
 use App\Models\Project;
 use App\Models\Server;
 use App\Models\Service;
@@ -212,6 +213,40 @@ describe('GithubPrivateRepository destination team scope', function () {
 });
 
 describe('GithubPrivateRepositoryDeployKey destination team scope', function () {
+    test('submit with dockerfile persists base directory', function () {
+        $rsaKey = openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+        openssl_pkey_export($rsaKey, $pemKey);
+
+        $privateKey = PrivateKey::create([
+            'name' => 'Deploy Key',
+            'private_key' => $pemKey,
+            'team_id' => $this->teamA->id,
+        ]);
+
+        $routeParams = [
+            'project_uuid' => $this->projectA->uuid,
+            'environment_uuid' => $this->environmentA->uuid,
+        ];
+
+        Livewire::withUrlParams(['destination' => $this->destinationA->uuid])
+            ->test(GithubPrivateRepositoryDeployKey::class, $routeParams)
+            ->set('private_key_id', $privateKey->id)
+            ->set('repository_url', 'https://git.example.com/acme/monorepo')
+            ->set('branch', 'main')
+            ->set('build_pack', 'dockerfile')
+            ->set('base_directory', '/apps/api')
+            ->call('submit');
+
+        $application = Application::query()->latest('id')->first();
+
+        expect($application->base_directory)->toBe('/apps/api');
+        expect($application->build_pack)->toBe('dockerfile');
+        expect($application->private_key_id)->toBe($privateKey->id);
+    });
+
     test('submit with other team destination throws and creates no application', function () {
         $routeParams = [
             'project_uuid' => $this->projectA->uuid,


### PR DESCRIPTION
## Changes

- Persist Base Directory for deploy-key applications created with the Dockerfile build pack.
- Default the Deploy Key Base Directory field to slash, matching the other repository flows.
- Validate the value with the shared directory path rules.
- Add a Livewire regression test for the Deploy Key plus Dockerfile creation path.

## Issues

- Fixes #10319

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable; this is a backend persistence fix for an existing form field.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

If AI was used:

- Tools used: Codex
- How extensively: Used for repository search, patch drafting, and validation planning. I reviewed the issue, diff, and flow before submitting.

## Testing

- PHP syntax check passed for the changed component and regression test.
- Whitespace check passed with git diff --check.
- Pest and Pint could not be run in this checkout because vendor dependencies are not installed.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the contributor guidelines. If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched existing issues and pull requests, including closed ones, to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.