### PR TITLE
fix(postgresql): persist selected public access state

### DIFF
--- a/app/Livewire/Project/Database/Postgresql/General.php
+++ b/app/Livewire/Project/Database/Postgresql/General.php
@@ -209,10 +209,14 @@ class General extends Component
         }
     }
 
-    public function instantSave()
+    public function instantSave(?bool $isPublic = null)
     {
         try {
             $this->authorize('update', $this->database);
+
+            if ($isPublic !== null) {
+                $this->isPublic = $isPublic;
+            }
 
             if ($this->isPublic && ! $this->publicPort) {
                 $this->dispatch('error', 'Public port is required.');

--- a/resources/views/livewire/project/database/postgresql/general.blade.php
+++ b/resources/views/livewire/project/database/postgresql/general.blade.php
@@ -89,7 +89,7 @@
             <x-table.loading target="instantSave" text="Updating public access..." />
             <div class="grid gap-4 lg:grid-cols-2">
                 <div wire:key="public-access-{{ $publicPort ?: 'unset' }}">
-                    <x-forms.listbox id="isPublic" label="Access" live onChange="instantSave"
+                    <x-forms.listbox id="isPublic" label="Access" live onChange="instantSave" :onChangeArgs="[]"
                         :disabled="! auth()->user()->can('update', $database)" :options="[
                             ['value' => false, 'label' => 'Private'],
                             ['value' => true, 'label' => blank($publicPort) ? 'Public through TCP proxy (set public port first)' : 'Public through TCP proxy', 'disabled' => blank($publicPort)],

--- a/tests/Feature/DatabasePublicAccessLoadingTest.php
+++ b/tests/Feature/DatabasePublicAccessLoadingTest.php
@@ -26,3 +26,16 @@ it('shows a loading indicator while database public access is changing', functio
             ->not->toContain('id="publicPort" live');
     }
 });
+
+it('passes the selected PostgreSQL public access state to the save action', function () {
+    $generalSettings = file_get_contents(resource_path('views/livewire/project/database/postgresql/general.blade.php'));
+
+    expect($generalSettings)
+        ->toContain('onChange="instantSave" :onChangeArgs="[]"');
+
+    $component = file_get_contents(app_path('Livewire/Project/Database/Postgresql/General.php'));
+
+    expect($component)
+        ->toContain('public function instantSave(?bool $isPublic = null)')
+        ->toContain('$this->isPublic = $isPublic;');
+});


### PR DESCRIPTION
## Summary

- Persist the selected PostgreSQL public access state immediately.
- Prevent public access from reverting after a refresh or proxy restart.
- Add regression coverage for passing the selected state to the save action.

fixes #11345

---

Fixes #11345