### PR TITLE
fix(api-tokens): "Never" expiry stores null instead of defaulting to 30 days

### DIFF
--- a/app/Livewire/Security/ApiTokens.php
+++ b/app/Livewire/Security/ApiTokens.php
@@ -26,6 +26,7 @@ class ApiTokens extends Component
         60 => '60 days',
         90 => '90 days',
         365 => '1 year',
+        0 => 'Never',
     ];
 
     public $isApiEnabled;
@@ -103,7 +104,7 @@ class ApiTokens extends Component
 
             $this->validate([
                 'description' => 'required|min:3|max:255',
-                'expiresInDays' => 'nullable|integer|in:7,30,60,90,365',
+                'expiresInDays' => 'nullable|integer|in:0,7,30,60,90,365',
             ]);
             $expiresAt = $this->expiresInDays ? now()->addDays($this->expiresInDays) : null;
             $token = auth()->user()->createToken($this->description, array_values($this->permissions), $expiresAt);

--- a/resources/views/livewire/security/api-tokens.blade.php
+++ b/resources/views/livewire/security/api-tokens.blade.php
@@ -20,7 +20,6 @@
                     @foreach ($expirationOptions as $days => $label)
                         <option value="{{ $days }}">{{ $label }}</option>
                     @endforeach
-                    <option value="">Never</option>
                 </x-forms.select>
                 <x-forms.button type="submit">Create</x-forms.button>
             </div>


### PR DESCRIPTION
## Problem

Creating an API token with **expiration set to "Never"** produces a token that expires in **30 days** instead of never expiring.

## Steps to reproduce

1. Go to **Security → API Tokens**.
2. Enter a description, set **Expiration → Never**, create the token.
3. Inspect `personal_access_tokens.expires_at` — it is `now() + 30 days`, not `NULL`.

## Root cause

The "Never" `<option>` submits an **empty string**:

```blade
<option value="">Never</option>
```

…but the bound property is a **typed nullable int**:

```php
public ?int $expiresInDays = 30;
```

Livewire 3 cannot hydrate `""` into a typed `int` property, so the update is silently dropped and `$expiresInDays` keeps its **default of `30`**. The create logic then runs:

```php
$expiresAt = $this->expiresInDays ? now()->addDays($this->expiresInDays) : null; // 30 → +30 days
```

So "Never" always yields a 30-day token. (This is why tokens created before the expiration feature have `expires_at = NULL`, but every token created via the UI since does not.)

Regression from #9677 (which added API token expiration support).

## Fix

Give "Never" an explicit value of `0` by folding it into `$expirationOptions`, and allow `0` in validation. `0` coerces cleanly into the `?int` property, and `0 ? … : null` resolves to `null`, so Sanctum stores `expires_at = NULL`.

- `$expirationOptions` gains `0 => 'Never'` (rendered by the existing `@foreach`).
- The orphaned `<option value="">Never</option>` is removed.
- Validation rule: `in:7,30,60,90,365` → `in:0,7,30,60,90,365`.

All other options and the 30-day default are unchanged.

## Notes

Root-caused and reasoned against the running app's behavior (tokens come out exactly +30 days); not built/tested from source locally — CI and a maintainer pass will validate.
