### PR TITLE
fix(deploy): parse multi-domain fqdns entry-by-entry for COOLIFY_URL/COOLIFY_FQDN

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -2237,9 +2237,13 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             $fqdn = $this->preview->fqdn;
         }
         if (isset($fqdn)) {
-            $url = Url::fromString($fqdn);
-            $fqdn = $url->getHost();
-            $url = $url->withHost($fqdn)->withPort(null)->__toString();
+            // The fqdn may be a comma-separated list of domains (e.g. a compose
+            // service with multiple domains). Parse each entry separately:
+            // passing the whole list to Url::fromString() makes the second
+            // scheme's colon parse as a host:port separator, mangling both values.
+            $parsed = str($fqdn)->explode(',')->map(fn ($entry) => Url::fromString(trim($entry)));
+            $fqdn = $parsed->map(fn (Url $entry) => $entry->getHost())->implode(',');
+            $url = $parsed->map(fn (Url $entry) => (string) $entry->withPort(null))->implode(',');
             if ((int) $this->application->compose_parsing_version >= 3) {
                 $this->coolify_variables .= "COOLIFY_URL={$url} ";
                 $this->coolify_variables .= "COOLIFY_FQDN={$fqdn} ";

--- a/tests/Unit/ApplicationDeploymentMultiDomainFqdnTest.php
+++ b/tests/Unit/ApplicationDeploymentMultiDomainFqdnTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use Spatie\Url\Url;
+
+/**
+ * Tests for the COOLIFY_URL / COOLIFY_FQDN generation in set_coolify_variables().
+ *
+ * The application (or preview) fqdn may be a comma-separated list of domains,
+ * e.g. a docker compose service with multiple domains. Passing the whole list
+ * to Url::fromString() as one URL makes the second scheme's colon parse as a
+ * host:port separator, which mangles both generated values:
+ *
+ *   fqdn: https://a.example.com,https://b.example.com
+ *   COOLIFY_URL:  https://a.example.com,https//b.example.com   (colon lost)
+ *   COOLIFY_FQDN: a.example.com,https                          (truncated)
+ *
+ * The fix parses each comma-separated entry separately, mirroring how
+ * bootstrap/helpers/parsers.php already handles multi-domain fqdns.
+ */
+
+// Simulates the parsing logic from ApplicationDeploymentJob::set_coolify_variables()
+function parseCoolifyVariablesFqdn(string $fqdn): array
+{
+    $parsed = str($fqdn)->explode(',')->map(fn ($entry) => Url::fromString(trim($entry)));
+    $host = $parsed->map(fn (Url $entry) => $entry->getHost())->implode(',');
+    $url = $parsed->map(fn (Url $entry) => (string) $entry->withPort(null))->implode(',');
+
+    return ['url' => $url, 'fqdn' => $host];
+}
+
+it('keeps single-domain behavior: host extracted and port stripped', function () {
+    $result = parseCoolifyVariablesFqdn('https://app.example.com:8443');
+
+    expect($result['url'])->toBe('https://app.example.com');
+    expect($result['fqdn'])->toBe('app.example.com');
+});
+
+it('preserves every scheme colon in a multi-domain fqdn', function () {
+    $result = parseCoolifyVariablesFqdn('https://a.example.com,https://b.example.com,https://c.example.com');
+
+    expect($result['url'])->toBe('https://a.example.com,https://b.example.com,https://c.example.com');
+    expect($result['url'])->not->toContain('https//');
+    expect($result['fqdn'])->toBe('a.example.com,b.example.com,c.example.com');
+});
+
+it('strips ports from each entry of a multi-domain fqdn', function () {
+    $result = parseCoolifyVariablesFqdn('https://a.example.com:8443,http://b.example.com:8080');
+
+    expect($result['url'])->toBe('https://a.example.com,http://b.example.com');
+    expect($result['fqdn'])->toBe('a.example.com,b.example.com');
+});
+
+it('trims whitespace around comma-separated entries', function () {
+    $result = parseCoolifyVariablesFqdn('https://a.example.com, https://b.example.com');
+
+    expect($result['url'])->toBe('https://a.example.com,https://b.example.com');
+    expect($result['fqdn'])->toBe('a.example.com,b.example.com');
+});


### PR DESCRIPTION
Fixes #10824

## The bug

When an application (or PR preview) has **multiple comma-separated domains on one compose service**, `set_coolify_variables()` in `ApplicationDeploymentJob` passes the whole list to `Url::fromString()` as if it were a single URL. The parser treats the second scheme's `:` as a host:port separator, mangling both shell-prefix variables on the `docker compose up` command line:

```
fqdn:          https://a.example.com,https://b.example.com
COOLIFY_URL:   https://a.example.com,https//b.example.com   ← colon lost
COOLIFY_FQDN:  a.example.com,https                          ← truncated
```

The values stored in the DB are correct — only the generated command-line env is corrupted. Full root-cause analysis in #10824.

## The fix

Split the fqdn on commas and parse each entry separately, mirroring how `bootstrap/helpers/parsers.php` already handles multi-domain fqdns for `COOLIFY_URL`/`COOLIFY_FQDN` label/env generation. Single-domain behavior (host extraction, port stripping) is unchanged.

## Testing

- Added `tests/Unit/ApplicationDeploymentMultiDomainFqdnTest.php` (Pest, simulate-the-logic style like the neighboring deployment tests) covering single domain with port, multi-domain, multi-domain with ports, and whitespace trimming.
- Verified old vs. new logic against a live Coolify 4.1.2 instance (same `spatie/url` version): old logic reproduces the mangled output above byte-for-byte; new logic emits the correct list, and single-domain output is identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
