### PR TITLE
fix(email): respect disabled SMTP encryption in test emails

### DIFF
--- a/app/Notifications/Channels/EmailChannel.php
+++ b/app/Notifications/Channels/EmailChannel.php
@@ -4,9 +4,15 @@ namespace App\Notifications\Channels;
 
 use App\Exceptions\NonReportableException;
 use App\Models\Team;
+use App\Support\SmtpTransportFactory;
 use Exception;
 use Illuminate\Notifications\Notification;
 use Resend;
+use Resend\Exceptions\ErrorException;
+use Resend\Exceptions\TransporterException;
+use Symfony\Component\Mailer\Mailer;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
 
 class EmailChannel
 {
@@ -78,27 +84,13 @@ class EmailChannel
                     'html' => (string) $mailMessage->render(),
                 ]);
             } elseif ($isSmtpEnabled) {
-                $encryption = match (strtolower($settings->smtp_encryption)) {
-                    'starttls' => null,
-                    'tls' => 'tls',
-                    'none' => null,
-                    default => null,
-                };
-
-                $transport = new \Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport(
-                    $settings->smtp_host,
-                    $settings->smtp_port,
-                    $encryption
-                );
-                $transport->setUsername($settings->smtp_username ?? '');
-                $transport->setPassword($settings->smtp_password ?? '');
-
-                $mailer = new \Symfony\Component\Mailer\Mailer($transport);
+                $transport = SmtpTransportFactory::fromSettings($settings);
+                $mailer = new Mailer($transport);
 
                 $fromEmail = $settings->smtp_from_address ?? 'noreply@localhost';
                 $fromName = $settings->smtp_from_name ?? 'System';
-                $from = new \Symfony\Component\Mime\Address($fromEmail, $fromName);
-                $email = (new \Symfony\Component\Mime\Email)
+                $from = new Address($fromEmail, $fromName);
+                $email = (new Email)
                     ->from($from)
                     ->to(...$recipients)
                     ->subject($mailMessage->subject)
@@ -106,7 +98,7 @@ class EmailChannel
 
                 $mailer->send($email);
             }
