### PR TITLE
feat(auth): allow OAuth-only registration

### DIFF
--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -17,6 +17,10 @@ class ResetUserPassword implements ResetsUserPasswords
      */
     public function reset(User $user, array $input): void
     {
+        if (instanceSettings()->is_oauth_password_login_disabled && $user->isOauthUser()) {
+            abort(403, 'Password login is disabled for this OAuth account.');
+        }
+
         Validator::make($input, [
             'password' => ['required', Password::defaults(), 'confirmed'],
         ])->validate();

--- a/app/Actions/Fortify/UpdateUserPassword.php
+++ b/app/Actions/Fortify/UpdateUserPassword.php
@@ -17,6 +17,10 @@ class UpdateUserPassword implements UpdatesUserPasswords
      */
     public function update(User $user, array $input): void
     {
+        if (instanceSettings()->is_oauth_password_login_disabled && $user->isOauthUser()) {
+            abort(403, 'Password login is disabled for this OAuth account.');
+        }
+
         Validator::make($input, [
             'current_password' => ['required', 'string', 'current_password:web'],
             'password' => ['required', Password::defaults(), 'confirmed'],

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -79,6 +79,11 @@ class Controller extends BaseController
                 return response()->json(['message' => 'Transactional emails are not active'], 400);
             }
             $request->validate([Fortify::email() => 'required|email']);
+            $user = User::whereEmail($request->input(Fortify::email()))->first();
+            if (instanceSettings()->is_oauth_password_login_disabled && $user?->isOauthUser()) {
+                return response()->json(['message' => 'Password login is disabled for this OAuth account.'], 400);
+            }
+
             $status = Password::broker(config('fortify.passwords'))->sendResetLink(
                 $request->only(Fortify::email())
             );

--- a/app/Http/Controllers/OauthController.php
+++ b/app/Http/Controllers/OauthController.php
@@ -27,14 +27,17 @@ class OauthController extends Controller
             $user = User::whereEmail($email)->first();
             if (! $user) {
                 $settings = instanceSettings();
-                if (! $settings->is_registration_enabled) {
+                if (! $settings->is_registration_enabled && ! $settings->is_oauth_registration_enabled) {
                     abort(403, 'Registration is disabled');
                 }
 
                 $user = User::create([
                     'name' => $oauthUser->name,
                     'email' => $email,
+                    'oauth_provider' => $provider,
                 ]);
+            } elseif (! $user->hasPassword() && blank($user->oauth_provider)) {
+                $user->update(['oauth_provider' => $provider]);
             }
             Auth::login($user);
 

--- a/app/Livewire/Settings/Advanced.php
+++ b/app/Livewire/Settings/Advanced.php
@@ -20,6 +20,12 @@ class Advanced extends Component
     public bool $is_registration_enabled;
 
     #[Validate('boolean')]
+    public bool $is_oauth_registration_enabled;
+
+    #[Validate('boolean')]
+    public bool $is_oauth_password_login_disabled;
+
+    #[Validate('boolean')]
     public bool $do_not_track;
 
     #[Validate('boolean')]
@@ -59,6 +65,8 @@ class Advanced extends Component
     {
         return [
             'is_registration_enabled' => 'boolean',
+            'is_oauth_registration_enabled' => 'boolean',
+            'is_oauth_password_login_disabled' => 'boolean',
             'do_not_track' => 'boolean',
             'is_dns_validation_enabled' => 'boolean',
             'custom_dns_servers' => ['nullable', 'string', new ValidDnsServers],
@@ -84,6 +92,8 @@ class Advanced extends Component
         $this->allowed_ips = $this->settings->allowed_ips;
         $this->do_not_track = $this->settings->do_not_track;
         $this->is_registration_enabled = $this->settings->is_registration_enabled;
+        $this->is_oauth_registration_enabled = $this->settings->is_oauth_registration_enabled ?? false;
+        $this->is_oauth_password_login_disabled = $this->settings->is_oauth_password_login_disabled ?? false;
         $this->is_dns_validation_enabled = $this->settings->is_dns_validation_enabled;
         $this->is_api_enabled = $this->settings->is_api_enabled;
         $this->disable_two_step_confirmation = $this->settings->disable_two_step_confirmation;
@@ -199,6 +209,8 @@ class Advanced extends Component
         try {
             $this->authorize('update', $this->settings);
             $this->settings->is_registration_enabled = $this->is_registration_enabled;
+            $this->settings->is_oauth_registration_enabled = $this->is_oauth_registration_enabled;
+            $this->settings->is_oauth_password_login_disabled = $this->is_oauth_password_login_disabled;
             $this->settings->do_not_track = $this->do_not_track;
             $this->settings->is_dns_validation_enabled = $this->is_dns_validation_enabled;
             $this->settings->custom_dns_servers = $this->custom_dns_servers;

--- a/app/Models/InstanceSettings.php
+++ b/app/Models/InstanceSettings.php
@@ -18,6 +18,8 @@ class InstanceSettings extends Model
         'do_not_track',
         'is_auto_update_enabled',
         'is_registration_enabled',
+        'is_oauth_registration_enabled',
+        'is_oauth_password_login_disabled',
         'next_channel',
         'smtp_enabled',
         'smtp_from_address',
@@ -82,6 +84,9 @@ class InstanceSettings extends Model
 
         'allowed_ip_ranges' => 'array',
         'is_auto_update_enabled' => 'boolean',
+        'is_registration_enabled' => 'boolean',
+        'is_oauth_registration_enabled' => 'boolean',
+        'is_oauth_password_login_disabled' => 'boolean',
         'auto_update_frequency' => 'string',
         'update_check_frequency' => 'string',
         'sentinel_token' => 'encrypted',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -48,6 +48,7 @@ class User extends Authenticatable implements SendsEmail
         'name',
         'email',
         'password',
+        'oauth_provider',
         'force_password_reset',
         'marketing_emails',
         'pending_email',
@@ -514,5 +515,10 @@ class User extends Authenticatable implements SendsEmail
     public function hasPassword(): bool
     {
         return ! empty($this->password);
+    }
+
+    public function isOauthUser(): bool
+    {
+        return ! empty($this->oauth_provider);
     }
 }

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -75,6 +75,10 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::authenticateUsing(function (Request $request) {
             $email = strtolower($request->email);
             $user = User::where('email', $email)->with('teams')->first();
+            if (instanceSettings()->is_oauth_password_login_disabled && $user?->isOauthUser()) {
+                return null;
+            }
+
             if (
                 $user &&
                 Hash::check($request->password, $user->password)

--- a/database/migrations/2026_08_11_195953_add_oauth_access_settings_to_instance_settings_table.php
+++ b/database/migrations/2026_08_11_195953_add_oauth_access_settings_to_instance_settings_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->boolean('is_oauth_registration_enabled')->default(false)->after('is_registration_enabled');
+            $table->boolean('is_oauth_password_login_disabled')->default(false)->after('is_oauth_registration_enabled');
+        });
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('oauth_provider')->nullable()->after('password');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('instance_settings', function (Blueprint $table) {
+            $table->dropColumn([
+                'is_oauth_registration_enabled',
+                'is_oauth_password_login_disabled',
+            ]);
+        });
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('oauth_provider');
+        });
+    }
+};

--- a/database/schema/testing-schema.sql
+++ b/database/schema/testing-schema.sql
@@ -397,6 +397,8 @@ CREATE TABLE IF NOT EXISTS "instance_settings" (
     "do_not_track" INTEGER DEFAULT false NOT NULL,
     "is_auto_update_enabled" INTEGER DEFAULT true NOT NULL,
     "is_registration_enabled" INTEGER DEFAULT true NOT NULL,
+    "is_oauth_registration_enabled" INTEGER DEFAULT false NOT NULL,
+    "is_oauth_password_login_disabled" INTEGER DEFAULT false NOT NULL,
     "created_at" TEXT,
     "updated_at" TEXT,
     "next_channel" INTEGER DEFAULT false NOT NULL,
@@ -1298,6 +1300,7 @@ CREATE TABLE IF NOT EXISTS "users" (
     "email" TEXT NOT NULL,
     "email_verified_at" TEXT,
     "password" TEXT,
+    "oauth_provider" TEXT,
     "remember_token" TEXT,
     "created_at" TEXT,
     "updated_at" TEXT,
@@ -1886,3 +1889,4 @@ INSERT INTO "migrations" ("id", "migration", "batch") VALUES (317, '2026_06_16_1
 INSERT INTO "migrations" ("id", "migration", "batch") VALUES (318, '2026_06_19_140000_v5_create_applications_table', 318);
 INSERT INTO "migrations" ("id", "migration", "batch") VALUES (319, '2026_06_19_142000_v5_create_resource_connections_table', 319);
 INSERT INTO "migrations" ("id", "migration", "batch") VALUES (320, '2026_06_19_182231_create_container_statuses_table', 320);
+INSERT INTO "migrations" ("id", "migration", "batch") VALUES (321, '2026_08_11_195953_add_oauth_access_settings_to_instance_settings_table', 321);

--- a/database/seeders/InstanceSettingsSeeder.php
+++ b/database/seeders/InstanceSettingsSeeder.php
@@ -16,6 +16,8 @@ class InstanceSettingsSeeder extends Seeder
         InstanceSettings::create([
             'id' => 0,
             'is_registration_enabled' => true,
+            'is_oauth_registration_enabled' => false,
+            'is_oauth_password_login_disabled' => false,
             'is_api_enabled' => isDev(),
             'smtp_enabled' => true,
             'smtp_host' => 'coolify-mail',

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -19,6 +19,18 @@
                             ['value' => true, 'label' => 'Anyone can register'],
                             ['value' => false, 'label' => 'Registration disabled'],
                         ]" />
+                    <x-forms.listbox id="is_oauth_registration_enabled" label="OAuth registration"
+                        helper="Allow enabled OAuth providers to create new accounts even when regular registration is disabled."
+                        onChange="instantSave" :options="[
+                            ['value' => true, 'label' => 'Enabled for OAuth'],
+                            ['value' => false, 'label' => 'Use registration setting'],
+                        ]" />
+                    <x-forms.listbox id="is_oauth_password_login_disabled" label="OAuth password access"
+                        helper="Keep passwordless OAuth users from adding or using a local password through password reset."
+                        onChange="instantSave" :options="[
+                            ['value' => false, 'label' => 'Password reset allowed'],
+                            ['value' => true, 'label' => 'OAuth only for passwordless users'],
+                        ]" />
                     <x-forms.listbox id="disable_two_step_confirmation" label="Destructive action confirmation"
                         helper="Choose whether destructive actions require password and text confirmation."
                         onChange="instantSave" :options="[

--- a/tests/Feature/Auth/OAuthPasswordResetTest.php
+++ b/tests/Feature/Auth/OAuthPasswordResetTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Actions\Fortify\ResetUserPassword;
+use App\Models\InstanceSettings;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::create([
+        'id' => 0,
+        'is_registration_enabled' => false,
+    ]);
+});
+
+it('blocks password reset for passwordless oauth users when oauth password login is disabled', function () {
+    instanceSettings()->update([
+        'is_oauth_password_login_disabled' => true,
+    ]);
+
+    $user = User::factory()->create([
+        'password' => null,
+        'oauth_provider' => 'google',
+    ]);
+
+    expect(fn () => app(ResetUserPassword::class)->reset($user, [
+        'password' => 'New-password-1!',
+        'password_confirmation' => 'New-password-1!',
+    ]))->toThrow(HttpException::class);
+});

--- a/tests/Feature/ModelFillableCreationTest.php
+++ b/tests/Feature/ModelFillableCreationTest.php
@@ -48,6 +48,7 @@ it('creates User with all fillable attributes', function () {
         'name' => 'Test User',
         'email' => 'fillable-test@example.com',
         'password' => bcrypt('password123'),
+        'oauth_provider' => 'google',
         'force_password_reset' => true,
         'marketing_emails' => false,
         'pending_email' => 'newemail@example.com',
@@ -58,6 +59,7 @@ it('creates User with all fillable attributes', function () {
     expect($user->exists)->toBeTrue();
     expect($user->name)->toBe('Test User');
     expect($user->email)->toBe('fillable-test@example.com');
+    expect($user->oauth_provider)->toBe('google');
     expect($user->force_password_reset)->toBeTrue();
     expect($user->marketing_emails)->toBeFalse();
     expect($user->pending_email)->toBe('newemail@example.com');

--- a/tests/Feature/OauthControllerTest.php
+++ b/tests/Feature/OauthControllerTest.php
@@ -48,6 +48,58 @@ it('logs in an existing user when the oauth provider returns a mixed-case email'
     expect(User::count())->toBe(1);
 });
 
+it('creates an oauth user when regular registration is disabled but oauth registration is enabled', function () {
+    config()->set('app.maintenance.driver', 'file');
+    instanceSettings()->update([
+        'is_registration_enabled' => false,
+        'is_oauth_registration_enabled' => true,
+    ]);
+
+    $provider = Mockery::mock();
+    $provider->shouldReceive('setConfig')->once()->andReturnSelf();
+    $provider->shouldReceive('with')->once()->with(['hd' => 'example.com'])->andReturnSelf();
+    $provider->shouldReceive('user')->once()->andReturn((object) [
+        'email' => 'NewUser@example.edu',
+        'name' => 'New OAuth User',
+        'id' => 'google-user-id',
+    ]);
+
+    Socialite::shouldReceive('driver')->once()->with('google')->andReturn($provider);
+
+    $response = $this->get(route('auth.callback', 'google'));
+
+    $response->assertRedirect('/');
+    $user = User::whereEmail('newuser@example.edu')->first();
+    expect($user)->not->toBeNull();
+    expect($user->hasPassword())->toBeFalse()
+        ->and($user->oauth_provider)->toBe('google');
+    $this->assertAuthenticatedAs($user);
+});
+
+it('rejects new oauth users when both regular and oauth registration are disabled', function () {
+    config()->set('app.maintenance.driver', 'file');
+    instanceSettings()->update([
+        'is_registration_enabled' => false,
+        'is_oauth_registration_enabled' => false,
+    ]);
+
+    $provider = Mockery::mock();
+    $provider->shouldReceive('setConfig')->once()->andReturnSelf();
+    $provider->shouldReceive('with')->once()->with(['hd' => 'example.com'])->andReturnSelf();
+    $provider->shouldReceive('user')->once()->andReturn((object) [
+        'email' => 'NewUser@example.edu',
+        'name' => 'New OAuth User',
+        'id' => 'google-user-id',
+    ]);
+
+    Socialite::shouldReceive('driver')->once()->with('google')->andReturn($provider);
+
+    $response = $this->from('/login')->get(route('auth.callback', 'google'));
+
+    $response->assertRedirect('/login');
+    expect(User::count())->toBe(0);
+});
+
 it('rejects oauth logins when the provider does not return an email address', function (?string $providerEmail) {
     config()->set('app.maintenance.driver', 'file');
     InstanceSettings::firstOrCreate([

--- a/tests/Feature/SettingsAccessListboxTest.php
+++ b/tests/Feature/SettingsAccessListboxTest.php
@@ -21,6 +21,8 @@ test('settings advanced access section always uses listboxes', function () {
 
     expect($contents)
         ->toContain('id="is_registration_enabled"')
+        ->toContain('id="is_oauth_registration_enabled"')
+        ->toContain('id="is_oauth_password_login_disabled"')
         ->toContain('id="disable_two_step_confirmation"')
         ->toContain('onChange="instantSave"')
         ->not->toContain('toggleRegistration')
@@ -55,6 +57,39 @@ test('instance admin can toggle registration via listbox instantSave', function 
         ->assertDispatched('success');
 
     expect((bool) $settings->fresh()->is_registration_enabled)->toBeTrue();
+});
+
+test('instance admin can toggle oauth access options via listbox instantSave', function () {
+    $rootTeam = Team::find(0) ?? Team::factory()->create(['id' => 0]);
+    Server::factory()->create(['id' => 0, 'team_id' => $rootTeam->id]);
+    $settings = InstanceSettings::forceCreate([
+        'id' => 0,
+        'is_registration_enabled' => false,
+        'is_oauth_registration_enabled' => false,
+        'is_oauth_password_login_disabled' => false,
+        'disable_two_step_confirmation' => false,
+    ]);
+    Once::flush();
+
+    $user = User::factory()->create();
+    $rootTeam->members()->attach($user->id, ['role' => 'admin']);
+
+    $this->actingAs($user);
+    session(['currentTeam' => ['id' => $rootTeam->id]]);
+
+    Livewire::test(Advanced::class)
+        ->assertSet('is_oauth_registration_enabled', false)
+        ->assertSet('is_oauth_password_login_disabled', false)
+        ->assertSee('OAuth registration')
+        ->assertSee('OAuth password access')
+        ->set('is_oauth_registration_enabled', true)
+        ->set('is_oauth_password_login_disabled', true)
+        ->call('instantSave')
+        ->assertDispatched('success');
+
+    $freshSettings = $settings->fresh();
+    expect((bool) $freshSettings->is_oauth_registration_enabled)->toBeTrue()
+        ->and((bool) $freshSettings->is_oauth_password_login_disabled)->toBeTrue();
 });
 
 test('instance admin can toggle two-step confirmation via listbox instantSave', function () {

--- a/tests/Unit/ModelFillableRegressionTest.php
+++ b/tests/Unit/ModelFillableRegressionTest.php
@@ -55,7 +55,7 @@ it('keeps required mass-assignment attributes fillable for internal create flows
     [ServerSetting::class, ['server_id']],
     [SwarmDocker::class, ['server_id']],
     [StandaloneDocker::class, ['server_id']],
-    [User::class, ['pending_email', 'email_change_code', 'email_change_code_expires_at']],
+    [User::class, ['oauth_provider', 'pending_email', 'email_change_code', 'email_change_code_expires_at']],
     [Server::class, ['ip_previous']],
     [GithubApp::class, ['team_id', 'private_key_id']],
 


### PR DESCRIPTION
STRAWBERRY

## Changes

- Add a separate OAuth registration setting so enabled OAuth providers can create new users while regular username/password registration stays disabled.
- Track OAuth-created users with `oauth_provider` and add an OAuth password access setting that blocks local password login, password reset requests, password reset consumption, and password updates for OAuth accounts.
- Add Advanced settings controls, migration/schema updates, seed defaults, and regression tests for OAuth registration and settings persistence.

## Issues

- Fixes #8042
- /claim #8042

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A for screenshot: this is a small settings/auth flow change. The Advanced > Access page now includes `OAuth registration` and `OAuth password access` listboxes.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Drafted and edited the implementation and tests; final patch was reviewed before submission.

## Testing

- Added/updated feature tests covering OAuth registration when regular registration is disabled, rejection when both registration modes are disabled, OAuth password reset blocking, settings listbox persistence, and fillable coverage.
- Ran `git diff --check` successfully.
- Could not run Pest/PHP tests in this workspace because PHP, Composer, and Docker are not installed on the host.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.