### PR TITLE
fix(team): prevent danger zone source loading error

### DIFF
--- a/resources/views/livewire/team/danger-zone.blade.php
+++ b/resources/views/livewire/team/danger-zone.blade.php
@@ -75,7 +75,7 @@
                             'Projects' => currentTeam()->projects,
                             'Servers' => currentTeam()->servers,
                             'Private keys' => currentTeam()->privateKeys,
-                            'Sources' => currentTeam()->sources,
+                            'Sources' => currentTeam()->sources(),
                         ] as $label => $resources)
                             @if ($resources->isNotEmpty())
                                 <div class="rounded-lg border border-neutral-200 p-3 dark:border-white/[0.08]">

--- a/tests/Feature/TeamSettingsNavigationTest.php
+++ b/tests/Feature/TeamSettingsNavigationTest.php
@@ -28,7 +28,9 @@ it('uses shared sidebar navigation for every team settings page', function () {
     expect(file_get_contents(resource_path('views/livewire/team/danger-zone.blade.php')))
         ->toContain('Delete team')
         ->toContain('status="Permanent"')
-        ->toContain('border-red-300');
+        ->toContain('border-red-300')
+        ->toContain("'Sources' => currentTeam()->sources()")
+        ->not->toContain("'Sources' => currentTeam()->sources,");
     expect(file_get_contents(resource_path('views/livewire/switch-team.blade.php')))
         ->toContain('New team')
         ->toContain('team-switcher-create-expanded')


### PR DESCRIPTION
## Summary

- Load team sources correctly on the danger zone page.
- Prevent the relationship error that blocks viewing and deleting eligible teams.
- Add regression coverage for the sources lookup.

fixes #11303

---

Fixes #11303