### PR TITLE
chore(ci): gate docs reminder comments on "Waiting for Docs PR" label

### DIFF
--- a/.github/workflows/chore-pr-comments.yml
+++ b/.github/workflows/chore-pr-comments.yml
@@ -40,7 +40,10 @@ jobs:
           #    This will help ensure that our documentation remains accurate and up-to-date for all users.
     steps:
       - name: Add comment
-        if: github.event.label.name == matrix.label
+        if: >-
+          (github.event.label.name == matrix.label || github.event.label.name == '📑 Waiting for Docs PR')
+          && contains(github.event.pull_request.labels.*.name, matrix.label)
+          && contains(github.event.pull_request.labels.*.name, '📑 Waiting for Docs PR')
         run: gh pr comment "$NUMBER" --body "$BODY"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Right now adding Service or Feature labels to PR makes github action bot to comment a reminder message to send PR to docs repo but most of the time it's needed since the PR is for fixing existing stuff so gating the comment on "Waiting for Docs PR" label gives us more control over when the reminder comment is sent