### PR TITLE
fix(service): parse Airflow Compose anchors

### DIFF
--- a/app/Http/Controllers/Api/ServicesController.php
+++ b/app/Http/Controllers/Api/ServicesController.php
@@ -693,7 +693,7 @@ class ServicesController extends Controller
                 ], 422);
             }
             $dockerCompose = base64_decode($request->docker_compose_raw);
-            $dockerComposeRaw = Yaml::dump(Yaml::parse($dockerCompose), 10, 2, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK);
+            $dockerComposeRaw = Yaml::dump(parseDockerComposeYaml($dockerCompose), 10, 2, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK);
 
             // Validate for command injection BEFORE saving to database
             try {
@@ -1227,7 +1227,7 @@ class ServicesController extends Controller
                 ], 422);
             }
             $dockerCompose = base64_decode($request->docker_compose_raw);
-            $dockerComposeRaw = Yaml::dump(Yaml::parse($dockerCompose), 10, 2, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK);
+            $dockerComposeRaw = Yaml::dump(parseDockerComposeYaml($dockerCompose), 10, 2, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK);
 
             // Validate for command injection BEFORE saving to database
             try {

--- a/app/Livewire/Project/New/DockerCompose.php
+++ b/app/Livewire/Project/New/DockerCompose.php
@@ -38,7 +38,7 @@ class DockerCompose extends Component
             $this->validate([
                 'dockerComposeRaw' => 'required',
             ]);
-            $this->dockerComposeRaw = Yaml::dump(Yaml::parse($this->dockerComposeRaw), 10, 2, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK);
+            $this->dockerComposeRaw = Yaml::dump(parseDockerComposeYaml($this->dockerComposeRaw), 10, 2, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK);
 
             // Validate for command injection BEFORE saving to database
             validateDockerComposeForInjection($this->dockerComposeRaw);

--- a/bootstrap/helpers/parsers.php
+++ b/bootstrap/helpers/parsers.php
@@ -14,7 +14,91 @@ use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use Spatie\Url\Url;
+use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
+
+/** Parse Docker Compose YAML with compatibility for document markers and anchors. */
+function parseDockerComposeYaml(string $composeYaml): mixed
+{
+    try {
+        return Yaml::parse($composeYaml);
+    } catch (ParseException) {
+        $composeYaml = removeLeadingDockerComposeDocumentMarker($composeYaml);
+    }
+
+    while (true) {
+        try {
+            return Yaml::parse($composeYaml);
+        } catch (ParseException $exception) {
+            $normalizedYaml = moveStandaloneDockerComposeAnchor($composeYaml, $exception->getParsedLine());
+            if ($normalizedYaml === $composeYaml) {
+                throw $exception;
+            }
+            $composeYaml = $normalizedYaml;
+        }
+    }
+}
+
+function removeLeadingDockerComposeDocumentMarker(string $composeYaml): string
+{
+    $lines = preg_split('/\r\n|\r|\n/', $composeYaml);
+    if ($lines === false) {
+        return $composeYaml;
+    }
+
+    $markerIndexes = [];
+    foreach ($lines as $index => $line) {
+        if (rtrim($line, " \t") === '---') {
+            $markerIndexes[] = $index;
+        }
+    }
+
+    if (count($markerIndexes) !== 1) {
+        return $composeYaml;
+    }
+
+    $markerIndex = $markerIndexes[0];
+    for ($index = 0; $index < $markerIndex; $index++) {
+        $line = trim($lines[$index]);
+        if ($line !== '' && ! str_starts_with($line, '#')) {
+            return $composeYaml;
+        }
+    }
+
+    unset($lines[$markerIndex]);
+
+    return implode("\n", $lines);
+}
+
+function moveStandaloneDockerComposeAnchor(string $composeYaml, int $parsedLine): string
+{
+    $lines = preg_split('/\r\n|\r|\n/', $composeYaml);
+    $anchorIndex = $parsedLine - 1;
+    $mappingIndex = $anchorIndex - 1;
+
+    if ($lines === false || ! isset($lines[$anchorIndex], $lines[$mappingIndex])) {
+        return $composeYaml;
+    }
+
+    $mappingKey = rtrim($lines[$mappingIndex]);
+    $anchorLine = $lines[$anchorIndex];
+    $anchor = trim($anchorLine);
+    $mappingIndent = strspn($mappingKey, " \t");
+    $anchorIndent = strspn($anchorLine, " \t");
+
+    if ($anchorIndent <= $mappingIndent || ! str_ends_with($mappingKey, ':')) {
+        return $composeYaml;
+    }
+
+    if (preg_match('/^&[A-Za-z0-9_-]+$/', $anchor) !== 1) {
+        return $composeYaml;
+    }
+
+    $lines[$mappingIndex] = $mappingKey.' '.$anchor;
+    unset($lines[$anchorIndex]);
+
+    return implode("\n", $lines);
+}
 
 /**
  * Validates a Docker Compose YAML string for command injection vulnerabilities.

--- a/tests/Unit/DockerComposeYamlParserTest.php
+++ b/tests/Unit/DockerComposeYamlParserTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+it('parses Docker Compose document markers and multiline anchors', function () {
+    $compose = <<<'YAML'
+# Airflow-style Docker Compose file
+---
+x-airflow-common:
+  &airflow-common
+  image: apache/airflow:2.9.2
+  environment:
+    &airflow-common-env
+    AIRFLOW__CORE__EXECUTOR: CeleryExecutor
+services:
+  airflow-webserver:
+    <<: *airflow-common
+    environment:
+      <<: *airflow-common-env
+      AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
+YAML;
+
+    $parsed = parseDockerComposeYaml($compose);
+
+    expect($parsed['services']['airflow-webserver']['image'])
+        ->toBe('apache/airflow:2.9.2')
+        ->and($parsed['services']['airflow-webserver']['environment']['AIRFLOW__CORE__EXECUTOR'])
+        ->toBe('CeleryExecutor')
+        ->and($parsed['services']['airflow-webserver']['environment']['AIRFLOW__CORE__LOAD_EXAMPLES'])
+        ->toBe('false');
+});
+
+it('still rejects Docker Compose input containing multiple documents', function () {
+    expect(fn () => parseDockerComposeYaml("services: {}\n---\nservices: {}\n"))
+        ->toThrow(ParseException::class, 'Multiple documents are not supported');
+});
+
+it('preserves standard Docker Compose parsing', function () {
+    $compose = "services:\n  web:\n    image: nginx\n";
+
+    expect(parseDockerComposeYaml($compose))->toBe(Yaml::parse($compose));
+});
+
+it('rejects standalone anchors without deeper indentation', function () {
+    $compose = "services:\n&common\n  web:\n    image: nginx\n";
+
+    expect(fn () => parseDockerComposeYaml($compose))->toThrow(ParseException::class);
+});
+
+it('preserves anchor-like content inside block scalars', function () {
+    $compose = <<<'YAML'
+---
+x-common:
+  &common
+  image: nginx
+services:
+  web:
+    <<: *common
+    command: |
+      key:
+        &literal
+YAML;
+
+    expect(parseDockerComposeYaml($compose)['services']['web']['command'])
+        ->toBe("key:\n  &literal");
+});


### PR DESCRIPTION
## Changes

- Service Compose parsing now supports the leading YAML document marker and standalone anchor formatting used by Apache Airflow. Normal Symfony parsing remains the default, with a targeted compatibility retry only after parsing fails. Regression tests cover valid Airflow syntax and malformed YAML edge cases.

## Issues

- Fixes #2705

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable; this change has no visual interface changes.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Used to reproduce the parsing failure, investigate the root cause, and add regression tests. I reviewed and tested the resulting code locally.

## Testing

- Ran the focused parser and Docker Compose unit tests: 26 tests passed with 74 assertions.
- Parsed the official Apache Airflow 2.9.2 Compose file successfully, producing all 9 services.
- Confirmed the normalized Compose output passes Coolify's command-injection validation.
- Compared all 367 bundled Compose templates and confirmed their parsing results remain unchanged.
- Ran Laravel Pint against all four changed files successfully.
- Ran `git diff --check` successfully.
- The browser test suite could not run because Playwright is not installed locally. A broader Unit/Feature run also encountered an unrelated existing `CleanupDockerTest` failure.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/v4.x/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.