### PR TITLE
fix(github): honor skip flags for PR preview syncs

### DIFF
--- a/app/Jobs/ProcessGithubPullRequestWebhook.php
+++ b/app/Jobs/ProcessGithubPullRequestWebhook.php
@@ -101,7 +101,7 @@ class ProcessGithubPullRequestWebhook implements ShouldBeEncrypted, ShouldQueue
         $repo = $repository_parts[1] ?? '';
         $headCommitMessage = null;
 
-        if ($this->action === 'synchronize') {
+        if ($this->action === 'opened' || $this->action === 'synchronize' || $this->action === 'reopened') {
             $headCommitMessage = getGithubCommitMessage($githubApp, $owner, $repo, $this->commitSha);
         }
 

--- a/app/Jobs/ProcessGithubPullRequestWebhook.php
+++ b/app/Jobs/ProcessGithubPullRequestWebhook.php
@@ -96,7 +96,16 @@ class ProcessGithubPullRequestWebhook implements ShouldBeEncrypted, ShouldQueue
             return;
         }
 
-        if (self::shouldSkipDeployAny([$this->pullRequestTitle])) {
+        $repository_parts = explode('/', $this->fullName);
+        $owner = $repository_parts[0] ?? '';
+        $repo = $repository_parts[1] ?? '';
+        $headCommitMessage = null;
+
+        if ($this->action === 'synchronize') {
+            $headCommitMessage = getGithubCommitMessage($githubApp, $owner, $repo, $this->commitSha);
+        }
+
+        if (self::shouldSkipDeployAny([$this->pullRequestTitle, $headCommitMessage])) {
             return;
         }
 
@@ -120,9 +129,6 @@ class ProcessGithubPullRequestWebhook implements ShouldBeEncrypted, ShouldQueue
 
         // Get changed files for watch path filtering
         $changed_files = collect();
-        $repository_parts = explode('/', $this->fullName);
-        $owner = $repository_parts[0] ?? '';
-        $repo = $repository_parts[1] ?? '';
 
         if ($this->action === 'synchronize' && $this->beforeSha && $this->afterSha) {
             // For synchronize events, get files changed between before and after commits

--- a/bootstrap/helpers/github.php
+++ b/bootstrap/helpers/github.php
@@ -414,6 +414,28 @@ function getGithubCommitRangeFiles(?GithubApp $source, string $owner, string $re
     }
 }
 
+function getGithubCommitMessage(?GithubApp $source, string $owner, string $repo, string $commitSha): ?string
+{
+    try {
+        if (! $source) {
+            return null;
+        }
+
+        if (blank($owner) || blank($repo) || blank($commitSha) || $commitSha === 'HEAD') {
+            return null;
+        }
+
+        $endpoint = "/repos/{$owner}/{$repo}/commits/{$commitSha}";
+        $response = githubApi($source, $endpoint, 'get', null, false);
+
+        $message = data_get($response, 'data.commit.message');
+
+        return is_string($message) ? $message : null;
+    } catch (Exception $e) {
+        return null;
+    }
+}
+
 function getGithubPullRequestFiles(?GithubApp $source, string $owner, string $repo, int $pullRequestId): array
 {
     try {

--- a/tests/Feature/ProcessGithubPullRequestWebhookTest.php
+++ b/tests/Feature/ProcessGithubPullRequestWebhookTest.php
@@ -108,3 +108,50 @@ it('skips a synchronized GitHub pull request preview when the head commit messag
 
     Http::assertSent(fn (Request $request): bool => $request->url() === 'https://api.github.com/repos/example/repo/commits/after-sha');
 });
+
+it('skips a GitHub pull request preview when the opened or reopened head commit message contains skip ci', function (string $action) {
+    Queue::fake();
+
+    $this->application->settings->update([
+        'is_preview_deployments_enabled' => true,
+    ]);
+
+    $githubApp = GithubApp::create([
+        'name' => 'Public GitHub',
+        'api_url' => 'https://api.github.com',
+        'html_url' => 'https://github.com',
+        'is_public' => true,
+        'team_id' => $this->team->id,
+    ]);
+
+    Http::fake([
+        'https://api.github.com/repos/example/repo/commits/head-sha' => Http::response([
+            'commit' => [
+                'message' => 'docs: fix typo [skip ci]',
+            ],
+        ]),
+        'https://api.github.com/repos/example/repo/pulls/42/files' => Http::response([]),
+    ]);
+
+    $job = new ProcessGithubPullRequestWebhook(
+        applicationId: $this->application->id,
+        githubAppId: $githubApp->id,
+        action: $action,
+        pullRequestId: 42,
+        pullRequestHtmlUrl: 'https://github.com/example/repo/pull/42',
+        pullRequestTitle: 'Add feature',
+        beforeSha: null,
+        afterSha: null,
+        commitSha: 'head-sha',
+        authorAssociation: 'OWNER',
+        fullName: 'example/repo',
+    );
+
+    $job->handle();
+
+    expect(ApplicationPreview::where('application_id', $this->application->id)->where('pull_request_id', 42)->exists())->toBeFalse()
+        ->and(ApplicationDeploymentQueue::where('application_id', $this->application->id)->where('pull_request_id', 42)->exists())->toBeFalse();
+
+    Http::assertSent(fn (Request $request): bool => $request->url() === 'https://api.github.com/repos/example/repo/commits/head-sha');
+    Http::assertNotSent(fn (Request $request): bool => $request->url() === 'https://api.github.com/repos/example/repo/pulls/42/files');
+})->with(['opened', 'reopened']);

--- a/tests/Feature/ProcessGithubPullRequestWebhookTest.php
+++ b/tests/Feature/ProcessGithubPullRequestWebhookTest.php
@@ -3,14 +3,19 @@
 use App\Actions\Application\CleanupPreviewDeployment;
 use App\Jobs\ProcessGithubPullRequestWebhook;
 use App\Models\Application;
+use App\Models\ApplicationDeploymentQueue;
 use App\Models\ApplicationPreview;
 use App\Models\Environment;
+use App\Models\GithubApp;
 use App\Models\InstanceSettings;
 use App\Models\Project;
 use App\Models\Server;
 use App\Models\StandaloneDocker;
 use App\Models\Team;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
 
 uses(RefreshDatabase::class);
 
@@ -57,4 +62,49 @@ it('cleans up a closed pull request preview when pull request comment cleanup fa
     };
 
     $job->handle();
+});
+
+it('skips a synchronized GitHub pull request preview when the head commit message contains skip ci', function () {
+    Queue::fake();
+
+    $this->application->settings->update([
+        'is_preview_deployments_enabled' => true,
+    ]);
+
+    $githubApp = GithubApp::create([
+        'name' => 'Public GitHub',
+        'api_url' => 'https://api.github.com',
+        'html_url' => 'https://github.com',
+        'is_public' => true,
+        'team_id' => $this->team->id,
+    ]);
+
+    Http::fake([
+        'https://api.github.com/repos/example/repo/commits/after-sha' => Http::response([
+            'commit' => [
+                'message' => 'docs: fix typo [skip ci]',
+            ],
+        ]),
+    ]);
+
+    $job = new ProcessGithubPullRequestWebhook(
+        applicationId: $this->application->id,
+        githubAppId: $githubApp->id,
+        action: 'synchronize',
+        pullRequestId: 42,
+        pullRequestHtmlUrl: 'https://github.com/example/repo/pull/42',
+        pullRequestTitle: 'Add feature',
+        beforeSha: 'before-sha',
+        afterSha: 'after-sha',
+        commitSha: 'after-sha',
+        authorAssociation: 'OWNER',
+        fullName: 'example/repo',
+    );
+
+    $job->handle();
+
+    expect(ApplicationPreview::where('application_id', $this->application->id)->where('pull_request_id', 42)->exists())->toBeFalse()
+        ->and(ApplicationDeploymentQueue::where('application_id', $this->application->id)->where('pull_request_id', 42)->exists())->toBeFalse();
+
+    Http::assertSent(fn (Request $request): bool => $request->url() === 'https://api.github.com/repos/example/repo/commits/after-sha');
 });

