### PR TITLE
feat(var): environment variable copy button

### DIFF
--- a/app/Livewire/Project/Shared/EnvironmentVariable/Show.php
+++ b/app/Livewire/Project/Shared/EnvironmentVariable/Show.php
@@ -220,7 +220,7 @@ class Show extends Component
             $this->is_required = (bool) ($this->env->is_required ?? false);
             // Use the stored column, not the value-based accessor (that decrypts).
             $this->is_shared = (bool) ($this->env->getAttributes()['is_shared'] ?? false);
-            $this->isValueHidden = auth()->user()?->isMember() ?? false;
+            $this->isValueHidden = auth()->user()?->isMember() ?? true;
 
             if ($this->valuesLoaded) {
                 $this->hydrateValueFields();
@@ -247,12 +247,12 @@ class Show extends Component
             $this->is_really_required = $this->is_required && blank($this->value);
         }
 
-        if ($this->env->is_shown_once || auth()->user()?->isMember()) {
+        if ($this->env->is_shown_once || (auth()->user()?->isMember() ?? true)) {
             $this->value = null;
             $this->real_value = null;
         }
 
-        $this->isValueHidden = auth()->user()?->isMember() ?? false;
+        $this->isValueHidden = auth()->user()?->isMember() ?? true;
     }
 
     public function checkEnvs()

--- a/app/Livewire/Project/Shared/EnvironmentVariable/Show.php
+++ b/app/Livewire/Project/Shared/EnvironmentVariable/Show.php
@@ -161,6 +161,22 @@ class Show extends Component
         $this->valuesLoaded = true;
     }
 
