### PR TITLE
fix(api): prevent sanitizeLogsForExport regex from crossing line boundaries

### DIFF
--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -1508,8 +1508,26 @@ function removeAnsiColors($text)
 
 function sanitizeLogsForExport(string $text): string
 {
-    // All sanitization is now handled by remove_iip()
-    return remove_iip($text);
+    // Ensure valid UTF-8 before processing
+    $text = sanitize_utf8_text($text);
+
+    // Handle multi-line patterns on the full text first.
+    // Private key blocks legitimately span multiple lines and must be
+    // redacted as a whole before per-line sanitization.
+    $text = preg_replace('/-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/', REDACTED, $text);
+
+    // Split into individual lines and apply single-line sanitization to each
+    // one independently. This prevents regexes like the URL password pattern
+    // ([^@]+) from greedily matching across newline boundaries when no "@"
+    // exists on the same line (issue #11066).
+    $lines = explode("\n", $text);
+
+    foreach ($lines as &$line) {
+        $line = remove_iip($line);
+    }
+    unset($line);
+
+    return implode("\n", $lines);
 }
 
 function getTopLevelNetworks(Service|Application $resource)

--- a/tests/Unit/SanitizeLogsForExportTest.php
+++ b/tests/Unit/SanitizeLogsForExportTest.php
@@ -184,3 +184,78 @@ it('removes generic URL passwords', function () {
         expect($result)->toBe($expected);
     }
 });
+
+it('does not corrupt logs when URL password regex would cross line boundaries', function () {
+    $input = implode("\n", [
+        '{"timestamp":"2025-01-01T00:00:00Z","message":"connecting to postgres://user:secretpass"}',
+        '{"timestamp":"2025-01-01T00:00:01Z","message":"normal log line with no sensitive data"}',
+        '{"timestamp":"2025-01-01T00:00:02Z","message":"notification sent to admin@example.com"}',
+    ]);
+    $result = sanitizeLogsForExport($input);
+    $lines = explode("\n", $result);
+
+    // All 3 lines must be preserved as separate lines
+    expect($lines)->toHaveCount(3);
+
+    // Line 1 remains intact (no @ on this line means the URL regex does not match)
+    expect($lines[0])->toContain('postgres://user:secretpass');
+
+    // Line 2 should be completely untouched
+    expect($lines[1])->toBe('{"timestamp":"2025-01-01T00:00:01Z","message":"normal log line with no sensitive data"}');
+
+    // Line 3 email gets redacted independently
+    expect($lines[2])->not->toContain('admin@example.com');
+    expect($lines[2])->toContain(REDACTED);
+});
+
+it('sanitizes complete credential URLs on individual lines independently', function () {
+    $input = implode("\n", [
+        'postgres://user:secret1@localhost:5432/db',
+        'mysql://admin:secret2@db.host.com/app',
+    ]);
+    $result = sanitizeLogsForExport($input);
+    $lines = explode("\n", $result);
+
+    expect($lines)->toHaveCount(2);
+    expect($lines[0])->toBe('postgres://user:'.REDACTED.'@localhost:5432/db');
+    expect($lines[1])->toBe('mysql://admin:'.REDACTED.'@db.host.com/app');
+});
+
+it('still redacts private key blocks spanning multiple lines after line-by-line fix', function () {
+    $input = implode("\n", [
+        'Config:',
+        '-----BEGIN RSA PRIVATE KEY-----',
+        'MIIEowIBAAKCAQEAyZ3xL8v4xK3z9Z3',
+        'some-key-content-here',
+        '-----END RSA PRIVATE KEY-----',
+        'After key',
+    ]);
+    $result = sanitizeLogsForExport($input);
+
+    expect($result)->not->toContain('-----BEGIN RSA PRIVATE KEY-----');
+    expect($result)->not->toContain('MIIEowIBAAKCAQEAyZ3xL8v4xK3z9Z3');
+    expect($result)->not->toContain('some-key-content-here');
+    expect($result)->not->toContain('-----END RSA PRIVATE KEY-----');
+    expect($result)->toContain(REDACTED);
+    expect($result)->toContain('Config:');
+    expect($result)->toContain('After key');
+});
+
+it('preserves line count in multi-line log output', function () {
+    $input = implode("\n", [
+        '2025-01-01 INFO: Application started',
+        '2025-01-01 DEBUG: Connected to redis://default:mypass@redis:6379',
+        '2025-01-01 INFO: Processing complete',
+        '2025-01-01 WARN: Timeout on request',
+        '2025-01-01 INFO: Shutting down',
+    ]);
+    $result = sanitizeLogsForExport($input);
+    $inputLines = explode("\n", $input);
+    $outputLines = explode("\n", $result);
+
+    expect($outputLines)->toHaveCount(count($inputLines));
+    expect($outputLines[1])->toContain(REDACTED);
+    expect($outputLines[1])->not->toContain('mypass');
+    expect($outputLines[0])->toBe('2025-01-01 INFO: Application started');
+    expect($outputLines[2])->toBe('2025-01-01 INFO: Processing complete');
+});


### PR DESCRIPTION
## Changes

The `sanitizeLogsForExport()` function in `bootstrap/helpers/shared.php` applied `remove_iip()` regex patterns to the entire multi-line log text at once. The URL password regex `[^@]+` matched across newline boundaries when no `@` existed on the same line, consuming everything until the next `@` (often from an email on a different log line hours later). This corrupted exported JSON logs by merging separate records into one invalid line.

This fix processes logs line-by-line to prevent cross-boundary regex matches while still handling multi-line private key blocks correctly.

## Issues

- Fixes #11066

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A  backend-only change affecting log export sanitization. No visual changes.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Kiro AI assistant
- How extensively: Assisted with identifying the root cause, writing the fix, and generating test cases. All changes were reviewed, understood, and verified manually.

## Testing

1. Ran all 20 tests in `tests/Unit/SanitizeLogsForExportTest.php`  all pass (89 assertions)
2. Ran 136 broader pure unit tests  all pass (659 assertions, 0 failures)
3. Added 4 new test cases that specifically reproduce the cross-line corruption from issue #11066
4. Verified TDD: new tests fail with the old code, pass with the fix
5. Ran `vendor/bin/pint --dirty --format agent`  clean formatting

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
