### PR TITLE
Align resource access checks

### DIFF
--- a/app/Http/Controllers/Api/GithubController.php
+++ b/app/Http/Controllers/Api/GithubController.php
@@ -15,9 +15,9 @@ use OpenApi\Attributes as OA;
 
 class GithubController extends Controller
 {
-    private function removeSensitiveData($githubApp)
+    private function removeSensitiveData(GithubApp $githubApp, int $teamId)
     {
-        if (request()->attributes->get('can_read_sensitive', false) === true) {
+        if (request()->attributes->get('can_read_sensitive', false) === true && $githubApp->team_id === $teamId) {
             $githubApp->makeVisible([
                 'client_secret',
                 'webhook_secret',
@@ -97,8 +97,8 @@ class GithubController extends Controller
                 ->orWhere('is_system_wide', true);
         })->get();
 
-        $githubApps = $githubApps->map(function ($app) {
-            return $this->removeSensitiveData($app);
+        $githubApps = $githubApps->map(function ($app) use ($teamId) {
+            return $this->removeSensitiveData($app, $teamId);
         });
 
         return response()->json($githubApps);

--- a/app/Http/Controllers/Api/GitlabController.php
+++ b/app/Http/Controllers/Api/GitlabController.php
@@ -13,9 +13,9 @@ use OpenApi\Attributes as OA;
 
 class GitlabController extends Controller
 {
-    private function removeSensitiveData(GitlabApp $gitlabApp)
+    private function removeSensitiveData(GitlabApp $gitlabApp, int $teamId)
     {
-        if (request()->attributes->get('can_read_sensitive', false) === true) {
+        if (request()->attributes->get('can_read_sensitive', false) === true && $gitlabApp->team_id === $teamId) {
             $gitlabApp->makeVisible([
                 'client_secret',
                 'webhook_token',
@@ -108,8 +108,8 @@ class GitlabController extends Controller
                 ->orWhere('is_system_wide', true);
         })->get();
 
-        $gitlabApps = $gitlabApps->map(function ($app) {
-            return $this->removeSensitiveData($app);
+        $gitlabApps = $gitlabApps->map(function ($app) use ($teamId) {
+            return $this->removeSensitiveData($app, $teamId);
         });
 
         return response()->json($gitlabApps);
@@ -280,7 +280,7 @@ class GitlabController extends Controller
                 'gitlab_app_name' => $gitlabApp->name,
             ]);
 
-            return response()->json($this->removeSensitiveData($gitlabApp->fresh()), 201);
+            return response()->json($this->removeSensitiveData($gitlabApp->fresh(), $teamId), 201);
         } catch (\Throwable $e) {
             return handleError($e);
         }
@@ -441,7 +441,7 @@ class GitlabController extends Controller
 
             return response()->json([
                 'message' => 'GitLab app updated successfully',
-                'data' => $this->removeSensitiveData($gitlabApp->fresh()),
+                'data' => $this->removeSensitiveData($gitlabApp->fresh(), $teamId),
             ]);
         } catch (ModelNotFoundException $e) {
             return response()->json([

--- a/app/Http/Controllers/Api/ProjectController.php
+++ b/app/Http/Controllers/Api/ProjectController.php
@@ -158,6 +158,8 @@ class ProjectController extends Controller
         if (! $project) {
             return response()->json(['message' => 'Project not found.'], 404);
         }
+        $this->authorize('view', $project);
+
         $environment = $project->environments()->whereName($request->environment_name_or_uuid)->first();
         if (! $environment) {
             $environment = $project->environments()->whereUuid($request->environment_name_or_uuid)->first();

--- a/app/Http/Controllers/Api/ServersController.php
+++ b/app/Http/Controllers/Api/ServersController.php
@@ -550,11 +550,7 @@ class ServersController extends Controller
         }
         $foundServer = ModelsServer::whereIp($request->ip)->first();
         if ($foundServer) {
-            if ($foundServer->team_id === $teamId) {
-                return response()->json(['message' => 'A server with this IP/Domain already exists in your team.'], 400);
-            }
-
-            return response()->json(['message' => 'A server with this IP/Domain is already in use by another team.'], 400);
+            return response()->json(['message' => 'A server with this IP/Domain is already in use.'], 400);
         }
 
         $proxyType = $request->proxy_type ? str($request->proxy_type)->upper() : ProxyTypes::TRAEFIK->value;

--- a/app/Http/Controllers/Api/TeamController.php
+++ b/app/Http/Controllers/Api/TeamController.php
@@ -56,7 +56,7 @@ class TeamController extends Controller
         if (is_null($teamId)) {
             return invalidTokenResponse();
         }
-        $teams = auth()->user()->teams->sortBy('id');
+        $teams = auth()->user()->teams->where('id', $teamId)->values();
         $teams = $teams->map(function ($team) {
             return $this->removeSensitiveData($team);
         });
@@ -100,13 +100,14 @@ class TeamController extends Controller
     )]
     public function team_by_id(Request $request)
     {
-        $id = $request->id;
         $teamId = getTeamIdFromToken();
         if (is_null($teamId)) {
             return invalidTokenResponse();
         }
-        $teams = auth()->user()->teams;
-        $team = $teams->where('id', $id)->first();
+        if ((int) $request->id !== (int) $teamId) {
+            return response()->json(['message' => 'Team not found.'], 404);
+        }
+        $team = auth()->user()->teams->where('id', $teamId)->first();
         if (is_null($team)) {
             return response()->json(['message' => 'Team not found.'], 404);
         }
@@ -159,13 +160,14 @@ class TeamController extends Controller
     )]
     public function members_by_id(Request $request)
     {
-        $id = $request->id;
         $teamId = getTeamIdFromToken();
         if (is_null($teamId)) {
             return invalidTokenResponse();
         }
-        $teams = auth()->user()->teams;
-        $team = $teams->where('id', $id)->first();
+        if ((int) $request->id !== (int) $teamId) {
+            return response()->json(['message' => 'Team not found.'], 404);
+        }
+        $team = auth()->user()->teams->where('id', $teamId)->first();
         if (is_null($team)) {
             return response()->json(['message' => 'Team not found.'], 404);
         }

--- a/app/Livewire/Project/Shared/ScheduledTask/Add.php
+++ b/app/Livewire/Project/Shared/ScheduledTask/Add.php
@@ -2,7 +2,10 @@
 
 namespace App\Livewire\Project\Shared\ScheduledTask;
 
+use App\Models\Application;
 use App\Models\ScheduledTask;
+use App\Models\Service;
+use App\Models\StandalonePostgresql;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Collection;
 use Livewire\Attributes\Locked;
@@ -59,13 +62,13 @@ class Add extends Component
         // Get the resource based on type and id
         switch ($this->type) {
             case 'application':
-                $this->resource = \App\Models\Application::findOrFail($this->id);
+                $this->resource = Application::ownedByCurrentTeam()->findOrFail($this->id);
                 break;
             case 'service':
-                $this->resource = \App\Models\Service::findOrFail($this->id);
+                $this->resource = Service::ownedByCurrentTeam()->findOrFail($this->id);
                 break;
             case 'standalone-postgresql':
-                $this->resource = \App\Models\StandalonePostgresql::findOrFail($this->id);
+                $this->resource = StandalonePostgresql::ownedByCurrentTeam()->findOrFail($this->id);
                 break;
             default:
                 throw new \Exception('Invalid resource type');

--- a/app/Livewire/Server/DockerCleanupExecutions.php
+++ b/app/Livewire/Server/DockerCleanupExecutions.php
@@ -2,7 +2,6 @@
 
 namespace App\Livewire\Server;
 
-use App\Models\DockerCleanupExecution;
 use App\Models\Server;
 use Illuminate\Support\Collection;
 use Livewire\Component;
@@ -46,7 +45,7 @@ class DockerCleanupExecutions extends Component
             ->get();
 
         if ($this->selectedKey) {
-            $this->selectedExecution = DockerCleanupExecution::find($this->selectedKey);
+            $this->selectedExecution = $this->server->dockerCleanupExecutions()->find($this->selectedKey);
             if ($this->selectedExecution && $this->selectedExecution->status !== 'running') {
                 $this->isPollingActive = false;
             }
@@ -64,7 +63,7 @@ class DockerCleanupExecutions extends Component
             return;
         }
         $this->selectedKey = $key;
-        $this->selectedExecution = DockerCleanupExecution::find($key);
+        $this->selectedExecution = $this->server->dockerCleanupExecutions()->find($key);
         $this->currentPage = 1;
 
         if ($this->selectedExecution && $this->selectedExecution->status === 'running') {

--- a/tests/Feature/Api/GithubAppsListApiTest.php
+++ b/tests/Feature/Api/GithubAppsListApiTest.php
@@ -197,6 +197,39 @@ describe('GET /api/v1/github-apps', function () {
         ]);
     });
 
+    test('does not return system-wide github app secrets owned by another team', function () {
+        $otherTeam = Team::factory()->create();
+        $otherPrivateKey = PrivateKey::create([
+            'name' => 'System Key',
+            'private_key' => validGithubAppsApiPrivateKey(),
+            'team_id' => $otherTeam->id,
+        ]);
+        GithubApp::create([
+            'name' => 'Foreign System GitHub App',
+            'api_url' => 'https://api.github.com',
+            'html_url' => 'https://github.com',
+            'app_id' => 11111,
+            'installation_id' => 22222,
+            'client_id' => 'system-client-id',
+            'client_secret' => 'foreign-client-secret',
+            'webhook_secret' => 'foreign-webhook-secret',
+            'private_key_id' => $otherPrivateKey->id,
+            'team_id' => $otherTeam->id,
+            'is_system_wide' => true,
+        ]);
+
+        $sensitiveToken = createGithubAppsApiToken($this, ['read', 'read:sensitive']);
+
+        $response = $this->withToken($sensitiveToken)
+            ->getJson('/api/v1/github-apps')
+            ->assertSuccessful()
+            ->assertJsonFragment(['name' => 'Foreign System GitHub App']);
+
+        expect($response->json('0'))
+            ->not->toHaveKey('client_secret')
+            ->not->toHaveKey('webhook_secret');
+    });
+
     test('does not return other teams github apps', function () {
         // Create a GitHub app for this team
         GithubApp::create([

--- a/tests/Feature/Api/GitlabAppsApiTest.php
+++ b/tests/Feature/Api/GitlabAppsApiTest.php
@@ -64,6 +64,36 @@ describe('GET /api/v1/gitlab-apps', function () {
         expect($response->json('0'))->not->toHaveKey('client_secret')
             ->and($response->json('0'))->not->toHaveKey('webhook_token');
     });
+
+    test('does not return system-wide gitlab app secrets owned by another team', function () {
+        $otherTeam = Team::factory()->create();
+        GitlabApp::create([
+            'name' => 'Foreign System GitLab',
+            'api_url' => 'https://gitlab.com/api/v4',
+            'html_url' => 'https://gitlab.com',
+            'client_id' => 'foreign-client-id',
+            'client_secret' => 'foreign-client-secret',
+            'webhook_token' => 'foreign-webhook-token',
+            'access_token' => 'foreign-access-token',
+            'refresh_token' => 'foreign-refresh-token',
+            'team_id' => $otherTeam->id,
+            'is_system_wide' => true,
+        ]);
+
+        session(['currentTeam' => $this->team]);
+        $sensitiveToken = $this->user->createToken('sensitive-token', ['read', 'read:sensitive'])->plainTextToken;
+
+        $response = $this->withToken($sensitiveToken)
+            ->getJson('/api/v1/gitlab-apps')
+            ->assertSuccessful()
+            ->assertJsonFragment(['name' => 'Foreign System GitLab']);
+
+        expect($response->json('0'))
+            ->not->toHaveKey('client_secret')
+            ->not->toHaveKey('webhook_token')
+            ->not->toHaveKey('access_token')
+            ->not->toHaveKey('refresh_token');
+    });
 });
 
 describe('POST /api/v1/gitlab-apps', function () {

--- a/tests/Feature/Api/TeamTokenTeamApiTest.php
+++ b/tests/Feature/Api/TeamTokenTeamApiTest.php
@@ -8,6 +8,9 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 uses(RefreshDatabase::class);
 
 beforeEach(function () {
+    config()->set('app.maintenance.driver', 'file');
+    config()->set('cache.default', 'array');
+
     InstanceSettings::unguarded(fn () => InstanceSettings::updateOrCreate(['id' => 0], ['is_api_enabled' => true]));
 
     $this->team = Team::factory()->create(['name' => 'Token Team']);
@@ -27,6 +30,27 @@ function teamTokenApiHeaders(string $bearerToken): array
 }
 
 describe('token team endpoints', function () {
+    test('legacy team endpoints are restricted to the token team', function () {
+        $otherTeam = Team::factory()->create(['name' => 'Other Team']);
+        $otherMember = User::factory()->create();
+        $otherTeam->members()->attach($this->user->id, ['role' => 'owner']);
+        $otherTeam->members()->attach($otherMember->id, ['role' => 'member']);
+
+        $this->withHeaders(teamTokenApiHeaders($this->bearerToken))
+            ->getJson('/api/v1/teams')
+            ->assertOk()
+            ->assertJsonCount(1)
+            ->assertJsonPath('0.id', $this->team->id);
+
+        $this->withHeaders(teamTokenApiHeaders($this->bearerToken))
+            ->getJson("/api/v1/teams/{$otherTeam->id}")
+            ->assertNotFound();
+
+        $this->withHeaders(teamTokenApiHeaders($this->bearerToken))
+            ->getJson("/api/v1/teams/{$otherTeam->id}/members")
+            ->assertNotFound();
+    });
+
     test('GET /team returns the token team', function () {
         $this->withHeaders(teamTokenApiHeaders($this->bearerToken))
             ->getJson('/api/v1/team')

--- a/tests/Feature/ResourceAccessConsistencyTest.php
+++ b/tests/Feature/ResourceAccessConsistencyTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use App\Livewire\Project\Shared\ScheduledTask\Add;
+use App\Livewire\Server\DockerCleanupExecutions;
+use App\Models\Application;
+use App\Models\DockerCleanupExecution;
+use App\Models\Environment;
+use App\Models\InstanceSettings;
+use App\Models\PrivateKey;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    config(['app.maintenance.driver' => 'file']);
+
+    InstanceSettings::forceCreate(['id' => 0, 'is_api_enabled' => true]);
+
+    $this->team = Team::factory()->create();
+    $this->user = User::factory()->create();
+    $this->user->teams()->attach($this->team, ['role' => 'owner']);
+
+    $this->otherTeam = Team::factory()->create();
+
+    session(['currentTeam' => $this->team]);
+
+    $this->privateKey = PrivateKey::withoutEvents(fn () => PrivateKey::forceCreate([
+        'uuid' => (string) Str::uuid(),
+        'name' => 'IDOR test key',
+        'private_key' => 'test-private-key',
+        'team_id' => $this->team->id,
+    ]));
+
+    $token = $this->user->createToken('idor-hardening', ['*']);
+    $token->accessToken->forceFill(['team_id' => $this->team->id])->save();
+    $this->token = $token->plainTextToken;
+});
+
+test('server creation returns a consistent duplicate address response', function () {
+    $ownServer = Server::factory()->create([
+        'ip' => '192.0.2.10',
+        'team_id' => $this->team->id,
+    ]);
+    $otherServer = Server::factory()->create([
+        'ip' => '192.0.2.20',
+        'team_id' => $this->otherTeam->id,
+    ]);
+
+    $payload = fn (Server $server): array => [
+        'name' => 'Duplicate server',
+        'ip' => $server->ip,
+        'private_key_uuid' => $this->privateKey->uuid,
+        'user' => 'root',
+    ];
+
+    $ownResponse = $this->withToken($this->token)->postJson('/api/v1/servers', $payload($ownServer));
+    $otherResponse = $this->withToken($this->token)->postJson('/api/v1/servers', $payload($otherServer));
+
+    $ownResponse->assertBadRequest();
+    $otherResponse->assertBadRequest();
+    expect($ownResponse->json('message'))
+        ->toBe('A server with this IP/Domain is already in use.')
+        ->toBe($otherResponse->json('message'));
+});
+
+test('environment details applies the project view policy', function () {
+    $project = Project::factory()->create(['team_id' => $this->team->id]);
+    $environment = Environment::factory()->create(['project_id' => $project->id]);
+
+    Gate::before(fn (User $user, string $ability): ?bool => $ability === 'view' ? false : null);
+
+    $this->withToken($this->token)
+        ->getJson("/api/v1/projects/{$project->uuid}/{$environment->uuid}")
+        ->assertForbidden();
+});
+
+test('docker cleanup execution selection only uses the mounted server', function () {
+    $this->actingAs($this->user);
+
+    $server = Server::factory()->create(['team_id' => $this->team->id]);
+    $otherServer = Server::factory()->create(['team_id' => $this->otherTeam->id]);
+    $otherExecution = DockerCleanupExecution::create([
+        'server_id' => $otherServer->id,
+        'status' => 'success',
+        'message' => 'other team cleanup output',
+    ]);
+
+    Livewire::test(DockerCleanupExecutions::class, ['server' => $server])
+        ->call('selectExecution', $otherExecution->id)
+        ->assertSet('selectedExecution', null);
+});
+
+test('scheduled task form only mounts applications from the current team', function () {
+    $this->actingAs($this->user);
+
+    $server = Server::factory()->create(['team_id' => $this->otherTeam->id]);
+    $destination = StandaloneDocker::where('server_id', $server->id)->firstOrFail();
+    $project = Project::factory()->create(['team_id' => $this->otherTeam->id]);
+    $environment = Environment::factory()->create(['project_id' => $project->id]);
+    $application = Application::factory()->create([
+        'environment_id' => $environment->id,
+        'destination_id' => $destination->id,
+        'destination_type' => $destination->getMorphClass(),
+    ]);
+
+    Livewire::test(Add::class, [
+        'id' => (string) $application->id,
+        'type' => 'application',
+        'containerNames' => collect(),
+    ]);
+})->throws(ModelNotFoundException::class);


### PR DESCRIPTION
## Summary
- align team-scoped API response behavior across related endpoints
- apply existing project access rules when loading environment details
- resolve related records consistently through their owning server or current team
- keep shared source metadata responses consistent with token context

## Testing
- `php artisan test --compact tests/Feature/Api/GithubAppsListApiTest.php tests/Feature/Api/GitlabAppsApiTest.php tests/Feature/Api/TeamTokenTeamApiTest.php tests/Feature/ResourceAccessConsistencyTest.php`
- `vendor/bin/pint --dirty --format agent`
