### PR TITLE
feat(api): manage proxy dynamic configurations

### DIFF
--- a/app/Actions/Proxy/DeleteProxyDynamicConfiguration.php
+++ b/app/Actions/Proxy/DeleteProxyDynamicConfiguration.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Actions\Proxy;
+
+use App\Enums\ProxyTypes;
+use App\Models\Server;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class DeleteProxyDynamicConfiguration
+{
+    use AsAction;
+
+    public function handle(Server $server, string $filename): bool
+    {
+        validateFilenameSafe($filename, 'proxy configuration filename');
+
+        $file = $server->proxyPath()."/dynamic/{$filename}";
+        $escapedFile = escapeshellarg($file);
+        $result = instant_remote_process([
+            "if test -f {$escapedFile}; then rm -f {$escapedFile} && echo deleted; else echo missing; fi",
+        ], $server);
+
+        $deleted = trim((string) $result) === 'deleted';
+        if ($deleted && $server->proxyType() === ProxyTypes::CADDY->value) {
+            $server->reloadCaddy();
+        }
+
+        return $deleted;
+    }
+}

--- a/app/Actions/Proxy/ListProxyDynamicConfigurations.php
+++ b/app/Actions/Proxy/ListProxyDynamicConfigurations.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Actions\Proxy;
+
+use App\Models\Server;
+use App\Rules\ValidProxyConfigFilename;
+use Illuminate\Support\Facades\Validator;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class ListProxyDynamicConfigurations
+{
+    use AsAction;
+
+    private const MAX_CONTENT_SIZE = 1_048_576;
+
+    private const TOO_LARGE_MARKER = '__COOLIFY_DYNAMIC_CONFIG_TOO_LARGE__';
+
+    /**
+     * @return list<array{filename: string, content?: string}>
+     */
+    public function handle(Server $server, bool $includeContent = false): array
+    {
+        $dynamicPath = $server->proxyPath().'/dynamic';
+        $escapedDynamicPath = escapeshellarg($dynamicPath);
+        $output = instant_remote_process([
+            "mkdir -p {$escapedDynamicPath}",
+            "find {$escapedDynamicPath} -mindepth 1 -maxdepth 1 -type f -exec basename {} \\;",
+        ], $server);
+
+        $filenames = collect(explode("\n", (string) $output))
+            ->map(fn (string $filename): string => trim($filename))
+            ->filter(fn (string $filename): bool => filled($filename))
+            ->filter(fn (string $filename): bool => Validator::make(
+                ['filename' => $filename],
+                ['filename' => ['required', new ValidProxyConfigFilename]],
+            )->passes())
+            ->sort()
+            ->values();
+
+        return array_values($filenames->map(function (string $filename) use ($dynamicPath, $includeContent, $server): array {
+            $configuration = ['filename' => $filename];
+            if (! $includeContent) {
+                return $configuration;
+            }
+
+            $escapedFile = escapeshellarg("{$dynamicPath}/{$filename}");
+            $encodedContent = instant_remote_process([
+                "size=$(wc -c < {$escapedFile}); if test \"\$size\" -le ".self::MAX_CONTENT_SIZE."; then base64 < {$escapedFile} | tr -d '\\n'; else echo '".self::TOO_LARGE_MARKER."'; fi",
+            ], $server);
+            if ($encodedContent === self::TOO_LARGE_MARKER) {
+                return $configuration;
+            }
+
+            $content = base64_decode((string) $encodedContent, true);
+            $configuration['content'] = $content === false ? '' : sanitize_utf8_text($content);
+
+            return $configuration;
+        })->all());
+    }
+}

--- a/app/Actions/Proxy/SaveProxyDynamicConfiguration.php
+++ b/app/Actions/Proxy/SaveProxyDynamicConfiguration.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Actions\Proxy;
+
+use App\Enums\ProxyTypes;
+use App\Models\Server;
+use Illuminate\Support\Str;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class SaveProxyDynamicConfiguration
+{
+    use AsAction;
+
+    public function handle(Server $server, string $filename, string $configuration, bool $create): bool
+    {
+        validateFilenameSafe($filename, 'proxy configuration filename');
+
+        $dynamicPath = $server->proxyPath().'/dynamic';
+        $temporaryFilename = ".{$filename}.".Str::lower(Str::random(12)).'.tmp';
+        $escapedDynamicPath = escapeshellarg($dynamicPath);
+        $escapedFile = escapeshellarg("{$dynamicPath}/{$filename}");
+        $escapedTemporaryFile = escapeshellarg("{$dynamicPath}/{$temporaryFilename}");
+        $encodedConfiguration = base64_encode($configuration);
+
+        $saveCommand = $create
+            ? "if ln {$escapedTemporaryFile} {$escapedFile} 2>/dev/null; then rm -f {$escapedTemporaryFile}; echo saved; else rm -f {$escapedTemporaryFile}; echo exists; fi"
+            : "if test -f {$escapedFile}; then mv -f {$escapedTemporaryFile} {$escapedFile} && echo saved; else rm -f {$escapedTemporaryFile}; echo missing; fi";
+
+        $result = instant_remote_process([
+            "mkdir -p {$escapedDynamicPath}",
+            "printf '%s' '{$encodedConfiguration}' | base64 -d > {$escapedTemporaryFile}",
+            $saveCommand,
+        ], $server);
+
+        $saved = trim((string) $result) === 'saved';
+        if ($saved && $server->proxyType() === ProxyTypes::CADDY->value) {
+            $server->reloadCaddy();
+        }
+
+        return $saved;
+    }
+}

