### PR TITLE
fix(ssh): stop the aged mux master instead of killing it mid-deployment

### DIFF
--- a/app/Helpers/SshMultiplexingHelper.php
+++ b/app/Helpers/SshMultiplexingHelper.php
@@ -98,6 +98,21 @@ class SshMultiplexingHelper
         self::clearConnectionMetadata($server);
     }
 
+    /**
+     * Retire the master without disturbing the sessions already running on it.
+     *
+     * `ssh -O exit` terminates the master *and every channel multiplexed over
+     * it*. `-O stop` asks it to stop accepting new multiplexing requests
+     * instead: the control socket is unlinked immediately, so the next caller
+     * establishes a fresh master, while sessions already attached run to
+     * completion.
+     */
+    public static function stopAcceptingNewSessions(Server $server): void
+    {
+        Process::run(self::muxControlCommand($server, 'stop'));
+        self::clearConnectionMetadata($server);
+    }
+
     public static function generateScpCommand(Server $server, string $source, string $dest): string
     {
         $sshConfig = self::serverSshConfiguration($server);
@@ -263,7 +278,13 @@ class SshMultiplexingHelper
 
     public static function refreshMultiplexedConnection(Server $server): bool
     {
-        self::removeMuxFile($server);
+        // Recycling happens on age or health, on a connection shared by every
+        // job touching this server — so it can fire in the middle of somebody
+        // else's deployment. Tearing the master down would take that build's
+        // command with it (exit code 255, BuildKit "context canceled"), so the
+        // old master is only stopped from accepting new sessions. Callers that
+        // genuinely want it gone still use removeMuxFile().
+        self::stopAcceptingNewSessions($server);
 
         return self::establishNewMultiplexedConnection($server);
     }

--- a/tests/Feature/SshMultiplexingLockTest.php
+++ b/tests/Feature/SshMultiplexingLockTest.php
@@ -87,7 +87,13 @@ it('reuses an existing healthy master without spawning a new one', function () {
     Process::assertNotRan(fn ($process) => str_contains($process->command, 'ssh -fN'));
 });
 
-it('refreshes an expired master before reuse', function () {
+it('refreshes an expired master without killing the sessions running on it', function () {
+    // The master is shared by every job touching this server, so recycling it
+    // on age can land in the middle of an unrelated deployment. `ssh -O exit`
+    // would take that deployment's command down with it (exit code 255, and
+    // BuildKit logging "context canceled" a moment later, with nothing in the
+    // build output to explain it), so the aged master is only stopped from
+    // accepting new sessions.
     config([
         'constants.ssh.mux_enabled' => true,
         'constants.ssh.mux_health_check_enabled' => false,
@@ -98,14 +104,33 @@ it('refreshes an expired master before reuse', function () {
 
     Process::fake([
         '*-O check*' => Process::result(exitCode: 0),
+        '*-O stop*' => Process::result(exitCode: 0),
         '*-O exit*' => Process::result(exitCode: 0),
         '*-fN *' => Process::result(exitCode: 0),
     ]);
 
     expect(SshMultiplexingHelper::ensureMultiplexedConnection($server))->toBeTrue();
 
-    Process::assertRan(fn ($process) => str_contains($process->command, 'ssh -O exit'));
+    Process::assertRan(fn ($process) => str_contains($process->command, 'ssh -O stop'));
+    Process::assertNotRan(fn ($process) => str_contains($process->command, 'ssh -O exit'));
+    // -O stop unlinks the control socket as it stops listening, so the
+    // replacement master claims the same ControlPath straight away.
     Process::assertRan(fn ($process) => str_contains($process->command, 'ssh -fN '));
+});
+
+it('still uses ssh -O exit where the master is meant to be torn down', function () {
+    // Key rotation and the explicit cleanup job want the master gone rather
+    // than drained, so removeMuxFile() keeps its behaviour.
+    config(['constants.ssh.mux_enabled' => true]);
+    $server = makeMuxServer();
+
+    Process::fake([
+        '*-O exit*' => Process::result(exitCode: 0),
+    ]);
+
+    SshMultiplexingHelper::removeMuxFile($server);
+
+    Process::assertRan(fn ($process) => str_contains($process->command, 'ssh -O exit'));
 });
 
 it('does not spawn a master when the per-server lock is already held', function () {


### PR DESCRIPTION
Fixes #10853.

## The problem

`SshMultiplexingHelper::refreshMultiplexedConnection()` retires an aged or unhealthy ControlMaster with `ssh -O exit`, which terminates the master **and every channel multiplexed over it**.

That master is shared by every job touching a server. So when the age clock (`SSH_MUX_MAX_AGE`, default 1800 s) runs out while an unrelated deployment is streaming its build over the same connection, the deployment's command dies:

```
Command execution failed (exit code 255): docker exec <helper> bash -c '... docker compose ... build'
```

with `Solve error="rpc error: code = Canceled desc = context canceled"` in dockerd a second later, and the build log simply stopping mid-step. Nothing in the build output explains it, so it reads as a flaky build.

The age clock starts with the *connection*, not the deployment, so short builds are not safe either — any build overlapping the boundary dies regardless of its own duration.

Reproduced on a self-hosted instance today, twice in a row, on schedule:

| | |
|---|---|
| 14:54:07 | master established (`Accepted publickey ... port 39606`) |
| 15:22:00 | deployment starts |
| 15:23:59 | BuildKit begins `exporting to image` |
| 15:24:14 | `Received disconnect from ... port 39606:11: disconnected by user` |
| 15:24:14 | deployment fails, exit 255 |
| 15:24:14 | new master established (`port 51200`) |
| 15:24:16 | dockerd: `context canceled` |

30 min 07 s between establishing and killing. The next deployment failed at 15:54:23 — 30 min 09 s after that replacement master was created. The commit in flight was frontend-only and had compiled successfully; there was no OOM, no disk pressure, and the machine was idle.

## The change

Use `ssh -O stop` on the recycle path. Per `ssh(1)`, `stop` asks the master "to stop accepting further multiplexing requests" rather than to exit: it unlinks the control socket as it stops listening — so the replacement master claims the same `ControlPath` straight away — while sessions already attached run to completion.

`removeMuxFile()` is deliberately left alone and still issues `-O exit`. Its two callers (`refresh_server_connection()` on key rotation, and the `ServerCleanupMux` job) mean for the master to be gone rather than drained.

## Tests

`it('refreshes an expired master before reuse')` asserted `ssh -O exit` on the refresh path, so it encoded the behaviour being fixed. It now asserts `-O stop`, that no `-O exit` is issued, and that a fresh master is still established. A second test pins the teardown path so the two cannot drift together.

Both fail without the change and pass with it:

```
Tests:    31 passed (90 assertions)   # SshMultiplexingLockTest, SshMultiplexingDisableTest, SshRetryMechanismTest
```

## Note on the workaround in the issue thread

Raising `SSH_MUX_MAX_AGE` reduces how often the boundary lands inside a build, but it cannot remove the race — it only makes the window rarer.
