### PR TITLE
feat: add OpenLiteSpeed service template

### DIFF
--- a/templates/compose/openlitespeed.yaml
+++ b/templates/compose/openlitespeed.yaml
@@ -1,0 +1,24 @@
+# documentation: https://docs.litespeedtech.com/cloud/docker/openlitespeed/
+# slogan: OpenLiteSpeed is a lightweight, high-performance, open-source web server with built-in PHP support.
+# category: proxy
+# tags: webserver, openlitespeed, litespeed, php, http
+# port: 80
+
+services:
+  openlitespeed:
+    image: litespeedtech/openlitespeed:${OPENLITESPEED_VERSION:-1.8.5-lsphp85}
+    environment:
+      - SERVICE_URL_OPENLITESPEED_80
+      - TZ=${TZ:-UTC}
+    volumes:
+      - openlitespeed-conf:/usr/local/lsws/conf
+      - openlitespeed-admin-conf:/usr/local/lsws/admin/conf
+      - openlitespeed-sites:/var/www/vhosts
+      - openlitespeed-acme:/root/.acme.sh
+      - openlitespeed-logs:/usr/local/lsws/logs
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:80"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s


### PR DESCRIPTION
## Changes

- Added a standalone OpenLiteSpeed one-click service template.
- Exposes the HTTP service through Coolify on port 80.
- Persists OpenLiteSpeed configuration, admin configuration, site files, ACME data, and logs.

## Issues

- Related to #8264
- /claim #8264

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not available locally because Docker is not installed in this environment.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex
- How extensively: AI helped prepare the template; I reviewed the file and repository contribution checks before submission.

## Testing

- Added only `templates/compose/openlitespeed.yaml`.
- Verified the template includes Coolify metadata and `SERVICE_URL_OPENLITESPEED_80`.
- Local deployment was not run because Docker is not installed in this environment.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
