### PR TITLE
feat(oauth): add generic OIDC provider support with custom button labels

### DIFF
--- a/app/Livewire/SettingsOauth.php
+++ b/app/Livewire/SettingsOauth.php
@@ -18,6 +18,7 @@ class SettingsOauth extends Component
             $carry["oauth_settings_map.$setting->provider.redirect_uri"] = 'nullable';
             $carry["oauth_settings_map.$setting->provider.tenant"] = 'nullable';
             $carry["oauth_settings_map.$setting->provider.base_url"] = 'nullable';
+            $carry["oauth_settings_map.$setting->provider.custom_label"] = 'nullable|string';
 
             return $carry;
         }, []);
@@ -38,6 +39,7 @@ class SettingsOauth extends Component
                 'redirect_uri' => $setting->redirect_uri,
                 'tenant' => $setting->tenant,
                 'base_url' => $setting->base_url,
+                'custom_label' => $setting->custom_label,
             ];
 
             return $carry;
@@ -61,6 +63,7 @@ class SettingsOauth extends Component
                 'redirect_uri' => $oauthData['redirect_uri'],
                 'tenant' => $oauthData['tenant'],
                 'base_url' => $oauthData['base_url'],
+                'custom_label' => $oauthData['custom_label'],
             ]);
 
             if (! $oauth->couldBeEnabled()) {
@@ -79,6 +82,7 @@ class SettingsOauth extends Component
                 'redirect_uri' => $oauth->redirect_uri,
                 'tenant' => $oauth->tenant,
                 'base_url' => $oauth->base_url,
+                'custom_label' => $oauth->custom_label,
             ];
 
             $this->dispatch('success', 'OAuth settings for '.$oauth->provider.' updated successfully!');
@@ -100,6 +104,7 @@ class SettingsOauth extends Component
                     'redirect_uri' => $settingData['redirect_uri'],
                     'tenant' => $settingData['tenant'],
                     'base_url' => $settingData['base_url'],
+                    'custom_label' => $settingData['custom_label'],
                 ]);
 
                 if ($settingData['enabled'] && ! $oauth->couldBeEnabled()) {
@@ -119,6 +124,7 @@ class SettingsOauth extends Component
                     'redirect_uri' => $oauth->redirect_uri,
                     'tenant' => $oauth->tenant,
                     'base_url' => $oauth->base_url,
+                    'custom_label' => $oauth->custom_label,
                 ];
             }
 

--- a/app/Models/OauthSetting.php
+++ b/app/Models/OauthSetting.php
@@ -11,7 +11,7 @@ class OauthSetting extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['provider', 'client_id', 'client_secret', 'redirect_uri', 'tenant', 'base_url', 'enabled'];
+    protected $fillable = ['provider', 'client_id', 'client_secret', 'redirect_uri', 'tenant', 'base_url', 'enabled', 'custom_label'];
 
     protected function clientSecret(): Attribute
     {
@@ -28,6 +28,7 @@ class OauthSetting extends Model
                 return filled($this->client_id) && filled($this->client_secret) && filled($this->tenant);
             case 'authentik':
             case 'clerk':
+            case 'oidc':
                 return filled($this->client_id) && filled($this->client_secret) && filled($this->base_url);
             default:
                 return filled($this->client_id) && filled($this->client_secret);

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -10,6 +10,7 @@ use SocialiteProviders\Discord\DiscordExtendSocialite;
 use SocialiteProviders\Google\GoogleExtendSocialite;
 use SocialiteProviders\Infomaniak\InfomaniakExtendSocialite;
 use SocialiteProviders\Manager\SocialiteWasCalled;
+use SocialiteProviders\OIDC\OIDCExtendSocialite;
 use SocialiteProviders\Zitadel\ZitadelExtendSocialite;
 
 class EventServiceProvider extends ServiceProvider
@@ -23,6 +24,7 @@ class EventServiceProvider extends ServiceProvider
             GoogleExtendSocialite::class.'@handle',
             InfomaniakExtendSocialite::class.'@handle',
             ZitadelExtendSocialite::class.'@handle',
+            OIDCExtendSocialite::class.'@handle',
         ],
     ];
 

--- a/bootstrap/helpers/socialite.php
+++ b/bootstrap/helpers/socialite.php
@@ -44,6 +44,17 @@ function get_socialite_provider(string $provider)
         return Socialite::driver('zitadel')->setConfig($zitadel_config);
     }
 
