### PR TITLE
docs: Clarify the API documentation for `POST /deploy`

### DIFF
--- a/app/Http/Controllers/Api/DeployController.php
+++ b/app/Http/Controllers/Api/DeployController.php
@@ -303,7 +303,7 @@ class DeployController extends Controller
 
     #[OA\Get(
         summary: 'Deploy',
-        description: 'Deploy by tag or uuid. `Post` request also accepted with `uuid` and `tag` json body.',
+        description: 'Deploy by tag or uuid. `Post` request also accepted with `uuid` in the query parameters and `tag` in the json body.',
         path: '/deploy',
         operationId: 'deploy-by-tag-or-uuid',
         security: [


### PR DESCRIPTION
## Changes

- The previous description implied that both uuid and tag could be provided in the JSON request body. However, only tag is accepted in the JSON body, while uuid must remain a query parameter.

## Issues

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview


## AI Assistance

- [x] AI was NOT used to create this PR
- [ ] AI was used (please describe below)

**If AI was used:**

- Tools used:
- How extensively:

## Testing

<!-- Describe how you tested these changes. -->

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
