### PR TITLE
feat(api): add server metrics endpoint

### DIFF
--- a/app/Http/Controllers/Api/ServersController.php
+++ b/app/Http/Controllers/Api/ServersController.php
@@ -174,6 +174,90 @@ class ServersController extends Controller
     }
 
     #[OA\Get(
+        summary: 'Metrics',
+        description: 'Get current CPU and memory metrics by server UUID.',
+        path: '/servers/{uuid}/metrics',
+        operationId: 'get-server-metrics-by-uuid',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Servers'],
+        parameters: [
+            new OA\Parameter(name: 'uuid', in: 'path', required: true, description: 'Server\'s UUID', schema: new OA\Schema(type: 'string')),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Get current server metrics.',
+                content: [
+                    new OA\MediaType(
+                        mediaType: 'application/json',
+                        schema: new OA\Schema(
+                            type: 'object',
+                            properties: [
+                                'cpu' => [
+                                    'type' => 'object',
+                                    'properties' => [
+                                        'time' => ['type' => 'string'],
+                                        'percent' => ['type' => 'number'],
+                                    ],
+                                ],
+                                'memory' => [
+                                    'type' => 'object',
+                                    'properties' => [
+                                        'time' => ['type' => 'string'],
+                                        'total' => ['type' => 'integer'],
+                                        'available' => ['type' => 'integer'],
+                                        'used' => ['type' => 'integer'],
+                                        'usedPercent' => ['type' => 'number'],
+                                        'free' => ['type' => 'integer'],
+                                    ],
+                                ],
+                            ]
+                        )
+                    ),
+                ]),
+            new OA\Response(
+                response: 401,
+                ref: '#/components/responses/401',
+            ),
+            new OA\Response(
+                response: 400,
+                ref: '#/components/responses/400',
+            ),
+            new OA\Response(
+                response: 404,
+                ref: '#/components/responses/404',
+            ),
+            new OA\Response(
+                response: 409,
+                description: 'Metrics are disabled for this server.',
+            ),
+        ]
+    )]
+    public function metrics_by_server(Request $request): JsonResponse
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+
+        $server = ModelsServer::whereTeamId($teamId)->whereUuid($request->uuid)->first();
+        if (is_null($server)) {
+            return response()->json(['message' => 'Server not found.'], 404);
+        }
+
+        if (! $server->isMetricsEnabled()) {
+            return response()->json(['message' => 'Metrics are disabled for this server.'], 409);
+        }
+
+        return response()->json(serializeApiResponse([
+            'cpu' => $this->sentinelMetric($server, '/cpu/current'),
+            'memory' => $this->sentinelMetric($server, '/memory/current'),
+        ]));
+    }
+
+    #[OA\Get(
         summary: 'Resources',
         description: 'Get resources by server.',
         path: '/servers/{uuid}/resources',
@@ -244,6 +328,32 @@ class ServersController extends Controller
         $server = $this->removeSensitiveData($server);
 
         return response()->json(serializeApiResponse(data_get($server, 'resources')));
+    }
+
+    private function sentinelMetric(ModelsServer $server, string $path): array
+    {
+        $token = $server->settings->ensureValidSentinelToken();
+        $endpoint = "http://localhost:8888/api{$path}";
+        $response = instant_remote_process(
+            ["docker exec coolify-sentinel sh -c 'curl -sS -H \"Authorization: Bearer {$token}\" {$endpoint}'"],
+            $server,
+            false
+        );
+        $metric = json_decode($response, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \Exception('Sentinel returned invalid JSON: '.json_last_error_msg());
+        }
+
+        if (! is_array($metric)) {
+            throw new \Exception('Sentinel returned an invalid metrics payload.');
+        }
+
+        if (data_get($metric, 'error')) {
+            throw new \Exception(data_get($metric, 'error'));
+        }
+
+        return $metric;
     }
 
     #[OA\Get(

--- a/routes/api.php
+++ b/routes/api.php
@@ -83,6 +83,7 @@ Route::group([
 
     Route::get('/servers', [ServersController::class, 'servers'])->middleware(['api.ability:read']);
     Route::get('/servers/{uuid}', [ServersController::class, 'server_by_uuid'])->middleware(['api.ability:read']);
+    Route::get('/servers/{uuid}/metrics', [ServersController::class, 'metrics_by_server'])->middleware(['api.ability:read']);
     Route::get('/servers/{uuid}/domains', [ServersController::class, 'domains_by_server'])->middleware(['api.ability:read']);
     Route::get('/servers/{uuid}/resources', [ServersController::class, 'resources_by_server'])->middleware(['api.ability:read']);
 


### PR DESCRIPTION
## Summary
- Add a read-only `GET /api/v1/servers/{uuid}/metrics` endpoint.
- Return current Sentinel CPU and memory metrics for a server.
- Reuse the same Sentinel access pattern Coolify already uses internally via `docker exec coolify-sentinel`.
- Return `409` when metrics are disabled for the server.

## Notes
- Disk metrics are not included because Sentinel currently exposes CPU and memory current endpoints, but not a current disk endpoint.

## Testing
- `git diff --check`
- Not run: PHP/Laravel tests and Pint, because PHP/Composer are not available in this local environment.