### PR TITLE
feat: add Docker Mailserver service template

### DIFF
--- a/templates/compose/docker-mailserver.yaml
+++ b/templates/compose/docker-mailserver.yaml
@@ -1,0 +1,35 @@
+# documentation: https://docker-mailserver.github.io/docker-mailserver/latest/usage/
+# slogan: Production-ready fullstack mail server with SMTP, IMAP, Rspamd, Dovecot, Postfix, and account management.
+# category: email
+# tags: mail,email,smtp,imap,postfix,dovecot,rspamd
+# logo: svgs/default.webp
+
+services:
+  docker-mailserver:
+    image: ghcr.io/docker-mailserver/docker-mailserver:latest
+    hostname: ${MAILSERVER_HOSTNAME:-mail.example.com}
+    ports:
+      - "25:25"
+      - "465:465"
+      - "587:587"
+      - "993:993"
+    volumes:
+      - docker-mailserver-data:/var/mail
+      - docker-mailserver-state:/var/mail-state
+      - docker-mailserver-logs:/var/log/mail
+      - docker-mailserver-config:/tmp/docker-mailserver
+      - /etc/localtime:/etc/localtime:ro
+    environment:
+      - ENABLE_RSPAMD=${ENABLE_RSPAMD:-1}
+      - ENABLE_CLAMAV=${ENABLE_CLAMAV:-0}
+      - ENABLE_FAIL2BAN=${ENABLE_FAIL2BAN:-1}
+      - SSL_TYPE=${SSL_TYPE:-}
+      - SPOOF_PROTECTION=${SPOOF_PROTECTION:-1}
+      - POSTMASTER_ADDRESS=${POSTMASTER_ADDRESS:-postmaster@example.com}
+    stop_grace_period: 1m
+    healthcheck:
+      test: "ss --listening --tcp | grep -P 'LISTEN.+:smtp' || exit 1"
+      timeout: 3s
+      retries: 10
+    cap_add:
+      - NET_ADMIN


### PR DESCRIPTION
## Changes

- Add a Docker Mailserver one-click service template for self-hosted email domains.
- Persist mail data, state, logs, and configuration volumes.
- Expose SMTP, submission, SMTPS, and IMAPS ports with Rspamd, Fail2Ban, spoof protection, and postmaster settings.
- Keep certificate mode empty by default so the service can start before the administrator chooses manual or Let's Encrypt certificate handling.

## Issues

- Fixes #8266

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A for this service template change. The template adds a backend mail service without a web UI port.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Used to draft the template and run structural validation; I reviewed the service settings and validation output before submitting.

## Testing

- Parsed `templates/compose/docker-mailserver.yaml` as YAML.
- Confirmed the decoded service definition includes the expected ports, volumes, healthcheck, and NET_ADMIN capability.
- Ran `git diff --check` locally.
- I could not run a full Coolify development instance in this environment.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.