### PR TITLE
feat(ui): modernize dashboard, projects, servers and resource cards

### DIFF
--- a/app/Livewire/Dashboard.php
+++ b/app/Livewire/Dashboard.php
@@ -20,7 +20,9 @@ class Dashboard extends Component
     {
         $this->privateKeys = PrivateKey::ownedByCurrentTeamCached();
         $this->servers = Server::ownedByCurrentTeamCached();
-        $this->projects = Project::ownedByCurrentTeam()->with('environments')->get();
+        $this->projects = Project::ownedByCurrentTeam()
+            ->with(['environments.applications', 'environments.services'])
+            ->get();
     }
 
     public function render()

--- a/app/Livewire/Project/Index.php
+++ b/app/Livewire/Project/Index.php
@@ -18,7 +18,9 @@ class Index extends Component
     public function mount()
     {
         $this->private_keys = PrivateKey::ownedByCurrentTeamCached();
-        $this->projects = Project::ownedByCurrentTeamCached();
+        $this->projects = Project::ownedByCurrentTeam()
+            ->with(['environments.applications', 'environments.services'])
+            ->get();
         $this->servers = Server::ownedByCurrentTeamCached();
     }
 

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -151,10 +151,10 @@
         inset: 0;
         border-radius: inherit;
         background:
-            linear-gradient(var(--color-warning), var(--color-warning)),
-            linear-gradient(var(--color-warning), var(--color-warning)),
-            linear-gradient(var(--color-warning), var(--color-warning)),
-            linear-gradient(var(--color-warning), var(--color-warning));
+            linear-gradient(var(--color-coollabs), var(--color-coollabs)),
+            linear-gradient(var(--color-coollabs), var(--color-coollabs)),
+            linear-gradient(var(--color-coollabs), var(--color-coollabs)),
+            linear-gradient(var(--color-coollabs), var(--color-coollabs));
         background-repeat: no-repeat;
         animation: coolbox-border-track 2400ms linear infinite;
         pointer-events: none;
