### PR TITLE
fix(webhooks): match scp-style repository URLs with any SSH user

### DIFF
--- a/app/Http/Controllers/Webhook/Concerns/MatchesManualWebhookApplications.php
+++ b/app/Http/Controllers/Webhook/Concerns/MatchesManualWebhookApplications.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Webhook\Concerns;
 use App\Models\Application;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 
 trait MatchesManualWebhookApplications
 {
@@ -79,11 +78,15 @@ trait MatchesManualWebhookApplications
 
         if (is_array($parts) && isset($parts['scheme'])) {
             $path = data_get($parts, 'path');
-        } elseif (Str::startsWith($gitRepository, 'git@') && str_contains($gitRepository, ':')) {
-            $path = Str::after($gitRepository, ':');
-            // scp-style SSH URLs embed a custom port as "git@host:2222/owner/repo".
+        } elseif (preg_match('/\A[^@\/]+@[^@:\/]+:(?<path>.*)\z/', $gitRepository, $sshMatches) === 1) {
+            // scp-style SSH URLs are written as "<user>@host:owner/repo". The user is
+            // not always "git" — Gitea defaults to "gitea", and self-hosted setups may
+            // use anything else — so match on the shape instead of a fixed user,
+            // consistent with convertGitUrl() in shared.php.
+            $path = $sshMatches['path'];
+            // scp-style SSH URLs embed a custom port as "user@host:2222/owner/repo".
             // Strip the leading numeric port segment so the path matches the webhook
-            // payload's owner/repo, consistent with convertGitUrl() in shared.php.
+            // payload's owner/repo.
             $path = preg_replace('#^\d+/#', '', $path) ?? $path;
         } else {
             $path = $gitRepository;

--- a/tests/Feature/Webhook/WebhookHmacTest.php
+++ b/tests/Feature/Webhook/WebhookHmacTest.php
@@ -584,6 +584,102 @@ describe('Manual Webhook Repository Matching', function () {
         expect($response->getContent())->not->toContain('No applications found');
     });
 
+    test('gitea matches scp-style ssh repository URL with a non-default ssh user', function () {
+        $app = createApplicationWithWebhook(overrides: [
+            'git_repository' => 'gitea@git.example.com:test-org/test-repo.git',
+            'git_branch' => 'master',
+        ]);
+        $secret = $app->manual_webhook_secret_gitea;
+
+        $payload = json_encode([
+            'ref' => 'refs/heads/master',
+            'repository' => ['full_name' => 'test-org/test-repo'],
+            'after' => 'abc123',
+            'commits' => [],
+        ]);
+
+        $response = $this->call('POST', '/webhooks/source/gitea/events/manual', [], [], [], [
+            'HTTP_X-Gitea-Event' => 'push',
+            'HTTP_X-Hub-Signature-256' => 'sha256='.hash_hmac('sha256', $payload, $secret),
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+
+        $response->assertOk();
+        expect($response->getContent())->not->toContain('No applications found');
+    });
+
+    test('gitea matches scp-style ssh repository URL with a non-default ssh user and custom port', function () {
+        $app = createApplicationWithWebhook(overrides: [
+            'git_repository' => 'gitea@git.example.com:12345/test-org/test-repo.git',
+            'git_branch' => 'master',
+        ]);
+        $secret = $app->manual_webhook_secret_gitea;
+
+        $payload = json_encode([
+            'ref' => 'refs/heads/master',
+            'repository' => ['full_name' => 'test-org/test-repo'],
+            'after' => 'abc123',
+            'commits' => [],
+        ]);
+
+        $response = $this->call('POST', '/webhooks/source/gitea/events/manual', [], [], [], [
+            'HTTP_X-Gitea-Event' => 'push',
+            'HTTP_X-Hub-Signature-256' => 'sha256='.hash_hmac('sha256', $payload, $secret),
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+
+        $response->assertOk();
+        expect($response->getContent())->not->toContain('No applications found');
+    });
+
+    test('gitea matches explicit ssh:// repository URL with a non-default user and custom port', function () {
+        $app = createApplicationWithWebhook(overrides: [
+            'git_repository' => 'ssh://gitea@git.example.com:12345/test-org/test-repo.git',
+            'git_branch' => 'master',
+        ]);
+        $secret = $app->manual_webhook_secret_gitea;
+
+        $payload = json_encode([
+            'ref' => 'refs/heads/master',
+            'repository' => ['full_name' => 'test-org/test-repo'],
+            'after' => 'abc123',
+            'commits' => [],
+        ]);
+
+        $response = $this->call('POST', '/webhooks/source/gitea/events/manual', [], [], [], [
+            'HTTP_X-Gitea-Event' => 'push',
+            'HTTP_X-Hub-Signature-256' => 'sha256='.hash_hmac('sha256', $payload, $secret),
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+
+        $response->assertOk();
+        expect($response->getContent())->not->toContain('No applications found');
+    });
+
+    test('does not match a repository whose path differs only by the ssh user', function () {
+        $app = createApplicationWithWebhook(overrides: [
+            'git_repository' => 'gitea@git.example.com:test-org/other-repo.git',
+            'git_branch' => 'master',
+        ]);
+        $secret = $app->manual_webhook_secret_gitea;
+
+        $payload = json_encode([
+            'ref' => 'refs/heads/master',
+            'repository' => ['full_name' => 'test-org/test-repo'],
+            'after' => 'abc123',
+            'commits' => [],
+        ]);
+
+        $response = $this->call('POST', '/webhooks/source/gitea/events/manual', [], [], [], [
+            'HTTP_X-Gitea-Event' => 'push',
+            'HTTP_X-Hub-Signature-256' => 'sha256='.hash_hmac('sha256', $payload, $secret),
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+
+        $response->assertOk();
+        expect($response->getContent())->toContain('No applications found');
+    });
+
     test('github matches repository case-insensitively', function () {
         $app = createApplicationWithWebhook(overrides: [
             'git_repository' => 'https://github.com/Test-Org/Test-Repo.git',


### PR DESCRIPTION
## Changes

Fixes an issue where webhooks failed for Gitea (or other Git providers) when using non-standard SSH users (like gitea@domain.com instead of git@domain.com), resulting in the dreaded "Nothing to do" message.

**What was happening?**

- Manual deployments worked fine because convertGitUrl() accepts any SSH user.
- However, the webhook path had a stricter check hardcoded specifically to git@....
- When Gitea sent a payload with gitea@..., Coolify couldn't match the repo to an existing app and skipped the deployment.

(Note: I originally thought this was related to custom ports, ssh:// prefixes, or .git suffixes, but after debugging it boiled down to just the hardcoded SSH user prefix.)

**What changed?**

- Updated the regex / string matching in the webhook payload handler to match the general user@host:path structure instead of enforcing git@. Now webhooks and manual deployments share the same matching expectations.

## Issues

- Fixes #11120

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Root cause analysis, the fix and the tests. Reviewed by me.

## Testing

- Set up a Gitea repository with a custom SSH user (e.g. gitea@...).
- Trigger a push webhook.
- Coolify should now correctly find the corresponding app and start the build instead of dropping it with "Nothing to do".

Verified on a local instance with a real signed webhook: before the fix "Nothing to do...", after it the app is found and the deploy starts. A wrong repo or branch is still rejected.

Four tests added to WebhookHmacTest, including a negative one. All 33 pass.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
