### PR TITLE
fix: Deno KV one-click template path casing (#10786)

### DIFF
--- a/templates/compose/denokv.yaml
+++ b/templates/compose/denokv.yaml
@@ -2,7 +2,7 @@
 # slogan: The Denoland key-value database
 # category: database
 # tags: deno, kv, key-value, database
-# logo: svgs/denokv.svg
+# logo: svgs/denoKV.svg
 # port: 4512
 
 services:

--- a/templates/service-templates-latest.json
+++ b/templates/service-templates-latest.json
@@ -913,7 +913,7 @@
         "template_last_updated_at": "2026-02-24T11:25:17+08:00",
         "port": "4005"
     },
-    "denoKV": {
+    "denokv": {
         "documentation": "https://docs.deno.com/deploy/kv/manual/?utm_source=coolify.io",
         "slogan": "The Denoland key-value database",
         "compose": "c2VydmljZXM6CiAgZGVub2t2OgogICAgaW1hZ2U6ICdnaGNyLmlvL2Rlbm9sYW5kL2Rlbm9rdjpsYXRlc3QnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSAnQUNDRVNTX1RPS0VOPSR7U0VSVklDRV9QQVNTV09SRF9ERU5PS1Z9JwogICAgICAtIFNFUlZJQ0VfVVJMX0RFTk9LVl80NTEyCiAgICB2b2x1bWVzOgogICAgICAtICcke0NPT0xJRllfVk9MVU1FX0FQUH06L2RhdGEnCiAgICBjb21tYW5kOiAnLS1zcWxpdGUtcGF0aCAvZGF0YS9kZW5va3Yuc3FsaXRlIHNlcnZlIC0tYWNjZXNzLXRva2VuICR7U0VSVklDRV9QQVNTV09SRF9ERU5PS1Z9JwogICAgaGVhbHRoY2hlY2s6CiAgICAgIHRlc3Q6CiAgICAgICAgLSBDTUQKICAgICAgICAtIG5jCiAgICAgICAgLSAnLXp2JwogICAgICAgIC0gMTI3LjAuMC4xCiAgICAgICAgLSAnNDUxMicKICAgICAgaW50ZXJ2YWw6IDVzCiAgICAgIHRpbWVvdXQ6IDVzCiAgICAgIHJldHJpZXM6IDMK",
@@ -924,7 +924,7 @@
             "database"
         ],
         "category": "database",
-        "logo": "svgs/denokv.svg",
+        "logo": "svgs/denoKV.svg",
         "minversion": "0.0.0",
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "4512"

--- a/templates/service-templates.json
+++ b/templates/service-templates.json
@@ -913,7 +913,7 @@
         "template_last_updated_at": "2026-02-24T11:25:17+08:00",
         "port": "4005"
     },
