### PR TITLE
fix(notifications): include application name in Discord stopped alert

### DIFF
--- a/app/Notifications/Application/StatusChanged.php
+++ b/app/Notifications/Application/StatusChanged.php
@@ -60,7 +60,7 @@ class StatusChanged extends CustomEmailNotification
     {
         return new DiscordMessage(
             title: ':cross_mark: Application stopped',
-            description: '[Open Application in Coolify]('.$this->resource_url.')',
+            description: "{$this->resource_name} has been stopped.\n\n[Open Application in Coolify]({$this->resource_url})",
             color: DiscordMessage::errorColor(),
             isCritical: true,
         );


### PR DESCRIPTION
## Changes

`App\Notifications\Application\StatusChanged::toDiscord()` never referenced `$resource_name`, so
the Discord embed for a stopped application was a fixed title plus a bare link and did not say
which application had stopped. Every other channel for the same event — mail, Telegram, Pushover,
Slack, webhook — already includes the name. It also sends `isCritical: true`, so it pings `@here`
with a message nobody can act on without clicking through.

One line changed, following the description convention already used by
`App\Notifications\Application\RestartLimitReached` in the same directory:

```diff
-            description: '[Open Application in Coolify]('.$this->resource_url.')',
+            description: "{$this->resource_name} has been stopped.\n\n[Open Application in Coolify]({$this->resource_url})",
```

Nothing else is touched: no new fields, no title change, no change to the other channels, and the
link text and destination are unchanged.

## Issues

- Fixes #11113

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No UI surface. The change is in the Discord webhook payload.

Before — embed description:

```
[Open Application in Coolify](https://coolify.example.com/project/.../application/...)
```

After — embed description:

```
my-application has been stopped.

[Open Application in Coolify](https://coolify.example.com/project/.../application/...)
```

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude (Claude Code)
- How extensively: Extensively. The omission was found by comparing every `toDiscord()`
  implementation under `app/Notifications/` against its sibling channels; the patch, the linked
  issue and this description were all AI-drafted and then checked against the source. The change
  is one line and I understand exactly what it does and why it matches `RestartLimitReached`.

## Testing

Being straight with you about what was and was not run, because the guidelines ask for it:

- ✅ Verified the defect in source at tag `v4.1.2`, on `v4.x` (`940571e`) and on `next`
  (`5c49dfa`) — identical in all three, so this is not a recent regression.
- ✅ Verified `$resource_name` is set unconditionally in the constructor
  (`data_get($resource, 'name')`) and is already used by `toMail`, `toTelegram`, `toPushover`,
  `toSlack` and `toWebhook`, so no new data is introduced and no new failure mode is possible.
- ✅ Verified the replacement string is a direct application of the existing convention in
  `RestartLimitReached::toDiscord()`, which interpolates the same property in the same position
  ahead of the same link.
- ✅ Reviewed the full diff: one line, one file, no unrelated edits.
- ❌ **Not run against a local development instance, and no test added.** The machine this was
  prepared on has no PHP, Composer or Docker, so `php artisan test`, `vendor/bin/pint` and a
  `spin up` environment were all unavailable. That is a limitation on my side, not something
  pre-existing in the branch.

If a regression test is wanted before this is considered, say so and I will add one — I just did
not want to submit a test I had not been able to execute. Equally, if an unverified one-line fix
is not acceptable regardless, close it and the linked issue still stands on its own as a report.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them. — **not checked**, see Testing above.
