### PR TITLE
fix: refresh Traefik load-balancer port when ports_exposes changes

### DIFF
--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -3119,7 +3119,7 @@ class ApplicationsController extends Controller
             // Must run after fqdn is filled: flags are kept only for domains the app still has.
             $application->setNoindexDomains($request->input('noindex_domains') ?? []);
         }
-        if ($application->settings->is_container_label_readonly_enabled && ($requestHasDomains || $requestHasNoindexDomains || $requestHasHttpBasicAuth) && $server->isProxyShouldRun()) {
+        if ($application->settings->is_container_label_readonly_enabled && ($requestHasDomains || $requestHasNoindexDomains || $requestHasHttpBasicAuth || $request->has('ports_exposes')) && $server->isProxyShouldRun()) {
             $application->custom_labels = str(implode('|coolify|', generateLabelsApplication($application)))->replace('|coolify|', "\n");
         }
         $application->save();

--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -3230,6 +3230,9 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
             $labels = $labels->filter(function ($value, $key) {
                 return ! Str::startsWith($value, 'coolify.');
             });
+            if ($this->application->settings->is_container_label_readonly_enabled && persistedProxyPortsNeedReconcile($labels, $this->application)) {
+                $labels = applyGeneratedProxyPortLabels($labels, $this->application, $this->preview);
+            }
             $this->application->custom_labels = base64_encode($labels->implode("\n"));
             $this->application->save();
         } else {

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -2240,6 +2240,9 @@ class Application extends BaseModel
         if (mb_detect_encoding($customLabels, 'UTF-8', true) === false) {
             $customLabels = str(implode('|coolify|', generateLabelsApplication($this, $preview)))->replace('|coolify|', "\n");
         }
+        if ($this->settings?->is_container_label_readonly_enabled && persistedProxyPortsNeedReconcile($customLabels, $this)) {
+            $customLabels = applyGeneratedProxyPortLabels($customLabels, $this, $preview)->implode("\n");
+        }
         $this->custom_labels = base64_encode($customLabels);
         $this->save();
 

--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -827,6 +827,85 @@ function fqdnLabelsForTraefik(string $uuid, Collection $domains, bool $is_force_
 
     return $labels->sort();
 }
+
+function isGeneratedProxyPortLabel(string $label): bool
+{
+    return str_contains($label, '.loadbalancer.server.port=')
+        || str_contains($label, '_reverse_proxy={{upstreams ');
+}
+
+function persistedProxyPortsNeedReconcile(Collection|string $labels, Application $application): bool
+{
+    $labelText = $labels instanceof Collection ? $labels->implode("\n") : $labels;
+    $expected = collect($application->settings->is_static ? [80] : $application->ports_exposes_array)
+        ->filter(fn ($port) => $port !== null && $port !== '')
+        ->map(fn ($port) => (string) $port)
+        ->values();
+
+    if ($application->fqdn) {
+        foreach (str($application->fqdn)->explode(',') as $domain) {
+            try {
+                $port = Url::fromString(trim($domain))->getPort();
+                if ($port) {
+                    $expected->push((string) $port);
+                }
+            } catch (Throwable) {
+                continue;
+            }
+        }
+    }
+
+    preg_match_all('/loadbalancer\.server\.port=(\d+)/', $labelText, $traefikPorts);
+    preg_match_all('/\{\{upstreams (\d+)\}\}/', $labelText, $caddyPorts);
+
+    $persisted = collect($traefikPorts[1] ?? [])
+        ->merge($caddyPorts[1] ?? [])
+        ->unique()
+        ->values();
+
+    if ($persisted->isEmpty()) {
+        return false;
+    }
+
+    return $persisted->contains(fn (string $port) => ! $expected->contains($port));
+}
+
+/**
+ * Overlay generated proxy backend-port labels onto persisted labels.
+ * Router/service keys stay stable (uuid + domain index); only the port values change.
+ *
+ * @param  Collection<int, string>|string  $labels
+ * @return Collection<int, string>
+ */
+function applyGeneratedProxyPortLabels(Collection|string $labels, Application $application, ?ApplicationPreview $preview = null): Collection
+{
+    $lines = $labels instanceof Collection
+        ? $labels
+        : collect(preg_split("/\r\n|\n|\r/", (string) $labels));
+
+    $generatedPortLabels = collect(generateLabelsApplication($application, $preview))
+        ->filter(fn (string $label) => isGeneratedProxyPortLabel($label))
+        ->mapWithKeys(function (string $label) {
+            [$key, $value] = explode('=', $label, 2);
+
+            return [$key => $value];
+        });
+
+    return $lines->map(function (string $label) use ($generatedPortLabels) {
+        if ($label === '' || ! str_contains($label, '=')) {
+            return $label;
+        }
+
+        [$key] = explode('=', $label, 2);
+
+        if ($generatedPortLabels->has($key)) {
+            return $key.'='.$generatedPortLabels->get($key);
+        }
+
+        return $label;
+    });
+}
+
 function generateLabelsApplication(Application $application, ?ApplicationPreview $preview = null): array
 {
     $ports = $application->settings->is_static ? [80] : $application->ports_exposes_array;

--- a/tests/Feature/ApplicationTraefikPortLabelReconciliationTest.php
+++ b/tests/Feature/ApplicationTraefikPortLabelReconciliationTest.php
@@ -1,0 +1,118 @@
+<?php
+
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\InstanceSettings;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    config(['app.maintenance.driver' => 'file']);
+
+    InstanceSettings::unguarded(fn () => InstanceSettings::firstOrCreate(['id' => 0]));
+
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->team->members()->attach($this->user->id, ['role' => 'owner']);
+    session(['currentTeam' => $this->team]);
+
+    $this->bearerToken = $this->user->createToken('traefik-port-label-test', ['*'])->plainTextToken;
+    $this->server = Server::factory()->create(['team_id' => $this->team->id]);
+    $this->destination = StandaloneDocker::where('server_id', $this->server->id)->first();
+    $this->project = Project::factory()->create(['team_id' => $this->team->id]);
+    $this->environment = Environment::factory()->create(['project_id' => $this->project->id]);
+    $this->application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+        'destination_id' => $this->destination->id,
+        'destination_type' => $this->destination->getMorphClass(),
+        'fqdn' => 'https://app.example.com',
+        'ports_exposes' => '80',
+    ]);
+    $this->application->settings->update([
+        'is_container_label_readonly_enabled' => true,
+    ]);
+});
+
+function persistGeneratedApplicationLabels(Application $application): string
+{
+    $application->refresh();
+    $labels = implode("\n", generateLabelsApplication($application));
+    $application->custom_labels = base64_encode($labels);
+    $application->save();
+
+    return $labels;
+}
+
+function decodedApplicationLabels(Application $application): string
+{
+    $stored = $application->getRawOriginal('custom_labels');
+
+    if (! $stored) {
+        return '';
+    }
+
+    if (base64_encode(base64_decode($stored, true)) === $stored) {
+        return (string) base64_decode($stored);
+    }
+
+    return (string) $stored;
+}
+
+test('changing ports_exposes reconciles stale traefik load balancer port labels', function () {
+    $initialLabels = persistGeneratedApplicationLabels($this->application);
+
+    expect($initialLabels)->toContain('loadbalancer.server.port=80')
+        ->and($initialLabels)->not->toContain('loadbalancer.server.port=9000');
+
+    $this->application->update(['ports_exposes' => '9000']);
+    $this->application->refresh();
+
+    $reconciled = $this->application->parseContainerLabels();
+
+    expect($this->application->ports_exposes)->toBe('9000')
+        ->and($reconciled)->toContain('loadbalancer.server.port=9000')
+        ->and($reconciled)->not->toContain('loadbalancer.server.port=80')
+        ->and($reconciled)->not->toContain('{{upstreams 80}}');
+});
+
+test('updating ports_exposes via the api regenerates managed load balancer port labels', function () {
+    persistGeneratedApplicationLabels($this->application);
+
+    $this->withHeaders([
+        'Authorization' => 'Bearer '.$this->bearerToken,
+        'Content-Type' => 'application/json',
+    ])->patchJson("/api/v1/applications/{$this->application->uuid}", [
+        'ports_exposes' => '9000',
+    ])->assertOk();
+
+    $application = $this->application->fresh();
+    $labels = decodedApplicationLabels($application);
+
+    expect($application->ports_exposes)->toBe('9000')
+        ->and($labels)->toContain('loadbalancer.server.port=9000')
+        ->and($labels)->not->toContain('loadbalancer.server.port=80');
+});
+
+test('changing ports_exposes preserves user-managed labels when readonly is disabled', function () {
+    $this->application->settings->update([
+        'is_container_label_readonly_enabled' => false,
+    ]);
+    $this->application->update([
+        'custom_labels' => base64_encode("sentinel-label=true\ntraefik.http.services.http-0-{$this->application->uuid}.loadbalancer.server.port=80"),
+    ]);
+
+    $this->application->update(['ports_exposes' => '9000']);
+    $this->application->refresh();
+
+    $labels = $this->application->parseContainerLabels();
+
+    expect($labels)->toContain('sentinel-label=true')
+        ->and($labels)->toContain('loadbalancer.server.port=80')
+        ->and($labels)->not->toContain('loadbalancer.server.port=9000');
+});


### PR DESCRIPTION
Generated Traefik labels are stored in `custom_labels` and reused on later deploys. Changing `ports_exposes` did not refresh `loadbalancer.server.port`, so traffic kept targeting the old container port.

Regenerate managed labels when `ports_exposes` is PATCHed (same path as domains / HTTP basic auth). Overlay generated Traefik/Caddy backend-port labels when read-only labels are enabled. Leave user-managed labels alone when read-only is off.

## Test
- RED: generate labels with exposed port 80, set `ports_exposes` to 9000, re-run parse/API reconciliation → labels still targeted 80.
- GREEN: those cases pass; user-managed labels stay put when read-only is off.

Fixes #11074