### PR TITLE
fix(applications): exclude health-check-excluded containers from restart limit

### DIFF
--- a/app/Actions/Docker/GetContainersStatus.php
+++ b/app/Actions/Docker/GetContainersStatus.php
@@ -458,11 +458,15 @@ class GetContainersStatus
                     continue;
                 }
 
-                // Track restart counts first
+                // Exclude health-check-excluded containers from the restart limit too
+                $excludedContainers = $this->getExcludedContainersFromDockerCompose(data_get($application, 'docker_compose_raw'));
+
                 $maxRestartCount = 0;
                 if (isset($this->applicationContainerRestartCounts) && $this->applicationContainerRestartCounts->has($applicationId)) {
-                    $containerRestartCounts = $this->applicationContainerRestartCounts->get($applicationId);
-                    $maxRestartCount = $containerRestartCounts->max() ?? 0;
+                    $maxRestartCount = $this->maxRestartCountExcluding(
+                        $this->applicationContainerRestartCounts->get($applicationId),
+                        $excludedContainers
+                    );
                 }
 
                 // Wrap all database updates in a transaction to ensure consistency
@@ -510,6 +514,16 @@ class GetContainersStatus
         $this->aggregateServiceContainerStatuses($services);
 
         ServiceChecked::dispatch($this->server->team->id);
+    }
+
+    // Highest restart count across containers, ignoring health-check-excluded ones.
+    private function maxRestartCountExcluding(Collection $restartCounts, Collection $excludedContainers): int
+    {
+        return (int) ($restartCounts
+            ->reject(function ($count, $containerName) use ($excludedContainers) {
+                return $excludedContainers->contains($containerName);
+            })
+            ->max() ?? 0);
     }
 
     private function aggregateApplicationStatus($application, Collection $containerStatuses, int $maxRestartCount = 0): ?string

--- a/tests/Feature/RestartLimitExcludedContainersHandleTest.php
+++ b/tests/Feature/RestartLimitExcludedContainersHandleTest.php
@@ -1,0 +1,124 @@
+<?php
+
+use App\Actions\Application\StopApplication;
+use App\Actions\Docker\GetContainersStatus;
+use App\Events\ServiceChecked;
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use App\Notifications\Application\RestartLimitReached;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Queue;
+use Lorisleiva\Actions\Decorators\JobDecorator;
+
+uses(RefreshDatabase::class);
+
+function makeComposeApplication(): Application
+{
+    $team = Team::factory()->create();
+    $server = Server::factory()->create(['team_id' => $team->id]);
+    $server->settings()->update(['is_reachable' => true, 'is_usable' => true, 'force_disabled' => false]);
+
+    $destination = StandaloneDocker::where('server_id', $server->id)->first()
+        ?? StandaloneDocker::factory()->create(['server_id' => $server->id]);
+    $project = Project::factory()->create(['team_id' => $team->id]);
+    $environment = Environment::factory()->create(['project_id' => $project->id]);
+
+    $compose = <<<'YAML'
+    services:
+      web:
+        image: nginx
+        restart: unless-stopped
+      cron:
+        image: busybox
+        restart: no
+      ofelia:
+        image: mcuadros/ofelia:latest
+        restart: unless-stopped
+        exclude_from_hc: true
+    YAML;
+
+    return Application::factory()->create([
+        'destination_id' => $destination->id,
+        'destination_type' => $destination->getMorphClass(),
+        'environment_id' => $environment->id,
+        'build_pack' => 'dockercompose',
+        'docker_compose_raw' => $compose,
+        'status' => 'running:healthy',
+        'restart_count' => 0,
+        'max_restart_count' => 10,
+    ]);
+}
+
+function inspectContainer(int $applicationId, string $service, string $state, ?string $health, int $restartCount): array
+{
+    $stateData = ['Status' => $state];
+    if ($health !== null) {
+        $stateData['Health'] = ['Status' => $health];
+    }
+
+    return [
+        'Config' => [
+            'Labels' => [
+                'coolify.managed' => 'true',
+                'coolify.applicationId' => (string) $applicationId,
+                'com.docker.compose.service' => $service,
+            ],
+        ],
+        'State' => $stateData,
+        'RestartCount' => $restartCount,
+    ];
+}
+
+test('excluded containers do not trip the restart limit', function () {
+    Queue::fake();
+    Notification::fake();
+    Event::fake([ServiceChecked::class]);
+
+    $application = makeComposeApplication();
+    $server = $application->destination->server;
+    $team = $application->environment->project->team;
+
+    // Excluded cron (restart:no) and ofelia (exclude_from_hc) have restarted 10x; web is healthy.
+    GetContainersStatus::run($server, collect([
+        inspectContainer($application->id, 'web', 'running', 'healthy', 0),
+        inspectContainer($application->id, 'cron', 'exited', null, 10),
+        inspectContainer($application->id, 'ofelia', 'running', 'healthy', 10),
+    ]));
+
+    $application->refresh();
+
+    expect($application->restart_count)->toBe(0)
+        ->and($application->status)->toBe('running:healthy');
+
+    Notification::assertNotSentTo($team, RestartLimitReached::class);
+});
+
+test('a real crash loop on a monitored container still trips the restart limit', function () {
+    Queue::fake();
+    Notification::fake();
+    Event::fake([ServiceChecked::class]);
+
+    $application = makeComposeApplication();
+    $server = $application->destination->server;
+
+    // The monitored web container itself has restarted up to the limit.
+    GetContainersStatus::run($server, collect([
+        inspectContainer($application->id, 'web', 'running', 'healthy', 10),
+        inspectContainer($application->id, 'cron', 'exited', null, 0),
+    ]));
+
+    $application->refresh();
+
+    // Non-excluded restarts ARE counted, reaching the limit as a crash.
+    expect($application->restart_count)->toBe(10)
+        ->and($application->last_restart_type)->toBe('crash');
+
+    // Which is exactly when the app is stopped (AsAction queues via JobDecorator).
+    Queue::assertPushed(JobDecorator::class, fn (JobDecorator $job) => $job->getAction() instanceof StopApplication);
+});

