### PR TITLE
fix(hetzner): normalize IPv6 server addresses

### DIFF
--- a/app/Http/Controllers/Api/HetznerController.php
+++ b/app/Http/Controllers/Api/HetznerController.php
@@ -926,13 +926,11 @@ class HetznerController extends Controller
             // Create server on Hetzner
             $hetznerServer = $hetznerService->createServer($params);
 
-            // Determine IP address to use (prefer IPv4, fallback to IPv6)
-            $ipAddress = null;
-            if ($request->enable_ipv4 && isset($hetznerServer['public_net']['ipv4']['ip'])) {
-                $ipAddress = $hetznerServer['public_net']['ipv4']['ip'];
-            } elseif ($request->enable_ipv6 && isset($hetznerServer['public_net']['ipv6']['ip'])) {
-                $ipAddress = $hetznerServer['public_net']['ipv6']['ip'];
-            }
+            $ipAddress = $hetznerService->getPublicIpAddress(
+                $hetznerServer,
+                $request->boolean('enable_ipv4'),
+                $request->boolean('enable_ipv6')
+            );
 
             if (! $ipAddress) {
                 throw new \Exception('No public IP address available. Enable at least one of IPv4 or IPv6.');

--- a/app/Livewire/Server/New/ByHetzner.php
+++ b/app/Livewire/Server/New/ByHetzner.php
@@ -709,13 +709,11 @@ class ByHetzner extends Component
             // Create server on Hetzner
             $hetznerServer = $this->createHetznerServer($hetznerService);
 
-            // Determine IP address to use (prefer IPv4, fallback to IPv6)
-            $ipAddress = null;
-            if ($this->enable_ipv4 && isset($hetznerServer['public_net']['ipv4']['ip'])) {
-                $ipAddress = $hetznerServer['public_net']['ipv4']['ip'];
-            } elseif ($this->enable_ipv6 && isset($hetznerServer['public_net']['ipv6']['ip'])) {
-                $ipAddress = $hetznerServer['public_net']['ipv6']['ip'];
-            }
+            $ipAddress = $hetznerService->getPublicIpAddress(
+                $hetznerServer,
+                $this->enable_ipv4,
+                $this->enable_ipv6
+            );
 
             // Create server in Coolify database immediately so the Hetzner
             // server is always tracked, even when no IP is assigned yet —

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -384,7 +384,7 @@ class Server extends BaseModel
         $hetznerService = new HetznerService($this->cloudProviderToken->token);
         $server = $hetznerService->getServer($this->hetzner_server_id);
         $status = $server['status'] ?? null;
-        $assignedIp = data_get($server, 'public_net.ipv4.ip') ?? data_get($server, 'public_net.ipv6.ip');
+        $assignedIp = $hetznerService->getPublicIpAddress($server);
 
         $updates = [];
         if ($this->hetzner_server_status !== $status) {

--- a/app/Services/HetznerService.php
+++ b/app/Services/HetznerService.php
@@ -177,6 +177,21 @@ class HetznerService
         return $this->requestPaginated('get', '/servers', 'servers');
     }
 
+    public function getPublicIpAddress(array $server, bool $enableIpv4 = true, bool $enableIpv6 = true): ?string
+    {
+        $ipv4 = data_get($server, 'public_net.ipv4.ip');
+        if ($enableIpv4 && filled($ipv4)) {
+            return $ipv4;
+        }
+
+        $ipv6 = data_get($server, 'public_net.ipv6.ip');
+        if ($enableIpv6 && filled($ipv6)) {
+            return $this->firstIpv6Address($ipv6);
+        }
+
+        return null;
+    }
+
     public function findServerByIp(string $ip): ?array
     {
         $servers = $this->getServers();
@@ -188,13 +203,98 @@ class HetznerService
                 return $server;
             }
 
-            // Check IPv6 (Hetzner returns the full /64 block)
-            $ipv6 = data_get($server, 'public_net.ipv6.ip');
-            if ($ipv6 && str_starts_with($ip, rtrim($ipv6, '/'))) {
+            if ($this->ipv6AddressBelongsToAllocation($ip, data_get($server, 'public_net.ipv6.ip'))) {
                 return $server;
             }
         }
 
         return null;
+    }
+
+    private function firstIpv6Address(?string $allocation): ?string
+    {
+        $parsedAllocation = $this->parseIpv6Allocation($allocation);
+        if ($parsedAllocation === null) {
+            return null;
+        }
+
+        $networkAddress = $this->maskIpv6Address(
+            $parsedAllocation['address'],
+            $parsedAllocation['prefix']
+        );
+
+        if ($parsedAllocation['prefix'] < 128) {
+            $networkAddress[15] = chr(ord($networkAddress[15]) | 1);
+        }
+
+        return inet_ntop($networkAddress) ?: null;
+    }
+
+    private function ipv6AddressBelongsToAllocation(string $ip, ?string $allocation): bool
+    {
+        $parsedAllocation = $this->parseIpv6Allocation($allocation);
+        if ($parsedAllocation === null || filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) === false) {
+            return false;
+        }
+
+        $packedIp = inet_pton($ip);
+        if ($packedIp === false) {
+            return false;
+        }
+
+        return $this->maskIpv6Address($packedIp, $parsedAllocation['prefix'])
+            === $this->maskIpv6Address($parsedAllocation['address'], $parsedAllocation['prefix']);
+    }
+
+    /**
+     * @return array{address: string, prefix: int}|null
+     */
+    private function parseIpv6Allocation(?string $allocation): ?array
+    {
+        if (blank($allocation)) {
+            return null;
+        }
+
+        $parts = explode('/', $allocation);
+        if (count($parts) > 2) {
+            return null;
+        }
+
+        if (filter_var($parts[0], FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) === false) {
+            return null;
+        }
+
+        $packedAddress = inet_pton($parts[0]);
+        if ($packedAddress === false) {
+            return null;
+        }
+
+        $prefix = $parts[1] ?? '128';
+        if (! ctype_digit($prefix) || (int) $prefix > 128) {
+            return null;
+        }
+
+        return [
+            'address' => $packedAddress,
+            'prefix' => (int) $prefix,
+        ];
+    }
+
+    private function maskIpv6Address(string $packedAddress, int $prefix): string
+    {
+        $networkAddress = '';
+
+        for ($byteIndex = 0; $byteIndex < 16; $byteIndex++) {
+            $remainingPrefixBits = $prefix - ($byteIndex * 8);
+            $mask = match (true) {
+                $remainingPrefixBits >= 8 => 0xFF,
+                $remainingPrefixBits <= 0 => 0,
+                default => (0xFF << (8 - $remainingPrefixBits)) & 0xFF,
+            };
+
+            $networkAddress .= chr(ord($packedAddress[$byteIndex]) & $mask);
+        }
+
+        return $networkAddress;
     }
 }