@@ -208,11 +208,16 @@ option {
 }
 
 button[isError]:not(:disabled) {
-    @apply text-red-800 dark:text-red-300 bg-red-50 dark:bg-red-900/30 border-red-300 dark:border-red-800 hover:bg-red-300 hover:text-white dark:hover:bg-red-800 dark:hover:text-white;
+    @apply text-white bg-red-700 dark:bg-red-700 border-red-700 dark:border-red-700 hover:bg-red-800 hover:border-red-800 hover:text-white dark:hover:bg-red-800 dark:hover:border-red-800 dark:hover:text-white;
 }
 
 button[isHighlighted]:not(:disabled) {
     @apply text-coollabs-200 dark:text-white bg-coollabs-50 dark:bg-coollabs/20 border-coollabs dark:border-coollabs-100 hover:bg-coollabs hover:text-white dark:hover:bg-coollabs-100 dark:hover:text-white;
+}
+
+/* Primary form-submit buttons ("Save") get the brand accent everywhere, without touching every form. */
+button[type='submit'].button:not(:disabled) {
+    @apply text-white bg-coollabs border-coollabs hover:bg-coollabs-100 hover:border-coollabs-100 hover:text-white dark:hover:bg-coollabs-100 dark:hover:text-white;
 }
 
 h1 {
@@ -237,7 +242,7 @@ a {
 
 button:focus-visible,
 a:focus-visible {
-    @apply outline-none ring-2 ring-coollabs dark:ring-warning ring-offset-2 dark:ring-offset-coolgray-100;
+    @apply outline-none ring-2 ring-coollabs ring-offset-2 dark:ring-offset-coolgray-100;
 }
 
 label {

--- a/resources/css/utilities.css
+++ b/resources/css/utilities.css
@@ -44,17 +44,17 @@
     }
 
     &:where(.dark, .dark *):focus-visible {
-        box-shadow: inset 4px 0 0 #fcd452, inset 0 0 0 1px #242424;
+        box-shadow: inset 4px 0 0 #6b16ed, inset 0 0 0 1px #242424;
     }
 }
 
 @utility input-sticky-active {
-    @apply text-black border-2 border-coollabs dark:border-warning dark:text-white focus:bg-neutral-200 dark:focus:bg-coolgray-400 focus:border-coollabs dark:focus:border-warning;
+    @apply text-black border-2 border-coollabs dark:border-coollabs dark:text-white focus:bg-neutral-200 dark:focus:bg-coolgray-400 focus:border-coollabs dark:focus:border-coollabs;
 }
 
 /* Focus */
 @utility input-focus {
-    @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coollabs dark:focus-visible:ring-warning focus-visible:ring-offset-2 dark:focus-visible:ring-offset-base;
+    @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coollabs focus-visible:ring-offset-2 dark:focus-visible:ring-offset-base;
 }
 
 /*  input, select before */
@@ -86,7 +86,7 @@
     }
 
     &:where(.dark, .dark *):focus-visible {
-        box-shadow: inset 4px 0 0 #fcd452, inset 0 0 0 2px #242424;
+        box-shadow: inset 4px 0 0 #6b16ed, inset 0 0 0 2px #242424;
     }
 
     &:read-only {
@@ -117,12 +117,20 @@
     }
 
     &:where(.dark, .dark *):focus-visible {
-        box-shadow: inset 4px 0 0 #fcd452, inset 0 0 0 2px #242424;
+        box-shadow: inset 4px 0 0 #6b16ed, inset 0 0 0 2px #242424;
     }
 }
 
 @utility button {
-    @apply flex gap-2 justify-center items-center px-2 h-8 text-sm text-black normal-case rounded-sm border-2 outline-0 cursor-pointer font-medium bg-white border-neutral-200 hover:bg-neutral-100 dark:bg-coolgray-100 dark:text-white dark:hover:text-white dark:hover:bg-coolgray-200 dark:border-coolgray-300 hover:text-black disabled:cursor-not-allowed min-w-fit dark:disabled:text-neutral-600 disabled:border-neutral-200 dark:disabled:border-coolgray-300 disabled:hover:bg-transparent disabled:bg-transparent disabled:text-neutral-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coollabs dark:focus-visible:ring-warning focus-visible:ring-offset-2 dark:focus-visible:ring-offset-base;
+    @apply flex gap-2 justify-center items-center px-2 h-8 text-sm text-black normal-case rounded-sm border-2 outline-0 cursor-pointer font-medium bg-white border-neutral-200 hover:bg-neutral-100 dark:bg-coolgray-100 dark:text-white dark:hover:text-white dark:hover:bg-coolgray-200 dark:border-coolgray-300 hover:text-black disabled:cursor-not-allowed min-w-fit dark:disabled:text-neutral-600 disabled:border-neutral-200 dark:disabled:border-coolgray-300 disabled:hover:bg-transparent disabled:bg-transparent disabled:text-neutral-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coollabs focus-visible:ring-offset-2 dark:focus-visible:ring-offset-base;
+}
+
+@utility button-primary {
+    @apply flex gap-2 justify-center items-center px-4 h-9 text-sm font-semibold text-white normal-case rounded-lg outline-0 cursor-pointer bg-coollabs hover:bg-coollabs-100 shadow-sm transition-colors min-w-fit disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coollabs focus-visible:ring-offset-2 dark:focus-visible:ring-offset-base;
+}
+
+@utility resource-avatar {
+    @apply flex items-center justify-center rounded-lg size-10 shrink-0 bg-coollabs/10 text-coollabs dark:bg-coollabs/20;
 }
 
 @utility auth-tooltip {
@@ -193,7 +201,7 @@
 }
 
 @utility menu-item-active {
-    @apply text-black rounded-sm dark:bg-coolgray-200 dark:text-warning bg-neutral-200 overflow-hidden;
+    @apply text-white rounded-sm bg-coollabs dark:bg-coollabs overflow-hidden;
 }
 
 @utility sub-menu-wrapper {
@@ -209,7 +217,7 @@
 }
 
 @utility heading-item-active {
-    @apply text-black rounded-sm dark:bg-coolgray-200 dark:text-warning;
+    @apply text-white rounded-sm bg-coollabs dark:bg-coollabs;
 }
 
 @utility icon {
@@ -233,11 +241,11 @@
 }
 
 @utility loading {
-    @apply w-4 dark:text-warning text-coollabs;
+    @apply w-4 text-coollabs;
 }
 
 @utility kbd-custom {
-    @apply px-2 text-xs rounded-sm border border-dashed border-neutral-700 dark:text-warning;
+    @apply px-2 text-xs rounded-sm border border-dashed border-neutral-700 dark:text-coollabs;
 }
 
 @utility box {
@@ -257,7 +265,7 @@
 }
 
 @utility coolbox {
-    @apply relative flex transition-all duration-150 dark:bg-coolgray-100 bg-white p-2 rounded border border-neutral-200 dark:border-coolgray-400 hover:ring-2 dark:hover:ring-warning hover:ring-coollabs cursor-pointer min-h-[4rem];
+    @apply relative flex transition-all duration-150 dark:bg-coolgray-100 bg-white p-2 rounded-xl border border-neutral-200 dark:border-coolgray-300 hover:ring-2 hover:ring-coollabs cursor-pointer min-h-[4rem];
 }
 
 @utility on-box {
@@ -281,11 +289,11 @@
 }
 
 @utility text-helper {
-    @apply inline-block font-bold text-coollabs dark:text-warning;
+    @apply inline-block font-bold text-coollabs;
 }
 
 @utility info-helper {
-    @apply cursor-pointer text-coollabs dark:text-warning;
+    @apply cursor-pointer text-coollabs;
 }
 
 @utility info-helper-popup {

--- a/resources/views/livewire/dashboard.blade.php
+++ b/resources/views/livewire/dashboard.blade.php
@@ -5,23 +5,29 @@
     @if (session('error'))
         <span x-data x-init="$wire.emit('error', '{{ session('error') }}')" />
     @endif
-    <h1>Dashboard</h1>
-    <div class="subtitle">Your self-hosted infrastructure.</div>
 
-    <section class="-mt-2">
-        <div class="flex items-center gap-2 pb-2">
-            <h3>Projects</h3>
-@can('create', App\Models\Project::class)
+    <div class="flex flex-col gap-1 pb-4">
+        <h1>Dashboard</h1>
+        <div class="subtitle">Your self-hosted infrastructure.</div>
+    </div>
+
+    <section class="pb-8">
+        <div class="flex items-center justify-between gap-2 pb-4">
+            <div class="flex items-center gap-2">
+                <h3>Projects</h3>
+                <span class="text-xs text-neutral-500 dark:text-coolgray-500">{{ $projects->count() }}</span>
+            </div>
+            @can('create', App\Models\Project::class)
                 @if ($projects->count() > 0)
-                    <x-modal-input buttonTitle="Add" title="New Project">
+                    <x-modal-input title="New Project">
                         <x-slot:content>
-                            <button
-                                class="flex items-center justify-center size-4 text-black dark:text-white rounded hover:bg-coolgray-400 dark:hover:bg-coolgray-300 cursor-pointer">
-                                <svg class="size-3" xmlns="http://www.w3.org/2000/svg" fill="none"
-                                    viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                            <button type="button" class="button-primary">
+                                <svg class="size-4" xmlns="http://www.w3.org/2000/svg" fill="none"
+                                    viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor">
                                     <path stroke-linecap="round" stroke-linejoin="round"
                                         d="M12 4.5v15m7.5-7.5h-15" />
                                 </svg>
+                                New Project
                             </button>
                         </x-slot:content>
                         <livewire:project.add-empty />
@@ -29,22 +35,53 @@
                 @endif
             @endcan
         </div>
+
         @if ($projects->count() > 0)
-            <div class="grid grid-cols-1 gap-4 xl:grid-cols-2">
+            <div class="grid grid-cols-1 gap-4 lg:grid-cols-2 xl:grid-cols-3">
                 @foreach ($projects as $project)
-                    <div class="relative gap-2 cursor-pointer coolbox group">
+                    @php
+                        $resourceCount = $project->environments->sum(
+                            fn($env) => $env->applications->count() + $env->databases()->count() + $env->services->count(),
+                        );
+                        $runningCount = $project->environments->sum(
+                            fn($env) => $env->applications->filter(fn($a) => str($a->status)->startsWith('running'))->count(),
+                        );
+                    @endphp
+                    <div
+                        class="relative flex flex-col gap-4 p-5 border rounded-xl cursor-pointer group border-neutral-200 dark:border-coolgray-300 bg-white dark:bg-coolgray-100 hover:border-coollabs hover:shadow-md dark:hover:shadow-none transition-all">
                         <a href="{{ $project->navigateTo() }}" {{ wireNavigate() }} class="absolute inset-0"></a>
-                        <div class="flex flex-1 mx-6">
-                            <div class="flex flex-col justify-center flex-1">
-                                <div class="box-title">{{ $project->name }}</div>
-                                <div class="box-description">
-                                    {{ $project->description }}
+                        <div class="flex items-start justify-between gap-3">
+                            <div class="flex items-start flex-1 min-w-0 gap-3">
+                                <div class="resource-avatar">
+                                    <svg class="size-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.75V12A2.25 2.25 0 014.5 9.75h15A2.25 2.25 0 0121.75 12v.75m-19.5 0v6a2.25 2.25 0 002.25 2.25h15a2.25 2.25 0 002.25-2.25v-6m-19.5 0a2.25 2.25 0 012.25-2.25h15a2.25 2.25 0 012.25 2.25m-19.5 0v-1.5a2.25 2.25 0 012.25-2.25h6a2.25 2.25 0 012.25 2.25v1.5" />
+                                    </svg>
+                                </div>
+                                <div class="flex flex-col min-w-0 gap-1 pt-0.5">
+                                    <div class="font-semibold truncate text-black dark:text-white">{{ $project->name }}</div>
+                                    <div class="text-sm text-neutral-500 dark:text-coolgray-500 line-clamp-2">
+                                        {{ $project->description ?: 'No description' }}
+                                    </div>
                                 </div>
                             </div>
-                            <div class="relative z-10 flex items-center justify-center gap-4 text-xs font-bold">
+                            @if ($resourceCount > 0)
+                                <span
+                                    class="flex items-center gap-1.5 text-xs font-medium px-2 py-1 rounded-full bg-neutral-100 dark:bg-coolgray-200 text-neutral-600 dark:text-coolgray-500 shrink-0">
+                                    <span
+                                        class="size-1.5 rounded-full {{ $runningCount > 0 ? 'bg-success' : 'bg-neutral-400 dark:bg-coolgray-400' }}"></span>
+                                    {{ $runningCount }}/{{ $resourceCount }} running
+                                </span>
+                            @endif
+                        </div>
+
+                        <div class="flex items-center justify-between pt-3 mt-auto border-t border-neutral-100 dark:border-coolgray-300">
+                            <span class="text-xs text-neutral-400 dark:text-coolgray-500">
+                                {{ $project->environments->count() }} {{ Str::plural('environment', $project->environments->count()) }}
+                            </span>
+                            <div class="relative z-10 flex items-center gap-4 text-xs font-semibold">
                                 @if ($project->environments->first())
                                     @can('createAnyResource')
-                                        <a class="hover:underline" {{ wireNavigate() }}
+                                        <a class="hover:underline hover:text-coollabs" {{ wireNavigate() }}
                                             href="{{ route('project.resource.create', [
                                                 'project_uuid' => $project->uuid,
                                                 'environment_uuid' => $project->environments->first()->uuid,
@@ -54,7 +91,7 @@
                                     @endcan
                                 @endif
                                 @can('update', $project)
-                                    <a class="hover:underline" {{ wireNavigate() }}
+                                    <a class="hover:underline hover:text-coollabs" {{ wireNavigate() }}
                                         href="{{ route('project.edit', ['project_uuid' => $project->uuid]) }}">
                                         Settings
                                     </a>
@@ -63,17 +100,33 @@
                         </div>
                     </div>
                 @endforeach
+                @can('create', App\Models\Project::class)
+                    <x-modal-input title="New Project">
+                        <x-slot:content>
+                            <button type="button"
+                                class="flex flex-col items-center justify-center w-full h-full gap-2 p-5 text-center transition-colors border border-dashed rounded-xl min-h-[9rem] border-neutral-300 dark:border-coolgray-400 text-neutral-500 dark:text-coolgray-500 hover:border-coollabs hover:text-coollabs">
+                                <span class="flex items-center justify-center text-lg rounded-full size-9 bg-neutral-100 dark:bg-coolgray-200">+</span>
+                                <span class="text-sm font-medium">Create New Project</span>
+                            </button>
+                        </x-slot:content>
+                        <livewire:project.add-empty />
+                    </x-modal-input>
+                @endcan
             </div>
         @else
-            <div class="flex flex-col gap-1">
-                <div class='font-bold dark:text-warning'>No projects found.</div>
+            <div class="flex flex-col items-center justify-center gap-3 p-10 text-center border border-dashed rounded-xl border-neutral-300 dark:border-coolgray-400">
+                <span class="flex items-center justify-center text-xl rounded-full size-11 bg-neutral-100 dark:bg-coolgray-200 text-neutral-400 dark:text-coolgray-500">+</span>
+                <div class="font-semibold text-black dark:text-white">No projects found</div>
                 @can('create', App\Models\Project::class)
-                    <div class="flex items-center gap-1">
-                        <x-modal-input buttonTitle="Add" title="New Project">
+                    <div class="flex items-center gap-3">
+                        <x-modal-input title="New Project">
+                            <x-slot:content>
+                                <button type="button" class="button-primary">+ New Project</button>
+                            </x-slot:content>
                             <livewire:project.add-empty />
-                        </x-modal-input> your first project or
-                        go to the <a class="underline dark:text-white" href="{{ route('onboarding') }}"
-                            {{ wireNavigate() }}>onboarding</a> page.
+                        </x-modal-input>
+                        <a class="text-sm underline text-neutral-500 dark:text-coolgray-500 hover:text-black dark:hover:text-white"
+                            href="{{ route('onboarding') }}" {{ wireNavigate() }}>go to onboarding</a>
                     </div>
                 @endcan
             </div>
@@ -81,82 +134,119 @@
     </section>
 
     <section>
-        <div class="flex items-center gap-2 pb-2">
-            <h3>Servers</h3>
-@can('create', App\Models\Server::class)
+        <div class="flex items-center justify-between gap-2 pb-4">
+            <div class="flex items-center gap-2">
+                <h3>Servers</h3>
+                <span class="text-xs text-neutral-500 dark:text-coolgray-500">{{ $servers->count() }}</span>
+            </div>
+            @can('create', App\Models\Server::class)
                 @if ($servers->count() > 0 && $privateKeys->count() > 0)
-                    <a href="{{ route('server.create') }}" {{ wireNavigate() }}
-                        class="flex items-center justify-center size-4 text-black dark:text-white rounded hover:bg-coolgray-400 dark:hover:bg-coolgray-300 cursor-pointer">
-                        <svg class="size-3" xmlns="http://www.w3.org/2000/svg" fill="none"
-                            viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                    <a href="{{ route('server.create') }}" {{ wireNavigate() }} class="button-primary">
+                        <svg class="size-4" xmlns="http://www.w3.org/2000/svg" fill="none"
+                            viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round"
                                 d="M12 4.5v15m7.5-7.5h-15" />
                         </svg>
+                        New Server
                     </a>
                 @endif
             @endcan
         </div>
+
         @if ($servers->count() > 0)
-            <div class="grid grid-cols-1 gap-4 xl:grid-cols-2">
-                @foreach ($servers as $server)
-                    <a href="{{ route('server.show', ['server_uuid' => data_get($server, 'uuid')]) }}" {{ wireNavigate() }}
-                        @class([
-                            'gap-2 border cursor-pointer coolbox group',
-                            'border-red-500' =>
-                                !$server->settings->is_reachable || $server->settings->force_disabled,
-                        ])>
-                        <div class="flex flex-col justify-center mx-6">
-                            <div class="box-title">
-                                {{ $server->name }}
-                            </div>
-                            <div class="box-description">
-                                {{ $server->description }}</div>
-                            <div class="flex gap-1 text-xs text-error">
-                                @if (!$server->settings->is_reachable)
-                                    Not reachable
-                                @endif
-                                @if (!$server->settings->is_reachable && !$server->settings->is_usable)
-                                    &
-                                @endif
-                                @if (!$server->settings->is_usable)
-                                    Not usable by Coolify
-                                @endif
-                            </div>
-                        </div>
-                        <div class="flex-1"></div>
-                    </a>
-                @endforeach
+            <div class="overflow-hidden border rounded-xl border-neutral-200 dark:border-coolgray-300">
+                <table class="w-full text-sm">
+                    <thead>
+                        <tr class="text-xs text-left uppercase bg-neutral-50 dark:bg-coolgray-200 text-neutral-500 dark:text-coolgray-500">
+                            <th class="px-5 py-3 font-medium">Server</th>
+                            <th class="px-5 py-3 font-medium">IP Address</th>
+                            <th class="px-5 py-3 font-medium">Status</th>
+                            <th class="px-5 py-3 font-medium text-right">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-neutral-100 dark:divide-coolgray-300">
+                        @foreach ($servers as $server)
+                            @php
+                                $unreachable = !$server->settings->is_reachable || $server->settings->force_disabled;
+                                $unusable = !$server->settings->is_usable;
+                            @endphp
+                            <tr class="transition-colors hover:bg-neutral-50 dark:hover:bg-coolgray-200">
+                                <td class="px-5 py-3">
+                                    <div class="flex items-center gap-3">
+                                        <div class="resource-avatar size-8 rounded-md">
+                                            <svg class="size-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 17.25v-.228a4.5 4.5 0 00-.12-1.03l-2.268-9.64a3.375 3.375 0 00-3.285-2.602H7.923a3.375 3.375 0 00-3.285 2.602l-2.268 9.64a4.5 4.5 0 00-.12 1.03v.228m19.5 0a3 3 0 01-3 3H5.25a3 3 0 01-3-3m19.5 0a3 3 0 00-3-3H5.25a3 3 0 00-3 3m16.5 0h.008v.008h-.008v-.008zm-3 0h.008v.008h-.008v-.008z" />
+                                            </svg>
+                                        </div>
+                                        <div>
+                                            <a href="{{ route('server.show', ['server_uuid' => data_get($server, 'uuid')]) }}"
+                                                {{ wireNavigate() }} class="font-medium text-black dark:text-white hover:underline">
+                                                {{ $server->name }}
+                                            </a>
+                                            @if ($server->description)
+                                                <div class="text-xs text-neutral-400 dark:text-coolgray-500">{{ $server->description }}</div>
+                                            @endif
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="px-5 py-3 font-mono text-xs text-neutral-600 dark:text-coolgray-500">
+                                    {{ $server->ip }}
+                                </td>
+                                <td class="px-5 py-3">
+                                    @if ($unreachable || $unusable)
+                                        <span class="flex items-center gap-1.5 text-xs font-medium text-error">
+                                            <span class="size-1.5 rounded-full bg-error"></span>
+                                            @if ($unreachable) Not reachable @endif
+                                            @if ($unreachable && $unusable) & @endif
+                                            @if ($unusable) Not usable @endif
+                                        </span>
+                                    @else
+                                        <span class="flex items-center gap-1.5 text-xs font-medium text-success">
+                                            <span class="size-1.5 rounded-full bg-success"></span>
+                                            Reachable
+                                        </span>
+                                    @endif
+                                </td>
+                                <td class="px-5 py-3 text-right">
+                                    <a href="{{ route('server.show', ['server_uuid' => data_get($server, 'uuid')]) }}"
+                                        {{ wireNavigate() }}
+                                        class="text-xs font-semibold hover:underline hover:text-coollabs">
+                                        Manage
+                                    </a>
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
             </div>
         @else
             @if ($privateKeys->count() === 0)
-                <div class="flex flex-col gap-1">
-                    <div class='font-bold dark:text-warning'>No private keys found.</div>
+                <div class="flex flex-col items-center justify-center gap-3 p-10 text-center border border-dashed rounded-xl border-neutral-300 dark:border-coolgray-400">
+                    <span class="flex items-center justify-center text-xl rounded-full size-11 bg-neutral-100 dark:bg-coolgray-200 text-neutral-400 dark:text-coolgray-500">+</span>
+                    <div class="font-semibold text-black dark:text-white">No private keys found</div>
+                    <p class="max-w-sm text-sm text-neutral-500 dark:text-coolgray-500">Before you can add your server, first add a private key.</p>
                     @can('create', App\Models\Server::class)
-                        <div class="flex items-center gap-1">Before you can add your server, first <x-modal-input
-                                buttonTitle="add" title="New Private Key">
+                        <div class="flex items-center gap-3">
+                            <x-modal-input title="New Private Key">
+                                <x-slot:content>
+                                    <button type="button" class="button-primary">+ Add Private Key</button>
+                                </x-slot:content>
                                 <livewire:security.private-key.create from="server" />
-                            </x-modal-input> a private key
-                            or
-                            go to the <a class="underline dark:text-white"
-                                href="{{ route('onboarding') }}"
-                                {{ wireNavigate() }}>onboarding</a>
-                            page.
+                            </x-modal-input>
+                            <a class="text-sm underline text-neutral-500 dark:text-coolgray-500 hover:text-black dark:hover:text-white"
+                                href="{{ route('onboarding') }}" {{ wireNavigate() }}>go to onboarding</a>
                         </div>
                     @endcan
                 </div>
             @else
-                <div class="flex flex-col gap-1">
-                    <div class='font-bold dark:text-warning'>No servers found.</div>
+                <div class="flex flex-col items-center justify-center gap-3 p-10 text-center border border-dashed rounded-xl border-neutral-300 dark:border-coolgray-400">
+                    <span class="flex items-center justify-center text-xl rounded-full size-11 bg-neutral-100 dark:bg-coolgray-200 text-neutral-400 dark:text-coolgray-500">+</span>
+                    <div class="font-semibold text-black dark:text-white">No servers found</div>
                     @can('create', App\Models\Server::class)
-                        <div class="flex items-center gap-1">
-                            <a href="{{ route('server.create') }}" {{ wireNavigate() }}>
-                                <x-forms.button>Add</x-forms.button>
-                            </a> your first server
-                            or
-                            go to the <a class="underline dark:text-white"
-                                href="{{ route('onboarding') }}"
-                                {{ wireNavigate() }}>onboarding</a>
-                            page.
+                        <div class="flex items-center gap-3">
+                            <a href="{{ route('server.create') }}" {{ wireNavigate() }} class="button-primary">+ New Server</a>
+                            <a class="text-sm underline text-neutral-500 dark:text-coolgray-500 hover:text-black dark:hover:text-white"
+                                href="{{ route('onboarding') }}" {{ wireNavigate() }}>go to onboarding</a>
                         </div>
                     @endcan
                 </div>

--- a/resources/views/livewire/project/application/general.blade.php
+++ b/resources/views/livewire/project/application/general.blade.php
@@ -6,21 +6,25 @@
     }
 }">
     <form wire:submit='submit' class="flex flex-col pb-32">
