### PR TITLE
fix(docker): bump pinned NGINX_VERSION to 1.31.2-r1 in dev Dockerfile

### DIFF
--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -9,7 +9,7 @@ ARG CLOUDFLARED_VERSION=2025.7.0
 # Note: We are using version 18 of the postgres client (while still using postgres 15 for the postgres server) as version 15 has been removed from Alpine 3.23+ https://pkgs.alpinelinux.org/packages?name=postgresql*-client&branch=v3.23&repo=&arch=x86_64&origin=&flagged=&maintainer=
 ARG POSTGRES_VERSION=18
 # https://nginx.org/en/linux_packages.html
-ARG NGINX_VERSION=1.31.0-r1
+ARG NGINX_VERSION=1.31.2-r1
 
 # =================================================================
 # Get MinIO client


### PR DESCRIPTION
## Summary
- `docker/development/Dockerfile` pins `NGINX_VERSION=1.31.0-r1` from the nginx.org mainline Alpine repo, but that repo only retains the latest package build. The pinned version no longer exists, so any fresh build of the dev image fails during `apk add --no-cache --upgrade "nginx@nginx=${NGINX_VERSION}"` with:
  ```
  ERROR: unable to select packages:
    nginx-1.30.3-r0:
      breaks: world[nginx=1.31.0-r1@nginx]
  ```
- Bumped the pin to the currently available `1.31.2-r1` to unblock local dev environment setup.

## Test plan
- [x] `docker compose -f docker-compose.yml -f docker-compose.dev.yml --env-file .env up -d --build` completes successfully with the fix (previously failed at the `coolify` image build step).
- [x] Confirmed `apk list -a nginx@nginx` against the live nginx.org Alpine 3.24 repo shows `1.31.2-r1` as the only available version.