### PR TITLE
perf(templates): tune LiteLLM defaults for lower RAM/CPU

### DIFF
--- a/templates/compose/litellm.yaml
+++ b/templates/compose/litellm.yaml
@@ -40,6 +40,7 @@ services:
         content: |
           general_settings:
             proxy_batch_write_at: 60
+            store_prompts_in_spend_logs: false
 
           router_settings:
             redis_host: os.environ/REDIS_HOST
@@ -50,15 +51,15 @@ services:
           litellm_settings:
             set_verbose: false
             json_logs: true
-            log_raw_request_response: true
+            log_raw_request_response: false
             # turn_off_message_logging: false
             # redact_user_api_key_info: false
             service_callback: ["prometheus_system"]
             drop_params: true
             # max_budget: 100
             # budget_duration: 30d
-            num_retries: 3
-            request_timeout: 600
+            num_retries: 1
+            request_timeout: 120
             telemetry: false
             cache: true
             cache_params:
@@ -131,17 +132,21 @@ services:
         - CMD
         - python
         - "-c"
-        - "import requests as r;r.get('http://127.0.0.1:4000/health/liveliness').raise_for_status()"
-      interval: 5s
+        - "import urllib.request;urllib.request.urlopen('http://127.0.0.1:4000/health/liveliness',timeout=5)"
+      interval: 30s
       timeout: 5s
       retries: 3
+      start_period: 30s
     command:
       - "--config"
       - /app/config.yaml
       - "--port"
       - "4000"
       - "--num_workers"
-      - "8"
+      - "2"
+      - "--run_gunicorn"
+      - "--max_requests_before_restart"
+      - "1000"
   postgres:
     image: "postgres:16-alpine"
     environment:


### PR DESCRIPTION
## Changes

Tunes the default LiteLLM service template for lower memory and CPU usage. The current defaults run 8 worker processes and capture/persist full request+response bodies, which on small hosts (e.g. 2 vCPU / 4 GB) leads to OOM kills and restart loops.

- `--num_workers` 8 -> 2 so worker count matches a typical small-host core count instead of thrashing 2 cores with 8 interpreters.
- Run under `--run_gunicorn` with `--max_requests_before_restart 1000` so workers recycle and long-lived Python RSS does not creep toward OOM.
- `log_raw_request_response` true -> false to drop the dominant per-request serialization/allocation cost.
- `store_prompts_in_spend_logs` set to false (its default) so spend/cost accounting is kept without writing full prompt/response payloads into Postgres SpendLogs.
- `num_retries` 3 -> 1 and `request_timeout` 600 -> 120 so a single hung upstream call cannot pin a worker for up to ~30 minutes.
- Healthcheck interval 5s -> 30s plus a `start_period`, and the probe uses stdlib `urllib.request` instead of `requests`. The image (chainguard/wolfi-base) ships `python3` but not `curl`/`wget`, so a curl probe is not an option; switching off `requests` avoids re-importing a heavy dependency tree on every check.

Only the source template `templates/compose/litellm.yaml` is changed; the generated `service-templates*.json` files are intentionally left for regeneration.

## Issues

- Fixes

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A — configuration-only change to a service template; no UI surface.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: AI located the settings, verified the LiteLLM CLI flags (`--run_gunicorn`, `--max_requests_before_restart`) and the `store_prompts_in_spend_logs` default against the LiteLLM source, confirmed the runtime image lacks `curl`/`wget`, and drafted the edits. Changes were human-reviewed before submission.

## Testing

- Validated both the outer compose YAML and the embedded `config.yaml` block parse correctly.
- Verified the new CLI flags exist and their types in the LiteLLM `proxy_cli.py`.
- Confirmed the runtime base image (chainguard/wolfi-base) provides `python3` but not `curl`/`wget`, so the healthcheck stays python-based.
- Not yet deployed against a live local Coolify instance — opening as a draft for that reason.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
