### PR TITLE
fix(backups): render form for directory-only targets

### DIFF
--- a/app/Livewire/Project/Application/Backup/Create.php
+++ b/app/Livewire/Project/Application/Backup/Create.php
@@ -82,7 +82,7 @@ class Create extends Component
                 'type' => 'Directory',
                 'name' => $directory->fs_path,
             ]);
-        $this->targets = $volumes->concat($directories)->values();
+        $this->targets = collect($volumes->concat($directories)->all())->values();
         $this->targetKey = $this->selectedTargetKey ?? data_get($this->targets->first(), 'key');
         $this->loadSelectedBackup();
     }

--- a/tests/Feature/VolumeBackupTest.php
+++ b/tests/Feature/VolumeBackupTest.php
@@ -222,6 +222,18 @@ it('creates a scheduled backup for a preselected application directory', functio
     expect(ScheduledVolumeBackup::query()->sole()->backupable->is($directory))->toBeTrue();
 });
 
+it('renders the backup form for an application with only a directory target', function () {
+    $team = Team::factory()->create();
+    signInForVolumeBackups($this, $team);
+    [$application, $volume] = createVolumeBackupApplication($team);
+    $volume->delete();
+    $directory = createApplicationBackupDirectory($application);
+
+    Livewire::test(CreateScheduledVolumeBackup::class, ['application' => $application])
+        ->assertSet('targetKey', 'directory:'.$directory->id)
+        ->assertSuccessful();
+});
+
 it('rejects files and directory mounts owned by another application as backup targets', function () {
     $team = Team::factory()->create();
     signInForVolumeBackups($this, $team);


### PR DESCRIPTION
## Summary

- Fix the project backup page failing to load when an application has only a directory backup target.
- Add regression coverage for rendering the backup form in this scenario.
- fixes #11307

---

Fixes #11307