### PR TITLE
fix(webhooks): match scp-style repository URLs with any SSH user

### DIFF
--- a/app/Http/Controllers/Webhook/Concerns/MatchesManualWebhookApplications.php
+++ b/app/Http/Controllers/Webhook/Concerns/MatchesManualWebhookApplications.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Webhook\Concerns;
 use App\Models\Application;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 
 trait MatchesManualWebhookApplications
 {
@@ -79,11 +78,15 @@ trait MatchesManualWebhookApplications
 
         if (is_array($parts) && isset($parts['scheme'])) {
             $path = data_get($parts, 'path');
-        } elseif (Str::startsWith($gitRepository, 'git@') && str_contains($gitRepository, ':')) {
-            $path = Str::after($gitRepository, ':');
-            // scp-style SSH URLs embed a custom port as "git@host:2222/owner/repo".
+        } elseif (preg_match('/\A[^@\/]+@[^@:\/]+:(?<path>.*)\z/', $gitRepository, $sshMatches) === 1) {
+            // scp-style SSH URLs are written as "<user>@host:owner/repo". The user is
+            // not always "git" — Gitea defaults to "gitea", and self-hosted setups may
+            // use anything else — so match on the shape instead of a fixed user,
+            // consistent with convertGitUrl() in shared.php.
+            $path = $sshMatches['path'];
+            // scp-style SSH URLs embed a custom port as "user@host:2222/owner/repo".
             // Strip the leading numeric port segment so the path matches the webhook
-            // payload's owner/repo, consistent with convertGitUrl() in shared.php.
+            // payload's owner/repo.
             $path = preg_replace('#^\d+/#', '', $path) ?? $path;
         } else {
             $path = $gitRepository;

--- a/tests/Feature/Webhook/WebhookHmacTest.php
+++ b/tests/Feature/Webhook/WebhookHmacTest.php
@@ -584,6 +584,102 @@ describe('Manual Webhook Repository Matching', function () {
         expect($response->getContent())->not->toContain('No applications found');
     });
 
+    test('gitea matches scp-style ssh repository URL with a non-default ssh user', function () {
+        $app = createApplicationWithWebhook(overrides: [
+            'git_repository' => 'gitea@git.example.com:test-org/test-repo.git',
+            'git_branch' => 'master',
+        ]);
+        $secret = $app->manual_webhook_secret_gitea;
+
+        $payload = json_encode([
+            'ref' => 'refs/heads/master',
+            'repository' => ['full_name' => 'test-org/test-repo'],
+            'after' => 'abc123',
+            'commits' => [],
+        ]);
+
+        $response = $this->call('POST', '/webhooks/source/gitea/events/manual', [], [], [], [
+            'HTTP_X-Gitea-Event' => 'push',
+            'HTTP_X-Hub-Signature-256' => 'sha256='.hash_hmac('sha256', $payload, $secret),
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+
+        $response->assertOk();
+        expect($response->getContent())->not->toContain('No applications found');
+    });
+
+    test('gitea matches scp-style ssh repository URL with a non-default ssh user and custom port', function () {
+        $app = createApplicationWithWebhook(overrides: [
+            'git_repository' => 'gitea@git.example.com:12345/test-org/test-repo.git',
+            'git_branch' => 'master',
+        ]);
+        $secret = $app->manual_webhook_secret_gitea;
+
+        $payload = json_encode([
+            'ref' => 'refs/heads/master',
+            'repository' => ['full_name' => 'test-org/test-repo'],
+            'after' => 'abc123',
+            'commits' => [],
+        ]);
+
+        $response = $this->call('POST', '/webhooks/source/gitea/events/manual', [], [], [], [
+            'HTTP_X-Gitea-Event' => 'push',
+            'HTTP_X-Hub-Signature-256' => 'sha256='.hash_hmac('sha256', $payload, $secret),
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+
+        $response->assertOk();
+        expect($response->getContent())->not->toContain('No applications found');
+    });
+
+    test('gitea matches explicit ssh:// repository URL with a non-default user and custom port', function () {
+        $app = createApplicationWithWebhook(overrides: [
+            'git_repository' => 'ssh://gitea@git.example.com:12345/test-org/test-repo.git',
+            'git_branch' => 'master',
+        ]);
+        $secret = $app->manual_webhook_secret_gitea;
+
+        $payload = json_encode([
+            'ref' => 'refs/heads/master',
+            'repository' => ['full_name' => 'test-org/test-repo'],
+            'after' => 'abc123',
+            'commits' => [],
+        ]);
+
+        $response = $this->call('POST', '/webhooks/source/gitea/events/manual', [], [], [], [
+            'HTTP_X-Gitea-Event' => 'push',
+            'HTTP_X-Hub-Signature-256' => 'sha256='.hash_hmac('sha256', $payload, $secret),
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+
+        $response->assertOk();
+        expect($response->getContent())->not->toContain('No applications found');
+    });
+
+    test('does not match a repository whose path differs only by the ssh user', function () {
+        $app = createApplicationWithWebhook(overrides: [
+            'git_repository' => 'gitea@git.example.com:test-org/other-repo.git',
+            'git_branch' => 'master',
+        ]);
+        $secret = $app->manual_webhook_secret_gitea;
+
+        $payload = json_encode([
+            'ref' => 'refs/heads/master',
+            'repository' => ['full_name' => 'test-org/test-repo'],
+            'after' => 'abc123',
+            'commits' => [],
+        ]);
+
+        $response = $this->call('POST', '/webhooks/source/gitea/events/manual', [], [], [], [
+            'HTTP_X-Gitea-Event' => 'push',
+            'HTTP_X-Hub-Signature-256' => 'sha256='.hash_hmac('sha256', $payload, $secret),
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+
+        $response->assertOk();
+        expect($response->getContent())->toContain('No applications found');
+    });
+
     test('github matches repository case-insensitively', function () {
         $app = createApplicationWithWebhook(overrides: [
             'git_repository' => 'https://github.com/Test-Org/Test-Repo.git',


### PR DESCRIPTION
Fixes #11120

## Problem

Manual Gitea webhooks fail with `Nothing to do. No applications found with deploy key set, branch is '...' and Git Repository name has ...`, while manual deployments of the very same application work fine.

## Root cause

`canonicalManualWebhookRepository()` in `MatchesManualWebhookApplications` only recognised the scp-style SSH form when the URL started with the literal `git@`:

```php
} elseif (Str::startsWith($gitRepository, 'git@') && str_contains($gitRepository, ':')) {
```

Gitea defaults to a `gitea@` SSH user, and self-hosted setups may use anything else. A repository stored as `gitea@git.example.com:my-org/my-repo.git` therefore fell through to the raw-path branch and was compared verbatim against the webhook payload's `full_name` (`my-org/my-repo`) — which can never match.

This also explains why manual deployments kept working: `convertGitUrl()` in `bootstrap/helpers/shared.php` detects SSH URLs by *shape* (`/((.*?)\:\/\/)?(.*@.*:.*)/`) rather than by a fixed user. The webhook trait was stricter than the deploy path, so Coolify could clone a repository it could no longer find on push.

## Note on the hypotheses in the issue

The issue suspected `ssh://` URLs, custom SSH ports and the `.git` suffix. I verified each of these against the current code, and none of them is the trigger:

- `ssh://gitea@host:12345/org/repo.git` was **already handled correctly** by the `parse_url()` branch (a scheme is present, so `path` is used). A regression test now covers it.
- Custom ports in scp-style URLs were already stripped by the existing `^\d+/` replacement.
- The `.git` suffix was already removed by `normalizeManualWebhookRepositoryPath()`.

The sole trigger is the non-default SSH user.

## Fix

Match on the `<user>@host:path` shape instead of a hardcoded `git@`, consistent with `convertGitUrl()`:

```php
} elseif (preg_match('/\A[^@\/]+@[^@:\/]+:(?<path>.*)\z/', $gitRepository, $sshMatches) === 1) {
```

The port handling is unchanged. The now-unused `Str` import was dropped.

The pattern stays deliberately narrow — it requires exactly one `@`, no slash before it and no slash or colon in the host — so plain `owner/repo` values and URLs carrying a scheme still take their own branches, and `a@b@c.com:x/y` is rejected.

## Tests

Four tests added to `tests/Feature/Webhook/WebhookHmacTest.php`:

- `gitea@host:org/repo.git` (scp-style, non-default user) — **failed before, passes now**
- `gitea@host:12345/org/repo.git` (scp-style, non-default user + custom port) — **failed before, passes now**
- `ssh://gitea@host:12345/org/repo.git` (explicit scheme) — passed before, added as a regression guard
- a negative test asserting that a *different* repository under the same SSH user still does **not** match, so the loosened pattern does not over-match

All 33 tests in `tests/Feature/Webhook/WebhookHmacTest.php` pass.

Note: two pre-existing `QueryException` failures in `tests/Feature/Helpers/ConvertingGitUrlsTest.php` are unrelated to this change — I confirmed they fail identically on an unmodified checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
