### PR TITLE
fix(table): keep page-size dropdown within viewport

### DIFF
--- a/resources/views/components/table/dropdown.blade.php
+++ b/resources/views/components/table/dropdown.blade.php
@@ -36,7 +36,7 @@
     </div>
 
     <div x-ref="panel" x-show="open" x-cloak :style="panelStyle"
-        class="listbox-panel fixed! top-auto! right-auto! bottom-auto! z-[90]! mt-0! {{ $panelClass }}" role="{{ $role }}"
+        class="listbox-panel fixed! right-auto! bottom-auto! z-[90]! mt-0! {{ $panelClass }}" role="{{ $role }}"
         @if ($multiselectable) aria-multiselectable="true" @endif>
         {{ $slot }}
     </div>

--- a/tests/Feature/TablePaginationLoadingTest.php
+++ b/tests/Feature/TablePaginationLoadingTest.php
@@ -41,7 +41,8 @@ it('positions table dropdown panels outside overflowing containers', function ()
     expect($html)
         ->toContain('position: fixed')
         ->toContain('getBoundingClientRect()')
-        ->toContain('x-on:scroll.window');
+        ->toContain('x-on:scroll.window')
+        ->not->toContain('top-auto!');
 });
 
 it('renders compact client-side pagination', function () {


### PR DESCRIPTION
## Summary

- Preserve the dynamically calculated top position for table dropdown panels.
- Keep the page-size dropdown visible and usable near the bottom of the viewport.
- Add regression coverage for conflicting dropdown positioning styles.

fixes #11336

---

Fixes #11336