### PR TITLE
fix: twenty worker fails to start due to duplicate service URL

### DIFF
--- a/templates/compose/twenty.yaml
+++ b/templates/compose/twenty.yaml
@@ -50,10 +50,10 @@ services:
         - curl
         - '-f'
         - 'http://127.0.0.1:3000/healthz'
-      interval: 2s
-      timeout: 5s
-      retries: 10
-      start_period: 30s
+      interval: 5s
+      timeout: 10s
+      retries: 30
+      start_period: 120s
     depends_on:
       postgres:
         condition: service_healthy
@@ -64,7 +64,6 @@ services:
     volumes:
       - twenty-local-storage:/app/packages/twenty-server/.local-storage
     environment:
-      - SERVICE_URL_TWENTY_3000
       - SERVER_URL=${SERVICE_URL_TWENTY}
       - FRONT_BASE_URL=${SERVICE_URL_TWENTY}
       - APP_SECRET=${SERVICE_BASE64_32_SECRET}
@@ -110,7 +109,7 @@ services:
       timeout: 5s
       retries: 3
       start_period: 30s
-      
+
   postgres:
     image: postgres:16-alpine
     environment:


### PR DESCRIPTION
## What this fixes

A clean one-click deploy of the **Twenty** template fails: the `worker` container aborts with `dependency twenty failed to start: container twenty-... is unhealthy`, and even when the stack does eventually come up, the main app returns intermittent 502/504s through the proxy. This is the problem reported in #8381 (reproduced by several others in that thread).

## Root cause

Two independent problems in `templates/compose/twenty.yaml`:

1. **`SERVICE_URL_TWENTY_3000` is set on the `worker` service.** This makes Coolify generate a domain + proxy router for the worker on port 3000. But the worker runs `yarn worker:prod` and never starts an HTTP server on 3000, so the proxy ends up with a second, dead backend registered under the same host/port as the main `twenty` app — which is what produces the intermittent 502/504s. That variable is only meaningful for the `twenty` service (which actually serves on 3000), so it should not be on the worker.

2. **The `twenty` healthcheck is too aggressive for the first boot.** With `ENABLE_DB_MIGRATIONS=true`, the very first start runs all database migrations before the server opens port 3000. On a small VPS this takes well over two minutes, but the template allows only `start_period: 30s` with `retries: 10`. The container is marked `unhealthy`, and because `worker` has `depends_on: { twenty: { condition: service_healthy } }`, the whole deploy aborts.

## The change

- Remove `- SERVICE_URL_TWENTY_3000` from the **worker** `environment` (kept on `twenty`, where it is correct and needed).
- Relax the **twenty** healthcheck to `interval: 5s`, `timeout: 10s`, `retries: 30`, `start_period: 120s`, giving the first-boot migrations enough time to finish before the readiness probe gives up.

No other services or variables are touched.

## How to test

1. On Coolify v4.1.1 (Traefik), deploy the stock Twenty template on a modest VPS → `worker` aborts with `dependency twenty failed to start`, as in #8381.
2. Apply this template → all four containers (`twenty`, `worker`, `postgres`, `redis`) reach `healthy`, `/healthz` returns 200 through the proxy, and onboarding (workspace activation) completes without the intermittent 502/504s.

Verified on Coolify v4.1.1 with Traefik 3.6 on a Hetzner VPS.

## Breaking changes

None. Existing deployments are unaffected — the change only drops an unused router for the worker and lengthens the first-boot grace period.

Fixes #8381