### PR TITLE
fix(domains): accept underscores in hostnames for domain validation

### DIFF
--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -1087,7 +1087,7 @@ class ApplicationsController extends Controller
 
                 $errors = [];
                 $urls = $urls->map(function ($url) use (&$errors) {
-                    if (! filter_var($url, FILTER_VALIDATE_URL)) {
+                    if (! isValidDomainUrl($url)) {
                         $errors[] = "Invalid URL: {$url}";
 
                         return $url;
@@ -1328,7 +1328,7 @@ class ApplicationsController extends Controller
 
                 $errors = [];
                 $urls = $urls->map(function ($url) use (&$errors) {
-                    if (! filter_var($url, FILTER_VALIDATE_URL)) {
+                    if (! isValidDomainUrl($url)) {
                         $errors[] = "Invalid URL: {$url}";
 
                         return $url;
@@ -1541,7 +1541,7 @@ class ApplicationsController extends Controller
 
                 $errors = [];
                 $urls = $urls->map(function ($url) use (&$errors) {
-                    if (! filter_var($url, FILTER_VALIDATE_URL)) {
+                    if (! isValidDomainUrl($url)) {
                         $errors[] = "Invalid URL: {$url}";
 
                         return $url;
@@ -2493,7 +2493,7 @@ class ApplicationsController extends Controller
                     return null;
                 }
 
-                if (! filter_var($url, FILTER_VALIDATE_URL)) {
+                if (! isValidDomainUrl($url)) {
                     $errors[] = 'Invalid URL: '.$url;
 
                     return $url;
@@ -2556,7 +2556,7 @@ class ApplicationsController extends Controller
 
             $errors = [];
             $urls = $urls->map(function ($url) use (&$errors) {
-                if (! filter_var($url, FILTER_VALIDATE_URL)) {
+                if (! isValidDomainUrl($url)) {
                     $errors[] = "Invalid URL: {$url}";
 
                     return $url;
@@ -3869,7 +3869,7 @@ class ApplicationsController extends Controller
                     return null;
                 }
 
-                if (! filter_var($url, FILTER_VALIDATE_URL)) {
+                if (! isValidDomainUrl($url)) {
                     $errors[] = 'Invalid URL: '.$url;
 
                     return str($url)->lower();

--- a/app/Http/Controllers/Api/ServicesController.php
+++ b/app/Http/Controllers/Api/ServicesController.php
@@ -61,7 +61,7 @@ class ServicesController extends Controller
         });
 
         $urls = $urls->map(function ($url) use (&$errors) {
-            if (! filter_var($url, FILTER_VALIDATE_URL)) {
+            if (! isValidDomainUrl($url)) {
                 $errors[] = "Invalid URL: {$url}";
 
                 return $url;

--- a/bootstrap/helpers/domains.php
+++ b/bootstrap/helpers/domains.php
@@ -4,6 +4,30 @@ use App\Models\Application;
 use App\Models\ServiceApplication;
 use Illuminate\Support\Collection;
 
+/**
+ * Validate that a string is a well-formed domain URL, tolerating underscores
+ * in the host. FILTER_VALIDATE_URL follows RFC 3986 and rejects underscores,
+ * but they are common in Docker service domains and accepted by browsers and
+ * Let's Encrypt, so we re-validate with host underscores swapped for hyphens.
+ */
+function isValidDomainUrl(string $url): bool
+{
+    if (filter_var($url, FILTER_VALIDATE_URL) !== false) {
+        return true;
+    }
+
+    $host = parse_url($url, PHP_URL_HOST);
+    if (blank($host) || ! str_contains($host, '_')) {
+        return false;
+    }
+
+    // Replace only the first occurrence (the authority), not a path/query match.
+    $position = strpos($url, $host);
+    $sanitized = substr_replace($url, str_replace('_', '-', $host), $position, strlen($host));
+
+    return filter_var($sanitized, FILTER_VALIDATE_URL) !== false;
+}
+
 function checkDomainUsage(ServiceApplication|Application|null $resource = null, ?string $domain = null)
 {
     $conflicts = [];

--- a/tests/Unit/IsValidDomainUrlTest.php
+++ b/tests/Unit/IsValidDomainUrlTest.php
@@ -1,0 +1,24 @@
+<?php
+
+it('accepts valid domain URLs', function (string $url) {
+    expect(isValidDomainUrl($url))->toBeTrue();
+})->with([
+    'https host' => 'https://myapp.example.com',
+    'http host' => 'http://myapp.example.com',
+    'underscore in host' => 'https://myapp_service.example.com',
+    'multiple underscores in host' => 'https://my_app_service.example.com',
+    'underscore in subdomain' => 'https://my_app.staging.example.com',
+    'host with port' => 'https://myapp_service.example.com:8080',
+    'underscore host with path' => 'https://myapp_service.example.com/path_to/resource',
+    'hyphen host' => 'https://my-app.example.com',
+]);
+
+it('rejects invalid domain URLs', function (string $url) {
+    expect(isValidDomainUrl($url))->toBeFalse();
+})->with([
+    'plain text' => 'not a url',
+    'empty string' => '',
+    'host only no scheme' => 'myapp_service.example.com',
+    'scheme only' => 'https://',
+    'space in host' => 'https://my app.example.com',
+]);


### PR DESCRIPTION
## Changes

The applications and services API rejected any custom domain whose hostname contained an underscore, for example myapp_service.example.com. PHP's built-in URL validation follows a strict RFC that forbids underscores in the host, even though browsers and Let's Encrypt accept them and Docker service names commonly use them. Because of this the domain was never saved, Traefik config was not generated, and the service fell back to a self-signed certificate.

I added a small helper, `isValidDomainUrl`, in the domains helper file. It validates the URL normally first, and only when that fails because of an underscore in the host does it re-check a copy with the host underscores replaced by hyphens, so the rest of the URL is still validated strictly and malformed input (missing scheme, spaces, empty) is still rejected. The seven domain checks across the two API controllers now call this helper. Webhook, external, and git URL validation are left unchanged because their stricter rules are deliberate.

## Issues

- Fixes #10597

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable. This is a backend validation fix with no UI change.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: AI coding assistant
- How extensively: Helped locate the validation call sites, draft the helper, and write the unit test. I reviewed and tested the change myself.

## Testing

Added a unit test covering underscore hostnames, subdomains, ports, and paths, plus rejection of malformed URLs. Ran it with the existing docker compose domain and git URL validation tests: the new test passes and the others are unaffected.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
