### PR TITLE
fix(proxy): protect HTTP routes with basic auth

### DIFF
--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -608,6 +608,8 @@ function fqdnLabelsForTraefik(string $uuid, Collection $domains, bool $is_force_
                 }
                 if ($is_force_https_enabled) {
                     $labels->push("traefik.http.routers.{$http_label}.middlewares=redirect-to-https");
+                } elseif ($is_http_basic_auth_enabled) {
+                    $labels->push("traefik.http.routers.{$http_label}.middlewares={$http_basic_auth_label}");
                 }
             } else {
                 // Set labels for http

--- a/tests/Unit/TraefikHttpBasicAuthLabelsTest.php
+++ b/tests/Unit/TraefikHttpBasicAuthLabelsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+it('protects both routers with basic auth when force https is disabled', function () {
+    $labels = fqdnLabelsForTraefik(
+        uuid: 'test-app',
+        domains: collect(['https://example.com']),
+        is_force_https_enabled: false,
+        is_http_basic_auth_enabled: true,
+        http_basic_auth_username: 'coolify',
+        http_basic_auth_password: 'secret',
+    );
+
+    expect($labels)
+        ->toContain('traefik.http.routers.https-0-test-app.middlewares=gzip,http-basic-auth-test-app')
+        ->toContain('traefik.http.routers.http-0-test-app.middlewares=http-basic-auth-test-app');
+});
+
+it('keeps the http router redirect only when force https is enabled', function () {
+    $labels = fqdnLabelsForTraefik(
+        uuid: 'test-app',
+        domains: collect(['https://example.com']),
+        is_force_https_enabled: true,
+        is_http_basic_auth_enabled: true,
+        http_basic_auth_username: 'coolify',
+        http_basic_auth_password: 'secret',
+    );
+
+    expect($labels)
+        ->toContain('traefik.http.routers.https-0-test-app.middlewares=gzip,http-basic-auth-test-app')
+        ->toContain('traefik.http.routers.http-0-test-app.middlewares=redirect-to-https')
+        ->not->toContain('traefik.http.routers.http-0-test-app.middlewares=redirect-to-https,http-basic-auth-test-app');
+});


### PR DESCRIPTION
## Changes

- Apply the existing HTTP Basic Auth middleware to the HTTP router generated for an HTTPS domain when Force HTTPS is disabled.
- Keep the Force HTTPS path redirect-only so HTTP requests continue to move directly to the protected HTTPS router.
- Add regression coverage for both router configurations and their middleware ordering.

## Issues

- Fixes #9913

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable; this changes generated Traefik labels and has no Coolify UI change.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Codex helped trace the Traefik router label generation, implement the focused middleware change and regression tests, and run formatting and targeted verification. The final diff and behavior were independently reviewed against the current `next` branch.

## Testing

- `vendor/bin/pint --dirty --format agent`
- `php artisan test --compact tests/Unit/TraefikHttpBasicAuthLabelsTest.php tests/Unit/DockerComposeLabelParsingTest.php` (8 tests, 18 assertions)
- `git diff --check`

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
