### PR TITLE
feat(auth): enhance focus behavior on authentication forms

### DIFF
--- a/resources/views/auth/confirm-password.blade.php
+++ b/resources/views/auth/confirm-password.blade.php
@@ -1,5 +1,5 @@
 <x-layout-simple>
-    <section class="bg-gray-50 dark:bg-base">
+    <section class="bg-gray-50 dark:bg-base" x-init="$nextTick(() => $el.querySelector('input[name=password]')?.focus())">
         <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0">
             <div class="w-full max-w-md space-y-8">
                 <div class="text-center space-y-2">

--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -1,5 +1,5 @@
 <x-layout-simple>
-    <section class="bg-gray-50 dark:bg-base">
+    <section class="bg-gray-50 dark:bg-base" x-init="$nextTick(() => document.querySelector('input[name=email]')?.focus())">
         <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0">
             <div class="w-full max-w-md space-y-8">
                 <div class="text-center space-y-2">

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,5 +1,5 @@
 <x-layout-simple>
-    <section class="bg-gray-50 dark:bg-base">
+    <section class="bg-gray-50 dark:bg-base" x-init="$nextTick(() => document.querySelector('input[name=email]')?.focus())">
         <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0">
             <div class="w-full max-w-md space-y-8">
                 <div class="text-center space-y-2">

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -11,7 +11,7 @@ $email = getOldOrLocal('email', 'test3@example.com');
 ?>
 
 <x-layout-simple>
-    <section class="bg-gray-50 dark:bg-base">
+    <section class="bg-gray-50 dark:bg-base" x-init="$nextTick(() => document.querySelector('input[name=name]')?.focus())">
         <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0">
             <div class="w-full max-w-md space-y-8">
                 <div class="text-center space-y-2">

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -1,5 +1,5 @@
 <x-layout-simple>
-    <section class="bg-gray-50 dark:bg-base">
+    <section class="bg-gray-50 dark:bg-base" x-init="$nextTick(() => $el.querySelector('input[name=password]')?.focus())">
         <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0">
             <div class="w-full max-w-md space-y-8">
                 <div class="text-center space-y-2">

--- a/resources/views/auth/two-factor-challenge.blade.php
+++ b/resources/views/auth/two-factor-challenge.blade.php
@@ -42,6 +42,33 @@
                 const lastIndex = Math.min(pasteDigits.length - 1, 5);
                 inputs[lastIndex].focus();
             }
+        },
+        toggleShowRecovery() {
+            this.showRecovery = !this.showRecovery;
+
+            if(this.showRecovery) {
+                return this.focusRecoveryCodeInput();
+            }
+
+            this.focusEmptyTwoFactorCodeInput();
+        },
+        focusEmptyTwoFactorCodeInput() {
+            this.$nextTick(() => {
+                const emptyDigitIndex = this.digits.findIndex(digit => digit === '');
+
+                if (emptyDigitIndex === -1) return;
+
+                const twoFactorCodeInput = document.getElementById(`two_factor_code_input_${emptyDigitIndex}`);
+
+                twoFactorCodeInput?.focus();
+            });
+        },
+        focusRecoveryCodeInput() {
+            this.$nextTick(() => {
+                const recoveryCodeInput = document.querySelector('input[name=\'recovery_code\']');
+
+                recoveryCodeInput?.focus();
+            });
         }
     }">
         <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0">
@@ -85,27 +112,27 @@
                         </div>
                     </div>
 
-                    <form action="/two-factor-challenge" method="POST" class="flex flex-col gap-4">
+                    <form action="/two-factor-challenge" method="POST" class="flex flex-col gap-4" x-init="focusEmptyTwoFactorCodeInput()">
                         @csrf
                         <div x-show="!showRecovery">
                             <input type="hidden" name="code" x-model="code">
                             <div class="flex gap-2 justify-center" @paste="pasteCode($event)">
                                 <template x-for="(digit, index) in digits" :key="index">
-                                    <input type="text" inputmode="numeric" maxlength="1" x-model="digits[index]"
+                                    <input :id="`two_factor_code_input_${index}`" type="text" inputmode="numeric" maxlength="1" x-model="digits[index]"
                                         @input="if ($event.target.value) { focusNext($event); updateCode(); }"
                                         @keydown="focusPrevious($event)"
                                         class="w-12 h-14 text-center text-2xl font-bold bg-white dark:bg-coolgray-100 border-2 border-neutral-200 dark:border-coolgray-300 rounded-lg focus:border-coollabs dark:focus:border-warning focus:outline-none focus:ring-0 transition-colors"
                                         autocomplete="off" />
                                 </template>
                             </div>
-                            <button type="button" x-on:click="showRecovery = !showRecovery"
+                            <button type="button" x-on:click="toggleShowRecovery()"
                                 class="mt-4 text-sm dark:text-neutral-400 hover:text-black dark:hover:text-white hover:underline transition-colors cursor-pointer">
                                 Use Recovery Code Instead
                             </button>
                         </div>
                         <div x-show="showRecovery" x-cloak>
                             <x-forms.input name="recovery_code" label="{{ __('input.recovery_code') }}" />
