### PR TITLE
feat(auth): add generic OIDC provider

### DIFF
--- a/app/Models/OauthSetting.php
+++ b/app/Models/OauthSetting.php
@@ -32,6 +32,7 @@ class OauthSetting extends Model
                 return filled($this->client_id) && filled($this->client_secret) && filled($this->tenant);
             case 'authentik':
             case 'clerk':
+            case 'oidc':
                 return filled($this->client_id) && filled($this->client_secret) && filled($this->base_url);
             default:
                 return filled($this->client_id) && filled($this->client_secret);

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -10,6 +10,7 @@ use SocialiteProviders\Discord\DiscordExtendSocialite;
 use SocialiteProviders\Google\GoogleExtendSocialite;
 use SocialiteProviders\Infomaniak\InfomaniakExtendSocialite;
 use SocialiteProviders\Manager\SocialiteWasCalled;
+use SocialiteProviders\OIDC\OIDCExtendSocialite;
 use SocialiteProviders\Zitadel\ZitadelExtendSocialite;
 
 class EventServiceProvider extends ServiceProvider
@@ -23,6 +24,7 @@ class EventServiceProvider extends ServiceProvider
             GoogleExtendSocialite::class.'@handle',
             InfomaniakExtendSocialite::class.'@handle',
             ZitadelExtendSocialite::class.'@handle',
+            OIDCExtendSocialite::class.'@handle',
         ],
     ];
 

--- a/bootstrap/helpers/socialite.php
+++ b/bootstrap/helpers/socialite.php
@@ -44,6 +44,17 @@ function get_socialite_provider(string $provider)
         return Socialite::driver('zitadel')->setConfig($zitadel_config);
     }
 
+    if ($provider == 'oidc') {
+        $oidc_config = new \SocialiteProviders\Manager\Config(
+            $oauth_setting->client_id,
+            $oauth_setting->client_secret,
+            $oauth_setting->redirect_uri,
+            ['base_url' => $oauth_setting->base_url],
+        );
+
+        return Socialite::driver('oidc')->setConfig($oidc_config);
+    }
+
     if ($provider == 'google') {
         $google_config = new \SocialiteProviders\Manager\Config(
             $oauth_setting->client_id,

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "doctrine/dbal": "^4.4.1",
         "guzzlehttp/guzzle": "^7.10.0",
         "inertiajs/inertia-laravel": "^3.1",
+        "kovah/laravel-socialite-oidc": "^0.5.0",
         "laravel/fortify": "^1.34.0",
         "laravel/framework": "^12.49.0",
         "laravel/horizon": "^5.43.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3bc1d41688bd98785b556172ae2410ed",
+    "content-hash": "d7e502a7581aa50496f584ee9673ebad",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -1779,6 +1779,74 @@
                 "source": "https://github.com/Jean85/pretty-package-versions/tree/2.1.1"
             },
             "time": "2025-03-19T14:43:43+00:00"
+        },
+        {
+            "name": "kovah/laravel-socialite-oidc",
+            "version": "v0.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Kovah/laravel-socialite-oidc.git",
+                "reference": "b3e14d9b797b12ff3c8526ece43020dc8af2ecdf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Kovah/laravel-socialite-oidc/zipball/b3e14d9b797b12ff3c8526ece43020dc8af2ecdf",
+                "reference": "b3e14d9b797b12ff3c8526ece43020dc8af2ecdf",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "firebase/php-jwt": "^6.11.1",
+                "illuminate/http": "^9.0 | ^10.0 | ^11.0 | ^12.0",
+                "illuminate/support": "^9.0 | ^10.0 | ^11.0 | ^12.0",
+                "php": "^8.1",
+                "socialiteproviders/manager": "^4.0"
+            },
+            "conflict": {
+                "jp-gauthier/socialiteproviders-oidc": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "SocialiteProviders\\OIDC\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "JPG Dev",
+                    "homepage": "https://jpgdev.com"
+                },
+                {
+                    "name": "Kevin Woblick",
+                    "email": "mail@woblick.dev",
+                    "homepage": "https://woblick.dev",
+                    "role": "Developer"
+                }
+            ],
+            "description": "OpenID Connect OAuth2 Provider for Laravel Socialite",
+            "homepage": "https://github.com/kovah/laravel-socialite-oidc",
+            "keywords": [
+                "laravel",
+                "oauth",
+                "oidc",
+                "provider",
+                "socialite"
+            ],
+            "support": {
+                "issues": "https://github.com/Kovah/laravel-socialite-oidc/issues",
+                "source": "https://github.com/Kovah/laravel-socialite-oidc/tree/v0.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/kovah",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-31T18:41:24+00:00"
         },
         {
             "name": "laravel/fortify",

--- a/config/services.php
+++ b/config/services.php
@@ -67,4 +67,11 @@ return [
         'base_url' => env('ZITADEL_BASE_URL'),
     ],
 
+    'oidc' => [
+        'client_id' => env('OIDC_CLIENT_ID'),
+        'client_secret' => env('OIDC_CLIENT_SECRET'),
+        'redirect' => env('OIDC_REDIRECT_URI'),
+        'base_url' => env('OIDC_BASE_URL'),
+    ],
+
 ];

