### PR TITLE
fix(caddy): prevent exact label generation argument error

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -12,6 +12,7 @@ use App\Traits\HasConfiguration;
 use App\Traits\HasMetrics;
 use App\Traits\HasNoindexDomains;
 use App\Traits\HasSafeStringAttribute;
+use Database\Factories\ApplicationFactory;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -120,7 +121,10 @@ use Symfony\Component\Yaml\Yaml;
 
 class Application extends BaseModel
 {
-    use ClearsGlobalSearchCache, HasConfiguration, HasFactory, HasMetrics, HasNoindexDomains, HasSafeStringAttribute, SoftDeletes;
+    use ClearsGlobalSearchCache, HasConfiguration, HasMetrics, HasNoindexDomains, HasSafeStringAttribute, SoftDeletes;
+
+    /** @use HasFactory<ApplicationFactory> */
+    use HasFactory;
 
     public const MAX_DOCKER_COMPOSE_SIZE_BYTES = 5 * 1024 * 1024;
 

--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -891,7 +891,6 @@ function generateLabelsApplication(Application $application, ?ApplicationPreview
                             http_basic_auth_username: $application->http_basic_auth_username,
                             http_basic_auth_password: $application->http_basic_auth_password,
                             noindex_domains: $noindexDomains,
-                            escape_redirect_replacement_for_compose: false,
                         ));
                         break;
                 }

--- a/database/factories/ApplicationFactory.php
+++ b/database/factories/ApplicationFactory.php
@@ -2,8 +2,12 @@
 
 namespace Database\Factories;
 
+use App\Models\Application;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
+/**
+ * @extends Factory<Application>
+ */
 class ApplicationFactory extends Factory
 {
     public function definition(): array

--- a/tests/Feature/CaddyApplicationLabelGenerationTest.php
+++ b/tests/Feature/CaddyApplicationLabelGenerationTest.php
@@ -21,7 +21,7 @@ test('generates exact Caddy labels for an application with a domain', function (
     ]);
     $server->settings->update(['generate_exact_labels' => true]);
     $destination = StandaloneDocker::query()->where('server_id', $server->id)->firstOrFail();
-    $application = Application::factory()->create([
+    $application = Application::factory()->createOne([
         'environment_id' => $environment->id,
         'destination_id' => $destination->id,
         'destination_type' => $destination->getMorphClass(),

--- a/tests/Feature/CaddyApplicationLabelGenerationTest.php
+++ b/tests/Feature/CaddyApplicationLabelGenerationTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Enums\ProxyTypes;
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('generates exact Caddy labels for an application with a domain', function () {
+    $team = Team::factory()->create();
+    $project = Project::factory()->create(['team_id' => $team->id]);
+    $environment = Environment::factory()->create(['project_id' => $project->id]);
+    $server = Server::factory()->create([
+        'team_id' => $team->id,
+        'proxy' => ['type' => ProxyTypes::CADDY->value],
+    ]);
+    $server->settings->update(['generate_exact_labels' => true]);
+    $destination = StandaloneDocker::query()->where('server_id', $server->id)->firstOrFail();
+    $application = Application::factory()->create([
+        'environment_id' => $environment->id,
+        'destination_id' => $destination->id,
+        'destination_type' => $destination->getMorphClass(),
+        'fqdn' => 'https://example.com',
+        'redirect' => 'both',
+        'is_http_basic_auth_enabled' => false,
+    ]);
+
+    $labels = generateLabelsApplication($application);
+
+    expect($labels)
+        ->toContain('caddy_ingress_network=coolify')
+        ->not->toContain('traefik.enable=true');
+});


### PR DESCRIPTION
## Summary

- Remove the unsupported argument passed during exact Caddy label generation.
- Restore application configuration and deployment label generation for Caddy proxies.
- Add regression coverage for applications with generated Caddy labels and a configured domain.

fixes #11394

---

Fixes #11394