### PR TITLE
fix(invitations): regenerate magic link after expired invite

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -126,7 +126,6 @@ class Controller extends BaseController
             $invitation = TeamInvitation::query()
                 ->where('email', $email)
                 ->when($invitationUuid, fn ($query) => $query->where('uuid', $invitationUuid))
-                ->where('link', request()->fullUrl())
                 ->first();
             if (! $invitation || ! $invitation->isValid()) {
                 return redirect()->route('login')->with('error', 'Invitation has expired or been revoked.');
@@ -139,10 +138,10 @@ class Controller extends BaseController
                 }
                 $invitation->delete();
 
-                Auth::login($user);
                 $user->forceFill([
                     'password' => Hash::make(Str::random(64)),
                 ])->save();
+                Auth::login($user);
                 session(['currentTeam' => $team]);
 
                 return redirect()->route('dashboard');

--- a/app/Livewire/Team/InviteLink.php
+++ b/app/Livewire/Team/InviteLink.php
@@ -59,20 +59,26 @@ class InviteLink extends Component
 
             $member_emails = currentTeam()->members()->get()->pluck('email');
             if ($member_emails->contains($this->email)) {
-                return handleError(livewire: $this, customErrorMessage: "$this->email is already a member of ".currentTeam()->name.'.');
+                return handleError(livewire: $this, customErrorMessage: "$this->email is already a member of " . currentTeam()->name . '.');
             }
             $uuid = (string) new Cuid2(32);
-            $link = url('/').config('constants.invitation.link.base_url').$uuid;
+            $link = url('/') . config('constants.invitation.link.base_url') . $uuid;
             $user = User::whereEmail($this->email)->first();
 
-            if (is_null($user)) {
+            if (is_null($user) || $user->force_password_reset) {
                 $password = Str::password();
-                $user = User::create([
-                    'name' => str($this->email)->before('@'),
-                    'email' => $this->email,
-                    'password' => Hash::make($password),
-                    'force_password_reset' => true,
-                ]);
+                if (is_null($user)) {
+                    $user = User::create([
+                        'name' => str($this->email)->before('@'),
+                        'email' => $this->email,
+                        'password' => Hash::make($password),
+                        'force_password_reset' => true,
+                    ]);
+                } else {
+                    $user->update([
+                        'password' => Hash::make($password),
+                    ]);
+                }
                 $token = Crypt::encryptString("{$user->email}@@@{$uuid}@@@{$password}");
                 $link = route('auth.link', ['token' => $token]);
             }
@@ -100,7 +106,7 @@ class InviteLink extends Component
                     'team' => currentTeam()->name,
                     'invitation_link' => $link,
                 ]);
-                $mail->subject('You have been invited to '.currentTeam()->name.' on '.config('app.name').'.');
+                $mail->subject('You have been invited to ' . currentTeam()->name . ' on ' . config('app.name') . '.');
                 send_user_an_email($mail, $this->email);
                 $this->dispatch('success', 'Invitation sent via email.');
                 $this->dispatch('refreshInvitations');


### PR DESCRIPTION

When registration is closed, re-inviting a user who still exists with `force_password_reset` no longer falls back to the auth-required `/invitations/{uuid}` link. Also drop strict invitation URL matching on `/auth/link` so valid tokens are accepted reliably.

Fixes coollabsio/coolify#10755

## Changes

When the first invite expires and a new one is created for the same email, Coolify sometimes still has a user record with `force_password_reset = true`. In that case, the old code generated a plain `/invitations/{uuid}` link instead of a magic link. That link requires the user to already be logged in, so they ended up on the login page with no way to set a password.

This PR fixes that by:
- Generating a new magic link (`/auth/link?token=...`) when re-inviting users who still have `force_password_reset` set, and rotating their temporary password
- Removing the strict `request()->fullUrl()` match when validating magic links, since email+uuid+password validation is enough
- Logging the user in after the temporary password is rotated during invitation acceptance

## Issues

- Fixes #10755

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable — backend/auth flow change only.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Cursor (Claude)
- How extensively: Used to investigate the invitation flow, identify the root cause, review the fix, and help write the PR description. Code changes were manually tested locally before opening the PR.

## Testing

Tested manually on a local Coolify dev instance:

1. Disabled registration in **Settings → Advanced**
2. Invited a new user via **Team → Members → Generate Invitation Link**
3. Expired the first invitation (backdated `created_at` in tinker)
4. Revoked the expired invite and generated a new invitation for the same email
5. Confirmed the new link uses `/auth/link?token=...` (not `/invitations/...`)
6. Opened the link in an incognito window
7. Completed password setup via the force-password-reset flow successfully

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.