### PR TITLE
fix(service): correct Convex origin env vars and expose HTTP actions port

### DIFF
--- a/templates/compose/convex.yaml
+++ b/templates/compose/convex.yaml
@@ -12,14 +12,15 @@ services:
       - data:/convex/data
     environment:
       - SERVICE_URL_BACKEND_3210
+      - SERVICE_URL_SITE_3211
       - INSTANCE_NAME=${INSTANCE_NAME:-self-hosted-convex}
       - INSTANCE_SECRET=${SERVICE_HEX_64_SECRET}
       - CONVEX_RELEASE_VERSION_DEV=${CONVEX_RELEASE_VERSION_DEV:-}
       - ACTIONS_USER_TIMEOUT_SECS=${ACTIONS_USER_TIMEOUT_SECS:-}
       # URL of the Convex API as accessed by the client/frontend.
-      - CONVEX_CLOUD_ORIGIN=${SERVICE_URL_DASHBOARD}
+      - CONVEX_CLOUD_ORIGIN=${SERVICE_URL_BACKEND}
       # URL of Convex HTTP actions as accessed by the client/frontend.
-      - CONVEX_SITE_ORIGIN=${SERVICE_URL_BACKEND}
+      - CONVEX_SITE_ORIGIN=${SERVICE_URL_SITE}
       - DATABASE_URL=${DATABASE_URL:-}
       - DISABLE_BEACON=${DISABLE_BEACON:?false}
       - REDACT_LOGS_TO_CLIENT=${REDACT_LOGS_TO_CLIENT:?false}


### PR DESCRIPTION
## Changes

The Convex one click service template assigns the origin env vars to the wrong services: CONVEX_CLOUD_ORIGIN points at the dashboard URL and CONVEX_SITE_ORIGIN points at the backend API URL. Convex generates file upload URLs from CONVEX_CLOUD_ORIGIN, so every upload gets POSTed to the dashboard and fails with a 404 ("Uploaded file appears to be HTML content" in the dashboard, "Failed to fetch" in apps). I hit this myself when my app's image upload broke after moving from Convex cloud to self-hosted on Coolify.

This PR points CONVEX_CLOUD_ORIGIN at the backend, declares SERVICE_URL_SITE_3211 so Coolify generates a second domain for the HTTP actions port (3211, previously unreachable), and points CONVEX_SITE_ORIGIN at that new domain. Three lines changed.

## Issues

- Fixes #7989
- Fixes #7232
- Same approach as #7208, closed when Coolify could not generate URLs for two ports on one service. That works now.

## Category

- [x] Bug fix
- [x] Fixing or updating existing one click service

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Helped diagnose the root cause and draft this description, which I reviewed and edited. The change itself is three lines that I made and verified myself.

## Testing

Deployed the modified compose on my own Coolify v4 instance (Hetzner VPS) running a Next.js + Convex app. Before the change, browser file uploads failed with a 404 because the upload URL pointed at the dashboard domain, matching the reports in #7989. After assigning a domain to the new SITE entry and redeploying: uploads work, stored files are servable, HTTP actions respond on the new domain, and the Convex CLI syncs the correct site URL into the env file.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
