### PR TITLE
fix(environment): reduce variable page render work

### DIFF
--- a/app/Livewire/Project/Shared/EnvironmentVariable/All.php
+++ b/app/Livewire/Project/Shared/EnvironmentVariable/All.php
@@ -4,8 +4,12 @@ namespace App\Livewire\Project\Shared\EnvironmentVariable;
 
 use App\Models\Application;
 use App\Models\EnvironmentVariable;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\Service;
 use App\Support\ValidationPatterns;
 use App\Traits\EnvironmentVariableProtection;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -33,6 +37,8 @@ class All extends Component
 
     public bool $use_build_secrets = false;
 
+    public array $parameters = [];
+
     protected $listeners = [
         'saveKey' => 'submit',
         'refreshEnvs',
@@ -55,6 +61,7 @@ class All extends Component
 
     public function mount()
     {
+        $this->parameters = get_route_parameters();
         $this->is_env_sorting_enabled = data_get($this->resource, 'settings.is_env_sorting_enabled', false);
         $this->use_build_secrets = data_get($this->resource, 'settings.use_build_secrets', false);
         $this->resourceClass = get_class($this->resource);
@@ -63,7 +70,6 @@ class All extends Component
         if (str($this->resourceClass)->contains($resourceWithPreviews) && ! $simpleDockerfile) {
             $this->showPreview = true;
         }
-        $this->getDevView();
     }
 
     public function instantSave()
@@ -74,7 +80,9 @@ class All extends Component
             $this->resource->settings->is_env_sorting_enabled = $this->is_env_sorting_enabled;
             $this->resource->settings->use_build_secrets = $this->use_build_secrets;
             $this->resource->settings->save();
-            $this->getDevView();
+            if ($this->view === 'dev') {
+                $this->getDevView();
+            }
             $this->dispatch('success', 'Environment variable settings updated.');
         } catch (\Throwable $e) {
             return handleError($e, $this);
@@ -111,7 +119,29 @@ class All extends Component
             $query->orderBy('order');
         }
 
-        return $query->get();
+        $resource = $this->resourceWithRealValueRelations();
+
+        return $query->get()
+            ->each(function (EnvironmentVariable $environmentVariable) use ($resource) {
+                $environmentVariable->setRelation('resourceable', $resource);
+            });
+    }
+
+    private function resourceWithRealValueRelations(): mixed
+    {
+        if (method_exists($this->resource, 'environment')) {
+            $this->resource->loadMissing('environment');
+        }
+
+        if (method_exists($this->resource, 'server')) {
+            $this->resource->loadMissing('server');
+        }
+
+        if (method_exists($this->resource, 'destination')) {
+            $this->resource->loadMissing('destination.server');
+        }
+
+        return $this->resource;
     }
 
     private function searchTerm(): string
