### PR TITLE
fix(proxy): preserve negation in non-root sudo conditions

### DIFF
--- a/bootstrap/helpers/sudo.php
+++ b/bootstrap/helpers/sudo.php
@@ -63,9 +63,9 @@ function parseCommandsByLineForSudo(Collection $commands, Server $server): array
         // Match keyword followed by space, semicolon, or end of line
         foreach ($bashKeywords as $keyword) {
             if (preg_match('/^'.preg_quote($keyword, '/').'(\s|;|$)/', $trimmedLine)) {
-                // Special handling for 'if' - insert sudo after 'if '
+                // Special handling for 'if' - insert sudo after 'if' and an optional negation operator
                 if ($keyword === 'if') {
-                    return preg_replace('/^(\s*)if\s+/', '$1if sudo ', $line);
+                    return preg_replace('/^(\s*)if\s+(!\s+)?/', '$1if $2sudo ', $line);
                 }
 
                 return $line;

--- a/tests/Unit/ParseCommandsByLineForSudoTest.php
+++ b/tests/Unit/ParseCommandsByLineForSudoTest.php
@@ -166,6 +166,16 @@ test('handles if statements by adding sudo to condition', function () {
     expect($result[0])->toBe('if sudo command -v docker');
 });
 
+test('handles negated if statements by adding sudo after negation', function () {
+    $commands = collect([
+        'if ! docker ps; then',
+    ]);
+
+    $result = parseCommandsByLineForSudo($commands, $this->server);
+
+    expect($result[0])->toBe('if ! sudo docker ps; then');
+});
+
 test('skips sudo for fi statements', function () {
     $commands = collect([
         'fi',
@@ -439,6 +449,7 @@ test('handles real-world proxy startup with for loop from StartProxy action', fu
 
     // Verify other control structures remain correct
     expect($result[0])->toStartWith('if sudo docker ps');
+    expect($result[6])->toBe('        if ! sudo docker ps -a --format "{{.Names}}" | sudo grep -q "^coolify-proxy$"; then');
     expect($result[8])->toBe('        fi');
     expect($result[13])->toBe('fi');
 });


### PR DESCRIPTION
## Changes

- Fix sudo insertion for negated Bash `if` statements executed on remote servers through a non-root SSH user.
- Preserve the `!` operator before `sudo`, producing `if ! sudo docker ...` instead of the invalid `if sudo ! docker ...`.
- Add regression coverage for a simple negated condition and the proxy container removal pipeline.

## Issues

- Fixes #11087
- Related to #7622
- Related to #8285

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Before:

```text
sudo: !: command not found
Waiting for container to be removed... (1/15)
...
Waiting for container to be removed... (15/15)
```

After:

```text
Container removed successfully.
Proxy stopped successfully.
Container coolify-proxy Healthy
Successfully started coolify-proxy.
```

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Used to analyze the root cause, prepare the targeted code change, audit related sudo handling, and add regression tests. The behavior was manually reproduced and validated on a self-hosted Coolify instance.

## Testing

- `vendor/bin/pint --dirty --format agent` passed under PHP 8.5.8.
- `php artisan test --compact tests/Unit/ParseCommandsByLineForSudoTest.php` passed: 51 tests, 109 assertions.
- Manually reproduced on Coolify 4.1.2, Debian 13.6, using a non-root SSH user with sudo.
- Confirmed that the proxy container is removed and restarted successfully after the fix.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
