### PR TITLE
fix: preserve custom preview domains on redeploy

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -278,9 +278,9 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             }
             if ($this->preview) {
                 if ($this->application->build_pack === 'dockercompose') {
-                    $this->preview->generate_preview_fqdn_compose();
+                    $this->preview->generate_preview_fqdn_compose(force: false);
                 } else {
-                    $this->preview->generate_preview_fqdn();
+                    $this->preview->generate_preview_fqdn(force: false);
                 }
             }
             if ($this->application->is_github_based()) {

--- a/app/Livewire/Project/Application/Previews.php
+++ b/app/Livewire/Project/Application/Previews.php
@@ -175,7 +175,7 @@ class Previews extends Component
                 return;
             }
             if ($this->application->build_pack === 'dockercompose') {
-                $preview->generate_preview_fqdn_compose();
+                $preview->generate_preview_fqdn_compose(force: true);
                 $this->application->refresh();
                 $this->syncData(false);
                 $this->dispatch('success', 'Domain generated.');
@@ -183,7 +183,7 @@ class Previews extends Component
                 return;
             }
 
-            $preview->generate_preview_fqdn();
+            $preview->generate_preview_fqdn(force: true);
             $this->application->refresh();
             $this->syncData(false);
             $this->dispatch('update_links');

--- a/app/Models/ApplicationPreview.php
+++ b/app/Models/ApplicationPreview.php
@@ -95,9 +95,13 @@ class ApplicationPreview extends BaseModel
         return $this->morphMany(LocalPersistentVolume::class, 'resource');
     }
 
