### PR TITLE
feat(auth): add generic OpenID Connect (OIDC) OAuth provider

### DIFF
--- a/app/Models/OauthSetting.php
+++ b/app/Models/OauthSetting.php
@@ -28,6 +28,7 @@ class OauthSetting extends Model
                 return filled($this->client_id) && filled($this->client_secret) && filled($this->tenant);
             case 'authentik':
             case 'clerk':
+            case 'oidc':
                 return filled($this->client_id) && filled($this->client_secret) && filled($this->base_url);
             default:
                 return filled($this->client_id) && filled($this->client_secret);

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -10,6 +10,7 @@ use SocialiteProviders\Discord\DiscordExtendSocialite;
 use SocialiteProviders\Google\GoogleExtendSocialite;
 use SocialiteProviders\Infomaniak\InfomaniakExtendSocialite;
 use SocialiteProviders\Manager\SocialiteWasCalled;
+use SocialiteProviders\OIDC\OIDCExtendSocialite;
 use SocialiteProviders\Zitadel\ZitadelExtendSocialite;
 
 class EventServiceProvider extends ServiceProvider
@@ -22,6 +23,7 @@ class EventServiceProvider extends ServiceProvider
             DiscordExtendSocialite::class.'@handle',
             GoogleExtendSocialite::class.'@handle',
             InfomaniakExtendSocialite::class.'@handle',
+            OIDCExtendSocialite::class.'@handle',
             ZitadelExtendSocialite::class.'@handle',
         ],
     ];

--- a/bootstrap/helpers/socialite.php
+++ b/bootstrap/helpers/socialite.php
@@ -2,6 +2,11 @@
 
 use App\Models\OauthSetting;
 use Laravel\Socialite\Facades\Socialite;