+    public function copyValue(): ?string
+    {
+        if ($this->env->is_shown_once || (auth()->user()?->isMember() ?? true)) {
+            return null;
+        }
+
+        if (! $this->env instanceof ModelsEnvironmentVariable) {
+            return $this->env->value;
+        }
+
+        return $this->env->get_real_environment_variables_with_server(
+            $this->env->resolveReferencedValue(),
+            $this->env->resourceable,
+        );
+    }
+
     public function syncData(bool $toModel = false)
     {
         if ($toModel) {

--- a/app/Livewire/Project/Shared/EnvironmentVariable/ShowHardcoded.php
+++ b/app/Livewire/Project/Shared/EnvironmentVariable/ShowHardcoded.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\Project\Shared\EnvironmentVariable;
 
+use App\Models\EnvironmentVariable;
 use Livewire\Component;
 
 class ShowHardcoded extends Component
@@ -20,12 +21,30 @@ class ShowHardcoded extends Component
 
     public bool $isPreview = false;
 
+    public ?string $resourceableType = null;
+
+    public ?int $resourceableId = null;
+
     public function mount()
     {
         $this->key = $this->env['key'];
         $this->value = $this->env['value'] ?? null;
         $this->comment = $this->env['comment'] ?? null;
         $this->serviceName = $this->env['service_name'] ?? null;
+    }
+
+    public function copyValue(): ?string
+    {
+        if (auth()->user()?->isMember() ?? true) {
+            return null;
+        }
+
+        return EnvironmentVariable::make([
+            'value' => $this->value,
+            'is_preview' => $this->isPreview,
+            'resourceable_type' => $this->resourceableType,
+            'resourceable_id' => $this->resourceableId,
+        ])->resolveReferencedValue();
     }
 
     public function render()

--- a/app/Models/EnvironmentVariable.php
+++ b/app/Models/EnvironmentVariable.php
@@ -302,6 +302,23 @@ class EnvironmentVariable extends BaseModel
         return $real_value;
     }
 
+    public function resolveReferencedValue(): ?string
+    {
+        $value = $this->value;
+
+        if ($this->is_literal || blank($value) || ! str($value)->startsWith('$')) {
+            return $value;
+        }
+
+        $referencedKey = str($value)->after('$')->trim('{}')->value();
+
+        return static::where('resourceable_type', $this->resourceable_type)
+            ->where('resourceable_id', $this->resourceable_id)
+            ->where('is_preview', (bool) $this->is_preview)
+            ->where('key', $referencedKey)
+            ->first()?->value ?? $value;
+    }
+
     private function get_real_environment_variables(?string $environment_variable = null, $resource = null)
     {
         return $this->get_real_environment_variables_internal($environment_variable, $resource);

--- a/resources/views/livewire/project/shared/environment-variable/all.blade.php
+++ b/resources/views/livewire/project/shared/environment-variable/all.blade.php
@@ -219,7 +219,8 @@
                             @else
                                 <livewire:project.shared.environment-variable.show-hardcoded
                                     wire:key="{{ $row['id'] }}" :env="$row['environmentVariable']"
-                                    :isPreview="$row['scope'] === 'preview'" :showEnvironmentType="$showEnvironmentType" />
+                                    :isPreview="$row['scope'] === 'preview'" :showEnvironmentType="$showEnvironmentType"
+                                    :resourceableType="get_class($resource)" :resourceableId="$resource->id" />
                             @endif
                             @endforeach
                             </div>

--- a/resources/views/livewire/project/shared/environment-variable/show-hardcoded.blade.php
+++ b/resources/views/livewire/project/shared/environment-variable/show-hardcoded.blade.php
@@ -28,7 +28,10 @@
         <span class="data-table-cell-dash">-</span>
         <span class="data-table-cell-dash">-</span>
         <span class="data-table-cell-dash">-</span>
-        <div class="justify-self-end">
+        <div class="flex items-center gap-0.5 justify-self-end">
+            @unless (auth()->user()?->isMember() ?? true)
+                <x-copy-button resolve="$wire.copyValue()" label="Copy value" />
+            @endunless
             <x-modal-input title="Environment variable details" :closeOutside="false">
                 <x-slot:content>
                     <button type="button" data-env-settings-trigger class="icon-button shrink-0"

--- a/resources/views/livewire/project/shared/environment-variable/show.blade.php
+++ b/resources/views/livewire/project/shared/environment-variable/show.blade.php
@@ -83,7 +83,10 @@
                 @endif
             @endforeach
         @endif
-        <div class="justify-self-end">
+        <div class="flex items-center gap-0.5 justify-self-end">
+            @if (! $isLocked && ! $isValueHidden)
+                <x-copy-button resolve="$wire.copyValue()" label="Copy value" />
+            @endif
             {{-- Open modal immediately (Alpine); decrypt value in a follow-up Livewire request. --}}
             <x-modal-input title="Edit environment variable" :closeOutside="false" :wireIgnore="false"
                 wireOpen="editorOpen">

--- a/tests/Feature/Authorization/EnvironmentVariableValueHidingTest.php
+++ b/tests/Feature/Authorization/EnvironmentVariableValueHidingTest.php
@@ -18,7 +18,7 @@ use Livewire\Livewire;
 uses(RefreshDatabase::class);
 
 beforeEach(function () {
-    InstanceSettings::updateOrCreate(['id' => 0], ['is_api_enabled' => true]);
+    InstanceSettings::forceCreate(['id' => 0, 'is_api_enabled' => true]);
 
     $this->team = Team::factory()->create();
 
@@ -102,6 +102,11 @@ test('admin sees unlocked env value in Show component', function () {
         'env' => $this->unlockedEnv,
         'type' => 'application',
     ]);
+
+    // Values hydrate lazily; the edit modal triggers loadValues() on open.
+    expect($component->get('value'))->toBeNull();
+
+    $component->call('loadValues');
 
     expect($component->get('value'))->toBe('secret-unlocked-value');
 });
@@ -241,6 +246,17 @@ test('API hides locked env value with root token', function () {
 test('API hides env values for member even with read:sensitive token', function () {
     session(['currentTeam' => $this->team]);
     $token = $this->member->createToken('member-sensitive', ['read', 'read:sensitive']);
+
+    $response = $this->withHeaders([
+        'Authorization' => 'Bearer '.$token->plainTextToken,
+    ])->getJson("/api/v1/applications/{$this->application->uuid}/envs");
+
+    $response->assertForbidden();
+});
+
+test('API hides env values for member with read token', function () {
+    session(['currentTeam' => $this->team]);
+    $token = $this->member->createToken('member-read', ['read']);
 
     $response = $this->withHeaders([
         'Authorization' => 'Bearer '.$token->plainTextToken,

--- a/tests/Feature/EnvironmentVariableAsyncLoadTest.php
+++ b/tests/Feature/EnvironmentVariableAsyncLoadTest.php
@@ -71,7 +71,7 @@ it('loads environment variables when loadEnvironmentVariables is called', functi
         ->assertSee('Loading environment variables...')
         ->call('loadEnvironmentVariables')
         ->assertSet('readyToLoad', true)
-        ->assertDontSee('Loading environment variables...')
+        ->assertDontSeeText('Loading environment variables...')
         ->assertSee('API_KEY');
 
     expect($component->instance()->environmentVariables->pluck('key')->all())

--- a/tests/Feature/EnvironmentVariableCopyValueTest.php
+++ b/tests/Feature/EnvironmentVariableCopyValueTest.php
@@ -1,0 +1,151 @@
+<?php
+
+use App\Livewire\Project\Shared\EnvironmentVariable\Show;
+use App\Livewire\Project\Shared\EnvironmentVariable\ShowHardcoded;
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\EnvironmentVariable;
+use App\Models\InstanceSettings;
+use App\Models\Project;
+use App\Models\SharedEnvironmentVariable;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::forceCreate(['id' => 0]);
+
+    $this->user = User::factory()->create();
+    $this->team = Team::factory()->create();
+    $this->team->members()->attach($this->user, ['role' => 'owner']);
+    $this->project = Project::factory()->create(['team_id' => $this->team->id]);
+    $this->environment = Environment::factory()->create(['project_id' => $this->project->id]);
+    $this->application = Application::factory()->create(['environment_id' => $this->environment->id]);
+
+    $this->actingAs($this->user);
+    session(['currentTeam' => $this->team]);
+});
+
+function createEnvironmentVariable(array $attributes = []): EnvironmentVariable
+{
+    return EnvironmentVariable::create(array_merge([
+        'key' => 'API_KEY',
+        'value' => 'secret-value',
+        'resourceable_type' => Application::class,
+        'resourceable_id' => test()->application->id,
+    ], $attributes));
+}
+
+function assertCopiedValue(EnvironmentVariable|SharedEnvironmentVariable $env, ?string $expected): void
+{
+    Livewire::test(Show::class, ['env' => $env, 'type' => 'application'])
+        ->call('copyValue')
+        ->assertReturned($expected);
+}
+
+function assertCopiedComposeValue(string $value, ?string $expected): void
+{
+    Livewire::test(ShowHardcoded::class, [
+        'env' => ['key' => 'MYSQL_USER', 'value' => $value],
+        'resourceableType' => Application::class,
+        'resourceableId' => test()->application->id,
+    ])
+        ->call('copyValue')
+        ->assertReturned($expected);
+}
+
+test('copies the plain value', function () {
+    assertCopiedValue(createEnvironmentVariable(), 'secret-value');
+});
+
+test('copies the referenced variable value instead of the reference', function (string $reference) {
+    createEnvironmentVariable(['key' => 'SERVICE_USER_CLASSICPRESS', 'value' => 'classicpress-user']);
+
+    assertCopiedValue(createEnvironmentVariable(['key' => 'MYSQL_USER', 'value' => $reference]), 'classicpress-user');
+})->with(['bare' => '$SERVICE_USER_CLASSICPRESS', 'braced' => '${SERVICE_USER_CLASSICPRESS}']);
+
+test('copies the resolved shared variable value', function () {
+    SharedEnvironmentVariable::create([
+        'key' => 'MY_SECRET',
+        'value' => 'resolved-secret',
+        'type' => 'team',
+        'team_id' => $this->team->id,
+    ]);
+
+    assertCopiedValue(createEnvironmentVariable(['value' => '{{team.MY_SECRET}}']), 'resolved-secret');
+});
+
+test('copies embedded, literal and unknown references as stored', function () {
+    createEnvironmentVariable(['key' => 'SERVICE_PASSWORD_MYSQL', 'value' => 'generated-password']);
+
+    assertCopiedValue(
+        createEnvironmentVariable(['key' => 'DATABASE_URL', 'value' => 'mysql://root:$SERVICE_PASSWORD_MYSQL@db:3306']),
+        'mysql://root:$SERVICE_PASSWORD_MYSQL@db:3306',
+    );
+    assertCopiedValue(
+        createEnvironmentVariable(['key' => 'LITERAL', 'value' => '$SERVICE_PASSWORD_MYSQL', 'is_literal' => true]),
+        '$SERVICE_PASSWORD_MYSQL',
+    );
+    assertCopiedValue(createEnvironmentVariable(['key' => 'UNKNOWN', 'value' => '$DOES_NOT_EXIST']), '$DOES_NOT_EXIST');
+});
+
+test('copies literal values without .env-style quoting', function () {
+    $env = createEnvironmentVariable(['value' => 'pa$$word', 'is_literal' => true]);
+
+    expect($env->real_value)->toBe("'pa\$\$word'");
+    assertCopiedValue($env, 'pa$$word');
+});
+
+test('copies the value of a shared environment variable row', function () {
+    $shared = SharedEnvironmentVariable::create([
+        'key' => 'TEAM_WIDE',
+        'value' => 'team-wide-value',
+        'type' => 'team',
+        'team_id' => $this->team->id,
+    ]);
+
+    assertCopiedValue($shared, 'team-wide-value');
+});
+
+test('members get no copy button and no value', function () {
+    $member = User::factory()->create();
+    $this->team->members()->attach($member, ['role' => 'member']);
+    $this->actingAs($member);
+
+    Livewire::test(Show::class, ['env' => createEnvironmentVariable(), 'type' => 'application'])
+        ->assertDontSeeHtml('Copy value')
+        ->call('copyValue')
+        ->assertReturned(null);
+});
+
+test('locked variables get no copy button and no value', function () {
+    Livewire::test(Show::class, ['env' => createEnvironmentVariable(['is_shown_once' => true]), 'type' => 'application'])
+        ->assertDontSeeHtml('Copy value')
+        ->call('copyValue')
+        ->assertReturned(null);
+});
+
+test('compose-managed rows copy the referenced variable value', function () {
+    createEnvironmentVariable(['key' => 'SERVICE_USER_CLASSICPRESS', 'value' => 'classicpress-user']);
+
+    assertCopiedComposeValue('$SERVICE_USER_CLASSICPRESS', 'classicpress-user');
+    assertCopiedComposeValue('production', 'production');
+});
+
+test('compose-managed rows hide copying from members', function () {
+    $member = User::factory()->create();
+    $this->team->members()->attach($member, ['role' => 'member']);
+    $this->actingAs($member);
+
+    Livewire::test(ShowHardcoded::class, [
+        'env' => ['key' => 'MYSQL_USER', 'value' => '$SERVICE_USER_CLASSICPRESS'],
+        'resourceableType' => Application::class,
+        'resourceableId' => $this->application->id,
+    ])
+        ->assertDontSeeHtml('Copy value')
+        ->call('copyValue')
+        ->assertReturned(null);
+});


### PR DESCRIPTION
## Changes

- Add copy button to environment variable page
- Add environment variable copy functionality
  - Values are copied directly
  - Shared variable are resolved to their value
  - Referenced variables like `MYSQL_USER=$SERVICE_USER_MYSQL` are resolved to the value of the `SERVICE_USER_MYSQL` autogenerated variable
  - Locked variables do not have a copy button

## Why?

I need to get the values of environment variables multiple times a day and a few times for each app (especially new ones). Having the value hidden behind 4 clicks (Settings > Eye > Double click > Close button) is cumbersome. This PR adds a direct copy button.

### Before

https://github.com/user-attachments/assets/83c443da-f8eb-4d0f-a960-31352cd025ac

### After

https://github.com/user-attachments/assets/50c457e4-f58a-4b61-8cc6-60de6ed0a4ec
