### PR TITLE
fix(deployment): remove orphaned containers when consistent/custom container name is enabled

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -3287,6 +3287,9 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
         }
 
         if ($this->pull_request_id === 0) {
+            if (customDockerRunOptionsContainsName($this->application->custom_docker_run_options)) {
+                $this->application_deployment_queue->addLogEntry("WARNING: The '--name' option in Custom Docker Options is not supported and will be ignored. Use the 'Custom Internal Name' setting (Advanced) to set a custom container name.", 'stderr');
+            }
             $custom_compose = convertDockerRunToCompose($this->application->custom_docker_run_options);
             if ((bool) $this->application->settings->is_consistent_container_name_enabled) {
                 if (! $this->application->settings->custom_internal_name) {
@@ -3838,7 +3841,7 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
         $this->application_deployment_queue->addLogEntry('Building docker image completed.');
     }
 
-    private function graceful_shutdown_container(string $containerName, bool $skipRemove = false)
+    protected function graceful_shutdown_container(string $containerName, bool $skipRemove = false)
     {
         try {
             $timeout = $this->application->settings->deploymentStopGracePeriodSeconds();
@@ -3858,6 +3861,11 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
         }
     }
 
+    protected function get_current_application_containers(): Collection
+    {
+        return getCurrentApplicationContainerStatus($this->server, $this->application->id, $this->pull_request_id);
+    }
+
     private function stop_running_container(bool $force = false)
     {
         try {
@@ -3865,8 +3873,14 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
             if ($this->newVersionIsHealthy || $force) {
                 if ($this->application->settings->is_consistent_container_name_enabled || str($this->application->settings->custom_internal_name)->isNotEmpty()) {
                     $this->graceful_shutdown_container($this->container_name);
+                    // Clean up orphaned containers left behind by a previous naming scheme
+                    // (e.g. timestamped names from before the consistent/custom name setting
+                    // was enabled, or an older custom name) — matched by label, not by name.
+                    $this->get_current_application_containers()
+                        ->filter(fn ($container) => data_get($container, 'Names') !== $this->container_name)
+                        ->each(fn ($container) => $this->graceful_shutdown_container(data_get($container, 'Names')));
                 } else {
-                    $containers = getCurrentApplicationContainerStatus($this->server, $this->application->id, $this->pull_request_id);
+                    $containers = $this->get_current_application_containers();
                     if ($this->pull_request_id === 0) {
                         $containers = $containers->filter(function ($container) {
                             return data_get($container, 'Names') !== $this->container_name && data_get($container, 'Names') !== addPreviewDeploymentSuffix($this->container_name, $this->pull_request_id);

--- a/app/Livewire/Project/Application/General.php
+++ b/app/Livewire/Project/Application/General.php
@@ -766,6 +766,12 @@ class General extends Component
 
             $this->validate();
 
+            if (customDockerRunOptionsContainsName($this->customDockerRunOptions)) {
+                $this->dispatch('error', 'The --name option is not supported in Custom Docker Options.', "It would break Coolify's container lifecycle management. Use the 'Custom Internal Name' setting under Advanced instead.");
+
+                return;
+            }
+
             $oldPortsExposes = $this->application->ports_exposes;
             $oldIsContainerLabelEscapeEnabled = $this->application->settings->is_container_label_escape_enabled;
             $oldDockerComposeLocation = $this->initialDockerComposeLocation;

--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -987,6 +987,15 @@ function isDatabaseImageWithContext(string $imageName, array $serviceConfig): bo
     return true;
 }
 
+function customDockerRunOptionsContainsName(?string $custom_docker_run_options = null): bool
+{
+    if (blank($custom_docker_run_options)) {
+        return false;
+    }
+
+    return (bool) preg_match('/(^|\s)--name(=|\s|$)/', $custom_docker_run_options);
+}
+
 function convertDockerRunToCompose(?string $custom_docker_run_options = null)
 {
     $options = [];

--- a/tests/Feature/DockerCustomCommandsTest.php
+++ b/tests/Feature/DockerCustomCommandsTest.php
@@ -233,3 +233,28 @@ test('ConvertIpAndIp6Together', function () {
         'ip6' => ['2001:db8::1'],
     ]);
 });
+
+test('NameOptionIsIgnoredByConvert', function () {
+    $input = '--name my-container --init';
+    $output = convertDockerRunToCompose($input);
+    expect($output)->toBe([
+        'init' => true,
+    ]);
+});
+
+test('DetectsNameOptionWithSpace', function () {
+    expect(customDockerRunOptionsContainsName('--name my-container'))->toBeTrue();
+});
+
+test('DetectsNameOptionWithEquals', function () {
+    expect(customDockerRunOptionsContainsName('--init --name=my-container'))->toBeTrue();
+});
+
+test('DoesNotDetectNameInOtherOptions', function () {
+    expect(customDockerRunOptionsContainsName('--network host --hostname myname'))->toBeFalse();
+});
+
+test('DoesNotDetectNameOnNullOrEmpty', function () {
+    expect(customDockerRunOptionsContainsName(null))->toBeFalse()
+        ->and(customDockerRunOptionsContainsName(''))->toBeFalse();
+});

--- a/tests/Unit/ApplicationDeploymentStopRunningContainerCleanupTest.php
+++ b/tests/Unit/ApplicationDeploymentStopRunningContainerCleanupTest.php
@@ -1,0 +1,135 @@
+<?php
+
+use App\Jobs\ApplicationDeploymentJob;
+use App\Models\Application;
+use App\Models\ApplicationDeploymentQueue;
+use App\Models\ApplicationSetting;
+use Illuminate\Support\Collection;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+class TestableStopContainerDeploymentJob extends ApplicationDeploymentJob
+{
+    public array $shutdownContainers = [];
+
+    public Collection $fakeRunningContainers;
+
+    public function __construct()
+    {
+        $this->fakeRunningContainers = collect([]);
+    }
+
+    protected function get_current_application_containers(): Collection
+    {
+        return $this->fakeRunningContainers;
+    }
+
+    protected function graceful_shutdown_container(string $containerName, bool $skipRemove = false)
+    {
+        $this->shutdownContainers[] = $containerName;
+    }
+
+    public function execute_remote_command(...$commands)
+    {
+        // no-op
+    }
+}
+
+function makeStopContainerJob(array $settings, string $containerName, Collection $runningContainers): array
+{
+    $job = new TestableStopContainerDeploymentJob;
+    $job->fakeRunningContainers = $runningContainers;
+
+    $reflection = new ReflectionClass(ApplicationDeploymentJob::class);
+
+    $application = new Application;
+    $application->setRelation('settings', new ApplicationSetting($settings));
+
+    $queue = Mockery::mock(ApplicationDeploymentQueue::class);
+    $queue->shouldReceive('addLogEntry')->andReturnNull();
+
+    foreach ([
+        'application' => $application,
+        'application_deployment_queue' => $queue,
+        'container_name' => $containerName,
+        'pull_request_id' => 0,
+        'newVersionIsHealthy' => true,
+    ] as $property => $value) {
+        $reflectionProperty = $reflection->getProperty($property);
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue($job, $value);
+    }
+
+    return [$job, $reflection];
+}
+
+function invokeStopRunningContainer(object $job, ReflectionClass $reflection, bool $force = false): void
+{
+    $method = $reflection->getMethod('stop_running_container');
+    $method->setAccessible(true);
+    $method->invokeArgs($job, [$force]);
+}
+
+it('removes orphaned containers by label when consistent container name is enabled', function () {
+    [$job, $reflection] = makeStopContainerJob(
+        settings: ['is_consistent_container_name_enabled' => true],
+        containerName: 'appuuid',
+        runningContainers: collect([
+            ['Names' => 'appuuid-142233123456'], // orphan from before the setting was enabled
+            ['Names' => 'appuuid'],
+        ]),
+    );
+
+    invokeStopRunningContainer($job, $reflection, force: true);
+
+    expect($job->shutdownContainers)->toContain('appuuid')
+        ->toContain('appuuid-142233123456');
+});
+
+it('removes orphaned containers by label when a custom internal name is set', function () {
+    [$job, $reflection] = makeStopContainerJob(
+        settings: ['custom_internal_name' => 'my-custom-name'],
+        containerName: 'my-custom-name',
+        runningContainers: collect([
+            ['Names' => 'appuuid-142233123456'],
+            ['Names' => 'old-custom-name'],
+        ]),
+    );
+
+    invokeStopRunningContainer($job, $reflection, force: true);
+
+    expect($job->shutdownContainers)->toContain('my-custom-name')
+        ->toContain('appuuid-142233123456')
+        ->toContain('old-custom-name');
+});
+
+it('does not shut down the new container twice with consistent naming', function () {
+    [$job, $reflection] = makeStopContainerJob(
+        settings: ['is_consistent_container_name_enabled' => true],
+        containerName: 'appuuid',
+        runningContainers: collect([
+            ['Names' => 'appuuid'],
+        ]),
+    );
+
+    invokeStopRunningContainer($job, $reflection, force: true);
+
+    expect(array_count_values($job->shutdownContainers)['appuuid'])->toBe(1);
+});
+
+it('keeps label based cleanup for default naming', function () {
+    [$job, $reflection] = makeStopContainerJob(
+        settings: [],
+        containerName: 'appuuid-999999999999',
+        runningContainers: collect([
+            ['Names' => 'appuuid-142233123456'],
+            ['Names' => 'appuuid-999999999999'], // new container, must survive
+        ]),
+    );
+
+    invokeStopRunningContainer($job, $reflection, force: true);
+
+    expect($job->shutdownContainers)->toContain('appuuid-142233123456')
+        ->not->toContain('appuuid-999999999999');
+});


### PR DESCRIPTION
## Changes

When "Consistent Container Name" is enabled or a "Custom Internal Name" is set on an application, every deployment after changing that setting leaves the previous container running next to the new one — you end up with two (or more) containers for the same application.

Root cause: `stop_running_container()` in `ApplicationDeploymentJob` has two cleanup paths. The default path finds old containers by the `coolify.applicationId` label, so it catches everything. But the consistent/custom name path only shuts down the one container matching the current expected name. Any container created under a previous naming scheme (timestamped `uuid-<timestamp>` names from before the setting was enabled, or an older custom name) never matches, is never queried, and keeps running forever.

- Cleanup for the consistent/custom name path now also queries containers by the `coolify.applicationId` label and gracefully shuts down any container whose name does not match the current one, so orphans from previous naming schemes are removed on the next deployment
- Extracted the container lookup into a `get_current_application_containers()` method and made `graceful_shutdown_container()` protected so the cleanup logic is unit-testable
- Related trap fixed: `--name` in Custom Docker Options was silently ignored (`convertDockerRunToCompose()` has no mapping for it), which misled users into thinking they had set a container name. Saving `--name` is now rejected in the UI with a message pointing to the Custom Internal Name setting, and deployments log a warning if a stored value (e.g. set via API) still contains it

## Issues

- No existing issue found — searched open and closed issues/PRs for duplicate/orphaned container reports related to consistent or custom container names

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No visual changes — deployment lifecycle fix. Only user-visible UI change: saving `--name` in Custom Docker Options now shows an error toast instead of being silently ignored.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Claude is credited as co-author on the commit)
- How extensively: Used to trace the deployment/cleanup code paths, identify the root cause, and draft the fix and tests. I reviewed and verified all changes and ran the test suites myself.

## Testing

- TDD: added `tests/Unit/ApplicationDeploymentStopRunningContainerCleanupTest.php` (4 cases: orphan cleanup with consistent naming, orphan cleanup with an old custom name, no double-shutdown of the new container, default label-based path unchanged). All 4 fail on the previous code and pass with the fix
- Added 5 cases to `tests/Feature/DockerCustomCommandsTest.php` covering the new `customDockerRunOptionsContainsName()` helper (`--name x`, `--name=x`, no false positives on `--network`/`--hostname`, null/empty)
- Ran Unit and Feature suites in the local dev container against this branch and against the unmodified base: failure counts are identical apart from the new tests (no regressions)

Manual reproduction of the bug:

1. Deploy an application with default settings (container is named `uuid-<timestamp>`)
2. Enable "Consistent Container Name" (or set a "Custom Internal Name") and redeploy via git push
3. Before: the old `uuid-<timestamp>` container keeps running next to the new one — duplicate containers
4. After: the orphaned container is detected via the `coolify.applicationId` label and removed during cleanup

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
