### PR TITLE
fix(mcp): allow tokens when REST API is disabled

### DIFF
--- a/app/Livewire/Security/ApiTokens.php
+++ b/app/Livewire/Security/ApiTokens.php
@@ -2,7 +2,6 @@
 
 namespace App\Livewire\Security;
 
-use App\Models\InstanceSettings;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Laravel\Sanctum\PersonalAccessToken;
 use Livewire\Attributes\Locked;
@@ -28,8 +27,6 @@ class ApiTokens extends Component
         365 => '1 year',
     ];
 
-    public $isApiEnabled;
-
     #[Locked]
     public bool $canUseRootPermissions = false;
 
@@ -49,7 +46,6 @@ class ApiTokens extends Component
 
     public function mount()
     {
-        $this->isApiEnabled = InstanceSettings::get()->is_api_enabled;
         $this->canUseRootPermissions = auth()->user()->can('useRootPermissions', PersonalAccessToken::class);
         $this->canUseWritePermissions = auth()->user()->can('useWritePermissions', PersonalAccessToken::class);
         $this->canUseDeployPermissions = auth()->user()->can('useDeployPermissions', PersonalAccessToken::class);

--- a/resources/views/livewire/security/api-tokens.blade.php
+++ b/resources/views/livewire/security/api-tokens.blade.php
@@ -5,22 +5,6 @@
 
     <x-security.settings-layout>
 
-    @if (!$isApiEnabled)
-        <div class="application-settings-form">
-            <x-application.settings-section title="API disabled"
-                description="Enable the Coolify API before creating access tokens.">
-                <x-empty title="API access is turned off"
-                    description="Enable API access in instance settings to issue tokens." icon-name="keys"
-                    size="sm">
-                    <x-slot:actions>
-                        <a href="{{ route('settings.advanced') }}" class="button" {{ wireNavigate() }}>
-                            Open settings
-                        </a>
-                    </x-slot:actions>
-                </x-empty>
-            </x-application.settings-section>
-        </div>
-    @else
         @php
             $expirationList = collect($expirationOptions)
                 ->map(fn ($label, $days) => ['value' => (string) $days, 'label' => $label])
@@ -304,6 +288,5 @@
                 </div>
             </x-application.settings-section>
         </div>
-    @endif
     </x-security.settings-layout>
 </div>

--- a/resources/views/livewire/settings/advanced.blade.php
+++ b/resources/views/livewire/settings/advanced.blade.php
@@ -83,7 +83,7 @@
                         ]" />
                     <div class="lg:col-span-2">
                         <x-forms.input id="allowed_ips" label="Allowed API IPs"
-                            helper="Comma-separated IPs or CIDR ranges. Empty or 0.0.0.0 allows all sources."
+                            helper="Comma-separated IPs or CIDR ranges for the REST API only. Empty or 0.0.0.0 allows all sources. This allowlist does not apply to the MCP endpoint."
                             placeholder="192.168.1.100, 10.0.0.0/8" />
                     </div>
                 </div>
@@ -94,7 +94,13 @@
                 @endif
                 @if ($is_mcp_server_enabled)
                     <x-callout type="info" title="MCP endpoint" class="mt-4">
-                        <code>{{ url('/mcp') }}</code> uses Sanctum bearer tokens from Security → API Tokens.
+                        <div class="flex flex-wrap items-center gap-x-1 gap-y-1">
+                            <code>{{ url('/mcp') }}</code>
+                            <x-copy-button :value="url('/mcp')" label="Copy MCP endpoint" class="size-5!" />
+                            <span>uses Sanctum bearer tokens from
+                                <a href="{{ route('security.api-tokens') }}"
+                                    class="font-medium text-coollabs hover:underline dark:text-warning" {{ wireNavigate() }}>Security → API Tokens</a>.</span>
+                        </div>
                     </x-callout>
                 @endif
             </x-application.settings-section>

--- a/tests/Feature/ApiTokenLivewireAuthorizationTest.php
+++ b/tests/Feature/ApiTokenLivewireAuthorizationTest.php
@@ -76,6 +76,29 @@ test('member can still create read token', function () {
         ->and($token->abilities)->toBe(['read']);
 });
 
