### PR TITLE
fix(api): accept CUID2 private key identifiers

### DIFF
--- a/app/Http/Controllers/Api/GithubController.php
+++ b/app/Http/Controllers/Api/GithubController.php
@@ -642,7 +642,7 @@ class GithubController extends Controller
                 $rules['webhook_secret'] = 'string';
             }
             if (isset($payload['private_key_uuid'])) {
-                $rules['private_key_uuid'] = 'string|uuid';
+                $rules['private_key_uuid'] = 'string';
             }
             if (! isCloud() && isset($payload['is_system_wide'])) {
                 $rules['is_system_wide'] = 'boolean';

--- a/tests/Feature/Api/GithubAppsListApiTest.php
+++ b/tests/Feature/Api/GithubAppsListApiTest.php
@@ -286,6 +286,69 @@ describe('GET /api/v1/github-apps', function () {
     });
 });
 
+describe('PATCH /api/v1/github-apps/{github_app_id}', function () {
+    test('updates the private key using its CUID2 identifier', function () {
+        $newPrivateKey = PrivateKey::create([
+            'name' => 'New Test Key',
+            'private_key' => validGithubAppsApiPrivateKey(),
+            'team_id' => $this->team->id,
+        ]);
+        $githubApp = GithubApp::create([
+            'name' => 'Test GitHub App',
+            'api_url' => 'https://api.github.com',
+            'html_url' => 'https://github.com',
+            'app_id' => 12345,
+            'installation_id' => 67890,
+            'client_id' => 'test-client-id',
+            'client_secret' => 'test-client-secret',
+            'webhook_secret' => 'test-webhook-secret',
+            'private_key_id' => $this->privateKey->id,
+            'team_id' => $this->team->id,
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+        ])->patchJson("/api/v1/github-apps/{$githubApp->id}", [
+            'private_key_uuid' => $newPrivateKey->uuid,
+        ]);
+
+        $response->assertSuccessful()
+            ->assertJsonPath('data.private_key_id', $newPrivateKey->id);
+        expect($githubApp->refresh()->private_key_id)->toBe($newPrivateKey->id);
+    });
+
+    test('rejects a private key owned by another team', function () {
+        $otherTeam = Team::factory()->create();
+        $otherTeamPrivateKey = PrivateKey::create([
+            'name' => 'Other Team Key',
+            'private_key' => validGithubAppsApiPrivateKey(),
+            'team_id' => $otherTeam->id,
+        ]);
+        $githubApp = GithubApp::create([
+            'name' => 'Test GitHub App',
+            'api_url' => 'https://api.github.com',
+            'html_url' => 'https://github.com',
+            'app_id' => 12345,
+            'installation_id' => 67890,
+            'client_id' => 'test-client-id',
+            'client_secret' => 'test-client-secret',
+            'webhook_secret' => 'test-webhook-secret',
+            'private_key_id' => $this->privateKey->id,
+            'team_id' => $this->team->id,
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+        ])->patchJson("/api/v1/github-apps/{$githubApp->id}", [
+            'private_key_uuid' => $otherTeamPrivateKey->uuid,
+        ]);
+
+        $response->assertNotFound()
+            ->assertJsonPath('message', 'Private key not found or does not belong to your team');
+        expect($githubApp->refresh()->private_key_id)->toBe($this->privateKey->id);
+    });
+});
+
 describe('GitHub app API url normalization', function () {
     test('normalizes ghe dot com api url when creating github apps', function () {
         $response = $this->withHeaders([


### PR DESCRIPTION
## Changes

- Accept Coolify private-key identifiers as strings when updating a GitHub App instead of requiring an RFC UUID. Coolify stores these identifiers as CUID2 values, so the UUID validation rejected valid keys before the lookup ran.
- Keep the existing team-scoped private-key lookup and 404 behavior unchanged.
- Add regression coverage for switching to a valid CUID2 key and for rejecting a key owned by another team without changing the existing key.

## Issues

- Fixes #10936

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable; this is an API validation fix with no UI change.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Codex helped inspect the issue and relevant controller flow, implement the focused validation change and regression tests, and run formatting and targeted verification. The resulting diff and behavior were reviewed against the current `next` branch.

## Testing

- `vendor/bin/pint --dirty --format agent`
- `php artisan test --compact tests/Feature/Api/GithubAppsListApiTest.php` (16 tests, 62 assertions)
- `git diff --check`

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
