### PR TITLE
fix(service): allow desktop app origins in Buzz template CORS

### DIFF
--- a/templates/compose/buzz.yaml
+++ b/templates/compose/buzz.yaml
@@ -16,7 +16,7 @@ services:
       - RELAY_URL=wss://${SERVICE_FQDN_BUZZ}
       - BUZZ_MEDIA_BASE_URL=${SERVICE_URL_BUZZ}/media
       - BUZZ_MEDIA_SERVER_DOMAIN=${SERVICE_FQDN_BUZZ}
-      - BUZZ_CORS_ORIGINS=${SERVICE_URL_BUZZ}
+      - BUZZ_CORS_ORIGINS=${SERVICE_URL_BUZZ},tauri://localhost,http://tauri.localhost
       - DATABASE_URL=postgres://${SERVICE_USER_POSTGRES}:${SERVICE_PASSWORD_POSTGRES}@postgres:5432/${POSTGRES_DB:-buzz}
       - REDIS_URL=redis://:${SERVICE_PASSWORD_REDIS}@redis:6379
       - BUZZ_S3_ENDPOINT=http://minio:9000


### PR DESCRIPTION
## Changes

- Add the two Tauri origins (tauri://localhost, http://tauri.localhost) to
  `BUZZ_CORS_ORIGINS` in the Buzz template, so the Buzz desktop app can connect
  to the deployed relay.

## Issues

- Fixes #11044
- Supersedes #11045, which the quality bot closed. That diff also touched the
  two generated service-templates JSON files, which are a blocked path for
  contributors; this one changes the template only.

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [x] Fixing or updating existing one click service

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Used to trace the cause and prepare the patch. The desktop
  app failed with "Load failed" against my own self-hosted Buzz relay. The two
  origins come from Buzz's own source, which documents them in its relay config
  and hardcodes the same pair in the desktop media proxy. Verified on a live
  deployment before opening this PR. Human-reviewed.

## Testing

Deployed Buzz behind Coolify's proxy and compared CORS responses before and
after the change:

| Origin | before | after |
|---|---|---|
| the relay's own https origin | allowed | allowed |
| tauri://localhost | no access-control-allow-origin header | allowed |

The desktop app went from "Load failed" to connecting normally, with no other
change. The relay parses the variable as a comma-separated list, so the existing
web origin is unaffected.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
