### PR TITLE
fix(deployment): remove orphaned containers when consistent or custom container name is enabled

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -3958,7 +3958,7 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
         $this->application_deployment_queue->addLogEntry('Building docker image completed.');
     }
 
-    private function graceful_shutdown_container(string $containerName, bool $skipRemove = false)
+    protected function graceful_shutdown_container(string $containerName, bool $skipRemove = false)
     {
         try {
             $timeout = $this->application->settings->deploymentStopGracePeriodSeconds();
@@ -3978,6 +3978,11 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
         }
     }
 
+    protected function get_current_application_containers(): Collection
+    {
+        return getCurrentApplicationContainerStatus($this->server, $this->application->id, $this->pull_request_id);
+    }
+
     private function stop_running_container(bool $force = false)
     {
         try {
@@ -3985,8 +3990,14 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
             if ($this->newVersionIsHealthy || $force) {
                 if ($this->application->settings->is_consistent_container_name_enabled || str($this->application->settings->custom_internal_name)->isNotEmpty()) {
                     $this->graceful_shutdown_container($this->container_name);
+                    // Clean up orphaned containers left behind by a previous naming scheme
+                    // (e.g. timestamped names from before the consistent/custom name setting
+                    // was enabled, or an older custom name) — matched by label, not by name.
+                    $this->get_current_application_containers()
+                        ->filter(fn ($container) => data_get($container, 'Names') !== $this->container_name)
+                        ->each(fn ($container) => $this->graceful_shutdown_container(data_get($container, 'Names')));
                 } else {
-                    $containers = getCurrentApplicationContainerStatus($this->server, $this->application->id, $this->pull_request_id);
+                    $containers = $this->get_current_application_containers();
                     if ($this->pull_request_id === 0) {
                         $containers = $containers->filter(function ($container) {
                             return data_get($container, 'Names') !== $this->container_name && data_get($container, 'Names') !== addPreviewDeploymentSuffix($this->container_name, $this->pull_request_id);

--- a/tests/Unit/ApplicationDeploymentStopRunningContainerCleanupTest.php
+++ b/tests/Unit/ApplicationDeploymentStopRunningContainerCleanupTest.php
@@ -1,0 +1,135 @@
+<?php
+
+use App\Jobs\ApplicationDeploymentJob;
+use App\Models\Application;
+use App\Models\ApplicationDeploymentQueue;
+use App\Models\ApplicationSetting;
+use Illuminate\Support\Collection;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+class TestableStopContainerDeploymentJob extends ApplicationDeploymentJob
+{
+    public array $shutdownContainers = [];
+
+    public Collection $fakeRunningContainers;
+
+    public function __construct()
+    {
+        $this->fakeRunningContainers = collect([]);
+    }
+
+    protected function get_current_application_containers(): Collection
+    {
+        return $this->fakeRunningContainers;
+    }
+
+    protected function graceful_shutdown_container(string $containerName, bool $skipRemove = false)
+    {
+        $this->shutdownContainers[] = $containerName;
+    }
+
+    public function execute_remote_command(...$commands)
+    {
+        // no-op
+    }
+}
+
+function makeStopContainerJob(array $settings, string $containerName, Collection $runningContainers): array
+{
+    $job = new TestableStopContainerDeploymentJob;
+    $job->fakeRunningContainers = $runningContainers;
+
+    $reflection = new ReflectionClass(ApplicationDeploymentJob::class);
+
+    $application = new Application;
+    $application->setRelation('settings', new ApplicationSetting($settings));
+
+    $queue = Mockery::mock(ApplicationDeploymentQueue::class);
+    $queue->shouldReceive('addLogEntry')->andReturnNull();
+
+    foreach ([
+        'application' => $application,
+        'application_deployment_queue' => $queue,
+        'container_name' => $containerName,
+        'pull_request_id' => 0,
+        'newVersionIsHealthy' => true,
+    ] as $property => $value) {
+        $reflectionProperty = $reflection->getProperty($property);
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue($job, $value);
+    }
+
+    return [$job, $reflection];
+}
+
+function invokeStopRunningContainer(object $job, ReflectionClass $reflection, bool $force = false): void
+{
+    $method = $reflection->getMethod('stop_running_container');
+    $method->setAccessible(true);
+    $method->invokeArgs($job, [$force]);
+}
+
+it('removes orphaned containers by label when consistent container name is enabled', function () {
+    [$job, $reflection] = makeStopContainerJob(
+        settings: ['is_consistent_container_name_enabled' => true],
+        containerName: 'appuuid',
+        runningContainers: collect([
+            ['Names' => 'appuuid-142233123456'], // orphan from before the setting was enabled
+            ['Names' => 'appuuid'],
+        ]),
+    );
+
+    invokeStopRunningContainer($job, $reflection, force: true);
+
+    expect($job->shutdownContainers)->toContain('appuuid')
+        ->toContain('appuuid-142233123456');
+});
+
+it('removes orphaned containers by label when a custom internal name is set', function () {
+    [$job, $reflection] = makeStopContainerJob(
+        settings: ['custom_internal_name' => 'my-custom-name'],
+        containerName: 'my-custom-name',
+        runningContainers: collect([
+            ['Names' => 'appuuid-142233123456'],
+            ['Names' => 'old-custom-name'],
+        ]),
+    );
+
+    invokeStopRunningContainer($job, $reflection, force: true);
+
+    expect($job->shutdownContainers)->toContain('my-custom-name')
+        ->toContain('appuuid-142233123456')
+        ->toContain('old-custom-name');
+});
+
+it('does not shut down the new container twice with consistent naming', function () {
+    [$job, $reflection] = makeStopContainerJob(
+        settings: ['is_consistent_container_name_enabled' => true],
+        containerName: 'appuuid',
+        runningContainers: collect([
+            ['Names' => 'appuuid'],
+        ]),
+    );
+
+    invokeStopRunningContainer($job, $reflection, force: true);
+
+    expect(array_count_values($job->shutdownContainers)['appuuid'])->toBe(1);
+});
+
+it('keeps label based cleanup for default naming', function () {
+    [$job, $reflection] = makeStopContainerJob(
+        settings: [],
+        containerName: 'appuuid-999999999999',
+        runningContainers: collect([
+            ['Names' => 'appuuid-142233123456'],
+            ['Names' => 'appuuid-999999999999'], // new container, must survive
+        ]),
+    );
+
+    invokeStopRunningContainer($job, $reflection, force: true);
+
+    expect($job->shutdownContainers)->toContain('appuuid-142233123456')
+        ->not->toContain('appuuid-999999999999');
+});


### PR DESCRIPTION
## Changes

When Consistent Container Name is enabled, or a Custom Internal Name is set, deployment cleanup only stopped the container matching the currently expected name. A container left from an earlier naming scheme, a timestamped name or an older custom name, was never matched and kept running next to the new one.

Cleanup now also looks containers up by the `coolify.applicationId` label and shuts down any whose name differs from the current one.

Scope note: this PR originally also rejected --name in Custom Docker Options. I removed that so this stays one logical change, and will raise it as a discussion first.

Two visibility changes are here because the tests need them: the shutdown helper is now protected, and the container lookup moved into its own protected method, so a test double can override both without touching a real server.

## Issues

- No existing issue found, searched open and closed issues and PRs

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No visual changes.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code, credited as co-author on the commit
- How extensively: traced the code paths, found the root cause, drafted the fix and tests. I reviewed every change and ran the tests myself.

## Testing

- Four unit tests, failing before the change and passing after: orphan removal with a consistent name, orphan removal with a custom internal name, no double shutdown of the new container, and default naming left unchanged
- Manual repro: deploy with defaults, enable Consistent Container Name, redeploy. Before, the old container keeps running. After, it is removed during cleanup

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