-    public function generate_preview_fqdn()
+    public function generate_preview_fqdn(bool $force = true)
     {
         if ($this->application->fqdn) {
+            if (! $force && filled($this->fqdn)) {
+                return $this;
+            }
+
             if (str($this->application->fqdn)->contains(',')) {
                 $url = Url::fromString(str($this->application->fqdn)->explode(',')[0]);
             } else {
@@ -122,7 +126,7 @@ class ApplicationPreview extends BaseModel
         return $this;
     }
 
-    public function generate_preview_fqdn_compose()
+    public function generate_preview_fqdn_compose(bool $force = true)
     {
         $applicationDomains = json_decode($this->application->docker_compose_domains ?: '[]', true) ?: [];
         $previewDomains = json_decode(data_get($this, 'docker_compose_domains') ?: '[]', true) ?: [];
@@ -171,6 +175,18 @@ class ApplicationPreview extends BaseModel
                     $docker_compose_domains,
                     $service_name,
                     '',
+                    $serviceNames,
+                );
+
+                continue;
+            }
+
+            // Preserve existing preview domain unless forcing regeneration
+            if (! $force && filled(getComposeServiceDomainString($previewDomains, $service_name))) {
+                $docker_compose_domains = putComposeServiceDomain(
+                    $docker_compose_domains,
+                    $service_name,
+                    getComposeServiceDomainString($previewDomains, $service_name),
                     $serviceNames,
                 );
 

--- a/bootstrap/helpers/parsers.php
+++ b/bootstrap/helpers/parsers.php
@@ -1247,7 +1247,7 @@ function applicationParser(Application $resource, int $pull_request_id = 0, ?int
                 if ($docker_compose_domains->count() > 0) {
                     $found_fqdn = getComposeServiceDomainString($docker_compose_domains, (string) $serviceName);
                     if ($found_fqdn) {
-                        $fqdns = collect($found_fqdn);
+                        $fqdns = str($found_fqdn)->explode(',')->map(fn ($d) => trim($d))->filter()->values();
                     } else {
                         $fqdns = collect([]);
                     }

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -3796,7 +3796,7 @@ function parseDockerComposeFile(Service|Application $resource, bool $isNew = fal
                             if (count($docker_compose_domains) > 0) {
                                 $found_fqdn = getComposeServiceDomainString($docker_compose_domains, (string) $serviceName);
                                 if ($found_fqdn) {
-                                    $fqdns = collect($found_fqdn);
+                                    $fqdns = str($found_fqdn)->explode(',')->map(fn ($d) => trim($d))->filter()->values();
                                 } else {
                                     $fqdns = collect([]);
                                 }

--- a/tests/Feature/ApplicationParserDockerComposeDomainsTest.php
+++ b/tests/Feature/ApplicationParserDockerComposeDomainsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\Application;
+use App\Models\ApplicationPreview;
 use App\Models\Environment;
 use App\Models\PrivateKey;
 use App\Models\Project;
@@ -397,4 +398,47 @@ YAML;
     $plainApplication->refresh();
 
     expect(json_decode($plainApplication->docker_compose_domains, true))->toBeNull();
+});
+
+test('applicationParser splits preview compose domains into separate traefik router rules', function () {
+    $dockerCompose = <<<'YAML'
+services:
+  frontend:
+    image: myapp/frontend:latest
+    environment:
+      - SERVICE_FQDN_FRONTEND=${FRONTEND_URL}
+YAML;
+
+    $application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => StandaloneDocker::class,
+        'build_pack' => 'dockercompose',
+        'docker_compose_raw' => $dockerCompose,
+        'preview_url_template' => '{{pr_id}}.{{domain}}',
+        'docker_compose_domains' => json_encode([
+            'frontend' => ['domain' => 'https://example.com,https://www.example.com'],
+        ]),
+    ]);
+
+    $preview = ApplicationPreview::create([
+        'application_id' => $application->id,
+        'pull_request_id' => 42,
+        'pull_request_html_url' => 'https://github.com/example/repo/pull/42',
+        'docker_compose_domains' => json_encode([
+            'frontend' => ['domain' => 'https://42.example.com, https://42.www.example.com'],
+        ]),
+    ]);
+
+    $parsed = applicationParser($application, pull_request_id: 42, preview_id: $preview->id);
+
+    $services = $parsed->get('services');
+    $frontend = $services->get('frontend-pr-42');
+    $labels = collect(data_get($frontend, 'labels'));
+
+    $hostRules = $labels->filter(fn ($label) => str($label)->startsWith('traefik.http.routers.') && str($label)->contains('.rule=Host('));
+
+    expect($hostRules)->toHaveCount(4)
+        ->and($hostRules->implode("\n"))->toContain('42.example.com')
+        ->and($hostRules->implode("\n"))->toContain('42.www.example.com');
 });

--- a/tests/Feature/PreviewCustomDomainPreservationTest.php
+++ b/tests/Feature/PreviewCustomDomainPreservationTest.php
@@ -1,0 +1,137 @@
+<?php
+
+use App\Models\Application;
+use App\Models\ApplicationPreview;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('preserves custom preview domain when regeneration is not forced', function () {
+    $application = Application::factory()->create([
+        'fqdn' => 'https://example.com',
+        'preview_url_template' => '{{pr_id}}.{{domain}}',
+    ]);
+
+    $preview = ApplicationPreview::create([
+        'application_id' => $application->id,
+        'pull_request_id' => 42,
+        'pull_request_html_url' => 'https://github.com/example/repo/pull/42',
+        'fqdn' => 'https://custom-preview-domain.com',
+    ]);
+
+    $preview->generate_preview_fqdn(force: false);
+    $preview->refresh();
+
+    expect($preview->fqdn)->toBe('https://custom-preview-domain.com');
+});
+
+it('regenerates preview domain from template when forced', function () {
+    $application = Application::factory()->create([
+        'fqdn' => 'https://example.com',
+        'preview_url_template' => '{{pr_id}}.{{domain}}',
+    ]);
+
+    $preview = ApplicationPreview::create([
+        'application_id' => $application->id,
+        'pull_request_id' => 42,
+        'pull_request_html_url' => 'https://github.com/example/repo/pull/42',
+        'fqdn' => 'https://custom-preview-domain.com',
+    ]);
+
+    $preview->generate_preview_fqdn(force: true);
+    $preview->refresh();
+
+    expect($preview->fqdn)->not->toBe('https://custom-preview-domain.com');
+    expect($preview->fqdn)->toContain('42');
+    expect($preview->fqdn)->toContain('example.com');
+});
+
+it('generates preview domain from template when none exists and not forced', function () {
+    $application = Application::factory()->create([
+        'fqdn' => 'https://example.com',
+        'preview_url_template' => '{{pr_id}}.{{domain}}',
+    ]);
+
+    $preview = ApplicationPreview::create([
+        'application_id' => $application->id,
+        'pull_request_id' => 42,
+        'pull_request_html_url' => 'https://github.com/example/repo/pull/42',
+    ]);
+
+    $preview->generate_preview_fqdn(force: false);
+    $preview->refresh();
+
+    expect($preview->fqdn)->not->toBeNull();
+    expect($preview->fqdn)->toContain('42');
+    expect($preview->fqdn)->toContain('example.com');
+});
+
+it('preserves custom docker compose preview domains when regeneration is not forced', function () {
+    $application = Application::factory()->create([
+        'build_pack' => 'dockercompose',
+        'docker_compose_domains' => json_encode([
+            'web' => ['domain' => 'https://example.com'],
+        ]),
+    ]);
+
+    $preview = ApplicationPreview::create([
+        'application_id' => $application->id,
+        'pull_request_id' => 42,
+        'pull_request_html_url' => 'https://github.com/example/repo/pull/42',
+        'docker_compose_domains' => json_encode([
+            'web' => ['domain' => 'https://custom-preview-domain.com'],
+        ]),
+    ]);
+
+    $preview->generate_preview_fqdn_compose(force: false);
+    $preview->refresh();
+
+    expect($preview->docker_compose_domains)->toContain('custom-preview-domain.com');
+    expect($preview->docker_compose_domains)->not->toContain('42.example.com');
+});
+
+it('regenerates docker compose preview domains from template when forced', function () {
+    $application = Application::factory()->create([
+        'build_pack' => 'dockercompose',
+        'docker_compose_domains' => json_encode([
+            'web' => ['domain' => 'https://example.com'],
+        ]),
+    ]);
+
+    $preview = ApplicationPreview::create([
+        'application_id' => $application->id,
+        'pull_request_id' => 42,
+        'pull_request_html_url' => 'https://github.com/example/repo/pull/42',
+        'docker_compose_domains' => json_encode([
+            'web' => ['domain' => 'https://custom-preview-domain.com'],
+        ]),
+    ]);
+
+    $preview->generate_preview_fqdn_compose(force: true);
+    $preview->refresh();
+
+    expect($preview->docker_compose_domains)->not->toContain('custom-preview-domain.com');
+    expect($preview->docker_compose_domains)->toContain('42.example.com');
+});
+
+it('generates multiple docker compose preview domains when main app has multiple domains', function () {
+    $application = Application::factory()->create([
+        'build_pack' => 'dockercompose',
+        'preview_url_template' => '{{pr_id}}.{{domain}}',
+        'docker_compose_domains' => json_encode([
+            'web' => ['domain' => 'https://example.com,https://www.example.com'],
+        ]),
+    ]);
+
+    $preview = ApplicationPreview::create([
+        'application_id' => $application->id,
+        'pull_request_id' => 42,
+        'pull_request_html_url' => 'https://github.com/example/repo/pull/42',
+    ]);
+
+    $preview->generate_preview_fqdn_compose(force: true);
+    $preview->refresh();
+
+    expect($preview->docker_compose_domains)->toContain('42.example.com');
+    expect($preview->docker_compose_domains)->toContain('42.www.example.com');
+});

--- a/tests/Feature/PreviewCustomDomainRedeployFlowTest.php
+++ b/tests/Feature/PreviewCustomDomainRedeployFlowTest.php
@@ -1,0 +1,147 @@
+<?php
+
+use App\Livewire\Project\Application\Previews;
+use App\Models\Application;
+use App\Models\ApplicationPreview;
+use App\Models\Environment;
+use App\Models\InstanceSettings;
+use App\Models\PrivateKey;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\ServerSetting;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    if (! InstanceSettings::find(0)) {
+        $settings = new InstanceSettings;
+        $settings->id = 0;
+        $settings->save();
+    }
+
+    $this->user = User::factory()->create();
+    $this->team = Team::factory()->create();
+    $this->user->teams()->attach($this->team->id, ['role' => 'owner']);
+    $this->actingAs($this->user);
+    session(['currentTeam' => $this->team]);
+
+    $this->project = Project::factory()->create(['team_id' => $this->team->id]);
+    $this->environment = Environment::factory()->create(['project_id' => $this->project->id]);
+
+    $privateKey = PrivateKey::factory()->create(['team_id' => $this->team->id]);
+
+    $this->server = Server::factory()->create([
+        'team_id' => $this->team->id,
+        'private_key_id' => $privateKey->id,
+    ]);
+
+    ServerSetting::create([
+        'server_id' => $this->server->id,
+        'wildcard_domain' => 'http://127.0.0.1.sslip.io',
+    ]);
+
+    $this->destination = StandaloneDocker::factory()->create([
+        'server_id' => $this->server->id,
+        'network' => 'test-network-'.fake()->uuid(),
+    ]);
+});
+
+it('preserves a custom preview domain through save and simulated redeploy', function () {
+    $application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => StandaloneDocker::class,
+        'fqdn' => 'https://example.com',
+        'preview_url_template' => '{{pr_id}}.{{domain}}',
+        'build_pack' => 'nixpacks',
+    ]);
+
+    $preview = ApplicationPreview::create([
+        'application_id' => $application->id,
+        'pull_request_id' => 42,
+        'pull_request_html_url' => 'https://github.com/example/repo/pull/42',
+    ]);
+
+    $customDomain = 'https://custom-preview.127.0.0.1.sslip.io';
+
+    $application->refresh();
+    $previewKey = $application->previews->search(fn ($p) => $p->id === $preview->id);
+
+    $component = Livewire::test(Previews::class, ['application' => $application]);
+
+    $component
+        ->set('previewFqdns.'.$previewKey, $customDomain)
+        ->call('save_preview', $preview->id)
+        ->assertHasNoErrors()
+        ->assertDispatched('success');
+
+    $preview->refresh();
+    expect($preview->fqdn)->toBe($customDomain);
+
+    // Simulate what ApplicationDeploymentJob does during redeploy
+    $preview->generate_preview_fqdn(force: false);
+    $preview->refresh();
+
+    expect($preview->fqdn)->toBe($customDomain);
+});
+
+it('preserves custom docker compose preview domains through save and simulated redeploy', function () {
+    $dockerCompose = <<<'YAML'
+services:
+  web:
+    image: myapp/web:latest
+    environment:
+      - SERVICE_FQDN_WEB=${WEB_URL}
+YAML;
+
+    $application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => StandaloneDocker::class,
+        'build_pack' => 'dockercompose',
+        'docker_compose_raw' => $dockerCompose,
+        'preview_url_template' => '{{pr_id}}.{{domain}}',
+        'docker_compose_domains' => json_encode([
+            'web' => ['domain' => 'https://example.com'],
+        ]),
+    ]);
+
+    $customDomain = 'https://custom-preview.127.0.0.1.sslip.io';
+
+    $preview = ApplicationPreview::create([
+        'application_id' => $application->id,
+        'pull_request_id' => 42,
+        'pull_request_html_url' => 'https://github.com/example/repo/pull/42',
+        'docker_compose_domains' => json_encode([
+            'web' => ['domain' => $customDomain],
+        ]),
+    ]);
+
+    $application->refresh();
+    $previewKey = $application->previews->search(fn ($p) => $p->id === $preview->id);
+
+    $component = Livewire::test(Previews::class, ['application' => $application]);
+
+    // The Previews component stores the primary fqdn only; compose-specific
+    // domains are edited via the PreviewsCompose component.
+    $component
+        ->set('previewFqdns.'.$previewKey, $customDomain)
+        ->call('save_preview', $preview->id)
+        ->assertHasNoErrors()
+        ->assertDispatched('success');
+
+    $preview->refresh();
+    expect($preview->fqdn)->toBe($customDomain);
+
+    // Simulate what ApplicationDeploymentJob does during redeploy
+    $preview->generate_preview_fqdn_compose(force: false);
+    $preview->refresh();
+
+    expect($preview->docker_compose_domains)->toContain('custom-preview.127.0.0.1.sslip.io');
+    expect($preview->docker_compose_domains)->not->toContain('42.127.0.0.1.sslip.io');
+});


### PR DESCRIPTION


## Changes

- Adds a force parameter to the ApplicaitonPreview::generate_preview_fqdn() & ApplicationPreview::generate_preview_fqdn_compose() function, When force is false, the methods keep the values instead of regenerating it from the template
- The ApplicationDeploymentJob now calls the generation methods with `force: false` to not overwrite a manually set domain
- Parser for docker compose fqdn now splits by comma and trims each entry to produce valid router rules


## Issues

- Fixes:
- #6536 
- #9399 
- #7915 

## Category

- [X] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

<!-- Screenshot or short video showing your changes in action. Mandatory for new features. -->

## AI Assistance

<!-- AI-assisted PRs that are human reviewed are welcome, just let us know so we can review appropriately. -->

- [ ] AI was NOT used to create this PR
- [X] AI was used (please describe below)

**If AI was used:**

- Tools used: Copilot Kimi 2.7 Code
- How extensively: Used for creating tests and reviewing changes

## Testing

Running tests with and without these changes. No manual (by hand) browser tests were made.

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
