### PR TITLE
feat: add generic OIDC provider support

### DIFF
--- a/app/Models/OauthSetting.php
+++ b/app/Models/OauthSetting.php
@@ -28,6 +28,8 @@ class OauthSetting extends Model
                 return filled($this->client_id) && filled($this->client_secret) && filled($this->tenant);
             case 'authentik':
             case 'clerk':
+            case 'zitadel':
+            case 'oidc':
                 return filled($this->client_id) && filled($this->client_secret) && filled($this->base_url);
             default:
                 return filled($this->client_id) && filled($this->client_secret);

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -10,6 +10,7 @@ use SocialiteProviders\Discord\DiscordExtendSocialite;
 use SocialiteProviders\Google\GoogleExtendSocialite;
 use SocialiteProviders\Infomaniak\InfomaniakExtendSocialite;
 use SocialiteProviders\Manager\SocialiteWasCalled;
+use SocialiteProviders\OIDC\OIDCExtendSocialite;
 use SocialiteProviders\Zitadel\ZitadelExtendSocialite;
 
 class EventServiceProvider extends ServiceProvider
@@ -22,6 +23,7 @@ class EventServiceProvider extends ServiceProvider
             DiscordExtendSocialite::class.'@handle',
             GoogleExtendSocialite::class.'@handle',
             InfomaniakExtendSocialite::class.'@handle',
+            OIDCExtendSocialite::class.'@handle',
             ZitadelExtendSocialite::class.'@handle',
         ],
     ];

--- a/bootstrap/helpers/socialite.php
+++ b/bootstrap/helpers/socialite.php
@@ -22,26 +22,15 @@ function get_socialite_provider(string $provider)
         return Socialite::driver('azure')->setConfig($azure_config);
     }
 
