### PR TITLE
fix(databases): regenerate SSL certs with correct file layout

### DIFF
--- a/app/Livewire/Project/Database/Mongodb/StatusInfo.php
+++ b/app/Livewire/Project/Database/Mongodb/StatusInfo.php
@@ -19,6 +19,11 @@ class StatusInfo extends Component
         return 'Mongo';
     }
 
+    protected function sslPemKeyFileRequired(): bool
+    {
+        return true;
+    }
+
     protected function sslModeOptions(): array
     {
         return [

--- a/app/Traits/HasDatabaseStatusInfo.php
+++ b/app/Traits/HasDatabaseStatusInfo.php
@@ -37,6 +37,18 @@ trait HasDatabaseStatusInfo
         return true;
     }
 
+    /**
+     * Whether SSL material must be written as a single combined PEM file.
+     *
+     * Only MongoDB consumes a combined server.pem; every other database
+     * (Postgres, MySQL, MariaDB, Redis, KeyDB, Dragonfly) expects separate
+     * server.crt and server.key files. See coolify#10388.
+     */
+    protected function sslPemKeyFileRequired(): bool
+    {
+        return false;
+    }
+
     protected function sslModeOptions(): ?array
     {
         return null;
@@ -148,7 +160,7 @@ trait HasDatabaseStatusInfo
                 caKey: $caCert->ssl_private_key,
                 configurationDir: $existingCert->configuration_dir,
                 mountPath: $existingCert->mount_path,
-                isPemKeyFileRequired: true,
+                isPemKeyFileRequired: $this->sslPemKeyFileRequired(),
             );
 
             $this->refresh();

--- a/tests/Unit/DatabaseSslPemRequirementTest.php
+++ b/tests/Unit/DatabaseSslPemRequirementTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use App\Livewire\Project\Database\Dragonfly\StatusInfo as DragonflyStatusInfo;
+use App\Livewire\Project\Database\Keydb\StatusInfo as KeydbStatusInfo;
+use App\Livewire\Project\Database\Mariadb\StatusInfo as MariadbStatusInfo;
+use App\Livewire\Project\Database\Mongodb\StatusInfo as MongodbStatusInfo;
+use App\Livewire\Project\Database\Mysql\StatusInfo as MysqlStatusInfo;
+use App\Livewire\Project\Database\Postgresql\StatusInfo as PostgresqlStatusInfo;
+use App\Livewire\Project\Database\Redis\StatusInfo as RedisStatusInfo;
+
+/**
+ * Guards coolify#10388: regenerating SSL certificates must produce the file
+ * layout each database actually consumes. Only MongoDB reads a combined
+ * server.pem; everything else loads separate server.crt + server.key.
+ */
+function resolveSslPemKeyFileRequired(string $componentClass): bool
+{
+    $component = new $componentClass;
+    $method = new ReflectionMethod($componentClass, 'sslPemKeyFileRequired');
+
+    return $method->invoke($component);
+}
+
+test('MongoDB regenerates SSL as a combined pem file', function () {
+    expect(resolveSslPemKeyFileRequired(MongodbStatusInfo::class))->toBeTrue();
+});
+
+test('crt/key databases do not regenerate SSL as a pem file', function (string $componentClass) {
+    expect(resolveSslPemKeyFileRequired($componentClass))->toBeFalse();
+})->with([
+    'Postgresql' => [PostgresqlStatusInfo::class],
+    'MySQL' => [MysqlStatusInfo::class],
+    'MariaDB' => [MariadbStatusInfo::class],
+    'Redis' => [RedisStatusInfo::class],
+    'KeyDB' => [KeydbStatusInfo::class],
+    'Dragonfly' => [DragonflyStatusInfo::class],
+]);


### PR DESCRIPTION
## Summary
- Regenerates database SSL certificates using the file format each database expects.
- Keeps MongoDB regeneration on combined `server.pem` while Postgres and other databases regenerate separate `server.crt` and `server.key` files.
- Adds regression coverage for database-specific SSL PEM requirements.

fixes #10388

---

Fixes #10388