### PR TITLE
feat(service): add LibreDB Studio template

### DIFF
--- a/public/svgs/libredb-studio.svg
+++ b/public/svgs/libredb-studio.svg
@@ -1,0 +1,22 @@
+<svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="logo-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4F46E5" />
+      <stop offset="100%" stop-color="#9333EA" />
+    </linearGradient>
+    <linearGradient id="code-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#10B981" />
+      <stop offset="100%" stop-color="#3B82F6" />
+    </linearGradient>
+  </defs>
+  <path d="M100 20L169.282 60V140L100 180L30.718 140V60L100 20Z" fill="url(#logo-gradient)" fill-opacity="0.05" stroke="url(#logo-gradient)" stroke-width="1.5"/>
+  <g opacity="0.3">
+    <rect x="70" y="80" width="60" height="10" rx="2" fill="url(#logo-gradient)" />
+    <rect x="70" y="95" width="60" height="10" rx="2" fill="url(#logo-gradient)" />
+    <rect x="70" y="110" width="60" height="10" rx="2" fill="url(#logo-gradient)" />
+  </g>
+  <g>
+    <path d="M55 70L35 100L55 130" stroke="url(#code-gradient)" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M145 70L165 100L145 130" stroke="url(#code-gradient)" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  </g>
+</svg>

--- a/templates/compose/libredb-studio.yaml
+++ b/templates/compose/libredb-studio.yaml
@@ -1,0 +1,26 @@
+# documentation: https://github.com/libredb/libredb-studio
+# slogan: Modern, AI-powered open-source SQL IDE for PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB and Redis.
+# category: database
+# tags: database,sql,ide,developer-tools,ai,self-hosted
+# logo: svgs/libredb-studio.svg
+# port: 3000
+
+services:
+  libredb-studio:
+    image: ghcr.io/libredb/libredb-studio:v0.9.27
+    environment:
+      - SERVICE_URL_LIBREDBSTUDIO_3000
+      - ADMIN_EMAIL=${ADMIN_EMAIL:-admin@libredb.org}
+      - ADMIN_PASSWORD=${SERVICE_PASSWORD_ADMIN}
+      - USER_EMAIL=${USER_EMAIL:-user@libredb.org}
+      - USER_PASSWORD=${SERVICE_PASSWORD_USER}
+      - JWT_SECRET=${SERVICE_PASSWORD_64_JWT}
+      - STORAGE_PROVIDER=sqlite
+      - STORAGE_SQLITE_PATH=/app/data/libredb-storage.db
+    volumes:
+      - libredb-data:/app/data
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:3000/"]
+      interval: 10s
+      timeout: 5s
+      retries: 10

--- a/templates/compose/libredb-studio.yaml
+++ b/templates/compose/libredb-studio.yaml
@@ -7,7 +7,7 @@
 
 services:
   libredb-studio:
-    image: ghcr.io/libredb/libredb-studio:v0.9.27
+    image: ghcr.io/libredb/libredb-studio:0.9.27
     environment:
       - SERVICE_URL_LIBREDBSTUDIO_3000
       - ADMIN_EMAIL=${ADMIN_EMAIL:-admin@libredb.org}


### PR DESCRIPTION
## Changes

Adds **LibreDB Studio** as a one-click Coolify service — an MIT-licensed, AI-powered open-source SQL IDE that connects to PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB and Redis from the browser.

## Category

- [x] Adding new one click service

## AI Assistance

- [x] AI was NOT used to create this PR

## Testing

- [x] I have tested the changes thoroughly and am confident that they will work as expected when a maintainer tests them

## Contributor Agreement

- [x] I have read and understood the contributor guidelines.
- [x] I have searched existing issues and pull requests to ensure this isn't a duplicate.
- [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.

## Links

- GitHub: https://github.com/libredb/libredb-studio
- Website: https://libredb.org/