### PR TITLE
fix(ui): render raw compose state for Alpine

### DIFF
--- a/resources/views/livewire/project/application/general.blade.php
+++ b/resources/views/livewire/project/application/general.blade.php
@@ -405,7 +405,7 @@
                 <div x-data="{ showRaw: true }">
                     <div class="flex items-center gap-2">
                         <h3>Docker Compose</h3>
-                        <x-forms.button x-show="!($application->settings->is_raw_compose_deployment_enabled)"
+                        <x-forms.button x-show="!@js($application->settings->is_raw_compose_deployment_enabled)"
                             @click.prevent="showRaw = !showRaw"
                             x-text="showRaw ? 'Show Deployable Compose' : 'Show Raw Compose'"></x-forms.button>
                     </div>

--- a/tests/Unit/RawComposeAlpineExpressionTest.php
+++ b/tests/Unit/RawComposeAlpineExpressionTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Unit;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\View\Compilers\BladeCompiler;
+use PHPUnit\Framework\TestCase;
+
+class RawComposeAlpineExpressionTest extends TestCase
+{
+    public function test_it_renders_the_raw_compose_toggle_condition_as_a_javascript_boolean(): void
+    {
+        $expression = 'x-show="!@js($application->settings->is_raw_compose_deployment_enabled)"';
+        $viewPath = dirname(__DIR__, 2).'/resources/views/livewire/project/application/general.blade.php';
+        $view = file_get_contents($viewPath);
+
+        $this->assertStringContainsString($expression, $view);
+
+        foreach ([[true, 'true'], [false, 'false']] as [$isEnabled, $expected]) {
+            $application = (object) [
+                'settings' => (object) ['is_raw_compose_deployment_enabled' => $isEnabled],
+            ];
+            $compiler = new BladeCompiler(new Filesystem, sys_get_temp_dir());
+            $compiled = $compiler->compileString("<div {$expression}></div>");
+
+            ob_start();
+            eval('?>'.$compiled);
+            $html = ob_get_clean();
+
+            $this->assertStringContainsString("x-show=\"!{$expected}\"", $html);
+            $this->assertStringNotContainsString('$application->', $html);
+        }
+    }
+}


### PR DESCRIPTION
## Changes

- Serialize the raw Compose setting with Blade's `@js` directive before Alpine evaluates it.
- Add regression coverage for both boolean states.

## Issues

- Fixes #11049

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable; this removes a console error without changing the intended UI.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Used to inspect the reported expression, implement the narrow fix, and write the regression test. The resulting diff and test output were reviewed.

## Testing

- `php vendor/bin/phpunit --no-extensions --bootstrap vendor/autoload.php tests/Unit/RawComposeAlpineExpressionTest.php` (1 test, 5 assertions)
- `php vendor/bin/pint --dirty --format agent`
- `git diff --check`

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.

The focused Blade compiler regression test was run under PHP 8.5; a full local Coolify UI instance was not started.
