### PR TITLE
fix: invitation magic link redirects immediately to /login

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -126,7 +126,6 @@ class Controller extends BaseController
             $invitation = TeamInvitation::query()
                 ->where('email', $email)
                 ->when($invitationUuid, fn ($query) => $query->where('uuid', $invitationUuid))
-                ->where('link', request()->fullUrl())
                 ->first();
             if (! $invitation || ! $invitation->isValid()) {
                 return redirect()->route('login')->with('error', 'Invitation has expired or been revoked.');

--- a/tests/Feature/InvitationLinkHandlingTest.php
+++ b/tests/Feature/InvitationLinkHandlingTest.php
@@ -77,6 +77,24 @@ it('accepts a valid magic link invitation only once and rotates the temporary pa
     $this->assertGuest();
 });
 
+it('accepts a valid magic link even when the stored link does not match the request url', function () {
+    // Reproduces #10633: in real deployments the stored link is generated from
+    // APP_URL via route(), but request()->fullUrl() reflects the live request
+    // (e.g. http vs https behind a reverse proxy, or a different host/port).
+    // Binding on the encrypted invitation uuid must be enough to accept it.
+    [$team, $user, , $token] = createInvitationLinkFixture();
+
+    TeamInvitation::where('email', $user->email)->update([
+        'link' => 'https://behind-a-proxy.example.com/auth/link?token=stored-under-a-different-url',
+    ]);
+
+    $this->get(route('auth.link', ['token' => $token]))
+        ->assertRedirect(route('dashboard'));
+
+    $this->assertAuthenticatedAs($user);
+    expect($user->teams()->where('team_id', $team->id)->exists())->toBeTrue();
+});
+
 it('rejects a magic link when the invitation was revoked', function () {
     [, $user, , $token, $invitation] = createInvitationLinkFixture();
     $invitation->delete();


### PR DESCRIPTION
## Changes

Newly invited people (no account yet) get a magic link like /auth/link?token=... Opening it immediately bounces them to /login, so they can never join the team.

This removes one line in Controller::link() that required the stored invitation link to exactly equal the live request URL. The stored link is built from APP_URL via route(), while the request URL is rebuilt from the incoming request. Behind Coolify's reverse proxy (https APP_URL vs http seen by the container), or on any host/port/encoding difference, the two never match, so the lookup finds nothing and the user is rejected.

The invitation uuid in the encrypted token already binds each magic link to its invitation (matched separately), so the URL check was redundant and fragile. Removing it keeps that property while fixing the redirect. Regression from v4.1.2 (commit cd06e10b1).

## Issues

- Fixes #10633

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable, auth flow with no UI change. After the fix, opening an invitation link logs the invitee in and adds them to the team instead of redirecting to /login.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude (Claude Code)
- How extensively: Used to bisect the regression and draft the fix and test. The change deletes one redundant WHERE clause; the existing uuid match preserves the original intent.

## Testing

Added a regression test in tests/Feature/InvitationLinkHandlingTest.php that overwrites the stored link with an unrelated URL and asserts the invitation is still accepted. Ran the file locally (PHP 8.5, sqlite): 6 passed (32 assertions). Verified the new test fails on the pre-fix code (redirects to /login), reproducing the bug, and the existing rejection tests still pass via the uuid and email match. Pint passes.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.

