### PR TITLE
feat(service): add Obsidian template

### DIFF
--- a/public/svgs/obsidian.svg
+++ b/public/svgs/obsidian.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <polygon points="50,4 78,22 88,56 68,92 32,92 12,56 22,22" fill="#7C3AED"/>
+  <polygon points="50,4 22,22 32,52 50,38" fill="#9F67FF" opacity="0.7"/>
+  <polygon points="50,4 78,22 68,52 50,38" fill="#4C1D95" opacity="0.6"/>
+  <polygon points="32,52 68,52 68,92 32,92" fill="#5B21B6" opacity="0.5"/>
+  <line x1="50" y1="4" x2="50" y2="38" stroke="#C4B5FD" stroke-width="1.5" opacity="0.8"/>
+</svg>

--- a/templates/compose/obsidian.yaml
+++ b/templates/compose/obsidian.yaml
@@ -1,0 +1,33 @@
+# documentation: https://docs.linuxserver.io/images/docker-obsidian
+# slogan: Note-taking app with linking, organizing, and hundreds of plugins - runs in your browser via remote desktop
+# category: productivity
+# tags: notes,obsidian,markdown,desktop,gui,productivity
+# logo: svgs/obsidian.svg
+# port: 3000
+
+services:
+  obsidian:
+    image: lscr.io/linuxserver/obsidian:latest
+    environment:
+      # Coolify routing - do not remove
+      - SERVICE_URL_OBSIDIAN_3000
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=${TZ:-Etc/UTC}
+      # HTTP Basic Auth - auto-generated on first deploy; change via Coolify env vars
+      - CUSTOM_USER=${SERVICE_USER_OBSIDIAN}
+      - PASSWORD=${SERVICE_PASSWORD_OBSIDIAN}
+    volumes:
+      - obsidian-config:/config
+    # Required for Electron/Chromium shared memory
+    shm_size: "1gb"
+    # Needed on hosts with older kernels or libseccomp; safe to remove on modern hosts
+    security_opt:
+      - seccomp=unconfined
+    healthcheck:
+      test: ["CMD", "curl", "-s", "-o", "/dev/null", "http://127.0.0.1:3000/"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
+      start_period: 90s
+    restart: unless-stopped

--- a/templates/compose/obsidian.yaml
+++ b/templates/compose/obsidian.yaml
@@ -9,12 +9,10 @@ services:
   obsidian:
     image: lscr.io/linuxserver/obsidian:latest
     environment:
-      # Coolify routing - do not remove
       - SERVICE_URL_OBSIDIAN_3000
       - PUID=${PUID:-1000}
       - PGID=${PGID:-1000}
       - TZ=${TZ:-Etc/UTC}
-      # HTTP Basic Auth - auto-generated on first deploy; change via Coolify env vars
       - CUSTOM_USER=${SERVICE_USER_OBSIDIAN}
       - PASSWORD=${SERVICE_PASSWORD_OBSIDIAN}
     volumes:
@@ -30,4 +28,3 @@ services:
       timeout: 20s
       retries: 10
       start_period: 90s
-    restart: unless-stopped


### PR DESCRIPTION
## Changes

Adds Obsidian as a one-click Coolify service. The LinuxServer.io image streams a full
Linux desktop to the browser via Selkies WebSocket - no client install required. The vault
persists in a named Docker volume across updates.

- `templates/compose/obsidian.yaml` â€” one-click service template
- `public/svgs/obsidian.svg` â€” service logo

## Issues

- Service Template Request: https://github.com/coollabsio/coolify/discussions/6526
- Related docs PR: coollabsio/coolify-docs#651

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

After deploying, the browser prompts for HTTP Basic Auth credentials (auto-generated as
`CUSTOM_USER` / `PASSWORD`). A full Linux desktop with Obsidian running appears in the
browser. On first launch the vault picker is shown; notes persist in `/config` inside the
`obsidian-config` volume.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Used to draft and validate the compose template. Template manually
  tested by the author on a live Coolify instance before submission.

## Testing

Deployed against a live Coolify instance (v4.1.2):

- Image: `lscr.io/linuxserver/obsidian:latest`
- Container reached `running:healthy` at 144s (start_period: 90s + probe window)
- Healthcheck: `curl -s -o /dev/null http://127.0.0.1:3000/` exits 0 on HTTP 401
  (HTTP Basic Auth is always active; wget and curl -f both fail on 401 â€” intentional)
- Root `/` responds HTTP 401, confirming the server is up behind the auth wall

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
