### PR TITLE
fix: scope compose env vars per service to prevent cross-container secret leak

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -690,14 +690,11 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             }
         } else {
             $composeFile = $this->application->parse(pull_request_id: $this->pull_request_id, preview_id: data_get($this->preview, 'id'), commit: $this->commit);
-            // Always add .env file to services
-            $services = collect(data_get($composeFile, 'services', []));
-            $services = $services->map(function ($service, $name) {
-                $service['env_file'] = ['.env'];
-
-                return $service;
-            });
-            $composeFile['services'] = $services->toArray();
+            // Scope environment variables per service: each container receives only the
+            // variables it declares in its own environment/env_file, never the shared
+            // project-wide .env, which would leak every service's secrets to every
+            // container. See https://github.com/coollabsio/coolify/issues/7655
+            $composeFile = stripSharedEnvFileFromComposeServices(is_array($composeFile) ? $composeFile : convertToArray($composeFile));
             if (empty($composeFile)) {
                 $this->application_deployment_queue->addLogEntry('Failed to parse docker-compose file.');
                 $this->fail('Failed to parse docker-compose file.');

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -3725,6 +3725,48 @@ function convertToKeyValueCollection($environment)
 
     return $convertedServiceVariables;
 }
+
+/**
+ * Remove the shared project-wide `.env` file from every Compose service's
+ * `env_file` directive.
+ *
+ * Coolify writes a single `.env` containing every environment variable of the
+ * whole Compose project. Attaching that file to each service leaks the secrets
+ * of one container to all the others (e.g. the Redis container could read the
+ * app's OPENAI_API_KEY). Each service already receives its own variables through
+ * its resolved `environment:` block (values are interpolated at deploy time via
+ * `docker compose --env-file .env`), so the shared file is unnecessary for a
+ * service to get its own values and only serves to expose unrelated secrets.
+ *
+ * Variables/files a service explicitly declares for itself are preserved.
+ *
+ * @see https://github.com/coollabsio/coolify/issues/7655
+ *
+ * @param  array<string, mixed>  $composeFile
+ * @return array<string, mixed>
+ */
+function stripSharedEnvFileFromComposeServices(array $composeFile): array
+{
+    $services = data_get($composeFile, 'services', []);
+    foreach ($services as $serviceName => $service) {
+        $existingEnvFiles = data_get($service, 'env_file');
+        $scopedEnvFiles = collect(is_null($existingEnvFiles) ? [] : (is_array($existingEnvFiles) ? $existingEnvFiles : [$existingEnvFiles]))
+            ->reject(fn ($envFile) => $envFile === '.env')
+            ->unique()
+            ->values();
+
+        if ($scopedEnvFiles->isEmpty()) {
+            unset($service['env_file']);
+        } else {
+            $service['env_file'] = $scopedEnvFiles->all();
+        }
+
+        $services[$serviceName] = $service;
+    }
+
+    return data_set($composeFile, 'services', $services);
+}
+
 function instanceSettings()
 {
     return InstanceSettings::get();

--- a/tests/Unit/ComposeEnvIsolationTest.php
+++ b/tests/Unit/ComposeEnvIsolationTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * Unit tests for stripSharedEnvFileFromComposeServices().
+ *
+ * Verifies that Docker Compose services do not receive the shared project-wide
+ * `.env` file, which would expose every service's secrets to every container.
+ *
+ * @see https://github.com/coollabsio/coolify/issues/7655
+ */
+it('removes the shared project .env from every service so secrets are not leaked across containers', function () {
+    $composeFile = [
+        'services' => [
+            'app' => [
+                'image' => 'node',
+                'environment' => ['OPENAI_API_KEY' => '${OPENAI_API_KEY}'],
+                'env_file' => ['.env'],
+            ],
+            'db' => [
+                'image' => 'postgres',
+                'environment' => ['POSTGRES_PASSWORD' => '${POSTGRES_PASSWORD}'],
+                'env_file' => ['.env'],
+            ],
+            'redis' => [
+                'image' => 'redis',
+                'env_file' => ['.env'],
+            ],
+        ],
+    ];
+
+    $result = stripSharedEnvFileFromComposeServices($composeFile);
+
+    foreach ($result['services'] as $service) {
+        expect(data_get($service, 'env_file', []))->not->toContain('.env');
+    }
+
+    // Each service still only declares its own variables.
+    expect(array_keys($result['services']['app']['environment']))->toBe(['OPENAI_API_KEY']);
+    expect(array_keys($result['services']['db']['environment']))->toBe(['POSTGRES_PASSWORD']);
+});
+
+it('preserves a service-specific env_file while dropping the shared one', function () {
+    $composeFile = [
+        'services' => [
+            'app' => ['env_file' => ['./app.env', '.env']],
+        ],
+    ];
+
+    $result = stripSharedEnvFileFromComposeServices($composeFile);
+
+    expect($result['services']['app']['env_file'])->toBe(['./app.env']);
+});
+
+it('unsets env_file entirely when only the shared .env was present', function () {
+    $composeFile = [
+        'services' => [
+            'app' => ['image' => 'node', 'env_file' => ['.env']],
+        ],
+    ];
+
+    $result = stripSharedEnvFileFromComposeServices($composeFile);
+
+    expect(data_get($result, 'services.app.env_file'))->toBeNull();
+    expect(data_get($result, 'services.app.image'))->toBe('node');
+});
+
+it('handles a string env_file value', function () {
+    $composeFile = [
+        'services' => [
+            'app' => ['env_file' => '.env'],
+        ],
+    ];
+
+    $result = stripSharedEnvFileFromComposeServices($composeFile);
+
+    expect(data_get($result, 'services.app.env_file'))->toBeNull();
+});
+
+it('is a no-op for services without any env_file', function () {
+    $composeFile = [
+        'services' => [
+            'app' => ['image' => 'node', 'environment' => ['FOO' => 'bar']],
+        ],
+    ];
+
+    $result = stripSharedEnvFileFromComposeServices($composeFile);
+
+    expect($result['services']['app'])->toBe(['image' => 'node', 'environment' => ['FOO' => 'bar']]);
+});


### PR DESCRIPTION
## Changes

Docker Compose deployments attach a single project-wide `.env` (containing every variable in the project) to every service via `env_file: ['.env']` in `ApplicationDeploymentJob`. Any container can then read every other container's secrets — e.g. the Redis container can read the app's `OPENAI_API_KEY`, and each database can see the others' credentials. If one container is compromised, all project credentials leak.

Each service already receives its own variables through its resolved `environment:` block (values are interpolated at deploy time via `docker compose --env-file .env`, which only substitutes `${VAR}` in the compose file and does not inject the file into containers). So the shared `.env` attachment is unnecessary and only exposes unrelated secrets.

This adds `stripSharedEnvFileFromComposeServices()` (`bootstrap/helpers/shared.php`) and applies it in `ApplicationDeploymentJob`, removing the shared `.env` from every service while preserving any `env_file` a service declares for itself.

## Issues

- Fixes #7655

## Category

- [x] Bug fix

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude (Claude Code)
- How extensively: AI drafted the helper, the wiring, and the unit tests, reviewed before submitting.

## Testing

Added `tests/Unit/ComposeEnvIsolationTest.php` (5 cases) proving per-service isolation; the existing parser/env unit tests remain green (21 passed total, run against a local dev checkout). Honest scope note: verified at the unit level on the env-file transform — I have not exercised it through a full multi-container deployment, so a maintainer sanity-check on the runtime env-precedence (e.g. services that relied on bare-name pass-through of undeclared vars) would be appreciated.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them. (Unit-tested only; see Testing note above — no full local deployment available.)

/claim #7655