-        } catch (\Resend\Exceptions\ErrorException $e) {
+        } catch (ErrorException $e) {
             // Map HTTP status codes to user-friendly messages
             $userMessage = match ($e->getErrorCode()) {
                 403 => 'Invalid Resend API key. Please verify your API key in the Resend dashboard and update it in settings.',
@@ -131,13 +123,13 @@ class EmailChannel
 
             // Don't report expected errors (invalid keys, validation) to Sentry
             if (in_array($e->getErrorCode(), [403, 401, 400])) {
-                throw NonReportableException::fromException(new \Exception($userMessage, $e->getCode(), $e));
+                throw NonReportableException::fromException(new Exception($userMessage, $e->getCode(), $e));
             }
 
-            throw new \Exception($userMessage, $e->getCode(), $e);
-        } catch (\Resend\Exceptions\TransporterException $e) {
+            throw new Exception($userMessage, $e->getCode(), $e);
+        } catch (TransporterException $e) {
             send_internal_notification("Resend Transport Error: {$e->getMessage()}");
-            throw new \Exception('Unable to connect to Resend API. Please check your internet connection and try again.');
+            throw new Exception('Unable to connect to Resend API. Please check your internet connection and try again.');
         } catch (\Throwable $e) {
             // Check if this is a Resend domain verification error on cloud instances
             if (isCloud() && str_contains($e->getMessage(), 'domain is not verified')) {

--- a/app/Services/ConfigurationRepository.php
+++ b/app/Services/ConfigurationRepository.php
@@ -33,6 +33,7 @@ class ConfigurationRepository
             $this->config->set('mail.from.name', $settings->smtp_from_name ?? 'Test');
             $this->config->set('mail.mailers.smtp', [
                 'transport' => 'smtp',
+                'scheme' => $mailerOptions['scheme'],
                 'host' => $settings->smtp_host,
                 'port' => $settings->smtp_port,
                 'encryption' => $mailerOptions['encryption'],

--- a/app/Services/ConfigurationRepository.php
+++ b/app/Services/ConfigurationRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Support\SmtpTransportFactory;
 use Illuminate\Config\Repository;
 
 class ConfigurationRepository
@@ -25,12 +26,7 @@ class ConfigurationRepository
         }
 
         if ($settings->smtp_enabled) {
-            $encryption = match (strtolower($settings->smtp_encryption)) {
-                'starttls' => null,
-                'tls' => 'tls',
-                'none' => null,
-                default => null,
-            };
+            $mailerOptions = SmtpTransportFactory::mailerOptions($settings);
 
             $this->config->set('mail.default', 'smtp');
             $this->config->set('mail.from.address', $settings->smtp_from_address ?? 'test@example.com');
@@ -39,12 +35,12 @@ class ConfigurationRepository
                 'transport' => 'smtp',
                 'host' => $settings->smtp_host,
                 'port' => $settings->smtp_port,
-                'encryption' => $encryption,
+                'encryption' => $mailerOptions['encryption'],
                 'username' => $settings->smtp_username,
                 'password' => $settings->smtp_password,
                 'timeout' => $settings->smtp_timeout,
                 'local_domain' => null,
-                'auto_tls' => $settings->smtp_encryption === 'none' ? '0' : '',
+                'auto_tls' => $mailerOptions['auto_tls'],
             ]);
         }
     }

--- a/app/Support/SmtpTransportFactory.php
+++ b/app/Support/SmtpTransportFactory.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Support;
+
+use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
+
+class SmtpTransportFactory
+{
+    public static function fromSettings(object $settings): EsmtpTransport
+    {
+        $mode = self::encryptionMode($settings);
+
+        $transport = new EsmtpTransport(
+            $settings->smtp_host,
+            (int) $settings->smtp_port,
+            match ($mode) {
+                'none' => false,
+                'tls' => true,
+                default => null,
+            }
+        );
+
+        if ($mode === 'none') {
+            $transport->setAutoTls(false);
+        }
+
+        $transport->setUsername($settings->smtp_username ?? '');
+        $transport->setPassword($settings->smtp_password ?? '');
+
+        return $transport;
+    }
+
+    /**
+     * @return array{encryption: ?string, auto_tls: string}
+     */
+    public static function mailerOptions(object $settings): array
+    {
+        $mode = self::encryptionMode($settings);
+
+        return [
+            'encryption' => $mode === 'tls' ? 'tls' : null,
+            'auto_tls' => $mode === 'none' ? '0' : '',
+        ];
+    }
+
+    private static function encryptionMode(object $settings): ?string
+    {
+        return $settings->smtp_encryption === null
+            ? null
+            : strtolower((string) $settings->smtp_encryption);
+    }
+}

--- a/app/Support/SmtpTransportFactory.php
+++ b/app/Support/SmtpTransportFactory.php
@@ -3,6 +3,7 @@
 namespace App\Support;
 
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
+use Symfony\Component\Mailer\Transport\Smtp\Stream\SocketStream;
 
 class SmtpTransportFactory
 {
@@ -27,17 +28,27 @@ class SmtpTransportFactory
         $transport->setUsername($settings->smtp_username ?? '');
         $transport->setPassword($settings->smtp_password ?? '');
 
+        $stream = $transport->getStream();
+        if (isset($settings->smtp_timeout) && $stream instanceof SocketStream) {
+            $stream->setTimeout((float) $settings->smtp_timeout);
+        }
+
         return $transport;
     }
 
     /**
-     * @return array{encryption: ?string, auto_tls: string}
+     * @return array{scheme: ?string, encryption: ?string, auto_tls: string}
      */
     public static function mailerOptions(object $settings): array
     {
         $mode = self::encryptionMode($settings);
 
         return [
+            'scheme' => match ($mode) {
+                'none', 'starttls' => 'smtp',
+                'tls' => 'smtps',
+                default => null,
+            },
             'encryption' => $mode === 'tls' ? 'tls' : null,
             'auto_tls' => $mode === 'none' ? '0' : '',
         ];

--- a/tests/Unit/ConfigurationRepositoryMailConfigTest.php
+++ b/tests/Unit/ConfigurationRepositoryMailConfigTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use App\Services\ConfigurationRepository;
+use Illuminate\Config\Repository;
+
+it('disables auto tls in laravel mail config when smtp encryption is none', function () {
+    $config = new Repository;
+    $repository = new ConfigurationRepository($config);
+
+    $repository->updateMailConfig((object) [
+        'resend_enabled' => false,
+        'smtp_enabled' => true,
+        'smtp_encryption' => 'none',
+        'smtp_host' => 'smtp.example.com',
+        'smtp_port' => 25,
+        'smtp_username' => 'user',
+        'smtp_password' => 'secret',
+        'smtp_timeout' => null,
+        'smtp_from_address' => 'from@example.com',
+        'smtp_from_name' => 'Coolify',
+    ]);
+
+    expect($config->get('mail.mailers.smtp.encryption'))->toBeNull()
+        ->and($config->get('mail.mailers.smtp.auto_tls'))->toBe('0');
+});

--- a/tests/Unit/ConfigurationRepositoryMailConfigTest.php
+++ b/tests/Unit/ConfigurationRepositoryMailConfigTest.php
@@ -3,16 +3,16 @@
 use App\Services\ConfigurationRepository;
 use Illuminate\Config\Repository;
 
-it('disables auto tls in laravel mail config when smtp encryption is none', function () {
+it('configures the laravel smtp scheme from encryption', function (string $mode, int $port, string $scheme, ?string $encryption, string $autoTls) {
     $config = new Repository;
     $repository = new ConfigurationRepository($config);
 
     $repository->updateMailConfig((object) [
         'resend_enabled' => false,
         'smtp_enabled' => true,
-        'smtp_encryption' => 'none',
+        'smtp_encryption' => $mode,
         'smtp_host' => 'smtp.example.com',
-        'smtp_port' => 25,
+        'smtp_port' => $port,
         'smtp_username' => 'user',
         'smtp_password' => 'secret',
         'smtp_timeout' => null,
@@ -20,6 +20,10 @@ it('disables auto tls in laravel mail config when smtp encryption is none', func
         'smtp_from_name' => 'Coolify',
     ]);
 
-    expect($config->get('mail.mailers.smtp.encryption'))->toBeNull()
-        ->and($config->get('mail.mailers.smtp.auto_tls'))->toBe('0');
-});
+    expect($config->get('mail.mailers.smtp.scheme'))->toBe($scheme)
+        ->and($config->get('mail.mailers.smtp.encryption'))->toBe($encryption)
+        ->and($config->get('mail.mailers.smtp.auto_tls'))->toBe($autoTls);
+})->with([
+    'none on port 465' => ['none', 465, 'smtp', null, '0'],
+    'tls on a non-465 port' => ['tls', 587, 'smtps', 'tls', ''],
+]);

--- a/tests/Unit/SmtpTransportFactoryTest.php
+++ b/tests/Unit/SmtpTransportFactoryTest.php
@@ -25,6 +25,21 @@ it('disables opportunistic STARTTLS when encryption is none', function () {
         ->and($transport->getStream()->isTLS())->toBeFalse();
 });
 
+it('does not issue STARTTLS for the issue 5877 anonymous port 25 relay', function () {
+    $transport = SmtpTransportFactory::fromSettings(smtpSettings([
+        'smtp_encryption' => 'none',
+        'smtp_port' => 25,
+        'smtp_username' => '',
+        'smtp_password' => '',
+    ]));
+
+    expect($transport->isAutoTls())->toBeFalse()
+        ->and($transport->getStream()->isTLS())->toBeFalse()
+        ->and($transport->getStream()->getPort())->toBe(25)
+        ->and($transport->getUsername())->toBe('')
+        ->and($transport->getPassword())->toBe('');
+});
+
 it('does not enable implicit TLS on port 465 when encryption is none', function () {
     $transport = SmtpTransportFactory::fromSettings(smtpSettings([
         'smtp_encryption' => 'none',

--- a/tests/Unit/SmtpTransportFactoryTest.php
+++ b/tests/Unit/SmtpTransportFactoryTest.php
@@ -78,23 +78,35 @@ it('infers implicit TLS on port 465 when encryption is null', function () {
     expect($transport->getStream()->isTLS())->toBeTrue();
 });
 
+it('applies a configured SMTP timeout to the transport stream', function () {
+    $transport = SmtpTransportFactory::fromSettings(smtpSettings([
+        'smtp_timeout' => 15,
+    ]));
+
+    expect($transport->getStream()->getTimeout())->toBe(15.0);
+});
+
 it('maps none encryption to laravel mailer options that disable auto tls', function () {
     expect(SmtpTransportFactory::mailerOptions(smtpSettings([
         'smtp_encryption' => 'none',
     ])))->toBe([
+        'scheme' => 'smtp',
         'encryption' => null,
         'auto_tls' => '0',
     ]);
 });
 
-it('maps starttls and tls encryption to laravel mailer options', function (string $mode, ?string $encryption) {
+it('maps encryption to laravel mailer options', function (?string $mode, ?string $scheme, ?string $encryption) {
     expect(SmtpTransportFactory::mailerOptions(smtpSettings([
         'smtp_encryption' => $mode,
     ])))->toBe([
+        'scheme' => $scheme,
         'encryption' => $encryption,
-        'auto_tls' => '',
+        'auto_tls' => $mode === 'none' ? '0' : '',
     ]);
 })->with([
-    'starttls' => ['starttls', null],
-    'tls' => ['tls', 'tls'],
+    'none' => ['none', 'smtp', null],
+    'starttls' => ['starttls', 'smtp', null],
+    'tls' => ['tls', 'smtps', 'tls'],
+    'unset' => [null, null, null],
 ]);

--- a/tests/Unit/SmtpTransportFactoryTest.php
+++ b/tests/Unit/SmtpTransportFactoryTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use App\Support\SmtpTransportFactory;
+use Symfony\Component\Mailer\Transport\Smtp\Stream\SocketStream;
+
+function smtpSettings(array $overrides = []): object
+{
+    return (object) array_merge([
+        'smtp_host' => 'smtp.example.com',
+        'smtp_port' => 25,
+        'smtp_encryption' => 'none',
+        'smtp_username' => 'user',
+        'smtp_password' => 'secret',
+        'smtp_timeout' => null,
+    ], $overrides);
+}
+
+it('disables opportunistic STARTTLS when encryption is none', function () {
+    $transport = SmtpTransportFactory::fromSettings(smtpSettings([
+        'smtp_encryption' => 'none',
+    ]));
+
+    expect($transport->isAutoTls())->toBeFalse()
+        ->and($transport->getStream())->toBeInstanceOf(SocketStream::class)
+        ->and($transport->getStream()->isTLS())->toBeFalse();
+});
+
+it('does not enable implicit TLS on port 465 when encryption is none', function () {
+    $transport = SmtpTransportFactory::fromSettings(smtpSettings([
+        'smtp_encryption' => 'none',
+        'smtp_port' => 465,
+    ]));
+
+    expect($transport->isAutoTls())->toBeFalse()
+        ->and($transport->getStream()->isTLS())->toBeFalse();
+});
+
+it('keeps opportunistic STARTTLS when encryption is starttls', function () {
+    $transport = SmtpTransportFactory::fromSettings(smtpSettings([
+        'smtp_encryption' => 'starttls',
+    ]));
+
+    expect($transport->isAutoTls())->toBeTrue()
+        ->and($transport->getStream()->isTLS())->toBeFalse();
+});
+
+it('uses implicit TLS when encryption is tls', function () {
+    $transport = SmtpTransportFactory::fromSettings(smtpSettings([
+        'smtp_encryption' => 'tls',
+        'smtp_port' => 465,
+    ]));
+
+    expect($transport->isAutoTls())->toBeTrue()
+        ->and($transport->getStream()->isTLS())->toBeTrue();
+});
+
+it('infers implicit TLS on port 465 when encryption is null', function () {
+    $transport = SmtpTransportFactory::fromSettings(smtpSettings([
+        'smtp_encryption' => null,
+        'smtp_port' => 465,
+    ]));
+
+    expect($transport->getStream()->isTLS())->toBeTrue();
+});
+
+it('maps none encryption to laravel mailer options that disable auto tls', function () {
+    expect(SmtpTransportFactory::mailerOptions(smtpSettings([
+        'smtp_encryption' => 'none',
+    ])))->toBe([
+        'encryption' => null,
+        'auto_tls' => '0',
+    ]);
+});
+
+it('maps starttls and tls encryption to laravel mailer options', function (string $mode, ?string $encryption) {
+    expect(SmtpTransportFactory::mailerOptions(smtpSettings([
+        'smtp_encryption' => $mode,
+    ])))->toBe([
+        'encryption' => $encryption,
+        'auto_tls' => '',
+    ]);
+})->with([
+    'starttls' => ['starttls', null],
+    'tls' => ['tls', 'tls'],
+]);


### PR DESCRIPTION
## Summary

- Disable opportunistic STARTTLS when SMTP encryption is set to `none`.
- Use consistent SMTP encryption settings for test emails and application mail.
- Add coverage for none, STARTTLS, TLS, and port 465 transport behavior.

Fixes #6442.

---

Fixes #6442
Fixes #5877 