### PR TITLE
fix(service): change cyberchef port from 80 to 8080

### DIFF
--- a/templates/compose/cyberchef.yaml
+++ b/templates/compose/cyberchef.yaml
@@ -3,14 +3,14 @@
 # category: security
 # tags: encryption, encoding, compression, data analysis, tools, development
 # logo: svgs/cyberchef.jpeg
-# port: 80
+# port: 8080
 
 services:
   cyberchef:
     image: ghcr.io/gchq/cyberchef:latest
     platform: linux/amd64
     environment:
-      - SERVICE_URL_CYBERCHEF_80
+      - SERVICE_URL_CYBERCHEF_8080
     volumes:
       - cyberchef-data:/app/data
     healthcheck:
@@ -18,7 +18,7 @@ services:
         - CMD
         - curl
         - '-f'
-        - 'http://127.0.0.1:80'
+        - 'http://127.0.0.1:8080'
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Changes


- Change the port of CyberChef to port 8080, this was set to port 80 but this is incorrect. This causes the app to fail to serve and causes healthchecks to fail

## Category

- [X] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service


## AI Assistance

<!-- AI-assisted PRs that are human reviewed are welcome, just let us know so we can review appropriately. -->

- [X] AI was NOT used to create this PR
- [ ] AI was used (please describe below)

**If AI was used:**

- Tools used:
- How extensively:

## Testing

Tested on my own coolify instance

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [X] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [X] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [X] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
