### PR TITLE
fix: use actual timezone abbreviation in PR preview comment timestamp

### DIFF
--- a/app/Jobs/ApplicationPullRequestUpdateJob.php
+++ b/app/Jobs/ApplicationPullRequestUpdateJob.php
@@ -57,7 +57,7 @@ class ApplicationPullRequestUpdateJob implements ShouldBeEncrypted, ShouldQueue
             $application_logs_url = base_url()."/project/{$this->application->environment->project->uuid}/environment/{$this->application->environment->uuid}/application/{$this->application->uuid}/logs";
 
             $this->body .= '[Open Build Logs]('.$this->build_logs_url.') | [Open Application Logs]('.$application_logs_url.")\n\n\n";
-            $this->body .= 'Last updated at: '.now()->toDateTimeString().' CET';
+            $this->body .= 'Last updated at: '.now()->format('Y-m-d H:i:s T');
             if ($this->preview->pull_request_issue_comment_id) {
                 $this->update_comment();
             } else {


### PR DESCRIPTION
## Changes

The "Last updated at" timestamp in the PR preview deployment comment always says "CET", but the time itself comes from `now()` in the instance's configured timezone — UTC by default. So on any instance not running in CET, the comment shows a mislabeled time (e.g. our UTC instance posted `Last updated at: 2026-07-17 23:24:12 CET` for a deployment that happened at 23:24 **UTC** / 01:24 CEST), which sent us down a confusing "why is this timestamp two hours off?" debugging session.

- Replaced the hardcoded `' CET'` suffix with the `T` format specifier, so the comment renders the instance's real timezone abbreviation: `Last updated at: 2026-07-17 23:24:12 UTC` on a default instance, `... 01:24:12 CEST` on one configured for `Europe/Amsterdam`, and still `... CET` where that is actually true.

## Issues

- No existing issue found; searched open and closed issues/PRs for this timestamp label first.

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Before (UTC instance, actual comment posted by v4.1.2 — the deployment happened at 23:24 UTC, not 23:24 CET):

> Last updated at: 2026-07-17 23:24:12 CET

After (same instant, same instance, new format):

> Last updated at: 2026-07-17 23:24:12 UTC

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: located the hardcoded label, authored the one-line change and this PR text; directed and reviewed by the account owner.

## Testing

- Bug confirmed on our production Coolify v4.1.2 instance: GitHub's API recorded the bot comment edit at `23:24:13Z` while the comment body said `23:24:12 CET` — same instant, mislabeled.
- `php -l` passes on the changed file.
- Format specifier verified directly in PHP: `date('Y-m-d H:i:s T')` yields `2026-07-17 23:45:22 UTC` under UTC and `2026-07-18 01:45:22 CEST` under `Europe/Amsterdam`.
- Not yet exercised end-to-end on a local dev instance of Coolify; the change is confined to this one string concatenation.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
