### PR TITLE
fix(storage): validate connection tests the form's values, not the saved ones

### DIFF
--- a/app/Livewire/Storage/Form.php
+++ b/app/Livewire/Storage/Form.php
@@ -120,22 +120,81 @@ class Form extends Component
         }
     }
 
+    /**
+     * The values currently shown in the form, i.e. what the user is looking at.
+     * Key/secret fall back to the saved storage for members, since those fields
+     * are hidden (and blanked out) in the form for them - see mount().
+     */
+    private function formValues(): array
+    {
+        return [
+            'name' => $this->name,
+            'description' => $this->description,
+            'endpoint' => $this->endpoint,
+            'bucket' => $this->bucket,
+            'region' => $this->region,
+            'key' => $this->isPasswordHiddenForMember ? $this->storage->key : $this->key,
+            'secret' => $this->isPasswordHiddenForMember ? $this->storage->secret : $this->secret,
+        ];
+    }
+
+    /**
+     * Whether the form is still identical to the saved storage, i.e. there are
+     * no unsaved changes to test.
+     */
+    private function formMatchesSavedStorage(array $formValues): bool
+    {
+        foreach ($formValues as $attribute => $value) {
+            if ($this->storage->{$attribute} !== $value) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     public function testConnection()
     {
         try {
             $this->authorize('validateConnection', $this->storage);
 
-            $this->storage->testConnection(shouldSave: true);
+            $formValues = $this->formValues();
+
+            if ($this->formMatchesSavedStorage($formValues)) {
+                // No unsaved changes: test (and persist the outcome on) the saved
+                // storage, exactly as before.
+                $this->storage->testConnection(shouldSave: true);
+            } else {
+                // There are unsaved changes: test what's actually in the form
+                // instead of the stale saved values. Use a throwaway copy of the
+                // model so a passing or failing test never persists credentials
+                // or settings the user hasn't saved yet.
+                $unsavedStorage = $this->storage->replicate();
+                $unsavedStorage->name = $formValues['name'];
+                $unsavedStorage->description = $formValues['description'];
+                $unsavedStorage->endpoint = $formValues['endpoint'];
+                $unsavedStorage->bucket = $formValues['bucket'];
+                $unsavedStorage->region = $formValues['region'];
+                $unsavedStorage->key = $formValues['key'];
+                $unsavedStorage->secret = $formValues['secret'];
+
+                $unsavedStorage->testConnection(shouldSave: false);
+            }
 
             // Update component property to reflect the new validation status
-            $this->isUsable = $this->storage->is_usable;
+            $this->isUsable = true;
             $this->dispatch('storage-status-changed', isUsable: $this->isUsable);
 
             return $this->dispatch('success', 'Connection is working.', 'Tested with "ListObjectsV2" action.');
         } catch (\Throwable $e) {
-            // Refresh model and sync to get the latest state
-            $this->storage->refresh();
-            $this->isUsable = $this->storage->is_usable;
+            if ($this->formMatchesSavedStorage($this->formValues())) {
+                // Refresh model and sync to get the latest state
+                $this->storage->refresh();
+                $this->isUsable = $this->storage->is_usable;
+            } else {
+                // Unsaved changes failed the test; nothing was persisted above.
+                $this->isUsable = false;
+            }
             $this->dispatch('storage-status-changed', isUsable: $this->isUsable);
 
             $this->dispatch('error', 'Failed to test connection.', $e->getMessage());


### PR DESCRIPTION
Closes #11289

## What broke

`App\Livewire\Storage\Form::testConnection()` calls:

```php
$this->storage->testConnection(shouldSave: true);
```

`$this->storage` is the **persisted** Eloquent model, not the form. `submit()` in the same file does it correctly (`$this->validate()` -> `syncData(true)` -> `save()` -> `testConnection(shouldSave: false)`), but the "Validate connection" button never syncs the form into the model first, so it always tests the last-saved endpoint/bucket/region/key/secret - never what's currently typed in.

## Why it matters

Coolify 4.3.0 added SSRF validation on the S3 endpoint (`SafeWebhookUrl`, used by both `S3Storage::testConnection()` and `S3Storage::filesystem()`). An endpoint that worked before the upgrade can start failing that check. The fix is to edit the Endpoint field - but "Validate connection" keeps testing the old, still-rejected saved value, so the button can never turn green for the value the user is actively fixing, and the error message refers to a value no longer visible in the form.

Concrete case: a RustFS/S3 server reached over Tailscale. `http://filserver:9540` had to become the Tailscale FQDN because the bare hostname doesn't resolve inside the Coolify container - the button could never confirm the fix, because it kept testing `http://filserver:9540`.

Root cause: `app/Livewire/Storage/Form.php`, `testConnection()` (around the `$this->storage->testConnection(shouldSave: true);` call).

## Why not just add `syncData(true)` before the existing call

`S3Storage::testConnection()` ends with:

```php
} finally {
    if ($shouldSave) {
        $this->save();
    }
}
```

`syncData(true)` + `testConnection(shouldSave: true)` would make the button *work*, but it would also silently **persist** the endpoint, bucket, region, access key and secret straight from the form on every click - including a failed test, and including credentials the user hasn't asked to save yet (no "Save" click, no validation, no confirmation). That's a worse bug than the one being fixed.

## The fix

`testConnection()` now:
1. Builds the form's current values (`formValues()`), falling back to the saved key/secret for the "hidden for members" case, since those two fields are blanked out (not bound) in the form for non-admin members.
2. If the form is unchanged from the saved storage (`formMatchesSavedStorage()`), behaves exactly as before: `$this->storage->testConnection(shouldSave: true)`.
3. Otherwise, tests a `replicate()` of the model populated with the form's values, always with `shouldSave: false` - so a validate click on an edited-but-unsaved form can never write anything to the database, whether the test passes or fails.

This keeps the existing "storage recovered" persistence behaviour intact for the common case (re-testing an already-saved, already-broken storage), while making the button actually test what the user is looking at, and never persisting unsaved credentials as a side effect.

## Workaround for anyone hitting this now

Ignore "Validate connection". Edit the field and click "Save" in the unsaved-changes bar - `submit()` already syncs, saves, and tests in one DB transaction, rolling back if the test fails.

## Verification

- No `php`, `composer`, or a usable Docker are available in the environment this patch was written in, so `pint`, `phpstan`/larastan (none configured in this repo), and `php artisan test` could **not** be run locally. CI will be the first execution of the test suite against this change.
- Verified by reading, not running:
  - Confirmed the bug is still present on `next` HEAD (`app/Livewire/Storage/Form.php`, fetched from GitHub) before writing the patch.
  - Traced every attribute `S3Storage::testConnection()`/`filesystem()`/`trustedInternalHosts()` read (`endpoint`, `bucket`, `region`, `key`, `secret`, `uuid`) to confirm `replicate()` carries what's needed and the new code doesn't miss one.
  - Checked `resources/views/livewire/storage/form.blade.php`: for `isPasswordHiddenForMember`, the key/secret inputs aren't rendered/bound at all, so the component's `$key`/`$secret` stay `''` - hence `formValues()`'s explicit fallback to `$this->storage->key`/`secret` for that case, both for the connection test itself and for the "does the form match the saved row" comparison.
  - Manually diffed the new `testConnection()` against `submit()`'s existing sync/save/rollback pattern for consistency.
- Not tested: no Pest test added. I looked for an existing Livewire-component test I could mirror 1:1 (checked `tests/Feature/Livewire`, `tests/Unit/Livewire`, `tests/Unit/S3StorageTest.php`, `tests/Unit/S3StorageEndpointValidationTest.php`) and found nothing that exercises `Storage\Form::testConnection()` or mocks the underlying S3 filesystem call it depends on. Per this repo's contribution guidance I'd rather add no test than a low-confidence one likely to be flaky/wrong in CI.

## Scope

Single file changed (`app/Livewire/Storage/Form.php`). `SafeWebhookUrl` and the allowlist logic are untouched on purpose - a separate, unrelated issue exists there (hostname allowlist entries not matching special-use ranges like `100.64.0.0/10`) and is out of scope for this PR.

## AI usage disclosure

Written with Claude Code (Anthropic). I read the diagnosis, the current `S3Storage`/`Form` source, and every line of the patch before committing; the change is scoped to exactly what's described above.

---

By submitting this pull request, I confirm that I've read and complied with this repository's [Contributing Guidelines](https://github.com/coollabsio/coolify/blob/main/CONTRIBUTING.md).
