### PR TITLE
fix(sentinel): prevent restart after Sentinel is disabled

### DIFF
--- a/app/Jobs/CheckAndStartSentinelJob.php
+++ b/app/Jobs/CheckAndStartSentinelJob.php
@@ -21,6 +21,10 @@ class CheckAndStartSentinelJob implements ShouldBeEncrypted, ShouldQueue
 
     public function handle(): void
     {
+        if (! $this->sentinelIsEnabled()) {
+            return;
+        }
+
         $latestVersion = get_latest_sentinel_version();
 
         // Check if sentinel is running
@@ -28,7 +32,7 @@ class CheckAndStartSentinelJob implements ShouldBeEncrypted, ShouldQueue
         $sentinelFoundJson = json_decode($sentinelFound, true);
         $sentinelStatus = data_get($sentinelFoundJson, '0.State.Status', 'exited');
         if ($sentinelStatus !== 'running') {
-            StartSentinel::run(server: $this->server, restart: true, latestVersion: $latestVersion);
+            $this->startSentinel($latestVersion);
 
             return;
         }
@@ -38,15 +42,31 @@ class CheckAndStartSentinelJob implements ShouldBeEncrypted, ShouldQueue
             $runningVersion = '0.0.0';
         }
         if ($latestVersion === '0.0.0' && $runningVersion === '0.0.0') {
-            StartSentinel::run(server: $this->server, restart: true, latestVersion: 'latest');
+            $this->startSentinel('latest');
 
             return;
         } else {
             if (version_compare($runningVersion, $latestVersion, '<')) {
-                StartSentinel::run(server: $this->server, restart: true, latestVersion: $latestVersion);
+                $this->startSentinel($latestVersion);
 
                 return;
             }
         }
+    }
+
+    private function sentinelIsEnabled(): bool
+    {
+        $this->server->unsetRelation('settings');
+
+        return $this->server->isSentinelEnabled();
+    }
+
+    private function startSentinel(string $latestVersion): void
+    {
+        if (! $this->sentinelIsEnabled()) {
+            return;
+        }
+
+        StartSentinel::run(server: $this->server, restart: true, latestVersion: $latestVersion);
     }
 }

--- a/tests/Feature/Jobs/CheckAndStartSentinelJobTest.php
+++ b/tests/Feature/Jobs/CheckAndStartSentinelJobTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use App\Jobs\CheckAndStartSentinelJob;
+use App\Models\Server;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+
+uses(RefreshDatabase::class);
+
+it('does not start Sentinel after it has been disabled', function () {
+    DB::table('instance_settings')->insert(['id' => 0]);
+    $user = User::factory()->create();
+    $server = Server::factory()->create([
+        'team_id' => $user->teams()->first()->id,
+    ]);
+    $server->settings->update([
+        'is_metrics_enabled' => false,
+        'is_sentinel_enabled' => false,
+    ]);
+
+    (new CheckAndStartSentinelJob($server))->handle();
+
+    expect((bool) $server->settings->fresh()->is_sentinel_enabled)->toBeFalse();
+});


### PR DESCRIPTION
## Summary

- Respect the server’s current Sentinel setting before starting or updating Sentinel.
- Recheck the setting immediately before startup to prevent queued jobs from re-enabling Sentinel after it is disabled.
- Add regression coverage confirming Sentinel remains disabled.

---

Fixes #11280