### PR TITLE
feat(api): add server metrics endpoint

### DIFF
--- a/app/Http/Controllers/Api/ServersController.php
+++ b/app/Http/Controllers/Api/ServersController.php
@@ -174,6 +174,90 @@ class ServersController extends Controller
     }
 
     #[OA\Get(
+        summary: 'Metrics',
+        description: 'Get current CPU and memory metrics by server UUID.',
+        path: '/servers/{uuid}/metrics',
+        operationId: 'get-server-metrics-by-uuid',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Servers'],
+        parameters: [
+            new OA\Parameter(name: 'uuid', in: 'path', required: true, description: 'Server\'s UUID', schema: new OA\Schema(type: 'string')),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Get current server metrics.',
+                content: [
+                    new OA\MediaType(
+                        mediaType: 'application/json',
+                        schema: new OA\Schema(
+                            type: 'object',
+                            properties: [
+                                'cpu' => [
+                                    'type' => 'object',
+                                    'properties' => [
+                                        'time' => ['type' => 'string'],
+                                        'percent' => ['type' => 'number'],
+                                    ],
+                                ],
+                                'memory' => [
+                                    'type' => 'object',
+                                    'properties' => [
+                                        'time' => ['type' => 'string'],
+                                        'total' => ['type' => 'integer'],
+                                        'available' => ['type' => 'integer'],
+                                        'used' => ['type' => 'integer'],
+                                        'usedPercent' => ['type' => 'number'],
+                                        'free' => ['type' => 'integer'],
+                                    ],
+                                ],
+                            ]
+                        )
+                    ),
+                ]),
+            new OA\Response(
+                response: 401,
+                ref: '#/components/responses/401',
+            ),
+            new OA\Response(
+                response: 400,
+                ref: '#/components/responses/400',
+            ),
+            new OA\Response(
+                response: 404,
+                ref: '#/components/responses/404',
+            ),
+            new OA\Response(
+                response: 409,
+                description: 'Metrics are disabled for this server.',
+            ),
+        ]
+    )]
+    public function metrics_by_server(Request $request): JsonResponse
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+
+        $server = ModelsServer::whereTeamId($teamId)->whereUuid($request->uuid)->first();
+        if (is_null($server)) {
+            return response()->json(['message' => 'Server not found.'], 404);
+        }
+
+        if (! $server->isMetricsEnabled()) {
+            return response()->json(['message' => 'Metrics are disabled for this server.'], 409);
+        }
+
+        return response()->json(serializeApiResponse([
+            'cpu' => $this->sentinelMetric($server, '/cpu/current'),
+            'memory' => $this->sentinelMetric($server, '/memory/current'),
+        ]));
+    }
+
+    #[OA\Get(
         summary: 'Resources',
         description: 'Get resources by server.',
         path: '/servers/{uuid}/resources',
@@ -244,6 +328,32 @@ class ServersController extends Controller
         $server = $this->removeSensitiveData($server);
 
         return response()->json(serializeApiResponse(data_get($server, 'resources')));
+    }
+
+    private function sentinelMetric(ModelsServer $server, string $path): array
+    {
+        $token = $server->settings->ensureValidSentinelToken();
+        $endpoint = "http://localhost:8888/api{$path}";
+        $response = instant_remote_process(
+            ["docker exec coolify-sentinel sh -c 'curl -sS -H \"Authorization: Bearer {$token}\" {$endpoint}'"],
+            $server,
+            false
+        );
+        $metric = json_decode($response, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \Exception('Sentinel returned invalid JSON: '.json_last_error_msg());
+        }
+
+        if (! is_array($metric)) {
+            throw new \Exception('Sentinel returned an invalid metrics payload.');
+        }
+
+        if (data_get($metric, 'error')) {
+            throw new \Exception(data_get($metric, 'error'));
+        }
+
+        return $metric;
     }
 
     #[OA\Get(

