### PR TITLE
feat: add Stalwart Mail + Roundcube service template

### DIFF
--- a/templates/compose/stalwart-roundcube.yaml
+++ b/templates/compose/stalwart-roundcube.yaml
@@ -1,0 +1,61 @@
+# documentation: https://stalw.art/docs/get-started/?utm_source=coolify.io
+# slogan: Modern all-in-one mail server (SMTP/IMAP/Sieve) with Roundcube webmail.
+# category: email
+# tags: stalwart,email,mail,smtp,imap,roundcube,webmail,self-hosted
+# logo: svgs/stalwart.svg
+# port: 80
+
+services:
+  stalwart:
+    image: stalwartlabs/stalwart:latest
+    restart: unless-stopped
+    environment:
+      - SERVICE_FQDN_STALWART_8080
+      - STALWART_RECOVERY_ADMIN=$SERVICE_PASSWORD_STALWART
+    volumes:
+      - stalwart-data:/opt/stalwart-mail
+    ports:
+      - "25:25"
+      - "587:587"
+      - "465:465"
+      - "143:143"
+      - "993:993"
+      - "4190:4190"
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - "bash -c ':> /dev/tcp/127.0.0.1/8080' || exit 1"
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  roundcube:
+    image: roundcube/roundcubemail:latest
+    restart: unless-stopped
+    depends_on:
+      stalwart:
+        condition: service_healthy
+    environment:
+      - SERVICE_FQDN_ROUNDCUBE_80
+      - ROUNDCUBEMAIL_DEFAULT_HOST=ssl://stalwart
+      - ROUNDCUBEMAIL_DEFAULT_PORT=993
+      - ROUNDCUBEMAIL_SMTP_SERVER=tls://stalwart
+      - ROUNDCUBEMAIL_SMTP_PORT=587
+      - ROUNDCUBEMAIL_PLUGINS=archive,zipdownload,managesieve
+      - ROUNDCUBEMAIL_SKIN=elastic
+      - ROUNDCUBEMAIL_DBTYPE=sqlite
+    volumes:
+      - roundcube-data:/var/www/html/config
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - "bash -c ':> /dev/tcp/127.0.0.1/80' || exit 1"
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+volumes:
+  stalwart-data:
+  roundcube-data:


### PR DESCRIPTION
## Changes

Added a new one-click service template for Stalwart Mail Server with Roundcube webmail. I self-host email and wanted a simpler alternative to Docker Mailserver — Stalwart is a single Rust binary that handles SMTP, IMAP, and Sieve, making it much easier to deploy. Paired it with Roundcube so users get a full webmail UI out of the box.

## Issues

- Closes #6723

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Template adds `stalwart-roundcube` as a new service with two containers: Stalwart (mail server) and Roundcube (webmail). Roundcube waits for Stalwart's health check before starting.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Used to help write the docker-compose YAML structure and environment variable wiring. I reviewed and verified the configuration.

## Testing

Verified the compose file structure matches existing Coolify service templates. The health check on Stalwart's port 8080 ensures Roundcube only starts once the mail server is ready. Mail ports (25, 465, 587, 143, 993, 4190) are exposed directly as required for a mail server.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.