### PR TITLE
fix(backup): keep S3 toggle on by selecting an available storage

### DIFF
--- a/app/Livewire/Project/Database/BackupEdit.php
+++ b/app/Livewire/Project/Database/BackupEdit.php
@@ -211,8 +211,13 @@ class BackupEdit extends Component
         // S3 backup cannot be enabled without a valid S3 storage owned by the team
         $availableS3Ids = collect($this->s3s)->pluck('id');
         if ($this->backup->save_s3 && ! $availableS3Ids->contains($this->backup->s3_storage_id)) {
-            $this->backup->save_s3 = $this->saveS3 = false;
-            $this->backup->s3_storage_id = $this->s3StorageId = null;
+            if ($availableS3Ids->isNotEmpty()) {
+                // Select the first available S3 storage instead of silently disabling the toggle
+                $this->backup->s3_storage_id = $this->s3StorageId = $availableS3Ids->first();
+            } else {
+                $this->backup->save_s3 = $this->saveS3 = false;
+                $this->backup->s3_storage_id = $this->s3StorageId = null;
+            }
         }
 
         // Validate that disable_local_backup can only be true when S3 backup is enabled

--- a/tests/Feature/BackupEditS3ToggleTest.php
+++ b/tests/Feature/BackupEditS3ToggleTest.php
@@ -1,0 +1,123 @@
+<?php
+
+use App\Livewire\Project\Database\BackupEdit;
+use App\Models\Environment;
+use App\Models\InstanceSettings;
+use App\Models\Project;
+use App\Models\S3Storage;
+use App\Models\ScheduledDatabaseBackup;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\StandalonePostgresql;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+function createDatabaseForBackupEditTest(Team $team): StandalonePostgresql
+{
+    $server = Server::factory()->create(['team_id' => $team->id]);
+    $destination = StandaloneDocker::where('server_id', $server->id)->firstOrFail();
+    $project = Project::factory()->create(['team_id' => $team->id]);
+    $environment = Environment::factory()->create(['project_id' => $project->id]);
+
+    return StandalonePostgresql::create([
+        'name' => 'pg-backup-edit',
+        'image' => 'postgres:16-alpine',
+        'postgres_user' => 'postgres',
+        'postgres_password' => 'password',
+        'postgres_db' => 'postgres',
+        'environment_id' => $environment->id,
+        'destination_id' => $destination->id,
+        'destination_type' => $destination->getMorphClass(),
+    ]);
+}
+
+function createS3StorageForBackupEditTest(Team $team, string $name = 'Test S3'): S3Storage
+{
+    return S3Storage::create([
+        'name' => $name,
+        'region' => 'us-east-1',
+        'key' => 'test-key',
+        'secret' => 'test-secret',
+        'bucket' => 'test-bucket',
+        'endpoint' => 'https://s3.example.com',
+        'is_usable' => true,
+        'team_id' => $team->id,
+    ]);
+}
+
+function createScheduledBackupForEditTest(StandalonePostgresql $database, Team $team): ScheduledDatabaseBackup
+{
+    $backup = new ScheduledDatabaseBackup;
+    $backup->forceFill([
+        'enabled' => true,
+        'save_s3' => false,
+        's3_storage_id' => null,
+        'frequency' => '0 0 * * *',
+        'database_backup_retention_amount_locally' => 0,
+        'database_backup_retention_days_locally' => 0,
+        'database_backup_retention_max_storage_locally' => 0,
+        'database_backup_retention_amount_s3' => 0,
+        'database_backup_retention_days_s3' => 0,
+        'database_backup_retention_max_storage_s3' => 0,
+        'dump_all' => false,
+        'timeout' => 3600,
+        'database_id' => $database->id,
+        'database_type' => $database->getMorphClass(),
+        'team_id' => $team->id,
+    ]);
+    $backup->save();
+
+    return $backup;
+}
+
+beforeEach(function () {
+    $instanceSettings = new InstanceSettings;
+    $instanceSettings->forceFill([
+        'id' => 0,
+        'is_registration_enabled' => true,
+        'smtp_enabled' => true,
+        'smtp_host' => 'coolify-mail',
+        'smtp_port' => 1025,
+        'smtp_from_address' => 'hi@localhost.com',
+        'smtp_from_name' => 'Coolify',
+    ]);
+    $instanceSettings->save();
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->user->teams()->attach($this->team, ['role' => 'owner']);
+    $this->actingAs($this->user);
+    session(['currentTeam' => $this->team]);
+});
+
+it('selects an available S3 storage instead of silently disabling the toggle when the selection is invalid', function () {
+    $database = createDatabaseForBackupEditTest($this->team);
+    $backup = createScheduledBackupForEditTest($database, $this->team);
+    $s3 = createS3StorageForBackupEditTest($this->team);
+
+    Livewire::test(BackupEdit::class, ['backup' => $backup, 's3s' => collect([$s3])])
+        ->set('s3StorageId', 999999)
+        ->set('saveS3', true)
+        ->call('instantSave')
+        ->assertDispatched('success');
+
+    $backup->refresh();
+    expect($backup->save_s3)->toBeTrue();
+    expect($backup->s3_storage_id)->toBe($s3->id);
+});
+
+it('disables the S3 toggle when no S3 storage is available', function () {
+    $database = createDatabaseForBackupEditTest($this->team);
+    $backup = createScheduledBackupForEditTest($database, $this->team);
+
+    Livewire::test(BackupEdit::class, ['backup' => $backup, 's3s' => collect()])
+        ->set('saveS3', true)
+        ->call('instantSave');
+
+    $backup->refresh();
+    expect($backup->save_s3)->toBeFalse();
+    expect($backup->s3_storage_id)->toBeNull();
+});


### PR DESCRIPTION
## What

Turning on "S3 Enabled" for a database backup looked like it did nothing. You
got a "Backup updated successfully" toast, but the setting flipped back to off.
Closes #10692.

## Why it happened

The S3 storage dropdown in the backup form only shows up once `save_s3` is true.
But `customValidate()` in `BackupEdit` turns `save_s3` back off whenever the
selected `s3_storage_id` is not one of the team's storages. A backup that never
had a storage picked fails that check the moment you flip the toggle, so it
reverts before the dropdown appears. The component still fires the success
toast, which is why it feels like a silent no-op. It is a shared component, so
every backup section behaves the same way, which matches the report.

## The change

When S3 is enabled and the current selection is not valid, pick the first
available storage instead of switching the toggle off. The toggle stays on, the
dropdown appears, and the user can change the storage from there. If the team
has no S3 storage at all, it still switches the toggle off like before.

## Tests

New `tests/Feature/BackupEditS3ToggleTest.php`:
- enabling S3 with an invalid selection keeps it on and picks an available storage
- enabling S3 with no storage available switches the toggle off

The first test fails without this change and passes with it.

## One thing worth a look

`BackupEdit` now auto-picks a storage rather than erroring when the selection is
invalid. `CreateScheduledBackup` rejects with an error in that case. I went with
auto-pick because it unblocks the reported bug, but if you would rather both
behave the same, I can change it
