### PR TITLE
feat(templates): add MyNeS - My Network Scanner

### DIFF
--- a/public/svgs/mynes.svg
+++ b/public/svgs/mynes.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="7" fill="#2049e0"/>
+  <g fill="#ffffff">
+    <rect x="12" y="4"  width="8" height="7" rx="2"/>
+    <rect x="3"  y="21" width="8" height="7" rx="2"/>
+    <rect x="21" y="21" width="8" height="7" rx="2"/>
+    <rect x="15" y="11" width="2" height="4"/>
+    <rect x="6"  y="15" width="20" height="2" rx="1"/>
+    <rect x="6"  y="15" width="2" height="7"/>
+    <rect x="24" y="15" width="2" height="7"/>
+  </g>
+</svg>

--- a/templates/compose/mynes.yaml
+++ b/templates/compose/mynes.yaml
@@ -1,0 +1,34 @@
+# documentation: https://github.com/fxerkan/my_network_scanner#readme
+# slogan: See every device on your home network - including the Zigbee, Z-Wave, Matter and Bluetooth LE ones an IP scan cannot find.
+# category: monitoring
+# tags: network, scanner, monitoring, homelab, home-assistant, iot, mdns, matter, zigbee, zwave, discovery
+# logo: svgs/mynes.svg
+# port: 5883
+
+# MyNeS runs on the host network. Raw ARP frames and mDNS/SSDP multicast do not cross a bridge
+# network, so from a bridge the scanner would see the Docker bridge instead of the LAN. That also
+# means the proxy cannot route to it by container name: the UI is served directly on host port
+# 5883. Put it behind a domain by pointing a reverse proxy at <host>:5883 if you need one.
+services:
+  mynes:
+    image: fxerkan/my_network_scanner:1.3.0
+    network_mode: host
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    environment:
+      - MYNES_PORT=5883
+      # All optional - MyNeS scans with zero configuration and these can also be set in its UI.
+      - MYNES_PASSWORD=${SERVICE_PASSWORD_MYNES}
+      - MYNES_MQTT_HOST=${MYNES_MQTT_HOST:-}
+      - MYNES_HA_URL=${MYNES_HA_URL:-}
+      - MYNES_HA_TOKEN=${MYNES_HA_TOKEN:-}
+    volumes:
+      - mynes-data:/app/data
+      - mynes-config:/app/config
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5883/api/version"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s


### PR DESCRIPTION
Adds a service template for **MyNeS (My Network Scanner)** — a self-hosted LAN scanner and device inventory.

- Source: https://github.com/fxerkan/my_network_scanner (MIT)
- Image: https://hub.docker.com/r/fxerkan/my_network_scanner — `linux/amd64` + `linux/arm64`, pinned to `1.3.0`

It discovers devices over ARP, mDNS/Bonjour, SSDP/UPnP, Matter, Bluetooth LE **and MQTT**. Reading retained Zigbee2MQTT / Z-Wave JS / Tasmota topics is the only way to inventory a radio device that has no IP address at all, so Zigbee bulbs and Z-Wave sensors end up in the same list as your servers.

## Please read this bit before merging

**The template uses `network_mode: host`, so the proxy cannot route to it by container name.**

That is not an oversight. Raw ARP frames and mDNS/SSDP multicast do not cross a bridge network — from a bridge the scanner sees the Docker bridge instead of the LAN, which makes the app pointless. So there is no `SERVICE_FQDN_*` variable here: the UI is served directly on host port 5883, and the header comment says so explicitly rather than generating a domain that would not resolve to anything.

If you would rather not carry a template that opts out of the proxy, I completely understand — say so and I will close it.

The container asks for `NET_ADMIN` + `NET_RAW` but is **not** privileged and runs as uid 1000, not root. Without those capabilities it degrades to a ping sweep rather than failing.

## Files

- `templates/compose/mynes.yaml`
- `public/svgs/mynes.svg`

Metadata header comments: `documentation`, `slogan`, `category: monitoring`, `tags`, `logo`, `port`.