### PR TITLE
fix(ui): align deployment and runtime log download menus

### DIFF
--- a/resources/views/livewire/project/application/deployment/show.blade.php
+++ b/resources/views/livewire/project/application/deployment/show.blade.php
@@ -276,7 +276,7 @@
                 <div @if ($isKeepAliveOn) wire:poll.2000ms="polling" @endif
                     class="logs-viewer flex min-h-0 w-full flex-col overflow-hidden bg-white text-neutral-800 dark:bg-log dark:text-neutral-100"
                     :class="fullscreen ? 'h-full' : 'flex-1 rounded-xl border border-neutral-200 shadow-sm dark:border-coolgray-200'">
-                    <div class="logs-viewer-toolbar">
+                    <div class="logs-viewer-toolbar relative z-20">
                         @php
                             $deploymentStatus = data_get($application_deployment_queue, 'status');
                             $deploymentStatusLabel = $deploymentStatus === 'in_progress'
@@ -365,10 +365,10 @@
                                         x-transition:leave="transition ease-in duration-75"
                                         x-transition:leave-start="transform opacity-100 scale-100"
                                         x-transition:leave-end="transform opacity-0 scale-95"
-                                        class="absolute right-0 z-50 mt-2 w-max origin-top-right rounded-lg border border-neutral-200 bg-white p-1 shadow-modal focus:outline-none dark:border-white/[0.1] dark:bg-[#181818]">
+                                        class="runtime-log-menu listbox-panel left-0! right-auto! z-[90]! min-w-52!">
                                         <div>
                                             <button x-on:click="downloadLogs(); downloadMenuOpen = false"
-                                                class="listbox-option text-neutral-700! hover:bg-neutral-100! dark:text-neutral-200! dark:hover:bg-white/[0.07]!">
+                                                class="listbox-option">
                                                 Download displayed logs
                                             </button>
                                             @can('update', $application)
@@ -392,7 +392,7 @@
                                             "
                                                 :disabled="downloadingAllLogs"
                                                 :class="{ 'opacity-50 cursor-not-allowed': downloadingAllLogs }"
-                                                class="listbox-option text-neutral-700! hover:bg-neutral-100! dark:text-neutral-200! dark:hover:bg-white/[0.07]!">
+                                                class="listbox-option">
                                                 <span x-show="!downloadingAllLogs">Download all logs</span>
                                                 <span x-show="downloadingAllLogs" class="flex items-center gap-2">
                                                     <svg class="w-4 h-4 animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">

--- a/resources/views/livewire/project/shared/get-logs.blade.php
+++ b/resources/views/livewire/project/shared/get-logs.blade.php
@@ -346,7 +346,7 @@
                                     x-transition:leave="transition ease-in duration-75"
                                     x-transition:leave-start="transform opacity-100 scale-100"
                                     x-transition:leave-end="transform opacity-0 scale-95"
-                                    class="runtime-log-menu listbox-panel left-auto! right-0! z-[90]! min-w-52!">
+                                    class="runtime-log-menu listbox-panel left-0! right-auto! z-[90]! min-w-52!">
                                     <div>
                                         <button x-on:click="downloadLogs(); downloadMenuOpen = false"
                                             class="listbox-option">

--- a/tests/Feature/DeploymentLogToolbarStyleTest.php
+++ b/tests/Feature/DeploymentLogToolbarStyleTest.php
@@ -23,3 +23,17 @@ test('deployment logs use light surfaces in light mode and dark surfaces in dark
         ->toMatch('/\.logs-viewer\s*\{[^}]*background:\s*#fff;[^}]*color:\s*#262626;/s')
         ->toMatch('/\.dark \.logs-viewer\s*\{[^}]*background:\s*var\(--color-log\);/s');
 });
+
+test('deployment log downloads use the shared runtime log menu', function () {
+    $deploymentView = file_get_contents(resource_path('views/livewire/project/application/deployment/show.blade.php'));
+    $runtimeView = file_get_contents(resource_path('views/livewire/project/shared/get-logs.blade.php'));
+    $downloadMenuClasses = 'runtime-log-menu listbox-panel left-0! right-auto! z-[90]! min-w-52!';
+
+    expect($runtimeView)
+        ->toContain($downloadMenuClasses)
+        ->and($deploymentView)
+        ->toContain('logs-viewer-toolbar relative z-20')
+        ->toContain($downloadMenuClasses)
+        ->not->toContain('absolute right-0 z-50 mt-2 w-max origin-top-right')
+        ->not->toContain('listbox-option text-neutral-700!');
+});


### PR DESCRIPTION
## Changes

- Make the deployment log download menu use the shared runtime log menu styling.
- Keep the deployment menu above log content instead of rendering behind it.
- Align both deployment and runtime download menus beneath their download buttons.
- Add regression coverage for shared menu styling and positioning.

## Issues

- Fixes #11228

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Attach the original clipped-menu screenshot and corrected screenshots of both deployment and runtime menus.
Before:
<img width="337" height="160" alt="Coolify-Before" src="https://github.com/user-attachments/assets/4b78d7d8-95d0-4bdc-8007-15896e872a26" />
After:
<img width="553" height="186" alt="Coolify-AFter" src="https://github.com/user-attachments/assets/8daf12de-0f9a-4ce6-a0d3-b5c1737c82da" />


## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Assisted with investigation, local setup, implementation, and tests. I reviewed the diff and manually tested both menus.

## Testing

- `php artisan test tests/Feature/DeploymentLogToolbarStyleTest.php`: 3 passed, 15 assertions.
- Pint formatting check passed.
- TypeScript check passed.
- Vitest passed: 7 files and 86 tests.
- Frontend build passed.
- Manually tested deployment logs with a failed deployment.
- Manually tested runtime logs with a crash-loop container.
- Verified both menus align beneath their buttons and stay above log content.

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.

