### PR TITLE
fix(service): qbittorrent template proxies its API through its own public URL

### DIFF
--- a/templates/compose/qbittorrent.yaml
+++ b/templates/compose/qbittorrent.yaml
@@ -32,7 +32,7 @@ services:
     environment:
       - SERVICE_URL_QBITORRENT_8080
       - PORT=${WEBUI_PORT:-8080}
-      - QBIT_BASE=${SERVICE_URL_QBITORRENT}
+      - QBIT_BASE=http://qbit:${WEBUI_PORT:-8080}
       - RELEASE_TYPE=${RELEASE_TYPE:-stable}
       - UPDATE_VT_CRON=${UPDATE_VT_CRON:-"0 * * * *"}
     volumes:


### PR DESCRIPTION
## Changes

<!-- TODO(author): rewrite this section in your own words before marking ready for review. -->

- In the qBittorrent template, `vuetorrent-backend` reverse-proxies `/api/*` to `QBIT_BASE`, which was set to `${SERVICE_URL_QBITORRENT}`. That magic variable resolves to the same public FQDN that already routes to `vuetorrent-backend`, so every API request left the server, hit the public domain, and re-entered the same container.
- Users behind Cloudflare see the loop as `Error 1000: DNS points to prohibited IP` (`dns_loop`, HTTP 403) when logging in. The WebUI itself still loads, because static assets are served locally and only `/api/*` is proxied. On a direct-to-origin setup the same loop surfaces as a 500 or a hang.
- `QBIT_BASE` now points at the `qbit` container over the compose network, so API traffic never leaves the host.
- The public domain is unchanged. It is still generated from the `SERVICE_URL_QBITORRENT_8080` entry in the same environment block, which is what binds the domain to `vuetorrent-backend` port 8080.

## Issues

- Fixes
<!-- TODO(author): open an issue or discussion and link it here, per CONTRIBUTING.md. -->

Prior art: #5234 proposed the identical one-line change in March 2025 and was closed without merging. The variable has since been renamed from `SERVICE_FQDN_QBITORRENT` to `SERVICE_URL_QBITORRENT`, but the loop is still present on `next`.

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [x] Fixing or updating existing one click service

## Preview

Request to `/api/v2/auth/login` on a deployed instance before the change:

```
HTTP/2 403
x-powered-by: Express
<title>DNS points to prohibited IP | Cloudflare</title>
```

The `x-powered-by: Express` header shows that Cloudflare's error page was relayed back through `vuetorrent-backend` rather than served at the edge, and `vary: Accept-Encoding` was repeated 16 times, once per trip around the loop.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Cursor
- How extensively: Diagnosing the loop, local reproduction and verification, and the one-line change.

## Testing

Brought the template up locally with Docker Compose using the fixed `QBIT_BASE`, then exercised the API through `vuetorrent-backend` with `Host`, `Origin` and `Referer` set to a public-style domain, matching what the Coolify proxy forwards:

```
POST /api/v2/auth/login   -> 204, Set-Cookie: QBT_SID_8080=...
GET  /api/v2/app/version  -> 200, v5.2.3
```

No qBittorrent configuration change is required alongside this. `WebUI\ServerDomains` defaults to `*`, and `vuetorrent-backend` forwards `Host`, `Origin` and `Referer` unmodified (verified by pointing `QBIT_BASE` at a header-echo container), so host-header validation and CSRF protection both pass.

Note that `templates/service-templates.json` embeds a base64 copy of this compose file and is listed under `blocked-paths` in `pr-quality.yaml`, so it has deliberately not been regenerated here.

## Contributor Agreement

> [!IMPORTANT]
>
> - [ ] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [ ] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.

Made with [Cursor](https://cursor.com)