### PR TITLE
fix(parser): preserve file volume state

### DIFF
--- a/bootstrap/helpers/parsers.php
+++ b/bootstrap/helpers/parsers.php
@@ -370,8 +370,6 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
     $pullRequestId = $pull_request_id;
     $isPullRequest = $pullRequestId == 0 ? false : true;
     $server = data_get($resource, 'destination.server');
-    $fileStorages = $resource->fileStorages();
-
     try {
         $yaml = Yaml::parse($compose);
     } catch (Exception) {
@@ -703,14 +701,11 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
                     $source = $parsed['source'];
                     $target = $parsed['target'];
                     // Mode is available in $parsed['mode'] if needed
-                    $foundConfig = $fileStorages->whereMountPath($target)->first();
+                    $foundConfig = $originalResource->fileStorages()->whereMountPath($target)->first();
                     if (sourceIsLocal($source)) {
                         $type = str('bind');
                         if ($foundConfig) {
-                            $contentNotNull_temp = data_get($foundConfig, 'content');
-                            if ($contentNotNull_temp) {
-                                $content = $contentNotNull_temp;
-                            }
+                            $content = data_get($foundConfig, 'content');
                             $isDirectory = data_get($foundConfig, 'is_directory');
                         } else {
                             // By default, we cannot determine if the bind is a directory or not, so we set it to directory
@@ -756,12 +751,9 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
                         }
                     }
 
-                    $foundConfig = $fileStorages->whereMountPath($target)->first();
+                    $foundConfig = $originalResource->fileStorages()->whereMountPath($target)->first();
                     if ($foundConfig) {
-                        $contentNotNull_temp = data_get($foundConfig, 'content');
-                        if ($contentNotNull_temp) {
-                            $content = $contentNotNull_temp;
-                        }
+                        $content = data_get($foundConfig, 'content');
                         $isDirectory = data_get($foundConfig, 'is_directory');
                     } else {
                         // if isDirectory is not set (or false) & content is also not set, we assume it is a directory
@@ -2070,7 +2062,6 @@ function serviceParser(Service $resource): Collection
                 'service_id' => $resource->id,
             ]);
         }
