### PR TITLE
fix(api): allow is_container_label_readonly_enabled in application updates

### DIFF
--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -49,6 +49,7 @@ class ApplicationsController extends Controller
         'is_gzip_enabled',
         'is_stripprefix_enabled',
         'is_raw_compose_deployment_enabled',
+        'is_container_label_readonly_enabled',
     ];
 
     private const BOOLEAN_APPLICATION_SETTING_FIELDS = [
@@ -63,6 +64,7 @@ class ApplicationsController extends Controller
         'is_gzip_enabled',
         'is_stripprefix_enabled',
         'is_raw_compose_deployment_enabled',
+        'is_container_label_readonly_enabled',
     ];
 
     protected function findTaggableResource(string $uuid, int|string $teamId): mixed


### PR DESCRIPTION
Fixes #11092

### Description

This PR fixes a bug where `is_container_label_readonly_enabled` was rejected by the public API (both create and update endpoints) due to its absence from the `APPLICATION_SETTING_FIELDS` and `BOOLEAN_APPLICATION_SETTING_FIELDS` arrays in `ApplicationsController.php`. 

Because validation rejected the request as a whole, it was impossible to opportunistically set this field via the API, which broke IaC tools like Terraform from taking ownership of labels for custom routing logic.

**Changes:**
- Added `is_container_label_readonly_enabled` to `APPLICATION_SETTING_FIELDS` so it is permitted in the `$allowedFields` list.
- Added `is_container_label_readonly_enabled` to `BOOLEAN_APPLICATION_SETTING_FIELDS` to ensure the setting casts/updates properly in the controller logic.

### Expected Behavior
- Sending a `PATCH` request to `/api/v1/applications/{uuid}` with `{"is_container_label_readonly_enabled": false}` will now return a `200 OK` and save the setting properly, just like the UI does.
- The field is accepted on the creation endpoints (`POST /api/v1/applications/...`) as well.
