### PR TITLE
fix(healthcheck): allow more time for Coolify startup

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -27,7 +27,8 @@ services:
     healthcheck:
       test: curl --fail http://127.0.0.1:8080/api/health || exit 1
       interval: 5s
-      retries: 10
+      retries: 24
+      start_period: 1m
       timeout: 2s
     depends_on:
       postgres:

--- a/other/nightly/docker-compose.prod.yml
+++ b/other/nightly/docker-compose.prod.yml
@@ -27,7 +27,8 @@ services:
     healthcheck:
       test: curl --fail http://127.0.0.1:8080/api/health || exit 1
       interval: 5s
-      retries: 10
+      retries: 24
+      start_period: 1m
       timeout: 2s
     depends_on:
       postgres:

--- a/tests/Unit/ProductionComposeHealthcheckTest.php
+++ b/tests/Unit/ProductionComposeHealthcheckTest.php
@@ -1,0 +1,15 @@
+<?php
+
+use Symfony\Component\Yaml\Yaml;
+
+it('allows Coolify enough time to start before counting healthcheck failures', function (string $composeFile) {
+    $compose = Yaml::parseFile(dirname(__DIR__, 2).'/'.$composeFile);
+
+    expect($compose['services']['coolify']['healthcheck'])
+        ->start_period->toBe('1m')
+        ->interval->toBe('5s')
+        ->retries->toBe(24);
+})->with([
+    'stable' => 'docker-compose.prod.yml',
+    'nightly' => 'other/nightly/docker-compose.prod.yml',
+]);


### PR DESCRIPTION
## Summary

- Add a one-minute startup grace period before healthcheck failures are counted.
- Increase healthcheck retries to support cold starts on busy hosts and slower storage.
- Apply the updated healthcheck settings to stable and nightly production configurations.
- Add unit coverage for both Compose files.

Fixes #11277

---

Fixes #11277