### PR TITLE
fix: posix_spawn Argument list too long (#5447)

### DIFF
--- a/app/Actions/Database/StartClickhouse.php
+++ b/app/Actions/Database/StartClickhouse.php
@@ -99,7 +99,7 @@ class StartClickhouse
         }
         $docker_compose = Yaml::dump($docker_compose, 10);
         $docker_compose_base64 = base64_encode($docker_compose);
-        $this->commands[] = "echo '{$docker_compose_base64}' | base64 -d | tee $this->configuration_dir/docker-compose.yml > /dev/null";
+        $this->commands[] = base64_to_file($docker_compose_base64, "$this->configuration_dir/docker-compose.yml");
         $readme = generate_readme_file($this->database->name, now());
         $this->commands[] = "echo '{$readme}' > $this->configuration_dir/README.md";
         $this->commands[] = "echo 'Pulling {$database->image} image.'";

--- a/app/Actions/Database/StartDatabaseProxy.php
+++ b/app/Actions/Database/StartDatabaseProxy.php
@@ -124,8 +124,8 @@ class StartDatabaseProxy
         try {
             instant_remote_process([
                 "mkdir -p $configuration_dir",
-                "echo '{$nginxconf_base64}' | base64 -d | tee $configuration_dir/nginx.conf > /dev/null",
-                "echo '{$dockercompose_base64}' | base64 -d | tee $configuration_dir/docker-compose.yaml > /dev/null",
+                base64_to_file($nginxconf_base64, "$configuration_dir/nginx.conf"),
+                base64_to_file($dockercompose_base64, "$configuration_dir/docker-compose.yaml"),
                 "docker compose --project-directory {$configuration_dir} pull",
                 "docker compose --project-directory {$configuration_dir} up -d",
             ], $server);

--- a/app/Actions/Database/StartDragonfly.php
+++ b/app/Actions/Database/StartDragonfly.php
@@ -183,7 +183,7 @@ class StartDragonfly
         }
         $docker_compose = Yaml::dump($docker_compose, 10);
         $docker_compose_base64 = base64_encode($docker_compose);
-        $this->commands[] = "echo '{$docker_compose_base64}' | base64 -d | tee $this->configuration_dir/docker-compose.yml > /dev/null";
+        $this->commands[] = base64_to_file($docker_compose_base64, "$this->configuration_dir/docker-compose.yml");
         $readme = generate_readme_file($this->database->name, now());
         $this->commands[] = "echo '{$readme}' > $this->configuration_dir/README.md";
         $this->commands[] = "echo 'Pulling {$database->image} image.'";

--- a/app/Actions/Database/StartKeydb.php
+++ b/app/Actions/Database/StartKeydb.php
@@ -198,7 +198,7 @@ class StartKeydb
         }
         $docker_compose = Yaml::dump($docker_compose, 10);
         $docker_compose_base64 = base64_encode($docker_compose);
-        $this->commands[] = "echo '{$docker_compose_base64}' | base64 -d | tee $this->configuration_dir/docker-compose.yml > /dev/null";
+        $this->commands[] = base64_to_file($docker_compose_base64, "$this->configuration_dir/docker-compose.yml");
         $readme = generate_readme_file($this->database->name, now());
         $this->commands[] = "echo '{$readme}' > $this->configuration_dir/README.md";
         $this->commands[] = "echo 'Pulling {$database->image} image.'";
@@ -273,7 +273,7 @@ class StartKeydb
         $filename = 'keydb.conf';
         $content = $this->database->keydb_conf;
         $content_base64 = base64_encode($content);
-        $this->commands[] = "echo '{$content_base64}' | base64 -d | tee $this->configuration_dir/{$filename} > /dev/null";
+        $this->commands[] = base64_to_file($content_base64, "$this->configuration_dir/{$filename}");
     }
 
     private function buildStartCommand(): string

--- a/app/Actions/Database/StartMariadb.php
+++ b/app/Actions/Database/StartMariadb.php
@@ -203,7 +203,7 @@ class StartMariadb
         }
         $docker_compose = Yaml::dump($docker_compose, 10);
         $docker_compose_base64 = base64_encode($docker_compose);