--- a/app/Http/Controllers/Api/ServerProxyController.php
+++ b/app/Http/Controllers/Api/ServerProxyController.php
@@ -2,18 +2,26 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Actions\Proxy\DeleteProxyDynamicConfiguration;
+use App\Actions\Proxy\ListProxyDynamicConfigurations;
 use App\Actions\Proxy\SaveProxyConfiguration;
+use App\Actions\Proxy\SaveProxyDynamicConfiguration;
 use App\Enums\ProxyTypes;
 use App\Http\Controllers\Controller;
 use App\Jobs\RestartProxyJob;
 use App\Models\Server;
 use App\Rules\SafeExternalUrl;
+use App\Rules\ValidProxyConfigFilename;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use OpenApi\Attributes as OA;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
 
 class ServerProxyController extends Controller
 {
+    private const MAX_DYNAMIC_CONFIGURATION_SIZE = 1_048_576;
+
     private function teamIdOrAbort(): int|JsonResponse
     {
         $teamId = getTeamIdFromToken();
@@ -62,6 +70,110 @@ class ServerProxyController extends Controller
         }
 
         return $payload;
+    }
+
+    private function normalizeDynamicFilename(Server $server, string $filename): string
+    {
+        if ($server->proxyType() === ProxyTypes::TRAEFIK->value && ! str($filename)->endsWith(['.yaml', '.yml'])) {
+            return "{$filename}.yaml";
+        }
+
+        if ($server->proxyType() === ProxyTypes::CADDY->value && ! str($filename)->endsWith('.caddy')) {
+            return "{$filename}.caddy";
+        }
+
+        return $filename;
+    }
+
+    private function validateDynamicFilename(string $filename): ?JsonResponse
+    {
+        $validator = customApiValidator(
+            ['filename' => $filename],
+            ['filename' => ['required', 'string', new ValidProxyConfigFilename]],
+        );
+
+        if ($validator->fails()) {
+            return response()->json([
+                'message' => 'Validation failed.',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        try {
+            validateFilenameSafe($filename, 'proxy configuration filename');
+        } catch (\Throwable) {
+            return response()->json([
+                'message' => 'Validation failed.',
+                'errors' => ['filename' => ['The filename is not safe.']],
+            ], 422);
+        }
+
+        return null;
+    }
+
+    private function validateDynamicConfigurationRequest(Request $request, mixed $filename, array $allowedFields): ?JsonResponse
+    {
+        if (! is_string($filename)) {
+            return response()->json([
+                'message' => 'Validation failed.',
+                'errors' => ['filename' => ['The filename must be a string.']],
+            ], 422);
+        }
+
+        $validator = customApiValidator([
+            'filename' => $filename,
+            'content' => $request->input('content'),
+        ], [
+            'filename' => ['required', 'string', new ValidProxyConfigFilename],
+            'content' => ['required', 'string', 'max:'.self::MAX_DYNAMIC_CONFIGURATION_SIZE],
+        ]);
+
+        $extraFields = array_diff(array_keys($request->all()), $allowedFields);
+        $content = $request->input('content');
+        $validationFailed = $validator->fails();
+        $contentTooLarge = is_string($content) && strlen($content) > self::MAX_DYNAMIC_CONFIGURATION_SIZE;
+        if ($contentTooLarge) {
+            $validator->errors()->add('content', 'The content must not exceed 1 MiB.');
+        }
+
+        if ($validationFailed || $contentTooLarge || ! empty($extraFields)) {
+            $errors = $validator->errors();
+            foreach ($extraFields as $field) {
+                $errors->add($field, 'This field is not allowed.');
+            }
+
+            return response()->json([
+                'message' => 'Validation failed.',
+                'errors' => $errors,
+            ], 422);
+        }
+
+        try {
+            validateFilenameSafe($filename, 'proxy configuration filename');
+        } catch (\Throwable) {
+            return response()->json([
+                'message' => 'Validation failed.',
+                'errors' => ['filename' => ['The filename is not safe.']],
+            ], 422);
+        }
+
+        return null;
+    }
+
+    private function normalizeDynamicContent(Server $server, string $content): string|JsonResponse
+    {
+        if ($server->proxyType() !== ProxyTypes::TRAEFIK->value) {
+            return $content;
+        }
+
+        try {
+            return Yaml::dump(Yaml::parse($content), 10, 2);
+        } catch (ParseException) {
+            return response()->json([
+                'message' => 'Validation failed.',
+                'errors' => ['content' => ['The content must be valid YAML.']],
+            ], 422);
+        }
     }
 
     #[OA\Get(
@@ -418,5 +530,243 @@ class ServerProxyController extends Controller
         ]);
 
         return response()->json(['message' => 'Proxy restart queued.']);
+    }
+
+    #[OA\Get(
+        summary: 'List proxy dynamic configurations',
+        description: 'List safe dynamic configuration files for a team-owned server. File contents are only included when the token has `read:sensitive` (or `root`) and the user is a team admin or owner.',
+        path: '/servers/{uuid}/proxy/dynamic-configurations',
+        operationId: 'list-server-proxy-dynamic-configurations',
+        security: [['bearerAuth' => []]],
+        tags: ['Servers'],
+        parameters: [
+            new OA\Parameter(name: 'uuid', in: 'path', required: true, description: 'Server UUID', schema: new OA\Schema(type: 'string')),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Dynamic configuration files.',
+                content: new OA\JsonContent(
+                    type: 'array',
+                    items: new OA\Items(
+                        required: ['filename'],
+                        type: 'object',
+                        properties: [
+                            new OA\Property(property: 'filename', type: 'string', example: 'pos.yaml'),
+                            new OA\Property(property: 'content', type: 'string', description: 'Only present with read:sensitive.', example: "http:\n  routers: {}\n"),
+                        ],
+                    ),
+                ),
+            ),
+            new OA\Response(response: 401, ref: '#/components/responses/401'),
+            new OA\Response(response: 404, ref: '#/components/responses/404'),
+        ],
+    )]
+    public function dynamicConfigurations(string $uuid): JsonResponse
+    {
+        $teamId = $this->teamIdOrAbort();
+        if (! is_int($teamId)) {
+            return $teamId;
+        }
+
+        $server = $this->findServerForTeam($teamId, $uuid);
+        if (! $server) {
+            return response()->json(['message' => 'Server not found.'], 404);
+        }
+
+        $this->authorize('view', $server);
+
+        return response()->json(ListProxyDynamicConfigurations::run($server, $this->canReadSensitive()));
+    }
+
+    #[OA\Post(
+        summary: 'Create proxy dynamic configuration',
+        description: 'Create a dynamic configuration file. Traefik content must be valid YAML. Proxy-specific extensions are appended when omitted, and Caddy is reloaded after a successful write.',
+        path: '/servers/{uuid}/proxy/dynamic-configurations',
+        operationId: 'create-server-proxy-dynamic-configuration',
+        security: [['bearerAuth' => []]],
+        tags: ['Servers'],
+        parameters: [
+            new OA\Parameter(name: 'uuid', in: 'path', required: true, description: 'Server UUID', schema: new OA\Schema(type: 'string')),
+        ],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['filename', 'content'],
+                type: 'object',
+                properties: [
+                    new OA\Property(property: 'filename', type: 'string', maxLength: 255, example: 'pos.yaml'),
+                    new OA\Property(property: 'content', type: 'string', maxLength: self::MAX_DYNAMIC_CONFIGURATION_SIZE, example: "http:\n  routers: {}\n"),
+                ],
+            ),
+        ),
+        responses: [
+            new OA\Response(response: 201, description: 'Dynamic configuration created.'),
+            new OA\Response(response: 401, ref: '#/components/responses/401'),
+            new OA\Response(response: 404, ref: '#/components/responses/404'),
+            new OA\Response(response: 409, description: 'Dynamic configuration already exists.'),
+            new OA\Response(response: 422, ref: '#/components/responses/422'),
+        ],
+    )]
+    public function createDynamicConfiguration(Request $request, string $uuid): JsonResponse
+    {
+        return $this->saveDynamicConfiguration($request, $uuid, $request->input('filename'), true);
+    }
+
+    #[OA\Patch(
+        summary: 'Update proxy dynamic configuration',
+        description: 'Replace an existing dynamic configuration atomically. Traefik content must be valid YAML, and Caddy is reloaded after a successful write.',
+        path: '/servers/{uuid}/proxy/dynamic-configurations/{filename}',
+        operationId: 'update-server-proxy-dynamic-configuration',
+        security: [['bearerAuth' => []]],
+        tags: ['Servers'],
+        parameters: [
+            new OA\Parameter(name: 'uuid', in: 'path', required: true, description: 'Server UUID', schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'filename', in: 'path', required: true, description: 'Configuration filename', schema: new OA\Schema(type: 'string', maxLength: 255)),
+        ],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['content'],
+                type: 'object',
+                properties: [
+                    new OA\Property(property: 'content', type: 'string', maxLength: self::MAX_DYNAMIC_CONFIGURATION_SIZE, example: "http:\n  routers: {}\n"),
+                ],
+            ),
+        ),
+        responses: [
+            new OA\Response(response: 200, description: 'Dynamic configuration updated.'),
+            new OA\Response(response: 401, ref: '#/components/responses/401'),
+            new OA\Response(response: 404, ref: '#/components/responses/404'),
+            new OA\Response(response: 422, ref: '#/components/responses/422'),
+        ],
+    )]
+    public function updateDynamicConfiguration(Request $request, string $uuid, string $filename): JsonResponse
+    {
+        return $this->saveDynamicConfiguration($request, $uuid, $filename, false);
+    }
+
+    private function saveDynamicConfiguration(Request $request, string $uuid, mixed $filename, bool $create): JsonResponse
+    {
+        $teamId = $this->teamIdOrAbort();
+        if (! is_int($teamId)) {
+            return $teamId;
+        }
+
+        $return = validateIncomingRequest($request);
+        if ($return instanceof JsonResponse) {
+            return $return;
+        }
+
+        $allowedFields = $create ? ['filename', 'content'] : ['content'];
+        $validationResponse = $this->validateDynamicConfigurationRequest($request, $filename, $allowedFields);
+        if ($validationResponse) {
+            return $validationResponse;
+        }
+
+        if (! is_string($filename)) {
+            return response()->json(['message' => 'Validation failed.'], 422);
+        }
+
+        $server = $this->findServerForTeam($teamId, $uuid);
+        if (! $server) {
+            return response()->json(['message' => 'Server not found.'], 404);
+        }
+
+        $this->authorize('update', $server);
+
+        $filename = $this->normalizeDynamicFilename($server, $filename);
+        $validationResponse = $this->validateDynamicFilename($filename);
+        if ($validationResponse) {
+            return $validationResponse;
+        }
+
+        $requestedContent = $request->input('content');
+        if (! is_string($requestedContent)) {
+            return response()->json(['message' => 'Validation failed.'], 422);
+        }
+
+        $content = $this->normalizeDynamicContent($server, $requestedContent);
+        if ($content instanceof JsonResponse) {
+            return $content;
+        }
+
+        $saved = SaveProxyDynamicConfiguration::run($server, $filename, $content, $create);
+        if (! $saved) {
+            return response()->json([
+                'message' => $create
+                    ? 'Dynamic configuration already exists. Use PATCH to update it.'
+                    : 'Dynamic configuration not found.',
+            ], $create ? 409 : 404);
+        }
+
+        auditLog($create ? 'api.server.proxy.dynamic_configuration_created' : 'api.server.proxy.dynamic_configuration_updated', [
+            'team_id' => $teamId,
+            'server_uuid' => $server->uuid,
+            'server_name' => $server->name,
+            'filename' => $filename,
+        ]);
+
+        return response()->json([
+            'message' => $create ? 'Dynamic configuration created.' : 'Dynamic configuration updated.',
+            'filename' => $filename,
+        ], $create ? 201 : 200);
+    }
+
+    #[OA\Delete(
+        summary: 'Delete proxy dynamic configuration',
+        description: 'Delete a dynamic configuration file. Coolify-managed filenames are rejected, and Caddy is reloaded after a successful deletion.',
+        path: '/servers/{uuid}/proxy/dynamic-configurations/{filename}',
+        operationId: 'delete-server-proxy-dynamic-configuration',
+        security: [['bearerAuth' => []]],
+        tags: ['Servers'],
+        parameters: [
+            new OA\Parameter(name: 'uuid', in: 'path', required: true, description: 'Server UUID', schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'filename', in: 'path', required: true, description: 'Configuration filename', schema: new OA\Schema(type: 'string', maxLength: 255)),
+        ],
+        responses: [
+            new OA\Response(response: 200, description: 'Dynamic configuration deleted.'),
+            new OA\Response(response: 401, ref: '#/components/responses/401'),
+            new OA\Response(response: 404, ref: '#/components/responses/404'),
+            new OA\Response(response: 422, ref: '#/components/responses/422'),
+        ],
+    )]
+    public function deleteDynamicConfiguration(string $uuid, string $filename): JsonResponse
+    {
+        $teamId = $this->teamIdOrAbort();
+        if (! is_int($teamId)) {
+            return $teamId;
+        }
+
+        $validationResponse = $this->validateDynamicFilename($filename);
+        if ($validationResponse) {
+            return $validationResponse;
+        }
+
+        $server = $this->findServerForTeam($teamId, $uuid);
+        if (! $server) {
+            return response()->json(['message' => 'Server not found.'], 404);
+        }
+
+        $this->authorize('update', $server);
+
+        $filename = $this->normalizeDynamicFilename($server, $filename);
+        $validationResponse = $this->validateDynamicFilename($filename);
+        if ($validationResponse) {
+            return $validationResponse;
+        }
+
+        if (! DeleteProxyDynamicConfiguration::run($server, $filename)) {
+            return response()->json(['message' => 'Dynamic configuration not found.'], 404);
+        }
+
+        auditLog('api.server.proxy.dynamic_configuration_deleted', [
+            'team_id' => $teamId,
+            'server_uuid' => $server->uuid,
+            'server_name' => $server->name,
+            'filename' => $filename,
+        ]);
+
+        return response()->json(['message' => 'Dynamic configuration deleted.']);
     }
 }

