### PR TITLE
fix(api-tokens): "Never" expiry stores null instead of defaulting to 30 days

### DIFF
--- a/app/Livewire/Security/ApiTokens.php
+++ b/app/Livewire/Security/ApiTokens.php
@@ -26,6 +26,7 @@ class ApiTokens extends Component
         60 => '60 days',
         90 => '90 days',
         365 => '1 year',
+        0 => 'Never',
     ];
 
     public $isApiEnabled;
@@ -133,7 +134,7 @@ class ApiTokens extends Component
 
             $this->validate([
                 'description' => 'required|min:3|max:255',
-                'expiresInDays' => 'nullable|integer|in:7,30,60,90,365',
+                'expiresInDays' => 'nullable|integer|in:0,7,30,60,90,365',
             ]);
             $expiresAt = $this->expiresInDays ? now()->addDays($this->expiresInDays) : null;
             $token = auth()->user()->createToken($this->description, array_values($this->permissions), $expiresAt);

--- a/resources/views/livewire/security/api-tokens.blade.php
+++ b/resources/views/livewire/security/api-tokens.blade.php
@@ -20,7 +20,6 @@
                     @foreach ($expirationOptions as $days => $label)
                         <option value="{{ $days }}">{{ $label }}</option>
                     @endforeach
-                    <option value="">Never</option>
                 </x-forms.select>
                 <x-forms.button type="submit">Create</x-forms.button>
             </div>


### PR DESCRIPTION
## Changes

- Selecting "Never" when creating an API token now stores a NULL expiry instead of silently creating a 30-day token.
- Root cause: the Never option submitted an empty string, which Livewire 3 cannot hydrate into the typed nullable int property `expiresInDays`, so the update was silently dropped and the default of 30 was kept.
- Fix: "Never" is folded into `expirationOptions` with an explicit value of 0, validation allows 0, and the orphaned hardcoded Never option is removed from the blade view. 0 resolves the expiry to null, so the token never expires.

## Issues

- Regression introduced by #9677.
- Resubmission of #10607 (auto-closed for targeting v4.x and not using the PR template). Now targets next with the template; the code change is identical.

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No visual change, the "Never" option stays in the same place in the dropdown; it just works now.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: root-cause analysis and the patch were AI-assisted; the author reviewed the change and this description before submitting.

## Testing

- Reproduced against a running Coolify instance: a token created with Expiration set to Never got an expires_at of exactly now + 30 days.
- Verified the fix by code-path analysis: 0 hydrates cleanly into the nullable int property, passes the updated validation, and resolves the expiry to null, matching tokens created before the expiration feature existed.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
