### PR TITLE
feat(api): add GET /applications/{uuid}/settings endpoint

### DIFF
--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -2279,6 +2279,81 @@ class ApplicationsController extends Controller
     }
 
     #[OA\Get(
+        summary: 'Get settings',
+        description: 'Get application settings by application UUID.',
+        path: '/applications/{uuid}/settings',
+        operationId: 'get-application-settings-by-uuid',
+        security: [
+            ['bearerAuth' => []],
+        ],
+        tags: ['Applications'],
+        parameters: [
+            new OA\Parameter(
+                name: 'uuid',
+                in: 'path',
+                description: 'UUID of the application.',
+                required: true,
+                schema: new OA\Schema(
+                    type: 'string',
+                )
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Get application settings by application UUID.',
+                content: [
+                    new OA\MediaType(
+                        mediaType: 'application/json',
+                        schema: new OA\Schema(
+                            ref: '#/components/schemas/ApplicationSetting'
+                        )
+                    ),
+                ]
+            ),
+            new OA\Response(
+                response: 401,
+                ref: '#/components/responses/401',
+            ),
+            new OA\Response(
+                response: 400,
+                ref: '#/components/responses/400',
+            ),
+            new OA\Response(
+                response: 404,
+                ref: '#/components/responses/404',
+            ),
+        ]
+    )]
+    public function settings_by_uuid(Request $request)
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+        $uuid = $request->route('uuid');
+        if (! $uuid) {
+            return response()->json(['message' => 'UUID is required.'], 400);
+        }
+        $application = Application::ownedByCurrentTeamAPI($teamId)->where('uuid', $request->uuid)->first();
+        if (! $application) {
+            return response()->json(['message' => 'Application not found.'], 404);
+        }
+
+        $this->authorize('view', $application);
+
+        $settings = $application->settings;
+        $settings->makeHidden([
+            'id',
+            'application_id',
+            'created_at',
+            'updated_at',
+        ]);
+
+        return response()->json(serializeApiResponse($settings));
+    }
+
+    #[OA\Get(
         summary: 'Get application logs.',
         description: 'Get application logs by UUID.',
         path: '/applications/{uuid}/logs',

--- a/openapi.json
+++ b/openapi.json
@@ -3077,6 +3077,53 @@
                 ]
             }
         },