--- a/app/Rules/ValidProxyConfigFilename.php
+++ b/app/Rules/ValidProxyConfigFilename.php
@@ -13,6 +13,7 @@ class ValidProxyConfigFilename implements ValidationRule
     private const RESERVED_FILENAMES = [
         'coolify.yaml',
         'coolify.yml',
+        'coolify.caddy',
         'Caddyfile',
     ];
 
@@ -63,7 +64,7 @@ class ValidProxyConfigFilename implements ValidationRule
             return;
         }
 
-        // Check for reserved filenames (case-sensitive for coolify.yaml/yml, case-insensitive check not needed as Caddyfile is exact)
+        // Check for reserved filenames (managed proxy files use exact casing on disk).
         if (in_array($filename, self::RESERVED_FILENAMES, true)) {
             $fail('The :attribute uses a reserved filename.');
 

--- a/openapi.json
+++ b/openapi.json
@@ -15290,6 +15290,252 @@
                 ]
             }
         },
+        "\/servers\/{uuid}\/proxy\/dynamic-configurations": {
+            "get": {
+                "tags": [
+                    "Servers"
+                ],
+                "summary": "List proxy dynamic configurations",
+                "description": "List safe dynamic configuration files for a team-owned server. File contents are only included when the token has `read:sensitive` (or `root`) and the user is a team admin or owner.",
+                "operationId": "list-server-proxy-dynamic-configurations",
+                "parameters": [
+                    {
+                        "name": "uuid",
+                        "in": "path",
+                        "description": "Server UUID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Dynamic configuration files.",
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "required": [
+                                            "filename"
+                                        ],
+                                        "properties": {
+                                            "filename": {
+                                                "type": "string",
+                                                "example": "pos.yaml"
+                                            },
+                                            "content": {
+                                                "description": "Only present with read:sensitive.",
+                                                "type": "string",
+                                                "example": "http:\n  routers: {}\n"
+                                            }
+                                        },
+                                        "type": "object"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "$ref": "#\/components\/responses\/401"
+                    },
+                    "404": {
+                        "$ref": "#\/components\/responses\/404"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Servers"
+                ],
+                "summary": "Create proxy dynamic configuration",
+                "description": "Create a dynamic configuration file. Traefik content must be valid YAML. Proxy-specific extensions are appended when omitted, and Caddy is reloaded after a successful write.",
+                "operationId": "create-server-proxy-dynamic-configuration",
+                "parameters": [
+                    {
+                        "name": "uuid",
+                        "in": "path",
+                        "description": "Server UUID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "required": [
+                                    "filename",
+                                    "content"
+                                ],
+                                "properties": {
+                                    "filename": {
+                                        "type": "string",
+                                        "maxLength": 255,
+                                        "example": "pos.yaml"
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 1048576,
+                                        "example": "http:\n  routers: {}\n"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Dynamic configuration created."
+                    },
+                    "401": {
+                        "$ref": "#\/components\/responses\/401"
+                    },
+                    "404": {
+                        "$ref": "#\/components\/responses\/404"
+                    },
+                    "409": {
+                        "description": "Dynamic configuration already exists."
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "\/servers\/{uuid}\/proxy\/dynamic-configurations\/{filename}": {
+            "delete": {
+                "tags": [
+                    "Servers"
+                ],
+                "summary": "Delete proxy dynamic configuration",
+                "description": "Delete a dynamic configuration file. Coolify-managed filenames are rejected, and Caddy is reloaded after a successful deletion.",
+                "operationId": "delete-server-proxy-dynamic-configuration",
+                "parameters": [
+                    {
+                        "name": "uuid",
+                        "in": "path",
+                        "description": "Server UUID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filename",
+                        "in": "path",
+                        "description": "Configuration filename",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "maxLength": 255
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Dynamic configuration deleted."
+                    },
+                    "401": {
+                        "$ref": "#\/components\/responses\/401"
+                    },
+                    "404": {
+                        "$ref": "#\/components\/responses\/404"
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "patch": {
+                "tags": [
+                    "Servers"
+                ],
+                "summary": "Update proxy dynamic configuration",
+                "description": "Replace an existing dynamic configuration atomically. Traefik content must be valid YAML, and Caddy is reloaded after a successful write.",
+                "operationId": "update-server-proxy-dynamic-configuration",
+                "parameters": [
+                    {
+                        "name": "uuid",
+                        "in": "path",
+                        "description": "Server UUID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filename",
+                        "in": "path",
+                        "description": "Configuration filename",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "maxLength": 255
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "required": [
+                                    "content"
+                                ],
+                                "properties": {
+                                    "content": {
+                                        "type": "string",
+                                        "maxLength": 1048576,
+                                        "example": "http:\n  routers: {}\n"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Dynamic configuration updated."
+                    },
+                    "401": {
+                        "$ref": "#\/components\/responses\/401"
+                    },
+                    "404": {
+                        "$ref": "#\/components\/responses\/404"
+                    },
+                    "422": {
+                        "$ref": "#\/components\/responses\/422"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
         "\/servers\/{uuid}\/sentinel": {
             "get": {
                 "tags": [

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9727,6 +9727,167 @@ paths:
       security:
         -
           bearerAuth: []
+  '/servers/{uuid}/proxy/dynamic-configurations':
+    get:
+      tags:
+        - Servers
+      summary: 'List proxy dynamic configurations'
+      description: 'List safe dynamic configuration files for a team-owned server. File contents are only included when the token has `read:sensitive` (or `root`) and the user is a team admin or owner.'
+      operationId: list-server-proxy-dynamic-configurations
+      parameters:
+        -
+          name: uuid
+          in: path
+          description: 'Server UUID'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'Dynamic configuration files.'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  required: [filename]
+                  properties: { filename: { type: string, example: pos.yaml }, content: { description: 'Only present with read:sensitive.', type: string, example: "http:\n  routers: {}\n" } }
+                  type: object
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+      security:
+        -
+          bearerAuth: []
+    post:
+      tags:
+        - Servers
+      summary: 'Create proxy dynamic configuration'
+      description: 'Create a dynamic configuration file. Traefik content must be valid YAML. Proxy-specific extensions are appended when omitted, and Caddy is reloaded after a successful write.'
+      operationId: create-server-proxy-dynamic-configuration
+      parameters:
+        -
+          name: uuid
+          in: path
+          description: 'Server UUID'
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - filename
+                - content
+              properties:
+                filename:
+                  type: string
+                  maxLength: 255
+                  example: pos.yaml
+                content:
+                  type: string
+                  maxLength: 1048576
+                  example: "http:\n  routers: {}\n"
+              type: object
+      responses:
+        '201':
+          description: 'Dynamic configuration created.'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
+          description: 'Dynamic configuration already exists.'
+        '422':
+          $ref: '#/components/responses/422'
+      security:
+        -
+          bearerAuth: []
+  '/servers/{uuid}/proxy/dynamic-configurations/{filename}':
+    delete:
+      tags:
+        - Servers
+      summary: 'Delete proxy dynamic configuration'
+      description: 'Delete a dynamic configuration file. Coolify-managed filenames are rejected, and Caddy is reloaded after a successful deletion.'
+      operationId: delete-server-proxy-dynamic-configuration
+      parameters:
+        -
+          name: uuid
+          in: path
+          description: 'Server UUID'
+          required: true
+          schema:
+            type: string
+        -
+          name: filename
+          in: path
+          description: 'Configuration filename'
+          required: true
+          schema:
+            type: string
+            maxLength: 255
+      responses:
+        '200':
+          description: 'Dynamic configuration deleted.'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
+      security:
+        -
+          bearerAuth: []
+    patch:
+      tags:
+        - Servers
+      summary: 'Update proxy dynamic configuration'
+      description: 'Replace an existing dynamic configuration atomically. Traefik content must be valid YAML, and Caddy is reloaded after a successful write.'
+      operationId: update-server-proxy-dynamic-configuration
+      parameters:
+        -
+          name: uuid
+          in: path
+          description: 'Server UUID'
+          required: true
+          schema:
+            type: string
+        -
+          name: filename
+          in: path
+          description: 'Configuration filename'
+          required: true
+          schema:
+            type: string
+            maxLength: 255
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - content
+              properties:
+                content:
+                  type: string
+                  maxLength: 1048576
+                  example: "http:\n  routers: {}\n"
+              type: object
+      responses:
+        '200':
+          description: 'Dynamic configuration updated.'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
+      security:
+        -
+          bearerAuth: []
   '/servers/{uuid}/sentinel':
     get:
       tags:

--- a/routes/api.php
+++ b/routes/api.php
@@ -187,6 +187,10 @@ Route::group([
     Route::patch('/servers/{uuid}/proxy', [ServerProxyController::class, 'update'])->middleware(['api.ability:write']);
     Route::put('/servers/{uuid}/proxy/configuration', [ServerProxyController::class, 'saveConfiguration'])->middleware(['api.ability:write']);
     Route::post('/servers/{uuid}/proxy/restart', [ServerProxyController::class, 'restart'])->middleware(['api.ability:write']);
+    Route::get('/servers/{uuid}/proxy/dynamic-configurations', [ServerProxyController::class, 'dynamicConfigurations'])->middleware(['api.ability:read']);
+    Route::post('/servers/{uuid}/proxy/dynamic-configurations', [ServerProxyController::class, 'createDynamicConfiguration'])->middleware(['api.ability:write']);
+    Route::patch('/servers/{uuid}/proxy/dynamic-configurations/{filename}', [ServerProxyController::class, 'updateDynamicConfiguration'])->middleware(['api.ability:write']);
+    Route::delete('/servers/{uuid}/proxy/dynamic-configurations/{filename}', [ServerProxyController::class, 'deleteDynamicConfiguration'])->middleware(['api.ability:write']);
 
     Route::post('/servers', [ServersController::class, 'create_server'])->middleware(['api.ability:write']);
     Route::patch('/servers/{uuid}', [ServersController::class, 'update_server'])->middleware(['api.ability:write']);

--- a/tests/Feature/Api/ServerProxyApiTest.php
+++ b/tests/Feature/Api/ServerProxyApiTest.php
@@ -1,15 +1,21 @@
 <?php
 
+use App\Actions\Proxy\DeleteProxyDynamicConfiguration;
+use App\Actions\Proxy\ListProxyDynamicConfigurations;
 use App\Actions\Proxy\SaveProxyConfiguration;
+use App\Actions\Proxy\SaveProxyDynamicConfiguration;
 use App\Actions\Proxy\StartProxy;
 use App\Enums\ProxyTypes;
 use App\Jobs\RestartProxyJob;
 use App\Models\InstanceSettings;
+use App\Models\PrivateKey;
 use App\Models\Server;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
 uses(RefreshDatabase::class);
@@ -33,7 +39,13 @@ beforeEach(function () {
     session(['currentTeam' => $this->team]);
 
     $this->bearerToken = serverProxyApiToken($this->user, $this->team, ['*']);
-    $this->server = Server::factory()->create(['team_id' => $this->team->id]);
+    $privateKey = PrivateKey::factory()->create(['team_id' => $this->team->id]);
+    Storage::fake('ssh-keys');
+    Storage::disk('ssh-keys')->put("ssh_key@{$privateKey->uuid}", $privateKey->private_key);
+    $this->server = Server::factory()->create([
+        'team_id' => $this->team->id,
+        'private_key_id' => $privateKey->id,
+    ]);
     $this->server->proxy->set('type', ProxyTypes::TRAEFIK->value);
     $this->server->proxy->set('status', 'exited');
     $this->server->proxy->redirect_enabled = true;
@@ -223,9 +235,236 @@ test('POST /api/v1/servers/{uuid}/proxy/restart queues RestartProxyJob', functio
     );
 });
 
+test('GET dynamic configurations lists filenames without content when read:sensitive is absent', function () {
+    $readToken = serverProxyApiToken($this->user, $this->team, ['read']);
+
+    ListProxyDynamicConfigurations::shouldRun()
+        ->once()
+        ->withArgs(fn (Server $server, bool $includeContent): bool => $server->is($this->server) && ! $includeContent)
+        ->andReturn([
+            ['filename' => 'pos.yaml'],
+        ]);
+
+    $this->withHeaders(serverProxyApiHeaders($readToken))
+        ->getJson("/api/v1/servers/{$this->server->uuid}/proxy/dynamic-configurations")
+        ->assertOk()
+        ->assertExactJson([
+            ['filename' => 'pos.yaml'],
+        ]);
+});
+
+test('GET dynamic configurations includes content with read:sensitive', function () {
+    $content = "http:\n  routers: {}\n";
+    $sensitiveToken = serverProxyApiToken($this->user, $this->team, ['read', 'read:sensitive']);
+
+    ListProxyDynamicConfigurations::shouldRun()
+        ->once()
+        ->withArgs(fn (Server $server, bool $includeContent): bool => $server->is($this->server) && $includeContent)
+        ->andReturn([
+            ['filename' => 'pos.yaml', 'content' => $content],
+        ]);
+
+    $this->withHeaders(serverProxyApiHeaders($sensitiveToken))
+        ->getJson("/api/v1/servers/{$this->server->uuid}/proxy/dynamic-configurations")
+        ->assertOk()
+        ->assertJsonPath('0.content', $content);
+});
+
+test('POST dynamic configurations creates a normalized Traefik file', function () {
+    $content = "http:\n  routers: {}\n";
+
+    SaveProxyDynamicConfiguration::shouldRun()
+        ->once()
+        ->withArgs(function (Server $server, string $filename, string $configuration, bool $create): bool {
+            return $server->is($this->server)
+                && $filename === 'pos.yaml'
+                && $configuration === "http:\n  routers: {  }\n"
+                && $create;
+        })
+        ->andReturnTrue();
+
+    $this->withHeaders(serverProxyApiHeaders($this->bearerToken))
+        ->postJson("/api/v1/servers/{$this->server->uuid}/proxy/dynamic-configurations", [
+            'filename' => 'pos',
+            'content' => $content,
+        ])
+        ->assertCreated()
+        ->assertJsonPath('message', 'Dynamic configuration created.')
+        ->assertJsonPath('filename', 'pos.yaml');
+});
+
+test('POST dynamic configurations returns conflict when the file exists', function () {
+    SaveProxyDynamicConfiguration::shouldRun()->once()->andReturnFalse();
+
+    $this->withHeaders(serverProxyApiHeaders($this->bearerToken))
+        ->postJson("/api/v1/servers/{$this->server->uuid}/proxy/dynamic-configurations", [
+            'filename' => 'pos.yaml',
+            'content' => "http:\n  routers: {}\n",
+        ])
+        ->assertConflict()
+        ->assertJsonPath('message', 'Dynamic configuration already exists. Use PATCH to update it.');
+});
+
+test('PATCH dynamic configurations updates an existing file', function () {
+    SaveProxyDynamicConfiguration::shouldRun()
+        ->once()
+        ->withArgs(fn (Server $server, string $filename, string $configuration, bool $create): bool => $server->is($this->server)
+            && $filename === 'pos.yaml'
+            && filled($configuration)
+            && ! $create)
+        ->andReturnTrue();
+
+    $this->withHeaders(serverProxyApiHeaders($this->bearerToken))
+        ->patchJson("/api/v1/servers/{$this->server->uuid}/proxy/dynamic-configurations/pos.yaml", [
+            'content' => "http:\n  routers: {}\n",
+        ])
+        ->assertOk()
+        ->assertJsonPath('message', 'Dynamic configuration updated.')
+        ->assertJsonPath('filename', 'pos.yaml');
+});
+
+test('PATCH dynamic configurations returns not found when the file is absent', function () {
+    SaveProxyDynamicConfiguration::shouldRun()->once()->andReturnFalse();
+
+    $this->withHeaders(serverProxyApiHeaders($this->bearerToken))
+        ->patchJson("/api/v1/servers/{$this->server->uuid}/proxy/dynamic-configurations/missing.yaml", [
+            'content' => "http:\n  routers: {}\n",
+        ])
+        ->assertNotFound()
+        ->assertJsonPath('message', 'Dynamic configuration not found.');
+});
+
+test('dynamic configuration writes reject invalid input before remote execution', function (array $payload, string $path) {
+    SaveProxyDynamicConfiguration::shouldRun()->never();
+
+    $this->withHeaders(serverProxyApiHeaders($this->bearerToken))
+        ->postJson("/api/v1/servers/{$this->server->uuid}/proxy/dynamic-configurations{$path}", $payload)
+        ->assertUnprocessable();
+})->with([
+    'path traversal' => [['filename' => '../pos.yaml', 'content' => 'http: {}'], ''],
+    'parent directory sequence' => [['filename' => 'pos..yaml', 'content' => 'http: {}'], ''],
+    'wrong filename type' => [['filename' => ['pos.yaml'], 'content' => 'http: {}'], ''],
+    'reserved normalized filename' => [['filename' => 'coolify', 'content' => 'http: {}'], ''],
+    'unknown field' => [['filename' => 'pos.yaml', 'content' => 'http: {}', 'force' => true], ''],
+    'wrong content type' => [['filename' => 'pos.yaml', 'content' => ['http']], ''],
+    'oversized content' => [['filename' => 'pos.yaml', 'content' => str_repeat('a', 1_048_577)], ''],
+]);
+
+test('POST dynamic configurations rejects malformed Traefik YAML', function () {
+    SaveProxyDynamicConfiguration::shouldRun()->never();
+
+    $this->withHeaders(serverProxyApiHeaders($this->bearerToken))
+        ->postJson("/api/v1/servers/{$this->server->uuid}/proxy/dynamic-configurations", [
+            'filename' => 'pos.yaml',
+            'content' => "http:\n  routers: [",
+        ])
+        ->assertUnprocessable()
+        ->assertJsonPath('errors.content.0', 'The content must be valid YAML.');
+});
+
+test('POST dynamic configurations cannot overwrite the Coolify-managed Caddy file', function () {
+    $this->server->proxy->set('type', ProxyTypes::CADDY->value);
+    $this->server->save();
+
+    SaveProxyDynamicConfiguration::shouldRun()->never();
+
+    $this->withHeaders(serverProxyApiHeaders($this->bearerToken))
+        ->postJson("/api/v1/servers/{$this->server->uuid}/proxy/dynamic-configurations", [
+            'filename' => 'coolify',
+            'content' => 'example.com { reverse_proxy app:3000 }',
+        ])
+        ->assertUnprocessable();
+});
+
+test('POST dynamic configurations enforces the content limit in bytes', function () {
+    SaveProxyDynamicConfiguration::shouldRun()->never();
+
+    $this->withHeaders(serverProxyApiHeaders($this->bearerToken))
+        ->postJson("/api/v1/servers/{$this->server->uuid}/proxy/dynamic-configurations", [
+            'filename' => 'pos.yaml',
+            'content' => str_repeat('á', 524_289),
+        ])
+        ->assertUnprocessable()
+        ->assertJsonPath('errors.content.0', 'The content must not exceed 1 MiB.');
+});
+
+test('DELETE dynamic configurations removes an existing file', function () {
+    DeleteProxyDynamicConfiguration::shouldRun()
+        ->once()
+        ->withArgs(fn (Server $server, string $filename): bool => $server->is($this->server) && $filename === 'pos.yaml')
+        ->andReturnTrue();
+
+    $this->withHeaders(serverProxyApiHeaders($this->bearerToken))
+        ->deleteJson("/api/v1/servers/{$this->server->uuid}/proxy/dynamic-configurations/pos.yaml")
+        ->assertOk()
+        ->assertJsonPath('message', 'Dynamic configuration deleted.');
+});
+
+test('DELETE dynamic configurations rejects reserved files before remote execution', function () {
+    DeleteProxyDynamicConfiguration::shouldRun()->never();
+
+    $this->withHeaders(serverProxyApiHeaders($this->bearerToken))
+        ->deleteJson("/api/v1/servers/{$this->server->uuid}/proxy/dynamic-configurations/coolify.yaml")
+        ->assertUnprocessable();
+});
+
+test('dynamic configuration endpoints do not expose another team server', function () {
+    $otherTeam = Team::factory()->create();
+    $otherServer = Server::factory()->create(['team_id' => $otherTeam->id]);
+
+    ListProxyDynamicConfigurations::shouldRun()->never();
+
+    $this->withHeaders(serverProxyApiHeaders($this->bearerToken))
+        ->getJson("/api/v1/servers/{$otherServer->uuid}/proxy/dynamic-configurations")
+        ->assertNotFound();
+});
+
+test('dynamic configuration actions use safe atomic remote commands', function () {
+    $content = "http:\n  routers: {}\n";
+    Process::fake([
+        '*find *-exec basename*' => Process::result(output: "pos.yaml\n../unsafe.yaml\n"),
+        '*wc -c*base64 <*' => Process::result(output: base64_encode($content)),
+        '*' => Process::result(output: 'saved'),
+    ]);
+
+    expect(SaveProxyDynamicConfiguration::run($this->server, 'pos.yaml', $content, true))->toBeTrue()
+        ->and(ListProxyDynamicConfigurations::run($this->server, true))->toBe([
+            ['filename' => 'pos.yaml', 'content' => $content],
+        ]);
+
+    Process::assertRan(fn ($process): bool => str_contains($process->command, 'ln ')
+        && str_contains($process->command, base64_encode($content))
+        && ! str_contains($process->command, $content));
+});
+
+test('listing omits oversized file content while retaining the filename', function () {
+    Process::fake([
+        '*find *-exec basename*' => Process::result(output: "large.yaml\n"),
+        '*wc -c*' => Process::result(output: '__COOLIFY_DYNAMIC_CONFIG_TOO_LARGE__'),
+    ]);
+
+    expect(ListProxyDynamicConfigurations::run($this->server, true))->toBe([
+        ['filename' => 'large.yaml'],
+    ]);
+});
+
+test('dynamic configuration actions report retry-safe conflicts and missing files', function () {
+    Process::fake([
+        '*ln *' => Process::result(output: 'exists'),
+        '*test -f*rm -f*' => Process::result(output: 'missing'),
+    ]);
+
+    expect(SaveProxyDynamicConfiguration::run($this->server, 'pos.yaml', 'http: {}', true))->toBeFalse()
+        ->and(DeleteProxyDynamicConfiguration::run($this->server, 'pos.yaml'))->toBeFalse();
+});
+
 test('proxy endpoints require authentication', function () {
     $this->getJson("/api/v1/servers/{$this->server->uuid}/proxy")->assertUnauthorized();
     $this->patchJson("/api/v1/servers/{$this->server->uuid}/proxy", ['redirect_enabled' => false])->assertUnauthorized();
     $this->putJson("/api/v1/servers/{$this->server->uuid}/proxy/configuration", ['configuration' => 'x'])->assertUnauthorized();
     $this->postJson("/api/v1/servers/{$this->server->uuid}/proxy/restart")->assertUnauthorized();
+    $this->getJson("/api/v1/servers/{$this->server->uuid}/proxy/dynamic-configurations")->assertUnauthorized();
+    $this->postJson("/api/v1/servers/{$this->server->uuid}/proxy/dynamic-configurations")->assertUnauthorized();
+    $this->patchJson("/api/v1/servers/{$this->server->uuid}/proxy/dynamic-configurations/pos.yaml")->assertUnauthorized();
+    $this->deleteJson("/api/v1/servers/{$this->server->uuid}/proxy/dynamic-configurations/pos.yaml")->assertUnauthorized();
 });


### PR DESCRIPTION
## Changes

- Adds REST endpoints to list, create, update, and delete proxy dynamic configurations.
- Validates filenames, Traefik YAML, unknown fields, and a 1 MiB byte limit; managed files are protected.
- Uses atomic SSH writes, sensitive-read permissions, audit events, and Caddy reloads. Traefik watches this directory directly.
- Documents the endpoints in OpenAPI and covers authorization, tenant isolation, invalid input, conflicts, and command safety.

## Issues

- Related discussion: https://github.com/coollabsio/coolify/discussions/11128
- Reconsiders #10634 with the `next` target, current template, and local validation.

## Category

- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

This is API-only and has no UI change. The local HTTP-to-SSH smoke test returned:

```text
POST   /dynamic-configurations                 201
GET    /dynamic-configurations                 200 (normalized content)
PATCH  /dynamic-configurations/codex-smoke.yaml 200
DELETE /dynamic-configurations/codex-smoke.yaml 200
GET    /dynamic-configurations                 200 []
```

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Codex
- How extensively: Implementation, threat modeling, tests, and documentation; validated in a local end-to-end environment.

## Testing

- API tests: 35 passed, 96 assertions on host and in the built container.
- Pint passed; PHPStan level 8 passed on the three new actions.
- Built the ARM64 stack and verified `/api/health`.
- Ran create/list/update/delete through HTTP against `coolify-testing-host`; confirmed remote cleanup and token revocation.
- Parsed both OpenAPI files successfully.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
