### PR TITLE
fix(ui): show unsaved bar after switching label management to manual

### DIFF
--- a/resources/views/components/forms/monaco-editor.blade.php
+++ b/resources/views/components/forms/monaco-editor.blade.php
@@ -1,7 +1,7 @@
 <div wire:key="{{ random_int(0, PHP_INT_MAX) }}" class="coolify-monaco-editor flex-1">
     <div x-ref="monacoRef" x-data="{
         monacoVersion: '0.52.2',
-        monacoContent: @entangle($id),
+        monacoContent: $wire.{{ $id }} ?? '',
         monacoLanguage: '',
         monacoPlaceholder: true,
         monacoPlaceholderText: 'Start typing here',
@@ -13,8 +13,9 @@
         },
         monacoEditor(editor) {
             editor.onDidChangeModelContent((e) => {
-                this.monacoContent = editor.getValue();
-                this.updatePlaceholder(editor.getValue());
+                const value = editor.getValue();
+                this.monacoContent = value;
+                this.updatePlaceholder(value);
             });
             editor.onDidBlurEditorWidget(() => {
                 this.updatePlaceholder(editor.getValue());
@@ -44,7 +45,7 @@
                 document.head.appendChild(script);
             }
         }
-    }" x-modelable="monacoContent">
+    }" x-modelable="monacoContent" wire:model="{{ $id }}">
         <div x-cloak x-init="if (typeof _amdLoaderGlobal == 'undefined' && !window.__coolifyMonacoLoaderAdding) {
             monacoEditorAddLoaderScriptToHead();
         }

--- a/resources/views/components/unsaved-bar.blade.php
+++ b/resources/views/components/unsaved-bar.blade.php
@@ -5,6 +5,7 @@
     // appears when those fields differ from the last server snapshot — not on
     // incidental component state (e.g. $wire.set from x-init, display-only props).
     'targets' => null,
+    'wireKey' => null,
 ])
 
 {{-- Floating "unsaved changes" pill (bottom center). Reveals itself via
@@ -19,7 +20,7 @@
      Mobile: stacked layout (full label, buttons on the next line) inset from
      the viewport edges so body overflow-x-clip cannot clip it.
      Desktop: compact single-row centered pill. --}}
-<div x-data="{
+<div @if ($wireKey) wire:key="{{ $wireKey }}" @endif x-data="{
     keyboardInset: 0,
     updateKeyboardInset: null,
     init() {

--- a/resources/views/livewire/project/application/general.blade.php
+++ b/resources/views/livewire/project/application/general.blade.php
@@ -6,7 +6,7 @@
     }
 }">
     <form wire:submit='submit' class="application-settings-form flex flex-col">
-        <x-unsaved-bar action="submit"
+        <x-unsaved-bar action="submit" wireKey="application-general-unsaved-bar-{{ $isContainerLabelReadonlyEnabled ? 'managed' : 'manual' }}"
             targets="name,description,buildPack,staticImage,baseDirectory,dockerComposeLocation,dockerComposeCustomBuildCommand,dockerComposeCustomStartCommand,watchPaths,dockerfileLocation,dockerfileTargetBuild,publishDirectory,installCommand,buildCommand,startCommand,customNginxConfiguration,dockerfile,dockerRegistryImageName,dockerRegistryImageTag,portsExposes,portsMappings,customNetworkAliases,customDockerRunOptions,httpBasicAuthUsername,httpBasicAuthPassword,preDeploymentCommand,preDeploymentCommandContainer,postDeploymentCommand,postDeploymentCommandContainer,isContainerLabelReadonlyEnabled,isContainerLabelEscapeEnabled,customLabels" />
         <div class="application-settings-grid flex flex-col gap-6">
             <x-application.settings-section id="application-details-section" title="Application details" helper="Name the application and choose the build strategy Coolify should use to deploy it." class="application-details-card">

--- a/tests/Feature/ApplicationGeneralLayoutTest.php
+++ b/tests/Feature/ApplicationGeneralLayoutTest.php
@@ -36,6 +36,18 @@ test('unsaved changes ignore compose initialization state', function () {
         ->not->toContain('dockerCompose,');
 });
 
+test('unsaved bar remounts when label management mode changes', function () {
+    $view = file_get_contents(resource_path('views/livewire/project/application/general.blade.php'));
+    $unsavedBar = str($view)
+        ->after('<x-unsaved-bar action="submit"')
+        ->before('/>')
+        ->toString();
+
+    expect($unsavedBar)
+        ->toContain('wireKey="application-general-unsaved-bar-{{ $isContainerLabelReadonlyEnabled ? \'managed\' : \'manual\' }}"')
+        ->toContain('customLabels');
+});
+
 test('onboarding uses the reusable advanced settings component', function () {
     $view = file_get_contents(resource_path('views/livewire/project/application/general.blade.php'));
     $onboarding = file_get_contents(resource_path('views/livewire/boarding/index.blade.php'));

--- a/tests/Feature/MonacoEditorBindingTest.php
+++ b/tests/Feature/MonacoEditorBindingTest.php
@@ -1,0 +1,13 @@
+<?php
+
+test('monaco editor binds to livewire through x-modelable and wire:model', function () {
+    $contents = file_get_contents(resource_path('views/components/forms/monaco-editor.blade.php'));
+
+    expect($contents)
+        ->toContain('monacoContent: $wire.{{ $id }} ?? \'\',')
+        ->toContain('x-modelable="monacoContent" wire:model="{{ $id }}"')
+        ->toContain('this.monacoContent = value;')
+        ->not->toContain('@entangle($id)')
+        ->not->toContain('x-ref="livewireInput"')
+        ->not->toContain('syncingFromLivewire');
+});

--- a/tests/Feature/SentinelUnsavedBarFlashTest.php
+++ b/tests/Feature/SentinelUnsavedBarFlashTest.php
@@ -25,6 +25,14 @@ test('unsaved bar component accepts optional wire:target list', function () {
         ->toContain('wire:target="{{ $targets }}"');
 });
 
+test('unsaved bar accepts optional wire key to remount dirty tracking', function () {
+    $contents = file_get_contents(resource_path('views/components/unsaved-bar.blade.php'));
+
+    expect($contents)
+        ->toContain("'wireKey' => null")
+        ->toContain('wire:key="{{ $wireKey }}"');
+});
+
 test('unsaved bar delays show and hides while loading to avoid instant-save flash', function () {
     $path = resource_path('views/components/unsaved-bar.blade.php');
     $contents = file_get_contents($path);


### PR DESCRIPTION
## Changes

Switching Label management from Coolify-managed to manual swaps the labels editor. The Monaco editor used `@entangle`, which stops updating Livewire after that swap, so the unsaved bar never appears.

The editor now binds with `x-modelable` and `wire:model`. The unsaved bar remounts when label management mode changes.

## Issues

- #11265

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

https://github.com/user-attachments/assets/9c215ac7-719a-4578-8234-8d1075a890c1

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Cursor
- How extensively: Helped locate the Livewire/`@entangle` cause, implement the Monaco/`wire:model` bind, and add Blade markup tests. I reviewed the diff and ran the related tests.

## Testing

- Reproduced #11265: Coolify-managed → switch to manual → edit Active labels → unsaved bar missing until refresh.
- After the change, same path: unsaved bar appears without refresh. Page already on manual: bar still appears on edit.

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.