### PR TITLE
fix(ui): show unavailable action menu items as disabled

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1985,12 +1985,14 @@ html[data-theme="custom"] textarea:disabled {
     color: var(--coollabs-fg);
 }
 
-.listbox-option-disabled {
+.listbox-option-disabled,
+.listbox-option:disabled {
     cursor: not-allowed;
     opacity: 0.4;
 }
 
-.listbox-option-disabled:hover {
+.listbox-option-disabled:hover,
+.listbox-option:disabled:hover {
     background: transparent;
 }
 

--- a/tests/Feature/Authorization/ResourceHeadingAuthorizationTest.php
+++ b/tests/Feature/Authorization/ResourceHeadingAuthorizationTest.php
@@ -19,7 +19,9 @@ use Livewire\Livewire;
 uses(RefreshDatabase::class);
 
 beforeEach(function () {
-    InstanceSettings::updateOrCreate(['id' => 0]);
+    // `id` is not fillable, so `updateOrCreate` would seed an autoincremented
+    // row and `InstanceSettings::get()` (findOrFail(0)) would fail on render.
+    InstanceSettings::forceCreate(['id' => 0]);
 
     $this->team = Team::factory()->create();
 
@@ -245,4 +247,59 @@ test('admin sees terminal link for service', function () {
         'query' => [],
     ])
         ->assertSee('Terminal');
+});
+
+// --- Denied action menu items must carry the disabled attribute ---
+//
+// The `.listbox-option:disabled` style relies on it to render the item as
+// unavailable. Without the attribute the item looks clickable and silently
+// does nothing.
+
+/**
+ * Collect the disabled state of every `.listbox-option` button whose visible
+ * text matches the given label exactly.
+ *
+ * @return array<int, bool>
+ */
+function listboxOptionDisabledStates(string $html, string $label): array
+{
+    preg_match_all('/<button\b[^>]*class="[^"]*listbox-option[^"]*"[^>]*>(.*?)<\/button>/s', $html, $matches, PREG_SET_ORDER);
+
+    return collect($matches)
+        ->filter(fn (array $match): bool => trim(preg_replace('/\s+/', ' ', strip_tags($match[1]))) === $label)
+        ->map(fn (array $match): bool => str_contains($match[0], 'disabled'))
+        ->values()
+        ->all();
+}
+
+test('member sees application action items as disabled', function () {
+    $this->actingAs($this->member);
+    session(['currentTeam' => $this->team]);
+
+    $html = Livewire::test(ApplicationHeading::class, ['application' => $this->application])->html();
+
+    foreach (['Redeploy', 'Restart', 'Stop'] as $label) {
+        $states = listboxOptionDisabledStates($html, $label);
+
+        expect($states)->not->toBeEmpty("Expected a '{$label}' action item to be rendered.");
+        expect($states)->each->toBeTrue();
+    }
+});
+
+test('member sees service action items as disabled', function () {
+    $this->actingAs($this->member);
+    session(['currentTeam' => $this->team]);
+
+    $html = Livewire::test(ServiceHeading::class, [
+        'service' => $this->service,
+        'parameters' => $this->serviceParams,
+        'query' => [],
+    ])->html();
+
+    foreach (['Deploy', 'Force Deploy'] as $label) {
+        $states = listboxOptionDisabledStates($html, $label);
+
+        expect($states)->not->toBeEmpty("Expected a '{$label}' action item to be rendered.");
+        expect($states)->each->toBeTrue();
+    }
 });


### PR DESCRIPTION
## Changes

Items in the "Actions" menus (application, database and service headings) that the current user is not allowed to use are rendered as `<button disabled>` but carry the plain `listbox-option` class. Nothing indicates the disabled state — no dimming, no `cursor: not-allowed`, no tooltip — so the item looks perfectly clickable and silently does nothing. There is no console error either, which makes it look like a broken button rather than a permission issue.

This is a regression from the heading rework: before it, these were `<x-forms.button canGate="deploy" :canResource="...">`, and `App\View\Components\Forms\Button` set `authDisabled`, which rendered the "You do not have permission to perform this action." tooltip.

The fix styles `.listbox-option:disabled` exactly like the existing `.listbox-option-disabled` class already used by the form listboxes (`opacity: 0.4`, `cursor: not-allowed`, no hover background). Doing it in CSS covers all 32 disabled items across the three headings — both the `@can/@else` and the `@disabled(...)` variants — without touching any template, and keeps future menu items consistent.

Reported by a team `member`, who as of the ACL enforcement is read-only and cannot deploy/restart/stop. The permission itself is not changed here — only the missing feedback.

Also fixed while testing: `ResourceHeadingAuthorizationTest` seeded `InstanceSettings::updateOrCreate(['id' => 0])`, but `id` is not fillable, so the row was created with an autoincremented id and every rendering test in that file blew up on `InstanceSettings::get()` (`findOrFail(0)`). Switched to `forceCreate`, as documented for instance sentinel rows.

## Issues

- Fixes

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Menu items the user cannot use are now dimmed with a `not-allowed` cursor, matching the form listboxes.

<!-- screenshot -->

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Used to trace the regression through the git history and to draft the CSS rule and the tests. Every change was reviewed and verified manually against a local dev instance.

## Testing

- Added `member sees application action items as disabled` and `member sees service action items as disabled` to `tests/Feature/Authorization/ResourceHeadingAuthorizationTest.php`. They parse the rendered heading HTML and assert every `.listbox-option` matching a denied action label carries `disabled` — the attribute the new CSS rule hangs off.
- `php artisan test --compact tests/Feature/Authorization/ResourceHeadingAuthorizationTest.php` — the two new tests pass, and the `forceCreate` fix takes the file from 12 failures down to 4. The remaining 4 (`admin sees terminal link for application`, `admin sees terminal link for service`, `admin/member can access database page`) fail with `Connection refused` in my local environment because they reach out to the server, and are unrelated to this change.
- `vendor/bin/pint --dirty` — passed.
- `npm run build` — the rule compiles to `listbox-option:disabled{cursor:not-allowed;opacity:.4}`.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
