### PR TITLE
feat: add project names to Slack deployment titles

### DIFF
--- a/app/Livewire/Notifications/Slack.php
+++ b/app/Livewire/Notifications/Slack.php
@@ -30,6 +30,9 @@ class Slack extends Component
     public ?string $slackWebhookUrl = null;
 
     #[Validate(['boolean'])]
+    public bool $includeProjectNameInTitle = false;
+
+    #[Validate(['boolean'])]
     public bool $deploymentSuccessSlackNotifications = false;
 
     #[Validate(['boolean'])]
@@ -90,6 +93,7 @@ class Slack extends Component
             $this->authorize('update', $this->settings);
             $this->settings->slack_enabled = $this->slackEnabled;
             $this->settings->slack_webhook_url = $this->slackWebhookUrl;
+            $this->settings->include_project_name_in_title = $this->includeProjectNameInTitle;
 
             $this->settings->deployment_success_slack_notifications = $this->deploymentSuccessSlackNotifications;
             $this->settings->deployment_failure_slack_notifications = $this->deploymentFailureSlackNotifications;
@@ -113,6 +117,7 @@ class Slack extends Component
             $this->slackWebhookUrl = auth()->user()->can('update', $this->settings)
                 ? $this->settings->slack_webhook_url
                 : null;
+            $this->includeProjectNameInTitle = $this->settings->include_project_name_in_title;
 
             $this->deploymentSuccessSlackNotifications = $this->settings->deployment_success_slack_notifications;
             $this->deploymentFailureSlackNotifications = $this->settings->deployment_failure_slack_notifications;

--- a/app/Models/SlackNotificationSettings.php
+++ b/app/Models/SlackNotificationSettings.php
@@ -16,6 +16,7 @@ class SlackNotificationSettings extends Model
 
         'slack_enabled',
         'slack_webhook_url',
+        'include_project_name_in_title',
 
         'deployment_success_slack_notifications',
         'deployment_failure_slack_notifications',
@@ -40,6 +41,7 @@ class SlackNotificationSettings extends Model
     protected $casts = [
         'slack_enabled' => 'boolean',
         'slack_webhook_url' => 'encrypted',
+        'include_project_name_in_title' => 'boolean',
 
         'deployment_success_slack_notifications' => 'boolean',
         'deployment_failure_slack_notifications' => 'boolean',

--- a/app/Notifications/Application/DeploymentFailed.php
+++ b/app/Notifications/Application/DeploymentFailed.php
@@ -182,7 +182,8 @@ class DeploymentFailed extends CustomEmailNotification
         return new SlackMessage(
             title: $title,
             description: $description,
-            color: SlackMessage::errorColor()
+            color: SlackMessage::errorColor(),
+            projectName: data_get($this->application, 'environment.project.name'),
         );
     }
 

--- a/app/Notifications/Application/DeploymentSuccess.php
+++ b/app/Notifications/Application/DeploymentSuccess.php
@@ -202,7 +202,8 @@ class DeploymentSuccess extends CustomEmailNotification
         return new SlackMessage(
             title: $title,
             description: $description,
-            color: SlackMessage::successColor()
+            color: SlackMessage::successColor(),
+            projectName: data_get($this->application, 'environment.project.name'),
         );
     }
 

--- a/app/Notifications/Channels/SlackChannel.php
+++ b/app/Notifications/Channels/SlackChannel.php
@@ -19,6 +19,10 @@ class SlackChannel
             return;
         }
 
+        if ($slackSettings->include_project_name_in_title) {
+            $message->prependProjectNameToTitle();
+        }
+
         SendMessageToSlackJob::dispatch($message, $slackSettings->slack_webhook_url);
     }
 }

--- a/app/Notifications/Dto/SlackMessage.php
+++ b/app/Notifications/Dto/SlackMessage.php
@@ -7,8 +7,18 @@ class SlackMessage
     public function __construct(
         public string $title,
         public string $description,
-        public string $color = '#0099ff'
+        public string $color = '#0099ff',
+        public ?string $projectName = null,
     ) {}
