### PR TITLE
fix(github): resolve app by installation_id for webhooks

### DIFF
--- a/app/Http/Controllers/Webhook/Github.php
+++ b/app/Http/Controllers/Webhook/Github.php
@@ -260,7 +260,7 @@ class Github extends Controller
             if ($installation_id) {
                 $github_app = GithubApp::where('installation_id', $installation_id)->first();
             }
-            if (! isset($github_app) || is_null($github_app)) {
+            if (empty($github_app)) {
                 $github_app = GithubApp::where('app_id', $x_github_hook_installation_target_id)->first();
             }
             if (is_null($github_app)) {

--- a/app/Http/Controllers/Webhook/Github.php
+++ b/app/Http/Controllers/Webhook/Github.php
@@ -256,7 +256,13 @@ class Github extends Controller
                 // Just pong
                 return response('pong');
             }
-            $github_app = GithubApp::where('app_id', $x_github_hook_installation_target_id)->first();
+            $installation_id = data_get($payload, 'installation.id');
+            if ($installation_id) {
+                $github_app = GithubApp::where('installation_id', $installation_id)->first();
+            }
+            if (! isset($github_app) || is_null($github_app)) {
+                $github_app = GithubApp::where('app_id', $x_github_hook_installation_target_id)->first();
+            }
             if (is_null($github_app)) {
                 return response('Nothing to do. No GitHub App found.');
             }

--- a/app/Http/Controllers/Webhook/Github.php
+++ b/app/Http/Controllers/Webhook/Github.php
@@ -257,12 +257,8 @@ class Github extends Controller
                 return response('pong');
             }
             $installation_id = data_get($payload, 'installation.id');
-            if ($installation_id) {
-                $github_app = GithubApp::where('installation_id', $installation_id)->first();
-            }
-            if (empty($github_app)) {
-                $github_app = GithubApp::where('app_id', $x_github_hook_installation_target_id)->first();
-            }
+            $github_app = GithubApp::where('installation_id', $installation_id)->first()
+                ?? GithubApp::where('app_id', $x_github_hook_installation_target_id)->first();
             if (is_null($github_app)) {
                 return response('Nothing to do. No GitHub App found.');
             }


### PR DESCRIPTION
## Changes

- Resolves GitHub App source by `installation_id` (from `payload.installation.id`) before falling back to `app_id` (`X-GitHub-Hook-Installation-Target-Id`).
- Fixes push and PR webhook matching for applications when a single GitHub App is installed across multiple accounts / organizations.

## Issues

- Fixes #11271
- Related #5364

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A (Backend webhook resolution fix)

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Antigravity AI coding assistant
- How extensively: Used to diagnose why webhooks were failing on multi-org installations, trace the controller logic in `app/Http/Controllers/Webhook/Github.php`, and draft the patch. Tested and verified on a live self-hosted instance.

## Testing

1. Setup a Coolify instance with a single GitHub App installed on both a personal account and an organization (creating multiple `github_apps` records with the same `app_id`).
2. Create an application under the second source.
3. Push a commit to the tracked branch (`main`).
4. Verified that the webhook delivery successfully resolves the matching source and triggers the deployment (previously returned `Nothing to do. No applications found with branch 'main'.`).

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.