### PR TITLE
fix(metrics): convert container memory samples from bytes to MB

### DIFF
--- a/app/Traits/HasMetrics.php
+++ b/app/Traits/HasMetrics.php
@@ -15,9 +15,16 @@ trait HasMetrics
 
     public function getMemoryMetrics(int $mins = 5): ?array
     {
-        $field = $this->isServerMetrics() ? 'usedPercent' : 'used';
+        if ($this->isServerMetrics()) {
+            return $this->getMetrics('memory', $mins, 'usedPercent');
+        }
 
-        return $this->getMetrics('memory', $mins, $field);
+        $metrics = $this->getMetrics('memory', $mins, 'used');
+        if ($metrics === null) {
+            return null;
+        }
+
+        return convertContainerMemoryBytesToMegabytes($metrics);
     }
 
     private function getMetrics(string $type, int $mins, string $valueField): ?array

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -4725,6 +4725,23 @@ function downsampleLTTB(array $data, int $threshold): array
 }
 
 /**
+ * Convert Sentinel container memory samples from bytes to megabytes.
+ *
+ * Sentinel stores container `used` memory in bytes. Application and database
+ * metric charts label the series as megabytes, so the values must be converted
+ * before they are sent to the frontend.
+ *
+ * @param  array<int, array{0: int|float, 1: int|float}>  $metrics
+ * @return array<int, array{0: int, 1: float}>
+ */
+function convertContainerMemoryBytesToMegabytes(array $metrics): array
+{
+    return array_map(static function (array $point): array {
+        return [(int) $point[0], round(((float) $point[1]) / 1024 / 1024, 2)];
+    }, $metrics);
+}
+
+/**
  * Resolve shared environment variable patterns like {{environment.VAR}}, {{project.VAR}}, {{team.VAR}}.
  *
  * This is the canonical implementation used by both EnvironmentVariable::realValue and the compose parsers

--- a/tests/Unit/ContainerMemoryMetricsConversionTest.php
+++ b/tests/Unit/ContainerMemoryMetricsConversionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Sentinel reports container memory `used` in bytes. The application metrics
+ * chart labels those values as megabytes, so the series must be converted.
+ *
+ * @see https://github.com/coollabsio/coolify/issues/11246
+ */
+it('converts sentinel container memory samples from bytes to megabytes', function () {
+    $metrics = [
+        [1_700_000_000_000, 84_996_096.0],
+        [1_700_000_005_000, 104_857_600.0],
+    ];
+
+    $converted = convertContainerMemoryBytesToMegabytes($metrics);
+
+    expect($converted)->toBe([
+        [1_700_000_000_000, 81.06],
+        [1_700_000_005_000, 100.0],
+    ]);
+});
+
+it('preserves timestamps and converts a zero byte sample to zero megabytes', function () {
+    expect(convertContainerMemoryBytesToMegabytes([
+        [1_700_000_000_000, 0.0],
+    ]))->toBe([
+        [1_700_000_000_000, 0.0],
+    ]);
+});
+
+it('leaves an empty series unchanged', function () {
+    expect(convertContainerMemoryBytesToMegabytes([]))->toBe([]);
+});


### PR DESCRIPTION
## Summary

- Convert application and database container memory samples from Sentinel's byte values to megabytes before they reach the metrics chart (fixes #11246).
- Leave server memory metrics as `usedPercent` so host graphs are unchanged.
- Add unit coverage for the byte-to-MB conversion, including zero and empty series.

---

Fixes #11246