### PR TITLE
feat(auth): autofocus auth form fields and profile 2FA OTP

### DIFF
--- a/resources/views/auth/two-factor-challenge.blade.php
+++ b/resources/views/auth/two-factor-challenge.blade.php
@@ -31,7 +31,21 @@
                 this.updateCode();
                 inputs[Math.min(pastedDigits.length, 6) - 1]?.focus();
             },
-        }">
+            focusEmptyTwoFactorCodeInput() {
+                this.$nextTick(() => {
+                    const emptyDigitIndex = this.digits.findIndex(digit => digit === '');
+
+                    if (emptyDigitIndex === -1) {
+                        return;
+                    }
+
+                    document.getElementById(`two_factor_code_input_${emptyDigitIndex}`)?.focus();
+                });
+            },
+            focusRecoveryCodeInput() {
+                this.$nextTick(() => this.$refs.recoveryCode?.focus());
+            },
+        }" x-init="focusEmptyTwoFactorCodeInput()">
             @if (session('status'))
                 <x-auth.alert type="success">{{ session('status') }}</x-auth.alert>
             @endif
@@ -60,7 +74,7 @@
                     <div class="flex justify-center gap-2" aria-label="Two-factor authentication code"
                         @paste="pasteCode($event)">
                         <template x-for="(digit, index) in digits" :key="index">
-                            <input type="text" inputmode="numeric" pattern="[0-9]*" maxlength="1"
+                            <input :id="`two_factor_code_input_${index}`" type="text" inputmode="numeric" pattern="[0-9]*" maxlength="1"
                                 x-model="digits[index]" :aria-label="`Digit ${index + 1}`"
                                 @input="focusNext($event); updateCode()" @keydown="focusPrevious($event)"
                                 class="h-12 w-11 rounded-md border border-neutral-300 bg-white text-center text-lg font-semibold text-neutral-900 transition-colors focus:border-warning focus:outline-none focus:ring-1 focus:ring-warning dark:border-white/10 dark:bg-coolgray-100 dark:text-white sm:h-14 sm:w-12 sm:text-xl"
@@ -68,7 +82,7 @@
                         </template>
                     </div>
                     <button type="button" class="auth-text-link self-center"
-                        x-on:click="showRecovery = true; $nextTick(() => $refs.recoveryCode.focus())">
+                        x-on:click="showRecovery = true; focusRecoveryCodeInput()">
                         Use a recovery code
                     </button>
                 </div>
@@ -77,7 +91,7 @@
                     <x-forms.input x-ref="recoveryCode" name="recovery_code" autocomplete="one-time-code"
                         x-bind:disabled="!showRecovery" label="{{ __('input.recovery_code') }}" />
                     <button type="button" class="auth-text-link self-center"
-                        x-on:click="showRecovery = false; $nextTick(() => $el.closest('form').querySelector('input[type=text]').focus())">
+                        x-on:click="showRecovery = false; focusEmptyTwoFactorCodeInput()">
                         Use an authenticator code
                     </button>
                 </div>

--- a/resources/views/components/forms/input.blade.php
+++ b/resources/views/components/forms/input.blade.php
@@ -37,7 +37,7 @@
                 @readonly($readonly) @disabled($disabled) id="{{ $htmlId }}"
                 name="{{ $name }}" placeholder="{{ $attributes->get('placeholder') }}"
                 aria-placeholder="{{ $attributes->get('placeholder') }}"
-                @if ($autofocus) x-ref="autofocusInput" @endif>
+                @if ($autofocus) x-ref="autofocusInput" autofocus @endif>
             @if ($allowToPeak)
                 <button type="button" x-on:click="type = type === 'password' ? 'text' : 'password'"
                     class="password-toggle flex absolute inset-y-0 right-0 z-10 items-center pr-2 cursor-pointer text-neutral-500 hover:text-black dark:text-neutral-400 dark:hover:text-white"
@@ -60,7 +60,7 @@
             maxlength="{{ $attributes->get('maxlength') }}"
             @if ($htmlId !== 'null') id={{ $htmlId }} @endif name="{{ $name }}"
             placeholder="{{ $attributes->get('placeholder') }}"
-            @if ($autofocus) x-ref="autofocusInput" @endif>
+            @if ($autofocus) x-ref="autofocusInput" autofocus @endif>
     @endif
     @if (!$label && $helper)
         <x-helper :helper="$helper" />

