### PR TITLE
fix(applications): detect domain conflicts with docker compose applications

### DIFF
--- a/bootstrap/helpers/domains.php
+++ b/bootstrap/helpers/domains.php
@@ -108,7 +108,7 @@ function checkDomainUsage(ServiceApplication|Application|null $resource = null, 
     }
     $apps = $appsQuery->get();
     foreach ($apps as $app) {
-        $list_of_domains = collect(explode(',', $app->fqdn))->filter(fn ($fqdn) => $fqdn !== '');
+        $list_of_domains = collect(explode(',', (string) $app->fqdn))->filter(fn ($fqdn) => $fqdn !== '');
         foreach ($list_of_domains as $domain) {
             if (str($domain)->endsWith('/')) {
                 $domain = str($domain)->beforeLast('/');
@@ -133,6 +133,48 @@ function checkDomainUsage(ServiceApplication|Application|null $resource = null, 
                         'resource_type' => 'application',
                         'message' => "Domain $naked_domain is already in use by application '{$app->name}'",
                     ];
+                }
+            }
+        }
+
+        if ($app->build_pack === 'dockercompose' && ! empty($app->docker_compose_domains)) {
+            $dockerComposeDomains = json_decode($app->docker_compose_domains, true);
+            if (is_array($dockerComposeDomains)) {
+                foreach ($dockerComposeDomains as $serviceName => $domainConfig) {
+                    $domainValue = data_get($domainConfig, 'domain');
+                    if (empty($domainValue)) {
+                        continue;
+                    }
+                    $list_of_domains = collect(explode(',', $domainValue))->filter(fn ($fqdn) => $fqdn !== '');
+                    foreach ($list_of_domains as $domain) {
+                        if (str($domain)->endsWith('/')) {
+                            $domain = str($domain)->beforeLast('/');
+                        }
+                        $naked_domain = str($domain)->value();
+                        if ($domains->contains($naked_domain)) {
+                            if (data_get($resource, 'uuid')) {
+                                if ($resource->uuid !== $app->uuid) {
+                                    $conflicts[] = [
+                                        'domain' => $naked_domain,
+                                        'resource_name' => $app->name,
+                                        'resource_link' => $app->link(),
+                                        'resource_type' => 'application',
+                                        'service_name' => $serviceName,
+                                        'message' => "Domain $naked_domain is already in use by application '{$app->name}' (service: {$serviceName})",
+                                    ];
+                                }
+                            } elseif ($domain) {
+                                $conflicts[] = [
+                                    'domain' => $naked_domain,
+                                    'resource_name' => $app->name,
+                                    'resource_link' => $app->link(),
+                                    'resource_type' => 'application',
+                                    'service_name' => $serviceName,
+                                    'message' => "Domain $naked_domain is already in use by application '{$app->name}' (service: {$serviceName})",
+                                ];
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/tests/Feature/ApplicationDomainsTest.php
+++ b/tests/Feature/ApplicationDomainsTest.php
@@ -1208,6 +1208,79 @@ it('clears pending conflict action when the conflict modal is dismissed', functi
     expect($this->application->fresh()->fqdn)->toBeNull();
 });
 
+it('warns when adding a domain already used by a docker compose application', function () {
+    Application::factory()->create([
+        'uuid' => (string) Str::uuid(),
+        'name' => 'Compose Conflict App',
+        'environment_id' => $this->environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => $this->destination->getMorphClass(),
+        'fqdn' => null,
+        'build_pack' => 'dockercompose',
+        'docker_compose_domains' => json_encode([
+            'web' => ['domain' => 'https://compose-taken.example.com', 'redirect' => 'both'],
+        ]),
+    ]);
+
+    Livewire::test(Domains::class, ['application' => $this->application->fresh()])
+        ->set('newDomain', 'https://compose-taken.example.com')
+        ->call('addDomain')
+        ->assertSet('showDomainConflictModal', true)
+        ->assertSet('pendingAction', 'add')
+        ->call('confirmDomainUsage')
+        ->assertSet('showDomainConflictModal', false)
+        ->assertDispatched('success');
+
+    expect(explode(',', (string) $this->application->fresh()->fqdn))
+        ->toContain('https://compose-taken.example.com');
+});
+
+it('detects a domain conflict between two docker compose applications', function () {
+    $composeApplication = Application::factory()->create([
+        'uuid' => (string) Str::uuid(),
+        'name' => 'First Compose App',
+        'environment_id' => $this->environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => $this->destination->getMorphClass(),
+        'fqdn' => null,
+        'build_pack' => 'dockercompose',
+        'docker_compose_domains' => json_encode([
+            'api' => ['domain' => 'https://compose-shared.example.com', 'redirect' => 'both'],
+        ]),
+    ]);
+
+    $this->application->update([
+        'build_pack' => 'dockercompose',
+        'fqdn' => null,
+        'docker_compose_domains' => json_encode([
+            'web' => ['domain' => 'https://compose-shared.example.com', 'redirect' => 'both'],
+        ]),
+    ]);
+
+    $result = checkDomainUsage(resource: $this->application->fresh());
+
+    expect($result['hasConflicts'])->toBeTrue()
+        ->and($result['conflicts'])->toHaveCount(1)
+        ->and($result['conflicts'][0]['domain'])->toBe('https://compose-shared.example.com')
+        ->and($result['conflicts'][0]['resource_name'])->toBe($composeApplication->name)
+        ->and($result['conflicts'][0]['service_name'])->toBe('api');
+});
+
+it('does not report a docker compose domain as conflicting with itself', function () {
+    $this->application->update([
+        'build_pack' => 'dockercompose',
+        'fqdn' => null,
+        'docker_compose_domains' => json_encode([
+            'web' => ['domain' => 'https://self-compose.example.com', 'redirect' => 'both'],
+        ]),
+    ]);
+
+    $result = checkDomainUsage(resource: $this->application->fresh());
+
+    expect($result['hasConflicts'])->toBeFalse()
+        ->and($result['conflicts'])->toBeEmpty();
+});
+
 it('does not show a suggested row when both www variants are configured', function () {
     $this->application->update([
         'fqdn' => 'https://example.com,https://www.example.com',


### PR DESCRIPTION
## Changes

- The UI-side domain conflict check (`checkDomainUsage`) only compared against the `fqdn` column. Docker Compose applications store their domains in `docker_compose_domains` and have `fqdn` set to null, so their domains never participated in the check: a domain already assigned to a compose application — or shared between two compose applications — could be assigned again without any warning. The check now scans compose domains the same way the API-side helper (`checkIfDomainIsAlreadyUsedViaAPI`) already does, and includes the compose service name in the conflict message.

## Issues

- Fixes #11169

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

<!-- Screenshot or short video showing your changes in action. Mandatory for new features. -->

## AI Assistance

<!-- AI-assisted PRs that are human reviewed are welcome, just let us know so we can review appropriately. -->

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: opencode
- How extensively: implementation and test code; the diff was reviewed manually against the existing API-side helper and project test conventions

## Testing

- Added three Pest tests in `tests/Feature/ApplicationDomainsTest.php`:
  - adding a domain already used by a docker compose application shows the conflict modal, and confirming still saves;
  - a conflict between two docker compose applications is detected, including the compose service name;
  - a compose application is not flagged as conflicting with itself.
- Verified the new tests fail without the fix and pass with it.
- `php artisan test --compact tests/Feature/ApplicationDomainsTest.php tests/Feature/ServiceDomainsTest.php` plus the related domain unit suites: no new failures compared to the same run without the change (the remaining failures are pre-existing, environment-dependent ones around Vite/DNS).
- `vendor/bin/pint --dirty --format agent` passes.

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
