### PR TITLE
fix(backups): pin a single bracket-free IP for mc --resolve

### DIFF
--- a/app/Rules/SafeWebhookUrl.php
+++ b/app/Rules/SafeWebhookUrl.php
@@ -134,10 +134,17 @@ class SafeWebhookUrl implements ValidationRule
             return [];
         }
 
-        return array_map(
-            fn (string $ip): string => sprintf('%s:%d=%s', $target['host'], $target['port'], filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) ? '['.$ip.']' : $ip),
+        // The MinIO client keeps one --resolve IP per host and parses it with Go's
+        // netip.ParseAddr, which rejects bracketed IPv6. Emit a single entry, preferring
+        // IPv4 for reachability, without brackets.
+        $preferredIps = array_values(array_filter(
             $target['ips'],
-        );
+            fn (string $ip): bool => filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false,
+        ));
+
+        $ip = $preferredIps[0] ?? $target['ips'][0];
+
+        return [sprintf('%s:%d=%s', $target['host'], $target['port'], $ip)];
     }
 
     public static function redactedUrlForLog(string $url): string

--- a/tests/Unit/SafeWebhookUrlTest.php
+++ b/tests/Unit/SafeWebhookUrlTest.php
@@ -239,6 +239,19 @@ it('builds MinIO client resolve options for S3 backup uploads', function () {
     expect($options)->toContain('localhost:9000=127.0.0.1');
 });
 
+it('collapses dual-stack S3 hosts to a single bracket-free IPv4 resolve entry', function () {
+    InstanceSettings::unguarded(fn () => InstanceSettings::query()->updateOrCreate(['id' => 0], [
+        'webhook_allowed_internal_hosts' => ['localhost'],
+        'webhook_allow_localhost' => true,
+    ]));
+
+    // localhost resolves to both 127.0.0.1 and ::1. The MinIO client keeps one IP per
+    // host and rejects bracketed IPv6, so exactly one bracket-free IPv4 entry is produced.
+    $options = SafeWebhookUrl::minioClientResolveOptions('http://localhost:9000');
+
+    expect($options)->toBe(['localhost:9000=127.0.0.1']);
+});
+
 it('rejects trailing-dot hostnames to avoid DNS pinning mismatch', function () {
     $rule = new SafeWebhookUrl(fn (string $host): array => ['93.184.216.34']);
 


### PR DESCRIPTION
## Changes

Fix S3 backup uploads to endpoints whose hostname resolves to IPv6.

`SafeWebhookUrl::minioClientResolveOptions()` builds the `mc --resolve` entries used to pin the S3 endpoint during backup upload (`DatabaseBackupJob`). It emitted every resolved IP and wrapped IPv6 addresses in brackets (`host:port=[2001:db8::1]`). The MinIO client parses each `--resolve` value with Go's `netip.ParseAddr`, which rejects bracketed literals, so `mc` aborts before connecting:

```
mc: <ERROR> invalid DNS resolve entry nbg1.your-objectstorage.com:443=[2a01:4f8:b000::1]:
ParseAddr("[2a01:4f8:b000::1]"): each colon-separated field must have at least one digit
```

`mc` also stores resolvers in a `map[string]netip.Addr` keyed by host (`minio/mc`, `cmd/globals.go`), so only one IP per host is honored regardless of how many `--resolve` entries are passed.

This change emits a single entry, preferring IPv4 for reachability and falling back to IPv6, without brackets. The pinned IP is still one of the already-validated addresses, so the SSRF / DNS-rebind protection is unchanged.

Reproduces with any S3 endpoint that has an AAAA record (e.g. Hetzner Object Storage). Regular application containers upload to the same endpoint without issue (normal S3 SDK over IPv4), which confirms a formatting bug rather than a connectivity problem.

## Issues

No existing issue — bug described above.

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable; this is backup-upload internals with no UI change.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude
- How extensively: Helped trace the `mc --resolve` failure to `minioClientResolveOptions`, confirmed the MinIO client's parsing behavior against `minio/mc` source, implemented the single-IP / IPv4-preferred fix, and added regression coverage. The final behavior and diff were reviewed manually.

## Testing

- `php artisan test --compact tests/Unit/SafeWebhookUrlTest.php` — existing MinIO resolve test plus new dual-stack regression test (`collapses dual-stack S3 hosts to a single bracket-free IPv4 resolve entry`)
- `vendor/bin/pint --dirty --format agent`
- `php -l` on changed PHP files

## Contributor Agreement

- [x] I have read and understood the contributor guidelines.
- [x] I have searched existing issues and pull requests to ensure this isn't a duplicate.
- [x] I have tested all the changes thoroughly with a local development instance of Coolify.