--- a/database/seeders/OauthSettingSeeder.php
+++ b/database/seeders/OauthSettingSeeder.php
@@ -25,6 +25,7 @@ class OauthSettingSeeder extends Seeder
                 'authentik',
                 'infomaniak',
                 'zitadel',
+                'oidc',
             ]);
 
             $isOauthSeeded = OauthSetting::count() > 0;

--- a/lang/de.json
+++ b/lang/de.json
@@ -1,5 +1,6 @@
 {
     "auth.login": "Anmelden",
+    "auth.login.oidc": "Mit SSO anmelden",
     "auth.login.azure": "Mit Microsoft anmelden",
     "auth.login.bitbucket": "Mit Bitbucket anmelden",
     "auth.login.clerk": "Mit Clerk anmelden",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,5 +1,6 @@
 {
     "auth.login": "Login",
+    "auth.login.oidc": "Login with SSO",
     "auth.login.authentik": "Login with Authentik",
     "auth.login.azure": "Login with Microsoft",
     "auth.login.bitbucket": "Login with Bitbucket",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -1,5 +1,6 @@
 {
     "auth.login": "Zaloguj",
+    "auth.login.oidc": "Zaloguj przez SSO",
     "auth.login.authentik": "Zaloguj się przez Authentik",
     "auth.login.azure": "Zaloguj się przez Microsoft",
     "auth.login.bitbucket": "Zaloguj się przez Bitbucket",

--- a/resources/views/livewire/settings-oauth.blade.php
+++ b/resources/views/livewire/settings-oauth.blade.php
@@ -40,6 +40,7 @@
                         @if (
                             $oauth_setting['provider'] == 'authentik' ||
                                 $oauth_setting['provider'] == 'clerk' ||
+                                $oauth_setting['provider'] == 'oidc' ||
                                 $oauth_setting['provider'] == 'zitadel' ||
                                 $oauth_setting['provider'] == 'gitlab')
                             <x-forms.input id="oauth_settings_map.{{ $oauth_setting['provider'] }}.base_url"

--- a/tests/Feature/OauthControllerTest.php
+++ b/tests/Feature/OauthControllerTest.php
@@ -48,6 +48,37 @@ it('logs in an existing user when the oauth provider returns a mixed-case email'
     expect(User::count())->toBe(1);
 });
 
+it('logs in an existing user with a generic oidc provider', function () {
+    config()->set('app.maintenance.driver', 'file');
+
+    OauthSetting::create([
+        'provider' => 'oidc',
+        'client_id' => 'oidc-client-id',
+        'client_secret' => 'oidc-client-secret',
+        'redirect_uri' => 'https://coolify.example.com/auth/oidc/callback',
+        'base_url' => 'https://id.example.com',
+    ]);
+
+    $user = User::factory()->create([
+        'email' => 'oidc-user@example.edu',
+    ]);
+
+    $provider = Mockery::mock();
+    $provider->shouldReceive('setConfig')->once()->andReturnSelf();
+    $provider->shouldReceive('user')->once()->andReturn((object) [
+        'email' => 'oidc-user@example.edu',
+        'name' => 'OIDC User',
+        'id' => 'oidc-user-id',
+    ]);
+
+    Socialite::shouldReceive('driver')->once()->with('oidc')->andReturn($provider);
+
+    $response = $this->get(route('auth.callback', 'oidc'));
+
+    $response->assertRedirect('/');
+    $this->assertAuthenticatedAs($user);
+});
+
 it('rejects oauth logins when the provider does not return an email address', function (?string $providerEmail) {
     config()->set('app.maintenance.driver', 'file');
     InstanceSettings::firstOrCreate([


### PR DESCRIPTION
## Changes

- Add a generic OIDC provider using kovah/laravel-socialite-oidc.
- Add OIDC configuration, seeding, OAuth settings UI support, translations, and provider registration.
- Add a feature test covering login through the generic OIDC driver.

## Issues

- Fixes #6696

## Category

- [x] New feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Adding a new one click service
- [ ] Fixing or updating an existing one click service

## Preview

No visual preview is included because this extends the existing OAuth settings form with the provider base URL field.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

Tools used: OpenAI Codex
How extensively: The implementation, test additions, and repository checks were performed with Codex and are submitted for maintainer review.

## Testing

- git diff --check passes.
- Composer and language JSON files parse successfully.
- The local environment does not include PHP or Composer, so the Laravel feature test and formatter could not be run locally; CI should run the project normal checks.

## Contributor Agreement

- [x] I have read and understood the contributor guidelines.
- [x] I have searched existing issues and pull requests to ensure this is not a duplicate.
- [ ] I have tested all the changes thoroughly with a local development instance of Coolify; the local PHP runtime is unavailable in this environment.