### PR TITLE
feat(template): Add WordPress + OpenLiteSpeed service template (#8264)

### DIFF
--- a/templates/compose/wordpress-with-openlitespeed.yaml
+++ b/templates/compose/wordpress-with-openlitespeed.yaml
@@ -1,0 +1,39 @@
+# documentation: https://openlitespeed.org
+# slogan: OpenLiteSpeed is a high-performance, lightweight, open-source HTTP server with LSCache support for WordPress.
+# category: cms
+# tags: cms, blog, content, management, openlitespeed, litespeed, wordpress
+# logo: svgs/wordpress.svg
+# port: 80
+
+services:
+  wordpress:
+    image: litespeedtech/openlitespeed:latest
+    volumes:
+      - wordpress-files:/usr/local/lsws/Example/html
+    environment:
+      - SERVICE_URL_WORDPRESS_80
+      - MYSQL_HOST=mariadb
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+      - MYSQL_DATABASE=wordpress
+    depends_on:
+      - mariadb
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:80"]
+      interval: 5s
+      timeout: 10s
+      retries: 10
+  mariadb:
+    image: mariadb:11
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=$SERVICE_PASSWORD_ROOT
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=$SERVICE_USER_WORDPRESS
+      - MYSQL_PASSWORD=$SERVICE_PASSWORD_WORDPRESS
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
Resolves #8264. Adds a reusable service template for WordPress running on OpenLiteSpeed with LSCache support and MariaDB backend.

/claim #8264