+    if ($provider === 'oidc') {
+        $oidc_config = new \SocialiteProviders\Manager\Config(
+            $oauth_setting->client_id,
+            $oauth_setting->client_secret,
+            $oauth_setting->redirect_uri,
+            ['base_url' => $oauth_setting->base_url],
+        );
+
+        return Socialite::driver('oidc')->setConfig($oidc_config);
+    }
+
     if ($provider == 'google') {
         $google_config = new \SocialiteProviders\Manager\Config(
             $oauth_setting->client_id,

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
         "socialiteproviders/google": "^4.1",
         "socialiteproviders/infomaniak": "^4.0",
         "socialiteproviders/microsoft-azure": "^5.2",
+        "socialiteproviders/oidc": "^5.2",
         "socialiteproviders/zitadel": "^4.2",
         "spatie/laravel-activitylog": "^4.11.0",
         "spatie/laravel-data": "^4.19.1",

--- a/config/services.php
+++ b/config/services.php
@@ -67,4 +67,11 @@ return [
         'base_url' => env('ZITADEL_BASE_URL'),
     ],
 
+    'oidc' => [
+        'client_id' => env('OIDC_CLIENT_ID'),
+        'client_secret' => env('OIDC_CLIENT_SECRET'),
+        'redirect' => env('OIDC_REDIRECT_URI'),
+        'base_url' => env('OIDC_BASE_URL'),
+    ],
+
 ];

--- a/database/migrations/2026_06_18_094500_add_custom_label_to_oauth_settings_table.php
+++ b/database/migrations/2026_06_18_094500_add_custom_label_to_oauth_settings_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('oauth_settings', function (Blueprint $table) {
+            $table->string('custom_label')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('oauth_settings', function (Blueprint $table) {
+            $table->dropColumn('custom_label');
+        });
+    }
+};

--- a/database/seeders/OauthSettingSeeder.php
+++ b/database/seeders/OauthSettingSeeder.php
@@ -25,6 +25,7 @@ class OauthSettingSeeder extends Seeder
                 'authentik',
                 'infomaniak',
                 'zitadel',
+                'oidc',
             ]);
 
             $isOauthSeeded = OauthSetting::count() > 0;

--- a/lang/de.json
+++ b/lang/de.json
@@ -8,6 +8,7 @@
     "auth.login.gitlab": "Mit GitLab anmelden",
     "auth.login.google": "Mit Google anmelden",
     "auth.login.infomaniak": "Mit Infomaniak anmelden",
+    "auth.login.oidc": "Mit OpenID Connect anmelden",
     "auth.login.zitadel": "Mit Zitadel anmelden",
     "auth.already_registered": "Bereits registriert?",
     "auth.confirm_password": "Passwort bestätigen",

--- a/lang/en.json
+++ b/lang/en.json
@@ -9,6 +9,7 @@
     "auth.login.gitlab": "Login with Gitlab",
     "auth.login.google": "Login with Google",
     "auth.login.infomaniak": "Login with Infomaniak",
+    "auth.login.oidc": "Login with OpenID Connect",
     "auth.login.zitadel": "Login with Zitadel",
     "auth.already_registered": "Already registered?",
     "auth.confirm_password": "Confirm password",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -9,6 +9,7 @@
     "auth.login.gitlab": "Zaloguj się przez Gitlab",
     "auth.login.google": "Zaloguj się przez Google",
     "auth.login.infomaniak": "Zaloguj się przez Infomaniak",
+    "auth.login.oidc": "Zaloguj się przez OpenID Connect",
     "auth.login.zitadel": "Zaloguj się przez Zitadel",
     "auth.already_registered": "Już zarejestrowany?",
     "auth.confirm_password": "Potwierdź hasło",

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -90,7 +90,7 @@
                             @foreach ($enabled_oauth_providers as $provider_setting)
                                 <x-forms.button class="w-full justify-center" type="button"
                                     onclick="document.location.href='/auth/{{ $provider_setting->provider }}/redirect'">
-                                    {{ __("auth.login.$provider_setting->provider") }}
+                                    {{ $provider_setting->custom_label ?? __("auth.login.$provider_setting->provider") }}
                                 </x-forms.button>
                             @endforeach
                         </div>

--- a/resources/views/livewire/settings-oauth.blade.php
+++ b/resources/views/livewire/settings-oauth.blade.php
@@ -16,7 +16,7 @@
         <div class="flex flex-col gap-2 pt-4">
             @foreach ($oauth_settings_map as $oauth_setting)
                 <div class="p-4 border dark:border-coolgray-300 border-neutral-200">
-                    <h3>{{ ucfirst($oauth_setting['provider']) }}</h3>
+                    <h3>{{ $oauth_setting['provider'] === 'oidc' ? 'OIDC' : ucfirst($oauth_setting['provider']) }}</h3>
                     <div class="w-32">
                         <x-forms.checkbox instantSave="instantSave('{{ $oauth_setting['provider'] }}')"
                             id="oauth_settings_map.{{ $oauth_setting['provider'] }}.enabled" label="Enabled" />
@@ -28,6 +28,8 @@
                             type="password" label="Client Secret" autocomplete="new-password" />
                         <x-forms.input id="oauth_settings_map.{{ $oauth_setting['provider'] }}.redirect_uri"
                             placeholder="{{ route('auth.callback', $oauth_setting['provider']) }}" label="Redirect URI" />
