### PR TITLE
Add Huly self-host service template

### DIFF
--- a/templates/compose/huly.yaml
+++ b/templates/compose/huly.yaml
@@ -1,36 +1,177 @@
-# ignore: true
-# documentation: https://huly.io/
-# category: cms
-# slogan: Open Source All-in-One Project Management Platform
-# tags: linear,jira,slack,project,management,notion,motion
+# documentation: https://github.com/hcengineering/huly-selfhost
+# category: productivity
+# slogan: Open-source all-in-one project management platform
+# tags: project-management,collaboration,linear,jira,slack,notion,motion,self-hosted
 # port: 8080
 
 services:
-  mongodb:
-    image: "mongo:7-jammy"
-    container_name: mongodb
+  nginx:
+    image: nginx:1.29.2
     environment:
-      - PUID=1000
-      - PGID=1000
+      - SERVICE_URL_HULY_8080
+    depends_on:
+      - front
+      - account
+      - transactor
+      - collaborator
+      - rekoni
+      - stats
     volumes:
-      - huly-db:/data/db
+      - type: bind
+        source: ./nginx/huly.conf
+        target: /etc/nginx/conf.d/default.conf
+        read_only: true
+        content: |
+          server {
+              listen 8080;
+              server_name _;
+              client_max_body_size 100M;
+
+              location / {
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+                  proxy_pass http://front:8080;
+              }
+
+              location /_accounts {
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+                  rewrite ^/_accounts(/.*)$ $1 break;
+                  proxy_pass http://account:3000/;
+              }
+
+              location /_collaborator {
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+                  proxy_http_version 1.1;
+                  proxy_set_header Upgrade $http_upgrade;
+                  proxy_set_header Connection "upgrade";
+                  rewrite ^/_collaborator(/.*)$ $1 break;
+                  proxy_pass http://collaborator:3078/;
+              }
+
+              location /_transactor {
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+                  proxy_http_version 1.1;
+                  proxy_set_header Upgrade $http_upgrade;
+                  proxy_set_header Connection "upgrade";
+                  rewrite ^/_transactor(/.*)$ $1 break;
+                  proxy_pass http://transactor:3333/;
+              }
+
+              location ~ ^/eyJ {
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+                  proxy_http_version 1.1;
+                  proxy_set_header Upgrade $http_upgrade;
+                  proxy_set_header Connection "upgrade";
+                  proxy_pass http://transactor:3333;
+              }
+
+              location /_rekoni {
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+                  rewrite ^/_rekoni(/.*)$ $1 break;
+                  proxy_pass http://rekoni:4004/;
+              }
+
+              location /_stats {
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+                  rewrite ^/_stats(/.*)$ $1 break;
+                  proxy_pass http://stats:4900/;
+              }
+
+              location /files {
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+                  rewrite ^/files(/.*)$ $1 break;
+                  proxy_pass http://minio:9000/;
+              }
+          }
+    healthcheck:
+      test: ["CMD", "nginx", "-t"]
+      interval: 5s
+      timeout: 10s
+      retries: 20
+    restart: unless-stopped
+
+  cockroach:
+    image: cockroachdb/cockroach:latest-v24.2
+    command: start-single-node --accept-sql-without-tls
+    environment:
+      - COCKROACH_DATABASE=huly
+      - COCKROACH_USER=$SERVICE_USER_COCKROACH
+      - COCKROACH_PASSWORD=$SERVICE_PASSWORD_COCKROACH
+    volumes:
+      - cockroach-data:/cockroach/cockroach-data
+      - cockroach-certs:/cockroach/certs
+    restart: unless-stopped
+
+  redpanda:
+    image: docker.redpanda.com/redpandadata/redpanda:v24.3.6
+    command:
+      - redpanda
+      - start
+      - --kafka-addr internal://0.0.0.0:9092,external://0.0.0.0:19092
+      - --advertise-kafka-addr internal://redpanda:9092,external://localhost:19092
+      - --pandaproxy-addr internal://0.0.0.0:8082,external://0.0.0.0:18082
+      - --advertise-pandaproxy-addr internal://redpanda:8082,external://localhost:18082
+      - --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:18081
+      - --rpc-addr redpanda:33145
+      - --advertise-rpc-addr redpanda:33145
+      - --mode dev-container
+      - --smp 1
+      - --default-log-level=info
+    environment:
+      - REDPANDA_SUPERUSER_USERNAME=$SERVICE_USER_REDPANDA
+      - REDPANDA_SUPERUSER_PASSWORD=$SERVICE_PASSWORD_REDPANDA
+    volumes:
+      - redpanda-data:/var/lib/redpanda/data
+    healthcheck:
+      test: ["CMD", "rpk", "cluster", "info"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
   minio:
-    image: ghcr.io/coollabsio/minio:RELEASE.2025-10-15T17-29-55Z # Released on 15 October 2025
+    image: minio/minio:RELEASE.2025-10-15T17-29-55Z
     command: server /data --address ":9000" --console-address ":9001"
+    environment:
+      - MINIO_ROOT_USER=minioadmin
+      - MINIO_ROOT_PASSWORD=minioadmin
     volumes:
-      - huly-files:/data      
+      - minio-data:/data
     healthcheck:
       test: ["CMD", "mc", "ready", "local"]
       interval: 5s
       timeout: 20s
       retries: 10
+    restart: unless-stopped
+
   elastic:
-    image: "elasticsearch:7.14.2"
+    image: elasticsearch:7.14.2
     command: |
       /bin/sh -c "./bin/elasticsearch-plugin list | grep -q ingest-attachment || yes | ./bin/elasticsearch-plugin install --silent ingest-attachment;
       /usr/local/bin/docker-entrypoint.sh eswrapper"
-    volumes:
-      - huly-elastic:/usr/share/elasticsearch/data
     environment:
       - ELASTICSEARCH_PORT_NUMBER=9200
       - BITNAMI_DEBUG=true
@@ -38,86 +179,163 @@ services:
       - ES_JAVA_OPTS=-Xms1024m -Xmx1024m
       - http.cors.enabled=true
       - http.cors.allow-origin=http://localhost:8082
+    volumes:
+      - elastic-data:/usr/share/elasticsearch/data
     healthcheck:
-      test: curl -s http://127.0.0.1:9200/_cluster/health | grep -vq '"status":"red"'
-      interval: 5s
+      test: ["CMD-SHELL", "curl -s http://127.0.0.1:9200/_cluster/health | grep -vq '\"status\":\"red\"'"]
+      interval: 20s
       retries: 10
-  account:
-    image: hardcoreeng/account:v0.6.246
-    environment:
-      - SERVICE_URL_HULY_3000
-      - SERVER_PORT=3000
-      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
-      - MONGO_URL=mongodb://mongodb:27017
-      - TRANSACTOR_URL=ws://transactor:3333
-      - ENDPOINT_URL=ws://transactor:3333
-      - MINIO_ENDPOINT=minio
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadmin
-      - FRONT_URL=http://front:8080
-      - INIT_WORKSPACE=demo-tracker
-      - MODEL_ENABLED=*
-      - ACCOUNTS_URL=http://localhost:3000
-  front:
-    image: hardcoreeng/front:v0.6.246
-    environment:
-      - SERVICE_URL_HULY_8080
-      - MONGO_URL=mongodb://mongodb:27017
-      - SERVER_PORT=8080
-      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
-      - ACCOUNTS_URL=http://account:3000
-      - REKONI_URL=http://rekoni:4004
-      - CALENDAR_URL=http://localhost:8095
-      - GMAIL_URL=http://localhost:8088
-      - TELEGRAM_URL=http://localhost:8086
-      - UPLOAD_URL=/files
-      - TRANSACTOR_URL=ws://transactor:3333
-      - ELASTIC_URL=http://elastic:9200
-      - COLLABORATOR_URL=ws://collaborator:3078
-      - COLLABORATOR_API_URL=http://collaborator:3078
-      - MINIO_ENDPOINT=minio
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadmin
-      - TITLE=Huly Self Hosted
-      - DEFAULT_LANGUAGE=en
-      - LAST_NAME_FIRST=true
     restart: unless-stopped
-  collaborator:
-    image: hardcoreeng/collaborator:v0.6.246
-    environment:
-      - COLLABORATOR_PORT=3078
-      - SECRET=secret
-      - ACCOUNTS_URL=http://account:3000
-      - TRANSACTOR_URL=ws://transactor:3333
-      - UPLOAD_URL=/files
-      - MONGO_URL=mongodb://mongodb:27017
-      - MINIO_ENDPOINT=minio
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadmin
-  transactor:
-    image: hardcoreeng/transactor:v0.6.246
-    environment:
-      - SERVER_PORT=3333
-      - ELASTIC_INDEX_NAME=huly
-      - SERVER_SECRET=$SERVICE_PASSWORD_SECRET
-      - SERVER_CURSOR_MAXTIMEMS=30000
-      - ELASTIC_URL=http://elastic:9200
-      - MONGO_URL=mongodb://mongodb:27017
-      - METRICS_CONSOLE=false
-      - METRICS_FILE=metrics.txt
-      - MINIO_ENDPOINT=minio
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadmin
-      - REKONI_URL=http://rekoni:4004
-      - FRONT_URL=http://localhost:8087
-      - SERVER_PROVIDER=ws
-      - ACCOUNTS_URL=http://account:3000
-      - LAST_NAME_FIRST=true
-      - UPLOAD_URL=/files
-    restart: unless-stopped
+
   rekoni:
-    image: hardcoreeng/rekoni-service:latest
+    image: hardcoreeng/rekoni-service:${HULY_VERSION:-v0.7.423}
+    environment:
+      - SECRET=$SERVICE_PASSWORD_HULYSECRET
     deploy:
       resources:
         limits:
           memory: 500M
+    restart: unless-stopped
+
+  transactor:
+    image: hardcoreeng/transactor:${HULY_VERSION:-v0.7.423}
+    environment:
+      - SERVER_PORT=3333
+      - SERVER_SECRET=$SERVICE_PASSWORD_HULYSECRET
+      - DB_URL=postgres://$SERVICE_USER_COCKROACH:$SERVICE_PASSWORD_COCKROACH@cockroach:26257/huly
+      - STORAGE_CONFIG=minio|minio?accessKey=minioadmin&secretKey=minioadmin
+      - FRONT_URL=${SERVICE_URL_HULY_8080}
+      - ACCOUNTS_URL=http://account:3000
+      - FULLTEXT_URL=http://fulltext:4700
+      - STATS_URL=http://stats:4900
+      - LAST_NAME_FIRST=true
+      - QUEUE_CONFIG=redpanda:9092
+    depends_on:
+      - cockroach
+      - minio
+      - elastic
+      - redpanda
+    restart: unless-stopped
+
+  collaborator:
+    image: hardcoreeng/collaborator:${HULY_VERSION:-v0.7.423}
+    environment:
+      - COLLABORATOR_PORT=3078
+      - SECRET=$SERVICE_PASSWORD_HULYSECRET
+      - ACCOUNTS_URL=http://account:3000
+      - STATS_URL=http://stats:4900
+      - STORAGE_CONFIG=minio|minio?accessKey=minioadmin&secretKey=minioadmin
+    depends_on:
+      - account
+      - minio
+    restart: unless-stopped
+
+  account:
+    image: hardcoreeng/account:${HULY_VERSION:-v0.7.423}
+    environment:
+      - SERVER_PORT=3000
+      - SERVER_SECRET=$SERVICE_PASSWORD_HULYSECRET
+      - DB_URL=postgres://$SERVICE_USER_COCKROACH:$SERVICE_PASSWORD_COCKROACH@cockroach:26257/huly
+      - TRANSACTOR_URL=ws://transactor:3333;${SERVICE_URL_HULY_8080}/_transactor
+      - STORAGE_CONFIG=minio|minio?accessKey=minioadmin&secretKey=minioadmin
+      - FRONT_URL=${SERVICE_URL_HULY_8080}
+      - STATS_URL=${SERVICE_URL_HULY_8080}/_stats
+      - MODEL_ENABLED=*
+      - ACCOUNTS_URL=${SERVICE_URL_HULY_8080}/_accounts
+      - ACCOUNT_PORT=3000
+      - QUEUE_CONFIG=redpanda:9092
+    depends_on:
+      - cockroach
+      - minio
+      - redpanda
+    restart: unless-stopped
+
+  workspace:
+    image: hardcoreeng/workspace:${HULY_VERSION:-v0.7.423}
+    environment:
+      - SERVER_SECRET=$SERVICE_PASSWORD_HULYSECRET
+      - DB_URL=postgres://$SERVICE_USER_COCKROACH:$SERVICE_PASSWORD_COCKROACH@cockroach:26257/huly
+      - TRANSACTOR_URL=ws://transactor:3333;${SERVICE_URL_HULY_8080}/_transactor
+      - STORAGE_CONFIG=minio|minio?accessKey=minioadmin&secretKey=minioadmin
+      - MODEL_ENABLED=*
+      - ACCOUNTS_URL=http://account:3000
+      - STATS_URL=http://stats:4900
+      - QUEUE_CONFIG=redpanda:9092
+      - ACCOUNTS_DB_URL=postgres://$SERVICE_USER_COCKROACH:$SERVICE_PASSWORD_COCKROACH@cockroach:26257/huly
+    depends_on:
+      - cockroach
+      - account
+      - redpanda
+    restart: unless-stopped
+
+  front:
+    image: hardcoreeng/front:${HULY_VERSION:-v0.7.423}
+    environment:
+      - SERVER_PORT=8080
+      - SERVER_SECRET=$SERVICE_PASSWORD_HULYSECRET
+      - LOVE_ENDPOINT=${SERVICE_URL_HULY_8080}/_love
+      - ACCOUNTS_URL=${SERVICE_URL_HULY_8080}/_accounts
+      - ACCOUNTS_URL_INTERNAL=http://account:3000
+      - REKONI_URL=${SERVICE_URL_HULY_8080}/_rekoni
+      - CALENDAR_URL=${SERVICE_URL_HULY_8080}/_calendar
+      - GMAIL_URL=${SERVICE_URL_HULY_8080}/_gmail
+      - TELEGRAM_URL=${SERVICE_URL_HULY_8080}/_telegram
+      - STATS_URL=${SERVICE_URL_HULY_8080}/_stats
+      - UPLOAD_URL=/files
+      - ELASTIC_URL=http://elastic:9200
+      - COLLABORATOR_URL=${SERVICE_URL_HULY_8080}/_collaborator
+      - STORAGE_CONFIG=minio|minio?accessKey=minioadmin&secretKey=minioadmin
+      - TITLE=${HULY_TITLE:-Huly Self Host}
+      - DEFAULT_LANGUAGE=${HULY_DEFAULT_LANGUAGE:-en}
+      - LAST_NAME_FIRST=true
+      - DESKTOP_UPDATES_CHANNEL=${HULY_DESKTOP_CHANNEL:-0.7.423}
+      - DISABLED_FEATURES=auto-translate,mailboxes
+    depends_on:
+      - account
+      - transactor
+      - collaborator
+      - elastic
+      - minio
+    restart: unless-stopped
+
+  fulltext:
+    image: hardcoreeng/fulltext:${HULY_VERSION:-v0.7.423}
+    environment:
+      - SERVER_SECRET=$SERVICE_PASSWORD_HULYSECRET
+      - DB_URL=postgres://$SERVICE_USER_COCKROACH:$SERVICE_PASSWORD_COCKROACH@cockroach:26257/huly
+      - FULLTEXT_DB_URL=http://elastic:9200
+      - ELASTIC_INDEX_NAME=huly_storage_index
+      - STORAGE_CONFIG=minio|minio?accessKey=minioadmin&secretKey=minioadmin
+      - REKONI_URL=http://rekoni:4004
+      - ACCOUNTS_URL=http://account:3000
+      - STATS_URL=http://stats:4900
+      - QUEUE_CONFIG=redpanda:9092
+    depends_on:
+      - cockroach
+      - elastic
+      - redpanda
+      - rekoni
+    restart: unless-stopped
+
+  stats:
+    image: hardcoreeng/stats:${HULY_VERSION:-v0.7.423}
+    environment:
+      - PORT=4900
+      - SERVER_SECRET=$SERVICE_PASSWORD_HULYSECRET
+    restart: unless-stopped
+
+  kvs:
+    image: hardcoreeng/hulykvs:${HULY_VERSION:-v0.7.423}
+    environment:
+      - HULY_DB_CONNECTION=postgres://$SERVICE_USER_COCKROACH:$SERVICE_PASSWORD_COCKROACH@cockroach:26257/huly
+      - HULY_TOKEN_SECRET=$SERVICE_PASSWORD_HULYSECRET
+    depends_on:
+      - cockroach
+    restart: unless-stopped
+
+volumes:
+  cockroach-data:
+  cockroach-certs:
+  redpanda-data:
+  minio-data:
+  elastic-data:


### PR DESCRIPTION
## Summary
- enable and modernize the Huly service template
- align the compose stack with the official huly-selfhost topology
- expose Huly through Coolify using SERVICE_URL_HULY_8080

Fixes #2543

## Verification
- Parsed templates/compose/huly.yaml with PyYAML
- Decoded and parsed the generated local Huly entries for service-templates.json and service-templates-latest.json
- Confirmed the fork raw file matches the local validated huly.yaml exactly

Note: PHP/Pest and Docker are not installed in this environment, so I could not run the full Coolify test suite locally.