### PR TITLE
feat: add global deployment history page

### DIFF
--- a/app/Livewire/Deployments/Index.php
+++ b/app/Livewire/Deployments/Index.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace App\Livewire\Deployments;
+
+use App\Enums\ApplicationDeploymentStatus;
+use App\Models\Application;
+use App\Models\ApplicationDeploymentQueue;
+use App\Models\Server;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class Index extends Component
+{
+    use WithPagination;
+
+    public const PER_PAGE = 20;
+
+    public string $deployment_type = 'all';
+
+    public string $status = 'all';
+
+    protected $queryString = [
+        'deployment_type' => ['except' => 'all'],
+        'status' => ['except' => 'all'],
+    ];
+
+    public function mount(): void
+    {
+        $this->sanitizeFilters();
+    }
+
+    public function updatedDeploymentType(): void
+    {
+        $this->sanitizeFilters();
+        $this->resetPage();
+    }
+
+    public function updatedStatus(): void
+    {
+        $this->sanitizeFilters();
+        $this->resetPage();
+    }
+
+    public function deploymentTypeOptions(): array
+    {
+        return [
+            'all' => 'All',
+            'production' => 'Production',
+            'preview' => 'Preview PR',
+        ];
+    }
+
+    public function statusOptions(): array
+    {
+        return [
+            'all' => 'All statuses',
+            ApplicationDeploymentStatus::QUEUED->value => 'Queued',
+            ApplicationDeploymentStatus::IN_PROGRESS->value => 'In Progress',
+            ApplicationDeploymentStatus::FINISHED->value => 'Finished',
+            ApplicationDeploymentStatus::FAILED->value => 'Failed',
+            ApplicationDeploymentStatus::CANCELLED_BY_USER->value => 'Cancelled',
+        ];
+    }
+
+    public function deployments(): LengthAwarePaginator
+    {
+        $teamId = currentTeam()?->id;
+        $applicationIds = Application::query()
+            ->whereHas('environment.project', function ($query) use ($teamId) {
+                $query->where('team_id', $teamId);
+            })
+            ->pluck('id')
+            ->map(fn ($id) => (string) $id);
+
+        return ApplicationDeploymentQueue::query()
+            ->select([
+                'id',
+                'deployment_uuid',
+                'application_id',
+                'pull_request_id',
+                'commit',
+                'commit_message',
+                'status',
+                'is_webhook',
+                'is_api',
+                'created_at',
+                'finished_at',
+                'server_id',
+                'application_name',
+                'server_name',
+                'deployment_url',
+                'rollback',
+            ])
+            ->with(['application.environment.project'])
+            ->whereIn('application_id', $applicationIds)
+            ->when($this->deployment_type === 'production', function ($query) {
+                $query->where(function ($query) {
+                    $query->whereNull('pull_request_id')->orWhere('pull_request_id', 0);
+                });
+            })
+            ->when($this->deployment_type === 'preview', function ($query) {
+                $query->where('pull_request_id', '>', 0);
+            })
+            ->when($this->status !== 'all', function ($query) {
+                $query->where('status', $this->status);
+            })
+            ->orderByDesc('created_at')
+            ->orderByDesc('id')
+            ->paginate(self::PER_PAGE)
+            ->withQueryString();
+    }
+
+    public function render()
+    {
+        $deployments = $this->deployments();
+        $servers = Server::query()
+            ->with('settings')
+            ->whereIn('id', $deployments->getCollection()->pluck('server_id')->filter()->unique())
+            ->get()
+            ->keyBy('id');
+
+        return view('livewire.deployments.index', [
+            'deployments' => $deployments,
+            'servers' => $servers,
+        ]);
+    }
+
+    private function sanitizeFilters(): void
+    {
+        if (! array_key_exists($this->deployment_type, $this->deploymentTypeOptions())) {
+            $this->deployment_type = 'all';
+        }
+
+        if (! array_key_exists($this->status, $this->statusOptions())) {
+            $this->status = 'all';
+        }
+    }
+}

