### PR TITLE
ci(images): add edge tag for v4.x SHA builds

### DIFF
--- a/.github/workflows/coolify-sha-build.yml
+++ b/.github/workflows/coolify-sha-build.yml
@@ -76,15 +76,35 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Create & publish manifest on ${{ env.GITHUB_REGISTRY }}
+        env:
+          REGISTRY: ${{ env.GITHUB_REGISTRY }}
+          BRANCH: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
         run: |
+          IMAGE="${REGISTRY}/${IMAGE_NAME}"
+          TAG_ARGS=(--tag "${IMAGE}:sha-${SHA}")
+          # Moving tag for the latest production-line SHA image (v4.x only).
+          if [ "${BRANCH}" = "v4.x" ]; then
+            TAG_ARGS+=(--tag "${IMAGE}:edge")
+          fi
           docker buildx imagetools create \
-          ${{ env.GITHUB_REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}-amd64 \
-          ${{ env.GITHUB_REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}-aarch64 \
-          --tag ${{ env.GITHUB_REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+            "${IMAGE}:sha-${SHA}-amd64" \
+            "${IMAGE}:sha-${SHA}-aarch64" \
+            "${TAG_ARGS[@]}"
 
       - name: Create & publish manifest on ${{ env.DOCKER_REGISTRY }}
+        env:
+          REGISTRY: ${{ env.DOCKER_REGISTRY }}
+          BRANCH: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
         run: |
+          IMAGE="${REGISTRY}/${IMAGE_NAME}"
+          TAG_ARGS=(--tag "${IMAGE}:sha-${SHA}")
+          # Moving tag for the latest production-line SHA image (v4.x only).
+          if [ "${BRANCH}" = "v4.x" ]; then
+            TAG_ARGS+=(--tag "${IMAGE}:edge")
+          fi
           docker buildx imagetools create \
-          ${{ env.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}-amd64 \
-          ${{ env.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}-aarch64 \
-          --tag ${{ env.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+            "${IMAGE}:sha-${SHA}-amd64" \
+            "${IMAGE}:sha-${SHA}-aarch64" \
+            "${TAG_ARGS[@]}"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,7 +20,7 @@ Coolify uses two long-lived branches so production fixes can ship without waitin
 
 | Branch | Role | Docker image tags | How it ships |
 | --- | --- | --- | --- |
-| **`v4.x`** | Production / releasable line | `sha-<commit>` via **Build Coolify (SHA)** | GitHub release promotes the SHA image to a semantic version (and `latest` for stable releases) |
+| **`v4.x`** | Production / releasable line | `sha-<commit>` and moving `edge` via **Build Coolify (SHA)** | GitHub release promotes the SHA image to a semantic version (and `latest` for stable releases) |
 | **`next`** | Development line for features and larger changes | Branch tag (for example `next`) via **Staging Build** | Becomes production only after merge into `v4.x` |
 
 ### Where to merge
@@ -59,6 +59,7 @@ Only commits on **`v4.x`** produce production SHA images and can be tagged for a
    - Merge the release commit into `v4.x` through a pull request.
    - The `Build Coolify (SHA)` workflow builds AMD64 and ARM64 images and publishes them to Docker Hub and GHCR using immutable architecture tags.
    - After both builds complete, the workflow creates the multi-architecture `sha-<commit-sha>` manifest in both registries.
+   - For pushes to **`v4.x`**, the same multi-architecture manifest is also tagged as `edge`, so `coollabsio/coolify:edge` always points at the latest production-line SHA image. Builds from `main` publish only the immutable `sha-<commit-sha>` tags.
    - This workflow does not update a semantic version tag or `latest`.
 
 3. **Wait for the SHA Image**


### PR DESCRIPTION
## Summary

- Tag multi-arch Coolify SHA images as `edge` on both GHCR and Docker Hub when the **Build Coolify (SHA)** workflow runs on `v4.x`.
- Keep immutable `sha-<commit>` tags for all branches; non-`v4.x` builds (for example `main`) publish only the SHA tags.
- Document the moving `edge` tag in the release process so `coollabsio/coolify:edge` always points at the latest production-line SHA image.