### PR TITLE
fix(realtime): separate backend Pusher scheme

### DIFF
--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -38,9 +38,9 @@ return [
             'options' => [
                 'host' => env('PUSHER_BACKEND_HOST', 'coolify-realtime'),
                 'port' => env('PUSHER_BACKEND_PORT', 6001),
-                'scheme' => env('PUSHER_SCHEME', 'http'),
+                'scheme' => env('PUSHER_BACKEND_SCHEME', 'http'),
                 'encrypted' => true,
-                'useTLS' => env('PUSHER_SCHEME', 'https') === 'https',
+                'useTLS' => env('PUSHER_BACKEND_SCHEME', 'http') === 'https',
             ],
             'client_options' => [
                 // Guzzle client options: https://docs.guzzlephp.org/en/stable/request-options.html

--- a/tests/Unit/BroadcastingConfigTest.php
+++ b/tests/Unit/BroadcastingConfigTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Support\Env;
+
+function broadcastingConfigWithEnvironment(array $overrides): array
+{
+    $keys = [
+        'PUSHER_SCHEME',
+        'PUSHER_BACKEND_SCHEME',
+    ];
+    $repository = Env::getRepository();
+    $original = [];
+
+    foreach ($keys as $key) {
+        $original[$key] = $repository->get($key);
+        $repository->clear($key);
+    }
+
+    try {
+        foreach ($overrides as $key => $value) {
+            $repository->set($key, $value);
+        }
+
+        return require __DIR__.'/../../config/broadcasting.php';
+    } finally {
+        foreach ($keys as $key) {
+            $repository->clear($key);
+
+            if ($original[$key] !== null) {
+                $repository->set($key, $original[$key]);
+            }
+        }
+    }
+}
+
+it('keeps the backend pusher connection on http when the browser scheme is https', function () {
+    $options = broadcastingConfigWithEnvironment([
+        'PUSHER_SCHEME' => 'https',
+    ])['connections']['pusher']['options'];
+
+    expect($options['scheme'])->toBe('http')
+        ->and($options['useTLS'])->toBeFalse();
+});
+
+it('enables backend pusher TLS when its scheme is explicitly https', function () {
+    $options = broadcastingConfigWithEnvironment([
+        'PUSHER_SCHEME' => 'http',
+        'PUSHER_BACKEND_SCHEME' => 'https',
+    ])['connections']['pusher']['options'];
+
+    expect($options['scheme'])->toBe('https')
+        ->and($options['useTLS'])->toBeTrue();
+});


### PR DESCRIPTION
## Changes

- Give the backend Pusher client its own `PUSHER_BACKEND_SCHEME` setting with an internal HTTP default.
- Derive both backend scheme and TLS usage from that setting so a browser-facing HTTPS configuration no longer forces TLS against the plain internal realtime endpoint.
- Add regression coverage for the default internal HTTP path and an explicit backend HTTPS override.

## Issues

- Fixes #10637

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable; this is a backend broadcasting configuration fix with no UI change.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Codex helped inspect the broadcasting and container configuration, implement the scoped setting change and regression tests, and run formatting and targeted verification. The final diff was independently reviewed.

## Testing

- `vendor/bin/pint --dirty --format agent`
- Broadcasting and related config tests: 5 tests, 7 assertions
- `git diff --check`
- PHP syntax checks for changed PHP files

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
