### PR TITLE
feat(service): upgrade opnform to v2.0

### DIFF
--- a/templates/compose/opnform.yaml
+++ b/templates/compose/opnform.yaml
@@ -55,7 +55,7 @@ x-shared-env: &shared-api-env
 
 services:
   opnform-api:
-    image: jhumanj/opnform-api:2.0.0
+    image: jhumanj/opnform-api:2.0.1
     volumes:
       - api-storage:/usr/share/nginx/html/storage
     environment:
@@ -82,7 +82,7 @@ services:
       start_period: 60s
 
   api-worker:
-    image: jhumanj/opnform-api:2.0.0
+    image: jhumanj/opnform-api:2.0.1
     volumes:
       - api-storage:/usr/share/nginx/html/storage
     environment:
@@ -103,7 +103,7 @@ services:
       start_period: 30s
 
   api-scheduler:
-    image: jhumanj/opnform-api:2.0.0
+    image: jhumanj/opnform-api:2.0.1
     volumes:
       - api-storage:/usr/share/nginx/html/storage
     environment:
@@ -127,7 +127,7 @@ services:
       start_period: 70s # Allow time for first scheduled run and cache write
 
   opnform-ui:
-    image: jhumanj/opnform-client:2.0.0
+    image: jhumanj/opnform-client:2.0.1
     environment:
       - NUXT_PUBLIC_APP_URL=/
       - NUXT_PUBLIC_API_BASE=/api

--- a/templates/compose/opnform.yaml
+++ b/templates/compose/opnform.yaml
@@ -47,10 +47,15 @@ x-shared-env: &shared-api-env
   PHP_MAX_EXECUTION_TIME: "600"
   PHP_UPLOAD_MAX_FILESIZE: "64M"
   PHP_POST_MAX_SIZE: "64M"
+  # Frontend settings
+  FRONT_URL: ${SERVICE_URL_NGINX}
+  FRONT_API_SECRET: ${SERVICE_PASSWORD_FRONTAPISECRET}
+  PUBLIC_UPLOADS_RATE_LIMIT_PER_MINUTE: ${PUBLIC_UPLOADS_RATE_LIMIT_PER_MINUTE:-30}
+  PUBLIC_UPLOADS_RATE_LIMIT_PER_HOUR: ${PUBLIC_UPLOADS_RATE_LIMIT_PER_HOUR:-300}
 
 services:
   opnform-api:
-    image: jhumanj/opnform-api:1.12.1
+    image: jhumanj/opnform-api:2.0.0
     volumes:
       - api-storage:/usr/share/nginx/html/storage
     environment:
@@ -58,7 +63,7 @@ services:
       <<: *shared-api-env
       JWT_TTL: ${JWT_TTL:-1440}
       JWT_SECRET: ${SERVICE_PASSWORD_JWTSECRET}
-      JWT_SKIP_IP_UA_VALIDATION: ${JWT_SKIP_IP_UA_VALIDATION:-true}
+      JWT_SKIP_IP_UA_VALIDATION: ${JWT_SKIP_IP_UA_VALIDATION:-false}
       H_CAPTCHA_SITE_KEY: ${H_CAPTCHA_SITE_KEY}
       H_CAPTCHA_SECRET_KEY: ${H_CAPTCHA_SECRET_KEY}
       RE_CAPTCHA_SITE_KEY: ${RE_CAPTCHA_SITE_KEY}
@@ -77,7 +82,7 @@ services:
       start_period: 60s
 
   api-worker:
-    image: jhumanj/opnform-api:1.12.1
+    image: jhumanj/opnform-api:2.0.0
     volumes:
       - api-storage:/usr/share/nginx/html/storage
     environment:
@@ -98,7 +103,7 @@ services:
       start_period: 30s
 
   api-scheduler:
-    image: jhumanj/opnform-api:1.12.1
+    image: jhumanj/opnform-api:2.0.0
     volumes:
       - api-storage:/usr/share/nginx/html/storage
     environment:
