### PR TITLE
fix(api): expose include_source_commit_in_build via REST API

### DIFF
--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -2365,7 +2365,7 @@ class ApplicationsController extends Controller
         $this->authorize('update', $application);
 
         $server = $application->destination->server;
-        $allowedFields = ['name', 'description', 'is_static', 'is_spa', 'is_auto_deploy_enabled', 'is_force_https_enabled', 'domains', 'git_repository', 'git_branch', 'git_commit_sha', 'docker_registry_image_name', 'docker_registry_image_tag', 'build_pack', 'static_image', 'install_command', 'build_command', 'start_command', 'ports_exposes', 'ports_mappings', 'custom_network_aliases', 'base_directory', 'publish_directory', 'health_check_enabled', 'health_check_type', 'health_check_command', 'health_check_path', 'health_check_port', 'health_check_host', 'health_check_method', 'health_check_return_code', 'health_check_scheme', 'health_check_response_text', 'health_check_interval', 'health_check_timeout', 'health_check_retries', 'health_check_start_period', 'limits_memory', 'limits_memory_swap', 'limits_memory_swappiness', 'limits_memory_reservation', 'limits_cpus', 'limits_cpuset', 'limits_cpu_shares', 'custom_labels', 'custom_docker_run_options', 'post_deployment_command', 'post_deployment_command_container', 'pre_deployment_command', 'pre_deployment_command_container', 'watch_paths', 'manual_webhook_secret_github', 'manual_webhook_secret_gitlab', 'manual_webhook_secret_bitbucket', 'manual_webhook_secret_gitea', 'dockerfile_location', 'dockerfile_target_build', 'docker_compose_location', 'docker_compose_custom_start_command', 'docker_compose_custom_build_command', 'docker_compose_domains', 'redirect', 'instant_deploy', 'use_build_server', 'custom_nginx_configuration', 'is_http_basic_auth_enabled', 'http_basic_auth_username', 'http_basic_auth_password', 'connect_to_docker_network', 'force_domain_override', 'is_container_label_escape_enabled', 'is_preserve_repository_enabled'];
+        $allowedFields = ['name', 'description', 'is_static', 'is_spa', 'is_auto_deploy_enabled', 'is_force_https_enabled', 'domains', 'git_repository', 'git_branch', 'git_commit_sha', 'docker_registry_image_name', 'docker_registry_image_tag', 'build_pack', 'static_image', 'install_command', 'build_command', 'start_command', 'ports_exposes', 'ports_mappings', 'custom_network_aliases', 'base_directory', 'publish_directory', 'health_check_enabled', 'health_check_type', 'health_check_command', 'health_check_path', 'health_check_port', 'health_check_host', 'health_check_method', 'health_check_return_code', 'health_check_scheme', 'health_check_response_text', 'health_check_interval', 'health_check_timeout', 'health_check_retries', 'health_check_start_period', 'limits_memory', 'limits_memory_swap', 'limits_memory_swappiness', 'limits_memory_reservation', 'limits_cpus', 'limits_cpuset', 'limits_cpu_shares', 'custom_labels', 'custom_docker_run_options', 'post_deployment_command', 'post_deployment_command_container', 'pre_deployment_command', 'pre_deployment_command_container', 'watch_paths', 'manual_webhook_secret_github', 'manual_webhook_secret_gitlab', 'manual_webhook_secret_bitbucket', 'manual_webhook_secret_gitea', 'dockerfile_location', 'dockerfile_target_build', 'docker_compose_location', 'docker_compose_custom_start_command', 'docker_compose_custom_build_command', 'docker_compose_domains', 'redirect', 'instant_deploy', 'use_build_server', 'custom_nginx_configuration', 'is_http_basic_auth_enabled', 'http_basic_auth_username', 'http_basic_auth_password', 'connect_to_docker_network', 'force_domain_override', 'is_container_label_escape_enabled', 'is_preserve_repository_enabled', 'include_source_commit_in_build'];
 
         $validationRules = [
             'name' => 'string|max:255',
@@ -2616,6 +2616,7 @@ class ApplicationsController extends Controller
         $useBuildServer = $request->use_build_server;
         $isContainerLabelEscapeEnabled = $request->boolean('is_container_label_escape_enabled');
         $isPreserveRepositoryEnabled = $request->boolean('is_preserve_repository_enabled');
+        $includeSourceCommitInBuild = $request->boolean('include_source_commit_in_build');
         if (isset($useBuildServer)) {
             $application->settings->is_build_server_enabled = $useBuildServer;
             $application->settings->save();
@@ -2652,6 +2653,10 @@ class ApplicationsController extends Controller
         }
         if ($request->has('is_preserve_repository_enabled')) {
             $application->settings->is_preserve_repository_enabled = $isPreserveRepositoryEnabled;
+            $application->settings->save();
+        }
+        if ($request->has('include_source_commit_in_build')) {
+            $application->settings->include_source_commit_in_build = $includeSourceCommitInBuild;
             $application->settings->save();
         }
         removeUnnecessaryFieldsFromRequest($request);

--- a/tests/Feature/ApplicationIncludeSourceCommitApiTest.php
+++ b/tests/Feature/ApplicationIncludeSourceCommitApiTest.php
@@ -1,0 +1,111 @@
+<?php
+
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\InstanceSettings;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::create(['id' => 0, 'is_api_enabled' => true]);
+
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+
+    session(['currentTeam' => $this->team]);
+
+    $plainTextToken = Str::random(40);
+    $token = $this->user->tokens()->create([
+        'name' => 'source-commit-api-test-'.Str::random(6),
+        'token' => hash('sha256', $plainTextToken),
+        'abilities' => ['*'],
+        'team_id' => $this->team->id,
+    ]);
+    $this->bearerToken = $token->getKey().'|'.$plainTextToken;
+
+    $this->server = Server::factory()->create(['team_id' => $this->team->id]);
+    $this->destination = StandaloneDocker::factory()->create([
+        'server_id' => $this->server->id,
+        'network' => 'coolify-'.Str::lower(Str::random(8)),
+    ]);
+    $this->project = Project::factory()->create(['team_id' => $this->team->id]);
+    $this->environment = Environment::factory()->create(['project_id' => $this->project->id]);
+});
+
+function sourceCommitApiHeaders(string $bearerToken): array
+{
+    return [
+        'Authorization' => 'Bearer '.$bearerToken,
+        'Content-Type' => 'application/json',
+    ];
+}
+
+function makeSourceCommitApplication(array $overrides = []): Application
+{
+    return Application::factory()->create(array_merge([
+        'environment_id' => test()->environment->id,
+        'destination_id' => test()->destination->id,
+        'destination_type' => test()->destination->getMorphClass(),
+        'build_pack' => 'nixpacks',
+    ], $overrides));
+}
+
+describe('PATCH /api/v1/applications/{uuid} include_source_commit_in_build', function () {
+    test('accepts include_source_commit_in_build via API', function () {
+        $application = makeSourceCommitApplication();
+        expect($application->settings->include_source_commit_in_build)->toBeFalse();
+
+        $response = $this->withHeaders(sourceCommitApiHeaders($this->bearerToken))
+            ->patchJson("/api/v1/applications/{$application->uuid}", [
+                'include_source_commit_in_build' => true,
+            ]);
+
+        $response->assertOk();
+
+        $application->refresh();
+        expect($application->settings->include_source_commit_in_build)->toBeTrue();
+    });
+
+    test('can disable include_source_commit_in_build via API', function () {
+        $application = makeSourceCommitApplication();
+        $application->settings->include_source_commit_in_build = true;
+        $application->settings->save();
+
+        $response = $this->withHeaders(sourceCommitApiHeaders($this->bearerToken))
+            ->patchJson("/api/v1/applications/{$application->uuid}", [
+                'include_source_commit_in_build' => false,
+            ]);
+
+        $response->assertOk();
+
+        $application->refresh();
+        expect($application->settings->include_source_commit_in_build)->toBeFalse();
+    });
+
+    test('does not affect other application fields', function () {
+        $application = makeSourceCommitApplication([
+            'name' => 'Original Name',
+            'docker_registry_image_tag' => 'v1.0.0',
+        ]);
+
+        $response = $this->withHeaders(sourceCommitApiHeaders($this->bearerToken))
+            ->patchJson("/api/v1/applications/{$application->uuid}", [
+                'include_source_commit_in_build' => true,
+            ]);
+
+        $response->assertOk();
+
+        $application->refresh();
+        expect($application->name)->toBe('Original Name')
+            ->and($application->docker_registry_image_tag)->toBe('v1.0.0')
+            ->and($application->settings->include_source_commit_in_build)->toBeTrue();
+    });
+});


### PR DESCRIPTION
## Summary

The `include_source_commit_in_build` setting is configurable in the UI (Application → Advanced → "Include Source Commit in Build") but was rejected with `422 {"message":"Validation failed.","errors":{"include_source_commit_in_build":["This field is not allowed."]}}` when sent via `PATCH /api/v1/applications/{uuid}`.

## Changes

- Added `include_source_commit_in_build` to `$allowedFields` in `ApplicationsController::update_by_uuid()`
- Added handler to extract the value and save it to `application.settings`, following the same pattern as other boolean settings (`use_build_server`, `is_preserve_repository_enabled`, etc.)
- Added feature tests covering enable, disable, and no side-effects on other fields

## Testing

```
PATCH /api/v1/applications/{uuid}
{"include_source_commit_in_build": true}
→ 200 OK, setting persisted
```

Fixes #10280