### PR TITLE
fix(previews): generate preview FQDNs for every application domain

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -2269,16 +2269,18 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
         } else {
             $fqdn = $this->preview->fqdn;
         }
-        if (isset($fqdn)) {
-            $url = Url::fromString($fqdn);
-            $fqdn = $url->getHost();
-            $url = $url->withHost($fqdn)->withPort(null)->__toString();
+        // The FQDN may be a comma-separated list; parse each entry on its own
+        // (Url::fromString cannot parse a comma-joined list as a whole).
+        $fqdns = collect(ValidationPatterns::applicationDomainList($fqdn));
+        if ($fqdns->isNotEmpty()) {
+            $hosts = $fqdns->map(fn (string $domain) => Url::fromString($domain)->getHost())->implode(',');
+            $urls = $fqdns->map(fn (string $domain) => Url::fromString($domain)->withPort(null)->__toString())->implode(',');
             if ((int) $this->application->compose_parsing_version >= 3) {
-                $this->coolify_variables .= 'COOLIFY_URL='.escapeShellValue($url).' ';
-                $this->coolify_variables .= 'COOLIFY_FQDN='.escapeShellValue($fqdn).' ';
+                $this->coolify_variables .= 'COOLIFY_URL='.escapeShellValue($urls).' ';
+                $this->coolify_variables .= 'COOLIFY_FQDN='.escapeShellValue($hosts).' ';
             } else {
-                $this->coolify_variables .= 'COOLIFY_URL='.escapeShellValue($fqdn).' ';
-                $this->coolify_variables .= 'COOLIFY_FQDN='.escapeShellValue($url).' ';
+                $this->coolify_variables .= 'COOLIFY_URL='.escapeShellValue($hosts).' ';
+                $this->coolify_variables .= 'COOLIFY_FQDN='.escapeShellValue($urls).' ';
             }
         }
         if (isset($this->application->git_branch)) {

--- a/app/Jobs/ApplicationPullRequestUpdateJob.php
+++ b/app/Jobs/ApplicationPullRequestUpdateJob.php
@@ -5,12 +5,14 @@ namespace App\Jobs;
 use App\Enums\ProcessStatus;
 use App\Models\Application;
 use App\Models\ApplicationPreview;
+use App\Support\ValidationPatterns;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Spatie\Url\Url;
 
 class ApplicationPullRequestUpdateJob implements ShouldBeEncrypted, ShouldQueue
 {
@@ -112,6 +114,16 @@ class ApplicationPullRequestUpdateJob implements ShouldBeEncrypted, ShouldQueue
             return ! empty($links) ? implode(' | ', $links).' | ' : '';
         }
 
-        return $this->preview->fqdn ? "[Open Preview]({$this->preview->fqdn}) | " : '';
+        $fqdns = collect(ValidationPatterns::applicationDomainList($this->preview->fqdn));
+        if ($fqdns->isEmpty()) {
+            return '';
+        }
+        if ($fqdns->count() === 1) {
+            return "[Open Preview]({$fqdns->first()}) | ";
+        }
+
+        return $fqdns
+            ->map(fn (string $domain) => '[Open Preview ('.Url::fromString($domain)->getHost().")]({$domain})")
+            ->implode(' | ').' | ';
     }
 }

--- a/app/Livewire/Project/Application/Previews.php
+++ b/app/Livewire/Project/Application/Previews.php
@@ -129,12 +129,16 @@ class Previews extends Component
                     $fqdn = ValidationPatterns::normalizeApplicationDomains($fqdn);
                     $this->previewFqdns[$previewKey] = $fqdn;
 