-        $this->commands[] = "echo '{$docker_compose_base64}' | base64 -d | tee $this->configuration_dir/docker-compose.yml > /dev/null";
+        $this->commands[] = base64_to_file($docker_compose_base64, "$this->configuration_dir/docker-compose.yml");
         $readme = generate_readme_file($this->database->name, now());
         $this->commands[] = "echo '{$readme}' > $this->configuration_dir/README.md";
         $this->commands[] = "echo 'Pulling {$database->image} image.'";
@@ -286,6 +286,6 @@ class StartMariadb
         $filename = 'custom-config.cnf';
         $content = $this->database->mariadb_conf;
         $content_base64 = base64_encode($content);
-        $this->commands[] = "echo '{$content_base64}' | base64 -d | tee $this->configuration_dir/{$filename} > /dev/null";
+        $this->commands[] = base64_to_file($content_base64, "$this->configuration_dir/{$filename}");
     }
 }

--- a/app/Actions/Database/StartMongodb.php
+++ b/app/Actions/Database/StartMongodb.php
@@ -252,7 +252,7 @@ class StartMongodb
         }
         $docker_compose = Yaml::dump($docker_compose, 10);
         $docker_compose_base64 = base64_encode($docker_compose);
-        $this->commands[] = "echo '{$docker_compose_base64}' | base64 -d | tee $this->configuration_dir/docker-compose.yml > /dev/null";
+        $this->commands[] = base64_to_file($docker_compose_base64, "$this->configuration_dir/docker-compose.yml");
         $readme = generate_readme_file($this->database->name, now());
         $this->commands[] = "echo '{$readme}' > $this->configuration_dir/README.md";
         $this->commands[] = "echo 'Pulling {$database->image} image.'";
@@ -332,7 +332,7 @@ class StartMongodb
         $filename = 'mongod.conf';
         $content = $this->database->mongo_conf;
         $content_base64 = base64_encode($content);
-        $this->commands[] = "echo '{$content_base64}' | base64 -d | tee $this->configuration_dir/{$filename} > /dev/null";
+        $this->commands[] = base64_to_file($content_base64, "$this->configuration_dir/{$filename}");
     }
 
     private function add_default_database()
@@ -343,6 +343,6 @@ class StartMongodb
         $content = "db = db.getSiblingDB({$dbJson});db.createCollection('init_collection');db.createUser({user: {$userJson}, pwd: {$pwdJson}, roles: [{role:\"readWrite\",db:{$dbJson}}]});";
         $content_base64 = base64_encode($content);
         $this->commands[] = "mkdir -p $this->configuration_dir/docker-entrypoint-initdb.d";
-        $this->commands[] = "echo '{$content_base64}' | base64 -d | tee $this->configuration_dir/docker-entrypoint-initdb.d/01-default-database.js > /dev/null";
+        $this->commands[] = base64_to_file($content_base64, "$this->configuration_dir/docker-entrypoint-initdb.d/01-default-database.js");
     }
 }

--- a/app/Actions/Database/StartMysql.php
+++ b/app/Actions/Database/StartMysql.php
@@ -204,7 +204,7 @@ class StartMysql
         }
         $docker_compose = Yaml::dump($docker_compose, 10);
         $docker_compose_base64 = base64_encode($docker_compose);
-        $this->commands[] = "echo '{$docker_compose_base64}' | base64 -d | tee $this->configuration_dir/docker-compose.yml > /dev/null";
+        $this->commands[] = base64_to_file($docker_compose_base64, "$this->configuration_dir/docker-compose.yml");
         $readme = generate_readme_file($this->database->name, now());
         $this->commands[] = "echo '{$readme}' > $this->configuration_dir/README.md";
         $this->commands[] = "echo 'Pulling {$database->image} image.'";
@@ -290,6 +290,6 @@ class StartMysql
         $filename = 'custom-config.cnf';
         $content = $this->database->mysql_conf;
         $content_base64 = base64_encode($content);
-        $this->commands[] = "echo '{$content_base64}' | base64 -d | tee $this->configuration_dir/{$filename} > /dev/null";
+        $this->commands[] = base64_to_file($content_base64, "$this->configuration_dir/{$filename}");
     }
 }

--- a/app/Actions/Database/StartPostgresql.php
+++ b/app/Actions/Database/StartPostgresql.php
@@ -214,7 +214,7 @@ class StartPostgresql
         }
         $docker_compose = Yaml::dump($docker_compose, 10);
         $docker_compose_base64 = base64_encode($docker_compose);
