### PR TITLE
fix(scheduled-tasks): capture stderr output

### DIFF
--- a/app/Jobs/ScheduledTaskJob.php
+++ b/app/Jobs/ScheduledTaskJob.php
@@ -147,7 +147,7 @@ class ScheduledTaskJob implements ShouldBeEncrypted, ShouldQueue
 
             foreach ($this->containers as $containerName) {
                 if (count($this->containers) == 1 || str_starts_with($containerName, $this->task->container.'-'.$this->resource->uuid)) {
-                    $cmd = "sh -c '".str_replace("'", "'\''", $this->task->command)."'";
+                    $cmd = $this->containerShellCommand($this->task->command);
                     $exec = "docker exec {$containerName} {$cmd}";
                     // Disable SSH multiplexing to prevent race conditions when multiple tasks run concurrently
                     // See: https://github.com/coollabsio/coolify/issues/6736
@@ -273,5 +273,10 @@ class ScheduledTaskJob implements ShouldBeEncrypted, ShouldQueue
 
         // Notify team about permanent failure
         $this->team?->notify(new TaskFailed($this->task, $exception?->getMessage() ?? 'Unknown error'));
+    }
+
+    private function containerShellCommand(string $command): string
+    {
+        return "sh -c '".str_replace("'", "'\''", "($command) 2>&1")."'";
     }
 }

--- a/tests/Unit/ScheduledTaskJobTimeoutTest.php
+++ b/tests/Unit/ScheduledTaskJobTimeoutTest.php
@@ -94,3 +94,15 @@ it('failed method logs when execution cannot be found', function () {
         ->toContain('Could not find execution log')
         ->toContain('warning');
 });
+
+it('wraps scheduled task commands so stderr is captured with stdout', function () {
+    $reflection = new ReflectionClass(ScheduledTaskJob::class);
+    $job = $reflection->newInstanceWithoutConstructor();
+    $method = $reflection->getMethod('containerShellCommand');
+    $method->setAccessible(true);
+
+    expect($method->invoke($job, 'echo stdout; echo stderr >&2'))
+        ->toBe("sh -c '(echo stdout; echo stderr >&2) 2>&1'")
+        ->and($method->invoke($job, "echo 'stderr' >&2"))
+        ->toBe("sh -c '(echo '\''stderr'\'' >&2) 2>&1'");
+});


### PR DESCRIPTION
## Changes

- Wrap scheduled task commands so stderr is redirected into stdout before the remote process helper captures output.
- Keep the existing Docker exec and SSH multiplexing behavior unchanged.
- Add regression coverage for the scheduled-task command wrapper, including single-quote escaping.

## Issues

- Fixes #10107

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable; this is backend scheduled-task execution behavior.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

If AI was used:

- Tools used: Codex
- How extensively: Used for repository search, patch drafting, and validation planning. I reviewed the issue, affected command path, and diff before submitting.

## Testing

- PHP syntax check passed for the changed job and regression test.
- Whitespace check passed with git diff --check.
- Pest and Pint could not be run in this checkout because vendor dependencies are not installed.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the contributor guidelines. If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched existing issues and pull requests, including closed ones, to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.