### PR TITLE
fix(ui): improve highlighted button contrast

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -993,8 +993,7 @@ html[data-theme="custom"] {
 }
 
 html[data-theme="custom"] .control-selected,
-html[data-theme="custom"] .logs-viewer-btn-active,
-html[data-theme="custom"] .button-highlighted:hover {
+html[data-theme="custom"] .logs-viewer-btn-active {
     color: var(--color-accent-foreground);
 }
 

--- a/resources/css/utilities.css
+++ b/resources/css/utilities.css
@@ -131,7 +131,7 @@
 }
 
 @utility button-highlighted {
-    @apply border-coollabs-200 bg-linear-to-b from-coollabs-100 to-coollabs-200 text-white! hover:from-coollabs-100 hover:to-coollabs hover:text-white!;
+    @apply border-coollabs-200 bg-linear-to-b from-coollabs-100 to-coollabs-200 text-accent-foreground! hover:from-coollabs-100 hover:to-coollabs hover:text-accent-foreground!;
 }
 
 @utility control-selected {

--- a/resources/views/components/unsaved-bar.blade.php
+++ b/resources/views/components/unsaved-bar.blade.php
@@ -67,7 +67,7 @@
             class="button-highlighted flex h-8 items-center gap-2 rounded-lg px-4 text-[13px] font-semibold transition-[transform,background-color] active:scale-[0.98]">
             <span>Save changes</span>
             <kbd
-                class="rounded border border-coollabs/20 bg-coollabs/10 px-1.5 py-0.5 text-[10px] leading-none font-medium text-coollabs-200 dark:border-white/20 dark:bg-white/10 dark:text-white/75">Enter</kbd>
+                class="rounded border border-current/20 bg-current/10 px-1.5 py-0.5 text-[10px] leading-none font-medium text-current">Enter</kbd>
         </button>
     </div>
 </div>

--- a/tests/Feature/HighlightedButtonStylingTest.php
+++ b/tests/Feature/HighlightedButtonStylingTest.php
@@ -10,10 +10,19 @@ test('highlighted buttons use the shared coollabs style in every color scheme', 
 
     expect($utilities)
         ->toContain('@utility button-highlighted')
-        ->toContain('@apply border-coollabs-200 bg-linear-to-b from-coollabs-100 to-coollabs-200 text-white! hover:from-coollabs-100 hover:to-coollabs hover:text-white!;')
+        ->toContain('@apply border-coollabs-200 bg-linear-to-b from-coollabs-100 to-coollabs-200 text-accent-foreground! hover:from-coollabs-100 hover:to-coollabs hover:text-accent-foreground!;')
         ->and($appStyles)
         ->toContain('button[isHighlighted]:not(:disabled)')
         ->toContain('@apply button-highlighted;')
         ->and($views)
         ->not->toContain('dark:bg-warning/15! dark:text-warning! dark:ring-warning/25');
+});
+
+test('custom theme highlighted buttons use the computed contrasting foreground', function () {
+    $utilities = file_get_contents(resource_path('css/utilities.css'));
+
+    expect($utilities)
+        ->toContain('text-accent-foreground!')
+        ->toContain('hover:text-accent-foreground!')
+        ->not->toContain('text-white! hover:');
 });

--- a/tests/Feature/SentinelUnsavedBarFlashTest.php
+++ b/tests/Feature/SentinelUnsavedBarFlashTest.php
@@ -76,9 +76,9 @@ test('unsaved bar keyboard shortcut remains visible in light mode', function () 
     $contents = file_get_contents(resource_path('views/components/unsaved-bar.blade.php'));
 
     expect($contents)
-        ->toContain('border-coollabs/20 bg-coollabs/10')
-        ->toContain('text-coollabs-200')
-        ->toContain('dark:border-white/20 dark:bg-white/10 dark:text-white/75');
+        ->toContain('border-current/20 bg-current/10')
+        ->toContain('text-current')
+        ->not->toContain('text-coollabs-200');
 });
 
 test('unsaved bar uses a light surface in light mode', function () {


### PR DESCRIPTION
## Changes

- Use the computed accent foreground for highlighted buttons so custom light themes receive dark text while dark themes retain white text.
- Make the unsaved changes `Enter` shortcut inherit its button foreground, border, and tint instead of using fixed purple and white values.
- Add regression coverage for highlighted-button and keyboard-shortcut contrast.

## Issues

- Fixes the unreadable `Enter` shortcut and highlighted-button labels reported with some theme colors.

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

**Before**

![Before: the Enter shortcut has insufficient contrast](https://raw.githubusercontent.com/fsioni/coolify/pr-assets/pr-assets/coolify-11278-before.png)

**After**

![After: the Enter shortcut inherits the readable button foreground](https://raw.githubusercontent.com/fsioni/coolify/pr-assets/pr-assets/coolify-11278-after.png)

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Used for diagnosis, implementation, automated tests, a 12-theme visual contrast matrix, and PR preparation. The changes were reviewed and tested by the contributor on a local Coolify instance.

## Testing

- Ran the focused Pest suite: 24 tests passed with 103 assertions.
- Ran the Vite production build successfully.
- Verified the real unsaved changes bar on a local Coolify instance.
- Checked 12 light and dark custom theme colors in a browser; the button and shortcut foreground matched in every case.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
