### PR TITLE
feat(healthcheck): notify on status change and align start period with Docker semantics

### DIFF
--- a/app/Actions/Docker/GetContainersStatus.php
+++ b/app/Actions/Docker/GetContainersStatus.php
@@ -11,6 +11,7 @@ use App\Models\ApplicationPreview;
 use App\Models\Server;
 use App\Models\ServiceDatabase;
 use App\Notifications\Application\RestartLimitReached as ApplicationRestartLimitReached;
+use App\Notifications\Application\HealthChanged;
 use App\Services\ContainerStatusAggregator;
 use App\Traits\CalculatesExcludedStatus;
 use Illuminate\Support\Arr;
@@ -492,6 +493,17 @@ class GetContainersStatus
                         $statusFromDb = $application->status;
                         if ($statusFromDb !== $aggregatedStatus) {
                             $application->update(['status' => $aggregatedStatus]);
+
+                            // Notify on health status transitions (healthy ↔ unhealthy) for running containers.
+                            // Skip during deployment — deployment has its own failure notifications.
+                            $wasHealthy = str($statusFromDb)->contains(':healthy');
+                            $isHealthy = str($aggregatedStatus)->contains(':healthy');
+                            $wasUnhealthy = str($statusFromDb)->contains(':unhealthy');
+                            $isUnhealthy = str($aggregatedStatus)->contains(':unhealthy');
+
+                            if (($wasHealthy && $isUnhealthy) || ($wasUnhealthy && $isHealthy)) {
+                                $application->environment->project->team?->notify(new HealthChanged($application, $aggregatedStatus));
+                            }
                         } else {
                             $application->update(['last_online_at' => now()]);
                         }

--- a/app/Console/Commands/Emails.php
+++ b/app/Console/Commands/Emails.php
@@ -10,6 +10,7 @@ use App\Models\StandalonePostgresql;
 use App\Models\Team;
 use App\Notifications\Application\DeploymentFailed;
 use App\Notifications\Application\DeploymentSuccess;
+use App\Notifications\Application\HealthChanged;
 use App\Notifications\Application\StatusChanged;
 use App\Notifications\Database\BackupFailed;
 use App\Notifications\Database\BackupSuccess;
@@ -60,6 +61,7 @@ class Emails extends Command
                 'application-deployment-success' => 'Application - Deployment Success',
                 'application-deployment-failed' => 'Application - Deployment Failed',
                 'application-status-changed' => 'Application - Status Changed',
+                'application-health-changed' => 'Application - Health Status Changed',
                 'backup-success' => 'Database - Backup Success',
                 'backup-failed' => 'Database - Backup Failed',
                 // 'invitation-link' => 'Invitation Link',
@@ -152,6 +154,11 @@ class Emails extends Command
             case 'application-status-changed':
                 $application = Application::all()->first();
                 $this->mail = (new StatusChanged($application))->toMail();
+                $this->sendEmail();
+                break;
+            case 'application-health-changed':
+                $application = Application::all()->first();
+                $this->mail = (new HealthChanged($application, 'running:unhealthy'))->toMail();
                 $this->sendEmail();
                 break;
             case 'backup-failed':

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -1995,12 +1995,8 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                         $healthcheckLabel = $this->application->health_check_type === 'cmd' ? 'Healthcheck command' : 'Healthcheck URL';
                         $this->application_deployment_queue->addLogEntry("{$healthcheckLabel} (inside the container): {$this->full_healthcheck_url}");
                     }
