### PR TITLE
fix(docker): raise nginx request header buffers above the 8k default

### DIFF
--- a/docker/development/etc/nginx/conf.d/custom.conf
+++ b/docker/development/etc/nginx/conf.d/custom.conf
@@ -3,10 +3,8 @@
 # Disable access logs
 access_log off;
 
-# Allow larger request headers than nginx's 4 8k default.
-# Coolify is often deployed on a subdomain of a parent domain whose other apps
-# set cookies on that parent, and frequently behind an identity proxy that adds
-# a JWT cookie of its own. The combined Cookie header then exceeds 8k and nginx
-# rejects the request with a bare 400 before it reaches the application.
+# Allow request headers up to 32k (nginx default is 8k). Large JWT cookies can push the
+# Cookie header past 8k, and nginx would then reject the request with a bare 400
+# before it reaches the application.
 client_header_buffer_size 8k;
 large_client_header_buffers 8 32k;

--- a/docker/development/etc/nginx/conf.d/custom.conf
+++ b/docker/development/etc/nginx/conf.d/custom.conf
@@ -2,3 +2,11 @@
 
 # Disable access logs
 access_log off;
+
+# Allow larger request headers than nginx's 4 8k default.
+# Coolify is often deployed on a subdomain of a parent domain whose other apps
+# set cookies on that parent, and frequently behind an identity proxy that adds
+# a JWT cookie of its own. The combined Cookie header then exceeds 8k and nginx
+# rejects the request with a bare 400 before it reaches the application.
+client_header_buffer_size 8k;
+large_client_header_buffers 8 32k;

--- a/docker/production/etc/nginx/conf.d/custom.conf
+++ b/docker/production/etc/nginx/conf.d/custom.conf
@@ -3,10 +3,8 @@
 # Disable access logs
 access_log off;
 
-# Allow larger request headers than nginx's 4 8k default.
-# Coolify is often deployed on a subdomain of a parent domain whose other apps
-# set cookies on that parent, and frequently behind an identity proxy that adds
-# a JWT cookie of its own. The combined Cookie header then exceeds 8k and nginx
-# rejects the request with a bare 400 before it reaches the application.
+# Allow request headers up to 32k (nginx default is 8k). Large JWT cookies can push the
+# Cookie header past 8k, and nginx would then reject the request with a bare 400
+# before it reaches the application.
 client_header_buffer_size 8k;
 large_client_header_buffers 8 32k;

--- a/docker/production/etc/nginx/conf.d/custom.conf
+++ b/docker/production/etc/nginx/conf.d/custom.conf
@@ -2,3 +2,11 @@
 
 # Disable access logs
 access_log off;
+
+# Allow larger request headers than nginx's 4 8k default.
+# Coolify is often deployed on a subdomain of a parent domain whose other apps
+# set cookies on that parent, and frequently behind an identity proxy that adds
+# a JWT cookie of its own. The combined Cookie header then exceeds 8k and nginx
+# rejects the request with a bare 400 before it reaches the application.
+client_header_buffer_size 8k;
+large_client_header_buffers 8 32k;


### PR DESCRIPTION
## Changes

- Add `client_header_buffer_size 8k;` and `large_client_header_buffers 8 32k;`
  to `docker/{production,development}/etc/nginx/conf.d/custom.conf`.

nginx in the Coolify container currently runs on its compiled default of
`large_client_header_buffers 4 8k` — the directive appears nowhere in
`nginx -T`. Any single request header over 8 KB gets a bare nginx `400` before
Laravel is reached.

A dashboard on a subdomain of a parent domain that also hosts cookie-setting
apps receives those cookies too, because cookie domains match on suffix. Example Supabase OATP providers.
Add an identity proxy in front and its JWT joins the same jar. 8 KB is then not much
headroom. The error is also misleading: it comes from nginx, while Coolify's own
proxy is Traefik, which has no comparable limit.

`custom.conf` already exists in the image and is included from `http {}`, so
this is two lines in a file the project already owns. Both the production and
development copies are changed to keep them in sync.

## Issues

- Fixes #11403

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not applicable — no UI change.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Opus 5 (Claude Code)
- How extensively: Extensively.

## Testing

**Tested locally by editing the files on the instance and it works. I can now sign in with OATP in other projects on same domain, and also Coolify. No side effects found. 

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
