### PR TITLE
fix(railpack): interpolate build-time env variables by sourcing build…

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -1833,8 +1833,8 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                     ]
                 );
             }
-        } elseif ($this->build_pack === 'dockercompose' || $this->build_pack === 'dockerfile') {
-            // For Docker Compose and Dockerfile, create an empty .env file even if there are no build-time variables
+        } elseif (in_array($this->build_pack, ['dockercompose', 'dockerfile', 'railpack'], true)) {
+            // For build packs that source the build-time .env file, create an empty file even if there are no build-time variables
             // This ensures the file exists when referenced in build commands
             $this->application_deployment_queue->addLogEntry('Creating empty build-time .env file in /artifacts (no build-time variables defined).', hidden: true);
 

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -2667,12 +2667,22 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             $cacheArgs .= ' --build-arg secrets-hash='.$this->generate_secrets_hash($variables);
         }
 
-        $environmentPrefix = $this->railpack_build_environment_prefix($variables);
+        // Build-time variables reach the build through the sourced build-time .env file
+        // (written by save_buildtime_environment_variables), which interpolates shell-style
+        // references such as BETTER_AUTH_URL=$COOLIFY_URL. Passing them inline via `env`
+        // would forward the literal `$COOLIFY_URL` because each value is single-quoted and
+        // `env` does not interpolate its own assignments. Only buildpack control variables
+        // (NIXPACKS_/RAILPACK_) — which are excluded from the build-time .env file and never
+        // need interpolation — are still passed inline.
+        $controlVariables = $variables->filter(
+            fn ($value, $key) => str($key)->startsWith(EnvironmentVariable::BUILDPACK_CONTROL_VARIABLE_PREFIXES)
+        );
+
+        $environmentPrefix = $this->railpack_build_environment_prefix($controlVariables);
         $secretFlags = $this->railpack_build_secret_flags($variables);
         $frontendImage = 'ghcr.io/railwayapp/railpack-frontend:v'.config('constants.coolify.railpack_version');
 
-        return 'docker buildx create --name coolify-railpack --driver docker-container 2>/dev/null || true'
-            ." && {$environmentPrefix}docker buildx build --builder coolify-railpack"
+        $buildxBuildCommand = "{$environmentPrefix}docker buildx build --builder coolify-railpack"
             ." {$this->addHosts} --network host"
             ." --build-arg BUILDKIT_SYNTAX=\"{$frontendImage}\""
             ." {$cacheArgs}"
@@ -2682,6 +2692,9 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             .' --load'
             ." -t {$imageName}"
             ." {$this->workdir}";
+
+        return 'docker buildx create --name coolify-railpack --driver docker-container 2>/dev/null || true'
+            .' && '.$this->wrap_build_command_with_env_export($buildxBuildCommand);
     }
 
     private function decode_railpack_config(string $config, string $source): array

--- a/tests/Unit/ApplicationDeploymentRailpackConfigTest.php
+++ b/tests/Unit/ApplicationDeploymentRailpackConfigTest.php
@@ -236,14 +236,47 @@ it('builds railpack docker command with matching env and secret flags for all ra
         ],
     );
 
+    // Build-time variables are interpolated by sourcing the build-time .env file before
+    // the build, so user/Coolify variables must NOT be forwarded inline as literals.
+    expect($command)->toContain('set -a && source /artifacts/build-time.env && set +a');
     expect($command)->toContain("env 'RAILPACK_NODE_VERSION=22'");
     expect($command)->toContain("'RAILPACK_INSTALL_CMD=npm ci && npm run postinstall'");
     expect($command)->toContain("'RAILPACK_DEPLOY_APT_PACKAGES=curl wget'");
-    expect($command)->toContain("'SECRET_JSON={\"token\":\"abc\"}'");
+    // SECRET_JSON is not a buildpack control variable, so it is provided via the sourced
+    // build-time .env file (which supports $VAR interpolation) rather than inline `env`.
+    expect($command)->not->toContain("'SECRET_JSON={\"token\":\"abc\"}'");
     expect($command)->toContain("--secret 'id=RAILPACK_NODE_VERSION,env=RAILPACK_NODE_VERSION'");
     expect($command)->toContain("--secret 'id=RAILPACK_INSTALL_CMD,env=RAILPACK_INSTALL_CMD'");
     expect($command)->toContain("--secret 'id=RAILPACK_DEPLOY_APT_PACKAGES,env=RAILPACK_DEPLOY_APT_PACKAGES'");
     expect($command)->toContain("--secret 'id=SECRET_JSON,env=SECRET_JSON'");
     expect($command)->toContain(' --build-arg secrets-hash=');
     expect($command)->toContain('--build-arg BUILDKIT_SYNTAX="ghcr.io/railwayapp/railpack-frontend:v'.config('constants.coolify.railpack_version').'"');
