### PR TITLE
fix(docker): keep MinIO client versions consistent

### DIFF
--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -2,7 +2,7 @@
 # https://hub.docker.com/r/serversideup/php/tags?name=8.4-fpm-nginx-alpine
 ARG SERVERSIDEUP_PHP_VERSION=8.4-fpm-nginx-alpine
 # https://github.com/minio/mc/releases
-ARG MINIO_VERSION=RELEASE.2025-05-21T01-59-54Z
+ARG MINIO_VERSION=RELEASE.2025-08-13T08-35-41Z
 # https://github.com/cloudflare/cloudflared/releases
 ARG CLOUDFLARED_VERSION=2025.7.0
 # https://github.com/coollabsio/coold/releases/tag/nightly

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -2,7 +2,7 @@
 # https://hub.docker.com/r/serversideup/php/tags?name=8.4-fpm-nginx-alpine
 ARG SERVERSIDEUP_PHP_VERSION=8.4-fpm-nginx-alpine
 # https://github.com/minio/mc/releases
-ARG MINIO_VERSION=RELEASE.2025-05-21T01-59-54Z
+ARG MINIO_VERSION=RELEASE.2025-08-13T08-35-41Z
 # https://github.com/cloudflare/cloudflared/releases
 ARG CLOUDFLARED_VERSION=2026.7.3
 # https://www.postgresql.org/support/versioning/

--- a/tests/Unit/MinioClientPackagingTest.php
+++ b/tests/Unit/MinioClientPackagingTest.php
@@ -1,0 +1,20 @@
+<?php
+
+it('pins the same MinIO client release in every Coolify image', function () {
+    $dockerfiles = [
+        dirname(__DIR__, 2).'/docker/production/Dockerfile',
+        dirname(__DIR__, 2).'/docker/development/Dockerfile',
+        dirname(__DIR__, 2).'/docker/coolify-helper/Dockerfile',
+    ];
+
+    $versions = collect($dockerfiles)->map(function (string $dockerfile): string {
+        $contents = file_get_contents($dockerfile);
+
+        expect(preg_match('/^ARG MINIO_VERSION=(.+)$/m', $contents, $matches))->toBe(1);
+
+        return $matches[1];
+    });
+
+    expect($versions->unique()->values()->all())
+        ->toBe(['RELEASE.2025-08-13T08-35-41Z']);
+});


### PR DESCRIPTION
## Changes

- I found that Coolify was packaging different mc versions across its images.
  This change aligns production and development with the helper image and adds
  a test to prevent that drift from returning.

## Issues

- Fixes #11288

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable; this change only aligns a packaged command-line dependency.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: OpenAI Codex and Claude
- How extensively: Used to assist with the patch and local validation harness;
  the author reviewed the diff and results.

## Testing

- `php artisan test --compact tests/Unit/MinioClientPackagingTest.php`
  (1 test, 4 assertions)
- Pint and `git diff --check`
- Clean amd64 builds of production, development, and `coolify-helper`
- Confirmed `mc version RELEASE.2025-08-13T08-35-41Z` in all three images
- Production frontend build completed as part of the image build
- Full isolated Coolify development instance built and started successfully:
  health endpoint returned `OK`, the login page rendered, all 373 migrations
  were applied, and the focused test passed inside the running container
- S3 alias/upload/stat/download smoke test against MinIO with byte comparison
- Confirmed the upstream image manifest includes linux/amd64 and linux/arm64;
  native arm64 remains a CI gate
- Trivy still reports two critical findings inside `mc`; this change is not
  presented as vulnerability remediation

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