-        <div class="flex items-center gap-2">
-            <h2>General</h2>
-            @if (isDev())
-                <div>{{ $application->compose_parsing_version }}</div>
-            @endif
-            <x-forms.button canGate="update" :canResource="$application" type="submit">Save</x-forms.button>
-            <x-modal-input title="Resource Details" buttonTitle="Details">
-                <livewire:project.shared.resource-details :resource="$application" />
-            </x-modal-input>
-            @if ($buildPack === 'dockercompose')
-                <x-forms.button canGate="update" :canResource="$application" wire:target='initLoadingCompose'
-                    x-on:click="$wire.dispatch('loadCompose', false)">
-                    {{ $application->docker_compose_raw ? 'Reload Compose File' : 'Load Compose File' }}
-                </x-forms.button>
-            @endif
+        <div class="flex flex-wrap items-center justify-between gap-2">
+            <div class="flex items-center gap-2">
+                <h2>General</h2>
+                @if (isDev())
+                    <div>{{ $application->compose_parsing_version }}</div>
+                @endif
+            </div>
+            <div class="flex flex-wrap items-center gap-2">
+                <x-modal-input title="Resource Details" buttonTitle="Details">
+                    <livewire:project.shared.resource-details :resource="$application" />
+                </x-modal-input>
+                @if ($buildPack === 'dockercompose')
+                    <x-forms.button canGate="update" :canResource="$application" wire:target='initLoadingCompose'
+                        x-on:click="$wire.dispatch('loadCompose', false)">
+                        {{ $application->docker_compose_raw ? 'Reload Compose File' : 'Load Compose File' }}
+                    </x-forms.button>
+                @endif
+                <x-forms.button canGate="update" :canResource="$application" type="submit">Save</x-forms.button>
+            </div>
         </div>
         <div>General configuration for your application.</div>
         <div class="flex flex-col gap-2 py-4">

--- a/resources/views/livewire/project/index.blade.php
+++ b/resources/views/livewire/project/index.blade.php
@@ -2,31 +2,72 @@
     <x-slot:title>
         Projects | Coolify
     </x-slot>
-    <div class="flex gap-2 items-center">
-        <h1>Projects</h1>
+    <div class="flex items-start justify-between gap-2">
+        <div class="flex flex-col gap-1">
+            <h1>Projects</h1>
+            <div class="subtitle">All your projects are here.</div>
+        </div>
         @can('createAnyResource')
