### PR TITLE
fix(api): prevent sanitizeLogsForExport regex from crossing line boundaries

### DIFF
--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -1508,8 +1508,26 @@ function removeAnsiColors($text)
 
 function sanitizeLogsForExport(string $text): string
 {
-    // All sanitization is now handled by remove_iip()
-    return remove_iip($text);
+    // Ensure valid UTF-8 before processing
+    $text = sanitize_utf8_text($text);
+
+    // Handle multi-line patterns on the full text first.
+    // Private key blocks legitimately span multiple lines and must be
+    // redacted as a whole before per-line sanitization.
+    $text = preg_replace('/-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/', REDACTED, $text);
+
+    // Split into individual lines and apply single-line sanitization to each
+    // one independently. This prevents regexes like the URL password pattern
+    // ([^@]+) from greedily matching across newline boundaries when no "@"
+    // exists on the same line (issue #11066).
+    $lines = explode("\n", $text);
+
+    foreach ($lines as &$line) {
+        $line = remove_iip($line);
+    }
+    unset($line);
+
+    return implode("\n", $lines);
 }
 
 function getTopLevelNetworks(Service|Application $resource)

--- a/tests/Unit/SanitizeLogsForExportTest.php
+++ b/tests/Unit/SanitizeLogsForExportTest.php
@@ -184,3 +184,78 @@ it('removes generic URL passwords', function () {
         expect($result)->toBe($expected);
     }
 });
+
+it('does not corrupt logs when URL password regex would cross line boundaries', function () {
+    $input = implode("\n", [
+        '{"timestamp":"2025-01-01T00:00:00Z","message":"connecting to postgres://user:secretpass"}',
+        '{"timestamp":"2025-01-01T00:00:01Z","message":"normal log line with no sensitive data"}',
+        '{"timestamp":"2025-01-01T00:00:02Z","message":"notification sent to admin@example.com"}',
+    ]);
+    $result = sanitizeLogsForExport($input);
+    $lines = explode("\n", $result);
+
+    // All 3 lines must be preserved as separate lines
+    expect($lines)->toHaveCount(3);
+
+    // Line 1 remains intact (no @ on this line means the URL regex does not match)
+    expect($lines[0])->toContain('postgres://user:secretpass');
+
+    // Line 2 should be completely untouched
+    expect($lines[1])->toBe('{"timestamp":"2025-01-01T00:00:01Z","message":"normal log line with no sensitive data"}');
+
+    // Line 3 email gets redacted independently
+    expect($lines[2])->not->toContain('admin@example.com');
+    expect($lines[2])->toContain(REDACTED);
+});
+
+it('sanitizes complete credential URLs on individual lines independently', function () {
+    $input = implode("\n", [
+        'postgres://user:secret1@localhost:5432/db',
+        'mysql://admin:secret2@db.host.com/app',
+    ]);
+    $result = sanitizeLogsForExport($input);
+    $lines = explode("\n", $result);
+
+    expect($lines)->toHaveCount(2);
+    expect($lines[0])->toBe('postgres://user:'.REDACTED.'@localhost:5432/db');
+    expect($lines[1])->toBe('mysql://admin:'.REDACTED.'@db.host.com/app');
+});
+
+it('still redacts private key blocks spanning multiple lines after line-by-line fix', function () {
+    $input = implode("\n", [
+        'Config:',
+        '-----BEGIN RSA PRIVATE KEY-----',
+        'MIIEowIBAAKCAQEAyZ3xL8v4xK3z9Z3',
+        'some-key-content-here',
+        '-----END RSA PRIVATE KEY-----',
+        'After key',
+    ]);
+    $result = sanitizeLogsForExport($input);
+
+    expect($result)->not->toContain('-----BEGIN RSA PRIVATE KEY-----');
+    expect($result)->not->toContain('MIIEowIBAAKCAQEAyZ3xL8v4xK3z9Z3');
+    expect($result)->not->toContain('some-key-content-here');
+    expect($result)->not->toContain('-----END RSA PRIVATE KEY-----');
+    expect($result)->toContain(REDACTED);
+    expect($result)->toContain('Config:');
+    expect($result)->toContain('After key');
+});
+
+it('preserves line count in multi-line log output', function () {
+    $input = implode("\n", [
+        '2025-01-01 INFO: Application started',
+        '2025-01-01 DEBUG: Connected to redis://default:mypass@redis:6379',
+        '2025-01-01 INFO: Processing complete',
+        '2025-01-01 WARN: Timeout on request',
+        '2025-01-01 INFO: Shutting down',
+    ]);
+    $result = sanitizeLogsForExport($input);
+    $inputLines = explode("\n", $input);
+    $outputLines = explode("\n", $result);
+
+    expect($outputLines)->toHaveCount(count($inputLines));
+    expect($outputLines[1])->toContain(REDACTED);
+    expect($outputLines[1])->not->toContain('mypass');
+    expect($outputLines[0])->toBe('2025-01-01 INFO: Application started');
+    expect($outputLines[2])->toBe('2025-01-01 INFO: Processing complete');
+});


### PR DESCRIPTION
## Summary

Fixes the cross line regex corruption bug in `sanitizeLogsForExport()` that destroys multi-line log exports.

**Upstream target:** This PR should be submitted to `coollabsio/coolify` targeting the `next` branch.
**Closes:** coollabsio/coolify#11066

## Problem

The `remove_iip()` function applies URL password sanitization regex `[^@]+` to the **entire** log text at once. When a log line contains a URL like `postgres://user:password` but has no `@` on that same line, the regex matches across newline boundaries until it finds the next `@` (often from an email address lines/hours later). This destroys all intermediate log lines, producing invalid JSON.

**Impact observed in production:** 7 of 7,488 lines corrupted per export. Two separate JSON records merge into one invalid line.

## Solution

Refactored `sanitizeLogsForExport()` to:
1. Handle multi-line patterns first (private key blocks that legitimately span lines)
2. Split remaining text into individual lines
3. Apply `remove_iip()` to each line independently (prevents cross-boundary matches)
4. Rejoin with newlines

Does NOT modify `remove_iip()` itself (shared by other callers including real-time log display).

## Changes

- `bootstrap/helpers/shared.php`  Rewrote `sanitizeLogsForExport()` with line-by-line processing
- `tests/Unit/SanitizeLogsForExportTest.php`  Added 4 new test cases covering the cross-line bug, per-line credential handling, multi-line private key blocks, and line count preservation

## Testing

- All 136 unit tests pass (659 assertions total, 0 failures)
- The 4 new tests specifically cover the cross-line corruption scenario
- TDD verified: new tests fail with old code, pass with the fix
- `vendor/bin/pint --dirty --format agent` passes cleanly

## AI Disclosure

AI tools were used to assist with this contribution. All changes have been reviewed, understood, and verified for correctness.

---

### Contributor Agreement

- [x] I agree to the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My changes target the `next` branch
- [x] I have tested these changes locally
- [x] I understand this PR may be closed at maintainer discretion