### PR TITLE
feat(auth): enhance focus behavior on authentication forms

### DIFF
--- a/resources/views/auth/confirm-password.blade.php
+++ b/resources/views/auth/confirm-password.blade.php
@@ -1,5 +1,5 @@
 <x-layout-simple>
-    <section class="bg-gray-50 dark:bg-base">
+    <section class="bg-gray-50 dark:bg-base" x-init="$nextTick(() => $el.querySelector('input[name=password]')?.focus())">
         <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0">
             <div class="w-full max-w-md space-y-8">
                 <div class="text-center space-y-2">

--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -1,5 +1,5 @@
 <x-layout-simple>
-    <section class="bg-gray-50 dark:bg-base">
+    <section class="bg-gray-50 dark:bg-base" x-init="$nextTick(() => document.querySelector('input[name=email]')?.focus())">
         <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0">
             <div class="w-full max-w-md space-y-8">
                 <div class="text-center space-y-2">

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,5 +1,5 @@
 <x-layout-simple>
-    <section class="bg-gray-50 dark:bg-base">
+    <section class="bg-gray-50 dark:bg-base" x-init="$nextTick(() => document.querySelector('input[name=email]')?.focus())">
         <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0">
             <div class="w-full max-w-md space-y-8">
                 <div class="text-center space-y-2">

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -11,7 +11,7 @@ $email = getOldOrLocal('email', 'test3@example.com');
 ?>
 
 <x-layout-simple>
-    <section class="bg-gray-50 dark:bg-base">
+    <section class="bg-gray-50 dark:bg-base" x-init="$nextTick(() => document.querySelector('input[name=name]')?.focus())">
         <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0">
             <div class="w-full max-w-md space-y-8">
                 <div class="text-center space-y-2">

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -1,5 +1,5 @@
 <x-layout-simple>
-    <section class="bg-gray-50 dark:bg-base">
+    <section class="bg-gray-50 dark:bg-base" x-init="$nextTick(() => $el.querySelector('input[name=password]')?.focus())">
         <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0">
             <div class="w-full max-w-md space-y-8">
                 <div class="text-center space-y-2">

--- a/resources/views/auth/two-factor-challenge.blade.php
+++ b/resources/views/auth/two-factor-challenge.blade.php
@@ -42,6 +42,33 @@
                 const lastIndex = Math.min(pasteDigits.length - 1, 5);
                 inputs[lastIndex].focus();
             }
+        },
+        toggleShowRecovery() {
+            this.showRecovery = !this.showRecovery;
+
+            if(this.showRecovery) {
+                return this.focusRecoveryCodeInput();
+            }
+
+            this.focusEmptyTwoFactorCodeInput();
+        },
+        focusEmptyTwoFactorCodeInput() {
+            this.$nextTick(() => {
+                const emptyDigitIndex = this.digits.findIndex(digit => digit === '');
+
+                if (emptyDigitIndex === -1) return;
+
+                const twoFactorCodeInput = document.getElementById(`two_factor_code_input_${emptyDigitIndex}`);
+
+                twoFactorCodeInput?.focus();
+            });
+        },
+        focusRecoveryCodeInput() {
+            this.$nextTick(() => {
+                const recoveryCodeInput = document.querySelector('input[name=\'recovery_code\']');
+
+                recoveryCodeInput?.focus();
+            });
         }
     }">
         <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0">
@@ -85,27 +112,27 @@
                         </div>
                     </div>
 
-                    <form action="/two-factor-challenge" method="POST" class="flex flex-col gap-4">
+                    <form action="/two-factor-challenge" method="POST" class="flex flex-col gap-4" x-init="focusEmptyTwoFactorCodeInput()">
                         @csrf
                         <div x-show="!showRecovery">
                             <input type="hidden" name="code" x-model="code">
                             <div class="flex gap-2 justify-center" @paste="pasteCode($event)">
                                 <template x-for="(digit, index) in digits" :key="index">