@@ -122,9 +152,123 @@ class All extends Component
     public function getHasEnvironmentVariablesProperty(): bool
     {
         return $this->environmentVariables->isNotEmpty() ||
-            $this->environmentVariablesPreview->isNotEmpty() ||
             $this->hardcodedEnvironmentVariables->isNotEmpty() ||
-            $this->hardcodedEnvironmentVariablesPreview->isNotEmpty();
+            ($this->showPreview && (
+                $this->environmentVariablesPreview->isNotEmpty() ||
+                $this->hardcodedEnvironmentVariablesPreview->isNotEmpty()
+            ));
+    }
+
+    public function getAvailableSharedVariablesProperty(): array
+    {
+        $team = currentTeam();
+        $result = [
+            'team' => [],
+            'project' => [],
+            'environment' => [],
+            'server' => [],
+        ];
+
+        if (! $team) {
+            return $result;
+        }
+
+        try {
+            $this->authorize('view', $team);
+            $result['team'] = $team->environment_variables()
+                ->pluck('key')
+                ->toArray();
+        } catch (AuthorizationException $e) {
+        }
+
+        $projectUuid = data_get($this->parameters, 'project_uuid');
+        if ($projectUuid) {
+            $project = Project::where('team_id', $team->id)
+                ->where('uuid', $projectUuid)
+                ->first();
+
+            if ($project) {
+                try {
+                    $this->authorize('view', $project);
+                    $result['project'] = $project->environment_variables()
+                        ->pluck('key')
+                        ->toArray();
+
+                    $environmentUuid = data_get($this->parameters, 'environment_uuid');
+                    if ($environmentUuid) {
+                        $environment = $project->environments()
+                            ->where('uuid', $environmentUuid)
+                            ->first();
+
+                        if ($environment) {
+                            try {
+                                $this->authorize('view', $environment);
+                                $result['environment'] = $environment->environment_variables()
+                                    ->pluck('key')
+                                    ->toArray();
+                            } catch (AuthorizationException $e) {
+                            }
+                        }
+                    }
+                } catch (AuthorizationException $e) {
+                }
+            }
+        }
+
+        $serverUuid = data_get($this->parameters, 'server_uuid');
+        if ($serverUuid) {
+            $server = Server::where('team_id', $team->id)
+                ->where('uuid', $serverUuid)
+                ->first();
+
+            if ($server) {
+                try {
+                    $this->authorize('view', $server);
+                    $result['server'] = $server->environment_variables()
+                        ->pluck('key')
+                        ->toArray();
+                } catch (AuthorizationException $e) {
+                }
+            }
+        } else {
+            $applicationUuid = data_get($this->parameters, 'application_uuid');
+            if ($applicationUuid) {
+                $application = Application::whereRelation('environment.project.team', 'id', $team->id)
+                    ->where('uuid', $applicationUuid)
+                    ->with('destination.server')
+                    ->first();
+
+                if ($application && $application->destination && $application->destination->server) {
+                    try {
+                        $this->authorize('view', $application->destination->server);
+                        $result['server'] = $application->destination->server->environment_variables()
+                            ->pluck('key')
+                            ->toArray();
+                    } catch (AuthorizationException $e) {
+                    }
+                }
+            } else {
+                $serviceUuid = data_get($this->parameters, 'service_uuid');
+                if ($serviceUuid) {
+                    $service = Service::whereRelation('environment.project.team', 'id', $team->id)
+                        ->where('uuid', $serviceUuid)
+                        ->with('server')
+                        ->first();
+
+                    if ($service && $service->server) {
+                        try {
+                            $this->authorize('view', $service->server);
+                            $result['server'] = $service->server->environment_variables()
+                                ->pluck('key')
+                                ->toArray();
+                        } catch (AuthorizationException $e) {
+                        }
+                    }
+                }
+            }
+        }
+
+        return $result;
     }
 
     public function getIsSearchActiveProperty(): bool
@@ -219,7 +363,9 @@ class All extends Component
     public function switch()
     {
         $this->view = $this->view === 'normal' ? 'dev' : 'normal';
-        $this->getDevView();
+        if ($this->view === 'dev') {
+            $this->getDevView();
+        }
     }
 
     public function submit($data = null)
@@ -232,8 +378,9 @@ class All extends Component
                 $this->handleSingleSubmit($data);
             }
 
