### PR TITLE
fix(service): optimize chatwoot sidekiq healthcheck

### DIFF
--- a/templates/compose/chatwoot.yaml
+++ b/templates/compose/chatwoot.yaml
@@ -84,7 +84,7 @@ services:
     volumes:
       - rails-data:/app/storage
     healthcheck:
-      test: ["CMD-SHELL", "bundle exec rails runner 'puts Sidekiq.redis(&:info)' > /dev/null 2>&1"]
+      test: ["CMD-SHELL", "bundle exec sidekiqmon processes | grep -q 'sidekiq'"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Changes

Optimized the default Sidekiq healthcheck inside the Chatwoot one-click service template.

The current implementation uses `bundle exec rails runner 'puts Sidekiq.redis(&:info)'`. Running `rails runner` every 30 seconds forces a full Rails application boot cycle. On resource-constrained servers or ARM-based VPS (like Oracle Cloud Ampere instances), this causes severe, compounding CPU and I/O spikes, eventually leading to Docker daemon freezes (`DeadlineExceeded`).

I changed the healthcheck command to `bundle exec sidekiqmon processes | grep -q 'sidekiq'`, which leverages Sidekiq's lightweight CLI monitoring tool to check the process status directly, avoiding the heavy Rails framework initialization overhead.

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [x] Fixing or updating existing one click service

## Preview

Before
<img width="2074" height="333" alt="{FDDB5499-2A8A-4D2C-9EBC-9DB7EC1269C3}" src="https://github.com/user-attachments/assets/ad1cb6cc-ecfa-449d-8608-eb44dbacd450" />

After
<img width="2082" height="340" alt="{F0D4B799-C51C-4411-9BE1-50497104E9E8}" src="https://github.com/user-attachments/assets/9c22924f-28ca-4508-9be8-9cb3e0dca0f9" />

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Gemini
- How extensively: Used to help diagnose the container metrics log and draft the technical description of the Rails boot overhead, but the fix was manually verified and tested on my live instance.

## Testing

Tested the new docker-compose configuration on a live Ubuntu 24.04 aarch64 instance running Coolify v4. The Sidekiq container now successfully reports a `healthy` status almost instantly, and the constant CPU serrated spikes every 30 seconds completely disappeared.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.