### PR TITLE
fix(services): handle empty compose environment sections

### DIFF
--- a/bootstrap/helpers/services.php
+++ b/bootstrap/helpers/services.php
@@ -233,7 +233,7 @@ function updateCompose(ServiceApplication|ServiceDatabase $resource)
         // IMPORTANT: Only extract variables that are DIRECTLY DECLARED for this service,
         // not variables that are merely referenced from other services
         $serviceConfig = data_get($dockerCompose, "services.{$name}");
-        $environment = data_get($serviceConfig, 'environment', []);
+        $environment = data_get($serviceConfig, 'environment') ?? [];
         $templateVariableNames = [];
 
         foreach ($environment as $key => $value) {

--- a/tests/Feature/ServiceDomainsTest.php
+++ b/tests/Feature/ServiceDomainsTest.php
@@ -318,6 +318,21 @@ it('adds a domain to a selected service application', function () {
         ->not->toBeNull();
 });
 
+it('adds a domain when the compose service has an empty environment section', function () {
+    $this->service->update([
+        'docker_compose_raw' => "services:\n  web:\n    image: nginx:alpine\n    environment:\n  api:\n    image: node:alpine\n",
+    ]);
+
+    Livewire::test(Domains::class, ['service' => $this->service->fresh(['applications', 'server'])])
+        ->set('newServiceApplicationId', $this->webApp->id)
+        ->set('newDomain', 'https://web.example.com')
+        ->call('addDomain')
+        ->assertHasNoErrors()
+        ->assertDispatched('success');
+
+    expect($this->webApp->fresh()->fqdn)->toBe('https://web.example.com');
+});
+
 it('keeps a stable key for the rendered domain list', function () {
     $view = file_get_contents(resource_path('views/livewire/project/service/domains.blade.php'));
 


### PR DESCRIPTION
## Summary

- Prevent domain creation from failing when a service has an empty Compose `environment` section.
- Add regression coverage confirming domains can be added successfully in this scenario.
- Fixes #11381.

---

Fixes #11381