### PR TITLE
feat(migration): move a Coolify instance to a new VM

### DIFF
--- a/app/Actions/Database/RestoreDatabaseDump.php
+++ b/app/Actions/Database/RestoreDatabaseDump.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Actions\Database;
+
+use App\Models\Server;
+use App\Models\ServiceDatabase;
+use App\Models\StandaloneClickhouse;
+use App\Models\StandaloneMariadb;
+use App\Models\StandaloneMongodb;
+use App\Models\StandaloneMysql;
+use App\Models\StandalonePostgresql;
+use App\Support\DatabaseBackupFileValidator;
+use Lorisleiva\Actions\Concerns\AsAction;
+use RuntimeException;
+
+class RestoreDatabaseDump
+{
+    use AsAction;
+
+    public function handle(object $database, Server $server, string $dumpPath, bool $dumpAll = false): void
+    {
+        $container = $database->uuid;
+        $tmpPath = '/tmp/restore_'.new_public_id();
+        $scriptPath = $tmpPath.'.sh';
+        $restoreCommand = $this->buildRestoreCommand($database, $tmpPath, $dumpAll);
+
+        if ($restoreCommand === '') {
+            throw new RuntimeException('Logical dump restore is not supported for this database type.');
+        }
+
+        if ($this->isPostgresql($database) && is_file($dumpPath) && DatabaseBackupFileValidator::fileContainsPostgresqlProgramExecution($dumpPath)) {
+            throw new RuntimeException('The dump contains disallowed PostgreSQL restore directives.');
+        }
+
+        $restoreCommandBase64 = base64_encode($restoreCommand);
+
+        instant_remote_process([
+            'docker cp '.escapeshellarg($dumpPath).' '.escapeshellarg($container.':'.$tmpPath),
+            'echo '.escapeshellarg($restoreCommandBase64).' | base64 -d > '.escapeshellarg($scriptPath),
+            'chmod +x '.escapeshellarg($scriptPath),
+            'docker cp '.escapeshellarg($scriptPath).' '.escapeshellarg($container.':'.$scriptPath),
+            'docker exec '.escapeshellarg($container).' sh -c '.escapeshellarg($scriptPath),
+            'docker exec '.escapeshellarg($container).' rm -f '.escapeshellarg($tmpPath).' '.escapeshellarg($scriptPath).' || true',
+            'rm -f '.escapeshellarg($scriptPath),
+        ], $server);
+    }
+
+    public function buildRestoreCommand(object $database, string $tmpPath, bool $dumpAll = false): string
+    {
+        $escapedTmpPath = escapeshellarg($tmpPath);
+        $morphClass = $database->getMorphClass();
+
+        if ($morphClass === ServiceDatabase::class) {
+            $dbType = $database->databaseType();
+            if (str_contains($dbType, 'mysql')) {
+                $morphClass = 'mysql';
+            } elseif (str_contains($dbType, 'mariadb')) {
+                $morphClass = 'mariadb';
+            } elseif (str_contains($dbType, 'postgres')) {
+                $morphClass = 'postgresql';
+            } elseif (str_contains($dbType, 'mongo')) {
+                $morphClass = 'mongodb';
+            }
+        }
+
+        return match ($morphClass) {
+            StandaloneMariadb::class, 'mariadb' => $dumpAll
+                ? "(gunzip -cf {$escapedTmpPath} 2>/dev/null || cat {$escapedTmpPath}) | mariadb -u root -p\$MARIADB_ROOT_PASSWORD"
+                : "mariadb -u \$MARIADB_USER -p\$MARIADB_PASSWORD \$MARIADB_DATABASE < {$escapedTmpPath}",
+            StandaloneMysql::class, 'mysql' => $dumpAll
+                ? "(gunzip -cf {$escapedTmpPath} 2>/dev/null || cat {$escapedTmpPath}) | mysql -u root -p\$MYSQL_ROOT_PASSWORD"
+                : "mysql -u \$MYSQL_USER -p\$MYSQL_PASSWORD \$MYSQL_DATABASE < {$escapedTmpPath}",
+            StandalonePostgresql::class, 'postgresql' => $dumpAll
+                ? "(gunzip -cf {$escapedTmpPath} 2>/dev/null || cat {$escapedTmpPath}) | psql -U \${POSTGRES_USER} -d \${POSTGRES_DB:-\${POSTGRES_USER:-postgres}}"
+                : "pg_restore -U \$POSTGRES_USER -d \${POSTGRES_DB:-\${POSTGRES_USER:-postgres}} {$escapedTmpPath}",
+            StandaloneMongodb::class, 'mongodb' => 'mongorestore --authenticationDatabase=admin --username $MONGO_INITDB_ROOT_USERNAME --password $MONGO_INITDB_ROOT_PASSWORD --uri mongodb://localhost:27017 --gzip --archive='.$escapedTmpPath,
+            StandaloneClickhouse::class, 'clickhouse' => "clickhouse-client --query \"RESTORE DATABASE \${CLICKHOUSE_DB} FROM File('{$tmpPath}')\"",
+            default => '',
+        };
+    }
+
+    private function isPostgresql(object $database): bool
+    {
+        $morphClass = $database->getMorphClass();
+
+        if ($morphClass === StandalonePostgresql::class) {
+            return true;
+        }
+
+        return $morphClass === ServiceDatabase::class && str_contains((string) $database->databaseType(), 'postgres');
+    }
+}

--- a/app/Actions/Migration/CloneResourceToDestination.php
+++ b/app/Actions/Migration/CloneResourceToDestination.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace App\Actions\Migration;
+
+use App\Actions\Database\StartDatabase;
+use App\Actions\Database\StopDatabase;
+use App\Actions\Service\StartService;
+use App\Actions\Service\StopService;
+use App\Jobs\VolumeCloneJob;
+use App\Models\Application;
+use App\Models\Service;
+use App\Models\StandaloneClickhouse;
+use App\Models\StandaloneDocker;
+use App\Models\StandaloneDragonfly;
+use App\Models\StandaloneKeydb;
+use App\Models\StandaloneMariadb;
+use App\Models\StandaloneMongodb;
+use App\Models\StandaloneMysql;
+use App\Models\StandalonePostgresql;
+use App\Models\StandaloneRedis;
+use App\Models\SwarmDocker;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Bus;
+use Lorisleiva\Actions\Concerns\AsAction;
+use RuntimeException;
+
+class CloneResourceToDestination
+{
+    use AsAction;
+
+    public function handle(Model $resource, StandaloneDocker|SwarmDocker $destination, bool $cloneVolumeData = true): Model
+    {
+        if ($resource instanceof Application) {
+            return clone_application($resource, $destination, [], $cloneVolumeData);
+        }
+
+        if ($this->isStandaloneDatabase($resource)) {
+            return $this->cloneDatabase($resource, $destination, $cloneVolumeData);
+        }
+
+        if ($resource instanceof Service) {
+            return $this->cloneService($resource, $destination, $cloneVolumeData);
+        }
+
+        throw new RuntimeException('Unsupported resource type ['.$resource->type().'].');
+    }
+
+    private function isStandaloneDatabase(Model $resource): bool
+    {
+        return $resource instanceof StandalonePostgresql
+            || $resource instanceof StandaloneMongodb
+            || $resource instanceof StandaloneMysql
+            || $resource instanceof StandaloneMariadb
+            || $resource instanceof StandaloneRedis
+            || $resource instanceof StandaloneKeydb
+            || $resource instanceof StandaloneDragonfly
+            || $resource instanceof StandaloneClickhouse;
+    }
+
+    private function cloneDatabase(Model $resource, StandaloneDocker|SwarmDocker $destination, bool $cloneVolumeData): Model
+    {
+        $cloneResult = clone_standalone_database($resource, $destination, $cloneVolumeData);
+        $newResource = $cloneResult['database'];
+        $volumesToClone = $cloneResult['volume_pairs'];
+
+        if ($cloneVolumeData && $volumesToClone !== []) {
+            $jobs = [StopDatabase::makeJob($resource, false)];
+            foreach ($volumesToClone as [$sourceVolume, $targetVolume]) {
+                $jobs[] = new VolumeCloneJob(
+                    $sourceVolume->name,
+                    $targetVolume->name,
+                    $resource->destination->server,
+                    $newResource->destination->server,
+                    $targetVolume,
+                );
+            }
+            $jobs[] = StartDatabase::makeJob($resource);
+            Bus::chain($jobs)->onQueue('high')->dispatch();
+        }
+
+        return $newResource;
+    }
+
+    private function cloneService(Service $resource, StandaloneDocker|SwarmDocker $destination, bool $cloneVolumeData): Service
+    {
+        $uuid = new_public_id();
+        $newResource = $resource->replicate([
+            'id',
+            'created_at',
+            'updated_at',
+        ])->fill([
+            'uuid' => $uuid,
+            'name' => $resource->name.'-clone-'.$uuid,
+            'destination_id' => $destination->id,
+            'destination_type' => $destination->getMorphClass(),
+            'server_id' => $destination->server_id,
+        ]);
+        $newResource->save();
+
+        foreach ($resource->tags as $tag) {
+            $newResource->tags()->attach($tag->id);
+        }
+
+        foreach ($resource->scheduled_tasks()->get() as $task) {
+            $task->replicate(['id', 'created_at', 'updated_at'])->fill([
+                'uuid' => new_public_id(),
+                'service_id' => $newResource->id,
+                'team_id' => currentTeam()->id,
+            ])->save();
+        }
+
+        foreach ($resource->environment_variables()->get() as $environmentVariable) {
+            $environmentVariable->replicate(['id', 'created_at', 'updated_at'])->fill([
+                'resourceable_id' => $newResource->id,
+                'resourceable_type' => $newResource->getMorphClass(),
+            ])->save();
+        }
+
+        $newResource->parse();
+        $newResource->refresh();
+
+        $volumesToClone = [];
+        foreach ($resource->applications as $sourceApplication) {
+            $newApplication = $newResource->applications()->where('name', $sourceApplication->name)->first();
+            if (! $newApplication) {
+                continue;
+            }
+            $newApplication->fill(['status' => 'exited'])->save();
+            if ($cloneVolumeData) {
+                foreach ($sourceApplication->persistentStorages as $sourceVolume) {
+                    $targetVolume = $newApplication->persistentStorages()->where('mount_path', $sourceVolume->mount_path)->first();
+                    if ($targetVolume) {
+                        $volumesToClone[] = [$sourceVolume, $targetVolume];
+                    }
+                }
+            }
+        }
+
+        foreach ($resource->databases as $sourceDatabase) {
+            $newDatabase = $newResource->databases()->where('name', $sourceDatabase->name)->first();
+            if (! $newDatabase) {
+                continue;
+            }
+            $newDatabase->fill(['status' => 'exited'])->save();
+            if ($cloneVolumeData) {
+                foreach ($sourceDatabase->persistentStorages as $sourceVolume) {
+                    $targetVolume = $newDatabase->persistentStorages()->where('mount_path', $sourceVolume->mount_path)->first();
+                    if ($targetVolume) {
+                        $volumesToClone[] = [$sourceVolume, $targetVolume];
+                    }
+                }
+            }
+        }
+
+        if ($cloneVolumeData && $volumesToClone !== []) {
+            $jobs = [StopService::makeJob($resource, false, false)];
+            foreach ($volumesToClone as [$sourceVolume, $targetVolume]) {
+                $jobs[] = new VolumeCloneJob(
+                    $sourceVolume->name,
+                    $targetVolume->name,
+                    $resource->destination->server,
+                    $newResource->destination->server,
+                    $targetVolume,
+                );
+            }
+            $jobs[] = StartService::makeJob($resource);
+            Bus::chain($jobs)->onQueue('high')->dispatch();
+        }
+
+        return $newResource;
+    }
+}

--- a/app/Actions/Migration/CollectResourceVolumes.php
+++ b/app/Actions/Migration/CollectResourceVolumes.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Actions\Migration;
+
+use App\Models\Application;
+use App\Models\LocalPersistentVolume;
+use App\Models\Service;
+use App\Models\StandaloneClickhouse;
+use App\Models\StandaloneDragonfly;
+use App\Models\StandaloneKeydb;
+use App\Models\StandaloneMariadb;
+use App\Models\StandaloneMongodb;
+use App\Models\StandaloneMysql;
+use App\Models\StandalonePostgresql;
+use App\Models\StandaloneRedis;
+use Illuminate\Database\Eloquent\Model;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class CollectResourceVolumes
+{
+    use AsAction;
+
+    /**
+     * @return list<LocalPersistentVolume>
+     */
+    public function handle(Model $resource): array
+    {
+        if ($resource instanceof Application) {
+            return $resource->persistentStorages()->get()->all();
+        }
+
+        if ($this->isStandaloneDatabase($resource) && method_exists($resource, 'persistentStorages')) {
+            return $resource->persistentStorages()->get()->all();
+        }
+
+        if ($resource instanceof Service) {
+            $volumes = [];
+            foreach ($resource->applications as $application) {
+                foreach ($application->persistentStorages as $volume) {
+                    $volumes[] = $volume;
+                }
+            }
+            foreach ($resource->databases as $database) {
+                foreach ($database->persistentStorages as $volume) {
+                    $volumes[] = $volume;
+                }
+            }
+
+            return $volumes;
+        }
+
+        return [];
+    }
+
+    private function isStandaloneDatabase(Model $resource): bool
+    {
+        return $resource instanceof StandalonePostgresql
+            || $resource instanceof StandaloneMongodb
+            || $resource instanceof StandaloneMysql
+            || $resource instanceof StandaloneMariadb
+            || $resource instanceof StandaloneRedis
+            || $resource instanceof StandaloneKeydb
+            || $resource instanceof StandaloneDragonfly
+            || $resource instanceof StandaloneClickhouse;
+    }
+}

