### PR TITLE
fix(service): add short network aliases

### DIFF
--- a/app/Actions/Service/StartService.php
+++ b/app/Actions/Service/StartService.php
@@ -42,17 +42,35 @@ class StartService
         $commands[] = 'echo Starting service.';
         $commands[] = "docker compose --project-directory {$workdir} -f {$workdir}/docker-compose.yml --project-name {$service->uuid} up -d --remove-orphans --force-recreate --build";
         $commands[] = "docker network connect $service->uuid coolify-proxy >/dev/null 2>&1 || true";
-        if (data_get($service, 'connect_to_docker_network')) {
-            $compose = data_get($service, 'docker_compose', []);
-            $safeNetwork = escapeshellarg($service->destination->network);
-            $serviceNames = data_get(Yaml::parse($compose), 'services', []);
-            foreach ($serviceNames as $serviceName => $serviceConfig) {
-                $commands[] = "docker network connect --alias {$serviceName}-{$service->uuid} {$safeNetwork} {$serviceName}-{$service->uuid} >/dev/null 2>&1 || true";
-            }
-        }
+        $commands = array_merge($commands, $this->serviceNetworkConnectCommands($service));
         $commands = array_merge($commands, $this->logDrainNetworkConnectCommands($service));
 
         return remote_process($commands, $service->server, type_uuid: $service->uuid, callEventOnFinish: 'ServiceStatusChanged');
+    }
+
+    private function serviceNetworkConnectCommands(Service $service): array
+    {
+        if (! data_get($service, 'connect_to_docker_network')) {
+            return [];
+        }
+
+        $compose = data_get($service, 'docker_compose', []);
+        $network = data_get($service, 'destination.network');
+
+        if (blank($network)) {
+            return [];
+        }
+
+        $commands = [];
+        $safeNetwork = escapeshellarg($network);
+        $serviceNames = data_get(Yaml::parse($compose), 'services', []);
+
+        foreach ($serviceNames as $serviceName => $serviceConfig) {
+            $containerName = "{$serviceName}-{$service->uuid}";
+            $commands[] = 'docker network connect --alias '.escapeshellarg($serviceName).' --alias '.escapeshellarg($containerName).' '.$safeNetwork.' '.escapeshellarg($containerName).' >/dev/null 2>&1 || true';
+        }
+
+        return $commands;
     }
 
     private function logDrainNetworkConnectCommands(Service $service): array

--- a/app/Actions/Service/StartService.php
+++ b/app/Actions/Service/StartService.php
@@ -65,7 +65,7 @@ class StartService
         $safeNetwork = escapeshellarg($network);
         $serviceNames = data_get(Yaml::parse($compose), 'services', []);
 
-        foreach ($serviceNames as $serviceName => $serviceConfig) {
+        foreach (array_keys($serviceNames) as $serviceName) {
             $containerName = "{$serviceName}-{$service->uuid}";
             $commands[] = 'docker network connect --alias '.escapeshellarg($serviceName).' --alias '.escapeshellarg($containerName).' '.$safeNetwork.' '.escapeshellarg($containerName).' >/dev/null 2>&1 || true';
         }

--- a/tests/Feature/LogDrain/LogDrainNetworkConnectCommandTest.php
+++ b/tests/Feature/LogDrain/LogDrainNetworkConnectCommandTest.php
@@ -20,6 +20,14 @@ function reflectedLogDrainNetworkCommands(object $action, Server|Service $model)
     return $method->invoke($action, $model);
 }
 
+function reflectedServiceNetworkCommands(StartService $action, Service $service): array
+{
+    $method = new ReflectionMethod($action, 'serviceNetworkConnectCommands');
+    $method->setAccessible(true);
+
+    return $method->invoke($action, $service);
+}
+
 function createServerWithTeam(): Server
 {
     $team = Team::factory()->create();
@@ -63,6 +71,28 @@ it('does not connect the log drain container when service preferred network is d
     $service = createServiceOnServer($server, 'signoz-net', false);
 
     $commands = reflectedLogDrainNetworkCommands(new StartService, $service->fresh(['destination.server.settings']));
+
+    expect($commands)->toBeEmpty();
+});
+
+it('connects service containers to the preferred network with short and generated aliases', function () {
+    $server = createServerWithTeam();
+    $service = createServiceOnServer($server, 'signoz-net', true);
+    $service->forceFill([
+        'uuid' => 'service-uuid',
+        'docker_compose' => "services:\n  signoz:\n    image: signoz/signoz:latest\n",
+    ])->save();
+
+    $commands = reflectedServiceNetworkCommands(new StartService, $service->fresh(['destination']));
+
+    expect($commands)->toContain("docker network connect --alias 'signoz' --alias 'signoz-service-uuid' 'signoz-net' 'signoz-service-uuid' >/dev/null 2>&1 || true");
+});
+
+it('does not connect service containers to the preferred network when disabled', function () {
+    $server = createServerWithTeam();
+    $service = createServiceOnServer($server, 'signoz-net', false);
+
+    $commands = reflectedServiceNetworkCommands(new StartService, $service->fresh(['destination']));
 
     expect($commands)->toBeEmpty();
 });


### PR DESCRIPTION
## Changes

- Add the short service name as a Docker network alias when services are connected to the preferred Docker network.
- Keep the generated service container alias as well, so existing behavior stays available.
- Move service network connect command generation into a small testable helper.
- Add regression coverage for preferred-network connect commands.

## Issues

- Fixes #10581
- Related to #5597

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable; this is backend service deployment command generation.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

If AI was used:

- Tools used: Codex
- How extensively: Used for issue triage, repository search, patch drafting, and validation planning. I reviewed the existing issue history, command path, and diff before submitting.

## Testing

- PHP syntax check passed for the changed action and regression test.
- Whitespace check passed with git diff --check.
- Pest and Pint could not be run in this checkout because vendor dependencies are not installed.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the contributor guidelines. If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched existing issues and pull requests, including closed ones, to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.