### PR TITLE
fix(service): revive posthog template

### DIFF
--- a/templates/compose/posthog.yaml
+++ b/templates/compose/posthog.yaml
@@ -1,694 +1,123 @@
-# ignore: true
 # documentation: https://posthog.com
 # slogan: The single platform to analyze, test, observe, and deploy new features
 # category: analytics
 # tags: analytics, product, open-source, self-hosted, ab-testing, event-tracking
 # logo: svgs/posthog.svg
 # minversion: 4.0.0-beta.222
-
 services:
   db:
-    image: postgres:12-alpine
-    volumes:
-      - posthog-postgres-data:/var/lib/postgresql/data
+    image: postgres:15.12-alpine
     environment:
       - POSTGRES_USER=posthog
       - POSTGRES_DB=posthog
-      - POSTGRES_PASSWORD=$SERVICE_PASSWORD_POSTGRES
+      - POSTGRES_PASSWORD=${SERVICE_PASSWORD_POSTGRES}
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U posthog"]
-      interval: 2s
-      timeout: 10s
-      retries: 15
+      test: ['CMD-SHELL', 'pg_isready -U posthog']
+      interval: 5s
+      timeout: 30s
+      retries: 30
+      start_period: 10s
+    volumes:
+      - posthog-postgres-data:/var/lib/postgresql/data
 
   redis:
-    image: redis:6.2.7-alpine
-    command: redis-server --maxmemory-policy allkeys-lru --maxmemory 200mb
+    image: redis:7.2-alpine
+    command: redis-server --maxmemory-policy allkeys-lru --maxmemory 500mb
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 3s
+      timeout: 10s
+      retries: 10
+    volumes:
+      - posthog-redis-data:/data
 
-  clickhouse:
-    image: clickhouse/clickhouse-server:23.11.2.11-alpine
+  zookeeper:
+    image: zookeeper:3.7.0
+    volumes:
+      - posthog-zookeeper-data:/data
+      - posthog-zookeeper-datalog:/datalog
+      - posthog-zookeeper-logs:/logs
+
+  permissions-init:
+    image: alpine:3.19
+    command:
+      - sh
+      - -c
+      - |
+        set -e
+        mkdir -p /mnt/clickhouse /mnt/livestream /mnt/temporal
+        chown -R 101:101 /mnt/clickhouse
+        chown -R 1000:1000 /mnt/livestream /mnt/temporal
+        find /mnt/clickhouse /mnt/livestream /mnt/temporal -type d -exec chmod 755 {} \;
+        find /mnt/clickhouse /mnt/livestream /mnt/temporal -type f -exec chmod 644 {} \;
     volumes:
       - type: bind
-        source: ./idl/events_dead_letter_queue.json
-        target: /idl/events_dead_letter_queue.json
-        content: |
-          {
-            "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$id": "file://posthog/idl/events_dead_letter_queue.json",
-            "title": "events_dead_letter_queue",
-            "description": "Events that failed to be validated or processed and are sent to the DLQ",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "description": "uuid for the submission",
-                    "type": "string"
-                },
-                "event_uuid": {
-                    "description": "uuid for the event",
-                    "type": "string"
-                },
-                "event": {
-                    "description": "event type",
-                    "type": "string"
-                },
-                "properties": {
-                    "description": "String representation of the properties json object",
-                    "type": "string"
-                },
-                "distinct_id": {
-                    "description": "PostHog distinct_id",
-                    "type": "string"
-                },
-                "team_id": {
-                    "description": "team_id (maps to the project under the organization)",
-                    "type": "number"
-                },
-                "elements_chain": {
-                    "description": "Used for autocapture. DOM element hierarchy",
-                    "type": "string"
-                },
-                "created_at": {
-                    "description": "Used for autocapture. DOM element hierarchy",
-                    "type": "number"
-                },
-                "ip": {
-                    "description": "IP Address of the associated with the event",
-                    "type": "string"
-                },
-                "site_url": {
-                    "description": "Site URL associated with the event the event",
-                    "type": "string"
-                },
-                "now": {
-                    "description": "Timestamp of the DLQ event",
-                    "type": "number"
-                },
-                "raw_payload": {
-                    "description": "Raw payload of the event that failed to be consumed",
-                    "type": "string"
-                },
-                "error_timestamp": {
-                    "description": "Timestamp that the error of ingestion occurred",
-                    "type": "number"
-                },
-                "error_location": {
-                    "description": "Source of error if known",
-                    "type": "string"
-                },
-                "error": {
-                    "description": "Error if known",
-                    "type": "string"
-                },
-                "tags": {
-                    "description": "Tags associated with the error or event",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            },
-            "required": ["raw_payload"]
-          }
+        source: ./clickhouse
+        target: /mnt/clickhouse
+        is_directory: true
       - type: bind
-        source: ./idl/events_json.json
-        target: /idl/events_json.json
-        content: |
-          {
-            "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$id": "file://posthog/idl/events_json.json",
-            "title": "events_json",
-            "description": "Event schema that is destined for ClickHouse",
-            "type": "object",
-            "properties": {
-                "uuid": {
-                    "description": "uuid for the event",
-                    "type": "string"
-                },
-                "event": {
-                    "description": "event type",
-                    "type": "string"
-                },
-                "properties": {
-                    "description": "String representation of the properties json object",
-                    "type": "string"
-                },
-                "timestamp": {
-                    "description": "Timestamp that the event occurred",
-                    "type": "number"
-                },
-                "team_id": {
-                    "description": "team_id (maps to the project under the organization)",
-                    "type": "number"
-                },
-                "distinct_id": {
-                    "description": "PostHog distinct_id",
-                    "type": "string"
-                },
-                "elements_chain": {
-                    "description": "Used for autocapture. DOM element hierarchy",
-                    "type": "string"
-                },
-                "created_at": {
-                    "description": "Timestamp when event was created",
-                    "type": "number"
-                },
-                "person_id": {
-                    "description": "UUID for the associated person if available",
-                    "type": "string"
-                },
-                "person_created_at": {
-                    "description": "Timestamp for when the associated person was created",
-                    "type": "number"
-                },
-                "person_properties": {
-                    "description": "String representation of the person JSON object",
-                    "type": "string"
-                },
-                "group0_properties": {
-                    "description": "String representation of a group's properties",
-                    "type": "string"
-                },
-                "group1_properties": {
-                    "description": "String representation of a group's properties",
-                    "type": "string"
-                },
-                "group2_properties": {
-                    "description": "String representation of a group's properties",
-                    "type": "string"
-                },
-                "group3_properties": {
-                    "description": "String representation of a group's properties",
-                    "type": "string"
-                },
-                "group4_properties": {
-                    "description": "String representation of a group's properties",
-                    "type": "string"
-                },
-                "group0_created_at": {
-                    "description": "Group's creation timestamp",
-                    "type": "number"
-                },
-                "group1_created_at": {
-                    "description": "Group's creation timestamp",
-                    "type": "number"
-                },
-                "group2_created_at": {
-                    "description": "Group's creation timestamp",
-                    "type": "number"
-                },
-                "group3_created_at": {
-                    "description": "Group's creation timestamp",
-                    "type": "number"
-                },
-                "group4_created_at": {
-                    "description": "Group's creation timestamp",
-                    "type": "number"
-                }
-            },
-            "required": ["uuid", "event", "properties", "timestamp", "team_id"]
-          }
+        source: ./livestream
+        target: /mnt/livestream
+        is_directory: true
       - type: bind
-        source: ./idl/groups.json
-        target: /idl/groups.json
-        content: |
-          {
-            "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$id": "file://posthog/idl/groups.json",
-            "title": "groups",
-            "description": "Groups schema that is destined for ClickHouse",
-            "type": "object",
-            "properties": {
-                "group_type_index": {
-                    "description": "Group type index",
-                    "type": "number"
-                },
-                "group_key": {
-                    "description": "Group Key",
-                    "type": "string"
-                },
-                "created_at": {
-                    "description": "Group creation timestamp",
-                    "type": "number"
-                },
-                "team_id": {
-                    "description": "Team ID associated with group",
-                    "type": "number"
-                },
-                "group_properties": {
-                    "description": "String representation of group JSON properties object",
-                    "type": "string"
-                }
-            },
-            "required": ["group_type_index", "group_key", "created_at", "team_id", "group_properties"]
-          }
-      - type: bind
-        source: ./idl/idl.md
-        target: /idl/idl.md
-        content: |
-          # IDL - Interface Definition Language
+        source: ./temporal
+        target: /mnt/temporal
+        is_directory: true
+    restart: 'no'
 
-          This directory is responsible for defining the schemas of the data between services.
-          Primarily this will be between services and ClickHouse, but can be really any thing at the boundry of services.
-
-          The reason why we do this is because it makes generating code, validating data, and understanding the system a whole lot easier. We've had a few customers request this of us for engineering a deeper integration with us.
+  clickhouse:
+    image: clickhouse/clickhouse-server:25.12.5.44
+    depends_on:
+      permissions-init:
+        condition: service_completed_successfully
+      kafka:
+        condition: service_started
+      zookeeper:
+        condition: service_started
+    environment:
+      - CLICKHOUSE_SKIP_USER_SETUP=1
+      - KAFKA_HOSTS=kafka:9092
+    healthcheck:
+      test: ['CMD-SHELL', 'wget --no-verbose --tries=1 --spider http://localhost:8123/ping || exit 1']
+      interval: 5s
+      timeout: 10s
+      retries: 30
+      start_period: 30s
+    volumes:
       - type: bind
