### PR TITLE
fix(ui): remove duplicate metrics tooltip border

### DIFF
--- a/resources/css/utilities.css
+++ b/resources/css/utilities.css
@@ -1,5 +1,5 @@
 @utility apexcharts-tooltip {
-    @apply dark:text-white! dark:border-coolgray-300! dark:bg-coolgray-200! shadow-none!;
+    @apply overflow-visible! rounded-none! border-0! bg-transparent! shadow-none! dark:text-white!;
 }
 
 @utility apexcharts-tooltip-title {

--- a/tests/Feature/MetricsTooltipStylingTest.php
+++ b/tests/Feature/MetricsTooltipStylingTest.php
@@ -1,0 +1,31 @@
+<?php
+
+test('apexcharts delegates tooltip chrome to the custom content', function () {
+    $utilities = file_get_contents(resource_path('css/utilities.css'));
+
+    preg_match('/@utility apexcharts-tooltip \{[^}]*\}/s', $utilities, $tooltip);
+    preg_match('/@utility apexcharts-tooltip-custom \{[^}]*\}/s', $utilities, $customTooltip);
+
+    expect($tooltip[0] ?? '')
+        ->toContain('overflow-visible!')
+        ->toContain('rounded-none!')
+        ->toContain('border-0!')
+        ->toContain('bg-transparent!')
+        ->toContain('shadow-none!')
+        ->not->toContain('dark:border-coolgray-300!')
+        ->not->toContain('dark:bg-coolgray-200!')
+        ->and($customTooltip[0] ?? '')
+        ->toContain('border-neutral-200')
+        ->toContain('dark:border-coolgray-300')
+        ->toContain('rounded-lg')
+        ->toContain('shadow-lg');
+});
+
+test('metrics charts render custom tooltip content', function (string $view) {
+    expect(file_get_contents(resource_path($view)))
+        ->toContain('apexcharts-tooltip-custom');
+})->with([
+    'dashboard server metrics' => 'views/livewire/dashboard/server-metrics-chart.blade.php',
+    'server metrics' => 'views/livewire/server/charts.blade.php',
+    'resource metrics' => 'views/livewire/project/shared/metrics.blade.php',
+]);


### PR DESCRIPTION
## Changes

- Remove the default ApexCharts border, background, radius, shadow, and clipping from the outer tooltip wrapper.
- Keep the existing custom metrics tooltip as the single visual surface in light and dark themes.
- Add scoped Pest contract tests for both tooltip utility blocks and all three metrics chart consumers.

## Issues

- Fixes #11212

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

### Before

The ApexCharts wrapper and custom tooltip both render a visible border with different corner radii.

![Metrics chart tooltip with duplicate borders](https://raw.githubusercontent.com/nexmoe/coolify/pr-assets-11213/pr-assets/11213/metrics-tooltip-double-border.png)

### After

The CPU and memory chart tooltip displays one consistent border and corner radius when hovering a data point.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Used to diagnose the conflicting ApexCharts wrapper styles, implement the scoped CSS fix, add regression coverage, and prepare the contribution. The resulting changes were reviewed and confirmed by the contributor.

## Testing

- Confirmed the tooltip fix on the local Metrics page.
- `npm run build`
- `git diff --check`
- Verified the compiled CSS makes the outer tooltip transparent, borderless, radiusless, and non-clipping.
- Pest and Pint were not available in the host checkout because PHP and Composer dependencies are not installed; CI will run the PHP checks.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
