### PR TITLE
fix: accept underscores in domain hostnames for API URL validation

### DIFF
--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -1084,7 +1084,7 @@ class ApplicationsController extends Controller
 
                 $errors = [];
                 $urls = $urls->map(function ($url) use (&$errors) {
-                    if (! filter_var($url, FILTER_VALIDATE_URL)) {
+                    if (! isValidDomainUrl($url)) {
                         $errors[] = "Invalid URL: {$url}";
 
                         return $url;
@@ -1325,7 +1325,7 @@ class ApplicationsController extends Controller
 
                 $errors = [];
                 $urls = $urls->map(function ($url) use (&$errors) {
-                    if (! filter_var($url, FILTER_VALIDATE_URL)) {
+                    if (! isValidDomainUrl($url)) {
                         $errors[] = "Invalid URL: {$url}";
 
                         return $url;
@@ -1538,7 +1538,7 @@ class ApplicationsController extends Controller
 
                 $errors = [];
                 $urls = $urls->map(function ($url) use (&$errors) {
-                    if (! filter_var($url, FILTER_VALIDATE_URL)) {
+                    if (! isValidDomainUrl($url)) {
                         $errors[] = "Invalid URL: {$url}";
 
                         return $url;
@@ -2490,7 +2490,7 @@ class ApplicationsController extends Controller
                     return null;
                 }
 
-                if (! filter_var($url, FILTER_VALIDATE_URL)) {
+                if (! isValidDomainUrl($url)) {
                     $errors[] = 'Invalid URL: '.$url;
 
                     return $url;
@@ -2553,7 +2553,7 @@ class ApplicationsController extends Controller
 
             $errors = [];
             $urls = $urls->map(function ($url) use (&$errors) {
-                if (! filter_var($url, FILTER_VALIDATE_URL)) {
+                if (! isValidDomainUrl($url)) {
                     $errors[] = "Invalid URL: {$url}";
 
                     return $url;
@@ -3866,7 +3866,7 @@ class ApplicationsController extends Controller
                     return null;
                 }
 
-                if (! filter_var($url, FILTER_VALIDATE_URL)) {
+                if (! isValidDomainUrl($url)) {
                     $errors[] = 'Invalid URL: '.$url;
 
                     return str($url)->lower();

--- a/app/Http/Controllers/Api/ServicesController.php
+++ b/app/Http/Controllers/Api/ServicesController.php
@@ -57,7 +57,7 @@ class ServicesController extends Controller
         });
 
         $urls = $urls->map(function ($url) use (&$errors) {
-            if (! filter_var($url, FILTER_VALIDATE_URL)) {
+            if (! isValidDomainUrl($url)) {
                 $errors[] = "Invalid URL: {$url}";
 
                 return $url;

--- a/bootstrap/helpers/domains.php
+++ b/bootstrap/helpers/domains.php
@@ -4,6 +4,16 @@ use App\Models\Application;
 use App\Models\ServiceApplication;
 use Illuminate\Support\Collection;
 
+function isValidDomainUrl(string $url): bool
+{
+    // PHP's FILTER_VALIDATE_URL rejects underscores in the host, but they are
+    // accepted by browsers, Let's Encrypt, and common Docker service naming
+    // (e.g. https://myapp_service.example.com). Validate against a copy with
+    // underscores replaced by hyphens (a valid host character) so such domains
+    // are not wrongly rejected; URLs without underscores are unaffected.
+    return filter_var(str_replace('_', '-', $url), FILTER_VALIDATE_URL) !== false;
+}
+
 function checkDomainUsage(ServiceApplication|Application|null $resource = null, ?string $domain = null)
 {
     $conflicts = [];

--- a/tests/Unit/IsValidDomainUrlTest.php
+++ b/tests/Unit/IsValidDomainUrlTest.php
@@ -1,0 +1,22 @@
+<?php
+
+it('accepts hostnames containing underscores', function () {
+    // Regression: PHP's FILTER_VALIDATE_URL rejects underscores in the host,
+    // which blocked valid service domains (e.g. Docker service naming) from
+    // being saved and getting Let's Encrypt certificates. See issue #10597.
+    expect(isValidDomainUrl('https://myapp_service.example.com'))->toBeTrue();
+    expect(isValidDomainUrl('http://my_app.example.com'))->toBeTrue();
+    expect(isValidDomainUrl('https://a_b_c.example.com/path'))->toBeTrue();
+});
+
+it('accepts ordinary domains and URLs', function () {
+    expect(isValidDomainUrl('https://example.com'))->toBeTrue();
+    expect(isValidDomainUrl('http://sub.example.com:8080/path?q=1'))->toBeTrue();
+    expect(isValidDomainUrl('https://example.com/a_b'))->toBeTrue();
+});
+
+it('rejects strings that are not valid URLs', function () {
+    expect(isValidDomainUrl('not a url'))->toBeFalse();
+    expect(isValidDomainUrl('example.com'))->toBeFalse();
+    expect(isValidDomainUrl(''))->toBeFalse();
+});


### PR DESCRIPTION
## Changes

PHP's `FILTER_VALIDATE_URL` rejects underscores in the host portion of a URL, so a service domain such as https://myapp_service.example.com was rejected with "Invalid URL" by the API. The domain could not be saved, Traefik never generated config for it, and the service fell back to a self-signed certificate instead of requesting Let's Encrypt, leaving it unreachable over HTTPS. Underscores are accepted by browsers and Let's Encrypt and are common in Docker service naming.

This adds a small `isValidDomainUrl()` helper in bootstrap/helpers/domains.php that validates the URL after replacing underscores with hyphens (a valid host character), and routes the docker_compose_domains and fqdn/domain validation in the Applications and Services API controllers through it. URLs without underscores are unaffected, and the existing http/https scheme checks are left unchanged.

## Issues

- Fixes #10597

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable — backend API/validation change, no UI. Behaviour change: a PATCH to /api/v1/applications/{uuid} with a domain containing an underscore is now accepted instead of returning an "Invalid URL" validation error.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [ ] AI was used (please describe below)

**If AI was used:**

- Tools used:
- How extensively:

## Testing

Validated with unit tests in tests/Unit/IsValidDomainUrlTest.php covering underscore hostnames, ordinary domains/URLs, and invalid inputs; these run as part of the existing Pest suite in CI. Also verified on a local development instance: a service domain containing an underscore now saves successfully instead of being rejected with "Invalid URL". Underscore-free URLs are unaffected.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