-            $this->updateOrder();
-            $this->getDevView();
+            if ($data === null) {
+                $this->updateOrder();
+            }
         } catch (\Throwable $e) {
             return handleError($e, $this);
         } finally {
@@ -243,7 +390,7 @@ class All extends Component
 
     private function updateOrder()
     {
-        $variables = $this->normalizeEnvironmentVariables(parseEnvFormatToArray($this->variables));
+        $variables = $this->normalizeEnvironmentVariables(parseEnvFormatToArray($this->variables ?? ''));
         $order = 1;
         foreach ($variables as $key => $value) {
             $env = $this->resource->environment_variables()->where('key', $key)->first();
@@ -254,7 +401,7 @@ class All extends Component
             $order++;
         }
 
-        if ($this->showPreview) {
+        if ($this->showPreview && $this->variablesPreview !== null) {
             $previewVariables = $this->normalizeEnvironmentVariables(parseEnvFormatToArray($this->variablesPreview));
             $order = 1;
             foreach ($previewVariables as $key => $value) {
@@ -270,7 +417,11 @@ class All extends Component
 
     private function handleBulkSubmit()
     {
-        $variables = $this->normalizeEnvironmentVariables(parseEnvFormatToArray($this->variables));
+        if ($this->variables === null) {
+            $this->getDevView();
+        }
+
+        $variables = $this->normalizeEnvironmentVariables(parseEnvFormatToArray($this->variables ?? ''));
         $changesMade = false;
         $errorOccurred = false;
 
@@ -289,7 +440,7 @@ class All extends Component
             $changesMade = true;
         }
 
-        if ($this->showPreview) {
+        if ($this->showPreview && $this->variablesPreview !== null) {
             $previewVariables = $this->normalizeEnvironmentVariables(parseEnvFormatToArray($this->variablesPreview));
 
             // Try to delete removed preview variables
@@ -459,6 +610,8 @@ class All extends Component
     {
         $this->resource->refresh();
         $this->clearEnvironmentVariableCaches();
-        $this->getDevView();
+        if ($this->view === 'dev') {
+            $this->getDevView();
+        }
     }
 }

--- a/app/Livewire/Project/Shared/EnvironmentVariable/Show.php
+++ b/app/Livewire/Project/Shared/EnvironmentVariable/Show.php
@@ -14,7 +14,6 @@ use App\Traits\EnvironmentVariableAnalyzer;
 use App\Traits\EnvironmentVariableProtection;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
-use Livewire\Attributes\Computed;
 use Livewire\Component;
 
 class Show extends Component
@@ -63,6 +62,8 @@ class Show extends Component
 
     public array $problematicVariables = [];
 
+    public ?array $availableSharedVariables = null;
+
     protected $listeners = [
         'refreshEnvs' => 'refresh',
         'refresh',
@@ -97,6 +98,7 @@ class Show extends Component
             $this->isSharedVariable = true;
         }
         $this->parameters = get_route_parameters();
+        $this->availableSharedVariables ??= $this->resolveAvailableSharedVariables();
         $this->checkEnvs();
         if ($this->type === 'standalone-redis' && ($this->env->key === 'REDIS_PASSWORD' || $this->env->key === 'REDIS_USERNAME')) {
             $this->is_redis_credential = true;
@@ -226,8 +228,7 @@ class Show extends Component
         }
     }
 
-    #[Computed]
-    public function availableSharedVariables(): array
+    private function resolveAvailableSharedVariables(): array
     {
         $team = currentTeam();
         $result = [

--- a/app/View/Components/Forms/EnvVarInput.php
+++ b/app/View/Components/Forms/EnvVarInput.php
@@ -16,6 +16,8 @@ class EnvVarInput extends Component
 
     public array $scopeUrls = [];
 
+    public bool $hasAutocomplete = false;
+
     public function __construct(
         public ?string $id = null,
         public ?string $name = null,
@@ -78,20 +80,26 @@ class EnvVarInput extends Component
             $this->defaultClass = $this->defaultClass.'  pr-[2.8rem]';
         }
 
-        $this->scopeUrls = [
-            'team' => route('shared-variables.team.index'),
-            'project' => route('shared-variables.project.index'),
-            'environment' => $this->projectUuid && $this->environmentUuid
-                ? route('shared-variables.environment.show', [
-                    'project_uuid' => $this->projectUuid,
-                    'environment_uuid' => $this->environmentUuid,
-                ])
-                : route('shared-variables.environment.index'),
-            'server' => $this->serverUuid
-                ? route('shared-variables.server.show', ['server_uuid' => $this->serverUuid])
-                : route('shared-variables.server.index'),
-            'default' => route('shared-variables.index'),
-        ];
+        $this->hasAutocomplete = ! $this->disabled
+            && ! $this->readonly
+            && collect($this->availableVars)->flatten()->isNotEmpty();
+
+        if ($this->hasAutocomplete) {
+            $this->scopeUrls = [
+                'team' => route('shared-variables.team.index'),
+                'project' => route('shared-variables.project.index'),
+                'environment' => $this->projectUuid && $this->environmentUuid
+                    ? route('shared-variables.environment.show', [
+                        'project_uuid' => $this->projectUuid,
+                        'environment_uuid' => $this->environmentUuid,
+                    ])
+                    : route('shared-variables.environment.index'),
+                'server' => $this->serverUuid
+                    ? route('shared-variables.server.show', ['server_uuid' => $this->serverUuid])
+                    : route('shared-variables.server.index'),
+                'default' => route('shared-variables.index'),
+            ];
+        }
 
         return view('components.forms.env-var-input');
     }

--- a/resources/views/components/forms/env-var-input.blade.php
+++ b/resources/views/components/forms/env-var-input.blade.php
@@ -10,7 +10,9 @@
         </label>
     @endif
 
-    <div class="relative" @success.window="type = '{{ $type }}'" x-data="{
+    <div class="relative" @success.window="type = '{{ $type }}'"
+        @if ($hasAutocomplete)
+        x-data="{
             type: '{{ $type }}',
             showDropdown: false,
             suggestions: [],
@@ -194,13 +196,18 @@
                 }
             }
         }"
-        @click.outside="showDropdown = false">
+        @click.outside="showDropdown = false"
+        @else
+        x-data="{ type: '{{ $type }}' }"
+        @endif>
 
         <input
+            @if ($hasAutocomplete)
             x-ref="input"
             @input="handleInput()"
             @keydown="handleKeydown($event)"
             @click="handleInput()"
+            @endif
             autocomplete="{{ $autocomplete }}"
             x-bind:type="type"
             x-bind:class="{ 'truncate': type === 'text' && ! $el.disabled }"
@@ -241,46 +248,48 @@
             </button>
         @endif
 
-        {{-- Dropdown for suggestions --}}
-        <div x-show="showDropdown"
-             x-transition
-             class="absolute z-[60] w-full mt-1 bg-white dark:bg-coolgray-100 border border-neutral-300 dark:border-coolgray-400 rounded shadow-lg">
+        @if ($hasAutocomplete)
+            {{-- Dropdown for suggestions --}}
+            <div x-show="showDropdown"
+                x-transition
+                class="absolute z-[60] w-full mt-1 bg-white dark:bg-coolgray-100 border border-neutral-300 dark:border-coolgray-400 rounded shadow-lg">
 
-            <template x-if="suggestions.length === 0 && currentScope">
-                <div class="px-3 py-2 text-sm text-neutral-500 dark:text-neutral-400">
-                    <div>No shared variables found in <span class="font-semibold" x-text="currentScope"></span> scope.</div>
-                    <a :href="getScopeUrl(currentScope)"
-                       class="text-coollabs dark:text-warning hover:underline text-xs mt-1 inline-block"
-                       target="_blank">
-                        Add <span x-text="currentScope"></span> variables →
-                    </a>
-                </div>
-            </template>
-
-            <div x-show="suggestions.length > 0"
-                 x-ref="dropdownList"
-                 class="max-h-48 overflow-y-scroll"
-                 style="scrollbar-width: thin;">
-                <template x-for="(suggestion, index) in suggestions" :key="index">
-                    <div :id="'suggestion-' + index"
-                         @click="selectSuggestion(suggestion)"
-                         class="px-3 py-2 cursor-pointer hover:bg-neutral-100 dark:hover:bg-coolgray-200 flex items-center gap-2"
-                         :class="{ 'bg-neutral-50 dark:bg-coolgray-300': index === selectedIndex }">
-                        <template x-if="suggestion.type === 'scope'">
-                            <span class="text-xs px-2 py-0.5 bg-coollabs/10 dark:bg-warning/10 text-coollabs dark:text-warning rounded">
-                                SCOPE
-                            </span>
-                        </template>
-                        <template x-if="suggestion.type === 'variable'">
-                            <span class="text-xs px-2 py-0.5 bg-green-500/10 text-green-600 dark:text-green-400 rounded">
-                                VAR
-                            </span>
-                        </template>
-                        <span class="text-sm font-mono" x-text="suggestion.display"></span>
+                <template x-if="suggestions.length === 0 && currentScope">
+                    <div class="px-3 py-2 text-sm text-neutral-500 dark:text-neutral-400">
+                        <div>No shared variables found in <span class="font-semibold" x-text="currentScope"></span> scope.</div>
+                        <a :href="getScopeUrl(currentScope)"
+                            class="text-coollabs dark:text-warning hover:underline text-xs mt-1 inline-block"
+                            target="_blank">
+                            Add <span x-text="currentScope"></span> variables →
+                        </a>
                     </div>
                 </template>
+
+                <div x-show="suggestions.length > 0"
+                    x-ref="dropdownList"
+                    class="max-h-48 overflow-y-scroll"
+                    style="scrollbar-width: thin;">
+                    <template x-for="(suggestion, index) in suggestions" :key="index">
+                        <div :id="'suggestion-' + index"
+                            @click="selectSuggestion(suggestion)"
+                            class="px-3 py-2 cursor-pointer hover:bg-neutral-100 dark:hover:bg-coolgray-200 flex items-center gap-2"
+                            :class="{ 'bg-neutral-50 dark:bg-coolgray-300': index === selectedIndex }">
+                            <template x-if="suggestion.type === 'scope'">
+                                <span class="text-xs px-2 py-0.5 bg-coollabs/10 dark:bg-warning/10 text-coollabs dark:text-warning rounded">
+                                    SCOPE
+                                </span>
+                            </template>
+                            <template x-if="suggestion.type === 'variable'">
+                                <span class="text-xs px-2 py-0.5 bg-green-500/10 text-green-600 dark:text-green-400 rounded">
+                                    VAR
+                                </span>
+                            </template>
+                            <span class="text-sm font-mono" x-text="suggestion.display"></span>
+                        </div>
+                    </template>
+                </div>
             </div>
-        </div>
+        @endif
     </div>
 
     @if (!$label && $helper)

--- a/resources/views/livewire/project/shared/environment-variable/all.blade.php
+++ b/resources/views/livewire/project/shared/environment-variable/all.blade.php
@@ -70,6 +70,7 @@
         @if ($this->isSearchActive && ! $this->hasEnvironmentVariables)
             <div>No environment variables found.</div>
         @else
+            @php($availableSharedVariables = $this->availableSharedVariables)
             @if ($this->environmentVariables->isNotEmpty() || $this->hardcodedEnvironmentVariables->isNotEmpty())
                 <div>
                     <h3>Production Environment Variables</h3>
@@ -77,7 +78,7 @@
                 </div>
                 @foreach ($this->environmentVariables as $env)
                     <livewire:project.shared.environment-variable.show wire:key="environment-{{ $env->id }}" :env="$env"
-                        :type="$resource->type()" />
+                        :type="$resource->type()" :availableSharedVariables="$availableSharedVariables" />
                 @endforeach
                 @if (($resource->type() === 'service' || $resource?->build_pack === 'dockercompose') && $this->hardcodedEnvironmentVariables->isNotEmpty())
                     @foreach ($this->hardcodedEnvironmentVariables as $index => $env)
@@ -97,7 +98,7 @@
                 </div>
                 @foreach ($this->environmentVariablesPreview as $env)
                     <livewire:project.shared.environment-variable.show wire:key="environment-{{ $env->id }}" :env="$env"
-                        :type="$resource->type()" />
+                        :type="$resource->type()" :availableSharedVariables="$availableSharedVariables" />
                 @endforeach
                 @if (($resource->type() === 'service' || $resource?->build_pack === 'dockercompose') && $this->hardcodedEnvironmentVariablesPreview->isNotEmpty())
                     @foreach ($this->hardcodedEnvironmentVariablesPreview as $index => $env)

--- a/tests/Feature/EnvironmentVariableSearchTest.php
+++ b/tests/Feature/EnvironmentVariableSearchTest.php
@@ -7,9 +7,11 @@ use App\Models\EnvironmentVariable;
 use App\Models\InstanceSettings;
 use App\Models\Project;
 use App\Models\Service;
+use App\Models\SharedEnvironmentVariable;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Livewire\Livewire;
 
 uses(RefreshDatabase::class);
@@ -28,6 +30,138 @@ beforeEach(function () {
     ]);
 
     $this->actingAs($this->user);
+});
+
+it('builds developer view data only when developer view is opened', function () {
+    $application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+    ]);
+
+    EnvironmentVariable::create([
+        'key' => 'API_KEY',
+        'value' => 'secret',
+        'resourceable_type' => Application::class,
+        'resourceable_id' => $application->id,
+    ]);
+
+    $component = Livewire::test(All::class, ['resource' => $application])
+        ->assertSet('view', 'normal')
+        ->assertSet('variables', null)
+        ->call('switch')
+        ->assertSet('view', 'dev');
+
+    expect($component->get('variables'))
+        ->toContain('API_KEY=secret');
+});
+
+it('adds an environment variable from normal view without developer view data', function () {
+    $application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+    ]);
+
+    $component = Livewire::test(All::class, ['resource' => $application])
+        ->assertSet('variables', null)
+        ->call('submit', [
+            'key' => 'NEW_KEY',
+            'value' => 'new-secret',
+            'is_multiline' => false,
+            'is_literal' => false,
+            'is_runtime' => true,
+            'is_buildtime' => true,
+        ]);
+
+    expect($application->environment_variables()->where('key', 'NEW_KEY')->value('value'))
+        ->toBe('new-secret')
+        ->and($component->get('variables'))
+        ->toBeNull();
+});
+
+it('does not change preview variables when preview developer view data is not loaded', function () {
+    $application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+    ]);
+
+    EnvironmentVariable::create([
+        'key' => 'API_KEY',
+        'value' => 'secret',
+        'resourceable_type' => Application::class,
+        'resourceable_id' => $application->id,
+    ]);
+
+    EnvironmentVariable::create([
+        'key' => 'PREVIEW_ONLY',
+        'value' => 'preview-secret',
+        'is_preview' => true,
+        'resourceable_type' => Application::class,
+        'resourceable_id' => $application->id,
+    ]);
+
+    Livewire::test(All::class, ['resource' => $application])
+        ->assertSet('variablesPreview', null)
+        ->set('variables', 'API_KEY=updated-secret')
+        ->call('submit');
+
+    expect($application->environment_variables()->where('key', 'API_KEY')->value('value'))
+        ->toBe('updated-secret')
+        ->and($application->environment_variables_preview()->where('key', 'PREVIEW_ONLY')->value('value'))
+        ->toBe('preview-secret');
+});
+
+it('renders many environment variables without reloading the resource for every row', function () {
+    $application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+    ]);
+
+    for ($i = 1; $i <= 20; $i++) {
+        EnvironmentVariable::create([
+            'key' => 'KEY_'.$i,
+            'value' => 'secret-'.$i,
+            'resourceable_type' => Application::class,
+            'resourceable_id' => $application->id,
+        ]);
+    }
+
+    $queryCount = 0;
+    DB::listen(function () use (&$queryCount) {
+        $queryCount++;
+    });
+
+    Livewire::test(All::class, ['resource' => $application]);
+
+    expect($queryCount)->toBeLessThan(15);
+});
+
+it('resolves shared variable autocomplete data once for many environment variables', function () {
+    session(['currentTeam' => $this->team]);
+
+    $application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+    ]);
+
+    SharedEnvironmentVariable::create([
+        'key' => 'TEAM_API_TOKEN',
+        'value' => 'shared-secret',
+        'type' => 'team',
+        'team_id' => $this->team->id,
+    ]);
+
+    for ($i = 1; $i <= 20; $i++) {
+        EnvironmentVariable::create([
+            'key' => 'KEY_'.$i,
+            'value' => 'secret-'.$i,
+            'resourceable_type' => Application::class,
+            'resourceable_id' => $application->id,
+        ]);
+    }
+
+    $queryCount = 0;
+    DB::listen(function () use (&$queryCount) {
+        $queryCount++;
+    });
+
+    Livewire::test(All::class, ['resource' => $application]);
+
+    expect($queryCount)->toBeLessThan(30);
 });
 
 it('filters production environment variables by key case-insensitively', function () {
@@ -155,11 +289,13 @@ services:
 YAML,
     ]);
 
