### PR TITLE
fix(ui): allow clearing custom Fluent Bit config

### DIFF
--- a/resources/views/livewire/server/log-drains.blade.php
+++ b/resources/views/livewire/server/log-drains.blade.php
@@ -99,7 +99,7 @@
                                     <x-forms.textarea disabled id="logDrainCustomConfigParser"
                                         label="Custom Parser Configuration" />
                                 @else
-                                    <x-forms.textarea canGate="update" :canResource="$server" rows="6" required
+                                    <x-forms.textarea canGate="update" :canResource="$server" rows="6"
                                         id="logDrainCustomConfig" label="Custom FluentBit Configuration" />
                                     <x-forms.textarea canGate="update" :canResource="$server"
                                         id="logDrainCustomConfigParser" label="Custom Parser Configuration" />

--- a/tests/Feature/Livewire/LogDrainsCustomConfigTest.php
+++ b/tests/Feature/Livewire/LogDrainsCustomConfigTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use App\Livewire\Server\LogDrains;
+use App\Models\Server;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+
+    $this->actingAs($this->user);
+    session(['currentTeam' => $this->team]);
+
+    $this->server = Server::factory()->create(['team_id' => $this->team->id]);
+    $this->server->settings()->update([
+        'is_reachable' => true,
+        'is_usable' => true,
+    ]);
+});
+
+it('does not require custom Fluent Bit config in the browser while the drain is disabled', function () {
+    $html = Livewire::test(LogDrains::class, ['server_uuid' => $this->server->uuid])->html();
+    $document = new DOMDocument;
+    $previousState = libxml_use_internal_errors(true);
+    $document->loadHTML($html);
+    libxml_clear_errors();
+    libxml_use_internal_errors($previousState);
+
+    $textarea = (new DOMXPath($document))
+        ->query('//textarea[@*[name()="wire:model" and .="logDrainCustomConfig"]]')
+        ?->item(0);
+
+    expect($textarea)->toBeInstanceOf(DOMElement::class)
+        ->and($textarea->hasAttribute('required'))->toBeFalse();
+});
+
+it('allows clearing custom Fluent Bit config while the drain is disabled', function () {
+    $this->server->settings()->update([
+        'is_logdrain_custom_enabled' => false,
+        'logdrain_custom_config' => "[OUTPUT]\n    Name http",
+    ]);
+
+    Livewire::test(LogDrains::class, ['server_uuid' => $this->server->uuid])
+        ->set('logDrainCustomConfig', null)
+        ->call('submit', 'custom')
+        ->assertHasNoErrors()
+        ->assertDispatched('success');
+
+    expect($this->server->settings()->value('logdrain_custom_config'))->toBeNull();
+});
+
+it('requires custom Fluent Bit config when enabling the drain', function () {
+    Livewire::test(LogDrains::class, ['server_uuid' => $this->server->uuid])
+        ->set('isLogDrainCustomEnabled', true)
+        ->set('logDrainCustomConfig', null)
+        ->call('customValidation')
+        ->assertHasErrors(['logDrainCustomConfig' => ['required']]);
+});


### PR DESCRIPTION
## Changes

- Remove the unconditional browser `required` constraint from the editable Custom FluentBit Configuration textarea.
- Keep the existing server-side validation that requires configuration when the custom log drain is enabled.
- Add Livewire regression coverage for rendered HTML, clearing the stored value while disabled, and enabled-state validation.

## Issues

- Fixes #6123

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable; this removes an incorrect HTML form constraint without changing the page layout.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Codex helped reproduce the browser constraint in rendered Livewire HTML, implement the minimal Blade change and behavioral regression coverage, and run formatting and targeted verification. The final diff and validation behavior were independently reviewed against the current `next` branch.

## Testing

- `vendor/bin/pint --dirty --format agent`
- `php artisan test --compact tests/Feature/Livewire/LogDrainsCustomConfigTest.php tests/Feature/LogDrain/` (7 tests, 15 assertions)
- `git diff --check`

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