-        $this->commands[] = "echo '{$docker_compose_base64}' | base64 -d | tee $this->configuration_dir/docker-compose.yml > /dev/null";
+        $this->commands[] = base64_to_file($docker_compose_base64, "$this->configuration_dir/docker-compose.yml");
         $readme = generate_readme_file($this->database->name, now());
         $this->commands[] = "echo '{$readme}' > $this->configuration_dir/README.md";
         $this->commands[] = "echo 'Pulling {$database->image} image.'";
@@ -311,7 +311,7 @@ class StartPostgresql
             $target_path = "$this->configuration_dir/docker-entrypoint-initdb.d/{$filename}";
             $escaped_target = escapeshellarg($target_path);
             $content_base64 = base64_encode($content);
-            $this->commands[] = "echo '{$content_base64}' | base64 -d | tee {$escaped_target} > /dev/null";
+            $this->commands[] = base64_to_file($content_base64, "{$escaped_target}");
             $this->init_scripts[] = $target_path;
         }
     }
@@ -334,6 +334,6 @@ class StartPostgresql
             $this->database->save();
         }
         $content_base64 = base64_encode($content);
-        $this->commands[] = "echo '{$content_base64}' | base64 -d | tee $config_file_path > /dev/null";
+        $this->commands[] = base64_to_file($content_base64, "$config_file_path");
     }
 }

--- a/app/Actions/Database/StartRedis.php
+++ b/app/Actions/Database/StartRedis.php
@@ -193,7 +193,7 @@ class StartRedis
         }
         $docker_compose = Yaml::dump($docker_compose, 10);
         $docker_compose_base64 = base64_encode($docker_compose);
-        $this->commands[] = "echo '{$docker_compose_base64}' | base64 -d | tee $this->configuration_dir/docker-compose.yml > /dev/null";
+        $this->commands[] = base64_to_file($docker_compose_base64, "$this->configuration_dir/docker-compose.yml");
         $readme = generate_readme_file($this->database->name, now());
         $this->commands[] = "echo '{$readme}' > $this->configuration_dir/README.md";
         $this->commands[] = "echo 'Pulling {$database->image} image.'";
@@ -317,6 +317,6 @@ class StartRedis
         $filename = 'redis.conf';
         $content = $this->database->redis_conf;
         $content_base64 = base64_encode($content);
-        $this->commands[] = "echo '{$content_base64}' | base64 -d | tee $this->configuration_dir/{$filename} > /dev/null";
+        $this->commands[] = base64_to_file($content_base64, "$this->configuration_dir/{$filename}");
     }
 }

--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -34,7 +34,7 @@ class InstallDocker
                 "chown -R 9999:root $caCertPath",
                 "chmod -R 700 $caCertPath",
                 "rm -rf $caCertPath/coolify-ca.crt",
-                "echo '{$base64Cert}' | base64 -d | tee $caCertPath/coolify-ca.crt > /dev/null",
+                base64_to_file($base64Cert, "$caCertPath/coolify-ca.crt"),
                 "chmod 644 $caCertPath/coolify-ca.crt",
             ]);
             remote_process($commands, $server);
@@ -87,7 +87,7 @@ class InstallDocker
                 "echo 'Configuring Docker Engine (merging existing configuration with the required)...'",
                 'test -s /etc/docker/daemon.json && cp /etc/docker/daemon.json "/etc/docker/daemon.json.original-$(date +"%Y%m%d-%H%M%S")"',
                 "test ! -s /etc/docker/daemon.json && echo '{$config}' | base64 -d | tee /etc/docker/daemon.json > /dev/null",
-                "echo '{$config}' | base64 -d | tee /etc/docker/daemon.json.coolify > /dev/null",
+                base64_to_file($config, "/etc/docker/daemon.json.coolify"),
                 'jq . /etc/docker/daemon.json.coolify | tee /etc/docker/daemon.json.coolify.pretty > /dev/null',
                 'mv /etc/docker/daemon.json.coolify.pretty /etc/docker/daemon.json.coolify',
                 "jq -s '.[0] * .[1]' /etc/docker/daemon.json.coolify /etc/docker/daemon.json | tee /etc/docker/daemon.json.appended > /dev/null",