-            <x-modal-input buttonTitle="+ Add" title="New Project">
+            <x-modal-input title="New Project">
+                <x-slot:content>
+                    <button type="button" class="button-primary">
+                        <svg class="size-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                            stroke-width="2.5" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+                        </svg>
+                        New Project
+                    </button>
+                </x-slot:content>
                 <livewire:project.add-empty />
             </x-modal-input>
         @endcan
     </div>
-    <div class="subtitle">All your projects are here.</div>
     @if ($projects->count() > 0)
-        <div class="grid grid-cols-1 gap-4 xl:grid-cols-2 -mt-1">
+        <div class="grid grid-cols-1 gap-4 pt-6 lg:grid-cols-2 xl:grid-cols-3">
             @foreach ($projects as $project)
-                <div class="relative gap-2 cursor-pointer coolbox group">
+                @php
+                    $resourceCount = $project->environments->sum(
+                        fn($env) => $env->applications->count() + $env->databases()->count() + $env->services->count(),
+                    );
+                    $runningCount = $project->environments->sum(
+                        fn($env) => $env->applications->filter(fn($a) => str($a->status)->startsWith('running'))->count(),
+                    );
+                @endphp
+                <div
+                    class="relative flex flex-col gap-4 p-5 border rounded-xl cursor-pointer group border-neutral-200 dark:border-coolgray-300 bg-white dark:bg-coolgray-100 hover:border-coollabs hover:shadow-md dark:hover:shadow-none transition-all">
                     <a href="{{ $project->navigateTo() }}" {{ wireNavigate() }} class="absolute inset-0"></a>
-                    <div class="flex flex-1 mx-6">
-                        <div class="flex flex-col justify-center flex-1">
-                            <div class="box-title">{{ $project->name }}</div>
-                            <div class="box-description">
-                                {{ $project->description }}
+                    <div class="flex items-start justify-between gap-3">
+                        <div class="flex items-start flex-1 min-w-0 gap-3">
+                            <div class="resource-avatar">
+                                <svg class="size-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.75V12A2.25 2.25 0 014.5 9.75h15A2.25 2.25 0 0121.75 12v.75m-19.5 0v6a2.25 2.25 0 002.25 2.25h15a2.25 2.25 0 002.25-2.25v-6m-19.5 0a2.25 2.25 0 012.25-2.25h15a2.25 2.25 0 012.25 2.25m-19.5 0v-1.5a2.25 2.25 0 012.25-2.25h6a2.25 2.25 0 012.25 2.25v1.5" />
+                                </svg>
+                            </div>
+                            <div class="flex flex-col min-w-0 gap-1 pt-0.5">
+                                <div class="font-semibold truncate text-black dark:text-white">{{ $project->name }}</div>
+                                <div class="text-sm text-neutral-500 dark:text-coolgray-500 line-clamp-2">
+                                    {{ $project->description ?: 'No description' }}
+                                </div>
                             </div>
                         </div>
-                        <div class="relative z-10 flex items-center justify-center gap-4 text-xs font-bold">
+                        @if ($resourceCount > 0)
+                            <span
+                                class="flex items-center gap-1.5 text-xs font-medium px-2 py-1 rounded-full bg-neutral-100 dark:bg-coolgray-200 text-neutral-600 dark:text-coolgray-500 shrink-0">
+                                <span
+                                    class="size-1.5 rounded-full {{ $runningCount > 0 ? 'bg-success' : 'bg-neutral-400 dark:bg-coolgray-400' }}"></span>
+                                {{ $runningCount }}/{{ $resourceCount }} running
+                            </span>
+                        @endif
+                    </div>
+
+                    <div class="flex items-center justify-between pt-3 mt-auto border-t border-neutral-100 dark:border-coolgray-300">
+                        <span class="text-xs text-neutral-400 dark:text-coolgray-500">
+                            {{ $project->environments->count() }} {{ Str::plural('environment', $project->environments->count()) }}
+                        </span>
+                        <div class="relative z-10 flex items-center gap-4 text-xs font-semibold">
                             @if ($project->environments->first())
                                 @can('createAnyResource')
-                                    <a class="hover:underline" {{ wireNavigate() }}
+                                    <a class="hover:underline hover:text-coollabs" {{ wireNavigate() }}
                                         href="{{ route('project.resource.create', [
                                             'project_uuid' => $project->uuid,
                                             'environment_uuid' => $project->environments->first()->uuid,
@@ -36,7 +77,7 @@
                                 @endcan
                             @endif
                             @can('update', $project)
-                                <a class="hover:underline" {{ wireNavigate() }}
+                                <a class="hover:underline hover:text-coollabs" {{ wireNavigate() }}
                                     href="{{ route('project.edit', ['project_uuid' => $project->uuid]) }}">
                                     Settings
                                 </a>
@@ -45,21 +86,38 @@
                     </div>
                 </div>
             @endforeach
+            @can('createAnyResource')
+                <x-modal-input title="New Project">
+                    <x-slot:content>
+                        <button type="button"
+                            class="flex flex-col items-center justify-center w-full h-full gap-2 p-5 text-center transition-colors border border-dashed rounded-xl min-h-[9rem] border-neutral-300 dark:border-coolgray-400 text-neutral-500 dark:text-coolgray-500 hover:border-coollabs hover:text-coollabs">
+                            <span class="flex items-center justify-center text-lg rounded-full size-9 bg-neutral-100 dark:bg-coolgray-200">+</span>
+                            <span class="text-sm font-medium">Create New Project</span>
+                        </button>
+                    </x-slot:content>
+                    <livewire:project.add-empty />
+                </x-modal-input>
+            @endcan
         </div>
     @else
-        <div class="flex flex-col gap-1">
-            <div class='font-bold dark:text-warning'>No projects found.</div>
-            <div class="flex items-center gap-1">
-                @can('createAnyResource')
-                    <x-modal-input buttonTitle="Add" title="New Project">
+        <div class="flex flex-col items-center justify-center gap-3 p-10 mt-6 text-center border border-dashed rounded-xl border-neutral-300 dark:border-coolgray-400">
+            <span class="flex items-center justify-center text-xl rounded-full size-11 bg-neutral-100 dark:bg-coolgray-200 text-neutral-400 dark:text-coolgray-500">+</span>
+            <div class="font-semibold text-black dark:text-white">No projects found</div>
+            @can('createAnyResource')
+                <div class="flex items-center gap-3">
+                    <x-modal-input title="New Project">
+                        <x-slot:content>
+                            <button type="button" class="button-primary">+ New Project</button>
+                        </x-slot:content>
                         <livewire:project.add-empty />
-                    </x-modal-input> your first project or
-                @else
-                    Create your first project or
-                @endcan
-                go to the <a class="underline dark:text-white" href="{{ route('onboarding') }}"
-                    {{ wireNavigate() }}>onboarding</a> page.
-            </div>
+                    </x-modal-input>
+                    <a class="text-sm underline text-neutral-500 dark:text-coolgray-500 hover:text-black dark:hover:text-white"
+                        href="{{ route('onboarding') }}" {{ wireNavigate() }}>go to onboarding</a>
+                </div>
+            @else
+                <p class="text-sm text-neutral-500 dark:text-coolgray-500">Contact your team administrator to create a
+                    project, or go to the <a class="underline" href="{{ route('onboarding') }}" {{ wireNavigate() }}>onboarding</a> page.</p>
+            @endcan
         </div>
     @endif
 </div>

--- a/resources/views/livewire/project/resource/index.blade.php
+++ b/resources/views/livewire/project/resource/index.blade.php
@@ -3,31 +3,36 @@
         {{ data_get_str($project, 'name')->limit(10) }} > Resources | Coolify
     </x-slot>
     <div class="flex flex-col">
-        <div class="flex min-w-0 flex-nowrap items-center gap-1">
+        <div class="flex flex-wrap items-start justify-between min-w-0 gap-2">
             <h1>Resources</h1>
-            @if ($environment->isEmpty())
-                @can('createAnyResource')
-                    <a class="button" {{ wireNavigate() }}
-                        href="{{ route('project.clone-me', ['project_uuid' => data_get($project, 'uuid'), 'environment_uuid' => data_get($environment, 'uuid')]) }}">
-                        Clone
-                    </a>
+            <div class="flex items-center gap-2">
+                @if ($environment->isEmpty())
+                    @can('createAnyResource')
+                        <a class="button" {{ wireNavigate() }}
+                            href="{{ route('project.clone-me', ['project_uuid' => data_get($project, 'uuid'), 'environment_uuid' => data_get($environment, 'uuid')]) }}">
+                            Clone
+                        </a>
+                    @endcan
+                @else
+                    @can('createAnyResource')
+                        <a class="button" {{ wireNavigate() }}
+                            href="{{ route('project.clone-me', ['project_uuid' => data_get($project, 'uuid'), 'environment_uuid' => data_get($environment, 'uuid')]) }}">
+                            Clone
+                        </a>
+                        <a href="{{ route('project.resource.create', ['project_uuid' => data_get($parameters, 'project_uuid'), 'environment_uuid' => data_get($environment, 'uuid')]) }}"
+                            {{ wireNavigate() }} class="button-primary">
+                            <svg class="size-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                                stroke-width="2.5" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+                            </svg>
+                            New Resource
+                        </a>
+                    @endcan
+                @endif
+                @can('delete', $environment)
+                    <livewire:project.delete-environment :disabled="!$environment->isEmpty()" :environment_id="$environment->id" />
                 @endcan
-            @else
-                @can('createAnyResource')
-                    <a href="{{ route('project.resource.create', ['project_uuid' => data_get($parameters, 'project_uuid'), 'environment_uuid' => data_get($environment, 'uuid')]) }}"
-                        {{ wireNavigate() }} class="button">+
-                        New</a>
-                @endcan
-                @can('createAnyResource')
-                    <a class="button" {{ wireNavigate() }}
-                        href="{{ route('project.clone-me', ['project_uuid' => data_get($project, 'uuid'), 'environment_uuid' => data_get($environment, 'uuid')]) }}">
-                        Clone
-                    </a>
-                @endcan
-            @endif
-            @can('delete', $environment)
-                <livewire:project.delete-environment :disabled="!$environment->isEmpty()" :environment_id="$environment->id" />
-            @endcan
+            </div>
         </div>
         <nav class="flex pt-2 pb-6">
             <ol class="flex items-center">
