### PR TITLE
fix(domains): prevent search indexing header overflow

### DIFF
--- a/resources/views/livewire/project/application/domains.blade.php
+++ b/resources/views/livewire/project/application/domains.blade.php
@@ -237,7 +237,7 @@
                             <div class="data-table-header domains-table-grid-service">
                                 <span>Domain</span>
                                 <span>DNS Check</span>
-                                <span>Search engine indexing</span>
+                                <span class="whitespace-nowrap">Search engine indexing</span>
                                 <span></span>
                             </div>
                             @foreach ($rows as $row)
@@ -273,7 +273,7 @@
                 <div class="data-table-header domains-table-grid">
                     <span>Domain</span>
                     <span>DNS Check</span>
-                    <span>Search engine indexing</span>
+                    <span class="whitespace-nowrap">Search engine indexing</span>
                     <span>Direction</span>
                     <span></span>
                 </div>

--- a/resources/views/livewire/project/service/partials/domain-table.blade.php
+++ b/resources/views/livewire/project/service/partials/domain-table.blade.php
@@ -12,7 +12,7 @@
                 <span>Service</span>
             @endif
             <span>DNS Check</span>
-            <span>Search engine indexing</span>
+            <span class="whitespace-nowrap">Search engine indexing</span>
             <span>Direction</span>
             <span></span>
         </div>

--- a/tests/Feature/ApplicationDomainsTest.php
+++ b/tests/Feature/ApplicationDomainsTest.php
@@ -1168,13 +1168,23 @@ it('uses the compact service domains layout for compose applications', function 
         ->toContain('bg-neutral-50 px-4 py-3 dark:border-white/10 dark:bg-white/[0.04]')
         ->toContain('class="data-table-header domains-table-grid-service"')
         ->toContain('<span>Direction</span>')
-        ->toContain('<span>Search engine indexing</span>')
+        ->toContain('<span class="whitespace-nowrap">Search engine indexing</span>')
         ->not->toContain('<span>Last checked</span>')
         ->not->toContain('id="edit-domain-direction"')
         ->toContain('id="domain-direction-service-{{ $redirectWireKey }}"')
         ->toContain('onChange="updateServiceRedirect"')
         ->toContain("'showDirectionControl' => false")
         ->not->toContain('title="No domains for this service"');
+});
+
+it('keeps search engine indexing table headers on one line', function () {
+    $applicationView = file_get_contents(resource_path('views/livewire/project/application/domains.blade.php'));
+    $serviceView = file_get_contents(resource_path('views/livewire/project/service/partials/domain-table.blade.php'));
+
+    expect(substr_count($applicationView, '<span class="whitespace-nowrap">Search engine indexing</span>'))
+        ->toBe(2)
+        ->and($serviceView)
+        ->toContain('<span class="whitespace-nowrap">Search engine indexing</span>');
 });
 
 it('shows domain guidance in the application domains section', function () {


### PR DESCRIPTION
## Summary

- Keep the “Search engine indexing” header on one line across application and service domain tables.
- Prevent the header from overlapping table content.
- Add regression coverage for the affected headers.

Fixes #11263.

---

Fixes #11263