+test('member can create a token while REST API access is disabled', function () {
+    InstanceSettings::query()->where('id', 0)->update(['is_api_enabled' => false]);
+
+    $member = User::factory()->create();
+    $this->team->members()->attach($member->id, ['role' => 'member']);
+
+    $this->actingAs($member);
+    session(['currentTeam' => $this->team]);
+
+    Livewire::test(ApiTokens::class)
+        ->assertSee('New API token')
+        ->set('description', 'mcp-read-token')
+        ->set('expiresInDays', 30)
+        ->set('permissions', ['read'])
+        ->call('addNewToken')
+        ->assertHasNoErrors();
+
+    $token = $member->tokens()->latest()->first();
+
+    expect($token)->not->toBeNull()
+        ->and($token->abilities)->toBe(['read']);
+});
+
 test('owner can create root token', function () {
     $owner = User::factory()->create();
     $this->team->members()->attach($owner->id, ['role' => 'owner']);

--- a/tests/Feature/Mcp/McpEndpointTest.php
+++ b/tests/Feature/Mcp/McpEndpointTest.php
@@ -143,6 +143,15 @@ test('MCP endpoint lists tools for an authenticated token', function () {
     expect($toolNames)->toContain('coolify_help', 'control', 'deploy');
 });
 
+test('MCP endpoint accepts an authenticated token while REST API access is disabled', function () {
+    InstanceSettings::query()->where('id', 0)->update(['is_api_enabled' => false]);
+    Once::flush();
+
+    $token = $this->user->createToken('mcp-read', ['read'])->plainTextToken;
+
+    mcpListTools($token)->assertOk();
+});
+
 test('list_projects returns summary + pagination scoped to the token team', function () {
     $project = Project::create(['name' => 'Mine', 'team_id' => $this->team->id]);
 

--- a/tests/Feature/SettingsAccessListboxTest.php
+++ b/tests/Feature/SettingsAccessListboxTest.php
@@ -123,3 +123,19 @@ test('open API allowlist warning is shown when API access is enabled without all
         ->assertSet('is_api_enabled', true)
         ->assertSee('API access is open to every source');
 });
+
+test('MCP settings link to token management and explain the API allowlist scope', function () {
+    $path = resource_path('views/livewire/settings/advanced.blade.php');
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain("route('security.api-tokens')")
+        ->toContain('Security → API Tokens')
+        ->toContain('class="flex flex-wrap items-center gap-x-1 gap-y-1"')
+        ->toContain('label="Copy MCP endpoint" class="size-5!"')
+        ->toContain('<span>uses Sanctum bearer tokens from')
+        ->toContain('Security → API Tokens</a>.')
+        ->toContain('does not apply to the MCP endpoint')
+        ->not->toContain('size-7! border')
+        ->not->toContain('REST API access can remain disabled when using MCP.');
+});


### PR DESCRIPTION
## Changes

- API tokens remain available when REST API access is disabled, so MCP can use its independently authenticated endpoint without temporarily enabling the REST API.
- Advanced settings now clarify the REST-only IP allowlist scope, link directly to API token management, and provide a compact MCP endpoint copy action.
- Regression coverage locks down token creation and MCP authentication while REST API access is disabled.

## Issues

- Fixes #11281

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

### Before

![Before: MCP endpoint without linked token management or copy action](https://raw.githubusercontent.com/fsioni/coolify/assets-mcp-api-token-access-sanitized/before-localhost.png)

### After

![After: MCP endpoint with compact copy action and linked API Tokens page](https://raw.githubusercontent.com/fsioni/coolify/assets-mcp-api-token-access-sanitized/after-localhost.png)

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex
- How extensively: Used to inspect the existing middleware and UI behavior, implement the scoped fix, add regression tests, and run local verification. The resulting behavior and UI were manually reviewed in a local Coolify instance.

## Testing

Automated:

```bash
php artisan test --compact tests/Feature/ApiTokenLivewireAuthorizationTest.php tests/Feature/SettingsAccessListboxTest.php tests/Feature/Mcp/McpEndpointTest.php
vendor/bin/pint --dirty --format agent
```

Result: 29 tests passed with 127 assertions; Pint passed.

Manual:

1. Disable **API access** and enable **MCP server** in **Settings → Advanced**.
2. Confirm the MCP endpoint copy action copies the complete `/mcp` URL.
3. Follow **Security → API Tokens** and create a read token while REST API access remains disabled.
4. Confirm the token authenticates against `/mcp` while REST API routes remain disabled.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.