--- a/app/Livewire/Deployments/Index.php
+++ b/app/Livewire/Deployments/Index.php
@@ -67,11 +67,11 @@ class Index extends Component
     {
         $teamId = currentTeam()?->id;
         $applicationIds = Application::query()
+            ->withoutGlobalScope('withRelations')
+            ->selectRaw('CAST(id AS TEXT)')
             ->whereHas('environment.project', function ($query) use ($teamId) {
                 $query->where('team_id', $teamId);
-            })
-            ->pluck('id')
-            ->map(fn ($id) => (string) $id);
+            });
 
         return ApplicationDeploymentQueue::query()
             ->select([

--- a/app/Livewire/GlobalSearch.php
+++ b/app/Livewire/GlobalSearch.php
@@ -620,6 +620,13 @@ class GlobalSearch extends Component
                     'search_text' => 'projects all list view',
                 ],
                 [
+                    'name' => 'Deployments',
+                    'type' => 'navigation',
+                    'description' => 'View all deployment history',
+                    'link' => route('deployments.index'),
+                    'search_text' => 'deployments history logs applications',
+                ],
+                [
                     'name' => 'Destinations',
                     'type' => 'navigation',
                     'description' => 'View all destinations',

--- a/resources/views/components/navbar.blade.php
+++ b/resources/views/components/navbar.blade.php
@@ -154,6 +154,24 @@
                         </a>
                     </li>
                     <li>
+                        <a title="Deployments" {{ wireNavigate() }}
+                            class="{{ request()->is('deployments') ? 'menu-item menu-item-active' : 'menu-item' }}"
+                            href="{{ route('deployments.index') }}">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="menu-item-icon" viewBox="0 0 24 24"
+                                stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round"
+                                stroke-linejoin="round">
+                                <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                                <path d="M4 5h4v4h-4z" />
+                                <path d="M4 15h4v4h-4z" />
+                                <path d="M16 5h4v4h-4z" />
+                                <path d="M16 15h4v4h-4z" />
+                                <path d="M8 7h8" />
+                                <path d="M8 17h8" />
+                            </svg>
+                            <span class="menu-item-label" :class="collapsed && 'lg:hidden'">Deployments</span>
+                        </a>
+                    </li>
+                    <li>
                         <a title="Servers" {{ wireNavigate() }}
                             class="{{ request()->is('server/*') || request()->is('servers') ? 'menu-item menu-item-active' : 'menu-item' }}"
                             href="/servers">

--- a/resources/views/livewire/deployments/index.blade.php
+++ b/resources/views/livewire/deployments/index.blade.php
@@ -6,7 +6,7 @@
             <h1>Deployments <span class="text-xs">({{ $deployments->total() }})</span></h1>
             @if ($deployments->total() > 0)
                 <div class="flex items-center gap-2">
-                    <x-forms.button type="button" disabled="{{ $deployments->onFirstPage() }}" wire:click="previousPage">
+                    <x-forms.button type="button" :disabled="$deployments->onFirstPage()" wire:click="previousPage">
                         <svg class="w-4 h-4" viewBox="0 0 24 24">
                             <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"
                                 stroke-width="2" d="m14 6l-6 6l6 6z" />
@@ -15,7 +15,7 @@
                     <span class="px-2 text-sm text-gray-600 dark:text-gray-400">
                         Page {{ $deployments->currentPage() }} of {{ $deployments->lastPage() }}
                     </span>
-                    <x-forms.button type="button" disabled="{{ ! $deployments->hasMorePages() }}" wire:click="nextPage">
+                    <x-forms.button type="button" :disabled="! $deployments->hasMorePages()" wire:click="nextPage">
                         <svg class="w-4 h-4" viewBox="0 0 24 24">
                             <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"
                                 stroke-width="2" d="m10 18l6-6l-6-6z" />

--- a/resources/views/livewire/deployments/index.blade.php
+++ b/resources/views/livewire/deployments/index.blade.php
@@ -69,89 +69,85 @@
                     $server = $servers->get(data_get($deployment, 'server_id'));
                 @endphp
 
-                <div data-deployment-uuid="{{ data_get($deployment, 'deployment_uuid') }}" @class([
+                <div data-deployment-uuid="{{ data_get($deployment, 'deployment_uuid') }}"
+                    @if ($deploymentUrl) x-on:click="if (!$event.target.closest('a')) {
+                            const url = @js($deploymentUrl);
+                            window.Livewire?.navigate ? window.Livewire.navigate(url) : window.location.href = url;
+                        }" @endif
+                    @class([
                     'p-3 border-l-2 bg-white dark:bg-coolgray-100',
+                    'cursor-pointer' => $deploymentUrl,
                     'border-blue-500/50 border-dashed' => $status === 'in_progress',
                     'border-purple-500/50 border-dashed' => $status === 'queued',
                     'border-white border-dashed' => $status === 'cancelled-by-user',
                     'border-error' => $status === 'failed',
                     'border-success' => $status === 'finished',
                 ])>
-                    @if ($deploymentUrl)
-                        <a href="{{ $deploymentUrl }}" {{ wireNavigate() }} class="block">
-                    @else
-                        <div>
-                    @endif
-                        <div class="flex flex-col gap-2">
-                            <div class="flex flex-wrap items-center gap-2">
-                                <span @class([
-                                    'px-3 py-1 rounded-md text-xs font-medium shadow-xs',
-                                    'bg-blue-100/80 text-blue-700 dark:bg-blue-500/20 dark:text-blue-300' => $status === 'in_progress',
-                                    'bg-purple-100/80 text-purple-700 dark:bg-purple-500/20 dark:text-purple-300' => $status === 'queued',
-                                    'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-200' => $status === 'failed',
-                                    'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-200' => $status === 'finished',
-                                    'bg-gray-100 text-gray-700 dark:bg-gray-600/30 dark:text-gray-300' => $status === 'cancelled-by-user',
-                                ])>{{ $statusText }}</span>
-                                <span
-                                    class="bg-gray-200/70 dark:bg-gray-600/20 px-2 py-0.5 rounded-md text-xs text-gray-800 dark:text-gray-100 border border-gray-400/30">
-                                    {{ $triggerText }}
-                                </span>
+                    <div class="flex flex-col gap-2">
+                        <div class="flex flex-wrap items-center gap-2">
+                            <span @class([
+                                'px-3 py-1 rounded-md text-xs font-medium shadow-xs',
+                                'bg-blue-100/80 text-blue-700 dark:bg-blue-500/20 dark:text-blue-300' => $status === 'in_progress',
+                                'bg-purple-100/80 text-purple-700 dark:bg-purple-500/20 dark:text-purple-300' => $status === 'queued',
+                                'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-200' => $status === 'failed',
+                                'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-200' => $status === 'finished',
+                                'bg-gray-100 text-gray-700 dark:bg-gray-600/30 dark:text-gray-300' => $status === 'cancelled-by-user',
+                            ])>{{ $statusText }}</span>
+                            <span
+                                class="bg-gray-200/70 dark:bg-gray-600/20 px-2 py-0.5 rounded-md text-xs text-gray-800 dark:text-gray-100 border border-gray-400/30">
+                                {{ $triggerText }}
+                            </span>
+                        </div>
+
+                        <div class="flex flex-col gap-1">
+                            <div class="font-medium dark:text-white">
+                                {{ data_get($deployment, 'application_name') ?? data_get($application, 'name') ?? 'Unknown application' }}
                             </div>
-
-                            <div class="flex flex-col gap-1">
-                                <div class="font-medium dark:text-white">
-                                    {{ data_get($deployment, 'application_name') ?? data_get($application, 'name') ?? 'Unknown application' }}
-                                </div>
-                                <div class="text-sm text-gray-600 dark:text-gray-400">
-                                    {{ data_get($project, 'name') ?? 'Unknown project' }}
-                                    /
-                                    {{ data_get($environment, 'name') ?? 'Unknown environment' }}
-                                    @if (data_get($deployment, 'server_name'))
-                                        <span class="px-1">/</span>
-                                        {{ data_get($deployment, 'server_name') }}
-                                    @endif
-                                </div>
-                            </div>
-
-                            @if (data_get($deployment, 'commit'))
-                                <div class="text-sm text-gray-600 dark:text-gray-400">
-                                    <span class="font-medium">Commit:</span>
-                                    @if ($application)
-                                        <a href="{{ $application->gitCommitLink(data_get($deployment, 'commit')) }}" target="_blank"
-                                            rel="noopener noreferrer" class="underline">
-                                            {{ substr(data_get($deployment, 'commit'), 0, 7) }}
-                                        </a>
-                                    @else
-                                        {{ substr(data_get($deployment, 'commit'), 0, 7) }}
-                                    @endif
-                                    @if ($deployment->commitMessage())
-                                        <span>-</span>
-                                        <span>{{ Str::before($deployment->commitMessage(), "\n") }}</span>
-                                    @endif
-                                </div>
-                            @endif
-
                             <div class="text-sm text-gray-600 dark:text-gray-400">
-                                Started:
-                                {{ formatDateInServerTimezone(data_get($deployment, 'created_at'), $server) }}
-                                @if ($status !== 'queued')
-                                    @if ($status === 'in_progress')
-                                        <br>Running for:
-                                        {{ calculateDuration(data_get($deployment, 'created_at'), now()) }}
-                                    @elseif (data_get($deployment, 'finished_at'))
-                                        <br>Ended:
-                                        {{ formatDateInServerTimezone(data_get($deployment, 'finished_at'), $server) }}
-                                        <br>Duration:
-                                        {{ calculateDuration(data_get($deployment, 'created_at'), data_get($deployment, 'finished_at')) }}
-                                    @endif
+                                {{ data_get($project, 'name') ?? 'Unknown project' }}
+                                /
+                                {{ data_get($environment, 'name') ?? 'Unknown environment' }}
+                                @if (data_get($deployment, 'server_name'))
+                                    <span class="px-1">/</span>
+                                    {{ data_get($deployment, 'server_name') }}
                                 @endif
                             </div>
                         </div>
-                    @if ($deploymentUrl)
-                        </a>
-                    @else
+
+                        @if (data_get($deployment, 'commit'))
+                            <div class="text-sm text-gray-600 dark:text-gray-400">
+                                <span class="font-medium">Commit:</span>
+                                @if ($application)
+                                    <a href="{{ $application->gitCommitLink(data_get($deployment, 'commit')) }}" target="_blank"
+                                        rel="noopener noreferrer" class="underline">
+                                        {{ substr(data_get($deployment, 'commit'), 0, 7) }}
+                                    </a>
+                                @else
+                                    {{ substr(data_get($deployment, 'commit'), 0, 7) }}
+                                @endif
+                                @if ($deployment->commitMessage())
+                                    <span>-</span>
+                                    <span>{{ Str::before($deployment->commitMessage(), "\n") }}</span>
+                                @endif
+                            </div>
+                        @endif
+
+                        <div class="text-sm text-gray-600 dark:text-gray-400">
+                            Started:
+                            {{ formatDateInServerTimezone(data_get($deployment, 'created_at'), $server) }}
+                            @if ($status !== 'queued')
+                                @if ($status === 'in_progress')
+                                    <br>Running for:
+                                    {{ calculateDuration(data_get($deployment, 'created_at'), now()) }}
+                                @elseif (data_get($deployment, 'finished_at'))
+                                    <br>Ended:
+                                    {{ formatDateInServerTimezone(data_get($deployment, 'finished_at'), $server) }}
+                                    <br>Duration:
+                                    {{ calculateDuration(data_get($deployment, 'created_at'), data_get($deployment, 'finished_at')) }}
+                                @endif
+                            @endif
                         </div>
-                    @endif
+                    </div>
                 </div>
             @empty
                 <div>No deployments found</div>

--- a/resources/views/livewire/deployments/index.blade.php
+++ b/resources/views/livewire/deployments/index.blade.php
@@ -1,0 +1,146 @@
+<div>
+    <x-slot:title>Deployments | Coolify</x-slot:title>
+
+    <h1>Deployments</h1>
+
+    <div class="flex flex-col gap-4 pb-10" @if ($deployments->currentPage() === 1) wire:poll.5000ms @endif>
+        <div class="flex flex-col gap-3 md:flex-row md:items-end">
+            <div class="w-full md:w-48">
+                <x-forms.select id="deployment_type" label="Type" wire:model.live="deployment_type">
+                    @foreach ($this->deploymentTypeOptions() as $value => $label)
+                        <option value="{{ $value }}">{{ $label }}</option>
+                    @endforeach
+                </x-forms.select>
+            </div>
+            <div class="w-full md:w-48">
+                <x-forms.select id="status" label="Status" wire:model.live="status">
+                    @foreach ($this->statusOptions() as $value => $label)
+                        <option value="{{ $value }}">{{ $label }}</option>
+                    @endforeach
+                </x-forms.select>
+            </div>
+        </div>
+
+        <div class="flex flex-col gap-2">
+            @forelse ($deployments as $deployment)
+                @php
+                    $application = data_get($deployment, 'application');
+                    $environment = data_get($application, 'environment');
+                    $project = data_get($environment, 'project');
+                    $status = data_get($deployment, 'status');
+                    $statusText = match ($status) {
+                        'finished' => 'Success',
+                        'in_progress' => 'In Progress',
+                        'cancelled-by-user' => 'Cancelled',
+                        'queued' => 'Queued',
+                        default => ucfirst((string) $status),
+                    };
+                    $triggerText = match (true) {
+                        (bool) data_get($deployment, 'is_webhook') => data_get($deployment, 'pull_request_id')
+                            ? 'Webhook | Pull Request #' . data_get($deployment, 'pull_request_id')
+                            : 'Webhook',
+                        (bool) data_get($deployment, 'pull_request_id') => 'Pull Request #' . data_get($deployment, 'pull_request_id'),
+                        (bool) data_get($deployment, 'rollback') => 'Rollback',
+                        (bool) data_get($deployment, 'is_api') => 'API',
+                        default => 'Manual',
+                    };
+                    $deploymentUrl = data_get($deployment, 'deployment_url');
+                    $server = $servers->get(data_get($deployment, 'server_id'));
+                @endphp
+
+                <div data-deployment-uuid="{{ data_get($deployment, 'deployment_uuid') }}" @class([
+                    'p-3 border-l-2 bg-white dark:bg-coolgray-100',
+                    'border-blue-500/50 border-dashed' => $status === 'in_progress',
+                    'border-purple-500/50 border-dashed' => $status === 'queued',
+                    'border-white border-dashed' => $status === 'cancelled-by-user',
+                    'border-error' => $status === 'failed',
+                    'border-success' => $status === 'finished',
+                ])>
+                    @if ($deploymentUrl)
+                        <a href="{{ $deploymentUrl }}" {{ wireNavigate() }} class="block">
+                    @else
+                        <div>
+                    @endif
+                        <div class="flex flex-col gap-2">
+                            <div class="flex flex-wrap items-center gap-2">
+                                <span @class([
+                                    'px-3 py-1 rounded-md text-xs font-medium shadow-xs',
+                                    'bg-blue-100/80 text-blue-700 dark:bg-blue-500/20 dark:text-blue-300' => $status === 'in_progress',
+                                    'bg-purple-100/80 text-purple-700 dark:bg-purple-500/20 dark:text-purple-300' => $status === 'queued',
+                                    'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-200' => $status === 'failed',
+                                    'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-200' => $status === 'finished',
+                                    'bg-gray-100 text-gray-700 dark:bg-gray-600/30 dark:text-gray-300' => $status === 'cancelled-by-user',
+                                ])>{{ $statusText }}</span>
+                                <span
+                                    class="bg-gray-200/70 dark:bg-gray-600/20 px-2 py-0.5 rounded-md text-xs text-gray-800 dark:text-gray-100 border border-gray-400/30">
+                                    {{ $triggerText }}
+                                </span>
+                            </div>
+
+                            <div class="flex flex-col gap-1">
+                                <div class="font-medium dark:text-white">
+                                    {{ data_get($deployment, 'application_name') ?? data_get($application, 'name') ?? 'Unknown application' }}
+                                </div>
+                                <div class="text-sm text-gray-600 dark:text-gray-400">
+                                    {{ data_get($project, 'name') ?? 'Unknown project' }}
+                                    /
+                                    {{ data_get($environment, 'name') ?? 'Unknown environment' }}
+                                    @if (data_get($deployment, 'server_name'))
+                                        <span class="px-1">/</span>
+                                        {{ data_get($deployment, 'server_name') }}
+                                    @endif
+                                </div>
+                            </div>
+
+                            @if (data_get($deployment, 'commit'))
+                                <div class="text-sm text-gray-600 dark:text-gray-400">
+                                    <span class="font-medium">Commit:</span>
+                                    @if ($application)
+                                        <a href="{{ $application->gitCommitLink(data_get($deployment, 'commit')) }}" target="_blank"
+                                            rel="noopener noreferrer" class="underline">
+                                            {{ substr(data_get($deployment, 'commit'), 0, 7) }}
+                                        </a>
+                                    @else
+                                        {{ substr(data_get($deployment, 'commit'), 0, 7) }}
+                                    @endif
+                                    @if ($deployment->commitMessage())
+                                        <span>-</span>
+                                        <span>{{ Str::before($deployment->commitMessage(), "\n") }}</span>
+                                    @endif
+                                </div>
+                            @endif
+
+                            <div class="text-sm text-gray-600 dark:text-gray-400">
+                                Started:
+                                {{ formatDateInServerTimezone(data_get($deployment, 'created_at'), $server) }}
+                                @if ($status !== 'queued')
+                                    @if ($status === 'in_progress')
+                                        <br>Running for:
+                                        {{ calculateDuration(data_get($deployment, 'created_at'), now()) }}
+                                    @elseif (data_get($deployment, 'finished_at'))
+                                        <br>Ended:
+                                        {{ formatDateInServerTimezone(data_get($deployment, 'finished_at'), $server) }}
+                                        <br>Duration:
+                                        {{ calculateDuration(data_get($deployment, 'created_at'), data_get($deployment, 'finished_at')) }}
+                                    @endif
+                                @endif
+                            </div>
+                        </div>
+                    @if ($deploymentUrl)
+                        </a>
+                    @else
+                        </div>
+                    @endif
+                </div>
+            @empty
+                <div>No deployments found</div>
+            @endforelse
+        </div>
+
+        @if ($deployments->hasPages())
+            <div>
+                {{ $deployments->links() }}
+            </div>
+        @endif
+    </div>
+</div>

--- a/resources/views/livewire/deployments/index.blade.php
+++ b/resources/views/livewire/deployments/index.blade.php
@@ -1,9 +1,30 @@
 <div>
     <x-slot:title>Deployments | Coolify</x-slot:title>
 
-    <h1>Deployments</h1>
-
     <div class="flex flex-col gap-4 pb-10" @if ($deployments->currentPage() === 1) wire:poll.5000ms @endif>
+        <div class="flex flex-wrap items-center gap-4">
+            <h1>Deployments <span class="text-xs">({{ $deployments->total() }})</span></h1>
+            @if ($deployments->total() > 0)
+                <div class="flex items-center gap-2">
+                    <x-forms.button type="button" disabled="{{ $deployments->onFirstPage() }}" wire:click="previousPage">
+                        <svg class="w-4 h-4" viewBox="0 0 24 24">
+                            <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"
+                                stroke-width="2" d="m14 6l-6 6l6 6z" />
+                        </svg>
+                    </x-forms.button>
+                    <span class="px-2 text-sm text-gray-600 dark:text-gray-400">
+                        Page {{ $deployments->currentPage() }} of {{ $deployments->lastPage() }}
+                    </span>
+                    <x-forms.button type="button" disabled="{{ ! $deployments->hasMorePages() }}" wire:click="nextPage">
+                        <svg class="w-4 h-4" viewBox="0 0 24 24">
+                            <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"
+                                stroke-width="2" d="m10 18l6-6l-6-6z" />
+                        </svg>
+                    </x-forms.button>
+                </div>
+            @endif
+        </div>
+
         <div class="flex flex-col gap-3 md:flex-row md:items-end">
             <div class="w-full md:w-48">
                 <x-forms.select id="deployment_type" label="Type" wire:model.live="deployment_type">
@@ -137,10 +158,5 @@
             @endforelse
         </div>
 
-        @if ($deployments->hasPages())
-            <div>
-                {{ $deployments->links() }}
-            </div>
-        @endif
     </div>
 </div>

--- a/resources/views/livewire/deployments/index.blade.php
+++ b/resources/views/livewire/deployments/index.blade.php
@@ -6,7 +6,8 @@
             <h1>Deployments <span class="text-xs">({{ $deployments->total() }})</span></h1>
             @if ($deployments->total() > 0)
                 <div class="flex items-center gap-2">
-                    <x-forms.button type="button" :disabled="$deployments->onFirstPage()" wire:click="previousPage">
+                    <x-forms.button type="button" aria-label="Previous page" :disabled="$deployments->onFirstPage()"
+                        wire:click="previousPage">
                         <svg class="w-4 h-4" viewBox="0 0 24 24">
                             <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"
                                 stroke-width="2" d="m14 6l-6 6l6 6z" />
@@ -15,7 +16,8 @@
                     <span class="px-2 text-sm text-gray-600 dark:text-gray-400">
                         Page {{ $deployments->currentPage() }} of {{ $deployments->lastPage() }}
                     </span>
-                    <x-forms.button type="button" :disabled="! $deployments->hasMorePages()" wire:click="nextPage">
+                    <x-forms.button type="button" aria-label="Next page" :disabled="! $deployments->hasMorePages()"
+                        wire:click="nextPage">
                         <svg class="w-4 h-4" viewBox="0 0 24 24">
                             <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"
                                 stroke-width="2" d="m10 18l6-6l-6-6z" />
@@ -70,10 +72,19 @@
                 @endphp
 
                 <div data-deployment-uuid="{{ data_get($deployment, 'deployment_uuid') }}"
-                    @if ($deploymentUrl) x-on:click="if (!$event.target.closest('a')) {
+                    @if ($deploymentUrl) tabindex="0" role="link" aria-label="View deployment logs for {{ data_get($deployment, 'application_name') ?? data_get($application, 'name') ?? 'application' }}"
+                        x-on:click="if (!$event.target.closest('a')) {
                             const url = @js($deploymentUrl);
                             window.Livewire?.navigate ? window.Livewire.navigate(url) : window.location.href = url;
-                        }" @endif
+                        }"
+                        x-on:keydown.enter.prevent="
+                            const url = @js($deploymentUrl);
+                            window.Livewire?.navigate ? window.Livewire.navigate(url) : window.location.href = url;
+                        "
+                        x-on:keydown.space.prevent="
+                            const url = @js($deploymentUrl);
+                            window.Livewire?.navigate ? window.Livewire.navigate(url) : window.location.href = url;
+                        " @endif
                     @class([
                     'p-3 border-l-2 bg-white dark:bg-coolgray-100',
                     'cursor-pointer' => $deploymentUrl,

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\UploadController;
 use App\Livewire\Admin\Index as AdminIndex;
 use App\Livewire\Boarding\Index as BoardingIndex;
 use App\Livewire\Dashboard;
+use App\Livewire\Deployments\Index as DeploymentsIndex;
 use App\Livewire\Destination\Index as DestinationIndex;
 use App\Livewire\Destination\Resources as DestinationResources;
 use App\Livewire\Destination\Show as DestinationShow;
@@ -204,6 +205,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     });
 
     Route::get('/projects', ProjectIndex::class)->name('project.index');
+    Route::get('/deployments', DeploymentsIndex::class)->name('deployments.index');
     Route::prefix('project/{project_uuid}')->group(function () {
         Route::get('/', ProjectShow::class)->name('project.show');
         Route::get('/edit', ProjectEdit::class)->name('project.edit')->middleware('can.update.resource');

--- a/tests/Feature/GlobalDeploymentHistoryTest.php
+++ b/tests/Feature/GlobalDeploymentHistoryTest.php
@@ -117,6 +117,17 @@ it('shows paginated deployment history for the current team only', function () {
         $newDeployment->deployment_uuid,
         $oldDeployment->deployment_uuid,
     ]);
+
+    $dom = new DOMDocument;
+    $previousLibxmlState = libxml_use_internal_errors(true);
+    $dom->loadHTML($response->getContent());
+    libxml_clear_errors();
+    libxml_use_internal_errors($previousLibxmlState);
+
+    $xpath = new DOMXPath($dom);
+
+    expect($xpath->query('//button[@aria-label="Previous page"]')->length)->toBe(1);
+    expect($xpath->query('//button[@aria-label="Next page"]')->length)->toBe(1);
 });
 
 it('paginates global deployments', function () {
@@ -240,9 +251,11 @@ it('keeps deployment row navigation separate from commit links', function () {
     $xpath = new DOMXPath($dom);
     $deploymentUrlAnchors = $xpath->query('//*[@data-deployment-uuid="deployment-with-url"]//a[@href="'.$deploymentUrl.'"]');
     $commitAnchors = $xpath->query('//*[@data-deployment-uuid="deployment-with-url"]//a[@target="_blank" and contains(@rel, "noopener")]');
+    $deploymentRows = $xpath->query('//*[@data-deployment-uuid="deployment-with-url" and @role="link" and @tabindex="0"]');
 
     expect($deploymentUrlAnchors->length)->toBe(0);
     expect($commitAnchors->length)->toBe(1);
+    expect($deploymentRows->length)->toBe(1);
 });
 
 it('renders deployments without log urls as non-clickable rows', function () {

--- a/tests/Feature/GlobalDeploymentHistoryTest.php
+++ b/tests/Feature/GlobalDeploymentHistoryTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Enums\ApplicationDeploymentStatus;
+use App\Livewire\Deployments\Index as DeploymentsIndex;
 use App\Models\Application;
 use App\Models\ApplicationDeploymentQueue;
 use App\Models\Environment;
@@ -11,6 +12,7 @@ use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
+use Livewire\Livewire;
 
 uses(RefreshDatabase::class);
 
@@ -109,7 +111,7 @@ it('shows paginated deployment history for the current team only', function () {
     $response->assertSee('Production Server');
     $response->assertSee('Newest same team deployment');
     $response->assertSee('Old same team deployment');
-    $response->assertSee('/project/storefront/environment/production/application/checkout/deployment/new-deployment', false);
+    $response->assertSee('\/project\/storefront\/environment\/production\/application\/checkout\/deployment\/new-deployment', false);
     $response->assertDontSee('Hidden other team deployment');
     $response->assertSeeInOrder([
         $newDeployment->deployment_uuid,
@@ -141,6 +143,38 @@ it('paginates global deployments', function () {
     $this->get('/deployments?page=2')
         ->assertSuccessful()
         ->assertSee('Last page unique deployment');
+});
+
+it('paginates global deployments through Livewire controls', function () {
+    createGlobalHistoryDeployment([
+        'deployment_uuid' => 'failed-deployment',
+        'commit_message' => 'Filtered failed deployment',
+        'status' => ApplicationDeploymentStatus::FAILED->value,
+        'created_at' => now(),
+        'finished_at' => now()->addMinute(),
+    ]);
+
+    for ($deploymentNumber = 1; $deploymentNumber <= 21; $deploymentNumber++) {
+        createGlobalHistoryDeployment([
+            'deployment_uuid' => "livewire-deployment-{$deploymentNumber}",
+            'commit_message' => "Livewire deployment {$deploymentNumber}",
+            'created_at' => now()->subMinutes($deploymentNumber),
+            'finished_at' => now()->subMinutes($deploymentNumber)->addMinute(),
+        ]);
+    }
+
+    Livewire::test(DeploymentsIndex::class)
+        ->assertSee('Livewire deployment 1')
+        ->assertDontSee('Livewire deployment 21')
+        ->call('nextPage')
+        ->assertSee('Livewire deployment 21')
+        ->assertDontSee('Livewire deployment 1')
+        ->call('previousPage')
+        ->assertSee('Livewire deployment 1')
+        ->call('nextPage')
+        ->set('status', ApplicationDeploymentStatus::FAILED->value)
+        ->assertSee('Filtered failed deployment')
+        ->assertDontSee('Livewire deployment 21');
 });
 
 it('filters deployments by deployment type and status', function () {
@@ -180,6 +214,35 @@ it('filters deployments by deployment type and status', function () {
         ->assertDontSee('Production finished deployment')
         ->assertSee('Preview failed deployment')
         ->assertDontSee('Preview queued deployment');
+});
+
+it('keeps deployment row navigation separate from commit links', function () {
+    $deploymentUrl = '/project/storefront/environment/production/application/checkout/deployment/deployment-with-url';
+
+    createGlobalHistoryDeployment([
+        'deployment_uuid' => 'deployment-with-url',
+        'deployment_url' => $deploymentUrl,
+        'commit_message' => 'Deployment with URL',
+    ]);
+
+    $response = $this->get('/deployments')
+        ->assertSuccessful()
+        ->assertSee('Deployment with URL')
+        ->assertSee(str_replace('/', '\/', $deploymentUrl), false)
+        ->assertSee('window.Livewire?.navigate', false);
+
+    $dom = new DOMDocument;
+    $previousLibxmlState = libxml_use_internal_errors(true);
+    $dom->loadHTML($response->getContent());
+    libxml_clear_errors();
+    libxml_use_internal_errors($previousLibxmlState);
+
+    $xpath = new DOMXPath($dom);
+    $deploymentUrlAnchors = $xpath->query('//*[@data-deployment-uuid="deployment-with-url"]//a[@href="'.$deploymentUrl.'"]');
+    $commitAnchors = $xpath->query('//*[@data-deployment-uuid="deployment-with-url"]//a[@target="_blank" and contains(@rel, "noopener")]');
+
+    expect($deploymentUrlAnchors->length)->toBe(0);
+    expect($commitAnchors->length)->toBe(1);
 });
 
 it('renders deployments without log urls as non-clickable rows', function () {

--- a/tests/Feature/GlobalDeploymentHistoryTest.php
+++ b/tests/Feature/GlobalDeploymentHistoryTest.php
@@ -1,0 +1,205 @@
+<?php
+
+use App\Enums\ApplicationDeploymentStatus;
+use App\Models\Application;
+use App\Models\ApplicationDeploymentQueue;
+use App\Models\Environment;
+use App\Models\InstanceSettings;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Config::set('cache.default', 'array');
+    Config::set('app.maintenance.store', 'array');
+    InstanceSettings::forceCreate(['id' => 0]);
+
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+    session(['currentTeam' => $this->team]);
+    $this->actingAs($this->user);
+    $this->withoutVite();
+
+    $this->server = Server::factory()->create([
+        'name' => 'Production Server',
+        'team_id' => $this->team->id,
+    ]);
+
+    $this->project = Project::factory()->create([
+        'name' => 'Storefront',
+        'team_id' => $this->team->id,
+    ]);
+
+    $this->environment = Environment::factory()->create([
+        'name' => 'Live',
+        'project_id' => $this->project->id,
+    ]);
+
+    $this->application = Application::factory()->create([
+        'name' => 'Checkout API',
+        'environment_id' => $this->environment->id,
+    ]);
+});
+
+function createGlobalHistoryDeployment(array $attributes = []): ApplicationDeploymentQueue
+{
+    return ApplicationDeploymentQueue::forceCreate(array_merge([
+        'deployment_uuid' => str()->uuid()->toString(),
+        'application_id' => test()->application->id,
+        'application_name' => test()->application->name,
+        'server_id' => test()->server->id,
+        'server_name' => test()->server->name,
+        'deployment_url' => '/project/project-uuid/environment/environment-uuid/application/application-uuid/deployment/deployment-uuid',
+        'commit' => '1234567890abcdef',
+        'commit_message' => 'Update checkout flow',
+        'status' => ApplicationDeploymentStatus::FINISHED->value,
+        'created_at' => now(),
+        'finished_at' => now()->addMinute(),
+    ], $attributes));
+}
+
+it('shows paginated deployment history for the current team only', function () {
+    $oldDeployment = createGlobalHistoryDeployment([
+        'deployment_uuid' => 'old-deployment',
+        'commit_message' => 'Old same team deployment',
+        'created_at' => now()->subHour(),
+        'finished_at' => now()->subHour()->addMinute(),
+    ]);
+    $newDeployment = createGlobalHistoryDeployment([
+        'deployment_uuid' => 'new-deployment',
+        'commit_message' => 'Newest same team deployment',
+        'deployment_url' => '/project/storefront/environment/production/application/checkout/deployment/new-deployment',
+        'created_at' => now(),
+        'finished_at' => now()->addMinute(),
+    ]);
+
+    $otherTeam = Team::factory()->create();
+    $otherProject = Project::factory()->create(['team_id' => $otherTeam->id]);
+    $otherEnvironment = Environment::factory()->create(['project_id' => $otherProject->id]);
+    $otherApplication = Application::factory()->create([
+        'name' => 'Other Team App',
+        'environment_id' => $otherEnvironment->id,
+    ]);
+    $otherServer = Server::factory()->create(['team_id' => $otherTeam->id]);
+    ApplicationDeploymentQueue::create([
+        'deployment_uuid' => 'other-team-deployment',
+        'application_id' => $otherApplication->id,
+        'application_name' => $otherApplication->name,
+        'server_id' => $otherServer->id,
+        'server_name' => $otherServer->name,
+        'status' => ApplicationDeploymentStatus::FINISHED->value,
+        'commit_message' => 'Hidden other team deployment',
+        'created_at' => now()->addHour(),
+        'finished_at' => now()->addHour()->addMinute(),
+    ]);
+
+    $response = $this->get('/deployments');
+
+    $response->assertSuccessful();
+    $response->assertSee('Deployments');
+    $response->assertSee('Checkout API');
+    $response->assertSee('Storefront');
+    $response->assertSee('Production');
+    $response->assertSee('Production Server');
+    $response->assertSee('Newest same team deployment');
+    $response->assertSee('Old same team deployment');
+    $response->assertSee('/project/storefront/environment/production/application/checkout/deployment/new-deployment', false);
+    $response->assertDontSee('Hidden other team deployment');
+    $response->assertSeeInOrder([
+        $newDeployment->deployment_uuid,
+        $oldDeployment->deployment_uuid,
+    ]);
+});
+
+it('paginates global deployments', function () {
+    for ($deploymentNumber = 1; $deploymentNumber <= 21; $deploymentNumber++) {
+        createGlobalHistoryDeployment([
+            'deployment_uuid' => "deployment-{$deploymentNumber}",
+            'commit_message' => $deploymentNumber === 1
+                ? 'First page unique deployment'
+                : "Deployment {$deploymentNumber}",
+            'created_at' => now()->subMinutes($deploymentNumber),
+            'finished_at' => now()->subMinutes($deploymentNumber)->addMinute(),
+        ]);
+    }
+
+    ApplicationDeploymentQueue::where('deployment_uuid', 'deployment-21')->update([
+        'commit_message' => 'Last page unique deployment',
+    ]);
+
+    $this->get('/deployments')
+        ->assertSuccessful()
+        ->assertSee('First page unique deployment')
+        ->assertDontSee('Last page unique deployment');
+
+    $this->get('/deployments?page=2')
+        ->assertSuccessful()
+        ->assertSee('Last page unique deployment');
+});
+
+it('filters deployments by deployment type and status', function () {
+    createGlobalHistoryDeployment([
+        'deployment_uuid' => 'production-finished',
+        'commit_message' => 'Production finished deployment',
+        'pull_request_id' => 0,
+        'status' => ApplicationDeploymentStatus::FINISHED->value,
+    ]);
+    createGlobalHistoryDeployment([
+        'deployment_uuid' => 'preview-failed',
+        'commit_message' => 'Preview failed deployment',
+        'pull_request_id' => 42,
+        'status' => ApplicationDeploymentStatus::FAILED->value,
+    ]);
+    createGlobalHistoryDeployment([
+        'deployment_uuid' => 'preview-queued',
+        'commit_message' => 'Preview queued deployment',
+        'pull_request_id' => 43,
+        'status' => ApplicationDeploymentStatus::QUEUED->value,
+    ]);
+
+    $this->get('/deployments?deployment_type=production')
+        ->assertSuccessful()
+        ->assertSee('Production finished deployment')
+        ->assertDontSee('Preview failed deployment')
+        ->assertDontSee('Preview queued deployment');
+
+    $this->get('/deployments?deployment_type=preview')
+        ->assertSuccessful()
+        ->assertDontSee('Production finished deployment')
+        ->assertSee('Preview failed deployment')
+        ->assertSee('Preview queued deployment');
+
+    $this->get('/deployments?status=failed')
+        ->assertSuccessful()
+        ->assertDontSee('Production finished deployment')
+        ->assertSee('Preview failed deployment')
+        ->assertDontSee('Preview queued deployment');
+});
+
+it('renders deployments without log urls as non-clickable rows', function () {
+    createGlobalHistoryDeployment([
+        'deployment_uuid' => 'deployment-without-url',
+        'deployment_url' => null,
+        'commit_message' => 'Deployment without URL',
+    ]);
+
+    $response = $this->get('/deployments')
+        ->assertSuccessful()
+        ->assertSee('Deployment without URL');
+
+    $dom = new DOMDocument;
+    $previousLibxmlState = libxml_use_internal_errors(true);
+    $dom->loadHTML($response->getContent());
+    libxml_clear_errors();
+    libxml_use_internal_errors($previousLibxmlState);
+
+    $anchors = (new DOMXPath($dom))->query('//*[@data-deployment-uuid="deployment-without-url"]//a[contains(concat(" ", normalize-space(@class), " "), " block ")]');
+
+    expect($anchors->length)->toBe(0);
+});


### PR DESCRIPTION
## Changes

- Add a top-level Deployments page showing application deployment history for the current team.
- Add Livewire pagination with type and status filters.
- Link deployment rows to existing deployment logs when a log URL is available.
- Add Deployments to the sidebar and global search navigation.

## Issues

- Fixes #7596

## Category

- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

<img width="1512" height="684" alt="image" src="https://github.com/user-attachments/assets/cef93d22-200d-421c-a5c5-8be78dcd3c4b" />
<img width="595" height="226" alt="image" src="https://github.com/user-attachments/assets/3f8713f8-39f4-40d3-a9f4-16d801d22f76" />
<img width="570" height="294" alt="image" src="https://github.com/user-attachments/assets/3f9abc0f-1805-4c6f-92ec-f7c237f02166" />
<img width="298" height="535" alt="image" src="https://github.com/user-attachments/assets/b6f223f8-e111-475d-8319-6dc042ea1f61" />


## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex, CodeRabbit CLI
- How extensively: Assisted with implementation and review; final changes were reviewed and tested locally.

## Testing

- `vendor/bin/pint --dirty --format agent`
- `php artisan test --compact tests/Feature/GlobalDeploymentHistoryTest.php tests/Feature/DeploymentsIndicatorLayoutTest.php`

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.