### PR TITLE
fix(models): add datetime cast for finished_at in ScheduledDatabaseBackupExecution

### DIFF
--- a/app/Models/ScheduledDatabaseBackupExecution.php
+++ b/app/Models/ScheduledDatabaseBackupExecution.php
@@ -24,6 +24,7 @@ class ScheduledDatabaseBackupExecution extends BaseModel
     {
         return [
             'size' => 'integer',
+            'finished_at' => 'datetime',
             's3_uploaded' => 'boolean',
             'local_storage_deleted' => 'boolean',
             's3_storage_deleted' => 'boolean',

--- a/tests/Unit/ScheduledDatabaseBackupExecutionTest.php
+++ b/tests/Unit/ScheduledDatabaseBackupExecutionTest.php
@@ -1,0 +1,8 @@
+<?php
+
+use App\Models\ScheduledDatabaseBackupExecution;
+
+it('casts finished_at to a datetime', function () {
+    expect((new ScheduledDatabaseBackupExecution)->getCasts())
+        ->toHaveKey('finished_at', 'datetime');
+});


### PR DESCRIPTION
## Changes

Adds the missing `finished_at` => `datetime` Eloquent cast to the `ScheduledDatabaseBackupExecution` model.

The `ScheduledVolumeBackupExecution` model already has this cast, but `ScheduledDatabaseBackupExecution` does not. When Blade calls `diffForHumans()` on `finished_at`, it throws `Call to a member function diffForHumans() on string` because the field is returned as a raw string instead of a Carbon instance.

## Issues

- Fixes volume backup page 500 error when database backup execution logs exist.

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A - one line model cast change.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used to identify the root cause and prepare the fix.

**If AI was used:**

- Tools used: Hermes Agent
- How extensively: Root cause analysis, diff comparison, and patch preparation.

## Testing

Verified locally by comparing `ScheduledVolumeBackupExecution` (which already has the cast) with `ScheduledDatabaseBackupExecution` (which was missing it). The runtime fix was also applied to a live Coolify instance and confirmed the 500 error on the volume backup page was resolved.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.