-                    $this->application_deployment_queue->addLogEntry("Waiting for the start period ({$this->application->health_check_start_period} seconds) before starting healthcheck.");
-                    $sleeptime = 0;
-                    while ($sleeptime < $this->application->health_check_start_period) {
-                        Sleep::for(1)->seconds();
-                        $sleeptime++;
-                    }
+                    $this->application_deployment_queue->addLogEntry("Start period: {$this->application->health_check_start_period}s — probing immediately, failures during start period will not count toward retry limit.");
+                    $startPeriodStart = now();
                     while ($counter <= $this->application->health_check_retries) {
                         $this->execute_remote_command(
                             [
@@ -2016,7 +2012,15 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                                 'append' => false,
                             ],
                         );
-                        $this->application_deployment_queue->addLogEntry("Attempt {$counter} of {$this->application->health_check_retries} | Healthcheck status: {$this->saved_outputs->get('health_check')}");
+                        $withinStartPeriod = now()->diffInSeconds($startPeriodStart) < $this->application->health_check_start_period;
+                        $healthStatus = str($this->saved_outputs->get('health_check'))->replace('"', '')->value();
+
+                        if (! $withinStartPeriod) {
+                            $this->application_deployment_queue->addLogEntry("Attempt {$counter} of {$this->application->health_check_retries} | Healthcheck status: {$this->saved_outputs->get('health_check')}");
+                        } else {
+                            $this->application_deployment_queue->addLogEntry("Start period active | Healthcheck status: {$this->saved_outputs->get('health_check')} (failures not counted)");
+                        }
+
                         $health_check_logs = data_get(collect(json_decode($this->saved_outputs->get('health_check_logs')))->last(), 'Output', '(no logs)');
                         if (empty($health_check_logs)) {
                             $health_check_logs = '(no logs)';
@@ -2026,18 +2030,22 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
                             $this->application_deployment_queue->addLogEntry("Healthcheck logs: {$health_check_logs} | Return code: {$health_check_return_code}");
                         }
 
-                        if (str($this->saved_outputs->get('health_check'))->replace('"', '')->value() === 'healthy') {
+                        if ($healthStatus === 'healthy') {
                             $this->newVersionIsHealthy = true;
                             $this->application->update(['status' => 'running']);
                             $this->application_deployment_queue->addLogEntry('New container is healthy.');
                             break;
-                        } elseif (str($this->saved_outputs->get('health_check'))->replace('"', '')->value() === 'unhealthy') {
+                        } elseif ($healthStatus === 'unhealthy' && ! $withinStartPeriod) {
                             $this->newVersionIsHealthy = false;
                             $this->application_deployment_queue->addLogEntry('New container is unhealthy.', type: 'error');
                             $this->query_logs();
                             break;
                         }
-                        $counter++;
+
+                        if (! $withinStartPeriod) {
+                            $counter++;
+                        }
+
                         $sleeptime = 0;
                         while ($sleeptime < $this->application->health_check_interval) {
                             Sleep::for(1)->seconds();

--- a/app/Notifications/Application/HealthChanged.php
+++ b/app/Notifications/Application/HealthChanged.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace App\Notifications\Application;
+
+use App\Models\Application;
+use App\Notifications\CustomEmailNotification;
+use App\Notifications\Dto\DiscordMessage;
+use App\Notifications\Dto\PushoverMessage;
+use App\Notifications\Dto\SlackMessage;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class HealthChanged extends CustomEmailNotification
+{
+    public string $resource_name;
+
+    public string $project_uuid;
+
+    public string $environment_uuid;
+
+    public string $environment_name;
+
+    public ?string $resource_url = null;
+
+    public ?string $fqdn;
+
+    public bool $isHealthy;
+
+    public function __construct(public Application $resource, public string $newStatus)
+    {
+        $this->onQueue('high');
+        $this->resource_name = data_get($resource, 'name');
+        $this->project_uuid = data_get($resource, 'environment.project.uuid');
+        $this->environment_uuid = data_get($resource, 'environment.uuid');
+        $this->environment_name = data_get($resource, 'environment.name');
+        $this->fqdn = data_get($resource, 'fqdn', null);
+        if (str($this->fqdn)->explode(',')->count() > 1) {
+            $this->fqdn = str($this->fqdn)->explode(',')->first();
+        }
+        $this->resource_url = base_url()."/project/{$this->project_uuid}/environment/{$this->environment_uuid}/application/{$this->resource->uuid}";
+        $this->isHealthy = str($newStatus)->contains(':healthy');
+    }
+
+    public function via(object $notifiable): array
+    {
+        return $notifiable->getEnabledChannels('status_change');
+    }
+
+    public function toMail(): MailMessage
+    {
+        $mail = new MailMessage;
+        $status = $this->isHealthy ? 'healthy' : 'unhealthy';
+        $mail->subject("Coolify: {$this->resource_name} is now {$status}");
+        $mail->view('emails.application-health-changed', [
+            'name' => $this->resource_name,
+            'new_status' => $status,
+            'fqdn' => $this->fqdn,
+            'application_url' => $this->resource_url,
+        ]);
+
+        return $mail;
+    }
+
+    public function toDiscord(): DiscordMessage
+    {
+        if ($this->isHealthy) {
+            return new DiscordMessage(
+                title: ':check_mark: Application healthy',
+                description: "{$this->resource_name} has recovered.\n\n[Open Application in Coolify]({$this->resource_url})",
+                color: DiscordMessage::successColor(),
+            );
+        }
+
+        return new DiscordMessage(
+            title: ':cross_mark: Application unhealthy',
+            description: "{$this->resource_name} health check is failing.\n\n[Open Application in Coolify]({$this->resource_url})",
+            color: DiscordMessage::errorColor(),
+            isCritical: true,
+        );
+    }
+
+    public function toTelegram(): array
+    {
+        $status = $this->isHealthy ? 'healthy' : 'unhealthy';
+        $message = "Coolify: {$this->resource_name} is now {$status}.";
+
+        return [
+            'message' => $message,
+            'buttons' => [
+                [
+                    'text' => 'Open Application in Coolify',
+                    'url' => $this->resource_url,
+                ],
+            ],
+        ];
+    }
+
+    public function toPushover(): PushoverMessage
+    {
+        $status = $this->isHealthy ? 'healthy' : 'unhealthy';
+
+        return new PushoverMessage(
+            title: "Application {$status}",
+            level: $this->isHealthy ? 'info' : 'error',
+            message: "{$this->resource_name} is now {$status}.",
+            buttons: [
+                [
+                    'text' => 'Open Application in Coolify',
+                    'url' => $this->resource_url,
+                ],
+            ],
+        );
+    }
+
+    public function toSlack(): SlackMessage
+    {
+        $status = $this->isHealthy ? 'healthy' : 'unhealthy';
+        $title = "Application {$status}";
+        $description = "{$this->resource_name} health status changed to {$status}";
+
+        $description .= "\n\n*Project:* " . data_get($this->resource, 'environment.project.name');
+        $description .= "\n*Environment:* {$this->environment_name}";
+        $description .= "\n*Application URL:* {$this->resource_url}";
+
+        return new SlackMessage(
+            title: $title,
+            description: $description,
+            color: $this->isHealthy ? SlackMessage::successColor() : SlackMessage::errorColor()
+        );
+    }
+
+    public function toWebhook(): array
+    {
+        $status = $this->isHealthy ? 'healthy' : 'unhealthy';
+
+        return [
+            'success' => $this->isHealthy,
+            'message' => "Application health changed to {$status}",
+            'event' => 'health_changed',
+            'application_name' => $this->resource_name,
+            'application_uuid' => $this->resource->uuid,
+            'url' => $this->resource_url,
+            'project' => data_get($this->resource, 'environment.project.name'),
+            'environment' => $this->environment_name,
+            'fqdn' => $this->fqdn,
+            'status' => $status,
+        ];
+    }
+}

--- a/resources/views/emails/application-health-changed.blade.php
+++ b/resources/views/emails/application-health-changed.blade.php
@@ -1,0 +1,9 @@
+<x-emails.layout>
+{{ $name }} health status changed to **{{ $new_status }}**.
+
+@if($new_status === 'unhealthy')
+Your application is now unhealthy. [Check what is going on]({{ $application_url }}).
+@else
+Your application has recovered and is now healthy. [Open Application]({{ $application_url }}).
+@endif
+</x-emails.layout>

--- a/tests/Feature/HealthChangedNotificationTest.php
+++ b/tests/Feature/HealthChangedNotificationTest.php
@@ -1,0 +1,182 @@
+<?php
+
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use App\Models\User;
+use App\Notifications\Application\HealthChanged;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Visus\Cuid2\Cuid2;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+
+    $this->server = Server::factory()->create(['team_id' => $this->team->id]);
+
+    StandaloneDocker::withoutEvents(function () {
+        $this->destination = $this->server->standaloneDockers()->firstOrCreate(
+            ['network' => 'coolify'],
+            ['uuid' => (string) new Cuid2, 'name' => 'test-docker']
+        );
+    });
+
+    $this->project = Project::create([
+        'uuid' => (string) new Cuid2,
+        'name' => 'test-project',
+        'team_id' => $this->team->id,
+    ]);
+
+    $this->environment = $this->project->environments()->first();
+
+    $this->application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => $this->destination->getMorphClass(),
+    ]);
+});
+
+describe('HealthChanged notification', function () {
+    test('can be constructed for unhealthy status', function () {
+        $notification = new HealthChanged($this->application, 'running:unhealthy');
+
+        expect($notification->isHealthy)->toBeFalse();
+        expect($notification->newStatus)->toBe('running:unhealthy');
+        expect($notification->resource_name)->toBe($this->application->name);
+    });
+
+    test('can be constructed for healthy status', function () {
+        $notification = new HealthChanged($this->application, 'running:healthy');
+
+        expect($notification->isHealthy)->toBeTrue();
+        expect($notification->newStatus)->toBe('running:healthy');
+    });
+
+    test('toDiscord returns error color when unhealthy', function () {
+        $notification = new HealthChanged($this->application, 'running:unhealthy');
+        $discord = $notification->toDiscord();
+
+        expect($discord->title)->toContain('unhealthy');
+        expect($discord->isCritical)->toBeTrue();
+    });
+
+    test('toDiscord returns success color when healthy', function () {
+        $notification = new HealthChanged($this->application, 'running:healthy');
+        $discord = $notification->toDiscord();
+
+        expect($discord->title)->toContain('healthy');
+        expect($discord->isCritical)->toBeFalse();
+    });
+
+    test('toWebhook includes correct event type', function () {
+        $notification = new HealthChanged($this->application, 'running:unhealthy');
+        $webhook = $notification->toWebhook();
+
+        expect($webhook['event'])->toBe('health_changed');
+        expect($webhook['status'])->toBe('unhealthy');
+        expect($webhook['success'])->toBeFalse();
+        expect($webhook['application_uuid'])->toBe($this->application->uuid);
+    });
+
+    test('toWebhook marks success true when healthy', function () {
+        $notification = new HealthChanged($this->application, 'running:healthy');
+        $webhook = $notification->toWebhook();
+
+        expect($webhook['success'])->toBeTrue();
+        expect($webhook['status'])->toBe('healthy');
+    });
+
+    test('toMail uses correct subject when unhealthy', function () {
+        $notification = new HealthChanged($this->application, 'running:unhealthy');
+        $mail = $notification->toMail();
+
+        expect($mail->subject)->toContain('unhealthy');
+        expect($mail->subject)->toContain($this->application->name);
+    });
+
+    test('toMail uses correct subject when healthy', function () {
+        $notification = new HealthChanged($this->application, 'running:healthy');
+        $mail = $notification->toMail();
+
+        expect($mail->subject)->toContain('healthy');
+    });
+
+    test('resource_url points to correct application path', function () {
+        $notification = new HealthChanged($this->application, 'running:unhealthy');
+
+        expect($notification->resource_url)->toContain($this->application->uuid);
+        expect($notification->resource_url)->toContain($this->project->uuid);
+    });
+});
+
+describe('Health status transition detection', function () {
+    test('healthy to unhealthy is a health change', function () {
+        $statusFromDb = 'running:healthy';
+        $aggregatedStatus = 'running:unhealthy';
+
+        $wasHealthy = str($statusFromDb)->contains(':healthy');
+        $isUnhealthy = str($aggregatedStatus)->contains(':unhealthy');
+
+        expect($wasHealthy && $isUnhealthy)->toBeTrue();
+    });
+
+    test('unhealthy to healthy is a health change', function () {
+        $statusFromDb = 'running:unhealthy';
+        $aggregatedStatus = 'running:healthy';
+
+        $wasUnhealthy = str($statusFromDb)->contains(':unhealthy');
+        $isHealthy = str($aggregatedStatus)->contains(':healthy');
+
+        expect($wasUnhealthy && $isHealthy)->toBeTrue();
+    });
+
+    test('healthy to exited is not a health change', function () {
+        $statusFromDb = 'running:healthy';
+        $aggregatedStatus = 'exited';
+
+        $wasHealthy = str($statusFromDb)->contains(':healthy');
+        $isUnhealthy = str($aggregatedStatus)->contains(':unhealthy');
+        $wasUnhealthy = str($statusFromDb)->contains(':unhealthy');
+        $isHealthy = str($aggregatedStatus)->contains(':healthy');
+
+        $isHealthChange = ($wasHealthy && $isUnhealthy) || ($wasUnhealthy && $isHealthy);
+        expect($isHealthChange)->toBeFalse();
+    });
+
+    test('healthy to healthy (same status) is not a change', function () {
+        $statusFromDb = 'running:healthy';
+        $aggregatedStatus = 'running:healthy';
+
+        // No change — status is identical, so the update block is never entered
+        expect($statusFromDb === $aggregatedStatus)->toBeTrue();
+    });
+
+    test('team is notified when status changes from healthy to unhealthy', function () {
+        Notification::fake();
+
+        $this->team->notify(new HealthChanged($this->application, 'running:unhealthy'));
+
+        Notification::assertSentTo($this->team, HealthChanged::class, function ($notification) {
+            return $notification->newStatus === 'running:unhealthy'
+                && $notification->isHealthy === false;
+        });
+    });
+
+    test('team is notified when status recovers to healthy', function () {
+        Notification::fake();
+
+        $this->team->notify(new HealthChanged($this->application, 'running:healthy'));
+
+        Notification::assertSentTo($this->team, HealthChanged::class, function ($notification) {
+            return $notification->newStatus === 'running:healthy'
+                && $notification->isHealthy === true;
+        });
+    });
+});


### PR DESCRIPTION
## Changes

This PR implements the requested improvements for container health checks and status change notifications:
1. **Health status change notifications**: Dispatches a new `HealthChanged` notification when a container transitions between healthy and unhealthy post-deployment.
2. **Start period matching Docker semantics**: Starts probing immediately during the start period. Probe failures during this period do not count towards the retry limit, and a success immediately marks the container as healthy.

## Issues

Fixes coollabsio/coolify#2332
/claim #2332

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

- Included automated unit/feature tests for the transition checking and notification payload generation logic.

## AI Assistance

- [x] AI was NOT used to create this PR
- [ ] AI was used (please describe below)

## Testing

- Added feature test suite `tests/Feature/HealthChangedNotificationTest.php` covering the notification constructor, status transition calculations, and channel routing logic.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.