### PR TITLE
fix: attach gzip middleware to coolify-https router so the dashboard is compressed over HTTPS

### DIFF
--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -534,6 +534,9 @@ class Server extends BaseModel
                     ];
 
                     $traefik_dynamic_conf['http']['routers']['coolify-https'] = [
+                        'middlewares' => [
+                            0 => 'gzip',
+                        ],
                         'entryPoints' => [
                             0 => 'https',
                         ],


### PR DESCRIPTION
Closes #10802.

The dynamic-config generator in `setupDynamicProxyConfiguration()` defines a `gzip` (`compress: true`) middleware and applies it to the `coolify-http` router, but the `coolify-https` router that serves the dashboard over HTTPS was created without `middlewares`. As a result the dashboard was served **uncompressed** on every HTTPS instance.

This attaches the already-defined `gzip` middleware to `coolify-https`, matching the compression Coolify already applies to user applications' `https-*` routers.

The websocket routers (`coolify-realtime-wss`, `coolify-terminal-wss`) are intentionally left untouched — Traefik's compress middleware skips websockets, and `text/event-stream` (SSE) is excluded by default.

### Verification

`GET /login` with `Accept-Encoding: gzip, br`:

- **Before:** no `content-encoding` header, full uncompressed body (~42 KB on 4.1.2).
- **After:** `content-encoding: gzip`, body several times smaller.
