### PR TITLE
Add Docker Mailserver service template

### DIFF
--- a/templates/compose/docker-mailserver.yaml
+++ b/templates/compose/docker-mailserver.yaml
@@ -1,0 +1,35 @@
+# documentation: https://docker-mailserver.github.io/docker-mailserver/latest/usage/
+# slogan: Production-ready fullstack mail server with SMTP, IMAP, Rspamd, Dovecot, Postfix, and account management.
+# category: email
+# tags: mail,email,smtp,imap,postfix,dovecot,rspamd
+# logo: svgs/default.webp
+
+services:
+  docker-mailserver:
+    image: ghcr.io/docker-mailserver/docker-mailserver:latest
+    hostname: ${MAILSERVER_HOSTNAME:-mail.example.com}
+    ports:
+      - "25:25"
+      - "465:465"
+      - "587:587"
+      - "993:993"
+    volumes:
+      - docker-mailserver-data:/var/mail
+      - docker-mailserver-state:/var/mail-state
+      - docker-mailserver-logs:/var/log/mail
+      - docker-mailserver-config:/tmp/docker-mailserver
+      - /etc/localtime:/etc/localtime:ro
+    environment:
+      - ENABLE_RSPAMD=${ENABLE_RSPAMD:-1}
+      - ENABLE_CLAMAV=${ENABLE_CLAMAV:-0}
+      - ENABLE_FAIL2BAN=${ENABLE_FAIL2BAN:-1}
+      - SSL_TYPE=${SSL_TYPE:-}
+      - SPOOF_PROTECTION=${SPOOF_PROTECTION:-1}
+      - POSTMASTER_ADDRESS=${POSTMASTER_ADDRESS:-postmaster@example.com}
+    stop_grace_period: 1m
+    healthcheck:
+      test: "ss --listening --tcp | grep -P 'LISTEN.+:smtp' || exit 1"
+      timeout: 3s
+      retries: 10
+    cap_add:
+      - NET_ADMIN

--- a/templates/service-templates-latest.json
+++ b/templates/service-templates-latest.json
@@ -882,6 +882,23 @@
         "logo": "svgs/diun.svg",
         "minversion": "0.0.0"
     },
+    "docker-mailserver": {
+        "documentation": "https://docker-mailserver.github.io/docker-mailserver/latest/usage/?utm_source=coolify.io",
+        "slogan": "Production-ready fullstack mail server with SMTP, IMAP, Rspamd, Dovecot, Postfix, and account management.",
+        "compose": "c2VydmljZXM6CiAgZG9ja2VyLW1haWxzZXJ2ZXI6CiAgICBpbWFnZTogZ2hjci5pby9kb2NrZXItbWFpbHNlcnZlci9kb2NrZXItbWFpbHNlcnZlcjpsYXRlc3QKICAgIGhvc3RuYW1lOiAke01BSUxTRVJWRVJfSE9TVE5BTUU6LW1haWwuZXhhbXBsZS5jb219CiAgICBwb3J0czoKICAgICAgLSAnMjU6MjUnCiAgICAgIC0gNDY1OjQ2NQogICAgICAtIDU4Nzo1ODcKICAgICAgLSA5OTM6OTkzCiAgICB2b2x1bWVzOgogICAgICAtIGRvY2tlci1tYWlsc2VydmVyLWRhdGE6L3Zhci9tYWlsCiAgICAgIC0gZG9ja2VyLW1haWxzZXJ2ZXItc3RhdGU6L3Zhci9tYWlsLXN0YXRlCiAgICAgIC0gZG9ja2VyLW1haWxzZXJ2ZXItbG9nczovdmFyL2xvZy9tYWlsCiAgICAgIC0gZG9ja2VyLW1haWxzZXJ2ZXItY29uZmlnOi90bXAvZG9ja2VyLW1haWxzZXJ2ZXIKICAgICAgLSAvZXRjL2xvY2FsdGltZTovZXRjL2xvY2FsdGltZTpybwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gRU5BQkxFX1JTUEFNRD0ke0VOQUJMRV9SU1BBTUQ6LTF9CiAgICAgIC0gRU5BQkxFX0NMQU1BVj0ke0VOQUJMRV9DTEFNQVY6LTB9CiAgICAgIC0gRU5BQkxFX0ZBSUwyQkFOPSR7RU5BQkxFX0ZBSUwyQkFOOi0xfQogICAgICAtIFNTTF9UWVBFPSR7U1NMX1RZUEU6LX0KICAgICAgLSBTUE9PRl9QUk9URUNUSU9OPSR7U1BPT0ZfUFJPVEVDVElPTjotMX0KICAgICAgLSBQT1NUTUFTVEVSX0FERFJFU1M9JHtQT1NUTUFTVEVSX0FERFJFU1M6LXBvc3RtYXN0ZXJAZXhhbXBsZS5jb219CiAgICBzdG9wX2dyYWNlX3BlcmlvZDogMW0KICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OiBzcyAtLWxpc3RlbmluZyAtLXRjcCB8IGdyZXAgLVAgJ0xJU1RFTi4rOnNtdHAnIHx8IGV4aXQgMQogICAgICB0aW1lb3V0OiAzcwogICAgICByZXRyaWVzOiAxMAogICAgY2FwX2FkZDoKICAgICAgLSBORVRfQURNSU4K",
+        "tags": [
+            "mail",
+            "email",
+            "smtp",
+            "imap",
+            "postfix",
+            "dovecot",
+            "rspamd"
+        ],
+        "category": "email",
+        "logo": "svgs/default.webp",
+        "minversion": "0.0.0"
+    },
     "docker-registry": {
         "documentation": "https://distribution.github.io/distribution/?utm_source=coolify.io",
         "slogan": "The Docker Registry lets you distribute Docker images.",

--- a/templates/service-templates.json
+++ b/templates/service-templates.json
@@ -882,6 +882,23 @@
         "logo": "svgs/diun.svg",
         "minversion": "0.0.0"
     },
