### PR TITLE
fix: fallback to instance timezone when server timezone is not set

### DIFF
--- a/app/Jobs/ScheduledJobManager.php
+++ b/app/Jobs/ScheduledJobManager.php
@@ -540,9 +540,19 @@ class ScheduledJobManager implements ShouldQueue
 
     private function serverTimezone(Server $server): string
     {
-        $timezone = data_get($server->settings, 'server_timezone', config('app.timezone'));
+        $timezone = data_get($server->settings, 'server_timezone');
 
-        return validate_timezone($timezone) ? $timezone : config('app.timezone');
+        if ($timezone && validate_timezone($timezone)) {
+            return $timezone;
+        }
+
+        $instanceTimezone = instanceSettings()->instance_timezone;
+
+        if ($instanceTimezone && validate_timezone($instanceTimezone)) {
+            return $instanceTimezone;
+        }
+
+        return config('app.timezone');
     }
 
     private function logBackupSkip(ScheduledDatabaseBackup $backup, string $reason): void


### PR DESCRIPTION
## Changes

Scheduled Tasks and Scheduled Backups were ignoring the Instance Timezone
setting and falling back directly to config('app.timezone') (UTC) when
no server-specific timezone was configured on the server.

Updated `ScheduledJobManager::serverTimezone()` to check the Instance
Timezone as a fallback before defaulting to UTC.

Priority order is now:
1. Server-specific timezone (server_timezone)
2. Instance Timezone (instance_timezone)
3. App default timezone (UTC fallback)

## Issues

- Fixes #10904

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service