### PR TITLE
fix: group Traefik labels for matching domains

### DIFF
--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -490,6 +490,146 @@ function fqdnLabelsForTraefik(string $uuid, Collection $domains, bool $is_force_
             ->filter()
             ->unique();
     }
+
+    if ($domains->count() > 1 && ! $generate_unique_uuid && ! str($image)->contains('ghost')) {
+        $domainGroups = collect([]);
+        $redirectMiddlewares = collect([]);
+
+        foreach ($domains as $domain) {
+            try {
+                $url = Url::fromString($domain);
+                $host = $url->getHost();
+                $path = $url->getPath();
+                $schema = $url->getScheme();
+                $port = $url->getPort();
+                if (is_null($port) && ! is_null($onlyPort)) {
+                    $port = $onlyPort;
+                }
+
+                $redirect_middleware = null;
+                $redirect_label_base = $service_name ? "{$uuid}-{$service_name}" : $uuid;
+                if ($redirect_direction === 'non-www' && str($host)->startsWith('www.')) {
+                    $redirect_middleware = "{$redirect_label_base}-to-non-www";
+                    $redirectMiddlewares->put($redirect_middleware, [
+                        "traefik.http.middlewares.{$redirect_middleware}.redirectregex.regex=^(http|https)://www\.(.+)",
+                        "traefik.http.middlewares.{$redirect_middleware}.redirectregex.replacement=\${1}://\${2}",
+                        "traefik.http.middlewares.{$redirect_middleware}.redirectregex.permanent=false",
+                    ]);
+                }
+                if ($redirect_direction === 'www' && ! str($host)->startsWith('www.')) {
+                    $redirect_middleware = "{$redirect_label_base}-to-www";
+                    $redirectMiddlewares->put($redirect_middleware, [
+                        "traefik.http.middlewares.{$redirect_middleware}.redirectregex.regex=^(http|https)://(?:www\.)?(.+)",
+                        "traefik.http.middlewares.{$redirect_middleware}.redirectregex.replacement=\${1}://www.\${2}",
+                        "traefik.http.middlewares.{$redirect_middleware}.redirectregex.permanent=false",
+                    ]);
+                }
+
+                $groupKey = implode('|', [
+                    $schema,
+                    $path,
+                    $port ?? '',
+                    $redirect_middleware ?? '',
+                ]);
+                $group = $domainGroups->get($groupKey, [
+                    'schema' => $schema,
+                    'path' => $path,
+                    'port' => $port,
+                    'redirect_middleware' => $redirect_middleware,
+                    'hosts' => collect([]),
+                ]);
+                $group['hosts']->push($host);
+                $domainGroups->put($groupKey, $group);
+            } catch (Throwable) {
+                continue;
+            }
+        }
+
+        $redirectMiddlewares->each(function ($middlewareLabels) use ($labels) {
+            collect($middlewareLabels)->each(function ($middlewareLabel) use ($labels) {
+                $labels->push($middlewareLabel);
+            });
+        });
+
+        $groupIndex = 0;
+        $domainGroups->each(function ($group) use ($labels, &$groupIndex, $uuid, $service_name, $is_force_https_enabled, $is_gzip_enabled, $is_stripprefix_enabled, $is_http_basic_auth_enabled, $http_basic_auth_label, $middlewares_from_labels) {
+            $groupIndex++;
+            $label_suffix = "{$groupIndex}-{$uuid}";
+            if ($service_name) {
+                $label_suffix = "{$label_suffix}-{$service_name}";
+            }
+            $hostRule = $group['hosts']->unique()->map(fn ($host) => "Host(`{$host}`)")->join(' || ');
+            $rule = "({$hostRule}) && PathPrefix(`{$group['path']}`)";
+            $service_label = "service-{$label_suffix}";
+
+            $buildMiddlewares = function (string $router_label) use ($labels, $group, $is_gzip_enabled, $is_stripprefix_enabled, $is_http_basic_auth_enabled, $http_basic_auth_label, $middlewares_from_labels) {
+                $middlewares = collect([]);
+                if ($group['path'] !== '/' && $is_stripprefix_enabled) {
+                    $labels->push("traefik.http.middlewares.{$router_label}-stripprefix.stripprefix.prefixes={$group['path']}");
+                    $middlewares->push("{$router_label}-stripprefix");
+                }
+                if ($is_gzip_enabled) {
+                    $middlewares->push('gzip');
+                }
+                if ($group['redirect_middleware']) {
+                    $middlewares->push($group['redirect_middleware']);
+                }
+                if ($is_http_basic_auth_enabled) {
+                    $middlewares->push($http_basic_auth_label);
+                }
+                $middlewares_from_labels->each(function ($middleware_name) use ($middlewares) {
+                    $middlewares->push($middleware_name);
+                });
+
+                return $middlewares->unique()->join(',');
+            };
+
+            if ($group['port']) {
+                $labels->push("traefik.http.services.{$service_label}.loadbalancer.server.port={$group['port']}");
+            }
+
+            if ($group['schema'] === 'https') {
+                $https_label = "https-{$label_suffix}";
+                $http_label = "http-{$label_suffix}";
+
+                $labels->push("traefik.http.routers.{$https_label}.rule={$rule}");
+                $labels->push("traefik.http.routers.{$https_label}.entryPoints=https");
+                if ($group['port']) {
+                    $labels->push("traefik.http.routers.{$https_label}.service={$service_label}");
+                }
+                $middlewares = $buildMiddlewares($https_label);
+                if ($middlewares !== '') {
+                    $labels->push("traefik.http.routers.{$https_label}.middlewares={$middlewares}");
+                }
+                $labels->push("traefik.http.routers.{$https_label}.tls=true");
+                $labels->push("traefik.http.routers.{$https_label}.tls.certresolver=letsencrypt");
+
+                $labels->push("traefik.http.routers.{$http_label}.rule={$rule}");
+                $labels->push("traefik.http.routers.{$http_label}.entryPoints=http");
+                if ($group['port']) {
+                    $labels->push("traefik.http.routers.{$http_label}.service={$service_label}");
+                }
+                if ($is_force_https_enabled) {
+                    $labels->push("traefik.http.routers.{$http_label}.middlewares=redirect-to-https");
+                }
+            } else {
+                $http_label = "http-{$label_suffix}";
+
+                $labels->push("traefik.http.routers.{$http_label}.rule={$rule}");
+                $labels->push("traefik.http.routers.{$http_label}.entryPoints=http");
+                if ($group['port']) {
+                    $labels->push("traefik.http.routers.{$http_label}.service={$service_label}");
+                }
+                $middlewares = $buildMiddlewares($http_label);
+                if ($middlewares !== '') {
+                    $labels->push("traefik.http.routers.{$http_label}.middlewares={$middlewares}");
+                }
+            }
+        });
+
+        return $labels->sort();
+    }
+
     foreach ($domains as $loop => $domain) {
         try {
             if ($generate_unique_uuid) {

--- a/tests/Unit/FqdnLabelsForTraefikGroupingTest.php
+++ b/tests/Unit/FqdnLabelsForTraefikGroupingTest.php
@@ -1,0 +1,50 @@
+<?php
+
+it('groups traefik router rules for domains with matching routing options', function () {
+    $domains = collect([
+        'https://example.com',
+        'https://example.org',
+        'https://example.net',
+    ]);
+
+    $labels = fqdnLabelsForTraefik(
+        uuid: 'app123',
+        domains: $domains,
+        is_force_https_enabled: true,
+        onlyPort: 3000,
+    );
+
+    $httpsRules = $labels->filter(fn ($label) => str($label)->startsWith('traefik.http.routers.https-') && str($label)->contains('.rule='));
+    $httpRules = $labels->filter(fn ($label) => str($label)->startsWith('traefik.http.routers.http-') && str($label)->contains('.rule='));
+
+    expect($httpsRules)->toHaveCount(1)
+        ->and($httpRules)->toHaveCount(1)
+        ->and($httpsRules->first())->toContain('Host(`example.com`) || Host(`example.org`) || Host(`example.net`)')
+        ->and($httpsRules->first())->toContain('PathPrefix(`/`)')
+        ->and($labels->filter(fn ($label) => str($label)->contains('loadbalancer.server.port=3000')))->toHaveCount(1);
+});
+
+it('keeps separate traefik groups when domains need different redirect middleware', function () {
+    $domains = collect([
+        'https://example.com',
+        'https://www.example.com',
+        'https://example.org',
+        'https://www.example.org',
+    ]);
+
+    $labels = fqdnLabelsForTraefik(
+        uuid: 'app123',
+        domains: $domains,
+        is_force_https_enabled: true,
+        onlyPort: 3000,
+        redirect_direction: 'non-www',
+    );
+
+    $httpsRules = $labels->filter(fn ($label) => str($label)->startsWith('traefik.http.routers.https-') && str($label)->contains('.rule='));
+    $redirectMiddlewares = $labels->filter(fn ($label) => str($label)->contains('redirectregex.regex=^(http|https)://www\.'));
+
+    expect($httpsRules)->toHaveCount(2)
+        ->and($redirectMiddlewares)->toHaveCount(1)
+        ->and($labels->filter(fn ($label) => str($label)->contains('to-non-www')))->not->toBeEmpty();
+});
+


### PR DESCRIPTION
## Changes

- Groups Traefik router labels when domains share the same scheme, path, port, and redirect middleware requirements.
- Reuses one service label per compatible domain group instead of emitting a full router/service set for every domain.
- Leaves single-domain, generated-unique-uuid, and Ghost-specific paths on the existing implementation.
- Adds unit coverage for grouped Host(...) rules and for splitting domains that need www/non-www redirect middleware.

## Issues

- Fixes #5447
- Replaces closed PR #10878, which targeted `v4.x` by mistake.

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

This is a backend label-generation change. No UI preview is included.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex
- How extensively: AI helped draft and implement the patch. I reviewed the generated code path, kept the change scoped to Traefik label generation, and preserved the existing behavior for single-domain and complex routing cases.

## Testing

- `git diff --check`
- Added `tests/Unit/FqdnLabelsForTraefikGroupingTest.php`
- Not run locally: PHP/Pest suite and full Coolify development instance, because this environment does not have PHP or Docker installed.

/claim #5447

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.