### PR TITLE
fix(ui): strip internal ports from preview PR links

### DIFF
--- a/app/Jobs/ApplicationPullRequestUpdateJob.php
+++ b/app/Jobs/ApplicationPullRequestUpdateJob.php
@@ -101,8 +101,7 @@ class ApplicationPullRequestUpdateJob implements ShouldBeEncrypted, ShouldQueue
             foreach ($dockerComposeDomains as $serviceName => $config) {
                 $domain = data_get($config, 'domain');
                 if (! empty($domain)) {
-                    $firstDomain = str($domain)->explode(',')->first();
-                    $firstDomain = trim($firstDomain);
+                    $firstDomain = getFqdnWithoutPort(firstDomainFromList($domain));
                     if (! empty($firstDomain)) {
                         $links[] = "[Open {$serviceName}]({$firstDomain})";
                     }
@@ -112,6 +111,10 @@ class ApplicationPullRequestUpdateJob implements ShouldBeEncrypted, ShouldQueue
             return ! empty($links) ? implode(' | ', $links).' | ' : '';
         }
 
-        return $this->preview->fqdn ? "[Open Preview]({$this->preview->fqdn}) | " : '';
+        if (! $this->preview->fqdn) {
+            return '';
+        }
+
+        return '[Open Preview]('.getFqdnWithoutPort($this->preview->fqdn).') | ';
     }
 }

--- a/tests/Unit/ApplicationPullRequestUpdateJobTest.php
+++ b/tests/Unit/ApplicationPullRequestUpdateJobTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use App\Enums\ProcessStatus;
+use App\Jobs\ApplicationPullRequestUpdateJob;
+use App\Models\Application;
+use App\Models\ApplicationPreview;
+
+function previewLinksFor(Application $application, ApplicationPreview $preview): string
+{
+    $job = new ApplicationPullRequestUpdateJob(
+        application: $application,
+        preview: $preview,
+        status: ProcessStatus::FINISHED,
+        deployment_uuid: 'deployment-uuid'
+    );
+
+    return (fn (): string => $this->getPreviewLinks())->call($job);
+}
+
+test('docker compose preview links strip internal ports and keep paths', function () {
+    $application = new Application([
+        'build_pack' => 'dockercompose',
+    ]);
+
+    $preview = new ApplicationPreview([
+        'docker_compose_domains' => json_encode([
+            'web' => [
+                'domain' => 'https://136.example.com:3000,https://fallback.example.com:3001',
+            ],
+            'api' => [
+                'domain' => 'https://136.example.com:3001/backend',
+            ],
+        ], JSON_THROW_ON_ERROR),
+    ]);
+
+    expect(previewLinksFor($application, $preview))
+        ->toBe('[Open web](https://136.example.com) | [Open api](https://136.example.com/backend) | ');
+});
+
+test('single preview link strips internal port and keeps path', function () {
+    $application = new Application([
+        'build_pack' => 'nixpacks',
+    ]);
+
+    $preview = new ApplicationPreview([
+        'fqdn' => 'https://136.example.com:3001/backend',
+    ]);
+
+    expect(previewLinksFor($application, $preview))
+        ->toBe('[Open Preview](https://136.example.com/backend) | ');
+});


### PR DESCRIPTION
STRAWBERRY

## Changes
- Normalize preview deployment links posted to GitHub pull request comments so internal container ports are not shown.
- Reuse existing domain helpers to avoid duplicate parsing logic and preserve existing behavior for scheme and path handling.
- Add regression tests that verify compose preview links and single preview links strip internal ports while keeping paths intact.

## Issues
- Fixes #11065

## Category
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview
- No UI layout change. Behavior change is in generated GitHub pull request comment links.

## AI Assistance
- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

If AI was used:
- Tools used: GitHub Copilot
- How extensively: issue triage, focused implementation, and regression test scaffolding with full human review

## Testing
- vendor/bin/pint --dirty --format agent
- php artisan test --compact tests/Unit/ApplicationPullRequestUpdateJobTest.php tests/Unit/GetFqdnWithoutPortTest.php
- php artisan test --compact tests/Feature/ProcessGithubPullRequestWebhookTest.php

## Contributor Agreement
> [!IMPORTANT]
>
> - [x] I have read and understood the contributor guidelines. If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched existing issues and pull requests (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
