### PR TITLE
feat(api): expose proxy Dynamic Configurations via REST API

### DIFF
--- a/app/Http/Controllers/Api/ProxyController.php
+++ b/app/Http/Controllers/Api/ProxyController.php
@@ -1,0 +1,373 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Enums\ProxyTypes;
+use App\Http\Controllers\Controller;
+use App\Models\Server;
+use App\Rules\ValidProxyConfigFilename;
+use Illuminate\Http\Request;
+use OpenApi\Attributes as OA;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+class ProxyController extends Controller
+{
+    /**
+     * Files managed by Coolify itself that must never be modified or
+     * deleted through this API (mirrors ValidProxyConfigFilename).
+     */
+    private const RESERVED_FILENAMES = [
+        'coolify.yaml',
+        'coolify.yml',
+        'Caddyfile',
+    ];
+
+    private function findServer(Request $request, int $teamId): ?Server
+    {
+        return Server::whereTeamId($teamId)->whereUuid($request->uuid)->first();
+    }
+
+    /**
+     * Normalize the filename the same way the dashboard does: append the
+     * proxy-specific extension when missing.
+     */
+    private function normalizeFilename(string $fileName, string $proxyType): string
+    {
+        if ($proxyType === ProxyTypes::TRAEFIK->value) {
+            if (! str($fileName)->endsWith('.yaml') && ! str($fileName)->endsWith('.yml')) {
+                return "{$fileName}.yaml";
+            }
+        } elseif ($proxyType === 'CADDY') {
+            if (! str($fileName)->endsWith('.caddy')) {
+                return "{$fileName}.caddy";
+            }
+        }
+
+        return $fileName;
+    }
+
+    private function fileExists(Server $server, string $path): bool
+    {
+        $escaped = escapeshellarg($path);
+
+        return trim(instant_remote_process(["test -f {$escaped} && echo 1 || echo 0"], $server)) === '1';
+    }
+
+    #[OA\Get(
+        summary: 'List Proxy Dynamic Configurations',
+        description: 'List all dynamic configuration files of the proxy on the server.',
+        path: '/servers/{uuid}/proxy/dynamic-configurations',
+        operationId: 'list-proxy-dynamic-configurations-by-server-uuid',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Servers'],
+        parameters: [
+            new OA\Parameter(name: 'uuid', in: 'path', required: true, description: 'Server UUID', schema: new OA\Schema(type: 'string')),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Get the dynamic configurations of the proxy.',
+                content: [
+                    new OA\MediaType(
+                        mediaType: 'application/json',
+                        schema: new OA\Schema(
+                            type: 'array',
+                            items: new OA\Items(
+                                type: 'object',
+                                properties: [
+                                    new OA\Property(property: 'filename', type: 'string'),
+                                    new OA\Property(property: 'content', type: 'string'),
+                                ]
+                            )
+                        )
+                    ),
+                ]),
+            new OA\Response(
+                response: 401,
+                ref: '#/components/responses/401',
+            ),
+            new OA\Response(
+                response: 400,
+                ref: '#/components/responses/400',
+            ),
+            new OA\Response(
+                response: 404,
+                ref: '#/components/responses/404',
+            ),
+        ]
+    )]
+    public function dynamic_configurations(Request $request)
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+        $server = $this->findServer($request, $teamId);
+        if (is_null($server)) {
+            return response()->json(['message' => 'Server not found.'], 404);
+        }
+
+        $proxyPath = $server->proxyPath();
+        $files = instant_remote_process(["mkdir -p {$proxyPath}/dynamic && ls -1 {$proxyPath}/dynamic"], $server);
+        $configurations = collect(explode("\n", (string) $files))
+            ->map(fn ($file) => trim($file))
+            ->filter()
+            ->map(function ($file) use ($proxyPath, $server) {
+                $escaped = escapeshellarg("{$proxyPath}/dynamic/{$file}");
+
+                return [
+                    'filename' => $file,
+                    'content' => instant_remote_process(["cat {$escaped}"], $server),
+                ];
+            })
+            ->values();
+
+        return response()->json(serializeApiResponse($configurations));
+    }
+
+    #[OA\Post(
+        summary: 'Create Proxy Dynamic Configuration',
+        description: 'Create a new dynamic configuration file for the proxy on the server. For Traefik the content must be valid YAML; for Caddy the proxy is reloaded automatically.',
+        path: '/servers/{uuid}/proxy/dynamic-configurations',
+        operationId: 'create-proxy-dynamic-configuration-by-server-uuid',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Servers'],
+        parameters: [
+            new OA\Parameter(name: 'uuid', in: 'path', required: true, description: 'Server UUID', schema: new OA\Schema(type: 'string')),
+        ],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\MediaType(
+                mediaType: 'application/json',
+                schema: new OA\Schema(
+                    type: 'object',
+                    required: ['filename', 'content'],
+                    properties: [
+                        new OA\Property(property: 'filename', type: 'string', description: 'The configuration filename. The proxy specific extension (.yaml / .caddy) is appended when missing.'),
+                        new OA\Property(property: 'content', type: 'string', description: 'The configuration content.'),
+                    ]
+                )
+            )
+        ),
+        responses: [
+            new OA\Response(
+                response: 201,
+                description: 'Dynamic configuration created.',
+            ),
+            new OA\Response(
+                response: 401,
+                ref: '#/components/responses/401',
+            ),
+            new OA\Response(
+                response: 400,
+                ref: '#/components/responses/400',
+            ),
+            new OA\Response(
+                response: 404,
+                ref: '#/components/responses/404',
+            ),
+        ]
+    )]
+    public function create_dynamic_configuration(Request $request)
+    {
+        return $this->saveDynamicConfiguration($request, isNew: true);
+    }
+
+    #[OA\Patch(
+        summary: 'Update Proxy Dynamic Configuration',
+        description: 'Update an existing dynamic configuration file of the proxy on the server.',
+        path: '/servers/{uuid}/proxy/dynamic-configurations/{filename}',
+        operationId: 'update-proxy-dynamic-configuration-by-server-uuid',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Servers'],
+        parameters: [
+            new OA\Parameter(name: 'uuid', in: 'path', required: true, description: 'Server UUID', schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'filename', in: 'path', required: true, description: 'Configuration filename', schema: new OA\Schema(type: 'string')),
+        ],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\MediaType(
+                mediaType: 'application/json',
+                schema: new OA\Schema(
+                    type: 'object',
+                    required: ['content'],
+                    properties: [
+                        new OA\Property(property: 'content', type: 'string', description: 'The configuration content.'),
+                    ]
+                )
+            )
+        ),
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Dynamic configuration updated.',
+            ),
+            new OA\Response(
+                response: 401,
+                ref: '#/components/responses/401',
+            ),
+            new OA\Response(
+                response: 400,
+                ref: '#/components/responses/400',
+            ),
+            new OA\Response(
+                response: 404,
+                ref: '#/components/responses/404',
+            ),
+        ]
+    )]
+    public function update_dynamic_configuration(Request $request)
+    {
+        return $this->saveDynamicConfiguration($request, isNew: false);
+    }
+
+    #[OA\Delete(
+        summary: 'Delete Proxy Dynamic Configuration',
+        description: 'Delete a dynamic configuration file of the proxy on the server. Files managed by Coolify (coolify.yaml, Caddyfile) cannot be deleted.',
+        path: '/servers/{uuid}/proxy/dynamic-configurations/{filename}',
+        operationId: 'delete-proxy-dynamic-configuration-by-server-uuid',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Servers'],
+        parameters: [
+            new OA\Parameter(name: 'uuid', in: 'path', required: true, description: 'Server UUID', schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'filename', in: 'path', required: true, description: 'Configuration filename', schema: new OA\Schema(type: 'string')),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Dynamic configuration deleted.',
+            ),
+            new OA\Response(
+                response: 401,
+                ref: '#/components/responses/401',
+            ),
+            new OA\Response(
+                response: 400,
+                ref: '#/components/responses/400',
+            ),
+            new OA\Response(
+                response: 404,
+                ref: '#/components/responses/404',
+            ),
+        ]
+    )]
+    public function delete_dynamic_configuration(Request $request)
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+        $server = $this->findServer($request, $teamId);
+        if (is_null($server)) {
+            return response()->json(['message' => 'Server not found.'], 404);
+        }
+
+        $fileName = $request->route('filename');
+
+        try {
+            validateFilenameSafe($fileName, 'proxy configuration filename');
+        } catch (\Throwable $e) {
+            return response()->json(['message' => $e->getMessage()], 422);
+        }
+
+        if (in_array($fileName, self::RESERVED_FILENAMES, true)) {
+            return response()->json(['message' => 'This file is managed by Coolify and cannot be deleted.'], 400);
+        }
+
+        $proxyPath = $server->proxyPath();
+        $fullPath = "{$proxyPath}/dynamic/{$fileName}";
+        if (! $this->fileExists($server, $fullPath)) {
+            return response()->json(['message' => 'Dynamic configuration not found.'], 404);
+        }
+
+        $escapedPath = escapeshellarg($fullPath);
+        instant_remote_process(["rm -f {$escapedPath}"], $server);
+        if ($server->proxyType() === 'CADDY') {
+            $server->reloadCaddy();
+        }
+
+        return response()->json(['message' => 'Dynamic configuration deleted.']);
+    }
+
+    private function saveDynamicConfiguration(Request $request, bool $isNew)
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+        $server = $this->findServer($request, $teamId);
+        if (is_null($server)) {
+            return response()->json(['message' => 'Server not found.'], 404);
+        }
+
+        $fileName = $isNew ? $request->get('filename') : $request->route('filename');
+        $validator = customApiValidator([
+            'filename' => $fileName,
+            'content' => $request->get('content'),
+        ], [
+            'filename' => ['required', new ValidProxyConfigFilename],
+            'content' => 'required|string',
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'message' => 'Validation failed.',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        try {
+            validateFilenameSafe($fileName, 'proxy configuration filename');
+        } catch (\Throwable $e) {
+            return response()->json(['message' => $e->getMessage()], 422);
+        }
+
+        $proxyType = $server->proxyType();
+        $fileName = $this->normalizeFilename($fileName, $proxyType);
+        if (in_array($fileName, self::RESERVED_FILENAMES, true)) {
+            return response()->json(['message' => 'This file is managed by Coolify and cannot be modified.'], 400);
+        }
+
+        $content = $request->get('content');
+        if ($proxyType === ProxyTypes::TRAEFIK->value) {
+            try {
+                $content = Yaml::dump(Yaml::parse($content), 10, 2);
+            } catch (ParseException $e) {
+                return response()->json(['message' => "Invalid YAML: {$e->getMessage()}"], 422);
+            }
+        }
+
+        $proxyPath = $server->proxyPath();
+        $fullPath = "{$proxyPath}/dynamic/{$fileName}";
+        $exists = $this->fileExists($server, $fullPath);
+        if ($isNew && $exists) {
+            return response()->json(['message' => 'Dynamic configuration already exists. Use PATCH to update it.'], 409);
+        }
+        if (! $isNew && ! $exists) {
+            return response()->json(['message' => 'Dynamic configuration not found.'], 404);
+        }
+
+        $escapedFile = escapeshellarg($fullPath);
+        $base64Value = base64_encode($content);
+        instant_remote_process([
+            "mkdir -p {$proxyPath}/dynamic",
+            "echo '{$base64Value}' | base64 -d | tee {$escapedFile} > /dev/null",
+        ], $server);
+        if ($proxyType === 'CADDY') {
+            $server->reloadCaddy();
+        }
+
+        return response()->json([
+            'message' => $isNew ? 'Dynamic configuration created.' : 'Dynamic configuration updated.',
+            'filename' => $fileName,
+        ], $isNew ? 201 : 200);
+    }
+}

