### PR TITLE
fix: widen HTTP basic auth password column

### DIFF
--- a/database/migrations/2026_06_21_000000_widen_application_http_basic_auth_password_column.php
+++ b/database/migrations/2026_06_21_000000_widen_application_http_basic_auth_password_column.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('applications', function (Blueprint $table) {
+            $table->text('http_basic_auth_password')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('applications', function (Blueprint $table) {
+            $table->string('http_basic_auth_password')->nullable()->change();
+        });
+    }
+};

--- a/tests/Feature/ApplicationHttpBasicAuthPasswordStorageTest.php
+++ b/tests/Feature/ApplicationHttpBasicAuthPasswordStorageTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use App\Models\Application;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+it('widens existing HTTP Basic Authentication password columns before storing long encrypted passwords', function () {
+    $defaultConnection = config('database.default');
+
+    config()->set('database.connections.basic_auth_migration_test', [
+        'driver' => 'sqlite',
+        'database' => ':memory:',
+        'prefix' => '',
+        'foreign_key_constraints' => true,
+    ]);
+    config()->set('database.default', 'basic_auth_migration_test');
+    DB::purge('basic_auth_migration_test');
+
+    try {
+        Schema::create('applications', function (Blueprint $table) {
+            $table->id();
+            $table->string('uuid');
+            $table->string('name');
+            $table->string('git_repository');
+            $table->string('git_branch');
+            $table->string('build_pack');
+            $table->string('ports_exposes');
+            $table->unsignedBigInteger('environment_id');
+            $table->boolean('is_http_basic_auth_enabled')->default(false);
+            $table->string('http_basic_auth_username')->nullable();
+            $table->string('http_basic_auth_password')->nullable();
+            $table->timestamps();
+        });
+
+        expect(Schema::getColumnType('applications', 'http_basic_auth_password'))->toBe('varchar');
+
+        $migrationFiles = glob(database_path('migrations/*_widen_application_http_basic_auth_password_column.php'));
+        expect($migrationFiles)->toHaveCount(1);
+
+        $migration = require $migrationFiles[0];
+        $migration->up();
+
+        expect(Schema::getColumnType('applications', 'http_basic_auth_password'))->toBe('text');
+
+        $password = str_repeat('a', 64);
+
+        $application = Application::withoutEvents(fn () => Application::create([
+            'uuid' => 'basic-auth-password-storage-test',
+            'name' => 'basic-auth-password-storage-test',
+            'git_repository' => 'https://github.com/coollabsio/coolify',
+            'git_branch' => 'main',
+            'build_pack' => 'nixpacks',
+            'ports_exposes' => '3000',
+            'environment_id' => 1,
+            'is_http_basic_auth_enabled' => true,
+            'http_basic_auth_username' => 'admin',
+            'http_basic_auth_password' => $password,
+        ]));
+
+        $rawPassword = DB::table('applications')
+            ->where('id', $application->id)
+            ->value('http_basic_auth_password');
+
+        expect(strlen($rawPassword))->toBeGreaterThan(255)
+            ->and(Crypt::decryptString($rawPassword))->toBe($password)
+            ->and($application->fresh()->http_basic_auth_password)->toBe($password);
+    } finally {
+        DB::disconnect('basic_auth_migration_test');
+        config()->set('database.default', $defaultConnection);
+    }
+});


### PR DESCRIPTION
## Summary
- Widen application HTTP Basic Authentication password storage from varchar to text
- Add a regression test proving long encrypted passwords survive storage and retrieval

## Test Plan
- php -l database/migrations/2026_06_21_000000_widen_application_http_basic_auth_password_column.php
- php -l tests/Feature/ApplicationHttpBasicAuthPasswordStorageTest.php
- APP_KEY=base64:$(php -r 'echo base64_encode(random_bytes(32));') vendor/bin/pest tests/Feature/ApplicationHttpBasicAuthPasswordStorageTest.php --colors=never
- vendor/bin/pint --dirty --test

Fixes #9643