### PR TITLE
feat(templates): add MyNeS - My Network Scanner

### DIFF
--- a/public/svgs/mynes.svg
+++ b/public/svgs/mynes.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="7" fill="#2049e0"/>
+  <g fill="#ffffff">
+    <rect x="12" y="4"  width="8" height="7" rx="2"/>
+    <rect x="3"  y="21" width="8" height="7" rx="2"/>
+    <rect x="21" y="21" width="8" height="7" rx="2"/>
+    <rect x="15" y="11" width="2" height="4"/>
+    <rect x="6"  y="15" width="20" height="2" rx="1"/>
+    <rect x="6"  y="15" width="2" height="7"/>
+    <rect x="24" y="15" width="2" height="7"/>
+  </g>
+</svg>

--- a/templates/compose/mynes.yaml
+++ b/templates/compose/mynes.yaml
@@ -1,0 +1,32 @@
+# documentation: https://github.com/fxerkan/my_network_scanner#readme
+# slogan: See every device on your home network - including the Zigbee, Z-Wave, Matter and Bluetooth LE ones an IP scan cannot find.
+# category: monitoring
+# tags: network, scanner, monitoring, homelab, home-assistant, iot, mdns, matter, zigbee, zwave, discovery
+# logo: svgs/mynes.svg
+# port: 5883
+
+# Host networking is required: raw ARP frames and mDNS/SSDP multicast do not cross a bridge
+# network, so the proxy cannot route by container name and the UI is served on host port 5883.
+# Every environment variable below is optional and can also be set in the app's own settings.
+services:
+  mynes:
+    image: fxerkan/my_network_scanner:1.3.0
+    network_mode: host
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    environment:
+      - MYNES_PORT=5883
+      - MYNES_PASSWORD=${SERVICE_PASSWORD_MYNES}
+      - MYNES_MQTT_HOST=${MYNES_MQTT_HOST:-}
+      - MYNES_HA_URL=${MYNES_HA_URL:-}
+      - MYNES_HA_TOKEN=${MYNES_HA_TOKEN:-}
+    volumes:
+      - mynes-data:/app/data
+      - mynes-config:/app/config
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5883/api/version"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s


### PR DESCRIPTION
## Changes

- Added My Network Scanner (MyNeS) application template, it is a simple user friendly LAN devices scanner
- See every device on your home network - including the Zigbee, Z-Wave, Matter and Bluetooth LE ones an IP scan cannot find.
  
- Host networking is required: raw ARP frames and mDNS/SSDP multicast do not cross a bridge etwork, so the proxy cannot route by container name and the UI is served on host port 5883.

## Issues

- N/A — new one-click service.

## Category

- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [x] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

![MyNeS device inventory](https://raw.githubusercontent.com/fxerkan/my_network_scanner/main/assets/mynes.png)

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: it drafted the compose template and this PR scaffold from the project's
  existing deploy files. I wrote the Changes section, reviewed every line of the template, and
  tested the deployment myself before opening this.

## Testing

Deployed the template on a local Coolify instance, confirmed the container starts, the health
check on `/api/version` passes, and the UI is reachable on host port 5883 via from my raspberry pi with devices appearing in the first scan.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
