### PR TITLE
fix(domains): accept underscores in hostnames for domain validation

### DIFF
--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -1084,7 +1084,7 @@ class ApplicationsController extends Controller
 
                 $errors = [];
                 $urls = $urls->map(function ($url) use (&$errors) {
-                    if (! filter_var($url, FILTER_VALIDATE_URL)) {
+                    if (! isValidDomainUrl($url)) {
                         $errors[] = "Invalid URL: {$url}";
 
                         return $url;
@@ -1325,7 +1325,7 @@ class ApplicationsController extends Controller
 
                 $errors = [];
                 $urls = $urls->map(function ($url) use (&$errors) {
-                    if (! filter_var($url, FILTER_VALIDATE_URL)) {
+                    if (! isValidDomainUrl($url)) {
                         $errors[] = "Invalid URL: {$url}";
 
                         return $url;
@@ -1538,7 +1538,7 @@ class ApplicationsController extends Controller
 
                 $errors = [];
                 $urls = $urls->map(function ($url) use (&$errors) {
-                    if (! filter_var($url, FILTER_VALIDATE_URL)) {
+                    if (! isValidDomainUrl($url)) {
                         $errors[] = "Invalid URL: {$url}";
 
                         return $url;
@@ -2490,7 +2490,7 @@ class ApplicationsController extends Controller
                     return null;
                 }
 
-                if (! filter_var($url, FILTER_VALIDATE_URL)) {
+                if (! isValidDomainUrl($url)) {
                     $errors[] = 'Invalid URL: '.$url;
 
                     return $url;
@@ -2553,7 +2553,7 @@ class ApplicationsController extends Controller
 
             $errors = [];
             $urls = $urls->map(function ($url) use (&$errors) {
-                if (! filter_var($url, FILTER_VALIDATE_URL)) {
+                if (! isValidDomainUrl($url)) {
                     $errors[] = "Invalid URL: {$url}";
 
                     return $url;
@@ -3866,7 +3866,7 @@ class ApplicationsController extends Controller
                     return null;
                 }
 
-                if (! filter_var($url, FILTER_VALIDATE_URL)) {
+                if (! isValidDomainUrl($url)) {
                     $errors[] = 'Invalid URL: '.$url;
 
                     return str($url)->lower();

--- a/app/Http/Controllers/Api/ServicesController.php
+++ b/app/Http/Controllers/Api/ServicesController.php
@@ -57,7 +57,7 @@ class ServicesController extends Controller
         });
 
         $urls = $urls->map(function ($url) use (&$errors) {
-            if (! filter_var($url, FILTER_VALIDATE_URL)) {
+            if (! isValidDomainUrl($url)) {
                 $errors[] = "Invalid URL: {$url}";
 
                 return $url;

--- a/bootstrap/helpers/domains.php
+++ b/bootstrap/helpers/domains.php
@@ -4,6 +4,34 @@ use App\Models\Application;
 use App\Models\ServiceApplication;
 use Illuminate\Support\Collection;
 
+/**
+ * Validate that a string is a well-formed domain URL.
+ *
+ * PHP's FILTER_VALIDATE_URL follows RFC 3986 and rejects underscores in the
+ * host, but underscores are common in Docker service domains and are accepted
+ * by browsers and Let's Encrypt. When validation fails only because of an
+ * underscore in the host, we re-validate a copy whose host underscores are
+ * swapped for hyphens so the rest of the URL is still strictly validated.
+ */
+function isValidDomainUrl(string $url): bool
+{
+    if (filter_var($url, FILTER_VALIDATE_URL) !== false) {
+        return true;
+    }
+
+    $host = parse_url($url, PHP_URL_HOST);
+    if (blank($host) || ! str_contains($host, '_')) {
+        return false;
+    }
+
+    // Replace only the first occurrence (the authority) so a matching
+    // path or query segment is not accidentally rewritten.
+    $position = strpos($url, $host);
+    $sanitized = substr_replace($url, str_replace('_', '-', $host), $position, strlen($host));
+
+    return filter_var($sanitized, FILTER_VALIDATE_URL) !== false;
+}
+
 function checkDomainUsage(ServiceApplication|Application|null $resource = null, ?string $domain = null)
 {
     $conflicts = [];

--- a/tests/Unit/IsValidDomainUrlTest.php
+++ b/tests/Unit/IsValidDomainUrlTest.php
@@ -1,0 +1,24 @@
+<?php
+
+it('accepts valid domain URLs', function (string $url) {
+    expect(isValidDomainUrl($url))->toBeTrue();
+})->with([
+    'https host' => 'https://myapp.example.com',
+    'http host' => 'http://myapp.example.com',
+    'underscore in host' => 'https://myapp_service.example.com',
+    'multiple underscores in host' => 'https://my_app_service.example.com',
+    'underscore in subdomain' => 'https://my_app.staging.example.com',
+    'host with port' => 'https://myapp_service.example.com:8080',
+    'underscore host with path' => 'https://myapp_service.example.com/path_to/resource',
+    'hyphen host' => 'https://my-app.example.com',
+]);
+
+it('rejects invalid domain URLs', function (string $url) {
+    expect(isValidDomainUrl($url))->toBeFalse();
+})->with([
+    'plain text' => 'not a url',
+    'empty string' => '',
+    'host only no scheme' => 'myapp_service.example.com',
+    'scheme only' => 'https://',
+    'space in host' => 'https://my app.example.com',
+]);


### PR DESCRIPTION
## What

Custom domains containing an underscore in the host (e.g. `https://myapp_service.example.com`) are accepted by the application & service domain APIs again.

Fixes #10597

## Why

PHP's `filter_var($url, FILTER_VALIDATE_URL)` follows RFC 3986 and rejects underscores in the host. The applications/services API used it to validate domain fields, so setting a domain with an underscore failed:

```json
{"message":"Validation failed.","errors":{"docker_compose_domains":["Invalid URL: https://myapp_service.example.com"]}}
```

The domain was never saved, Traefik config wasn't generated, and the service fell back to a self-signed cert (`TRAEFIK DEFAULT CERT`) instead of requesting Let's Encrypt — leaving it unreachable over valid HTTPS. Underscores are common in Docker service naming and are accepted by browsers and Let's Encrypt. The Livewire/UI path already used Spatie's permissive `Url::fromString`, so this was a backend-only regression (matching the reporter's note).

## How

Added a small helper `isValidDomainUrl()` in `bootstrap/helpers/domains.php`:

```php
function isValidDomainUrl(string $url): bool
{
    if (filter_var($url, FILTER_VALIDATE_URL) !== false) {
        return true;
    }

    $host = parse_url($url, PHP_URL_HOST);
    if (blank($host) || ! str_contains($host, '_')) {
        return false;
    }

    $position = strpos($url, $host);
    $sanitized = substr_replace($url, str_replace('_', '-', $host), $position, strlen($host));

    return filter_var($sanitized, FILTER_VALIDATE_URL) !== false;
}
```

It validates the URL normally and, only when validation fails because of an underscore in the host, re-validates a copy whose host underscores are swapped for hyphens — so the rest of the URL is still strictly validated and a genuinely malformed URL (no scheme, spaces, etc.) is still rejected.

The bare `filter_var($url, FILTER_VALIDATE_URL)` domain checks in `ApplicationsController` (6 call sites: standard `domains` and `docker_compose_domains` across create/update) and `ServicesController` (1 call site) now delegate to this helper. The subsequent `http`/`https` scheme check is left untouched. `SafeWebhookUrl`, `SafeExternalUrl`, and `ValidGitRepositoryUrl` are intentionally **not** changed — their strict host rules / SSRF protection are deliberate.

## Tests

Added `tests/Unit/IsValidDomainUrlTest.php` (13 cases): underscore hosts, multiple/subdomain underscores, host+port, underscore-in-path, and hyphen hosts are accepted; plain text, empty, scheme-less host, scheme-only, and spaces are rejected.

Verified locally:
- New unit test: **13/13 pass**.
- `tests/Feature/ComposePreviewFqdnTest.php` (docker_compose_domains): **3/3 pass** — no regression.
- `tests/Unit/ValidGitRepositoryUrlTest.php` and `tests/Unit/ValidHostnameTest.php`: pass — other URL/host validation unaffected.