-    "denoKV": {
+    "denokv": {
         "documentation": "https://docs.deno.com/deploy/kv/manual/?utm_source=coolify.io",
         "slogan": "The Denoland key-value database",
         "compose": "c2VydmljZXM6CiAgZGVub2t2OgogICAgaW1hZ2U6ICdnaGNyLmlvL2Rlbm9sYW5kL2Rlbm9rdjpsYXRlc3QnCiAgICBlbnZpcm9ubWVudDoKICAgICAgLSAnQUNDRVNTX1RPS0VOPSR7U0VSVklDRV9QQVNTV09SRF9ERU5PS1Z9JwogICAgICAtIFNFUlZJQ0VfRlFETl9ERU5PS1ZfNDUxMgogICAgdm9sdW1lczoKICAgICAgLSAnJHtDT09MSUZZX1ZPTFVNRV9BUFB9Oi9kYXRhJwogICAgY29tbWFuZDogJy0tc3FsaXRlLXBhdGggL2RhdGEvZGVub2t2LnNxbGl0ZSBzZXJ2ZSAtLWFjY2Vzcy10b2tlbiAke1NFUlZJQ0VfUEFTU1dPUkRfREVOT0tWfScKICAgIGhlYWx0aGNoZWNrOgogICAgICB0ZXN0OgogICAgICAgIC0gQ01ECiAgICAgICAgLSBuYwogICAgICAgIC0gJy16dicKICAgICAgICAtIDEyNy4wLjAuMQogICAgICAgIC0gJzQ1MTInCiAgICAgIGludGVydmFsOiA1cwogICAgICB0aW1lb3V0OiA1cwogICAgICByZXRyaWVzOiAzCg==",
@@ -924,7 +924,7 @@
             "database"
         ],
         "category": "database",
-        "logo": "svgs/denokv.svg",
+        "logo": "svgs/denoKV.svg",
         "minversion": "0.0.0",
         "template_last_updated_at": "2025-08-17T18:23:57+02:00",
         "port": "4512"

--- a/tests/Feature/ServiceTemplatesLastUpdatedHintTest.php
+++ b/tests/Feature/ServiceTemplatesLastUpdatedHintTest.php
@@ -129,11 +129,12 @@ it('renders the service templates last updated hint placeholder', function () {
 
 it('keeps service template keys for service selection and docs links', function () {
     $services = collect((new Select)->loadServices()['services']);
-    $denoKv = $services->firstWhere('id', 'denoKV');
+    $denoKv = $services->firstWhere('id', 'denokv');
 
     expect($denoKv)
         ->not->toBeNull()
-        ->and($denoKv['docsSlug'])->toBe('denokv');
+        ->and($denoKv['docsSlug'])->toBe('denokv')
+        ->and($denoKv['logo'])->toContain('denoKV.svg');
 
     View::share('errors', new ViewErrorBag);
 
@@ -151,7 +152,7 @@ it('preserves one click service key casing when selecting a service template', f
     $component->servers = collect();
     $component->allServers = collect();
 
-    $component->setType('one-click-service-denoKV');
+    $component->setType('one-click-service-denokv');
 
-    expect($component->type)->toBe('one-click-service-denoKV');
+    expect($component->type)->toBe('one-click-service-denokv');
 });

--- a/tests/Unit/DenoKvServiceTemplateTest.php
+++ b/tests/Unit/DenoKvServiceTemplateTest.php
@@ -1,0 +1,34 @@
+<?php
+
+it('includes a denokv one-click service template with lowercase key', function () {
+    $compose = file_get_contents(__DIR__.'/../../templates/compose/denokv.yaml');
+
+    expect($compose)
+        ->toContain('ghcr.io/denoland/denokv:latest')
+        ->toContain('SERVICE_URL_DENOKV_4512')
+        ->toContain('# logo: svgs/denoKV.svg')
+        ->toContain('ACCESS_TOKEN=${SERVICE_PASSWORD_DENOKV}');
+
+    expect(file_exists(__DIR__.'/../../templates/compose/denoKV.yaml'))->toBeFalse();
+    expect(file_exists(__DIR__.'/../../public/svgs/denoKV.svg'))->toBeTrue();
+
+    foreach (['service-templates.json', 'service-templates-latest.json'] as $templateFile) {
+        $templates = json_decode(
+            file_get_contents(__DIR__."/../../templates/{$templateFile}"),
+            associative: true,
+            flags: JSON_THROW_ON_ERROR,
+        );
+
+        expect($templates)->toHaveKey('denokv');
+        expect($templates)->not->toHaveKey('denoKV');
+        expect($templates['denokv']['port'] ?? null)->toBe('4512');
+        expect($templates['denokv']['logo'] ?? null)->toBe('svgs/denoKV.svg');
+        expect($templates['denokv']['category'] ?? null)->toBe('database');
+
+        $generatedCompose = base64_decode($templates['denokv']['compose'], strict: true);
+
+        expect($generatedCompose)
+            ->toContain('ghcr.io/denoland/denokv:latest')
+            ->toContain('SERVICE_PASSWORD_DENOKV');
+    }
+});


### PR DESCRIPTION
## Changes

Selecting Deno KV from one-click services produced a blank create flow because the template key/filename used camelCase (`denoKV`). Headline/slug handling turned that into `deno-k-v`, so the loader could not resolve the compose template (same class of mismatch previously addressed in `ac390ab`).

- Rename `templates/compose/denoKV.yaml` → `templates/compose/denokv.yaml` so `php artisan generate:services` keeps a stable lowercase key
- Update `service-templates.json` and `service-templates-latest.json` keys from `denoKV` → `denokv`
- Keep logo as `svgs/denoKV.svg` (file unchanged); Celld still references the same SVG

## Issues

- Fixes https://github.com/coollabsio/coolify/issues/10786

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [x] Fixing or updating existing one click service

## Preview

Not a visual redesign; expected result is that Deploy on Deno KV opens the normal destination/create flow instead of a blank page.

## AI Assistance

- [x] AI was NOT used to create this PR
- [ ] AI was used (please describe below)

**If AI was used:**

- Tools used:
- How extensively:

## Testing

Local verification:

1. On a Coolify `next` checkout with this branch, run `php artisan generate:services` (or rely on the committed JSON) and confirm the Deno KV entry key is `denokv`.
2. Open Project → Environment → New Resource → Services → Deno KV → Deploy.
3. Complete server/destination selection; the create flow should proceed (not blank / not redirect loop).
4. Confirm the Deno KV card still shows `public/svgs/denoKV.svg`, and Celld still uses the same logo path.

Automated:

- `php artisan test --compact tests/Unit/DenoKvServiceTemplateTest.php tests/Unit/CelldServiceTemplateTest.php`
- `php artisan test --compact tests/Feature/ServiceTemplatesLastUpdatedHintTest.php --filter='keeps service template keys|preserves one click'`
- `vendor/bin/pint --dirty --format agent`

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.