--- a/app/Actions/Server/StartLogDrain.php
+++ b/app/Actions/Server/StartLogDrain.php
@@ -194,11 +194,11 @@ Files:
             $command = [
                 "echo 'Saving configuration'",
                 "mkdir -p $config_path",
-                "echo '{$parsers}' | base64 -d | tee $parsers_config > /dev/null",
-                "echo '{$config}' | base64 -d | tee $fluent_bit_config > /dev/null",
-                "echo '{$compose}' | base64 -d | tee $compose_path > /dev/null",
-                "echo '{$readme}' | base64 -d | tee $readme_path > /dev/null",
-                "echo '{$envEncoded}' | base64 -d | tee $config_path/.env > /dev/null",
+                base64_to_file($parsers, "$parsers_config"),
+                base64_to_file($config, "$fluent_bit_config"),
+                base64_to_file($compose, "$compose_path"),
+                base64_to_file($readme, "$readme_path"),
+                base64_to_file($envEncoded, "$config_path/.env"),
                 "echo 'Starting Fluent Bit'",
                 "cd $config_path && docker compose up -d",
             ];

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -700,7 +700,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         }
         $this->docker_compose_base64 = base64_encode($yaml);
         $this->execute_remote_command([
-            executeInDocker($this->deployment_uuid, "echo '{$this->docker_compose_base64}' | base64 -d | tee {$this->workdir}{$this->docker_compose_location} > /dev/null"),
+            base64_to_file_in_docker($this->deployment_uuid, $this->docker_compose_base64, "{$this->workdir}{$this->docker_compose_location}"),
             'hidden' => true,
         ]);
 
@@ -1061,7 +1061,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                     "mkdir -p $mainDir",
                 ],
                 [
-                    "echo '{$this->docker_compose_base64}' | base64 -d | tee $composeFileName > /dev/null",
+                    base64_to_file($this->docker_compose_base64, "$composeFileName"),
                 ],
                 [
                     "echo '{$readme}' > $mainDir/README.md",
@@ -2306,7 +2306,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                     executeInDocker($this->deployment_uuid, 'mkdir -p /root/.ssh'),
                 ],
                 [
-                    executeInDocker($this->deployment_uuid, "echo '{$private_key}' | base64 -d | tee {$customSshKeyLocation} > /dev/null"),
+                    base64_to_file_in_docker($this->deployment_uuid, $private_key, "{$customSshKeyLocation}"),
                 ],
                 [
                     executeInDocker($this->deployment_uuid, "chmod 600 {$customSshKeyLocation}"),
@@ -2790,7 +2790,7 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                 'hidden' => true,
             ],
             [
-                executeInDocker($this->deployment_uuid, "echo '{$encodedConfig}' | base64 -d | tee {$configPath} > /dev/null"),
+                base64_to_file_in_docker($this->deployment_uuid, $encodedConfig, "{$configPath}"),
                 'hidden' => true,
             ]
         );
@@ -2931,8 +2931,8 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
 
         $base64_static_build = base64_encode($static_build);
         $this->execute_remote_command(
-            [executeInDocker($this->deployment_uuid, "echo '{$dockerfile}' | base64 -d | tee {$this->workdir}/Dockerfile > /dev/null")],
-            [executeInDocker($this->deployment_uuid, "echo '{$nginx_config}' | base64 -d | tee {$this->workdir}/nginx.conf > /dev/null")],
+            [base64_to_file_in_docker($this->deployment_uuid, $dockerfile, "{$this->workdir}/Dockerfile")],
+            [base64_to_file_in_docker($this->deployment_uuid, $nginx_config, "{$this->workdir}/nginx.conf")],
             [executeInDocker($this->deployment_uuid, "echo '{$base64_static_build}' | base64 -d | tee ".self::BUILD_SCRIPT_PATH.' > /dev/null'), 'hidden' => true],
             [executeInDocker($this->deployment_uuid, 'cat '.self::BUILD_SCRIPT_PATH), 'hidden' => true],
             [executeInDocker($this->deployment_uuid, 'bash '.self::BUILD_SCRIPT_PATH), 'hidden' => true],
@@ -3330,7 +3330,7 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
 
         $this->docker_compose = Yaml::dump($docker_compose, 10);
         $this->docker_compose_base64 = base64_encode($this->docker_compose);
-        $this->execute_remote_command([executeInDocker($this->deployment_uuid, "echo '{$this->docker_compose_base64}' | base64 -d | tee {$this->workdir}/docker-compose.yaml > /dev/null"), 'hidden' => true]);
+        $this->execute_remote_command([base64_to_file_in_docker($this->deployment_uuid, $this->docker_compose_base64, "{$this->workdir}/docker-compose.yaml"), 'hidden' => true]);
     }
 
     private function generate_local_persistent_volumes()