-        $fileStorages = $savedService->fileStorages();
         if ($savedService->image !== $image) {
             $savedService->image = $image;
             $savedService->save();
@@ -2090,14 +2081,11 @@ function serviceParser(Service $resource): Collection
                     $source = $parsed['source'];
                     $target = $parsed['target'];
                     // Mode is available in $parsed['mode'] if needed
-                    $foundConfig = $fileStorages->whereMountPath($target)->first();
+                    $foundConfig = $originalResource->fileStorages()->whereMountPath($target)->first();
                     if (sourceIsLocal($source)) {
                         $type = str('bind');
                         if ($foundConfig) {
-                            $contentNotNull_temp = data_get($foundConfig, 'content');
-                            if ($contentNotNull_temp) {
-                                $content = $contentNotNull_temp;
-                            }
+                            $content = data_get($foundConfig, 'content');
                             $isDirectory = data_get($foundConfig, 'is_directory');
                         } else {
                             // By default, we cannot determine if the bind is a directory or not, so we set it to directory
@@ -2143,12 +2131,9 @@ function serviceParser(Service $resource): Collection
                         }
                     }
 
-                    $foundConfig = $fileStorages->whereMountPath($target)->first();
+                    $foundConfig = $originalResource->fileStorages()->whereMountPath($target)->first();
                     if ($foundConfig) {
-                        $contentNotNull_temp = data_get($foundConfig, 'content');
-                        if ($contentNotNull_temp) {
-                            $content = $contentNotNull_temp;
-                        }
+                        $content = data_get($foundConfig, 'content');
                         $isDirectory = data_get($foundConfig, 'is_directory');
                     } else {
                         // if isDirectory is not set (or false) & content is also not set, we assume it is a directory

--- a/tests/Feature/FileStorageParserStateTest.php
+++ b/tests/Feature/FileStorageParserStateTest.php
@@ -14,6 +14,23 @@ use Illuminate\Support\Facades\Bus;
 
 uses(RefreshDatabase::class);
 
+const TWO_FILE_COMPOSE = <<<'YAML'
+services:
+  app:
+    image: nginx:latest
+    volumes:
+      - ./wg_config.conf:/app/ps/wg0.conf
+      - ./override_trays.json:/app/ps/override_tray.json
+YAML;
+
+const DATA_DIR_COMPOSE = <<<'YAML'
+services:
+  app:
+    image: nginx:latest
+    volumes:
+      - ./data:/app/data
+YAML;
+
 beforeEach(function () {
     Bus::fake();
 
@@ -27,39 +44,56 @@ beforeEach(function () {
     $this->environment = $environment;
 });
 
-it('preserves existing application file volume content when reparsing compose bind mounts', function () {
-    $application = Application::factory()->create([
-        'environment_id' => $this->environment->id,
-        'destination_id' => $this->destination->id,
-        'destination_type' => $this->destination->getMorphClass(),
+function makeComposeApplication(string $dockerComposeRaw): Application
+{
+    return Application::factory()->create([
+        'environment_id' => test()->environment->id,
+        'destination_id' => test()->destination->id,
+        'destination_type' => test()->destination->getMorphClass(),
         'build_pack' => 'dockercompose',
-        'docker_compose_raw' => <<<'YAML'
-services:
-  app:
-    image: nginx:latest
-    volumes:
-      - ./wg_config.conf:/app/ps/wg0.conf
-      - ./override_trays.json:/app/ps/override_tray.json
-YAML,
+        'docker_compose_raw' => $dockerComposeRaw,
+    ]);
+}
+
+/**
+ * @return array{0: Service, 1: ServiceApplication}
+ */
+function makeComposeService(string $dockerComposeRaw): array
+{
+    $service = Service::factory()->create([
+        'environment_id' => test()->environment->id,
+        'server_id' => test()->destination->server_id,
+        'destination_id' => test()->destination->id,
+        'destination_type' => test()->destination->getMorphClass(),
+        'docker_compose_raw' => $dockerComposeRaw,
     ]);
 
-    LocalFileVolume::create([
-        'fs_path' => application_configuration_dir()."/{$application->uuid}/wg_config.conf",
-        'mount_path' => '/app/ps/wg0.conf',
-        'content' => 'test-conf',
-        'is_directory' => false,
-        'resource_id' => $application->id,
-        'resource_type' => $application->getMorphClass(),
+    $serviceApplication = ServiceApplication::create([
+        'name' => 'app',
+        'service_id' => $service->id,
     ]);
 
+    return [$service, $serviceApplication];
+}
+
+function seedFileVolume($resource, string $baseDir, string $fileName, string $mountPath, string $content): void
+{
     LocalFileVolume::create([
-        'fs_path' => application_configuration_dir()."/{$application->uuid}/override_trays.json",
-        'mount_path' => '/app/ps/override_tray.json',
-        'content' => '0',
+        'fs_path' => "{$baseDir}/{$fileName}",
+        'mount_path' => $mountPath,
+        'content' => $content,
         'is_directory' => false,
-        'resource_id' => $application->id,
-        'resource_type' => $application->getMorphClass(),
+        'resource_id' => $resource->id,
+        'resource_type' => $resource->getMorphClass(),
     ]);
+}
+
+it('preserves existing application file volume content when reparsing compose bind mounts', function () {
+    $application = makeComposeApplication(TWO_FILE_COMPOSE);
+    $baseDir = application_configuration_dir()."/{$application->uuid}";
+
+    seedFileVolume($application, $baseDir, 'wg_config.conf', '/app/ps/wg0.conf', 'test-conf');
+    seedFileVolume($application, $baseDir, 'override_trays.json', '/app/ps/override_tray.json', '0');
 
     applicationParser($application);
 
@@ -70,38 +104,11 @@ YAML,
 });
 
 it('keeps existing application file volumes as files when content is empty', function () {
-    $application = Application::factory()->create([
-        'environment_id' => $this->environment->id,
-        'destination_id' => $this->destination->id,
-        'destination_type' => $this->destination->getMorphClass(),
-        'build_pack' => 'dockercompose',
-        'docker_compose_raw' => <<<'YAML'
-services:
-  app:
-    image: nginx:latest
-    volumes:
-      - ./wg_config.conf:/app/ps/wg0.conf
-      - ./override_trays.json:/app/ps/override_tray.json
-YAML,
-    ]);
+    $application = makeComposeApplication(TWO_FILE_COMPOSE);
+    $baseDir = application_configuration_dir()."/{$application->uuid}";
 
-    LocalFileVolume::create([
-        'fs_path' => application_configuration_dir()."/{$application->uuid}/wg_config.conf",
-        'mount_path' => '/app/ps/wg0.conf',
-        'content' => 'test-conf',
-        'is_directory' => false,
-        'resource_id' => $application->id,
-        'resource_type' => $application->getMorphClass(),
-    ]);
-
-    LocalFileVolume::create([
-        'fs_path' => application_configuration_dir()."/{$application->uuid}/override_trays.json",
-        'mount_path' => '/app/ps/override_tray.json',
-        'content' => '',
-        'is_directory' => false,
-        'resource_id' => $application->id,
-        'resource_type' => $application->getMorphClass(),
-    ]);
+    seedFileVolume($application, $baseDir, 'wg_config.conf', '/app/ps/wg0.conf', 'test-conf');
+    seedFileVolume($application, $baseDir, 'override_trays.json', '/app/ps/override_tray.json', '');
 
     applicationParser($application);
 
@@ -112,19 +119,7 @@ YAML,
 });
 
 it('defaults new application bind mounts to directories', function () {
-    $application = Application::factory()->create([
-        'environment_id' => $this->environment->id,
-        'destination_id' => $this->destination->id,
-        'destination_type' => $this->destination->getMorphClass(),
-        'build_pack' => 'dockercompose',
-        'docker_compose_raw' => <<<'YAML'
-services:
-  app:
-    image: nginx:latest
-    volumes:
-      - ./data:/app/data
-YAML,
-    ]);
+    $application = makeComposeApplication(DATA_DIR_COMPOSE);
 
     applicationParser($application);
 
@@ -135,43 +130,11 @@ YAML,
 });
 
 it('preserves existing service file volume content when reparsing compose bind mounts', function () {
-    $service = Service::factory()->create([
-        'environment_id' => $this->environment->id,
-        'server_id' => $this->destination->server_id,
-        'destination_id' => $this->destination->id,
-        'destination_type' => $this->destination->getMorphClass(),
-        'docker_compose_raw' => <<<'YAML'
-services:
-  app:
-    image: nginx:latest
-    volumes:
-      - ./wg_config.conf:/app/ps/wg0.conf
-      - ./override_trays.json:/app/ps/override_tray.json
-YAML,
-    ]);
+    [$service, $serviceApplication] = makeComposeService(TWO_FILE_COMPOSE);
+    $baseDir = service_configuration_dir()."/{$service->uuid}";
 
-    $serviceApplication = ServiceApplication::create([
-        'name' => 'app',
-        'service_id' => $service->id,
-    ]);
-
-    LocalFileVolume::create([
-        'fs_path' => service_configuration_dir()."/{$service->uuid}/wg_config.conf",
-        'mount_path' => '/app/ps/wg0.conf',
-        'content' => 'test-conf',
-        'is_directory' => false,
-        'resource_id' => $serviceApplication->id,
-        'resource_type' => $serviceApplication->getMorphClass(),
-    ]);
-
-    LocalFileVolume::create([
-        'fs_path' => service_configuration_dir()."/{$service->uuid}/override_trays.json",
-        'mount_path' => '/app/ps/override_tray.json',
-        'content' => '0',
-        'is_directory' => false,
-        'resource_id' => $serviceApplication->id,
-        'resource_type' => $serviceApplication->getMorphClass(),
-    ]);
+    seedFileVolume($serviceApplication, $baseDir, 'wg_config.conf', '/app/ps/wg0.conf', 'test-conf');
+    seedFileVolume($serviceApplication, $baseDir, 'override_trays.json', '/app/ps/override_tray.json', '0');
 
     serviceParser($service);
 
@@ -182,43 +145,11 @@ YAML,
 });
 
 it('keeps existing service file volumes as files when content is empty', function () {
-    $service = Service::factory()->create([
-        'environment_id' => $this->environment->id,
-        'server_id' => $this->destination->server_id,
-        'destination_id' => $this->destination->id,
-        'destination_type' => $this->destination->getMorphClass(),
-        'docker_compose_raw' => <<<'YAML'
-services:
-  app:
-    image: nginx:latest
-    volumes:
-      - ./wg_config.conf:/app/ps/wg0.conf
-      - ./override_trays.json:/app/ps/override_tray.json
-YAML,
-    ]);
+    [$service, $serviceApplication] = makeComposeService(TWO_FILE_COMPOSE);
+    $baseDir = service_configuration_dir()."/{$service->uuid}";
 
-    $serviceApplication = ServiceApplication::create([
-        'name' => 'app',
-        'service_id' => $service->id,
-    ]);
-
-    LocalFileVolume::create([
-        'fs_path' => service_configuration_dir()."/{$service->uuid}/wg_config.conf",
-        'mount_path' => '/app/ps/wg0.conf',
-        'content' => 'test-conf',
-        'is_directory' => false,
-        'resource_id' => $serviceApplication->id,
-        'resource_type' => $serviceApplication->getMorphClass(),
-    ]);
-
-    LocalFileVolume::create([
-        'fs_path' => service_configuration_dir()."/{$service->uuid}/override_trays.json",
-        'mount_path' => '/app/ps/override_tray.json',
-        'content' => '',
-        'is_directory' => false,
-        'resource_id' => $serviceApplication->id,
-        'resource_type' => $serviceApplication->getMorphClass(),
-    ]);
+    seedFileVolume($serviceApplication, $baseDir, 'wg_config.conf', '/app/ps/wg0.conf', 'test-conf');
+    seedFileVolume($serviceApplication, $baseDir, 'override_trays.json', '/app/ps/override_tray.json', '');
 
     serviceParser($service);
 
@@ -229,25 +160,10 @@ YAML,
 });
 
 it('defaults new service bind mounts to directories', function () {
-    $service = Service::factory()->create([
-        'environment_id' => $this->environment->id,
-        'server_id' => $this->destination->server_id,
-        'destination_id' => $this->destination->id,
-        'destination_type' => $this->destination->getMorphClass(),
-        'docker_compose_raw' => <<<'YAML'
-services:
-  app:
-    image: nginx:latest
-    volumes:
-      - ./data:/app/data
-YAML,
-    ]);
+    [$service, $serviceApplication] = makeComposeService(DATA_DIR_COMPOSE);
 
     serviceParser($service);
 
-    $serviceApplication = ServiceApplication::where('name', 'app')
-        ->where('service_id', $service->id)
-        ->first();
     $fileVolume = $serviceApplication->fileStorages()->where('mount_path', '/app/data')->first();
 
     expect($fileVolume->content)->toBeNull()

--- a/tests/Feature/FileStorageParserStateTest.php
+++ b/tests/Feature/FileStorageParserStateTest.php
@@ -1,0 +1,255 @@
+<?php
+
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\LocalFileVolume;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\Service;
+use App\Models\ServiceApplication;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Bus::fake();
+
+    $team = Team::factory()->create();
+    $server = Server::factory()->create(['team_id' => $team->id]);
+    $destination = StandaloneDocker::where('server_id', $server->id)->first();
+    $project = Project::factory()->create(['team_id' => $team->id]);
+    $environment = Environment::factory()->create(['project_id' => $project->id]);
+
+    $this->destination = $destination;
+    $this->environment = $environment;
+});
+
+it('preserves existing application file volume content when reparsing compose bind mounts', function () {
+    $application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => $this->destination->getMorphClass(),
+        'build_pack' => 'dockercompose',
+        'docker_compose_raw' => <<<'YAML'
+services:
+  app:
+    image: nginx:latest
+    volumes:
+      - ./wg_config.conf:/app/ps/wg0.conf
+      - ./override_trays.json:/app/ps/override_tray.json
+YAML,
+    ]);
+
+    LocalFileVolume::create([
+        'fs_path' => application_configuration_dir()."/{$application->uuid}/wg_config.conf",
+        'mount_path' => '/app/ps/wg0.conf',
+        'content' => 'test-conf',
+        'is_directory' => false,
+        'resource_id' => $application->id,
+        'resource_type' => $application->getMorphClass(),
+    ]);
+
+    LocalFileVolume::create([
+        'fs_path' => application_configuration_dir()."/{$application->uuid}/override_trays.json",
+        'mount_path' => '/app/ps/override_tray.json',
+        'content' => '0',
+        'is_directory' => false,
+        'resource_id' => $application->id,
+        'resource_type' => $application->getMorphClass(),
+    ]);
+
+    applicationParser($application);
+
+    $fileVolume = $application->fileStorages()->where('mount_path', '/app/ps/override_tray.json')->first();
+
+    expect($fileVolume->content)->toBe('0')
+        ->and($fileVolume->is_directory)->toBeFalse();
+});
+
+it('keeps existing application file volumes as files when content is empty', function () {
+    $application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => $this->destination->getMorphClass(),
+        'build_pack' => 'dockercompose',
+        'docker_compose_raw' => <<<'YAML'
+services:
+  app:
+    image: nginx:latest
+    volumes:
+      - ./wg_config.conf:/app/ps/wg0.conf
+      - ./override_trays.json:/app/ps/override_tray.json
+YAML,
+    ]);
+
+    LocalFileVolume::create([
+        'fs_path' => application_configuration_dir()."/{$application->uuid}/wg_config.conf",
+        'mount_path' => '/app/ps/wg0.conf',
+        'content' => 'test-conf',
+        'is_directory' => false,
+        'resource_id' => $application->id,
+        'resource_type' => $application->getMorphClass(),
+    ]);
+
+    LocalFileVolume::create([
+        'fs_path' => application_configuration_dir()."/{$application->uuid}/override_trays.json",
+        'mount_path' => '/app/ps/override_tray.json',
+        'content' => '',
+        'is_directory' => false,
+        'resource_id' => $application->id,
+        'resource_type' => $application->getMorphClass(),
+    ]);
+
+    applicationParser($application);
+
+    $fileVolume = $application->fileStorages()->where('mount_path', '/app/ps/override_tray.json')->first();
+
+    expect($fileVolume->content)->toBe('')
+        ->and($fileVolume->is_directory)->toBeFalse();
+});
+
+it('defaults new application bind mounts to directories', function () {
+    $application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => $this->destination->getMorphClass(),
+        'build_pack' => 'dockercompose',
+        'docker_compose_raw' => <<<'YAML'
+services:
+  app:
+    image: nginx:latest
+    volumes:
+      - ./data:/app/data
+YAML,
+    ]);
+
+    applicationParser($application);
+
+    $fileVolume = $application->fileStorages()->where('mount_path', '/app/data')->first();
+
+    expect($fileVolume->content)->toBeNull()
+        ->and($fileVolume->is_directory)->toBeTrue();
+});
+
+it('preserves existing service file volume content when reparsing compose bind mounts', function () {
+    $service = Service::factory()->create([
+        'environment_id' => $this->environment->id,
+        'server_id' => $this->destination->server_id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => $this->destination->getMorphClass(),
+        'docker_compose_raw' => <<<'YAML'
+services:
+  app:
+    image: nginx:latest
+    volumes:
+      - ./wg_config.conf:/app/ps/wg0.conf
+      - ./override_trays.json:/app/ps/override_tray.json
+YAML,
+    ]);
+
+    $serviceApplication = ServiceApplication::create([
+        'name' => 'app',
+        'service_id' => $service->id,
+    ]);
+
+    LocalFileVolume::create([
+        'fs_path' => service_configuration_dir()."/{$service->uuid}/wg_config.conf",
+        'mount_path' => '/app/ps/wg0.conf',
+        'content' => 'test-conf',
+        'is_directory' => false,
+        'resource_id' => $serviceApplication->id,
+        'resource_type' => $serviceApplication->getMorphClass(),
+    ]);
+
+    LocalFileVolume::create([
+        'fs_path' => service_configuration_dir()."/{$service->uuid}/override_trays.json",
+        'mount_path' => '/app/ps/override_tray.json',
+        'content' => '0',
+        'is_directory' => false,
+        'resource_id' => $serviceApplication->id,
+        'resource_type' => $serviceApplication->getMorphClass(),
+    ]);
+
+    serviceParser($service);
+
+    $fileVolume = $serviceApplication->fileStorages()->where('mount_path', '/app/ps/override_tray.json')->first();
+
+    expect($fileVolume->content)->toBe('0')
+        ->and($fileVolume->is_directory)->toBeFalse();
+});
+
+it('keeps existing service file volumes as files when content is empty', function () {
+    $service = Service::factory()->create([
+        'environment_id' => $this->environment->id,
+        'server_id' => $this->destination->server_id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => $this->destination->getMorphClass(),
+        'docker_compose_raw' => <<<'YAML'
+services:
+  app:
+    image: nginx:latest
+    volumes:
+      - ./wg_config.conf:/app/ps/wg0.conf
+      - ./override_trays.json:/app/ps/override_tray.json
+YAML,
+    ]);
+
+    $serviceApplication = ServiceApplication::create([
+        'name' => 'app',
+        'service_id' => $service->id,
+    ]);
+
+    LocalFileVolume::create([
+        'fs_path' => service_configuration_dir()."/{$service->uuid}/wg_config.conf",
+        'mount_path' => '/app/ps/wg0.conf',
+        'content' => 'test-conf',
+        'is_directory' => false,
+        'resource_id' => $serviceApplication->id,
+        'resource_type' => $serviceApplication->getMorphClass(),
+    ]);
+
+    LocalFileVolume::create([
+        'fs_path' => service_configuration_dir()."/{$service->uuid}/override_trays.json",
+        'mount_path' => '/app/ps/override_tray.json',
+        'content' => '',
+        'is_directory' => false,
+        'resource_id' => $serviceApplication->id,
+        'resource_type' => $serviceApplication->getMorphClass(),
+    ]);
+
+    serviceParser($service);
+
+    $fileVolume = $serviceApplication->fileStorages()->where('mount_path', '/app/ps/override_tray.json')->first();
+
+    expect($fileVolume->content)->toBe('')
+        ->and($fileVolume->is_directory)->toBeFalse();
+});
+
+it('defaults new service bind mounts to directories', function () {
+    $service = Service::factory()->create([
+        'environment_id' => $this->environment->id,
+        'server_id' => $this->destination->server_id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => $this->destination->getMorphClass(),
+        'docker_compose_raw' => <<<'YAML'
+services:
+  app:
+    image: nginx:latest
+    volumes:
+      - ./data:/app/data
+YAML,
+    ]);
+
+    serviceParser($service);
+
+    $serviceApplication = ServiceApplication::where('name', 'app')
+        ->where('service_id', $service->id)
+        ->first();
+    $fileVolume = $serviceApplication->fileStorages()->where('mount_path', '/app/data')->first();
+
+    expect($fileVolume->content)->toBeNull()
+        ->and($fileVolume->is_directory)->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- Preserve existing converted file-volume content and file/directory state when Docker Compose bind mounts are reparsed during rebuilds.
- Keep empty-string and falsy file contents, such as `0`, from being treated as missing content.
- Add parser coverage for application and service bind mounts to ensure existing files remain files while new bind mounts still default to directories.

fixes #10525

---

Fixes #10525