-                    if (! validateDNSEntry($fqdn, $this->application->destination->server)) {
-                        $server = $this->application->destination->server;
-                        $target = serverDnsTargetIp($server) ?? $server->ip;
-                        $guidance = dnsMismatchGuidanceMessage($target, $target);
-                        $this->dispatch('error', 'Validating DNS failed.', "{$guidance}<br><br>Check this <a target='_blank' class='underline dark:text-white' href='https://coolify.io/docs/knowledge-base/dns-configuration'>documentation</a> for further help.");
-                        $success = false;
+                    foreach (ValidationPatterns::applicationDomainList($fqdn) as $domain) {
+                        if (! validateDNSEntry($domain, $this->application->destination->server)) {
+                            $server = $this->application->destination->server;
+                            $target = serverDnsTargetIp($server) ?? $server->ip;
+                            $guidance = dnsMismatchGuidanceMessage($target, $target);
+                            $this->dispatch('error', 'Validating DNS failed.', "{$guidance}<br><br>Check this <a target='_blank' class='underline dark:text-white' href='https://coolify.io/docs/knowledge-base/dns-configuration'>documentation</a> for further help.");
+                            $success = false;
+
+                            break;
+                        }
                     }
 
                     // Check for domain conflicts if not forcing save
@@ -184,7 +188,7 @@ class Previews extends Component
                 return;
             }
 
-            $preview->generate_preview_fqdn();
+            $preview->generate_preview_fqdn(force: true);
             $this->application->refresh();
             $this->syncData(false);
             $this->dispatch('update_links');

--- a/app/Models/ApplicationPreview.php
+++ b/app/Models/ApplicationPreview.php
@@ -95,29 +95,42 @@ class ApplicationPreview extends BaseModel
         return $this->morphMany(LocalPersistentVolume::class, 'resource');
     }
 
-    public function generate_preview_fqdn()
+    public function generate_preview_fqdn(bool $force = false)
     {
-        if ($this->application->fqdn) {
-            if (str($this->application->fqdn)->contains(',')) {
-                $url = Url::fromString(str($this->application->fqdn)->explode(',')[0]);
-            } else {
-                $url = Url::fromString($this->application->fqdn);
-            }
-            $template = $this->application->preview_url_template;
+        // A preview that already has a domain keeps it (it may have been
+        // customized by the user); only explicit regeneration overwrites it.
+        // generate_preview_fqdn_compose() has no equivalent guard yet, so
+        // compose previews are still regenerated on every deployment.
+        if (filled($this->fqdn) && ! $force) {
+            return $this;
+        }
+
+        $domains = ValidationPatterns::applicationDomainList($this->application->fqdn);
+        if (count($domains) === 0) {
+            return $this;
+        }
+
+        $template = $this->application->preview_url_template;
+        $random = new_public_id();
+
+        $preview_fqdns = collect($domains)->map(function (string $domain) use ($template, $random) {
+            $url = Url::fromString($domain);
             $host = $url->getHost();
             $schema = $url->getScheme();
             $portInt = $url->getPort();
             $port = $portInt !== null ? ':'.$portInt : '';
             $urlPath = $url->getPath();
             $path = ($urlPath !== '' && $urlPath !== '/') ? $urlPath : '';
-            $random = new_public_id();
+
             $preview_fqdn = str_replace('{{random}}', $random, $template);
             $preview_fqdn = str_replace('{{domain}}', $host, $preview_fqdn);
             $preview_fqdn = str_replace('{{pr_id}}', $this->pull_request_id, $preview_fqdn);
-            $preview_fqdn = "$schema://$preview_fqdn{$port}{$path}";
-            $this->fqdn = $preview_fqdn;
-            $this->save();
-        }
+
+            return "$schema://$preview_fqdn{$port}{$path}";
+        });
+
+        $this->fqdn = $preview_fqdns->unique()->implode(',');
+        $this->save();
 
         return $this;
     }

--- a/app/Notifications/Application/DeploymentFailed.php
+++ b/app/Notifications/Application/DeploymentFailed.php
@@ -30,6 +30,8 @@ class DeploymentFailed extends CustomEmailNotification
 
     public ?string $fqdn = null;
 
