### PR TITLE
fix: preserve secure Docker run options

### DIFF
--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -1025,7 +1025,7 @@ function convertDockerRunToCompose(?string $custom_docker_run_options = null)
 {
     $options = [];
     $compose_options = collect([]);
-    preg_match_all('/(--\w+(?:-\w+)*)(?:\s|=)?([^\s-]+)?/', $custom_docker_run_options, $matches, PREG_SET_ORDER);
+    preg_match_all('/(--\w+(?:-\w+)*)(?:\s|=)?((?!--)[^\s]+)?/', $custom_docker_run_options, $matches, PREG_SET_ORDER);
     $list_options = collect([
         '--cap-add',
         '--cap-drop',
@@ -1052,6 +1052,7 @@ function convertDockerRunToCompose(?string $custom_docker_run_options = null)
         '--gpus' => 'gpus',
         '--hostname' => 'hostname',
         '--entrypoint' => 'entrypoint',
+        '--pids-limit' => 'pids_limit',
     ]);
     foreach ($matches as $match) {
         $option = $match[1];
@@ -1143,6 +1144,10 @@ function convertDockerRunToCompose(?string $custom_docker_run_options = null)
         } elseif ($option === '--shm-size' || $option === '--hostname') {
             if (! is_null($value) && is_array($value) && count($value) > 0 && ! empty(trim($value[0]))) {
                 $compose_options->put($mapping[$option], $value[0]);
+            }
+        } elseif ($option === '--pids-limit') {
+            if (is_array($value) && isset($value[0]) && preg_match('/^-?\d+$/', $value[0])) {
+                $compose_options->put($mapping[$option], (int) $value[0]);
             }
         } elseif ($option === '--entrypoint') {
             if (! is_null($value) && is_array($value) && count($value) > 0 && ! empty(trim($value[0]))) {

--- a/tests/Feature/Helpers/DockerCustomCommandsTest.php
+++ b/tests/Feature/Helpers/DockerCustomCommandsTest.php
@@ -37,6 +37,33 @@ test('ConvertCapAdd', function () {
     ]);
 });
 
+test('ConvertSecurityOptPreservesHyphenatedValues', function () {
+    $input = '--security-opt no-new-privileges:true --security-opt=apparmor=docker-default';
+    $output = convertDockerRunToCompose($input);
+    expect($output)->toBe([
+        'security_opt' => ['no-new-privileges:true', 'apparmor=docker-default'],
+    ]);
+});
+
+test('ConvertPidsLimit', function () {
+    expect(convertDockerRunToCompose('--pids-limit 256'))->toBe([
+        'pids_limit' => 256,
+    ])->and(convertDockerRunToCompose('--pids-limit=-1'))->toBe([
+        'pids_limit' => -1,
+    ]);
+});
+
+test('ConvertTenantHardeningOptionsTogether', function () {
+    $input = '--cap-drop ALL --security-opt no-new-privileges:true --pids-limit 256 --init';
+    $output = convertDockerRunToCompose($input);
+    expect($output)->toBe([
+        'cap_drop' => ['ALL'],
+        'security_opt' => ['no-new-privileges:true'],
+        'pids_limit' => 256,
+        'init' => true,
+    ]);
+});
+
 test('ConvertIp', function () {
     $input = '--cap-add=NET_ADMIN --cap-add=NET_RAW --cap-add SYS_ADMIN --ip 127.0.0.1 --ip 127.0.0.2';
     $output = convertDockerRunToCompose($input);


### PR DESCRIPTION
## What

- preserve hyphenated values such as `no-new-privileges:true` in custom Docker run options
- translate Docker `--pids-limit` to Compose `pids_limit`
- cover equals, space-separated, unlimited, and combined hardening options

## Why

The parser currently stops values at the first hyphen, so `--security-opt no-new-privileges:true` becomes `no`. It also silently ignores `--pids-limit`, preventing applications created through the API from receiving these standard container boundaries.

This includes the focused parser fix from the currently conflicting #9497 and extends it with PID-limit translation. Fixes #8173.

## Checks

- focused translation cases passed against the v4.2.0 production image
- patched helper passes `php -l` on PHP 8.4.23
- full Pest coverage added in `DockerCustomCommandsTest.php`