--- a/openapi.json
+++ b/openapi.json
@@ -9176,6 +9176,241 @@
                 ]
             }
         },
+        "\/servers\/{uuid}\/proxy\/dynamic-configurations": {
+            "get": {
+                "tags": [
+                    "Servers"
+                ],
+                "summary": "List Proxy Dynamic Configurations",
+                "description": "List all dynamic configuration files of the proxy on the server.",
+                "operationId": "list-proxy-dynamic-configurations-by-server-uuid",
+                "parameters": [
+                    {
+                        "name": "uuid",
+                        "in": "path",
+                        "description": "Server UUID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Get the dynamic configurations of the proxy.",
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "filename": {
+                                                "type": "string"
+                                            },
+                                            "content": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "$ref": "#\/components\/responses\/401"
+                    },
+                    "400": {
+                        "$ref": "#\/components\/responses\/400"
+                    },
+                    "404": {
+                        "$ref": "#\/components\/responses\/404"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Servers"
+                ],
+                "summary": "Create Proxy Dynamic Configuration",
+                "description": "Create a new dynamic configuration file for the proxy on the server. For Traefik the content must be valid YAML; for Caddy the proxy is reloaded automatically.",
+                "operationId": "create-proxy-dynamic-configuration-by-server-uuid",
+                "parameters": [
+                    {
+                        "name": "uuid",
+                        "in": "path",
+                        "description": "Server UUID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "required": [
+                                    "filename",
+                                    "content"
+                                ],
+                                "properties": {
+                                    "filename": {
+                                        "description": "The configuration filename. The proxy specific extension (.yaml \/ .caddy) is appended when missing.",
+                                        "type": "string"
+                                    },
+                                    "content": {
+                                        "description": "The configuration content.",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Dynamic configuration created."
+                    },
+                    "401": {
+                        "$ref": "#\/components\/responses\/401"
+                    },
+                    "400": {
+                        "$ref": "#\/components\/responses\/400"
+                    },
+                    "404": {
+                        "$ref": "#\/components\/responses\/404"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "\/servers\/{uuid}\/proxy\/dynamic-configurations\/{filename}": {
+            "delete": {
+                "tags": [
+                    "Servers"
+                ],
+                "summary": "Delete Proxy Dynamic Configuration",
+                "description": "Delete a dynamic configuration file of the proxy on the server. Files managed by Coolify (coolify.yaml, Caddyfile) cannot be deleted.",
+                "operationId": "delete-proxy-dynamic-configuration-by-server-uuid",
+                "parameters": [
+                    {
+                        "name": "uuid",
+                        "in": "path",
+                        "description": "Server UUID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filename",
+                        "in": "path",
+                        "description": "Configuration filename",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Dynamic configuration deleted."
+                    },
+                    "401": {
+                        "$ref": "#\/components\/responses\/401"
+                    },
+                    "400": {
+                        "$ref": "#\/components\/responses\/400"
+                    },
+                    "404": {
+                        "$ref": "#\/components\/responses\/404"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "patch": {
+                "tags": [
+                    "Servers"
+                ],
+                "summary": "Update Proxy Dynamic Configuration",
+                "description": "Update an existing dynamic configuration file of the proxy on the server.",
+                "operationId": "update-proxy-dynamic-configuration-by-server-uuid",
+                "parameters": [
+                    {
+                        "name": "uuid",
+                        "in": "path",
+                        "description": "Server UUID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filename",
+                        "in": "path",
+                        "description": "Configuration filename",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "required": [
+                                    "content"
+                                ],
+                                "properties": {
+                                    "content": {
+                                        "description": "The configuration content.",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Dynamic configuration updated."
+                    },
+                    "401": {
+                        "$ref": "#\/components\/responses\/401"
+                    },
+                    "400": {
+                        "$ref": "#\/components\/responses\/400"
+                    },
+                    "404": {
+                        "$ref": "#\/components\/responses\/404"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
         "\/resources": {
             "get": {
                 "tags": [
@@ -13650,6 +13885,10 @@
             "description": "Projects"
         },
         {
+            "name": "Servers",
+            "description": "Servers"
+        },
+        {
             "name": "Resources",
             "description": "Resources"
         },
@@ -13660,10 +13899,6 @@
         {
             "name": "Private Keys",
             "description": "Private Keys"
-        },
-        {
-            "name": "Servers",
-            "description": "Servers"
         },
         {
             "name": "Services",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5832,6 +5832,161 @@ paths:
       security:
         -
           bearerAuth: []
+  '/servers/{uuid}/proxy/dynamic-configurations':
+    get:
+      tags:
+        - Servers
+      summary: 'List Proxy Dynamic Configurations'
+      description: 'List all dynamic configuration files of the proxy on the server.'
+      operationId: list-proxy-dynamic-configurations-by-server-uuid
+      parameters:
+        -
+          name: uuid
+          in: path
+          description: 'Server UUID'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'Get the dynamic configurations of the proxy.'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  properties: { filename: { type: string }, content: { type: string } }
+                  type: object
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+        '404':
+          $ref: '#/components/responses/404'
+      security:
+        -
+          bearerAuth: []
+    post:
+      tags:
+        - Servers
+      summary: 'Create Proxy Dynamic Configuration'
+      description: 'Create a new dynamic configuration file for the proxy on the server. For Traefik the content must be valid YAML; for Caddy the proxy is reloaded automatically.'
+      operationId: create-proxy-dynamic-configuration-by-server-uuid
+      parameters:
+        -
+          name: uuid
+          in: path
+          description: 'Server UUID'
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - filename
+                - content
+              properties:
+                filename:
+                  description: 'The configuration filename. The proxy specific extension (.yaml / .caddy) is appended when missing.'
+                  type: string
+                content:
+                  description: 'The configuration content.'
+                  type: string
+              type: object
+      responses:
+        '201':
+          description: 'Dynamic configuration created.'
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+        '404':
+          $ref: '#/components/responses/404'
+      security:
+        -
+          bearerAuth: []
+  '/servers/{uuid}/proxy/dynamic-configurations/{filename}':
+    delete:
+      tags:
+        - Servers
+      summary: 'Delete Proxy Dynamic Configuration'
+      description: 'Delete a dynamic configuration file of the proxy on the server. Files managed by Coolify (coolify.yaml, Caddyfile) cannot be deleted.'
+      operationId: delete-proxy-dynamic-configuration-by-server-uuid
+      parameters:
+        -
+          name: uuid
+          in: path
+          description: 'Server UUID'
+          required: true
+          schema:
+            type: string
+        -
+          name: filename
+          in: path
+          description: 'Configuration filename'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'Dynamic configuration deleted.'
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+        '404':
+          $ref: '#/components/responses/404'
+      security:
+        -
+          bearerAuth: []
+    patch:
+      tags:
+        - Servers
+      summary: 'Update Proxy Dynamic Configuration'
+      description: 'Update an existing dynamic configuration file of the proxy on the server.'
+      operationId: update-proxy-dynamic-configuration-by-server-uuid
+      parameters:
+        -
+          name: uuid
+          in: path
+          description: 'Server UUID'
+          required: true
+          schema:
+            type: string
+        -
+          name: filename
+          in: path
+          description: 'Configuration filename'
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - content
+              properties:
+                content:
+                  description: 'The configuration content.'
+                  type: string
+              type: object
+      responses:
+        '200':
+          description: 'Dynamic configuration updated.'
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+        '404':
+          $ref: '#/components/responses/404'
+      security:
+        -
+          bearerAuth: []
   /resources:
     get:
       tags:
@@ -8759,6 +8914,9 @@ tags:
     name: Projects
     description: Projects
   -
+    name: Servers
+    description: Servers
+  -
     name: Resources
     description: Resources
   -
@@ -8767,9 +8925,6 @@ tags:
   -
     name: 'Private Keys'
     description: 'Private Keys'
-  -
-    name: Servers
-    description: Servers
   -
     name: Services
     description: Services

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Api\GithubController;
 use App\Http\Controllers\Api\HetznerController;
 use App\Http\Controllers\Api\OtherController;
 use App\Http\Controllers\Api\ProjectController;
+use App\Http\Controllers\Api\ProxyController;
 use App\Http\Controllers\Api\ResourcesController;
 use App\Http\Controllers\Api\ScheduledTasksController;
 use App\Http\Controllers\Api\SecurityController;
@@ -87,6 +88,11 @@ Route::group([
     Route::get('/servers/{uuid}/resources', [ServersController::class, 'resources_by_server'])->middleware(['api.ability:read']);
 
     Route::get('/servers/{uuid}/validate', [ServersController::class, 'validate_server'])->middleware(['api.ability:write']);
+
+    Route::get('/servers/{uuid}/proxy/dynamic-configurations', [ProxyController::class, 'dynamic_configurations'])->middleware(['api.ability:read']);
+    Route::post('/servers/{uuid}/proxy/dynamic-configurations', [ProxyController::class, 'create_dynamic_configuration'])->middleware(['api.ability:write']);
+    Route::patch('/servers/{uuid}/proxy/dynamic-configurations/{filename}', [ProxyController::class, 'update_dynamic_configuration'])->middleware(['api.ability:write']);
+    Route::delete('/servers/{uuid}/proxy/dynamic-configurations/{filename}', [ProxyController::class, 'delete_dynamic_configuration'])->middleware(['api.ability:write']);
 
     Route::post('/servers', [ServersController::class, 'create_server'])->middleware(['api.ability:write']);
     Route::patch('/servers/{uuid}', [ServersController::class, 'update_server'])->middleware(['api.ability:write']);


### PR DESCRIPTION
## Changes

The dashboard already has a great feature for managing the proxy's dynamic configuration files (**Server → Proxy → Dynamic Configurations**), but it is not exposed through the REST API. This PR adds API parity for it:

| Method | Path | Ability |
|---|---|---|
| `GET` | `/servers/{uuid}/proxy/dynamic-configurations` | `read` |
| `POST` | `/servers/{uuid}/proxy/dynamic-configurations` | `write` |
| `PATCH` | `/servers/{uuid}/proxy/dynamic-configurations/{filename}` | `write` |
| `DELETE` | `/servers/{uuid}/proxy/dynamic-configurations/{filename}` | `write` |

**Why:** we run a multi-tenant POS/storefront platform on Coolify where each merchant can connect their own custom domain. The right way to route those domains (Traefik file provider + per-host router with a Let's Encrypt certresolver, hot-reloaded, no container restarts) currently requires bind-mounting `/data/coolify/proxy/dynamic` into an app container and fixing host permissions by hand, because there is no API. Updating the app's `domains` instead is not viable: it restarts the container on every domain change. With these endpoints, any automation can manage per-domain proxy config with a scoped API token — useful for white-label/SaaS setups in general.

**Implementation notes:**

- The endpoints mirror the existing Livewire logic 1:1 (`NewDynamicConfiguration` / `DynamicConfigurationNavbar`): `ValidProxyConfigFilename` + `validateFilenameSafe`, automatic extension handling (`.yaml` / `.caddy`), YAML validation + normalization for Traefik, automatic Caddy reload, and Coolify-managed files (`coolify.yaml`, `Caddyfile`) protected from modification/deletion. The Livewire components are not touched.
- Follows the existing API controller conventions: `getTeamIdFromToken()` team scoping, `api.ability` middleware, `customApiValidator`, OpenAPI attributes.
- `openapi.yaml` / `openapi.json` regenerated (`generate:openapi`); Pint passes.

**Testing status:** validated with `php -l`, Pint and the OpenAPI generator; the file-write/read/delete logic is copied verbatim from the Livewire components that run in production today. I have not yet exercised these exact endpoints against a dev instance — happy to add tests or adjust anything if you'd like a different shape for the routes.

## Issues

- No existing issue found for this; opening directly as the change is additive and mirrors an existing dashboard feature. Happy to open a discussion first if preferred.

## Category

- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Example usage (Traefik):

```bash
# Create a per-domain router (hot-reloaded by Traefik, no restarts)
curl -X POST https://coolify.example.com/api/v1/servers/<uuid>/proxy/dynamic-configurations \
  -H "Authorization: Bearer <token>" -H "Content-Type: application/json" \
  -d '{
    "filename": "customer-domain-42",
    "content": "http:\n  routers:\n    customer-42:\n      rule: Host(`shop.customer.com`)\n      entryPoints: [https]\n      service: my-app@docker\n      tls:\n        certResolver: letsencrypt\n"
  }'

# List
curl -H "Authorization: Bearer <token>" \
  https://coolify.example.com/api/v1/servers/<uuid>/proxy/dynamic-configurations

# Delete
curl -X DELETE -H "Authorization: Bearer <token>" \
  https://coolify.example.com/api/v1/servers/<uuid>/proxy/dynamic-configurations/customer-domain-42.yaml
```

## AI Assistance

This PR was developed with AI assistance (Claude Code), directed and reviewed by a human. The logic intentionally mirrors the existing Livewire components line-by-line to minimize review surface.
