### PR TITLE
fix(scheduler): process zero-id schedules

### DIFF
--- a/app/Jobs/ScheduledJobManager.php
+++ b/app/Jobs/ScheduledJobManager.php
@@ -136,8 +136,8 @@ class ScheduledJobManager implements ShouldQueue
 
     private function processScheduledBackupsAndTasks(): void
     {
-        $lastBackupId = 0;
-        $lastTaskId = 0;
+        $lastBackupId = -1;
+        $lastTaskId = -1;
 
         do {
             $backups = $this->scheduledBackupQuery($lastBackupId)->get();

--- a/tests/Feature/ScheduledJobManagerDispatchTest.php
+++ b/tests/Feature/ScheduledJobManagerDispatchTest.php
@@ -1,14 +1,17 @@
 <?php
 
+use App\Jobs\DatabaseBackupJob;
 use App\Jobs\ScheduledJobManager;
 use App\Jobs\ScheduledTaskJob;
 use App\Models\Application;
 use App\Models\Environment;
 use App\Models\PrivateKey;
 use App\Models\Project;
+use App\Models\ScheduledDatabaseBackup;
 use App\Models\ScheduledTask;
 use App\Models\Server;
 use App\Models\StandaloneDocker;
+use App\Models\StandalonePostgresql;
 use App\Models\Team;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
@@ -69,6 +72,70 @@ uZx9iFkCELtxrh31QJ68AAAAEXNhaWxANzZmZjY2ZDJlMmRkAQIDBA==
     (new ScheduledJobManager)->handle();
 
     Queue::assertPushed(ScheduledTaskJob::class, 101);
+});
+
+it('dispatches zero-id schedules and continues with positive ids', function () {
+    config(['constants.coolify.self_hosted' => true]);
+    Carbon::setTestNow(Carbon::create(2026, 5, 27, 0, 1, 0, 'UTC'));
+    Queue::fake();
+
+    $application = createScheduledTaskApplication();
+    $database = StandalonePostgresql::create([
+        'name' => 'scheduled-backup-database',
+        'image' => 'postgres:16-alpine',
+        'postgres_user' => 'postgres',
+        'postgres_password' => 'password',
+        'postgres_db' => 'postgres',
+        'environment_id' => $application->environment_id,
+        'destination_id' => $application->destination_id,
+        'destination_type' => $application->destination_type,
+        'status' => 'running',
+    ]);
+
+    $zeroIdBackup = ScheduledDatabaseBackup::forceCreate([
+        'id' => 0,
+        'team_id' => $application->environment->project->team_id,
+        'database_id' => $database->id,
+        'database_type' => $database->getMorphClass(),
+        'frequency' => '* * * * *',
+        'enabled' => true,
+    ]);
+    $positiveIdBackup = ScheduledDatabaseBackup::create([
+        'team_id' => $application->environment->project->team_id,
+        'database_id' => $database->id,
+        'database_type' => $database->getMorphClass(),
+        'frequency' => '* * * * *',
+        'enabled' => true,
+    ]);
+    $zeroIdTask = ScheduledTask::forceCreate([
+        'id' => 0,
+        'team_id' => $application->environment->project->team_id,
+        'application_id' => $application->id,
+        'name' => 'Zero ID task',
+        'command' => 'echo zero',
+        'frequency' => '* * * * *',
+        'enabled' => true,
+    ]);
+    $positiveIdTask = ScheduledTask::factory()->create([
+        'team_id' => $application->environment->project->team_id,
+        'application_id' => $application->id,
+        'frequency' => '* * * * *',
+        'enabled' => true,
+    ]);
+
+    expect($zeroIdBackup->id)->toBe(0)
+        ->and($positiveIdBackup->id)->toBeGreaterThan(0)
+        ->and($zeroIdTask->id)->toBe(0)
+        ->and($positiveIdTask->id)->toBeGreaterThan(0);
+
+    (new ScheduledJobManager)->handle();
+
+    Queue::assertPushed(DatabaseBackupJob::class, 2);
+    Queue::assertPushed(DatabaseBackupJob::class, fn (DatabaseBackupJob $job) => $job->backup->id === 0);
+    Queue::assertPushed(DatabaseBackupJob::class, fn (DatabaseBackupJob $job) => $job->backup->id === $positiveIdBackup->id);
+    Queue::assertPushed(ScheduledTaskJob::class, 2);
+    Queue::assertPushed(ScheduledTaskJob::class, fn (ScheduledTaskJob $job) => $job->task->id === 0);
+    Queue::assertPushed(ScheduledTaskJob::class, fn (ScheduledTaskJob $job) => $job->task->id === $positiveIdTask->id);
 });
 
 it('skips expensive dispatch for non-due schedules while seeding dedup cache', function () {


### PR DESCRIPTION
## Changes

- Start the scheduled-backup and scheduled-task ID cursors at `-1` instead of `0`.
- The manager uses a strict `id > cursor` query, so starting at zero silently skipped valid schedules whose ID is zero. Beginning below zero includes those rows while preserving the existing monotonic cursor and chunking behavior.
- Add regression coverage that dispatches both zero-ID and positive-ID backups and tasks; the existing multi-chunk task coverage remains intact.

## Issues

- Fixes #10636

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable; this is a scheduler fix with no UI change.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Codex helped trace the cursor query, reproduce the zero-ID omission in a regression test, implement the minimal cursor fix, and run formatting and targeted verification. The resulting diff and behavior were reviewed against the current `next` branch.

## Testing

- `vendor/bin/pint --dirty --format agent`
- `php artisan test --compact tests/Feature/ScheduledJobManagerDispatchTest.php` (4 tests, 16 assertions)
- `git diff --check`

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
