### PR TITLE
fix(ui): stop portaled listbox panels stretching to the viewport

### DIFF
--- a/resources/views/components/forms/listbox.blade.php
+++ b/resources/views/components/forms/listbox.blade.php
@@ -94,7 +94,8 @@
             </svg>
         </button>
         @if ($portal)
-            <div id="{{ $panelId }}" class="listbox-panel"
+            {{-- floating-dropdown-panel drops the min-width floor: the panel is fixed, so 100% would be the viewport. --}}
+            <div id="{{ $panelId }}" class="listbox-panel floating-dropdown-panel"
                 style="position: fixed; z-index: 9999; visibility: hidden" x-show="open"
                 x-cloak :style="{ visibility: positioned ? 'visible' : 'hidden' }"
                 x-transition:enter="transition ease-out duration-100"

--- a/tests/Feature/ListboxTriggerTruncationTest.php
+++ b/tests/Feature/ListboxTriggerTruncationTest.php
@@ -45,6 +45,7 @@ test('portaled listboxes center in the mobile viewport', function () {
     expect($html)
         ->toContain('floatingDropdown(')
         ->not->toContain('x-teleport="body"')
+        ->toContain('class="listbox-panel floating-dropdown-panel"')
         ->toContain("align: 'left'")
         ->toContain('matchTriggerWidth: true')
         ->toContain('x-show="open"')


### PR DESCRIPTION
## Changes

Since v4.3.4 every form select opens a dropdown spanning the whole screen instead of sitting under its field.

The panel keeps the listbox-panel floor of min-width: max(100%, 13rem). It is fixed positioned, so that 100% resolves against the viewport. Until v4.3.4 the panel was display:none while measured, so offsetWidth was 0 and the trigger width won; it is now laid out during measurement, so offsetWidth returns the viewport width and positionPanel writes an inline width and max-width that override the 24rem cap.

The fix is the floating-dropdown-panel helper from #11311, which zeroes that floor. The table dropdown already carries it, which is why only form selects broke. positionPanel still applies the trigger-matched min-width.

## Issues

- Fixes #11314

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Headless Chromium, this repo's CSS and positioning code, 1400px viewport, 400px trigger:

| | final width | final left |
|---|---|---|
| before | 1386 | 12 |
| after | 410 | 515 |

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: I hit this on my own instance. Diagnosis and fix were worked out with Claude Code, checked by me against the v4.3.3 and v4.3.4 sources. This text was AI-drafted and reviewed by me.

## Testing

Applied to a self-hosted v4.3.5 instance, view cache cleared. Selects now open at field width, aligned with the trigger, and long labels cap at 24rem again. Could not run the Pest suite (production image ships no tests or vendor); the added assertion is a string check in the existing portaled listbox test.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
