### PR TITLE
oauth: check enabled flag before redirect and callback

### DIFF
--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\OauthSetting;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -10,6 +11,11 @@ class OauthController extends Controller
 {
     public function redirect(string $provider)
     {
+        $oauth_setting = OauthSetting::firstWhere('provider', $provider);
+        if (! $oauth_setting || ! $oauth_setting->couldBeEnabled() || ! $oauth_setting->enabled) {
+            abort(403, 'OAuth provider is not enabled.');
+        }
+
         $socialite_provider = get_socialite_provider($provider);
 
         return $socialite_provider->redirect();
@@ -17,6 +23,11 @@ class OauthController extends Controller
 
     public function callback(string $provider)
     {
+        $oauth_setting = OauthSetting::firstWhere('provider', $provider);
+        if (! $oauth_setting || ! $oauth_setting->couldBeEnabled() || ! $oauth_setting->enabled) {
+            abort(403, 'OAuth provider is not enabled.');
+        }
+
         try {
             $oauthUser = get_socialite_provider($provider)->user();
             $email = trim((string) $oauthUser->email);

--- a/tests/Feature/OauthControllerTest.php
+++ b/tests/Feature/OauthControllerTest.php
@@ -77,3 +77,27 @@ it('rejects oauth logins when the provider does not return an email address', fu
     'null email' => [null],
     'blank email' => ['   '],
 ]);
+
+it('rejects callback when oauth provider is configured but not enabled', function () {
+    config()->set('app.maintenance.driver', 'file');
+
+    $user = User::factory()->create([
+        'email' => 'user@example.com',
+    ]);
+
+    OauthSetting::where('provider', 'google')->update(['enabled' => false]);
+
+    $response = $this->from('/login')->get(route('auth.callback', 'google'));
+
+    $response->assertStatus(403);
+    $this->assertGuest();
+    expect(User::count())->toBe(1);
+});
+
+it('rejects redirect when oauth provider is configured but not enabled', function () {
+    config()->set('app.maintenance.driver', 'file');
+
+    $response = $this->get(route('auth.redirect', 'google'));
+
+    $response->assertStatus(403);
+});


### PR DESCRIPTION
STRAWBERRY

## Changes

Google OAuth allowed callbacks and redirects when the provider was configured
but not enabled (enabled=false in oauth_settings). This let users reach the
callback endpoint with empty credentials, causing auth failures that redirected
to /login with a generic error instead of a clear 403.

The fix adds an early guard in OauthController::redirect() and callback() that
checks the OauthSetting record exists, couldBeEnabled() returns true, and the
enabled flag is true before calling Socialite.

## Issues

- Fixes #9181

## Category

- [x] Bug fix

## Testing

Two new test cases added to tests/Feature/OauthControllerTest.php:

1. rejects callback when oauth provider is configured but not enabled
2. rejects redirect when oauth provider is configured but not enabled

Both verify a 403 response when enabled=false. Tests follow the same pattern
as the existing email-not-returned OAuth test.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used

**If AI was used:**

- Tools used: Hermes Agent ( Nous Research ), git, gh CLI
- How extensively: Root cause analysis, test writing, code changes, PR creation

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the contributor guidelines. If I have failed
>   to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched existing issues and pull requests (including closed ones)
>   to ensure this is not a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance
>   of Coolify and I am confident that they will work as expected when a
>   maintainer tests them.
