### PR TITLE
Fix server connection check timeouts

### DIFF
--- a/app/Jobs/ServerConnectionCheckJob.php
+++ b/app/Jobs/ServerConnectionCheckJob.php
@@ -22,18 +22,32 @@ class ServerConnectionCheckJob implements ShouldBeEncrypted, ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    private const CONNECTION_CHECK_BUFFER = 5;
+
+    private const DOCKER_CHECK_COMMAND_TIMEOUT = 30;
+
+    private const JOB_TIMEOUT_BUFFER = 10;
+
+    private const OVERLAP_LOCK_BUFFER = 10;
+
     public $tries = 1;
 
-    public $timeout = 15;
+    public $timeout = 65;
 
     public function __construct(
         public Server $server,
         public bool $disableMux = true
-    ) {}
+    ) {
+        $this->timeout = $this->jobTimeout();
+    }
 
     public function middleware(): array
     {
-        return [(new WithoutOverlapping('server-connection-check-'.$this->server->uuid))->expireAfter(25)->dontRelease()];
+        return [
+            (new WithoutOverlapping('server-connection-check-'.$this->server->uuid))
+                ->expireAfter($this->timeout + self::OVERLAP_LOCK_BUFFER)
+                ->dontRelease(),
+        ];
     }
 
     private function disableSshMux(): void
@@ -42,7 +56,7 @@ class ServerConnectionCheckJob implements ShouldBeEncrypted, ShouldQueue
         $configRepository->disableSshMux();
     }
 
-    public function handle()
+    public function handle(): void
     {
         $wasReachable = (bool) $this->server->settings->is_reachable;
         $wasNotified = (bool) $this->server->unreachable_notification_sent;
@@ -197,8 +211,14 @@ class ServerConnectionCheckJob implements ShouldBeEncrypted, ShouldQueue
             }
             $commandString = implode("\n", $commands);
 