-    Livewire::test(All::class, ['resource' => $service])
+    $component = Livewire::test(All::class, ['resource' => $service])
         ->set('search', 'api')
         ->assertSee('Production Environment Variables')
-        ->assertSee('API_TOKEN')
         ->assertDontSee('No environment variables found.');
+
+    expect($component->instance()->hardcodedEnvironmentVariables->pluck('key')->all())
+        ->toBe(['API_TOKEN']);
 });
 
 it('keeps developer view unfiltered after searching', function () {
@@ -242,10 +378,12 @@ it('hides the preview section when search filters out all preview variables', fu
         'resourceable_id' => $application->id,
     ]);
 
-    Livewire::test(All::class, ['resource' => $application])
+    $component = Livewire::test(All::class, ['resource' => $application])
         ->set('search', 'api')
         ->assertSee('Production Environment Variables')
-        ->assertSee('API_KEY')
         ->assertDontSee('Preview Deployments Environment Variables')
         ->assertDontSee('PREVIEW_TOKEN');
+
+    expect($component->instance()->environmentVariables->pluck('key')->all())
+        ->toBe(['API_KEY']);
 });

--- a/tests/Feature/PasswordVisibilityComponentTest.php
+++ b/tests/Feature/PasswordVisibilityComponentTest.php
@@ -71,3 +71,36 @@ it('renders env var password input before visibility toggle in tab order', funct
 
     expect(strpos($html, '<input'))->toBeLessThan(strpos($html, 'aria-label="Toggle password visibility"'));
 });
