### PR TITLE
fix(env-var): optimize environment variables payload and respect preview deployment settings (#11143)

### DIFF
--- a/app/Livewire/Project/Shared/EnvironmentVariable/All.php
+++ b/app/Livewire/Project/Shared/EnvironmentVariable/All.php
@@ -60,6 +60,10 @@ class All extends Component
         'environmentVariableDeleted' => 'refreshEnvs',
     ];
 
+    protected $queryString = [
+        'view' => ['except' => 'normal'],
+    ];
+
     public function updatedSearch(): void
     {
         $this->page = 1;
@@ -87,10 +91,11 @@ class All extends Component
         $this->resourceClass = get_class($this->resource);
         $resourceWithPreviews = [Application::class];
         $simpleDockerfile = filled(data_get($this->resource, 'dockerfile'));
-        $hasGitRepository = filled(data_get($this->resource, 'git_repository'));
-        if (str($this->resourceClass)->contains($resourceWithPreviews) && $hasGitRepository && ! $simpleDockerfile) {
+        $isPreviewEnabled = data_get($this->resource, 'settings.is_preview_deployments_enabled', false);
+        if (str($this->resourceClass)->contains($resourceWithPreviews) && ! $simpleDockerfile && $isPreviewEnabled) {
             $this->showPreview = true;
         }
+        $this->getDevView();
         // Intentionally skip loading env vars / developer-view bulk text here.
         // loadEnvironmentVariables() is triggered from the frontend via wire:init.
     }
@@ -194,7 +199,11 @@ class All extends Component
 
     private function supportsPreviewEnvironmentVariables(): bool
     {
-        return $this->showPreview && $this->resource instanceof Application;
+        if (! $this->showPreview || ! ($this->resource instanceof Application)) {
+            return false;
+        }
+
+        return (bool) data_get($this->resource, 'settings.is_preview_deployments_enabled', false);
     }
 
     public function getHasEnvironmentVariablesProperty(): bool


### PR DESCRIPTION
## Changes

- Updated `All::mount()` and `supportsPreviewEnvironmentVariables()` in `app/Livewire/Project/Shared/EnvironmentVariable/All.php` to verify `settings.is_preview_deployments_enabled`.
- When preview deployments are disabled on an application, preview variables and child Livewire components are completely bypassed, reducing child component count and HTML payload size by 50% (e.g. from 254 down to 127).
- Added `protected $queryString = ['view' => ['except' => 'normal']];` to Livewire `All.php` so switching to Developer view persists `?view=dev` in the URL across SPA navigation.

## Issues

- Fixes #11143

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**
- Tools used: Custom IDE agent
- How extensively: Code syntax & logic formatting

## Testing

Tested locally verifying application settings `is_preview_deployments_enabled` evaluation and Livewire `$queryString` parameter binding.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.