-            $sshCommand = SshMultiplexingHelper::generateSshCommand($this->server, $commandString, true);
-            $process = Process::timeout(10)->run($sshCommand);
+            $timeout = $this->connectionCheckProcessTimeout();
+            $sshCommand = SshMultiplexingHelper::generateSshCommand(
+                $this->server,
+                $commandString,
+                true,
+                $timeout,
+            );
+            $process = Process::timeout($timeout)->run($sshCommand);
 
             return $process->exitCode() === 0;
         } catch (\Throwable $e) {
@@ -214,20 +234,27 @@ class ServerConnectionCheckJob implements ShouldBeEncrypted, ShouldQueue
     private function checkDockerAvailability(): bool
     {
         try {
-            // Use instant_remote_process to check Docker
-            // The function will automatically handle sudo for non-root users
-            $output = instant_remote_process_with_timeout(
-                ['docker version --format json'],
-                $this->server,
-                false // don't throw error
-            );
+            $commands = ['docker version --format json'];
+            if ($this->server->isNonRoot()) {
+                $commands = parseCommandsByLineForSudo(collect($commands), $this->server);
+            }
 
-            if ($output === null) {
+            $commandString = implode("\n", $commands);
+            $timeout = $this->dockerCheckProcessTimeout();
+            $sshCommand = SshMultiplexingHelper::generateSshCommand(
+                $this->server,
+                $commandString,
+                true,
+                $timeout,
+            );
+            $process = Process::timeout($timeout)->run($sshCommand);
+
+            if ($process->exitCode() !== 0) {
                 return false;
             }
 
             // Try to parse the JSON output to ensure Docker is really working
-            $output = trim($output);
+            $output = trim($process->output());
             if (! empty($output)) {
                 $dockerInfo = json_decode($output, true);
 
@@ -243,5 +270,31 @@ class ServerConnectionCheckJob implements ShouldBeEncrypted, ShouldQueue
 
             return false;
         }
+    }
+
+    private function connectionCheckProcessTimeout(): int
+    {
+        return $this->connectionTimeout() + self::CONNECTION_CHECK_BUFFER;
+    }
+
+    private function dockerCheckProcessTimeout(): int
+    {
+        return $this->connectionTimeout() + self::DOCKER_CHECK_COMMAND_TIMEOUT;
+    }
+
+    private function jobTimeout(): int
+    {
+        $connectionTimeout = $this->connectionTimeout();
+
+        return $connectionTimeout
+            + self::CONNECTION_CHECK_BUFFER
+            + $connectionTimeout
+            + self::DOCKER_CHECK_COMMAND_TIMEOUT
+            + self::JOB_TIMEOUT_BUFFER;
+    }
+
+    private function connectionTimeout(): int
+    {
+        return SshMultiplexingHelper::getConnectionTimeout($this->server);
     }
 }

--- a/tests/Unit/ServerBackoffTest.php
+++ b/tests/Unit/ServerBackoffTest.php
@@ -127,11 +127,29 @@ describe('shouldSkipDueToBackoff', function () {
 });
 
 describe('ServerConnectionCheckJob unreachable_count', function () {
+    it('scales job and overlap timeouts from the server connection timeout', function () {
+        $server = new Server;
+        $server->uuid = 'server-uuid';
+        $server->setRelation('settings', (object) [
+            'connection_timeout' => 45,
+        ]);
+
+        $job = new ServerConnectionCheckJob($server);
+
+        expect($job->timeout)->toBe(135);
+
+        $middleware = $job->middleware()[0];
+        $expiresAfter = new ReflectionProperty($middleware, 'expiresAfter');
+
+        expect($expiresAfter->getValue($middleware))->toBe(145);
+    });
+
     it('increments unreachable_count on timeout', function () {
         Event::fake([ServerReachabilityChanged::class]);
 
         $settings = Mockery::mock();
         $settings->is_reachable = true;
+        $settings->connection_timeout = 10;
         $settings->shouldReceive('update')
             ->with(['is_reachable' => false, 'is_usable' => false])
             ->once();
@@ -150,6 +168,9 @@ describe('ServerConnectionCheckJob unreachable_count', function () {
 
     it('does not increment unreachable_count for non-timeout failures', function () {
         $server = Mockery::mock(Server::class)->makePartial()->shouldAllowMockingProtectedMethods();
+        $server->shouldReceive('getAttribute')->with('settings')->andReturn((object) [
+            'connection_timeout' => 10,
+        ]);
         $server->shouldNotReceive('increment');
         $server->id = 1;
         $server->name = 'test-server';
@@ -163,8 +184,17 @@ describe('ServerConnectionCheckJob ServerReachabilityChanged dispatch', function
     // ServerReachabilityChanged's constructor calls $server->isReachableChanged() — verifying that
     // call is a clean proxy for "the event was dispatched", and avoids serializing a Mockery proxy
     // through the event dispatcher (which trips Eloquent static method lookups on the proxy class).
-    $invoke = function (bool $wasReachable, bool $wasNotified, bool $isReachable, int $unreachableCount, bool $expectDispatch) {
+    $invoke = function (
+        bool $wasReachable,
+        bool $wasNotified,
+        bool $isReachable,
+        int $unreachableCount,
+        bool $expectDispatch
+    ) {
         $server = Mockery::mock(Server::class)->makePartial()->shouldAllowMockingProtectedMethods();
+        $server->shouldReceive('getAttribute')->with('settings')->andReturn((object) [
+            'connection_timeout' => 10,
+        ]);
         $server->shouldReceive('getAttribute')->with('unreachable_count')->andReturn($unreachableCount);
         $server->shouldReceive('getAttribute')->with('id')->andReturn(1);
         if ($expectDispatch) {


### PR DESCRIPTION
## Changes

- Adjusted `ServerConnectionCheckJob` so SSH and job timeouts scale with each server's configured `connection_timeout`.
- Extended the overlap lock expiry to match the effective job timeout.
- Changed the Docker availability check to use a single direct SSH command, avoiding retry amplification that could turn a slow Docker response into a false unreachable server state.
- Added unit coverage for the dynamic timeout and overlap lock calculation.

## Issues

- Fixes coollabsio/coolify#10732

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable. This is a backend queue/job reliability fix.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex
- How extensively: Used to analyze the issue, inspect the relevant Laravel job, implement the timeout handling changes, and draft/update the related test. Changes were reviewed before submission.

## Testing

- Ran `git diff --check`.
- Performed static review of the changed job, queue/Horizon timeout configuration, dispatch path, and test coverage.

Could not run Pint or Pest locally because PHP dependencies are not available in this workspace (`php` and `vendor/bin/pint` are missing) and Docker is not running on the host.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.