@@ -122,7 +127,7 @@ services:
       start_period: 70s # Allow time for first scheduled run and cache write
 
   opnform-ui:
-    image: jhumanj/opnform-client:1.12.1
+    image: jhumanj/opnform-client:2.0.0
     environment:
       - NUXT_PUBLIC_APP_URL=/
       - NUXT_PUBLIC_API_BASE=/api
@@ -130,6 +135,8 @@ services:
       - NUXT_PUBLIC_ENV=production
       - NUXT_PUBLIC_H_CAPTCHA_SITE_KEY=${H_CAPTCHA_SITE_KEY}
       - NUXT_PUBLIC_RE_CAPTCHA_SITE_KEY=${RE_CAPTCHA_SITE_KEY}
+      - NUXT_API_SECRET=${SERVICE_PASSWORD_FRONTAPISECRET}
+      - NUXT_PUBLIC_LICENSE_API_ENDPOINT=${NUXT_PUBLIC_LICENSE_API_ENDPOINT:-https://api.opnform.com}
     healthcheck:
       test:
         ["CMD-SHELL", "wget --spider -q http://opnform-ui:3000/login || exit 1"]

--- a/templates/compose/opnform.yaml
+++ b/templates/compose/opnform.yaml
@@ -55,7 +55,7 @@ x-shared-env: &shared-api-env
 
 services:
   opnform-api:
-    image: jhumanj/opnform-api:2.0.1
+    image: jhumanj/opnform-api:2.2.4
     volumes:
       - api-storage:/usr/share/nginx/html/storage
     environment:
@@ -82,7 +82,7 @@ services:
       start_period: 60s
 
   api-worker:
-    image: jhumanj/opnform-api:2.0.1
+    image: jhumanj/opnform-api:2.2.4
     volumes:
       - api-storage:/usr/share/nginx/html/storage
     environment:
@@ -103,7 +103,7 @@ services:
       start_period: 30s
 
   api-scheduler:
-    image: jhumanj/opnform-api:2.0.1
+    image: jhumanj/opnform-api:2.2.4
     volumes:
       - api-storage:/usr/share/nginx/html/storage
     environment:
@@ -127,7 +127,7 @@ services:
       start_period: 70s # Allow time for first scheduled run and cache write
 
   opnform-ui:
-    image: jhumanj/opnform-client:2.0.1
+    image: jhumanj/opnform-client:2.2.4
     environment:
       - NUXT_PUBLIC_APP_URL=/
       - NUXT_PUBLIC_API_BASE=/api
@@ -149,9 +149,9 @@ services:
         condition: service_healthy
 
   postgresql:
-    image: postgres:16
+    image: postgres:18
     volumes:
-      - opnform-postgresql-data:/var/lib/postgresql/data
+      - opnform-postgresql-data:/var/lib/postgresql
     environment:
       - POSTGRES_USER=${SERVICE_USER_POSTGRESQL}
       - POSTGRES_PASSWORD=${SERVICE_PASSWORD_POSTGRESQL}
@@ -178,7 +178,7 @@ services:
   # The nginx reverse proxy.
   # used for reverse proxying the API service and Web service.
   nginx:
-    image: nginx:1.29.2
+    image: nginx:1.31.3
     environment:
       - SERVICE_URL_NGINX
     volumes:


### PR DESCRIPTION
## Summary
- Bump OpnForm Docker images from `1.12.1` to `2.0.0`
- Add V2 environment variables (`FRONT_URL`, shared API secret, upload rate limits, license endpoint)
- Set `JWT_SKIP_IP_UA_VALIDATION` default to `false` for production

## Test plan
- [ ] Deploy OpnForm service template on Coolify dev instance
- [ ] Verify all containers become healthy (api, worker, scheduler, ui, nginx, postgres, redis)
- [ ] Complete initial setup and create a test form
- [ ] Verify form share URL uses the assigned Coolify domain (not nginx internal URL)
- [ ] Test upgrade path from existing 1.12.1 deployment (backup DB first)

Related: https://github.com/coollabsio/coolify/pull/5875