+                        <x-forms.input id="oauth_settings_map.{{ $oauth_setting['provider'] }}.custom_label"
+                            label="Custom Button Label" placeholder="e.g. Login with Okta" />
                         @if ($oauth_setting['provider'] == 'azure')
                             <x-forms.input id="oauth_settings_map.{{ $oauth_setting['provider'] }}.tenant"
                                 label="Tenant" />
@@ -41,7 +43,8 @@
                             $oauth_setting['provider'] == 'authentik' ||
                                 $oauth_setting['provider'] == 'clerk' ||
                                 $oauth_setting['provider'] == 'zitadel' ||
-                                $oauth_setting['provider'] == 'gitlab')
+                                $oauth_setting['provider'] == 'gitlab' ||
+                                $oauth_setting['provider'] == 'oidc')
                             <x-forms.input id="oauth_settings_map.{{ $oauth_setting['provider'] }}.base_url"
                                 label="Base URL" />
                         @endif

--- a/tests/Feature/OauthControllerTest.php
+++ b/tests/Feature/OauthControllerTest.php
@@ -77,3 +77,39 @@ it('rejects oauth logins when the provider does not return an email address', fu
     'null email' => [null],
     'blank email' => ['   '],
 ]);
+
+it('logs in an existing user via generic OIDC provider', function () {
+    config()->set('app.maintenance.driver', 'file');
+
+    OauthSetting::create([
+        'provider' => 'oidc',
+        'client_id' => 'oidc-client-id',
+        'client_secret' => 'oidc-client-secret',
+        'redirect_uri' => 'https://coolify.example.com/auth/oidc/callback',
+        'base_url' => 'https://oidc.example.com',
+        'custom_label' => 'Login with Keycloak',
+    ]);
+
+    $oauth = OauthSetting::where('provider', 'oidc')->first();
+    expect($oauth->custom_label)->toBe('Login with Keycloak');
+
+    $user = User::factory()->create([
+        'email' => 'oidcuser@example.com',
+    ]);
+
+    $provider = Mockery::mock();
+    $provider->shouldReceive('setConfig')->once()->andReturnSelf();
+    $provider->shouldReceive('user')->once()->andReturn((object) [
+        'email' => 'oidcuser@example.com',
+        'name' => 'OIDC User',
+        'id' => 'oidc-user-id',
+    ]);
+
+    Socialite::shouldReceive('driver')->once()->with('oidc')->andReturn($provider);
+
+    $response = $this->get(route('auth.callback', 'oidc'));
+
+    $response->assertRedirect('/');
+    $this->assertAuthenticatedAs($user);
+    expect(User::count())->toBe(1);
+});


### PR DESCRIPTION
## Changes

Added support for a generic OpenID Connect (OIDC) OAuth provider using `socialiteproviders/oidc`. This allows administrators to set up authentication with any OIDC-compliant identity provider (such as Keycloak, Auth0, or Okta) dynamically via the settings UI.

To make this solution robust and highly customizable for organizations, the following improvements were introduced:
- **Custom Button Label Support**: Added a `custom_label` column to the `oauth_settings` database schema and Livewire settings interface. This enables administrators to label the login button specifically for their provider (e.g., "Login with Keycloak" or "Login with Okta") instead of having a generic "Login with OpenID Connect" button.
- **OIDC Configuration Validation**: Ensured that `base_url` is a required field when OIDC authentication is enabled.
- **Settings Casing**: Displays the proper capitalized `"OIDC"` header instead of `"Oidc"` on the settings UI.
- **Localization**: Added OIDC login button translation entries for English, German, and Polish.

## Issues

- Fixes #6696

## Category

- [ ] Bug fix
- [x] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview / Validation Proof

An automated feature test has been added to verify database persistence, redirection, and callback authentication flows specifically for the generic OIDC driver:

```php
it('logs in an existing user via generic OIDC provider', function () {
    config()->set('app.maintenance.driver', 'file');

    OauthSetting::create([
        'provider' => 'oidc',
        'client_id' => 'oidc-client-id',
        'client_secret' => 'oidc-client-secret',
        'redirect_uri' => 'https://coolify.example.com/auth/oidc/callback',
        'base_url' => 'https://oidc.example.com',
        'custom_label' => 'Login with Keycloak',
    ]);

    $oauth = OauthSetting::where('provider', 'oidc')->first();
    expect($oauth->custom_label)->toBe('Login with Keycloak');

    $user = User::factory()->create([
        'email' => 'oidcuser@example.com',
    ]);

    $provider = Mockery::mock();
    $provider->shouldReceive('setConfig')->once()->andReturnSelf();
    $provider->shouldReceive('user')->once()->andReturn((object) [
        'email' => 'oidcuser@example.com',
        'name' => 'OIDC User',
        'id' => 'oidc-user-id',
    ]);

    Socialite::shouldReceive('driver')->once()->with('oidc')->andReturn($provider);

    $response = $this->get(route('auth.callback', 'oidc'));

    $response->assertRedirect('/');
    $this->assertAuthenticatedAs($user);
    expect(User::count())->toBe(1);
});
