### PR TITLE
fix(postgres): ignore commented listen_addresses in custom conf

### DIFF
--- a/app/Actions/Database/StartPostgresql.php
+++ b/app/Actions/Database/StartPostgresql.php
@@ -328,12 +328,20 @@ class StartPostgresql
         }
 
         $content = $this->database->postgres_conf;
-        if (! str($content)->contains('listen_addresses')) {
+        if (! self::hasListenAddresses($content)) {
             $content .= "\nlisten_addresses = '*'";
             $this->database->postgres_conf = $content;
             $this->database->save();
         }
         $content_base64 = base64_encode($content);
         $this->commands[] = "echo '{$content_base64}' | base64 -d | tee $config_file_path > /dev/null";
+    }
+
+    /**
+     * Detects an active (uncommented) listen_addresses setting in a custom postgresql.conf.
+     */
+    public static function hasListenAddresses(?string $conf): bool
+    {
+        return preg_match('/^[ \t]*listen_addresses[ \t]*=/mi', (string) $conf) === 1;
     }
 }

--- a/tests/Unit/PostgresqlCustomConfTest.php
+++ b/tests/Unit/PostgresqlCustomConfTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * A commented out listen_addresses line must not count as an active setting,
+ * otherwise PostgreSQL falls back to its localhost default.
+ */
+
+use App\Actions\Database\StartPostgresql;
+
+test('commented out listen_addresses is not treated as an active setting', function () {
+    expect(StartPostgresql::hasListenAddresses("#listen_addresses = 'localhost'"))->toBeFalse();
+    expect(StartPostgresql::hasListenAddresses("# listen_addresses = 'localhost'"))->toBeFalse();
+    expect(StartPostgresql::hasListenAddresses("\t#\tlisten_addresses = '*'"))->toBeFalse();
+});
+
+test('active listen_addresses is detected', function () {
+    expect(StartPostgresql::hasListenAddresses("listen_addresses = '*'"))->toBeTrue();
+    expect(StartPostgresql::hasListenAddresses("listen_addresses='*'"))->toBeTrue();
+    expect(StartPostgresql::hasListenAddresses("  listen_addresses = '*'"))->toBeTrue();
+    expect(StartPostgresql::hasListenAddresses("LISTEN_ADDRESSES = '*'"))->toBeTrue();
+});
+
+test('a conf that only comments out listen_addresses is detected as missing', function () {
+    $conf = "max_connections = 200\n#listen_addresses = 'localhost'\nshared_buffers = 1GB\n";
+
+    expect(StartPostgresql::hasListenAddresses($conf))->toBeFalse();
+});
+
+test('an active listen_addresses is detected next to a commented one', function () {
+    $conf = "max_connections = 200\n#listen_addresses = 'localhost'\nlisten_addresses = '*'\n";
+
+    expect(StartPostgresql::hasListenAddresses($conf))->toBeTrue();
+});
+
+test('windows line endings are handled', function () {
+    expect(StartPostgresql::hasListenAddresses("max_connections = 200\r\nlisten_addresses = '*'\r\n"))->toBeTrue();
+    expect(StartPostgresql::hasListenAddresses("max_connections = 200\r\n#listen_addresses = 'localhost'\r\n"))->toBeFalse();
+});
+
+test('listen_addresses inside another setting value does not count', function () {
+    expect(StartPostgresql::hasListenAddresses("log_line_prefix = 'listen_addresses = '"))->toBeFalse();
+});
+
+test('empty and null confs are detected as missing', function () {
+    expect(StartPostgresql::hasListenAddresses(''))->toBeFalse();
+    expect(StartPostgresql::hasListenAddresses(null))->toBeFalse();
+});


### PR DESCRIPTION
## Changes

Coolify appends `listen_addresses = '*'` to a custom Postgres configuration only when the setting is missing, but the check was a plain substring match. A commented out line counted as configured, so nothing was appended. Since the custom file is mounted as the complete config file, PostgreSQL then falls back to its built in default of localhost. The container still reports healthy, because the health check connects over the local socket, while the database is unreachable from every other container.

The check now looks for an active, uncommented assignment at the start of a line. It is case insensitive and tolerates CRLF input and a missing space around the equals sign.

## Issues

- Fixes

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No UI change.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: used to locate the substring check and to draft the fix and the unit test. I read the diff, confirmed the PostgreSQL default for this setting, and verified the tests myself.

## Testing

Added tests/Unit/PostgresqlCustomConfTest.php covering a commented out line, an active line, both in one file, CRLF input, the name appearing inside another setting value, and empty or null input.

Manually: saved a Postgres configuration whose only mention of the setting was commented out, restarted the database, and confirmed the generated custom-postgres.conf now ends with the appended value and that the container is reachable from another container on the same network.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