@@ -193,10 +198,14 @@
     @if ($environment->isEmpty())
         @can('createAnyResource')
             <a href="{{ route('project.resource.create', ['project_uuid' => data_get($parameters, 'project_uuid'), 'environment_uuid' => data_get($environment, 'uuid')]) }}"
-                {{ wireNavigate() }} class="items-center justify-center coolbox">+ Add Resource</a>
+                {{ wireNavigate() }}
+                class="flex flex-col items-center justify-center gap-2 p-8 text-center border border-dashed rounded-xl border-neutral-300 dark:border-coolgray-400 text-neutral-500 dark:text-coolgray-500 hover:border-coollabs hover:text-coollabs transition-colors">
+                <span class="flex items-center justify-center rounded-full size-9 bg-neutral-100 dark:bg-coolgray-200 text-lg">+</span>
+                <span class="text-sm font-medium">Add Resource</span>
+            </a>
         @else
             <div
-                class="flex flex-col items-center justify-center p-8 text-center border border-dashed border-neutral-300 dark:border-coolgray-300 rounded-lg">
+                class="flex flex-col items-center justify-center p-8 text-center border border-dashed border-neutral-300 dark:border-coolgray-300 rounded-xl">
                 <h3 class="mb-2 text-lg font-semibold text-neutral-600 dark:text-neutral-400">No Resources Found</h3>
                 <p class="text-sm text-neutral-600 dark:text-neutral-400">
                     This environment doesn't have any resources yet.<br>
@@ -232,50 +241,41 @@
             <div x-show="filteredApplications.length > 0"
                 class="grid grid-cols-1 gap-4 pt-4 lg:grid-cols-2 xl:grid-cols-3">
                 <template x-for="item in filteredApplications" :key="item.uuid">
-                    <span>
-                        <a class="h-24 coolbox group" :href="item.hrefLink" {{ wireNavigate() }}>
-                            <div class="flex flex-col w-full">
-                                <div class="flex gap-2 px-4">
-                                    <div class="pb-2 truncate box-title" x-text="item.name"></div>
-                                    <div class="flex-1"></div>
-                                    <template x-if="item.status.startsWith('running')">
-                                        <div title="running" class="bg-success badge-dashboard"></div>
-                                    </template>
-                                    <template x-if="item.status.startsWith('exited')">
-                                        <div title="exited" class="bg-error badge-dashboard"></div>
-                                    </template>
-                                    <template x-if="item.status.startsWith('starting')">
-                                        <div title="starting" class="bg-warning badge-dashboard"></div>
-                                    </template>
-                                    <template x-if="item.status.startsWith('restarting')">
-                                        <div title="restarting" class="bg-warning badge-dashboard"></div>
-                                    </template>
-                                    <template x-if="item.status.startsWith('degraded')">
-                                        <div title="degraded" class="bg-warning badge-dashboard"></div>
-                                    </template>
+                    <div class="relative flex flex-col gap-3 p-5 border rounded-xl group border-neutral-200 dark:border-coolgray-300 bg-white dark:bg-coolgray-100 hover:border-coollabs transition-colors">
+                        <a class="absolute inset-0" :href="item.hrefLink" {{ wireNavigate() }}></a>
+                        <div class="flex items-start justify-between gap-2">
+                            <div class="flex items-start flex-1 min-w-0 gap-3">
+                                <div class="resource-avatar">
+                                    <svg class="size-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 7.5l3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0021 18V6a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 6v12a2.25 2.25 0 002.25 2.25z" />
+                                    </svg>
                                 </div>
-                                <div class="max-w-full px-4 truncate box-description" x-text="item.description"></div>
-                                <div class="max-w-full px-4 truncate box-description" x-text="item.fqdn"></div>
-                                <div class="max-w-full px-4 pt-1 truncate box-description">Server: <span
-                                        x-text="item.destination?.server?.name || 'Unknown'"></span></div>
-                                <template x-if="item.server_status == false">
-                                    <div class="px-4 text-xs font-bold text-error">Server is unreachable or
-                                        misconfigured
-                                    </div>
-                                </template>
+                                <div class="min-w-0 pt-0.5">
+                                    <div class="font-semibold truncate text-black dark:text-white" x-text="item.name"></div>
+                                    <div class="text-sm truncate text-neutral-500 dark:text-coolgray-500"
+                                        x-text="item.description || item.fqdn || 'No description'"></div>
+                                </div>
                             </div>
-                        </a>
-                        <div
-                            class="flex flex-wrap gap-1 pt-1 dark:group-hover:text-white group-hover:text-black group min-h-6">
-                            <template x-for="tag in item.tags">
-                                <a :href="`/tags/${tag.name}`" class="tag" x-text="tag.name">
-                                </a>
-                            </template>
-                            <a :href="`${item.hrefLink}/tags`" class="add-tag">
-                                Add tag
-                            </a>
+                            <span class="flex items-center gap-1.5 text-xs font-medium px-2 py-1 rounded-full bg-neutral-100 dark:bg-coolgray-200 shrink-0"
+                                :class="statusTextClass(item.status)">
+                                <span class="rounded-full size-1.5" :class="statusDotClass(item.status)"></span>
+                                <span x-text="statusLabel(item.status)"></span>
+                            </span>
                         </div>
-                    </span>
+                        <template x-if="item.server_status == false">
+                            <div class="text-xs font-semibold text-error">Server unreachable or misconfigured</div>
+                        </template>
+                        <div class="relative z-10 flex items-center justify-between gap-2 pt-3 mt-auto border-t border-neutral-100 dark:border-coolgray-300">
+                            <span class="text-xs truncate text-neutral-400 dark:text-coolgray-500"
+                                x-text="item.destination?.server?.name || 'Unknown'"></span>
+                            <div class="flex flex-wrap justify-end gap-1">
+                                <template x-for="tag in item.tags" :key="tag.id">
+                                    <a :href="`/tags/${tag.name}`" class="tag" x-text="tag.name"></a>
+                                </template>
+                                <a :href="`${item.hrefLink}/tags`" class="add-tag">Add tag</a>
+                            </div>
+                        </div>
+                    </div>
                 </template>
             </div>
             <template x-if="filteredDatabases.length > 0">
@@ -284,50 +284,41 @@
             <div x-show="filteredDatabases.length > 0"
                 class="grid grid-cols-1 gap-4 pt-4 lg:grid-cols-2 xl:grid-cols-3">
                 <template x-for="item in filteredDatabases" :key="item.uuid">
-                    <span>
-                        <a class="h-24 coolbox group" :href="item.hrefLink" {{ wireNavigate() }}>
-                            <div class="flex flex-col w-full">
-                                <div class="flex gap-2 px-4">
-                                    <div class="pb-2 truncate box-title" x-text="item.name"></div>
-                                    <div class="flex-1"></div>
-                                    <template x-if="item.status.startsWith('running')">
-                                        <div title="running" class="bg-success badge-dashboard"></div>
-                                    </template>
-                                    <template x-if="item.status.startsWith('exited')">
-                                        <div title="exited" class="bg-error badge-dashboard"></div>
-                                    </template>
-                                    <template x-if="item.status.startsWith('starting')">
-                                        <div title="starting" class="bg-warning badge-dashboard"></div>
-                                    </template>
-                                    <template x-if="item.status.startsWith('restarting')">
-                                        <div title="restarting" class="bg-warning badge-dashboard"></div>
-                                    </template>
-                                    <template x-if="item.status.startsWith('degraded')">
-                                        <div title="degraded" class="bg-warning badge-dashboard"></div>
-                                    </template>
+                    <div class="relative flex flex-col gap-3 p-5 border rounded-xl group border-neutral-200 dark:border-coolgray-300 bg-white dark:bg-coolgray-100 hover:border-coollabs transition-colors">
+                        <a class="absolute inset-0" :href="item.hrefLink" {{ wireNavigate() }}></a>
+                        <div class="flex items-start justify-between gap-2">
+                            <div class="flex items-start flex-1 min-w-0 gap-3">
+                                <div class="resource-avatar">
+                                    <svg class="size-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 7.5l3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0021 18V6a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 6v12a2.25 2.25 0 002.25 2.25z" />
+                                    </svg>
                                 </div>
-                                <div class="max-w-full px-4 truncate box-description" x-text="item.description"></div>
-                                <div class="max-w-full px-4 truncate box-description" x-text="item.fqdn"></div>
-                                <div class="max-w-full px-4 pt-1 truncate box-description">Server: <span
-                                        x-text="item.destination?.server?.name || 'Unknown'"></span></div>
-                                <template x-if="item.server_status == false">
-                                    <div class="px-4 text-xs font-bold text-error">Server is unreachable or
-                                        misconfigured
-                                    </div>
-                                </template>
+                                <div class="min-w-0 pt-0.5">
+                                    <div class="font-semibold truncate text-black dark:text-white" x-text="item.name"></div>
+                                    <div class="text-sm truncate text-neutral-500 dark:text-coolgray-500"
+                                        x-text="item.description || item.fqdn || 'No description'"></div>
+                                </div>
                             </div>
-                        </a>
-                        <div
-                            class="flex flex-wrap gap-1 pt-1 dark:group-hover:text-white group-hover:text-black group min-h-6">
-                            <template x-for="tag in item.tags">
-                                <a :href="`/tags/${tag.name}`" class="tag" x-text="tag.name">
-                                </a>
-                            </template>
-                            <a :href="`${item.hrefLink}/tags`" class="add-tag">
-                                Add tag
-                            </a>
+                            <span class="flex items-center gap-1.5 text-xs font-medium px-2 py-1 rounded-full bg-neutral-100 dark:bg-coolgray-200 shrink-0"
+                                :class="statusTextClass(item.status)">
+                                <span class="rounded-full size-1.5" :class="statusDotClass(item.status)"></span>
+                                <span x-text="statusLabel(item.status)"></span>
+                            </span>
                         </div>
