### PR TITLE
fix(models): add datetime cast for finished_at in ScheduledDatabaseBackupExecution

### DIFF
--- a/app/Models/ScheduledDatabaseBackupExecution.php
+++ b/app/Models/ScheduledDatabaseBackupExecution.php
@@ -24,6 +24,7 @@ class ScheduledDatabaseBackupExecution extends BaseModel
     {
         return [
             'size' => 'integer',
+            'finished_at' => 'datetime',
             's3_uploaded' => 'boolean',
             'local_storage_deleted' => 'boolean',
             's3_storage_deleted' => 'boolean',


### PR DESCRIPTION
## Summary
Adds the missing `finished_at` => `datetime` Eloquent cast to the `ScheduledDatabaseBackupExecution` model.

## Problem
The `ScheduledVolumeBackupExecution` model already has this cast, but `ScheduledDatabaseBackupExecution` does not. When the Blade view `livewire/project/service/volume-backup/index.blade.php` calls `diffForHumans()` on `latestExecution->finished_at`, it throws:

```
Call to a member function diffForHumans() on string
```

because `finished_at` is returned as a raw string instead of a Carbon instance.

## Fix
One-line addition to the `casts()` method in `app/Models/ScheduledDatabaseBackupExecution.php`.

## Checklist
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Requires documentation update

## Related
Fixes volume backup page 500 error when database backups have execution logs.