### PR TITLE
fix: allow environment variable references in Docker image tags

### DIFF
--- a/app/Support/ValidationPatterns.php
+++ b/app/Support/ValidationPatterns.php
@@ -126,9 +126,10 @@ class ValidationPatterns
      * Pattern for Docker image tags.
      *
      * Docker tags may contain letters, digits, underscores, dots, and hyphens,
-     * must start with an alphanumeric/underscore, and are limited to 128 chars.
+     * must start with an alphanumeric/underscore/dollar sign, and are limited to 128 chars.
+     * Dollar sign, curly braces are allowed for environment variable substitution ($VAR, ${VAR}).
      */
-    public const DOCKER_IMAGE_TAG_PATTERN = '/\A[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}\z/';
+    public const DOCKER_IMAGE_TAG_PATTERN = '/\A[A-Za-z0-9_$][A-Za-z0-9_.-${}]{0,127}\z/';
 
     /**
      * Normalize environment variable keys before validation and storage.

--- a/tests/Feature/ApplicationDockerRegistryImageValidationApiTest.php
+++ b/tests/Feature/ApplicationDockerRegistryImageValidationApiTest.php
@@ -105,4 +105,34 @@ describe('PATCH /api/v1/applications/{uuid} docker registry image validation', f
         expect($application->docker_registry_image_name)->toBe('registry.example.com:5000/team/app')
             ->and($application->docker_registry_image_tag)->toBe('v1.2.3');
     });
+
+    test('accepts env var reference in docker registry image tag', function () {
+        $application = makeDockerRegistryValidationApplication();
+
+        $response = $this->withHeaders(dockerRegistryApiHeaders($this->bearerToken))
+            ->patchJson("/api/v1/applications/{$application->uuid}", [
+                'docker_registry_image_name' => 'ghcr.io/coollabsio/example',
+                'docker_registry_image_tag' => '$API_VERSION',
+            ]);
+
+        $response->assertOk();
+
+        $application->refresh();
+        expect($application->docker_registry_image_tag)->toBe('$API_VERSION');
+    });
+
+    test('accepts env var reference with braces in docker registry image tag', function () {
+        $application = makeDockerRegistryValidationApplication();
+
+        $response = $this->withHeaders(dockerRegistryApiHeaders($this->bearerToken))
+            ->patchJson("/api/v1/applications/{$application->uuid}", [
+                'docker_registry_image_name' => 'ghcr.io/coollabsio/example',
+                'docker_registry_image_tag' => 'v1.0-${API_VERSION}',
+            ]);
+
+        $response->assertOk();
+
+        $application->refresh();
+        expect($application->docker_registry_image_tag)->toBe('v1.0-${API_VERSION}');
+    });
 });

--- a/tests/Unit/DockerImageReferenceValidationTest.php
+++ b/tests/Unit/DockerImageReferenceValidationTest.php
@@ -39,6 +39,10 @@ it('accepts valid docker registry image tags', function (string $tag) {
     'uppercase and underscore' => 'PR_123',
     'sha256 hash' => '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
     'legacy sha256 prefixed hash' => 'sha256-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+    'env var reference' => '$API_VERSION',
+    'env var reference with braces' => '${API_VERSION}',
+    'version with env var' => 'v1.0-$API_VERSION',
+    'version with env var braces' => 'v1.0_${API_VERSION}',
 ]);
 
 it('rejects docker registry image tags with shell metacharacters', function (string $tag) {


### PR DESCRIPTION
## Summary

The `DOCKER_IMAGE_TAG_PATTERN` introduced in v4.1.2 (`e7dff30b`) rejects tags containing `$` or `{}` characters. This breaks environment variable substitution in Docker Image application tags — e.g. `$API_VERSION` or `${API_VERSION}` — which worked correctly in v4.0.0 and earlier.

## Changes

- Updated `DOCKER_IMAGE_TAG_PATTERN` in `ValidationPatterns.php` to allow `$`, `{`, `}` characters for environment variable references
- Added test cases for `$VAR`, `${VAR}`, and mixed formats like `v1.0-$VAR`
- Added API feature tests for env var tags via PATCH `/api/v1/applications/{uuid}`

## Security

Shell metacharacters (`()`, backticks, `;`, `|`, `&`, spaces, newlines) remain blocked. Only `$`, `{`, `}` are newly allowed — these enable variable substitution but cannot trigger command execution without parentheses or backticks.

| Tag | Before | After |
|-----|--------|-------|
| `$API_VERSION` | ❌ rejected | ✅ accepted |
| `${API_VERSION}` | ❌ rejected | ✅ accepted |
| `v1.0-$TAG` | ❌ rejected | ✅ accepted |
| `latest$(cmd)` | ❌ rejected | ❌ rejected |
| `latest;id` | ❌ rejected | ❌ rejected |

Fixes #10642