-                    </span>
+                        <template x-if="item.server_status == false">
+                            <div class="text-xs font-semibold text-error">Server unreachable or misconfigured</div>
+                        </template>
+                        <div class="relative z-10 flex items-center justify-between gap-2 pt-3 mt-auto border-t border-neutral-100 dark:border-coolgray-300">
+                            <span class="text-xs truncate text-neutral-400 dark:text-coolgray-500"
+                                x-text="item.destination?.server?.name || 'Unknown'"></span>
+                            <div class="flex flex-wrap justify-end gap-1">
+                                <template x-for="tag in item.tags" :key="tag.id">
+                                    <a :href="`/tags/${tag.name}`" class="tag" x-text="tag.name"></a>
+                                </template>
+                                <a :href="`${item.hrefLink}/tags`" class="add-tag">Add tag</a>
+                            </div>
+                        </div>
+                    </div>
                 </template>
             </div>
             <template x-if="filteredServices.length > 0">
@@ -336,50 +327,41 @@
             <div x-show="filteredServices.length > 0"
                 class="grid grid-cols-1 gap-4 pt-4 lg:grid-cols-2 xl:grid-cols-3">
                 <template x-for="item in filteredServices" :key="item.uuid">
-                    <span>
-                        <a class="h-24 coolbox group" :href="item.hrefLink" {{ wireNavigate() }}>
-                            <div class="flex flex-col w-full">
-                                <div class="flex gap-2 px-4">
-                                    <div class="pb-2 truncate box-title" x-text="item.name"></div>
-                                    <div class="flex-1"></div>
-                                    <template x-if="item.status.startsWith('running')">
-                                        <div title="running" class="bg-success badge-dashboard"></div>
-                                    </template>
-                                    <template x-if="item.status.startsWith('exited')">
-                                        <div title="exited" class="bg-error badge-dashboard"></div>
-                                    </template>
-                                    <template x-if="item.status.startsWith('starting')">
-                                        <div title="starting" class="bg-warning badge-dashboard"></div>
-                                    </template>
-                                    <template x-if="item.status.startsWith('restarting')">
-                                        <div title="restarting" class="bg-warning badge-dashboard"></div>
-                                    </template>
-                                    <template x-if="item.status.startsWith('degraded')">
-                                        <div title="degraded" class="bg-warning badge-dashboard"></div>
-                                    </template>
+                    <div class="relative flex flex-col gap-3 p-5 border rounded-xl group border-neutral-200 dark:border-coolgray-300 bg-white dark:bg-coolgray-100 hover:border-coollabs transition-colors">
+                        <a class="absolute inset-0" :href="item.hrefLink" {{ wireNavigate() }}></a>
+                        <div class="flex items-start justify-between gap-2">
+                            <div class="flex items-start flex-1 min-w-0 gap-3">
+                                <div class="resource-avatar">
+                                    <svg class="size-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 7.5l3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0021 18V6a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 6v12a2.25 2.25 0 002.25 2.25z" />
+                                    </svg>
                                 </div>
-                                <div class="max-w-full px-4 truncate box-description" x-text="item.description"></div>
-                                <div class="max-w-full px-4 truncate box-description" x-text="item.fqdn"></div>
-                                <div class="max-w-full px-4 pt-1 truncate box-description">Server: <span
-                                        x-text="item.destination?.server?.name || 'Unknown'"></span></div>
-                                <template x-if="item.server_status == false">
-                                    <div class="px-4 text-xs font-bold text-error">Server is unreachable or
-                                        misconfigured
-                                    </div>
-                                </template>
+                                <div class="min-w-0 pt-0.5">
+                                    <div class="font-semibold truncate text-black dark:text-white" x-text="item.name"></div>
+                                    <div class="text-sm truncate text-neutral-500 dark:text-coolgray-500"
+                                        x-text="item.description || item.fqdn || 'No description'"></div>
+                                </div>
                             </div>
-                        </a>
-                        <div
-                            class="flex flex-wrap gap-1 pt-1 dark:group-hover:text-white group-hover:text-black group min-h-6">
-                            <template x-for="tag in item.tags">
-                                <a :href="`/tags/${tag.name}`" class="tag" x-text="tag.name">
-                                </a>
-                            </template>
-                            <a :href="`${item.hrefLink}/tags`" class="add-tag">
-                                Add tag
-                            </a>
+                            <span class="flex items-center gap-1.5 text-xs font-medium px-2 py-1 rounded-full bg-neutral-100 dark:bg-coolgray-200 shrink-0"
+                                :class="statusTextClass(item.status)">
+                                <span class="rounded-full size-1.5" :class="statusDotClass(item.status)"></span>
+                                <span x-text="statusLabel(item.status)"></span>
+                            </span>
                         </div>
-                    </span>
+                        <template x-if="item.server_status == false">
+                            <div class="text-xs font-semibold text-error">Server unreachable or misconfigured</div>
+                        </template>
+                        <div class="relative z-10 flex items-center justify-between gap-2 pt-3 mt-auto border-t border-neutral-100 dark:border-coolgray-300">
+                            <span class="text-xs truncate text-neutral-400 dark:text-coolgray-500"
+                                x-text="item.destination?.server?.name || 'Unknown'"></span>
+                            <div class="flex flex-wrap justify-end gap-1">
+                                <template x-for="tag in item.tags" :key="tag.id">
+                                    <a :href="`/tags/${tag.name}`" class="tag" x-text="tag.name"></a>
+                                </template>
+                                <a :href="`${item.hrefLink}/tags`" class="add-tag">Add tag</a>
+                            </div>
+                        </div>
+                    </div>
                 </template>
             </div>
         </div>
@@ -434,6 +416,26 @@
             },
             get filteredServices() {
                 return this.filterAndSort(this.services)
+            },
+            statusLabel(status) {
+                if (status.startsWith('running')) return 'running';
+                if (status.startsWith('exited')) return 'exited';
+                if (status.startsWith('restarting')) return 'restarting';
+                if (status.startsWith('degraded')) return 'degraded';
+                if (status.startsWith('starting')) return 'starting';
+                return 'idle';
+            },
+            statusDotClass(status) {
+                if (status.startsWith('running')) return 'bg-success';
+                if (status.startsWith('exited')) return 'bg-error';
+                if (status.startsWith('starting') || status.startsWith('restarting') || status.startsWith('degraded')) return 'bg-warning';
+                return 'bg-neutral-400 dark:bg-coolgray-400';
+            },
+            statusTextClass(status) {
+                if (status.startsWith('running')) return 'text-success';
+                if (status.startsWith('exited')) return 'text-error';
+                if (status.startsWith('starting') || status.startsWith('restarting') || status.startsWith('degraded')) return 'text-warning';
+                return 'text-neutral-500 dark:text-coolgray-500';
             }
         };
     }

--- a/resources/views/livewire/server/index.blade.php
+++ b/resources/views/livewire/server/index.blade.php
@@ -2,55 +2,104 @@
     <x-slot:title>
         Servers | Coolify
     </x-slot>
-    <div class="flex items-center gap-2">
-        <h1>Servers</h1>
+    <div class="flex items-start justify-between gap-2">
+        <div class="flex flex-col gap-1">
+            <h1>Servers</h1>
+            <div class="subtitle">All your servers are here.</div>
+        </div>
         @can('createAnyResource')
-            <a href="{{ route('server.create') }}" {{ wireNavigate() }}>
-                <x-forms.button>+ Add</x-forms.button>
+            <a href="{{ route('server.create') }}" {{ wireNavigate() }} class="button-primary">
+                <svg class="size-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                    stroke-width="2.5" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+                </svg>
+                New Server
             </a>
         @endcan
     </div>
