### PR TITLE
fix(applications): exclude health-check-excluded containers from restart limit

### DIFF
--- a/app/Actions/Docker/GetContainersStatus.php
+++ b/app/Actions/Docker/GetContainersStatus.php
@@ -458,17 +458,25 @@ class GetContainersStatus
                     continue;
                 }
 
-                // Track restart counts first
+                // Containers excluded from health checks (exclude_from_hc: true or restart: no)
+                // must also be excluded from the crash restart limit. Otherwise legitimately
+                // scheduled / one-shot sidecars (e.g. Ofelia jobs) inflate the restart count
+                // and wrongly trip the limit, stopping the whole application. See issue #10624.
+                $excludedContainers = $this->getExcludedContainersFromDockerCompose(data_get($application, 'docker_compose_raw'));
+
+                // Track restart counts first (ignoring excluded containers)
                 $maxRestartCount = 0;
                 if (isset($this->applicationContainerRestartCounts) && $this->applicationContainerRestartCounts->has($applicationId)) {
-                    $containerRestartCounts = $this->applicationContainerRestartCounts->get($applicationId);
-                    $maxRestartCount = $containerRestartCounts->max() ?? 0;
+                    $maxRestartCount = $this->maxRestartCountExcludingExcluded(
+                        $this->applicationContainerRestartCounts->get($applicationId),
+                        $excludedContainers
+                    );
                 }
 
                 // Wrap all database updates in a transaction to ensure consistency
                 $restartLimitReached = false;
 