--- a/tests/Feature/Api/HetznerApiTest.php
+++ b/tests/Feature/Api/HetznerApiTest.php
@@ -646,7 +646,7 @@ describe('POST /api/v1/servers/hetzner', function () {
                     'id' => 456,
                     'public_net' => [
                         'ipv4' => ['ip' => null],
-                        'ipv6' => ['ip' => '2001:db8::1'],
+                        'ipv6' => ['ip' => '2001:db8::/64'],
                     ],
                 ],
             ], 201),

--- a/tests/Feature/Server/HetznerServerCreationTest.php
+++ b/tests/Feature/Server/HetznerServerCreationTest.php
@@ -3,6 +3,7 @@
 use App\Livewire\Server\New\ByHetzner;
 use App\Models\CloudProviderToken;
 use App\Models\PrivateKey;
+use App\Models\Server;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -315,5 +316,42 @@ describe('Hetzner data loading', function () {
             ->assertHasErrors(['enable_ipv4', 'enable_ipv6']);
 
         Http::assertNothingSent();
+    });
+
+    test('stores the first host from the Hetzner IPv6 allocation', function () {
+        Http::fake([
+            'https://api.hetzner.cloud/v1/ssh_keys' => Http::response([
+                'ssh_key' => ['id' => 123],
+            ], 201),
+            'https://api.hetzner.cloud/v1/ssh_keys*' => Http::response([
+                'ssh_keys' => [],
+                'meta' => ['pagination' => ['next_page' => null]],
+            ], 200),
+            'https://api.hetzner.cloud/v1/servers' => Http::response([
+                'server' => [
+                    'id' => 456,
+                    'status' => 'running',
+                    'public_net' => [
+                        'ipv4' => ['ip' => null],
+                        'ipv6' => ['ip' => '2a01:4f8:c17:4c00::/64'],
+                    ],
+                ],
+            ], 201),
+        ]);
+
+        Livewire::test(ByHetzner::class)
+            ->set('current_step', 2)
+            ->set('selected_token_id', $this->hetznerToken->id)
+            ->set('server_name', 'ipv6-server')
+            ->set('selected_location', 'nbg1')
+            ->set('selected_server_type', 'cx11')
+            ->set('selected_image', 15512617)
+            ->set('private_key_id', $this->privateKey->id)
+            ->set('enable_ipv4', false)
+            ->set('enable_ipv6', true)
+            ->call('submit')
+            ->assertRedirect();
+
+        expect(Server::query()->sole()->ip)->toBe('2a01:4f8:c17:4c00::1');
     });
 });

