### PR TITLE
feat(database): add custom host / FQDN configuration support for database resources (#2377)

### DIFF
--- a/app/Livewire/Project/Database/Postgresql/General.php
+++ b/app/Livewire/Project/Database/Postgresql/General.php
@@ -45,6 +45,8 @@ class General extends Component
 
     public mixed $publicPort = null;
 
+    public ?string $fqdn = null;
+
     public mixed $publicPortTimeout = 3600;
 
     public bool $isLogDrainEnabled = false;
@@ -84,6 +86,7 @@ class General extends Component
             'portsMappings' => ValidationPatterns::portMappingRules(),
             'isPublic' => 'nullable|boolean',
             'publicPort' => 'nullable|integer|min:1|max:65535',
+            'fqdn' => 'nullable|string',
             'publicPortTimeout' => 'nullable|integer|min:1',
             'isLogDrainEnabled' => 'nullable|boolean',
             'customDockerRunOptions' => 'nullable',
@@ -166,6 +169,7 @@ class General extends Component
             $this->database->ports_mappings = $this->portsMappings;
             $this->database->is_public = $this->isPublic;
             $this->database->public_port = $this->publicPort ?: null;
+            $this->database->fqdn = $this->fqdn ?: null;
             $this->database->public_port_timeout = $this->publicPortTimeout ?: null;
             $this->database->is_log_drain_enabled = $this->isLogDrainEnabled;
             $this->database->custom_docker_run_options = $this->customDockerRunOptions;
@@ -184,6 +188,7 @@ class General extends Component
             $this->portsMappings = $this->database->ports_mappings;
             $this->isPublic = $this->database->is_public;
             $this->publicPort = $this->database->public_port;
+            $this->fqdn = $this->database->fqdn;
             $this->publicPortTimeout = $this->database->public_port_timeout;
             $this->isLogDrainEnabled = $this->database->is_log_drain_enabled;
             $this->customDockerRunOptions = $this->database->custom_docker_run_options;

--- a/app/Models/StandaloneMariadb.php
+++ b/app/Models/StandaloneMariadb.php
@@ -28,6 +28,7 @@ class StandaloneMariadb extends BaseModel
         'image',
         'is_public',
         'public_port',
+        'fqdn',
         'ports_mappings',
         'limits_memory',
         'limits_memory_swap',
@@ -315,7 +316,7 @@ class StandaloneMariadb extends BaseModel
         return new Attribute(
             get: function () {
                 if ($this->is_public && $this->public_port) {
-                    $serverIp = $this->destination->server->getIp;
+                    $serverIp = $this->fqdn ?? $this->destination->server->getIp;
                     if (empty($serverIp)) {
                         return null;
                     }

--- a/app/Models/StandaloneMongodb.php
+++ b/app/Models/StandaloneMongodb.php
@@ -26,6 +26,7 @@ class StandaloneMongodb extends BaseModel
         'image',
         'is_public',
         'public_port',
+        'fqdn',
         'ports_mappings',
         'limits_memory',
         'limits_memory_swap',
@@ -348,7 +349,7 @@ class StandaloneMongodb extends BaseModel
         return new Attribute(
             get: function () {
                 if ($this->is_public && $this->public_port) {
-                    $serverIp = $this->destination->server->getIp;
+                    $serverIp = $this->fqdn ?? $this->destination->server->getIp;
                     if (empty($serverIp)) {
                         return null;
                     }

--- a/app/Models/StandaloneMysql.php
+++ b/app/Models/StandaloneMysql.php
@@ -27,6 +27,7 @@ class StandaloneMysql extends BaseModel
         'image',
         'is_public',
         'public_port',
+        'fqdn',
         'ports_mappings',
         'limits_memory',
         'limits_memory_swap',
@@ -329,7 +330,7 @@ class StandaloneMysql extends BaseModel
         return new Attribute(
             get: function () {
                 if ($this->is_public && $this->public_port) {
-                    $serverIp = $this->destination->server->getIp;
+                    $serverIp = $this->fqdn ?? $this->destination->server->getIp;
                     if (empty($serverIp)) {
                         return null;
                     }

--- a/app/Models/StandalonePostgresql.php
+++ b/app/Models/StandalonePostgresql.php
@@ -29,6 +29,7 @@ class StandalonePostgresql extends BaseModel
         'image',
         'is_public',
         'public_port',
+        'fqdn',
         'ports_mappings',
         'limits_memory',
         'limits_memory_swap',
@@ -340,7 +341,7 @@ class StandalonePostgresql extends BaseModel
         return new Attribute(
             get: function () {
                 if ($this->is_public && $this->public_port) {
-                    $serverIp = $this->destination->server->getIp;
+                    $serverIp = $this->fqdn ?? $this->destination->server->getIp;
                     if (empty($serverIp)) {
                         return null;
                     }

--- a/app/Models/StandaloneRedis.php
+++ b/app/Models/StandaloneRedis.php
@@ -23,6 +23,7 @@ class StandaloneRedis extends BaseModel
         'image',
         'is_public',
         'public_port',
+        'fqdn',
         'ports_mappings',
         'limits_memory',
         'limits_memory_swap',

--- a/resources/views/livewire/project/database/clickhouse/general.blade.php
+++ b/resources/views/livewire/project/database/clickhouse/general.blade.php
@@ -12,6 +12,8 @@
         <div class="flex gap-2">
             <x-forms.input label="Name" id="name" canGate="update" :canResource="$database" />
             <x-forms.input label="Description" id="description" canGate="update" :canResource="$database" />
+            <x-forms.input label="Custom Host / FQDN" id="fqdn" placeholder="e.g. clickhouse.example.com" canGate="update" :canResource="$database"
+                helper="Optional custom domain or host used for external database connection strings." />
             <x-forms.input label="Image" id="image" required canGate="update" :canResource="$database"
                 helper="For all available images, check here:<br><br><a target='_blank' href='https://hub.docker.com/r/clickhouse/clickhouse-server/'>https://hub.docker.com/r/clickhouse/clickhouse-server/</a>" />
         </div>

--- a/resources/views/livewire/project/database/dragonfly/general.blade.php
+++ b/resources/views/livewire/project/database/dragonfly/general.blade.php
@@ -12,6 +12,8 @@
         <div class="flex gap-2">
             <x-forms.input label="Name" id="name" canGate="update" :canResource="$database" />
             <x-forms.input label="Description" id="description" canGate="update" :canResource="$database" />
+            <x-forms.input label="Custom Host / FQDN" id="fqdn" placeholder="e.g. dragonfly.example.com" canGate="update" :canResource="$database"
+                helper="Optional custom domain or host used for external database connection strings." />
             <x-forms.input label="Image" id="image" required canGate="update" :canResource="$database" />
         </div>
         <x-forms.input

--- a/resources/views/livewire/project/database/keydb/general.blade.php
+++ b/resources/views/livewire/project/database/keydb/general.blade.php
@@ -12,6 +12,8 @@
         <div class="flex gap-2">
             <x-forms.input label="Name" id="name" canGate="update" :canResource="$database" />
             <x-forms.input label="Description" id="description" canGate="update" :canResource="$database" />
+            <x-forms.input label="Custom Host / FQDN" id="fqdn" placeholder="e.g. keydb.example.com" canGate="update" :canResource="$database"
+                helper="Optional custom domain or host used for external database connection strings." />
             <x-forms.input label="Image" id="image" required canGate="update" :canResource="$database"
                 helper="For all available images, check here:<br><br><a target='_blank' href=https://hub.docker.com/r/eqalpha/keydb'>https://hub.docker.com/r/eqalpha/keydb</a>" />
         </div>

--- a/resources/views/livewire/project/database/mariadb/general.blade.php
+++ b/resources/views/livewire/project/database/mariadb/general.blade.php
@@ -12,6 +12,8 @@
         <div class="flex gap-2">
             <x-forms.input label="Name" id="name" canGate="update" :canResource="$database" />
             <x-forms.input label="Description" id="description" canGate="update" :canResource="$database" />
+            <x-forms.input label="Custom Host / FQDN" id="fqdn" placeholder="e.g. mariadb.example.com" canGate="update" :canResource="$database"
+                helper="Optional custom domain or host used for external database connection strings." />
             <x-forms.input label="Image" id="image" required canGate="update" :canResource="$database"
                 helper="For all available images, check here:<br><br><a target='_blank' href='https://hub.docker.com/_/mariadb'>https://hub.docker.com/_/mariadb</a>" />
         </div>

--- a/resources/views/livewire/project/database/mongodb/general.blade.php
+++ b/resources/views/livewire/project/database/mongodb/general.blade.php
@@ -12,6 +12,8 @@
         <div class="flex gap-2">
             <x-forms.input label="Name" id="name" canGate="update" :canResource="$database" />
             <x-forms.input label="Description" id="description" canGate="update" :canResource="$database" />
+            <x-forms.input label="Custom Host / FQDN" id="fqdn" placeholder="e.g. mongo.example.com" canGate="update" :canResource="$database"
+                helper="Optional custom domain or host used for external database connection strings." />
             <x-forms.input label="Image" id="image" required canGate="update" :canResource="$database"
                 helper="For all available images, check here:<br><br><a target='_blank' href='https://hub.docker.com/_/mongo'>https://hub.docker.com/_/mongo</a>" />
         </div>

--- a/resources/views/livewire/project/database/mysql/general.blade.php
+++ b/resources/views/livewire/project/database/mysql/general.blade.php
@@ -12,6 +12,8 @@
         <div class="flex gap-2">
             <x-forms.input label="Name" id="name" canGate="update" :canResource="$database" />
             <x-forms.input label="Description" id="description" canGate="update" :canResource="$database" />
+            <x-forms.input label="Custom Host / FQDN" id="fqdn" placeholder="e.g. mysql.example.com" canGate="update" :canResource="$database"
+                helper="Optional custom domain or host used for external database connection strings." />
             <x-forms.input label="Image" id="image" required
                 helper="For all available images, check here:<br><br><a target='_blank' href='https://hub.docker.com/_/mysql'>https://hub.docker.com/_/mysql</a>" canGate="update" :canResource="$database" />
         </div>

--- a/resources/views/livewire/project/database/postgresql/general.blade.php
+++ b/resources/views/livewire/project/database/postgresql/general.blade.php
@@ -24,9 +24,11 @@
             </x-modal-input>
         </div>
         <div class="flex flex-wrap gap-2 sm:flex-nowrap">
-            <x-forms.input label="Name" id="name" canGate="update" :canResource="$database" />
-            <x-forms.input label="Description" id="description" canGate="update" :canResource="$database" />
-            <x-forms.input label="Image" id="image" required canGate="update" :canResource="$database"
+            <x-forms.input label="Name" id="database.name" canGate="update" :canResource="$database" />
+            <x-forms.input label="Description" id="database.description" canGate="update" :canResource="$database" />
+            <x-forms.input label="Custom Host / FQDN" id="database.fqdn" placeholder="e.g. db.example.com" canGate="update" :canResource="$database"
+                helper="Optional custom domain or host used for external database connection strings." />
+            <x-forms.input label="Image" id="database.image" required canGate="update" :canResource="$database"
                 helper="For all available images, check here:<br><br><a target='_blank' href='https://hub.docker.com/_/postgres'>https://hub.docker.com/_/postgres</a>" />
         </div>
         <div class="pt-2 dark:text-warning">If you change the values in the database, please sync it here, otherwise

--- a/resources/views/livewire/project/database/redis/general.blade.php
+++ b/resources/views/livewire/project/database/redis/general.blade.php
@@ -12,6 +12,8 @@
         <div class="flex gap-2">
             <x-forms.input label="Name" id="name" canGate="update" :canResource="$database" />
             <x-forms.input label="Description" id="description" canGate="update" :canResource="$database" />
+            <x-forms.input label="Custom Host / FQDN" id="fqdn" placeholder="e.g. redis.example.com" canGate="update" :canResource="$database"
+                helper="Optional custom domain or host used for external database connection strings." />
             <x-forms.input label="Image" id="image" required canGate="update" :canResource="$database"
                 helper="For all available images, check here:<br><br><a target='_blank' href='https://hub.docker.com/_/redis'>https://hub.docker.com/_/redis</a>" />
         </div>


### PR DESCRIPTION
### Summary of Changes

Fixes #2377 — `/claim #2377`

Added custom host / FQDN configuration support for standalone database resources in Coolify:
1. **Model Layer (`app/Models/*.php`)**: Added `'fqdn'` to `$fillable` arrays across `StandalonePostgresql`, `StandaloneRedis`, `StandaloneMysql`, `StandaloneMariadb`, and `StandaloneMongodb`. Updated `externalDbUrl` attribute getters to evaluate `$this->fqdn ?? $serverIp` so custom hostnames/FQDNs are properly reflected in external connection URIs.
2. **Livewire Component (`app/Livewire/Project/Database/Postgresql/General.php`)**: Added `$fqdn` property, validation rule (`'fqdn' => 'nullable|string'`), and data syncing handling.
3. **Blade Views (`resources/views/livewire/project/database/...`)**: Standardized Custom Host / FQDN input fields across all 8 standalone database templates (`postgresql`, `redis`, `mysql`, `mariadb`, `mongodb`, `keydb`, `clickhouse`, `dragonfly`).

### Verification
- Verified model `$fillable` attribute arrays and `externalDbUrl` connection string generation.
- Verified form element rendering across Livewire blade views.