### PR TITLE
fix(api): regenerate basic auth labels after updates

### DIFF
--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -2884,6 +2884,10 @@ class ApplicationsController extends Controller
             ], 422);
         }
 
+        $requestHasHttpBasicAuth = $request->has('is_http_basic_auth_enabled')
+            || $request->has('http_basic_auth_username')
+            || $request->has('http_basic_auth_password');
+
         if ($request->has('is_http_basic_auth_enabled') && $request->is_http_basic_auth_enabled === true) {
             if (blank($application->http_basic_auth_username) || blank($application->http_basic_auth_password)) {
                 $validationErrors = [];
@@ -2900,10 +2904,6 @@ class ApplicationsController extends Controller
                     ], 422);
                 }
             }
-        }
-        if ($request->has('is_http_basic_auth_enabled') && $application->is_container_label_readonly_enabled === false) {
-            $application->custom_labels = str(implode('|coolify|', generateLabelsApplication($application)))->replace('|coolify|', "\n");
-            $application->save();
         }
 
         // For dockercompose applications, domains (fqdn) field should not be used
@@ -3119,7 +3119,7 @@ class ApplicationsController extends Controller
             // Must run after fqdn is filled: flags are kept only for domains the app still has.
             $application->setNoindexDomains($request->input('noindex_domains') ?? []);
         }
-        if ($application->settings->is_container_label_readonly_enabled && ($requestHasDomains || $requestHasNoindexDomains) && $server->isProxyShouldRun()) {
+        if ($application->settings->is_container_label_readonly_enabled && ($requestHasDomains || $requestHasNoindexDomains || $requestHasHttpBasicAuth) && $server->isProxyShouldRun()) {
             $application->custom_labels = str(implode('|coolify|', generateLabelsApplication($application)))->replace('|coolify|', "\n");
         }
         $application->save();

--- a/tests/Feature/Api/ApplicationSettingsApiTest.php
+++ b/tests/Feature/Api/ApplicationSettingsApiTest.php
@@ -14,6 +14,8 @@ use Illuminate\Support\Facades\Queue;
 uses(RefreshDatabase::class);
 
 beforeEach(function () {
+    config(['app.maintenance.driver' => 'file']);
+
     InstanceSettings::unguarded(fn () => InstanceSettings::firstOrCreate(['id' => 0]));
 
     $this->team = Team::factory()->create();
@@ -134,6 +136,53 @@ test('proxy settings regenerate managed labels', function () {
         ->assertOk();
 
     expect(base64_decode($this->application->fresh()->custom_labels))->not->toContain('sentinel-label=true');
+});
+
+test('http basic auth updates regenerate managed labels', function () {
+    $this->application->settings->update(['is_container_label_readonly_enabled' => true]);
+    $this->application->update([
+        'fqdn' => 'https://app.example.com',
+        'is_http_basic_auth_enabled' => false,
+        'http_basic_auth_username' => null,
+        'http_basic_auth_password' => null,
+        'custom_labels' => base64_encode('sentinel-label=true'),
+    ]);
+
+    $this->withHeaders(applicationSettingsApiHeaders($this->bearerToken))
+        ->patchJson("/api/v1/applications/{$this->application->uuid}", [
+            'is_http_basic_auth_enabled' => true,
+            'http_basic_auth_username' => 'api-user',
+            'http_basic_auth_password' => 'api-password',
+        ])
+        ->assertOk();
+
+    $application = $this->application->fresh();
+    $labels = $application->parseContainerLabels();
+
+    expect((bool) $application->is_http_basic_auth_enabled)->toBeTrue()
+        ->and($application->http_basic_auth_username)->toBe('api-user')
+        ->and($application->http_basic_auth_password)->toBe('api-password')
+        ->and($labels)->toContain('basicauth')
+        ->and($labels)->toContain('api-user')
+        ->and($labels)->not->toContain('sentinel-label=true');
+});
+
+test('http basic auth updates preserve user-managed labels', function () {
+    $this->application->settings->update(['is_container_label_readonly_enabled' => false]);
+    $this->application->update([
+        'fqdn' => 'https://app.example.com',
+        'custom_labels' => base64_encode('sentinel-label=true'),
+    ]);
+
+    $this->withHeaders(applicationSettingsApiHeaders($this->bearerToken))
+        ->patchJson("/api/v1/applications/{$this->application->uuid}", [
+            'is_http_basic_auth_enabled' => true,
+            'http_basic_auth_username' => 'api-user',
+            'http_basic_auth_password' => 'api-password',
+        ])
+        ->assertOk();
+
+    expect(base64_decode($this->application->fresh()->custom_labels))->toBe('sentinel-label=true');
 });
 
 test('rejects invalid boolean application settings', function () {


### PR DESCRIPTION
## Changes

- Regenerate managed application labels after the API applies HTTP Basic Auth fields, so the next deployment uses the submitted protection.
- Preserve custom labels when the application is configured to manage them manually.
- Add regression coverage for the managed and user-managed label paths.

## Issues

- Fixes #11191

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable; this is an API-only fix.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Assisted with source analysis and regression-test drafting. I reproduced the failure first, reviewed the controller flow and final diff, and ran the focused and related test suites locally.

## Testing

- Confirmed the new regression fails on unchanged `next`: the PATCH persisted the Basic Auth fields while deployment labels remained unchanged.
- `php artisan test --compact tests/Feature/Api/ApplicationSettingsApiTest.php tests/Feature/ApplicationHttpBasicAuthUiTest.php` — 25 tests, 143 assertions passed.
- `vendor/bin/pint --dirty --format agent`
- `php -l app/Http/Controllers/Api/ApplicationsController.php`
- `php -l tests/Feature/Api/ApplicationSettingsApiTest.php`

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
