### PR TITLE
chore(docker): bump cloudflared to 2026.7.3 (fixes 2 CRITICAL CVEs)

### DIFF
--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -4,7 +4,7 @@ ARG SERVERSIDEUP_PHP_VERSION=8.4-fpm-nginx-alpine
 # https://github.com/minio/mc/releases
 ARG MINIO_VERSION=RELEASE.2025-05-21T01-59-54Z
 # https://github.com/cloudflare/cloudflared/releases
-ARG CLOUDFLARED_VERSION=2025.7.0
+ARG CLOUDFLARED_VERSION=2026.7.3
 # https://www.postgresql.org/support/versioning/
 # Note: We are using version 18 of the postgres client (while still using postgres 15 for the postgres server) as version 15 has been removed from Alpine 3.23+ https://pkgs.alpinelinux.org/packages?name=postgresql*-client&branch=v3.23&repo=&arch=x86_64&origin=&flagged=&maintainer=
 ARG POSTGRES_VERSION=18


### PR DESCRIPTION
## Summary
- Bump the pinned `CLOUDFLARED_VERSION` in `docker/production/Dockerfile` from 2025.7.0 to 2026.7.3.

## Why
The bundled cloudflared 2025.7.0 is built with Go 1.24.4 and `google.golang.org/grpc` v1.72.2, which carry two CRITICAL vulnerabilities reported by Trivy on the published `coollabsio/coolify:latest` image:

| CVE | Component | Installed | Fixed in |
|---|---|---|---|
| CVE-2025-68121 (crypto/tls: incorrect certificate validation during TLS session resumption) | stdlib | go1.24.4 | go1.24.13+ |
| CVE-2026-33186 (grpc-go authz: authorization bypass via improper HTTP/2 path validation) | grpc | v1.72.2 | v1.79.3 |

cloudflared 2026.7.3 ships with patched Go/grpc. Verified by scanning the official release binary:

```
trivy rootfs --scanners vuln --severity CRITICAL /scan
cloudflared-linux-amd64 (2026.7.3): 0 CRITICAL
```

Release assets exist for both `linux-amd64` and `linux-arm64`, so the multi-arch build is unaffected.

## Notes
- The pinned `MINIO_VERSION=RELEASE.2025-05-21T01-59-54Z` is affected by the same two CVEs, but even the latest upstream mc release (RELEASE.2025-08-13) still ships the vulnerable grpc/stdlib, so there is no fixed version to bump to yet.