-    <div class="subtitle">All your servers are here.</div>
-    <div class="grid gap-4 lg:grid-cols-2 -mt-1">
-        @forelse ($servers as $server)
-            <a href="{{ route('server.show', ['server_uuid' => data_get($server, 'uuid')]) }}" {{ wireNavigate() }}
-                @class([
-                    'gap-2 border cursor-pointer coolbox group',
-                    'border-red-500' =>
-                        !$server->settings->is_reachable || $server->settings->force_disabled,
-                ])>
-                <div class="flex flex-col justify-center mx-6">
-                    <div class="font-bold dark:text-white">
-                        {{ $server->name }}
-                    </div>
-                    <div class="description">
-                        {{ $server->description }}</div>
-                    <div class="flex gap-1 text-xs text-error">
-                        @if (!$server->settings->is_reachable)
-                            <span>Not reachable</span>
-                        @endif
-                        @if (!$server->settings->is_reachable && !$server->settings->is_usable)
-                            &
-                        @endif
-                        @if (!$server->settings->is_usable)
-                            <span>Not usable by Coolify</span>
-                        @endif
-                        @if ($server->settings->force_disabled)
-                            <span>Disabled by the system</span>
-                        @endif
-                    </div>
-                </div>
-                <div class="flex-1"></div>
-            </a>
-        @empty
-            <div>
-                <div>No servers found. Without a server, you won't be able to do much.</div>
-            </div>
-        @endforelse
-        @isset($error)
-            <div class="text-center text-error">
-                <span>{{ $error }}</span>
-            </div>
-        @endisset
-    </div>
+
+    @isset($error)
+        <div class="mt-4 text-center text-error">
+            <span>{{ $error }}</span>
+        </div>
+    @endisset
+
+    @if ($servers->count() > 0)
+        <div class="overflow-hidden border rounded-xl border-neutral-200 dark:border-coolgray-300 mt-6">
+            <table class="w-full text-sm">
+                <thead>
+                    <tr class="text-xs text-left uppercase bg-neutral-50 dark:bg-coolgray-200 text-neutral-500 dark:text-coolgray-500">
+                        <th class="px-5 py-3 font-medium">Server</th>
+                        <th class="px-5 py-3 font-medium">IP Address</th>
+                        <th class="px-5 py-3 font-medium">Status</th>
+                        <th class="px-5 py-3 font-medium text-right">Actions</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-neutral-100 dark:divide-coolgray-300">
+                    @foreach ($servers as $server)
+                        @php
+                            $unreachable = !$server->settings->is_reachable || $server->settings->force_disabled;
+                            $unusable = !$server->settings->is_usable;
+                        @endphp
+                        <tr class="transition-colors hover:bg-neutral-50 dark:hover:bg-coolgray-200">
+                            <td class="px-5 py-3">
+                                <div class="flex items-center gap-3">
+                                    <div class="resource-avatar size-8 rounded-md">
+                                        <svg class="size-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 17.25v-.228a4.5 4.5 0 00-.12-1.03l-2.268-9.64a3.375 3.375 0 00-3.285-2.602H7.923a3.375 3.375 0 00-3.285 2.602l-2.268 9.64a4.5 4.5 0 00-.12 1.03v.228m19.5 0a3 3 0 01-3 3H5.25a3 3 0 01-3-3m19.5 0a3 3 0 00-3-3H5.25a3 3 0 00-3 3m16.5 0h.008v.008h-.008v-.008zm-3 0h.008v.008h-.008v-.008z" />
+                                        </svg>
+                                    </div>
+                                    <div>
+                                        <a href="{{ route('server.show', ['server_uuid' => data_get($server, 'uuid')]) }}"
+                                            {{ wireNavigate() }} class="font-medium text-black dark:text-white hover:underline">
+                                            {{ $server->name }}
+                                        </a>
+                                        @if ($server->description)
+                                            <div class="text-xs text-neutral-400 dark:text-coolgray-500">{{ $server->description }}</div>
+                                        @endif
+                                    </div>
+                                </div>
+                            </td>
+                            <td class="px-5 py-3 font-mono text-xs text-neutral-600 dark:text-coolgray-500">
+                                {{ $server->ip }}
+                            </td>
+                            <td class="px-5 py-3">
+                                @if ($unreachable || $unusable || $server->settings->force_disabled)
+                                    <span class="flex items-center gap-1.5 text-xs font-medium text-error">
+                                        <span class="size-1.5 rounded-full bg-error"></span>
+                                        @if ($unreachable) Not reachable @endif
+                                        @if ($unreachable && $unusable) & @endif
+                                        @if ($unusable) Not usable @endif
+                                        @if ($server->settings->force_disabled) Disabled by the system @endif
+                                    </span>
+                                @else
+                                    <span class="flex items-center gap-1.5 text-xs font-medium text-success">
+                                        <span class="size-1.5 rounded-full bg-success"></span>
+                                        Reachable
+                                    </span>
+                                @endif
+                            </td>
+                            <td class="px-5 py-3 text-right">
+                                <a href="{{ route('server.show', ['server_uuid' => data_get($server, 'uuid')]) }}"
+                                    {{ wireNavigate() }}
+                                    class="text-xs font-semibold hover:underline hover:text-coollabs">
+                                    Manage
+                                </a>
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    @else
+        <div class="flex flex-col items-center justify-center gap-3 p-10 mt-6 text-center border border-dashed rounded-xl border-neutral-300 dark:border-coolgray-400">
+            <span class="flex items-center justify-center text-xl rounded-full size-11 bg-neutral-100 dark:bg-coolgray-200 text-neutral-400 dark:text-coolgray-500">+</span>
+            <div class="font-semibold text-black dark:text-white">No servers found</div>
+            <p class="max-w-sm text-sm text-neutral-500 dark:text-coolgray-500">Without a server, you won't be able to
+                deploy anything.</p>
+            @can('createAnyResource')
+                <a href="{{ route('server.create') }}" {{ wireNavigate() }} class="button-primary">+ New Server</a>
+            @endcan
+        </div>
+    @endif
 </div>

--- a/resources/views/livewire/server/resources.blade.php
+++ b/resources/views/livewire/server/resources.blade.php
@@ -10,26 +10,26 @@
                     <h2>Resources</h2>
                     <x-forms.button wire:click="refreshStatus">Refresh</x-forms.button>
                 </div>
-                <div>Here you can find all resources that are managed by Coolify.</div>
-                <div class="flex flex-row gap-4 py-10">
-                    <div @class([
-                        'box-without-bg cursor-pointer dark:bg-coolgray-100 dark:text-white w-full text-center items-center justify-center',
-                        'dark:bg-coollabs bg-coollabs text-white' => $activeTab === 'managed',
-                    ]) wire:click="loadManagedContainers">
+                <div class="subtitle">Here you can find all resources that are managed by Coolify.</div>
+                <div class="inline-flex gap-1 p-1 mt-6 mb-6 border rounded-xl border-neutral-200 dark:border-coolgray-300 bg-neutral-50 dark:bg-coolgray-200 w-fit">
+                    <button type="button" wire:click="loadManagedContainers"
+                        @class([
+                            'flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg cursor-pointer transition-colors',
+                            'bg-coollabs text-white' => $activeTab === 'managed',
+                            'text-neutral-500 dark:text-coolgray-500 hover:text-black dark:hover:text-white' => $activeTab !== 'managed',
+                        ])>
                         Managed
-                        <div class="flex flex-col items-center justify-center">
-                            <x-loading wire:loading wire:target="loadManagedContainers" />
-                        </div>
-                    </div>
-                    <div @class([
-                        'box-without-bg cursor-pointer dark:bg-coolgray-100 dark:text-white w-full text-center items-center justify-center',
-                        'dark:bg-coollabs bg-coollabs text-white' => $activeTab === 'unmanaged',
-                    ]) wire:click="loadUnmanagedContainers">
+                        <x-loading wire:loading wire:target="loadManagedContainers" />
+                    </button>
+                    <button type="button" wire:click="loadUnmanagedContainers"
+                        @class([
+                            'flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg cursor-pointer transition-colors',
+                            'bg-coollabs text-white' => $activeTab === 'unmanaged',
+                            'text-neutral-500 dark:text-coolgray-500 hover:text-black dark:hover:text-white' => $activeTab !== 'unmanaged',
+                        ])>
                         Unmanaged
-                        <div class="flex flex-col items-center justify-center">
-                            <x-loading wire:loading wire:target="loadUnmanagedContainers" />
-                        </div>
-                    </div>
+                        <x-loading wire:loading wire:target="loadUnmanagedContainers" />
+                    </button>
                 </div>
             </div>
             @if ($activeTab === 'managed')
@@ -37,131 +37,106 @@
                     $managedResources = $server->definedResources()->sortBy('name', SORT_NATURAL);
                 @endphp
                 @if ($managedResources->count() > 0)
-                    <div class="flex flex-col">
-                        <div class="flex flex-col">
-                            <div class="overflow-x-auto">
-                                <div class="inline-block min-w-full">
-                                    <div class="overflow-hidden">
-                                        <table class="min-w-full">
-                                            <thead>
-                                                <tr>
-                                                    <th class="px-5 py-3 text-xs font-medium text-left uppercase">
-                                                        Project
-                                                    </th>
-                                                    <th class="px-5 py-3 text-xs font-medium text-left uppercase">
-                                                        Environment</th>
-                                                    <th class="px-5 py-3 text-xs font-medium text-left uppercase">
-                                                        Name
-                                                    </th>
-                                                    <th class="px-5 py-3 text-xs font-medium text-left uppercase">
-                                                        Type
-                                                    </th>
-                                                    <th class="px-5 py-3 text-xs font-medium text-left uppercase">
-                                                        Status
-                                                    </th>
-                                                </tr>
-                                            </thead>
-                                            <tbody>
-                                                @foreach ($managedResources as $resource)
-                                                    <tr>
-                                                        <td class="px-5 py-4 text-sm whitespace-nowrap">
-                                                            {{ data_get($resource->project(), 'name') }}
-                                                        </td>
-                                                        <td class="px-5 py-4 text-sm whitespace-nowrap">
-                                                            {{ data_get($resource, 'environment.name') }}
-                                                        </td>
-                                                        <td class="px-5 py-4 text-sm whitespace-nowrap hover:underline">
-                                                            <a class="" {{ wireNavigate() }}
-                                                                href="{{ $resource->link() }}">{{ $resource->name }}
-                                                                <x-internal-link /></a>
-                                                        </td>
-                                                        <td class="px-5 py-4 text-sm whitespace-nowrap">
-                                                            {{ str($resource->type())->headline() }}</td>
-                                                        <td class="px-5 py-4 text-sm font-medium whitespace-nowrap">
-                                                            @if ($resource->type() === 'service')
-                                                                <x-status.services :service="$resource"
-                                                                    :showRefreshButton="false" />
-                                                            @else
-                                                                <x-status.index :resource="$resource" :showRefreshButton="false" />
-                                                            @endif
-                                                        </td>
-                                                    </tr>
-                                                @endforeach
-                                            </tbody>
-                                        </table>
-                                    </div>
-                                </div>
-                            </div>
+                    <div class="overflow-hidden border rounded-xl border-neutral-200 dark:border-coolgray-300">
+                        <div class="overflow-x-auto">
+                            <table class="w-full text-sm">
+                                <thead>
+                                    <tr class="text-xs text-left uppercase bg-neutral-50 dark:bg-coolgray-200 text-neutral-500 dark:text-coolgray-500">
+                                        <th class="px-5 py-3 font-medium">Project</th>
+                                        <th class="px-5 py-3 font-medium">Environment</th>
+                                        <th class="px-5 py-3 font-medium">Name</th>
+                                        <th class="px-5 py-3 font-medium">Type</th>
+                                        <th class="px-5 py-3 font-medium">Status</th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-neutral-100 dark:divide-coolgray-300">
+                                    @foreach ($managedResources as $resource)
+                                        <tr class="transition-colors hover:bg-neutral-50 dark:hover:bg-coolgray-200">
+                                            <td class="px-5 py-3 whitespace-nowrap text-neutral-600 dark:text-coolgray-500">
+                                                {{ data_get($resource->project(), 'name') }}
+                                            </td>
+                                            <td class="px-5 py-3 whitespace-nowrap text-neutral-600 dark:text-coolgray-500">
+                                                {{ data_get($resource, 'environment.name') }}
+                                            </td>
+                                            <td class="px-5 py-3 font-medium whitespace-nowrap">
+                                                <a class="text-black dark:text-white hover:text-coollabs hover:underline" {{ wireNavigate() }}
+                                                    href="{{ $resource->link() }}">{{ $resource->name }}
+                                                    <x-internal-link /></a>
+                                            </td>
+                                            <td class="px-5 py-3 whitespace-nowrap text-neutral-600 dark:text-coolgray-500">
+                                                {{ str($resource->type())->headline() }}</td>
+                                            <td class="px-5 py-3 text-sm font-medium whitespace-nowrap">
+                                                @if ($resource->type() === 'service')
+                                                    <x-status.services :service="$resource"
+                                                        :showRefreshButton="false" />
+                                                @else
+                                                    <x-status.index :resource="$resource" :showRefreshButton="false" />
+                                                @endif
+                                            </td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
                         </div>
                     </div>
                 @else
