### PR TITLE
fix(docker): resolve numeric Debian 13 (trixie) codename bug in installer and checkupdates

### DIFF
--- a/app/Actions/Server/CheckUpdates.php
+++ b/app/Actions/Server/CheckUpdates.php
@@ -89,6 +89,26 @@ class CheckUpdates
 
                     return $out;
                 case 'apt':
+                    $versionCodename = $osInfo['UBUNTU_CODENAME'] ?? $osInfo['VERSION_CODENAME'] ?? '';
+                    $versionId = $osInfo['VERSION_ID'] ?? '';
+
+                    if (empty($versionCodename) || is_numeric($versionCodename)) {
+                        $versionCodename = match ($versionId) {
+                            '13' => 'trixie',
+                            '12' => 'bookworm',
+                            '11' => 'bullseye',
+                            '10' => 'buster',
+                            '9' => 'stretch',
+                            default => 'bookworm',
+                        };
+                    }
+
+                    if (!empty($versionCodename)) {
+                        instant_remote_process([
+                            'test -f /etc/apt/sources.list.d/docker.list && sed -i -E \'s|(download.docker.com/linux/[a-z]+)[[:space:]]+[0-9]+[[:space:]]+|\\1 ' . $versionCodename . ' |g\' /etc/apt/sources.list.d/docker.list || true'
+                        ], $server);
+                    }
+
                     instant_remote_process(['apt-get update -qq'], $server);
                     $output = instant_remote_process(['LANG=C apt list --upgradable 2>/dev/null'], $server);
 

--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -120,7 +120,9 @@ class InstallDocker
             'install -m 0755 -d /etc/apt/keyrings && '.
             'curl -fsSL https://download.docker.com/linux/${ID}/gpg -o /etc/apt/keyrings/docker.asc && '.
             'chmod a+r /etc/apt/keyrings/docker.asc && '.
-            'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${ID} ${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list && '.
+            'CODENAME=${UBUNTU_CODENAME:-$VERSION_CODENAME} && '.
+            'case "$CODENAME" in *[!0-9]*) ;; *) case "$VERSION_ID" in "13") CODENAME="trixie" ;; "12") CODENAME="bookworm" ;; "11") CODENAME="bullseye" ;; "10") CODENAME="buster" ;; "9") CODENAME="stretch" ;; *) CODENAME="bookworm" ;; esac ;; esac && '.
+            'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${ID} ${CODENAME} stable" > /etc/apt/sources.list.d/docker.list && '.
             'apt-get update && '.
             'apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin'.
             ')';

--- a/other/nightly/install.sh
+++ b/other/nightly/install.sh
@@ -520,9 +520,24 @@ install_docker_manually() {
         chmod a+r /etc/apt/keyrings/docker.asc
 
         # Add the repository to Apt sources
+        CODENAME=$(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")
+        case "$CODENAME" in
+            *[!0-9]*) ;;
+            *)
+                VERSION_ID=$(. /etc/os-release && echo "$VERSION_ID")
+                case "$VERSION_ID" in
+                    "13") CODENAME="trixie" ;;
+                    "12") CODENAME="bookworm" ;;
+                    "11") CODENAME="bullseye" ;;
+                    "10") CODENAME="buster" ;;
+                    "9") CODENAME="stretch" ;;
+                    *) CODENAME="bookworm" ;;
+                esac
+                ;;
+        esac
         echo \
             "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/$OS_TYPE \
-                  $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" |
+                  $CODENAME stable" |
             tee /etc/apt/sources.list.d/docker.list
         apt-get update
         apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -520,9 +520,24 @@ install_docker_manually() {
         chmod a+r /etc/apt/keyrings/docker.asc
 
         # Add the repository to Apt sources
+        CODENAME=$(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")
+        case "$CODENAME" in
+            *[!0-9]*) ;;
+            *)
+                VERSION_ID=$(. /etc/os-release && echo "$VERSION_ID")
+                case "$VERSION_ID" in
+                    "13") CODENAME="trixie" ;;
+                    "12") CODENAME="bookworm" ;;
+                    "11") CODENAME="bullseye" ;;
+                    "10") CODENAME="buster" ;;
+                    "9") CODENAME="stretch" ;;
+                    *) CODENAME="bookworm" ;;
+                esac
+                ;;
+        esac
         echo \
             "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/$OS_TYPE \
-                  $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" |
+                  $CODENAME stable" |
             tee /etc/apt/sources.list.d/docker.list
         apt-get update
         apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin


### PR DESCRIPTION
Fixes #9455. This PR resolves the issue where servers running Debian 13 (Trixie) or derivative OSs get invalid Docker apt sources configured with numeric versions (`13`) instead of codenames (`trixie`), breaking `apt-get update` and the patch check feature. /claim coollabsio/coolify#9455