--- a/routes/api.php
+++ b/routes/api.php
@@ -83,6 +83,7 @@ Route::group([
 
     Route::get('/servers', [ServersController::class, 'servers'])->middleware(['api.ability:read']);
     Route::get('/servers/{uuid}', [ServersController::class, 'server_by_uuid'])->middleware(['api.ability:read']);
+    Route::get('/servers/{uuid}/metrics', [ServersController::class, 'metrics_by_server'])->middleware(['api.ability:read']);
     Route::get('/servers/{uuid}/domains', [ServersController::class, 'domains_by_server'])->middleware(['api.ability:read']);
     Route::get('/servers/{uuid}/resources', [ServersController::class, 'resources_by_server'])->middleware(['api.ability:read']);
 

--- a/tests/Feature/ServerMetricsApiTest.php
+++ b/tests/Feature/ServerMetricsApiTest.php
@@ -1,0 +1,107 @@
+<?php
+
+use App\Models\InstanceSettings;
+use App\Models\PrivateKey;
+use App\Models\Server;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Process;
+use Illuminate\Testing\TestResponse;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    config(['constants.ssh.mux_enabled' => false]);
+
+    InstanceSettings::forceCreate(['id' => 0, 'is_api_enabled' => true]);
+
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+    session(['currentTeam' => $this->team]);
+
+    $this->privateKey = PrivateKey::create([
+        'name' => 'Metrics API Key',
+        'private_key' => generateSSHKey('ed25519')['private'],
+        'team_id' => $this->team->id,
+    ]);
+
+    $this->server = Server::factory()->create([
+        'team_id' => $this->team->id,
+        'private_key_id' => $this->privateKey->id,
+    ]);
+
+    $token = $this->user->createToken('read-token', ['read']);
+    $token->accessToken->forceFill(['team_id' => $this->team->id])->save();
+    $this->bearerToken = $token->plainTextToken;
+});
+
+function getServerMetricsApi(Server $server): TestResponse
+{
+    return test()->withHeaders([
+        'Authorization' => 'Bearer '.test()->bearerToken,
+        'Content-Type' => 'application/json',
+    ])->getJson('/api/v1/servers/'.$server->uuid.'/metrics');
+}
+
+it('returns current cpu and memory metrics for a server', function () {
+    $this->server->settings()->update(['is_metrics_enabled' => true]);
+
+    Process::fake([
+        '*/cpu/current*' => Process::result(output: json_encode([
+            'time' => '2026-06-19T10:00:00Z',
+            'percent' => 12.5,
+        ]), exitCode: 0),
+        '*/memory/current*' => Process::result(output: json_encode([
+            'time' => '2026-06-19T10:00:00Z',
+            'total' => 1024,
+            'available' => 768,
+            'used' => 256,
+            'usedPercent' => 25,
+            'free' => 512,
+        ]), exitCode: 0),
+    ]);
+
+    getServerMetricsApi($this->server)
+        ->assertOk()
+        ->assertJsonPath('cpu.percent', 12.5)
+        ->assertJsonPath('memory.usedPercent', 25);
+
+    Process::assertRan(fn ($process) => str_contains($process->command, '/cpu/current'));
+    Process::assertRan(fn ($process) => str_contains($process->command, '/memory/current'));
+});
+
+it('returns conflict when metrics are disabled for the server', function () {
+    $this->server->settings()->update(['is_metrics_enabled' => false]);
+
+    Process::fake();
+
+    getServerMetricsApi($this->server)
+        ->assertStatus(409)
+        ->assertJson(['message' => 'Metrics are disabled for this server.']);
+
+    Process::assertNothingRan();
+});
+
+it('does not expose metrics for another team server', function () {
+    $otherTeam = Team::factory()->create();
+    $otherPrivateKey = PrivateKey::create([
+        'name' => 'Other Metrics API Key',
+        'private_key' => generateSSHKey('ed25519')['private'],
+        'team_id' => $otherTeam->id,
+    ]);
+    $otherServer = Server::factory()->create([
+        'team_id' => $otherTeam->id,
+        'private_key_id' => $otherPrivateKey->id,
+    ]);
+    $otherServer->settings()->update(['is_metrics_enabled' => true]);
+
+    Process::fake();
+
+    getServerMetricsApi($otherServer)
+        ->assertNotFound()
+        ->assertJson(['message' => 'Server not found.']);
+
+    Process::assertNothingRan();
+});


### PR DESCRIPTION
## Summary
- Add a read-only `GET /api/v1/servers/{uuid}/metrics` endpoint.
- Return current Sentinel CPU and memory metrics for a server.
- Reuse the same Sentinel access pattern Coolify already uses internally via `docker exec coolify-sentinel`.
- Return `409` when metrics are disabled for the server.
- Add feature coverage for success, disabled metrics, and cross-team access.

## Notes
- Disk metrics are not included because Sentinel currently exposes CPU and memory current endpoints, but not a current disk endpoint.
- Replaces closed PR #10705 with test coverage added.

## Testing
- `git diff --check`
- Docker compose Coolify container against compose Postgres/Redis: `./vendor/bin/pest --compact --configuration phpunit.pg.xml tests/Feature/ServerMetricsApiTest.php` - 3 passed, 11 assertions

`phpunit.pg.xml` was generated temporarily for the local run to use Postgres instead of the default SQLite testing connection; the current migration set includes PostgreSQL-specific `ALTER COLUMN ... USING` SQL.
