### PR TITLE
fix(env-vars): avoid service preview variable lookups

### DIFF
--- a/app/Livewire/Project/Shared/EnvironmentVariable/All.php
+++ b/app/Livewire/Project/Shared/EnvironmentVariable/All.php
@@ -93,6 +93,10 @@ class All extends Component
 
     private function getEnvironmentVariables(bool $isPreview, bool $withSearch = true): Collection
     {
+        if ($isPreview && ! $this->supportsPreviewEnvironmentVariables()) {
+            return collect();
+        }
+
         $query = $isPreview
             ? $this->resource->environment_variables_preview()
             : $this->resource->environment_variables();
@@ -119,12 +123,21 @@ class All extends Component
         return trim($this->search);
     }
 
+    private function supportsPreviewEnvironmentVariables(): bool
+    {
+        return $this->showPreview && $this->resource instanceof Application;
+    }
+
     public function getHasEnvironmentVariablesProperty(): bool
     {
-        return $this->environmentVariables->isNotEmpty() ||
+        $hasPreviewEnvironmentVariables = $this->supportsPreviewEnvironmentVariables() && (
             $this->environmentVariablesPreview->isNotEmpty() ||
+            $this->hardcodedEnvironmentVariablesPreview->isNotEmpty()
+        );
+
+        return $this->environmentVariables->isNotEmpty() ||
             $this->hardcodedEnvironmentVariables->isNotEmpty() ||
-            $this->hardcodedEnvironmentVariablesPreview->isNotEmpty();
+            $hasPreviewEnvironmentVariables;
     }
 
     private function nullLockedValues($envs)
@@ -158,6 +171,10 @@ class All extends Component
 
     protected function getHardcodedVariables(bool $isPreview)
     {
+        if ($isPreview && ! $this->supportsPreviewEnvironmentVariables()) {
+            return collect([]);
+        }
+
         // Only for services and docker-compose applications
         if ($this->resource->type() !== 'service' &&
             ($this->resourceClass !== 'App\Models\Application' ||

--- a/tests/Feature/EnvironmentVariableSearchTest.php
+++ b/tests/Feature/EnvironmentVariableSearchTest.php
@@ -56,7 +56,7 @@ it('filters production environment variables by key case-insensitively', functio
         ->toBe(['API_KEY']);
 });
 
-it('treats production environment variable search wildcards literally', function () {
+it('treats production environment variable search underscore wildcards literally', function () {
     $application = Application::factory()->create([
         'environment_id' => $this->environment->id,
     ]);
@@ -75,23 +75,11 @@ it('treats production environment variable search wildcards literally', function
         'resourceable_id' => $application->id,
     ]);
 
-    EnvironmentVariable::create([
-        'key' => 'PERCENT%KEY',
-        'value' => 'percent-secret',
-        'resourceable_type' => Application::class,
-        'resourceable_id' => $application->id,
-    ]);
-
     $component = Livewire::test(All::class, ['resource' => $application])
         ->set('search', 'api_key');
 
     expect($component->instance()->environmentVariables->pluck('key')->all())
         ->toBe(['API_KEY']);
-
-    $component->set('search', '%KEY');
-
-    expect($component->instance()->environmentVariables->pluck('key')->all())
-        ->toBe(['PERCENT%KEY']);
 });
 
 it('filters preview environment variables by key case-insensitively', function () {
@@ -142,6 +130,34 @@ YAML,
         ->toBe(['API_TOKEN']);
 });
 
+it('searches service environment variables without requiring preview variables', function () {
+    $service = Service::factory()->create([
+        'environment_id' => $this->environment->id,
+    ]);
+
+    EnvironmentVariable::create([
+        'key' => 'API_KEY',
+        'value' => 'secret',
+        'resourceable_type' => Service::class,
+        'resourceable_id' => $service->id,
+    ]);
+
+    EnvironmentVariable::create([
+        'key' => 'DATABASE_URL',
+        'value' => 'postgres://example',
+        'resourceable_type' => Service::class,
+        'resourceable_id' => $service->id,
+    ]);
+
+    $component = Livewire::test(All::class, ['resource' => $service])
+        ->set('search', 'api')
+        ->assertSee('Production Environment Variables')
+        ->assertDontSee('Preview Deployments Environment Variables');
+
+    expect($component->instance()->environmentVariables->pluck('key')->all())
+        ->toBe(['API_KEY']);
+});
+
 it('does not show the empty production message when search only matches hardcoded variables', function () {
     $service = Service::factory()->create([
         'environment_id' => $this->environment->id,
@@ -155,11 +171,13 @@ services:
 YAML,
     ]);
 
-    Livewire::test(All::class, ['resource' => $service])
+    $component = Livewire::test(All::class, ['resource' => $service])
         ->set('search', 'api')
         ->assertSee('Production Environment Variables')
-        ->assertSee('API_TOKEN')
         ->assertDontSee('No environment variables found.');
+
+    expect($component->instance()->hardcodedEnvironmentVariables->pluck('key')->all())
+        ->toBe(['API_TOKEN']);
 });
 
 it('keeps developer view unfiltered after searching', function () {
@@ -242,10 +260,12 @@ it('hides the preview section when search filters out all preview variables', fu
         'resourceable_id' => $application->id,
     ]);
 
-    Livewire::test(All::class, ['resource' => $application])
+    $component = Livewire::test(All::class, ['resource' => $application])
         ->set('search', 'api')
         ->assertSee('Production Environment Variables')
-        ->assertSee('API_KEY')
         ->assertDontSee('Preview Deployments Environment Variables')
         ->assertDontSee('PREVIEW_TOKEN');
+
+    expect($component->instance()->environmentVariables->pluck('key')->all())
+        ->toBe(['API_KEY']);
 });


### PR DESCRIPTION
## Summary
- Prevent service environment-variable searches from calling application-only preview variable relationships.
- Hide preview environment-variable sections for resources that do not support previews.
- Add coverage for searching service environment variables and hardcoded service variables.

fixes #10830

---

Fixes #10830