+
+    public function prependProjectNameToTitle(): void
+    {
+        if ($this->projectName === null || $this->projectName === '') {
+            return;
+        }
+
+        $this->title = "{$this->projectName}: {$this->title}";
+    }
 
     public static function infoColor(): string
     {

--- a/database/migrations/2026_07_14_000000_add_include_project_name_in_title_to_slack_notification_settings.php
+++ b/database/migrations/2026_07_14_000000_add_include_project_name_in_title_to_slack_notification_settings.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('slack_notification_settings', function (Blueprint $table) {
+            $table->boolean('include_project_name_in_title')->default(false);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('slack_notification_settings', function (Blueprint $table) {
+            $table->dropColumn('include_project_name_in_title');
+        });
+    }
+};

--- a/resources/views/livewire/notifications/slack.blade.php
+++ b/resources/views/livewire/notifications/slack.blade.php
@@ -45,6 +45,9 @@
                     label="Deployment Success" />
                 <x-forms.checkbox canGate="update" :canResource="$settings" instantSave="saveModel" id="deploymentFailureSlackNotifications"
                     label="Deployment Failure" />
+                <x-forms.checkbox canGate="update" :canResource="$settings" instantSave="saveModel" id="includeProjectNameInTitle"
+                    helper="Prefix deployment notification titles with the project name, for example: My Project: Deployment failed."
+                    label="Show Project Name in Title" />
                 <x-forms.checkbox canGate="update" :canResource="$settings" instantSave="saveModel"
                     helper="Send a notification when a container status changes. It will notify for Stopped and Restarted events of a container."
                     id="statusChangeSlackNotifications" label="Container Status Changes" />

--- a/tests/Feature/SlackNotificationProjectNameTest.php
+++ b/tests/Feature/SlackNotificationProjectNameTest.php
@@ -3,6 +3,7 @@
 use App\Jobs\SendMessageToSlackJob;
 use App\Models\Application;
 use App\Models\Environment;
+use App\Models\InstanceSettings;
 use App\Models\Project;
 use App\Models\Team;
 use App\Notifications\Application\DeploymentFailed;
@@ -12,6 +13,10 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Queue;
 
 uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::forceCreate(['id' => 0]);
+});
 
 it('prefixes a Slack title with the project name when enabled', function () {
     Queue::fake();
@@ -23,6 +28,9 @@ it('prefixes a Slack title with the project name when enabled', function () {
     ]);
     $environment = Environment::factory()->create(['project_id' => $project->id]);
     $application = Application::factory()->create(['environment_id' => $environment->id]);
+
+    expect($team->slackNotificationSettings->include_project_name_in_title)->toBeFalse();
+
     $team->slackNotificationSettings->update([
         'slack_enabled' => true,
         'slack_webhook_url' => 'https://hooks.slack.com/services/test',

--- a/tests/Feature/SlackNotificationProjectNameTest.php
+++ b/tests/Feature/SlackNotificationProjectNameTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use App\Jobs\SendMessageToSlackJob;
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\Project;
+use App\Models\Team;
+use App\Notifications\Application\DeploymentFailed;
+use App\Notifications\Application\DeploymentSuccess;
+use App\Notifications\Channels\SlackChannel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+
+uses(RefreshDatabase::class);
+
+it('prefixes a Slack title with the project name when enabled', function () {
+    Queue::fake();
+
+    $team = Team::factory()->create();
+    $project = Project::factory()->create([
+        'name' => 'My Project',
+        'team_id' => $team->id,
+    ]);
+    $environment = Environment::factory()->create(['project_id' => $project->id]);
+    $application = Application::factory()->create(['environment_id' => $environment->id]);
+    $team->slackNotificationSettings->update([
+        'slack_enabled' => true,
+        'slack_webhook_url' => 'https://hooks.slack.com/services/test',
+        'include_project_name_in_title' => true,
+    ]);
+    $notification = new DeploymentFailed($application, 'deployment-uuid');
+    $message = $notification->toSlack();
+
+    app(SlackChannel::class)->send($team, $notification);
+
+    expect($message->projectName)->toBe('My Project');
+    Queue::assertPushed(SendMessageToSlackJob::class, function (SendMessageToSlackJob $job) {
+        $message = (new ReflectionProperty($job, 'message'))->getValue($job);
+
+        return $message->title === 'My Project: Deployment failed';
+    });
+});
+
+it('keeps the original Slack title when the project name option is disabled', function () {
+    Queue::fake();
+
+    $team = Team::factory()->create();
+    $project = Project::factory()->create([
+        'name' => 'My Project',
+        'team_id' => $team->id,
+    ]);
+    $environment = Environment::factory()->create(['project_id' => $project->id]);
+    $application = Application::factory()->create(['environment_id' => $environment->id]);
+    $team->slackNotificationSettings->update([
+        'slack_enabled' => true,
+        'slack_webhook_url' => 'https://hooks.slack.com/services/test',
+        'include_project_name_in_title' => false,
+    ]);
+    $notification = new DeploymentSuccess($application, 'deployment-uuid');
+    $message = $notification->toSlack();
+
+    app(SlackChannel::class)->send($team, $notification);
+
+    expect($message->projectName)->toBe('My Project');
+    Queue::assertPushed(SendMessageToSlackJob::class, function (SendMessageToSlackJob $job) {
+        $message = (new ReflectionProperty($job, 'message'))->getValue($job);
+
+        return $message->title === 'New version successfully deployed';
+    });
+});


### PR DESCRIPTION
## Changes

- Add an optional Slack setting under `/notifications/slack` to prefix deployment notification titles with the project name.
- Keep the current notification titles unchanged by default.
- Cover enabled, disabled, and default-off behavior with focused tests.

## Issues

- Fixes #10926
- Supersedes #10927, which was closed by the automated quality check before the PR template and local verification were completed.

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

The Deployments section now includes a `Show Project Name in Title` checkbox. It was verified checked and persisted after a hard reload while global Slack delivery remained disabled and the webhook remained blank.

![Slack deployment settings with Show Project Name in Title enabled](https://raw.githubusercontent.com/dunctk/coolify/pr-assets/assets/pr-10928-slack-project-name-setting.png)

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex
- How extensively: Extensively for implementation, tests, local environment and browser verification, and PR preparation.

## Testing

- Started a local Coolify development instance with Docker Compose and confirmed `/api/health` returned `OK`.
- Ran `php artisan test --compact tests/Feature/SlackNotificationProjectNameTest.php` (2 tests, 5 assertions).
- Ran `vendor/bin/pint --format agent` on all changed PHP files and `vendor/bin/pint --dirty --format agent`.
- Verified `/notifications/slack` in a real browser: the option saved, remained checked after reload, and produced no browser console errors.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