--- a/tests/Feature/ServerCloudProviderStatusCheckJobTest.php
+++ b/tests/Feature/ServerCloudProviderStatusCheckJobTest.php
@@ -109,7 +109,8 @@ it('backfills a Hetzner placeholder without changing reachability', function () 
                 'id' => 123,
                 'status' => 'running',
                 'public_net' => [
-                    'ipv4' => ['ip' => '198.51.100.20'],
+                    'ipv4' => ['ip' => null],
+                    'ipv6' => ['ip' => '2a01:4f8:c17:4c00::/64'],
                 ],
             ],
         ]),
@@ -118,7 +119,7 @@ it('backfills a Hetzner placeholder without changing reachability', function () 
     (new ServerCloudProviderStatusCheckJob($server))->handle();
 
     $server->refresh();
-    expect($server->ip)->toBe('198.51.100.20')
+    expect($server->ip)->toBe('2a01:4f8:c17:4c00::1')
         ->and($server->hetzner_server_status)->toBe('running')
         ->and((bool) $server->settings->fresh()->is_reachable)->toBeTrue()
         ->and((bool) $server->settings->fresh()->is_usable)->toBeTrue();

--- a/tests/Unit/HetznerServiceTest.php
+++ b/tests/Unit/HetznerServiceTest.php
@@ -2,6 +2,9 @@
 
 use App\Services\HetznerService;
 use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+uses(TestCase::class);
 
 beforeEach(function () {
     Http::preventStrayRequests();
@@ -67,6 +70,113 @@ it('findServerByIp returns matching server by IPv4', function () {
     expect($result)->not->toBeNull()
         ->and($result['id'])->toBe(12345)
         ->and($result['name'])->toBe('test-server');
+});
+
+it('prefers the public IPv4 address over the IPv6 allocation', function () {
+    $service = new HetznerService('fake-token');
+
+    $result = $service->getPublicIpAddress([
+        'public_net' => [
+            'ipv4' => ['ip' => '123.45.67.89'],
+            'ipv6' => ['ip' => '2a01:4f8:c17:4c00::/64'],
+        ],
+    ]);
+
+    expect($result)->toBe('123.45.67.89');
+});
+
+it('uses the first host address from an IPv6 allocation', function () {
+    $service = new HetznerService('fake-token');
+
+    $result = $service->getPublicIpAddress([
+        'public_net' => [
+            'ipv4' => ['ip' => null],
+            'ipv6' => ['ip' => '2a01:4f8:c17:4c00:dead:beef::/64'],
+        ],
+    ]);
+
+    expect($result)->toBe('2a01:4f8:c17:4c00::1');
+});
+
+it('findServerByIp matches the first host in an IPv6 allocation', function () {
+    Http::fake([
+        'api.hetzner.cloud/v1/servers*' => Http::response([
+            'servers' => [
+                [
+                    'id' => 12345,
+                    'name' => 'ipv6-server',
+                    'status' => 'running',
+                    'public_net' => [
+                        'ipv4' => ['ip' => null],
+                        'ipv6' => ['ip' => '2a01:4f8:c17:4c00::/64'],
+                    ],
+                ],
+            ],
+            'meta' => ['pagination' => ['next_page' => null]],
+        ], 200),
+    ]);
+
+    $service = new HetznerService('fake-token');
+    $result = $service->findServerByIp('2a01:4f8:c17:4c00::1');
+
+    expect($result)->not->toBeNull()
+        ->and($result['id'])->toBe(12345);
+});
+
+it('findServerByIp matches any host in an IPv6 allocation but not an adjacent allocation', function () {
+    Http::fake([
+        'api.hetzner.cloud/v1/servers*' => Http::response([
+            'servers' => [
+                [
+                    'id' => 12345,
+                    'name' => 'ipv6-server',
+                    'status' => 'running',
+                    'public_net' => [
+                        'ipv4' => ['ip' => null],
+                        'ipv6' => ['ip' => '2a01:4f8:c17:4c00::/64'],
+                    ],
+                ],
+            ],
+            'meta' => ['pagination' => ['next_page' => null]],
+        ], 200),
+    ]);
+
+    $service = new HetznerService('fake-token');
+    $sameAllocation = $service->findServerByIp('2a01:4f8:c17:4c00::42');
+    $adjacentAllocation = $service->findServerByIp('2a01:4f8:c17:4c01::1');
+
+    expect($sameAllocation)->not->toBeNull()
+        ->and($sameAllocation['id'])->toBe(12345)
+        ->and($adjacentAllocation)->toBeNull();
+});
+
+it('findServerByIp rejects invalid IPv6 addresses and allocation prefixes', function () {
+    Http::fake([
+        'api.hetzner.cloud/v1/servers*' => Http::response([
+            'servers' => [
+                [
+                    'id' => 12345,
+                    'public_net' => [
+                        'ipv4' => ['ip' => null],
+                        'ipv6' => ['ip' => '2a01:4f8:c17:4c00::/64'],
+                    ],
+                ],
+                [
+                    'id' => 67890,
+                    'public_net' => [
+                        'ipv4' => ['ip' => null],
+                        'ipv6' => ['ip' => '2a01:4f8:c17:4c01::/129'],
+                    ],
+                ],
+            ],
+            'meta' => ['pagination' => ['next_page' => null]],
+        ], 200),
+    ]);
+
+    $service = new HetznerService('fake-token');
+
+    expect($service->findServerByIp('not-an-ip'))->toBeNull()
+        ->and($service->findServerByIp('2a01:4f8:c17:4c01::1'))->toBeNull();
 });
 
 it('findServerByIp returns null when no match', function () {


### PR DESCRIPTION
## Changes

- Normalize Hetzner IPv6 allocations to their first host address while continuing to prefer IPv4 when available.
- Reuse the normalization in API provisioning, Livewire provisioning, and placeholder-IP refresh.
- Match stored IPv6 hosts to Hetzner allocations with binary CIDR comparison, including non-first hosts, and reject invalid or adjacent networks.

## Issues

- Fixes #10952

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable; this is a server provisioning and lookup fix with no UI change.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Codex helped trace all Hetzner address consumers, implement shared IPv6 normalization and CIDR matching, add regression coverage, and run formatting and targeted verification. The final behavior and diff were independently reviewed.

## Testing

- `vendor/bin/pint --dirty --format agent`
- Affected Hetzner unit and feature suites: 63 tests, 168 assertions
- `git diff --check`
- PHP syntax checks for changed PHP files

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
