### PR TITLE
fix(validation): allow colon in description fields

### DIFF
--- a/app/Support/ValidationPatterns.php
+++ b/app/Support/ValidationPatterns.php
@@ -15,7 +15,7 @@ class ValidationPatterns
     /**
      * Pattern for descriptions excluding all dangerous characters with some additional allowed characters
      */
-    public const DESCRIPTION_PATTERN = '/^[\p{L}\p{M}\p{N}\s\-_.,!?()\'\"+=*@\/&]+$/u';
+    public const DESCRIPTION_PATTERN = '/^[\p{L}\p{M}\p{N}\s\-_.,!?()\'\"+=*@\/&:]+$/u';
 
     /**
      * Pattern for file paths (dockerfile location, docker compose location, etc.)
@@ -125,7 +125,7 @@ class ValidationPatterns
     public static function descriptionMessages(): array
     {
         return [
-            'description.regex' => "The description may only contain letters (including Unicode), numbers, spaces, and common punctuation: - _ . , ! ? ( ) ' \" + = * / @ &",
+            'description.regex' => "The description may only contain letters (including Unicode), numbers, spaces, and common punctuation: - _ . , ! ? ( ) ' \" + = * / @ & :",
             'description.max' => 'The description may not be greater than :max characters.',
         ];
     }


### PR DESCRIPTION
## Summary
- Adds `:` to the allowed characters in `DESCRIPTION_PATTERN` in `ValidationPatterns.php`
- Updates the validation error message to list `:` among allowed punctuation
- The `NAME_PATTERN` already allows colons; this brings descriptions into parity

## Context
Users cannot enter URLs (e.g. `http://host:9119/path`) in resource description fields because the colon character is rejected by the validation regex. There is no security reason to exclude it — the description is not used in shell commands, SQL, or HTML rendering, and more arguably dangerous characters (`"`, `'`, `*`) are already permitted.

## Test plan
- [ ] Enter a URL with a port (e.g. `http://100.102.205.5:9119/chat`) in a service description field
- [ ] Verify it saves without validation error
- [ ] Verify descriptions without colons still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)