+    "docker-mailserver": {
+        "documentation": "https://docker-mailserver.github.io/docker-mailserver/latest/usage/?utm_source=coolify.io",
+        "slogan": "Production-ready fullstack mail server with SMTP, IMAP, Rspamd, Dovecot, Postfix, and account management.",
+        "compose": "c2VydmljZXM6CiAgZG9ja2VyLW1haWxzZXJ2ZXI6CiAgICBpbWFnZTogZ2hjci5pby9kb2NrZXItbWFpbHNlcnZlci9kb2NrZXItbWFpbHNlcnZlcjpsYXRlc3QKICAgIGhvc3RuYW1lOiAke01BSUxTRVJWRVJfSE9TVE5BTUU6LW1haWwuZXhhbXBsZS5jb219CiAgICBwb3J0czoKICAgICAgLSAnMjU6MjUnCiAgICAgIC0gNDY1OjQ2NQogICAgICAtIDU4Nzo1ODcKICAgICAgLSA5OTM6OTkzCiAgICB2b2x1bWVzOgogICAgICAtIGRvY2tlci1tYWlsc2VydmVyLWRhdGE6L3Zhci9tYWlsCiAgICAgIC0gZG9ja2VyLW1haWxzZXJ2ZXItc3RhdGU6L3Zhci9tYWlsLXN0YXRlCiAgICAgIC0gZG9ja2VyLW1haWxzZXJ2ZXItbG9nczovdmFyL2xvZy9tYWlsCiAgICAgIC0gZG9ja2VyLW1haWxzZXJ2ZXItY29uZmlnOi90bXAvZG9ja2VyLW1haWxzZXJ2ZXIKICAgICAgLSAvZXRjL2xvY2FsdGltZTovZXRjL2xvY2FsdGltZTpybwogICAgZW52aXJvbm1lbnQ6CiAgICAgIC0gRU5BQkxFX1JTUEFNRD0ke0VOQUJMRV9SU1BBTUQ6LTF9CiAgICAgIC0gRU5BQkxFX0NMQU1BVj0ke0VOQUJMRV9DTEFNQVY6LTB9CiAgICAgIC0gRU5BQkxFX0ZBSUwyQkFOPSR7RU5BQkxFX0ZBSUwyQkFOOi0xfQogICAgICAtIFNTTF9UWVBFPSR7U1NMX1RZUEU6LX0KICAgICAgLSBTUE9PRl9QUk9URUNUSU9OPSR7U1BPT0ZfUFJPVEVDVElPTjotMX0KICAgICAgLSBQT1NUTUFTVEVSX0FERFJFU1M9JHtQT1NUTUFTVEVSX0FERFJFU1M6LXBvc3RtYXN0ZXJAZXhhbXBsZS5jb219CiAgICBzdG9wX2dyYWNlX3BlcmlvZDogMW0KICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OiBzcyAtLWxpc3RlbmluZyAtLXRjcCB8IGdyZXAgLVAgJ0xJU1RFTi4rOnNtdHAnIHx8IGV4aXQgMQogICAgICB0aW1lb3V0OiAzcwogICAgICByZXRyaWVzOiAxMAogICAgY2FwX2FkZDoKICAgICAgLSBORVRfQURNSU4K",
+        "tags": [
+            "mail",
+            "email",
+            "smtp",
+            "imap",
+            "postfix",
+            "dovecot",
+            "rspamd"
+        ],
+        "category": "email",
+        "logo": "svgs/default.webp",
+        "minversion": "0.0.0"
+    },
     "docker-registry": {
         "documentation": "https://distribution.github.io/distribution/?utm_source=coolify.io",
         "slogan": "The Docker Registry lets you distribute Docker images.",


### PR DESCRIPTION
Closes #8266

## Summary
- Add a Docker Mailserver service template for self-hosted client email domains.
- Persist mail data, state, logs, and configuration volumes.
- Expose SMTP, submission, SMTPS, and IMAPS ports with common security toggles.
- Update both generated service template indexes with the new compose payload.

## Validation
- Validated the new compose template parses as YAML.
- Validated `templates/service-templates.json` and `templates/service-templates-latest.json` parse as JSON and include `docker-mailserver`.
- Validated each encoded compose payload decodes back to a Docker Compose services map.
- `git diff --check`