### PR TITLE
feat: add correct amazon linux install commands

### DIFF
--- a/app/Actions/Server/InstallDocker.php
+++ b/app/Actions/Server/InstallDocker.php
@@ -73,6 +73,8 @@ class InstallDocker
 
             if ($supported_os_type->contains('debian')) {
                 $command = $command->merge([$this->getDebianDockerInstallCommand()]);
+            } elseif ($supported_os_type->contains('amzn')) {
+                $command = $command->merge([$this->getAmazonLinuxDockerInstallCommand()]);
             } elseif ($supported_os_type->contains('rhel')) {
                 $command = $command->merge([$this->getRhelDockerInstallCommand()]);
             } elseif ($supported_os_type->contains('sles')) {
@@ -124,6 +126,14 @@ class InstallDocker
             'apt-get update && '.
             'apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin'.
             ')';
+    }
+
+    private function getAmazonLinuxDockerInstallCommand(): string
+    {
+        return 'dnf install -y docker && '.
+            'mkdir -p /usr/local/lib/docker/cli-plugins && '.
+            'curl -fsSL "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/lib/docker/cli-plugins/docker-compose && '.
+            'chmod +x /usr/local/lib/docker/cli-plugins/docker-compose';
     }
 
     private function getRhelDockerInstallCommand(): string

--- a/app/Actions/Server/InstallPrerequisites.php
+++ b/app/Actions/Server/InstallPrerequisites.php
@@ -29,6 +29,14 @@ class InstallPrerequisites
                 'command -v git >/dev/null || apt install -y git',
                 'command -v jq >/dev/null || apt install -y jq',
             ]);
+        } elseif ($supported_os_type->contains('amzn')) {
+            $command = $command->merge([
+                "echo 'Installing Prerequisites...'",
+                'dnf install -y findutils',
+                'command -v wget >/dev/null || dnf install -y wget',
+                'command -v git >/dev/null || dnf install -y git',
+                'command -v jq >/dev/null || dnf install -y jq',
+            ]);
         } elseif ($supported_os_type->contains('rhel')) {
             $command = $command->merge([
                 "echo 'Installing Prerequisites...'",

--- a/tests/Unit/AmazonLinuxSupportTest.php
+++ b/tests/Unit/AmazonLinuxSupportTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use App\Actions\Server\InstallDocker;
+use App\Actions\Server\InstallPrerequisites;
+
+it('includes amzn in the supported OS list', function () {
+    $rhel = collect(SUPPORTED_OS)->first(fn ($os) => str($os)->contains('amzn'));
+    expect($rhel)->not->toBeNull();
+});
+
+it('install script handles amazon linux prerequisites', function () {
+    $installScript = file_get_contents(base_path('scripts/install.sh'));
+
+    expect($installScript)
+        ->toContain('"amzn"')
+        ->toContain('dnf install -y findutils')
+        ->toContain('dnf install -y wget git jq openssl');
+});
+
+it('nightly install script handles amazon linux prerequisites', function () {
+    $installScript = file_get_contents(base_path('other/nightly/install.sh'));
+
+    expect($installScript)
+        ->toContain('"amzn"')
+        ->toContain('dnf install -y findutils')
+        ->toContain('dnf install -y wget git jq openssl');
+});
+
+it('install script handles amazon linux docker installation separately from rhel', function () {
+    $installScript = file_get_contents(base_path('scripts/install.sh'));
+
+    expect($installScript)
+        ->toContain('"amzn")')
+        ->toContain('dnf install docker -y');
+});
+
+it('nightly install script handles amazon linux docker installation separately from rhel', function () {
+    $installScript = file_get_contents(base_path('other/nightly/install.sh'));
+
+    expect($installScript)
+        ->toContain('"amzn")')
+        ->toContain('dnf install docker -y');
+});
+
+it('InstallPrerequisites uses findutils for amazon linux', function () {
+    $action = new InstallPrerequisites;
+    $reflection = new ReflectionClass($action);
+
+    $source = file_get_contents($reflection->getFileName());
+
+    expect($source)
+        ->toContain("contains('amzn')")
+        ->toContain('findutils');
+});
+
+it('InstallDocker uses native amazon repos not centos docker repo', function () {
+    $action = new InstallDocker;
+    $reflection = new ReflectionClass($action);
+
+    $source = file_get_contents($reflection->getFileName());
+
+    expect($source)
+        ->toContain("contains('amzn')")
+        ->toContain('getAmazonLinuxDockerInstallCommand')
+        ->toContain('dnf install -y docker')
+        ->not->toContain('DOCKER_CONFIG=${DOCKER_CONFIG');
+});


### PR DESCRIPTION
STRAWBERRY

## Changes

- This PR will add a dedicated getAmazonLinuxDockerInstallCommand. Amazon Linux has docker pre-installed and with the current system it falled back to the CentOS/RHEL docker compose plugin installation, causing the installation to fail.
This adds the correct installation commands.

## Issues

- Fixes

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

<img width="901" height="348" alt="Screenshot_2026-06-22_15-31-22" src="https://github.com/user-attachments/assets/a8c39cca-99f2-4cac-ae5a-a8d3dcb8c269" />
<img width="1360" height="169" alt="Screenshot_2026-06-22_15-31-46" src="https://github.com/user-attachments/assets/af717f6b-6cd1-4a6e-b9f0-f4352045b2f7" />

## AI Assistance

<!-- AI-assisted PRs that are human reviewed are welcome, just let us know so we can review appropriately. -->

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

 - Tools used: Claude Sonnet 4.6
 - How extensively: It was asked to see what caused the amzn command to fail even if the rhel and centos have the same packet manager and the installation seemed to be compatible.

## Testing

I added a UnitTest for this specific case, then i spin up in local coolify and added an Amazon Linux 2023 Server. The validation succeeded as shown in the screenshots

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