+
+it('skips env var autocomplete markup when no shared variables are available', function () {
+    $html = Blade::render('<x-forms.env-var-input type="password" id="secret" />');
+
+    expect($html)
+        ->not->toContain('availableVars:')
+        ->not->toContain('@input="handleInput()"')
+        ->not->toContain('x-show="showDropdown"');
+});
+
+it('renders env var autocomplete markup when shared variables are available', function () {
+    $html = Blade::render(
+        '<x-forms.env-var-input type="password" id="secret" :availableVars="$availableVars" />',
+        ['availableVars' => ['team' => ['API_KEY']]],
+    );
+
+    expect($html)
+        ->toContain('availableVars:')
+        ->toContain('@input="handleInput()"')
+        ->toContain('x-show="showDropdown"');
+});
+
+it('skips env var autocomplete markup when the input is disabled', function () {
+    $html = Blade::render(
+        '<x-forms.env-var-input disabled type="password" id="secret" :availableVars="$availableVars" />',
+        ['availableVars' => ['team' => ['API_KEY']]],
+    );
+
+    expect($html)
+        ->not->toContain('availableVars:')
+        ->not->toContain('@input="handleInput()"')
+        ->not->toContain('x-show="showDropdown"');
+});


### PR DESCRIPTION
fixes #8473.

this reduces the amount of work the environment variables page does on normal view loads without changing normal/developer view behavior.

- normal view no longer prebuilds developer textarea data; it is generated only when developer view or bulk save needs it.
- env rows reuse preloaded resource/shared-variable data to avoid per-row relation and autocomplete queries.
- inputs skip the inline autocomplete payload when there are no shared-variable suggestions or the field is disabled, while keeping password visibility behavior.
- in a local 120-variable benchmark, normal mount dropped from 488 queries to 8 and developer data is no longer built on normal mount.
