### PR TITLE
fix(ui): center icon tooltips over their trigger

### DIFF
--- a/resources/views/components/icon-tooltip.blade.php
+++ b/resources/views/components/icon-tooltip.blade.php
@@ -38,11 +38,11 @@
         this.visible = true;
         const rect = target.getBoundingClientRect();
         this.below = rect.top < 48;
-        this.x = rect.left;
+        this.x = rect.left + rect.width / 2;
         this.y = this.below ? rect.bottom + 8 : rect.top - 8;
         this.$nextTick(() => {
             const width = this.$refs.tooltip?.offsetWidth || 0;
-            this.x = Math.max(8, Math.min(window.innerWidth - width - 8, this.x));
+            this.x = Math.max(8, Math.min(window.innerWidth - width - 8, this.x - width / 2));
             this.$nextTick(() => this.positioned = true);
         });
     },

--- a/tests/Feature/GlobalIconTooltipTest.php
+++ b/tests/Feature/GlobalIconTooltipTest.php
@@ -36,12 +36,11 @@ it('keeps a tooltip hidden until its measured position is applied', function () 
         ->toContain("positioned ? 'visible' : 'invisible'");
 });
 
-it('anchors tooltips to the trigger and lets them grow toward the right', function () {
+it('centers tooltips on the trigger and keeps them within the viewport', function () {
     $tooltip = file_get_contents(resource_path('views/components/icon-tooltip.blade.php'));
 
     expect($tooltip)
-        ->toContain('this.x = rect.left;')
-        ->toContain('Math.min(window.innerWidth - width - 8, this.x)')
-        ->not->toContain('rect.left + rect.width / 2')
+        ->toContain('this.x = rect.left + rect.width / 2;')
+        ->toContain('Math.min(window.innerWidth - width - 8, this.x - width / 2)')
         ->not->toContain('-translate-x-1/2');
 });


### PR DESCRIPTION
## Changes

- Center icon tooltips over their trigger

## Preview

### Before

<img width="95" height="84" alt="image" src="https://github.com/user-attachments/assets/d5edf77e-0f4a-4c44-9818-7e4a5283c45e" />

### After

<img width="101" height="83" alt="image" src="https://github.com/user-attachments/assets/3bd699a8-517b-406f-b31b-e980a523fcaf" />
