### PR TITLE
fix(backups): honor per-backup timeout in the ssh timeout wrapper

### DIFF
--- a/app/Jobs/DatabaseBackupJob.php
+++ b/app/Jobs/DatabaseBackupJob.php
@@ -785,7 +785,7 @@ class DatabaseBackupJob implements ShouldBeEncrypted, ShouldQueue
 
             $commands[] = "docker exec backup-of-{$this->backup_log_uuid} mc alias set{$resolveOptions} temporary {$escapedEndpoint} {$escapedKey} {$escapedSecret}";
             $commands[] = "docker exec backup-of-{$this->backup_log_uuid} mc cp {$escapedBackupLocation} {$escapedS3Destination}";
-            instant_remote_process($commands, $this->server, true, false, null, disableMultiplexing: true);
+            instant_remote_process($commands, $this->server, true, false, $this->timeout, disableMultiplexing: true);
 
             $this->s3_uploaded = true;
         } catch (Throwable $e) {

--- a/bootstrap/helpers/remoteProcess.php
+++ b/bootstrap/helpers/remoteProcess.php
@@ -148,7 +148,7 @@ function instant_remote_process(Collection|array $command, Server $server, bool 
 
     return SshRetryHandler::retry(
         function () use ($server, $command_string, $effectiveTimeout, $disableMultiplexing) {
-            $sshCommand = SshMultiplexingHelper::generateSshCommand($server, $command_string, $disableMultiplexing);
+            $sshCommand = SshMultiplexingHelper::generateSshCommand($server, $command_string, $disableMultiplexing, (int) $effectiveTimeout);
             $process = Process::timeout($effectiveTimeout)->run($sshCommand);
 
             $output = trim($process->output());

--- a/config/constants.php
+++ b/config/constants.php
@@ -77,7 +77,7 @@ return [
         'mux_orphan_reap_enabled' => env('SSH_MUX_ORPHAN_REAP_ENABLED', false), // false = dry-run, only log orphans
         'connection_timeout' => 10,
         'server_interval' => 20,
-        'command_timeout' => 3600,
+        'command_timeout' => env('SSH_COMMAND_TIMEOUT', 3600),
         'max_retries' => env('SSH_MAX_RETRIES', 3),
         'retry_base_delay' => env('SSH_RETRY_BASE_DELAY', 2), // seconds
         'retry_max_delay' => env('SSH_RETRY_MAX_DELAY', 30), // seconds

--- a/tests/Feature/RemoteProcessTimeoutTest.php
+++ b/tests/Feature/RemoteProcessTimeoutTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use App\Helpers\SshMultiplexingHelper;
+use App\Models\PrivateKey;
+use App\Models\Server;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * Tests that per-call SSH command timeouts (e.g. a scheduled backup's configured
+ * timeout) reach the shell-level `timeout N ssh` wrapper instead of being capped
+ * by the global constants.ssh.command_timeout default.
+ *
+ * @see https://github.com/coollabsio/coolify DatabaseBackupJob/VolumeBackupJob pass
+ *      a per-backup timeout to instant_remote_process()
+ */
+uses(RefreshDatabase::class);
+
+function makeTimeoutTestServer(): Server
+{
+    $user = User::factory()->create();
+    $team = $user->teams()->first();
+
+    $privateKeyContent = '-----BEGIN OPENSSH PRIVATE KEY-----
+'.
+        'b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+'.
+        'QyNTUxOQAAACBbhpqHhqv6aI67Mj9abM3DVbmcfYhZAhC7ca4d9UCevAAAAJi/QySHv0Mk
+'.
+        'hwAAAAtzc2gtZWQyNTUxOQAAACBbhpqHhqv6aI67Mj9abM3DVbmcfYhZAhC7ca4d9UCevA
+'.
+        'AAAECBQw4jg1WRT2IGHMncCiZhURCts2s24HoDS0thHnnRKVuGmoeGq/pojrsyP1pszcNV
+'.
+        'uZx9iFkCELtxrh31QJ68AAAAEXNhaWxANzZmZjY2ZDJlMmRkAQIDBA==
+'.
+        '-----END OPENSSH PRIVATE KEY-----';
+
+    $privateKey = PrivateKey::create([
+        'name' => 'timeout-test-key-'.uniqid(),
+        'private_key' => $privateKeyContent,
+        'team_id' => $team->id,
+    ]);
+
+    Storage::fake('ssh-keys');
+    Storage::disk('ssh-keys')->put("ssh_key@{$privateKey->uuid}", $privateKeyContent);
+
+    $server = Server::factory()->create([
+        'team_id' => $team->id,
+        'private_key_id' => $privateKey->id,
+    ]);
+
+    Storage::disk('ssh-keys')->put("ssh_key@{$server->privateKey->uuid}", $server->privateKey->private_key);
+
+    return $server;
+}
+
+it('wraps ssh commands with an explicitly passed command timeout', function () {
+    config(['constants.ssh.mux_enabled' => false]);
+    $server = makeTimeoutTestServer();
+
+    $command = SshMultiplexingHelper::generateSshCommand($server, 'echo ok', commandTimeout: 7200);
+
+    expect($command)->toStartWith('timeout 7200 ssh ');
+});
+
+it('wraps ssh commands with the configured default timeout when none is passed', function () {
+    config([
+        'constants.ssh.mux_enabled' => false,
+        'constants.ssh.command_timeout' => 1234,
+    ]);
+    $server = makeTimeoutTestServer();
+
+    $command = SshMultiplexingHelper::generateSshCommand($server, 'echo ok');
+
+    expect($command)->toStartWith('timeout 1234 ssh ');
+});
+
+it('forwards the per-call timeout of instant_remote_process to the ssh timeout wrapper', function () {
+    config(['constants.ssh.mux_enabled' => false]);
+    $server = makeTimeoutTestServer();
+
+    Process::fake();
+
+    instant_remote_process(['echo ok'], $server, timeout: 7200, disableMultiplexing: true);
+
+    Process::assertRan(fn ($process) => str_starts_with($process->command, 'timeout 7200 ssh '));
+});
+
+it('uses the configured default timeout in instant_remote_process when no timeout is passed', function () {
+    config([
+        'constants.ssh.mux_enabled' => false,
+        'constants.ssh.command_timeout' => 1234,
+    ]);
+    $server = makeTimeoutTestServer();
+
+    Process::fake();
+
+    instant_remote_process(['echo ok'], $server, disableMultiplexing: true);
+
+    Process::assertRan(fn ($process) => str_starts_with($process->command, 'timeout 1234 ssh '));
+});


### PR DESCRIPTION
## Problem

Backups of large databases (200+ GB, ~2h dumps) consistently fail after exactly one hour with:

```
SSH command failed with exit code: 255
```

even when the backup schedule's timeout is raised in the UI (which allows up to 36000s).

## Root cause

Every remote command is wrapped in a shell-level `timeout N ssh ...` by `SshMultiplexingHelper::generateSshCommand()`. `instant_remote_process()` accepts a per-call `$timeout` and applies it to the PHP-side `Process::timeout()`, but never forwards it to `generateSshCommand()` — so the shell wrapper always uses the global `constants.ssh.command_timeout` default (3600s). At the one-hour mark `timeout` SIGTERMs `ssh`, which surfaces as the generic exit-255 error from `excludeCertainErrors()`.

The per-backup timeout column, the UI field (60–36000s), Horizon's 36000s worker timeout, and the queue's 86400s `retry_after` all suggest long backups were intended to be supported — the shell wrapper was the one place the configured value never reached.

## Changes

- **`bootstrap/helpers/remoteProcess.php`** — forward the effective timeout from `instant_remote_process()` into the generated ssh command's `timeout` wrapper. `DatabaseBackupJob` and `VolumeBackupJob` already pass their per-backup timeout, so this makes the existing UI setting actually work.
- **`app/Jobs/DatabaseBackupJob.php`** — pass the backup timeout to the S3 upload step (`mc cp`), which previously always ran with the 3600s default; uploading a large archive can itself take longer than an hour. (`VolumeBackupJob` already passed it.)
- **`config/constants.php`** — make the global default configurable via `SSH_COMMAND_TIMEOUT`, consistent with the neighboring `SSH_*` settings, so self-hosters can raise the ceiling for non-backup operations without patching code.

## Tests

New `tests/Feature/RemoteProcessTimeoutTest.php` (written first, TDD):

- `generateSshCommand` wraps with an explicitly passed `commandTimeout`
- `generateSshCommand` falls back to the configured default
- `instant_remote_process` forwards its per-call timeout to the `timeout N ssh` wrapper *(failed before the fix, passes after)*
- `instant_remote_process` uses the configured default when no timeout is passed

`php artisan test` on the SSH/backup suites (`RemoteProcessTimeoutTest`, `SshMultiplexingLockTest`, `SshMultiplexingDisableTest`, `SshRetryMechanismTest`, `DatabaseBackupSecurityTest`): 59 passed. `vendor/bin/pint --dirty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)