### PR TITLE
fix(env): preserve empty service variable values

### DIFF
--- a/app/Models/EnvironmentVariable.php
+++ b/app/Models/EnvironmentVariable.php
@@ -356,7 +356,7 @@ class EnvironmentVariable extends BaseModel
 
     private function set_environment_variables(?string $environment_variable = null): ?string
     {
-        if (is_null($environment_variable) && $environment_variable === '') {
+        if (is_null($environment_variable)) {
             return null;
         }
         $environment_variable = trim($environment_variable);

--- a/tests/Feature/EnvironmentVariableValueCastingTest.php
+++ b/tests/Feature/EnvironmentVariableValueCastingTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Models\Application;
+use App\Models\EnvironmentVariable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+
+uses(RefreshDatabase::class);
+
+it('stores null environment variable values as database null', function () {
+    $env = EnvironmentVariable::create([
+        'key' => 'NULL_VALUE',
+        'value' => null,
+        'resourceable_type' => Application::class,
+        'resourceable_id' => 1,
+    ]);
+
+    $rawValue = DB::table('environment_variables')
+        ->where('id', $env->id)
+        ->value('value');
+
+    expect($rawValue)->toBeNull();
+
+    $env->refresh();
+    expect($env->value)->toBeNull();
+});
+
+it('preserves intentional empty string environment variable values', function () {
+    $env = EnvironmentVariable::create([
+        'key' => 'EMPTY_STRING_VALUE',
+        'value' => '',
+        'resourceable_type' => Application::class,
+        'resourceable_id' => 1,
+    ]);
+
+    $rawValue = DB::table('environment_variables')
+        ->where('id', $env->id)
+        ->value('value');
+
+    expect($rawValue)->not->toBeNull()
+        ->and(decrypt($rawValue))->toBe('');
+
+    $env->refresh();
+    expect($env->value)->toBe('');
+});


### PR DESCRIPTION
## Summary
- Fixes environment variable value casting so `null` remains database `null` while intentional empty strings are preserved as encrypted empty strings.
- Adds regression coverage for null and empty string environment variable values.

## Issue
- fixes #10827

---

Fixes #10827