### PR TITLE
fix: prevent invitation link session invalidation

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -140,9 +140,6 @@ class Controller extends BaseController
                 $invitation->delete();
 
                 Auth::login($user);
-                $user->forceFill([
-                    'password' => Hash::make(Str::random(64)),
-                ])->save();
                 session(['currentTeam' => $team]);
 
                 return redirect()->route('dashboard');


### PR DESCRIPTION
## Problem

Invitation links redirect immediately to `/login` instead of letting the invited user set up their account (issue #10633).

## Root Cause

The magic-link flow in `Controller::link()` destroys the user password immediately after `Auth::login()`:

```php
Auth::login($user);
$user->forceFill(['password' => Hash::make(Str::random(64))])->save();
```

The `User` model uses the `DeletesUserSessions` trait, which hooks into `static::updated` and calls `deleteAllSessions()` whenever the password changes. This deletes the session that was just created by `Auth::login()`, so the redirect response carries a cookie pointing to a non-existent session. The next request sees an unauthenticated user and redirects to `/login`.

## Fix

Remove the password destruction from `Controller::link()`. Three lines deleted, no new code.

This is safe because:

- **One-time-use is already guaranteed** — the invitation record is deleted before `Auth::login()`, and `Hash::check()` validates the token password on each attempt
- **The password does get changed** — the `force_password_reset` flag is still `true`, so `CheckForcePasswordReset` middleware redirects to the `ForcePasswordReset` component where the user sets their own password
- **No replay risk** — without a valid invitation record, the token cannot be reused

## Testing

1. Invite a new team member (generate link or send email)
2. Open the invitation link in a new browser session
3. Before fix: redirects to `/login` with no way to proceed
4. After fix: redirects to force-password-reset page where the user sets their password and completes onboarding

Fixes #10633