-                                    <input type="text" inputmode="numeric" maxlength="1" x-model="digits[index]"
+                                    <input :id="`two_factor_code_input_${index}`" type="text" inputmode="numeric" maxlength="1" x-model="digits[index]"
                                         @input="if ($event.target.value) { focusNext($event); updateCode(); }"
                                         @keydown="focusPrevious($event)"
                                         class="w-12 h-14 text-center text-2xl font-bold bg-white dark:bg-coolgray-100 border-2 border-neutral-200 dark:border-coolgray-300 rounded-lg focus:border-coollabs dark:focus:border-warning focus:outline-none focus:ring-0 transition-colors"
                                         autocomplete="off" />
                                 </template>
                             </div>
-                            <button type="button" x-on:click="showRecovery = !showRecovery"
+                            <button type="button" x-on:click="toggleShowRecovery()"
                                 class="mt-4 text-sm dark:text-neutral-400 hover:text-black dark:hover:text-white hover:underline transition-colors cursor-pointer">
                                 Use Recovery Code Instead
                             </button>
                         </div>
                         <div x-show="showRecovery" x-cloak>
                             <x-forms.input name="recovery_code" label="{{ __('input.recovery_code') }}" />
-                            <button type="button" x-on:click="showRecovery = !showRecovery"
+                            <button type="button" x-on:click="toggleShowRecovery()"
                                 class="mt-2 text-sm dark:text-neutral-400 hover:text-black dark:hover:text-white hover:underline transition-colors cursor-pointer">
                                 Use Authenticator Code Instead
                             </button>

--- a/resources/views/livewire/profile/index.blade.php
+++ b/resources/views/livewire/profile/index.blade.php
@@ -75,9 +75,10 @@
             manually.
         </div>
         <div class="flex flex-col gap-4">
-            <form action="/user/confirmed-two-factor-authentication" method="POST" class="flex items-end gap-2">
+            <form action="/user/confirmed-two-factor-authentication" method="POST" class="flex items-end gap-2"
+                x-init="$nextTick(() => $el.querySelector('input[name=code]')?.focus())">
                 @csrf
-                <x-forms.input type="text" inputmode="numeric" pattern="[0-9]*" id="code"
+                <x-forms.input name="code" type="text" inputmode="numeric" pattern="[0-9]*" id="code"
                     label="One time (OTP) code" required />
                 <x-forms.button type="submit">Validate 2FA</x-forms.button>
             </form>


### PR DESCRIPTION
## Changes

Authentication forms did not auto-focus the primary input on page load. This PR adds automatic focus so users can start typing immediately on auth-related pages.

**Login & password:** login, forgot-password, register, reset-password, confirm-password

**Two-factor authentication**
- two-factor-challenge → first empty OTP digit
- toggling OTP and recovery code moves focus correctly

**Profile 2FA validation**
- profile → OTP code on 2FA validation form

Frontend-only. No backend or database changes.

## Issues

- Related discussion: https://github.com/coollabsio/coolify/discussions/10594

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

### Login, register, forgot password

[login-register-forgot-password.webm](https://github.com/user-attachments/assets/934e4ec7-4dcc-4fd9-899c-719657db9bb9)

### Reset password

[reset-password.webm](https://github.com/user-attachments/assets/6321af55-3146-4e61-8d67-563a09e9118f)

### Confirm password

[confirm-password.webm](https://github.com/user-attachments/assets/dcdb2d41-cf28-4a60-a08b-0b59050ec9d2)

### Profile 2FA validation

[profile-index.webm](https://github.com/user-attachments/assets/3d3e00f0-2967-4f9e-8f07-ac52c1f8a3fe)

### Two-factor challenge

[two-factor-challenge.webm](https://github.com/user-attachments/assets/7b99f101-4be4-4449-8a4e-52f4a143d585)

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Cursor AI
- How extensively: Autocomplete while coding. Tested and verified locally.

## Testing

Tested with docker compose at localhost:8000.

Verified auto-focus on all affected auth flows (Telescope Mail for reset password).

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
