### PR TITLE
fix(applications): Add null check for sslipDomainWarning in General.php

### DIFF
--- a/app/Livewire/Project/Application/General.php
+++ b/app/Livewire/Project/Application/General.php
@@ -773,9 +773,13 @@ class General extends Component
 
             // Process FQDN with intermediate variable to avoid Collection/string confusion
             $this->fqdn = ValidationPatterns::normalizeApplicationDomains($this->fqdn);
-            $warning = sslipDomainWarning($this->fqdn);
-            if ($warning) {
-                $this->dispatch('warning', __('warning.sslipdomain'));
+
+            // fqdn may be null for docker compose, in which case don't check
+            if ($this->fqdn !== null) {
+                $warning = sslipDomainWarning($this->fqdn);
+                if ($warning) {
+                    $this->dispatch('warning', __('warning.sslipdomain'));
+                }
             }
 
             $this->syncData(toModel: true);


### PR DESCRIPTION
Added null check for fqdn before warning dispatch (for Docker Compose applications).

## Changes

- Added a NULL check on $this->fqdn (which is NULL for Docker Compose apps) before calling sslipDomainWarning in the Application/General.php controller

## Issues

Fix #11030

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## AI Assistance

- [x] AI was NOT used to create this PR
- [ ] AI was used (please describe below)

## Testing

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.