### PR TITLE
fix(email): prevent Proton SMTP From header folding

### DIFF
--- a/app/Notifications/Channels/EmailChannel.php
+++ b/app/Notifications/Channels/EmailChannel.php
@@ -85,8 +85,7 @@ class EmailChannel
                 $transport = SmtpTransportFactory::fromSettings($settings);
                 $mailer = new Mailer($transport);
 
-                $email = (new Email)
-                    ->from(mail_from_address($settings))
+                $email = mail_from_email(new Email, $settings)
                     ->to(...$recipients)
                     ->subject($mailMessage->subject)
                     ->html((string) $mailMessage->render());

--- a/app/Notifications/Channels/TransactionalEmailChannel.php
+++ b/app/Notifications/Channels/TransactionalEmailChannel.php
@@ -27,12 +27,10 @@ class TransactionalEmailChannel
         }
         $this->bootConfigs();
         $mailMessage = $notification->toMail($notifiable);
-        $from = mail_from_identity($settings);
         Mail::send(
             [],
             [],
-            fn (Message $message) => $message
-                ->from($from['address'], $from['name'])
+            fn (Message $message) => mail_from_message($message, $settings)
                 ->to($email)
                 ->subject($mailMessage->subject)
                 ->html((string) $mailMessage->render())

--- a/app/Notifications/TransactionalEmails/ResetPassword.php
+++ b/app/Notifications/TransactionalEmails/ResetPassword.php
@@ -57,6 +57,7 @@ class ResetPassword extends Notification
         $from = mail_from_identity($this->settings);
         $mail = new MailMessage;
         $mail->from($from['address'], $from['name']);
+        $mail->withSymfonyMessage(fn ($message) => prevent_mail_from_header_folding($message, $this->settings));
         $mail->subject('Coolify: Reset Password');
         $mail->view('emails.reset-password', ['url' => $url, 'count' => config('auth.passwords.'.config('auth.defaults.passwords').'.expire')]);
 

--- a/bootstrap/helpers/notifications.php
+++ b/bootstrap/helpers/notifications.php
@@ -6,6 +6,7 @@ use Illuminate\Mail\Message;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Support\Facades\Mail;
 use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
 
 function is_transactional_emails_enabled(): bool
 {
@@ -45,6 +46,32 @@ function mail_from_formatted(object $settings): string
     return mail_from_address($settings)->toString();
 }
 
+function mail_from_email(Email $email, object $settings): Email
+{
+    $email->from(mail_from_address($settings));
+    prevent_mail_from_header_folding($email, $settings);
+
+    return $email;
+}
+
+function mail_from_message(Message $message, object $settings): Message
+{
+    $identity = mail_from_identity($settings);
+    $message->from($identity['address'], $identity['name']);
+    prevent_mail_from_header_folding($message->getSymfonyMessage(), $settings);
+
+    return $message;
+}
+
+function prevent_mail_from_header_folding(Email $email, object $settings): void
+{
+    if (strtolower(trim((string) ($settings->smtp_host ?? ''))) !== 'smtp.protonmail.ch') {
+        return;
+    }
+
+    $email->getHeaders()->get('From')?->setMaxLineLength(998);
+}
+
 function send_internal_notification(string $message): void
 {
     try {
@@ -61,14 +88,11 @@ function send_user_an_email(MailMessage $mail, string $email, ?string $cc = null
     if (blank($type)) {
         throw new Exception('No email settings found.');
     }
-    $from = mail_from_identity($settings);
-
     if ($cc) {
         Mail::send(
             [],
             [],
-            fn (Message $message) => $message
-                ->from($from['address'], $from['name'])
+            fn (Message $message) => mail_from_message($message, $settings)
                 ->to($email)
                 ->replyTo($email)
                 ->cc($cc)
@@ -79,8 +103,7 @@ function send_user_an_email(MailMessage $mail, string $email, ?string $cc = null
         Mail::send(
             [],
             [],
-            fn (Message $message) => $message
-                ->from($from['address'], $from['name'])
+            fn (Message $message) => mail_from_message($message, $settings)
                 ->to($email)
                 ->subject($mail->subject)
                 ->html((string) $mail->render())

--- a/tests/Unit/MailFromIdentityTest.php
+++ b/tests/Unit/MailFromIdentityTest.php
@@ -1,6 +1,8 @@
 <?php
 
+use Illuminate\Mail\Message;
 use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
 
 it('uses the configured transactional from name and address', function () {
     $identity = mail_from_identity((object) [
@@ -31,6 +33,39 @@ it('formats the transactional sender for resend', function () {
     ]);
 
     expect($formattedAddress)->toBe('"Coolify" <admin@example.com>');
+});
+
+it('keeps the smtp from name and address on the same header line', function () {
+    $email = mail_from_email(new Email, (object) [
+        'smtp_host' => 'smtp.protonmail.ch',
+        'smtp_from_address' => 'contact@advanceddigitalmarketingltda.com',
+        'smtp_from_name' => 'Advanced Digital Marketing LTDA',
+    ]);
+
+    expect($email->getHeaders()->get('From')?->toString())
+        ->toBe('From: Advanced Digital Marketing LTDA <contact@advanceddigitalmarketingltda.com>');
+});
+
+it('keeps the Laravel mail from name and address on the same header line', function () {
+    $message = mail_from_message(new Message(new Email), (object) [
+        'smtp_host' => 'smtp.protonmail.ch',
+        'smtp_from_address' => 'contact@advanceddigitalmarketingltda.com',
+        'smtp_from_name' => 'Advanced Digital Marketing LTDA',
+    ]);
+
+    expect($message->getSymfonyMessage()->getHeaders()->get('From')?->toString())
+        ->toBe('From: Advanced Digital Marketing LTDA <contact@advanceddigitalmarketingltda.com>');
+});
+
+it('keeps Symfony header folding for other smtp providers', function () {
+    $email = mail_from_email(new Email, (object) [
+        'smtp_host' => 'smtp.example.com',
+        'smtp_from_address' => 'contact@advanceddigitalmarketingltda.com',
+        'smtp_from_name' => 'Advanced Digital Marketing LTDA',
+    ]);
+
+    expect($email->getHeaders()->get('From')?->toString())
+        ->toBe("From: Advanced Digital Marketing LTDA\r\n <contact@advanceddigitalmarketingltda.com>");
 });
 
 it('treats a blank from name as missing instead of sending an unnamed address', function () {


### PR DESCRIPTION
## Summary

- Keep long SMTP sender names and addresses on one `From` header line for Proton Mail compatibility.
- Apply the fix consistently across notification, transactional, and password-reset emails.
- Preserve Symfony’s standard header folding for other SMTP providers.
- Add coverage for Symfony and Laravel mail messages.

Fixes #11380

---

Fixes #11380