### PR TITLE
fix(docker-cleanup): finalize executions after job failure

### DIFF
--- a/app/Jobs/DockerCleanupJob.php
+++ b/app/Jobs/DockerCleanupJob.php
@@ -155,4 +155,38 @@ class DockerCleanupJob implements ShouldBeEncrypted, ShouldQueue
             }
         }
     }
+
+    public function failed(?\Throwable $exception): void
+    {
+        $execution = DockerCleanupExecution::query()
+            ->where('server_id', $this->server->id)
+            ->where('status', 'running')
+            ->whereNull('finished_at')
+            ->latest('id')
+            ->first();
+
+        if (! $execution) {
+            return;
+        }
+
+        $message = $exception?->getMessage() ?? 'Docker cleanup job failed without an exception.';
+
+        $updated = DockerCleanupExecution::query()
+            ->whereKey($execution->id)
+            ->where('status', 'running')
+            ->whereNull('finished_at')
+            ->update([
+                'status' => 'failed',
+                'message' => $message,
+                'finished_at' => Carbon::now()->toImmutable(),
+            ]);
+
+        if ($updated === 0) {
+            return;
+        }
+
+        $execution->refresh();
+        event(new DockerCleanupDone($execution));
+        $this->server->team?->notify(new DockerCleanupFailed($this->server, 'Docker cleanup job failed with the following error: '.$message));
+    }
 }

--- a/tests/Feature/DockerCleanupJobTest.php
+++ b/tests/Feature/DockerCleanupJobTest.php
@@ -64,3 +64,25 @@ it('creates a failed execution record when server is force disabled', function (
         ->and($execution->status)->toBe('failed')
         ->and($execution->message)->toContain('not functional');
 });
+
+it('finishes the latest running execution when the job fails after a timeout', function () {
+    $user = User::factory()->create();
+    $team = $user->teams()->first();
+    $server = Server::factory()->create(['team_id' => $team->id]);
+
+    $olderExecution = DockerCleanupExecution::create([
+        'server_id' => $server->id,
+    ]);
+    $timedOutExecution = DockerCleanupExecution::create([
+        'server_id' => $server->id,
+    ]);
+
+    $job = new DockerCleanupJob($server);
+    $job->failed(new RuntimeException('Docker cleanup job has timed out.'));
+
+    expect($timedOutExecution->refresh()->status)->toBe('failed')
+        ->and($timedOutExecution->message)->toBe('Docker cleanup job has timed out.')
+        ->and($timedOutExecution->finished_at)->not->toBeNull()
+        ->and($olderExecution->refresh()->status)->toBe('running')
+        ->and($olderExecution->finished_at)->toBeNull();
+});


### PR DESCRIPTION
## Summary

- Mark the latest running Docker cleanup execution as failed when its job times out or otherwise fails.
- Record the failure message and completion time, then dispatch the completion event and failure notification.
- Add coverage ensuring only the latest running execution is finalized.

fixes #11383

---

Fixes #11383