### PR TITLE
fix(api): preserve env values on patch

### DIFF
--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -2905,7 +2905,9 @@ class ApplicationsController extends Controller
         if ($is_preview) {
             $env = $application->environment_variables_preview->where('key', $key)->first();
             if ($env) {
-                $env->value = $request->value;
+                if ($request->has('value')) {
+                    $env->value = $request->value;
+                }
                 if ($env->is_literal != $is_literal) {
                     $env->is_literal = $is_literal;
                 }
@@ -2946,7 +2948,9 @@ class ApplicationsController extends Controller
         } else {
             $env = $application->environment_variables->where('key', $key)->first();
             if ($env) {
-                $env->value = $request->value;
+                if ($request->has('value')) {
+                    $env->value = $request->value;
+                }
                 if ($env->is_literal != $is_literal) {
                     $env->is_literal = $is_literal;
                 }
@@ -3126,7 +3130,9 @@ class ApplicationsController extends Controller
             if ($is_preview) {
                 $env = $application->environment_variables_preview->where('key', $key)->first();
                 if ($env) {
-                    $env->value = $item->get('value');
+                    if ($item->has('value')) {
+                        $env->value = $item->get('value');
+                    }
 
                     if ($env->is_literal != $is_literal) {
                         $env->is_literal = $is_literal;
@@ -3165,7 +3171,9 @@ class ApplicationsController extends Controller
             } else {
                 $env = $application->environment_variables->where('key', $key)->first();
                 if ($env) {
-                    $env->value = $item->get('value');
+                    if ($item->has('value')) {
+                        $env->value = $item->get('value');
+                    }
                     if ($env->is_literal != $is_literal) {
                         $env->is_literal = $is_literal;
                     }

--- a/tests/Feature/EnvironmentVariableBulkCommentApiTest.php
+++ b/tests/Feature/EnvironmentVariableBulkCommentApiTest.php
@@ -152,6 +152,87 @@ describe('PATCH /api/v1/applications/{uuid}/envs/bulk', function () {
         expect($env->comment)->toBe('Keep this comment');
     });
 
+    test('preserves existing value when not provided in bulk update', function () {
+        $application = Application::factory()->create([
+            'environment_id' => $this->environment->id,
+            'destination_id' => $this->destination->id,
+            'destination_type' => $this->destination->getMorphClass(),
+        ]);
+
+        EnvironmentVariable::create([
+            'key' => 'API_TOKEN',
+            'value' => 'keep-this-secret',
+            'resourceable_type' => Application::class,
+            'resourceable_id' => $application->id,
+            'is_preview' => false,
+            'is_buildtime' => false,
+            'is_runtime' => true,
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->patchJson("/api/v1/applications/{$application->uuid}/envs/bulk", [
+            'data' => [
+                [
+                    'key' => 'API_TOKEN',
+                    'is_buildtime' => true,
+                ],
+            ],
+        ]);
+
+        $response->assertStatus(201);
+
+        $env = EnvironmentVariable::where('key', 'API_TOKEN')
+            ->where('resourceable_id', $application->id)
+            ->where('is_preview', false)
+            ->first();
+
+        expect($env->value)->toBe('keep-this-secret');
+        expect((bool) $env->is_buildtime)->toBeTrue();
+    });
+
+    test('preserves existing preview value when not provided in bulk update', function () {
+        $application = Application::factory()->create([
+            'environment_id' => $this->environment->id,
+            'destination_id' => $this->destination->id,
+            'destination_type' => $this->destination->getMorphClass(),
+        ]);
+
+        EnvironmentVariable::create([
+            'key' => 'PREVIEW_API_TOKEN',
+            'value' => 'keep-this-preview-secret',
+            'resourceable_type' => Application::class,
+            'resourceable_id' => $application->id,
+            'is_preview' => true,
+            'is_buildtime' => false,
+            'is_runtime' => true,
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->patchJson("/api/v1/applications/{$application->uuid}/envs/bulk", [
+            'data' => [
+                [
+                    'key' => 'PREVIEW_API_TOKEN',
+                    'is_preview' => true,
+                    'is_buildtime' => true,
+                ],
+            ],
+        ]);
+
+        $response->assertStatus(201);
+
+        $env = EnvironmentVariable::where('key', 'PREVIEW_API_TOKEN')
+            ->where('resourceable_id', $application->id)
+            ->where('is_preview', true)
+            ->first();
+
+        expect($env->value)->toBe('keep-this-preview-secret');
+        expect((bool) $env->is_buildtime)->toBeTrue();
+    });
+
     test('rejects comment exceeding 256 characters', function () {
         $application = Application::factory()->create([
             'environment_id' => $this->environment->id,

--- a/tests/Feature/EnvironmentVariableUpdateApiTest.php
+++ b/tests/Feature/EnvironmentVariableUpdateApiTest.php
@@ -189,6 +189,79 @@ describe('PATCH /api/v1/applications/{uuid}/envs', function () {
         $response->assertJsonMissing(['message' => 'Environment variable updated.']);
     });
 
+    test('preserves existing value when updating flags without value', function () {
+        $application = Application::factory()->create([
+            'environment_id' => $this->environment->id,
+            'destination_id' => $this->destination->id,
+            'destination_type' => $this->destination->getMorphClass(),
+        ]);
+
+        EnvironmentVariable::create([
+            'key' => 'API_TOKEN',
+            'value' => 'keep-this-secret',
+            'resourceable_type' => Application::class,
+            'resourceable_id' => $application->id,
+            'is_preview' => false,
+            'is_buildtime' => false,
+            'is_runtime' => true,
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->patchJson("/api/v1/applications/{$application->uuid}/envs", [
+            'key' => 'API_TOKEN',
+            'is_buildtime' => true,
+        ]);
+
+        $response->assertStatus(201);
+
+        $env = EnvironmentVariable::where('key', 'API_TOKEN')
+            ->where('resourceable_id', $application->id)
+            ->where('is_preview', false)
+            ->first();
+
+        expect($env->value)->toBe('keep-this-secret');
+        expect((bool) $env->is_buildtime)->toBeTrue();
+    });
+
+    test('preserves existing preview value when updating flags without value', function () {
+        $application = Application::factory()->create([
+            'environment_id' => $this->environment->id,
+            'destination_id' => $this->destination->id,
+            'destination_type' => $this->destination->getMorphClass(),
+        ]);
+
+        EnvironmentVariable::create([
+            'key' => 'PREVIEW_API_TOKEN',
+            'value' => 'keep-this-preview-secret',
+            'resourceable_type' => Application::class,
+            'resourceable_id' => $application->id,
+            'is_preview' => true,
+            'is_buildtime' => false,
+            'is_runtime' => true,
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+            'Content-Type' => 'application/json',
+        ])->patchJson("/api/v1/applications/{$application->uuid}/envs", [
+            'key' => 'PREVIEW_API_TOKEN',
+            'is_preview' => true,
+            'is_buildtime' => true,
+        ]);
+
+        $response->assertStatus(201);
+
+        $env = EnvironmentVariable::where('key', 'PREVIEW_API_TOKEN')
+            ->where('resourceable_id', $application->id)
+            ->where('is_preview', true)
+            ->first();
+
+        expect($env->value)->toBe('keep-this-preview-secret');
+        expect((bool) $env->is_buildtime)->toBeTrue();
+    });
+
     test('returns 404 when environment variable does not exist', function () {
         $application = Application::factory()->create([
             'environment_id' => $this->environment->id,


### PR DESCRIPTION
## Changes

- Preserve existing application env values when PATCH requests omit `value`.
- Apply the same preserve-on-omit behavior to preview and bulk application env updates.
- Add regression coverage for single and bulk application env updates.

## Issues

- Fixes #9977
- Supersedes closed PRs #10040 and #10387; the issue is still open and the value wipe is still present on `next` before this change.

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

API-only bug fix; no UI preview is applicable.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex for code search, editing, and local verification commands.
- How extensively: Assisted with a focused controller change and regression tests; the change was reviewed against the issue report, existing code paths, and the project PR guidelines before submission.

## Testing

- `php -l app/Http/Controllers/Api/ApplicationsController.php`
- `php -l tests/Feature/EnvironmentVariableUpdateApiTest.php`
- `php -l tests/Feature/EnvironmentVariableBulkCommentApiTest.php`
- `git diff --check`
- `vendor/bin/pint --dirty --format agent`
- `composer validate --no-check-publish --no-interaction`
- Attempted targeted Pest coverage for `EnvironmentVariableUpdateApiTest.php` and `EnvironmentVariableBulkCommentApiTest.php`; the local Windows test run stops during migrations before assertions because SQLite `:memory:` cannot execute the PostgreSQL-style `ALTER TABLE ... ALTER COLUMN ... TYPE text USING ...` statement in an existing migration.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.