### PR TITLE
feat(service): update plausible community-edition to v3.2.1

### DIFF
--- a/templates/compose/plausible.yaml
+++ b/templates/compose/plausible.yaml
@@ -7,7 +7,7 @@
 
 services:
   plausible:
-    image: "ghcr.io/plausible/community-edition:v3.0.1"
+    image: "ghcr.io/plausible/community-edition:v3.2.1"
     command: 'sh -c "sleep 10 && /entrypoint.sh db createdb && /entrypoint.sh db migrate && /entrypoint.sh run"'
     environment:
       - SERVICE_URL_PLAUSIBLE
@@ -68,14 +68,24 @@ services:
       - plausible-events-data:/var/lib/clickhouse
       - type: bind
         source: ./clickhouse/clickhouse-config.xml
-        target: /etc/clickhouse-server/config.d/logging.xml
+        target: /etc/clickhouse-server/config.d/logs.xml
         read_only: true
-        content: '<clickhouse><logger><level>warning</level><console>true</console></logger><query_thread_log remove="remove"/><query_log remove="remove"/><text_log remove="remove"/><trace_log remove="remove"/><metric_log remove="remove"/><asynchronous_metric_log remove="remove"/><session_log remove="remove"/><part_log remove="remove"/></clickhouse>'
+        content: '<clickhouse><logger><level>warning</level><console>true</console></logger><query_log replace="1"><database>system</database><table>query_log</table><engine>ENGINE = MergeTree PARTITION BY event_date ORDER BY event_time TTL event_date + interval 30 day SETTINGS ttl_only_drop_parts=1</engine><flush_interval_milliseconds>7500</flush_interval_milliseconds></query_log><query_thread_log remove="remove"/><text_log remove="remove"/><trace_log remove="remove"/><metric_log remove="remove"/><asynchronous_metric_log remove="remove"/><session_log remove="remove"/><part_log remove="remove"/></clickhouse>'
+      - type: bind
+        source: ./clickhouse/clickhouse-ipv4-only.xml
+        target: /etc/clickhouse-server/config.d/ipv4-only.xml
+        read_only: true
+        content: '<clickhouse><listen_host>0.0.0.0</listen_host></clickhouse>'
+      - type: bind
+        source: ./clickhouse/clickhouse-low-resources.xml
+        target: /etc/clickhouse-server/config.d/low-resources.xml
+        read_only: true
+        content: '<clickhouse><mark_cache_size>524288000</mark_cache_size></clickhouse>'
       - type: bind
         source: ./clickhouse/clickhouse-user-config.xml
-        target: /etc/clickhouse-server/users.d/logging.xml
+        target: /etc/clickhouse-server/users.d/default-profile-low-resources-overrides.xml
         read_only: true
-        content: '<clickhouse><profiles><default><log_queries>0</log_queries><log_query_threads>0</log_query_threads></default></profiles></clickhouse>'
+        content: '<clickhouse><profiles><default><max_threads>1</max_threads><max_block_size>8192</max_block_size><max_download_threads>1</max_download_threads><input_format_parallel_parsing>0</input_format_parallel_parsing><output_format_parallel_formatting>0</output_format_parallel_formatting></default></profiles></clickhouse>'
     ulimits:
       nofile:
         soft: 262144


### PR DESCRIPTION
## Changes

- Bumped Plausible Community Edition image from `v3.0.1` to `v3.2.1`. This is a critical security update that fixes CVE-2026-8467, a remote code execution vulnerability via the `/storybook` endpoint present in all versions from v3.0.0-rc.0 through v3.2.0.
- Updated the inline ClickHouse configuration to match upstream v3.2.1:
  - Replaced the old `query_log remove` directive with a properly configured `query_log` using MergeTree engine and a 30-day TTL, preventing unbounded disk growth while keeping queries debuggable.
  - Added `ipv4-only.xml` bind mount to suppress IPv6 binding warnings on Docker bridge networks.
  - Added `low-resources.xml` bind mount with `mark_cache_size` of ~500 MB for resource-constrained deployments.
  - Replaced the old user profile (which only disabled `log_queries` and `log_query_threads`) with the upstream `default-profile-low-resources-overrides.xml`, which properly limits threads and parallel processing for setups under 16 GB of RAM.
- Renamed the ClickHouse config target filenames to match upstream (`logging.xml` → `logs.xml`, `logging.xml` → `default-profile-low-resources-overrides.xml`).

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [x] Fixing or updating existing one click service


## Preview

N/A. Tested by deploying the updated compose on a live VPS with an existing Plausible instance. The upgrade ran without errors: database migrations completed successfully and the health check endpoint responded correctly.


## AI Assistance

- [x] AI was NOT used to create this PR
- [ ] AI was used (please describe below)

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.