### PR TITLE
fix: update osTicket image to ghcr.io/tiredofit/docker-osticket

### DIFF
--- a/templates/compose/osticket.yaml
+++ b/templates/compose/osticket.yaml
@@ -7,7 +7,7 @@
 
 services:
   osticket:
-    image: tiredofit/osticket:latest
+    image: ghcr.io/tiredofit/docker-osticket:latest
     environment:
       - SERVICE_URL_OSTICKET_80
       - APP_URL=${SERVICE_URL_OSTICKET}


### PR DESCRIPTION
## Changes

<!-- Describe what changes were made and why in your own words. This "Changes" section must be human-written and not AI-generated. -->

- Updated the osTicket one-click service template to pull ghcr.io/tiredofit/docker-osticket:latest instead of tiredofit/osticket:latest.
- The Docker Hub repository tiredofit/osticket no longer exists (pull fails with "repository does not exist or may require 'docker login'"), so the osTicket service cannot be deployed at all. The image maintainer now publishes only to GHCR: https://github.com/tiredofit/docker-osticket/pkgs/container/docker-osticket
- Same image/project, only the registry location changed, so all existing environment variables in the template keep working.

## Issues

<!-- Link related issues or discussions. If reopening a closed PR, explain why it should be reconsidered. -->

- Fixes #10446

## Category

- [x] Fixing or updating existing one click service

## Preview
<img width="1866" height="964" alt="image" src="https://github.com/user-attachments/assets/4b5caa43-d678-46d0-ab09-2908f2ddc37e" />

<!-- Screenshot or short video showing your changes in action. Mandatory for new features. -->

## AI Assistance

<!-- AI-assisted PRs that are human reviewed are welcome, just let us know so we can review appropriately. -->

- [x] AI was NOT used to create this PR

**If AI was used:**

- Tools used:
- How extensively:

## Testing

<!-- Describe how you tested these changes. -->

1. docker pull tiredofit/osticket:latest → fails ("repository does not exist"), reproducing #10446.
2. docker pull ghcr.io/tiredofit/docker-osticket:latest → succeeds (multi-arch: amd64 + arm64).
3. Deployed the osTicket one-click service on a local Coolify dev instance (spin up) with this change: image pulls, mariadb and osticket containers start and pass healthchecks, osTicket setup page loads. Screenshots attached.

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