--- a/tests/Unit/RestartLimitExcludesExcludedContainersTest.php
+++ b/tests/Unit/RestartLimitExcludesExcludedContainersTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use App\Actions\Docker\GetContainersStatus;
+
+function invokeGetContainersStatusMethod(string $method, array $args)
+{
+    $action = new GetContainersStatus;
+    $reflection = new ReflectionMethod(GetContainersStatus::class, $method);
+    $reflection->setAccessible(true);
+
+    return $reflection->invoke($action, ...$args);
+}
+
+it('ignores excluded containers when computing the max restart count', function () {
+    $maxRestartCount = invokeGetContainersStatusMethod('maxRestartCountExcluding', [
+        collect(['web' => 0, 'cron' => 15, 'sidecar' => 20]),
+        collect(['cron', 'sidecar']),
+    ]);
+
+    expect($maxRestartCount)->toBe(0);
+});
+
+it('still counts restarts for non-excluded containers', function () {
+    $maxRestartCount = invokeGetContainersStatusMethod('maxRestartCountExcluding', [
+        collect(['web' => 20, 'cron' => 3]),
+        collect(['cron']),
+    ]);
+
+    expect($maxRestartCount)->toBe(20);
+});
+
+it('preserves legacy behaviour when nothing is excluded', function () {
+    $maxRestartCount = invokeGetContainersStatusMethod('maxRestartCountExcluding', [
+        collect(['web' => 5, 'worker' => 12]),
+        collect(),
+    ]);
+
+    expect($maxRestartCount)->toBe(12);
+});
+
+it('returns zero for an empty restart count collection', function () {
+    $maxRestartCount = invokeGetContainersStatusMethod('maxRestartCountExcluding', [
+        collect(),
+        collect(),
+    ]);
+
+    expect($maxRestartCount)->toBe(0);
+});
+
+it('treats restart:no and exclude_from_hc services as excluded from the restart limit', function () {
+    $dockerComposeRaw = <<<'YAML'
+    services:
+      web:
+        image: nginx
+        restart: unless-stopped
+      cron:
+        image: busybox
+        restart: no
+      ofelia:
+        image: mcuadros/ofelia:latest
+        restart: unless-stopped
+        exclude_from_hc: true
+    YAML;
+
+    $excludedContainers = invokeGetContainersStatusMethod('getExcludedContainersFromDockerCompose', [$dockerComposeRaw]);
+
+    expect($excludedContainers->all())->toContain('cron', 'ofelia')
+        ->and($excludedContainers->all())->not->toContain('web');
+
+    $maxRestartCount = invokeGetContainersStatusMethod('maxRestartCountExcluding', [
+        collect(['web' => 1, 'cron' => 30, 'ofelia' => 50]),
+        $excludedContainers,
+    ]);
+
+    expect($maxRestartCount)->toBe(1);
+});


### PR DESCRIPTION
## Changes

The crash restart-limit feature (default 10) counted Docker's lifetime `RestartCount` across every container of an application — including containers that are excluded from health checks via `exclude_from_hc` or `restart: no`. Status aggregation already skips those containers, so the two code paths disagreed.

Because of this, a scheduled or one-shot sidecar that legitimately starts and stops (an Ofelia scheduler, or any restart:no cron/job container) inflated the count, hit the limit, and Coolify stopped the whole application with a "10x restarts" warning.

This change excludes the same health-check-excluded containers from the restart-count calculation, so restart counting matches status aggregation:

- A one-shot job with restart:no is excluded automatically.
- A long-running scheduler sidecar can be opted out by adding exclude_from_hc.
- Genuine single-container crash loops are unaffected and still stop at the limit.

No configuration, schema, UI, or default-behaviour changes.

## Issues

- Fixes #10624

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code, human reviewed.
- How extensively: root-cause analysis, the fix, and the added unit tests.

## Testing

Added tests/Unit/RestartLimitExcludesExcludedContainersTest.php covering: excluded containers dropped from the max restart count, non-excluded crash loops still counted, legacy behaviour when nothing is excluded, and restart:no / exclude_from_hc resolved through the real trait helper. Ran the new suite plus the existing RestartCountTrackingTest — 10 passed. Pint clean on the changed files.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
