### PR TITLE
fix(deployment): restore deployment log download actions

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -3119,7 +3119,6 @@ html[data-theme="custom"] .logs-viewer-timestamp {
     overscroll-behavior-x: contain;
     scrollbar-width: none;
     -webkit-overflow-scrolling: touch;
-    isolation: isolate;
 }
 
 .logs-viewer-actions::-webkit-scrollbar {

--- a/tests/Feature/DeploymentLogsLayoutTest.php
+++ b/tests/Feature/DeploymentLogsLayoutTest.php
@@ -136,6 +136,13 @@ it('uses a mobile-friendly stacked logs toolbar markup', function () {
         ->toContain('flex-direction: column')
         ->toContain('@media (min-width: 640px)');
 
+    $actionsCss = str($appCss)
+        ->after('.logs-viewer-actions {')
+        ->before('}')
+        ->toString();
+
+    expect($actionsCss)->not->toContain('isolation: isolate');
+
     $primaryGroup = str($deploymentView)
         ->after('class="logs-viewer-primary"')
         ->before('class="logs-viewer-end"')


### PR DESCRIPTION
## Summary

- Restore clickable deployment log action buttons by correcting their stacking behavior.
- Add regression coverage for the log viewer action styles.

Fixes #11301.

---

Fixes #11301