-    if ($provider == 'authentik' || $provider == 'clerk') {
-        $authentik_clerk_config = new \SocialiteProviders\Manager\Config(
+    if (in_array($provider, ['authentik', 'clerk', 'zitadel', 'oidc'])) {
+        $config = new \SocialiteProviders\Manager\Config(
             $oauth_setting->client_id,
             $oauth_setting->client_secret,
             $oauth_setting->redirect_uri,
             ['base_url' => $oauth_setting->base_url],
         );
 
-        return Socialite::driver($provider)->setConfig($authentik_clerk_config);
-    }
-
-    if ($provider == 'zitadel') {
-        $zitadel_config = new \SocialiteProviders\Manager\Config(
-            $oauth_setting->client_id,
-            $oauth_setting->client_secret,
-            $oauth_setting->redirect_uri,
-            ['base_url' => $oauth_setting->base_url],
-        );
-
-        return Socialite::driver('zitadel')->setConfig($zitadel_config);
+        return Socialite::driver($provider)->setConfig($config);
     }
 
     if ($provider == 'google') {

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "danharrin/livewire-rate-limiting": "^2.1.0",
         "doctrine/dbal": "^4.4.1",
         "guzzlehttp/guzzle": "^7.10.0",
+        "kovah/laravel-socialite-oidc": "^0.5.0",
         "laravel/fortify": "^1.34.0",
         "laravel/framework": "^12.49.0",
         "laravel/horizon": "^5.43.0",

--- a/config/services.php
+++ b/config/services.php
@@ -60,6 +60,13 @@ return [
         'tenant' => env('GOOGLE_TENANT'),
     ],
 
+    'oidc' => [
+        'client_id' => env('OIDC_CLIENT_ID'),
+        'client_secret' => env('OIDC_CLIENT_SECRET'),
+        'redirect' => env('OIDC_REDIRECT_URI'),
+        'base_url' => env('OIDC_BASE_URL'),
+    ],
+
     'zitadel' => [
         'client_id' => env('ZITADEL_CLIENT_ID'),
         'client_secret' => env('ZITADEL_CLIENT_SECRET'),

--- a/database/seeders/OauthSettingSeeder.php
+++ b/database/seeders/OauthSettingSeeder.php
@@ -24,6 +24,7 @@ class OauthSettingSeeder extends Seeder
                 'google',
                 'authentik',
                 'infomaniak',
+                'oidc',
                 'zitadel',
             ]);
 

--- a/lang/de.json
+++ b/lang/de.json
@@ -8,6 +8,7 @@
     "auth.login.gitlab": "Mit GitLab anmelden",
     "auth.login.google": "Mit Google anmelden",
     "auth.login.infomaniak": "Mit Infomaniak anmelden",
+    "auth.login.oidc": "Mit SSO anmelden",
     "auth.login.zitadel": "Mit Zitadel anmelden",
     "auth.already_registered": "Bereits registriert?",
     "auth.confirm_password": "Passwort bestätigen",

--- a/lang/en.json
+++ b/lang/en.json
@@ -9,6 +9,7 @@
     "auth.login.gitlab": "Login with Gitlab",
     "auth.login.google": "Login with Google",
     "auth.login.infomaniak": "Login with Infomaniak",
+    "auth.login.oidc": "Login with SSO",
     "auth.login.zitadel": "Login with Zitadel",
     "auth.already_registered": "Already registered?",
     "auth.confirm_password": "Confirm password",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -9,6 +9,7 @@
     "auth.login.gitlab": "Zaloguj się przez Gitlab",
     "auth.login.google": "Zaloguj się przez Google",
     "auth.login.infomaniak": "Zaloguj się przez Infomaniak",
+    "auth.login.oidc": "Zaloguj się przez SSO",
     "auth.login.zitadel": "Zaloguj się przez Zitadel",
     "auth.already_registered": "Już zarejestrowany?",
     "auth.confirm_password": "Potwierdź hasło",

--- a/resources/views/livewire/settings-oauth.blade.php
+++ b/resources/views/livewire/settings-oauth.blade.php
@@ -41,7 +41,8 @@
                             $oauth_setting['provider'] == 'authentik' ||
                                 $oauth_setting['provider'] == 'clerk' ||
                                 $oauth_setting['provider'] == 'zitadel' ||
-                                $oauth_setting['provider'] == 'gitlab')
+                                $oauth_setting['provider'] == 'gitlab' ||
+                                $oauth_setting['provider'] == 'oidc')
                             <x-forms.input id="oauth_settings_map.{{ $oauth_setting['provider'] }}.base_url"
                                 label="Base URL" />
                         @endif


### PR DESCRIPTION
STRAWBERRY

## Changes

Added support for a generic OIDC provider so users can authenticate with any OIDC-compliant identity provider by configuring a Base URL, Client ID, Client Secret, and Redirect URI.

Changes include:

* Added the OIDC Socialite provider dependency.
* Registered the OIDC Socialite event listener.
* Added OIDC configuration entries.
* Updated Socialite provider initialization to support OIDC using the configured Base URL.
* Added OIDC to OAuth provider seeding.
* Added validation requiring a Base URL for OIDC.
* Updated the OAuth settings UI to display the Base URL field for OIDC.
* Added translation entries for the OIDC login button.

## Issues

* Fixes #6696

## Category

* [ ] Bug fix
* [ ] Improvement
* [x] New feature
* [ ] Adding new one click service
* [ ] Fixing or updating existing one click service

## Preview

N/A

## AI Assistance

* [ ] AI was NOT used to create this PR
* [x] AI was used (please describe below)

**If AI was used:**

* Tools used: ChatGPT
* How extensively: Used for implementation guidance, code review, and verification. All changes were reviewed before committing.

## Testing

* Verified all modified files compile logically together.
* Verified provider registration, configuration wiring, seeder updates, UI changes, and translations.
* Full runtime testing could not be completed because the local Docker development environment was not fully operational.

## Contributor Agreement

> [!IMPORTANT]
>
> * [x] I have read and understood the contributor guidelines. If I have failed to follow any guideline, I understand that this PR may be closed without review.
> * [x] I have searched existing issues and pull requests (including closed ones) to ensure this isn't a duplicate.
> * [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.