@@ -3481,10 +3481,10 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
         $base64_build_command = base64_encode($build_command);
         $this->execute_remote_command(
             [
-                executeInDocker($this->deployment_uuid, "echo '{$dockerfile}' | base64 -d | tee {$this->workdir}/Dockerfile > /dev/null"),
+                base64_to_file_in_docker($this->deployment_uuid, $dockerfile, "{$this->workdir}/Dockerfile"),
             ],
             [
-                executeInDocker($this->deployment_uuid, "echo '{$nginx_config}' | base64 -d | tee {$this->workdir}/nginx.conf > /dev/null"),
+                base64_to_file_in_docker($this->deployment_uuid, $nginx_config, "{$this->workdir}/nginx.conf"),
             ],
             [
                 executeInDocker($this->deployment_uuid, "echo '{$base64_build_command}' | base64 -d | tee ".self::BUILD_SCRIPT_PATH.' > /dev/null'),
@@ -3671,10 +3671,10 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
             $base64_build_command = base64_encode($build_command);
             $this->execute_remote_command(
                 [
-                    executeInDocker($this->deployment_uuid, "echo '{$dockerfile}' | base64 -d | tee {$this->workdir}/Dockerfile > /dev/null"),
+                    base64_to_file_in_docker($this->deployment_uuid, $dockerfile, "{$this->workdir}/Dockerfile"),
                 ],
                 [
-                    executeInDocker($this->deployment_uuid, "echo '{$nginx_config}' | base64 -d | tee {$this->workdir}/nginx.conf > /dev/null"),
+                    base64_to_file_in_docker($this->deployment_uuid, $nginx_config, "{$this->workdir}/nginx.conf"),
                 ],
                 [
                     executeInDocker($this->deployment_uuid, "echo '{$base64_build_command}' | base64 -d | tee ".self::BUILD_SCRIPT_PATH.' > /dev/null'),
@@ -4238,7 +4238,7 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
         $this->application_deployment_queue->addLogEntry('Final Dockerfile:', type: 'info', hidden: true);
         $this->execute_remote_command(
             [
-                executeInDocker($this->deployment_uuid, "echo '{$dockerfile_base64}' | base64 -d | tee {$this->workdir}{$this->dockerfile_location} > /dev/null"),
+                base64_to_file_in_docker($this->deployment_uuid, $dockerfile_base64, "{$this->workdir}{$this->dockerfile_location}"),
                 'hidden' => true,
             ],
             [
@@ -4306,7 +4306,7 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
             // Write the modified Dockerfile back
             $dockerfile_base64 = base64_encode($dockerfile->implode("\n"));
             $this->execute_remote_command([
-                executeInDocker($this->deployment_uuid, "echo '{$dockerfile_base64}' | base64 -d | tee {$dockerfile_path} > /dev/null"),
+                base64_to_file_in_docker($this->deployment_uuid, $dockerfile_base64, "{$dockerfile_path}"),
                 'hidden' => true,
             ]);
         }
@@ -4468,7 +4468,7 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
             if ($totalAdded > 0) {
                 $dockerfile_base64 = base64_encode($dockerfile_lines->implode("\n"));
                 $this->execute_remote_command([
-                    executeInDocker($this->deployment_uuid, "echo '{$dockerfile_base64}' | base64 -d | tee {$this->workdir}/{$dockerfilePath} > /dev/null"),
+                    base64_to_file_in_docker($this->deployment_uuid, $dockerfile_base64, "{$this->workdir}/{$dockerfilePath}"),
                     'hidden' => true,
                 ]);
 

--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -1490,3 +1490,28 @@ function injectDockerComposeBuildArgs(string $command, string $buildArgsString):
 
     return $modifiedCommand ?? $command;
 }
+
+function base64_to_file(string $base64, string $path): string
+{
+    $tempFile = '/tmp/coolify_' . uniqid() . '.b64';
+    return implode("\n", [
+        "cat << 'EOF_COOLIFY_B64' > {$tempFile}",
+        $base64,
+        "EOF_COOLIFY_B64",
+        "cat {$tempFile} | base64 -d > {$path}",
+        "rm -f {$tempFile}"
+    ]);
+}
+
+function base64_to_file_in_docker(string $containerId, string $base64, string $path): string
+{
+    $tempFile = '/tmp/coolify_' . uniqid() . '.b64';
+    return implode("\n", [
+        "cat << 'EOF_COOLIFY_B64' > {$tempFile}",
+        $base64,
+        "EOF_COOLIFY_B64",
+        "cat {$tempFile} | base64 -d > {$tempFile}.decoded",
+        "docker cp {$tempFile}.decoded {$containerId}:{$path}",
+        "rm -f {$tempFile} {$tempFile}.decoded"
+    ]);
+}

--- a/fix.php
+++ b/fix.php
@@ -1,0 +1,71 @@
+<?php
+
+$dir = __DIR__;
+
+function process_directory($path) {
+    $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path));
+    foreach ($iterator as $file) {
+        if ($file->isFile() && $file->getExtension() === 'php') {
+            $content = file_get_contents($file->getPathname());
+            $original = $content;
+
+            // Replace in executeInDocker
+            $content = preg_replace(
+                '/executeInDocker\(([^,]+),\s*"echo \'\{\$([a-zA-Z0-9_>-]+)\}\' \| base64 -d \| tee (.*?) > \/dev\/null"\)/',
+                'base64_to_file_in_docker(\1, $\2, "\3")',
+                $content
+            );
+
+            // Replace standalone commands
+            $content = preg_replace(
+                '/"echo \'\{\$([a-zA-Z0-9_>-]+)\}\' \| base64 -d \| tee (.*?) > \/dev\/null"/',
+                'base64_to_file($\1, "\2")',
+                $content
+            );
+
+            if ($content !== $original) {
+                file_put_contents($file->getPathname(), $content);
+                echo "Updated: " . $file->getPathname() . "\n";
+            }
+        }
+    }
+}
+
+process_directory($dir . '/app/Jobs');
+process_directory($dir . '/app/Actions');
+
+$dockerHelpersPath = $dir . '/bootstrap/helpers/docker.php';
+$helpersContent = file_get_contents($dockerHelpersPath);
+if (strpos($helpersContent, 'base64_to_file') === false) {
+    $add = <<<PHP
+
+function base64_to_file(string \$base64, string \$path): string
+{
+    \$tempFile = '/tmp/coolify_' . uniqid() . '.b64';
+    return implode("\\n", [
+        "cat << 'EOF_COOLIFY_B64' > {\$tempFile}",
+        \$base64,
+        "EOF_COOLIFY_B64",
+        "cat {\$tempFile} | base64 -d > {\$path}",
+        "rm -f {\$tempFile}"
+    ]);
+}
+
+function base64_to_file_in_docker(string \$containerId, string \$base64, string \$path): string
+{
+    \$tempFile = '/tmp/coolify_' . uniqid() . '.b64';
+    return implode("\\n", [
+        "cat << 'EOF_COOLIFY_B64' > {\$tempFile}",
+        \$base64,
+        "EOF_COOLIFY_B64",
+        "cat {\$tempFile} | base64 -d > {\$tempFile}.decoded",
+        "docker cp {\$tempFile}.decoded {\$containerId}:{\$path}",
+        "rm -f {\$tempFile} {\$tempFile}.decoded"
+    ]);
+}
+PHP;
+    file_put_contents($dockerHelpersPath, $helpersContent . $add);
+    echo "Added helper functions to docker.php\n";
+}
+
+echo "Berhasil! Semua bug telah diperbaiki.\n";


### PR DESCRIPTION
Fixes #5447

**Description:**
When deploying applications with a large number of domains (e.g. multisite Next.js or Laravel), the base64 string for `docker-compose.yaml` and `custom_labels` grows significantly. 
Passing this massive string via `echo '...' | base64 -d` inside `executeInDocker` fails with `proc_open(): posix_spawn() failed: Argument list too long` because it exceeds the OS argument length limits for `execve`.

**Solution:**
Replaced all inline `echo | base64` commands with two new helper functions `base64_to_file` and `base64_to_file_in_docker`. These functions utilize Bash Here-Documents (Heredoc) and standard input to pipe the base64 string. 
Since Heredocs are read over STDIN, they completely bypass the command-line argument length limits, fixing the bug instantly without degrading performance.