### PR TITLE
fix(ui): close account menu on outside click when appearance is expanded

### DIFF
--- a/resources/views/components/top-user-menu.blade.php
+++ b/resources/views/components/top-user-menu.blade.php
@@ -16,13 +16,19 @@
     themeColor: localStorage.getItem('themeColor') || '#6b16ed',
     themeColorFrame: null,
     avatarUrl: @js($user?->avatar_path ? route('profile.avatar', ['v' => $user->updated_at->timestamp]) : null),
+    openPanel() {
+        this.appearanceOpen = false;
+        this.open = true;
+    },
+    closePanel() {
+        this.open = false;
+    },
     setTheme(type, closeMenu = true) {
         this.theme = type;
         localStorage.setItem('theme', type);
 
         if (closeMenu) {
-            this.appearanceOpen = false;
-            this.open = false;
+            this.closePanel();
         }
 
         const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
@@ -62,9 +68,9 @@
         localStorage.setItem('themeColor', color);
         localStorage.setItem('theme', 'custom');
     },
-}" @avatar-updated.window="avatarUrl = $event.detail.url" @keydown.escape.window="open = false; appearanceOpen = false"
-    @click.outside="open = false; appearanceOpen = false">
-    <button type="button" @click="open = !open"
+}" @avatar-updated.window="avatarUrl = $event.detail.url" @keydown.escape.window="closePanel()"
+    @click.outside="closePanel()">
+    <button type="button" @click="open ? closePanel() : openPanel()"
         title="{{ $userName }}" aria-label="Account menu for {{ $userName }}"
         @if ($sidebar) :class="collapsed && 'w-8 justify-center px-0'" @endif
         @class([
@@ -188,7 +194,7 @@
         </a>
         <x-modal-input title="How can we help?">
             <x-slot:content>
-                <div class="listbox-option cursor-pointer" @click="open = false">
+                <div class="listbox-option cursor-pointer" @click="closePanel()">
                     <span class="flex items-center gap-2">
                         <x-reicon name="feedback" class="size-4 opacity-80" />
                         Feedback


### PR DESCRIPTION
## Changes

**Before** — Appearance expanded, one click outside leaves the panel on screen:

https://github.com/user-attachments/assets/0af2436c-a3a7-4a00-a74c-6afbdda2b1b1

**After** — the panel closes on the first click outside:

https://github.com/user-attachments/assets/5ba3d08d-3c13-4201-8b12-a573ab3fb015


## Issues

<!-- Link related issues or discussions. If reopening a closed PR, explain why it should be reconsidered. -->

- Fixes : issue : #11373

## Category

- [X] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

<!-- Screenshot or short video showing your changes in action. Mandatory for new features. -->

## AI Assistance

<!-- AI-assisted PRs that are human reviewed are welcome, just let us know so we can review appropriately. -->

- [ ] AI was NOT used to create this PR
- [X] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: To identify the locations and understand the issue where the issue is in the code and why

## Testing

Tested on a local dev instance (`docker compose -f docker-compose.yml -f docker-compose.dev.yml up`),
in both places the account menu renders — the desktop sidebar and the mobile top bar:

1. Open the account menu, expand **Appearance**, then click anywhere outside the
   panel — the whole panel closes on the first click.
2. Open the account menu, expand **Appearance**, pick a theme — the panel closes
   and the theme applies.
3. Open the account menu, expand **Appearance**, press <kbd>Escape</kbd> — the
   panel closes.
4. Re-open the menu — Appearance is collapsed again, with no visible jump.
5. Toggle **Appearance** open/closed while the panel stays open — the collapse
   animation is unchanged.


## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [X] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [X] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [X] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