+    public ?string $preview_fqdn = null;
+
     public function __construct(Application $application, string $deployment_uuid, ?ApplicationPreview $preview = null)
     {
         $this->onQueue('high');
@@ -43,6 +45,10 @@ class DeploymentFailed extends CustomEmailNotification
         $this->fqdn = data_get($application, 'fqdn');
         if (str($this->fqdn)->explode(',')->count() > 1) {
             $this->fqdn = str($this->fqdn)->explode(',')->first();
+        }
+        $this->preview_fqdn = data_get($preview, 'fqdn');
+        if (str($this->preview_fqdn)->explode(',')->count() > 1) {
+            $this->preview_fqdn = str($this->preview_fqdn)->explode(',')->first();
         }
         $this->deployment_url = base_url()."/project/{$this->project_uuid}/environment/{$this->environment_uuid}/application/{$this->application->uuid}/deployment/{$this->deployment_uuid}";
     }
@@ -60,7 +66,7 @@ class DeploymentFailed extends CustomEmailNotification
         if ($pull_request_id === 0) {
             $mail->subject('Coolify: Deployment failed of '.$this->application_name.'.');
         } else {
-            $fqdn = $this->preview->fqdn;
+            $fqdn = $this->preview_fqdn;
             $mail->subject('Coolify: Deployment failed of pull request #'.$this->preview->pull_request_id.' of '.$this->application_name.'.');
         }
         $mail->view('emails.application-deployment-failed', [
@@ -117,7 +123,7 @@ class DeploymentFailed extends CustomEmailNotification
     public function toTelegram(): array
     {
         if ($this->preview) {
-            $message = 'Coolify: Pull request #'.$this->preview->pull_request_id.' of '.$this->application_name.' ('.$this->preview->fqdn.') deployment failed: ';
+            $message = 'Coolify: Pull request #'.$this->preview->pull_request_id.' of '.$this->application_name.' ('.$this->preview_fqdn.') deployment failed: ';
         } else {
             $message = 'Coolify: Deployment failed of '.$this->application_name.' ('.$this->fqdn.'): ';
         }
@@ -164,8 +170,8 @@ class DeploymentFailed extends CustomEmailNotification
         if ($this->preview) {
             $title = "Pull request #{$this->preview->pull_request_id} deployment failed";
             $description = "Pull request deployment failed for {$this->application_name}";
-            if ($this->preview->fqdn) {
-                $description .= "\nPreview URL: {$this->preview->fqdn}";
+            if ($this->preview_fqdn) {
+                $description .= "\nPreview URL: {$this->preview_fqdn}";
             }
         } else {
             $title = 'Deployment failed';

--- a/app/Notifications/Application/DeploymentSuccess.php
+++ b/app/Notifications/Application/DeploymentSuccess.php
@@ -30,6 +30,8 @@ class DeploymentSuccess extends CustomEmailNotification
 
     public ?string $fqdn;
 
+    public ?string $preview_fqdn = null;
+
     public function __construct(Application $application, string $deployment_uuid, ?ApplicationPreview $preview = null)
     {
         $this->onQueue('high');
@@ -43,6 +45,10 @@ class DeploymentSuccess extends CustomEmailNotification
         $this->fqdn = data_get($application, 'fqdn');
         if (str($this->fqdn)->explode(',')->count() > 1) {
             $this->fqdn = str($this->fqdn)->explode(',')->first();
+        }
+        $this->preview_fqdn = data_get($preview, 'fqdn');
+        if (str($this->preview_fqdn)->explode(',')->count() > 1) {
+            $this->preview_fqdn = str($this->preview_fqdn)->explode(',')->first();
         }
         $this->deployment_url = base_url()."/project/{$this->project_uuid}/environment/{$this->environment_uuid}/application/{$this->application->uuid}/deployment/{$this->deployment_uuid}";
     }
@@ -60,7 +66,7 @@ class DeploymentSuccess extends CustomEmailNotification
         if ($pull_request_id === 0) {
             $mail->subject("Coolify: New version is deployed of {$this->application_name}");
         } else {
-            $fqdn = $this->preview->fqdn;
+            $fqdn = $this->preview_fqdn;
             $mail->subject("Coolify: Pull request #{$pull_request_id} of {$this->application_name} deployed successfully");
         }
         $mail->view('emails.application-deployment-success', [
@@ -82,8 +88,8 @@ class DeploymentSuccess extends CustomEmailNotification
                 color: DiscordMessage::successColor(),
             );
 
-            if ($this->preview->fqdn) {
-                $message->addField('Application', '[Link]('.$this->preview->fqdn.')');
+            if ($this->preview_fqdn) {
+                $message->addField('Application', '[Link]('.$this->preview_fqdn.')');
             }
 
             $message->addField('Project', data_get($this->application, 'environment.project.name'), true);
@@ -115,10 +121,10 @@ class DeploymentSuccess extends CustomEmailNotification
     {
         if ($this->preview) {
             $message = 'Coolify: New PR'.$this->preview->pull_request_id.' version successfully deployed of '.$this->application_name.'';
-            if ($this->preview->fqdn) {
+            if ($this->preview_fqdn) {
                 $buttons[] = [
                     'text' => 'Open Application',
-                    'url' => $this->preview->fqdn,
+                    'url' => $this->preview_fqdn,
                 ];
             }
         } else {
@@ -148,10 +154,10 @@ class DeploymentSuccess extends CustomEmailNotification
         if ($this->preview) {
             $title = "Pull request #{$this->preview->pull_request_id} successfully deployed";
             $message = 'New PR'.$this->preview->pull_request_id.' version successfully deployed of '.$this->application_name.'';
-            if ($this->preview->fqdn) {
+            if ($this->preview_fqdn) {
                 $buttons[] = [
                     'text' => 'Open Application',
-                    'url' => $this->preview->fqdn,
+                    'url' => $this->preview_fqdn,
                 ];
             }
         } else {
@@ -184,8 +190,8 @@ class DeploymentSuccess extends CustomEmailNotification
         if ($this->preview) {
             $title = "Pull request #{$this->preview->pull_request_id} successfully deployed";
             $description = "New version successfully deployed for {$this->application_name}";
-            if ($this->preview->fqdn) {
-                $description .= "\nPreview URL: {$this->preview->fqdn}";
+            if ($this->preview_fqdn) {
+                $description .= "\nPreview URL: {$this->preview_fqdn}";
             }
         } else {
             $title = 'New version successfully deployed';

--- a/bootstrap/helpers/domains.php
+++ b/bootstrap/helpers/domains.php
@@ -3,6 +3,7 @@
 use App\Models\Application;
 use App\Models\Service;
 use App\Models\ServiceApplication;
+use App\Support\ValidationPatterns;
 use Illuminate\Support\Collection;
 
 /**
@@ -78,15 +79,18 @@ function checkDomainUsage(ServiceApplication|Application|null $resource = null, 
         $currentTeam = $resource->team();
     }
 
-    if ($resource) {
+    // An explicit domain list wins over the resource's stored domains, so
+    // callers can validate not-yet-persisted input (e.g. a preview domain)
+    // while keeping the resource's team scoping and self-exclusion.
+    if ($domain) {
+        $domains = collect(ValidationPatterns::applicationDomainList($domain));
+    } elseif ($resource) {
         if ($resource->getMorphClass() === Application::class && $resource->build_pack === 'dockercompose') {
             $domains = data_get(json_decode($resource->docker_compose_domains, true), '*.domain');
             $domains = collect($domains);
         } else {
             $domains = collect($resource->fqdns);
         }
-    } elseif ($domain) {
-        $domains = collect([$domain]);
     } else {
         return ['conflicts' => [], 'hasConflicts' => false];
     }

--- a/resources/views/components/applications/links.blade.php
+++ b/resources/views/components/applications/links.blade.php
@@ -96,14 +96,16 @@
                 @else
                     @foreach (data_get($application, 'previews') as $preview)
                         @if (data_get($preview, 'fqdn'))
-                            <a class="{{ $linkItemClasses }}" target="_blank"
-                                href="{{ getFqdnWithoutPort(data_get($preview, 'fqdn')) }}">
-                                <span
-                                    class="shrink-0 rounded-md bg-coollabs/10 px-1.5 py-0.5 text-[10px] font-semibold text-coollabs ring-1 ring-coollabs/20 dark:bg-warning/10 dark:text-warning dark:ring-warning/20">
-                                    PR #{{ data_get($preview, 'pull_request_id') }}
-                                </span>
-                                <span class="min-w-0 truncate">{{ getFqdnWithoutPort(data_get($preview, 'fqdn')) }}</span>
-                            </a>
+                            @foreach (str(data_get($preview, 'fqdn'))->explode(',')->map(fn($domain) => trim($domain))->filter() as $previewFqdn)
+                                <a class="{{ $linkItemClasses }}" target="_blank"
+                                    href="{{ getFqdnWithoutPort($previewFqdn) }}">
+                                    <span
+                                        class="shrink-0 rounded-md bg-coollabs/10 px-1.5 py-0.5 text-[10px] font-semibold text-coollabs ring-1 ring-coollabs/20 dark:bg-warning/10 dark:text-warning dark:ring-warning/20">
+                                        PR #{{ data_get($preview, 'pull_request_id') }}
+                                    </span>
+                                    <span class="min-w-0 truncate">{{ getFqdnWithoutPort($previewFqdn) }}</span>
+                                </a>
+                            @endforeach
                         @endif
                     @endforeach
                 @endif

--- a/resources/views/livewire/project/application/previews-compose.blade.php
+++ b/resources/views/livewire/project/application/previews-compose.blade.php
@@ -1,6 +1,6 @@
 <form wire:submit="save"
     class="grid gap-3 rounded-lg bg-neutral-50 p-3 ring-1 ring-neutral-200 md:grid-cols-[minmax(0,1fr)_auto] md:items-end dark:bg-white/[0.025] dark:ring-white/[0.07]">
-    <x-forms.input helper="One domain per preview." label="{{ Str::headline($serviceName) }} domain"
+    <x-forms.input helper="You can specify one domain, or multiple as a comma separated list." label="{{ Str::headline($serviceName) }} domain"
         id="domain" wire:change="save" canGate="update" :canResource="$preview->application" />
     <x-forms.button wire:click="generate">Generate domain</x-forms.button>
 </form>

--- a/resources/views/livewire/project/application/previews.blade.php
+++ b/resources/views/livewire/project/application/previews.blade.php
@@ -121,12 +121,14 @@
                                 class="listbox-panel top-full! right-0! left-auto! z-[90]! mt-1! w-56! min-w-56!"
                                 role="menu">
                                 @if (!$previewIsStopped && filled(data_get($preview, 'fqdn')))
-                                    <a target="_blank" title="Open preview in a new tab"
-                                        class="listbox-option justify-start! gap-2.5!"
-                                        href="{{ data_get($preview, 'fqdn') }}" @click="open = false" role="menuitem">
-                                        <x-reicon name="external-link" class="size-3.5 opacity-70" />
-                                        <span class="min-w-0 truncate">Open preview</span>
-                                    </a>
+                                    @foreach (str(data_get($preview, 'fqdn'))->explode(',')->map(fn($domain) => trim($domain))->filter() as $previewUrl)
+                                        <a target="_blank" title="Open preview in a new tab"
+                                            class="listbox-option justify-start! gap-2.5!"
+                                            href="{{ $previewUrl }}" @click="open = false" role="menuitem">
+                                            <x-reicon name="external-link" class="size-3.5 opacity-70" />
+                                            <span class="min-w-0 truncate">{{ $loop->count > 1 ? getFqdnWithoutPort($previewUrl) : 'Open preview' }}</span>
+                                        </a>
+                                    @endforeach
                                 @endif
                                 @if (filled(data_get($preview, 'pull_request_html_url')))
                                     <a target="_blank" title="Open pull request in a new tab"
@@ -255,7 +257,7 @@
                         @if (collect(json_decode($preview->docker_compose_domains))->count() === 0)
                             <form wire:submit="save_preview('{{ $preview->id }}')"
                                 class="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
-                                <x-forms.input label="Domain" helper="One domain per preview."
+                                <x-forms.input label="Domain" helper="You can specify one domain, or multiple as a comma separated list."
                                     id="previewFqdns.{{ $previewName }}" canGate="update"
                                     :canResource="$application"
                                     wire:change="save_preview('{{ $preview->id }}')" />
@@ -279,7 +281,7 @@
                             class="grid gap-3 {{ $application->build_pack === 'dockerimage'
                                 ? 'md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]'
                                 : 'md:grid-cols-[minmax(0,1fr)_auto]' }} md:items-end">
-                            <x-forms.input label="Domain" helper="One domain per preview."
+                            <x-forms.input label="Domain" helper="You can specify one domain, or multiple as a comma separated list."
                                 id="previewFqdns.{{ $previewName }}" canGate="update"
                                 :canResource="$application"
                                 wire:change="save_preview('{{ $preview->id }}')" />

--- a/tests/Feature/ApplicationPreviewFqdnTest.php
+++ b/tests/Feature/ApplicationPreviewFqdnTest.php
@@ -1,0 +1,149 @@
+<?php
+
+use App\Jobs\ApplicationDeploymentJob;
+use App\Models\Application;
+use App\Models\ApplicationPreview;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function makePreviewForApplication(array $applicationAttributes, int $pullRequestId = 42): ApplicationPreview
+{
+    $application = Application::factory()->create($applicationAttributes);
+
+    return ApplicationPreview::create([
+        'application_id' => $application->id,
+        'pull_request_id' => $pullRequestId,
+        'pull_request_html_url' => "https://github.com/example/repo/pull/{$pullRequestId}",
+    ]);
+}
+
+it('generates the preview fqdn from the application domain', function () {
+    $preview = makePreviewForApplication([
+        'fqdn' => 'https://example.com',
+        'preview_url_template' => '{{pr_id}}.{{domain}}',
+    ]);
+
+    $preview->generate_preview_fqdn();
+
+    expect($preview->refresh()->fqdn)->toBe('https://42.example.com');
+});
+
+it('generates one preview fqdn per application domain', function () {
+    $preview = makePreviewForApplication([
+        'fqdn' => 'https://app.example.com,https://api.example.com',
+        'preview_url_template' => '{{pr_id}}.{{domain}}',
+    ]);
+
+    $preview->generate_preview_fqdn();
+
+    expect($preview->refresh()->fqdn)->toBe('https://42.app.example.com,https://42.api.example.com');
+});
+
+it('preserves scheme, port and path per domain', function () {
+    $preview = makePreviewForApplication([
+        'fqdn' => 'http://app.example.com:3000/api,https://api.example.com',
+        'preview_url_template' => '{{pr_id}}.{{domain}}',
+    ]);
+
+    $preview->generate_preview_fqdn();
+
+    expect($preview->refresh()->fqdn)->toBe('http://42.app.example.com:3000/api,https://42.api.example.com');
+});
+
+it('deduplicates preview fqdns generated from a template without placeholders per domain', function () {
+    $preview = makePreviewForApplication([
+        'fqdn' => 'https://app.example.com,https://api.example.com',
+        'preview_url_template' => '{{pr_id}}.preview.example.com',
+    ]);
+
+    $preview->generate_preview_fqdn();
+
+    expect($preview->refresh()->fqdn)->toBe('https://42.preview.example.com');
+});
+
+it('keeps a customized preview fqdn on regeneration', function () {
+    $preview = makePreviewForApplication([
+        'fqdn' => 'https://example.com',
+        'preview_url_template' => '{{pr_id}}.{{domain}}',
+    ]);
+
+    $preview->fqdn = 'https://custom.example.com';
+    $preview->save();
+
+    $preview->generate_preview_fqdn();
+
+    expect($preview->refresh()->fqdn)->toBe('https://custom.example.com');
+});
+
+it('overwrites a customized preview fqdn when forced', function () {
+    $preview = makePreviewForApplication([
+        'fqdn' => 'https://example.com',
+        'preview_url_template' => '{{pr_id}}.{{domain}}',
+    ]);
+
+    $preview->fqdn = 'https://custom.example.com';
+    $preview->save();
+
+    $preview->generate_preview_fqdn(force: true);
+
+    expect($preview->refresh()->fqdn)->toBe('https://42.example.com');
+});
+
+function coolifyVariablesForPreview(ApplicationPreview $preview): string
+{
+    $reflection = new ReflectionClass(ApplicationDeploymentJob::class);
+    $job = $reflection->newInstanceWithoutConstructor();
+
+    foreach ([
+        'application' => $preview->application,
+        'preview' => $preview,
+        'pull_request_id' => $preview->pull_request_id,
+        'commit' => 'HEAD',
+    ] as $property => $value) {
+        $reflectionProperty = $reflection->getProperty($property);
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue($job, $value);
+    }
+
+    $method = $reflection->getMethod('set_coolify_variables');
+    $method->setAccessible(true);
+    $method->invoke($job);
+
+    $variables = $reflection->getProperty('coolify_variables');
+    $variables->setAccessible(true);
+
+    return $variables->getValue($job);
+}
+
+it('sets COOLIFY_URL and COOLIFY_FQDN per domain for multi-domain previews', function () {
+    $preview = makePreviewForApplication([
+        'fqdn' => 'https://app.example.com,https://api.example.com',
+        'preview_url_template' => '{{pr_id}}.{{domain}}',
+        'compose_parsing_version' => '3',
+    ]);
+
+    $preview->generate_preview_fqdn();
+
+    $variables = coolifyVariablesForPreview($preview->refresh());
+
+    expect($variables)
+        ->toContain("COOLIFY_URL='https://42.app.example.com,https://42.api.example.com'")
+        ->toContain("COOLIFY_FQDN='42.app.example.com,42.api.example.com'");
+});
+
+it('keeps single-domain COOLIFY_URL and COOLIFY_FQDN unchanged', function () {
+    $preview = makePreviewForApplication([
+        'fqdn' => 'https://example.com',
+        'preview_url_template' => '{{pr_id}}.{{domain}}',
+        'compose_parsing_version' => '3',
+    ]);
+
+    $preview->generate_preview_fqdn();
+
+    $variables = coolifyVariablesForPreview($preview->refresh());
+
+    expect($variables)
+        ->toContain("COOLIFY_URL='https://42.example.com'")
+        ->toContain("COOLIFY_FQDN='42.example.com'");
+});


### PR DESCRIPTION
## Changes

- `\App\Jobs\ApplicationDeploymentJob::set_coolify_variables` add support for multiple comma-separated FQDNs by splitting the input value before mapping it via `Url::fromString`
- `\App\Jobs\ApplicationPullRequestUpdateJob::getPreviewLinks` also explodes the list and returns links for each supplied FQDN
- `\App\Livewire\Project\Application\Previews::generate_preview`, `::save_preview`, and `\App\Models\ApplicationPreview::generate_preview_fqdn`: Extrapolate each FQDN in the list (just like compose already does)
- `\App\Models\ApplicationPreview::generate_preview_fqdn`: keep an existing FQDN unless regeneration is forced, so a manually set preview domain survives a redeploy; `::generate_preview` passes `force: true`
- `\checkDomainUsage`: validate each item in the potential list and let custom domains have precedence over application-derived domains
- `\App\Notifications\Application\DeploymentSuccess` and `DeploymentFailed`: Adapt notifications; Only send the first extrapolated preview URL
- forms/blades: adapted helper labels

## Issues

- Fixes #10824
- Fixes #7915
- Fixes #6536 and #9399 for non-compose applications. Compose previews are still rebuilt from the application's `docker_compose_domains` on every deployment; giving `generate_preview_fqdn_compose()` the same behaviour is a larger change, since it also reconciles per-service domain slots, so I left it out of this PR.

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

No UI change beyond the preview links now listing each domain and the domain field's helper text. On a dev instance the preview's Domain field holds both generated hosts (`previewFqdns.0` = `http://42.app.127.0.0.1.sslip.io,http://42.api.127.0.0.1.sslip.io`).

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: implementation and tests. Reviewed by hand, and the test results below were verified against a clean checkout.

## Testing

Verified on a local dev instance (`docker-compose.dev.yml`, v4.3.0, seeded), by running the same script against this branch and against an unmodified `next` in the same running instance. Application: the seeded `Dockerfile Example` with two domains, `http://app.127.0.0.1.sslip.io,http://api.127.0.0.1.sslip.io`, template `{{pr_id}}.{{domain}}`, PR 42.

**On `next`:**

```
generated preview fqdn : http://42.app.127.0.0.1.sslip.io          <- 1 host, api.* dropped
proxy labels           : traefik.http.routers.http-0-dockerfile-pr-42.rule=Host(`42.app.127.0.0.1.sslip.io`) && PathPrefix(`/`)
                         caddy_0=http://42.app.127.0.0.1.sslip.io
COOLIFY_URL            : 'http://42.app.127.0.0.1.sslip.io'
COOLIFY_FQDN           : '42.app.127.0.0.1.sslip.io'
custom domain set      : http://custom.127.0.0.1.sslip.io
  after redeploy       : http://42.app.127.0.0.1.sslip.io          <- overwritten
```

**On this branch:**

```
generated preview fqdn : http://42.app.127.0.0.1.sslip.io,http://42.api.127.0.0.1.sslip.io
proxy labels           : traefik.http.routers.http-0-dockerfile-pr-42.rule=Host(`42.app.127.0.0.1.sslip.io`) && PathPrefix(`/`)
                         traefik.http.routers.http-1-dockerfile-pr-42.rule=Host(`42.api.127.0.0.1.sslip.io`) && PathPrefix(`/`)
                         caddy_0=http://42.app.127.0.0.1.sslip.io
                         caddy_1=http://42.api.127.0.0.1.sslip.io
COOLIFY_URL            : 'http://42.app.127.0.0.1.sslip.io,http://42.api.127.0.0.1.sslip.io'
COOLIFY_FQDN           : '42.app.127.0.0.1.sslip.io,42.api.127.0.0.1.sslip.io'
custom domain set      : http://custom.127.0.0.1.sslip.io
  after redeploy       : http://custom.127.0.0.1.sslip.io          <- preserved
```

Not covered: I could not run a live container deployment, because the `testing-host` image fails to build here (`apt update` rejects `bookworm-security InRelease` as unsigned), so the labels above are the generated output of `generateLabelsApplication()` rather than a running container's.

`tests/Feature/ApplicationPreviewFqdnTest.php` is new. Applied on top of an unpatched `next` it fails 5 of its 8 cases; on this branch all 8 pass. To reproduce on `next`:

```
git remote add schulzp https://github.com/schulzp/coolify.git && git fetch schulzp
git checkout next
git checkout schulzp/fix/multi-domain-preview-fqdn -- tests/Feature/ApplicationPreviewFqdnTest.php
./vendor/bin/pest tests/Feature/ApplicationPreviewFqdnTest.php
```

```
next:        Tests: 5 failed, 3 passed
this branch: Tests: 8 passed
```

The five failures on `next` are the reported bugs:

- second domain dropped: expected `https://42.app.example.com,https://42.api.example.com`, got `https://42.app.example.com`
- port and path lost on the second domain
- a custom preview FQDN is overwritten by the template on regeneration
- `force: true` regeneration is unavailable
- `COOLIFY_URL` / `COOLIFY_FQDN` carry only the first domain

Also run: `vendor/bin/pint --dirty` (clean), plus the existing `ComposePreviewFqdnTest`, `PreviewDeploymentPortTest`, `PreviewStatusSummaryTest`, `PreviewEnvVarFallbackTest`, `ApplicationPreviewImageNameTest`, `ModelFillableCreationTest`, `ApplicationClearDomainsTest`, `DomainChipsComponentTest`, `ServiceDomainsTest`, `CloudflareDomainConnectTest` and `ServiceDomainPortCorruptionTest` — no regressions. The remaining failures in `ApplicationDomainsTest` and the API test files fail identically on an unmodified `next` here.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
>
