### PR TITLE
feat(service): add OpenReplay template

### DIFF
--- a/public/svgs/openreplay.svg
+++ b/public/svgs/openreplay.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" fill="none">
+  <circle cx="100" cy="100" r="100" fill="#394EFF"/>
+  <polygon points="75,60 75,140 155,100" fill="#FFFFFF"/>
+  <rect x="42" y="60" width="18" height="80" rx="4" fill="#FFFFFF"/>
+</svg>

--- a/templates/compose/openreplay.yaml
+++ b/templates/compose/openreplay.yaml
@@ -1,0 +1,191 @@
+services:
+  postgresql:
+    image: "ghcr.io/openreplay/postgres:14.12.0-debian-12-r26"
+    environment:
+      - POSTGRESQL_PASSWORD=${SERVICE_PASSWORD_POSTGRES}
+    volumes:
+      - openreplay-pgdata:/bitnami/postgresql
+    networks:
+      - openreplay-net
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  clickhouse:
+    image: "clickhouse/clickhouse-server:24.3"
+    environment:
+      - CLICKHOUSE_USER=default
+      - CLICKHOUSE_PASSWORD=${SERVICE_PASSWORD_CLICKHOUSE}
+      - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
+    volumes:
+      - openreplay-clickhouse:/var/lib/clickhouse
+    networks:
+      - openreplay-net
+    healthcheck:
+      test: ["CMD-SHELL", "clickhouse-client --query 'SELECT 1'"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  redis:
+    image: "ghcr.io/openreplay/valkey:7.2.7-debian-12-r4"
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+    volumes:
+      - openreplay-redis:/data
+    networks:
+      - openreplay-net
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  minio:
+    image: "rustfs/rustfs:latest"
+    environment:
+      - RUSTFS_ACCESS_KEY=${SERVICE_PASSWORD_MINIOACCESS}
+      - RUSTFS_SECRET_KEY=${SERVICE_PASSWORD_MINIOSECRET}
+      - RUSTFS_ADDRESS=0.0.0.0:9000
+      - RUSTFS_CONSOLE_ENABLE=true
+      - RUSTFS_CONSOLE_ADDRESS=0.0.0.0:9001
+      - RUSTFS_VOLUMES=/data
+    volumes:
+      - openreplay-minio:/data
+    networks:
+      - openreplay-net
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:9000/health/ready || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
+  api:
+    image: "public.ecr.aws/p1t3u8a3/api:${OPENREPLAY_VERSION:-v1.27.0}"
+    depends_on:
+      postgresql:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+    environment:
+      - POSTGRES_STRING=postgresql://postgres:${SERVICE_PASSWORD_POSTGRES}@postgresql:5432/postgres
+      - CLICKHOUSE_HOST=clickhouse
+      - CLICKHOUSE_PORT=9000
+      - CLICKHOUSE_USER=default
+      - CLICKHOUSE_PASSWORD=${SERVICE_PASSWORD_CLICKHOUSE}
+      - REDIS_URL=redis://redis:6379
+      - S3_HOST=http://minio:9000
+      - S3_KEY=${SERVICE_PASSWORD_MINIOACCESS}
+      - S3_SECRET=${SERVICE_PASSWORD_MINIOSECRET}
+      - DOMAIN_NAME=${SERVICE_FQDN_NGINX_80}
+      - JWT_SECRET=${SERVICE_PASSWORD_JWT}
+    volumes:
+      - openreplay-shared:/mnt/efs
+    networks:
+      - openreplay-net
+    restart: unless-stopped
+
+  http:
+    image: "public.ecr.aws/p1t3u8a3/http:${OPENREPLAY_VERSION:-v1.27.0}"
+    depends_on:
+      - redis
+      - minio
+    environment:
+      - REDIS_URL=redis://redis:6379
+      - S3_HOST=http://minio:9000
+      - S3_KEY=${SERVICE_PASSWORD_MINIOACCESS}
+      - S3_SECRET=${SERVICE_PASSWORD_MINIOSECRET}
+      - DOMAIN_NAME=${SERVICE_FQDN_NGINX_80}
+    volumes:
+      - openreplay-shared:/mnt/efs
+    networks:
+      - openreplay-net
+    restart: unless-stopped
+
+  sink:
+    image: "public.ecr.aws/p1t3u8a3/sink:${OPENREPLAY_VERSION:-v1.27.0}"
+    depends_on:
+      - redis
+      - clickhouse
+    environment:
+      - REDIS_URL=redis://redis:6379
+      - CLICKHOUSE_HOST=clickhouse
+      - CLICKHOUSE_PORT=9000
+      - CLICKHOUSE_USER=default
+      - CLICKHOUSE_PASSWORD=${SERVICE_PASSWORD_CLICKHOUSE}
+      - S3_HOST=http://minio:9000
+      - S3_KEY=${SERVICE_PASSWORD_MINIOACCESS}
+      - S3_SECRET=${SERVICE_PASSWORD_MINIOSECRET}
+    volumes:
+      - openreplay-shared:/mnt/efs
+    networks:
+      - openreplay-net
+    restart: unless-stopped
+
+  storage:
+    image: "public.ecr.aws/p1t3u8a3/storage:${OPENREPLAY_VERSION:-v1.27.0}"
+    depends_on:
+      - minio
+      - redis
+    environment:
+      - REDIS_URL=redis://redis:6379
+      - S3_HOST=http://minio:9000
+      - S3_KEY=${SERVICE_PASSWORD_MINIOACCESS}
+      - S3_SECRET=${SERVICE_PASSWORD_MINIOSECRET}
+    volumes:
+      - openreplay-shared:/mnt/efs
+    networks:
+      - openreplay-net
+    restart: unless-stopped
+
+  frontend:
+    image: "public.ecr.aws/p1t3u8a3/frontend:${OPENREPLAY_VERSION:-v1.27.0}"
+    depends_on:
+      - api
+    environment:
+      - DOMAIN_NAME=${SERVICE_FQDN_NGINX_80}
+    volumes:
+      - openreplay-shared:/mnt/efs
+    networks:
+      - openreplay-net
+    restart: unless-stopped
+
+  nginx:
+    image: "nginx:1.27-alpine"
+    depends_on:
+      - api
+      - http
+      - frontend
+    environment:
+      - SERVICE_FQDN_NGINX_80
+    volumes:
+      - openreplay-shared:/mnt/efs
+    networks:
+      - openreplay-net
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:80/healthz || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    restart: unless-stopped
+
+volumes:
+  openreplay-pgdata:
+  openreplay-clickhouse:
+  openreplay-redis:
+  openreplay-minio:
+  openreplay-shared:
+
+networks:
+  openreplay-net:
+    driver: bridge


### PR DESCRIPTION
STRAWBERRY

## Changes

Adds OpenReplay as a one-click service template under `templates/compose/openreplay.yaml`, plus the OpenReplay logo at `public/svgs/openreplay.svg`. OpenReplay is an open-source session replay and product analytics platform — a self-hosted alternative to FullStory and LogRocket.

## Issues

- Fixes #8232

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No screenshot — catalog tile renders from the logo + YAML metadata.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude
- How extensively: Used to draft the compose YAML and SVG logo based on OpenReplay's upstream docker-compose. All content reviewed before submitting.

## Testing

Verified YAML structure matches existing templates in templates/compose/. Template follows Coolify conventions (SERVICE_PASSWORD_*, SERVICE_FQDN_*, named volumes, no version key, no container_name).

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the contributor guidelines. If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched existing issues and pull requests (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.