### PR TITLE
feat(template): add Paperclip

### DIFF
--- a/public/svgs/paperclip.svg
+++ b/public/svgs/paperclip.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none">
+  <rect width="24" height="24" rx="5" fill="#0A0A0A"/>
+  <g transform="translate(12 12) scale(0.86) translate(-12 -12)">
+    <path
+      d="m16 6-8.414 8.586a2 2 0 0 0 2.829 2.829l8.414-8.586a4 4 0 1 0-5.657-5.657l-8.379 8.551a6 6 0 1 0 8.485 8.485l8.379-8.551"
+      fill="none"
+      stroke="#FFFFFF"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </g>
+</svg>

--- a/templates/compose/paperclip.yaml
+++ b/templates/compose/paperclip.yaml
@@ -1,0 +1,88 @@
+# documentation: https://docs.paperclip.ing/
+# slogan: Manage AI agents for work.
+# category: ai
+# tags: ai, agents, orchestration, automation, self-hosted
+# logo: svgs/paperclip.svg
+# port: 3100
+
+services:
+  paperclip:
+    image: ghcr.io/lukasparke/paperclip-coolify:latest
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      - SERVICE_URL_PAPERCLIP_3100
+      - HOST=0.0.0.0
+      - PORT=3100
+      - PAPERCLIP_HOME=/paperclip
+      - HOME=/paperclip
+      - PAPERCLIP_DEPLOYMENT_MODE=${PAPERCLIP_DEPLOYMENT_MODE:-authenticated}
+      - PAPERCLIP_DEPLOYMENT_EXPOSURE=${PAPERCLIP_DEPLOYMENT_EXPOSURE:-public}
+      - PAPERCLIP_AUTH_BASE_URL_MODE=${PAPERCLIP_AUTH_BASE_URL_MODE:-explicit}
+      - PAPERCLIP_PUBLIC_URL=${SERVICE_URL_PAPERCLIP_3100}
+      - PAPERCLIP_AUTH_PUBLIC_BASE_URL=${SERVICE_URL_PAPERCLIP_3100}
+      - BETTER_AUTH_URL=${SERVICE_URL_PAPERCLIP_3100}
+      - BETTER_AUTH_TRUSTED_ORIGINS=${SERVICE_URL_PAPERCLIP_3100}
+      - DATABASE_URL=postgres://${POSTGRES_USER:-paperclip}:${SERVICE_PASSWORD_64_POSTGRES}@postgres:5432/${POSTGRES_DB:-paperclip}
+      - BETTER_AUTH_SECRET=${SERVICE_HEX_64_BETTERAUTH}
+      - PAPERCLIP_AGENT_JWT_SECRET=${SERVICE_HEX_64_AGENTJWT}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - GEMINI_API_KEY=${GEMINI_API_KEY:-}
+      - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
+      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      - KIMI_API_KEY=${KIMI_API_KEY:-}
+      - DEEPSEEK_API_KEY=${DEEPSEEK_API_KEY:-}
+      - GROQ_API_KEY=${GROQ_API_KEY:-}
+      - MISTRAL_API_KEY=${MISTRAL_API_KEY:-}
+      - XAI_API_KEY=${XAI_API_KEY:-}
+      - CEREBRAS_API_KEY=${CEREBRAS_API_KEY:-}
+      - NVIDIA_API_KEY=${NVIDIA_API_KEY:-}
+      - FIREWORKS_API_KEY=${FIREWORKS_API_KEY:-}
+      - TOGETHER_API_KEY=${TOGETHER_API_KEY:-}
+      - ZAI_API_KEY=${ZAI_API_KEY:-}
+      - ZAI_CODING_CN_API_KEY=${ZAI_CODING_CN_API_KEY:-}
+      - MINIMAX_API_KEY=${MINIMAX_API_KEY:-}
+      - MINIMAX_CN_API_KEY=${MINIMAX_CN_API_KEY:-}
+      - AI_GATEWAY_API_KEY=${AI_GATEWAY_API_KEY:-}
+      - AZURE_OPENAI_API_KEY=${AZURE_OPENAI_API_KEY:-}
+      - AZURE_OPENAI_BASE_URL=${AZURE_OPENAI_BASE_URL:-}
+      - AZURE_OPENAI_RESOURCE_NAME=${AZURE_OPENAI_RESOURCE_NAME:-}
+      - AZURE_OPENAI_API_VERSION=${AZURE_OPENAI_API_VERSION:-}
+      - AZURE_OPENAI_DEPLOYMENT_NAME_MAP=${AZURE_OPENAI_DEPLOYMENT_NAME_MAP:-}
+      - CLOUDFLARE_API_KEY=${CLOUDFLARE_API_KEY:-}
+      - CLOUDFLARE_ACCOUNT_ID=${CLOUDFLARE_ACCOUNT_ID:-}
+      - CLOUDFLARE_GATEWAY_ID=${CLOUDFLARE_GATEWAY_ID:-}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
+      - AWS_REGION=${AWS_REGION:-}
+      - AWS_ENDPOINT_URL_BEDROCK_RUNTIME=${AWS_ENDPOINT_URL_BEDROCK_RUNTIME:-}
+    volumes:
+      - paperclip-data:/paperclip
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:3100/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER:-paperclip}
+      - POSTGRES_PASSWORD=${SERVICE_PASSWORD_64_POSTGRES}
+      - POSTGRES_DB=${POSTGRES_DB:-paperclip}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+volumes:
+  paperclip-data:
+  postgres-data:


### PR DESCRIPTION
## Changes

Add a one-click service template for Paperclip, an open-source app for managing AI agent teams.

- Adds `templates/compose/paperclip.yaml`
- Uses the published image `ghcr.io/lukasparke/paperclip-coolify:latest`
- Includes a PostgreSQL 16 sidecar with health checks
- Persists Paperclip and Postgres data in named volumes
- Auto-generates Better Auth, agent JWT, and Postgres secrets with Coolify magic values
- Passes optional provider API keys through to Paperclip and child agent processes
- Adds the Paperclip SVG logo

## Issues

- Fixes N/A

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A - Template addition only, no UI changes.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: pi coding agent
- How extensively: Used to update the deployment image workflow, create the Coolify template, and run validation commands.

## Testing

- Published the image from `LukasParke/paperclip-coolify` using GitHub Actions:
  - https://github.com/LukasParke/paperclip-coolify/actions/runs/27863241346
- Verified the published image exists:
  - `docker manifest inspect ghcr.io/lukasparke/paperclip-coolify:latest`
- Ran Docker Compose validation with representative environment values:
  - `docker compose -f templates/compose/paperclip.yaml config --quiet`
- Ran a local Docker Compose deployment with representative public URL and generated secrets:
  - `docker compose -p paperclip-template-test-... -f templates/compose/paperclip.yaml up -d --wait --wait-timeout 240`
  - Verified `paperclip health=healthy`
  - Confirmed logs show external Postgres mode, migrations applied, auth ready, and server listening on `0.0.0.0:3100`

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
