### PR TITLE
fix(deploy): preserve multiple Coolify domains

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -2260,9 +2260,9 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             $fqdn = $this->preview->fqdn;
         }
         if (isset($fqdn)) {
-            $url = Url::fromString($fqdn);
-            $fqdn = $url->getHost();
-            $url = $url->withHost($fqdn)->withPort(null)->__toString();
+            $parsedUrls = str($fqdn)->explode(',')->map(fn (string $domain) => Url::fromString(trim($domain)));
+            $fqdn = $parsedUrls->map(fn (Url $url) => $url->getHost())->implode(',');
+            $url = $parsedUrls->map(fn (Url $url) => $url->withHost($url->getHost())->withPort(null)->__toString())->implode(',');
             if ((int) $this->application->compose_parsing_version >= 3) {
                 $this->coolify_variables .= 'COOLIFY_URL='.escapeShellValue($url).' ';
                 $this->coolify_variables .= 'COOLIFY_FQDN='.escapeShellValue($fqdn).' ';

--- a/tests/Feature/Security/CommandInjectionSecurityTest.php
+++ b/tests/Feature/Security/CommandInjectionSecurityTest.php
@@ -379,6 +379,42 @@ describe('deployment git command escaping', function () {
             ->toContain("COOLIFY_FQDN='app.example.com' ")
             ->toContain("COOLIFY_RESOURCE_UUID='app-uuid' ");
     });
+
+    test('coolify url and fqdn preserve multiple comma-separated domains', function () {
+        $job = new ReflectionClass(ApplicationDeploymentJob::class);
+        $instance = $job->newInstanceWithoutConstructor();
+
+        $application = new Application;
+        $application->uuid = 'app-uuid';
+        $application->git_branch = 'main';
+        $application->fqdn = 'https://admin.example.com:8443/path, https://gate.example.com:9443/other';
+        $application->compose_parsing_version = '3';
+
+        $settings = new ApplicationSetting;
+        $settings->include_source_commit_in_build = false;
+        $application->setRelation('settings', $settings);
+
+        foreach ([
+            'application' => $application,
+            'commit' => 'HEAD',
+            'pull_request_id' => 0,
+        ] as $property => $value) {
+            $reflectionProperty = $job->getProperty($property);
+            $reflectionProperty->setAccessible(true);
+            $reflectionProperty->setValue($instance, $value);
+        }
+
+        $method = $job->getMethod('set_coolify_variables');
+        $method->setAccessible(true);
+        $method->invoke($instance);
+
+        $coolifyVariables = $job->getProperty('coolify_variables');
+        $coolifyVariables->setAccessible(true);
+
+        expect($coolifyVariables->getValue($instance))
+            ->toContain("COOLIFY_URL='https://admin.example.com/path,https://gate.example.com/other' ")
+            ->toContain("COOLIFY_FQDN='admin.example.com,gate.example.com' ");
+    });
 });
 
 describe('sharedDataApplications rules survive array_merge in controller', function () {


### PR DESCRIPTION
## Changes

- Parse every comma-separated application or preview domain independently before generating `COOLIFY_URL` and `COOLIFY_FQDN`.
- Preserve paths, remove per-domain ports, and trim separator whitespace without changing the existing single-domain path.
- Add regression coverage that invokes the actual deployment job method with two domains.

## Issues

- Fixes #10824
- Supersedes #10825, which was auto-closed by the repository quality gate before review. This submission uses the current template and exercises the production method directly.

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable; this changes generated deployment environment variables and has no UI change.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Codex helped inspect the deployment flow, implement the focused parser change and regression test, and run formatting and targeted verification. The final diff was independently reviewed against the current `next` branch.

## Testing

- `vendor/bin/pint --dirty --format agent`
- `php artisan test --compact tests/Feature/Security/CommandInjectionSecurityTest.php` (166 tests, 214 assertions)
- `git diff --check`

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
