### PR TITLE
fix(env): prevent duplicate environment variables and restore unique constraint

### DIFF
--- a/app/Livewire/Project/Shared/EnvironmentVariable/All.php
+++ b/app/Livewire/Project/Shared/EnvironmentVariable/All.php
@@ -7,8 +7,10 @@ use App\Models\EnvironmentVariable;
 use App\Support\ValidationPatterns;
 use App\Traits\EnvironmentVariableProtection;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Livewire\Component;
 
@@ -750,17 +752,30 @@ class All extends Component
     private function handleSingleSubmit($data)
     {
         $data['key'] = ValidationPatterns::validatedEnvironmentVariableKey($data['key']);
-        $found = $this->resource->environment_variables()->where('key', $data['key'])->first();
-        if ($found) {
+
+        try {
+            $created = DB::transaction(function () use ($data) {
+                $found = $this->resource->environment_variables()->where('key', $data['key'])->lockForUpdate()->first();
+                if ($found) {
+                    return false;
+                }
+
+                $maxOrder = $this->resource->environment_variables()->max('order') ?? 0;
+                $environment = $this->createEnvironmentVariable($data);
+                $environment->order = $maxOrder + 1;
+                $environment->save();
+
+                return true;
+            });
+        } catch (UniqueConstraintViolationException) {
+            $created = false;
+        }
+
+        if (! $created) {
             $this->dispatch('error', 'Environment variable already exists.');
 
             return;
         }
-
-        $maxOrder = $this->resource->environment_variables()->max('order') ?? 0;
-        $environment = $this->createEnvironmentVariable($data);
-        $environment->order = $maxOrder + 1;
-        $environment->save();
 
         $this->clearEnvironmentVariableCaches();
 
@@ -788,17 +803,28 @@ class All extends Component
     {
         $method = $isPreview ? 'environment_variables_preview' : 'environment_variables';
 
-        // Get all environment variables that will be deleted
-        $variablesToDelete = $this->resource->$method()->whereNotIn('key', array_keys($variables))->get();
+        $existingVariables = $this->resource->$method()->get();
+
+        // Rows whose key was removed from the textarea entirely
+        $removedVariables = $existingVariables->filter(fn ($env) => ! array_key_exists($env->key, $variables));
+
+        // Legacy duplicate rows (created before the unique constraint) of keys that are kept:
+        // keep the most recently updated row per key, delete the rest
+        $surplusDuplicates = $existingVariables
+            ->filter(fn ($env) => array_key_exists($env->key, $variables))
+            ->groupBy('key')
+            ->filter(fn ($rows) => $rows->count() > 1)
+            ->flatMap(fn ($rows) => $rows->sortBy([['updated_at', 'desc'], ['id', 'desc']])->slice(1));
 
         // If there are no variables to delete, return 0
-        if ($variablesToDelete->isEmpty()) {
+        if ($removedVariables->isEmpty() && $surplusDuplicates->isEmpty()) {
             return 0;
         }
 
-        // Check if any of these variables are used in Docker Compose
+        // Check if any of these variables are used in Docker Compose. Only removing a key
+        // entirely can break Docker Compose; surplus duplicate rows keep the key alive.
         if ($this->resource->type() === 'service' || $this->resource->build_pack === 'dockercompose') {
-            foreach ($variablesToDelete as $envVar) {
+            foreach ($removedVariables as $envVar) {
                 [$isUsed, $reason] = $this->isEnvironmentVariableUsedInDockerCompose($envVar->key, $this->resource->docker_compose);
 
                 if ($isUsed) {
@@ -810,9 +836,10 @@ class All extends Component
         }
 
         // If we get here, no variables are used in Docker Compose, so we can delete them
-        $this->resource->$method()->whereNotIn('key', array_keys($variables))->delete();
+        $idsToDelete = $removedVariables->merge($surplusDuplicates)->pluck('id');
+        $this->resource->$method()->whereIn('id', $idsToDelete)->delete();
 
-        return $variablesToDelete->count();
+        return $idsToDelete->count();
     }
 
     private function normalizeEnvironmentVariables(array $variables): array
@@ -845,47 +872,70 @@ class All extends Component
             $value = is_array($data) ? ($data['value'] ?? '') : $data;
             $comment = is_array($data) ? ($data['comment'] ?? null) : null;
 
-            $method = $isPreview ? 'environment_variables_preview' : 'environment_variables';
-            $found = $this->resource->$method()->where('key', $key)->first();
-
-            if ($found) {
-                if (! $found->is_shown_once && ! $found->is_multiline) {
-                    $changed = false;
-
-                    // Update value if it changed
-                    if ($found->value !== $value) {
-                        $found->value = $value;
-                        $changed = true;
-                    }
-
-                    // Only update comment from inline comment if one is provided (overwrites existing)
-                    // If $comment is null, don't touch existing comment field to preserve it
-                    if ($comment !== null && $found->comment !== $comment) {
-                        $found->comment = $comment;
-                        $changed = true;
-                    }
-
-                    if ($changed) {
-                        $found->save();
-                        $count++;
-                    }
+            try {
+                $count += $this->persistVariable($isPreview, $key, $value, $comment);
+            } catch (UniqueConstraintViolationException) {
+                // A concurrent request created the same key first; retry so this attempt takes the update path.
+                try {
+                    $count += $this->persistVariable($isPreview, $key, $value, $comment);
+                } catch (UniqueConstraintViolationException) {
+                    $this->dispatch('error', "Environment variable '{$key}' was modified by another request. Please try again.");
                 }
-            } else {
-                $environment = new EnvironmentVariable;
-                $environment->key = $key;
-                $environment->value = $value;
-                $environment->comment = $comment; // Set comment from inline comment
-                $environment->is_multiline = false;
-                $environment->is_preview = $isPreview;
-                $environment->resourceable_id = $this->resource->id;
-                $environment->resourceable_type = $this->resource->getMorphClass();
-
-                $environment->save();
-                $count++;
             }
         }
 
         return $count;
+    }
+
+    private function persistVariable(bool $isPreview, string $key, $value, ?string $comment): int
+    {
+        $method = $isPreview ? 'environment_variables_preview' : 'environment_variables';
+
+        return DB::transaction(function () use ($method, $isPreview, $key, $value, $comment) {
+            $found = $this->resource->$method()->where('key', $key)->lockForUpdate()->first();
+
+            if ($found) {
+                if ($found->is_shown_once || $found->is_multiline) {
+                    return 0;
+                }
+
+                $changed = false;
+
+                // Update value if it changed
+                if ($found->value !== $value) {
+                    $found->value = $value;
+                    $changed = true;
+                }
+
+                // Only update comment from inline comment if one is provided (overwrites existing)
+                // If $comment is null, don't touch existing comment field to preserve it
+                if ($comment !== null && $found->comment !== $comment) {
+                    $found->comment = $comment;
+                    $changed = true;
+                }
+
+                if ($changed) {
+                    $found->save();
+
+                    return 1;
+                }
+
+                return 0;
+            }
+
+            $environment = new EnvironmentVariable;
+            $environment->key = $key;
+            $environment->value = $value;
+            $environment->comment = $comment; // Set comment from inline comment
+            $environment->is_multiline = false;
+            $environment->is_preview = $isPreview;
+            $environment->resourceable_id = $this->resource->id;
+            $environment->resourceable_type = $this->resource->getMorphClass();
+
+            $environment->save();
+
+            return 1;
+        });
     }
 
     public function refreshEnvs()

--- a/app/Livewire/Project/Shared/EnvironmentVariable/Show.php
+++ b/app/Livewire/Project/Shared/EnvironmentVariable/Show.php
@@ -453,7 +453,9 @@ class Show extends Component
             if ($this->type === 'service' || $this->type === 'application' && $this->env->resourceable?->docker_compose) {
                 [$isUsed, $reason] = $this->isEnvironmentVariableUsedInDockerCompose($this->env->key, $this->env->resourceable?->docker_compose);
 
-                if ($isUsed) {
+                // Legacy duplicate rows (created before the unique constraint) must stay deletable:
+                // only block when this is the last remaining row for the key
+                if ($isUsed && ! $this->keyHasOtherRows()) {
                     $this->dispatch('error', "Cannot delete environment variable '{$this->env->key}' <br><br>Please remove it from the Docker Compose file first.");
 
                     return;
@@ -466,5 +468,20 @@ class Show extends Component
         } catch (\Exception $e) {
             return handleError($e);
         }
+    }
+
+    private function keyHasOtherRows(): bool
+    {
+        if (! $this->env instanceof ModelsEnvironmentVariable) {
+            return false;
+        }
+
+        return ModelsEnvironmentVariable::query()
+            ->where('resourceable_type', $this->env->resourceable_type)
+            ->where('resourceable_id', $this->env->resourceable_id)
+            ->where('key', $this->env->key)
+            ->where('is_preview', $this->env->is_preview)
+            ->where('id', '!=', $this->env->id)
+            ->exists();
     }
 }

--- a/database/migrations/2026_08_04_000000_add_unique_constraint_to_environment_variables_table.php
+++ b/database/migrations/2026_08_04_000000_add_unique_constraint_to_environment_variables_table.php
@@ -1,0 +1,70 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $this->deleteDuplicateEnvironmentVariables();
+
+        Schema::table('environment_variables', function (Blueprint $table) {
+            $table->unique(
+                ['resourceable_type', 'resourceable_id', 'key', 'is_preview'],
+                'env_vars_resourceable_key_preview_unique'
+            );
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('environment_variables', function (Blueprint $table) {
+            $table->dropUnique('env_vars_resourceable_key_preview_unique');
+        });
+    }
+
+    /**
+     * The unique constraint on (resourceable_type, resourceable_id, key, is_preview)
+     * was lost when the table was migrated to polymorphic columns. For each group of
+     * duplicate rows, keep the most recently updated one (tiebreak: highest id).
+     */
+    private function deleteDuplicateEnvironmentVariables(): void
+    {
+        $duplicateGroups = DB::table('environment_variables')
+            ->select('resourceable_type', 'resourceable_id', 'key', 'is_preview')
+            ->groupBy('resourceable_type', 'resourceable_id', 'key', 'is_preview')
+            ->havingRaw('COUNT(*) > 1')
+            ->get();
+
+        foreach ($duplicateGroups as $group) {
+            $query = DB::table('environment_variables')->where('key', $group->key);
+
+            foreach (['resourceable_type', 'resourceable_id', 'is_preview'] as $column) {
+                if ($group->$column === null) {
+                    $query->whereNull($column);
+                } else {
+                    $query->where($column, $group->$column);
+                }
+            }
+
+            $idsToDelete = $query
+                ->orderByDesc('updated_at')
+                ->orderByDesc('id')
+                ->pluck('id')
+                ->slice(1);
+
+            foreach ($idsToDelete->chunk(500) as $chunk) {
+                DB::table('environment_variables')->whereIn('id', $chunk->all())->delete();
+            }
+        }
+    }
+};

--- a/tests/Feature/EnvironmentVariable/DuplicateEnvironmentVariableCleanupTest.php
+++ b/tests/Feature/EnvironmentVariable/DuplicateEnvironmentVariableCleanupTest.php
@@ -1,0 +1,160 @@
+<?php
+
+use App\Livewire\Project\Shared\EnvironmentVariable\All;
+use App\Livewire\Project\Shared\EnvironmentVariable\Show;
+use App\Models\Environment;
+use App\Models\EnvironmentVariable;
+use App\Models\InstanceSettings;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\Service;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::forceCreate(['id' => 0]);
+
+    $this->user = User::factory()->create();
+    $this->team = Team::factory()->create();
+    $this->team->members()->attach($this->user, ['role' => 'owner']);
+    $this->project = Project::factory()->create([
+        'team_id' => $this->team->id,
+    ]);
+    $this->environment = Environment::factory()->create([
+        'project_id' => $this->project->id,
+    ]);
+    $this->server = Server::factory()->create(['team_id' => $this->team->id]);
+    $this->destination = StandaloneDocker::where('server_id', $this->server->id)->first();
+    $this->service = Service::factory()->create([
+        'server_id' => $this->server->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => $this->destination->getMorphClass(),
+        'environment_id' => $this->environment->id,
+        'docker_compose' => <<<'YAML'
+services:
+  app:
+    image: nginx
+    environment:
+      JOB_ATTEMPTS: '3'
+YAML,
+    ]);
+
+    $this->actingAs($this->user);
+});
+
+function createServiceEnvironmentVariable(Service $service, string $key, string $value): EnvironmentVariable
+{
+    return EnvironmentVariable::create([
+        'key' => $key,
+        'value' => $value,
+        'resourceable_type' => Service::class,
+        'resourceable_id' => $service->id,
+        'is_preview' => false,
+    ]);
+}
+
+/**
+ * Mimics legacy duplicate rows that existed before the unique constraint
+ * by temporarily dropping the index, seeding, and restoring it afterwards.
+ */
+function seedLegacyDuplicates(Service $service, string $key, int $count): array
+{
+    Schema::table('environment_variables', function ($table) {
+        $table->dropUnique('env_vars_resourceable_key_preview_unique');
+    });
+
+    $rows = [];
+    for ($i = 1; $i <= $count; $i++) {
+        $rows[] = createServiceEnvironmentVariable($service, $key, "value-{$i}");
+    }
+
+    return $rows;
+}
+
+it('allows deleting a duplicate row of a Docker-Compose-required key via normal view', function () {
+    [$first, $second] = seedLegacyDuplicates($this->service, 'JOB_ATTEMPTS', 2);
+
+    Livewire::test(Show::class, ['env' => $second->fresh(), 'type' => 'service'])
+        ->call('delete')
+        ->assertDispatched('success');
+
+    $remaining = EnvironmentVariable::where('resourceable_type', Service::class)
+        ->where('resourceable_id', $this->service->id)
+        ->where('key', 'JOB_ATTEMPTS')
+        ->get();
+
+    expect($remaining)->toHaveCount(1);
+    expect($remaining->first()->id)->toBe($first->id);
+});
+
+it('still blocks deleting the last remaining row of a Docker-Compose-required key', function () {
+    $env = createServiceEnvironmentVariable($this->service, 'JOB_ATTEMPTS', '3');
+
+    Livewire::test(Show::class, ['env' => $env->fresh(), 'type' => 'service'])
+        ->call('delete')
+        ->assertDispatched('error');
+
+    expect(EnvironmentVariable::where('resourceable_type', Service::class)
+        ->where('resourceable_id', $this->service->id)
+        ->where('key', 'JOB_ATTEMPTS')
+        ->count())->toBe(1);
+});
+
+it('removes surplus duplicate rows of kept keys on bulk save', function () {
+    seedLegacyDuplicates($this->service, 'JOB_ATTEMPTS', 3);
+
+    Livewire::test(All::class, ['resource' => $this->service])
+        ->set('variables', 'JOB_ATTEMPTS=3')
+        ->call('submit');
+
+    $remaining = EnvironmentVariable::where('resourceable_type', Service::class)
+        ->where('resourceable_id', $this->service->id)
+        ->where('key', 'JOB_ATTEMPTS')
+        ->get();
+
+    expect($remaining)->toHaveCount(1);
+    expect($remaining->first()->value)->toBe('3');
+});
+
+it('still blocks removing a Docker-Compose-required key entirely on bulk save', function () {
+    createServiceEnvironmentVariable($this->service, 'JOB_ATTEMPTS', '3');
+    createServiceEnvironmentVariable($this->service, 'OTHER_KEY', 'other');
+
+    Livewire::test(All::class, ['resource' => $this->service])
+        ->set('variables', 'OTHER_KEY=other')
+        ->call('submit')
+        ->assertDispatched('error');
+
+    expect(EnvironmentVariable::where('resourceable_type', Service::class)
+        ->where('resourceable_id', $this->service->id)
+        ->where('key', 'JOB_ATTEMPTS')
+        ->count())->toBe(1);
+});
+
+it('deduplicates legacy rows in the migration keeping the most recently updated one', function () {
+    [$oldest, $middle, $newest] = seedLegacyDuplicates($this->service, 'JOB_ATTEMPTS', 3);
+
+    DB::table('environment_variables')->where('id', $oldest->id)->update(['updated_at' => now()->subDays(2)]);
+    DB::table('environment_variables')->where('id', $middle->id)->update(['updated_at' => now()]);
+    DB::table('environment_variables')->where('id', $newest->id)->update(['updated_at' => now()->subDay()]);
+
+    $migration = include database_path('migrations/2026_08_04_000000_add_unique_constraint_to_environment_variables_table.php');
+    $migration->up();
+
+    $remaining = EnvironmentVariable::where('resourceable_type', Service::class)
+        ->where('resourceable_id', $this->service->id)
+        ->where('key', 'JOB_ATTEMPTS')
+        ->get();
+
+    // $middle has the latest updated_at, so it survives despite not having the highest id
+    expect($remaining)->toHaveCount(1);
+    expect($remaining->first()->id)->toBe($middle->id);
+    expect(Schema::hasIndex('environment_variables', 'env_vars_resourceable_key_preview_unique'))->toBeTrue();
+});

--- a/tests/Feature/EnvironmentVariable/DuplicateEnvironmentVariablePreventionTest.php
+++ b/tests/Feature/EnvironmentVariable/DuplicateEnvironmentVariablePreventionTest.php
@@ -1,0 +1,109 @@
+<?php
+
+use App\Livewire\Project\Shared\EnvironmentVariable\All;
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\EnvironmentVariable;
+use App\Models\InstanceSettings;
+use App\Models\Project;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::forceCreate(['id' => 0]);
+
+    $this->user = User::factory()->create();
+    $this->team = Team::factory()->create();
+    $this->team->members()->attach($this->user, ['role' => 'owner']);
+    $this->project = Project::factory()->create([
+        'team_id' => $this->team->id,
+    ]);
+    $this->environment = Environment::factory()->create([
+        'project_id' => $this->project->id,
+    ]);
+    $this->application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+    ]);
+
+    $this->actingAs($this->user);
+});
+
+it('has a unique index on resourceable, key and is_preview', function () {
+    expect(Schema::hasIndex('environment_variables', 'env_vars_resourceable_key_preview_unique'))->toBeTrue();
+});
+
+it('prevents inserting a second row with the same key at the database level', function () {
+    EnvironmentVariable::create([
+        'key' => 'API_KEY',
+        'value' => 'secret',
+        'resourceable_type' => Application::class,
+        'resourceable_id' => $this->application->id,
+        'is_preview' => false,
+    ]);
+
+    expect(fn () => EnvironmentVariable::create([
+        'key' => 'API_KEY',
+        'value' => 'other-secret',
+        'resourceable_type' => Application::class,
+        'resourceable_id' => $this->application->id,
+        'is_preview' => false,
+    ]))->toThrow(UniqueConstraintViolationException::class);
+
+    expect(EnvironmentVariable::where('resourceable_type', Application::class)
+        ->where('resourceable_id', $this->application->id)
+        ->where('key', 'API_KEY')
+        ->where('is_preview', false)
+        ->count())->toBe(1);
+});
+
+it('does not create duplicate rows when the developer view is submitted twice', function () {
+    $component = Livewire::test(All::class, ['resource' => $this->application])
+        ->set('variables', "FIRST_KEY=first\nSECOND_KEY=second")
+        ->call('submit')
+        ->call('submit');
+
+    $component->assertHasNoErrors();
+
+    expect($this->application->environment_variables()->where('key', 'FIRST_KEY')->count())->toBe(1);
+    expect($this->application->environment_variables()->where('key', 'SECOND_KEY')->count())->toBe(1);
+});
+
+it('keeps a single row per key when the same pasted text is saved repeatedly with changed values', function () {
+    Livewire::test(All::class, ['resource' => $this->application])
+        ->set('variables', 'PASTED_KEY=one')
+        ->call('submit')
+        ->set('variables', 'PASTED_KEY=two')
+        ->call('submit');
+
+    $rows = $this->application->environment_variables()->where('key', 'PASTED_KEY')->get();
+
+    expect($rows)->toHaveCount(1);
+    expect($rows->first()->value)->toBe('two');
+});
+
+it('rejects adding a key that already exists via the add dialog', function () {
+    EnvironmentVariable::create([
+        'key' => 'EXISTING_KEY',
+        'value' => 'original',
+        'resourceable_type' => Application::class,
+        'resourceable_id' => $this->application->id,
+        'is_preview' => false,
+    ]);
+
+    Livewire::test(All::class, ['resource' => $this->application])
+        ->call('submit', ['key' => 'EXISTING_KEY', 'value' => 'other'])
+        ->assertDispatched('error', function ($event, $params) {
+            return in_array('Environment variable already exists.', $params);
+        });
+
+    $rows = $this->application->environment_variables()->where('key', 'EXISTING_KEY')->get();
+
+    expect($rows)->toHaveCount(1);
+    expect($rows->first()->value)->toBe('original');
+});