--- a/tests/Feature/ProcessGithubPullRequestWebhookTest.php
+++ b/tests/Feature/ProcessGithubPullRequestWebhookTest.php
@@ -109,6 +109,57 @@ it('skips a synchronized GitHub pull request preview when the head commit messag
     Http::assertSent(fn (Request $request): bool => $request->url() === 'https://api.github.com/repos/example/repo/commits/after-sha');
 });
 
+it('deploys a synchronized GitHub pull request preview when the head commit message does not contain skip ci', function () {
+    Queue::fake();
+
+    $this->application->settings->update([
+        'is_preview_deployments_enabled' => true,
+    ]);
+
+    $githubApp = GithubApp::create([
+        'name' => 'Public GitHub',
+        'api_url' => 'https://api.github.com',
+        'html_url' => 'https://github.com',
+        'is_public' => true,
+        'team_id' => $this->team->id,
+    ]);
+
+    Http::fake([
+        'https://api.github.com/repos/example/repo/commits/after-sha' => Http::response([
+            'commit' => [
+                'message' => 'docs: fix typo',
+            ],
+        ]),
+        'https://api.github.com/repos/example/repo/compare/before-sha...after-sha' => Http::response([
+            'files' => [
+                ['filename' => 'README.md'],
+            ],
+        ]),
+    ]);
+
+    $job = new ProcessGithubPullRequestWebhook(
+        applicationId: $this->application->id,
+        githubAppId: $githubApp->id,
+        action: 'synchronize',
+        pullRequestId: 42,
+        pullRequestHtmlUrl: 'https://github.com/example/repo/pull/42',
+        pullRequestTitle: 'Add feature',
+        beforeSha: 'before-sha',
+        afterSha: 'after-sha',
+        commitSha: 'after-sha',
+        authorAssociation: 'OWNER',
+        fullName: 'example/repo',
+    );
+
+    $job->handle();
+
+    expect(ApplicationPreview::where('application_id', $this->application->id)->where('pull_request_id', 42)->exists())->toBeTrue()
+        ->and(ApplicationDeploymentQueue::where('application_id', $this->application->id)->where('pull_request_id', 42)->where('commit', 'after-sha')->exists())->toBeTrue();
+
+    Http::assertSent(fn (Request $request): bool => $request->url() === 'https://api.github.com/repos/example/repo/commits/after-sha');
+    Http::assertSent(fn (Request $request): bool => $request->url() === 'https://api.github.com/repos/example/repo/compare/before-sha...after-sha');
+});
+
 it('skips a GitHub pull request preview when the opened or reopened head commit message contains skip ci', function (string $action) {
     Queue::fake();
 


### PR DESCRIPTION
## Summary
- Fetch the synchronized PR head commit message and include it in skip-deploy checks for GitHub preview deployments.
- Preserve PR title skip behavior while adding per-commit `[skip ci]` / `[skip cd]` parity with push webhooks.
- Add coverage confirming preview deployments and deployment queue entries are not created when the head commit contains a skip flag.

## Issue
- fixes #10870

---

Fixes #10870