### PR TITLE
fix(ui): use Alpine state for clone-to-environment destination uuid

### DIFF
--- a/resources/views/livewire/project/shared/resource-operations.blade.php
+++ b/resources/views/livewire/project/shared/resource-operations.blade.php
@@ -245,8 +245,7 @@
                     Uses {{ data_get($resource, 'destination.server.name') }} ·
                     {{ data_get($resource, 'destination.network') }}.
                 </p>
-                <x-forms.button
-                    @click="$wire.cloneTo(@js($resource->destination->uuid), selectedCloneEnvironment)">
+                <x-forms.button @click="$wire.cloneTo(currentDestinationUuid, selectedCloneEnvironment)">
                     Clone resource
                 </x-forms.button>
             </div>


### PR DESCRIPTION
## Changes

- Fixed the dead "Clone resource" button in the **Clone to another environment** section of Resource Operations.
- The button's `@click` used `@js($resource->destination->uuid)` inside a Blade component-tag attribute. Blade's `ComponentTagCompiler` does not compile directives inside component-tag attributes (only `{{ }}` echoes), so the literal text `@js($resource->destination->uuid)` reached the browser as the Alpine expression. Alpine threw `Alpine Expression Error: Unexpected token '@'` on click and `$wire.cloneTo()` never ran.
- The root `x-data` of this view already defines `currentDestinationUuid: @js($resource->destination->uuid)` (compiled correctly there), so the button now uses that existing Alpine variable: `$wire.cloneTo(currentDestinationUuid, selectedCloneEnvironment)`.

## Issues

- Fixes #11340

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable — one-line behavioral fix restoring the existing button; no visual change.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: Diagnosed the root cause (inspected the compiled view cache of a running v4.3.7 instance to confirm the uncompiled `@js()` output) and drafted the one-line fix; changes were reviewed and verified by me.

## Testing

- Confirmed the bug's mechanism from the compiled view cache of a live v4.3.7 instance: `withAttributes(['@click' => '$wire.cloneTo(@js($resource->destination->uuid), selectedCloneEnvironment)'])` — the directive passes through uncompiled.
- Verified the fixed attribute compiles cleanly through Laravel's Blade compiler: `withAttributes(['@click' => '$wire.cloneTo(currentDestinationUuid, selectedCloneEnvironment)'])`, a valid Alpine expression identical in shape to the working "Clone to another destination" button.
- `currentDestinationUuid` is defined in the section's root `x-data`, so the value is available in the button's Alpine scope.