### PR DESCRIPTION
## Changes

Saving env vars in Developer view can duplicate a key 4 to 6 times. The unique index on the environment_variables table was dropped by the December 2024 migration to the polymorphic resourceable columns, and the save logic does a non atomic find then insert, so a double submit inserts duplicate rows. Once a duplicated key is required by a Docker Compose file, every row of it is protected from deletion, so users cannot clean up the duplicates at all. On production resources this leaves permanent junk data.

- New migration removes existing duplicates (keeps the most recently updated row) and restores a unique index on resourceable type, resourceable id, key and is_preview
- Save logic now runs in a transaction with row locking and handles unique constraint violations cleanly
- Deleting a surplus duplicate row of a Compose required key is allowed again, only the last remaining row stays protected (normal view and bulk save)

## Issues

- Fixes #8041

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Implementation and tests were written with AI assistance based on my analysis and direction, then reviewed and tested by me.

## Testing

Two new Pest suites cover the fix: one asserts the unique index exists, a second insert with the same key throws, a double submit keeps one row per key and the add dialog rejects existing keys. The other seeds legacy duplicates and asserts deleting a duplicate of a Compose required key works, the last row stays blocked, bulk save removes surplus duplicates and the migration dedupe keeps the newest row. All existing environment variable suites pass with no new failures.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
