### PR TITLE
fix(upgrade): persist target image before container recreation

### DIFF
--- a/other/nightly/upgrade.sh
+++ b/other/nightly/upgrade.sh
@@ -148,6 +148,8 @@ set_env_var() {
 
 log "Checking environment variables..."
 set_env_var "REGISTRY_URL" "$REGISTRY_URL"
+set_env_var "LATEST_IMAGE" "$LATEST_IMAGE"
+set_env_var "COOLIFY_VERSION" "$LATEST_IMAGE"
 update_env_var "PUSHER_APP_ID" "$(openssl rand -hex 32)"
 update_env_var "PUSHER_APP_KEY" "$(openssl rand -hex 32)"
 update_env_var "PUSHER_APP_SECRET" "$(openssl rand -hex 32)"

--- a/other/nightly/upgrade.sh
+++ b/other/nightly/upgrade.sh
@@ -148,8 +148,6 @@ set_env_var() {
 
 log "Checking environment variables..."
 set_env_var "REGISTRY_URL" "$REGISTRY_URL"
-set_env_var "LATEST_IMAGE" "$LATEST_IMAGE"
-set_env_var "COOLIFY_VERSION" "$LATEST_IMAGE"
 update_env_var "PUSHER_APP_ID" "$(openssl rand -hex 32)"
 update_env_var "PUSHER_APP_KEY" "$(openssl rand -hex 32)"
 update_env_var "PUSHER_APP_SECRET" "$(openssl rand -hex 32)"
@@ -217,6 +215,9 @@ done
 
 log "All images pulled successfully"
 echo "     All images pulled successfully."
+
+set_env_var "LATEST_IMAGE" "$LATEST_IMAGE"
+set_env_var "COOLIFY_VERSION" "$LATEST_IMAGE"
 
 log_section "Step 4/6: Stopping and restarting containers"
 write_status "4" "Stopping containers"

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -148,8 +148,6 @@ set_env_var() {
 
 log "Checking environment variables..."
 set_env_var "REGISTRY_URL" "$REGISTRY_URL"
-set_env_var "LATEST_IMAGE" "$LATEST_IMAGE"
-set_env_var "COOLIFY_VERSION" "$LATEST_IMAGE"
 update_env_var "PUSHER_APP_ID" "$(openssl rand -hex 32)"
 update_env_var "PUSHER_APP_KEY" "$(openssl rand -hex 32)"
 update_env_var "PUSHER_APP_SECRET" "$(openssl rand -hex 32)"
@@ -230,6 +228,9 @@ done
 
 log "All images pulled successfully"
 echo "     All images pulled successfully."
+
+set_env_var "LATEST_IMAGE" "$LATEST_IMAGE"
+set_env_var "COOLIFY_VERSION" "$LATEST_IMAGE"
 
 log_section "Step 4/6: Stopping and restarting containers"
 write_status "4" "Stopping containers"

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -148,6 +148,8 @@ set_env_var() {
 
 log "Checking environment variables..."
 set_env_var "REGISTRY_URL" "$REGISTRY_URL"
+set_env_var "LATEST_IMAGE" "$LATEST_IMAGE"
+set_env_var "COOLIFY_VERSION" "$LATEST_IMAGE"
 update_env_var "PUSHER_APP_ID" "$(openssl rand -hex 32)"
 update_env_var "PUSHER_APP_KEY" "$(openssl rand -hex 32)"
 update_env_var "PUSHER_APP_SECRET" "$(openssl rand -hex 32)"

--- a/tests/Unit/UpgradePostgresScriptTest.php
+++ b/tests/Unit/UpgradePostgresScriptTest.php
@@ -64,15 +64,25 @@ it('persists the selected registry url during upgrades', function (string $path)
 
 it('persists the target image and runtime version before recreating containers', function (string $path) {
     $script = file_get_contents(getcwd().'/'.$path);
+    if ($script === false) {
+        throw new RuntimeException("Unable to read {$path}");
+    }
 
-    $latestImagePosition = strpos($script, 'set_env_var "LATEST_IMAGE" "$LATEST_IMAGE"');
-    $coolifyVersionPosition = strpos($script, 'set_env_var "COOLIFY_VERSION" "$LATEST_IMAGE"');
-    $imagesPulledPosition = strpos($script, 'log "All images pulled successfully"');
-    $composeUpPosition = strpos($script, 'docker compose --env-file /data/coolify/source/.env');
+    $position = static function (string $needle) use ($script): int {
+        $offset = strpos($script, $needle);
+        if ($offset === false) {
+            throw new RuntimeException("Missing marker: {$needle}");
+        }
 
-    expect($latestImagePosition)->not->toBeFalse()
-        ->and($coolifyVersionPosition)->not->toBeFalse()
-        ->and($latestImagePosition)->toBeGreaterThan($imagesPulledPosition)
+        return $offset;
+    };
+
+    $latestImagePosition = $position('set_env_var "LATEST_IMAGE" "$LATEST_IMAGE"');
+    $coolifyVersionPosition = $position('set_env_var "COOLIFY_VERSION" "$LATEST_IMAGE"');
+    $imagesPulledPosition = $position('log "All images pulled successfully"');
+    $composeUpPosition = $position('docker compose --env-file /data/coolify/source/.env');
+
+    expect($latestImagePosition)->toBeGreaterThan($imagesPulledPosition)
         ->and($coolifyVersionPosition)->toBeGreaterThan($imagesPulledPosition)
         ->and($latestImagePosition)->toBeLessThan($composeUpPosition)
         ->and($coolifyVersionPosition)->toBeLessThan($composeUpPosition);

--- a/tests/Unit/UpgradePostgresScriptTest.php
+++ b/tests/Unit/UpgradePostgresScriptTest.php
@@ -67,10 +67,13 @@ it('persists the target image and runtime version before recreating containers',
 
     $latestImagePosition = strpos($script, 'set_env_var "LATEST_IMAGE" "$LATEST_IMAGE"');
     $coolifyVersionPosition = strpos($script, 'set_env_var "COOLIFY_VERSION" "$LATEST_IMAGE"');
+    $imagesPulledPosition = strpos($script, 'log "All images pulled successfully"');
     $composeUpPosition = strpos($script, 'docker compose --env-file /data/coolify/source/.env');
 
     expect($latestImagePosition)->not->toBeFalse()
         ->and($coolifyVersionPosition)->not->toBeFalse()
+        ->and($latestImagePosition)->toBeGreaterThan($imagesPulledPosition)
+        ->and($coolifyVersionPosition)->toBeGreaterThan($imagesPulledPosition)
         ->and($latestImagePosition)->toBeLessThan($composeUpPosition)
         ->and($coolifyVersionPosition)->toBeLessThan($composeUpPosition);
 })->with([

--- a/tests/Unit/UpgradePostgresScriptTest.php
+++ b/tests/Unit/UpgradePostgresScriptTest.php
@@ -62,6 +62,22 @@ it('persists the selected registry url during upgrades', function (string $path)
     'nightly upgrade' => 'other/nightly/upgrade.sh',
 ]);
 
+it('persists the target image and runtime version before recreating containers', function (string $path) {
+    $script = file_get_contents(getcwd().'/'.$path);
+
+    $latestImagePosition = strpos($script, 'set_env_var "LATEST_IMAGE" "$LATEST_IMAGE"');
+    $coolifyVersionPosition = strpos($script, 'set_env_var "COOLIFY_VERSION" "$LATEST_IMAGE"');
+    $composeUpPosition = strpos($script, 'docker compose --env-file /data/coolify/source/.env');
+
+    expect($latestImagePosition)->not->toBeFalse()
+        ->and($coolifyVersionPosition)->not->toBeFalse()
+        ->and($latestImagePosition)->toBeLessThan($composeUpPosition)
+        ->and($coolifyVersionPosition)->toBeLessThan($composeUpPosition);
+})->with([
+    'stable upgrade' => 'scripts/upgrade.sh',
+    'nightly upgrade' => 'other/nightly/upgrade.sh',
+]);
+
 it('uses the existing env registry url when old callers do not pass a registry argument', function (string $path) {
     $script = file_get_contents(getcwd().'/'.$path);
 


### PR DESCRIPTION
## Summary

- Persist `LATEST_IMAGE` and `COOLIFY_VERSION` before recreating containers during stable and nightly upgrades.
- Keep the displayed version and future container recreations aligned with the installed image.
- Add tests verifying both values are written before Docker Compose runs.

fixes #11389

---

Fixes #11389