+use Laravel\Socialite\Two\BitbucketProvider;
+use Laravel\Socialite\Two\GithubProvider;
+use Laravel\Socialite\Two\GitlabProvider;
+use SocialiteProviders\Discord\Provider;
+use SocialiteProviders\Manager\Config;
 
 function get_socialite_provider(string $provider)
 {
@@ -12,7 +17,7 @@ function get_socialite_provider(string $provider)
     }
 
     if ($provider === 'azure') {
-        $azure_config = new \SocialiteProviders\Manager\Config(
+        $azure_config = new Config(
             $oauth_setting->client_id,
             $oauth_setting->client_secret,
             $oauth_setting->redirect_uri,
@@ -22,8 +27,8 @@ function get_socialite_provider(string $provider)
         return Socialite::driver('azure')->setConfig($azure_config);
     }
 
-    if ($provider == 'authentik' || $provider == 'clerk') {
-        $authentik_clerk_config = new \SocialiteProviders\Manager\Config(
+    if ($provider == 'authentik' || $provider == 'clerk' || $provider == 'oidc') {
+        $authentik_clerk_config = new Config(
             $oauth_setting->client_id,
             $oauth_setting->client_secret,
             $oauth_setting->redirect_uri,
@@ -34,7 +39,7 @@ function get_socialite_provider(string $provider)
     }
 
     if ($provider == 'zitadel') {
-        $zitadel_config = new \SocialiteProviders\Manager\Config(
+        $zitadel_config = new Config(
             $oauth_setting->client_id,
             $oauth_setting->client_secret,
             $oauth_setting->redirect_uri,
@@ -45,7 +50,7 @@ function get_socialite_provider(string $provider)
     }
 
     if ($provider == 'google') {
-        $google_config = new \SocialiteProviders\Manager\Config(
+        $google_config = new Config(
             $oauth_setting->client_id,
             $oauth_setting->client_secret,
             $oauth_setting->redirect_uri
@@ -63,11 +68,11 @@ function get_socialite_provider(string $provider)
     ];
 
     $provider_class_map = [
-        'bitbucket' => \Laravel\Socialite\Two\BitbucketProvider::class,
-        'discord' => \SocialiteProviders\Discord\Provider::class,
-        'github' => \Laravel\Socialite\Two\GithubProvider::class,
-        'gitlab' => \Laravel\Socialite\Two\GitlabProvider::class,
-        'infomaniak' => \SocialiteProviders\Infomaniak\Provider::class,
+        'bitbucket' => BitbucketProvider::class,
+        'discord' => Provider::class,
+        'github' => GithubProvider::class,
+        'gitlab' => GitlabProvider::class,
+        'infomaniak' => SocialiteProviders\Infomaniak\Provider::class,
     ];
 
     $socialite = Socialite::buildProvider(

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "danharrin/livewire-rate-limiting": "^2.1.0",
         "doctrine/dbal": "^4.4.1",
         "guzzlehttp/guzzle": "^7.10.0",
+        "kovah/laravel-socialite-oidc": "*",
         "laravel/fortify": "^1.34.0",
         "laravel/framework": "^12.49.0",
         "laravel/horizon": "^5.43.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "64b77285a7140ce68e83db2659e9a21d",
+    "content-hash": "a662d4cabbc11331a64ca3a129a9f159",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -1702,6 +1702,74 @@
                 "source": "https://github.com/Jean85/pretty-package-versions/tree/2.1.1"
             },
             "time": "2025-03-19T14:43:43+00:00"
+        },
+        {
+            "name": "kovah/laravel-socialite-oidc",
+            "version": "v0.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Kovah/laravel-socialite-oidc.git",
+                "reference": "cfd9c9a658da97b961d936159c45ca4ed082e62a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Kovah/laravel-socialite-oidc/zipball/cfd9c9a658da97b961d936159c45ca4ed082e62a",
+                "reference": "cfd9c9a658da97b961d936159c45ca4ed082e62a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "firebase/php-jwt": "^6.4|^7.0",
+                "illuminate/http": "^9.0 | ^10.0 | ^11.0 | ^12.0 | ^13.0",
+                "illuminate/support": "^9.0 | ^10.0 | ^11.0 | ^12.0 | ^13.0",
+                "php": "^8.1",
+                "socialiteproviders/manager": "^4.0"
+            },
+            "conflict": {
+                "jp-gauthier/socialiteproviders-oidc": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "SocialiteProviders\\OIDC\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "JPG Dev",
+                    "homepage": "https://jpgdev.com"
+                },
+                {
+                    "name": "Kevin Woblick",
+                    "email": "contact@woblick.dev",
+                    "homepage": "https://woblick.dev",
+                    "role": "Developer"
+                }
+            ],
+            "description": "OpenID Connect OAuth2 Provider for Laravel Socialite",
+            "homepage": "https://github.com/kovah/laravel-socialite-oidc",
+            "keywords": [
+                "laravel",
+                "oauth",
+                "oidc",
+                "provider",
+                "socialite"
+            ],
+            "support": {
+                "issues": "https://github.com/Kovah/laravel-socialite-oidc/issues",
+                "source": "https://github.com/Kovah/laravel-socialite-oidc/tree/v0.8.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/kovah",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-30T09:17:26+00:00"
         },
         {
             "name": "laravel/fortify",

--- a/config/services.php
+++ b/config/services.php
@@ -67,4 +67,11 @@ return [
         'base_url' => env('ZITADEL_BASE_URL'),
     ],
 
+    'oidc' => [
+        'base_url' => env('OIDC_BASE_URL'),
+        'client_id' => env('OIDC_CLIENT_ID'),
+        'client_secret' => env('OIDC_CLIENT_SECRET'),
+        'redirect' => env('OIDC_REDIRECT_URI'),
+    ],
+
 ];

--- a/database/seeders/OauthSettingSeeder.php
+++ b/database/seeders/OauthSettingSeeder.php
@@ -25,6 +25,7 @@ class OauthSettingSeeder extends Seeder
                 'authentik',
                 'infomaniak',
                 'zitadel',
+                'oidc',
             ]);
 
             $isOauthSeeded = OauthSetting::count() > 0;

--- a/lang/de.json
+++ b/lang/de.json
@@ -8,6 +8,7 @@
     "auth.login.gitlab": "Mit GitLab anmelden",
     "auth.login.google": "Mit Google anmelden",
     "auth.login.infomaniak": "Mit Infomaniak anmelden",
+    "auth.login.oidc": "Mit OpenID Connect anmelden",
     "auth.login.zitadel": "Mit Zitadel anmelden",
     "auth.already_registered": "Bereits registriert?",
     "auth.confirm_password": "Passwort bestätigen",

--- a/lang/en.json
+++ b/lang/en.json
@@ -9,6 +9,7 @@
     "auth.login.gitlab": "Login with Gitlab",
     "auth.login.google": "Login with Google",
     "auth.login.infomaniak": "Login with Infomaniak",
+    "auth.login.oidc": "Login with OpenID Connect",
     "auth.login.zitadel": "Login with Zitadel",
     "auth.already_registered": "Already registered?",
     "auth.confirm_password": "Confirm password",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -9,6 +9,7 @@
     "auth.login.gitlab": "Zaloguj się przez Gitlab",
     "auth.login.google": "Zaloguj się przez Google",
     "auth.login.infomaniak": "Zaloguj się przez Infomaniak",
+    "auth.login.oidc": "Zaloguj się przez OpenID Connect",
     "auth.login.zitadel": "Zaloguj się przez Zitadel",
     "auth.already_registered": "Już zarejestrowany?",
     "auth.confirm_password": "Potwierdź hasło",

--- a/resources/views/livewire/settings-oauth.blade.php
+++ b/resources/views/livewire/settings-oauth.blade.php
@@ -41,7 +41,8 @@
                             $oauth_setting['provider'] == 'authentik' ||
                                 $oauth_setting['provider'] == 'clerk' ||
                                 $oauth_setting['provider'] == 'zitadel' ||
-                                $oauth_setting['provider'] == 'gitlab')
+                                $oauth_setting['provider'] == 'gitlab' ||
+                                $oauth_setting['provider'] == 'oidc')
                             <x-forms.input id="oauth_settings_map.{{ $oauth_setting['provider'] }}.base_url"
                                 label="Base URL" />
                         @endif

--- a/tests/Feature/OauthControllerTest.php
+++ b/tests/Feature/OauthControllerTest.php
@@ -48,6 +48,37 @@ it('logs in an existing user when the oauth provider returns a mixed-case email'
     expect(User::count())->toBe(1);
 });
 
+it('logs in an existing user through the oidc provider', function () {
+    config()->set('app.maintenance.driver', 'file');
+
+    OauthSetting::create([
+        'provider' => 'oidc',
+        'client_id' => 'oidc-client-id',
+        'client_secret' => 'oidc-client-secret',
+        'redirect_uri' => 'https://coolify.example.com/auth/oidc/callback',
+        'base_url' => 'https://idp.example.com',
+    ]);
+
+    $user = User::factory()->create([
+        'email' => 'username@example.edu',
+    ]);
+
+    $provider = Mockery::mock();
+    $provider->shouldReceive('setConfig')->once()->andReturnSelf();
+    $provider->shouldReceive('user')->once()->andReturn((object) [
+        'email' => 'username@example.edu',
+        'name' => 'Example User',
+        'id' => 'oidc-user-id',
+    ]);
+
+    Socialite::shouldReceive('driver')->once()->with('oidc')->andReturn($provider);
+
+    $response = $this->get(route('auth.callback', 'oidc'));
+
+    $response->assertRedirect('/');
+    $this->assertAuthenticatedAs($user);
+});
+
 it('rejects oauth logins when the provider does not return an email address', function (?string $providerEmail) {
     config()->set('app.maintenance.driver', 'file');
     InstanceSettings::firstOrCreate([

--- a/tests/Feature/OauthSettingOidcTest.php
+++ b/tests/Feature/OauthSettingOidcTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use App\Models\OauthSetting;
+
+it('requires base_url for oidc to be enabled', function () {
+    $setting = new OauthSetting([
+        'provider' => 'oidc',
+        'client_id' => 'client-id',
+        'client_secret' => 'client-secret',
+    ]);
+
+    expect($setting->couldBeEnabled())->toBeFalse();
+
+    $setting->base_url = 'https://idp.example.com';
+
+    expect($setting->couldBeEnabled())->toBeTrue();
+});


### PR DESCRIPTION
Closes #6696

Adds a generic OpenID Connect (OIDC) login provider, following the same pattern as the existing authentik/clerk/zitadel providers.