### PR TITLE
fix(backup): keep S3 toggle on by selecting an available storage

### DIFF
--- a/app/Livewire/Project/Database/BackupEdit.php
+++ b/app/Livewire/Project/Database/BackupEdit.php
@@ -223,8 +223,13 @@ class BackupEdit extends Component
         // S3 backup cannot be enabled without a valid S3 storage owned by the team
         $availableS3Ids = collect($this->s3s)->pluck('id');
         if ($this->backup->save_s3 && ! $availableS3Ids->contains($this->backup->s3_storage_id)) {
-            $this->backup->save_s3 = $this->saveS3 = false;
-            $this->backup->s3_storage_id = $this->s3StorageId = null;
+            if ($availableS3Ids->isNotEmpty()) {
+                // Select the first available S3 storage instead of silently disabling the toggle
+                $this->backup->s3_storage_id = $this->s3StorageId = $availableS3Ids->first();
+            } else {
+                $this->backup->save_s3 = $this->saveS3 = false;
+                $this->backup->s3_storage_id = $this->s3StorageId = null;
+            }
         }
 
         // Validate that disable_local_backup can only be true when S3 backup is enabled

--- a/tests/Feature/BackupEditS3ToggleTest.php
+++ b/tests/Feature/BackupEditS3ToggleTest.php
@@ -1,0 +1,123 @@
+<?php
+
+use App\Livewire\Project\Database\BackupEdit;
+use App\Models\Environment;
+use App\Models\InstanceSettings;
+use App\Models\Project;
+use App\Models\S3Storage;
+use App\Models\ScheduledDatabaseBackup;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\StandalonePostgresql;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+function createDatabaseForBackupEditTest(Team $team): StandalonePostgresql
+{
+    $server = Server::factory()->create(['team_id' => $team->id]);
+    $destination = StandaloneDocker::where('server_id', $server->id)->firstOrFail();
+    $project = Project::factory()->create(['team_id' => $team->id]);
+    $environment = Environment::factory()->create(['project_id' => $project->id]);
+
+    return StandalonePostgresql::create([
+        'name' => 'pg-backup-edit',
+        'image' => 'postgres:16-alpine',
+        'postgres_user' => 'postgres',
+        'postgres_password' => 'password',
+        'postgres_db' => 'postgres',
+        'environment_id' => $environment->id,
+        'destination_id' => $destination->id,
+        'destination_type' => $destination->getMorphClass(),
+    ]);
+}
+
+function createS3StorageForBackupEditTest(Team $team, string $name = 'Test S3'): S3Storage
+{
+    return S3Storage::create([
+        'name' => $name,
+        'region' => 'us-east-1',
+        'key' => 'test-key',
+        'secret' => 'test-secret',
+        'bucket' => 'test-bucket',
+        'endpoint' => 'https://s3.example.com',
+        'is_usable' => true,
+        'team_id' => $team->id,
+    ]);
+}
+
+function createScheduledBackupForEditTest(StandalonePostgresql $database, Team $team): ScheduledDatabaseBackup
+{
+    $backup = new ScheduledDatabaseBackup;
+    $backup->forceFill([
+        'enabled' => true,
+        'save_s3' => false,
+        's3_storage_id' => null,
+        'frequency' => '0 0 * * *',
+        'database_backup_retention_amount_locally' => 0,
+        'database_backup_retention_days_locally' => 0,
+        'database_backup_retention_max_storage_locally' => 0,
+        'database_backup_retention_amount_s3' => 0,
+        'database_backup_retention_days_s3' => 0,
+        'database_backup_retention_max_storage_s3' => 0,
+        'dump_all' => false,
+        'timeout' => 3600,
+        'database_id' => $database->id,
+        'database_type' => $database->getMorphClass(),
+        'team_id' => $team->id,
+    ]);
+    $backup->save();
+
+    return $backup;
+}
+
+beforeEach(function () {
+    $instanceSettings = new InstanceSettings;
+    $instanceSettings->forceFill([
+        'id' => 0,
+        'is_registration_enabled' => true,
+        'smtp_enabled' => true,
+        'smtp_host' => 'coolify-mail',
+        'smtp_port' => 1025,
+        'smtp_from_address' => 'hi@localhost.com',
+        'smtp_from_name' => 'Coolify',
+    ]);
+    $instanceSettings->save();
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->user->teams()->attach($this->team, ['role' => 'owner']);
+    $this->actingAs($this->user);
+    session(['currentTeam' => $this->team]);
+});
+
+it('selects an available S3 storage instead of silently disabling the toggle when the selection is invalid', function () {
+    $database = createDatabaseForBackupEditTest($this->team);
+    $backup = createScheduledBackupForEditTest($database, $this->team);
+    $s3 = createS3StorageForBackupEditTest($this->team);
+
+    Livewire::test(BackupEdit::class, ['backup' => $backup, 's3s' => collect([$s3])])
+        ->set('s3StorageId', 999999)
+        ->set('saveS3', true)
+        ->call('instantSave')
+        ->assertDispatched('success');
+
+    $backup->refresh();
+    expect($backup->save_s3)->toBeTrue();
+    expect($backup->s3_storage_id)->toBe($s3->id);
+});
+
+it('disables the S3 toggle when no S3 storage is available', function () {
+    $database = createDatabaseForBackupEditTest($this->team);
+    $backup = createScheduledBackupForEditTest($database, $this->team);
+
+    Livewire::test(BackupEdit::class, ['backup' => $backup, 's3s' => collect()])
+        ->set('saveS3', true)
+        ->call('instantSave');
+
+    $backup->refresh();
+    expect($backup->save_s3)->toBeFalse();
+    expect($backup->s3_storage_id)->toBeNull();
+});


### PR DESCRIPTION
## Changes

Enabling the "S3 Enabled" toggle on a database backup did not stick. It showed a
"Backup updated successfully" message, but on refresh the toggle was off again.

The reason: the S3 storage selector only appears after S3 is enabled, but the
backup form's validation turns S3 back off whenever the selected storage is not
one of the team's storages. A backup that has never had a storage selected hits
that check the moment you enable S3, so it reverts before the selector is shown.
That makes it impossible to enable S3 on a fresh backup, and the success message
made it look like nothing was wrong. It is a shared form, so the same thing
happens in every backup section, which matches the report.

This change makes the form select the first available storage instead of
silently turning the toggle off, when the team has at least one storage. If the
team has no storage at all, the toggle still turns off as before.

## Issues

- Fixes #10692

This replaces #10789, which an automated quality check closed before review. This version targets the next branch and follows the PR template.

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable, this is a backend logic fix with no visual change. The behaviour
is covered by the tests below.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: an AI coding assistant
- How extensively: it helped locate the root cause and draft the fix and the test. I reviewed every line and verified the change locally (see Testing).

## Testing

Added a feature test for the backup edit form:

- enabling S3 with an invalid selection now keeps it on and picks an available storage
- enabling S3 with no storage available turns the toggle off

I ran the suite against a local Postgres database. The first test fails without
the change and passes with it.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
