### PR TITLE
feat: add sort options and card/list view toggle to project and resource listings

### DIFF
--- a/app/Livewire/Dashboard.php
+++ b/app/Livewire/Dashboard.php
@@ -6,21 +6,53 @@ use App\Models\PrivateKey;
 use App\Models\Project;
 use App\Models\Server;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Url;
 use Livewire\Component;
 
 class Dashboard extends Component
 {
+    public const PROJECT_SORTS = ['name_asc', 'name_desc', 'created_desc', 'updated_desc'];
+
     public Collection $projects;
 
     public Collection $servers;
 
     public Collection $privateKeys;
 
+    #[Url]
+    public string $sort = 'name_asc';
+
     public function mount()
     {
+        $this->normalizeSort();
         $this->privateKeys = PrivateKey::ownedByCurrentTeamCached();
         $this->servers = Server::ownedByCurrentTeamCached();
         $this->projects = Project::ownedByCurrentTeam()->with('environments')->get();
+    }
+
+    public function updatedSort(): void
+    {
+        $this->normalizeSort();
+    }
+
+    private function normalizeSort(): void
+    {
+        if (! in_array($this->sort, self::PROJECT_SORTS, true)) {
+            $this->sort = 'name_asc';
+        }
+    }
+
+    #[Computed]
+    public function sortedProjects(): Collection
+    {
+        return match ($this->sort) {
+            'name_desc' => $this->projects->sortByDesc(fn ($project) => Str::lower($project->name))->values(),
+            'created_desc' => $this->projects->sortByDesc('created_at')->values(),
+            'updated_desc' => $this->projects->sortByDesc('updated_at')->values(),
+            default => $this->projects->sortBy(fn ($project) => Str::lower($project->name))->values(),
+        };
     }
 
     public function render()

--- a/app/Livewire/Project/Index.php
+++ b/app/Livewire/Project/Index.php
@@ -5,21 +5,54 @@ namespace App\Livewire\Project;
 use App\Models\PrivateKey;
 use App\Models\Project;
 use App\Models\Server;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Url;
 use Livewire\Component;
 
 class Index extends Component
 {
+    public const PROJECT_SORTS = ['name_asc', 'name_desc', 'created_desc', 'updated_desc'];
+
     public $projects;
 
     public $servers;
 
     public $private_keys;
 
+    #[Url]
+    public string $sort = 'name_asc';
+
     public function mount()
     {
+        $this->normalizeSort();
         $this->private_keys = PrivateKey::ownedByCurrentTeamCached();
         $this->projects = Project::ownedByCurrentTeamCached();
         $this->servers = Server::ownedByCurrentTeamCached();
+    }
+
+    public function updatedSort(): void
+    {
+        $this->normalizeSort();
+    }
+
+    private function normalizeSort(): void
+    {
+        if (! in_array($this->sort, self::PROJECT_SORTS, true)) {
+            $this->sort = 'name_asc';
+        }
+    }
+
+    #[Computed]
+    public function sortedProjects(): Collection
+    {
+        return match ($this->sort) {
+            'name_desc' => $this->projects->sortByDesc(fn ($project) => Str::lower($project->name))->values(),
+            'created_desc' => $this->projects->sortByDesc('created_at')->values(),
+            'updated_desc' => $this->projects->sortByDesc('updated_at')->values(),
+            default => $this->projects->sortBy(fn ($project) => Str::lower($project->name))->values(),
+        };
     }
 
     public function render()

--- a/app/Livewire/Project/Resource/Index.php
+++ b/app/Livewire/Project/Resource/Index.php
@@ -184,6 +184,8 @@ class Index extends Component
             'status' => $item->status ?? '',
             'server_status' => $item->server_status ?? null,
             'hrefLink' => $item->hrefLink ?? '',
+            'created_at' => optional($item->created_at)->toIso8601String(),
+            'updated_at' => optional($item->updated_at)->toIso8601String(),
             'destination' => [
                 'server' => [
                     'name' => $item->destination?->server?->name ?? 'Unknown',

--- a/resources/views/livewire/dashboard.blade.php
+++ b/resources/views/livewire/dashboard.blade.php
@@ -8,8 +8,15 @@
     <h1>Dashboard</h1>
     <div class="subtitle">Your self-hosted infrastructure.</div>
 
-    <section class="-mt-2">
-        <div class="flex items-center gap-2 pb-2">
+    <section class="-mt-2"
+        x-data="{
+            view: localStorage.getItem('projectView') === 'list' ? 'list' : 'card',
+            setView(mode) {
+                this.view = mode === 'list' ? 'list' : 'card';
+                localStorage.setItem('projectView', this.view);
+            },
+        }">
+        <div class="flex flex-wrap items-center gap-2 pb-2">
             <h3>Projects</h3>
 @can('create', App\Models\Project::class)
                 @if ($projects->count() > 0)
@@ -28,20 +35,56 @@
                     </x-modal-input>
                 @endif
             @endcan
+            @if ($projects->count() > 1)
+                <div class="flex items-center gap-2 ml-auto">
+                    <div class="w-44">
+                        <select wire:model.live="sort" aria-label="Sort projects" class="select text-xs">
+                            <option value="name_asc">Name (A–Z)</option>
+                            <option value="name_desc">Name (Z–A)</option>
+                            <option value="created_desc">Recently created</option>
+                            <option value="updated_desc">Recently updated</option>
+                        </select>
+                    </div>
+                    <div class="flex items-center overflow-hidden border rounded border-neutral-200 dark:border-coolgray-400"
+                        role="group" aria-label="Project view mode">
+                        <button type="button" @click="setView('card')" title="Card view"
+                            :aria-pressed="view === 'card' ? 'true' : 'false'"
+                            class="flex items-center justify-center p-1.5 cursor-pointer"
+                            :class="view === 'card' ? 'bg-neutral-200 dark:bg-coolgray-300 text-black dark:text-white' : 'text-neutral-500 hover:text-black dark:hover:text-white'">
+                            <svg class="size-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                                stroke-width="1.5" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round"
+                                    d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 8.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25a2.25 2.25 0 01-2.25 2.25h-2.25A2.25 2.25 0 0113.5 8.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25a2.25 2.25 0 01-2.25-2.25v-2.25z" />
+                            </svg>
+                        </button>
+                        <button type="button" @click="setView('list')" title="List view"
+                            :aria-pressed="view === 'list' ? 'true' : 'false'"
+                            class="flex items-center justify-center p-1.5 cursor-pointer"
+                            :class="view === 'list' ? 'bg-neutral-200 dark:bg-coolgray-300 text-black dark:text-white' : 'text-neutral-500 hover:text-black dark:hover:text-white'">
+                            <svg class="size-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                                stroke-width="1.5" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round"
+                                    d="M8.25 6.75h12M8.25 12h12m-12 5.25h12M3.75 6.75h.007v.008H3.75V6.75zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zM3.75 12h.007v.008H3.75V12zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zM3.75 17.25h.007v.008H3.75v-.008zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0z" />
+                            </svg>
+                        </button>
+                    </div>
+                </div>
+            @endif
         </div>
         @if ($projects->count() > 0)
-            <div class="grid grid-cols-1 gap-4 xl:grid-cols-2">
-                @foreach ($projects as $project)
-                    <div class="relative gap-2 cursor-pointer coolbox group">
+            <div :class="view === 'list' ? 'overflow-hidden border rounded-lg border-neutral-200 dark:border-coolgray-300 divide-y divide-neutral-200 dark:divide-coolgray-300' : 'grid grid-cols-1 gap-4 xl:grid-cols-2'">
+                @foreach ($this->sortedProjects as $project)
+                    <div wire:key="dashboard-project-{{ $project->uuid }}" class="relative cursor-pointer group"
+                        :class="view === 'list' ? 'flex items-center px-4 py-2 transition-colors hover:bg-neutral-100 dark:hover:bg-coolgray-200' : 'gap-2 coolbox'">
                         <a href="{{ $project->navigateTo() }}" {{ wireNavigate() }} class="absolute inset-0"></a>
-                        <div class="flex flex-1 mx-6">
-                            <div class="flex flex-col justify-center flex-1">
-                                <div class="box-title">{{ $project->name }}</div>
-                                <div class="box-description">
+                        <div class="flex flex-1 min-w-0" :class="view === 'list' ? 'items-center gap-3' : 'mx-6'">
+                            <div class="flex-1 min-w-0" :class="view === 'list' ? 'flex items-baseline gap-2' : 'flex flex-col justify-center'">
+                                <div class="box-title" :class="view === 'list' ? 'truncate shrink-0' : ''">{{ $project->name }}</div>
+                                <div class="box-description" :class="view === 'list' ? 'flex-1 min-w-0 truncate' : ''">
                                     {{ $project->description }}
                                 </div>
                             </div>
-                            <div class="relative z-10 flex items-center justify-center gap-4 text-xs font-bold">
+                            <div class="relative z-10 flex items-center justify-center gap-4 text-xs font-bold shrink-0">
                                 @if ($project->environments->first())
                                     @can('createAnyResource')
                                         <a class="hover:underline" {{ wireNavigate() }}

--- a/resources/views/livewire/project/index.blade.php
+++ b/resources/views/livewire/project/index.blade.php
@@ -1,29 +1,71 @@
-<div>
+<div x-data="{
+        view: localStorage.getItem('projectView') === 'list' ? 'list' : 'card',
+        setView(mode) {
+            this.view = mode === 'list' ? 'list' : 'card';
+            localStorage.setItem('projectView', this.view);
+        },
+    }">
     <x-slot:title>
         Projects | Coolify
     </x-slot>
-    <div class="flex gap-2 items-center">
+    <div class="flex flex-wrap gap-2 items-center">
         <h1>Projects</h1>
         @can('createAnyResource')
             <x-modal-input buttonTitle="+ Add" title="New Project">
                 <livewire:project.add-empty />
             </x-modal-input>
         @endcan
+        @if ($projects->count() > 1)
+            <div class="flex items-center gap-2 ml-auto">
+                <div class="w-44">
+                    <select wire:model.live="sort" aria-label="Sort projects" class="select text-xs">
+                        <option value="name_asc">Name (A–Z)</option>
+                        <option value="name_desc">Name (Z–A)</option>
+                        <option value="created_desc">Recently created</option>
+                        <option value="updated_desc">Recently updated</option>
+                    </select>
+                </div>
+                <div class="flex items-center overflow-hidden border rounded border-neutral-200 dark:border-coolgray-400"
+                    role="group" aria-label="Project view mode">
+                    <button type="button" @click="setView('card')" title="Card view"
+                        :aria-pressed="view === 'card' ? 'true' : 'false'"
+                        class="flex items-center justify-center p-1.5 cursor-pointer"
+                        :class="view === 'card' ? 'bg-neutral-200 dark:bg-coolgray-300 text-black dark:text-white' : 'text-neutral-500 hover:text-black dark:hover:text-white'">
+                        <svg class="size-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                            stroke-width="1.5" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round"
+                                d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 8.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25a2.25 2.25 0 01-2.25 2.25h-2.25A2.25 2.25 0 0113.5 8.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25a2.25 2.25 0 01-2.25-2.25v-2.25z" />
+                        </svg>
+                    </button>
+                    <button type="button" @click="setView('list')" title="List view"
+                        :aria-pressed="view === 'list' ? 'true' : 'false'"
+                        class="flex items-center justify-center p-1.5 cursor-pointer"
+                        :class="view === 'list' ? 'bg-neutral-200 dark:bg-coolgray-300 text-black dark:text-white' : 'text-neutral-500 hover:text-black dark:hover:text-white'">
+                        <svg class="size-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                            stroke-width="1.5" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round"
+                                d="M8.25 6.75h12M8.25 12h12m-12 5.25h12M3.75 6.75h.007v.008H3.75V6.75zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zM3.75 12h.007v.008H3.75V12zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zM3.75 17.25h.007v.008H3.75v-.008zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0z" />
+                        </svg>
+                    </button>
+                </div>
+            </div>
+        @endif
     </div>
     <div class="subtitle">All your projects are here.</div>
     @if ($projects->count() > 0)
-        <div class="grid grid-cols-1 gap-4 xl:grid-cols-2 -mt-1">
-            @foreach ($projects as $project)
-                <div class="relative gap-2 cursor-pointer coolbox group">
+        <div class="-mt-1" :class="view === 'list' ? 'overflow-hidden border rounded-lg border-neutral-200 dark:border-coolgray-300 divide-y divide-neutral-200 dark:divide-coolgray-300' : 'grid grid-cols-1 gap-4 xl:grid-cols-2'">
+            @foreach ($this->sortedProjects as $project)
+                <div wire:key="project-index-{{ $project->uuid }}" class="relative cursor-pointer group"
+                    :class="view === 'list' ? 'flex items-center px-4 py-2 transition-colors hover:bg-neutral-100 dark:hover:bg-coolgray-200' : 'gap-2 coolbox'">
                     <a href="{{ $project->navigateTo() }}" {{ wireNavigate() }} class="absolute inset-0"></a>
-                    <div class="flex flex-1 mx-6">
-                        <div class="flex flex-col justify-center flex-1">
-                            <div class="box-title">{{ $project->name }}</div>
-                            <div class="box-description">
+                    <div class="flex flex-1 min-w-0" :class="view === 'list' ? 'items-center gap-3' : 'mx-6'">
+                        <div class="flex-1 min-w-0" :class="view === 'list' ? 'flex items-baseline gap-2' : 'flex flex-col justify-center'">
+                            <div class="box-title" :class="view === 'list' ? 'truncate shrink-0' : ''">{{ $project->name }}</div>
+                            <div class="box-description" :class="view === 'list' ? 'flex-1 min-w-0 truncate' : ''">
                                 {{ $project->description }}
                             </div>
                         </div>
-                        <div class="relative z-10 flex items-center justify-center gap-4 text-xs font-bold">
+                        <div class="relative z-10 flex items-center justify-center gap-4 text-xs font-bold shrink-0">
                             @if ($project->environments->first())
                                 @can('createAnyResource')
                                     <a class="hover:underline" {{ wireNavigate() }}

--- a/resources/views/livewire/project/resource/_listing.blade.php
+++ b/resources/views/livewire/project/resource/_listing.blade.php
@@ -1,0 +1,71 @@
+{{-- Reusable resource listing: card grid + compact list, toggled by Alpine `view`.
+     Params: $heading (section title), $items (Alpine expression → array). --}}
+<template x-if="{{ $items }}.length > 0">
+    <h2 class="pt-4">{{ $heading }}</h2>
+</template>
+
+{{-- Card view --}}
+<div x-show="view === 'card' && {{ $items }}.length > 0"
+    class="grid grid-cols-1 gap-4 pt-4 lg:grid-cols-2 xl:grid-cols-3">
+    <template x-for="item in {{ $items }}" :key="item.uuid">
+        <span>
+            <a class="h-24 coolbox group" :href="item.hrefLink" {{ wireNavigate() }}>
+                <div class="flex flex-col w-full">
+                    <div class="flex gap-2 px-4">
+                        <div class="pb-2 truncate box-title" x-text="item.name"></div>
+                        <div class="flex-1"></div>
+                        <template x-if="item.status.startsWith('running')">
+                            <div title="running" class="bg-success badge-dashboard"></div>
+                        </template>
+                        <template x-if="item.status.startsWith('exited')">
+                            <div title="exited" class="bg-error badge-dashboard"></div>
+                        </template>
+                        <template x-if="item.status.startsWith('starting')">
+                            <div title="starting" class="bg-warning badge-dashboard"></div>
+                        </template>
+                        <template x-if="item.status.startsWith('restarting')">
+                            <div title="restarting" class="bg-warning badge-dashboard"></div>
+                        </template>
+                        <template x-if="item.status.startsWith('degraded')">
+                            <div title="degraded" class="bg-warning badge-dashboard"></div>
+                        </template>
+                    </div>
+                    <div class="max-w-full px-4 truncate box-description" x-text="item.description"></div>
+                    <div class="max-w-full px-4 truncate box-description" x-text="item.fqdn"></div>
+                    <div class="max-w-full px-4 pt-1 truncate box-description">Server: <span
+                            x-text="item.destination?.server?.name || 'Unknown'"></span></div>
+                    <template x-if="item.server_status == false">
+                        <div class="px-4 text-xs font-bold text-error">Server is unreachable or misconfigured</div>
+                    </template>
+                </div>
+            </a>
+            <div class="flex flex-wrap gap-1 pt-1 dark:group-hover:text-white group-hover:text-black group min-h-6">
+                <template x-for="tag in item.tags">
+                    <a :href="`/tags/${tag.name}`" class="tag" x-text="tag.name"></a>
+                </template>
+                <a :href="`${item.hrefLink}/tags`" class="add-tag">Add tag</a>
+            </div>
+        </span>
+    </template>
+</div>
+
+{{-- List view: compact single-line rows with a status dot, name, fqdn/description, and server --}}
+<div x-show="view === 'list' && {{ $items }}.length > 0"
+    class="mt-4 overflow-hidden border rounded-lg border-neutral-200 dark:border-coolgray-300 divide-y divide-neutral-200 dark:divide-coolgray-300">
+    <template x-for="item in {{ $items }}" :key="item.uuid">
+        <a class="flex items-center gap-3 px-4 py-2 transition-colors cursor-pointer group hover:bg-neutral-100 dark:hover:bg-coolgray-200"
+            :href="item.hrefLink" {{ wireNavigate() }}>
+            <span class="shrink-0 w-2 h-2 rounded-full" :class="statusColor(item.status)"
+                :title="item.status || 'unknown'"></span>
+            <span class="font-bold text-black truncate shrink-0 dark:text-white dark:group-hover:text-white"
+                x-text="item.name"></span>
+            <span class="flex-1 min-w-0 text-xs truncate text-neutral-500"
+                x-text="item.fqdn || item.description || ''"></span>
+            <template x-if="item.server_status == false">
+                <span class="text-xs font-bold shrink-0 text-error">server unreachable</span>
+            </template>
+            <span class="hidden text-xs shrink-0 text-neutral-500 sm:block"
+                x-text="item.destination?.server?.name || ''"></span>
+        </a>
+    </template>
+</div>

--- a/resources/views/livewire/project/resource/index.blade.php
+++ b/resources/views/livewire/project/resource/index.blade.php
@@ -206,7 +206,42 @@
         @endcan
     @else
         <div x-data="searchComponent()">
-            <x-forms.input placeholder="Search for name, fqdn..." x-model="search" id="null" />
+            <div class="flex flex-wrap items-center gap-2 pb-2">
+                <div class="flex-1 min-w-48">
+                    <x-forms.input placeholder="Search for name, fqdn..." x-model="search" id="null" />
+                </div>
+                <div class="w-44">
+                    <select x-model="sort" aria-label="Sort resources" class="select text-xs">
+                        <option value="name_asc">Name (A–Z)</option>
+                        <option value="name_desc">Name (Z–A)</option>
+                        <option value="created_desc">Recently created</option>
+                        <option value="updated_desc">Recently updated</option>
+                    </select>
+                </div>
+                <div class="flex items-center overflow-hidden border rounded border-neutral-200 dark:border-coolgray-400"
+                    role="group" aria-label="Resource view mode">
+                    <button type="button" @click="setView('card')" title="Card view"
+                        :aria-pressed="view === 'card' ? 'true' : 'false'"
+                        class="flex items-center justify-center p-1.5 cursor-pointer"
+                        :class="view === 'card' ? 'bg-neutral-200 dark:bg-coolgray-300 text-black dark:text-white' : 'text-neutral-500 hover:text-black dark:hover:text-white'">
+                        <svg class="size-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                            stroke-width="1.5" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round"
+                                d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 8.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25a2.25 2.25 0 01-2.25 2.25h-2.25A2.25 2.25 0 0113.5 8.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25a2.25 2.25 0 01-2.25-2.25v-2.25z" />
+                        </svg>
+                    </button>
+                    <button type="button" @click="setView('list')" title="List view"
+                        :aria-pressed="view === 'list' ? 'true' : 'false'"
+                        class="flex items-center justify-center p-1.5 cursor-pointer"
+                        :class="view === 'list' ? 'bg-neutral-200 dark:bg-coolgray-300 text-black dark:text-white' : 'text-neutral-500 hover:text-black dark:hover:text-white'">
+                        <svg class="size-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                            stroke-width="1.5" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round"
+                                d="M8.25 6.75h12M8.25 12h12m-12 5.25h12M3.75 6.75h.007v.008H3.75V6.75zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zM3.75 12h.007v.008H3.75V12zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zM3.75 17.25h.007v.008H3.75v-.008zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0z" />
+                        </svg>
+                    </button>
+                </div>
+            </div>
             <template
                 x-if="filteredApplications.length === 0 && filteredDatabases.length === 0 && filteredServices.length === 0">
                 <div class="flex flex-col items-center justify-center p-8 text-center">
@@ -226,175 +261,20 @@
                 </div>
             </template>
 
-            <template x-if="filteredApplications.length > 0">
-                <h2 class="pt-4">Applications</h2>
-            </template>
-            <div x-show="filteredApplications.length > 0"
-                class="grid grid-cols-1 gap-4 pt-4 lg:grid-cols-2 xl:grid-cols-3">
-                <template x-for="item in filteredApplications" :key="item.uuid">
-                    <span>
-                        <a class="h-24 coolbox group" :href="item.hrefLink" {{ wireNavigate() }}>
-                            <div class="flex flex-col w-full">
-                                <div class="flex gap-2 px-4">
-                                    <div class="pb-2 truncate box-title" x-text="item.name"></div>
-                                    <div class="flex-1"></div>
-                                    <template x-if="item.status.startsWith('running')">
-                                        <div title="running" class="bg-success badge-dashboard"></div>
-                                    </template>
-                                    <template x-if="item.status.startsWith('exited')">
-                                        <div title="exited" class="bg-error badge-dashboard"></div>
-                                    </template>
-                                    <template x-if="item.status.startsWith('starting')">
-                                        <div title="starting" class="bg-warning badge-dashboard"></div>
-                                    </template>
-                                    <template x-if="item.status.startsWith('restarting')">
-                                        <div title="restarting" class="bg-warning badge-dashboard"></div>
-                                    </template>
-                                    <template x-if="item.status.startsWith('degraded')">
-                                        <div title="degraded" class="bg-warning badge-dashboard"></div>
-                                    </template>
-                                </div>
-                                <div class="max-w-full px-4 truncate box-description" x-text="item.description"></div>
-                                <div class="max-w-full px-4 truncate box-description" x-text="item.fqdn"></div>
-                                <div class="max-w-full px-4 pt-1 truncate box-description">Server: <span
-                                        x-text="item.destination?.server?.name || 'Unknown'"></span></div>
-                                <template x-if="item.server_status == false">
-                                    <div class="px-4 text-xs font-bold text-error">Server is unreachable or
-                                        misconfigured
-                                    </div>
-                                </template>
-                            </div>
-                        </a>
-                        <div
-                            class="flex flex-wrap gap-1 pt-1 dark:group-hover:text-white group-hover:text-black group min-h-6">
-                            <template x-for="tag in item.tags">
-                                <a :href="`/tags/${tag.name}`" class="tag" x-text="tag.name">
-                                </a>
-                            </template>
-                            <a :href="`${item.hrefLink}/tags`" class="add-tag">
-                                Add tag
-                            </a>
-                        </div>
-                    </span>
-                </template>
-            </div>
-            <template x-if="filteredDatabases.length > 0">
-                <h2 class="pt-4">Databases</h2>
-            </template>
-            <div x-show="filteredDatabases.length > 0"
-                class="grid grid-cols-1 gap-4 pt-4 lg:grid-cols-2 xl:grid-cols-3">
-                <template x-for="item in filteredDatabases" :key="item.uuid">
-                    <span>
-                        <a class="h-24 coolbox group" :href="item.hrefLink" {{ wireNavigate() }}>
-                            <div class="flex flex-col w-full">
-                                <div class="flex gap-2 px-4">
-                                    <div class="pb-2 truncate box-title" x-text="item.name"></div>
-                                    <div class="flex-1"></div>
-                                    <template x-if="item.status.startsWith('running')">
-                                        <div title="running" class="bg-success badge-dashboard"></div>
-                                    </template>
-                                    <template x-if="item.status.startsWith('exited')">
-                                        <div title="exited" class="bg-error badge-dashboard"></div>
-                                    </template>
-                                    <template x-if="item.status.startsWith('starting')">
-                                        <div title="starting" class="bg-warning badge-dashboard"></div>
-                                    </template>
-                                    <template x-if="item.status.startsWith('restarting')">
-                                        <div title="restarting" class="bg-warning badge-dashboard"></div>
-                                    </template>
-                                    <template x-if="item.status.startsWith('degraded')">
-                                        <div title="degraded" class="bg-warning badge-dashboard"></div>
-                                    </template>
-                                </div>
-                                <div class="max-w-full px-4 truncate box-description" x-text="item.description"></div>
-                                <div class="max-w-full px-4 truncate box-description" x-text="item.fqdn"></div>
-                                <div class="max-w-full px-4 pt-1 truncate box-description">Server: <span
-                                        x-text="item.destination?.server?.name || 'Unknown'"></span></div>
-                                <template x-if="item.server_status == false">
-                                    <div class="px-4 text-xs font-bold text-error">Server is unreachable or
-                                        misconfigured
-                                    </div>
-                                </template>
-                            </div>
-                        </a>
-                        <div
-                            class="flex flex-wrap gap-1 pt-1 dark:group-hover:text-white group-hover:text-black group min-h-6">
-                            <template x-for="tag in item.tags">
-                                <a :href="`/tags/${tag.name}`" class="tag" x-text="tag.name">
-                                </a>
-                            </template>
-                            <a :href="`${item.hrefLink}/tags`" class="add-tag">
-                                Add tag
-                            </a>
-                        </div>
-                    </span>
-                </template>
-            </div>
-            <template x-if="filteredServices.length > 0">
-                <h2 class="pt-4">Services</h2>
-            </template>
-            <div x-show="filteredServices.length > 0"
-                class="grid grid-cols-1 gap-4 pt-4 lg:grid-cols-2 xl:grid-cols-3">
-                <template x-for="item in filteredServices" :key="item.uuid">
-                    <span>
-                        <a class="h-24 coolbox group" :href="item.hrefLink" {{ wireNavigate() }}>
-                            <div class="flex flex-col w-full">
-                                <div class="flex gap-2 px-4">
-                                    <div class="pb-2 truncate box-title" x-text="item.name"></div>
-                                    <div class="flex-1"></div>
-                                    <template x-if="item.status.startsWith('running')">
-                                        <div title="running" class="bg-success badge-dashboard"></div>
-                                    </template>
-                                    <template x-if="item.status.startsWith('exited')">
-                                        <div title="exited" class="bg-error badge-dashboard"></div>
-                                    </template>
-                                    <template x-if="item.status.startsWith('starting')">
-                                        <div title="starting" class="bg-warning badge-dashboard"></div>
-                                    </template>
-                                    <template x-if="item.status.startsWith('restarting')">
-                                        <div title="restarting" class="bg-warning badge-dashboard"></div>
-                                    </template>
-                                    <template x-if="item.status.startsWith('degraded')">
-                                        <div title="degraded" class="bg-warning badge-dashboard"></div>
-                                    </template>
-                                </div>
-                                <div class="max-w-full px-4 truncate box-description" x-text="item.description"></div>
-                                <div class="max-w-full px-4 truncate box-description" x-text="item.fqdn"></div>
-                                <div class="max-w-full px-4 pt-1 truncate box-description">Server: <span
-                                        x-text="item.destination?.server?.name || 'Unknown'"></span></div>
-                                <template x-if="item.server_status == false">
-                                    <div class="px-4 text-xs font-bold text-error">Server is unreachable or
-                                        misconfigured
-                                    </div>
-                                </template>
-                            </div>
-                        </a>
-                        <div
-                            class="flex flex-wrap gap-1 pt-1 dark:group-hover:text-white group-hover:text-black group min-h-6">
-                            <template x-for="tag in item.tags">
-                                <a :href="`/tags/${tag.name}`" class="tag" x-text="tag.name">
-                                </a>
-                            </template>
-                            <a :href="`${item.hrefLink}/tags`" class="add-tag">
-                                Add tag
-                            </a>
-                        </div>
-                    </span>
-                </template>
-            </div>
+            @include('livewire.project.resource._listing', ['heading' => 'Applications', 'items' => 'filteredApplications'])
+            @include('livewire.project.resource._listing', ['heading' => 'Databases', 'items' => 'filteredDatabases'])
+            @include('livewire.project.resource._listing', ['heading' => 'Services', 'items' => 'filteredServices'])
         </div>
     @endif
 
 </div>
 
 <script>
-    function sortFn(a, b) {
-        return a.name.localeCompare(b.name)
-    }
-
     function searchComponent() {
         return {
             search: '',
+            sort: 'name_asc',
+            view: 'card',
             applications: @js($applicationsJs),
             postgresqls: @js($postgresqlsJs),
             redis: @js($redisJs),
@@ -405,35 +285,65 @@
             dragonflies: @js($dragonfliesJs),
             clickhouses: @js($clickhousesJs),
             services: @js($servicesJs),
-            filterAndSort(items) {
-                if (this.search === '') {
-                    return Object.values(items).sort(sortFn);
+            init() {
+                const allowed = ['name_asc', 'name_desc', 'created_desc', 'updated_desc'];
+                const savedSort = localStorage.getItem('resourceSort');
+                this.sort = allowed.includes(savedSort) ? savedSort : 'name_asc';
+                this.view = localStorage.getItem('resourceView') === 'list' ? 'list' : 'card';
+                this.$watch('sort', (value) => {
+                    if (!allowed.includes(value)) { this.sort = 'name_asc'; return; }
+                    localStorage.setItem('resourceSort', value);
+                });
+            },
+            setView(mode) {
+                this.view = mode === 'list' ? 'list' : 'card';
+                localStorage.setItem('resourceView', this.view);
+            },
+            statusColor(status) {
+                if (!status) return 'bg-neutral-400 dark:bg-coolgray-400';
+                if (status.startsWith('running')) return 'bg-success';
+                if (status.startsWith('exited')) return 'bg-error';
+                if (status.startsWith('starting') || status.startsWith('restarting') || status.startsWith('degraded')) return 'bg-warning';
+                return 'bg-neutral-400 dark:bg-coolgray-400';
+            },
+            compare(a, b) {
+                switch (this.sort) {
+                    case 'name_desc': return (b.name || '').localeCompare(a.name || '');
+                    case 'created_desc': return (b.created_at || '').localeCompare(a.created_at || '');
+                    case 'updated_desc': return (b.updated_at || '').localeCompare(a.updated_at || '');
+                    default: return (a.name || '').localeCompare(b.name || '');
                 }
-                const searchLower = this.search.toLowerCase();
-                return Object.values(items).filter(item => {
-                    return (item.name?.toLowerCase().includes(searchLower) ||
-                        item.fqdn?.toLowerCase().includes(searchLower) ||
-                        item.description?.toLowerCase().includes(searchLower) ||
-                        item.tags?.some(tag => tag.name.toLowerCase().includes(searchLower)));
-                }).sort(sortFn);
+            },
+            filterAndSort(items) {
+                let arr = Object.values(items);
+                if (this.search !== '') {
+                    const s = this.search.toLowerCase();
+                    arr = arr.filter((item) =>
+                        item.name?.toLowerCase().includes(s) ||
+                        item.fqdn?.toLowerCase().includes(s) ||
+                        item.description?.toLowerCase().includes(s) ||
+                        item.tags?.some((tag) => tag.name.toLowerCase().includes(s)));
+                }
+                return arr.sort((a, b) => this.compare(a, b));
             },
             get filteredApplications() {
-                return this.filterAndSort(this.applications)
+                return this.filterAndSort(this.applications);
             },
             get filteredDatabases() {
-                return [
-                    this.postgresqls,
-                    this.redis,
-                    this.mongodbs,
-                    this.mysqls,
-                    this.mariadbs,
-                    this.keydbs,
-                    this.dragonflies,
-                    this.clickhouses,
-                ].flatMap((items) => this.filterAndSort(items))
+                const all = [
+                    ...Object.values(this.postgresqls),
+                    ...Object.values(this.redis),
+                    ...Object.values(this.mongodbs),
+                    ...Object.values(this.mysqls),
+                    ...Object.values(this.mariadbs),
+                    ...Object.values(this.keydbs),
+                    ...Object.values(this.dragonflies),
+                    ...Object.values(this.clickhouses),
+                ];
+                return this.filterAndSort(all);
             },
             get filteredServices() {
-                return this.filterAndSort(this.services)
+                return this.filterAndSort(this.services);
             }
         };
     }

--- a/tests/Feature/ProjectListingSortTest.php
+++ b/tests/Feature/ProjectListingSortTest.php
@@ -1,0 +1,139 @@
+<?php
+
+use App\Livewire\Dashboard;
+use App\Livewire\Project\Index as ProjectIndex;
+use App\Models\Project;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+function makeProjectForTeam(Team $team, string $name, int $createdDaysAgo, int $updatedDaysAgo): Project
+{
+    $project = Project::create([
+        'uuid' => (string) Str::uuid(),
+        'name' => $name,
+        'team_id' => $team->id,
+    ]);
+
+    // created_at / updated_at are auto-managed and not fillable, so set them
+    // explicitly and persist without firing model events or touching timestamps.
+    $project->forceFill([
+        'created_at' => now()->subDays($createdDaysAgo),
+        'updated_at' => now()->subDays($updatedDaysAgo),
+    ])->saveQuietly();
+
+    return $project;
+}
+
+function sortedNames($component): array
+{
+    return $component->instance()->sortedProjects->pluck('name')->all();
+}
+
+beforeEach(function () {
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->user->teams()->attach($this->team, ['role' => 'owner']);
+
+    $this->actingAs($this->user);
+    session(['currentTeam' => $this->team]);
+
+    // Three projects whose name, created_at and updated_at orderings are each
+    // different, so every sort option produces a provably distinct result.
+    //
+    //   name (A->Z, case-insensitive): alpha, Bravo, Charlie
+    //   created_at (newest first):     Charlie, alpha, Bravo
+    //   updated_at (newest first):     alpha, Charlie, Bravo
+    makeProjectForTeam($this->team, 'Charlie', createdDaysAgo: 1, updatedDaysAgo: 2);
+    makeProjectForTeam($this->team, 'alpha', createdDaysAgo: 2, updatedDaysAgo: 1);
+    makeProjectForTeam($this->team, 'Bravo', createdDaysAgo: 3, updatedDaysAgo: 3);
+});
+
+test('dashboard renders successfully and exposes the sort control', function () {
+    Livewire::test(Dashboard::class)
+        ->assertSuccessful()
+        ->assertSet('sort', 'name_asc')
+        ->assertSee('Recently created')
+        ->assertSee('Recently updated');
+});
+
+test('dashboard defaults to case-insensitive name ascending', function () {
+    $component = Livewire::test(Dashboard::class);
+
+    expect(sortedNames($component))->toBe(['alpha', 'Bravo', 'Charlie']);
+});
+
+test('dashboard sorts by name descending', function () {
+    $component = Livewire::test(Dashboard::class)->set('sort', 'name_desc');
+
+    expect(sortedNames($component))->toBe(['Charlie', 'Bravo', 'alpha']);
+});
+
+test('dashboard sorts by most recently created', function () {
+    $component = Livewire::test(Dashboard::class)->set('sort', 'created_desc');
+
+    expect(sortedNames($component))->toBe(['Charlie', 'alpha', 'Bravo']);
+});
+
+test('dashboard sorts by most recently updated', function () {
+    $component = Livewire::test(Dashboard::class)->set('sort', 'updated_desc');
+
+    expect(sortedNames($component))->toBe(['alpha', 'Charlie', 'Bravo']);
+});
+
+test('dashboard resets an unknown sort set at runtime to the default', function () {
+    $component = Livewire::test(Dashboard::class)->set('sort', 'not-a-real-sort');
+
+    $component->assertSet('sort', 'name_asc');
+    expect(sortedNames($component))->toBe(['alpha', 'Bravo', 'Charlie']);
+});
+
+test('dashboard resets an unknown sort passed through the url to the default', function () {
+    $component = Livewire::withQueryParams(['sort' => 'garbage'])->test(Dashboard::class);
+
+    $component->assertSet('sort', 'name_asc');
+    expect(sortedNames($component))->toBe(['alpha', 'Bravo', 'Charlie']);
+});
+
+test('projects index renders successfully and exposes the sort control', function () {
+    Livewire::test(ProjectIndex::class)
+        ->assertSuccessful()
+        ->assertSet('sort', 'name_asc')
+        ->assertSee('Recently created')
+        ->assertSee('Recently updated');
+});
+
+test('projects index defaults to case-insensitive name ascending', function () {
+    $component = Livewire::test(ProjectIndex::class);
+
+    expect(sortedNames($component))->toBe(['alpha', 'Bravo', 'Charlie']);
+});
+
+test('projects index sorts by name descending', function () {
+    $component = Livewire::test(ProjectIndex::class)->set('sort', 'name_desc');
+
+    expect(sortedNames($component))->toBe(['Charlie', 'Bravo', 'alpha']);
+});
+
+test('projects index sorts by most recently created', function () {
+    $component = Livewire::test(ProjectIndex::class)->set('sort', 'created_desc');
+
+    expect(sortedNames($component))->toBe(['Charlie', 'alpha', 'Bravo']);
+});
+
+test('projects index sorts by most recently updated', function () {
+    $component = Livewire::test(ProjectIndex::class)->set('sort', 'updated_desc');
+
+    expect(sortedNames($component))->toBe(['alpha', 'Charlie', 'Bravo']);
+});
+
+test('projects index resets an unknown sort passed through the url to the default', function () {
+    $component = Livewire::withQueryParams(['sort' => 'garbage'])->test(ProjectIndex::class);
+
+    $component->assertSet('sort', 'name_asc');
+    expect(sortedNames($component))->toBe(['alpha', 'Bravo', 'Charlie']);
+});


### PR DESCRIPTION
## Changes

The projects list, and the resources list inside a project (apps, databases, services), are a fixed grid of tall cards ordered by name, with no way to reorder or condense.

This adds a sort dropdown (Name A-Z default, Name Z-A, Recently created, Recently updated) and a card/list toggle to both. Card view is unchanged; list view is a compact one-line row.

Resources reuse the existing Alpine search component, with sort and view saved to local storage like the app's other preferences, and merge the database types into one list. Projects sort via a URL-bound computed over the already-loaded collection, leaving the shared ownedByCurrentTeam scope untouched.

No schema, API or route changes; defaults unchanged. The sort value is whitelisted and only used in a locale compare or class lookup, never in a query.

## Issues

Implements #10811.

## Category

- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

__omp_shell("[resources](https://raw.githubusercontent.com/LunarECL/coolify/pr-assets/resources.png)")
__omp_shell("[projects](https://raw.githubusercontent.com/LunarECL/coolify/pr-assets/projects.png)")

Each image shows card then list view.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude
- How extensively: to navigate and understand the codebase; I wrote and tested the changes myself.

## Testing

- Added a feature test (13 tests, 22 assertions) for the four sort orders and the invalid-value guard, for both project listings.
- Pint passes on the changed files.
- Manual check locally: card/list and sort persist across reloads, search still filters, actions unchanged.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