-                            <button type="button" x-on:click="showRecovery = !showRecovery"
+                            <button type="button" x-on:click="toggleShowRecovery()"
                                 class="mt-2 text-sm dark:text-neutral-400 hover:text-black dark:hover:text-white hover:underline transition-colors cursor-pointer">
                                 Use Authenticator Code Instead
                             </button>

--- a/resources/views/livewire/profile/index.blade.php
+++ b/resources/views/livewire/profile/index.blade.php
@@ -75,9 +75,10 @@
             manually.
         </div>
         <div class="flex flex-col gap-4">
-            <form action="/user/confirmed-two-factor-authentication" method="POST" class="flex items-end gap-2">
+            <form action="/user/confirmed-two-factor-authentication" method="POST" class="flex items-end gap-2"
+                x-init="$nextTick(() => $el.querySelector('input[name=code]')?.focus())">
                 @csrf
-                <x-forms.input type="text" inputmode="numeric" pattern="[0-9]*" id="code"
+                <x-forms.input name="code" type="text" inputmode="numeric" pattern="[0-9]*" id="code"
                     label="One time (OTP) code" required />
                 <x-forms.button type="submit">Validate 2FA</x-forms.button>
             </form>


### PR DESCRIPTION
## Changes

Authentication forms did not auto-focus the primary input on page load, so users had to click before typing. This PR adds automatic focus on auth-related pages using Alpine.js (`x-init` + `$nextTick`), matching patterns already used in the codebase.

**Login & password flows**
- `/login` → focuses email
- `/forgot-password` → focuses email
- `/register` → focuses name
- `/reset-password` → focuses password
- `/confirm-password` → focuses password

**Two-factor authentication**
- `/two-factor-challenge` → focuses the first empty OTP digit on load
- Toggling OTP ↔ recovery code moves focus to the correct field
- OTP inputs get stable IDs (`two_factor_code_input_0` … `5`) for reliable focus targeting

**Profile 2FA validation**
- `/profile` → focuses OTP code on the 2FA validation form

No backend, database, or API changes. Frontend-only UX improvement.

## Issues

- Related discussion: https://github.com/coollabsio/coolify/discussions/10594

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

### Login, register & forgot password (`/login`, `/register`, `/forgot-password`)

Single recording covering all three pages:
- `/login` → email field focused on load
- `/register` → name field focused on load
- `/forgot-password` → email field focused on load

[login-register-forgot-password.webm](https://github.com/user-attachments/assets/90abf8ba-3eff-41c4-925e-ffea9efb66c7)

---

### Reset password (`/reset-password`)

Password field receives focus on page load.

[reset-password.webm](https://github.com/user-attachments/assets/2982d0ea-bb32-490f-a633-c4402320acb6)

---

### Confirm password (`/user/confirm-password`)

Triggered from **Profile → Two-factor Authentication → Configure**. Password field receives focus when the confirmation page is shown.

[confirm-password.webm](https://github.com/user-attachments/assets/f8a3d736-bea7-4fec-b2ab-f4b062ac8039)

---

### Profile — 2FA validation (`/profile`)

After clicking **Configure** and confirming your password, the OTP validation form appears with focus on the code input.

[profile-index.webm](https://github.com/user-attachments/assets/7ea6a5c1-9082-4840-97ac-dfda5d4693f3)

---

### Two-factor challenge (`/two-factor-challenge`)

- First OTP digit is focused on load
- Toggling to recovery code focuses the recovery input
- Toggling back to OTP focuses the first empty digit

[two-factor-challenge.webm](https://github.com/user-attachments/assets/f9b2cdf9-2b96-46c1-86a5-03eeb1f511c6)

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Cursor AI
- How extensively: Used for autocomplete while writing the code and reviewing the implementation approach. All changes were tested and verified locally by me.

## Testing

Tested locally with `docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d` at `http://localhost:8000`.

### 1. Login, register & forgot password

1. Open `/login` → confirm the email field is focused without clicking
2. Open `/register` (registration enabled) → confirm the name field is focused on load
3. Open `/forgot-password` → confirm the email field is focused on load

**Result:** ✅ Primary input auto-focused on all three pages (see combined preview video)

### 2. Reset password

1. Request a password reset email via `/forgot-password`
2. Open the reset link from either:
   - **Telescope** → Mail tab (`http://localhost:8000/telescope/mail`) — requires `TELESCOPE_ENABLED=true` in `.env`
   - **Mailpit** (`http://localhost:8025`)
3. Confirm the password field is focused on load

**Result:** ✅ Password auto-focused on load (tested via Telescope Mail tab)

### 3. Confirm password

1. Go to `/profile`
2. In the **Two-factor Authentication** section, click **Configure**
3. When redirected to the confirm password page (`/user/confirm-password`), confirm the password field is focused on load

**Result:** ✅ Password auto-focused on load

### 4. Profile 2FA validation

1. Go to `/profile` and start 2FA setup
2. When the OTP validation form appears, confirm the code input is focused

**Result:** ✅ OTP input auto-focused; form submits as expected

### 5. Two-factor challenge

1. Enable 2FA on a test account
2. Log in and reach `/two-factor-challenge`
3. Confirm the first OTP digit is focused
4. Click "Use Recovery Code Instead" → recovery input should be focused
5. Click "Use Authenticator Code Instead" → first empty OTP digit should be focused

**Result:** ✅ Focus follows the active input mode

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.