### PR TITLE
feat(oauth): add generic oidc provider

### DIFF
--- a/app/Models/OauthSetting.php
+++ b/app/Models/OauthSetting.php
@@ -28,6 +28,7 @@ class OauthSetting extends Model
                 return filled($this->client_id) && filled($this->client_secret) && filled($this->tenant);
             case 'authentik':
             case 'clerk':
+            case 'oidc':
                 return filled($this->client_id) && filled($this->client_secret) && filled($this->base_url);
             default:
                 return filled($this->client_id) && filled($this->client_secret);

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -11,6 +11,7 @@ use SocialiteProviders\Google\GoogleExtendSocialite;
 use SocialiteProviders\Infomaniak\InfomaniakExtendSocialite;
 use SocialiteProviders\Manager\SocialiteWasCalled;
 use SocialiteProviders\Zitadel\ZitadelExtendSocialite;
+use App\Providers\Oidc\OidcExtendSocialite;
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -23,6 +24,7 @@ class EventServiceProvider extends ServiceProvider
             GoogleExtendSocialite::class.'@handle',
             InfomaniakExtendSocialite::class.'@handle',
             ZitadelExtendSocialite::class.'@handle',
+            OidcExtendSocialite::class.'@handle',
         ],
     ];
 

--- a/app/Providers/Oidc/OidcExtendSocialite.php
+++ b/app/Providers/Oidc/OidcExtendSocialite.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Providers\Oidc;
+
+use SocialiteProviders\Manager\SocialiteWasCalled;
+
+class OidcExtendSocialite
+{
+    /**
+     * Register the provider.
+     *
+     * @param \SocialiteProviders\Manager\SocialiteWasCalled $socialiteWasCalled
+     */
+    public function handle(SocialiteWasCalled $socialiteWasCalled)
+    {
+        $socialiteWasCalled->extendSocialite('oidc', OidcProvider::class);
+    }
+}

--- a/app/Providers/Oidc/OidcProvider.php
+++ b/app/Providers/Oidc/OidcProvider.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Providers\Oidc;
+
+use Illuminate\Support\Arr;
+use SocialiteProviders\Manager\OAuth2\AbstractProvider;
+use SocialiteProviders\Manager\OAuth2\User;
+
+class OidcProvider extends AbstractProvider
+{
+    /**
+     * Unique Provider Identifier.
+     */
+    public const IDENTIFIER = 'OIDC';
+
+    /**
+     * The scopes being requested.
+     *
+     * @var array
+     */
+    protected $scopes = ['openid', 'profile', 'email'];
+
+    /**
+     * The separating character for the requested scopes.
+     *
+     * @var string
+     */
+    protected $scopeSeparator = ' ';
+
+    /**
+     * Get the OpenID Connect configuration.
+     *
+     * @return array
+     */
+    protected function getOpenIdConfiguration()
+    {
+        return cache()->remember('oidc_configuration_' . $this->getConfig('base_url'), 3600, function () {
+            $baseUrl = rtrim($this->getConfig('base_url'), '/');
+            $discoveryUrl = $baseUrl . '/.well-known/openid-configuration';
+
+            $response = $this->getHttpClient()->get($discoveryUrl);
+
+            return json_decode($response->getBody(), true);
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAuthUrl($state)
+    {
+        $url = $this->getOpenIdConfiguration()['authorization_endpoint'];
+
+        return $this->buildAuthUrlFromBase($url, $state);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenUrl()
+    {
+        return $this->getOpenIdConfiguration()['token_endpoint'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getUserByToken($token)
+    {
+        $url = $this->getOpenIdConfiguration()['userinfo_endpoint'];
+
+        $response = $this->getHttpClient()->get($url, [
+            'headers' => [
+                'Authorization' => 'Bearer ' . $token,
+            ],
+        ]);
+
+        return json_decode($response->getBody(), true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function mapUserToObject(array $user)
+    {
+        return (new User())->setRaw($user)->map([
+            'id'       => Arr::get($user, 'sub'),
+            'nickname' => Arr::get($user, 'preferred_username', Arr::get($user, 'nickname')),
+            'name'     => Arr::get($user, 'name', Arr::get($user, 'given_name', '') . ' ' . Arr::get($user, 'family_name', '')),
+            'email'    => Arr::get($user, 'email'),
+            'avatar'   => Arr::get($user, 'picture'),
+        ]);
+    }
+}

--- a/bootstrap/helpers/socialite.php
+++ b/bootstrap/helpers/socialite.php
@@ -44,6 +44,17 @@ function get_socialite_provider(string $provider)
         return Socialite::driver('zitadel')->setConfig($zitadel_config);
     }
 
+    if ($provider == 'oidc') {
+        $oidc_config = new \SocialiteProviders\Manager\Config(
+            $oauth_setting->client_id,
+            $oauth_setting->client_secret,
+            $oauth_setting->redirect_uri,
+            ['base_url' => $oauth_setting->base_url],
+        );
+
+        return Socialite::driver('oidc')->setConfig($oidc_config);
+    }
+
     if ($provider == 'google') {
         $google_config = new \SocialiteProviders\Manager\Config(
             $oauth_setting->client_id,

--- a/database/seeders/OauthSettingSeeder.php
+++ b/database/seeders/OauthSettingSeeder.php
@@ -25,6 +25,7 @@ class OauthSettingSeeder extends Seeder
                 'authentik',
                 'infomaniak',
                 'zitadel',
+                'oidc',
             ]);
 
             $isOauthSeeded = OauthSetting::count() > 0;

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,6 +1,7 @@
 {
     "auth.login": "Login",
     "auth.login.authentik": "Login with Authentik",
+    "auth.login.oidc": "Login with OIDC",
     "auth.login.azure": "Login with Microsoft",
     "auth.login.bitbucket": "Login with Bitbucket",
     "auth.login.clerk": "Login with Clerk",

--- a/resources/views/livewire/settings-oauth.blade.php
+++ b/resources/views/livewire/settings-oauth.blade.php
@@ -41,7 +41,8 @@
                             $oauth_setting['provider'] == 'authentik' ||
                                 $oauth_setting['provider'] == 'clerk' ||
                                 $oauth_setting['provider'] == 'zitadel' ||
-                                $oauth_setting['provider'] == 'gitlab')
+                                $oauth_setting['provider'] == 'gitlab' ||
+                                $oauth_setting['provider'] == 'oidc')
                             <x-forms.input id="oauth_settings_map.{{ $oauth_setting['provider'] }}.base_url"
                                 label="Base URL" />
                         @endif


### PR DESCRIPTION
Resolves #6696 by adding a generic OIDC provider. OIDC discovery is used to automatically configure endpoints based on the provided Base URL.