### PR TITLE
fix(service): close edit domain modal after successful save

### DIFF
--- a/app/Livewire/Project/Service/EditDomain.php
+++ b/app/Livewire/Project/Service/EditDomain.php
@@ -154,6 +154,7 @@ class EditDomain extends Component
             $this->dispatch('refresh');
             $this->dispatch('refreshServices');
             $this->dispatch('configurationChanged');
+            $this->dispatch('close-modal');
         } catch (\Throwable $e) {
             $originalFqdn = $this->application->getOriginal('fqdn');
             if ($originalFqdn !== $this->application->fqdn) {

--- a/database/factories/ServiceApplicationFactory.php
+++ b/database/factories/ServiceApplicationFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ServiceApplicationFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->unique()->word(),
+            'service_id' => 1,
+        ];
+    }
+}

--- a/tests/Feature/Service/EditDomainPortValidationTest.php
+++ b/tests/Feature/Service/EditDomainPortValidationTest.php
@@ -2,6 +2,7 @@
 
 use App\Livewire\Project\Service\EditDomain;
 use App\Models\Environment;
+use App\Models\InstanceSettings;
 use App\Models\Project;
 use App\Models\Server;
 use App\Models\Service;
@@ -9,24 +10,31 @@ use App\Models\ServiceApplication;
 use App\Models\StandaloneDocker;
 use App\Models\Team;
 use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
 
+uses(RefreshDatabase::class);
+
 beforeEach(function () {
+    // Required base instance settings (id 0)
+    $instanceSettings = new InstanceSettings;
+    $instanceSettings->id = 0;
+    $instanceSettings->save();
+
     // Create user and team
     $this->user = User::factory()->create();
     $this->team = Team::factory()->create();
     $this->user->teams()->attach($this->team, ['role' => 'owner']);
     $this->actingAs($this->user);
+    session(['currentTeam' => ['id' => $this->team->id]]);
 
     // Create server
     $this->server = Server::factory()->create([
         'team_id' => $this->team->id,
     ]);
 
-    // Create standalone docker destination
-    $this->destination = StandaloneDocker::factory()->create([
-        'server_id' => $this->server->id,
-    ]);
+    // Use the standalone docker destination auto-created with the server
+    $this->destination = StandaloneDocker::where('server_id', $this->server->id)->firstOrFail();
 
     // Create project and environment
     $this->project = Project::factory()->create([
@@ -130,6 +138,32 @@ it('shows warning when at least one domain is missing port (multiple domains)', 
         ->set('fqdn', 'http://example.com:8000,https://app.example.com') // Second domain missing port
         ->call('submit')
         ->assertSet('showPortWarningModal', true);
+});
+
+it('closes the modal after successfully saving domains', function () {
+    Livewire::test(EditDomain::class, ['applicationId' => $this->serviceApplication->id])
+        ->set('fqdn', 'http://example.com:3000') // Valid domain with a port
+        ->call('submit')
+        ->assertSet('showPortWarningModal', false)
+        ->assertDispatched('close-modal');
+});
+
+it('does not close the modal while the port warning is shown', function () {
+    Livewire::test(EditDomain::class, ['applicationId' => $this->serviceApplication->id])
+        ->set('fqdn', 'http://example.com') // Remove port -> triggers warning, early return
+        ->call('submit')
+        ->assertSet('showPortWarningModal', true)
+        ->assertNotDispatched('close-modal');
+});
+
+it('closes the modal after confirming port removal', function () {
+    Livewire::test(EditDomain::class, ['applicationId' => $this->serviceApplication->id])
+        ->set('fqdn', 'http://example.com') // Remove port
+        ->call('submit')
+        ->assertSet('showPortWarningModal', true)
+        ->call('confirmRemovePort')
+        ->assertSet('showPortWarningModal', false)
+        ->assertDispatched('close-modal');
 });
 
 it('does not show warning for services without required port', function () {


### PR DESCRIPTION
## Changes

- Fixed the service "Edit Domains" modal staying open after a successful save. Editing a domain on a service container (e.g. one that requires a specific port) saved correctly, but the modal never closed.
- Root cause: the component saved and refreshed but never dispatched the `close-modal` event the modal wrapper listens for. I dispatch it on the success path only, so the domain-conflict and required-port dialogs still behave as before — matching how the app's other modal forms close.

## Issues

- No existing issue found — searched open and closed issues and PRs. Reproduces on a service container's "Edit Domains": enter a valid domain, click Save, save succeeds but the modal stays open.

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Before: the service "Edit Domains" modal stayed open after saving. After: it closes once the domain is saved.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (credited as co-author on the commit)
- How extensively: It helped trace the root cause, wrote the one-line fix and the tests, and repaired the pre-existing test setup. I reviewed every change and ran the tests myself.

## Testing

- Extended the service edit-domain test to run in isolation (database refresh, current-team session, base instance settings, the server's auto-created destination) and added a missing factory the file already referenced.
- New cases: modal closes after a save and after a confirmed port removal, and stays open while the port warning shows.
- `php artisan test tests/Feature/Service/EditDomainPortValidationTest.php` — 11 passed.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
