### PR TITLE
fix(modal): use checkbox ids for Livewire bindings

### DIFF
--- a/resources/views/components/modal-confirmation.blade.php
+++ b/resources/views/components/modal-confirmation.blade.php
@@ -236,7 +236,6 @@
                             @foreach ($checkboxes as $index => $checkbox)
                                 <div class="flex justify-between items-center mb-2">
                                     <x-forms.checkbox fullWidth :label="$checkbox['label']" :id="$checkbox['id']"
-                                        :wire:model="$checkbox['id']"
                                         x-on:change="toggleAction('{{ $checkbox['id'] }}')" :checked="$this->{$checkbox['id']}"
                                         x-bind:checked="selectedActions.includes('{{ $checkbox['id'] }}')" />
                                 </div>

--- a/tests/Feature/ModalConfirmationStep1NoCancelTest.php
+++ b/tests/Feature/ModalConfirmationStep1NoCancelTest.php
@@ -13,3 +13,11 @@ test('modal confirmation step 1 does not render a cancel button', function () {
         ->toContain('step1ButtonText')
         ->not->toContain('Cancel');
 });
+
+test('modal confirmation lets checkbox ids define their Livewire model binding', function () {
+    $modal = file_get_contents(resource_path('views/components/modal-confirmation.blade.php'));
+
+    expect($modal)
+        ->not->toContain(':wire:model="$checkbox[\'id\']"')
+        ->toContain(':id="$checkbox[\'id\']"');
+});

--- a/tests/Feature/ModalConfirmationStep1NoCancelTest.php
+++ b/tests/Feature/ModalConfirmationStep1NoCancelTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Facades\Blade;
+
 /**
  * Step 1 (checkbox options) should only show Continue — dismiss is the header X.
  */
@@ -15,9 +17,15 @@ test('modal confirmation step 1 does not render a cancel button', function () {
 });
 
 test('modal confirmation lets checkbox ids define their Livewire model binding', function () {
-    $modal = file_get_contents(resource_path('views/components/modal-confirmation.blade.php'));
+    $checkbox = Blade::render(<<<'BLADE'
+        <x-forms.checkbox id="deleteVolumes"
+            x-on:change="toggleAction('deleteVolumes')"
+            x-bind:checked="selectedActions.includes('deleteVolumes')" />
+    BLADE);
 
-    expect($modal)
-        ->not->toContain(':wire:model="$checkbox[\'id\']"')
-        ->toContain(':id="$checkbox[\'id\']"');
+    expect($checkbox)
+        ->toContain('x-on:change="toggleAction(\'deleteVolumes\')"')
+        ->toContain('x-bind:checked="selectedActions.includes(\'deleteVolumes\')"')
+        ->toContain('wire:model=deleteVolumes')
+        ->toMatch('/id="deleteVolumes-[a-zA-Z0-9]{24}"/');
 });


### PR DESCRIPTION
## Summary

- Let confirmation modal checkbox IDs define their Livewire model bindings.
- Prevent malformed bindings caused by explicitly passing the dynamic `wire:model` attribute.
- Add regression coverage for the checkbox markup.