### PR TITLE
fix(env-vars): prevent 500 when searching env vars on services/databases

### DIFF
--- a/app/Livewire/Project/Shared/EnvironmentVariable/All.php
+++ b/app/Livewire/Project/Shared/EnvironmentVariable/All.php
@@ -88,6 +88,10 @@ class All extends Component
 
     public function getEnvironmentVariablesPreviewProperty()
     {
+        if (! $this->showPreview) {
+            return collect();
+        }
+
         return $this->getEnvironmentVariables(true);
     }
 
@@ -139,6 +143,10 @@ class All extends Component
 
     public function getHardcodedEnvironmentVariablesPreviewProperty()
     {
+        if (! $this->showPreview) {
+            return collect();
+        }
+
         return $this->getHardcodedVariables(true);
     }
 

--- a/tests/Feature/EnvironmentVariableSearchTest.php
+++ b/tests/Feature/EnvironmentVariableSearchTest.php
@@ -220,6 +220,26 @@ it('does not delete non-matching variables when saving developer view after sear
         ->toContain('DATABASE_URL');
 });
 
+it('shows the empty message instead of 500 when a service search matches nothing', function () {
+    $service = Service::factory()->create([
+        'environment_id' => $this->environment->id,
+    ]);
+
+    EnvironmentVariable::create([
+        'key' => 'API_KEY',
+        'value' => 'secret',
+        'resourceable_type' => Service::class,
+        'resourceable_id' => $service->id,
+    ]);
+
+    $component = Livewire::test(All::class, ['resource' => $service])
+        ->set('search', 'no-such-variable')
+        ->assertOk()
+        ->assertSee('No environment variables found.');
+
+    expect($component->instance()->hasEnvironmentVariables)->toBeFalse();
+});
+
 it('hides the preview section when search filters out all preview variables', function () {
     $application = Application::factory()->create([
         'environment_id' => $this->environment->id,


### PR DESCRIPTION
## What

Fixes a 500 error when searching the **Environment Variables** list on a **Service** or a **standalone Database** for a term that matches none of the variables.

Fixes #10740

## Why

`App\Livewire\Project\Shared\EnvironmentVariable\All` called `environment_variables_preview()` on the resource unconditionally. That relationship only exists on `Application` — `Service` and the `Standalone*` database models only define `environment_variables()`.

The component's `getHasEnvironmentVariablesProperty()` decides whether to render the *"No environment variables found."* message:

```php
return $this->environmentVariables->isNotEmpty() ||
    $this->environmentVariablesPreview->isNotEmpty() ||   // preview branch
    $this->hardcodedEnvironmentVariables->isNotEmpty() ||
    $this->hardcodedEnvironmentVariablesPreview->isNotEmpty();
```

When a search matched **no** production variables, the `||` no longer short-circuited on the first term, so evaluation fell through to the preview branch → `environment_variables_preview()` → `BadMethodCallException` → 500. With matching results the first term was truthy and the preview branch was never reached, which is why the bug only showed up on no-match searches.

## Fix

The component already has a `showPreview` flag that is set to `true` only for `Application` resources that support preview deployments. The preview property getters now respect it and return an empty collection for resources without preview support, instead of calling the non-existent relationship:

```php
public function getEnvironmentVariablesPreviewProperty()
{
    if (! $this->showPreview) {
        return collect();
    }

    return $this->getEnvironmentVariables(true);
}
```

The same guard is applied to `getHardcodedEnvironmentVariablesPreviewProperty()`. This is the single choke point reached by every failing path (`getHasEnvironmentVariablesProperty`, the blade preview loops); `getDevView()` was already guarded by `showPreview`.

## Tests

Added a feature test to `tests/Feature/EnvironmentVariableSearchTest.php` that searches a Service's env vars with a non-matching term and asserts the empty-state message renders instead of a 500. It fails before the fix (`BadMethodCallException`) and passes after. The existing Application preview tests continue to pass, confirming no regression to the preview path.
