### PR TITLE
oauth: check enabled flag before redirect and callback

### DIFF
--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\OauthSetting;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -10,6 +11,11 @@ class OauthController extends Controller
 {
     public function redirect(string $provider)
     {
+        $oauth_setting = OauthSetting::firstWhere('provider', $provider);
+        if (! $oauth_setting || ! $oauth_setting->couldBeEnabled() || ! $oauth_setting->enabled) {
+            abort(403, 'OAuth provider is not enabled.');
+        }
+
         $socialite_provider = get_socialite_provider($provider);
 
         return $socialite_provider->redirect();
@@ -17,6 +23,11 @@ class OauthController extends Controller
 
     public function callback(string $provider)
     {
+        $oauth_setting = OauthSetting::firstWhere('provider', $provider);
+        if (! $oauth_setting || ! $oauth_setting->couldBeEnabled() || ! $oauth_setting->enabled) {
+            abort(403, 'OAuth provider is not enabled.');
+        }
+
         try {
             $oauthUser = get_socialite_provider($provider)->user();
             $email = trim((string) $oauthUser->email);

--- a/tests/Feature/OauthControllerTest.php
+++ b/tests/Feature/OauthControllerTest.php
@@ -77,3 +77,27 @@ it('rejects oauth logins when the provider does not return an email address', fu
     'null email' => [null],
     'blank email' => ['   '],
 ]);
+
+it('rejects callback when oauth provider is configured but not enabled', function () {
+    config()->set('app.maintenance.driver', 'file');
+
+    $user = User::factory()->create([
+        'email' => 'user@example.com',
+    ]);
+
+    OauthSetting::where('provider', 'google')->update(['enabled' => false]);
+
+    $response = $this->from('/login')->get(route('auth.callback', 'google'));
+
+    $response->assertStatus(403);
+    $this->assertGuest();
+    expect(User::count())->toBe(1);
+});
+
+it('rejects redirect when oauth provider is configured but not enabled', function () {
+    config()->set('app.maintenance.driver', 'file');
+
+    $response = $this->get(route('auth.redirect', 'google'));
+
+    $response->assertStatus(403);
+});


### PR DESCRIPTION
## Summary

Google OAuth was allowing callbacks and redirects even when the provider was configured but not enabled (enabled=false in oauth_settings). This caused auth failures that redirected to /login instead of returning a clear 403 error.

## Fix

Add early guard in both redirect() and callback() that checks:
1. OauthSetting record exists for the provider
2. couldBeEnabled() returns true (client_id + client_secret configured)
3. enabled flag is true

## Testing
- ./vendor/bin/pest tests/Feature/OauthControllerTest.php

Fixes #9181