-                    <div>No managed resources found.</div>
+                    <div class="p-8 text-center border border-dashed rounded-xl border-neutral-300 dark:border-coolgray-300 text-neutral-500 dark:text-coolgray-500">
+                        No managed resources found.
+                    </div>
                 @endif
             @elseif ($activeTab === 'unmanaged')
                 @if (count($unmanagedContainers) > 0)
-                    <div class="flex flex-col">
-                        <div class="flex flex-col">
-                            <div class="overflow-x-auto">
-                                <div class="inline-block min-w-full">
-                                    <div class="overflow-hidden">
-                                        <table class="min-w-full">
-                                            <thead>
-                                                <tr>
-                                                    <th class="px-5 py-3 text-xs font-medium text-left uppercase">
-                                                        Name
-                                                    </th>
-                                                    <th class="px-5 py-3 text-xs font-medium text-left uppercase">
-                                                        Image
-                                                    </th>
-                                                    <th class="px-5 py-3 text-xs font-medium text-left uppercase">
-                                                        Status
-                                                    </th>
-                                                    <th class="px-5 py-3 text-xs font-medium text-left uppercase">
-                                                        Action
-                                                    </th>
-                                                </tr>
-                                            </thead>
-                                            <tbody>
-                                                @foreach (collect($unmanagedContainers)->sortBy('name', SORT_NATURAL) as $resource)
-                                                    <tr>
-                                                        <td class="px-5 py-4 text-sm whitespace-nowrap">
-                                                            {{ data_get($resource, 'Names') }}
-                                                        </td>
-                                                        <td class="px-5 py-4 text-sm whitespace-nowrap">
-                                                            {{ data_get($resource, 'Image') }}
-                                                        </td>
-                                                        <td class="px-5 py-4 text-sm whitespace-nowrap">
-                                                            {{ data_get($resource, 'State') }}
-                                                        </td>
-                                                        <td class="flex gap-2 px-5 py-4 text-sm whitespace-nowrap">
-                                                                @if (data_get($resource, 'State') === 'running')
-                                                                    <x-forms.button canGate="update" :canResource="$server"
-                                                                        wire:click="restartUnmanaged('{{ data_get($resource, 'ID') }}')"
-                                                                        wire:key="{{ data_get($resource, 'ID') }}">Restart</x-forms.button>
-                                                                    <x-forms.button canGate="update" :canResource="$server" isError
-                                                                        wire:click="stopUnmanaged('{{ data_get($resource, 'ID') }}')"
-                                                                        wire:key="{{ data_get($resource, 'ID') }}">Stop</x-forms.button>
-                                                                @elseif (data_get($resource, 'State') === 'exited')
-                                                                    <x-forms.button canGate="update" :canResource="$server"
-                                                                        wire:click="startUnmanaged('{{ data_get($resource, 'ID') }}')"
-                                                                        wire:key="{{ data_get($resource, 'ID') }}">Start</x-forms.button>
-                                                                @elseif (data_get($resource, 'State') === 'restarting')
-                                                                    <x-forms.button canGate="update" :canResource="$server"
-                                                                        wire:click="stopUnmanaged('{{ data_get($resource, 'ID') }}')"
-                                                                        wire:key="{{ data_get($resource, 'ID') }}">Stop</x-forms.button>
-                                                                @endif
-                                                        </td>
-                                                    </tr>
-                                                @endforeach
-                                            </tbody>
-                                        </table>
-                                    </div>
-                                </div>
-                            </div>
+                    <div class="overflow-hidden border rounded-xl border-neutral-200 dark:border-coolgray-300">
+                        <div class="overflow-x-auto">
+                            <table class="w-full text-sm">
+                                <thead>
+                                    <tr class="text-xs text-left uppercase bg-neutral-50 dark:bg-coolgray-200 text-neutral-500 dark:text-coolgray-500">
+                                        <th class="px-5 py-3 font-medium">Name</th>
+                                        <th class="px-5 py-3 font-medium">Image</th>
+                                        <th class="px-5 py-3 font-medium">Status</th>
+                                        <th class="px-5 py-3 font-medium">Action</th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-neutral-100 dark:divide-coolgray-300">
+                                    @foreach (collect($unmanagedContainers)->sortBy('name', SORT_NATURAL) as $resource)
+                                        <tr class="transition-colors hover:bg-neutral-50 dark:hover:bg-coolgray-200">
+                                            <td class="px-5 py-3 font-medium whitespace-nowrap text-black dark:text-white">
+                                                {{ data_get($resource, 'Names') }}
+                                            </td>
+                                            <td class="px-5 py-3 font-mono text-xs whitespace-nowrap text-neutral-600 dark:text-coolgray-500">
+                                                {{ data_get($resource, 'Image') }}
+                                            </td>
+                                            <td class="px-5 py-3 whitespace-nowrap text-neutral-600 dark:text-coolgray-500">
+                                                {{ data_get($resource, 'State') }}
+                                            </td>
+                                            <td class="flex gap-2 px-5 py-3 whitespace-nowrap">
+                                                    @if (data_get($resource, 'State') === 'running')
+                                                        <x-forms.button canGate="update" :canResource="$server"
+                                                            wire:click="restartUnmanaged('{{ data_get($resource, 'ID') }}')"
+                                                            wire:key="{{ data_get($resource, 'ID') }}">Restart</x-forms.button>
+                                                        <x-forms.button canGate="update" :canResource="$server" isError
+                                                            wire:click="stopUnmanaged('{{ data_get($resource, 'ID') }}')"
+                                                            wire:key="{{ data_get($resource, 'ID') }}">Stop</x-forms.button>
+                                                    @elseif (data_get($resource, 'State') === 'exited')
+                                                        <x-forms.button canGate="update" :canResource="$server"
+                                                            wire:click="startUnmanaged('{{ data_get($resource, 'ID') }}')"
+                                                            wire:key="{{ data_get($resource, 'ID') }}">Start</x-forms.button>
+                                                    @elseif (data_get($resource, 'State') === 'restarting')
+                                                        <x-forms.button canGate="update" :canResource="$server"
+                                                            wire:click="stopUnmanaged('{{ data_get($resource, 'ID') }}')"
+                                                            wire:key="{{ data_get($resource, 'ID') }}">Stop</x-forms.button>
+                                                    @endif
+                                            </td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
                         </div>
                     </div>
                 @else
-                    <div>No unmanaged resources found.</div>
+                    <div class="p-8 text-center border border-dashed rounded-xl border-neutral-300 dark:border-coolgray-300 text-neutral-500 dark:text-coolgray-500">
+                        No unmanaged resources found.
+                    </div>
                 @endif
             @endif
         </div>


### PR DESCRIPTION
## Summary

A visual refresh of the main list/dashboard pages, built on top of the existing brand accent (`coollabs` violet) rather than introducing a new color scheme. Goal: improve readability and information density without a full framework rewrite, per discussion in #5687.

- **Dashboard, Projects, Servers**: card-based grids with resource-type icons, running/status badges (real data, no mock content), a dashed "create new" tile in the grid, and a consistent `button-primary` CTA positioned top-right of each section instead of a tiny inline icon next to the heading.
- **Project Resources page**: consistent card treatment for Applications/Databases/Services with status pills (running/exited/building/idle) and server-unreachable warnings.
- **Server Resources page**: Managed/Unmanaged tabs restyled as a segmented control; tables restyled with the same header/row language used elsewhere.
- **Global CSS (`app.css`/`utilities.css`)**:
  - Active sidebar/sub-nav item: was low-contrast violet text on dark gray (`dark:text-coollabs` on `dark:bg-coolgray-200`), now a solid violet pill with white text — readable in both themes.
  - `button[type="submit"].button` now solid violet app-wide (via attribute selector, no per-form changes needed).
  - `button[isError]` (Delete/Stop/etc.) now solid dark red instead of a light/subtle outline.
- **Application > General**: separated the `<h2>` title from the action buttons (Save was previously crammed directly next to the heading, disconnected from the form fields it saves).

## Screenshots

Dashboard, Projects, Servers and Resources screens — see comment on #5687 for visuals.

## Test plan

- [x] `vendor/bin/pint --dirty --format agent` passes
- [x] `php artisan view:cache` compiles all Blade views without error
- [x] Manually verified in a local dev instance (`docker compose -f docker-compose.dev.yml up`): Dashboard, Projects, Servers, Resources, Profile (Save button), Team (submit button), Security > Private Keys (Delete button), Server empty states
- [ ] Not yet verified: pages requiring a live/reachable server (Application configuration tabs beyond General, Deployments, Terminal) — no SSH-reachable server was available in this environment

## AI Usage

This PR was developed with Claude Code (Anthropic), based on design direction and iterative feedback from the author across several rounds of review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)