+});
+
+it('interpolates build-time variable references for railpack by sourcing the build-time env file', function () {
+    [$job, $reflection] = makeRailpackDeploymentJob([
+        'uuid' => 'application-uuid',
+    ]);
+
+    // Mirrors the issue: BETTER_AUTH_URL=$COOLIFY_URL must be interpolated at build time.
+    $command = invokeRailpackMethod(
+        $job,
+        $reflection,
+        'railpack_build_command',
+        [
+            'coollabsio/coolify:test',
+            collect([
+                'BETTER_AUTH_URL' => '$COOLIFY_URL',
+                'COOLIFY_URL' => 'https://sapere-10.bobman.dev',
+            ]),
+        ],
+    );
+
+    // The literal `$COOLIFY_URL` must NOT be forwarded inline; it is resolved by the shell
+    // after sourcing the build-time .env file, then read through the build secret.
+    expect($command)->toContain('set -a && source /artifacts/build-time.env && set +a');
+    expect($command)->not->toContain("'BETTER_AUTH_URL=\$COOLIFY_URL'");
+    expect($command)->not->toContain("env 'BETTER_AUTH_URL");
+    expect($command)->toContain("--secret 'id=BETTER_AUTH_URL,env=BETTER_AUTH_URL'");
+    expect($command)->toContain("--secret 'id=COOLIFY_URL,env=COOLIFY_URL'");
 });

--- a/tests/Unit/ApplicationDeploymentRailpackConfigTest.php
+++ b/tests/Unit/ApplicationDeploymentRailpackConfigTest.php
@@ -3,6 +3,8 @@
 use App\Exceptions\DeploymentException;
 use App\Jobs\ApplicationDeploymentJob;
 use App\Models\Application;
+use App\Models\ApplicationSetting;
+use App\Models\EnvironmentVariable;
 use Illuminate\Support\Collection;
 use Tests\TestCase;
 
@@ -279,4 +281,42 @@ it('interpolates build-time variable references for railpack by sourcing the bui
     expect($command)->not->toContain("env 'BETTER_AUTH_URL");
     expect($command)->toContain("--secret 'id=BETTER_AUTH_URL,env=BETTER_AUTH_URL'");
     expect($command)->toContain("--secret 'id=COOLIFY_URL,env=COOLIFY_URL'");
+});
+
+it('creates an empty build-time env file for railpack when there are no generated build-time variables', function () {
+    [$job, $reflection] = makeRailpackDeploymentJob([
+        'build_pack' => 'railpack',
+        'compose_parsing_version' => '3',
+    ]);
+
+    $applicationProperty = $reflection->getProperty('application');
+    $applicationProperty->setAccessible(true);
+    $application = $applicationProperty->getValue($job);
+    $application->setRelation('settings', new ApplicationSetting([
+        'include_source_commit_in_build' => false,
+        'is_env_sorting_enabled' => false,
+    ]));
+    $application->setRelation('environment_variables', collect([
+        new EnvironmentVariable(['key' => 'COOLIFY_FQDN']),
+        new EnvironmentVariable(['key' => 'COOLIFY_URL']),
+        new EnvironmentVariable(['key' => 'COOLIFY_BRANCH']),
+        new EnvironmentVariable(['key' => 'COOLIFY_RESOURCE_UUID']),
+    ]));
+
+    foreach ([
+        'application_deployment_queue' => new class
+        {
+            public function addLogEntry(string $message, string $type = 'info', bool $hidden = false): void {}
+        },
+        'build_pack' => 'railpack',
+        'pull_request_id' => 0,
+    ] as $property => $value) {
+        $reflectionProperty = $reflection->getProperty($property);
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue($job, $value);
+    }
+
+    invokeRailpackMethod($job, $reflection, 'save_buildtime_environment_variables');
+
+    expect(collect($job->recordedCommands)->flatten()->implode(' '))->toContain('touch /artifacts/build-time.env');
 });


### PR DESCRIPTION
## Changes

<!-- Describe what changes were made and why in your own words. This "Changes" section must be human-written and not AI-generated. -->

- Buildtime variables were not getting real values from Coolify.

## Issues

<!-- Link related issues or discussions. If reopening a closed PR, explain why it should be reconsidered. -->

- Fixes #10736

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

<!-- Screenshot or short video showing your changes in action. Mandatory for new features. -->
<img width="804" height="38" alt="image" src="https://github.com/user-attachments/assets/0fa45767-daa1-4a47-81bd-cacdb5f1b06b" />

## AI Assistance

<!-- AI-assisted PRs that are human reviewed are welcome, just let us know so we can review appropriately. -->

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: To confirm the root cause and fix it

## Testing

<!-- Describe how you tested these changes. -->

**Unit tests** (`tests/Unit/ApplicationDeploymentRailpackConfigTest.php`):
- Build command now sources `/artifacts/build-time.env` and no longer forwards
  user/Coolify variables inline as single-quoted literals.
- Added a test mirroring the issue (`BETTER_AUTH_URL=$COOLIFY_URL`).

**End-to-end** (Railpack app, build-time var `BETTER_AUTH_URL=$COOLIFY_URL`):
- Build step `printenv BETTER_AUTH_URL` → `http://railpack-bun.127.0.0.1.sslip.io`
  (the resolved `$COOLIFY_URL`), instead of the literal `$COOLIFY_URL`.
- Confirmed generated `build.sh` contains
  `set -a && source /artifacts/build-time.env && set +a` before `docker buildx build`.

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