-        source: ./idl/person.json
-        target: /idl/person.json
-        content: |
-          {
-            "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$id": "file://posthog/idl/person.json",
-            "title": "person",
-            "description": "Person schema that is destined for ClickHouse",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "description": "UUID for the person",
-                    "type": "string"
-                },
-                "created_at": {
-                    "description": "Person creation timestamp",
-                    "type": "number"
-                },
-                "team_id": {
-                    "description": "Team ID associated with person",
-                    "type": "number"
-                },
-                "properties": {
-                    "description": "String representation of person JSON properties object",
-                    "type": "string"
-                },
-                "is_identified": {
-                    "description": "Boolean is the person identified?",
-                    "type": "boolean"
-                },
-                "is_deleted": {
-                    "description": "Boolean is the person deleted?",
-                    "type": "boolean"
-                },
-                "version": {
-                    "description": "Version field for collapsing later (psuedo-tombstone)",
-                    "type": "number"
-                }
-            },
-            "required": ["id", "created_at", "team_id", "properties", "is_identified", "is_deleted", "version"]
-          }
-      - type: bind
-        source: ./idl/person_distinct_id.json
-        target: /idl/person_distinct_id.json
-        content: |
-          {
-            "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$id": "file://posthog/idl/person_distinct_id.json",
-            "title": "person_distinct_id",
-            "description": "Person distinct id schema that is destined for ClickHouse",
-            "type": "object",
-            "properties": {
-                "distinct_id": {
-                    "description": "User provided ID for the distinct user",
-                    "type": "string"
-                },
-                "person_id": {
-                    "description": "UUID of the person",
-                    "type": "string"
-                },
-                "team_id": {
-                    "description": "Team ID associated with person_distinct_id",
-                    "type": "number"
-                },
-                "_sign": {
-                    "description": "Used for collapsing later different versions of a distinct id (psuedo-tombstone)",
-                    "type": "number"
-                },
-                "is_deleted": {
-                    "description": "Boolean is the person distinct_id deleted?",
-                    "type": "boolean"
-                }
-            },
-            "required": ["distinct_id", "person_id", "team_id", "_sign", "is_deleted"]
-           }
-      - type: bind
-        source: ./idl/person_distinct_id2.json
-        target: /idl/person_distinct_id2.json
-        content: |
-          {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "$id": "file://posthog/idl/person_distinct_id2.json",
-              "title": "person_distinct_id2",
-              "description": "Person distinct id2 schema that is destined for ClickHouse",
-              "type": "object",
-              "properties": {
-                  "distinct_id": {
-                      "description": "User provided ID for the distinct user",
-                      "type": "string"
-                  },
-                  "person_id": {
-                      "description": "UUID of the person",
-                      "type": "string"
-                  },
-                  "team_id": {
-                      "description": "Team ID associated with person_distinct_id",
-                      "type": "number"
-                  },
-                  "version": {
-                      "description": "Used for collapsing later different versions of a distinct id (psuedo-tombstone)",
-                      "type": "number"
-                  },
-                  "is_deleted": {
-                      "description": "Boolean is the person distinct_id deleted?",
-                      "type": "boolean"
-                  }
-              },
-              "required": ["distinct_id", "person_id", "team_id", "version", "is_deleted"]
-          }
-      - type: bind
-        source: ./idl/plugin_log_entries.json
-        target: /idl/plugin_log_entries.json
-        content: |
-          {
-              "$schema": "https://json-schema.org/draft/2020-12/schema",
-              "$id": "file://posthog/idl/plugin_log_entries.json",
-              "title": "plugin_log_entries",
-              "description": "Plugin log entries that are destined for ClickHouse",
-              "type": "object",
-              "properties": {
-                  "id": {
-                      "description": "UUID for the log entry",
-                      "type": "string"
-                  },
-                  "team_id": {
-                      "description": "Team ID associated with person_distinct_id",
-                      "type": "number"
-                  },
-                  "plugin_id": {
-                      "description": "Plugin ID associated with the log entry",
-                      "type": "number"
-                  },
-                  "plugin_config_id": {
-                      "description": "Plugin Config ID associated with the log entry",
-                      "type": "number"
-                  },
-                  "timestamp": {
-                      "description": "Timestamp for when the log entry was created",
-                      "type": "number"
-                  },
-                  "source": {
-                      "description": "Source of the log entry",
-                      "type": "string"
-                  },
-                  "type": {
-                      "description": "Log entry type",
-                      "type": "string"
-                  },
-                  "message": {
-                      "description": "Log entry body",
-                      "type": "string"
-                  },
-                  "instance_id": {
-                      "description": "UUID of the instance that generated the log entry",
-                      "type": "string"
-                  }
-              },
-              "required": [
-                  "id",
-                  "team_id",
-                  "plugin_id",
-                  "plugin_config_id",
-                  "timestamp",
-                  "source",
-                  "type",
-                  "message",
-                  "instance_id"
-              ]
-          }
-      - type: bind
-        source: ./docker/clickhouse/docker-entrypoint-initdb.d/init-db.sh
-        target: /docker-entrypoint-initdb.d/init-db.sh
-        content: |
-          #!/bin/bash
-          set -e
-
-          cp -r /idl/* /var/lib/clickhouse/format_schemas/
-      - type: bind
-        source: ./docker/clickhouse/config.xml
+        source: ./clickhouse/config.xml
         target: /etc/clickhouse-server/config.xml
+        read_only: true
         content: |
           <?xml version="1.0"?>
           <!--
             NOTE: User and query level settings are set up in "users.xml" file.
             If you have accidentally specified user-level settings here, server won't start.
             You can either move the settings to the right place inside "users.xml" file
-            or add <skip_check_for_incorrect_settings>1</skip_check_for_incorrect_settings> here.
+             or add <skip_check_for_incorrect_settings>1</skip_check_for_incorrect_settings> here.
           -->
-          <yandex>
+          <clickhouse>
               <logger>
-                  <!-- Possible levels [1]:
-
-                    - none (turns off logging)
-                    - fatal
-                    - critical
-                    - error
-                    - warning
-                    - notice
-                    - information
-                    - debug
-                    - trace
-                    - test (not for production usage)
-
-                      [1]:
-                  https://github.com/pocoproject/poco/blob/poco-1.9.4-release/Foundation/include/Poco/Logger.h#L105-L114
-                  -->
-                  <level>trace</level>
+                  <level>warning</level>
                   <log>/var/log/clickhouse-server/clickhouse-server.log</log>
                   <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
-                  <!-- Rotation policy
-                      See
-                  https://github.com/pocoproject/poco/blob/poco-1.9.4-release/Foundation/include/Poco/FileChannel.h#L54-L85
-                    -->
                   <size>1000M</size>
                   <count>10</count>
-                  <!-- <console>1</console> --> <!-- Default behavior is autodetection (log to console if not daemon mode
-                  and is tty) -->
-
-                  <!-- Per level overrides (legacy):
-
-                  For example to suppress logging of the ConfigReloader you can use:
-                  NOTE: levels.logger is reserved, see below.
-                  -->
-                  <!--
-                  <levels>
-                    <ConfigReloader>none</ConfigReloader>
-                  </levels>
-                  -->
-
-                  <!-- Per level overrides:
-
-                  For example to suppress logging of the RBAC for default user you can use:
-                  (But please note that the logger name maybe changed from version to version, even after minor
-                  upgrade)
-                  -->
-                  <!--
-                  <levels>
-                    <logger>
-                      <name>ContextAccess (default)</name>
-                      <level>none</level>
-                    </logger>
-                    <logger>
-                      <name>DatabaseOrdinary (test)</name>
-                      <level>none</level>
-                    </logger>
-                  </levels>
-                  -->
               </logger>
 
-              <!-- Add headers to response in options request. OPTIONS method is used in CORS preflight
-              requests. -->
-              <!-- It is off by default. Next headers are obligate for CORS.-->
-              <!-- http_options_response>
-                  <header>
-                      <name>Access-Control-Allow-Origin</name>
-                      <value>*</value>
-                  </header>
-                  <header>
-                      <name>Access-Control-Allow-Headers</name>
-                      <value>origin, x-requested-with</value>
-                  </header>
-                  <header>
-                      <name>Access-Control-Allow-Methods</name>
-                      <value>POST, GET, OPTIONS</value>
-                  </header>
-                  <header>
-                      <name>Access-Control-Max-Age</name>
-                      <value>86400</value>
-                  </header>
-              </http_options_response -->
-
-              <!-- It is the name that will be shown in the clickhouse-client.
-                  By default, anything with "production" will be highlighted in red in query prompt.
-              -->
-              <!--display_name>production</display_name-->
-
-              <!-- Port for HTTP API. See also 'https_port' for secure connections.
-                  This interface is also used by ODBC and JDBC drivers (DataGrip, Dbeaver, ...)
-                  and by most of web interfaces (embedded UI, Grafana, Redash, ...).
-                -->
               <http_port>8123</http_port>
-
-              <!-- Port for interaction by native protocol with:
-                  - clickhouse-client and other native ClickHouse tools (clickhouse-benchmark, clickhouse-copier);
-                  - clickhouse-server with other clickhouse-servers for distributed query processing;
-                  - ClickHouse drivers and applications supporting native protocol
-                  (this protocol is also informally called as "the TCP protocol");
-                  See also 'tcp_port_secure' for secure connections.
-              -->
-              <tcp_port>9000</tcp_port>
-
-              <!-- Compatibility with MySQL protocol.
-                  ClickHouse will pretend to be MySQL for applications connecting to this port.
-              -->
               <mysql_port>9004</mysql_port>
-
-              <!-- Compatibility with PostgreSQL protocol.
-                  ClickHouse will pretend to be PostgreSQL for applications connecting to this port.
-              -->
               <postgresql_port>9005</postgresql_port>
-
-              <!-- HTTP API with TLS (HTTPS).
-                  You have to configure certificate to enable this interface.
-                  See the openSSL section below.
-              -->
               <https_port>8443</https_port>
-
-              <!-- Native interface with TLS.
-                  You have to configure certificate to enable this interface.
-                  See the openSSL section below.
-              -->
               <tcp_port_secure>9440</tcp_port_secure>
-
-              <!-- Native interface wrapped with PROXYv1 protocol
-                  PROXYv1 header sent for every connection.
-                  ClickHouse will extract information about proxy-forwarded client address from the header.
-              -->
-              <!-- <tcp_with_proxy_port>9011</tcp_with_proxy_port> -->
-
-              <!-- Port for communication between replicas. Used for data exchange.
-                  It provides low-level data access between servers.
-                  This port should not be accessible from untrusted networks.
-                  See also 'interserver_http_credentials'.
-                  Data transferred over connections to this port should not go through untrusted networks.
-                  See also 'interserver_https_port'.
-                -->
               <interserver_http_port>9009</interserver_http_port>
-
-              <!-- Port for communication between replicas with TLS.
-                  You have to configure certificate to enable this interface.
-                  See the openSSL section below.
-                  See also 'interserver_http_credentials'.
-                -->
-              <!-- <interserver_https_port>9010</interserver_https_port> -->
-
-              <!-- Hostname that is used by other replicas to request this server.
-                  If not specified, than it is determined analogous to 'hostname -f' command.
-                  This setting could be used to switch replication to another network interface
-                  (the server may be connected to multiple networks via multiple addresses)
-                -->
-
-              <!--
-              <interserver_http_host>example.yandex.ru</interserver_http_host>
-              -->
-
-              <!-- You can specify credentials for authenthication between replicas.
-                  This is required when interserver_https_port is accessible from untrusted networks,
-                  and also recommended to avoid SSRF attacks from possibly compromised services in your network.
-                -->
-              <!--<interserver_http_credentials>
-                  <user>interserver</user>
-                  <password></password>
-              </interserver_http_credentials>-->
-
-              <!-- Listen specified address.
-                  Use :: (wildcard IPv6 address), if you want to accept connections both with IPv4 and IPv6 from
-              everywhere.
-                  Notes:
-                  If you open connections from wildcard address, make sure that at least one of the following
-              measures applied:
-                  - server is protected by firewall and not accessible from untrusted networks;
-                  - all users are restricted to subset of network addresses (see users.xml);
-                  - all users have strong passwords, only secure (TLS) interfaces are accessible, or connections are
-              only made via TLS interfaces.
-                  - users without password have readonly access.
-                  See also: https://www.shodan.io/search?query=clickhouse
-                -->
-              <!-- <listen_host>::</listen_host> -->
-
-
-              <!-- Same for hosts without support for IPv6: -->
-              <!-- <listen_host>0.0.0.0</listen_host> -->
-
-              <!-- Default values - try listen localhost on IPv4 and IPv6. -->
-              <!--
-              <listen_host>::1</listen_host>
-              <listen_host>127.0.0.1</listen_host>
-              -->
-
-              <!-- Don't exit if IPv6 or IPv4 networks are unavailable while trying to listen. -->
-              <!-- <listen_try>0</listen_try> -->
-
-              <!-- Allow multiple servers to listen on the same address:port. This is not recommended.
-                -->
-              <!-- <listen_reuse_port>0</listen_reuse_port> -->
-
-              <!-- <listen_backlog>4096</listen_backlog> -->
-
               <max_connections>4096</max_connections>
-
-              <!-- For 'Connection: keep-alive' in HTTP 1.1 -->
               <keep_alive_timeout>3</keep_alive_timeout>
 
-              <!-- gRPC protocol (see src/Server/grpc_protos/clickhouse_grpc.proto for the API) -->
-              <!-- <grpc_port>9100</grpc_port> -->
-              <grpc>
-                  <enable_ssl>false</enable_ssl>
-
-                  <!-- The following two files are used only if enable_ssl=1 -->
-                  <ssl_cert_file>/path/to/ssl_cert_file</ssl_cert_file>
-                  <ssl_key_file>/path/to/ssl_key_file</ssl_key_file>
-
-                  <!-- Whether server will request client for a certificate -->
-                  <ssl_require_client_auth>false</ssl_require_client_auth>
-
-                  <!-- The following file is used only if ssl_require_client_auth=1 -->
-                  <ssl_ca_cert_file>/path/to/ssl_ca_cert_file</ssl_ca_cert_file>
-
-                  <!-- Default transport compression type (can be overridden by client, see the
-                  transport_compression_type field in QueryInfo).
-                      Supported algorithms: none, deflate, gzip, stream_gzip -->
-                  <transport_compression_type>none</transport_compression_type>
-
-                  <!-- Default transport compression level. Supported levels: 0..3 -->
-                  <transport_compression_level>0</transport_compression_level>
-
-                  <!-- Send/receive message size limits in bytes. -1 means unlimited -->
-                  <max_send_message_size>-1</max_send_message_size>
-                  <max_receive_message_size>-1</max_receive_message_size>
-
-                  <!-- Enable if you want very detailed logs -->
-                  <verbose_logs>false</verbose_logs>
-              </grpc>
-
-              <!-- Used with https_port and tcp_port_secure. Full ssl options list:
-              https://github.com/ClickHouse-Extras/poco/blob/master/NetSSL_OpenSSL/include/Poco/Net/SSLManager.h#L71 -->
               <openSSL>
-                  <server> <!-- Used for https server AND secure tcp port -->
-                      <!-- openssl req -subj "/CN=localhost" -new -newkey rsa:2048 -days 365 -nodes -x509
-                      -keyout /etc/clickhouse-server/server.key -out /etc/clickhouse-server/server.crt -->
+                  <server>
                       <certificateFile>/etc/clickhouse-server/server.crt</certificateFile>
                       <privateKeyFile>/etc/clickhouse-server/server.key</privateKeyFile>
-                      <!-- dhparams are optional. You can delete the <dhParamsFile> element.
-                          To generate dhparams, use the following command:
-                            openssl dhparam -out /etc/clickhouse-server/dhparam.pem 4096
-                          Only file format with BEGIN DH PARAMETERS is supported.
-                        -->
                       <dhParamsFile>/etc/clickhouse-server/dhparam.pem</dhParamsFile>
                       <verificationMode>none</verificationMode>
                       <loadDefaultCAFile>true</loadDefaultCAFile>
@@ -697,42 +126,31 @@ services:
                       <preferServerCiphers>true</preferServerCiphers>
                   </server>
 
-                  <client> <!-- Used for connecting to https dictionary source and secured Zookeeper
-                      communication -->
+                  <client>
                       <loadDefaultCAFile>true</loadDefaultCAFile>
                       <cacheSessions>true</cacheSessions>
                       <disableProtocols>sslv2,sslv3</disableProtocols>
                       <preferServerCiphers>true</preferServerCiphers>
-                      <!-- Use for self-signed: <verificationMode>none</verificationMode> -->
                       <invalidCertificateHandler>
-                          <!-- Use for self-signed: <name>AcceptCertificateHandler</name> -->
                           <name>RejectCertificateHandler</name>
                       </invalidCertificateHandler>
                   </client>
               </openSSL>
 
-              <!-- Default root page on http[s] server. For example load UI from https://tabix.io/ when
-              opening http://localhost:8123 -->
-              <!--
-              <http_server_default_response><![CDATA[<html ng-app="SMI2"><head><base
-              href="http://ui.tabix.io/"></head><body><div ui-view="" class="content-ui"></div><script
-              src="http://loader.tabix.io/master.js"></script></body></html>]]></http_server_default_response>
-              -->
-
               <!-- Maximum number of concurrent queries. -->
-              <max_concurrent_queries>100</max_concurrent_queries>
+              <max_concurrent_queries>200</max_concurrent_queries>
 
               <!-- Maximum memory usage (resident set size) for server process.
-                  Zero value or unset means default. Default is "max_server_memory_usage_to_ram_ratio" of available
+                   Zero value or unset means default. Default is "max_server_memory_usage_to_ram_ratio" of available
               physical RAM.
-                  If the value is larger than "max_server_memory_usage_to_ram_ratio" of available physical RAM, it
+                   If the value is larger than "max_server_memory_usage_to_ram_ratio" of available physical RAM, it
               will be cut down.
 
-                  The constraint is checked on query execution time.
-                  If a query tries to allocate memory and the current memory usage plus allocation is greater
+                   The constraint is checked on query execution time.
+                   If a query tries to allocate memory and the current memory usage plus allocation is greater
                     than specified threshold, exception will be thrown.
 
-                  It is not practical to set this constraint to small values like just a few gigabytes,
+                   It is not practical to set this constraint to small values like just a few gigabytes,
                     because memory allocator will keep this amount of memory in caches and the server will deny service
               of queries.
                 -->
@@ -745,10 +163,14 @@ services:
               of the time, in which case a higher number of threads might be required.
               -->
 
+              <background_message_broker_schedule_pool_size>10</background_message_broker_schedule_pool_size>
               <max_thread_pool_size>10000</max_thread_pool_size>
 
+              <!-- how many threads merge files, default is 16 -->
+              <background_pool_size>4</background_pool_size>
+
               <!-- Number of workers to recycle connections in background (see also drain_timeout).
-                  If the pool is full, connection will be drained synchronously. -->
+                   If the pool is full, connection will be drained synchronously. -->
               <!-- <max_threads_for_connection_collector>10</max_threads_for_connection_collector> -->
 
               <!-- On memory constrained environments you may have to set this to value larger than 1.
@@ -757,64 +179,43 @@ services:
 
               <!-- Simple server-wide memory profiler. Collect a stack trace at every peak allocation step (in
               bytes).
-                  Data will be stored in system.trace_log table with query_id = empty string.
-                  Zero means disabled.
+                   Data will be stored in system.trace_log table with query_id = empty string.
+                   Zero means disabled.
                 -->
               <total_memory_profiler_step>4194304</total_memory_profiler_step>
 
               <!-- Collect random allocations and deallocations and write them into system.trace_log with
               'MemorySample' trace_type.
-                  The probability is for every alloc/free regardless to the size of the allocation.
-                  Note that sampling happens only when the amount of untracked memory exceeds the untracked memory
+                   The probability is for every alloc/free regardless to the size of the allocation.
+                   Note that sampling happens only when the amount of untracked memory exceeds the untracked memory
               limit,
                     which is 4 MiB by default but can be lowered if 'total_memory_profiler_step' is lowered.
-                  You may want to set 'total_memory_profiler_step' to 1 for extra fine grained sampling.
+                   You may want to set 'total_memory_profiler_step' to 1 for extra fine grained sampling.
                 -->
               <total_memory_tracker_sample_probability>0</total_memory_tracker_sample_probability>
 
               <!-- Set limit on number of open files (default: maximum). This setting makes sense on Mac OS X
               because getrlimit() fails to retrieve
-                  correct maximum value. -->
+                   correct maximum value. -->
               <!-- <max_open_files>262144</max_open_files> -->
 
               <!-- Size of cache of uncompressed blocks of data, used in tables of MergeTree family.
-                  In bytes. Cache is single for server. Memory is allocated only on demand.
-                  Cache is used when 'use_uncompressed_cache' user setting turned on (off by default).
-                  Uncompressed cache is advantageous only for very short queries and in rare cases.
+                   In bytes. Cache is single for server. Memory is allocated only on demand.
+                   Cache is used when 'use_uncompressed_cache' user setting turned on (off by default).
+                   Uncompressed cache is advantageous only for very short queries and in rare cases.
 
-                  Note: uncompressed cache can be pointless for lz4, because memory bandwidth
-                  is slower than multi-core decompression on some server configurations.
-                  Enabling it can sometimes paradoxically make queries slower.
+                   Note: uncompressed cache can be pointless for lz4, because memory bandwidth
+                   is slower than multi-core decompression on some server configurations.
+                   Enabling it can sometimes paradoxically make queries slower.
                 -->
               <uncompressed_cache_size>8589934592</uncompressed_cache_size>
 
               <!-- Approximate size of mark cache, used in tables of MergeTree family.
-                  In bytes. Cache is single for server. Memory is allocated only on demand.
-                  You should not lower this value.
+                   In bytes. Cache is single for server. Memory is allocated only on demand.
+                   You should not lower this value.
                 -->
               <mark_cache_size>5368709120</mark_cache_size>
 
-
-              <!-- If you enable the `min_bytes_to_use_mmap_io` setting,
-                  the data in MergeTree tables can be read with mmap to avoid copying from kernel to userspace.
-                  It makes sense only for large files and helps only if data reside in page cache.
-                  To avoid frequent open/mmap/munmap/close calls (which are very expensive due to consequent page
-              faults)
-                  and to reuse mappings from several threads and queries,
-                  the cache of mapped files is maintained. Its size is the number of mapped regions (usually equal to
-              the number of mapped files).
-                  The amount of data in mapped files can be monitored
-                  in system.metrics, system.metric_log by the MMappedFiles, MMappedFileBytes metrics
-                  and in system.asynchronous_metrics, system.asynchronous_metrics_log by the MMapCacheCells metric,
-                  and also in system.events, system.processes, system.query_log, system.query_thread_log,
-              system.query_views_log by the
-                  CreatedReadBufferMMap, CreatedReadBufferMMapFailed, MMappedFileCacheHits, MMappedFileCacheMisses
-              events.
-                  Note that the amount of data in mapped files does not consume memory directly and is not accounted
-                  in query or server memory usage - because this memory can be discarded similar to OS page cache.
-                  The cache is dropped (the files are closed) automatically on removal of old parts in MergeTree,
-                  also it can be dropped manually by the SYSTEM DROP MMAP CACHE query.
-                -->
               <mmap_cache_size>1000</mmap_cache_size>
 
               <!-- Cache size in bytes for compiled expressions.-->
@@ -829,124 +230,9 @@ services:
               <!-- Path to temporary data for processing hard queries. -->
               <tmp_path>/var/lib/clickhouse/tmp/</tmp_path>
 
-              <!-- Policy from the <storage_configuration> for the temporary files.
-                  If not set <tmp_path> is used, otherwise <tmp_path> is ignored.
-
-                  Notes:
-                  - move_factor              is ignored
-                  - keep_free_space_bytes    is ignored
-                  - max_data_part_size_bytes is ignored
-                  - you must have exactly one volume in that policy
-              -->
-              <!-- <tmp_policy>tmp</tmp_policy> -->
-
               <!-- Directory with user provided files that are accessible by 'file' table function. -->
               <user_files_path>/var/lib/clickhouse/user_files/</user_files_path>
 
-              <!-- LDAP server definitions. -->
-              <ldap_servers>
-                  <!-- List LDAP servers with their connection parameters here to later 1) use them as
-                  authenticators for dedicated local users,
-                        who have 'ldap' authentication mechanism specified instead of 'password', or to 2) use them as
-                  remote user directories.
-                      Parameters:
-                          host - LDAP server hostname or IP, this parameter is mandatory and cannot be empty.
-                          port - LDAP server port, default is 636 if enable_tls is set to true, 389 otherwise.
-                          bind_dn - template used to construct the DN to bind to.
-                                  The resulting DN will be constructed by replacing all '{user_name}' substrings of the template with
-                  the actual
-                                  user name during each authentication attempt.
-                          user_dn_detection - section with LDAP search parameters for detecting the actual user DN of the
-                  bound user.
-                                  This is mainly used in search filters for further role mapping when the server is Active Directory.
-                  The
-                                  resulting user DN will be used when replacing '{user_dn}' substrings wherever they are allowed. By
-                  default,
-                                  user DN is set equal to bind DN, but once search is performed, it will be updated with to the
-                  actual detected
-                                  user DN value.
-                              base_dn - template used to construct the base DN for the LDAP search.
-                                      The resulting DN will be constructed by replacing all '{user_name}' and '{bind_dn}' substrings
-                                      of the template with the actual user name and bind DN during the LDAP search.
-                              scope - scope of the LDAP search.
-                                      Accepted values are: 'base', 'one_level', 'children', 'subtree' (the default).
-                              search_filter - template used to construct the search filter for the LDAP search.
-                                      The resulting filter will be constructed by replacing all '{user_name}', '{bind_dn}', and
-                  '{base_dn}'
-                                      substrings of the template with the actual user name, bind DN, and base DN during the LDAP search.
-                                      Note, that the special characters must be escaped properly in XML.
-                          verification_cooldown - a period of time, in seconds, after a successful bind attempt, during which
-                  a user will be assumed
-                                  to be successfully authenticated for all consecutive requests without contacting the LDAP server.
-                                  Specify 0 (the default) to disable caching and force contacting the LDAP server for each
-                  authentication request.
-                          enable_tls - flag to trigger use of secure connection to the LDAP server.
-                                  Specify 'no' for plain text (ldap://) protocol (not recommended).
-                                  Specify 'yes' for LDAP over SSL/TLS (ldaps://) protocol (recommended, the default).
-                                  Specify 'starttls' for legacy StartTLS protocol (plain text (ldap://) protocol, upgraded to TLS).
-                          tls_minimum_protocol_version - the minimum protocol version of SSL/TLS.
-                                  Accepted values are: 'ssl2', 'ssl3', 'tls1.0', 'tls1.1', 'tls1.2' (the default).
-                          tls_require_cert - SSL/TLS peer certificate verification behavior.
-                                  Accepted values are: 'never', 'allow', 'try', 'demand' (the default).
-                          tls_cert_file - path to certificate file.
-                          tls_key_file - path to certificate key file.
-                          tls_ca_cert_file - path to CA certificate file.
-                          tls_ca_cert_dir - path to the directory containing CA certificates.
-                          tls_cipher_suite - allowed cipher suite (in OpenSSL notation).
-                      Example:
-                          <my_ldap_server>
-                              <host>localhost</host>
-                              <port>636</port>
-                              <bind_dn>uid={user_name},ou=users,dc=example,dc=com</bind_dn>
-                              <verification_cooldown>300</verification_cooldown>
-                              <enable_tls>yes</enable_tls>
-                              <tls_minimum_protocol_version>tls1.2</tls_minimum_protocol_version>
-                              <tls_require_cert>demand</tls_require_cert>
-                              <tls_cert_file>/path/to/tls_cert_file</tls_cert_file>
-                              <tls_key_file>/path/to/tls_key_file</tls_key_file>
-                              <tls_ca_cert_file>/path/to/tls_ca_cert_file</tls_ca_cert_file>
-                              <tls_ca_cert_dir>/path/to/tls_ca_cert_dir</tls_ca_cert_dir>
-                  <tls_cipher_suite>ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:AES256-GCM-SHA384</tls_cipher_suite>
-                          </my_ldap_server>
-                      Example (typical Active Directory with configured user DN detection for further role mapping):
-                          <my_ad_server>
-                              <host>localhost</host>
-                              <port>389</port>
-                              <bind_dn>EXAMPLE\{user_name}</bind_dn>
-                              <user_dn_detection>
-                                  <base_dn>CN=Users,DC=example,DC=com</base_dn>
-                                  <search_filter>(&amp;(objectClass=user)(sAMAccountName={user_name}))</search_filter>
-                              </user_dn_detection>
-                              <enable_tls>no</enable_tls>
-                          </my_ad_server>
-                  -->
-              </ldap_servers>
-
-              <!-- To enable Kerberos authentication support for HTTP requests (GSS-SPNEGO), for those users
-              who are explicitly configured
-                    to authenticate via Kerberos, define a single 'kerberos' section here.
-                  Parameters:
-                      principal - canonical service principal name, that will be acquired and used when accepting
-              security contexts.
-                              This parameter is optional, if omitted, the default principal will be used.
-                              This parameter cannot be specified together with 'realm' parameter.
-                      realm - a realm, that will be used to restrict authentication to only those requests whose
-              initiator's realm matches it.
-                              This parameter is optional, if omitted, no additional filtering by realm will be applied.
-                              This parameter cannot be specified together with 'principal' parameter.
-                  Example:
-                      <kerberos />
-                  Example:
-                      <kerberos>
-                          <principal>HTTP/clickhouse.example.com@EXAMPLE.COM</principal>
-                      </kerberos>
-                  Example:
-                      <kerberos>
-                          <realm>EXAMPLE.COM</realm>
-                      </kerberos>
-              -->
-
-              <!-- Sources to read users, roles, access rights, profiles of settings, quotas. -->
               <user_directories>
                   <users_xml>
                       <!-- Path to configuration file with predefined users. -->
@@ -957,236 +243,22 @@ services:
                       <path>/var/lib/clickhouse/access/</path>
                   </local_directory>
 
-                  <!-- To add an LDAP server as a remote user directory of users that are not defined locally,
-                  define a single 'ldap' section
-                        with the following parameters:
-                          server - one of LDAP server names defined in 'ldap_servers' config section above.
-                                  This parameter is mandatory and cannot be empty.
-                          roles - section with a list of locally defined roles that will be assigned to each user retrieved
-                  from the LDAP server.
-                                  If no roles are specified here or assigned during role mapping (below), user will not be able to
-                  perform any
-                                  actions after authentication.
-                          role_mapping - section with LDAP search parameters and mapping rules.
-                                  When a user authenticates, while still bound to LDAP, an LDAP search is performed using
-                  search_filter and the
-                                  name of the logged in user. For each entry found during that search, the value of the specified
-                  attribute is
-                                  extracted. For each attribute value that has the specified prefix, the prefix is removed, and the
-                  rest of the
-                                  value becomes the name of a local role defined in ClickHouse, which is expected to be created
-                  beforehand by
-                                  CREATE ROLE command.
-                                  There can be multiple 'role_mapping' sections defined inside the same 'ldap' section. All of them
-                  will be
-                                  applied.
-                              base_dn - template used to construct the base DN for the LDAP search.
-                                      The resulting DN will be constructed by replacing all '{user_name}', '{bind_dn}', and '{user_dn}'
-                                      substrings of the template with the actual user name, bind DN, and user DN during each LDAP search.
-                              scope - scope of the LDAP search.
-                                      Accepted values are: 'base', 'one_level', 'children', 'subtree' (the default).
-                              search_filter - template used to construct the search filter for the LDAP search.
-                                      The resulting filter will be constructed by replacing all '{user_name}', '{bind_dn}', '{user_dn}',
-                  and
-                                      '{base_dn}' substrings of the template with the actual user name, bind DN, user DN, and base DN
-                  during
-                                      each LDAP search.
-                                      Note, that the special characters must be escaped properly in XML.
-                              attribute - attribute name whose values will be returned by the LDAP search. 'cn', by default.
-                              prefix - prefix, that will be expected to be in front of each string in the original list of
-                  strings returned by
-                                      the LDAP search. Prefix will be removed from the original strings and resulting strings will be
-                  treated
-                                      as local role names. Empty, by default.
-                      Example:
-                          <ldap>
-                              <server>my_ldap_server</server>
-                              <roles>
-                                  <my_local_role1 />
-                                  <my_local_role2 />
-                              </roles>
-                              <role_mapping>
-                                  <base_dn>ou=groups,dc=example,dc=com</base_dn>
-                                  <scope>subtree</scope>
-                                  <search_filter>(&amp;(objectClass=groupOfNames)(member={bind_dn}))</search_filter>
-                                  <attribute>cn</attribute>
-                                  <prefix>clickhouse_</prefix>
-                              </role_mapping>
-                          </ldap>
-                      Example (typical Active Directory with role mapping that relies on the detected user DN):
-                          <ldap>
-                              <server>my_ad_server</server>
-                              <role_mapping>
-                                  <base_dn>CN=Users,DC=example,DC=com</base_dn>
-                                  <attribute>CN</attribute>
-                                  <scope>subtree</scope>
-                                  <search_filter>(&amp;(objectClass=group)(member={user_dn}))</search_filter>
-                                  <prefix>clickhouse_</prefix>
-                              </role_mapping>
-                          </ldap>
-                  -->
               </user_directories>
 
-              <!-- Default profile of settings. -->
               <default_profile>default</default_profile>
 
-              <!-- Comma-separated list of prefixes for user-defined settings. -->
               <custom_settings_prefixes></custom_settings_prefixes>
 
-              <!-- System profile of settings. This settings are used by internal processes (Distributed DDL
-              worker and so on). -->
-              <!-- <system_profile>default</system_profile> -->
-
-              <!-- Buffer profile of settings.
-                  This settings are used by Buffer storage to flush data to the underlying table.
-                  Default: used from system_profile directive.
-              -->
-              <!-- <buffer_profile>default</buffer_profile> -->
-
-              <!-- Default database. -->
               <default_database>default</default_database>
 
-              <!-- Server time zone could be set here.
-
-                  Time zone is used when converting between String and DateTime types,
-                    when printing DateTime in text formats and parsing DateTime from text,
-                    it is used in date and time related functions, if specific time zone was not passed as an argument.
-
-                  Time zone is specified as identifier from IANA time zone database, like UTC or Africa/Abidjan.
-                  If not specified, system time zone at server startup is used.
-
-                  Please note, that server could display time zone alias instead of specified name.
-                  Example: W-SU is an alias for Europe/Moscow and Zulu is an alias for UTC.
-              -->
-              <!-- <timezone>Europe/Moscow</timezone> -->
-
-              <!-- You can specify umask here (see "man umask"). Server will apply it on startup.
-                  Number is always parsed as octal. Default umask is 027 (other users cannot read logs, data files,
-              etc; group can only read).
-              -->
-              <!-- <umask>022</umask> -->
-
-              <!-- Perform mlockall after startup to lower first queries latency
-                    and to prevent clickhouse executable from being paged out under high IO load.
-                  Enabling this option is recommended but will lead to increased startup time for up to a few
-              seconds.
-              -->
               <mlock_executable>true</mlock_executable>
 
               <!-- Reallocate memory for machine code ("text") using huge pages. Highly experimental. -->
               <remap_executable>false</remap_executable>
 
-              <![CDATA[
-                  Uncomment below in order to use JDBC table engine and function.
-
-                  To install and run JDBC bridge in background:
-                  * [Debian/Ubuntu]
-                    export MVN_URL=https://repo1.maven.org/maven2/ru/yandex/clickhouse/clickhouse-jdbc-bridge
-                    export PKG_VER=$(curl -sL $MVN_URL/maven-metadata.xml | grep '<release>' | sed -e 's|.*>\(.*\)<.*|\1|')
-                    wget https://github.com/ClickHouse/clickhouse-jdbc-bridge/releases/download/v$PKG_VER/clickhouse-jdbc-bridge_$PKG_VER-1_all.deb
-                    apt install --no-install-recommends -f ./clickhouse-jdbc-bridge_$PKG_VER-1_all.deb
-                    clickhouse-jdbc-bridge &
-
-                  * [CentOS/RHEL]
-                    export MVN_URL=https://repo1.maven.org/maven2/ru/yandex/clickhouse/clickhouse-jdbc-bridge
-                    export PKG_VER=$(curl -sL $MVN_URL/maven-metadata.xml | grep '<release>' | sed -e 's|.*>\(.*\)<.*|\1|')
-                    wget https://github.com/ClickHouse/clickhouse-jdbc-bridge/releases/download/v$PKG_VER/clickhouse-jdbc-bridge-$PKG_VER-1.noarch.rpm
-                    yum localinstall -y clickhouse-jdbc-bridge-$PKG_VER-1.noarch.rpm
-                    clickhouse-jdbc-bridge &
-
-                  Please refer to https://github.com/ClickHouse/clickhouse-jdbc-bridge#usage for more information.
-              ]]>
-              <!--
-              <jdbc_bridge>
-                  <host>127.0.0.1</host>
-                  <port>9019</port>
-              </jdbc_bridge>
-              -->
-
-              <!-- Configuration of clusters that could be used in Distributed tables.
-                  https://clickhouse.com/docs/en/operations/table_engines/distributed/
-                -->
-              <remote_servers>
-
-                  <!-- Test only shard config for testing distributed storage -->
-                  <posthog>
-                      <!-- Inter-server per-cluster secret for Distributed queries
-                          default: no secret (no authentication will be performed)
-
-                          If set, then Distributed queries will be validated on shards, so at least:
-                          - such cluster should exist on the shard,
-                          - such cluster should have the same secret.
-
-                          And also (and which is more important), the initial_user will
-                          be used as current user for the query.
-
-                          Right now the protocol is pretty simple and it only takes into account:
-                          - cluster name
-                          - query
-
-                          Also it will be nice if the following will be implemented:
-                          - source hostname (see interserver_http_host), but then it will depends from DNS,
-                            it can use IP address instead, but then the you need to get correct on the initiator node.
-                          - target hostname / ip address (same notes as for source hostname)
-                          - time-based security tokens
-                      -->
-                      <!-- <secret></secret> -->
-
-                      <shard>
-                          <!-- Optional. Whether to write data to just one of the replicas. Default: false
-                          (write data to all replicas). -->
-                          <!-- <internal_replication>false</internal_replication> -->
-                          <!-- Optional. Shard weight when writing data. Default: 1. -->
-                          <!-- <weight>1</weight> -->
-                          <replica>
-                              <host>localhost</host>
-                              <port>9000</port>
-                              <!-- Optional. Priority of the replica for load_balancing. Default: 1 (less
-                              value has more priority). -->
-                              <!-- <priority>1</priority> -->
-                          </replica>
-                      </shard>
-                  </posthog>
-              </remote_servers>
-
-              <!-- The list of hosts allowed to use in URL-related storage engines and table functions.
-                  If this section is not present in configuration, all hosts are allowed.
-              -->
               <remote_url_allow_hosts>
-                  <!-- Host should be specified exactly as in URL. The name is checked before DNS resolution.
-                      Example: "yandex.ru", "yandex.ru." and "www.yandex.ru" are different hosts.
-                              If port is explicitly specified in URL, the host:port is checked as a whole.
-                              If host specified here without port, any port with this host allowed.
-                              "yandex.ru" -> "yandex.ru:443", "yandex.ru:80" etc. is allowed, but "yandex.ru:80" -> only
-                  "yandex.ru:80" is allowed.
-                      If the host is specified as IP address, it is checked as specified in URL. Example:
-                  "[2a02:6b8:a::a]".
-                      If there are redirects and support for redirects is enabled, every redirect (the Location field) is
-                  checked.
-                      Host should be specified using the host xml tag:
-                              <host>yandex.ru</host>
-                  -->
-
-                  <!-- Regular expression can be specified. RE2 engine is used for regexps.
-                      Regexps are not aligned: don't forget to add ^ and $. Also don't forget to escape dot (.)
-                  metacharacter
-                      (forgetting to do so is a common source of error).
-                  -->
                   <host_regexp>.*</host_regexp>
               </remote_url_allow_hosts>
-
-              <!-- If element has 'incl' attribute, then for it's value will be used corresponding
-              substitution from another file.
-                  By default, path to file with substitutions is /etc/metrika.xml. It could be changed in config in
-              'include_from' element.
-                  Values for substitutions are specified in /clickhouse/name_of_substitution elements in that file.
-                -->
-
-              <!-- ZooKeeper is used to store metadata about replicas, when using Replicated tables.
-                  Optional. If you don't use replicated tables, you could omit that.
-
-                  See https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/replication/
-                -->
 
               <zookeeper>
                   <node>
@@ -1195,22 +267,8 @@ services:
                   </node>
               </zookeeper>
 
-              <!-- Substitutions for parameters of replicated tables.
-                    Optional. If you don't use replicated tables, you could omit that.
-
-                  See
-              https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/replication/#creating-replicated-tables
-                -->
-
-              <macros>
-                  <shard>01</shard>
-                  <replica>ch1</replica>
-              </macros>
-
-
               <!-- Reloading interval for embedded dictionaries, in seconds. Default: 3600. -->
               <builtin_dictionaries_reload_interval>3600</builtin_dictionaries_reload_interval>
-
 
               <!-- Maximum session timeout, in seconds. Default: 3600. -->
               <max_session_timeout>3600</max_session_timeout>
@@ -1218,153 +276,72 @@ services:
               <!-- Default session timeout, in seconds. Default: 60. -->
               <default_session_timeout>60</default_session_timeout>
 
-              <!-- Sending data to Graphite for monitoring. Several sections can be defined. -->
-              <!--
-                  interval - send every X second
-                  root_path - prefix for keys
-                  hostname_in_path - append hostname to root_path (default = true)
-                  metrics - send data from table system.metrics
-                  events - send data from table system.events
-                  asynchronous_metrics - send data from table system.asynchronous_metrics
-              -->
-              <!--
-              <graphite>
-                  <host>localhost</host>
-                  <port>42000</port>
-                  <timeout>0.1</timeout>
-                  <interval>60</interval>
-                  <root_path>one_min</root_path>
-                  <hostname_in_path>true</hostname_in_path>
-
-                  <metrics>true</metrics>
-                  <events>true</events>
-                  <events_cumulative>false</events_cumulative>
-                  <asynchronous_metrics>true</asynchronous_metrics>
-              </graphite>
-              <graphite>
-                  <host>localhost</host>
-                  <port>42000</port>
-                  <timeout>0.1</timeout>
-                  <interval>1</interval>
-                  <root_path>one_sec</root_path>
-
-                  <metrics>true</metrics>
-                  <events>true</events>
-                  <events_cumulative>false</events_cumulative>
-                  <asynchronous_metrics>false</asynchronous_metrics>
-              </graphite>
-              -->
-
-              <!-- Serve endpoint for Prometheus monitoring. -->
-              <!--
-                  endpoint - mertics path (relative to root, statring with "/")
-                  port - port to setup server. If not defined or 0 than http_port used
-                  metrics - send data from table system.metrics
-                  events - send data from table system.events
-                  asynchronous_metrics - send data from table system.asynchronous_metrics
-                  status_info - send data from different component from CH, ex: Dictionaries status
-              -->
-              <!--
-              <prometheus>
-                  <endpoint>/metrics</endpoint>
-                  <port>9363</port>
-
-                  <metrics>true</metrics>
-                  <events>true</events>
-                  <asynchronous_metrics>true</asynchronous_metrics>
-                  <status_info>true</status_info>
-              </prometheus>
-              -->
-
               <!-- Query log. Used only for queries with setting log_queries = 1. -->
               <query_log>
                   <!-- What table to insert data. If table is not exist, it will be created.
-                      When query log structure is changed after system update,
+                       When query log structure is changed after system update,
                         then old table will be renamed and new table will be created automatically.
                   -->
                   <database>system</database>
                   <table>query_log</table>
-                  <!--
-                      PARTITION BY expr:
-                  https://clickhouse.com/docs/en/table_engines/mergetree-family/custom_partitioning_key/
-                      Example:
-                          event_date
-                          toMonday(event_date)
-                          toYYYYMM(event_date)
-                          toStartOfHour(event_time)
-                  -->
                   <partition_by>toYYYYMM(event_date)</partition_by>
-                  <!--
-                      Table TTL specification:
-                  https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/mergetree/#mergetree-table-ttl
-                      Example:
-                          event_date + INTERVAL 1 WEEK
-                          event_date + INTERVAL 7 DAY DELETE
-                          event_date + INTERVAL 2 WEEK TO DISK 'bbb'
-
-                  <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
-                  -->
-
-                  <!-- Instead of partition_by, you can provide full engine expression (starting with ENGINE =
-                  ) with parameters,
-                      Example: <engine>ENGINE = MergeTree PARTITION BY toYYYYMM(event_date) ORDER BY (event_date,
-                  event_time) SETTINGS index_granularity = 1024</engine>
-                    -->
 
                   <!-- Interval of flushing data. -->
-                  <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+                  <flush_interval_milliseconds>500</flush_interval_milliseconds>
+                  <!-- Maximal size in lines for the logs. When non-flushed logs amount reaches max_size, logs dumped to the disk. -->
+                  <max_size_rows>8388608</max_size_rows>
+                  <!-- Pre-allocated size in lines for the logs. -->
+                  <reserved_size_rows>8192</reserved_size_rows>
+                  <!-- Lines amount threshold, reaching it launches flushing logs to the disk in background. -->
+                  <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
+                  <!-- Indication whether logs should be dumped to the disk in case of a crash -->
+                  <flush_on_crash>true</flush_on_crash>
+
+                  <!-- example of using a different storage policy for a system table -->
+                  <!-- storage_policy>local_ssd</storage_policy -->
+
+                  <ttl>event_date + INTERVAL 12 DAY</ttl>
+                  <ttl_only_drop_parts>1</ttl_only_drop_parts>
               </query_log>
 
-              <!-- Trace log. Stores stack traces collected by query profilers.
-                  See query_profiler_real_time_period_ns and query_profiler_cpu_time_period_ns settings. -->
-              <trace_log>
-                  <database>system</database>
-                  <table>trace_log</table>
-
-                  <partition_by>toYYYYMM(event_date)</partition_by>
-                  <flush_interval_milliseconds>7500</flush_interval_milliseconds>
-              </trace_log>
-
               <!-- Query thread log. Has information about all threads participated in query execution.
-                  Used only for queries with setting log_query_threads = 1. -->
+                   Used only for queries with setting log_query_threads = 1. -->
               <query_thread_log>
                   <database>system</database>
                   <table>query_thread_log</table>
                   <partition_by>toYYYYMM(event_date)</partition_by>
                   <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+                  <max_size_rows>8388608</max_size_rows>
+                  <reserved_size_rows>8192</reserved_size_rows>
+                  <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
+                  <flush_on_crash>false</flush_on_crash>
+
+                  <ttl>event_date + INTERVAL 5 DAY</ttl>
+                  <ttl_only_drop_parts>1</ttl_only_drop_parts>
               </query_thread_log>
 
               <!-- Query views log. Has information about all dependent views associated with a query.
-                  Used only for queries with setting log_query_views = 1. -->
+                   Used only for queries with setting log_query_views = 1. -->
               <query_views_log>
                   <database>system</database>
                   <table>query_views_log</table>
                   <partition_by>toYYYYMM(event_date)</partition_by>
                   <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+
+                  <ttl>event_date + INTERVAL 5 DAY</ttl>
+                  <ttl_only_drop_parts>1</ttl_only_drop_parts>
               </query_views_log>
 
-              <!-- Uncomment if use part log.
-                  Part log contains information about all actions with parts in MergeTree tables (creation, deletion,
-              merges, downloads).-->
-              <part_log>
-                  <database>system</database>
-                  <table>part_log</table>
-                  <partition_by>toYYYYMM(event_date)</partition_by>
-                  <flush_interval_milliseconds>7500</flush_interval_milliseconds>
-              </part_log>
 
-              <!-- Uncomment to write text log into table.
-                  Text log contains all information from usual server log but stores it in structured and efficient
-              way.
-                  The level of the messages that goes to the table can be limited (<level>), if not specified all
-              messages will go to the table.
               <text_log>
                   <database>system</database>
                   <table>text_log</table>
                   <flush_interval_milliseconds>7500</flush_interval_milliseconds>
-                  <level></level>
+                  <level>trace</level>
+
+                  <ttl>event_date + INTERVAL 5 DAY</ttl>
+                  <ttl_only_drop_parts>1</ttl_only_drop_parts>
               </text_log>
-              -->
 
               <!-- Metric log contains rows with current values of ProfileEvents, CurrentMetrics collected
               with "collect_interval_milliseconds" interval. -->
@@ -1373,6 +350,9 @@ services:
                   <table>metric_log</table>
                   <flush_interval_milliseconds>7500</flush_interval_milliseconds>
                   <collect_interval_milliseconds>1000</collect_interval_milliseconds>
+
+                  <ttl>event_date + INTERVAL 5 DAY</ttl>
+                  <ttl_only_drop_parts>1</ttl_only_drop_parts>
               </metric_log>
 
               <!--
@@ -1387,6 +367,9 @@ services:
                       no need to flush more often.
                   -->
                   <flush_interval_milliseconds>7000</flush_interval_milliseconds>
+
+                  <ttl>event_date + INTERVAL 5 DAY</ttl>
+                  <ttl_only_drop_parts>1</ttl_only_drop_parts>
               </asynchronous_metric_log>
 
               <!--
@@ -1415,13 +398,17 @@ services:
 
 
               <!-- Crash log. Stores stack traces for fatal errors.
-                  This table is normally empty. -->
+                   This table is normally empty. -->
               <crash_log>
                   <database>system</database>
                   <table>crash_log</table>
 
                   <partition_by />
                   <flush_interval_milliseconds>1000</flush_interval_milliseconds>
+                  <max_size_rows>1024</max_size_rows>
+                  <reserved_size_rows>1024</reserved_size_rows>
+                  <buffer_size_rows_flush_threshold>512</buffer_size_rows_flush_threshold>
+                  <flush_on_crash>true</flush_on_crash>
               </crash_log>
 
               <!-- Session log. Stores user log in (successful or not) and log out events. -->
@@ -1431,26 +418,26 @@ services:
 
                   <partition_by>toYYYYMM(event_date)</partition_by>
                   <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+
+                  <ttl>event_date + INTERVAL 5 DAY</ttl>
+                  <ttl_only_drop_parts>1</ttl_only_drop_parts>
               </session_log>
 
-              <!-- Parameters for embedded dictionaries, used in Yandex.Metrica.
-                  See https://clickhouse.com/docs/en/dicts/internal_dicts/
-              -->
+              <backup_log>
+                  <database>system</database>
+                  <table>backup_log</table>
+                  <partition_by>toYYYYMM(event_date)</partition_by>
+                  <flush_interval_milliseconds>7500</flush_interval_milliseconds>
 
-              <!-- Path to file with region hierarchy. -->
-              <!--
-              <path_to_regions_hierarchy_file>/opt/geo/regions_hierarchy.txt</path_to_regions_hierarchy_file> -->
+                  <ttl>event_date + INTERVAL 5 DAY</ttl>
+                  <ttl_only_drop_parts>1</ttl_only_drop_parts>
+              </backup_log>
 
-              <!-- Path to directory with files containing names of regions -->
-              <!-- <path_to_regions_names_files>/opt/geo/</path_to_regions_names_files> -->
-
-
-              <!-- <top_level_domains_path>/var/lib/clickhouse/top_level_domains/</top_level_domains_path> -->
               <!-- Custom TLD lists.
-                  Format: <name>/path/to/file</name>
+                   Format: <name>/path/to/file</name>
 
-                  Changes will not be applied w/o server restart.
-                  Path to the list is under top_level_domains_path (see above).
+                   Changes will not be applied w/o server restart.
+                   Path to the list is under top_level_domains_path (see above).
               -->
               <top_level_domains_lists>
                   <!--
@@ -1459,108 +446,17 @@ services:
               </top_level_domains_lists>
 
               <!-- Configuration of external dictionaries. See:
-                  https://clickhouse.com/docs/en/sql-reference/dictionaries/external-dictionaries/external-dicts
+                   https://clickhouse.com/docs/en/sql-reference/dictionaries/external-dictionaries/external-dicts
               -->
               <dictionaries_config>*_dictionary.xml</dictionaries_config>
 
               <!-- Configuration of user defined executable functions -->
               <user_defined_executable_functions_config>*_function.xml</user_defined_executable_functions_config>
 
-              <!-- Uncomment if you want data to be compressed 30-100% better.
-                  Don't do that if you just started using ClickHouse.
-                -->
-              <!--
-              <compression>
-                  <!- - Set of variants. Checked in order. Last matching case wins. If nothing matches, lz4 will be
-              used. - ->
-                  <case>
-
-                      <!- - Conditions. All must be satisfied. Some conditions may be omitted. - ->
-                      <min_part_size>10000000000</min_part_size>        <!- - Min part size in bytes. - ->
-                      <min_part_size_ratio>0.01</min_part_size_ratio>   <!- - Min size of part relative to whole table
-              size. - ->
-
-                      <!- - What compression method to use. - ->
-                      <method>zstd</method>
-                  </case>
-              </compression>
-              -->
-
-              <!-- Configuration of encryption. The server executes a command to
-                  obtain an encryption key at startup if such a command is
-                  defined, or encryption codecs will be disabled otherwise. The
-                  command is executed through /bin/sh and is expected to write
-                  a Base64-encoded key to the stdout. -->
-              <encryption_codecs>
-                  <!-- aes_128_gcm_siv -->
-                  <!-- Example of getting hex key from env -->
-                  <!-- the code should use this key and throw an exception if its length is not 16 bytes -->
-                  <!--key_hex
-                  from_env="..."></key_hex -->
-
-                  <!-- Example of multiple hex keys. They can be imported from env or be written down in
-                  config-->
-                  <!-- the code should use these keys and throw an exception if their length is not 16 bytes -->
-                  <!-- key_hex id="0">...</key_hex -->
-                  <!-- key_hex id="1" from_env=".."></key_hex -->
-                  <!-- key_hex id="2">...</key_hex -->
-                  <!-- current_key_id>2</current_key_id -->
-
-                  <!-- Example of getting hex key from config -->
-                  <!-- the code should use this key and throw an exception if its length is not 16 bytes -->
-                  <!-- key>...</key -->
-
-                  <!-- example of adding nonce -->
-                  <!-- nonce>...</nonce -->
-
-                  <!-- /aes_128_gcm_siv -->
-              </encryption_codecs>
-
-              <!-- Allow to execute distributed DDL queries (CREATE, DROP, ALTER, RENAME) on cluster.
-                  Works only if ZooKeeper is enabled. Comment it if such functionality isn't required. -->
               <distributed_ddl>
                   <!-- Path in ZooKeeper to queue with DDL queries -->
                   <path>/clickhouse/task_queue/ddl</path>
-
-                  <!-- Settings from this profile will be used to execute DDL queries -->
-                  <!-- <profile>default</profile> -->
-
-                  <!-- Controls how much ON CLUSTER queries can be run simultaneously. -->
-                  <!-- <pool_size>1</pool_size> -->
-
-                  <!--
-                      Cleanup settings (active tasks will not be removed)
-                  -->
-
-                  <!-- Controls task TTL (default 1 week) -->
-                  <!-- <task_max_lifetime>604800</task_max_lifetime> -->
-
-                  <!-- Controls how often cleanup should be performed (in seconds) -->
-                  <!-- <cleanup_delay_period>60</cleanup_delay_period> -->
-
-                  <!-- Controls how many tasks could be in the queue -->
-                  <!-- <max_tasks_in_queue>1000</max_tasks_in_queue> -->
               </distributed_ddl>
-
-              <!-- Settings to fine tune MergeTree tables. See documentation in source code, in
-              MergeTreeSettings.h -->
-              <!--
-              <merge_tree>
-                  <max_suspicious_broken_parts>5</max_suspicious_broken_parts>
-              </merge_tree>
-              -->
-
-              <!-- Protection from accidental DROP.
-                  If size of a MergeTree table is greater than max_table_size_to_drop (in bytes) than table could not
-              be dropped with any DROP query.
-                  If you want do delete one table and don't want to change clickhouse-server config, you could create
-              special file <clickhouse-path>/flags/force_drop_table and make DROP once.
-                  By default max_table_size_to_drop is 50GB; max_table_size_to_drop=0 allows to DROP any tables.
-                  The same for max_partition_size_to_drop.
-                  Uncomment to disable protection.
-              -->
-              <!-- <max_table_size_to_drop>0</max_table_size_to_drop> -->
-              <!-- <max_partition_size_to_drop>0</max_partition_size_to_drop> -->
 
               <!-- Example of parameters for GraphiteMergeTree table engine -->
               <graphite_rollup_example>
@@ -1594,7 +490,7 @@ services:
               </graphite_rollup_example>
 
               <!-- Directory in <clickhouse-path> containing schema files for various input formats.
-                  The directory will be created if it doesn't exist.
+                   The directory will be created if it doesn't exist.
                 -->
               <format_schema_path>/var/lib/clickhouse/format_schemas/</format_schema_path>
 
@@ -1616,96 +512,16 @@ services:
                   </rule>
               </query_masking_rules>
 
-              <!-- Uncomment to use custom http handlers.
-                  rules are checked from top to bottom, first match runs the handler
-                      url - to match request URL, you can use 'regex:' prefix to use regex match(optional)
-                      methods - to match request method, you can use commas to separate multiple method matches(optional)
-                      headers - to match request headers, match each child element(child element name is header name),
-              you can use 'regex:' prefix to use regex match(optional)
-                  handler is request handler
-                      type - supported types: static, dynamic_query_handler, predefined_query_handler
-                      query - use with predefined_query_handler type, executes query when the handler is called
-                      query_param_name - use with dynamic_query_handler type, extracts and executes the value
-              corresponding to the <query_param_name> value in HTTP request params
-                      status - use with static type, response status code
-                      content_type - use with static type, response content-type
-                      response_content - use with static type, Response content sent to client, when using the prefix
-              'file://' or 'config://', find the content from the file or configuration send to client.
-
-              <http_handlers>
-                  <rule>
-                      <url>/</url>
-                      <methods>POST,GET</methods>
-                      <headers><pragma>no-cache</pragma></headers>
-                      <handler>
-                          <type>dynamic_query_handler</type>
-                          <query_param_name>query</query_param_name>
-                      </handler>
-                  </rule>
-
-                  <rule>
-                      <url>/predefined_query</url>
-                      <methods>POST,GET</methods>
-                      <handler>
-                          <type>predefined_query_handler</type>
-                          <query>SELECT * FROM system.settings</query>
-                      </handler>
-                  </rule>
-
-                  <rule>
-                      <handler>
-                          <type>static</type>
-                          <status>200</status>
-                          <content_type>text/plain; charset=UTF-8</content_type>
-                          <response_content>config://http_server_default_response</response_content>
-                      </handler>
-                  </rule>
-              </http_handlers>
-              -->
-
-              <send_crash_reports>
-                  <!-- Changing <enabled> to true allows sending crash reports to -->
-                  <!-- the ClickHouse core developers team via Sentry https://sentry.io -->
-                  <!-- Doing so at least in pre-production environments is highly appreciated -->
-                  <enabled>false</enabled>
-                  <!-- Change <anonymize> to true if you don't feel comfortable attaching the server hostname
-                  to the crash report -->
-                  <anonymize>false</anonymize>
-                  <!-- Default endpoint should be changed to different Sentry DSN only if you have -->
-                  <!-- some in-house engineers or hired consultants who're going to debug ClickHouse issues
-                  for you -->
-                  <endpoint>https://6f33034cfe684dd7a3ab9875e57b1c8d@o388870.ingest.sentry.io/5226277</endpoint>
-              </send_crash_reports>
-
-              <!-- Uncomment to disable ClickHouse internal DNS caching. -->
-              <!-- <disable_internal_dns_cache>1</disable_internal_dns_cache> -->
-
-              <!-- You can also configure rocksdb like this: -->
-              <!--
-              <rocksdb>
-                  <options>
-                      <max_background_jobs>8</max_background_jobs>
-                  </options>
-                  <column_family_options>
-                      <num_levels>2</num_levels>
-                  </column_family_options>
-                  <tables>
-                      <table>
-                          <name>TABLE</name>
-                          <options>
-                              <max_background_jobs>8</max_background_jobs>
-                          </options>
-                          <column_family_options>
-                              <num_levels>2</num_levels>
-                          </column_family_options>
-                      </table>
-                  </tables>
-              </rocksdb>
-              -->
-          </yandex>
+              <merge_tree>
+                  <max_bytes_to_merge_at_max_space_in_pool>1073741824</max_bytes_to_merge_at_max_space_in_pool>
+                  <number_of_free_entries_in_pool_to_execute_mutation>2</number_of_free_entries_in_pool_to_execute_mutation>
+                  <number_of_free_entries_in_pool_to_execute_optimize_entire_partition>2</number_of_free_entries_in_pool_to_execute_optimize_entire_partition>
+              </merge_tree>
+          </clickhouse>
       - type: bind
-        source: ./docker/clickhouse/users.xml
+        source: ./clickhouse/users.xml
         target: /etc/clickhouse-server/users.xml
+        read_only: true
         content: |
           <?xml version="1.0"?>
           <yandex>
@@ -1718,18 +534,30 @@ services:
                       <!-- Maximum memory usage for processing single query, in bytes. -->
                       <max_memory_usage>10000000000</max_memory_usage>
 
+
                       <!-- How to choose between replicas during distributed query processing.
-                          random - choose random replica from set of replicas with minimum number of errors
-                          nearest_hostname - from set of replicas with minimum number of errors, choose replica
+                           random - choose random replica from set of replicas with minimum number of errors
+                           nearest_hostname - from set of replicas with minimum number of errors, choose replica
                             with minimum number of different symbols between replica's hostname and local hostname
                             (Hamming distance).
-                          in_order - first live replica is chosen in specified order.
-                          first_or_random - if first replica one has higher number of errors, pick a random one from replicas
+                           in_order - first live replica is chosen in specified order.
+                           first_or_random - if first replica one has higher number of errors, pick a random one from replicas
                       with minimum number of errors.
                       -->
                       <load_balancing>random</load_balancing>
 
                       <allow_nondeterministic_mutations>1</allow_nondeterministic_mutations>
+
+                      <enable_analyzer>0</enable_analyzer>
+                      <compatibility>25.6</compatibility>
+                      <distributed_product_mode>global</distributed_product_mode>
+                      <enable_parallel_replicas>0</enable_parallel_replicas>
+                      <max_parallel_replicas>1</max_parallel_replicas>
+                      <allow_experimental_window_functions>1</allow_experimental_window_functions>
+                      <allow_suspicious_low_cardinality_types>1</allow_suspicious_low_cardinality_types>
+                      <insert_distributed_sync>1</insert_distributed_sync>
+                      <throw_on_max_partitions_per_insert_block>false</throw_on_max_partitions_per_insert_block>
+                      <number_of_mutations_to_throw>1</number_of_mutations_to_throw>
 
                   </default>
 
@@ -1737,6 +565,14 @@ services:
                   <readonly>
                       <readonly>1</readonly>
                   </readonly>
+
+                  <api>
+                      <profile>default</profile>
+                  </api>
+
+                  <app>
+                      <profile>default</profile>
+                  </app>
 
               </profiles>
 
@@ -1746,70 +582,70 @@ services:
                   <default>
                       <!-- See also the files in users.d directory where the password can be overridden.
 
-                          Password could be specified in plaintext or in SHA256 (in hex format).
+                           Password could be specified in plaintext or in SHA256 (in hex format).
 
-                          If you want to specify password in plaintext (not recommended), place it in 'password' element.
-                          Example: <password>qwerty</password>.
-                          Password could be empty.
+                           If you want to specify password in plaintext (not recommended), place it in 'password' element.
+                           Example: <password>qwerty</password>.
+                           Password could be empty.
 
-                          If you want to specify SHA256, place it in 'password_sha256_hex' element.
-                          Example:
+                           If you want to specify SHA256, place it in 'password_sha256_hex' element.
+                           Example:
                       <password_sha256_hex>65e84be33532fb784c48129675f9eff3a682b27168c0ea744b2cf58ee02337c5</password_sha256_hex>
-                          Restrictions of SHA256: impossibility to connect to ClickHouse using MySQL JS client (as of July
+                           Restrictions of SHA256: impossibility to connect to ClickHouse using MySQL JS client (as of July
                       2019).
 
-                          If you want to specify double SHA1, place it in 'password_double_sha1_hex' element.
-                          Example:
+                           If you want to specify double SHA1, place it in 'password_double_sha1_hex' element.
+                           Example:
                       <password_double_sha1_hex>e395796d6546b1b65db9d665cd43f0e858dd4303</password_double_sha1_hex>
 
-                          If you want to specify a previously defined LDAP server (see 'ldap_servers' in the main config) for
+                           If you want to specify a previously defined LDAP server (see 'ldap_servers' in the main config) for
                       authentication,
                             place its name in 'server' element inside 'ldap' element.
-                          Example: <ldap><server>my_ldap_server</server></ldap>
+                           Example: <ldap><server>my_ldap_server</server></ldap>
 
-                          If you want to authenticate the user via Kerberos (assuming Kerberos is enabled, see 'kerberos' in
+                           If you want to authenticate the user via Kerberos (assuming Kerberos is enabled, see 'kerberos' in
                       the main config),
                             place 'kerberos' element instead of 'password' (and similar) elements.
-                          The name part of the canonical principal name of the initiator must match the user name for
+                           The name part of the canonical principal name of the initiator must match the user name for
                       authentication to succeed.
-                          You can also place 'realm' element inside 'kerberos' element to further restrict authentication to
+                           You can also place 'realm' element inside 'kerberos' element to further restrict authentication to
                       only those requests
                             whose initiator's realm matches it.
-                          Example: <kerberos />
-                          Example: <kerberos><realm>EXAMPLE.COM</realm></kerberos>
+                           Example: <kerberos />
+                           Example: <kerberos><realm>EXAMPLE.COM</realm></kerberos>
 
-                          How to generate decent password:
-                          Execute: PASSWORD=$(base64 < /dev/urandom | head -c8); echo "$PASSWORD"; echo -n "$PASSWORD" |
+                           How to generate decent password:
+                           Execute: PASSWORD=$(base64 < /dev/urandom | head -c8); echo "$PASSWORD"; echo -n "$PASSWORD" |
                       sha256sum | tr -d '-'
-                          In first line will be password and in second - corresponding SHA256.
+                           In first line will be password and in second - corresponding SHA256.
 
-                          How to generate double SHA1:
-                          Execute: PASSWORD=$(base64 < /dev/urandom | head -c8); echo "$PASSWORD"; echo -n "$PASSWORD" |
+                           How to generate double SHA1:
+                           Execute: PASSWORD=$(base64 < /dev/urandom | head -c8); echo "$PASSWORD"; echo -n "$PASSWORD" |
                       sha1sum | tr -d '-' | xxd -r -p | sha1sum | tr -d '-'
-                          In first line will be password and in second - corresponding double SHA1.
+                           In first line will be password and in second - corresponding double SHA1.
                       -->
                       <password></password>
 
                       <!-- List of networks with open access.
 
-                          To open access from everywhere, specify:
+                           To open access from everywhere, specify:
                               <ip>::/0</ip>
 
-                          To open access only from localhost, specify:
+                           To open access only from localhost, specify:
                               <ip>::1</ip>
                               <ip>127.0.0.1</ip>
 
-                          Each element of list has one of the following forms:
-                          <ip> IP-address or network mask. Examples: 213.180.204.3 or 10.0.0.1/8 or 10.0.0.1/255.255.255.0
-                              2a02:6b8::3 or 2a02:6b8::3/64 or 2a02:6b8::3/ffff:ffff:ffff:ffff::.
-                          <host> Hostname. Example: server01.yandex.ru.
-                              To check access, DNS query is performed, and all received addresses compared to peer address.
-                          <host_regexp> Regular expression for host names. Example, ^server\d\d-\d\d-\d\.yandex\.ru$
-                              To check access, DNS PTR query is performed for peer address and then regexp is applied.
-                              Then, for result of PTR query, another DNS query is performed and all received addresses compared
+                           Each element of list has one of the following forms:
+                           <ip> IP-address or network mask. Examples: 213.180.204.3 or 10.0.0.1/8 or 10.0.0.1/255.255.255.0
+                               2a02:6b8::3 or 2a02:6b8::3/64 or 2a02:6b8::3/ffff:ffff:ffff:ffff::.
+                           <host> Hostname. Example: server01.yandex.ru.
+                               To check access, DNS query is performed, and all received addresses compared to peer address.
+                           <host_regexp> Regular expression for host names. Example, ^server\d\d-\d\d-\d\.yandex\.ru$
+                               To check access, DNS PTR query is performed for peer address and then regexp is applied.
+                               Then, for result of PTR query, another DNS query is performed and all received addresses compared
                       to peer address.
-                              Strongly recommended that regexp is ends with $
-                          All results of DNS requests are cached till server restart.
+                               Strongly recommended that regexp is ends with $
+                           All results of DNS requests are cached till server restart.
                       -->
                       <networks>
                           <ip>::/0</ip>
@@ -1822,8 +658,35 @@ services:
                       <quota>default</quota>
 
                       <!-- User can create other users and grant rights to them. -->
-                      <!-- <access_management>1</access_management> -->
+                      <access_management>1</access_management>
+                      <named_collection_control>1</named_collection_control>
+                      <show_named_collections>1</show_named_collections>
+                      <show_named_collections_secrets>1</show_named_collections_secrets>
                   </default>
+
+                  <api>
+                      <password>apipass</password>
+
+                      <networks>
+                          <ip>::/0</ip>
+                      </networks>
+
+                      <profile>api</profile>
+
+                      <quota>default</quota>
+                  </api>
+
+                  <app>
+                      <password>apppass</password>
+
+                      <networks>
+                          <ip>::/0</ip>
+                      </networks>
+
+                      <profile>app</profile>
+
+                      <quota>default</quota>
+                  </app>
               </users>
 
               <!-- Quotas. -->
@@ -1845,287 +708,1015 @@ services:
                   </default>
               </quotas>
           </yandex>
-      - clickhouse-data:/var/lib/clickhouse
-    depends_on:
-      - kafka
-      - zookeeper
+      - type: bind
+        source: ./clickhouse/config.d/default.xml
+        target: /etc/clickhouse-server/config.d/default.xml
+        read_only: true
+        content: |
+          <clickhouse>
+              <tcp_port>9000</tcp_port>
 
-  zookeeper:
-    image: zookeeper:3.7.0
-    volumes:
-      - zookeeper-datalog:/datalog
-      - zookeeper-data:/data
-      - zookeeper-logs:/logs
+              <remote_servers>
+                  <posthog>
+                      <shard>
+                          <replica>
+                              <host>clickhouse</host>
+                              <port>9000</port>
+                          </replica>
+                      </shard>
+                  </posthog>
+                  <posthog_single_shard>
+                      <shard>
+                          <replica>
+                              <host>clickhouse</host>
+                              <port>9000</port>
+                          </replica>
+                      </shard>
+                  </posthog_single_shard>
+                  <posthog_migrations>
+                      <shard>
+                          <replica>
+                              <host>clickhouse</host>
+                              <port>9000</port>
+                          </replica>
+                      </shard>
+                  </posthog_migrations>
+                  <posthog_writable>
+                      <shard>
+                          <replica>
+                              <host>clickhouse</host>
+                              <port>9000</port>
+                          </replica>
+                      </shard>
+                  </posthog_writable>
+                  <posthog_primary_replica>
+                      <shard>
+                          <replica>
+                              <host>clickhouse</host>
+                              <port>9000</port>
+                          </replica>
+                      </shard>
+                  </posthog_primary_replica>
+              </remote_servers>
+
+              <named_collections>
+                  <msk_cluster>
+                      <kafka_broker_list from_env="KAFKA_HOSTS"/>
+                  </msk_cluster>
+                  <warpstream_ingestion>
+                      <kafka_broker_list from_env="KAFKA_HOSTS"/>
+                  </warpstream_ingestion>
+              </named_collections>
+
+              <macros>
+                  <shard>01</shard>
+                  <replica>ch1</replica>
+                  <hostClusterType>online</hostClusterType>
+                  <hostClusterRole>data</hostClusterRole>
+              </macros>
+          </clickhouse>
+      - type: bind
+        source: ./clickhouse/user_defined_function.xml
+        target: /etc/clickhouse-server/user_defined_function.xml
+        read_only: true
+        content: |
+          <functions>
+              <function>
+                  <type>executable_pool</type>
+                  <name>aggregate_funnel</name>
+                  <return_type>Array(Tuple(Int8, Nullable(String), Array(Float64), Array(Array(UUID)), UInt32))</return_type>
+                  <return_name>result</return_name>
+                  <argument>
+                      <type>UInt8</type>
+                      <name>num_steps</name>
+                  </argument>
+                  <argument>
+                      <type>UInt64</type>
+                      <name>conversion_window_limit</name>
+                  </argument>
+                  <argument>
+                      <type>String</type>
+                      <name>breakdown_attribution_type</name>
+                  </argument>
+                  <argument>
+                      <type>String</type>
+                      <name>funnel_order_type</name>
+                  </argument>
+                  <argument>
+                      <type>Array(Nullable(String))</type>
+                      <name>prop_vals</name>
+                  </argument>
+                  <argument>
+                      <type>Array(Int8)</type>
+                      <name>optional_steps</name>
+                  </argument>
+                  <argument>
+                      <type>Array(Tuple(Nullable(Float64), UUID, Nullable(String), Array(Int8)))</type>
+                      <name>value</name>
+                  </argument>
+                  <format>JSONEachRow</format>
+                  <command>aggregate_funnel steps</command>
+                  <lifetime>600</lifetime>
+              </function>
+
+              <function>
+                  <type>executable_pool</type>
+                  <name>aggregate_funnel_cohort</name>
+                  <return_type>Array(Tuple(Int8, UInt64, Array(Float64), Array(Array(UUID)), UInt32))</return_type>
+                  <return_name>result</return_name>
+                  <argument>
+                      <type>UInt8</type>
+                      <name>num_steps</name>
+                  </argument>
+                  <argument>
+                      <type>UInt64</type>
+                      <name>conversion_window_limit</name>
+                  </argument>
+                  <argument>
+                      <type>String</type>
+                      <name>breakdown_attribution_type</name>
+                  </argument>
+                  <argument>
+                      <type>String</type>
+                      <name>funnel_order_type</name>
+                  </argument>
+                  <argument>
+                      <type>Array(UInt64)</type>
+                      <name>prop_vals</name>
+                  </argument>
+                  <argument>
+                      <type>Array(Int8)</type>
+                      <name>optional_steps</name>
+                  </argument>
+                  <argument>
+                      <type>Array(Tuple(Nullable(Float64), UUID, UInt64, Array(Int8)))</type>
+                      <name>value</name>
+                  </argument>
+                  <format>JSONEachRow</format>
+                  <command>aggregate_funnel steps</command>
+                  <lifetime>600</lifetime>
+              </function>
+
+              <function>
+                  <type>executable_pool</type>
+                  <name>aggregate_funnel_array</name>
+                  <return_type>Array(Tuple(Int8, Array(String), Array(Float64), Array(Array(UUID)), UInt32))</return_type>
+                  <return_name>result</return_name>
+                  <argument>
+                      <type>UInt8</type>
+                      <name>num_steps</name>
+                  </argument>
+                  <argument>
+                      <type>UInt64</type>
+                      <name>conversion_window_limit</name>
+                  </argument>
+                  <argument>
+                      <type>String</type>
+                      <name>breakdown_attribution_type</name>
+                  </argument>
+                  <argument>
+                      <type>String</type>
+                      <name>funnel_order_type</name>
+                  </argument>
+                  <argument>
+                      <type>Array(Array(String))</type>
+                      <name>prop_vals</name>
+                  </argument>
+                  <argument>
+                      <type>Array(Int8)</type>
+                      <name>optional_steps</name>
+                  </argument>
+                  <argument>
+                      <type>Array(Tuple(Nullable(Float64), UUID, Array(String), Array(Int8)))</type>
+                      <name>value</name>
+                  </argument>
+                  <format>JSONEachRow</format>
+                  <command>aggregate_funnel steps</command>
+                  <lifetime>600</lifetime>
+              </function>
+
+              <function>
+                  <type>executable_pool</type>
+                  <name>aggregate_funnel_test</name>
+                  <return_type>String</return_type>
+                  <return_name>result</return_name>
+                  <argument>
+                      <type>UInt8</type>
+                      <name>num_steps</name>
+                  </argument>
+                  <argument>
+                      <type>UInt64</type>
+                      <name>conversion_window_limit</name>
+                  </argument>
+                  <argument>
+                      <type>String</type>
+                      <name>breakdown_attribution_type</name>
+                  </argument>
+                  <argument>
+                      <type>String</type>
+                      <name>funnel_order_type</name>
+                  </argument>
+                  <argument>
+                      <type>Array(Array(String))</type>
+                      <name>prop_vals</name>
+                  </argument>
+                  <argument>
+                      <type>Array(Int8)</type>
+                      <name>optional_steps</name>
+                  </argument>
+                  <argument>
+                      <type>Array(Tuple(Nullable(Float64), UUID, Nullable(String), Array(Int8)))</type>
+                      <name>value</name>
+                  </argument>
+                  <format>JSONEachRow</format>
+                  <command>aggregate_funnel_test.py</command>
+                  <lifetime>600</lifetime>
+              </function>
+
+              <function>
+                  <type>executable_pool</type>
+                  <name>aggregate_funnel_trends</name>
+                  <return_type>Array(Tuple(UInt64, Int8, Nullable(String), UUID))</return_type>
+                  <return_name>result</return_name>
+                  <argument>
+                      <type>UInt8</type>
+                      <name>from_step</name>
+                  </argument>
+                  <argument>
+                      <type>UInt8</type>
+                      <name>to_step</name>
+                  </argument>
+                  <argument>
+                      <type>UInt8</type>
+                      <name>num_steps</name>
+                  </argument>
+                  <argument>
+                      <type>UInt64</type>
+                      <name>conversion_window_limit</name>
+                  </argument>
+                  <argument>
+                      <type>String</type>
+                      <name>breakdown_attribution_type</name>
+                  </argument>
+                  <argument>
+                      <type>String</type>
+                      <name>funnel_order_type</name>
+                  </argument>
+                  <argument>
+                      <type>Array(Nullable(String))</type>
+                      <name>prop_vals</name>
+                  </argument>
+                  <argument>
+                      <type>Array(Tuple(Nullable(Float64), UInt64, UUID, Nullable(String), Array(Int8)))</type>
+                      <name>value</name>
+                  </argument>
+                  <format>JSONEachRow</format>
+                  <command>aggregate_funnel trends</command>
+                  <lifetime>600</lifetime>
+              </function>
+
+              <function>
+                  <type>executable_pool</type>
+                  <name>aggregate_funnel_array_trends</name>
+                  <!-- Return type for trends is a start interval time, a success flag (1 or -1), and a breakdown value -->
+                  <return_type>Array(Tuple(UInt64, Int8, Array(String), UUID))</return_type>
+                  <return_name>result</return_name>
+                  <argument>
+                      <type>UInt8</type>
+                      <name>from_step</name>
+                  </argument>
+                  <argument>
+                      <type>UInt8</type>
+                      <name>to_step</name>
+                  </argument>
+                  <argument>
+                      <type>UInt8</type>
+                      <name>num_steps</name>
+                  </argument>
+                  <argument>
+                      <type>UInt64</type>
+                      <name>conversion_window_limit</name>
+                  </argument>
+                  <argument>
+                      <type>String</type>
+                      <name>breakdown_attribution_type</name>
+                  </argument>
+                  <argument>
+                      <type>String</type>
+                      <name>funnel_order_type</name>
+                  </argument>
+                  <argument>
+                      <type>Array(Array(String))</type>
+                      <name>prop_vals</name>
+                  </argument>
+                  <argument>
+                      <type>Array(Tuple(Nullable(Float64), UInt64, UUID, Array(String), Array(Int8)))</type>
+                      <name>value</name>
+                  </argument>
+                  <format>JSONEachRow</format>
+                  <command>aggregate_funnel trends</command>
+                  <lifetime>600</lifetime>
+              </function>
+
+              <function>
+                  <type>executable_pool</type>
+                  <name>aggregate_funnel_cohort_trends</name>
+                  <!-- Return type for trends is a start interval time, a success flag (1 or -1), and a breakdown value -->
+                  <return_type>Array(Tuple(UInt64, Int8, UInt64, UUID))</return_type>
+                  <return_name>result</return_name>
+                  <argument>
+                      <type>UInt8</type>
+                      <name>from_step</name>
+                  </argument>
+                  <argument>
+                      <type>UInt8</type>
+                      <name>to_step</name>
+                  </argument>
+                  <argument>
+                      <type>UInt8</type>
+                      <name>num_steps</name>
+                  </argument>
+                  <argument>
+                      <type>UInt64</type>
+                      <name>conversion_window_limit</name>
+                  </argument>
+                  <argument>
+                      <type>String</type>
+                      <name>breakdown_attribution_type</name>
+                  </argument>
+                  <argument>
+                      <type>String</type>
+                      <name>funnel_order_type</name>
+                  </argument>
+                  <argument>
+                      <type>Array(UInt64)</type>
+                      <name>prop_vals</name>
+                  </argument>
+                  <argument>
+                      <type>Array(Tuple(Nullable(Float64), UInt64, UUID, UInt64, Array(Int8)))</type>
+                      <name>value</name>
+                  </argument>
+                  <format>JSONEachRow</format>
+                  <command>aggregate_funnel trends</command>
+                  <lifetime>600</lifetime>
+              </function>
+
+              <function>
+                  <type>executable_pool</type>
+                  <name>aggregate_funnel_array_trends_test</name>
+                  <return_type>String</return_type>
+                  <return_name>result</return_name>
+                  <argument>
+                      <type>UInt8</type>
+                      <name>from_step</name>
+                  </argument>
+                  <argument>
+                      <type>UInt8</type>
+                      <name>to_step</name>
+                  </argument>
+                  <argument>
+                      <type>UInt8</type>
+                      <name>num_steps</name>
+                  </argument>
+                  <argument>
+                      <type>UInt64</type>
+                      <name>conversion_window_limit</name>
+                  </argument>
+                  <argument>
+                      <type>String</type>
+                      <name>breakdown_attribution_type</name>
+                  </argument>
+                  <argument>
+                      <type>String</type>
+                      <name>funnel_order_type</name>
+                  </argument>
+                  <argument>
+                      <type>Array(Array(String))</type>
+                      <name>prop_vals</name>
+                  </argument>
+                  <argument>
+                      <type>Array(Tuple(Nullable(Float64), UInt64, UUID, Array(String), Array(Int8)))</type>
+                      <name>value</name>
+                  </argument>
+                  <format>JSONEachRow</format>
+                  <command>aggregate_funnel_array_trends_test.py</command>
+                  <lifetime>600</lifetime>
+              </function>
+          </functions>
+      - posthog-clickhouse-data:/var/lib/clickhouse
+
+  # Workaround for ClickHouse crash_log table not existing on fresh installs.
+  # See: https://github.com/PostHog/posthog/issues/40300
+  clickhouse-init:
+    image: alpine:3.19
+    entrypoint: /bin/sh
+    command:
+      - '-c'
+      - |
+        apk add --no-cache curl
+        until curl -sf http://clickhouse:8123/ping >/dev/null 2>&1; do sleep 2; done
+        curl -sf 'http://clickhouse:8123/' --data "CREATE TABLE IF NOT EXISTS system.crash_log (hostname LowCardinality(String) DEFAULT hostName(), event_date Date, event_time DateTime, timestamp_ns UInt64, signal Int32, thread_id UInt64, query_id String, trace Array(UInt64), trace_full Array(String), version String, revision UInt32, build_id String) ENGINE = MergeTree ORDER BY (event_date, event_time) TTL event_date + INTERVAL 30 DAY"
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+    restart: 'no'
 
   kafka:
-    image: ghcr.io/posthog/kafka-container:v2.8.2
-    depends_on:
-      - zookeeper
+    image: docker.redpanda.com/redpandadata/redpanda:v25.1.9
+    command:
+      - redpanda
+      - start
+      - '--kafka-addr internal://0.0.0.0:9092'
+      - '--advertise-kafka-addr internal://kafka:9092'
+      - '--pandaproxy-addr internal://0.0.0.0:8082'
+      - '--advertise-pandaproxy-addr internal://kafka:8082'
+      - '--schema-registry-addr internal://0.0.0.0:8081'
+      - '--rpc-addr kafka:33145'
+      - '--advertise-rpc-addr kafka:33145'
+      - '--mode dev-container'
+      - '--smp 1'
+      - '--memory 1500M'
+      - '--reserve-memory 200M'
+      - '--overprovisioned'
+      - '--set redpanda.empty_seed_starts_cluster=false'
+      - '--seeds kafka:33145'
+      - '--set redpanda.auto_create_topics_enabled=true'
     environment:
-      - KAFKA_BROKER_ID=1001
-      - KAFKA_CFG_RESERVED_BROKER_MAX_ID=1001
-      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092
-      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
-      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
-      - ALLOW_PLAINTEXT_LISTENER=yes
-
-  object_storage:
-    image: ghcr.io/coollabsio/minio:RELEASE.2025-10-15T17-29-55Z # Released on 15 October 2025
-    environment:
-      - MINIO_ROOT_USER=$SERVICE_USER_MINIO
-      - MINIO_ROOT_PASSWORD=$SERVICE_PASSWORD_MINIO
-    entrypoint: sh
-    command: -c 'mkdir -p /data/posthog && minio server --address ":9000" --console-address ":9001" /data'
-    volumes:
-      - object_storage:/data
+      - ALLOW_PLAINTEXT_LISTENER=true
     healthcheck:
-      test: ["CMD", "mc", "ready", "local"]
+      test: curl -f http://localhost:9644/v1/status/ready || exit 1
       interval: 5s
-      timeout: 20s
-      retries: 10
-
-  maildev:
-    image: maildev/maildev:2.0.5
-
-  flower:
-    image: mher/flower:2.0.0
-    environment:
-      FLOWER_PORT: 5555
-      CELERY_BROKER_URL: redis://redis:6379
-
-  web:
-    image: posthog/posthog:latest
-    command: /compose/start
+      timeout: 10s
+      retries: 30
+      start_period: 30s
     volumes:
-      - type: bind
-        source: ./compose/start
-        target: /compose/start
-        content: |
-          #!/bin/bash
-          /compose/wait
-          ./bin/migrate
-          ./bin/docker-server
-      - type: bind
-        source: ./compose/wait
-        target: /compose/wait
-        content: |
-          #!/usr/bin/env python3
+      - posthog-kafka-data:/var/lib/redpanda/data
 
-          import socket
-          import time
-
-          def loop():
-              print("Waiting for ClickHouse and Postgres to be ready")
-              try:
-                  with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                      s.connect(('clickhouse', 9000))
-                  print("Clickhouse is ready")
-                  with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                      s.connect(('db', 5432))
-                  print("Postgres is ready")
-              except ConnectionRefusedError as e:
-                  time.sleep(5)
-                  loop()
-
-          loop()
-    environment:
-      - SERVICE_URL_WEB_8000
-      - OPT_OUT_CAPTURING=true
-      - DISABLE_SECURE_SSL_REDIRECT=true
-      - IS_BEHIND_PROXY=true
-      - TRUST_ALL_PROXIES=true
-      - DATABASE_URL=postgres://posthog:$SERVICE_PASSWORD_POSTGRES@db:5432/posthog
-      - CLICKHOUSE_HOST=clickhouse
-      - CLICKHOUSE_DATABASE=posthog
-      - CLICKHOUSE_SECURE=false
-      - CLICKHOUSE_VERIFY=false
-      - KAFKA_HOSTS=kafka
-      - REDIS_URL=redis://redis:6379/
-      - PGHOST=db
-      - PGUSER=posthog
-      - PGPASSWORD=$SERVICE_PASSWORD_POSTGRES
-      - DEPLOYMENT=hobby
-      - SITE_URL=$SERVICE_URL_WEB
-      - SECRET_KEY=$SERVICE_BASE64_64_SECRETKEY
-      - 'ENCRYPTION_SALT_KEYS=${SERVICE_ENCRYPTION_SALT_KEYS:-00beef0000beef0000beef0000beef00}'
+  kafka-init:
+    image: docker.redpanda.com/redpandadata/redpanda:v25.1.9
+    entrypoint: /bin/sh
+    command:
+      - '-c'
+      - |
+        TIMEOUT=120
+        ELAPSED=0
+        until rpk topic list --brokers kafka:9092 2>/dev/null; do
+          sleep 3
+          ELAPSED=$$((ELAPSED + 3))
+          if [ $$ELAPSED -ge $$TIMEOUT ]; then exit 1; fi
+        done
+        for topic in exceptions_ingestion clickhouse_events_json events_plugin_ingestion; do
+          rpk topic create "$$topic" --brokers kafka:9092 -p 1 -r 1 2>&1 || true
+        done
     depends_on:
-      - db
-      - redis
-      - clickhouse
-      - kafka
-      - object_storage
-  worker:
-    image: posthog/posthog:latest
-    command: ./bin/docker-worker-celery --with-scheduler
+      kafka:
+        condition: service_healthy
+    restart: 'no'
+
+  objectstorage:
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
     environment:
-      - OPT_OUT_CAPTURING=true
-      - DISABLE_SECURE_SSL_REDIRECT=true
-      - IS_BEHIND_PROXY=true
-      - TRUST_ALL_PROXIES=true
-      - DATABASE_URL=postgres://posthog:$SERVICE_PASSWORD_POSTGRES@db:5432/posthog
-      - CLICKHOUSE_HOST=clickhouse
-      - CLICKHOUSE_DATABASE=posthog
-      - CLICKHOUSE_SECURE=false
-      - CLICKHOUSE_VERIFY=false
-      - KAFKA_HOSTS=kafka
-      - REDIS_URL=redis://redis:6379/
-      - PGHOST=db
-      - PGUSER=posthog
-      - PGPASSWORD=$SERVICE_PASSWORD_POSTGRES
-      - DEPLOYMENT=hobby
-      - SITE_URL=$SERVICE_URL_WEB
-      - SECRET_KEY=$SERVICE_BASE64_64_SECRETKEY
-      - 'ENCRYPTION_SALT_KEYS=${SERVICE_ENCRYPTION_SALT_KEYS:-00beef0000beef0000beef0000beef00}'
-    depends_on:
-      - db
-      - redis
-      - clickhouse
-      - kafka
-      - object_storage
-
-  # capture:
-  #   image: ghcr.io/posthog/capture:main
-  #   environment:
-  #     ADDRESS: "0.0.0.0:3000"
-  #     KAFKA_TOPIC: "events_plugin_ingestion"
-  #     KAFKA_HOSTS: "kafka:9092"
-  #     REDIS_URL: "redis://redis:6379/"
-  #   depends_on:
-  #     - redis
-  #     - kafka
-
-  plugins:
-    image: posthog/posthog:latest
-    command: ./bin/plugin-server --no-restart-loop
-    environment:
-      - DATABASE_URL=postgres://posthog:$SERVICE_PASSWORD_POSTGRES@db:5432/posthog
-      - KAFKA_HOSTS=kafka:9092
-      - REDIS_URL=redis://redis:6379/
-      - CLICKHOUSE_HOST=clickhouse
-      - CLICKHOUSE_DATABASE=posthog
-      - CLICKHOUSE_SECURE=false
-      - CLICKHOUSE_VERIFY=false
-      - SITE_URL=$SERVICE_URL_WEB
-      - SECRET_KEY=$SERVICE_BASE64_64_SECRETKEY
-      - 'ENCRYPTION_SALT_KEYS=${SERVICE_ENCRYPTION_SALT_KEYS:-00beef0000beef0000beef0000beef00}'
-    depends_on:
-      - db
-      - redis
-      - clickhouse
-      - kafka
-      - object_storage
-
-  # migrate:
-  #   image: posthog/posthog:latest
-  #   restart: "no"
-  #   command: sh -c "python manage.py migrate && python manage.py migrate_clickhouse && python manage.py run_async_migrations"
-  #   environment:
-  #     - DISABLE_SECURE_SSL_REDIRECT=true
-  #     - IS_BEHIND_PROXY=true
-  #     - TRUST_ALL_PROXIES=true
-  #     - DATABASE_URL=postgres://posthog:$SERVICE_PASSWORD_POSTGRES@db:5432/posthog
-  #     - CLICKHOUSE_HOST=clickhouse
-  #     - CLICKHOUSE_DATABASE=posthog
-  #     - CLICKHOUSE_SECURE=false
-  #     - CLICKHOUSE_VERIFY=false
-  #     - KAFKA_HOSTS=kafka
-  #     - REDIS_URL=redis://redis:6379/
-  #     - PGHOST=db
-  #     - PGUSER=posthog
-  #     - PGPASSWORD=$SERVICE_PASSWORD_POSTGRES
-  #     - DEPLOYMENT=hobby
-  #     - SITE_URL=$SERVICE_URL_WEB
-  #     - SECRET_KEY=$SERVICE_BASE64_64_SECRETKEY
-  #     - 'ENCRYPTION_SALT_KEYS=${SERVICE_ENCRYPTION_SALT_KEYS:-00beef0000beef0000beef0000beef00}'
-  #   depends_on:
-  #     - db
-  #     - redis
-  #     - clickhouse
-  #     - kafka
-  #     - object_storage
-
-  # Temporal containers
-  elasticsearch:
-    image: elasticsearch:7.16.2
-    environment:
-      - cluster.routing.allocation.disk.threshold_enabled=true
-      - cluster.routing.allocation.disk.watermark.low=512mb
-      - cluster.routing.allocation.disk.watermark.high=256mb
-      - cluster.routing.allocation.disk.watermark.flood_stage=128mb
-      - discovery.type=single-node
-      - ES_JAVA_OPTS=-Xms256m -Xmx256m
-      - xpack.security.enabled=false
+      - MINIO_ROOT_USER=${SERVICE_USER_MINIO}
+      - MINIO_ROOT_PASSWORD=${SERVICE_PASSWORD_MINIO}
+    entrypoint: sh
+    command: -c 'mkdir -p /data/posthog && minio server --address ":19000" --console-address ":19001" /data'
     volumes:
-      - elasticsearch-data:/var/lib/elasticsearch/data
+      - posthog-objectstorage:/data
+
+  seaweedfs:
+    image: chrislusf/seaweedfs:4.03
+    entrypoint:
+      - /bin/sh
+      - '-c'
+      - |
+        /usr/bin/weed "$$@" &
+        WEED_PID=$$!
+        while true; do
+          sleep 5
+          if echo "s3.bucket.list" | /usr/bin/weed shell -master=localhost:9333 2>&1 | grep -q "posthog"; then break; fi
+          echo "s3.bucket.create -name posthog" | /usr/bin/weed shell -master=localhost:9333 2>&1 || true
+        done
+        wait $$WEED_PID
+      - '--'
+    command:
+      - server
+      - '-s3'
+      - '-s3.port=8333'
+      - '-dir=/data'
+    volumes:
+      - posthog-seaweedfs:/data
+    healthcheck:
+      test: ['CMD', 'sh', '-c', "echo 's3.bucket.list' | /usr/bin/weed shell -master=localhost:9333 2>&1 | grep -q posthog"]
+      interval: 5s
+      timeout: 10s
+      retries: 30
+      start_period: 15s
+
   temporal:
     image: temporalio/auto-setup:1.20.0
     environment:
       - DB=postgresql
       - DB_PORT=5432
       - POSTGRES_USER=posthog
-      - POSTGRES_PWD=$SERVICE_PASSWORD_POSTGRES
+      - POSTGRES_PWD=${SERVICE_PASSWORD_POSTGRES}
       - POSTGRES_SEEDS=db
       - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development-sql.yaml
-      - ENABLE_ES=true
-      - ES_SEEDS=elasticsearch
-      - ES_VERSION=v7
       - ENABLE_ES=false
+    healthcheck:
+      test: ['CMD-SHELL', 'nc -z $$(hostname) 7233']
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 300s
     depends_on:
+      permissions-init:
+        condition: service_completed_successfully
       db:
         condition: service_healthy
     volumes:
       - type: bind
-        source: ./docker/temporal/dynamicconfig/development-sql.yaml
+        source: ./temporal/dynamicconfig/development-sql.yaml
         target: /etc/temporal/config/dynamicconfig/development-sql.yaml
+        read_only: true
         content: |
           limit.maxIDLength:
               - value: 255
                 constraints: {}
           system.forceSearchAttributesCacheRefreshOnRead:
-              - value: false
+              - value: true
                 constraints: {}
+
   temporal-admin-tools:
     image: temporalio/admin-tools:1.20.0
-    depends_on:
-      - temporal
     environment:
       - TEMPORAL_CLI_ADDRESS=temporal:7233
-    stdin_open: true
-    tty: true
-  temporal-ui:
-    image: temporalio/ui:2.10.3
     depends_on:
       - temporal
+
+  temporal-ui:
+    image: temporalio/ui:2.31.2
     environment:
       - TEMPORAL_ADDRESS=temporal:7233
       - TEMPORAL_CORS_ORIGINS=http://localhost:3000
+      - TEMPORAL_CSRF_COOKIE_INSECURE=true
+    depends_on:
+      temporal:
+        condition: service_started
+      db:
+        condition: service_healthy
+
+  web:
+    image: posthog/posthog:latest
+    command:
+      - /bin/bash
+      - '-c'
+      - './bin/migrate && ./bin/docker-server'
+    environment:
+      - SERVICE_URL_POSTHOG_8000=/
+      - OTEL_SDK_DISABLED=true
+      - DISABLE_SECURE_SSL_REDIRECT=true
+      - IS_BEHIND_PROXY=true
+      - DATABASE_URL=postgres://posthog:${SERVICE_PASSWORD_POSTGRES}@db:5432/posthog
+      - CLICKHOUSE_HOST=clickhouse
+      - CLICKHOUSE_DATABASE=posthog
+      - CLICKHOUSE_SECURE=false
+      - CLICKHOUSE_VERIFY=false
+      - CLICKHOUSE_API_USER=api
+      - CLICKHOUSE_API_PASSWORD=apipass
+      - CLICKHOUSE_APP_USER=app
+      - CLICKHOUSE_APP_PASSWORD=apppass
+      - KAFKA_HOSTS=kafka
+      - REDIS_URL=redis://redis:6379/
+      - PGHOST=db
+      - PGUSER=posthog
+      - PGPASSWORD=${SERVICE_PASSWORD_POSTGRES}
+      - DEPLOYMENT=hobby
+      - CDP_API_URL=http://plugins:6738
+      - FLAGS_REDIS_ENABLED=false
+      - SITE_URL=${SERVICE_URL_POSTHOG}
+      - SECRET_KEY=${SERVICE_BASE64_64_SECRETKEY}
+      - ENCRYPTION_SALT_KEYS=${SERVICE_PASSWORD_ENCRYPTION}
+      - OBJECT_STORAGE_ACCESS_KEY_ID=${SERVICE_USER_MINIO}
+      - OBJECT_STORAGE_SECRET_ACCESS_KEY=${SERVICE_PASSWORD_MINIO}
+      - OBJECT_STORAGE_ENDPOINT=http://objectstorage:19000
+      - OBJECT_STORAGE_PUBLIC_ENDPOINT=${SERVICE_URL_POSTHOG}
+      - SESSION_RECORDING_V2_S3_ENDPOINT=http://seaweedfs:8333
+      - SESSION_RECORDING_V2_S3_ACCESS_KEY_ID=any
+      - SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY=any
+      - OBJECT_STORAGE_ENABLED=true
+      - RECORDING_API_URL=http://plugins:6738
+      - LIVESTREAM_HOST=${SERVICE_URL_POSTHOG}/livestream
+      - USE_GRANIAN=true
+      - GRANIAN_WORKERS=2
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
+      clickhouse-init:
+        condition: service_completed_successfully
+      kafka:
+        condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
+      objectstorage:
+        condition: service_started
+      seaweedfs:
+        condition: service_healthy
+
+  worker:
+    image: posthog/posthog:latest
+    command: ./bin/docker-worker-celery --with-scheduler
+    environment:
+      - OTEL_SDK_DISABLED=true
+      - DISABLE_SECURE_SSL_REDIRECT=true
+      - IS_BEHIND_PROXY=true
+      - DATABASE_URL=postgres://posthog:${SERVICE_PASSWORD_POSTGRES}@db:5432/posthog
+      - CLICKHOUSE_HOST=clickhouse
+      - CLICKHOUSE_DATABASE=posthog
+      - CLICKHOUSE_SECURE=false
+      - CLICKHOUSE_VERIFY=false
+      - CLICKHOUSE_API_USER=api
+      - CLICKHOUSE_API_PASSWORD=apipass
+      - CLICKHOUSE_APP_USER=app
+      - CLICKHOUSE_APP_PASSWORD=apppass
+      - KAFKA_HOSTS=kafka
+      - REDIS_URL=redis://redis:6379/
+      - PGHOST=db
+      - PGUSER=posthog
+      - PGPASSWORD=${SERVICE_PASSWORD_POSTGRES}
+      - DEPLOYMENT=hobby
+      - CDP_API_URL=http://plugins:6738
+      - FLAGS_REDIS_ENABLED=false
+      - SITE_URL=${SERVICE_URL_POSTHOG}
+      - SECRET_KEY=${SERVICE_BASE64_64_SECRETKEY}
+      - ENCRYPTION_SALT_KEYS=${SERVICE_PASSWORD_ENCRYPTION}
+      - OBJECT_STORAGE_ACCESS_KEY_ID=${SERVICE_USER_MINIO}
+      - OBJECT_STORAGE_SECRET_ACCESS_KEY=${SERVICE_PASSWORD_MINIO}
+      - OBJECT_STORAGE_ENDPOINT=http://objectstorage:19000
+      - OBJECT_STORAGE_PUBLIC_ENDPOINT=${SERVICE_URL_POSTHOG}
+      - SESSION_RECORDING_V2_S3_ENDPOINT=http://seaweedfs:8333
+      - SESSION_RECORDING_V2_S3_ACCESS_KEY_ID=any
+      - SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY=any
+      - OBJECT_STORAGE_ENABLED=true
+      - RECORDING_API_URL=http://plugins:6738
+      - POSTHOG_SKIP_MIGRATION_CHECKS=1
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+      web:
+        condition: service_started
+
+  plugins:
+    image: posthog/posthog-node:latest
+    command: node nodejs/dist/index.js
+    environment:
+      - DATABASE_URL=postgres://posthog:${SERVICE_PASSWORD_POSTGRES}@db:5432/posthog
+      - PERSONS_DATABASE_URL=postgres://posthog:${SERVICE_PASSWORD_POSTGRES}@db:5432/posthog
+      - BEHAVIORAL_COHORTS_DATABASE_URL=postgres://posthog:${SERVICE_PASSWORD_POSTGRES}@db:5432/posthog
+      - CYCLOTRON_DATABASE_URL=postgres://posthog:${SERVICE_PASSWORD_POSTGRES}@db:5432/posthog
+      - KAFKA_HOSTS=kafka:9092
+      - REDIS_URL=redis://redis:6379/
+      - POSTHOG_REDIS_HOST=redis
+      - POSTHOG_REDIS_PORT=6379
+      - INGESTION_REDIS_HOST=redis
+      - INGESTION_REDIS_PORT=6379
+      - LOGS_REDIS_HOST=redis
+      - LOGS_REDIS_PORT=6379
+      - LOGS_REDIS_TLS=false
+      - CDP_REDIS_HOST=redis
+      - CDP_REDIS_PORT=6379
+      - SESSION_RECORDING_API_REDIS_HOST=redis
+      - SESSION_RECORDING_API_REDIS_PORT=6379
+      - COOKIELESS_REDIS_HOST=redis
+      - COOKIELESS_REDIS_PORT=6379
+      - CLICKHOUSE_HOST=clickhouse
+      - CLICKHOUSE_DATABASE=posthog
+      - CLICKHOUSE_SECURE=false
+      - CLICKHOUSE_VERIFY=false
+      - SITE_URL=${SERVICE_URL_POSTHOG}
+      - SECRET_KEY=${SERVICE_BASE64_64_SECRETKEY}
+      - ENCRYPTION_SALT_KEYS=${SERVICE_PASSWORD_ENCRYPTION}
+      - OBJECT_STORAGE_ACCESS_KEY_ID=${SERVICE_USER_MINIO}
+      - OBJECT_STORAGE_SECRET_ACCESS_KEY=${SERVICE_PASSWORD_MINIO}
+      - SESSION_RECORDING_V2_S3_ACCESS_KEY_ID=any
+      - SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY=any
+      - SESSION_RECORDING_V2_S3_TIMEOUT_MS=120000
+      - OBJECT_STORAGE_ENDPOINT=http://objectstorage:19000
+      - OBJECT_STORAGE_PUBLIC_ENDPOINT=${SERVICE_URL_POSTHOG}
+      - SESSION_RECORDING_V2_S3_ENDPOINT=http://seaweedfs:8333
+      - OBJECT_STORAGE_ENABLED=true
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+      objectstorage:
+        condition: service_started
+      seaweedfs:
+        condition: service_healthy
+      web:
+        condition: service_started
 
   temporal-django-worker:
     image: posthog/posthog:latest
     command: ./bin/temporal-django-worker
     environment:
+      - OTEL_SDK_DISABLED=true
       - DISABLE_SECURE_SSL_REDIRECT=true
       - IS_BEHIND_PROXY=true
-      - TRUST_ALL_PROXIES=true
-      - DATABASE_URL=postgres://posthog:$SERVICE_PASSWORD_POSTGRES@db:5432/posthog
+      - DATABASE_URL=postgres://posthog:${SERVICE_PASSWORD_POSTGRES}@db:5432/posthog
       - CLICKHOUSE_HOST=clickhouse
       - CLICKHOUSE_DATABASE=posthog
       - CLICKHOUSE_SECURE=false
       - CLICKHOUSE_VERIFY=false
+      - CLICKHOUSE_API_USER=api
+      - CLICKHOUSE_API_PASSWORD=apipass
+      - CLICKHOUSE_APP_USER=app
+      - CLICKHOUSE_APP_PASSWORD=apppass
       - KAFKA_HOSTS=kafka
       - REDIS_URL=redis://redis:6379/
       - PGHOST=db
       - PGUSER=posthog
-      - PGPASSWORD=$SERVICE_PASSWORD_POSTGRES
+      - PGPASSWORD=${SERVICE_PASSWORD_POSTGRES}
       - DEPLOYMENT=hobby
-      - SITE_URL=$SERVICE_URL_WEB
-      - SECRET_KEY=$SERVICE_BASE64_64_SECRETKEY
-      - 'ENCRYPTION_SALT_KEYS=${SERVICE_ENCRYPTION_SALT_KEYS:-00beef0000beef0000beef0000beef00}'
+      - CDP_API_URL=http://plugins:6738
+      - FLAGS_REDIS_ENABLED=false
+      - SITE_URL=${SERVICE_URL_POSTHOG}
+      - SECRET_KEY=${SERVICE_BASE64_64_SECRETKEY}
+      - ENCRYPTION_SALT_KEYS=${SERVICE_PASSWORD_ENCRYPTION}
+      - OBJECT_STORAGE_ACCESS_KEY_ID=${SERVICE_USER_MINIO}
+      - OBJECT_STORAGE_SECRET_ACCESS_KEY=${SERVICE_PASSWORD_MINIO}
+      - OBJECT_STORAGE_ENDPOINT=http://objectstorage:19000
+      - OBJECT_STORAGE_PUBLIC_ENDPOINT=${SERVICE_URL_POSTHOG}
+      - SESSION_RECORDING_V2_S3_ENDPOINT=http://seaweedfs:8333
+      - SESSION_RECORDING_V2_S3_ACCESS_KEY_ID=any
+      - SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY=any
+      - OBJECT_STORAGE_ENABLED=true
+      - RECORDING_API_URL=http://plugins:6738
       - TEMPORAL_HOST=temporal
     depends_on:
-      - db
-      - redis
-      - clickhouse
-      - kafka
-      - object_storage
-      - temporal
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+      objectstorage:
+        condition: service_started
+      seaweedfs:
+        condition: service_healthy
+      temporal:
+        condition: service_healthy
+
+  asyncmigrationscheck:
+    image: posthog/posthog:latest
+    command: python manage.py run_async_migrations --check
+    restart: 'no'
+    environment:
+      - OTEL_SDK_DISABLED=true
+      - DISABLE_SECURE_SSL_REDIRECT=true
+      - IS_BEHIND_PROXY=true
+      - DATABASE_URL=postgres://posthog:${SERVICE_PASSWORD_POSTGRES}@db:5432/posthog
+      - CLICKHOUSE_HOST=clickhouse
+      - CLICKHOUSE_DATABASE=posthog
+      - CLICKHOUSE_SECURE=false
+      - CLICKHOUSE_VERIFY=false
+      - CLICKHOUSE_API_USER=api
+      - CLICKHOUSE_API_PASSWORD=apipass
+      - CLICKHOUSE_APP_USER=app
+      - CLICKHOUSE_APP_PASSWORD=apppass
+      - KAFKA_HOSTS=kafka
+      - REDIS_URL=redis://redis:6379/
+      - PGHOST=db
+      - PGUSER=posthog
+      - PGPASSWORD=${SERVICE_PASSWORD_POSTGRES}
+      - DEPLOYMENT=hobby
+      - CDP_API_URL=http://plugins:6738
+      - FLAGS_REDIS_ENABLED=false
+      - SITE_URL=${SERVICE_URL_POSTHOG}
+      - SECRET_KEY=${SERVICE_BASE64_64_SECRETKEY}
+      - ENCRYPTION_SALT_KEYS=${SERVICE_PASSWORD_ENCRYPTION}
+      - OBJECT_STORAGE_ACCESS_KEY_ID=${SERVICE_USER_MINIO}
+      - OBJECT_STORAGE_SECRET_ACCESS_KEY=${SERVICE_PASSWORD_MINIO}
+      - OBJECT_STORAGE_ENDPOINT=http://objectstorage:19000
+      - OBJECT_STORAGE_PUBLIC_ENDPOINT=${SERVICE_URL_POSTHOG}
+      - SESSION_RECORDING_V2_S3_ENDPOINT=http://seaweedfs:8333
+      - SESSION_RECORDING_V2_S3_ACCESS_KEY_ID=any
+      - SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY=any
+      - OBJECT_STORAGE_ENABLED=true
+      - RECORDING_API_URL=http://plugins:6738
+      - SKIP_ASYNC_MIGRATIONS_SETUP=0
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+      web:
+        condition: service_started
+
+  capture:
+    image: ghcr.io/posthog/posthog/capture:master
+    environment:
+      - SERVICE_URL_POSTHOG_3000=/e
+      - ADDRESS=0.0.0.0:3000
+      - KAFKA_TOPIC=events_plugin_ingestion
+      - KAFKA_HOSTS=kafka:9092
+      - REDIS_URL=redis://redis:6379/
+      - CAPTURE_MODE=events
+      - RUST_LOG=info,rdkafka=warn
+    depends_on:
+      kafka:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  replay-capture:
+    image: ghcr.io/posthog/posthog/capture:master
+    environment:
+      - SERVICE_URL_POSTHOG_3000=/s
+      - ADDRESS=0.0.0.0:3000
+      - KAFKA_TOPIC=session_recording_snapshot_item_events
+      - KAFKA_HOSTS=kafka:9092
+      - REDIS_URL=redis://redis:6379/
+      - CAPTURE_MODE=recordings
+    depends_on:
+      kafka:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  livestream:
+    image: ghcr.io/posthog/posthog/livestream:master
+    environment:
+      - SERVICE_URL_POSTHOG_8080=/livestream
+      - LIVESTREAM_JWT_SECRET=${SERVICE_BASE64_64_SECRETKEY}
+      - LIVESTREAM_MMDB_PATH=/share/GeoLite2-City.mmdb
+      - LIVESTREAM_REDIS_ADDRESS=redis:6379
+    depends_on:
+      permissions-init:
+        condition: service_completed_successfully
+      geoip-init:
+        condition: service_completed_successfully
+      kafka:
+        condition: service_started
+      redis:
+        condition: service_healthy
+    volumes:
+      - posthog-share:/share
+      - type: bind
+        source: ./livestream/configs.yml
+        target: /configs/configs.yml
+        read_only: true
+        content: |
+          debug: false
+          consumers:
+            event:
+              enabled: true
+              brokers: 'kafka:9092'
+              topic: 'events_plugin_ingestion'
+              security_protocol: 'PLAINTEXT'
+              group_id: 'livestream'
+            session_recording:
+              enabled: true
+              brokers: 'kafka:9092'
+              topic: 'session_recording_snapshot_item_events'
+              security_protocol: 'PLAINTEXT'
+              group_id: 'livestream-session-recordings'
+            notification:
+              enabled: false
+          mmdb:
+            path: 'GeoLite2-City.mmdb'
+
+  feature-flags:
+    image: ghcr.io/posthog/posthog/feature-flags:master
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:3001/_readiness']
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+    environment:
+      - SERVICE_URL_POSTHOG_3001=/flags
+      - WRITE_DATABASE_URL=postgres://posthog:${SERVICE_PASSWORD_POSTGRES}@db:5432/posthog
+      - READ_DATABASE_URL=postgres://posthog:${SERVICE_PASSWORD_POSTGRES}@db:5432/posthog
+      - PERSONS_WRITE_DATABASE_URL=postgres://posthog:${SERVICE_PASSWORD_POSTGRES}@db:5432/posthog
+      - PERSONS_READ_DATABASE_URL=postgres://posthog:${SERVICE_PASSWORD_POSTGRES}@db:5432/posthog
+      - MAXMIND_DB_PATH=/share/GeoLite2-City.mmdb
+      - REDIS_URL=redis://redis:6379/
+      - ADDRESS=0.0.0.0:3001
+      - RUST_LOG=info
+      - COOKIELESS_REDIS_HOST=redis
+      - COOKIELESS_REDIS_PORT=6379
+    volumes:
+      - posthog-share:/share
+    depends_on:
+      geoip-init:
+        condition: service_completed_successfully
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  property-defs-rs:
+    image: ghcr.io/posthog/posthog/property-defs-rs:master
+    environment:
+      - DATABASE_URL=postgres://posthog:${SERVICE_PASSWORD_POSTGRES}@db:5432/posthog
+      - KAFKA_HOSTS=kafka:9092
+      - SKIP_WRITES=false
+      - SKIP_READS=false
+      - FILTER_MODE=opt-out
+    depends_on:
+      kafka-init:
+        condition: service_completed_successfully
+      db:
+        condition: service_healthy
+
+  cyclotron-janitor:
+    image: ghcr.io/posthog/posthog/cyclotron-janitor:master
+    environment:
+      - DATABASE_URL=postgres://posthog:${SERVICE_PASSWORD_POSTGRES}@db:5432/posthog
+      - KAFKA_HOSTS=kafka:9092
+      - KAFKA_TOPIC=clickhouse_app_metrics2
+    depends_on:
+      db:
+        condition: service_healthy
+      kafka:
+        condition: service_started
+
+  geoip-init:
+    image: alpine:3.19
+    entrypoint: /bin/sh
+    command:
+      - '-c'
+      - |
+        set -euo pipefail
+        db=/share/GeoLite2-City.mmdb
+        tmp=/share/GeoLite2-City.mmdb.tmp
+        is_mmdb() {
+          test -s "$$1" || return 1
+          metadata=$$(strings "$$1" | tail -n 64)
+          case "$$metadata" in *MaxMind.com*) ;; *) return 1;; esac
+          case "$$metadata" in *GeoLite2-City*) return 0;; *) return 1;; esac
+        }
+        if is_mmdb "$$db"; then echo "GeoIP DB already exists"; exit 0; fi
+        rm -f "$$tmp"
+        apk add --no-cache curl brotli
+        curl -fL 'https://mmdbcdn.posthog.net/' --http1.1 | brotli --decompress > "$$tmp"
+        is_mmdb "$$tmp"
+        chmod 644 "$$tmp"
+        mv "$$tmp" "$$db"
+    restart: 'no'
+    volumes:
+      - posthog-share:/share
+
+  cymbal:
+    image: ghcr.io/posthog/posthog/cymbal:master
+    environment:
+      - KAFKA_HOSTS=kafka:9092
+      - KAFKA_CONSUMER_GROUP=cymbal
+      - KAFKA_CONSUMER_TOPIC=exceptions_ingestion
+      - OBJECT_STORAGE_BUCKET=posthog
+      - OBJECT_STORAGE_ACCESS_KEY_ID=any
+      - OBJECT_STORAGE_SECRET_ACCESS_KEY=any
+      - OBJECT_STORAGE_ENDPOINT=http://seaweedfs:8333
+      - OBJECT_STORAGE_FORCE_PATH_STYLE=true
+      - BIND_HOST=0.0.0.0
+      - BIND_PORT=3302
+      - DATABASE_URL=postgres://posthog:${SERVICE_PASSWORD_POSTGRES}@db:5432/posthog
+      - PERSONS_URL=postgres://posthog:${SERVICE_PASSWORD_POSTGRES}@db:5432/posthog
+      - MAXMIND_DB_PATH=/share/GeoLite2-City.mmdb
+      - REDIS_URL=redis://redis:6379/
+      - ISSUE_BUCKETS_REDIS_URL=redis://redis:6379/
+      - RUST_LOG=info
+    volumes:
+      - posthog-share:/share
+    depends_on:
+      geoip-init:
+        condition: service_completed_successfully
+      kafka-init:
+        condition: service_completed_successfully
+      seaweedfs:
+        condition: service_healthy
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy


### PR DESCRIPTION
## Changes

- Revives the abandoned PostHog template fix from #8739 on the current `next` branch.
- Re-enables PostHog as a one-click template and publishes it in both generated service catalogs.
- Uses Coolify service URL labels instead of an internal proxy container.
- Correctly builds routed magic URLs with the port before the path while keeping base `SERVICE_URL_*` / `SERVICE_FQDN_*` values pathless.
- Generates absolute HTTPS values for PostHog public URLs in the FQDN catalog while preserving `SERVICE_URL_*` values in the latest catalog.
- Keeps named volumes out of the source template.
- Adds `permissions-init` for ClickHouse UID 101 and livestream/Temporal UID 1000 bind directories.
- Updates livestream with shared GeoIP DB, `configs.yml`, and event/session-recording consumers from #8739 review feedback.
- Hardens `geoip-init` to replace corrupt GeoIP files, skip valid files, fail closed on invalid downloads, and preserve shell variables after Compose interpolation.
- Pins SeaweedFS to `4.29`, which preserves the `Content-Encoding` metadata required by PostHog object storage.

## Issues

- Fixes #3597
- Supersedes #8739.

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [x] Fixing or updating existing one click service

## Preview

N/A — service template change.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex and Claude Code
- How extensively: Used for PR/review inspection, implementation, test generation, local validation, and independent review/QA.

## Testing

- Added a Pest regression test that decodes and parses PostHog from both generated catalogs and verifies representative services.
- Verified the regular FQDN catalog generates absolute PostHog URLs:
  - `SITE_URL=https://${SERVICE_FQDN_POSTHOG}`
  - `OBJECT_STORAGE_PUBLIC_ENDPOINT=https://${SERVICE_FQDN_POSTHOG}`
  - `LIVESTREAM_HOST=https://${SERVICE_FQDN_POSTHOG}/livestream`
- Verified the latest catalog preserves the corresponding `${SERVICE_URL_POSTHOG}` values.
- Added behavioral coverage for base/routed magic URL generation, including path + port ordering, scheme-less hosts, and bracketed IPv6.
- Verified the generated PostHog compose pins `chrislusf/seaweedfs:4.29`.
- Final targeted suite: **24 tests passed, 204 assertions**.
- The repository-wide suite starts successfully but currently has **7 unrelated pre-existing unit failures with 152 tests passing before stop-on-failure** (Mockery model-attribute expectations and an existing Git command escaping assertion); none touch the files or behavior changed in this PR.
- `vendor/bin/pint --dirty --format agent` passed.
- `git diff --check` passed.
- Generated-catalog comparison confirms PostHog is the only added template and no existing template compose payload changed.
- Created an isolated temporary custom service from the exact current `posthog.yaml` on the connected Coolify `4.1.2` instance. Pre-start inspection confirmed all expected child services, but that older runtime still generated the pre-fix malformed path/port values (`/e:3000`, `/s:3000`, etc.). The stack was deliberately not started because that would not test the patched PHP code. The temporary service, environment, project, containers, and volumes were removed.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with the available local development environment and documented the connected-runtime limitation above.
