### PR TITLE
feat(oauth): add generic oidc provider

### DIFF
--- a/app/Models/OauthSetting.php
+++ b/app/Models/OauthSetting.php
@@ -28,6 +28,7 @@ class OauthSetting extends Model
                 return filled($this->client_id) && filled($this->client_secret) && filled($this->tenant);
             case 'authentik':
             case 'clerk':
+            case 'oidc':
                 return filled($this->client_id) && filled($this->client_secret) && filled($this->base_url);
             default:
                 return filled($this->client_id) && filled($this->client_secret);

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use Kovah\Oidc\OidcExtendSocialite;
 use SocialiteProviders\Authentik\AuthentikExtendSocialite;
 use SocialiteProviders\Azure\AzureExtendSocialite;
 use SocialiteProviders\Clerk\ClerkExtendSocialite;
@@ -22,6 +23,7 @@ class EventServiceProvider extends ServiceProvider
             DiscordExtendSocialite::class.'@handle',
             GoogleExtendSocialite::class.'@handle',
             InfomaniakExtendSocialite::class.'@handle',
+            OidcExtendSocialite::class.'@handle',
             ZitadelExtendSocialite::class.'@handle',
         ],
     ];

--- a/bootstrap/helpers/socialite.php
+++ b/bootstrap/helpers/socialite.php
@@ -33,6 +33,17 @@ function get_socialite_provider(string $provider)
         return Socialite::driver($provider)->setConfig($authentik_clerk_config);
     }
 
+    if ($provider == 'oidc') {
+        $oidc_config = new \SocialiteProviders\Manager\Config(
+            $oauth_setting->client_id,
+            $oauth_setting->client_secret,
+            $oauth_setting->redirect_uri,
+            ['base_url' => $oauth_setting->base_url],
+        );
+
+        return Socialite::driver('oidc')->setConfig($oidc_config);
+    }
+
     if ($provider == 'zitadel') {
         $zitadel_config = new \SocialiteProviders\Manager\Config(
             $oauth_setting->client_id,

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "pusher/pusher-php-server": "^7.2.7",
         "resend/resend-laravel": "^0.20.0",
         "sentry/sentry-laravel": "^4.20.1",
+        "kovah/laravel-socialite-oidc": "^0.8",
         "socialiteproviders/authentik": "^5.2",
         "socialiteproviders/clerk": "^5.1",
         "socialiteproviders/discord": "^4.2",
@@ -62,7 +63,6 @@
     },
     "require-dev": {
         "barryvdh/laravel-debugbar": "^3.16.5",
-        "driftingly/rector-laravel": "^2.1.9",
         "fakerphp/faker": "^1.24.1",
         "laravel/boost": "^2.1",
         "laravel/dusk": "^8.3.4",
@@ -73,7 +73,8 @@
         "pestphp/pest": "^4.3.2",
         "pestphp/pest-plugin-browser": "^4.2",
         "phpstan/phpstan": "^2.1.38",
-        "rector/rector": "^2.3.5",
+        "rector/rector": "^2.0",
+        "driftingly/rector-laravel": "^2.0",
         "serversideup/spin": "^3.1.1",
         "spatie/laravel-ignition": "^2.10.0",
         "symfony/http-client": "^7.4.5"

--- a/database/seeders/OauthSettingSeeder.php
+++ b/database/seeders/OauthSettingSeeder.php
@@ -24,6 +24,7 @@ class OauthSettingSeeder extends Seeder
                 'google',
                 'authentik',
                 'infomaniak',
+                'oidc',
                 'zitadel',
             ]);
 

--- a/lang/de.json
+++ b/lang/de.json
@@ -8,6 +8,7 @@
     "auth.login.gitlab": "Mit GitLab anmelden",
     "auth.login.google": "Mit Google anmelden",
     "auth.login.infomaniak": "Mit Infomaniak anmelden",
+    "auth.login.oidc": "Mit OIDC anmelden",
     "auth.login.zitadel": "Mit Zitadel anmelden",
     "auth.already_registered": "Bereits registriert?",
     "auth.confirm_password": "Passwort bestätigen",

--- a/lang/en.json
+++ b/lang/en.json
@@ -9,6 +9,7 @@
     "auth.login.gitlab": "Login with Gitlab",
     "auth.login.google": "Login with Google",
     "auth.login.infomaniak": "Login with Infomaniak",
+    "auth.login.oidc": "Login with OIDC",
     "auth.login.zitadel": "Login with Zitadel",
     "auth.already_registered": "Already registered?",
     "auth.confirm_password": "Confirm password",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -9,6 +9,7 @@
     "auth.login.gitlab": "Zaloguj się przez Gitlab",
     "auth.login.google": "Zaloguj się przez Google",
     "auth.login.infomaniak": "Zaloguj się przez Infomaniak",
+    "auth.login.oidc": "Zaloguj się przez OIDC",
     "auth.login.zitadel": "Zaloguj się przez Zitadel",
     "auth.already_registered": "Już zarejestrowany?",
     "auth.confirm_password": "Potwierdź hasło",

--- a/resources/views/livewire/settings-oauth.blade.php
+++ b/resources/views/livewire/settings-oauth.blade.php
@@ -40,6 +40,7 @@
                         @if (
                             $oauth_setting['provider'] == 'authentik' ||
                                 $oauth_setting['provider'] == 'clerk' ||
+                                $oauth_setting['provider'] == 'oidc' ||
                                 $oauth_setting['provider'] == 'zitadel' ||
                                 $oauth_setting['provider'] == 'gitlab')
                             <x-forms.input id="oauth_settings_map.{{ $oauth_setting['provider'] }}.base_url"

--- a/tests/Feature/OauthControllerTest.php
+++ b/tests/Feature/OauthControllerTest.php
@@ -77,3 +77,18 @@ it('rejects oauth logins when the provider does not return an email address', fu
     'null email' => [null],
     'blank email' => ['   '],
 ]);
+
+it('configures oidc provider with base_url', function () {
+    OauthSetting::create([
+        'provider' => 'oidc',
+        'client_id' => 'oidc-client-id',
+        'client_secret' => 'oidc-client-secret',
+        'redirect_uri' => 'https://coolify.example.com/auth/oidc/callback',
+        'base_url' => 'https://oidc.example.com',
+    ]);
+
+    $oauth_setting = OauthSetting::where('provider', 'oidc')->first();
+
+    expect($oauth_setting->couldBeEnabled())->toBeTrue();
+    expect($oauth_setting->base_url)->toBe('https://oidc.example.com');
+});


### PR DESCRIPTION
Adds generic OIDC OAuth provider support using kovah/laravel-socialite-oidc. Follows the existing authentik/clerk/zitadel pattern.

- Registers OIDC driver in socialite helper with ase_url support
- Adds ase_url validation and settings UI field
- Seeds OIDC provider in OAuth settings
- Adds EN/DE/PL translations

Implements #6696