+        "\/applications\/{uuid}\/settings": {
+            "get": {
+                "tags": [
+                    "Applications"
+                ],
+                "summary": "Get settings",
+                "description": "Get application settings by application UUID.",
+                "operationId": "get-application-settings-by-uuid",
+                "parameters": [
+                    {
+                        "name": "uuid",
+                        "in": "path",
+                        "description": "UUID of the application.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Get application settings by application UUID.",
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/ApplicationSetting"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "$ref": "#\/components\/responses\/401"
+                    },
+                    "400": {
+                        "$ref": "#\/components\/responses\/400"
+                    },
+                    "404": {
+                        "$ref": "#\/components\/responses\/404"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
         "\/applications\/{uuid}\/logs": {
             "get": {
                 "tags": [

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2017,6 +2017,37 @@ paths:
       security:
         -
           bearerAuth: []
+  '/applications/{uuid}/settings':
+    get:
+      tags:
+        - Applications
+      summary: 'Get settings'
+      description: 'Get application settings by application UUID.'
+      operationId: get-application-settings-by-uuid
+      parameters:
+        -
+          name: uuid
+          in: path
+          description: 'UUID of the application.'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'Get application settings by application UUID.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApplicationSetting'
+        '401':
+          $ref: '#/components/responses/401'
+        '400':
+          $ref: '#/components/responses/400'
+        '404':
+          $ref: '#/components/responses/404'
+      security:
+        -
+          bearerAuth: []
   '/applications/{uuid}/logs':
     get:
       tags:

--- a/routes/api.php
+++ b/routes/api.php
@@ -140,6 +140,8 @@ Route::group([
     Route::patch('/applications/{uuid}', [ApplicationsController::class, 'update_by_uuid'])->middleware(['api.ability:write']);
     Route::delete('/applications/{uuid}', [ApplicationsController::class, 'delete_by_uuid'])->middleware(['api.ability:write']);
 
+    Route::get('/applications/{uuid}/settings', [ApplicationsController::class, 'settings_by_uuid'])->middleware(['api.ability:read']);
+
     Route::get('/applications/{uuid}/envs', [ApplicationsController::class, 'envs'])->middleware(['api.ability:read']);
     Route::post('/applications/{uuid}/envs', [ApplicationsController::class, 'create_env'])->middleware(['api.ability:write']);
     Route::patch('/applications/{uuid}/envs/bulk', [ApplicationsController::class, 'create_bulk_envs'])->middleware(['api.ability:write']);

--- a/tests/Feature/Api/ApplicationSettingsApiTest.php
+++ b/tests/Feature/Api/ApplicationSettingsApiTest.php
@@ -181,3 +181,56 @@ test('raw compose deployment can only be enabled for Docker Compose applications
         ->assertUnprocessable()
         ->assertJsonValidationErrors('is_raw_compose_deployment_enabled');
 });
+
+test('GET /api/v1/applications/{uuid}/settings returns the full settings record', function () {
+    $this->application->settings->update(recommendedApplicationSettingsPayload());
+
+    $response = $this->withHeaders(applicationSettingsApiHeaders($this->bearerToken))
+        ->getJson("/api/v1/applications/{$this->application->uuid}/settings")
+        ->assertOk()
+        ->assertJsonPath('disable_build_cache', true)
+        ->assertJsonPath('stop_grace_period', 45)
+        ->assertJsonPath('docker_images_to_keep', 7)
+        ->assertJsonMissingPath('id')
+        ->assertJsonMissingPath('application_id')
+        ->assertJsonMissingPath('created_at')
+        ->assertJsonMissingPath('updated_at');
+
+    expect($response->json())->toHaveKeys([
+        'is_static',
+        'is_auto_deploy_enabled',
+        'is_force_https_enabled',
+        'is_debug_enabled',
+        'is_preview_deployments_enabled',
+        'is_build_server_enabled',
+        'is_gpu_enabled',
+    ]);
+});
+
+test('GET /api/v1/applications/{uuid}/settings returns 404 for applications owned by another team', function () {
+    $otherTeam = Team::factory()->create();
+    $otherServer = Server::factory()->create(['team_id' => $otherTeam->id]);
+    $otherDestination = StandaloneDocker::where('server_id', $otherServer->id)->first();
+    $otherProject = Project::factory()->create(['team_id' => $otherTeam->id]);
+    $otherEnvironment = Environment::factory()->create(['project_id' => $otherProject->id]);
+    $otherApplication = Application::factory()->create([
+        'environment_id' => $otherEnvironment->id,
+        'destination_id' => $otherDestination->id,
+        'destination_type' => $otherDestination->getMorphClass(),
+    ]);
+
+    $this->withHeaders(applicationSettingsApiHeaders($this->bearerToken))
+        ->getJson("/api/v1/applications/{$otherApplication->uuid}/settings")
+        ->assertNotFound();
+});
+
+test('GET /api/v1/applications/{uuid}/settings returns 404 for an unknown application uuid', function () {
+    $this->withHeaders(applicationSettingsApiHeaders($this->bearerToken))
+        ->getJson('/api/v1/applications/unknown-application-uuid/settings')
+        ->assertNotFound();
+});
+
+test('GET /api/v1/applications/{uuid}/settings rejects unauthenticated requests', function () {
+    $this->getJson("/api/v1/applications/{$this->application->uuid}/settings")
+        ->assertUnauthorized();
+});


### PR DESCRIPTION
## Changes

- Add a read-only endpoint `GET /api/v1/applications/{uuid}/settings` returning the application's full `ApplicationSetting` record (build, deploy, HTTPS, GPU and compose flags). These settings are writable via PATCH but had no dedicated read endpoint, which blocks external tools that need to inspect an application's configuration.
- The handler mirrors the auth flow of the existing get-application endpoint: team ownership, view policy, read token ability, same 400/401/404 responses. Internal metadata is hidden, consistent with how settings are embedded in the application response.
- OpenAPI attribute references the existing ApplicationSetting schema; both spec files updated. Feature tests added to the existing settings API test file.

## Issues

- Related to https://github.com/coollabsio/coolify/discussions/10950

## Category

- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Captured from a seeded local dev instance — `read` is the literal read-ability token created by `PersonalAccessTokenSeeder`, `crashloop` a seeded demo app; on a real instance use a token from Keys & Tokens (`1|...`):

```console
$ curl -sw '\n%{http_code}' -H "Authorization: Bearer read" \
    localhost:8000/api/v1/applications/crashloop/settings
{"connect_to_docker_network":false,"custom_internal_name":null,
 "disable_build_cache":false,"docker_images_to_keep":2, ...
 "is_auto_deploy_enabled":true,"is_force_https_enabled":true,
 "is_static":false,"stop_grace_period":null,"use_build_secrets":false}
200
```

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: help understanding the repo layout, OpenApi stuff and proper description

## Testing

- Four new Pest feature tests: full record with hidden metadata, cross-team 404, unknown-uuid 404, unauthenticated 401.
- Ran `tests/Feature/Api` and `tests/Unit` on this branch and on clean `next`: identical pre-existing failures, zero new failures, four new tests pass.
- Manually verified against a local dev instance: settings JSON returned, 404 for foreign/unknown apps, 401 without a token.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.