--- a/resources/views/components/forms/input.blade.php
+++ b/resources/views/components/forms/input.blade.php
@@ -33,7 +33,7 @@
                 @readonly($readonly) @disabled($disabled) id="{{ $htmlId }}"
                 name="{{ $name }}" placeholder="{{ $attributes->get('placeholder') }}"
                 aria-placeholder="{{ $attributes->get('placeholder') }}"
-                @if ($autofocus) x-ref="autofocusInput" @endif>
+                @if ($autofocus) x-ref="autofocusInput" autofocus @endif>
             @if ($allowToPeak)
                 <button type="button" x-on:click="type = type === 'password' ? 'text' : 'password'"
                     class="password-toggle flex absolute inset-y-0 right-0 z-10 items-center pr-2 cursor-pointer text-neutral-500 hover:text-black dark:text-neutral-400 dark:hover:text-white"
@@ -56,7 +56,7 @@
             maxlength="{{ $attributes->get('maxlength') }}"
             @if ($htmlId !== 'null') id={{ $htmlId }} @endif name="{{ $name }}"
             placeholder="{{ $attributes->get('placeholder') }}"
-            @if ($autofocus) x-ref="autofocusInput" @endif>
+            @if ($autofocus) x-ref="autofocusInput" autofocus @endif>
     @endif
     @if (!$label && $helper)
         <x-helper :helper="$helper" />

--- a/resources/views/livewire/profile/index.blade.php
+++ b/resources/views/livewire/profile/index.blade.php
@@ -249,9 +249,10 @@
                                 </p>
                             </div>
                             <form action="/user/confirmed-two-factor-authentication" method="POST"
-                                class="flex items-end gap-2">
+                                class="flex items-end gap-2"
+                                x-init="$nextTick(() => $el.querySelector('input[name=code]')?.focus())">
                                 @csrf
-                                <x-forms.input type="text" inputmode="numeric" pattern="[0-9]*" id="code"
+                                <x-forms.input name="code" type="text" inputmode="numeric" pattern="[0-9]*" id="code"
                                     label="One-time code" required />
                                 <x-forms.button type="submit">Validate 2FA</x-forms.button>
                             </form>

--- a/resources/views/livewire/profile/index.blade.php
+++ b/resources/views/livewire/profile/index.blade.php
@@ -241,9 +241,10 @@
                                 </p>
                             </div>
                             <form action="/user/confirmed-two-factor-authentication" method="POST"
-                                class="flex items-end gap-2">
+                                class="flex items-end gap-2"
+                                x-init="$nextTick(() => $el.querySelector('input[name=code]')?.focus())">
                                 @csrf
-                                <x-forms.input type="text" inputmode="numeric" pattern="[0-9]*" id="code"
+                                <x-forms.input name="code" type="text" inputmode="numeric" pattern="[0-9]*" id="code"
                                     label="One-time code" required />
                                 <x-forms.button type="submit">Validate 2FA</x-forms.button>
                             </form>


### PR DESCRIPTION
## Changes

Auth pages needed an extra click before typing. Login, register, forgot/reset/confirm password now focus the main field on load via the shared input `autofocus`. Profile 2FA validation focuses the OTP field when that form appears.

Frontend-only. No backend or database changes.

## Issues

- Related discussion: https://github.com/coollabsio/coolify/discussions/10594
- Replaces closed PR https://github.com/coollabsio/coolify/pull/10596 (old auth UI). Same UX on the current screens.

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

### Login, register, forgot password

[login-register-forgot-password.webm](https://github.com/user-attachments/assets/28585d62-697e-45ba-836a-8bb1d524f31e)

### Reset password

[reset-password.webm](https://github.com/user-attachments/assets/70f1773d-81d8-48a3-94ce-b278e224e2d4)

### Confirm password

[confirm-password.webm](https://github.com/user-attachments/assets/46ac447a-b1ff-457c-b55e-5aabe6ee6d0b)

### Profile 2FA validation

[profile-2fa-validation.webm](https://github.com/user-attachments/assets/427947d4-9159-42e5-b428-6e5947800c8b)

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Cursor
- How extensively: Helped rebase onto next and adapt the old contribution to the new auth UI. I reviewed every change and verified locally.

## Testing

Tested with docker compose at localhost:8000 on login, register, forgot/reset/confirm password, and profile 2FA validation.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.