### PR TITLE
fix(backups): pin all resolved addresses in one CURLOPT_RESOLVE entry

### DIFF
--- a/app/Rules/SafeWebhookUrl.php
+++ b/app/Rules/SafeWebhookUrl.php
@@ -111,11 +111,20 @@ class SafeWebhookUrl implements ValidationRule
             return $options;
         }
 
+        // libcurl keeps only the last CURLOPT_RESOLVE entry for a given
+        // host:port pair, so every resolved address must be pinned in a single
+        // comma-separated entry. Emitting one entry per address silently drops
+        // all but the last, which is an IPv6 address whenever the host has AAAA
+        // records -- and that fails instantly on hosts without IPv6 egress.
+        $addresses = implode(',', array_map(
+            fn (string $ip): string => filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) ? '['.$ip.']' : $ip,
+            $target['ips'],
+        ));
+
         $options['curl'] = [
-            CURLOPT_RESOLVE => array_map(
-                fn (string $ip): string => sprintf('%s:%d:%s', $target['host'], $target['port'], filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) ? '['.$ip.']' : $ip),
-                $target['ips'],
-            ),
+            CURLOPT_RESOLVE => [
+                sprintf('%s:%d:%s', $target['host'], $target['port'], $addresses),
+            ],
         ];
 
         return $options;

--- a/tests/Unit/SafeWebhookUrlTest.php
+++ b/tests/Unit/SafeWebhookUrlTest.php
@@ -219,8 +219,30 @@ it('builds HTTP client options that pin resolved DNS for the request', function 
     expect($options['allow_redirects'])->toBeFalse();
 
     if (defined('CURLOPT_RESOLVE')) {
-        expect($options['curl'][CURLOPT_RESOLVE])->toContain('localhost:8080:127.0.0.1');
+        expect($options['curl'][CURLOPT_RESOLVE])->toContain('localhost:8080:127.0.0.1,[::1]');
     }
+});
+
+it('pins every resolved address in a single CURLOPT_RESOLVE entry', function () {
+    InstanceSettings::unguarded(fn () => InstanceSettings::query()->updateOrCreate(['id' => 0], [
+        'webhook_allowed_internal_hosts' => ['localhost'],
+        'webhook_allow_localhost' => true,
+    ]));
+
+    if (! defined('CURLOPT_RESOLVE')) {
+        expect(true)->toBeTrue();
+
+        return;
+    }
+
+    $entries = SafeWebhookUrl::httpClientOptions('http://localhost:8080/webhook')['curl'][CURLOPT_RESOLVE];
+
+    // localhost resolves to both 127.0.0.1 and ::1. libcurl overrides an
+    // existing host:port cache entry with each new one, so multiple entries
+    // would leave only [::1] pinned and break every request on hosts without
+    // IPv6 egress.
+    expect($entries)->toHaveCount(1)
+        ->and($entries[0])->toBe('localhost:8080:127.0.0.1,[::1]');
 });
 
 it('fails closed while building HTTP options when the send-time resolution is unsafe', function () {


### PR DESCRIPTION
## Changes

- Fresh VPS, zero IPv6. Adding S3 storage for backups died instantly, so it never saved and backups were impossible. I spent ages blaming my key.

- SafeWebhookUrl pins DNS by adding one CURLOPT_RESOLVE entry per address for the same host and port. libcurl overrides an existing entry each time another is added, so only the last survives, and that one is IPv6 whenever the target has AAAA records. Webhooks use the same helper.

- Fix puts every address in one comma separated entry, the form libcurl documents. Same validated addresses, same isAllowedIp check, so the SSRF guarantee is untouched. Added a regression test too.

Root cause and measurements in #11059.

## Issues

- Fixes #11059

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Opus)
- How extensively: A lot, and I would rather say so than have you guess. I used it to trace the bug, design the experiments and write the patch, test and this text. The template asks for Changes to be human written and mine is not. Happy to redo that myself. I hit this on my own server and verified every result.

## Testing

Coolify 4.1.2, Ubuntu 26.04, VPS with no IPv6. Target Cloudflare R2.

Unit suite on PHP 8.4.23: next untouched 88 failed / 2753 passed, this branch 88 failed / 2754 passed. Those 88 already fail upstream. Revert the source change but keep the new test and it fails, so it catches the bug.

Live R2 from inside the container: patched returns HTTP 400 in 51 ms, connected and merely unauthenticated. Unpatched fails with cURL error 7 after 0 ms. After the fix S3 storage saves and backups run.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