--- a/app/Actions/Migration/ConsolidateResourcesToLocalhost.php
+++ b/app/Actions/Migration/ConsolidateResourcesToLocalhost.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Actions\Migration;
+
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\Service;
+use App\Models\StandaloneDocker;
+use App\Models\StandalonePostgresql;
+use Illuminate\Database\Eloquent\Model;
+use Lorisleiva\Actions\Concerns\AsAction;
+use RuntimeException;
+
+class ConsolidateResourcesToLocalhost
+{
+    use AsAction;
+
+    /**
+     * Move every team resource onto the Coolify host destination (server id 0).
+     *
+     * @param  ?Server  $volumeSourceOverride  When set (e.g. old Coolify host), volumes are pulled from this server for resources already pointing at localhost.
+     * @return list<array{uuid: string, name: string, status: string, error: string}>
+     */
+    public function handle(int $teamId, bool $copyVolumeData = true, ?Server $volumeSourceOverride = null): array
+    {
+        $localhost = Server::find(0);
+        if (! $localhost) {
+            throw new RuntimeException('Coolify host (server id 0) was not found.');
+        }
+
+        $destination = $localhost->destinations()
+            ->first(fn ($destination): bool => $destination instanceof StandaloneDocker);
+
+        if (! $destination instanceof StandaloneDocker) {
+            throw new RuntimeException('Coolify host has no Standalone Docker destination.');
+        }
+
+        $results = [];
+        foreach ($this->orderedResources($teamId) as $resource) {
+            $uuid = (string) $resource->uuid;
+            $name = (string) ($resource->name ?? $uuid);
+
+            if ($resource instanceof StandalonePostgresql && (int) $resource->id === 0) {
+                $results[] = ['uuid' => $uuid, 'name' => $name, 'status' => 'skipped', 'error' => 'coolify-db'];
+
+                continue;
+            }
+
+            $currentServer = $resource instanceof Service
+                ? $resource->server
+                : $resource->destination?->server;
+
+            $alreadyLocal = $currentServer && (int) $currentServer->id === 0;
+            $sourceForVolumes = $alreadyLocal && $volumeSourceOverride
+                ? $volumeSourceOverride
+                : null;
+
+            if ($alreadyLocal && ! $volumeSourceOverride) {
+                $results[] = ['uuid' => $uuid, 'name' => $name, 'status' => 'skipped', 'error' => 'Already on localhost.'];
+
+                continue;
+            }
+
+            try {
+                ReassignResourceToDestination::run(
+                    $resource,
+                    $destination,
+                    $copyVolumeData,
+                    false,
+                    $sourceForVolumes,
+                );
+                $results[] = ['uuid' => $uuid, 'name' => $name, 'status' => 'migrated', 'error' => ''];
+            } catch (\Throwable $exception) {
+                $results[] = [
+                    'uuid' => $uuid,
+                    'name' => $name,
+                    'status' => 'failed',
+                    'error' => $exception->getMessage(),
+                ];
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * @return list<Model>
+     */
+    private function orderedResources(int $teamId): array
+    {
+        $projects = Project::where('team_id', $teamId)->get();
+        $resources = collect();
+
+        foreach (collect(DATABASE_TYPES) as $db) {
+            $resources->push($projects->pluck(str($db)->plural(2))->flatten());
+        }
+        $resources->push($projects->pluck('services')->flatten());
+        $resources->push($projects->pluck('applications')->flatten());
+
+        return $resources->flatten()->filter()->values()->all();
+    }
+}

--- a/app/Actions/Migration/DetectIndependentCoolifyInstall.php
+++ b/app/Actions/Migration/DetectIndependentCoolifyInstall.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Actions\Migration;
+
+use App\Models\Server;
+use Lorisleiva\Actions\Concerns\AsAction;
+use Throwable;
+
+class DetectIndependentCoolifyInstall
+{
+    use AsAction;
+
+    /**
+     * Container names that belong to a Coolify control-plane install.
+     * Managed application servers only run coolify-proxy / sentinel / helper.
+     *
+     * @var list<string>
+     */
+    public const CONTROL_PLANE_NAMES = [
+        'coolify',
+        'coolify-db',
+        'coolify-redis',
+        'coolify-realtime',
+    ];
+
+    public function handle(Server $server): bool
+    {
+        if ($server->isLocalhost() || $server->isCoolifyHost) {
+            return false;
+        }
+
+        if (app()->environment('testing')) {
+            return false;
+        }
+
+        try {
+            $output = instant_remote_process([
+                "docker ps -a --format '{{.Names}}'; echo '---SOURCE_ENV---'; test -f /data/coolify/source/.env && echo yes || echo no",
+            ], $server, false, timeout: 10) ?? '';
+
+            [$names, $sourceEnv] = array_pad(explode('---SOURCE_ENV---', (string) $output, 2), 2, 'no');
+
+            return self::isIndependentInstall(
+                containerNamesOutput: $names,
+                hasSourceEnv: trim($sourceEnv) === 'yes',
+            );
+        } catch (Throwable) {
+            return false;
+        }
+    }
+
+    public static function isIndependentInstall(string $containerNamesOutput, bool $hasSourceEnv = false): bool
+    {
+        if ($hasSourceEnv) {
+            return true;
+        }
+
+        $names = collect(preg_split('/\R/', trim($containerNamesOutput)) ?: [])
+            ->map(fn (string $line): string => ltrim(trim($line), '/'))
+            ->filter();
+
+        if ($names->contains('coolify')) {
+            return true;
+        }
+
+        return $names->intersect(['coolify-db', 'coolify-redis', 'coolify-realtime'])->count() >= 2;
+    }
+}

--- a/app/Actions/Migration/DiscoverResources.php
+++ b/app/Actions/Migration/DiscoverResources.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Actions\Migration;
+
+use App\Models\Application;
+use App\Models\Project;
+use App\Models\Service;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class DiscoverResources
+{
+    use AsAction;
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function handle(
+        int $teamId,
+        ?string $serverUuid = null,
+        ?string $projectUuid = null,
+        ?string $environmentUuid = null,
+    ): array {
+        $projects = Project::where('team_id', $teamId)->get();
+        $resources = collect();
+        $resources->push($projects->pluck('applications')->flatten());
+        $resources->push($projects->pluck('services')->flatten());
+        foreach (collect(DATABASE_TYPES) as $db) {
+            $resources->push($projects->pluck(str($db)->plural(2))->flatten());
+        }
+
+        return $resources->flatten()->filter()->map(function ($resource) use ($serverUuid, $projectUuid, $environmentUuid): ?array {
+            $environment = $resource->environment;
+            $project = $environment?->project;
+            $server = $this->serverFor($resource);
+
+            if ($projectUuid && $project?->uuid !== $projectUuid) {
+                return null;
+            }
+            if ($environmentUuid && $environment?->uuid !== $environmentUuid) {
+                return null;
+            }
+            if ($serverUuid && $server?->uuid !== $serverUuid) {
+                return null;
+            }
+
+            $volumeCount = method_exists($resource, 'persistentStorages')
+                ? $resource->persistentStorages()->count()
+                : 0;
+
+            return [
+                'uuid' => $resource->uuid,
+                'type' => $resource->type(),
+                'name' => $resource->name,
+                'status' => $resource->status,
+                'server_uuid' => $server?->uuid,
+                'server_name' => $server?->name,
+                'project_uuid' => $project?->uuid,
+                'environment_uuid' => $environment?->uuid,
+                'volume_count' => $volumeCount,
+                'warnings' => $this->warnings($resource),
+            ];
+        })->filter()->values()->all();
+    }
+
+    private function serverFor(object $resource): mixed
+    {
+        if ($resource instanceof Service) {
+            return $resource->server;
+        }
+
+        return $resource->destination?->server;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function warnings(object $resource): array
+    {
+        if (! $resource instanceof Application) {
+            return [];
+        }
+
+        $warnings = [];
+        if ($resource->source_id) {
+            $warnings[] = 'Private GitHub App must exist on the target team.';
+        }
+        if ($resource->private_key_id) {
+            $warnings[] = 'Deploy key must exist on the target team.';
+        }
+
+        return $warnings;
+    }
+}

--- a/app/Actions/Migration/EnsureCoolifyDataDirsTraversable.php
+++ b/app/Actions/Migration/EnsureCoolifyDataDirsTraversable.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Actions\Migration;
+
+use App\Models\Server;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class EnsureCoolifyDataDirsTraversable
+{
+    use AsAction;
+
+    /**
+     * Coolify's installer runs `chmod -R 700 /data/coolify`, so a non-root SSH user
+     * cannot `cd` into `/data/coolify/services/<uuid>`. Directory execute (traverse)
+     * is enough; files stay unreadable to others.
+     */
+    public function handle(Server $target): void
+    {
+        instant_remote_process(self::commands(), $target);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function commands(): array
+    {
+        $script = <<<'SH'
+if [ -d /data/coolify ]; then
+  find /data/coolify -type d -exec chmod a+x {} +
+fi
+SH;
+
+        return [
+            'sh -c '.escapeshellarg($script),
+        ];
+    }
+}

--- a/app/Actions/Migration/ExportResources.php
+++ b/app/Actions/Migration/ExportResources.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace App\Actions\Migration;
+
+use App\Enums\ResourceMigrationStatus;
+use App\Models\ResourceMigration;
+use App\Models\ResourceMigrationItem;
+use App\Models\Server;
+use App\Services\Migration\Manifest;
+use App\Services\Migration\MigrationArchiver;
+use App\Services\Migration\ResourceSerializer;
+use App\Services\Migration\Storage\MigrationStorageFactory;
+use Lorisleiva\Actions\Concerns\AsAction;
+use Lorisleiva\Actions\Decorators\JobDecorator;
+use Throwable;
+
+class ExportResources
+{
+    use AsAction;
+
+    public int $jobTries = 1;
+
+    public int $jobTimeout = 3600;
+
+    public function configureJob(JobDecorator $job): void
+    {
+        $job->onQueue('high');
+    }
+
+    public function handle(ResourceMigration $migration): void
+    {
+        $migration->markRunning();
+        $serializer = new ResourceSerializer;
+        $archiver = new MigrationArchiver;
+        $storage = app(MigrationStorageFactory::class)->forMigration($migration);
+        $resources = [];
+
+        try {
+            foreach ($migration->items as $item) {
+                $item->mark(ResourceMigrationStatus::Exporting);
+                $model = getResourceByUuid($item->source_uuid, $migration->team_id);
+                if (! $model) {
+                    $item->mark(ResourceMigrationStatus::Failed, 'Resource not found.');
+
+                    continue;
+                }
+
+                $payload = $serializer->serialize($model);
+                $server = $this->serverFor($model);
+
+                if (! $migration->skip_data && $server) {
+                    $payload = $this->archiveAndUpload($payload, $model, $server, $item, $archiver, $storage, $migration);
+                }
+
+                $item->update([
+                    'archives' => $this->collectArchives($payload),
+                    'status' => ResourceMigrationStatus::Uploaded,
+                    'error' => null,
+                ]);
+                $resources[] = $payload;
+            }
+
+            $manifest = Manifest::make(
+                storage: [
+                    'driver' => $migration->storage_driver->value,
+                    'config' => collect($migration->storage_config ?? [])->except(['key', 'secret', 'sas', 'credentials'])->all(),
+                ],
+                resources: $resources,
+                skipData: $migration->skip_data,
+            );
+
+            $migration->update(['manifest' => $manifest->toArray()]);
+            $migration->refreshAggregateStatus();
+        } catch (Throwable $exception) {
+            $migration->markFailed($exception->getMessage());
+
+            throw $exception;
+        }
+    }
+
+    public function asJob(JobDecorator $job, ResourceMigration $migration): void
+    {
+        $this->handle($migration);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function archiveAndUpload(
+        array $payload,
+        object $model,
+        Server $server,
+        ResourceMigrationItem $item,
+        MigrationArchiver $archiver,
+        mixed $storage,
+        ResourceMigration $migration,
+    ): array {
+        $base = backup_dir().'/migrations/'.$migration->uuid.'/'.$item->source_uuid;
+
+        foreach ($payload['volumes'] as $index => $volume) {
+            $volumeModel = $model->persistentStorages()->where('name', $volume['name'])->first();
+            if (! $volumeModel) {
+                continue;
+            }
+            $path = $base.'/volume-'.$index.'.tar.gz';
+            $archiver->archiveVolume($server, $volumeModel, $path);
+            $key = $migration->uuid.'/'.$item->source_uuid.'/volume-'.$index.'.tar.gz';
+            $payload['volumes'][$index]['archive'] = $storage->put($server, $path, $key);
+        }
+
+        foreach ($payload['file_storages'] as $index => $fileStorage) {
+            if (! ($fileStorage['is_directory'] ?? false) && ! ($fileStorage['is_host_file'] ?? false)) {
+                continue;
+            }
+            $fileModel = $model->fileStorages()->where('mount_path', $fileStorage['mount_path'])->first();
+            if (! $fileModel || blank($fileModel->fs_path)) {
+                continue;
+            }
+            $path = $base.'/file-'.$index.'.tar.gz';
+            $archiver->archiveFileStorage($server, $fileModel, $path);
+            $key = $migration->uuid.'/'.$item->source_uuid.'/file-'.$index.'.tar.gz';
+            $payload['file_storages'][$index]['archive'] = $storage->put($server, $path, $key);
+        }
+
+        if ($archiver->supportsLogicalDump($model) && $model->persistentStorages()->count() === 0) {
+            $path = $base.'/dump';
+            $dump = $archiver->dumpDatabase($model, $server, $path);
+            $key = $migration->uuid.'/'.$item->source_uuid.'/dump';
+            $payload['dump'] = [
+                'archive' => $storage->put($server, $path, $key),
+                'dump_all' => $dump['dump_all'],
+            ];
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return list<array<string, mixed>>
+     */
+    private function collectArchives(array $payload): array
+    {
+        $archives = [];
+        foreach ($payload['volumes'] ?? [] as $volume) {
+            if (is_array($volume['archive'] ?? null)) {
+                $archives[] = $volume['archive'];
+            }
+        }
+        foreach ($payload['file_storages'] ?? [] as $fileStorage) {
+            if (is_array($fileStorage['archive'] ?? null)) {
+                $archives[] = $fileStorage['archive'];
+            }
+        }
+        if (is_array($payload['dump']['archive'] ?? null)) {
+            $archives[] = $payload['dump']['archive'];
+        }
+
+        return $archives;
+    }
+
+    private function serverFor(object $resource): ?Server
+    {
+        if (isset($resource->server) && $resource->server instanceof Server) {
+            return $resource->server;
+        }
+
+        return $resource->destination?->server;
+    }
+}

--- a/app/Actions/Migration/ImportResources.php
+++ b/app/Actions/Migration/ImportResources.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace App\Actions\Migration;
+
+use App\Actions\Database\RestoreDatabaseDump;
+use App\Actions\Database\StartDatabase;
+use App\Actions\Service\StartService;
+use App\Enums\ResourceMigrationStatus;
+use App\Jobs\VolumeRestoreJob;
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\LocalPersistentVolume;
+use App\Models\Project;
+use App\Models\ResourceMigration;
+use App\Models\ResourceMigrationItem;
+use App\Models\Server;
+use App\Models\Service;
+use App\Models\StandaloneDocker;
+use App\Models\SwarmDocker;
+use App\Services\Migration\Manifest;
+use App\Services\Migration\MigrationArchiver;
+use App\Services\Migration\ResourceImporter;
+use App\Services\Migration\Storage\MigrationStorageFactory;
+use Illuminate\Database\Eloquent\Model;
+use Lorisleiva\Actions\Concerns\AsAction;
+use Lorisleiva\Actions\Decorators\JobDecorator;
+use RuntimeException;
+use Throwable;
+
+class ImportResources
+{
+    use AsAction;
+
+    public int $jobTries = 1;
+
+    public int $jobTimeout = 3600;
+
+    public function configureJob(JobDecorator $job): void
+    {
+        $job->onQueue('high');
+    }
+
+    public function handle(ResourceMigration $migration): void
+    {
+        $migration->markRunning();
+        $manifest = Manifest::fromArray($migration->manifest ?? []);
+        $destination = $this->destination($migration);
+        $environment = $this->environment($migration);
+        $server = $destination->server;
+        $storage = app(MigrationStorageFactory::class)->forMigration($migration);
+        $archiver = new MigrationArchiver;
+        $importer = new ResourceImporter;
+        $uuidMap = [];
+
+        try {
+            if (! $migration->skip_data) {
+                $this->assertDiskSpace($server, $storage, $manifest);
+            }
+
+            foreach ($manifest->resourcesInImportOrder() as $resource) {
+                $item = $this->itemFor($migration, (string) $resource['source_uuid']);
+                if (! $item) {
+                    continue;
+                }
+
+                try {
+                    $item->mark(ResourceMigrationStatus::Importing);
+                    $created = $importer->import($resource, $destination, $environment, $uuidMap);
+                    $item->update(['target_uuid' => $created->uuid]);
+
+                    if (! $migration->skip_data) {
+                        $this->restoreData($resource, $created, $item, $server, $storage, $archiver);
+                    }
+
+                    if (! $migration->skip_data) {
+                        $item->mark(ResourceMigrationStatus::Deploying);
+                        $this->deploy($created);
+                        VerifyHealth::run(
+                            $created,
+                            $item,
+                            attempts: app()->environment('testing') ? 1 : 12,
+                            sleepSeconds: app()->environment('testing') ? 0 : 5,
+                        );
+                    } else {
+                        $item->mark(ResourceMigrationStatus::Healthy);
+                    }
+                } catch (Throwable $exception) {
+                    $item->mark(ResourceMigrationStatus::Failed, $exception->getMessage());
+                }
+            }
+
+            $migration->refreshAggregateStatus();
+        } catch (Throwable $exception) {
+            $migration->markFailed($exception->getMessage());
+
+            throw $exception;
+        }
+    }
+
+    public function asJob(JobDecorator $job, ResourceMigration $migration): void
+    {
+        $this->handle($migration);
+    }
+
+    private function destination(ResourceMigration $migration): StandaloneDocker|SwarmDocker
+    {
+        $destination = find_destination_for_team($migration->destination_uuid, $migration->team_id);
+        if (! $destination) {
+            throw new RuntimeException('Target destination was not found.');
+        }
+        if (! $destination->server?->canHostResources()) {
+            throw new RuntimeException('The selected server cannot host resources.');
+        }
+
+        return $destination;
+    }
+
+    private function environment(ResourceMigration $migration): Environment
+    {
+        $project = Project::where('team_id', $migration->team_id)
+            ->where('uuid', $migration->project_uuid)
+            ->first();
+
+        if (! $project) {
+            throw new RuntimeException('Target project was not found.');
+        }
+
+        $environment = $project->environments()->where('uuid', $migration->environment_uuid)->first()
+            ?? $project->environments()->first();
+
+        if (! $environment) {
+            throw new RuntimeException('Target environment was not found.');
+        }
+
+        return $environment;
+    }
+
+    private function itemFor(ResourceMigration $migration, string $sourceUuid): ?ResourceMigrationItem
+    {
+        return $migration->items->firstWhere('source_uuid', $sourceUuid);
+    }
+
+    private function assertDiskSpace(Server $server, mixed $storage, Manifest $manifest): void
+    {
+        $required = (int) ($manifest->totalArchiveBytes() * 1.1);
+        if ($required <= 0) {
+            return;
+        }
+
+        $free = $storage->diskFree($server);
+        if ($free !== null && $free < $required) {
+            throw new RuntimeException('Not enough disk space on the target server to restore migration archives.');
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $resource
+     */
+    private function restoreData(
+        array $resource,
+        Model $created,
+        ResourceMigrationItem $item,
+        Server $server,
+        mixed $storage,
+        MigrationArchiver $archiver,
+    ): void {
+        $item->mark(ResourceMigrationStatus::Restoring);
+        $restoredVolumes = 0;
+        $base = backup_dir().'/migrations/'.$item->migration->uuid.'/'.$created->uuid;
+
+        foreach ($resource['volumes'] ?? [] as $volume) {
+            $archive = $volume['archive'] ?? null;
+            if (! is_array($archive) || blank($archive['key'] ?? null)) {
+                continue;
+            }
+            $localPath = $base.'/'.basename((string) $archive['key']);
+            $storage->get($server, (string) $archive['key'], $localPath);
+            $target = $created->persistentStorages()->where('mount_path', $volume['mount_path'])->first();
+            if (! $target instanceof LocalPersistentVolume) {
+                continue;
+            }
+            (new VolumeRestoreJob($localPath, $target->name, $server, $target))->handle();
+            $restoredVolumes++;
+        }
+
+        foreach ($resource['file_storages'] ?? [] as $fileStorage) {
+            $archive = $fileStorage['archive'] ?? null;
+            if (! is_array($archive) || blank($archive['key'] ?? null) || blank($fileStorage['fs_path'] ?? null)) {
+                continue;
+            }
+            $localPath = $base.'/'.basename((string) $archive['key']);
+            $storage->get($server, (string) $archive['key'], $localPath);
+            $archiver->restoreFileStorage($server, $localPath, (string) $fileStorage['fs_path']);
+        }
+
+        $dump = $resource['dump']['archive'] ?? null;
+        if ($restoredVolumes === 0 && is_array($dump) && filled($dump['key'] ?? null)) {
+            $this->deploy($created);
+            $localPath = $base.'/dump';
+            $storage->get($server, (string) $dump['key'], $localPath);
+            RestoreDatabaseDump::run($created, $server, $localPath, (bool) ($resource['dump']['dump_all'] ?? false));
+        }
+    }
+
+    private function deploy(Model $resource): void
+    {
+        if ($resource instanceof Application) {
+            queue_application_deployment(
+                application: $resource,
+                deployment_uuid: new_public_id(),
+                no_questions_asked: true,
+                is_api: true,
+            );
+
+            return;
+        }
+
+        if ($resource instanceof Service) {
+            StartService::run($resource);
+
+            return;
+        }
+
+        StartDatabase::run($resource);
+    }
+}

--- a/app/Actions/Migration/InstallCoolifyOnHost.php
+++ b/app/Actions/Migration/InstallCoolifyOnHost.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Actions\Migration;
+
+use App\Models\Server;
+use Lorisleiva\Actions\Concerns\AsAction;
+use RuntimeException;
+
+class InstallCoolifyOnHost
+{
+    use AsAction;
+
+    public function handle(Server $target, bool $force = false): void
+    {
+        if (! $force && DetectIndependentCoolifyInstall::run($target)) {
+            throw new RuntimeException('Target already has an independent Coolify install. Use a fresh VM or pass force.');
+        }
+
+        $cdn = rtrim((string) config('constants.coolify.cdn_url', 'https://cdn.coollabs.io'), '/');
+        $installUrl = $cdn.'/coolify/install.sh';
+
+        instant_remote_process(self::installCommands($installUrl), $target, timeout: 3600);
+
+        $ready = instant_remote_process([
+            'docker ps --format "{{.Names}}" | grep -E "^coolify-db$" || true',
+        ], $target, false);
+
+        if (! str_contains((string) $ready, 'coolify-db')) {
+            throw new RuntimeException('Coolify install finished but coolify-db is not running on the target.');
+        }
+
+        EnsureCoolifyDataDirsTraversable::run($target);
+    }
+
+    /**
+     * Commands must survive parseCommandsByLineForSudo() on non-root targets.
+     * Avoid `|| (cmd && cmd)` — sudo rewriting turns that into invalid `|| sudo (`.
+     *
+     * @return list<string>
+     */
+    public static function installCommands(string $installUrl): array
+    {
+        return [
+            // InstallPrerequisites-style: no parentheses, tolerate apt on RHEL / dnf on Debian.
+            'command -v curl >/dev/null 2>&1 || apt-get update -y || true',
+            'command -v curl >/dev/null 2>&1 || apt-get install -y curl || true',
+            'command -v curl >/dev/null 2>&1 || dnf install -y curl || true',
+            'command -v curl',
+            'curl -fsSL '.escapeshellarg($installUrl).' -o /tmp/coolify-install.sh',
+            'bash /tmp/coolify-install.sh',
+            'rm -f /tmp/coolify-install.sh',
+        ];
+    }
+}

--- a/app/Actions/Migration/PackageInstanceBackup.php
+++ b/app/Actions/Migration/PackageInstanceBackup.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Actions\Migration;
+
+use App\Helpers\SshMultiplexingHelper;
+use App\Models\Server;
+use App\Models\User;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Process;
+use Lorisleiva\Actions\Concerns\AsAction;
+use RuntimeException;
+
+class PackageInstanceBackup
+{
+    use AsAction;
+
+    /**
+     * @return array{dump_path: string, app_key: string, ssh_keys_archive: string, package_dir: string, expected_user_count: int}
+     */
+    public function handle(?Server $localhost = null): array
+    {
+        $localhost ??= Server::find(0);
+        if (! $localhost) {
+            throw new RuntimeException('Coolify host (server id 0) was not found.');
+        }
+
+        $packageDir = storage_path('app/instance-migrations/'.uniqid('pkg_', true));
+        File::ensureDirectoryExists($packageDir);
+
+        $dumpPath = $packageDir.'/coolify-db.dmp';
+        $this->createDatabaseDump($localhost, $dumpPath);
+
+        $appKey = $this->readAppKey();
+        file_put_contents($packageDir.'/APP_KEY', $appKey);
+
+        $sshKeysArchive = $packageDir.'/ssh-keys.tar.gz';
+        $this->archiveSshKeys($sshKeysArchive);
+
+        return [
+            'dump_path' => $dumpPath,
+            'app_key' => $appKey,
+            'ssh_keys_archive' => $sshKeysArchive,
+            'package_dir' => $packageDir,
+            'expected_user_count' => User::query()->count(),
+        ];
+    }
+
+    private function createDatabaseDump(Server $localhost, string $dumpPath): void
+    {
+        $remoteTmp = '/tmp/coolify-instance-migration-'.uniqid('', true).'.dmp';
+
+        instant_remote_process([
+            'docker exec coolify-db sh -c '.escapeshellarg(
+                'pg_dump --format=custom --no-acl --no-owner -U "$POSTGRES_USER" --file='.$remoteTmp.' "${POSTGRES_DB:-coolify}"'
+            ),
+            'docker cp coolify-db:'.escapeshellarg($remoteTmp).' '.escapeshellarg($remoteTmp),
+            'docker exec coolify-db rm -f '.escapeshellarg($remoteTmp),
+        ], $localhost, timeout: 3600);
+
+        $download = SshMultiplexingHelper::generateScpDownloadCommand($localhost, $remoteTmp, $dumpPath);
+        $result = Process::timeout(3600)->run($download);
+        if ($result->failed() || ! is_file($dumpPath) || filesize($dumpPath) === 0) {
+            throw new RuntimeException('Failed to download Coolify database dump: '.$result->errorOutput());
+        }
+
+        instant_remote_process(['rm -f '.escapeshellarg($remoteTmp)], $localhost, false);
+    }
+
+    private function readAppKey(): string
+    {
+        $envPath = '/data/coolify/source/.env';
+        if (is_readable($envPath)) {
+            $contents = file_get_contents($envPath) ?: '';
+            foreach (preg_split('/\R/', $contents) ?: [] as $line) {
+                if (str_starts_with(trim($line), 'APP_KEY=')) {
+                    return trim(substr(trim($line), strlen('APP_KEY=')));
+                }
+            }
+        }
+
+        $key = (string) config('app.key');
+        if ($key === '') {
+            throw new RuntimeException('APP_KEY could not be read from /data/coolify/source/.env or config.');
+        }
+
+        return $key;
+    }
+
+    private function archiveSshKeys(string $archivePath): void
+    {
+        $keysDir = storage_path('app/ssh/keys');
+        File::ensureDirectoryExists($keysDir);
+
+        $result = Process::timeout(300)->run([
+            'tar',
+            '-czf',
+            $archivePath,
+            '-C',
+            storage_path('app/ssh'),
+            'keys',
+        ]);
+
+        if ($result->failed() || ! is_file($archivePath)) {
+            throw new RuntimeException('Failed to archive SSH keys: '.$result->errorOutput());
+        }
+    }
+}

--- a/app/Actions/Migration/ReassignDestinationsOnRemoteInstance.php
+++ b/app/Actions/Migration/ReassignDestinationsOnRemoteInstance.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Actions\Migration;
+
+use App\Models\Server;
+use Lorisleiva\Actions\Concerns\AsAction;
+use RuntimeException;
+
+class ReassignDestinationsOnRemoteInstance
+{
+    use AsAction;
+
+    /**
+     * Update destination FKs on the restored Coolify DB via psql (peer auth inside coolify-db).
+     * Do not use artisan tinker — that needs Laravel's DB_PASSWORD, which can disagree with Postgres after restore.
+     */
+    public function handle(Server $target): void
+    {
+        instant_remote_process(RestoreInstanceOnHost::syncDatabasePasswordCommands(), $target);
+
+        $output = instant_remote_process(self::reassignCommands(), $target, timeout: 300);
+
+        if (! str_contains((string) $output, 'ok')) {
+            throw new RuntimeException('Failed to reassign destinations on target: '.$output);
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function reassignCommands(): array
+    {
+        $remoteSql = '/tmp/coolify-reassign-destinations.sql';
+
+        return [
+            'printf %s '.escapeshellarg(self::reassignSql()).' | tee '.escapeshellarg($remoteSql).' >/dev/null',
+            'docker cp '.escapeshellarg($remoteSql).' coolify-db:/tmp/coolify-reassign-destinations.sql',
+            'docker exec coolify-db sh -c '.escapeshellarg(
+                'psql -U "$POSTGRES_USER" -d "${POSTGRES_DB:-coolify}" -v ON_ERROR_STOP=1 -f /tmp/coolify-reassign-destinations.sql'
+            ),
+            'docker exec coolify-db rm -f /tmp/coolify-reassign-destinations.sql || true',
+            'rm -f '.escapeshellarg($remoteSql).' || true',
+        ];
+    }
+
+    public static function reassignSql(): string
+    {
+        return <<<'SQL'
+DO $reassign$
+DECLARE
+  dest_id bigint;
+  dest_type text := 'App\Models\StandaloneDocker';
+BEGIN
+  SELECT id INTO dest_id FROM standalone_dockers WHERE server_id = 0 ORDER BY id ASC LIMIT 1;
+  IF dest_id IS NULL THEN
+    RAISE EXCEPTION 'localhost destination missing';
+  END IF;
+
+  UPDATE applications SET destination_id = dest_id, destination_type = dest_type;
+  UPDATE services SET destination_id = dest_id, destination_type = dest_type, server_id = 0;
+  UPDATE standalone_postgresqls SET destination_id = dest_id, destination_type = dest_type WHERE id <> 0;
+  UPDATE standalone_mysqls SET destination_id = dest_id, destination_type = dest_type WHERE id <> 0;
+  UPDATE standalone_mariadbs SET destination_id = dest_id, destination_type = dest_type WHERE id <> 0;
+  UPDATE standalone_mongodbs SET destination_id = dest_id, destination_type = dest_type WHERE id <> 0;
+  UPDATE standalone_redis SET destination_id = dest_id, destination_type = dest_type WHERE id <> 0;
+  UPDATE standalone_keydbs SET destination_id = dest_id, destination_type = dest_type WHERE id <> 0;
+  UPDATE standalone_dragonflies SET destination_id = dest_id, destination_type = dest_type WHERE id <> 0;
+  UPDATE standalone_clickhouses SET destination_id = dest_id, destination_type = dest_type WHERE id <> 0;
+END
+$reassign$;
+
+SELECT 'ok';
+SQL;
+    }
+}

--- a/app/Actions/Migration/ReassignResourceToDestination.php
+++ b/app/Actions/Migration/ReassignResourceToDestination.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace App\Actions\Migration;
+
+use App\Actions\Application\StopApplication;
+use App\Actions\Database\StartDatabase;
+use App\Actions\Database\StopDatabase;
+use App\Actions\Service\StartService;
+use App\Actions\Service\StopService;
+use App\Jobs\VolumeCloneJob;
+use App\Models\Application;
+use App\Models\Server;
+use App\Models\Service;
+use App\Models\StandaloneClickhouse;
+use App\Models\StandaloneDocker;
+use App\Models\StandaloneDragonfly;
+use App\Models\StandaloneKeydb;
+use App\Models\StandaloneMariadb;
+use App\Models\StandaloneMongodb;
+use App\Models\StandaloneMysql;
+use App\Models\StandalonePostgresql;
+use App\Models\StandaloneRedis;
+use App\Models\SwarmDocker;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Bus;
+use Lorisleiva\Actions\Concerns\AsAction;
+use RuntimeException;
+use Throwable;
+
+class ReassignResourceToDestination
+{
+    use AsAction;
+
+    public function handle(
+        Model $resource,
+        StandaloneDocker|SwarmDocker $destination,
+        bool $copyVolumeData = true,
+        bool $dispatchAsync = false,
+        ?Server $volumeSourceServer = null,
+    ): Model {
+        if ($destination instanceof SwarmDocker) {
+            throw new RuntimeException('Swarm destinations are not supported for instance consolidation.');
+        }
+
+        $sourceServer = $volumeSourceServer ?? $this->serverFor($resource);
+        if (! $sourceServer) {
+            throw new RuntimeException('Resource has no source server.');
+        }
+
+        $targetServer = $destination->server;
+        $volumes = CollectResourceVolumes::run($resource);
+
+        if ($copyVolumeData && $volumes !== [] && $sourceServer->id !== $targetServer->id) {
+            $this->stopResource($resource);
+
+            $jobs = [];
+            foreach ($volumes as $volume) {
+                $jobs[] = new VolumeCloneJob(
+                    $volume->name,
+                    $volume->name,
+                    $sourceServer,
+                    $targetServer,
+                    $volume,
+                );
+            }
+
+            if ($dispatchAsync) {
+                Bus::chain($jobs)->onQueue('high')->dispatch();
+            } else {
+                foreach ($jobs as $job) {
+                    dispatch_sync($job);
+                }
+            }
+        }
+
+        $this->updateDestination($resource, $destination);
+        $resource->refresh();
+
+        if (! $dispatchAsync) {
+            try {
+                $this->startResource($resource);
+            } catch (Throwable) {
+                // Destination was updated; deploy/start can be retried from the UI.
+            }
+        }
+
+        return $resource;
+    }
+
+    private function serverFor(Model $resource): ?Server
+    {
+        if ($resource instanceof Service) {
+            return $resource->server;
+        }
+
+        return $resource->destination?->server;
+    }
+
+    private function updateDestination(Model $resource, StandaloneDocker $destination): void
+    {
+        if ($resource instanceof Service) {
+            $resource->destination_id = $destination->id;
+            $resource->destination_type = $destination->getMorphClass();
+            $resource->server_id = $destination->server_id;
+            $resource->save();
+
+            return;
+        }
+
+        if ($resource instanceof StandalonePostgresql && (int) $resource->id === 0) {
+            throw new RuntimeException('Cannot reassign coolify-db.');
+        }
+
+        $resource->destination_id = $destination->id;
+        $resource->destination_type = $destination->getMorphClass();
+        $resource->save();
+    }
+
+    private function stopResource(Model $resource): void
+    {
+        if ($resource instanceof Application) {
+            StopApplication::run($resource, false, false);
+
+            return;
+        }
+        if ($resource instanceof Service) {
+            StopService::run($resource, false, false);
+
+            return;
+        }
+        if ($this->isStandaloneDatabase($resource)) {
+            StopDatabase::run($resource, false);
+        }
+    }
+
+    private function startResource(Model $resource): void
+    {
+        if ($resource instanceof Application) {
+            queue_application_deployment(
+                application: $resource,
+                deployment_uuid: new_public_id(),
+                force_rebuild: false,
+            );
+
+            return;
+        }
+        if ($resource instanceof Service) {
+            StartService::run($resource);
+
+            return;
+        }
+        if ($this->isStandaloneDatabase($resource)) {
+            StartDatabase::run($resource);
+        }
+    }
+
+    private function isStandaloneDatabase(Model $resource): bool
+    {
+        return $resource instanceof StandalonePostgresql
+            || $resource instanceof StandaloneMongodb
+            || $resource instanceof StandaloneMysql
+            || $resource instanceof StandaloneMariadb
+            || $resource instanceof StandaloneRedis
+            || $resource instanceof StandaloneKeydb
+            || $resource instanceof StandaloneDragonfly
+            || $resource instanceof StandaloneClickhouse;
+    }
+}

--- a/app/Actions/Migration/RestoreInstanceOnHost.php
+++ b/app/Actions/Migration/RestoreInstanceOnHost.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace App\Actions\Migration;
+
+use App\Helpers\SshMultiplexingHelper;
+use App\Models\Server;
+use Illuminate\Support\Facades\Process;
+use Lorisleiva\Actions\Concerns\AsAction;
+use RuntimeException;
+
+class RestoreInstanceOnHost
+{
+    use AsAction;
+
+    /**
+     * @param  array{dump_path: string, app_key: string, ssh_keys_archive: string, expected_user_count?: int}  $package
+     */
+    public function handle(Server $target, array $package): void
+    {
+        $dumpPath = $package['dump_path'] ?? '';
+        $appKey = $package['app_key'] ?? '';
+        $sshKeysArchive = $package['ssh_keys_archive'] ?? '';
+        $expectedUserCount = (int) ($package['expected_user_count'] ?? 1);
+
+        if (! is_file($dumpPath) || $appKey === '' || ! is_file($sshKeysArchive)) {
+            throw new RuntimeException('Instance backup package is incomplete.');
+        }
+
+        // SCP as a non-root user into a sudo-created /tmp/coolify-* dir fails (dir is root-owned).
+        // Upload files directly into world-writable /tmp — same pattern as database import.
+        $id = uniqid('', true);
+        $remoteDump = self::stagingFilePath($id, 'coolify-db.dmp');
+        $remoteKeys = self::stagingFilePath($id, 'ssh-keys.tar.gz');
+
+        try {
+            $this->upload($target, $dumpPath, $remoteDump);
+            $this->upload($target, $sshKeysArchive, $remoteKeys);
+
+            instant_remote_process(self::updateEnvCommands($appKey), $target);
+
+            instant_remote_process(self::restoreDatabaseCommands($remoteDump), $target, timeout: 3600);
+
+            instant_remote_process(self::syncDatabasePasswordCommands(), $target);
+
+            $userCount = trim((string) (instant_remote_process(self::countUsersCommand(), $target, false) ?? ''));
+            if (! is_numeric($userCount) || (int) $userCount < max(1, $expectedUserCount)) {
+                throw new RuntimeException('Coolify database restore finished but source data was not found in coolify-db.');
+            }
+
+            instant_remote_process(self::restoreKeysCommands($remoteKeys), $target, timeout: 300);
+
+            EnsureCoolifyDataDirsTraversable::run($target);
+
+            instant_remote_process(self::restartCoolifyCommands(), $target, timeout: 1800);
+
+            $health = instant_remote_process(self::coolifyRunningCheckCommands(), $target, false);
+
+            if (! str_contains((string) $health, 'coolify')) {
+                throw new RuntimeException('Coolify dashboard container did not start after restore.');
+            }
+        } finally {
+            instant_remote_process([
+                'rm -f '.escapeshellarg($remoteDump).' '.escapeshellarg($remoteKeys),
+            ], $target, false);
+        }
+    }
+
+    /**
+     * Write APP_KEY into root-owned /data/coolify/source/.env without shell `>>`
+     * (that redirect runs as the SSH user even when printf is sudo'd).
+     *
+     * @return list<string>
+     */
+    public static function updateEnvCommands(string $appKey): array
+    {
+        $env = '/data/coolify/source/.env';
+        $previousScript = 'if grep -q "^APP_PREVIOUS_KEYS=" '.$env.'; then sed -i "s|^APP_PREVIOUS_KEYS=.*|APP_PREVIOUS_KEYS='.$appKey.'|" '.$env.'; else printf "APP_PREVIOUS_KEYS=%s\n" "'.$appKey.'" | tee -a '.$env.' >/dev/null; fi';
+
+        return [
+            '[ -f '.$env.' ]',
+            'sh -c '.escapeshellarg($previousScript),
+            'sed -i "s|^APP_KEY=.*|APP_KEY='.$appKey.'|" '.$env,
+        ];
+    }
+
+    /**
+     * Restart Coolify without `cd` — non-root sudo rewriting skips `cd`, which fails on root-owned /data/coolify.
+     *
+     * @return list<string>
+     */
+    public static function restartCoolifyCommands(): array
+    {
+        $source = '/data/coolify/source';
+
+        return [
+            'docker compose --project-directory '.$source
+                .' -f '.$source.'/docker-compose.yml'
+                .' -f '.$source.'/docker-compose.prod.yml'
+                .' up -d --remove-orphans',
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function coolifyRunningCheckCommands(): array
+    {
+        return [
+            'docker ps --format "{{.Names}}" | grep -E "^coolify$" || true',
+        ];
+    }
+
+    /**
+     * Copy the dump into coolify-db and restore from a file path.
+     * Do not use `docker exec -i ... < dump` — SSH bash -se already owns stdin.
+     *
+     * @return list<string>
+     */
+    public static function restoreDatabaseCommands(string $remoteDumpPath): array
+    {
+        $containerDump = '/tmp/coolify-instance.dmp';
+
+        return [
+            'docker stop coolify coolify-realtime 2>/dev/null || true',
+            'sleep 3',
+            'docker exec coolify-db sh -c '.escapeshellarg('pg_isready -U "$POSTGRES_USER" -d "${POSTGRES_DB:-coolify}"'),
+            'docker cp '.escapeshellarg($remoteDumpPath).' coolify-db:'.$containerDump,
+            'docker exec coolify-db sh -c '.escapeshellarg(
+                'pg_restore --clean --if-exists --no-acl --no-owner -U "$POSTGRES_USER" -d "${POSTGRES_DB:-coolify}" '.$containerDump.'; code=$?; if [ "$code" -ge 2 ]; then exit "$code"; fi'
+            ),
+            'docker exec coolify-db rm -f '.$containerDump.' || true',
+        ];
+    }
+
+    /**
+     * Keep the Postgres role password in sync with the target .env.
+     * pg_restore does not change role passwords, but a later volume copy or a
+     * previous install can leave Laravel's DB_PASSWORD unable to authenticate.
+     *
+     * @return list<string>
+     */
+    public static function syncDatabasePasswordCommands(): array
+    {
+        $script = <<<'SH'
+set -e
+ENV=/data/coolify/source/.env
+PASS=$(awk -F= '/^DB_PASSWORD=/{print substr($0, index($0,"=")+1); exit}' "$ENV")
+USER=$(awk -F= '/^DB_USERNAME=/{print substr($0, index($0,"=")+1); exit}' "$ENV")
+USER=${USER:-coolify}
+if [ -z "$PASS" ]; then
+  echo "DB_PASSWORD missing from $ENV"
+  exit 1
+fi
+SQL=/tmp/coolify-sync-db-password.sql
+printf 'ALTER ROLE %s WITH PASSWORD $coolifypw$%s$coolifypw$;\n' "$USER" "$PASS" | tee "$SQL" >/dev/null
+docker cp "$SQL" coolify-db:/tmp/coolify-sync-db-password.sql
+docker exec coolify-db sh -c 'psql -U "$POSTGRES_USER" -d postgres -v ON_ERROR_STOP=1 -f /tmp/coolify-sync-db-password.sql'
+docker exec coolify-db rm -f /tmp/coolify-sync-db-password.sql || true
+rm -f "$SQL" || true
+SH;
+
+        return [
+            'sh -c '.escapeshellarg($script),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function countUsersCommand(): array
+    {
+        return [
+            'docker exec coolify-db sh -c '.escapeshellarg(
+                'psql -U "$POSTGRES_USER" -d "${POSTGRES_DB:-coolify}" -tAc "SELECT COUNT(*) FROM users"'
+            ),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function restoreKeysCommands(string $remoteKeysArchive): array
+    {
+        // Entire extract runs under one sudo'd sh -c so writes into root-owned /data/coolify/ssh succeed.
+        $script = 'mkdir -p /data/coolify/ssh'
+            .' && tar -xzf '.escapeshellarg($remoteKeysArchive).' -C /data/coolify/ssh'
+            .' && chown -R 9999:root /data/coolify/ssh'
+            .' && chmod -R 700 /data/coolify/ssh';
+
+        return [
+            'sh -c '.escapeshellarg($script),
+        ];
+    }
+
+    /**
+     * Flat file under /tmp so SCP does not need a pre-created directory.
+     */
+    public static function stagingFilePath(string $id, string $filename): string
+    {
+        return '/tmp/coolify-instance-migration-'.$id.'-'.$filename;
+    }
+
+    /**
+     * All remote command builders used during restore (for non-root permission audits).
+     *
+     * @return list<string>
+     */
+    public static function allRemoteCommands(string $appKey = 'base64:test', string $dump = '/tmp/d.dmp', string $keys = '/tmp/k.tgz'): array
+    {
+        return array_merge(
+            self::updateEnvCommands($appKey),
+            self::restoreDatabaseCommands($dump),
+            self::syncDatabasePasswordCommands(),
+            self::countUsersCommand(),
+            self::restoreKeysCommands($keys),
+            EnsureCoolifyDataDirsTraversable::commands(),
+            self::restartCoolifyCommands(),
+            self::coolifyRunningCheckCommands(),
+        );
+    }
+
+    private function upload(Server $server, string $localPath, string $remotePath): void
+    {
+        $command = SshMultiplexingHelper::generateScpCommand($server, $localPath, $remotePath);
+        $result = Process::timeout(3600)->run($command);
+        if ($result->failed()) {
+            throw new RuntimeException('Failed to upload '.$localPath.': '.$result->errorOutput());
+        }
+    }
+}

--- a/app/Actions/Migration/RunInstanceMigration.php
+++ b/app/Actions/Migration/RunInstanceMigration.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace App\Actions\Migration;
+
+use App\Enums\InstanceMigrationStatus;
+use App\Models\InstanceMigration;
+use App\Models\PrivateKey;
+use App\Models\Server;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Lorisleiva\Actions\Concerns\AsAction;
+use RuntimeException;
+use Throwable;
+
+class RunInstanceMigration
+{
+    use AsAction;
+
+    public string $jobQueue = 'high';
+
+    public int $jobTimeout = 7200;
+
+    public function handle(InstanceMigration $migration, ?Command $command = null): InstanceMigration
+    {
+        $package = null;
+
+        try {
+            if ($migration->dry_run) {
+                $this->preflight($migration, $command);
+                $migration->markCompleted();
+                $command?->info('Dry run complete. Target is reachable and ready for installation.');
+
+                return $migration->refresh();
+            }
+
+            $localhost = Server::find(0);
+            if (! $localhost) {
+                throw new RuntimeException('Coolify host (server id 0) was not found.');
+            }
+
+            $oldHostIp = $this->resolveOldHostIp($localhost);
+            $migration->update(['old_host_ip' => $oldHostIp]);
+
+            $target = $this->ensureTargetServer($migration);
+
+            $migration->markPhase(InstanceMigrationStatus::Packaging, 'Creating Coolify database dump and packaging keys');
+            $command?->info('Packaging instance backup...');
+            $package = PackageInstanceBackup::run($localhost);
+            $migration->update(['package_paths' => $package]);
+
+            if (DetectIndependentCoolifyInstall::run($target)) {
+                $migration->markPhase(InstanceMigrationStatus::Installing, 'Coolify already installed on target, skipping installer');
+                $command?->info('Coolify is already installed on '.$migration->target_ip.'; restoring the source database into it.');
+            } else {
+                $migration->markPhase(InstanceMigrationStatus::Installing, 'Installing Coolify on target');
+                $command?->info('Installing Coolify on '.$migration->target_ip.'...');
+                InstallCoolifyOnHost::run($target);
+            }
+
+            $migration->markPhase(InstanceMigrationStatus::Restoring, 'Restoring Coolify database and SSH keys');
+            $command?->info('Restoring Coolify database on target...');
+            RestoreInstanceOnHost::run($target, $package);
+
+            $migration->markPhase(InstanceMigrationStatus::SyncingVolumes, 'Copying volumes from all servers to target');
+            $command?->info('Syncing persistent volumes to target...');
+            $syncItems = SyncAllVolumesToServer::run($migration->team_id, $target);
+            $migration->update(['items' => $syncItems]);
+
+            $migration->markPhase(InstanceMigrationStatus::Consolidating, 'Pointing all resources at localhost on target');
+            $command?->info('Reassigning destinations on target...');
+            ReassignDestinationsOnRemoteInstance::run($target);
+
+            $migration->markPhase(InstanceMigrationStatus::Verifying, 'Checking Coolify dashboard container');
+            $dashboardUrl = 'http://'.$migration->target_ip.':8000';
+            $this->verifyDashboard($target);
+
+            $migration->markCompleted($dashboardUrl);
+            $command?->info('Instance migration completed. Open '.$dashboardUrl);
+            $command?->warn('Source resources were left in place. Validate servers and redeploy apps on the new dashboard if needed.');
+
+            return $migration->refresh();
+        } catch (Throwable $exception) {
+            $migration->markFailed($exception->getMessage());
+            $command?->error($exception->getMessage());
+
+            throw $exception;
+        } finally {
+            if (is_array($package) && isset($package['package_dir']) && is_dir($package['package_dir'])) {
+                if ($migration->fresh()->status === InstanceMigrationStatus::Completed) {
+                    File::deleteDirectory($package['package_dir']);
+                }
+            }
+        }
+    }
+
+    public function asCommand(Command $command): int
+    {
+        $privateKeyId = (int) $command->option('target-private-key-id');
+        if ($privateKeyId < 1) {
+            $command->error('--target-private-key-id is required.');
+
+            return 1;
+        }
+
+        $key = PrivateKey::find($privateKeyId);
+        if (! $key) {
+            $command->error('Private key not found.');
+
+            return 1;
+        }
+
+        $teamId = currentTeam()?->id ?? $key->team_id;
+        $migration = InstanceMigration::create([
+            'team_id' => $teamId,
+            'status' => InstanceMigrationStatus::Pending,
+            'target_ip' => (string) $command->option('target-ip'),
+            'target_port' => (int) ($command->option('target-port') ?: 22),
+            'target_user' => (string) ($command->option('target-user') ?: 'root'),
+            'target_private_key_id' => $key->id,
+            'dry_run' => (bool) $command->option('dry-run'),
+            'created_by_user_id' => auth()->id(),
+            'phases' => [],
+            'items' => [],
+        ]);
+
+        try {
+            $this->handle($migration, $command);
+
+            return 0;
+        } catch (Throwable) {
+            return 1;
+        }
+    }
+
+    private function preflight(InstanceMigration $migration, ?Command $command): void
+    {
+        $target = $this->ensureTargetServer($migration);
+        $command?->info('Checking SSH connectivity to '.$migration->target_ip.'...');
+        instant_remote_process(['echo ok'], $target, timeout: 30);
+
+        if (DetectIndependentCoolifyInstall::isIndependentInstall(
+            (string) (instant_remote_process(["docker ps -a --format '{{.Names}}'"], $target, false, timeout: 15) ?? ''),
+            trim((string) (instant_remote_process(['test -f /data/coolify/source/.env && echo yes || echo no'], $target, false, timeout: 15) ?? '')) === 'yes',
+        )) {
+            throw new RuntimeException('Target already has Coolify installed. Use a fresh VM.');
+        }
+    }
+
+    private function ensureTargetServer(InstanceMigration $migration): Server
+    {
+        $existing = Server::where('ip', $migration->target_ip)
+            ->where('team_id', $migration->team_id)
+            ->first();
+
+        if ($existing) {
+            $existing->update([
+                'user' => $migration->target_user,
+                'port' => $migration->target_port,
+                'private_key_id' => $migration->target_private_key_id,
+            ]);
+
+            return $existing->fresh();
+        }
+
+        $server = new Server;
+        $server->forceFill([
+            'name' => 'instance-migration-target-'.$migration->uuid,
+            'ip' => $migration->target_ip,
+            'user' => $migration->target_user,
+            'port' => $migration->target_port,
+            'team_id' => $migration->team_id,
+            'private_key_id' => $migration->target_private_key_id,
+            'description' => 'Temporary target for instance migration '.$migration->uuid,
+        ]);
+        $server->save();
+        $server->settings()->update([
+            'is_reachable' => true,
+            'is_usable' => true,
+            'is_build_server' => false,
+        ]);
+
+        return $server->fresh();
+    }
+
+    private function resolveOldHostIp(Server $localhost): string
+    {
+        if ($localhost->ip && $localhost->ip !== 'host.docker.internal') {
+            return (string) $localhost->ip;
+        }
+
+        $detected = trim((string) (instant_remote_process(['hostname -I | awk \'{print $1}\''], $localhost, false) ?? ''));
+
+        return $detected !== '' ? $detected : (string) $localhost->ip;
+    }
+
+    private function verifyDashboard(Server $target): void
+    {
+        $names = (string) (instant_remote_process(['docker ps --format "{{.Names}}"'], $target, false) ?? '');
+        foreach (['coolify', 'coolify-db'] as $required) {
+            if (! str_contains($names, $required)) {
+                throw new RuntimeException("Required container [{$required}] is not running on the target.");
+            }
+        }
+    }
+}

--- a/app/Actions/Migration/RunMigration.php
+++ b/app/Actions/Migration/RunMigration.php
@@ -1,0 +1,322 @@
+<?php
+
+namespace App\Actions\Migration;
+
+use App\Services\Migration\MigrationApiClient;
+use Illuminate\Console\Command;
+use Lorisleiva\Actions\Concerns\AsAction;
+use RuntimeException;
+use Throwable;
+
+use function Laravel\Prompts\error;
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\multiselect;
+use function Laravel\Prompts\warning;
+
+class RunMigration
+{
+    use AsAction;
+
+    public string $commandSignature = 'coolify:migrate
+                            {--source-url= : Source Coolify URL}
+                            {--source-token= : Source API token}
+                            {--target-url= : Target Coolify URL}
+                            {--target-token= : Target API token}
+                            {--storage=s3 : Storage driver (s3, local-ssh, azure, gcs)}
+                            {--storage-endpoint= : S3-compatible endpoint}
+                            {--storage-bucket= : Bucket or container name}
+                            {--storage-region= : Storage region}
+                            {--storage-key= : Storage access key}
+                            {--storage-secret= : Storage secret}
+                            {--s3-storage-uuid= : Existing team S3 storage UUID}
+                            {--destination= : Target destination UUID}
+                            {--project= : Target project UUID}
+                            {--environment= : Target environment UUID}
+                            {--resources= : Comma-separated source resource UUIDs}
+                            {--skip-data : Export and import metadata only}
+                            {--dry-run : Discover and validate without migrating}';
+
+    public string $commandDescription = 'Migrate resources from one Coolify instance to another.';
+
+    public function handle(
+        string $sourceUrl,
+        string $sourceToken,
+        string $targetUrl,
+        string $targetToken,
+        array $options = [],
+        ?Command $command = null,
+    ): int {
+        $source = new MigrationApiClient($sourceUrl, $sourceToken);
+        $target = new MigrationApiClient($targetUrl, $targetToken);
+        $interactive = ! (bool) ($options['no_interaction'] ?? false);
+
+        $this->preflight($source, $target, $command);
+
+        $resources = $source->get('migrations/resources');
+        $selected = $this->selectResources($resources, $options['resources'] ?? null, $interactive);
+        if ($selected === []) {
+            $command?->error('No resources selected.');
+
+            return self::failure();
+        }
+
+        $this->printSelection($selected, $command);
+
+        if ((bool) ($options['dry_run'] ?? false)) {
+            info('Dry run complete. No resources were exported or imported.');
+
+            return self::success();
+        }
+
+        $export = $source->post('migrations/export', [
+            'resource_uuids' => array_column($selected, 'uuid'),
+            'skip_data' => (bool) ($options['skip_data'] ?? false),
+            'storage' => $this->storagePayload($options),
+        ]);
+
+        $export = $this->poll($source, (string) $export['uuid'], $command, 'Export');
+        if (($export['status'] ?? null) === 'failed') {
+            error('Export failed: '.($export['error'] ?? 'unknown error'));
+
+            return self::failure();
+        }
+
+        $manifest = $export['manifest'] ?? null;
+        if (! is_array($manifest)) {
+            throw new RuntimeException('Export completed without a manifest. The source token needs read:sensitive.');
+        }
+
+        $import = $target->post('migrations/import', [
+            'manifest' => $manifest,
+            'destination_uuid' => $options['destination'] ?? null,
+            'project_uuid' => $options['project'] ?? null,
+            'environment_uuid' => $options['environment'] ?? null,
+            'skip_data' => (bool) ($options['skip_data'] ?? false),
+            'storage' => $this->storagePayload($options),
+        ]);
+
+        $import = $this->poll($target, (string) $import['uuid'], $command, 'Import');
+        $this->report($import, $command);
+
+        if (($import['status'] ?? null) === 'completed') {
+            $source->post('migrations/'.$export['uuid'].'/cleanup');
+            $target->post('migrations/'.$import['uuid'].'/cleanup');
+        } else {
+            warning('Staging archives were kept so you can retry the failed resources.');
+        }
+
+        return ($import['status'] ?? null) === 'failed' ? self::failure() : self::success();
+    }
+
+    public function asCommand(Command $command): int
+    {
+        $sourceUrl = (string) $command->option('source-url');
+        $sourceToken = (string) $command->option('source-token');
+        $targetUrl = (string) $command->option('target-url');
+        $targetToken = (string) $command->option('target-token');
+
+        if ($sourceUrl === '' || $sourceToken === '' || $targetUrl === '' || $targetToken === '') {
+            $command->error('source-url, source-token, target-url, and target-token are required.');
+
+            return self::failure();
+        }
+
+        if (! $command->option('dry-run') && blank($command->option('destination'))) {
+            $command->error('The --destination option is required unless --dry-run is set.');
+
+            return self::failure();
+        }
+
+        if (! $command->option('dry-run') && blank($command->option('project'))) {
+            $command->error('The --project option is required unless --dry-run is set.');
+
+            return self::failure();
+        }
+
+        try {
+            return $this->handle(
+                $sourceUrl,
+                $sourceToken,
+                $targetUrl,
+                $targetToken,
+                [
+                    'storage' => $command->option('storage'),
+                    'storage-endpoint' => $command->option('storage-endpoint'),
+                    'storage-bucket' => $command->option('storage-bucket'),
+                    'storage-region' => $command->option('storage-region'),
+                    'storage-key' => $command->option('storage-key'),
+                    'storage-secret' => $command->option('storage-secret'),
+                    's3-storage-uuid' => $command->option('s3-storage-uuid'),
+                    'destination' => $command->option('destination'),
+                    'project' => $command->option('project'),
+                    'environment' => $command->option('environment'),
+                    'resources' => $command->option('resources'),
+                    'skip_data' => (bool) $command->option('skip-data'),
+                    'dry_run' => (bool) $command->option('dry-run'),
+                    'no_interaction' => (bool) $command->option('no-interaction'),
+                ],
+                $command,
+            );
+        } catch (Throwable $exception) {
+            $command->error($exception->getMessage());
+
+            return self::failure();
+        }
+    }
+
+    private function preflight(MigrationApiClient $source, MigrationApiClient $target, ?Command $command): void
+    {
+        foreach (['source' => $source, 'target' => $target] as $label => $client) {
+            $result = $client->get('migrations/preflight');
+            if (! ($result['token_can_write'] ?? false)) {
+                throw new RuntimeException("The {$label} token is missing the write ability.");
+            }
+            if ($label === 'source' && ! ($result['token_can_read_sensitive'] ?? false)) {
+                throw new RuntimeException('The source token is missing the read:sensitive ability.');
+            }
+            $command?->info(ucfirst($label).' Coolify v'.($result['version'] ?? 'unknown').' is ready.');
+        }
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $resources
+     * @return list<array<string, mixed>>
+     */
+    private function selectResources(array $resources, ?string $requested, bool $interactive): array
+    {
+        $resources = array_values(array_filter(
+            $resources,
+            fn (mixed $resource): bool => is_array($resource) && isset($resource['uuid']),
+        ));
+        if (is_string($requested) && $requested !== '') {
+            $uuids = array_filter(array_map('trim', explode(',', $requested)));
+
+            return array_values(array_filter(
+                $resources,
+                fn (array $resource): bool => in_array($resource['uuid'] ?? null, $uuids, true),
+            ));
+        }
+
+        if (! $interactive || $resources === []) {
+            return $resources;
+        }
+
+        $labels = [];
+        foreach ($resources as $resource) {
+            $labels[$resource['uuid']] = sprintf(
+                '%s [%s] (%s)',
+                $resource['name'] ?? $resource['uuid'],
+                $resource['type'] ?? 'unknown',
+                $resource['uuid'],
+            );
+        }
+
+        $chosen = multiselect(
+            label: 'Select resources to migrate',
+            options: $labels,
+            required: true,
+        );
+
+        return array_values(array_filter(
+            $resources,
+            fn (array $resource): bool => in_array($resource['uuid'] ?? null, $chosen, true),
+        ));
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $selected
+     */
+    private function printSelection(array $selected, ?Command $command): void
+    {
+        foreach ($selected as $resource) {
+            $warnings = $resource['warnings'] ?? [];
+            $command?->line(sprintf(
+                '- %s (%s) %s',
+                $resource['name'] ?? $resource['uuid'],
+                $resource['type'] ?? 'unknown',
+                $warnings === [] ? '' : 'warnings: '.implode('; ', $warnings),
+            ));
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     * @return array<string, mixed>
+     */
+    private function storagePayload(array $options): array
+    {
+        return [
+            'driver' => $options['storage'] ?? 's3',
+            'config' => array_filter([
+                'endpoint' => $options['storage-endpoint'] ?? null,
+                'bucket' => $options['storage-bucket'] ?? null,
+                'region' => $options['storage-region'] ?? null,
+                'key' => $options['storage-key'] ?? null,
+                'secret' => $options['storage-secret'] ?? null,
+                's3_storage_uuid' => $options['s3-storage-uuid'] ?? null,
+            ], fn ($value) => $value !== null && $value !== ''),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function poll(MigrationApiClient $client, string $uuid, ?Command $command, string $phase): array
+    {
+        $attempts = app()->environment('testing') ? 3 : 120;
+        $sleep = app()->environment('testing') ? 0 : 5;
+        $status = 'pending';
+        $payload = [];
+
+        for ($attempt = 0; $attempt < $attempts; $attempt++) {
+            $payload = $client->get('migrations/'.$uuid);
+            $status = (string) ($payload['status'] ?? 'pending');
+            $command?->info("{$phase} status: {$status}");
+            if (in_array($status, ['completed', 'partial', 'failed'], true)) {
+                return $payload;
+            }
+            if ($sleep > 0) {
+                sleep($sleep);
+            }
+        }
+
+        throw new RuntimeException("Timed out waiting for {$phase} to finish.");
+    }
+
+    /**
+     * @param  array<string, mixed>  $import
+     */
+    private function report(array $import, ?Command $command): void
+    {
+        $migrated = 0;
+        $failed = 0;
+        $skipped = 0;
+
+        foreach ($import['items'] ?? [] as $item) {
+            $status = $item['status'] ?? 'unknown';
+            match ($status) {
+                'healthy' => $migrated++,
+                'skipped' => $skipped++,
+                default => $failed++,
+            };
+            $command?->line(sprintf(
+                '%s: %s%s',
+                $item['name'] ?? $item['source_uuid'],
+                $status,
+                filled($item['error'] ?? null) ? ' ('.$item['error'].')' : '',
+            ));
+        }
+
+        info("Migrated: {$migrated}. Failed: {$failed}. Skipped: {$skipped}.");
+    }
+
+    private static function success(): int
+    {
+        return Command::SUCCESS;
+    }
+
+    private static function failure(): int
+    {
+        return Command::FAILURE;
+    }
+}

--- a/app/Actions/Migration/SyncAllVolumesToServer.php
+++ b/app/Actions/Migration/SyncAllVolumesToServer.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace App\Actions\Migration;
+
+use App\Actions\Application\StopApplication;
+use App\Actions\Database\StartDatabase;
+use App\Actions\Database\StopDatabase;
+use App\Actions\Service\StartService;
+use App\Actions\Service\StopService;
+use App\Jobs\VolumeCloneJob;
+use App\Models\Application;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\Service;
+use App\Models\StandalonePostgresql;
+use Illuminate\Database\Eloquent\Model;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class SyncAllVolumesToServer
+{
+    use AsAction;
+
+    /**
+     * Copy every resource volume onto the target server, keeping volume names.
+     *
+     * @return list<array{uuid: string, name: string, status: string, error: string}>
+     */
+    public function handle(int $teamId, Server $targetServer): array
+    {
+        $results = [];
+
+        foreach ($this->orderedResources($teamId) as $resource) {
+            $uuid = (string) $resource->uuid;
+            $name = (string) ($resource->name ?? $uuid);
+
+            if ($resource instanceof StandalonePostgresql && (int) $resource->id === 0) {
+                $results[] = ['uuid' => $uuid, 'name' => $name, 'status' => 'skipped', 'error' => 'coolify-db'];
+
+                continue;
+            }
+
+            $sourceServer = $resource instanceof Service
+                ? $resource->server
+                : $resource->destination?->server;
+
+            if (! $sourceServer) {
+                $results[] = ['uuid' => $uuid, 'name' => $name, 'status' => 'skipped', 'error' => 'No source server.'];
+
+                continue;
+            }
+
+            if ((int) $sourceServer->id === (int) $targetServer->id) {
+                $results[] = ['uuid' => $uuid, 'name' => $name, 'status' => 'skipped', 'error' => 'Already on target.'];
+
+                continue;
+            }
+
+            $volumes = CollectResourceVolumes::run($resource);
+            $volumes = array_values(array_filter(
+                $volumes,
+                fn ($volume) => ! self::isReservedVolumeName((string) $volume->name),
+            ));
+            if ($volumes === []) {
+                $results[] = ['uuid' => $uuid, 'name' => $name, 'status' => 'skipped', 'error' => 'No volumes.'];
+
+                continue;
+            }
+
+            try {
+                $this->stopResource($resource);
+                foreach ($volumes as $volume) {
+                    dispatch_sync(new VolumeCloneJob(
+                        $volume->name,
+                        $volume->name,
+                        $sourceServer,
+                        $targetServer,
+                        $volume,
+                    ));
+                }
+                $this->startResource($resource);
+                $results[] = ['uuid' => $uuid, 'name' => $name, 'status' => 'synced', 'error' => ''];
+            } catch (\Throwable $exception) {
+                try {
+                    $this->startResource($resource);
+                } catch (\Throwable) {
+                    // ignore restart failure after sync error
+                }
+                $results[] = [
+                    'uuid' => $uuid,
+                    'name' => $name,
+                    'status' => 'failed',
+                    'error' => $exception->getMessage(),
+                ];
+            }
+        }
+
+        return $results;
+    }
+
+    public static function isReservedVolumeName(string $name): bool
+    {
+        return in_array($name, ['coolify-db', 'coolify-redis'], true);
+    }
+
+    /**
+     * @return list<Model>
+     */
+    private function orderedResources(int $teamId): array
+    {
+        $projects = Project::where('team_id', $teamId)->get();
+        $resources = collect();
+
+        foreach (collect(DATABASE_TYPES) as $db) {
+            $resources->push($projects->pluck(str($db)->plural(2))->flatten());
+        }
+        $resources->push($projects->pluck('services')->flatten());
+        $resources->push($projects->pluck('applications')->flatten());
+
+        return $resources->flatten()->filter()->values()->all();
+    }
+
+    private function stopResource(Model $resource): void
+    {
+        if ($resource instanceof Application) {
+            StopApplication::run($resource, false, false);
+
+            return;
+        }
+        if ($resource instanceof Service) {
+            StopService::run($resource, false, false);
+
+            return;
+        }
+        if (method_exists($resource, 'type') && str_starts_with((string) $resource->type(), 'standalone')) {
+            StopDatabase::run($resource, false);
+        }
+    }
+
+    private function startResource(Model $resource): void
+    {
+        if ($resource instanceof Application) {
+            queue_application_deployment(
+                application: $resource,
+                deployment_uuid: new_public_id(),
+                force_rebuild: false,
+            );
+
+            return;
+        }
+        if ($resource instanceof Service) {
+            StartService::run($resource);
+
+            return;
+        }
+        if (method_exists($resource, 'type') && str_starts_with((string) $resource->type(), 'standalone')) {
+            StartDatabase::run($resource);
+        }
+    }
+}

--- a/app/Actions/Migration/VerifyHealth.php
+++ b/app/Actions/Migration/VerifyHealth.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Actions\Migration;
+
+use App\Enums\ResourceMigrationStatus;
+use App\Models\ResourceMigrationItem;
+use Illuminate\Database\Eloquent\Model;
+use Lorisleiva\Actions\Concerns\AsAction;
+use RuntimeException;
+
+class VerifyHealth
+{
+    use AsAction;
+
+    public function handle(Model $resource, ResourceMigrationItem $item, int $attempts = 12, int $sleepSeconds = 5): void
+    {
+        $resource->refresh();
+        $status = (string) $resource->status;
+
+        for ($attempt = 0; $attempt < $attempts; $attempt++) {
+            if ($this->isHealthy($status)) {
+                $item->mark(ResourceMigrationStatus::Healthy);
+
+                return;
+            }
+
+            if ($this->isFailed($status)) {
+                $item->mark(ResourceMigrationStatus::Failed, "Resource status is {$status}.");
+
+                return;
+            }
+
+            sleep($sleepSeconds);
+            $resource->refresh();
+            $status = (string) $resource->status;
+        }
+
+        if ($this->isHealthy($status)) {
+            $item->mark(ResourceMigrationStatus::Healthy);
+
+            return;
+        }
+
+        throw new RuntimeException("Timed out waiting for {$resource->uuid} to become healthy (status: {$status}).");
+    }
+
+    private function isHealthy(string $status): bool
+    {
+        $normalized = strtolower($status);
+
+        return str_contains($normalized, 'healthy')
+            || str_contains($normalized, 'running');
+    }
+
+    private function isFailed(string $status): bool
+    {
+        $normalized = strtolower($status);
+
+        return str_contains($normalized, 'unhealthy')
+            || str_contains($normalized, 'error')
+            || str_contains($normalized, 'failed');
+    }
+}

--- a/app/Actions/Proxy/StartProxy.php
+++ b/app/Actions/Proxy/StartProxy.php
@@ -41,10 +41,9 @@ class StartProxy
         if ($server->isSwarmManager()) {
             $commands = $commands->merge([
                 "mkdir -p $proxy_path/dynamic",
-                "cd $proxy_path",
                 "echo 'Creating required Docker Compose file.'",
                 "echo 'Starting coolify-proxy.'",
-                'docker stack deploy --detach=true -c docker-compose.yml coolify-proxy',
+                "docker stack deploy --detach=true -c $proxy_path/docker-compose.yml coolify-proxy",
                 "echo 'Successfully started coolify-proxy.'",
             ]);
         } else {
@@ -56,11 +55,10 @@ class StartProxy
             $caddyfile = 'import /dynamic/*.caddy';
             $commands = $commands->merge([
                 "mkdir -p $proxy_path/dynamic",
-                "cd $proxy_path",
                 "echo '$caddyfile' > $proxy_path/dynamic/Caddyfile",
                 "echo 'Creating required Docker Compose file.'",
                 "echo 'Pulling docker image.'",
-                'docker compose pull',
+                "docker compose --project-directory $proxy_path pull",
                 'if docker ps -a --format "{{.Names}}" | grep -q "^coolify-proxy$"; then',
                 "    echo 'Stopping and removing existing coolify-proxy.'",
                 '    docker stop coolify-proxy 2>/dev/null || true',
@@ -80,7 +78,7 @@ class StartProxy
             $commands = $commands->merge(ensureProxyNetworksExist($server));
             $commands = $commands->merge([
                 "echo 'Starting coolify-proxy.'",
-                'docker compose up -d --wait --remove-orphans',
+                "docker compose --project-directory $proxy_path up -d --wait --remove-orphans",
                 "echo 'Successfully started coolify-proxy.'",
             ]);
             $commands = $commands->merge(connectProxyToNetworks($server));

--- a/app/Actions/Server/StartLogDrain.php
+++ b/app/Actions/Server/StartLogDrain.php
@@ -200,7 +200,7 @@ Files:
                 "echo '{$readme}' | base64 -d | tee $readme_path > /dev/null",
                 "echo '{$envEncoded}' | base64 -d | tee $config_path/.env > /dev/null",
                 "echo 'Starting Fluent Bit'",
-                "cd $config_path && docker compose up -d",
+                "docker compose --project-directory $config_path up -d",
             ];
             $command = array_merge($command, $this->logDrainNetworkConnectCommands($server));
 

--- a/app/Console/Commands/MigrateInstance.php
+++ b/app/Console/Commands/MigrateInstance.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Actions\Migration\RunInstanceMigration;
+use Illuminate\Console\Command;
+
+class MigrateInstance extends Command
+{
+    protected $signature = 'coolify:migrate-instance
+                            {--target-ip= : Target VM IP or hostname}
+                            {--target-user=root : SSH user}
+                            {--target-port=22 : SSH port}
+                            {--target-private-key-id= : Private key ID from Coolify}
+                            {--dry-run : Validate SSH and preflight only}';
+
+    protected $description = 'Migrate this Coolify instance (dashboard + all resources/volumes) to a new VM.';
+
+    public function handle(RunInstanceMigration $migration): int
+    {
+        if (! $this->option('target-ip')) {
+            $this->error('--target-ip is required.');
+
+            return 1;
+        }
+
+        return $migration->asCommand($this);
+    }
+}

--- a/app/Console/Commands/MigrateResources.php
+++ b/app/Console/Commands/MigrateResources.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Actions\Migration\RunMigration;
+use Illuminate\Console\Command;
+
+class MigrateResources extends Command
+{
+    protected $signature = 'coolify:migrate
+                            {--source-url= : Source Coolify URL}
+                            {--source-token= : Source API token}
+                            {--target-url= : Target Coolify URL}
+                            {--target-token= : Target API token}
+                            {--storage=s3 : Storage driver (s3, local-ssh, azure, gcs)}
+                            {--storage-endpoint= : S3-compatible endpoint}
+                            {--storage-bucket= : Bucket or container name}
+                            {--storage-region= : Storage region}
+                            {--storage-key= : Storage access key}
+                            {--storage-secret= : Storage secret}
+                            {--s3-storage-uuid= : Existing team S3 storage UUID}
+                            {--destination= : Target destination UUID}
+                            {--project= : Target project UUID}
+                            {--environment= : Target environment UUID}
+                            {--resources= : Comma-separated source resource UUIDs}
+                            {--skip-data : Export and import metadata only}
+                            {--dry-run : Discover and validate without migrating}';
+
+    protected $description = 'Migrate resources from one Coolify instance to another.';
+
+    public function handle(RunMigration $migration): int
+    {
+        return $migration->asCommand($this);
+    }
+}

--- a/app/Enums/InstanceMigrationStatus.php
+++ b/app/Enums/InstanceMigrationStatus.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Enums;
+
+enum InstanceMigrationStatus: string
+{
+    case Pending = 'pending';
+    case Packaging = 'packaging';
+    case Installing = 'installing';
+    case SyncingVolumes = 'syncing_localhost_volumes';
+    case Restoring = 'restoring';
+    case Consolidating = 'consolidating';
+    case Verifying = 'verifying';
+    case Completed = 'completed';
+    case Failed = 'failed';
+
+    public function isTerminal(): bool
+    {
+        return in_array($this, [self::Completed, self::Failed], true);
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Pending => 'Queued',
+            self::Packaging => 'Packaging backup',
+            self::Installing => 'Installing Coolify',
+            self::SyncingVolumes => 'Copying volumes',
+            self::Restoring => 'Restoring Coolify database',
+            self::Consolidating => 'Reassigning resources',
+            self::Verifying => 'Verifying dashboard',
+            self::Completed => 'Completed',
+            self::Failed => 'Failed',
+        };
+    }
+
+    /**
+     * Ordered steps shown in the progress UI (excludes Pending/Failed).
+     *
+     * @return list<self>
+     */
+    public static function progressSteps(): array
+    {
+        return [
+            self::Packaging,
+            self::Installing,
+            self::Restoring,
+            self::SyncingVolumes,
+            self::Consolidating,
+            self::Verifying,
+            self::Completed,
+        ];
+    }
+}

--- a/app/Enums/MigrationStorageDriver.php
+++ b/app/Enums/MigrationStorageDriver.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Enums;
+
+enum MigrationStorageDriver: string
+{
+    case S3 = 's3';
+    case LocalSsh = 'local-ssh';
+    case Azure = 'azure';
+    case Gcs = 'gcs';
+
+    public static function fromAlias(string $value): self
+    {
+        return match (strtolower($value)) {
+            's3', 'aws', 'coolify-cloud', 'coolify_cloud' => self::S3,
+            'local-ssh', 'local_ssh', 'local', 'ssh' => self::LocalSsh,
+            'azure', 'azure-blob', 'azure_blob' => self::Azure,
+            'gcs', 'gcp', 'google' => self::Gcs,
+            default => self::from($value),
+        };
+    }
+}

--- a/app/Enums/ResourceMigrationDirection.php
+++ b/app/Enums/ResourceMigrationDirection.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum ResourceMigrationDirection: string
+{
+    case Export = 'export';
+    case Import = 'import';
+}

--- a/app/Enums/ResourceMigrationStatus.php
+++ b/app/Enums/ResourceMigrationStatus.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Enums;
+
+enum ResourceMigrationStatus: string
+{
+    case Pending = 'pending';
+    case Exporting = 'exporting';
+    case Uploaded = 'uploaded';
+    case Importing = 'importing';
+    case Restoring = 'restoring';
+    case Deploying = 'deploying';
+    case Healthy = 'healthy';
+    case Failed = 'failed';
+    case Skipped = 'skipped';
+    case Completed = 'completed';
+    case Partial = 'partial';
+    case Running = 'running';
+
+    public function isTerminal(): bool
+    {
+        return in_array($this, [
+            self::Uploaded,
+            self::Healthy,
+            self::Failed,
+            self::Skipped,
+            self::Completed,
+            self::Partial,
+        ], true);
+    }
+}

--- a/app/Http/Controllers/Api/MigrationsController.php
+++ b/app/Http/Controllers/Api/MigrationsController.php
@@ -1,0 +1,398 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Actions\Migration\DiscoverResources;
+use App\Actions\Migration\ExportResources;
+use App\Actions\Migration\ImportResources;
+use App\Enums\MigrationStorageDriver;
+use App\Enums\ResourceMigrationDirection;
+use App\Enums\ResourceMigrationStatus;
+use App\Http\Controllers\Controller;
+use App\Models\Environment;
+use App\Models\Project;
+use App\Models\ResourceMigration;
+use App\Models\Server;
+use App\Services\Migration\Manifest;
+use App\Services\Migration\Storage\MigrationStorageFactory;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+use OpenApi\Attributes as OA;
+
+class MigrationsController extends Controller
+{
+    #[OA\Get(
+        summary: 'Preflight',
+        description: 'Validate that this Coolify instance can participate in a resource migration.',
+        path: '/migrations/preflight',
+        operationId: 'migration-preflight',
+        security: [['bearerAuth' => []]],
+        tags: ['Migrations'],
+    )]
+    public function preflight(Request $request): JsonResponse
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+
+        $this->authorize('create', ResourceMigration::class);
+
+        $token = $request->user()->currentAccessToken();
+        $canReadSensitive = $request->attributes->get('can_read_sensitive', false) === true;
+        $serverUuid = $request->query('server_uuid');
+        $dockerRunning = null;
+        $serverReachable = null;
+
+        if (is_string($serverUuid) && $serverUuid !== '') {
+            $server = Server::where('team_id', $teamId)->where('uuid', $serverUuid)->first();
+            if (! $server) {
+                return response()->json(['message' => 'Server not found.'], 404);
+            }
+            $serverReachable = $server->isFunctional();
+            $dockerRunning = $serverReachable;
+        }
+
+        return response()->json(serializeApiResponse([
+            'version' => config('constants.coolify.version'),
+            'manifest_version' => Manifest::VERSION,
+            'token_can_write' => $token->can('write') || $token->can('root'),
+            'token_can_read_sensitive' => $canReadSensitive,
+            'docker_running' => $dockerRunning,
+            'server_reachable' => $serverReachable,
+        ]));
+    }
+
+    #[OA\Get(
+        summary: 'List migratable resources',
+        description: 'Enumerate applications, databases, and services that can be exported.',
+        path: '/migrations/resources',
+        operationId: 'migration-resources',
+        security: [['bearerAuth' => []]],
+        tags: ['Migrations'],
+    )]
+    public function resources(Request $request): JsonResponse
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+
+        $this->authorize('create', ResourceMigration::class);
+
+        $resources = DiscoverResources::run(
+            $teamId,
+            $request->query('server_uuid'),
+            $request->query('project_uuid'),
+            $request->query('environment_uuid'),
+        );
+
+        return response()->json(serializeApiResponse(collect($resources)));
+    }
+
+    #[OA\Post(
+        summary: 'Export resources',
+        description: 'Start a resource export. Requires a token with write and read:sensitive abilities.',
+        path: '/migrations/export',
+        operationId: 'migration-export',
+        security: [['bearerAuth' => []]],
+        tags: ['Migrations'],
+    )]
+    public function export(Request $request): JsonResponse
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+
+        $this->authorize('create', ResourceMigration::class);
+
+        if ($request->attributes->get('can_read_sensitive', false) !== true) {
+            return response()->json([
+                'message' => 'Exporting resources requires a token with the read:sensitive ability.',
+            ], 403);
+        }
+
+        $validator = Validator::make($request->all(), [
+            'resource_uuids' => ['required', 'array', 'min:1'],
+            'resource_uuids.*' => ['required', 'string'],
+            'storage.driver' => ['required', 'string'],
+            'storage.config' => ['nullable', 'array'],
+            'skip_data' => ['sometimes', 'boolean'],
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(['message' => $validator->errors()->first()], 422);
+        }
+
+        try {
+            $driver = MigrationStorageDriver::fromAlias($request->input('storage.driver'));
+        } catch (\ValueError) {
+            return response()->json(['message' => 'Unsupported storage driver.'], 422);
+        }
+
+        $items = [];
+        foreach ($request->input('resource_uuids') as $index => $uuid) {
+            $resource = getResourceByUuid($uuid, $teamId);
+            if (! $resource) {
+                return response()->json(['message' => "Resource {$uuid} was not found."], 404);
+            }
+            $items[] = [
+                'resource_type' => $resource->type(),
+                'source_uuid' => $resource->uuid,
+                'name' => $resource->name,
+                'sort_order' => $this->sortOrder($resource->type(), $index),
+                'status' => ResourceMigrationStatus::Pending,
+            ];
+        }
+
+        usort($items, fn (array $left, array $right): int => $left['sort_order'] <=> $right['sort_order']);
+
+        $migration = ResourceMigration::create([
+            'team_id' => $teamId,
+            'direction' => ResourceMigrationDirection::Export,
+            'status' => ResourceMigrationStatus::Pending,
+            'storage_driver' => $driver,
+            'storage_config' => $request->input('storage.config', []),
+            'skip_data' => (bool) $request->boolean('skip_data'),
+            'created_by_user_id' => $request->user()->id,
+        ]);
+        $migration->items()->createMany($items);
+
+        ExportResources::dispatch($migration);
+
+        return response()->json(serializeApiResponse($this->payload($migration->fresh('items'))), 201);
+    }
+
+    #[OA\Get(
+        summary: 'Show migration',
+        description: 'Get migration status and per-resource progress.',
+        path: '/migrations/{uuid}',
+        operationId: 'migration-show',
+        security: [['bearerAuth' => []]],
+        tags: ['Migrations'],
+    )]
+    public function show(string $uuid): JsonResponse
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+
+        $migration = ResourceMigration::where('team_id', $teamId)->where('uuid', $uuid)->with('items')->first();
+        if (! $migration) {
+            return response()->json(['message' => 'Migration not found.'], 404);
+        }
+
+        $this->authorize('view', $migration);
+
+        return response()->json(serializeApiResponse($this->payload($migration)));
+    }
+
+    #[OA\Post(
+        summary: 'Import resources',
+        description: 'Import a migration manifest onto this Coolify instance.',
+        path: '/migrations/import',
+        operationId: 'migration-import',
+        security: [['bearerAuth' => []]],
+        tags: ['Migrations'],
+    )]
+    public function import(Request $request): JsonResponse
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+
+        $this->authorize('create', ResourceMigration::class);
+
+        $validator = Validator::make($request->all(), [
+            'manifest' => ['required', 'array'],
+            'manifest.version' => ['required', 'integer'],
+            'manifest.resources' => ['required', 'array', 'min:1'],
+            'destination_uuid' => ['required', 'string'],
+            'project_uuid' => ['required', 'string'],
+            'environment_uuid' => ['nullable', 'string'],
+            'project_name' => ['nullable', 'string'],
+            'environment_name' => ['nullable', 'string'],
+            'storage.driver' => ['nullable', 'string'],
+            'storage.config' => ['nullable', 'array'],
+            'skip_data' => ['sometimes', 'boolean'],
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(['message' => $validator->errors()->first()], 422);
+        }
+
+        $destination = find_destination_for_team($request->input('destination_uuid'), $teamId);
+        if (! $destination) {
+            return response()->json(['message' => 'Destination not found.'], 404);
+        }
+        if (! $destination->server?->canHostResources()) {
+            return response()->json(['message' => 'The selected server cannot host resources.'], 422);
+        }
+
+        $project = $this->resolveProject($teamId, $request);
+        $environment = $this->resolveEnvironment($project, $request);
+
+        $driverValue = $request->input('storage.driver', data_get($request->input('manifest'), 'storage.driver', 's3'));
+        try {
+            $driver = MigrationStorageDriver::fromAlias((string) $driverValue);
+        } catch (\ValueError) {
+            return response()->json(['message' => 'Unsupported storage driver.'], 422);
+        }
+
+        $manifest = $request->input('manifest');
+        $skipData = $request->has('skip_data')
+            ? $request->boolean('skip_data')
+            : (bool) data_get($manifest, 'skip_data', false);
+
+        $migration = ResourceMigration::create([
+            'team_id' => $teamId,
+            'direction' => ResourceMigrationDirection::Import,
+            'status' => ResourceMigrationStatus::Pending,
+            'storage_driver' => $driver,
+            'storage_config' => $request->input('storage.config', data_get($manifest, 'storage.config', [])),
+            'manifest' => $manifest,
+            'skip_data' => $skipData,
+            'destination_uuid' => $destination->uuid,
+            'project_uuid' => $project->uuid,
+            'environment_uuid' => $environment->uuid,
+            'created_by_user_id' => $request->user()->id,
+        ]);
+
+        foreach (array_values($manifest['resources']) as $index => $resource) {
+            $migration->items()->create([
+                'resource_type' => $resource['type'] ?? 'unknown',
+                'source_uuid' => $resource['source_uuid'] ?? new_public_id(),
+                'name' => $resource['name'] ?? 'resource',
+                'sort_order' => $this->sortOrder((string) ($resource['type'] ?? ''), $index),
+                'status' => ResourceMigrationStatus::Pending,
+            ]);
+        }
+
+        ImportResources::dispatch($migration);
+
+        return response()->json(serializeApiResponse($this->payload($migration->fresh('items'))), 201);
+    }
+
+    #[OA\Post(
+        summary: 'Cleanup migration staging',
+        description: 'Delete staging archives for a completed or failed migration.',
+        path: '/migrations/{uuid}/cleanup',
+        operationId: 'migration-cleanup',
+        security: [['bearerAuth' => []]],
+        tags: ['Migrations'],
+    )]
+    public function cleanup(string $uuid): JsonResponse
+    {
+        $teamId = getTeamIdFromToken();
+        if (is_null($teamId)) {
+            return invalidTokenResponse();
+        }
+
+        $migration = ResourceMigration::where('team_id', $teamId)->where('uuid', $uuid)->with('items')->first();
+        if (! $migration) {
+            return response()->json(['message' => 'Migration not found.'], 404);
+        }
+
+        $this->authorize('update', $migration);
+
+        $storage = app(MigrationStorageFactory::class)->forMigration($migration);
+        $server = Server::where('team_id', $teamId)->get()->first(fn (Server $server): bool => $server->isFunctional());
+
+        if ($server) {
+            foreach ($migration->items as $item) {
+                foreach ($item->archives ?? [] as $archive) {
+                    if (filled($archive['key'] ?? null)) {
+                        $storage->delete($server, (string) $archive['key']);
+                    }
+                }
+            }
+        }
+
+        return response()->json(['message' => 'Migration staging cleaned up.']);
+    }
+
+    private function resolveProject(int $teamId, Request $request): Project
+    {
+        $project = Project::where('team_id', $teamId)->where('uuid', $request->input('project_uuid'))->first();
+        if ($project) {
+            return $project;
+        }
+
+        return Project::create([
+            'uuid' => $request->input('project_uuid'),
+            'name' => $request->input('project_name', 'Migrated Project'),
+            'team_id' => $teamId,
+        ]);
+    }
+
+    private function resolveEnvironment(Project $project, Request $request): Environment
+    {
+        $uuid = $request->input('environment_uuid');
+        if (is_string($uuid) && $uuid !== '') {
+            $environment = $project->environments()->where('uuid', $uuid)->first();
+            if ($environment) {
+                return $environment;
+            }
+
+            return $project->environments()->create([
+                'uuid' => $uuid,
+                'name' => $request->input('environment_name', 'production'),
+            ]);
+        }
+
+        $environment = $project->environments()->first();
+        if ($environment) {
+            return $environment;
+        }
+
+        return $project->environments()->create([
+            'name' => $request->input('environment_name', 'production'),
+        ]);
+    }
+
+    private function sortOrder(string $type, int $index): int
+    {
+        $rank = match (true) {
+            str_starts_with($type, 'standalone') => 0,
+            $type === 'service' => 1,
+            default => 2,
+        };
+
+        return ($rank * 1000) + $index;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(ResourceMigration $migration): array
+    {
+        $includeManifest = request()->attributes->get('can_read_sensitive', false) === true
+            && $migration->direction === ResourceMigrationDirection::Export;
+
+        return [
+            'uuid' => $migration->uuid,
+            'direction' => $migration->direction->value,
+            'status' => $migration->status->value,
+            'skip_data' => $migration->skip_data,
+            'storage_driver' => $migration->storage_driver->value,
+            'destination_uuid' => $migration->destination_uuid,
+            'project_uuid' => $migration->project_uuid,
+            'environment_uuid' => $migration->environment_uuid,
+            'error' => $migration->error,
+            'manifest' => $includeManifest ? $migration->manifest : null,
+            'items' => $migration->items->map(fn ($item) => [
+                'uuid' => $item->uuid,
+                'resource_type' => $item->resource_type,
+                'source_uuid' => $item->source_uuid,
+                'target_uuid' => $item->target_uuid,
+                'name' => $item->name,
+                'status' => $item->status->value,
+                'error' => $item->error,
+            ])->all(),
+        ];
+    }
+}

--- a/app/Jobs/RestartProxyJob.php
+++ b/app/Jobs/RestartProxyJob.php
@@ -125,10 +125,9 @@ class RestartProxyJob implements ShouldBeEncrypted, ShouldQueue
             $commands = $commands->merge([
                 "echo 'Starting proxy (Swarm mode)...'",
                 "mkdir -p $proxy_path/dynamic",
-                "cd $proxy_path",
                 "echo 'Creating required Docker Compose file.'",
                 "echo 'Starting coolify-proxy.'",
-                'docker stack deploy --detach=true -c docker-compose.yml coolify-proxy',
+                "docker stack deploy --detach=true -c $proxy_path/docker-compose.yml coolify-proxy",
                 "echo 'Successfully started coolify-proxy.'",
             ]);
         } else {
@@ -139,17 +138,16 @@ class RestartProxyJob implements ShouldBeEncrypted, ShouldQueue
             $commands = $commands->merge([
                 "echo 'Starting proxy...'",
                 "mkdir -p $proxy_path/dynamic",
-                "cd $proxy_path",
                 "echo '$caddyfile' > $proxy_path/dynamic/Caddyfile",
                 "echo 'Creating required Docker Compose file.'",
                 "echo 'Pulling docker image.'",
-                'docker compose pull',
+                "docker compose --project-directory $proxy_path pull",
             ]);
             // Ensure required networks exist BEFORE docker compose up
             $commands = $commands->merge(ensureProxyNetworksExist($this->server));
             $commands = $commands->merge([
                 "echo 'Starting coolify-proxy.'",
-                'docker compose up -d --wait --remove-orphans',
+                "docker compose --project-directory $proxy_path up -d --wait --remove-orphans",
                 "echo 'Successfully started coolify-proxy.'",
             ]);
             $commands = $commands->merge(connectProxyToNetworks($this->server));

--- a/app/Jobs/VolumeRestoreJob.php
+++ b/app/Jobs/VolumeRestoreJob.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\LocalPersistentVolume;
+use App\Models\Server;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeEncrypted;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class VolumeRestoreJob implements ShouldBeEncrypted, ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(
+        public string $archivePath,
+        public string $targetVolume,
+        public Server $server,
+        public ?LocalPersistentVolume $persistentVolume = null,
+    ) {
+        $this->onQueue('high');
+    }
+
+    public function handle(): void
+    {
+        $tgtVol = escapeshellarg($this->targetVolume);
+        $image = escapeshellarg($this->helperImage());
+        $archive = escapeshellarg($this->archivePath);
+
+        instant_remote_process([
+            "docker volume create {$tgtVol}",
+            "docker run --rm -i -v {$tgtVol}:/target {$image} sh -c 'tar -xzf - -C /target && chown -R 1000:1000 /target' < {$archive}",
+        ], $this->server);
+    }
+
+    protected function helperImage(): string
+    {
+        return coolifyHelperImage().':'.getHelperVersion();
+    }
+}

--- a/app/Livewire/Settings/Migrations.php
+++ b/app/Livewire/Settings/Migrations.php
@@ -1,0 +1,543 @@
+<?php
+
+namespace App\Livewire\Settings;
+
+use App\Actions\Migration\CloneResourceToDestination;
+use App\Actions\Migration\DetectIndependentCoolifyInstall;
+use App\Actions\Migration\DiscoverResources;
+use App\Actions\Migration\RunInstanceMigration;
+use App\Enums\InstanceMigrationStatus;
+use App\Models\Application;
+use App\Models\InstanceMigration;
+use App\Models\PrivateKey;
+use App\Models\ResourceMigration;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\SwarmDocker;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Component;
+use RuntimeException;
+use Throwable;
+
+class Migrations extends Component
+{
+    use AuthorizesRequests;
+
+    public string $mode = 'resources';
+
+    public string $sourceServerUuid = '';
+
+    public string $targetServerUuid = '';
+
+    public bool $cloneVolumeData = true;
+
+    /** @var list<string> */
+    public array $selectedResourceUuids = [];
+
+    /** @var list<array<string, mixed>> */
+    public array $discoveredResources = [];
+
+    /** @var list<array<string, mixed>> */
+    public array $items = [];
+
+    public int $migratedCount = 0;
+
+    public int $failedCount = 0;
+
+    public int $skippedCount = 0;
+
+    public string $phase = 'idle';
+
+    public string $targetBlockReason = '';
+
+    /** @var list<array{uuid: string, name: string, ip: string}> */
+    public array $servers = [];
+
+    public string $instanceTargetIp = '';
+
+    public string $instanceTargetUser = 'root';
+
+    public int $instanceTargetPort = 22;
+
+    public string $instancePrivateKeyId = '';
+
+    public bool $instanceDryRun = false;
+
+    public string $instanceStatus = '';
+
+    public string $instanceDashboardUrl = '';
+
+    public string $instanceError = '';
+
+    public ?int $instanceMigrationId = null;
+
+    public int $instanceProgress = 0;
+
+    public bool $instanceMigrationRunning = false;
+
+    /** @var list<array{status: string, label: string, state: string, note: ?string}> */
+    public array $instanceSteps = [];
+
+    /** @var list<array{status: string, note: ?string, at: string}> */
+    public array $instancePhases = [];
+
+    /** @var list<array{id: int, name: string}> */
+    public array $privateKeys = [];
+
+    public function mount(): mixed
+    {
+        if (! isInstanceAdmin()) {
+            return redirect()->route('dashboard');
+        }
+
+        $this->loadServers();
+        $this->loadPrivateKeys();
+        $this->restoreActiveInstanceMigration();
+
+        return null;
+    }
+
+    public function setMode(string $mode): void
+    {
+        if (! in_array($mode, ['resources', 'instance'], true)) {
+            return;
+        }
+        $this->mode = $mode;
+    }
+
+    public function updatedSourceServerUuid(): void
+    {
+        $this->discoverResources();
+        $this->inspectTargetServer();
+    }
+
+    public function updatedTargetServerUuid(): void
+    {
+        $this->inspectTargetServer();
+    }
+
+    public function discoverResources(): void
+    {
+        $this->authorize('create', ResourceMigration::class);
+        $this->discoveredResources = [];
+        $this->selectedResourceUuids = [];
+        $this->items = [];
+        $this->phase = 'idle';
+
+        if ($this->sourceServerUuid === '') {
+            return;
+        }
+
+        $server = $this->serverByUuid($this->sourceServerUuid);
+        if (! $server) {
+            $this->dispatch('error', 'Source server was not found.');
+
+            return;
+        }
+
+        $this->discoveredResources = DiscoverResources::run(currentTeam()->id, $server->uuid);
+        $this->selectedResourceUuids = collect($this->discoveredResources)->pluck('uuid')->all();
+        $this->phase = $this->discoveredResources === [] ? 'idle' : 'discovered';
+    }
+
+    public function toggleSelectAll(): void
+    {
+        $uuids = collect($this->discoveredResources)->pluck('uuid')->all();
+        $this->selectedResourceUuids = count($this->selectedResourceUuids) === count($uuids)
+            ? []
+            : $uuids;
+    }
+
+    public function startMigration(): void
+    {
+        $this->authorize('create', ResourceMigration::class);
+        $this->validate([
+            'sourceServerUuid' => ['required', 'string'],
+            'targetServerUuid' => ['required', 'string', 'different:sourceServerUuid'],
+        ], [
+            'targetServerUuid.different' => 'Choose a different target server.',
+        ]);
+
+        try {
+            $sourceServer = $this->serverByUuid($this->sourceServerUuid);
+            $targetServer = $this->serverByUuid($this->targetServerUuid);
+            if (! $sourceServer || ! $targetServer) {
+                throw new RuntimeException('Source or target server was not found.');
+            }
+            $this->inspectTargetServer();
+            if ($this->targetBlockReason !== '') {
+                throw new RuntimeException($this->targetBlockMessage());
+            }
+
+            $destination = $this->destinationFor($targetServer);
+            if ($this->discoveredResources === []) {
+                $this->discoverResources();
+            }
+            if ($this->selectedResourceUuids === []) {
+                $this->selectedResourceUuids = collect($this->discoveredResources)->pluck('uuid')->all();
+            }
+
+            $selected = $this->orderedSelectedResources();
+            if ($selected === []) {
+                $this->dispatch('error', 'No resources found on the source server.');
+
+                return;
+            }
+
+            $skipDatabaseUuids = $this->linkedDatabaseUuids($selected);
+            $this->resetCounts();
+            $this->items = [];
+            $this->phase = 'running';
+
+            foreach ($selected as $resource) {
+                $uuid = (string) $resource['uuid'];
+                $name = (string) ($resource['name'] ?? $uuid);
+                if (in_array($uuid, $skipDatabaseUuids, true)) {
+                    $this->skippedCount++;
+                    $this->items[] = [
+                        'name' => $name,
+                        'status' => 'skipped',
+                        'error' => 'Cloned with its linked application.',
+                    ];
+
+                    continue;
+                }
+
+                try {
+                    $model = getResourceByUuid($uuid, currentTeam()->id);
+                    if (! $model) {
+                        throw new RuntimeException('Resource not found.');
+                    }
+                    $this->authorize('update', $model);
+                    CloneResourceToDestination::run($model, $destination, $this->cloneVolumeData);
+                    $this->migratedCount++;
+                    $this->items[] = [
+                        'name' => $name,
+                        'status' => 'migrated',
+                        'error' => '',
+                    ];
+                } catch (Throwable $exception) {
+                    $this->failedCount++;
+                    $this->items[] = [
+                        'name' => $name,
+                        'status' => 'failed',
+                        'error' => $exception->getMessage(),
+                    ];
+                }
+            }
+
+            $this->phase = $this->failedCount > 0
+                ? ($this->migratedCount > 0 ? 'partial' : 'failed')
+                : 'completed';
+
+            if ($this->phase === 'failed') {
+                $this->dispatch('error', 'Migration failed.');
+
+                return;
+            }
+
+            $this->dispatch('success', $this->phase === 'completed'
+                ? 'Migration completed.'
+                : 'Migration finished with partial success.');
+        } catch (Throwable $exception) {
+            $this->phase = 'failed';
+            handleError($exception, $this);
+        }
+    }
+
+    public function startInstanceMigration(): void
+    {
+        $this->authorize('create', InstanceMigration::class);
+        $this->validate([
+            'instanceTargetIp' => ['required', 'string'],
+            'instanceTargetUser' => ['required', 'string'],
+            'instanceTargetPort' => ['required', 'integer', 'min:1', 'max:65535'],
+            'instancePrivateKeyId' => ['required', 'integer'],
+        ]);
+
+        if ($this->instanceMigrationRunning) {
+            $this->dispatch('error', 'An instance migration is already running.');
+
+            return;
+        }
+
+        $this->instanceError = '';
+        $this->instanceDashboardUrl = '';
+        $this->instancePhases = [];
+        $this->instanceSteps = [];
+        $this->instanceProgress = 0;
+        $this->instanceStatus = InstanceMigrationStatus::Pending->value;
+        $this->items = [];
+
+        try {
+            $key = PrivateKey::whereTeamId(currentTeam()->id)->where('id', (int) $this->instancePrivateKeyId)->first()
+                ?? PrivateKey::whereTeamId(0)->where('id', (int) $this->instancePrivateKeyId)->first();
+            if (! $key) {
+                throw new RuntimeException('Private key was not found.');
+            }
+
+            $migration = InstanceMigration::create([
+                'team_id' => currentTeam()->id,
+                'status' => InstanceMigrationStatus::Pending,
+                'target_ip' => $this->instanceTargetIp,
+                'target_port' => $this->instanceTargetPort,
+                'target_user' => $this->instanceTargetUser,
+                'target_private_key_id' => $key->id,
+                'dry_run' => $this->instanceDryRun,
+                'created_by_user_id' => auth()->id(),
+                'phases' => [],
+                'items' => [],
+            ]);
+
+            $this->instanceMigrationId = $migration->id;
+            $this->syncInstanceMigrationState($migration);
+
+            RunInstanceMigration::dispatch($migration);
+
+            $this->dispatch('success', $this->instanceDryRun
+                ? 'Instance migration dry run queued. Progress updates below.'
+                : 'Instance migration queued. Progress updates below.');
+        } catch (Throwable $exception) {
+            $this->instanceStatus = InstanceMigrationStatus::Failed->value;
+            $this->instanceError = $exception->getMessage();
+            handleError($exception, $this);
+        }
+    }
+
+    public function refreshInstanceMigration(): void
+    {
+        if (! $this->instanceMigrationId || ! currentTeam()) {
+            return;
+        }
+
+        $migration = InstanceMigration::query()
+            ->where('team_id', currentTeam()->id)
+            ->find($this->instanceMigrationId);
+
+        if (! $migration) {
+            return;
+        }
+
+        $wasRunning = $this->instanceMigrationRunning;
+        $this->syncInstanceMigrationState($migration);
+
+        if ($wasRunning && $migration->status->isTerminal()) {
+            if ($migration->status === InstanceMigrationStatus::Failed) {
+                $this->dispatch('error', $migration->error ?: 'Instance migration failed.');
+            } else {
+                $this->dispatch('success', $migration->dry_run
+                    ? 'Instance migration dry run completed.'
+                    : 'Instance migration completed.');
+            }
+        }
+    }
+
+    public function render()
+    {
+        return view('livewire.settings.migrations');
+    }
+
+    private function syncInstanceMigrationState(InstanceMigration $migration): void
+    {
+        $this->instanceMigrationId = $migration->id;
+        $this->instanceStatus = $migration->status->value;
+        $this->instanceMigrationRunning = ! $migration->status->isTerminal();
+        $this->instancePhases = $migration->phases ?? [];
+        $this->instanceSteps = $migration->stepStates();
+        $this->instanceProgress = $migration->progressPercent();
+        $this->instanceDashboardUrl = (string) ($migration->dashboard_url ?? '');
+        $this->instanceError = (string) ($migration->error ?? '');
+        $this->items = $migration->items ?? [];
+        $this->instanceDryRun = (bool) $migration->dry_run;
+        $this->instanceTargetIp = (string) $migration->target_ip;
+        $this->instanceTargetUser = (string) $migration->target_user;
+        $this->instanceTargetPort = (int) $migration->target_port;
+        $this->instancePrivateKeyId = (string) $migration->target_private_key_id;
+    }
+
+    private function restoreActiveInstanceMigration(): void
+    {
+        if (! currentTeam()) {
+            return;
+        }
+
+        $migration = InstanceMigration::query()
+            ->where('team_id', currentTeam()->id)
+            ->latest('id')
+            ->first();
+
+        if (! $migration) {
+            return;
+        }
+
+        $this->syncInstanceMigrationState($migration);
+        if (! $migration->status->isTerminal()) {
+            $this->mode = 'instance';
+        }
+    }
+
+    private function loadServers(): void
+    {
+        if (! currentTeam()) {
+            return;
+        }
+
+        $this->servers = Server::ownedByCurrentTeam()
+            ->get()
+            ->reject(fn (Server $server): bool => $server->isBuildServer())
+            ->map(fn (Server $server): array => [
+                'uuid' => $server->uuid,
+                'name' => $server->name,
+                'ip' => $server->ip,
+            ])
+            ->values()
+            ->all();
+    }
+
+    private function loadPrivateKeys(): void
+    {
+        if (! currentTeam()) {
+            return;
+        }
+
+        $this->privateKeys = PrivateKey::whereIn('team_id', [currentTeam()->id, 0])
+            ->orderBy('name')
+            ->get(['id', 'name'])
+            ->map(fn (PrivateKey $key): array => [
+                'id' => $key->id,
+                'name' => $key->name,
+            ])
+            ->values()
+            ->all();
+    }
+
+    private function serverByUuid(string $uuid): ?Server
+    {
+        return Server::ownedByCurrentTeam()->where('uuid', $uuid)->first();
+    }
+
+    private function inspectTargetServer(): void
+    {
+        $this->targetBlockReason = '';
+        if ($this->targetServerUuid === '') {
+            return;
+        }
+
+        $targetServer = $this->serverByUuid($this->targetServerUuid);
+        if (! $targetServer) {
+            $this->targetBlockReason = 'not_found';
+
+            return;
+        }
+        if ($this->sourceServerUuid !== '' && $this->targetServerUuid === $this->sourceServerUuid) {
+            $this->targetBlockReason = 'same_server';
+
+            return;
+        }
+        if (! $targetServer->canHostResources()) {
+            $this->targetBlockReason = 'cannot_host';
+
+            return;
+        }
+        if (! $targetServer->isFunctional()) {
+            $this->targetBlockReason = 'not_ready';
+
+            return;
+        }
+        if (! $this->destinationFor($targetServer, throwIfMissing: false)) {
+            $this->targetBlockReason = 'no_destination';
+
+            return;
+        }
+        if (DetectIndependentCoolifyInstall::run($targetServer)) {
+            $this->targetBlockReason = 'independent_coolify';
+        }
+    }
+
+    private function targetBlockMessage(): string
+    {
+        return match ($this->targetBlockReason) {
+            'not_found' => 'Target server was not found.',
+            'same_server' => 'Choose a different target server.',
+            'cannot_host' => 'The selected target server cannot host resources.',
+            'not_ready' => 'The target server is not reachable or not validated. Open Servers, validate it, then try again.',
+            'no_destination' => 'The target server has no Docker destination.',
+            'independent_coolify' => 'The target already has Coolify installed. Use a server added to this instance, not a second Coolify dashboard.',
+            default => 'The target server cannot be used for migration.',
+        };
+    }
+
+    private function destinationFor(Server $server, bool $throwIfMissing = true): StandaloneDocker|SwarmDocker|null
+    {
+        $destination = $server->destinations()->first(fn ($destination): bool => $destination instanceof StandaloneDocker || $destination instanceof SwarmDocker);
+        if (! $destination && $throwIfMissing) {
+            throw new RuntimeException('The target server has no Docker destination.');
+        }
+
+        return $destination;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function orderedSelectedResources(): array
+    {
+        $selected = array_values(array_filter(
+            $this->discoveredResources,
+            fn (array $resource): bool => in_array($resource['uuid'] ?? null, $this->selectedResourceUuids, true),
+        ));
+
+        usort($selected, function (array $left, array $right): int {
+            return $this->typeRank((string) ($left['type'] ?? '')) <=> $this->typeRank((string) ($right['type'] ?? ''));
+        });
+
+        return $selected;
+    }
+
+    private function typeRank(string $type): int
+    {
+        return match (true) {
+            str_starts_with($type, 'standalone') => 0,
+            $type === 'service' => 1,
+            default => 2,
+        };
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $selected
+     * @return list<string>
+     */
+    private function linkedDatabaseUuids(array $selected): array
+    {
+        if (! $this->cloneVolumeData) {
+            return [];
+        }
+
+        $selectedUuids = collect($selected)->pluck('uuid')->all();
+        $linked = [];
+
+        foreach ($selected as $resource) {
+            if (($resource['type'] ?? null) !== 'application') {
+                continue;
+            }
+            $application = getResourceByUuid((string) $resource['uuid'], currentTeam()->id);
+            if (! $application instanceof Application) {
+                continue;
+            }
+            foreach (find_linked_standalone_databases($application) as $database) {
+                if (in_array($database->uuid, $selectedUuids, true)) {
+                    $linked[] = $database->uuid;
+                }
+            }
+        }
+
+        return array_values(array_unique($linked));
+    }
+
+    private function resetCounts(): void
+    {
+        $this->migratedCount = 0;
+        $this->failedCount = 0;
+        $this->skippedCount = 0;
+    }
+}

--- a/app/Models/InstanceMigration.php
+++ b/app/Models/InstanceMigration.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\InstanceMigrationStatus;
+use Database\Factories\InstanceMigrationFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class InstanceMigration extends BaseModel
+{
+    /** @use HasFactory<InstanceMigrationFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'uuid',
+        'team_id',
+        'status',
+        'target_ip',
+        'target_port',
+        'target_user',
+        'target_private_key_id',
+        'old_host_ip',
+        'package_paths',
+        'phases',
+        'items',
+        'error',
+        'dashboard_url',
+        'dry_run',
+        'created_by_user_id',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'status' => InstanceMigrationStatus::class,
+            'package_paths' => 'encrypted:array',
+            'phases' => 'array',
+            'items' => 'array',
+            'dry_run' => 'boolean',
+            'target_port' => 'integer',
+        ];
+    }
+
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by_user_id');
+    }
+
+    public function targetPrivateKey(): BelongsTo
+    {
+        return $this->belongsTo(PrivateKey::class, 'target_private_key_id');
+    }
+
+    public function markPhase(InstanceMigrationStatus $status, ?string $note = null): void
+    {
+        $phases = $this->phases ?? [];
+        $phases[] = [
+            'status' => $status->value,
+            'note' => $note,
+            'at' => now()->toIso8601String(),
+        ];
+
+        $this->update([
+            'status' => $status,
+            'phases' => $phases,
+            'error' => null,
+        ]);
+    }
+
+    public function markFailed(string $error): void
+    {
+        $phases = $this->phases ?? [];
+        $phases[] = [
+            'status' => InstanceMigrationStatus::Failed->value,
+            'note' => $error,
+            'at' => now()->toIso8601String(),
+        ];
+
+        $this->update([
+            'status' => InstanceMigrationStatus::Failed,
+            'error' => $error,
+            'phases' => $phases,
+        ]);
+    }
+
+    public function markCompleted(?string $dashboardUrl = null): void
+    {
+        $phases = $this->phases ?? [];
+        $phases[] = [
+            'status' => InstanceMigrationStatus::Completed->value,
+            'note' => 'Instance migration finished',
+            'at' => now()->toIso8601String(),
+        ];
+
+        $this->update([
+            'status' => InstanceMigrationStatus::Completed,
+            'dashboard_url' => $dashboardUrl ?? $this->dashboard_url,
+            'error' => null,
+            'phases' => $phases,
+        ]);
+    }
+
+    /**
+     * @return list<array{status: string, label: string, state: string, note: ?string}>
+     */
+    public function stepStates(): array
+    {
+        $ordered = InstanceMigrationStatus::progressSteps();
+        $phaseNotes = collect($this->phases ?? [])
+            ->keyBy('status')
+            ->map(fn (array $phase): ?string => $phase['note'] ?? null);
+
+        $activeIndex = $this->activeStepIndex($ordered);
+
+        return collect($ordered)->values()->map(function (InstanceMigrationStatus $step, int $index) use ($activeIndex, $phaseNotes): array {
+            $state = match (true) {
+                $this->status === InstanceMigrationStatus::Failed && $index === $activeIndex => 'failed',
+                $this->status === InstanceMigrationStatus::Completed || ($activeIndex !== null && $index < $activeIndex) => 'done',
+                $index === $activeIndex => 'active',
+                default => 'pending',
+            };
+
+            return [
+                'status' => $step->value,
+                'label' => $step->label(),
+                'state' => $state,
+                'note' => $phaseNotes->get($step->value),
+            ];
+        })->all();
+    }
+
+    public function progressPercent(): int
+    {
+        if ($this->status === InstanceMigrationStatus::Completed) {
+            return 100;
+        }
+
+        $steps = $this->stepStates();
+        $total = count($steps);
+        if ($total === 0) {
+            return 0;
+        }
+
+        $done = collect($steps)->whereIn('state', ['done', 'failed'])->count();
+        $active = collect($steps)->where('state', 'active')->count();
+
+        return (int) min(99, floor((($done + ($active * 0.45)) / $total) * 100));
+    }
+
+    /**
+     * @param  list<InstanceMigrationStatus>  $ordered
+     */
+    private function activeStepIndex(array $ordered): ?int
+    {
+        if ($this->status === InstanceMigrationStatus::Pending) {
+            return null;
+        }
+
+        if ($this->status === InstanceMigrationStatus::Completed) {
+            return count($ordered) - 1;
+        }
+
+        if ($this->status === InstanceMigrationStatus::Failed) {
+            $failedPhase = collect($this->phases ?? [])
+                ->reverse()
+                ->first(fn (array $phase): bool => ($phase['status'] ?? null) !== InstanceMigrationStatus::Failed->value);
+
+            if ($failedPhase) {
+                foreach ($ordered as $index => $step) {
+                    if ($step->value === ($failedPhase['status'] ?? null)) {
+                        return $index;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        foreach ($ordered as $index => $step) {
+            if ($step === $this->status) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+}

--- a/app/Models/LocalFileVolume.php
+++ b/app/Models/LocalFileVolume.php
@@ -247,7 +247,6 @@ class LocalFileVolume extends BaseModel
             $escapedFsPath = escapeshellarg($this->fs_path);
             $commands->push("mkdir -p {$escapedFsPath} > /dev/null 2>&1 || true");
             $commands->push("mkdir -p {$escapedWorkdir} > /dev/null 2>&1 || true");
-            $commands->push("cd {$escapedWorkdir}");
         }
         $path = data_get_str($this, 'fs_path');
         $content = data_get($this, 'content');

--- a/app/Models/ResourceMigration.php
+++ b/app/Models/ResourceMigration.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\MigrationStorageDriver;
+use App\Enums\ResourceMigrationDirection;
+use App\Enums\ResourceMigrationStatus;
+use Database\Factories\ResourceMigrationFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class ResourceMigration extends BaseModel
+{
+    /** @use HasFactory<ResourceMigrationFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'uuid',
+        'team_id',
+        'direction',
+        'status',
+        'storage_driver',
+        'storage_config',
+        'manifest',
+        'skip_data',
+        'destination_uuid',
+        'project_uuid',
+        'environment_uuid',
+        'error',
+        'created_by_user_id',
+    ];
+
+    protected $hidden = [
+        'storage_config',
+        'manifest',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'direction' => ResourceMigrationDirection::class,
+            'status' => ResourceMigrationStatus::class,
+            'storage_driver' => MigrationStorageDriver::class,
+            'storage_config' => 'encrypted:array',
+            'manifest' => 'encrypted:array',
+            'skip_data' => 'boolean',
+        ];
+    }
+
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by_user_id');
+    }
+
+    public function items(): HasMany
+    {
+        return $this->hasMany(ResourceMigrationItem::class)->orderBy('sort_order');
+    }
+
+    public function markRunning(): void
+    {
+        $this->update(['status' => ResourceMigrationStatus::Running, 'error' => null]);
+    }
+
+    public function markFailed(string $error): void
+    {
+        $this->update([
+            'status' => ResourceMigrationStatus::Failed,
+            'error' => $error,
+        ]);
+    }
+
+    public function refreshAggregateStatus(): void
+    {
+        $statuses = $this->items()->pluck('status');
+
+        if ($statuses->isEmpty()) {
+            $this->update(['status' => ResourceMigrationStatus::Pending]);
+
+            return;
+        }
+
+        $failed = $statuses->contains(ResourceMigrationStatus::Failed);
+        $skipped = $statuses->contains(ResourceMigrationStatus::Skipped);
+        $pending = $statuses->contains(fn (ResourceMigrationStatus $status) => ! $status->isTerminal());
+
+        if ($pending) {
+            $this->update(['status' => ResourceMigrationStatus::Running]);
+
+            return;
+        }
+
+        if ($failed || $skipped) {
+            $healthy = $statuses->contains(ResourceMigrationStatus::Healthy);
+            $this->update([
+                'status' => $healthy ? ResourceMigrationStatus::Partial : ResourceMigrationStatus::Failed,
+            ]);
+
+            return;
+        }
+
+        $this->update(['status' => ResourceMigrationStatus::Completed]);
+    }
+}

--- a/app/Models/ResourceMigrationItem.php
+++ b/app/Models/ResourceMigrationItem.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\ResourceMigrationStatus;
+use Database\Factories\ResourceMigrationItemFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ResourceMigrationItem extends BaseModel
+{
+    /** @use HasFactory<ResourceMigrationItemFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'uuid',
+        'resource_migration_id',
+        'resource_type',
+        'source_uuid',
+        'target_uuid',
+        'name',
+        'status',
+        'sort_order',
+        'archives',
+        'error',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'status' => ResourceMigrationStatus::class,
+            'archives' => 'array',
+            'sort_order' => 'integer',
+        ];
+    }
+
+    public function migration(): BelongsTo
+    {
+        return $this->belongsTo(ResourceMigration::class, 'resource_migration_id');
+    }
+
+    public function mark(ResourceMigrationStatus $status, ?string $error = null): void
+    {
+        $this->update([
+            'status' => $status,
+            'error' => $error,
+        ]);
+    }
+}

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -1591,9 +1591,10 @@ class Service extends BaseModel
 
         $workdir = $this->workdir();
 
+        // Never `cd` into /data/coolify/... — non-root SSH cannot enter root-owned parents.
+        // Use absolute paths only (same pattern as StartService docker compose).
         instant_remote_process([
             "mkdir -p $workdir",
-            "cd $workdir",
         ], $this->server);
 
         $filename = new_public_id().'-docker-compose.yml';
@@ -1602,8 +1603,7 @@ class Service extends BaseModel
         instant_scp($path, "{$workdir}/docker-compose.yml", $this->server);
         Storage::disk('local')->delete("tmp/{$filename}");
 
-        $commands[] = "cd $workdir";
-        $commands[] = 'rm -f .env || true';
+        $commands[] = "rm -f {$workdir}/.env || true";
 
         $envs = collect([]);
 
@@ -1634,10 +1634,10 @@ class Service extends BaseModel
             $envs->push("{$env->key}={$env->real_value}");
         }
         if ($envs->count() === 0) {
-            $commands[] = 'touch .env';
+            $commands[] = "touch {$workdir}/.env";
         } else {
             $envs_base64 = base64_encode($envs->implode("\n"));
-            $commands[] = "echo '$envs_base64' | base64 -d | tee .env > /dev/null";
+            $commands[] = "echo '$envs_base64' | base64 -d | tee {$workdir}/.env > /dev/null";
         }
 
         instant_remote_process($commands, $this->server);

--- a/app/Policies/InstanceMigrationPolicy.php
+++ b/app/Policies/InstanceMigrationPolicy.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\InstanceMigration;
+use App\Models\User;
+
+class InstanceMigrationPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->isAdmin();
+    }
+
+    public function view(User $user, InstanceMigration $instanceMigration): bool
+    {
+        return $user->teams->contains('id', $instanceMigration->team_id);
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->isAdmin();
+    }
+
+    public function update(User $user, InstanceMigration $instanceMigration): bool
+    {
+        return $user->isAdminOfTeam($instanceMigration->team_id);
+    }
+
+    public function delete(User $user, InstanceMigration $instanceMigration): bool
+    {
+        return $user->isAdminOfTeam($instanceMigration->team_id);
+    }
+}

--- a/app/Policies/ResourceMigrationPolicy.php
+++ b/app/Policies/ResourceMigrationPolicy.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\ResourceMigration;
+use App\Models\User;
+
+class ResourceMigrationPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->isAdmin();
+    }
+
+    public function view(User $user, ResourceMigration $resourceMigration): bool
+    {
+        return $user->teams->contains('id', $resourceMigration->team_id);
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->isAdmin();
+    }
+
+    public function update(User $user, ResourceMigration $resourceMigration): bool
+    {
+        return $user->isAdminOfTeam($resourceMigration->team_id);
+    }
+
+    public function delete(User $user, ResourceMigration $resourceMigration): bool
+    {
+        return $user->isAdminOfTeam($resourceMigration->team_id);
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -14,11 +14,13 @@ use App\Models\Environment;
 use App\Models\EnvironmentVariable;
 use App\Models\GithubApp;
 use App\Models\GitlabApp;
+use App\Models\InstanceMigration;
 use App\Models\InstanceSettings;
 use App\Models\IntegrationToken;
 use App\Models\PrivateKey;
 use App\Models\Project;
 use App\Models\PushoverNotificationSettings;
+use App\Models\ResourceMigration;
 use App\Models\S3Storage;
 use App\Models\ScheduledTask;
 use App\Models\Server;
@@ -52,12 +54,14 @@ use App\Policies\EnvironmentPolicy;
 use App\Policies\EnvironmentVariablePolicy;
 use App\Policies\GithubAppPolicy;
 use App\Policies\GitlabAppPolicy;
+use App\Policies\InstanceMigrationPolicy;
 use App\Policies\InstanceSettingsPolicy;
 use App\Policies\IntegrationTokenPolicy;
 use App\Policies\NotificationPolicy;
 use App\Policies\PrivateKeyPolicy;
 use App\Policies\ProjectPolicy;
 use App\Policies\ResourceCreatePolicy;
+use App\Policies\ResourceMigrationPolicy;
 use App\Policies\S3StoragePolicy;
 use App\Policies\ScheduledTaskPolicy;
 use App\Policies\ServerPolicy;
@@ -118,9 +122,11 @@ class AuthServiceProvider extends ServiceProvider
 
         // Instance settings policy
         InstanceSettings::class => InstanceSettingsPolicy::class,
+        InstanceMigration::class => InstanceMigrationPolicy::class,
 
         // S3 storage policy
         S3Storage::class => S3StoragePolicy::class,
+        ResourceMigration::class => ResourceMigrationPolicy::class,
 
         // Scheduled task policy
         ScheduledTask::class => ScheduledTaskPolicy::class,

--- a/app/Services/Migration/Manifest.php
+++ b/app/Services/Migration/Manifest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Services\Migration;
+
+use Spatie\LaravelData\Data;
+
+class Manifest extends Data
+{
+    public const VERSION = 1;
+
+    /**
+     * @param  array<int, array<string, mixed>>  $resources
+     * @param  array<string, mixed>  $storage
+     */
+    public function __construct(
+        public int $version,
+        public string $exported_at,
+        public string $source_version,
+        public bool $skip_data,
+        public array $storage,
+        public array $resources,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $storage
+     * @param  array<int, array<string, mixed>>  $resources
+     */
+    public static function make(array $storage, array $resources, bool $skipData = false): self
+    {
+        return new self(
+            version: self::VERSION,
+            exported_at: date('c'),
+            source_version: self::coolifyVersion(),
+            skip_data: $skipData,
+            storage: $storage,
+            resources: $resources,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public static function fromArray(array $payload): self
+    {
+        return new self(
+            version: (int) ($payload['version'] ?? self::VERSION),
+            exported_at: (string) ($payload['exported_at'] ?? date('c')),
+            source_version: (string) ($payload['source_version'] ?? 'unknown'),
+            skip_data: (bool) ($payload['skip_data'] ?? false),
+            storage: is_array($payload['storage'] ?? null) ? $payload['storage'] : [],
+            resources: is_array($payload['resources'] ?? null) ? $payload['resources'] : [],
+        );
+    }
+
+    public function resourceCount(): int
+    {
+        return count($this->resources);
+    }
+
+    private static function coolifyVersion(): string
+    {
+        if (function_exists('app') && app()->bound('config')) {
+            return (string) config('constants.coolify.version');
+        }
+
+        return 'unknown';
+    }
+
+    public function totalArchiveBytes(): int
+    {
+        $total = 0;
+
+        foreach ($this->resources as $resource) {
+            foreach ($resource['volumes'] ?? [] as $volume) {
+                $total += (int) data_get($volume, 'archive.size_bytes', 0);
+            }
+            foreach ($resource['file_storages'] ?? [] as $fileStorage) {
+                $total += (int) data_get($fileStorage, 'archive.size_bytes', 0);
+            }
+            $total += (int) data_get($resource, 'dump.archive.size_bytes', 0);
+        }
+
+        return $total;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function resourcesInImportOrder(): array
+    {
+        $rank = function (array $resource): int {
+            $type = (string) ($resource['type'] ?? '');
+
+            if (str_starts_with($type, 'standalone')) {
+                return 0;
+            }
+
+            if ($type === 'service') {
+                return 1;
+            }
+
+            return 2;
+        };
+
+        $resources = $this->resources;
+        usort($resources, fn (array $left, array $right): int => $rank($left) <=> $rank($right));
+
+        return $resources;
+    }
+}

--- a/app/Services/Migration/MigrationApiClient.php
+++ b/app/Services/Migration/MigrationApiClient.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Services\Migration;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+
+class MigrationApiClient
+{
+    public function __construct(
+        private string $baseUrl,
+        private string $token,
+    ) {
+        $this->baseUrl = rtrim($baseUrl, '/');
+    }
+
+    /**
+     * @param  array<string, mixed>  $query
+     * @return array<string, mixed>
+     */
+    public function get(string $path, array $query = []): array
+    {
+        $response = $this->http()->get($this->url($path), $query);
+        $this->throwIfFailed($response->status(), $response->json());
+
+        return $response->json() ?? [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $body
+     * @return array<string, mixed>
+     */
+    public function post(string $path, array $body = []): array
+    {
+        $response = $this->http()->post($this->url($path), $body);
+        $this->throwIfFailed($response->status(), $response->json());
+
+        return $response->json() ?? [];
+    }
+
+    private function http(): PendingRequest
+    {
+        return Http::withToken($this->token)
+            ->acceptJson()
+            ->timeout(60)
+            ->connectTimeout(10)
+            ->retry(3, 1000, throw: false);
+    }
+
+    private function url(string $path): string
+    {
+        $path = ltrim($path, '/');
+        if (str_contains($this->baseUrl, '/api/v1')) {
+            return $this->baseUrl.'/'.$path;
+        }
+
+        return $this->baseUrl.'/api/v1/'.$path;
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $payload
+     */
+    private function throwIfFailed(int $status, ?array $payload): void
+    {
+        if ($status >= 200 && $status < 300) {
+            return;
+        }
+
+        $message = $payload['message'] ?? "Migration API request failed with HTTP {$status}.";
+
+        throw new RuntimeException((string) $message);
+    }
+}

--- a/app/Services/Migration/MigrationArchiver.php
+++ b/app/Services/Migration/MigrationArchiver.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace App\Services\Migration;
+
+use App\Models\LocalFileVolume;
+use App\Models\LocalPersistentVolume;
+use App\Models\Server;
+use App\Models\StandaloneClickhouse;
+use App\Models\StandaloneMariadb;
+use App\Models\StandaloneMongodb;
+use App\Models\StandaloneMysql;
+use App\Models\StandalonePostgresql;
+use App\Support\ClickhouseBackupCommand;
+use RuntimeException;
+
+class MigrationArchiver
+{
+    public function archiveVolume(Server $server, LocalPersistentVolume $volume, string $destinationPath): int
+    {
+        $source = filled($volume->host_path) ? $volume->host_path : $volume->name;
+        $image = escapeshellarg(coolifyHelperImage().':'.getHelperVersion());
+        $verify = blank($volume->host_path)
+            ? 'docker volume inspect '.escapeshellarg($source).' >/dev/null'
+            : 'test -d '.escapeshellarg($source);
+
+        instant_remote_process([
+            $verify,
+            'mkdir -p '.escapeshellarg(dirname($destinationPath)),
+            'docker run --rm -v '.escapeshellarg($source.':/volume:ro').' '.$image
+                .' tar -czf - -C /volume . > '.escapeshellarg($destinationPath),
+        ], $server);
+
+        return $this->assertArchive($server, $destinationPath);
+    }
+
+    public function archiveFileStorage(Server $server, LocalFileVolume $fileVolume, string $destinationPath): int
+    {
+        $source = $fileVolume->fs_path;
+        if (blank($source)) {
+            throw new RuntimeException('File storage is missing a host path.');
+        }
+
+        $image = escapeshellarg(coolifyHelperImage().':'.getHelperVersion());
+        $isDirectory = $fileVolume->is_directory;
+
+        instant_remote_process([
+            $isDirectory ? 'test -d '.escapeshellarg($source) : 'test -e '.escapeshellarg($source),
+            'mkdir -p '.escapeshellarg(dirname($destinationPath)),
+            'docker run --rm -v '.escapeshellarg(dirname($source).':/volume:ro').' '.$image
+                .' tar -czf - -C /volume '.escapeshellarg(basename($source)).' > '.escapeshellarg($destinationPath),
+        ], $server);
+
+        return $this->assertArchive($server, $destinationPath);
+    }
+
+    public function dumpDatabase(object $database, Server $server, string $destinationPath): array
+    {
+        $container = $database->uuid;
+        instant_remote_process(['mkdir -p '.escapeshellarg(dirname($destinationPath))], $server);
+
+        $dumpAll = false;
+        $command = match ($database->getMorphClass()) {
+            StandalonePostgresql::class => $this->postgresDump($database, $container, $destinationPath),
+            StandaloneMysql::class => $this->mysqlDump($database, $container, $destinationPath),
+            StandaloneMariadb::class => $this->mariadbDump($database, $container, $destinationPath),
+            StandaloneMongodb::class => $this->mongoDump($database, $container, $destinationPath),
+            StandaloneClickhouse::class => null,
+            default => null,
+        };
+
+        if ($database instanceof StandaloneClickhouse) {
+            instant_remote_process(
+                ClickhouseBackupCommand::make($container, $database->clickhouse_db, basename($destinationPath), dirname($destinationPath)),
+                $server,
+            );
+        } elseif (is_string($command)) {
+            instant_remote_process([$command], $server);
+        } else {
+            throw new RuntimeException('Logical dumps are not supported for this database type.');
+        }
+
+        return [
+            'size_bytes' => $this->assertArchive($server, $destinationPath),
+            'dump_all' => $dumpAll,
+        ];
+    }
+
+    public function restoreFileStorage(Server $server, string $archivePath, string $destinationPath): void
+    {
+        $image = escapeshellarg(coolifyHelperImage().':'.getHelperVersion());
+        $parent = dirname($destinationPath);
+
+        instant_remote_process([
+            'mkdir -p '.escapeshellarg($parent),
+            'docker run --rm -i -v '.escapeshellarg($parent.':/target').' '.$image
+                .' tar -xzf - -C /target < '.escapeshellarg($archivePath),
+        ], $server);
+    }
+
+    public function supportsLogicalDump(object $database): bool
+    {
+        return in_array($database->getMorphClass(), [
+            StandalonePostgresql::class,
+            StandaloneMysql::class,
+            StandaloneMariadb::class,
+            StandaloneMongodb::class,
+            StandaloneClickhouse::class,
+        ], true);
+    }
+
+    private function postgresDump(object $database, string $container, string $destinationPath): string
+    {
+        $command = 'docker exec';
+        if (filled($database->postgres_password)) {
+            $command .= ' -e PGPASSWORD='.escapeshellarg($database->postgres_password);
+        }
+
+        return $command.' '.escapeshellarg($container)
+            .' pg_dump --format=custom --no-acl --no-owner --username '.escapeshellarg($database->postgres_user)
+            .' '.escapeshellarg($database->postgres_db)
+            .' > '.escapeshellarg($destinationPath);
+    }
+
+    private function mysqlDump(object $database, string $container, string $destinationPath): string
+    {
+        return 'docker exec '.escapeshellarg($container)
+            .' mysqldump -u root -p'.escapeshellarg($database->mysql_root_password)
+            .' '.escapeshellarg($database->mysql_database)
+            .' > '.escapeshellarg($destinationPath);
+    }
+
+    private function mariadbDump(object $database, string $container, string $destinationPath): string
+    {
+        return 'docker exec '.escapeshellarg($container)
+            .' mariadb-dump -u root -p'.escapeshellarg($database->mariadb_root_password)
+            .' '.escapeshellarg($database->mariadb_database)
+            .' > '.escapeshellarg($destinationPath);
+    }
+
+    private function mongoDump(object $database, string $container, string $destinationPath): string
+    {
+        return 'docker exec '.escapeshellarg($container)
+            .' mongodump --authenticationDatabase=admin --username '.escapeshellarg($database->mongo_initdb_root_username)
+            .' --password '.escapeshellarg($database->mongo_initdb_root_password)
+            .' --gzip --archive > '.escapeshellarg($destinationPath);
+    }
+
+    private function assertArchive(Server $server, string $path): int
+    {
+        $size = (int) instant_remote_process(
+            ['du -b '.escapeshellarg($path).' | cut -f1'],
+            $server,
+            throwError: false,
+        );
+
+        if ($size <= 0) {
+            throw new RuntimeException("Migration archive {$path} is empty or was not created.");
+        }
+
+        return $size;
+    }
+}

--- a/app/Services/Migration/ResourceImporter.php
+++ b/app/Services/Migration/ResourceImporter.php
@@ -1,0 +1,305 @@
+<?php
+
+namespace App\Services\Migration;
+
+use App\Models\Application;
+use App\Models\ApplicationSetting;
+use App\Models\Environment;
+use App\Models\EnvironmentVariable;
+use App\Models\GithubApp;
+use App\Models\LocalFileVolume;
+use App\Models\LocalPersistentVolume;
+use App\Models\PrivateKey;
+use App\Models\Service;
+use App\Models\StandaloneDocker;
+use App\Models\SwarmDocker;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Schema;
+use RuntimeException;
+
+class ResourceImporter
+{
+    /**
+     * @param  array<string, mixed>  $resource
+     * @param  array<string, string>  $uuidMap
+     */
+    public function import(
+        array $resource,
+        StandaloneDocker|SwarmDocker $destination,
+        Environment $environment,
+        array &$uuidMap,
+    ): Model {
+        $type = (string) ($resource['type'] ?? '');
+
+        $created = match (true) {
+            $type === 'application' => $this->importApplication($resource, $destination, $environment, $uuidMap),
+            $type === 'service' => $this->importService($resource, $destination, $environment, $uuidMap),
+            str_starts_with($type, 'standalone-') => $this->importDatabase($resource, $destination, $environment, $uuidMap),
+            default => throw new RuntimeException("Unsupported resource type [{$type}]."),
+        };
+
+        $uuidMap[(string) $resource['source_uuid']] = $created->uuid;
+
+        return $created;
+    }
+
+    /**
+     * @param  array<string, mixed>  $resource
+     * @param  array<string, string>  $uuidMap
+     */
+    private function importApplication(
+        array $resource,
+        StandaloneDocker|SwarmDocker $destination,
+        Environment $environment,
+        array $uuidMap,
+    ): Application {
+        $uuid = new_public_id();
+        $application = new Application;
+        $attributes = $this->attributes($resource, $application);
+        $server = $destination->server;
+        $application->fill($attributes);
+        $application->uuid = $uuid;
+        $application->name = $resource['name'] ?? ('migrated-'.$uuid);
+        $application->status = 'exited';
+        $application->environment_id = $environment->id;
+        $application->destination_id = $destination->id;
+        $application->destination_type = $destination->getMorphClass();
+        $this->applyGitSource($application, $resource, $environment->project->team_id);
+
+        try {
+            if ($server->proxyType() !== 'NONE') {
+                $application->fqdn = generateUrl(server: $server, random: $uuid);
+            }
+        } catch (\Throwable) {
+            // FQDN can be assigned on the target after import.
+        }
+
+        // Skip Application::created (settings + default NIXPACKS env) so import hydrates from the manifest.
+        Application::withoutEvents(fn () => $application->save());
+        ApplicationSetting::create(['application_id' => $application->id]);
+        $this->syncSettings($application, $resource['settings'] ?? []);
+        $application->load('settings');
+
+        try {
+            if ($application->destination->server->proxyType() !== 'NONE' && $application->settings?->is_container_label_readonly_enabled === true) {
+                $customLabels = str(implode('|coolify|', generateLabelsApplication($application)))->replace('|coolify|', "\n");
+                $application->custom_labels = base64_encode($customLabels);
+                $application->save();
+            }
+        } catch (\Throwable) {
+            // FQDN labels can be regenerated on the target after import.
+        }
+
+        $this->syncEnvironmentVariables($application, $resource['environment_variables'] ?? [], $uuidMap);
+        $this->syncVolumes($application, $resource['volumes'] ?? [], $resource['source_uuid']);
+        $this->syncFileStorages($application, $resource['file_storages'] ?? []);
+
+        return $application->fresh();
+    }
+
+    /**
+     * @param  array<string, mixed>  $resource
+     * @param  array<string, string>  $uuidMap
+     */
+    private function importService(
+        array $resource,
+        StandaloneDocker|SwarmDocker $destination,
+        Environment $environment,
+        array $uuidMap,
+    ): Service {
+        $uuid = new_public_id();
+        $service = new Service;
+        $service->fill($this->attributes($resource, $service));
+        $service->uuid = $uuid;
+        $service->name = $resource['name'] ?? ('migrated-'.$uuid);
+        $service->environment_id = $environment->id;
+        $service->destination_id = $destination->id;
+        $service->destination_type = $destination->getMorphClass();
+        $service->server_id = $destination->server_id;
+        $service->save();
+
+        $this->syncEnvironmentVariables($service, $resource['environment_variables'] ?? [], $uuidMap);
+        $service->parse();
+
+        return $service->fresh();
+    }
+
+    /**
+     * @param  array<string, mixed>  $resource
+     * @param  array<string, string>  $uuidMap
+     */
+    private function importDatabase(
+        array $resource,
+        StandaloneDocker|SwarmDocker $destination,
+        Environment $environment,
+        array $uuidMap,
+    ): Model {
+        $type = str_replace('standalone-', '', (string) $resource['type']);
+        $modelClass = STANDALONE_DATABASE_MODELS[$type] ?? null;
+        if (! is_string($modelClass)) {
+            throw new RuntimeException("Unknown database type [{$resource['type']}].");
+        }
+
+        $uuid = new_public_id();
+        /** @var Model $database */
+        $database = new $modelClass;
+        $database->fill($this->attributes($resource, $database));
+        $database->uuid = $uuid;
+        $database->name = $resource['name'] ?? ('migrated-'.$uuid);
+        $database->status = 'exited';
+        $database->environment_id = $environment->id;
+        $database->destination_id = $destination->id;
+        $database->destination_type = $destination->getMorphClass();
+        $database->save();
+
+        $this->syncEnvironmentVariables($database, $resource['environment_variables'] ?? [], $uuidMap);
+        $this->syncVolumes($database, $resource['volumes'] ?? [], $resource['source_uuid']);
+        $this->syncFileStorages($database, $resource['file_storages'] ?? []);
+
+        return $database->fresh();
+    }
+
+    /**
+     * @param  array<string, mixed>  $resource
+     * @return array<string, mixed>
+     */
+    private function attributes(array $resource, Model $model): array
+    {
+        $attributes = is_array($resource['attributes'] ?? null) ? $resource['attributes'] : [];
+        $columns = Schema::getColumnListing($model->getTable());
+
+        return collect($attributes)
+            ->only($columns)
+            ->except(['id', 'uuid', 'destination_id', 'destination_type', 'environment_id', 'server_id', 'status'])
+            ->all();
+    }
+
+    /**
+     * @param  array<string, mixed>  $settings
+     */
+    private function syncSettings(Application $application, array $settings): void
+    {
+        unset($settings['id'], $settings['application_id'], $settings['created_at'], $settings['updated_at']);
+        if ($settings === []) {
+            return;
+        }
+
+        $columns = Schema::getColumnListing((new ApplicationSetting)->getTable());
+        $payload = collect($settings)
+            ->only((new ApplicationSetting)->getFillable())
+            ->only($columns)
+            ->all();
+
+        if ($payload === []) {
+            return;
+        }
+
+        $application->settings()->update($payload);
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $variables
+     * @param  array<string, string>  $uuidMap
+     */
+    private function syncEnvironmentVariables(Model $resource, array $variables, array $uuidMap): void
+    {
+        EnvironmentVariable::withoutEvents(function () use ($resource, $variables, $uuidMap): void {
+            $resource->environment_variables()->delete();
+            if (method_exists($resource, 'environment_variables_preview')) {
+                $resource->environment_variables_preview()->delete();
+            }
+
+            foreach ($variables as $variable) {
+                $environmentVariable = new EnvironmentVariable([
+                    'key' => $variable['key'],
+                    'value' => replace_database_uuids_in_value((string) ($variable['value'] ?? ''), $uuidMap),
+                    'is_literal' => (bool) ($variable['is_literal'] ?? false),
+                    'is_multiline' => (bool) ($variable['is_multiline'] ?? false),
+                    'is_preview' => (bool) ($variable['is_preview'] ?? false),
+                    'is_runtime' => (bool) ($variable['is_runtime'] ?? true),
+                    'is_buildtime' => (bool) ($variable['is_buildtime'] ?? true),
+                    'is_shared' => (bool) ($variable['is_shared'] ?? false),
+                    'comment' => $variable['comment'] ?? null,
+                    'resourceable_type' => $resource->getMorphClass(),
+                    'resourceable_id' => $resource->id,
+                ]);
+                $environmentVariable->uuid = new_public_id();
+                $environmentVariable->save();
+            }
+        });
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $volumes
+     */
+    private function syncVolumes(Model $resource, array $volumes, string $sourceUuid): void
+    {
+        if (method_exists($resource, 'persistentStorages')) {
+            $resource->persistentStorages()->delete();
+        }
+
+        foreach ($volumes as $volume) {
+            LocalPersistentVolume::create([
+                'name' => generate_cloned_persistent_volume_name(
+                    (string) $volume['name'],
+                    $resource->uuid,
+                    $sourceUuid,
+                ),
+                'mount_path' => $volume['mount_path'],
+                'host_path' => $volume['host_path'] ?? null,
+                'is_preview_suffix_enabled' => (bool) ($volume['is_preview_suffix_enabled'] ?? false),
+                'resource_id' => $resource->id,
+                'resource_type' => $resource->getMorphClass(),
+            ]);
+        }
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $storages
+     */
+    private function syncFileStorages(Model $resource, array $storages): void
+    {
+        foreach ($storages as $storage) {
+            LocalFileVolume::withoutEvents(function () use ($resource, $storage): void {
+                $fileVolume = new LocalFileVolume([
+                    'fs_path' => $storage['fs_path'] ?? null,
+                    'mount_path' => $storage['mount_path'],
+                    'content' => $storage['content'] ?? null,
+                    'is_directory' => (bool) ($storage['is_directory'] ?? false),
+                    'is_host_file' => (bool) ($storage['is_host_file'] ?? false),
+                    'chown' => $storage['chown'] ?? null,
+                    'chmod' => $storage['chmod'] ?? null,
+                    'is_based_on_git' => $storage['is_based_on_git'] ?? null,
+                    'resource_id' => $resource->id,
+                    'resource_type' => $resource->getMorphClass(),
+                ]);
+                $fileVolume->uuid = new_public_id();
+                $fileVolume->save();
+            });
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $resource
+     */
+    private function applyGitSource(Application $application, array $resource, int $teamId): void
+    {
+        $git = $resource['git'] ?? [];
+        $sourceUuid = $git['source_uuid'] ?? null;
+        if (is_string($sourceUuid) && $sourceUuid !== '') {
+            $githubApp = GithubApp::where('uuid', $sourceUuid)->where('team_id', $teamId)->first();
+            if ($githubApp) {
+                $application->source_id = $githubApp->id;
+                $application->source_type = $githubApp->getMorphClass();
+            }
+        }
+
+        $privateKeyUuid = $git['private_key_uuid'] ?? null;
+        if (is_string($privateKeyUuid) && $privateKeyUuid !== '') {
+            $privateKey = PrivateKey::where('uuid', $privateKeyUuid)->where('team_id', $teamId)->first();
+            if ($privateKey) {
+                $application->private_key_id = $privateKey->id;
+            }
+        }
+    }
+}

--- a/app/Services/Migration/ResourceSerializer.php
+++ b/app/Services/Migration/ResourceSerializer.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace App\Services\Migration;
+
+use App\Models\Application;
+use App\Models\EnvironmentVariable;
+use App\Models\GithubApp;
+use App\Models\LocalFileVolume;
+use App\Models\LocalPersistentVolume;
+use App\Models\PrivateKey;
+use App\Models\Service;
+use Illuminate\Database\Eloquent\Model;
+
+class ResourceSerializer
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function serialize(Model $resource): array
+    {
+        $resource->makeVisible($resource->getHidden());
+
+        $payload = [
+            'type' => $resource->type(),
+            'source_uuid' => $resource->uuid,
+            'name' => $resource->name,
+            'attributes' => $this->attributes($resource),
+            'environment_variables' => $this->environmentVariables($resource),
+            'volumes' => $this->volumes($resource),
+            'file_storages' => $this->fileStorages($resource),
+            'warnings' => [],
+        ];
+
+        if ($resource instanceof Application) {
+            $payload['settings'] = $resource->settings?->only($resource->settings->getFillable()) ?? [];
+            $payload['git'] = $this->gitMetadata($resource, $payload['warnings']);
+        }
+
+        if ($resource instanceof Service) {
+            $payload['attributes']['docker_compose_raw'] = $resource->docker_compose_raw;
+            $payload['attributes']['docker_compose'] = $resource->docker_compose;
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function attributes(Model $resource): array
+    {
+        $excluded = [
+            'id',
+            'uuid',
+            'destination_id',
+            'destination_type',
+            'environment_id',
+            'server_id',
+            'status',
+            'started_at',
+            'last_online_at',
+            'restart_count',
+            'last_restart_at',
+            'last_restart_type',
+            'config_hash',
+            'source_id',
+            'source_type',
+            'private_key_id',
+            'created_at',
+            'updated_at',
+            'deleted_at',
+        ];
+
+        return collect($resource->only($resource->getFillable()))
+            ->except($excluded)
+            ->all();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function environmentVariables(Model $resource): array
+    {
+        if (! method_exists($resource, 'environment_variables')) {
+            return [];
+        }
+
+        $variables = $resource->environment_variables()->get();
+        if (method_exists($resource, 'environment_variables_preview')) {
+            $variables = $variables->concat($resource->environment_variables_preview()->get());
+        }
+
+        return $variables->map(function (EnvironmentVariable $variable): array {
+            $variable->makeVisible(['value', 'real_value']);
+
+            return [
+                'key' => $variable->key,
+                'value' => $variable->value,
+                'is_literal' => $variable->is_literal,
+                'is_multiline' => $variable->is_multiline,
+                'is_preview' => $variable->is_preview,
+                'is_runtime' => $variable->is_runtime,
+                'is_buildtime' => $variable->is_buildtime,
+                'is_shared' => $variable->is_shared,
+                'comment' => $variable->comment,
+            ];
+        })->all();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function volumes(Model $resource): array
+    {
+        if (! method_exists($resource, 'persistentStorages')) {
+            return [];
+        }
+
+        return $resource->persistentStorages()->get()->map(fn (LocalPersistentVolume $volume): array => [
+            'name' => $volume->name,
+            'mount_path' => $volume->mount_path,
+            'host_path' => $volume->host_path,
+            'is_preview_suffix_enabled' => $volume->is_preview_suffix_enabled,
+            'archive' => null,
+        ])->all();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function fileStorages(Model $resource): array
+    {
+        if (! method_exists($resource, 'fileStorages')) {
+            return [];
+        }
+
+        return $resource->fileStorages()->get()->map(function (LocalFileVolume $storage): array {
+            $storage->makeVisible(['content']);
+
+            return [
+                'fs_path' => $storage->fs_path,
+                'mount_path' => $storage->mount_path,
+                'content' => $storage->content,
+                'is_directory' => $storage->is_directory,
+                'is_host_file' => $storage->is_host_file,
+                'chown' => $storage->chown,
+                'chmod' => $storage->chmod,
+                'is_based_on_git' => $storage->is_based_on_git,
+                'archive' => null,
+            ];
+        })->all();
+    }
+
+    /**
+     * @param  array<int, string>  $warnings
+     * @return array<string, mixed>
+     */
+    private function gitMetadata(Application $application, array &$warnings): array
+    {
+        $git = [
+            'repository' => $application->git_repository,
+            'branch' => $application->git_branch,
+            'source_type' => $application->source_type,
+            'source_uuid' => $application->source instanceof GithubApp ? $application->source->uuid : null,
+            'private_key_uuid' => $application->private_key_id
+                ? PrivateKey::find($application->private_key_id)?->uuid
+                : null,
+        ];
+
+        if ($application->source_id && ! $application->source instanceof GithubApp) {
+            $warnings[] = 'Private Git source must be re-linked on the target team.';
+        }
+
+        if ($application->source instanceof GithubApp) {
+            $warnings[] = 'Private GitHub App apps migrate only if the same GitHub App exists on the target team.';
+        }
+
+        if ($application->private_key_id) {
+            $warnings[] = 'Deploy-key apps migrate only if an equivalent private key exists on the target team.';
+        }
+
+        return $git;
+    }
+}

--- a/app/Services/Migration/Storage/AzureBlobDriver.php
+++ b/app/Services/Migration/Storage/AzureBlobDriver.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace App\Services\Migration\Storage;
+
+use App\Models\Server;
+use RuntimeException;
+
+class AzureBlobDriver implements MigrationStorageDriver
+{
+    /**
+     * @param  array{account?: string, container?: string, key?: string, sas?: string}  $config
+     */
+    public function __construct(private array $config) {}
+
+    public function put(Server $server, string $localPath, string $objectKey): array
+    {
+        $this->runAzCopy($server, [
+            'azcopy copy '.escapeshellarg($localPath).' '.escapeshellarg($this->blobUrl($objectKey)),
+        ], $localPath);
+
+        $size = (int) instant_remote_process(
+            ['du -b '.escapeshellarg($localPath).' | cut -f1'],
+            $server,
+            throwError: false,
+        );
+
+        return [
+            'driver' => 'azure',
+            'bucket' => $this->container(),
+            'key' => $objectKey,
+            'checksum' => null,
+            'size_bytes' => $size,
+        ];
+    }
+
+    public function get(Server $server, string $objectKey, string $destinationPath): string
+    {
+        $this->runAzCopy($server, [
+            'mkdir -p '.escapeshellarg(dirname($destinationPath)),
+            'azcopy copy '.escapeshellarg($this->blobUrl($objectKey)).' '.escapeshellarg($destinationPath),
+        ]);
+
+        return $destinationPath;
+    }
+
+    public function exists(Server $server, string $objectKey): bool
+    {
+        try {
+            $this->runAzCopy($server, [
+                'azcopy list '.escapeshellarg($this->blobUrl($objectKey)).' >/dev/null',
+            ]);
+
+            return true;
+        } catch (RuntimeException) {
+            return false;
+        }
+    }
+
+    public function delete(Server $server, string $objectKey): void
+    {
+        try {
+            $this->runAzCopy($server, [
+                'azcopy remove '.escapeshellarg($this->blobUrl($objectKey)),
+            ]);
+        } catch (RuntimeException) {
+            // Ignore missing blobs during cleanup.
+        }
+    }
+
+    public function diskFree(Server $server): ?int
+    {
+        $output = instant_remote_process(
+            ['df -B1 --output=avail / | tail -1'],
+            $server,
+            throwError: false,
+        );
+
+        return is_numeric(trim((string) $output)) ? (int) trim((string) $output) : null;
+    }
+
+    /**
+     * @param  array<int, string>  $commands
+     */
+    private function runAzCopy(Server $server, array $commands, ?string $bindPath = null): void
+    {
+        $this->assertConfigured();
+        $container = 'migration-azure-'.uniqid();
+        $image = escapeshellarg(coolifyHelperImage().':'.getHelperVersion());
+        $volume = $bindPath
+            ? ' -v '.escapeshellarg($bindPath.':'.$bindPath)
+            : ' -v '.escapeshellarg('/data/coolify/backups:/data/coolify/backups');
+
+        $env = ' -e AZCOPY_AUTO_LOGIN_TYPE=SPN';
+        if (filled($this->config['key'] ?? null)) {
+            $env = ' -e AZURE_STORAGE_ACCOUNT='.escapeshellarg((string) $this->config['account'])
+                .' -e AZURE_STORAGE_KEY='.escapeshellarg((string) $this->config['key']);
+        }
+
+        $wrapped = array_map(
+            fn (string $command): string => str_starts_with($command, 'azcopy ')
+                ? 'docker exec '.escapeshellarg($container).' '.$command
+                : $command,
+            $commands,
+        );
+
+        try {
+            instant_remote_process([
+                'docker rm -f '.escapeshellarg($container).' >/dev/null 2>&1 || true',
+                'docker run -d --name '.escapeshellarg($container).' --rm'.$volume.$env.' '.$image,
+                ...$wrapped,
+            ], $server);
+        } finally {
+            instant_remote_process(
+                ['docker rm -f '.escapeshellarg($container)],
+                $server,
+                throwError: false,
+            );
+        }
+    }
+
+    private function blobUrl(string $objectKey): string
+    {
+        $base = sprintf(
+            'https://%s.blob.core.windows.net/%s/%s',
+            $this->config['account'],
+            $this->container(),
+            ltrim($objectKey, '/'),
+        );
+
+        if (filled($this->config['sas'] ?? null)) {
+            return $base.'?'.$this->config['sas'];
+        }
+
+        return $base;
+    }
+
+    private function container(): string
+    {
+        return (string) ($this->config['container'] ?? $this->config['bucket'] ?? '');
+    }
+
+    private function assertConfigured(): void
+    {
+        if (blank($this->config['account'] ?? null) || $this->container() === '') {
+            throw new RuntimeException('Azure Blob storage requires account and container.');
+        }
+    }
+}

--- a/app/Services/Migration/Storage/GcsDriver.php
+++ b/app/Services/Migration/Storage/GcsDriver.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Services\Migration\Storage;
+
+use App\Models\Server;
+use RuntimeException;
+
+class GcsDriver implements MigrationStorageDriver
+{
+    /**
+     * @param  array{bucket?: string, credentials?: string, project_id?: string}  $config
+     */
+    public function __construct(private array $config) {}
+
+    public function put(Server $server, string $localPath, string $objectKey): array
+    {
+        $this->runGcloud($server, [
+            'gcloud storage cp '.escapeshellarg($localPath).' '.escapeshellarg($this->objectUri($objectKey)),
+        ], $localPath);
+
+        $size = (int) instant_remote_process(
+            ['du -b '.escapeshellarg($localPath).' | cut -f1'],
+            $server,
+            throwError: false,
+        );
+
+        return [
+            'driver' => 'gcs',
+            'bucket' => $this->bucket(),
+            'key' => $objectKey,
+            'checksum' => null,
+            'size_bytes' => $size,
+        ];
+    }
+
+    public function get(Server $server, string $objectKey, string $destinationPath): string
+    {
+        $this->runGcloud($server, [
+            'mkdir -p '.escapeshellarg(dirname($destinationPath)),
+            'gcloud storage cp '.escapeshellarg($this->objectUri($objectKey)).' '.escapeshellarg($destinationPath),
+        ]);
+
+        return $destinationPath;
+    }
+
+    public function exists(Server $server, string $objectKey): bool
+    {
+        try {
+            $this->runGcloud($server, [
+                'gcloud storage ls '.escapeshellarg($this->objectUri($objectKey)).' >/dev/null',
+            ]);
+
+            return true;
+        } catch (RuntimeException) {
+            return false;
+        }
+    }
+
+    public function delete(Server $server, string $objectKey): void
+    {
+        try {
+            $this->runGcloud($server, [
+                'gcloud storage rm '.escapeshellarg($this->objectUri($objectKey)),
+            ]);
+        } catch (RuntimeException) {
+            // Ignore missing objects during cleanup.
+        }
+    }
+
+    public function diskFree(Server $server): ?int
+    {
+        $output = instant_remote_process(
+            ['df -B1 --output=avail / | tail -1'],
+            $server,
+            throwError: false,
+        );
+
+        return is_numeric(trim((string) $output)) ? (int) trim((string) $output) : null;
+    }
+
+    /**
+     * @param  array<int, string>  $commands
+     */
+    private function runGcloud(Server $server, array $commands, ?string $bindPath = null): void
+    {
+        $this->assertConfigured();
+        $container = 'migration-gcs-'.uniqid();
+        $image = escapeshellarg(coolifyHelperImage().':'.getHelperVersion());
+        $volume = $bindPath
+            ? ' -v '.escapeshellarg($bindPath.':'.$bindPath)
+            : ' -v '.escapeshellarg('/data/coolify/backups:/data/coolify/backups');
+
+        $wrapped = array_map(
+            fn (string $command): string => str_starts_with($command, 'gcloud ')
+                ? 'docker exec '.escapeshellarg($container).' '.$command
+                : $command,
+            $commands,
+        );
+
+        try {
+            instant_remote_process([
+                'docker rm -f '.escapeshellarg($container).' >/dev/null 2>&1 || true',
+                'docker run -d --name '.escapeshellarg($container).' --rm'.$volume.' '.$image,
+                ...$wrapped,
+            ], $server);
+        } finally {
+            instant_remote_process(
+                ['docker rm -f '.escapeshellarg($container)],
+                $server,
+                throwError: false,
+            );
+        }
+    }
+
+    private function objectUri(string $objectKey): string
+    {
+        return 'gs://'.$this->bucket().'/'.ltrim($objectKey, '/');
+    }
+
+    private function bucket(): string
+    {
+        return (string) ($this->config['bucket'] ?? '');
+    }
+
+    private function assertConfigured(): void
+    {
+        if ($this->bucket() === '') {
+            throw new RuntimeException('GCS storage requires a bucket.');
+        }
+    }
+}

--- a/app/Services/Migration/Storage/LocalSshDriver.php
+++ b/app/Services/Migration/Storage/LocalSshDriver.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Services\Migration\Storage;
+
+use App\Models\Server;
+use RuntimeException;
+
+class LocalSshDriver implements MigrationStorageDriver
+{
+    /**
+     * @param  array{base_path?: string}  $config
+     */
+    public function __construct(private array $config = []) {}
+
+    public function put(Server $server, string $localPath, string $objectKey): array
+    {
+        $destination = $this->objectPath($objectKey);
+        $this->ensureDirectory($destination);
+
+        if ($localPath !== $destination && ! copy($localPath, $destination)) {
+            throw new RuntimeException("Failed to store local migration archive {$objectKey}.");
+        }
+
+        if (! is_file($destination) || filesize($destination) === 0) {
+            throw new RuntimeException("Local migration archive {$objectKey} is empty or missing.");
+        }
+
+        return [
+            'driver' => 'local-ssh',
+            'bucket' => null,
+            'key' => $objectKey,
+            'checksum' => hash_file('sha256', $destination) ?: null,
+            'size_bytes' => (int) filesize($destination),
+        ];
+    }
+
+    public function get(Server $server, string $objectKey, string $destinationPath): string
+    {
+        $source = $this->objectPath($objectKey);
+        if (! is_file($source)) {
+            throw new RuntimeException("Local migration archive {$objectKey} was not found.");
+        }
+
+        $this->ensureDirectory($destinationPath);
+        if (! copy($source, $destinationPath)) {
+            throw new RuntimeException("Failed to read local migration archive {$objectKey}.");
+        }
+
+        return $destinationPath;
+    }
+
+    public function exists(Server $server, string $objectKey): bool
+    {
+        return is_file($this->objectPath($objectKey));
+    }
+
+    public function delete(Server $server, string $objectKey): void
+    {
+        $path = $this->objectPath($objectKey);
+        if (is_file($path)) {
+            unlink($path);
+        }
+    }
+
+    public function diskFree(Server $server): ?int
+    {
+        $path = $this->basePath();
+        if (! is_dir($path)) {
+            mkdir($path, 0777, true);
+        }
+
+        $free = disk_free_space($path);
+
+        return $free === false ? null : (int) $free;
+    }
+
+    public function objectPath(string $objectKey): string
+    {
+        return $this->basePath().'/'.ltrim($objectKey, '/');
+    }
+
+    private function ensureDirectory(string $path): void
+    {
+        $directory = dirname($path);
+        if (! is_dir($directory) && ! mkdir($directory, 0777, true) && ! is_dir($directory)) {
+            throw new RuntimeException("Failed to create directory {$directory}.");
+        }
+    }
+
+    private function basePath(): string
+    {
+        return $this->config['base_path'] ?? (function_exists('storage_path') && function_exists('app') && app()->bound('path.storage')
+            ? storage_path('app/tmp/migrations')
+            : sys_get_temp_dir().'/coolify-migrations');
+    }
+}

--- a/app/Services/Migration/Storage/MigrationStorageDriver.php
+++ b/app/Services/Migration/Storage/MigrationStorageDriver.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Services\Migration\Storage;
+
+use App\Models\Server;
+
+interface MigrationStorageDriver
+{
+    /**
+     * Upload a file that already exists on the managed server.
+     *
+     * @return array{driver: string, bucket: ?string, key: string, checksum: ?string, size_bytes: int}
+     */
+    public function put(Server $server, string $localPath, string $objectKey): array;
+
+    /**
+     * Download an object onto the managed server and return the local path.
+     */
+    public function get(Server $server, string $objectKey, string $destinationPath): string;
+
+    public function exists(Server $server, string $objectKey): bool;
+
+    public function delete(Server $server, string $objectKey): void;
+
+    /**
+     * Available disk space in bytes on the managed server, or null if unknown.
+     */
+    public function diskFree(Server $server): ?int;
+}

--- a/app/Services/Migration/Storage/MigrationStorageFactory.php
+++ b/app/Services/Migration/Storage/MigrationStorageFactory.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Services\Migration\Storage;
+
+use App\Enums\MigrationStorageDriver as DriverEnum;
+use App\Models\ResourceMigration;
+use App\Models\S3Storage;
+use InvalidArgumentException;
+
+class MigrationStorageFactory
+{
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    public function make(DriverEnum $driver, array $config, int $teamId): MigrationStorageDriver
+    {
+        $config = $this->resolveS3Storage($config, $teamId);
+
+        return match ($driver) {
+            DriverEnum::S3 => new S3CompatibleDriver($config),
+            DriverEnum::LocalSsh => new LocalSshDriver($config),
+            DriverEnum::Azure => new AzureBlobDriver($config),
+            DriverEnum::Gcs => new GcsDriver($config),
+        };
+    }
+
+    public function forMigration(ResourceMigration $migration): MigrationStorageDriver
+    {
+        return $this->make(
+            $migration->storage_driver,
+            $migration->storage_config ?? [],
+            $migration->team_id,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     * @return array<string, mixed>
+     */
+    private function resolveS3Storage(array $config, int $teamId): array
+    {
+        $uuid = $config['s3_storage_uuid'] ?? null;
+        if (! is_string($uuid) || $uuid === '') {
+            return $config;
+        }
+
+        $storage = S3Storage::where('team_id', $teamId)->where('uuid', $uuid)->first();
+        if (! $storage) {
+            throw new InvalidArgumentException('S3 storage not found for this team.');
+        }
+
+        return array_merge($config, [
+            'endpoint' => $storage->endpoint,
+            'bucket' => $storage->bucket,
+            'region' => $storage->region,
+            'key' => $storage->key,
+            'secret' => $storage->secret,
+        ]);
+    }
+}

--- a/app/Services/Migration/Storage/S3CompatibleDriver.php
+++ b/app/Services/Migration/Storage/S3CompatibleDriver.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace App\Services\Migration\Storage;
+
+use App\Models\Server;
+use App\Rules\SafeWebhookUrl;
+use RuntimeException;
+
+class S3CompatibleDriver implements MigrationStorageDriver
+{
+    /**
+     * @param  array{endpoint?: string, bucket?: string, region?: string, key?: string, secret?: string}  $config
+     */
+    public function __construct(private array $config) {}
+
+    public function put(Server $server, string $localPath, string $objectKey): array
+    {
+        $this->assertConfigured();
+        $this->runMc($server, [
+            'mc cp '.escapeshellarg($localPath).' '.escapeshellarg($this->objectUri($objectKey)),
+        ], $localPath);
+
+        $size = $this->fileSize($server, $localPath);
+        $checksum = $this->checksum($server, $localPath);
+
+        return [
+            'driver' => 's3',
+            'bucket' => $this->bucket(),
+            'key' => $objectKey,
+            'checksum' => $checksum,
+            'size_bytes' => $size,
+        ];
+    }
+
+    public function get(Server $server, string $objectKey, string $destinationPath): string
+    {
+        $this->assertConfigured();
+        $directory = dirname($destinationPath);
+        $this->runMc($server, [
+            'mkdir -p '.escapeshellarg($directory),
+            'mc cp '.escapeshellarg($this->objectUri($objectKey)).' '.escapeshellarg($destinationPath),
+        ]);
+
+        return $destinationPath;
+    }
+
+    public function exists(Server $server, string $objectKey): bool
+    {
+        try {
+            $this->runMc($server, [
+                'mc stat '.escapeshellarg($this->objectUri($objectKey)).' >/dev/null',
+            ]);
+
+            return true;
+        } catch (RuntimeException) {
+            return false;
+        }
+    }
+
+    public function delete(Server $server, string $objectKey): void
+    {
+        try {
+            $this->runMc($server, [
+                'mc rm '.escapeshellarg($this->objectUri($objectKey)),
+            ]);
+        } catch (RuntimeException) {
+            // Missing objects are not an error during cleanup.
+        }
+    }
+
+    public function diskFree(Server $server): ?int
+    {
+        $output = instant_remote_process(
+            ['df -B1 --output=avail / | tail -1'],
+            $server,
+            throwError: false,
+        );
+
+        if (! is_numeric(trim((string) $output))) {
+            return null;
+        }
+
+        return (int) trim((string) $output);
+    }
+
+    /**
+     * @param  array<int, string>  $commands
+     */
+    private function runMc(Server $server, array $commands, ?string $bindPath = null): void
+    {
+        $container = 'migration-s3-'.uniqid();
+        $image = escapeshellarg(coolifyHelperImage().':'.getHelperVersion());
+        $volume = $bindPath
+            ? ' -v '.escapeshellarg($bindPath.':'.$bindPath)
+            : ' -v '.escapeshellarg('/data/coolify/backups:/data/coolify/backups');
+
+        $resolveOptions = collect(SafeWebhookUrl::minioClientResolveOptions($this->endpoint()))
+            ->map(fn (string $option): string => '--resolve '.escapeshellarg($option))
+            ->implode(' ');
+        $resolveOptions = $resolveOptions === '' ? '' : ' '.$resolveOptions;
+
+        $alias = 'docker exec '.escapeshellarg($container).' mc alias set'.$resolveOptions.' temporary '
+            .escapeshellarg($this->endpoint()).' '.escapeshellarg($this->key()).' '.escapeshellarg($this->secret());
+
+        $wrapped = array_map(
+            fn (string $command): string => str_starts_with($command, 'mc ')
+                ? 'docker exec '.escapeshellarg($container).' '.$command
+                : $command,
+            $commands,
+        );
+
+        try {
+            instant_remote_process([
+                'docker rm -f '.escapeshellarg($container).' >/dev/null 2>&1 || true',
+                'docker run -d --name '.escapeshellarg($container).' --rm'.$volume.' '.$image,
+                $alias,
+                ...$wrapped,
+            ], $server);
+        } finally {
+            instant_remote_process(
+                ['docker rm -f '.escapeshellarg($container)],
+                $server,
+                throwError: false,
+            );
+        }
+    }
+
+    private function objectUri(string $objectKey): string
+    {
+        return 'temporary/'.$this->bucket().'/'.ltrim($objectKey, '/');
+    }
+
+    private function fileSize(Server $server, string $path): int
+    {
+        return (int) instant_remote_process(
+            ['du -b '.escapeshellarg($path).' | cut -f1'],
+            $server,
+            throwError: false,
+        );
+    }
+
+    private function checksum(Server $server, string $path): ?string
+    {
+        $output = instant_remote_process(
+            ['sha256sum '.escapeshellarg($path).' | awk \'{print $1}\''],
+            $server,
+            throwError: false,
+        );
+
+        $checksum = trim((string) $output);
+
+        return $checksum !== '' ? $checksum : null;
+    }
+
+    private function assertConfigured(): void
+    {
+        foreach (['endpoint', 'bucket', 'key', 'secret'] as $field) {
+            if (blank($this->config[$field] ?? null)) {
+                throw new RuntimeException("S3 storage is missing {$field}.");
+            }
+        }
+    }
+
+    private function endpoint(): string
+    {
+        return (string) $this->config['endpoint'];
+    }
+
+    private function bucket(): string
+    {
+        return (string) $this->config['bucket'];
+    }
+
+    private function key(): string
+    {
+        return (string) $this->config['key'];
+    }
+
+    private function secret(): string
+    {
+        return (string) $this->config['secret'];
+    }
+}

--- a/bootstrap/helpers/services.php
+++ b/bootstrap/helpers/services.php
@@ -149,7 +149,6 @@ function getFilesystemVolumesFromServer(ServiceApplication|ServiceDatabase|Appli
         $fileVolumes = $oneService->fileStorages()->get();
         $commands = collect([
             "mkdir -p $workdir > /dev/null 2>&1 || true",
-            "cd $workdir",
         ]);
         instant_remote_process($commands, $server);
         foreach ($fileVolumes as $fileVolume) {

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -546,6 +546,16 @@ function find_resource_destination_for_current_team(?string $uuid): StandaloneDo
     return $destination;
 }
 
+function find_destination_for_team(?string $uuid, int $teamId): StandaloneDocker|SwarmDocker|null
+{
+    if (blank($uuid)) {
+        return null;
+    }
+
+    return StandaloneDocker::ownedByCurrentTeamAPI($teamId)->where('uuid', $uuid)->first()
+        ?? SwarmDocker::ownedByCurrentTeamAPI($teamId)->where('uuid', $uuid)->first();
+}
+
 function showBoarding(): bool
 {
     if (isDev()) {

--- a/bootstrap/helpers/sudo.php
+++ b/bootstrap/helpers/sudo.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Str;
 
 function shouldChangeOwnership(string $path): bool
 {
-    $path = trim($path);
+    $path = trim($path, " \t\n\r\0\x0B'\"");
 
     $systemPaths = ['/var', '/etc', '/usr', '/opt', '/sys', '/proc', '/dev', '/bin', '/sbin', '/lib', '/lib64', '/boot', '/root', '/home', '/media', '/mnt', '/srv', '/run'];
 
@@ -20,6 +20,66 @@ function shouldChangeOwnership(string $path): bool
 
     return $isCoolifyPath;
 }
+
+/**
+ * First path argument of `mkdir -p`, ignoring redirects and trailing operators.
+ */
+function extractMkdirPath(string $line): ?string
+{
+    if (! preg_match('/mkdir -p\s+("[^"]+"|\'[^\']+\'|\S+)/', $line, $matches)) {
+        return null;
+    }
+
+    return trim($matches[1], " \t\n\r\0\x0B'\"");
+}
+
+/**
+ * Make a Coolify directory traversable/writable for a non-root SSH user.
+ * Uses `;` not `&&` so later sudo rewriting cannot inject `sudo cd`.
+ */
+function prepareCoolifyPathForNonRoot(string $path, Server $server): string
+{
+    $path = trim($path, " \t\n\r\0\x0B'\"");
+    $escapedPath = escapeshellarg($path);
+    $user = $server->user;
+
+    $toChmod = [];
+    $current = rtrim($path, '/') ?: $path;
+    while ($current !== '/' && $current !== '.' && $current !== '' && shouldChangeOwnership($current)) {
+        array_unshift($toChmod, $current);
+        $current = dirname($current);
+    }
+
+    $parts = [
+        'sudo mkdir -p '.$escapedPath,
+        'sudo chown '.$user.':'.$user.' '.$escapedPath,
+    ];
+    foreach ($toChmod as $dir) {
+        $parts[] = 'sudo chmod a+x '.escapeshellarg($dir);
+    }
+
+    return implode('; ', $parts);
+}
+
+/**
+ * `cd` is a shell builtin — `sudo cd` cannot work. For Coolify paths, chown/chmod first, then cd as the SSH user.
+ */
+function rewriteCdLineForNonRoot(string $line, Server $server): string
+{
+    $trimmed = trim($line);
+    if (! preg_match('/^cd\s+("[^"]+"|\'[^\']+\'|\S+)(.*)$/', $trimmed, $matches)) {
+        return $line;
+    }
+
+    $rawPath = $matches[1];
+    $path = trim($rawPath, " \t\n\r\0\x0B'\"");
+    if (! shouldChangeOwnership($path)) {
+        return $line;
+    }
+
+    return prepareCoolifyPathForNonRoot($path, $server).'; cd '.$rawPath.$matches[2];
+}
+
 function parseCommandsByLineForSudo(Collection $commands, Server $server): array
 {
     $commands = $commands->map(function ($line) {
@@ -76,10 +136,17 @@ function parseCommandsByLineForSudo(Collection $commands, Server $server): array
     });
 
     $commands = $commands->map(function ($line) use ($server) {
+        $trimmed = trim($line);
+        if (preg_match('/^cd(\s|;|$)/', $trimmed)) {
+            return rewriteCdLineForNonRoot($line, $server);
+        }
+
         if (Str::startsWith($line, 'sudo mkdir -p')) {
-            $path = trim(Str::after($line, 'sudo mkdir -p'));
-            if (shouldChangeOwnership($path)) {
-                return "$line && sudo chown -R $server->user:$server->user $path && sudo chmod -R o-rwx $path";
+            $path = extractMkdirPath($line);
+            if ($path && shouldChangeOwnership($path)) {
+                // Ensure parents like /data/coolify are traversable (often root 700 after install),
+                // then own the leaf directory for SCP / relative file writes.
+                return prepareCoolifyPathForNonRoot($path, $server).' && sudo chmod -R o-rwx '.escapeshellarg($path);
             }
 
             return $line;
@@ -130,13 +197,15 @@ function parseCommandsByLineForSudo(Collection $commands, Server $server): array
 }
 function parseLineForSudo(string $command, Server $server): string
 {
-    if (! str($command)->startSwith('cd') && ! str($command)->startSwith('command')) {
+    if (str($command)->startSwith('cd')) {
+        $command = rewriteCdLineForNonRoot($command, $server);
+    } elseif (! str($command)->startSwith('command')) {
         $command = "sudo $command";
     }
     if (Str::startsWith($command, 'sudo mkdir -p')) {
-        $path = trim(Str::after($command, 'sudo mkdir -p'));
-        if (shouldChangeOwnership($path)) {
-            $command = "$command && sudo chown -R $server->user:$server->user $path && sudo chmod -R o-rwx $path";
+        $path = extractMkdirPath($command);
+        if ($path && shouldChangeOwnership($path)) {
+            $command = prepareCoolifyPathForNonRoot($path, $server).' && sudo chmod -R o-rwx '.escapeshellarg($path);
         }
     }
     if (str($command)->contains('$(') || str($command)->contains('`')) {

--- a/database/factories/InstanceMigrationFactory.php
+++ b/database/factories/InstanceMigrationFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\InstanceMigrationStatus;
+use App\Models\InstanceMigration;
+use App\Models\PrivateKey;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<InstanceMigration>
+ */
+class InstanceMigrationFactory extends Factory
+{
+    protected $model = InstanceMigration::class;
+
+    public function definition(): array
+    {
+        return [
+            'team_id' => Team::factory(),
+            'status' => InstanceMigrationStatus::Pending,
+            'target_ip' => fake()->ipv4(),
+            'target_port' => 22,
+            'target_user' => 'root',
+            'target_private_key_id' => PrivateKey::factory(),
+            'old_host_ip' => fake()->ipv4(),
+            'package_paths' => null,
+            'phases' => [],
+            'items' => [],
+            'dry_run' => false,
+            'created_by_user_id' => User::factory(),
+        ];
+    }
+
+    public function dryRun(): static
+    {
+        return $this->state(fn (): array => [
+            'dry_run' => true,
+        ]);
+    }
+}

--- a/database/factories/ResourceMigrationFactory.php
+++ b/database/factories/ResourceMigrationFactory.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\MigrationStorageDriver;
+use App\Enums\ResourceMigrationDirection;
+use App\Enums\ResourceMigrationStatus;
+use App\Models\ResourceMigration;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ResourceMigration>
+ */
+class ResourceMigrationFactory extends Factory
+{
+    protected $model = ResourceMigration::class;
+
+    public function definition(): array
+    {
+        return [
+            'team_id' => Team::factory(),
+            'direction' => ResourceMigrationDirection::Export,
+            'status' => ResourceMigrationStatus::Pending,
+            'storage_driver' => MigrationStorageDriver::S3,
+            'storage_config' => [
+                'endpoint' => 'https://s3.example.com',
+                'bucket' => 'migrations',
+                'region' => 'us-east-1',
+                'key' => 'test-key',
+                'secret' => 'test-secret',
+            ],
+            'manifest' => null,
+            'skip_data' => false,
+            'created_by_user_id' => User::factory(),
+        ];
+    }
+
+    public function import(): static
+    {
+        return $this->state(fn (): array => [
+            'direction' => ResourceMigrationDirection::Import,
+        ]);
+    }
+
+    public function skipData(): static
+    {
+        return $this->state(fn (): array => [
+            'skip_data' => true,
+        ]);
+    }
+}

--- a/database/factories/ResourceMigrationItemFactory.php
+++ b/database/factories/ResourceMigrationItemFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\ResourceMigrationStatus;
+use App\Models\ResourceMigration;
+use App\Models\ResourceMigrationItem;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ResourceMigrationItem>
+ */
+class ResourceMigrationItemFactory extends Factory
+{
+    protected $model = ResourceMigrationItem::class;
+
+    public function definition(): array
+    {
+        return [
+            'resource_migration_id' => ResourceMigration::factory(),
+            'resource_type' => 'application',
+            'source_uuid' => fake()->uuid(),
+            'name' => fake()->words(2, true),
+            'status' => ResourceMigrationStatus::Pending,
+            'sort_order' => 0,
+            'archives' => [],
+        ];
+    }
+}

--- a/database/migrations/2026_08_12_105858_create_resource_migrations_table.php
+++ b/database/migrations/2026_08_12_105858_create_resource_migrations_table.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('resource_migrations', function (Blueprint $table) {
+            $table->id();
+            $table->string('uuid')->unique();
+            $table->foreignId('team_id')->constrained()->cascadeOnDelete();
+            $table->string('direction');
+            $table->string('status')->default('pending');
+            $table->string('storage_driver')->default('s3');
+            $table->text('storage_config')->nullable();
+            $table->longText('manifest')->nullable();
+            $table->boolean('skip_data')->default(false);
+            $table->string('destination_uuid')->nullable();
+            $table->string('project_uuid')->nullable();
+            $table->string('environment_uuid')->nullable();
+            $table->text('error')->nullable();
+            $table->foreignId('created_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+        });
+
+        Schema::create('resource_migration_items', function (Blueprint $table) {
+            $table->id();
+            $table->string('uuid')->unique();
+            $table->foreignId('resource_migration_id')->constrained('resource_migrations')->cascadeOnDelete();
+            $table->string('resource_type');
+            $table->string('source_uuid');
+            $table->string('target_uuid')->nullable();
+            $table->string('name');
+            $table->string('status')->default('pending');
+            $table->unsignedInteger('sort_order')->default(0);
+            $table->json('archives')->nullable();
+            $table->text('error')->nullable();
+            $table->timestamps();
+
+            $table->index(['resource_migration_id', 'sort_order']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('resource_migration_items');
+        Schema::dropIfExists('resource_migrations');
+    }
+};

--- a/database/migrations/2026_08_13_120000_create_instance_migrations_table.php
+++ b/database/migrations/2026_08_13_120000_create_instance_migrations_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('instance_migrations', function (Blueprint $table) {
+            $table->id();
+            $table->string('uuid')->unique();
+            $table->foreignId('team_id')->constrained()->cascadeOnDelete();
+            $table->string('status')->default('pending');
+            $table->string('target_ip');
+            $table->unsignedInteger('target_port')->default(22);
+            $table->string('target_user')->default('root');
+            $table->foreignId('target_private_key_id')->constrained('private_keys')->cascadeOnDelete();
+            $table->string('old_host_ip')->nullable();
+            $table->text('package_paths')->nullable();
+            $table->json('phases')->nullable();
+            $table->json('items')->nullable();
+            $table->text('error')->nullable();
+            $table->string('dashboard_url')->nullable();
+            $table->boolean('dry_run')->default(false);
+            $table->foreignId('created_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('instance_migrations');
+    }
+};

--- a/resources/views/components/settings/layout.blade.php
+++ b/resources/views/components/settings/layout.blade.php
@@ -4,6 +4,7 @@
             ['label' => 'General', 'route' => 'settings.index', 'icon' => 'settings'],
             ['label' => 'Advanced', 'route' => 'settings.advanced', 'icon' => 'grid'],
             ['label' => 'Updates', 'route' => 'settings.updates', 'icon' => 'refresh3'],
+            ['label' => 'Migrations', 'route' => 'settings.migrations', 'icon' => 'servers'],
         ],
         'Instance' => [
             ['label' => 'Backup', 'route' => 'settings.backup', 'icon' => 'database'],

--- a/resources/views/components/settings/sidebar.blade.php
+++ b/resources/views/components/settings/sidebar.blade.php
@@ -36,6 +36,12 @@
             'active' => $activeMenu === 'updates',
             'icon' => 'refresh3',
         ],
+        [
+            'label' => 'Migrations',
+            'route' => 'settings.migrations',
+            'active' => $activeMenu === 'migrations',
+            'icon' => 'servers',
+        ],
     ];
 @endphp
 

--- a/resources/views/livewire/settings/migrations.blade.php
+++ b/resources/views/livewire/settings/migrations.blade.php
@@ -1,0 +1,323 @@
+<div>
+    <x-slot:title>
+        Migrations | Coolify
+    </x-slot>
+
+    <x-settings.layout>
+        <div class="application-settings-form flex min-w-0 flex-col gap-6">
+            <x-application.settings-section title="Migrations">
+                <div class="flex min-w-0 flex-col gap-6">
+                    <p class="text-sm text-neutral-500">
+                        Move resources between servers, or migrate this entire Coolify instance to a new VM.
+                    </p>
+
+                    <div class="flex flex-wrap gap-2">
+                <x-forms.button wire:click="setMode('resources')"
+                    class="{{ $mode === 'resources' ? 'dark:bg-coolgray-200' : '' }}">
+                    Resource copy
+                </x-forms.button>
+                <x-forms.button wire:click="setMode('instance')"
+                    class="{{ $mode === 'instance' ? 'dark:bg-coolgray-200' : '' }}">
+                    Instance migration
+                </x-forms.button>
+            </div>
+
+            @if ($mode === 'resources')
+                <div class="flex flex-wrap items-center gap-2">
+                    <x-forms.button isHighlighted wire:click="startMigration"
+                        wire:loading.attr="disabled" wire:target="startMigration"
+                        :disabled="$targetBlockReason !== '' || $phase === 'running'">
+                        <span wire:loading.remove wire:target="startMigration">Start Migration</span>
+                        <span wire:loading wire:target="startMigration">Migrating…</span>
+                    </x-forms.button>
+                </div>
+
+                @if ($phase === 'running')
+                    <x-callout type="info" title="Migration in progress">
+                        Copying selected resources to the target server. Keep this page open until it finishes.
+                    </x-callout>
+                @endif
+
+                <x-callout type="info" title="How it works">
+                    Choose a source server and a target server. Coolify copies the selected resources onto the target.
+                    Source resources are left running. Enable volume copy to also transfer database and persistent
+                    storage data.
+                </x-callout>
+
+                <x-callout type="warning" title="Do not install Coolify on the target">
+                    Add the VM under Servers and validate it from this Coolify. That installs Docker and
+                    <code>coolify-proxy</code>, which binds ports 80/443 — that is expected. Migrated apps use that
+                    proxy
+                    for domains; they do not need host port 80 free. Do not run the Coolify installer on the target
+                    (no second dashboard / <code>coolify-db</code> / port 8000).
+                </x-callout>
+
+                @if ($servers === [])
+                    <x-callout type="warning" title="No servers">
+                        Add a server first under Servers, then come back to migrate resources between servers.
+                    </x-callout>
+                @endif
+
+                <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+                    <x-forms.select required id="sourceServerUuid" wire:model.live="sourceServerUuid"
+                        label="Source server" helper="The server you are copying resources from.">
+                        <option value="">Select source server</option>
+                        @foreach ($servers as $server)
+                            <option value="{{ $server['uuid'] }}">{{ $server['name'] }} ({{ $server['ip'] }})</option>
+                        @endforeach
+                    </x-forms.select>
+                    <x-forms.select required id="targetServerUuid" wire:model.live="targetServerUuid"
+                        label="Target server"
+                        helper="A server already added to this Coolify instance. Do not install Coolify on it.">
+                        <option value="">Select target server</option>
+                        @foreach ($servers as $server)
+                            <option value="{{ $server['uuid'] }}" @disabled($server['uuid'] === $sourceServerUuid)>
+                                {{ $server['name'] }} ({{ $server['ip'] }})
+                            </option>
+                        @endforeach
+                    </x-forms.select>
+                </div>
+
+                @if ($targetBlockReason === 'independent_coolify')
+                    <x-callout type="danger" title="Coolify is already installed on the target">
+                        This host is running its own Coolify dashboard. Pick a different server, or add a new VPS under
+                        Servers without running the Coolify installer on it.
+                    </x-callout>
+                @elseif ($targetBlockReason === 'not_ready')
+                    <x-callout type="warning" title="Target server is not ready">
+                        The target is not reachable or not validated. Open Servers, validate it, then try again.
+                    </x-callout>
+                @elseif ($targetBlockReason === 'cannot_host')
+                    <x-callout type="warning" title="Target cannot host resources">
+                        Build servers cannot be used as a migration target.
+                    </x-callout>
+                @elseif ($targetBlockReason === 'no_destination')
+                    <x-callout type="warning" title="No Docker destination">
+                        The target server has no Docker destination. Validate the server first.
+                    </x-callout>
+                @endif
+
+                <div class="md:w-96">
+                    <x-forms.checkbox id="cloneVolumeData" label="Copy persistent volume data"
+                        helper="Stops source resources briefly, copies Docker volumes to the target, then restarts the source." />
+                </div>
+
+                @if ($discoveredResources !== [])
+                    <div class="flex flex-col gap-2">
+                        <div class="flex items-center gap-2">
+                            <h4>Resources on source</h4>
+                            <x-forms.button wire:click="toggleSelectAll">
+                                {{ count($selectedResourceUuids) === count($discoveredResources) ? 'Clear all' : 'Select all' }}
+                            </x-forms.button>
+                        </div>
+                        <div class="overflow-x-auto border rounded-lg dark:border-coolgray-200">
+                            <table class="w-full text-sm">
+                                <thead class="text-left dark:bg-coolgray-100">
+                                    <tr>
+                                        <th class="p-2"></th>
+                                        <th class="p-2">Name</th>
+                                        <th class="p-2">Type</th>
+                                        <th class="p-2">Volumes</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach ($discoveredResources as $resource)
+                                        <tr wire:key="resource-{{ $resource['uuid'] }}"
+                                            class="border-t dark:border-coolgray-200">
+                                            <td class="p-2">
+                                                <input type="checkbox" class="rounded"
+                                                    wire:model="selectedResourceUuids"
+                                                    value="{{ $resource['uuid'] }}" />
+                                            </td>
+                                            <td class="p-2">{{ $resource['name'] ?? $resource['uuid'] }}</td>
+                                            <td class="p-2">{{ $resource['type'] ?? 'unknown' }}</td>
+                                            <td class="p-2">{{ $resource['volume_count'] ?? 0 }}</td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                @elseif ($sourceServerUuid !== '')
+                    <div class="text-sm text-neutral-500">No resources found on the source server.</div>
+                @endif
+
+                @if ($phase !== 'idle' && $items !== [])
+                    <div class="flex flex-col gap-2">
+                        <h4>Result</h4>
+                        <div class="text-sm">
+                            Migrated: {{ $migratedCount }}. Failed: {{ $failedCount }}. Skipped:
+                            {{ $skippedCount }}.
+                        </div>
+                        <div class="overflow-x-auto border rounded-lg dark:border-coolgray-200">
+                            <table class="w-full text-sm">
+                                <thead class="text-left dark:bg-coolgray-100">
+                                    <tr>
+                                        <th class="p-2">Resource</th>
+                                        <th class="p-2">Status</th>
+                                        <th class="p-2">Error</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach ($items as $item)
+                                        <tr wire:key="item-{{ $item['name'] }}-{{ $loop->index }}"
+                                            class="border-t dark:border-coolgray-200">
+                                            <td class="p-2">{{ $item['name'] }}</td>
+                                            <td class="p-2">{{ $item['status'] }}</td>
+                                            <td class="p-2">{{ $item['error'] ?? '' }}</td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                @endif
+            @else
+                <div @if ($instanceMigrationRunning) wire:poll.2s="refreshInstanceMigration" @endif
+                    class="flex flex-col gap-6">
+                    <div class="flex flex-wrap items-center gap-2">
+                        <x-forms.button isHighlighted wire:click="startInstanceMigration"
+                            wire:loading.attr="disabled" wire:target="startInstanceMigration"
+                            :disabled="$instanceMigrationRunning">
+                            <span wire:loading.remove wire:target="startInstanceMigration">
+                                {{ $instanceDryRun ? 'Run Dry Run' : 'Start Instance Migration' }}
+                            </span>
+                            <span wire:loading wire:target="startInstanceMigration">Queuing…</span>
+                        </x-forms.button>
+                        @if ($instanceMigrationRunning)
+                            <div class="text-sm text-neutral-500">Updating every 2 seconds…</div>
+                        @endif
+                    </div>
+
+                    <x-callout type="info" title="Full instance migration">
+                        This installs Coolify on the target VM, immediately restores this dashboard into
+                        <code>coolify-db</code> (database + APP_KEY + SSH keys), copies persistent volumes from every
+                        managed server onto that VM, and points all resources at localhost on the new host. Source
+                        servers are left running until you cut over DNS.
+                    </x-callout>
+
+                    <x-callout type="warning" title="Use a fresh VM">
+                        Prefer a new VPS. If a previous run already installed Coolify but left an empty dashboard, start
+                        the migration again — the installer is skipped and the source <code>coolify-db</code> is restored
+                        into it. Ports 80/443/8000 will be used by the new Coolify dashboard and proxy.
+                    </x-callout>
+
+                    <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+                        <x-forms.input required id="instanceTargetIp" label="Target IP / hostname"
+                            helper="SSH address of the new VM." :disabled="$instanceMigrationRunning" />
+                        <x-forms.input required id="instanceTargetUser" label="SSH user"
+                            :disabled="$instanceMigrationRunning" />
+                        <x-forms.input required id="instanceTargetPort" type="number" label="SSH port"
+                            :disabled="$instanceMigrationRunning" />
+                        <x-forms.select required id="instancePrivateKeyId" label="SSH private key"
+                            helper="Key that can log in to the target VM as the SSH user."
+                            :disabled="$instanceMigrationRunning">
+                            <option value="">Select private key</option>
+                            @foreach ($privateKeys as $key)
+                                <option value="{{ $key['id'] }}">{{ $key['name'] }}</option>
+                            @endforeach
+                        </x-forms.select>
+                    </div>
+
+                    <div class="md:w-96">
+                        <x-forms.checkbox id="instanceDryRun" label="Dry run only"
+                            helper="Validate SSH connectivity and that the target does not already have Coolify."
+                            :disabled="$instanceMigrationRunning" />
+                    </div>
+
+                    @if ($instanceStatus !== '')
+                        <div class="flex flex-col gap-4">
+                            <div class="flex flex-wrap items-end justify-between gap-2">
+                                <div>
+                                    <h4>Instance migration progress</h4>
+                                    <div class="text-sm text-neutral-500">
+                                        Status:
+                                        {{ \App\Enums\InstanceMigrationStatus::tryFrom($instanceStatus)?->label() ?? $instanceStatus }}
+                                    </div>
+                                </div>
+                                <div class="text-sm font-medium">{{ $instanceProgress }}%</div>
+                            </div>
+
+                            <div class="w-full h-2 overflow-hidden rounded bg-neutral-200 dark:bg-coolgray-200">
+                                <div class="h-full transition-all duration-500
+                                    {{ $instanceStatus === 'failed' ? 'bg-red-500' : ($instanceStatus === 'completed' ? 'bg-green-500' : 'bg-coollabs') }}"
+                                    style="width: {{ $instanceProgress }}%"></div>
+                            </div>
+
+                            @if ($instanceSteps !== [])
+                                <ol class="flex flex-col gap-2">
+                                    @foreach ($instanceSteps as $step)
+                                        <li wire:key="step-{{ $step['status'] }}"
+                                            class="flex items-start gap-3 rounded-lg border p-3 dark:border-coolgray-200
+                                            {{ $step['state'] === 'active' ? 'border-coollabs dark:border-coollabs' : '' }}
+                                            {{ $step['state'] === 'failed' ? 'border-red-500/50' : '' }}">
+                                            <div class="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-xs
+                                                {{ $step['state'] === 'done' ? 'bg-green-500 text-white' : '' }}
+                                                {{ $step['state'] === 'active' ? 'bg-coollabs text-white' : '' }}
+                                                {{ $step['state'] === 'failed' ? 'bg-red-500 text-white' : '' }}
+                                                {{ $step['state'] === 'pending' ? 'bg-neutral-200 text-neutral-500 dark:bg-coolgray-200' : '' }}">
+                                                @if ($step['state'] === 'done')
+                                                    ✓
+                                                @elseif ($step['state'] === 'failed')
+                                                    !
+                                                @elseif ($step['state'] === 'active')
+                                                    …
+                                                @else
+                                                    {{ $loop->iteration }}
+                                                @endif
+                                            </div>
+                                            <div class="min-w-0 flex-1">
+                                                <div class="font-medium">{{ $step['label'] }}</div>
+                                                @if (! empty($step['note']))
+                                                    <div class="text-sm text-neutral-500">{{ $step['note'] }}</div>
+                                                @elseif ($step['state'] === 'active')
+                                                    <div class="text-sm text-neutral-500">In progress…</div>
+                                                @endif
+                                            </div>
+                                        </li>
+                                    @endforeach
+                                </ol>
+                            @endif
+
+                            @if ($instanceDashboardUrl !== '')
+                                <div class="text-sm">Dashboard: <a class="underline"
+                                        href="{{ $instanceDashboardUrl }}" target="_blank"
+                                        rel="noopener">{{ $instanceDashboardUrl }}</a>
+                                </div>
+                            @endif
+                            @if ($instanceError !== '')
+                                <div class="text-sm text-red-500 break-words">{{ $instanceError }}</div>
+                            @endif
+
+                            @if ($items !== [])
+                                <div class="overflow-x-auto border rounded-lg dark:border-coolgray-200">
+                                    <table class="w-full text-sm">
+                                        <thead class="text-left dark:bg-coolgray-100">
+                                            <tr>
+                                                <th class="p-2">Resource</th>
+                                                <th class="p-2">Status</th>
+                                                <th class="p-2">Error</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            @foreach ($items as $item)
+                                                <tr wire:key="instance-item-{{ $item['name'] ?? $loop->index }}"
+                                                    class="border-t dark:border-coolgray-200">
+                                                    <td class="p-2">{{ $item['name'] ?? '' }}</td>
+                                                    <td class="p-2">{{ $item['status'] ?? '' }}</td>
+                                                    <td class="p-2">{{ $item['error'] ?? '' }}</td>
+                                                </tr>
+                                            @endforeach
+                                        </tbody>
+                                    </table>
+                                </div>
+                            @endif
+                        </div>
+                    @endif
+                </div>
+            @endif
+                </div>
+            </x-application.settings-section>
+        </div>
+    </x-settings.layout>
+</div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -11,6 +11,8 @@ use App\Http\Controllers\Api\GithubController;
 use App\Http\Controllers\Api\GitlabController;
 use App\Http\Controllers\Api\HetznerController;
 use App\Http\Controllers\Api\InstanceEmailSettingsController;
+use App\Http\Controllers\Api\Internal\FluxResourceStatusController;
+use App\Http\Controllers\Api\MigrationsController;
 use App\Http\Controllers\Api\NotificationsController;
 use App\Http\Controllers\Api\OtherController;
 use App\Http\Controllers\Api\ProjectController;
@@ -406,6 +408,13 @@ Route::group([
     Route::post('/services/{uuid}/databases/{database_uuid}/start', [ServiceDatabasesController::class, 'start'])->middleware(['api.ability:deploy']);
     Route::post('/services/{uuid}/databases/{database_uuid}/restart', [ServiceDatabasesController::class, 'restart'])->middleware(['api.ability:deploy']);
     Route::post('/services/{uuid}/databases/{database_uuid}/stop', [ServiceDatabasesController::class, 'stop'])->middleware(['api.ability:deploy']);
+
+    Route::get('/migrations/preflight', [MigrationsController::class, 'preflight'])->middleware(['api.ability:write']);
+    Route::get('/migrations/resources', [MigrationsController::class, 'resources'])->middleware(['api.ability:write']);
+    Route::post('/migrations/export', [MigrationsController::class, 'export'])->middleware(['api.ability:write']);
+    Route::get('/migrations/{uuid}', [MigrationsController::class, 'show'])->middleware(['api.ability:write']);
+    Route::post('/migrations/import', [MigrationsController::class, 'import'])->middleware(['api.ability:write']);
+    Route::post('/migrations/{uuid}/cleanup', [MigrationsController::class, 'cleanup'])->middleware(['api.ability:write']);
 
     Route::get('/applications/{uuid}/scheduled-tasks', [ScheduledTasksController::class, 'scheduled_tasks_by_application_uuid'])->middleware(['api.ability:read']);
     Route::post('/applications/{uuid}/scheduled-tasks', [ScheduledTasksController::class, 'create_scheduled_task_by_application_uuid'])->middleware(['api.ability:write']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -76,6 +76,7 @@ use App\Livewire\Server\Transfer as ServerTransfer;
 use App\Livewire\Server\TransferImport as ServerTransferImport;
 use App\Livewire\Settings\Advanced as SettingsAdvanced;
 use App\Livewire\Settings\Index as SettingsIndex;
+use App\Livewire\Settings\Migrations as SettingsMigrations;
 use App\Livewire\Settings\ScheduledJobs as SettingsScheduledJobs;
 use App\Livewire\Settings\Updates as SettingsUpdates;
 use App\Livewire\SettingsBackup;
@@ -161,6 +162,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/settings', SettingsIndex::class)->name('settings.index');
     Route::get('/settings/advanced', SettingsAdvanced::class)->name('settings.advanced');
     Route::get('/settings/updates', SettingsUpdates::class)->name('settings.updates');
+    Route::get('/settings/migrations', SettingsMigrations::class)->name('settings.migrations');
 
     Route::get('/settings/backup', SettingsBackup::class)->name('settings.backup');
     Route::get('/settings/email', SettingsEmail::class)->name('settings.email');

--- a/tests/Feature/InstanceMigrationTest.php
+++ b/tests/Feature/InstanceMigrationTest.php
@@ -1,0 +1,228 @@
+<?php
+
+use App\Actions\Migration\CollectResourceVolumes;
+use App\Actions\Migration\ConsolidateResourcesToLocalhost;
+use App\Actions\Migration\ReassignResourceToDestination;
+use App\Enums\InstanceMigrationStatus;
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\InstanceMigration;
+use App\Models\InstanceSettings;
+use App\Models\LocalPersistentVolume;
+use App\Models\PrivateKey;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\Service;
+use App\Models\ServiceApplication;
+use App\Models\StandaloneDocker;
+use App\Models\StandalonePostgresql;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Once;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Server::flushIdentityMap();
+});
+
+function createTeamContextForInstanceMigration(): Team
+{
+    $rootTeam = Team::find(0) ?? Team::factory()->create(['id' => 0]);
+    InstanceSettings::forceCreate(['id' => 0]);
+    Once::flush();
+
+    $user = User::factory()->create();
+    $rootTeam->members()->attach($user->id, ['role' => 'admin']);
+    test()->actingAs($user);
+    session(['currentTeam' => ['id' => $rootTeam->id]]);
+
+    return $rootTeam;
+}
+
+test('instance migration factory and phase helpers work', function () {
+    createTeamContextForInstanceMigration();
+    $key = PrivateKey::factory()->create(['team_id' => currentTeam()->id]);
+    $migration = InstanceMigration::factory()->create([
+        'team_id' => currentTeam()->id,
+        'target_private_key_id' => $key->id,
+        'created_by_user_id' => auth()->id(),
+    ]);
+
+    $migration->markPhase(InstanceMigrationStatus::Packaging, 'dump');
+    expect($migration->fresh()->status)->toBe(InstanceMigrationStatus::Packaging)
+        ->and($migration->fresh()->phases)->toHaveCount(1);
+
+    $migration->markCompleted('http://10.0.0.2:8000');
+    expect($migration->fresh()->status)->toBe(InstanceMigrationStatus::Completed)
+        ->and($migration->fresh()->dashboard_url)->toBe('http://10.0.0.2:8000')
+        ->and($migration->fresh()->phases)->toHaveCount(2)
+        ->and($migration->fresh()->progressPercent())->toBe(100);
+});
+
+test('instance migration step states show active packaging and pending later steps', function () {
+    createTeamContextForInstanceMigration();
+    $key = PrivateKey::factory()->create(['team_id' => currentTeam()->id]);
+    $migration = InstanceMigration::factory()->create([
+        'team_id' => currentTeam()->id,
+        'target_private_key_id' => $key->id,
+        'created_by_user_id' => auth()->id(),
+    ]);
+
+    $migration->markPhase(InstanceMigrationStatus::Packaging, 'Creating backup');
+    $steps = $migration->fresh()->stepStates();
+
+    expect($steps[0]['state'])->toBe('active')
+        ->and($steps[0]['label'])->toBe('Packaging backup')
+        ->and($steps[1]['state'])->toBe('pending')
+        ->and($migration->fresh()->progressPercent())->toBeGreaterThan(0)
+        ->and($migration->fresh()->progressPercent())->toBeLessThan(100);
+});
+
+test('instance migration failed step is marked on the last successful phase', function () {
+    createTeamContextForInstanceMigration();
+    $key = PrivateKey::factory()->create(['team_id' => currentTeam()->id]);
+    $migration = InstanceMigration::factory()->create([
+        'team_id' => currentTeam()->id,
+        'target_private_key_id' => $key->id,
+        'created_by_user_id' => auth()->id(),
+    ]);
+
+    $migration->markPhase(InstanceMigrationStatus::Packaging, 'ok');
+    $migration->markPhase(InstanceMigrationStatus::Installing, 'Installing Coolify');
+    $migration->markFailed('syntax error near unexpected token apt-get');
+
+    $steps = $migration->fresh()->stepStates();
+
+    expect($migration->fresh()->status)->toBe(InstanceMigrationStatus::Failed)
+        ->and($steps[0]['state'])->toBe('done')
+        ->and($steps[1]['state'])->toBe('failed')
+        ->and($steps[2]['state'])->toBe('pending');
+});
+
+test('reassign resource moves application destination without cloning uuid', function () {
+    Bus::fake();
+    createTeamContextForInstanceMigration();
+    $team = currentTeam();
+    $privateKey = PrivateKey::factory()->create(['team_id' => $team->id]);
+    $source = Server::factory()->create(['team_id' => $team->id, 'private_key_id' => $privateKey->id]);
+    $target = Server::factory()->create(['team_id' => $team->id, 'private_key_id' => $privateKey->id]);
+    $source->settings()->update(['is_reachable' => true, 'is_usable' => true]);
+    $target->settings()->update(['is_reachable' => true, 'is_usable' => true]);
+    $sourceDestination = StandaloneDocker::where('server_id', $source->id)->firstOrFail();
+    $targetDestination = StandaloneDocker::where('server_id', $target->id)->firstOrFail();
+    $project = Project::factory()->create(['team_id' => $team->id]);
+    $environment = $project->environments()->first()
+        ?? Environment::factory()->create(['project_id' => $project->id]);
+    $application = Application::factory()->create([
+        'environment_id' => $environment->id,
+        'destination_id' => $sourceDestination->id,
+        'destination_type' => $sourceDestination->getMorphClass(),
+    ]);
+    $uuid = $application->uuid;
+
+    ReassignResourceToDestination::run($application, $targetDestination, false);
+
+    $application->refresh();
+    expect($application->uuid)->toBe($uuid)
+        ->and($application->destination_id)->toBe($targetDestination->id)
+        ->and(Application::where('uuid', $uuid)->count())->toBe(1);
+});
+
+test('collect resource volumes includes service child volumes', function () {
+    createTeamContextForInstanceMigration();
+    $team = currentTeam();
+    $privateKey = PrivateKey::factory()->create(['team_id' => $team->id]);
+    $server = Server::factory()->create(['team_id' => $team->id, 'private_key_id' => $privateKey->id]);
+    $destination = StandaloneDocker::where('server_id', $server->id)->firstOrFail();
+    $project = Project::factory()->create(['team_id' => $team->id]);
+    $environment = $project->environments()->first()
+        ?? Environment::factory()->create(['project_id' => $project->id]);
+
+    $service = Service::factory()->create([
+        'environment_id' => $environment->id,
+        'destination_id' => $destination->id,
+        'destination_type' => $destination->getMorphClass(),
+        'server_id' => $server->id,
+        'docker_compose_raw' => 'services: { web: { image: nginx } }',
+    ]);
+
+    $serviceApp = ServiceApplication::create([
+        'service_id' => $service->id,
+        'name' => 'web',
+        'human_name' => 'web',
+        'exclude_from_status' => false,
+    ]);
+
+    LocalPersistentVolume::create([
+        'name' => 'svc-vol-1',
+        'mount_path' => '/data',
+        'resource_id' => $serviceApp->id,
+        'resource_type' => $serviceApp->getMorphClass(),
+    ]);
+
+    $volumes = CollectResourceVolumes::run($service->fresh());
+    expect($volumes)->toHaveCount(1)
+        ->and($volumes[0]->name)->toBe('svc-vol-1');
+});
+
+test('consolidate orders databases before services and applications', function () {
+    Bus::fake();
+    createTeamContextForInstanceMigration();
+    $team = currentTeam();
+    $privateKey = PrivateKey::factory()->create(['team_id' => $team->id]);
+
+    $localhost = Server::find(0);
+    if (! $localhost) {
+        $localhost = new Server;
+        $localhost->forceFill([
+            'id' => 0,
+            'name' => 'localhost',
+            'ip' => 'host.docker.internal',
+            'user' => 'root',
+            'port' => 22,
+            'team_id' => $team->id,
+            'private_key_id' => $privateKey->id,
+        ]);
+        $localhost->save();
+    } else {
+        $localhost->update(['private_key_id' => $privateKey->id, 'team_id' => $team->id]);
+    }
+    $localhost->settings()->update(['is_reachable' => true, 'is_usable' => true, 'is_build_server' => false]);
+
+    $remote = Server::factory()->create(['team_id' => $team->id, 'private_key_id' => $privateKey->id, 'name' => 'Remote']);
+    $remote->settings()->update(['is_reachable' => true, 'is_usable' => true]);
+    $remoteDestination = StandaloneDocker::where('server_id', $remote->id)->firstOrFail();
+    $localDestination = StandaloneDocker::where('server_id', 0)->firstOrFail();
+
+    $project = Project::factory()->create(['team_id' => $team->id]);
+    $environment = $project->environments()->first()
+        ?? Environment::factory()->create(['project_id' => $project->id]);
+
+    $db = StandalonePostgresql::create([
+        'name' => 'remote-db',
+        'postgres_user' => 'postgres',
+        'postgres_password' => 'password',
+        'postgres_db' => 'app',
+        'environment_id' => $environment->id,
+        'destination_id' => $remoteDestination->id,
+        'destination_type' => $remoteDestination->getMorphClass(),
+    ]);
+    $app = Application::factory()->create([
+        'name' => 'remote-app',
+        'environment_id' => $environment->id,
+        'destination_id' => $remoteDestination->id,
+        'destination_type' => $remoteDestination->getMorphClass(),
+    ]);
+
+    $results = ConsolidateResourcesToLocalhost::run($team->id, false);
+    $migrated = collect($results)->where('status', 'migrated')->pluck('name')->all();
+
+    expect($migrated)->toContain('remote-db')
+        ->and($migrated)->toContain('remote-app');
+
+    expect($db->fresh()->destination_id)->toBe($localDestination->id)
+        ->and($app->fresh()->destination_id)->toBe($localDestination->id);
+});

--- a/tests/Feature/MigrationCliTest.php
+++ b/tests/Feature/MigrationCliTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use App\Actions\Migration\RunMigration;
+use Illuminate\Support\Facades\Http;
+
+test('dry run discovers resources from the source api without exporting', function () {
+    Http::fake([
+        'source.test/api/v1/migrations/preflight' => Http::response([
+            'version' => '4.2.0',
+            'token_can_write' => true,
+            'token_can_read_sensitive' => true,
+        ]),
+        'target.test/api/v1/migrations/preflight' => Http::response([
+            'version' => '4.2.0',
+            'token_can_write' => true,
+            'token_can_read_sensitive' => true,
+        ]),
+        'source.test/api/v1/migrations/resources' => Http::response([
+            [
+                'uuid' => 'app-1',
+                'type' => 'application',
+                'name' => 'Demo',
+                'warnings' => [],
+            ],
+        ]),
+    ]);
+
+    $this->artisan('coolify:migrate', [
+        '--source-url' => 'https://source.test',
+        '--source-token' => 'source-token',
+        '--target-url' => 'https://target.test',
+        '--target-token' => 'target-token',
+        '--resources' => 'app-1',
+        '--dry-run' => true,
+        '--no-interaction' => true,
+    ])->assertSuccessful();
+
+    Http::assertSent(fn ($request) => str_contains($request->url(), '/migrations/preflight'));
+    Http::assertSent(fn ($request) => str_contains($request->url(), '/migrations/resources'));
+    Http::assertNotSent(fn ($request) => str_contains($request->url(), '/migrations/export'));
+});
+
+test('fails when the source token cannot read sensitive data', function () {
+    Http::fake([
+        'source.test/api/v1/migrations/preflight' => Http::response([
+            'version' => '4.2.0',
+            'token_can_write' => true,
+            'token_can_read_sensitive' => false,
+        ]),
+        'target.test/api/v1/migrations/preflight' => Http::response([
+            'version' => '4.2.0',
+            'token_can_write' => true,
+            'token_can_read_sensitive' => true,
+        ]),
+    ]);
+
+    $this->artisan('coolify:migrate', [
+        '--source-url' => 'https://source.test',
+        '--source-token' => 'source-token',
+        '--target-url' => 'https://target.test',
+        '--target-token' => 'target-token',
+        '--dry-run' => true,
+        '--no-interaction' => true,
+    ])->assertFailed();
+});
+
+test('run migration handle can be invoked directly for dry runs', function () {
+    Http::fake([
+        'source.test/api/v1/migrations/preflight' => Http::response([
+            'version' => '4.2.0',
+            'token_can_write' => true,
+            'token_can_read_sensitive' => true,
+        ]),
+        'target.test/api/v1/migrations/preflight' => Http::response([
+            'version' => '4.2.0',
+            'token_can_write' => true,
+            'token_can_read_sensitive' => true,
+        ]),
+        'source.test/api/v1/migrations/resources' => Http::response([]),
+    ]);
+
+    $exit = RunMigration::run(
+        'https://source.test',
+        'source-token',
+        'https://target.test',
+        'target-token',
+        [
+            'dry_run' => true,
+            'no_interaction' => true,
+            'resources' => 'missing',
+        ],
+    );
+
+    expect($exit)->toBe(1);
+});

--- a/tests/Feature/MigrationExportApiTest.php
+++ b/tests/Feature/MigrationExportApiTest.php
@@ -1,0 +1,175 @@
+<?php
+
+use App\Enums\ResourceMigrationStatus;
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\EnvironmentVariable;
+use App\Models\InstanceSettings;
+use App\Models\Project;
+use App\Models\ResourceMigration;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\StandalonePostgresql;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::forceCreate(['id' => 0, 'is_api_enabled' => true]);
+    config(['app.maintenance.driver' => 'file', 'app.maintenance.store' => 'array']);
+    $this->withoutMiddleware(PreventRequestsDuringMaintenance::class);
+
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+    session(['currentTeam' => $this->team]);
+
+    $this->token = $this->user->createToken('test-token', ['*']);
+    $this->bearerToken = $this->token->plainTextToken;
+
+    $this->server = Server::factory()->create(['team_id' => $this->team->id]);
+    $this->server->settings()->update([
+        'is_reachable' => true,
+        'is_usable' => true,
+        'is_build_server' => false,
+    ]);
+    $this->destination = StandaloneDocker::where('server_id', $this->server->id)->firstOrFail();
+    $this->project = Project::factory()->create(['team_id' => $this->team->id]);
+    $this->environment = $this->project->environments()->first()
+        ?? Environment::factory()->create(['project_id' => $this->project->id]);
+});
+
+function migrationHeaders(?string $token = null): array
+{
+    return [
+        'Authorization' => 'Bearer '.($token ?? test()->bearerToken),
+        'Content-Type' => 'application/json',
+    ];
+}
+
+test('preflight returns version and token abilities', function () {
+    $response = $this->withHeaders(migrationHeaders())
+        ->getJson('/api/v1/migrations/preflight?server_uuid='.$this->server->uuid);
+
+    $response->assertSuccessful()
+        ->assertJsonPath('token_can_write', true)
+        ->assertJsonPath('token_can_read_sensitive', true)
+        ->assertJsonPath('docker_running', true);
+});
+
+test('lists migratable resources for the token team', function () {
+    $application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => $this->destination->getMorphClass(),
+        'name' => 'migratable-app',
+    ]);
+
+    $response = $this->withHeaders(migrationHeaders())
+        ->getJson('/api/v1/migrations/resources');
+
+    $response->assertSuccessful();
+    $uuids = collect($response->json())->pluck('uuid');
+    expect($uuids)->toContain($application->uuid);
+});
+
+test('exports resource metadata and returns a manifest', function () {
+    $database = StandalonePostgresql::create([
+        'name' => 'export-db',
+        'postgres_user' => 'postgres',
+        'postgres_password' => 'secret',
+        'postgres_db' => 'app',
+        'environment_id' => $this->environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => $this->destination->getMorphClass(),
+    ]);
+
+    $application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => $this->destination->getMorphClass(),
+        'name' => 'export-app',
+    ]);
+
+    EnvironmentVariable::create([
+        'key' => 'DATABASE_URL',
+        'value' => "postgres://postgres:secret@{$database->uuid}:5432/app",
+        'resourceable_id' => $application->id,
+        'resourceable_type' => $application->getMorphClass(),
+        'is_preview' => false,
+    ]);
+
+    $response = $this->withHeaders(migrationHeaders())->postJson('/api/v1/migrations/export', [
+        'resource_uuids' => [$database->uuid, $application->uuid],
+        'skip_data' => true,
+        'storage' => [
+            'driver' => 's3',
+            'config' => [
+                'endpoint' => 'https://s3.example.com',
+                'bucket' => 'migrations',
+                'key' => 'key',
+                'secret' => 'secret',
+            ],
+        ],
+    ]);
+
+    $response->assertCreated()
+        ->assertJsonPath('status', ResourceMigrationStatus::Completed->value);
+
+    $show = $this->withHeaders(migrationHeaders())
+        ->getJson('/api/v1/migrations/'.$response->json('uuid'));
+
+    $show->assertSuccessful();
+    $types = collect($show->json('manifest.resources'))->pluck('type');
+    $envValues = collect($show->json('manifest.resources'))
+        ->pluck('environment_variables')
+        ->flatten(1)
+        ->pluck('value');
+
+    expect($types)->toContain('standalone-postgresql')
+        ->and($types)->toContain('application')
+        ->and($envValues->implode(' '))->toContain($database->uuid);
+});
+
+test('rejects export without the read sensitive ability', function () {
+    $token = $this->user->createToken('write-only', ['write'])->plainTextToken;
+    $application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => $this->destination->getMorphClass(),
+    ]);
+
+    $response = $this->withHeaders(migrationHeaders($token))->postJson('/api/v1/migrations/export', [
+        'resource_uuids' => [$application->uuid],
+        'skip_data' => true,
+        'storage' => ['driver' => 's3', 'config' => ['endpoint' => 'https://s3.example.com', 'bucket' => 'b', 'key' => 'k', 'secret' => 's']],
+    ]);
+
+    $response->assertForbidden();
+});
+
+test('rejects export of another teams resources', function () {
+    $otherTeam = Team::factory()->create();
+    $otherProject = Project::factory()->create(['team_id' => $otherTeam->id]);
+    $otherEnvironment = $otherProject->environments()->first()
+        ?? Environment::factory()->create(['project_id' => $otherProject->id]);
+    $otherServer = Server::factory()->create(['team_id' => $otherTeam->id]);
+    $otherDestination = StandaloneDocker::where('server_id', $otherServer->id)->firstOrFail();
+    $foreign = Application::factory()->create([
+        'environment_id' => $otherEnvironment->id,
+        'destination_id' => $otherDestination->id,
+        'destination_type' => $otherDestination->getMorphClass(),
+    ]);
+
+    $response = $this->withHeaders(migrationHeaders())->postJson('/api/v1/migrations/export', [
+        'resource_uuids' => [$foreign->uuid],
+        'skip_data' => true,
+        'storage' => ['driver' => 's3', 'config' => ['endpoint' => 'https://s3.example.com', 'bucket' => 'b', 'key' => 'k', 'secret' => 's']],
+    ]);
+
+    $response->assertNotFound();
+    expect(ResourceMigration::count())->toBe(0);
+});

--- a/tests/Feature/MigrationImportApiTest.php
+++ b/tests/Feature/MigrationImportApiTest.php
@@ -1,0 +1,122 @@
+<?php
+
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\EnvironmentVariable;
+use App\Models\InstanceSettings;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\StandalonePostgresql;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::forceCreate(['id' => 0, 'is_api_enabled' => true]);
+    config(['app.maintenance.driver' => 'file', 'app.maintenance.store' => 'array']);
+    $this->withoutMiddleware(PreventRequestsDuringMaintenance::class);
+
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+    session(['currentTeam' => $this->team]);
+
+    $this->token = $this->user->createToken('test-token', ['*']);
+    $this->bearerToken = $this->token->plainTextToken;
+
+    $this->server = Server::factory()->create(['team_id' => $this->team->id]);
+    $this->server->settings()->update([
+        'is_reachable' => true,
+        'is_usable' => true,
+        'is_build_server' => false,
+    ]);
+    $this->destination = StandaloneDocker::where('server_id', $this->server->id)->firstOrFail();
+    $this->project = Project::factory()->create(['team_id' => $this->team->id]);
+    $this->environment = $this->project->environments()->first()
+        ?? Environment::factory()->create(['project_id' => $this->project->id]);
+});
+
+test('imports a skip-data manifest and remaps linked database uuids', function () {
+    $sourceDatabase = StandalonePostgresql::create([
+        'name' => 'source-db',
+        'postgres_user' => 'postgres',
+        'postgres_password' => 'secret',
+        'postgres_db' => 'app',
+        'environment_id' => $this->environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => $this->destination->getMorphClass(),
+    ]);
+
+    $sourceApplication = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => $this->destination->getMorphClass(),
+        'name' => 'source-app',
+    ]);
+
+    EnvironmentVariable::create([
+        'key' => 'DATABASE_URL',
+        'value' => "postgres://postgres:secret@{$sourceDatabase->uuid}:5432/app",
+        'resourceable_id' => $sourceApplication->id,
+        'resourceable_type' => $sourceApplication->getMorphClass(),
+        'is_preview' => false,
+    ]);
+
+    $export = $this->withHeaders([
+        'Authorization' => 'Bearer '.$this->bearerToken,
+        'Content-Type' => 'application/json',
+    ])->postJson('/api/v1/migrations/export', [
+        'resource_uuids' => [$sourceDatabase->uuid, $sourceApplication->uuid],
+        'skip_data' => true,
+        'storage' => [
+            'driver' => 'local-ssh',
+            'config' => [],
+        ],
+    ]);
+
+    $export->assertCreated();
+    $manifest = $export->json('manifest');
+    expect($manifest)->toBeArray();
+
+    $targetProject = Project::factory()->create(['team_id' => $this->team->id, 'name' => 'Imported']);
+    $targetEnvironment = $targetProject->environments()->first();
+
+    $import = $this->withHeaders([
+        'Authorization' => 'Bearer '.$this->bearerToken,
+        'Content-Type' => 'application/json',
+    ])->postJson('/api/v1/migrations/import', [
+        'manifest' => $manifest,
+        'destination_uuid' => $this->destination->uuid,
+        'project_uuid' => $targetProject->uuid,
+        'environment_uuid' => $targetEnvironment->uuid,
+        'skip_data' => true,
+        'storage' => ['driver' => 'local-ssh', 'config' => []],
+    ]);
+
+    $import->assertCreated()
+        ->assertJsonPath('status', 'completed');
+
+    $items = collect($import->json('items'));
+    expect($items->pluck('status')->unique()->values()->all())->toBe(['healthy'])
+        ->and($items->pluck('name')->all())->toContain('source-db')
+        ->and($items->pluck('name')->all())->toContain('source-app');
+
+    $importedDatabase = StandalonePostgresql::where('environment_id', $targetEnvironment->id)
+        ->where('name', 'source-db')
+        ->first();
+    $importedApplication = Application::where('environment_id', $targetEnvironment->id)
+        ->where('name', 'source-app')
+        ->first();
+
+    expect($importedDatabase)->not->toBeNull()
+        ->and($importedApplication)->not->toBeNull()
+        ->and($importedDatabase->uuid)->not->toBe($sourceDatabase->uuid);
+
+    $url = $importedApplication->environment_variables()->where('key', 'DATABASE_URL')->first()?->value;
+    expect($url)->toContain($importedDatabase->uuid)
+        ->and($url)->not->toContain($sourceDatabase->uuid);
+});

--- a/tests/Feature/SettingsMigrationsTest.php
+++ b/tests/Feature/SettingsMigrationsTest.php
@@ -1,0 +1,301 @@
+<?php
+
+use App\Actions\Migration\DetectIndependentCoolifyInstall;
+use App\Actions\Migration\RunInstanceMigration;
+use App\Enums\InstanceMigrationStatus;
+use App\Livewire\Settings\Migrations;
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\InstanceMigration;
+use App\Models\InstanceSettings;
+use App\Models\PrivateKey;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Once;
+use Livewire\Livewire;
+use Lorisleiva\Actions\Decorators\JobDecorator;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Server::flushIdentityMap();
+});
+
+function createInstanceAdminForMigrations(): User
+{
+    $rootTeam = Team::find(0) ?? Team::factory()->create(['id' => 0]);
+    InstanceSettings::forceCreate(['id' => 0]);
+    Once::flush();
+
+    $user = User::factory()->create();
+    $rootTeam->members()->attach($user->id, ['role' => 'admin']);
+
+    test()->actingAs($user);
+    session(['currentTeam' => ['id' => $rootTeam->id]]);
+
+    return $user;
+}
+
+test('non-admin user is redirected from settings migrations page', function () {
+    $team = Team::factory()->create();
+    $user = User::factory()->create();
+    $team->members()->attach($user->id, ['role' => 'member']);
+
+    $this->actingAs($user);
+    session(['currentTeam' => ['id' => $team->id]]);
+
+    Livewire::test(Migrations::class)
+        ->assertRedirect(route('dashboard'));
+});
+
+test('instance settings layout includes migrations navigation', function () {
+    $layout = file_get_contents(resource_path('views/components/settings/layout.blade.php'));
+
+    expect($layout)
+        ->toContain("'label' => 'Migrations', 'route' => 'settings.migrations'");
+});
+
+test('migrations page stacks resource copy sections with vertical gap', function () {
+    $view = file_get_contents(resource_path('views/livewire/settings/migrations.blade.php'));
+
+    expect($view)
+        ->toContain('<div class="flex min-w-0 flex-col gap-6">')
+        ->not->toContain('pb-2 text-sm text-neutral-500');
+});
+
+test('instance admin can access settings migrations page', function () {
+    createInstanceAdminForMigrations();
+
+    Livewire::test(Migrations::class)
+        ->assertOk()
+        ->assertNoRedirect()
+        ->assertSee('Migrations')
+        ->assertSee('Resource copy')
+        ->assertSee('Instance migration')
+        ->assertSee('Source server')
+        ->assertSee('Target server')
+        ->assertSee('Do not install Coolify on the target')
+        ->assertSee('coolify-proxy')
+        ->assertDontSee('Source URL');
+});
+
+test('instance migration tab shows full migrate copy', function () {
+    createInstanceAdminForMigrations();
+
+    Livewire::test(Migrations::class)
+        ->call('setMode', 'instance')
+        ->assertSet('mode', 'instance')
+        ->assertSee('Full instance migration')
+        ->assertSee('Use a fresh VM')
+        ->assertSee('Target IP / hostname')
+        ->assertDontSee('Do not install Coolify on the target');
+});
+
+test('instance migration requires target fields', function () {
+    createInstanceAdminForMigrations();
+
+    Livewire::test(Migrations::class)
+        ->call('setMode', 'instance')
+        ->call('startInstanceMigration')
+        ->assertHasErrors(['instanceTargetIp', 'instancePrivateKeyId']);
+});
+
+test('starting instance migration queues the job and shows progress steps', function () {
+    Bus::fake();
+    createInstanceAdminForMigrations();
+    $team = currentTeam();
+    $key = PrivateKey::factory()->create(['team_id' => $team->id, 'name' => 'Target Key']);
+
+    $component = Livewire::test(Migrations::class)
+        ->call('setMode', 'instance')
+        ->set('instanceTargetIp', '10.0.0.50')
+        ->set('instanceTargetUser', 'root')
+        ->set('instanceTargetPort', 22)
+        ->set('instancePrivateKeyId', (string) $key->id)
+        ->call('startInstanceMigration')
+        ->assertHasNoErrors()
+        ->assertSet('instanceStatus', 'pending')
+        ->assertSet('instanceMigrationRunning', true)
+        ->assertSee('Instance migration progress')
+        ->assertSee('Packaging backup')
+        ->assertSee('Installing Coolify')
+        ->assertSee('Restoring Coolify database')
+        ->assertSee('Copying volumes');
+
+    expect($component->get('instanceSteps'))->not->toBeEmpty();
+
+    Bus::assertDispatched(function (JobDecorator $job): bool {
+        return $job->decorates(RunInstanceMigration::class);
+    });
+});
+
+test('refresh instance migration updates progress from database', function () {
+    createInstanceAdminForMigrations();
+    $team = currentTeam();
+    $key = PrivateKey::factory()->create(['team_id' => $team->id]);
+    $migration = InstanceMigration::factory()->create([
+        'team_id' => $team->id,
+        'target_private_key_id' => $key->id,
+        'created_by_user_id' => auth()->id(),
+        'status' => InstanceMigrationStatus::Pending,
+    ]);
+    $migration->markPhase(InstanceMigrationStatus::Installing, 'Installing Coolify on target');
+
+    Livewire::test(Migrations::class)
+        ->call('setMode', 'instance')
+        ->set('instanceMigrationId', $migration->id)
+        ->call('refreshInstanceMigration')
+        ->assertSet('instanceStatus', 'installing')
+        ->assertSee('Installing Coolify')
+        ->assertSee('Installing Coolify on target');
+});
+
+test('selecting a source server lists its resources', function () {
+    createInstanceAdminForMigrations();
+    $team = currentTeam();
+    $privateKey = PrivateKey::factory()->create(['team_id' => $team->id]);
+    $source = Server::factory()->create(['team_id' => $team->id, 'private_key_id' => $privateKey->id, 'name' => 'Source']);
+    $source->settings()->update(['is_reachable' => true, 'is_usable' => true, 'is_build_server' => false]);
+    $destination = StandaloneDocker::where('server_id', $source->id)->firstOrFail();
+    $project = Project::factory()->create(['team_id' => $team->id]);
+    $environment = $project->environments()->first()
+        ?? Environment::factory()->create(['project_id' => $project->id]);
+    $application = Application::factory()->create([
+        'name' => 'migratable-app',
+        'environment_id' => $environment->id,
+        'destination_id' => $destination->id,
+        'destination_type' => $destination->getMorphClass(),
+    ]);
+
+    Livewire::test(Migrations::class)
+        ->set('sourceServerUuid', $source->uuid)
+        ->assertSet('phase', 'discovered')
+        ->assertSee('migratable-app')
+        ->assertSet('selectedResourceUuids', [$application->uuid]);
+});
+
+test('start migration clones selected resources to the target server', function () {
+    Bus::fake();
+    createInstanceAdminForMigrations();
+    $team = currentTeam();
+    $privateKey = PrivateKey::factory()->create(['team_id' => $team->id]);
+    $source = Server::factory()->create(['team_id' => $team->id, 'private_key_id' => $privateKey->id, 'name' => 'Source']);
+    $target = Server::factory()->create(['team_id' => $team->id, 'private_key_id' => $privateKey->id, 'name' => 'Target']);
+    $source->settings()->update(['is_reachable' => true, 'is_usable' => true, 'is_build_server' => false]);
+    $target->settings()->update(['is_reachable' => true, 'is_usable' => true, 'is_build_server' => false]);
+    $sourceDestination = StandaloneDocker::where('server_id', $source->id)->firstOrFail();
+    $project = Project::factory()->create(['team_id' => $team->id]);
+    $environment = $project->environments()->first()
+        ?? Environment::factory()->create(['project_id' => $project->id]);
+    $application = Application::factory()->create([
+        'name' => 'source-app',
+        'environment_id' => $environment->id,
+        'destination_id' => $sourceDestination->id,
+        'destination_type' => $sourceDestination->getMorphClass(),
+    ]);
+
+    Livewire::test(Migrations::class)
+        ->set('sourceServerUuid', $source->uuid)
+        ->assertSet('phase', 'discovered')
+        ->set('targetServerUuid', $target->uuid)
+        ->set('cloneVolumeData', false)
+        ->call('startMigration')
+        ->assertHasNoErrors()
+        ->assertSet('phase', 'completed')
+        ->assertSet('migratedCount', 1);
+
+    $cloned = Application::where('environment_id', $environment->id)
+        ->where('id', '!=', $application->id)
+        ->first();
+
+    expect($cloned)->not->toBeNull()
+        ->and($cloned->destination_id)->not->toBe($sourceDestination->id);
+});
+
+test('requires a different target server', function () {
+    createInstanceAdminForMigrations();
+    $team = currentTeam();
+    $privateKey = PrivateKey::factory()->create(['team_id' => $team->id]);
+    $source = Server::factory()->create(['team_id' => $team->id, 'private_key_id' => $privateKey->id]);
+    $source->settings()->update(['is_build_server' => false]);
+    $destination = StandaloneDocker::where('server_id', $source->id)->firstOrFail();
+    $project = Project::factory()->create(['team_id' => $team->id]);
+    $environment = $project->environments()->first()
+        ?? Environment::factory()->create(['project_id' => $project->id]);
+    Application::factory()->create([
+        'environment_id' => $environment->id,
+        'destination_id' => $destination->id,
+        'destination_type' => $destination->getMorphClass(),
+    ]);
+
+    Livewire::test(Migrations::class)
+        ->set('sourceServerUuid', $source->uuid)
+        ->set('targetServerUuid', $source->uuid)
+        ->call('startMigration')
+        ->assertHasErrors(['targetServerUuid']);
+});
+
+test('blocks migration when the target is not validated', function () {
+    createInstanceAdminForMigrations();
+    $team = currentTeam();
+    $privateKey = PrivateKey::factory()->create(['team_id' => $team->id]);
+    $source = Server::factory()->create(['team_id' => $team->id, 'private_key_id' => $privateKey->id, 'name' => 'Source']);
+    $target = Server::factory()->create(['team_id' => $team->id, 'private_key_id' => $privateKey->id, 'name' => 'Target']);
+    $source->settings()->update(['is_reachable' => true, 'is_usable' => true, 'is_build_server' => false]);
+    $target->settings()->update(['is_reachable' => false, 'is_usable' => false, 'is_build_server' => false]);
+    $sourceDestination = StandaloneDocker::where('server_id', $source->id)->firstOrFail();
+    $project = Project::factory()->create(['team_id' => $team->id]);
+    $environment = $project->environments()->first()
+        ?? Environment::factory()->create(['project_id' => $project->id]);
+    Application::factory()->create([
+        'environment_id' => $environment->id,
+        'destination_id' => $sourceDestination->id,
+        'destination_type' => $sourceDestination->getMorphClass(),
+    ]);
+
+    Livewire::test(Migrations::class)
+        ->set('sourceServerUuid', $source->uuid)
+        ->set('targetServerUuid', $target->uuid)
+        ->assertSet('targetBlockReason', 'not_ready')
+        ->assertSee('Target server is not ready')
+        ->call('startMigration')
+        ->assertSet('phase', 'failed')
+        ->assertSet('migratedCount', 0);
+});
+
+test('blocks migration when the target already has coolify installed', function () {
+    $this->mock(DetectIndependentCoolifyInstall::class, function ($mock) {
+        $mock->shouldReceive('handle')->andReturn(true);
+    });
+
+    createInstanceAdminForMigrations();
+    $team = currentTeam();
+    $privateKey = PrivateKey::factory()->create(['team_id' => $team->id]);
+    $source = Server::factory()->create(['team_id' => $team->id, 'private_key_id' => $privateKey->id, 'name' => 'Source']);
+    $target = Server::factory()->create(['team_id' => $team->id, 'private_key_id' => $privateKey->id, 'name' => 'Target']);
+    $source->settings()->update(['is_reachable' => true, 'is_usable' => true, 'is_build_server' => false]);
+    $target->settings()->update(['is_reachable' => true, 'is_usable' => true, 'is_build_server' => false]);
+    $sourceDestination = StandaloneDocker::where('server_id', $source->id)->firstOrFail();
+    $project = Project::factory()->create(['team_id' => $team->id]);
+    $environment = $project->environments()->first()
+        ?? Environment::factory()->create(['project_id' => $project->id]);
+    Application::factory()->create([
+        'environment_id' => $environment->id,
+        'destination_id' => $sourceDestination->id,
+        'destination_type' => $sourceDestination->getMorphClass(),
+    ]);
+
+    Livewire::test(Migrations::class)
+        ->set('sourceServerUuid', $source->uuid)
+        ->set('targetServerUuid', $target->uuid)
+        ->assertSet('targetBlockReason', 'independent_coolify')
+        ->assertSee('Coolify is already installed on the target')
+        ->call('startMigration')
+        ->assertSet('phase', 'failed')
+        ->assertSet('migratedCount', 0);
+});

--- a/tests/Feature/SettingsTitleSidebarAlignmentTest.php
+++ b/tests/Feature/SettingsTitleSidebarAlignmentTest.php
@@ -21,6 +21,7 @@ test('instance settings pages use one shared sidebar workspace', function () {
         resource_path('views/livewire/settings-backup.blade.php'),
         resource_path('views/livewire/settings-email.blade.php'),
         resource_path('views/livewire/settings/scheduled-jobs.blade.php'),
+        resource_path('views/livewire/settings/migrations.blade.php'),
     ];
 
     foreach ($pages as $path) {

--- a/tests/Feature/VolumeRestoreJobTest.php
+++ b/tests/Feature/VolumeRestoreJobTest.php
@@ -1,0 +1,96 @@
+<?php
+
+use App\Helpers\SshMultiplexingHelper;
+use App\Jobs\VolumeRestoreJob;
+use App\Models\Environment;
+use App\Models\InstanceSettings;
+use App\Models\LocalPersistentVolume;
+use App\Models\PrivateKey;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\StandalonePostgresql;
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Process;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    config(['constants.ssh.mux_enabled' => false]);
+    Server::flushIdentityMap();
+    InstanceSettings::forceCreate(['id' => 0]);
+
+    $this->team = Team::factory()->create();
+    $this->privateKey = PrivateKey::factory()->create(['team_id' => $this->team->id]);
+    $this->server = Server::factory()->create([
+        'team_id' => $this->team->id,
+        'private_key_id' => $this->privateKey->id,
+        'ip' => '10.0.0.9',
+    ]);
+    $this->server->settings()->update([
+        'is_reachable' => true,
+        'is_usable' => true,
+    ]);
+
+    $project = Project::factory()->create(['team_id' => $this->team->id]);
+    $environment = Environment::factory()->create(['project_id' => $project->id]);
+    $destination = StandaloneDocker::where('server_id', $this->server->id)->firstOrFail();
+
+    $this->database = StandalonePostgresql::create([
+        'name' => 'pg-restore-test',
+        'postgres_user' => 'postgres',
+        'postgres_password' => 'password',
+        'postgres_db' => 'postgres',
+        'environment_id' => $environment->id,
+        'destination_id' => $destination->id,
+        'destination_type' => $destination->getMorphClass(),
+    ]);
+
+    $this->volume = LocalPersistentVolume::create([
+        'name' => 'postgres-data-restore',
+        'mount_path' => '/var/lib/postgresql/data',
+        'resource_id' => $this->database->id,
+        'resource_type' => $this->database->getMorphClass(),
+    ]);
+});
+
+afterEach(function () {
+    Server::flushIdentityMap();
+});
+
+test('builds an inline ssh command that can accept stdin', function () {
+    $command = SshMultiplexingHelper::generateSshCommandInline(
+        $this->server,
+        'docker run --rm -i alpine tar -xzf - -C /target'
+    );
+
+    expect($command)
+        ->toContain('ssh')
+        ->toContain("'10.0.0.9'")
+        ->toContain('docker run --rm -i alpine tar -xzf - -C /target');
+});
+
+test('restores a volume archive by piping tar into docker', function () {
+    Process::fake([
+        '*' => Process::result(output: 'ok'),
+    ]);
+
+    $job = new VolumeRestoreJob(
+        '/tmp/volume-data.tar.gz',
+        'target-volume',
+        $this->server,
+        $this->volume,
+    );
+
+    $job->handle();
+
+    Process::assertRan(function ($process) {
+        $command = $process->command;
+
+        return str_contains($command, "'10.0.0.9'")
+            && str_contains($command, 'target-volume')
+            && str_contains($command, 'tar -xzf -')
+            && str_contains($command, '/tmp/volume-data.tar.gz');
+    });
+});

--- a/tests/Unit/DetectIndependentCoolifyInstallTest.php
+++ b/tests/Unit/DetectIndependentCoolifyInstallTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Actions\Migration\DetectIndependentCoolifyInstall;
+
+test('managed host with only proxy and sentinel is not an independent coolify install', function () {
+    $output = implode("\n", ['coolify-proxy', 'coolify-sentinel', 'my-app-uuid']);
+
+    expect(DetectIndependentCoolifyInstall::isIndependentInstall($output))->toBeFalse();
+});
+
+test('dashboard container named coolify is an independent install', function () {
+    $output = implode("\n", ['coolify', 'coolify-proxy', 'coolify-db']);
+
+    expect(DetectIndependentCoolifyInstall::isIndependentInstall($output))->toBeTrue();
+});
+
+test('two control-plane containers without the dashboard name still count as an install', function () {
+    $output = implode("\n", ['coolify-db', 'coolify-redis', 'coolify-proxy']);
+
+    expect(DetectIndependentCoolifyInstall::isIndependentInstall($output))->toBeTrue();
+});
+
+test('source env file is enough to detect a coolify install even with no containers', function () {
+    expect(DetectIndependentCoolifyInstall::isIndependentInstall('', true))->toBeTrue();
+});
+
+test('empty docker output is not an independent install', function () {
+    expect(DetectIndependentCoolifyInstall::isIndependentInstall(''))->toBeFalse();
+});

--- a/tests/Unit/EnsureCoolifyDataDirsTraversableTest.php
+++ b/tests/Unit/EnsureCoolifyDataDirsTraversableTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Actions\Migration\EnsureCoolifyDataDirsTraversable;
+use App\Models\Server;
+
+beforeEach(function () {
+    $this->server = Mockery::mock(Server::class)->makePartial();
+    $this->server->shouldReceive('getAttribute')->with('user')->andReturn('ubuntu');
+    $this->server->shouldReceive('setAttribute')->andReturnSelf();
+});
+
+afterEach(function () {
+    Mockery::close();
+});
+
+test('opens coolify data directories for non-root ssh traversal without world-readable files', function () {
+    $joined = implode("\n", EnsureCoolifyDataDirsTraversable::commands());
+
+    expect($joined)
+        ->toContain('/data/coolify')
+        ->toContain('-type d')
+        ->toContain('chmod a+x')
+        ->not->toContain('chmod -R 700 /data/coolify')
+        ->not->toContain('chmod -R 755');
+});
+
+test('traversal commands survive non-root sudo rewriting', function () {
+    $rewritten = parseCommandsByLineForSudo(collect(EnsureCoolifyDataDirsTraversable::commands()), $this->server);
+
+    foreach ($rewritten as $command) {
+        expect($command)
+            ->not->toContain('sudo (')
+            ->not->toMatch('/\|\|\s*sudo\s*\(/');
+    }
+
+    expect(implode("\n", $rewritten))
+        ->toContain('chmod a+x')
+        ->toContain('/data/coolify');
+});

--- a/tests/Unit/InstallCoolifyOnHostTest.php
+++ b/tests/Unit/InstallCoolifyOnHostTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use App\Actions\Migration\EnsureCoolifyDataDirsTraversable;
+use App\Actions\Migration\InstallCoolifyOnHost;
+use App\Models\Server;
+
+beforeEach(function () {
+    $this->server = Mockery::mock(Server::class)->makePartial();
+    $this->server->shouldReceive('getAttribute')->with('user')->andReturn('ubuntu');
+    $this->server->shouldReceive('setAttribute')->andReturnSelf();
+});
+
+afterEach(function () {
+    Mockery::close();
+});
+
+test('install commands do not use parenthetical fallbacks that break sudo rewriting', function () {
+    $commands = InstallCoolifyOnHost::installCommands('https://cdn.coollabs.io/coolify/install.sh');
+
+    foreach ($commands as $command) {
+        expect($command)
+            ->not->toContain('|| (')
+            ->not->toContain('&& (');
+    }
+});
+
+test('install commands survive non-root sudo rewriting without sudo before parentheses', function () {
+    $commands = InstallCoolifyOnHost::installCommands('https://cdn.coollabs.io/coolify/install.sh');
+    $rewritten = parseCommandsByLineForSudo(collect($commands), $this->server);
+
+    foreach ($rewritten as $command) {
+        expect($command)
+            ->not->toContain('sudo (')
+            ->not->toMatch('/\|\|\s*sudo\s*\(/');
+    }
+
+    expect($rewritten[0])->toBe('command -v curl >/dev/null 2>&1 || sudo apt-get update -y || sudo true');
+    expect($rewritten[1])->toBe('command -v curl >/dev/null 2>&1 || sudo apt-get install -y curl || sudo true');
+    expect($rewritten[2])->toBe('command -v curl >/dev/null 2>&1 || sudo dnf install -y curl || sudo true');
+    expect($rewritten[3])->toBe('command -v curl');
+    expect($rewritten[4])->toStartWith('sudo curl -fsSL');
+    expect($rewritten[5])->toBe('sudo bash /tmp/coolify-install.sh');
+});
+
+test('install is followed by opening coolify data dirs for non-root ssh', function () {
+    $joined = implode("\n", EnsureCoolifyDataDirsTraversable::commands());
+
+    expect($joined)
+        ->toContain('chmod a+x')
+        ->toContain('/data/coolify');
+});
+
+test('legacy parenthetical curl ensure command becomes invalid after sudo rewriting', function () {
+    $legacy = [
+        'command -v curl >/dev/null 2>&1 || (apt-get update -y && apt-get install -y curl) || (dnf install -y curl) || true',
+    ];
+
+    $rewritten = parseCommandsByLineForSudo(collect($legacy), $this->server);
+
+    expect($rewritten[0])->toContain('sudo (');
+});

--- a/tests/Unit/InstanceMigrationTest.php
+++ b/tests/Unit/InstanceMigrationTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use App\Actions\Migration\CollectResourceVolumes;
+use App\Actions\Migration\DetectIndependentCoolifyInstall;
+use App\Actions\Migration\ReassignDestinationsOnRemoteInstance;
+use App\Actions\Migration\SyncAllVolumesToServer;
+use App\Enums\InstanceMigrationStatus;
+use Illuminate\Database\Eloquent\Model;
+
+test('instance migration status terminal detection', function () {
+    expect(InstanceMigrationStatus::Completed->isTerminal())->toBeTrue()
+        ->and(InstanceMigrationStatus::Failed->isTerminal())->toBeTrue()
+        ->and(InstanceMigrationStatus::Packaging->isTerminal())->toBeFalse()
+        ->and(InstanceMigrationStatus::Consolidating->isTerminal())->toBeFalse()
+        ->and(InstanceMigrationStatus::Installing->label())->toBe('Installing Coolify')
+        ->and(InstanceMigrationStatus::Restoring->label())->toBe('Restoring Coolify database')
+        ->and(InstanceMigrationStatus::progressSteps())->toHaveCount(7)
+        ->and(InstanceMigrationStatus::progressSteps()[2])->toBe(InstanceMigrationStatus::Restoring)
+        ->and(InstanceMigrationStatus::progressSteps()[3])->toBe(InstanceMigrationStatus::SyncingVolumes);
+});
+
+test('managed proxy only host is not an independent coolify install', function () {
+    expect(DetectIndependentCoolifyInstall::isIndependentInstall("coolify-proxy\ncoolify-sentinel"))->toBeFalse();
+});
+
+test('full coolify stack is an independent install', function () {
+    expect(DetectIndependentCoolifyInstall::isIndependentInstall("coolify\ncoolify-db\ncoolify-redis"))->toBeTrue();
+});
+
+test('collect resource volumes returns empty for unknown model', function () {
+    $resource = new class extends Model
+    {
+        public $uuid = 'x';
+
+        public function type(): string
+        {
+            return 'unknown';
+        }
+    };
+
+    expect(CollectResourceVolumes::run($resource))->toBe([]);
+});
+
+test('destination reassignment uses psql on coolify-db instead of artisan tinker', function () {
+    $sql = ReassignDestinationsOnRemoteInstance::reassignSql();
+    $commands = implode("\n", ReassignDestinationsOnRemoteInstance::reassignCommands());
+
+    expect($sql)
+        ->toContain('standalone_dockers')
+        ->toContain('server_id = 0')
+        ->toContain('UPDATE applications')
+        ->toContain('WHERE id <> 0')
+        ->toContain("SELECT 'ok'");
+
+    expect($commands)
+        ->toContain('docker cp')
+        ->toContain('psql')
+        ->toContain('coolify-db')
+        ->not->toContain('artisan tinker')
+        ->not->toContain('docker exec -i');
+});
+
+test('instance volume sync skips coolify control-plane volume names', function () {
+    expect(SyncAllVolumesToServer::isReservedVolumeName('coolify-db'))->toBeTrue()
+        ->and(SyncAllVolumesToServer::isReservedVolumeName('coolify-redis'))->toBeTrue()
+        ->and(SyncAllVolumesToServer::isReservedVolumeName('postgres-data-abc123'))->toBeFalse();
+});

--- a/tests/Unit/MigrationManifestTest.php
+++ b/tests/Unit/MigrationManifestTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\Services\Migration\Manifest;
+
+test('builds a versioned manifest and orders databases before services and applications', function () {
+    $manifest = Manifest::make(
+        storage: ['driver' => 's3'],
+        resources: [
+            ['type' => 'application', 'source_uuid' => 'app-1', 'volumes' => [['archive' => ['size_bytes' => 10]]]],
+            ['type' => 'standalone-postgresql', 'source_uuid' => 'db-1', 'volumes' => [['archive' => ['size_bytes' => 20]]]],
+            ['type' => 'service', 'source_uuid' => 'svc-1', 'dump' => ['archive' => ['size_bytes' => 5]]],
+        ],
+        skipData: false,
+    );
+
+    expect($manifest->version)->toBe(Manifest::VERSION)
+        ->and($manifest->resourceCount())->toBe(3)
+        ->and($manifest->totalArchiveBytes())->toBe(35);
+
+    $ordered = $manifest->resourcesInImportOrder();
+    expect($ordered[0]['type'])->toBe('standalone-postgresql')
+        ->and($ordered[1]['type'])->toBe('service')
+        ->and($ordered[2]['type'])->toBe('application');
+});
+
+test('round-trips a manifest through array serialization', function () {
+    $manifest = Manifest::make(
+        storage: ['driver' => 'local-ssh'],
+        resources: [['type' => 'application', 'source_uuid' => 'app-1']],
+        skipData: true,
+    );
+
+    $restored = Manifest::fromArray([
+        'version' => $manifest->version,
+        'exported_at' => $manifest->exported_at,
+        'source_version' => $manifest->source_version,
+        'skip_data' => $manifest->skip_data,
+        'storage' => $manifest->storage,
+        'resources' => $manifest->resources,
+    ]);
+
+    expect($restored->skip_data)->toBeTrue()
+        ->and($restored->storage['driver'])->toBe('local-ssh')
+        ->and($restored->resources[0]['source_uuid'])->toBe('app-1');
+});
+
+test('replaces linked database uuids in environment values', function () {
+    $value = replace_database_uuids_in_value(
+        'postgres://postgres:secret@old-db-uuid:5432/app',
+        ['old-db-uuid' => 'new-db-uuid'],
+    );
+
+    expect($value)->toBe('postgres://postgres:secret@new-db-uuid:5432/app');
+});

--- a/tests/Unit/MigrationStorageDriverTest.php
+++ b/tests/Unit/MigrationStorageDriverTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use App\Enums\MigrationStorageDriver;
+use App\Models\Server;
+use App\Services\Migration\Storage\AzureBlobDriver;
+use App\Services\Migration\Storage\GcsDriver;
+use App\Services\Migration\Storage\LocalSshDriver;
+use App\Services\Migration\Storage\MigrationStorageFactory;
+use App\Services\Migration\Storage\S3CompatibleDriver;
+
+test('local ssh driver stores and retrieves archives on disk', function () {
+    $base = sys_get_temp_dir().'/migrations-test-'.uniqid();
+    $driver = new LocalSshDriver(['base_path' => $base]);
+    $source = $base.'/source.txt';
+    mkdir($base, 0777, true);
+    file_put_contents($source, 'volume-bytes');
+
+    $server = new Server;
+    $pointer = $driver->put($server, $source, 'run/volume.tar.gz');
+
+    expect($pointer['driver'])->toBe('local-ssh')
+        ->and($pointer['size_bytes'])->toBe(12)
+        ->and($driver->exists($server, 'run/volume.tar.gz'))->toBeTrue();
+
+    $downloaded = $base.'/downloaded.txt';
+    $driver->get($server, 'run/volume.tar.gz', $downloaded);
+    expect(file_get_contents($downloaded))->toBe('volume-bytes');
+
+    $driver->delete($server, $pointer['key']);
+    expect($driver->exists($server, $pointer['key']))->toBeFalse();
+
+    @unlink($downloaded);
+    @unlink($source);
+    @rmdir($base.'/run');
+    @rmdir($base);
+});
+
+test('factory maps aws and coolify cloud aliases to the s3 driver', function () {
+    $factory = new MigrationStorageFactory;
+    $driver = $factory->make(MigrationStorageDriver::fromAlias('aws'), [
+        'endpoint' => 'https://s3.amazonaws.com',
+        'bucket' => 'migrations',
+        'key' => 'key',
+        'secret' => 'secret',
+    ], 1);
+
+    expect($driver)->toBeInstanceOf(S3CompatibleDriver::class);
+});
+
+test('factory maps azure and gcs drivers', function () {
+    $factory = new MigrationStorageFactory;
+
+    expect($factory->make(MigrationStorageDriver::fromAlias('azure'), [
+        'account' => 'account',
+        'container' => 'migrations',
+        'sas' => 'token',
+    ], 1))->toBeInstanceOf(AzureBlobDriver::class)
+        ->and($factory->make(MigrationStorageDriver::fromAlias('gcs'), [
+            'bucket' => 'migrations',
+        ], 1))->toBeInstanceOf(GcsDriver::class);
+});

--- a/tests/Unit/ParseCommandsByLineForSudoTest.php
+++ b/tests/Unit/ParseCommandsByLineForSudoTest.php
@@ -144,6 +144,47 @@ test('skips sudo for cd commands', function () {
     expect($result[0])->toBe('cd /var/www');
 });
 
+test('prepares Coolify paths before cd so non-root users can enter them', function () {
+    $commands = collect([
+        'cd /data/coolify/services/cju6fccpokhw7zkjtyxrjowk',
+    ]);
+
+    $result = parseCommandsByLineForSudo($commands, $this->server);
+
+    expect($result[0])
+        ->toContain('sudo mkdir -p '.escapeshellarg('/data/coolify/services/cju6fccpokhw7zkjtyxrjowk'))
+        ->toContain('sudo chown ubuntu:ubuntu '.escapeshellarg('/data/coolify/services/cju6fccpokhw7zkjtyxrjowk'))
+        ->toContain('sudo chmod a+x '.escapeshellarg('/data/coolify'))
+        ->toContain('sudo chmod a+x '.escapeshellarg('/data/coolify/services'))
+        ->toContain('cd /data/coolify/services/cju6fccpokhw7zkjtyxrjowk')
+        ->not->toContain('sudo cd ');
+});
+
+test('cd into Coolify path with follow-up command does not become sudo cd', function () {
+    $commands = collect([
+        'cd /data/coolify/source && docker compose up -d',
+    ]);
+
+    $result = parseCommandsByLineForSudo($commands, $this->server);
+
+    expect($result[0])
+        ->toContain('cd /data/coolify/source && sudo docker compose up -d')
+        ->not->toContain('sudo cd ');
+});
+
+test('mkdir with redirects still chowns only the Coolify directory', function () {
+    $commands = collect([
+        'mkdir -p /data/coolify/services/uuid > /dev/null 2>&1 || true',
+    ]);
+
+    $result = parseCommandsByLineForSudo($commands, $this->server);
+
+    expect($result[0])
+        ->toContain('sudo chown ubuntu:ubuntu '.escapeshellarg('/data/coolify/services/uuid'))
+        ->toContain('sudo chmod -R o-rwx '.escapeshellarg('/data/coolify/services/uuid'))
+        ->not->toContain('chown -R ubuntu:ubuntu /data/coolify/services/uuid >');
+});
+
 test('skips sudo for echo commands', function () {
     $commands = collect([
         'echo "test"',
@@ -201,9 +242,11 @@ test('adds ownership changes for Coolify data paths', function () {
 
     $result = parseCommandsByLineForSudo($commands, $this->server);
 
-    // Note: The && operator adds another sudo, creating double sudo for chown/chmod
-    // This is existing behavior that may need refactoring but isn't part of this bug fix
-    expect($result[0])->toBe('sudo mkdir -p /data/coolify/logs && sudo sudo chown -R ubuntu:ubuntu /data/coolify/logs && sudo sudo chmod -R o-rwx /data/coolify/logs');
+    expect($result[0])
+        ->toContain('sudo mkdir -p '.escapeshellarg('/data/coolify/logs'))
+        ->toContain('sudo chown ubuntu:ubuntu '.escapeshellarg('/data/coolify/logs'))
+        ->toContain('sudo chmod a+x '.escapeshellarg('/data/coolify'))
+        ->toContain('sudo chmod -R o-rwx '.escapeshellarg('/data/coolify/logs'));
 });
 
 test('adds ownership changes for Coolify tmp paths', function () {
@@ -213,9 +256,10 @@ test('adds ownership changes for Coolify tmp paths', function () {
 
     $result = parseCommandsByLineForSudo($commands, $this->server);
 
-    // Note: The && operator adds another sudo, creating double sudo for chown/chmod
-    // This is existing behavior that may need refactoring but isn't part of this bug fix
-    expect($result[0])->toBe('sudo mkdir -p /tmp/coolify/cache && sudo sudo chown -R ubuntu:ubuntu /tmp/coolify/cache && sudo sudo chmod -R o-rwx /tmp/coolify/cache');
+    expect($result[0])
+        ->toContain('sudo mkdir -p '.escapeshellarg('/tmp/coolify/cache'))
+        ->toContain('sudo chown ubuntu:ubuntu '.escapeshellarg('/tmp/coolify/cache'))
+        ->toContain('sudo chmod -R o-rwx '.escapeshellarg('/tmp/coolify/cache'));
 });
 
 test('does not add ownership changes for system paths', function () {

--- a/tests/Unit/RestoreDatabaseDumpTest.php
+++ b/tests/Unit/RestoreDatabaseDumpTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use App\Actions\Database\RestoreDatabaseDump;
+use App\Models\StandalonePostgresql;
+
+test('builds a pg_restore command for postgresql dumps', function () {
+    $database = new class
+    {
+        public function getMorphClass(): string
+        {
+            return StandalonePostgresql::class;
+        }
+    };
+
+    $command = (new RestoreDatabaseDump)->buildRestoreCommand($database, '/tmp/dump', false);
+
+    expect($command)->toContain('pg_restore')
+        ->and($command)->toContain('/tmp/dump');
+});

--- a/tests/Unit/RestoreInstanceOnHostTest.php
+++ b/tests/Unit/RestoreInstanceOnHostTest.php
@@ -1,0 +1,166 @@
+<?php
+
+use App\Actions\Migration\ReassignDestinationsOnRemoteInstance;
+use App\Actions\Migration\RestoreInstanceOnHost;
+use App\Models\Server;
+
+beforeEach(function () {
+    $this->server = Mockery::mock(Server::class)->makePartial();
+    $this->server->shouldReceive('getAttribute')->with('user')->andReturn('ubuntu');
+    $this->server->shouldReceive('setAttribute')->andReturnSelf();
+});
+
+afterEach(function () {
+    Mockery::close();
+});
+
+test('restore syncs the postgres role password to match target .env after pg_restore', function () {
+    $commands = RestoreInstanceOnHost::syncDatabasePasswordCommands();
+    $joined = implode("\n", $commands);
+
+    expect($joined)
+        ->toContain('/data/coolify/source/.env')
+        ->toContain('DB_PASSWORD')
+        ->toContain('ALTER ROLE')
+        ->toContain('coolify-db')
+        ->not->toContain('>> /data/coolify/source/.env');
+});
+
+test('restore commands copy the dump into coolify-db instead of piping stdin over ssh', function () {
+    $commands = RestoreInstanceOnHost::restoreDatabaseCommands('/tmp/coolify-instance-migration-abc-coolify-db.dmp');
+
+    $joined = implode("\n", $commands);
+
+    expect($joined)
+        ->toContain('docker cp')
+        ->toContain('/tmp/coolify-instance-migration-abc-coolify-db.dmp')
+        ->toContain('coolify-db:/tmp/coolify-instance.dmp')
+        ->toContain('pg_restore')
+        ->not->toContain('docker exec -i')
+        ->not->toContain('< /tmp/');
+});
+
+test('restore staging uploads flat files under /tmp without a subdirectory', function () {
+    $path = RestoreInstanceOnHost::stagingFilePath('abc', 'coolify-db.dmp');
+
+    expect($path)->toBe('/tmp/coolify-instance-migration-abc-coolify-db.dmp')
+        ->and($path)->not->toContain('/coolify-db.dmp/')
+        ->and(substr_count($path, '/'))->toBe(2);
+});
+
+test('shouldChangeOwnership strips shell quotes from mkdir paths', function () {
+    expect(shouldChangeOwnership("'/tmp/coolify-instance-migration-abc'"))->toBeTrue()
+        ->and(shouldChangeOwnership('"/data/coolify/backups"'))->toBeTrue()
+        ->and(shouldChangeOwnership("'/var/log'"))->toBeFalse();
+});
+
+test('env update does not use a non-root shell redirect into .env', function () {
+    $commands = RestoreInstanceOnHost::updateEnvCommands('base64:testkey');
+    $joined = implode("\n", $commands);
+
+    expect($joined)
+        ->toContain('/data/coolify/source/.env')
+        ->toContain('APP_KEY')
+        ->toContain('tee -a')
+        ->not->toContain('>> /data/coolify/source/.env');
+});
+
+test('env update writes .env as root after sudo rewriting', function () {
+    $commands = RestoreInstanceOnHost::updateEnvCommands('base64:testkey');
+    $rewritten = parseCommandsByLineForSudo(collect($commands), $this->server);
+    $joined = implode("\n", $rewritten);
+
+    expect($joined)
+        ->toContain('sudo sh -c')
+        ->toContain('sudo sed -i')
+        ->not->toContain('>> /data/coolify/source/.env')
+        ->not->toMatch('/sudo printf.*>> \\/data\\/coolify/');
+
+    foreach ($rewritten as $command) {
+        expect($command)
+            ->not->toContain('sudo (')
+            ->not->toMatch('/\|\|\s*sudo\s*\(/');
+    }
+});
+
+test('restart coolify does not cd into root-owned source directory', function () {
+    $commands = RestoreInstanceOnHost::restartCoolifyCommands();
+    $joined = implode("\n", $commands);
+
+    expect($joined)
+        ->toContain('--project-directory /data/coolify/source')
+        ->toContain('/data/coolify/source/docker-compose.yml')
+        ->not->toContain('cd /data/coolify');
+});
+
+test('all restore remote commands are safe for non-root sudo rewriting', function () {
+    $commands = RestoreInstanceOnHost::allRemoteCommands();
+    $joined = implode("\n", $commands);
+    $rewritten = parseCommandsByLineForSudo(collect($commands), $this->server);
+    $rewrittenJoined = implode("\n", $rewritten);
+
+    expect($joined)
+        ->toContain('ALTER ROLE')
+        ->toContain('chmod a+x')
+        ->not->toContain('cd /data/coolify')
+        ->not->toContain('>> /data/coolify')
+        ->not->toContain('docker exec -i');
+
+    expect($rewrittenJoined)
+        ->toContain('sudo docker compose --project-directory /data/coolify/source')
+        ->toContain('sudo sh -c')
+        ->not->toContain('cd /data/coolify');
+
+    foreach ($rewritten as $command) {
+        expect($command)
+            ->not->toContain('sudo (')
+            ->not->toMatch('/\|\|\s*sudo\s*\(/')
+            ->not->toMatch('/^cd /');
+    }
+});
+
+test('restore commands survive non-root sudo rewriting', function () {
+    $commands = RestoreInstanceOnHost::restoreDatabaseCommands('/tmp/coolify-instance-migration-abc-coolify-db.dmp');
+    $rewritten = parseCommandsByLineForSudo(collect($commands), $this->server);
+
+    foreach ($rewritten as $command) {
+        expect($command)
+            ->not->toContain('sudo (')
+            ->not->toMatch('/\|\|\s*sudo\s*\(/');
+    }
+
+    expect(implode("\n", $rewritten))
+        ->toContain('sudo docker cp')
+        ->toContain('sudo docker exec coolify-db sh -c');
+});
+
+test('database password sync survives non-root sudo rewriting', function () {
+    $rewritten = parseCommandsByLineForSudo(collect(RestoreInstanceOnHost::syncDatabasePasswordCommands()), $this->server);
+    $joined = implode("\n", $rewritten);
+
+    expect($joined)
+        ->toContain('sudo bash -c')
+        ->toContain('ALTER ROLE')
+        ->toContain('DB_PASSWORD');
+
+    foreach ($rewritten as $command) {
+        expect($command)
+            ->not->toContain('sudo (')
+            ->not->toMatch('/\|\|\s*sudo\s*\(/');
+    }
+});
+
+test('destination reassignment commands survive non-root sudo rewriting', function () {
+    $rewritten = parseCommandsByLineForSudo(collect(ReassignDestinationsOnRemoteInstance::reassignCommands()), $this->server);
+
+    foreach ($rewritten as $command) {
+        expect($command)
+            ->not->toContain('sudo (')
+            ->not->toMatch('/\|\|\s*sudo\s*\(/');
+    }
+
+    expect(implode("\n", $rewritten))
+        ->toContain('sudo docker cp')
+        ->toContain('sudo docker exec coolify-db')
+        ->not->toContain('artisan tinker');
+});

--- a/tests/Unit/ServiceComposeAbsolutePathsTest.php
+++ b/tests/Unit/ServiceComposeAbsolutePathsTest.php
@@ -1,0 +1,20 @@
+<?php
+
+test('service compose config commands never cd into coolify workdirs', function () {
+    $workdir = '/data/coolify/services/cju6fccpokhw7zkjtyxrjowk';
+    $commands = [
+        "mkdir -p $workdir",
+        "rm -f {$workdir}/.env || true",
+        "touch {$workdir}/.env",
+        "echo 'BASE64' | base64 -d | tee {$workdir}/.env > /dev/null",
+        "docker compose --project-directory {$workdir} -f {$workdir}/docker-compose.yml up -d",
+    ];
+
+    $joined = implode("\n", $commands);
+
+    expect($joined)
+        ->not->toContain('cd /data/coolify')
+        ->not->toContain("cd $workdir")
+        ->toContain("tee {$workdir}/.env")
+        ->toContain("--project-directory {$workdir}");
+});

--- a/tests/Unit/StartProxyTest.php
+++ b/tests/Unit/StartProxyTest.php
@@ -8,10 +8,9 @@ it('ensures container cleanup includes wait loop in command sequence', function 
     // Simulate the command generation pattern from StartProxy
     $commands = collect([
         'mkdir -p /data/coolify/proxy/dynamic',
-        'cd /data/coolify/proxy',
         "echo 'Creating required Docker Compose file.'",
         "echo 'Pulling docker image.'",
-        'docker compose pull',
+        'docker compose --project-directory /data/coolify/proxy pull',
         'if docker ps -a --format "{{.Names}}" | grep -q "^coolify-proxy$"; then',
         "    echo 'Stopping and removing existing coolify-proxy.'",
         '    docker stop coolify-proxy 2>/dev/null || true',
@@ -27,7 +26,7 @@ it('ensures container cleanup includes wait loop in command sequence', function 
         "    echo 'Successfully stopped and removed existing coolify-proxy.'",
         'fi',
         "echo 'Starting coolify-proxy.'",
-        'docker compose up -d --wait --remove-orphans',
+        'docker compose --project-directory /data/coolify/proxy up -d --wait --remove-orphans',
         "echo 'Successfully started coolify-proxy.'",
     ]);
 
@@ -40,12 +39,12 @@ it('ensures container cleanup includes wait loop in command sequence', function 
         ->and($commandsString)->toContain('if ! docker ps -a --format "{{.Names}}" | grep -q "^coolify-proxy$"; then')
         ->and($commandsString)->toContain('break')
         ->and($commandsString)->toContain('sleep 1')
-        ->and($commandsString)->toContain('docker compose up -d --wait --remove-orphans');
+        ->and($commandsString)->toContain('docker compose --project-directory /data/coolify/proxy up -d --wait --remove-orphans');
 
     // Verify the order: cleanup must come before compose up
     $stopPosition = strpos($commandsString, 'docker stop coolify-proxy');
     $waitLoopPosition = strpos($commandsString, 'for i in {1..10}');
-    $composeUpPosition = strpos($commandsString, 'docker compose up -d');
+    $composeUpPosition = strpos($commandsString, 'docker compose --project-directory /data/coolify/proxy up -d');
 
     expect($stopPosition)->toBeLessThan($waitLoopPosition)
         ->and($waitLoopPosition)->toBeLessThan($composeUpPosition);


### PR DESCRIPTION
## Changes

Adds Settings → Migrations so you can copy resources between servers, or move this whole Coolify instance (dashboard, `coolify-db`, APP_KEY, SSH keys, volumes) onto a new VM.

Related discussion: https://github.com/coollabsio/coolify/discussions/11253

Non-root SSH path handling lives in a smaller PR: https://github.com/coollabsio/coolify/pull/11259

## Issues

- https://github.com/coollabsio/coolify/discussions/11253

## Category

- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Settings → Migrations: Resource copy and Instance migration tabs, with progress while the instance move runs.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Cursor
- How extensively: Implementation and tests were written with AI assistance; the flow was verified on local Vagrant VMs (install, `coolify-db` restore, non-root `cd` into `/data/coolify/services`).

## Testing

- Unit tests: restore commands, sudo `cd` rewrite, traversable `/data/coolify` dirs, destination reassignment SQL
- Feature tests: settings page, instance migration job queue, export/import API
- Manual: instance migration between two VMs, including skip-install when Coolify was already present, and service start after restore as a non-root SSH user

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.


Made with [Cursor](https://cursor.com)