### PR TITLE
feat(service): update forgejo from v8 to v15

### DIFF
--- a/templates/compose/forgejo-with-mariadb.yaml
+++ b/templates/compose/forgejo-with-mariadb.yaml
@@ -7,7 +7,7 @@
 
 services:
   forgejo:
-    image: codeberg.org/forgejo/forgejo:8
+    image: codeberg.org/forgejo/forgejo:15
     environment:
       - SERVICE_URL_FORGEJO_3000
       - FORGEJO__server__ROOT_URL=${SERVICE_URL_FORGEJO}

--- a/templates/compose/forgejo-with-mysql.yaml
+++ b/templates/compose/forgejo-with-mysql.yaml
@@ -7,7 +7,7 @@
 
 services:
   forgejo:
-    image: codeberg.org/forgejo/forgejo:8
+    image: codeberg.org/forgejo/forgejo:15
     environment:
       - SERVICE_URL_FORGEJO_3000
       - FORGEJO__server__ROOT_URL=${SERVICE_URL_FORGEJO}

--- a/templates/compose/forgejo-with-postgresql.yaml
+++ b/templates/compose/forgejo-with-postgresql.yaml
@@ -7,7 +7,7 @@
 
 services:
   forgejo:
-    image: codeberg.org/forgejo/forgejo:8
+    image: codeberg.org/forgejo/forgejo:15
     environment:
       - SERVICE_URL_FORGEJO_3000
       - FORGEJO__server__ROOT_URL=${SERVICE_URL_FORGEJO}

--- a/templates/compose/forgejo-with-runner-with-mariadb.yaml
+++ b/templates/compose/forgejo-with-runner-with-mariadb.yaml
@@ -8,7 +8,7 @@
 
 services:
   forgejo:
-    image: codeberg.org/forgejo/forgejo:8
+    image: codeberg.org/forgejo/forgejo:15
     environment:
       - SERVICE_URL_FORGEJO_3000
       - FORGEJO__server__ROOT_URL=${SERVICE_URL_FORGEJO}

--- a/templates/compose/forgejo-with-runner-with-mysql.yaml
+++ b/templates/compose/forgejo-with-runner-with-mysql.yaml
@@ -8,7 +8,7 @@
 
 services:
   forgejo:
-    image: codeberg.org/forgejo/forgejo:8
+    image: codeberg.org/forgejo/forgejo:15
     environment:
       - SERVICE_URL_FORGEJO_3000
       - FORGEJO__server__ROOT_URL=${SERVICE_URL_FORGEJO}

--- a/templates/compose/forgejo-with-runner-with-postgresql.yaml
+++ b/templates/compose/forgejo-with-runner-with-postgresql.yaml
@@ -8,7 +8,7 @@
 
 services:
   forgejo:
-    image: codeberg.org/forgejo/forgejo:8
+    image: codeberg.org/forgejo/forgejo:15
     environment:
       - SERVICE_URL_FORGEJO_3000
       - FORGEJO__server__ROOT_URL=${SERVICE_URL_FORGEJO}

--- a/templates/compose/forgejo-with-runner.yaml
+++ b/templates/compose/forgejo-with-runner.yaml
@@ -8,7 +8,7 @@
 
 services:
   forgejo:
-    image: codeberg.org/forgejo/forgejo:8
+    image: codeberg.org/forgejo/forgejo:15
     environment:
       - SERVICE_URL_FORGEJO_3000
       - FORGEJO__server__ROOT_URL=${SERVICE_URL_FORGEJO}

--- a/templates/compose/forgejo.yaml
+++ b/templates/compose/forgejo.yaml
@@ -7,7 +7,7 @@
 
 services:
   forgejo:
-    image: codeberg.org/forgejo/forgejo:8
+    image: codeberg.org/forgejo/forgejo:15
     environment:
       - SERVICE_URL_FORGEJO_3000
       - FORGEJO__server__ROOT_URL=${SERVICE_URL_FORGEJO}


### PR DESCRIPTION
## Changes

Forgejo v8 is EOL as of 16 October 2024 
Updating Forgejo images from v8 to v15 - reference: https://forgejo.org/releases/


## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service


## AI Assistance

<!-- AI-assisted PRs that are human reviewed are welcome, just let us know so we can review appropriately. -->

- [x] AI was NOT used to create this PR
- [ ] AI was used (please describe below)


## Testing

Running v15 locally

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
