### PR TITLE
fix(service): correct Convex origin env vars and expose HTTP actions port

### DIFF
--- a/templates/compose/convex.yaml
+++ b/templates/compose/convex.yaml
@@ -12,14 +12,15 @@ services:
       - data:/convex/data
     environment:
       - SERVICE_URL_BACKEND_3210
+      - SERVICE_URL_SITE_3211
       - INSTANCE_NAME=${INSTANCE_NAME:-self-hosted-convex}
       - INSTANCE_SECRET=${SERVICE_HEX_64_SECRET}
       - CONVEX_RELEASE_VERSION_DEV=${CONVEX_RELEASE_VERSION_DEV:-}
       - ACTIONS_USER_TIMEOUT_SECS=${ACTIONS_USER_TIMEOUT_SECS:-}
       # URL of the Convex API as accessed by the client/frontend.
-      - CONVEX_CLOUD_ORIGIN=${SERVICE_URL_DASHBOARD}
+      - CONVEX_CLOUD_ORIGIN=${SERVICE_URL_BACKEND}
       # URL of Convex HTTP actions as accessed by the client/frontend.
-      - CONVEX_SITE_ORIGIN=${SERVICE_URL_BACKEND}
+      - CONVEX_SITE_ORIGIN=${SERVICE_URL_SITE}
       - DATABASE_URL=${DATABASE_URL:-}
       - DISABLE_BEACON=${DISABLE_BEACON:?false}
       - REDACT_LOGS_TO_CLIENT=${REDACT_LOGS_TO_CLIENT:?false}


### PR DESCRIPTION
## Changes

The Convex template currently sets `CONVEX_CLOUD_ORIGIN` to the dashboard URL and `CONVEX_SITE_ORIGIN` to the backend API URL. Convex generates file upload URLs from `CONVEX_CLOUD_ORIGIN`, so every upload gets POSTed to the dashboard and fails with a 404 ("Uploaded file appears to be HTML content" in the dashboard, `Failed to fetch` in apps). I hit this myself when my app's image upload broke after moving from Convex cloud to selfhosted on Coolify.

This PR points `CONVEX_CLOUD_ORIGIN` at the backend (`SERVICE_URL_BACKEND`), adds `SERVICE_URL_SITE_3211` so Coolify generates a second domain for the HTTP actions port, and points `CONVEX_SITE_ORIGIN` at that new domain. Three lines changed, all in the backend service env block.

## Issues

- Fixes #7989
- Fixes #7232
- Reopens the approach from #7208, which was closed because Coolify could not generate URLs for two ports on one service at the time. That limitation no longer applies; Coolify generates the second domain for port 3211 without issues.

## Category

- [x] Bug fix
- [x] Fixing or updating existing one click service

## Preview

<!-- Optional here (mandatory only for new features). If you want, attach a screenshot of the Coolify Domains section showing the BACKEND and SITE domains, or of a successful file upload. -->

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Helped diagnose the root cause and drafted this PR description (including the Changes section above), which I reviewed and edited. The template change itself is 3 lines; I made and verified it myself on my production Coolify instance (v4, Hetzner VPS): file uploads via `generateUploadUrl()` work, `storage.getUrl()` returns reachable URLs, HTTP actions are reachable on the SITE domain, and `npx convex dev` writes the correct `NEXT_PUBLIC_CONVEX_SITE_URL`.

## Testing

Deployed the modified compose on my own Coolify v4 instance (Hetzner VPS) running a real Next.js + Convex app:

1. Before the change: browser file uploads failed (`Failed to fetch` / 404, the upload URL pointed at the dashboard domain), matching the reports in #7989.
2. Applied the three-line change, assigned a domain to the new SITE entry (routed to port 3211), redeployed.
3. After: file uploads succeed, stored files are servable via `storage.getUrl()`, HTTP actions respond on the SITE domain, and the Convex CLI syncs the correct site URL into `.env.local`.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
