### PR TITLE
fix: scope compose env vars per service to prevent cross-container secret leak (#7655)

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -690,14 +690,11 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             }
         } else {
             $composeFile = $this->application->parse(pull_request_id: $this->pull_request_id, preview_id: data_get($this->preview, 'id'), commit: $this->commit);
-            // Always add .env file to services
-            $services = collect(data_get($composeFile, 'services', []));
-            $services = $services->map(function ($service, $name) {
-                $service['env_file'] = ['.env'];
-
-                return $service;
-            });
-            $composeFile['services'] = $services->toArray();
+            // Scope environment variables per service: each container receives only the
+            // variables it declares in its own environment/env_file, never the shared
+            // project-wide .env, which would leak every service's secrets to every
+            // container. See https://github.com/coollabsio/coolify/issues/7655
+            $composeFile = stripSharedEnvFileFromComposeServices(is_array($composeFile) ? $composeFile : convertToArray($composeFile));
             if (empty($composeFile)) {
                 $this->application_deployment_queue->addLogEntry('Failed to parse docker-compose file.');
                 $this->fail('Failed to parse docker-compose file.');

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -3725,6 +3725,48 @@ function convertToKeyValueCollection($environment)
 
     return $convertedServiceVariables;
 }
+
+/**
+ * Remove the shared project-wide `.env` file from every Compose service's
+ * `env_file` directive.
+ *
+ * Coolify writes a single `.env` containing every environment variable of the
+ * whole Compose project. Attaching that file to each service leaks the secrets
+ * of one container to all the others (e.g. the Redis container could read the
+ * app's OPENAI_API_KEY). Each service already receives its own variables through
+ * its resolved `environment:` block (values are interpolated at deploy time via
+ * `docker compose --env-file .env`), so the shared file is unnecessary for a
+ * service to get its own values and only serves to expose unrelated secrets.
+ *
+ * Variables/files a service explicitly declares for itself are preserved.
+ *
+ * @see https://github.com/coollabsio/coolify/issues/7655
+ *
+ * @param  array<string, mixed>  $composeFile
+ * @return array<string, mixed>
+ */
+function stripSharedEnvFileFromComposeServices(array $composeFile): array
+{
+    $services = data_get($composeFile, 'services', []);
+    foreach ($services as $serviceName => $service) {
+        $existingEnvFiles = data_get($service, 'env_file');
+        $scopedEnvFiles = collect(is_null($existingEnvFiles) ? [] : (is_array($existingEnvFiles) ? $existingEnvFiles : [$existingEnvFiles]))
+            ->reject(fn ($envFile) => $envFile === '.env')
+            ->unique()
+            ->values();
+
+        if ($scopedEnvFiles->isEmpty()) {
+            unset($service['env_file']);
+        } else {
+            $service['env_file'] = $scopedEnvFiles->all();
+        }
+
+        $services[$serviceName] = $service;
+    }
+
+    return data_set($composeFile, 'services', $services);
+}
+
 function instanceSettings()
 {
     return InstanceSettings::get();

--- a/tests/Unit/ComposeEnvIsolationTest.php
+++ b/tests/Unit/ComposeEnvIsolationTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * Unit tests for stripSharedEnvFileFromComposeServices().
+ *
+ * Verifies that Docker Compose services do not receive the shared project-wide
+ * `.env` file, which would expose every service's secrets to every container.
+ *
+ * @see https://github.com/coollabsio/coolify/issues/7655
+ */
+it('removes the shared project .env from every service so secrets are not leaked across containers', function () {
+    $composeFile = [
+        'services' => [
+            'app' => [
+                'image' => 'node',
+                'environment' => ['OPENAI_API_KEY' => '${OPENAI_API_KEY}'],
+                'env_file' => ['.env'],
+            ],
+            'db' => [
+                'image' => 'postgres',
+                'environment' => ['POSTGRES_PASSWORD' => '${POSTGRES_PASSWORD}'],
+                'env_file' => ['.env'],
+            ],
+            'redis' => [
+                'image' => 'redis',
+                'env_file' => ['.env'],
+            ],
+        ],
+    ];
+
+    $result = stripSharedEnvFileFromComposeServices($composeFile);
+
+    foreach ($result['services'] as $service) {
+        expect(data_get($service, 'env_file', []))->not->toContain('.env');
+    }
+
+    // Each service still only declares its own variables.
+    expect(array_keys($result['services']['app']['environment']))->toBe(['OPENAI_API_KEY']);
+    expect(array_keys($result['services']['db']['environment']))->toBe(['POSTGRES_PASSWORD']);
+});
+
+it('preserves a service-specific env_file while dropping the shared one', function () {
+    $composeFile = [
+        'services' => [
+            'app' => ['env_file' => ['./app.env', '.env']],
+        ],
+    ];
+
+    $result = stripSharedEnvFileFromComposeServices($composeFile);
+
+    expect($result['services']['app']['env_file'])->toBe(['./app.env']);
+});
+
+it('unsets env_file entirely when only the shared .env was present', function () {
+    $composeFile = [
+        'services' => [
+            'app' => ['image' => 'node', 'env_file' => ['.env']],
+        ],
+    ];
+
+    $result = stripSharedEnvFileFromComposeServices($composeFile);
+
+    expect(data_get($result, 'services.app.env_file'))->toBeNull();
+    expect(data_get($result, 'services.app.image'))->toBe('node');
+});
+
+it('handles a string env_file value', function () {
+    $composeFile = [
+        'services' => [
+            'app' => ['env_file' => '.env'],
+        ],
+    ];
+
+    $result = stripSharedEnvFileFromComposeServices($composeFile);
+
+    expect(data_get($result, 'services.app.env_file'))->toBeNull();
+});
+
+it('is a no-op for services without any env_file', function () {
+    $composeFile = [
+        'services' => [
+            'app' => ['image' => 'node', 'environment' => ['FOO' => 'bar']],
+        ],
+    ];
+
+    $result = stripSharedEnvFileFromComposeServices($composeFile);
+
+    expect($result['services']['app'])->toBe(['image' => 'node', 'environment' => ['FOO' => 'bar']]);
+});


### PR DESCRIPTION
## What & why

Closes #7655.

When deploying a Docker Compose project, Coolify writes a **single project-wide `.env`** containing every environment variable of the whole project and attaches it to **every** service via `env_file: ['.env']` (in `ApplicationDeploymentJob`). As a result, any container can read the secrets of every other container:

- In a Next.js + PostgreSQL + Redis stack, the Redis container can read `POSTGRES_PASSWORD` and the database can read the app's `OPENAI_API_KEY`.
- In a multi-database setup, each database sees the others' credentials.
- If one container is compromised, the attacker gains credentials for the entire project.

This matches the **Expected Behavior** in #7655: a container should only receive the variables it declares for itself, not the whole project's secrets.

## The fix

Each service already receives its own variables through its resolved `environment:` block — values are interpolated at deploy time via `docker compose --env-file .env` (that flag only feeds `${VAR}` interpolation of the compose file, it does not inject the file into containers). So the shared `.env` `env_file` attachment is **not needed** for a service to get its own values; it only exposes unrelated secrets.

- Adds `stripSharedEnvFileFromComposeServices()` in `bootstrap/helpers/shared.php`.
- Applies it in `ApplicationDeploymentJob` in place of the previous blanket `env_file = ['.env']` map, which also had the side effect of discarding a service's own explicitly-declared `env_file`.
- An `env_file` a service explicitly declares for itself is **preserved**; only the shared project-wide `.env` is removed.

## Tests

New `tests/Unit/ComposeEnvIsolationTest.php` (5 cases) proving the isolation property: the shared `.env` is stripped from every service, service-specific `env_file` entries are preserved, and services without an `env_file` are untouched. Existing parser/env unit tests remain green.

```
Tests: 21 passed (ComposeEnvIsolationTest + DockerComposeLabelParsingTest + ApplicationServiceEnvironmentVariablesTest)
```

## Verification notes (transparent)

Verified at unit level on the pure transform. I could not run a full end-to-end deployment locally (no Docker host here), so I'd appreciate a maintainer sanity-check that no deployment relies on the old cross-service injection for variables that are *not* declared in a service's `environment:`. Happy to adjust the approach (e.g. per-service scoped env files instead of relying on interpolation) if you prefer.

/claim #7655