### PR TITLE
fix(upgrade): handle missing status after restart

### DIFF
--- a/resources/views/livewire/upgrade.blade.php
+++ b/resources/views/livewire/upgrade.blade.php
@@ -295,6 +295,16 @@
                         }
                         throw error;
                     }
+                    if (!data) {
+                        if (this.instanceWentDown) {
+                            // The upgraded instance can no longer return data for the old Livewire component.
+                            // A healthy response after observed downtime confirms that the restart completed.
+                            this.showSuccess();
+                        } else {
+                            this.currentStatus = this.getReviveStatusMessage(elapsedMinutes, this.healthCheckAttempts);
+                        }
+                        return;
+                    }
                     if (data.status === 'complete') {
                         this.showSuccess();
                     } else if (data.status === 'error') {

--- a/tests/Unit/CoolifyUpgradeStatusTest.php
+++ b/tests/Unit/CoolifyUpgradeStatusTest.php
@@ -149,6 +149,16 @@ it('finishes after health recovers from observed downtime for older target relea
         ->toContain('return;');
 });
 
+it('finishes when the post-restart Livewire status response is undefined', function () {
+    $upgradeView = file_get_contents(__DIR__.'/../../resources/views/livewire/upgrade.blade.php');
+
+    expect($upgradeView)
+        ->toContain('if (!data) {')
+        ->toContain('if (this.instanceWentDown) {')
+        ->toContain('this.showSuccess();')
+        ->toContain('return;');
+});
+
 it('tells users to reload manually if the automatic reload does not happen', function () {
     $upgradeView = file_get_contents(__DIR__.'/../../resources/views/livewire/upgrade.blade.php');
 


### PR DESCRIPTION
## Summary

- Treat a recovered health check as a successful upgrade when the restarted instance cannot return status data to the old Livewire component.
- Keep polling with a progress message when status data is missing before any downtime is observed.
- Add regression coverage for an undefined post-restart status response.

fixes #11347

---

Fixes #11347