-                DB::transaction(function () use ($application, $maxRestartCount, $containerStatuses, &$restartLimitReached) {
+                DB::transaction(function () use ($application, $maxRestartCount, $containerStatuses, $excludedContainers, &$restartLimitReached) {
                     $previousRestartCount = $application->restart_count ?? 0;
 
                     if ($maxRestartCount > $previousRestartCount) {
@@ -487,7 +495,7 @@ class GetContainersStatus
                     }
 
                     // Aggregate status after tracking restart counts
-                    $aggregatedStatus = $this->aggregateApplicationStatus($application, $containerStatuses, $maxRestartCount);
+                    $aggregatedStatus = $this->aggregateApplicationStatus($application, $containerStatuses, $maxRestartCount, $excludedContainers);
                     if ($aggregatedStatus) {
                         $statusFromDb = $application->status;
                         if ($statusFromDb !== $aggregatedStatus) {
@@ -512,11 +520,25 @@ class GetContainersStatus
         ServiceChecked::dispatch($this->server->team->id);
     }
 
-    private function aggregateApplicationStatus($application, Collection $containerStatuses, int $maxRestartCount = 0): ?string
+    /**
+     * Return the highest restart count across an application's containers, ignoring any
+     * containers that are excluded from health checks (exclude_from_hc: true or restart: no).
+     * This keeps the crash restart limit from counting legitimately scheduled / one-shot
+     * sidecar containers (e.g. Ofelia jobs). See issue #10624.
+     */
+    private function maxRestartCountExcludingExcluded(Collection $restartCounts, Collection $excludedContainers): int
     {
-        // Parse docker compose to check for excluded containers
-        $dockerComposeRaw = data_get($application, 'docker_compose_raw');
-        $excludedContainers = $this->getExcludedContainersFromDockerCompose($dockerComposeRaw);
+        return (int) ($restartCounts
+            ->reject(function ($count, $containerName) use ($excludedContainers) {
+                return $excludedContainers->contains($containerName);
+            })
+            ->max() ?? 0);
+    }
+
+    private function aggregateApplicationStatus($application, Collection $containerStatuses, int $maxRestartCount = 0, ?Collection $excludedContainers = null): ?string
+    {
+        // Parse docker compose to check for excluded containers (reuse precomputed set when provided)
+        $excludedContainers ??= $this->getExcludedContainersFromDockerCompose(data_get($application, 'docker_compose_raw'));
 
         // Filter out excluded containers
         $relevantStatuses = $containerStatuses->filter(function ($status, $containerName) use ($excludedContainers) {

--- a/tests/Unit/RestartLimitExcludesExcludedContainersTest.php
+++ b/tests/Unit/RestartLimitExcludesExcludedContainersTest.php
@@ -1,0 +1,115 @@
+<?php
+
+use App\Actions\Docker\GetContainersStatus;
+
+/**
+ * Regression tests for issue #10624.
+ *
+ * Containers that are excluded from health checks (exclude_from_hc: true or restart: no)
+ * must also be excluded from the crash restart limit, so legitimately scheduled / one-shot
+ * sidecar containers (e.g. Ofelia jobs) do not inflate the restart count and stop the app.
+ */
+function invokeGetContainersStatusMethod(string $method, array $args)
+{
+    $action = new GetContainersStatus;
+    $reflection = new ReflectionMethod(GetContainersStatus::class, $method);
+    $reflection->setAccessible(true);
+
+    return $reflection->invoke($action, ...$args);
+}
+
+it('ignores excluded containers when computing the max restart count', function () {
+    $restartCounts = collect([
+        'web' => 0,
+        'cron' => 15,
+        'sidecar' => 20,
+    ]);
+    $excludedContainers = collect(['cron', 'sidecar']);
+
+    $maxRestartCount = invokeGetContainersStatusMethod(
+        'maxRestartCountExcludingExcluded',
+        [$restartCounts, $excludedContainers]
+    );
+
+    // Only "web" (0 restarts) is relevant, so the crash restart limit is never reached.
+    expect($maxRestartCount)->toBe(0);
+});
+
+it('still counts restarts for non-excluded containers', function () {
+    $restartCounts = collect([
+        'web' => 20,
+        'cron' => 3,
+    ]);
+    $excludedContainers = collect(['cron']);
+
+    $maxRestartCount = invokeGetContainersStatusMethod(
+        'maxRestartCountExcludingExcluded',
+        [$restartCounts, $excludedContainers]
+    );
+
+    // A genuine crash loop on "web" is unaffected by the exclusion of "cron".
+    expect($maxRestartCount)->toBe(20);
+});
+
+it('preserves legacy behaviour when nothing is excluded', function () {
+    $restartCounts = collect([
+        'web' => 5,
+        'worker' => 12,
+    ]);
+
+    $maxRestartCount = invokeGetContainersStatusMethod(
+        'maxRestartCountExcludingExcluded',
+        [$restartCounts, collect()]
+    );
+
+    expect($maxRestartCount)->toBe(12);
+});
+
+it('returns zero for an empty restart count collection', function () {
+    $maxRestartCount = invokeGetContainersStatusMethod(
+        'maxRestartCountExcludingExcluded',
+        [collect(), collect()]
+    );
+
+    expect($maxRestartCount)->toBe(0);
+});
+
+it('treats restart:no and exclude_from_hc services as excluded from the restart limit', function () {
+    // Compose with a normally-monitored service, a one-shot job (restart: no),
+    // and an explicitly excluded scheduler sidecar (exclude_from_hc: true).
+    $dockerComposeRaw = <<<'YAML'
+    services:
+      web:
+        image: nginx
+        restart: unless-stopped
+      cron:
+        image: busybox
+        restart: no
+      ofelia:
+        image: mcuadros/ofelia:latest
+        restart: unless-stopped
+        exclude_from_hc: true
+    YAML;
+
+    $excludedContainers = invokeGetContainersStatusMethod(
+        'getExcludedContainersFromDockerCompose',
+        [$dockerComposeRaw]
+    );
+
+    expect($excludedContainers->all())->toContain('cron', 'ofelia')
+        ->and($excludedContainers->all())->not->toContain('web');
+
+    // The excluded services' restart counts are dropped, leaving only "web".
+    $restartCounts = collect([
+        'web' => 1,
+        'cron' => 30,
+        'ofelia' => 50,
+    ]);
+
+    $maxRestartCount = invokeGetContainersStatusMethod(
+        'maxRestartCountExcludingExcluded',
+        [$restartCounts, $excludedContainers]
+    );
+
+    expect($maxRestartCount)->toBe(1);
+});


### PR DESCRIPTION
## Changes

Fixes a false positive in the crash restart-limit feature (added in #9231, default `max_restart_count = 10`) where legitimately scheduled or one-shot containers were counted as crash restarts and caused Coolify to stop the whole application with a **"10x restarts"** warning.

**Root cause:** In `GetContainersStatus`, Docker's lifetime `RestartCount` was aggregated across *every* container carrying `coolify.applicationId` when computing `$maxRestartCount` — **including containers that are excluded from health checks** (`exclude_from_hc: true` or `restart: no`). Status aggregation (`aggregateApplicationStatus`) already filters those excluded containers out, so the two code paths were inconsistent.

A scheduler like [Ofelia](https://github.com/mcuadros/ofelia), or any `restart: no` cron/job/init container that is part of a compose app, naturally accumulates restarts. Those restarts inflated the count, tripped the limit, and stopped the entire application.

**Fix:** Exclude the same health-check-excluded containers from the max restart-count calculation, making restart counting consistent with status aggregation. No new configuration, schema, UI, or default-behavior change:

- A one-shot job container with `restart: no` is now excluded from the restart limit **automatically**.
- A long-running scheduler sidecar (e.g. the Ofelia daemon) can be opted out with `exclude_from_hc: true`.
- Genuine single-container crash loops are unaffected and still stop at `max_restart_count`.

Both the excluded-set computation and the aggregation reuse the existing `CalculatesExcludedStatus::getExcludedContainersFromDockerCompose()`; the compose YAML is parsed once per application per poll.

## Issues

- Fixes #10624

## Category

- [x] Bugfix

## Testing

- Added `tests/Unit/RestartLimitExcludesExcludedContainersTest.php` covering: excluded containers dropped from the max restart count, non-excluded crash loops still counted, legacy behaviour preserved when nothing is excluded, and `restart: no` / `exclude_from_hc: true` services resolved via the real trait helper.
- `./vendor/bin/pest tests/Unit/RestartLimitExcludesExcludedContainersTest.php tests/Unit/RestartCountTrackingTest.php` — 10 passed.
- `./vendor/bin/pint` clean on the changed files.

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Opus 4.8), human-reviewed.
- How extensively: root-cause analysis, the fix, and the added tests.

## Contributor Agreement

- [x] I have read and understood the contributor guide, and agree to the terms.
