### PR TITLE
feat(ui): split action button into primary and secondary actions

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1870,6 +1870,72 @@ html[data-theme="custom"] textarea:disabled {
     flex-shrink: 0;
 }
 
+.split-action {
+    display: inline-flex;
+    align-items: stretch;
+}
+
+.split-action-main,
+.split-action-caret {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.375rem;
+    height: 2rem;
+    font-size: 13px;
+    font-weight: 500;
+    white-space: nowrap;
+    cursor: pointer;
+    border: none;
+    background: linear-gradient(to bottom, var(--color-coollabs-100), var(--color-coollabs-200));
+    color: #ffffff;
+    transition: background-color 0.15s, color 0.15s, filter 0.15s;
+}
+
+.split-action-main {
+    flex: 1 1 auto;
+    min-width: 0;
+    padding: 0 0.625rem;
+    border-radius: 6px 0 0 6px;
+}
+
+.split-action-caret {
+    flex-shrink: 0;
+    width: 1.75rem;
+    border-left: 1px solid rgba(255, 255, 255, 0.25);
+    border-radius: 0 6px 6px 0;
+}
+
+.split-action > .split-action-main:only-of-type {
+    border-radius: 6px;
+}
+
+.split-action-main:hover:not(:disabled),
+.split-action-caret:hover:not(:disabled) {
+    background: linear-gradient(to bottom, var(--color-coollabs-100), var(--color-coollabs));
+    color: #ffffff;
+}
+
+.split-action-main:disabled,
+.split-action-caret:disabled {
+    cursor: not-allowed;
+    opacity: 0.45;
+}
+
+.split-action-main:focus-visible,
+.split-action-caret:focus-visible {
+    outline: none;
+    position: relative;
+    z-index: 1;
+    box-shadow: 0 0 0 1px var(--color-accent);
+}
+
+/* Compact height inside the fixed heading action bar */
+.application-heading-actions .split-action-main,
+.application-heading-actions .split-action-caret {
+    height: 1.75rem;
+}
+
 /* Custom listbox (replaces native <select>) */
 .listbox-trigger {
     display: flex;

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1872,11 +1872,11 @@ html[data-theme="custom"] textarea:disabled {
 
 .split-action {
     display: inline-flex;
-    align-items: stretch;
 }
 
 .split-action-main,
 .split-action-caret {
+    @apply button-highlighted;
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -1886,10 +1886,6 @@ html[data-theme="custom"] textarea:disabled {
     font-weight: 500;
     white-space: nowrap;
     cursor: pointer;
-    border: none;
-    background: linear-gradient(to bottom, var(--color-coollabs-100), var(--color-coollabs-200));
-    color: #ffffff;
-    transition: background-color 0.15s, color 0.15s, filter 0.15s;
 }
 
 .split-action-main {
@@ -1910,12 +1906,6 @@ html[data-theme="custom"] textarea:disabled {
     border-radius: 6px;
 }
 
-.split-action-main:hover:not(:disabled),
-.split-action-caret:hover:not(:disabled) {
-    background: linear-gradient(to bottom, var(--color-coollabs-100), var(--color-coollabs));
-    color: #ffffff;
-}
-
 .split-action-main:disabled,
 .split-action-caret:disabled {
     cursor: not-allowed;
@@ -1930,7 +1920,6 @@ html[data-theme="custom"] textarea:disabled {
     box-shadow: 0 0 0 1px var(--color-accent);
 }
 
-/* Compact height inside the fixed heading action bar */
 .application-heading-actions .split-action-main,
 .application-heading-actions .split-action-caret {
     height: 1.75rem;

--- a/resources/views/components/split-action.blade.php
+++ b/resources/views/components/split-action.blade.php
@@ -1,0 +1,19 @@
+<div {{ $attributes->class(['split-action relative']) }} x-data="{ open: false }"
+    x-effect="$dispatch('resource-actions-toggled', { open })" @click.outside="open = false"
+    @keydown.escape.window="open = false">
+    <button type="button" {{ $main->attributes->class(['split-action-main']) }}>
+        {{ $main }}
+    </button>
+    @if ($slot->hasActualContent())
+        <button type="button" class="split-action-caret" @click="open = !open" :aria-expanded="open"
+            aria-haspopup="menu" aria-label="More actions">
+            <span class="inline-flex transition-transform" :class="open && 'rotate-180'">
+                <x-reicon name="chevron-down" class="size-3" />
+            </span>
+        </button>
+        <div x-cloak x-show="open" x-transition.origin.top
+            class="listbox-panel right-0! xl:left-auto! xl:min-w-60! xl:max-w-96!" role="menu">
+            {{ $slot }}
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/project/application/heading.blade.php
+++ b/resources/views/livewire/project/application/heading.blade.php
@@ -40,116 +40,62 @@
         <div class="w-full xl:hidden">
             @if (!($application->build_pack === 'dockercompose' && is_null($application->docker_compose_raw)))
                 @can('deploy', $application)
-                <div id="application-mobile-actions" class="relative mb-3"
-                    x-data="{ open: false }" @click.outside="open = false"
-                    @keydown.escape.window="open = false">
-                    <button type="button" class="button w-full justify-between" @click="open = !open"
-                        :aria-expanded="open" aria-haspopup="menu">
-                        <span class="inline-flex items-center gap-2">
-                            Actions
-                        </span>
-                        <span class="inline-flex transition-transform" :class="open && 'rotate-180'">
-                            <x-reicon name="chevron-down" class="size-3 opacity-55" />
-                        </span>
-                    </button>
-
-                    <div x-cloak x-show="open" x-transition.origin.top.left
-                        class="listbox-panel top-full! left-0! right-0! mt-1! w-full! min-w-0!" role="menu">
-                        @if (!str($application->status)->startsWith('exited'))
+                    <x-split-action id="application-mobile-actions" class="mb-3 flex w-full">
+                        @if (str($application->status)->startsWith('exited'))
+                            <x-slot:main wire:click="deploy">
+                                <x-reicon name="play-circle" class="size-3.5" />
+                                Deploy
+                            </x-slot:main>
                             @if (!$application->destination->server->isSwarm())
-                                @can('deploy', $application)
-                                    <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                        wire:click="deploy" @click="open = false" role="menuitem">
-                                        <x-reicon name="refresh" class="size-3.5 opacity-70" />
-                                        Deploy
-                                    </button>
-                                @else
-                                    <button type="button" class="listbox-option justify-start! gap-2.5!" disabled
-                                        role="menuitem">
-                                        <x-reicon name="refresh" class="size-3.5 opacity-70" />
-                                        Deploy
-                                    </button>
-                                @endcan
+                                <button type="button" class="listbox-option justify-start! gap-2.5!" wire:click="deploy(true)"
+                                    @click="open = false" role="menuitem">
+                                    <x-reicon name="refresh" class="size-3.5 opacity-70" />
+                                    Deploy (without cache)
+                                </button>
                             @endif
-                            @if ($application->build_pack !== 'dockercompose')
-                                @if ($application->destination->server->isSwarm())
-                                    @can('deploy', $application)
-                                        <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                            wire:click="deploy" @click="open = false" role="menuitem">
-                                            <x-reicon name="refresh" class="size-3.5 opacity-70" />
-                                            Update Service
-                                        </button>
-                                    @else
-                                        <button type="button" class="listbox-option justify-start! gap-2.5!" disabled
-                                            role="menuitem">
-                                            <x-reicon name="refresh" class="size-3.5 opacity-70" />
-                                            Update Service
-                                        </button>
-                                    @endcan
+                        @else
+                            @if ($application->destination->server->isSwarm())
+                                @if ($application->build_pack !== 'dockercompose')
+                                    <x-slot:main wire:click="deploy">
+                                        <x-reicon name="refresh" class="size-3.5" />
+                                        Update Service
+                                    </x-slot:main>
                                 @else
-                                    @can('deploy', $application)
-                                        <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                            @click="open = false; document.getElementById('application-mobile-restart-trigger')?.click()"
-                                            role="menuitem">
-                                            <x-reicon name="restart" class="size-3.5 opacity-70" />
-                                            Restart
-                                        </button>
-                                    @else
-                                        <button type="button" class="listbox-option justify-start! gap-2.5!" disabled
-                                            role="menuitem">
-                                            <x-reicon name="restart" class="size-3.5 opacity-70" />
-                                            Restart
-                                        </button>
-                                    @endcan
+                                    <x-slot:main @click="document.getElementById('application-mobile-stop-trigger')?.click()">
+                                        <x-reicon name="stop-circle" class="size-3.5" />
+                                        Stop
+                                    </x-slot:main>
+                                @endif
+                            @else
+                                <x-slot:main wire:click="deploy">
+                                    <x-reicon name="refresh" class="size-3.5" />
+                                    Redeploy
+                                </x-slot:main>
+                                <button type="button" class="listbox-option justify-start! gap-2.5!"
+                                    wire:click="{{ str($application->status)->startsWith('running') ? 'force_deploy_without_cache' : 'deploy(true)' }}"
+                                    @click="open = false" role="menuitem">
+                                    <x-reicon name="refresh" class="size-3.5 opacity-70" />
+                                    {{ str($application->status)->startsWith('running') ? 'Redeploy (without cache)' : 'Deploy (without cache)' }}
+                                </button>
+                                @if ($application->build_pack !== 'dockercompose')
+                                    <button type="button" class="listbox-option justify-start! gap-2.5!"
+                                        @click="open = false; document.getElementById('application-mobile-restart-trigger')?.click()"
+                                        role="menuitem">
+                                        <x-reicon name="restart" class="size-3.5 opacity-70" />
+                                        Restart
+                                    </button>
                                 @endif
                             @endif
-                            @can('deploy', $application)
+                            @unless ($application->destination->server->isSwarm() && $application->build_pack === 'dockercompose')
                                 <button type="button" class="listbox-option justify-start! gap-2.5!"
                                     @click="open = false; document.getElementById('application-mobile-stop-trigger')?.click()"
                                     role="menuitem">
                                     <x-reicon name="stop-circle" class="size-3.5 text-error" />
                                     Stop
                                 </button>
-                            @else
-                                <button type="button" class="listbox-option justify-start! gap-2.5!" disabled
-                                    role="menuitem">
-                                    <x-reicon name="stop-circle" class="size-3.5 opacity-70" />
-                                    Stop
-                                </button>
-                            @endcan
-                        @else
-                            @can('deploy', $application)
-                                <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                    wire:click="deploy" @click="open = false" role="menuitem">
-                                    <x-reicon name="play-circle" class="size-3.5 opacity-70" />
-                                    Deploy
-                                </button>
-                            @else
-                                <button type="button" class="listbox-option justify-start! gap-2.5!" disabled
-                                    role="menuitem">
-                                    <x-reicon name="play-circle" class="size-3.5 opacity-70" />
-                                    Deploy
-                                </button>
-                            @endcan
+                            @endunless
                         @endif
-                        @if (!$application->destination->server->isSwarm())
-                            @can('deploy', $application)
-                                <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                    wire:click="{{ $application->status === 'running' ? 'force_deploy_without_cache' : 'deploy(true)' }}"
-                                    @click="open = false" role="menuitem">
-                                    <x-reicon name="refresh" class="size-3.5 opacity-70" />
-                                    Deploy (without cache)
-                                </button>
-                            @else
-                                <button type="button" class="listbox-option justify-start! gap-2.5!" disabled
-                                    role="menuitem">
-                                    <x-reicon name="refresh" class="size-3.5 opacity-70" />
-                                    Deploy (without cache)
-                                </button>
-                            @endcan
-                        @endif
-                    </div>
-                </div>
+                    </x-split-action>
                 @endcan
             @endif
             <div class="hidden" aria-hidden="true">
@@ -188,100 +134,62 @@
                             <x-applications.links :application="$application" />
                         </div>
                         @can('deploy', $application)
-                        <div id="application-desktop-actions" class="relative" x-data="{ open: false }"
-                            x-effect="$dispatch('resource-actions-toggled', { open })"
-                            @click.outside="open = false" @keydown.escape.window="open = false">
-                            <button type="button" class="button button-highlighted" @click="open = !open" :aria-expanded="open"
-                                aria-haspopup="menu">
-                                Actions
-                                <x-reicon name="chevron-down" class="size-3 opacity-55" />
-                            </button>
-
-                            <div x-cloak x-show="open" x-transition.origin.top.right
-                                class="listbox-panel top-full! right-0! left-auto! mt-1! w-60! min-w-0!" role="menu">
+                            <x-split-action id="application-desktop-actions">
                                 @if (str($application->status)->startsWith('exited'))
-                                    <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                        @disabled(!auth()->user()->can('deploy', $application))
-                                        wire:click="deploy" @click="open = false" role="menuitem">
-                                        <x-reicon name="play-circle" class="size-3.5 opacity-70" />
+                                    <x-slot:main wire:click="deploy">
+                                        <x-reicon name="play-circle" class="size-3.5" />
                                         Deploy
-                                    </button>
+                                    </x-slot:main>
                                     @if (!$application->destination->server->isSwarm())
-                                        <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                            @disabled(!auth()->user()->can('deploy', $application))
-                                            wire:click="deploy(true)" @click="open = false" role="menuitem">
+                                        <button type="button" class="listbox-option justify-start! gap-2.5!" wire:click="deploy(true)"
+                                            @click="open = false" role="menuitem">
                                             <x-reicon name="refresh" class="size-3.5 opacity-70" />
                                             Deploy (without cache)
                                         </button>
                                     @endif
                                 @else
-                                    @if (!$application->destination->server->isSwarm())
-                                        @can('deploy', $application)
-                                            <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                                wire:click="deploy" @click="open = false" role="menuitem">
-                                                <x-reicon name="refresh" class="size-3.5 opacity-70" />
-                                                Redeploy
-                                            </button>
+                                    @if ($application->destination->server->isSwarm())
+                                        @if ($application->build_pack !== 'dockercompose')
+                                            <x-slot:main wire:click="deploy">
+                                                <x-reicon name="refresh" class="size-3.5" />
+                                                Update Service
+                                            </x-slot:main>
                                         @else
-                                            <button type="button" class="listbox-option justify-start! gap-2.5!" disabled>
-                                                <x-reicon name="refresh" class="size-3.5 opacity-70" />
-                                                Redeploy
-                                            </button>
-                                        @endcan
+                                            <x-slot:main @click="document.getElementById('application-mobile-stop-trigger')?.click()">
+                                                <x-reicon name="stop-circle" class="size-3.5" />
+                                                Stop
+                                            </x-slot:main>
+                                        @endif
+                                    @else
+                                        <x-slot:main wire:click="deploy">
+                                            <x-reicon name="refresh" class="size-3.5" />
+                                            Redeploy
+                                        </x-slot:main>
                                         <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                            @disabled(!auth()->user()->can('deploy', $application))
                                             wire:click="{{ str($application->status)->startsWith('running') ? 'force_deploy_without_cache' : 'deploy(true)' }}"
                                             @click="open = false" role="menuitem">
                                             <x-reicon name="refresh" class="size-3.5 opacity-70" />
                                             {{ str($application->status)->startsWith('running') ? 'Redeploy (without cache)' : 'Deploy (without cache)' }}
                                         </button>
-                                    @endif
-                                    @if ($application->build_pack !== 'dockercompose')
-                                        @if ($application->destination->server->isSwarm())
-                                            @can('deploy', $application)
-                                                <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                                    wire:click="deploy" @click="open = false" role="menuitem">
-                                                    <x-reicon name="refresh" class="size-3.5 opacity-70" />
-                                                    Update Service
-                                                </button>
-                                            @else
-                                                <button type="button" class="listbox-option justify-start! gap-2.5!" disabled>
-                                                    <x-reicon name="refresh" class="size-3.5 opacity-70" />
-                                                    Update Service
-                                                </button>
-                                            @endcan
-                                        @else
-                                            @can('deploy', $application)
-                                                <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                                    @click="open = false; document.getElementById('application-mobile-restart-trigger')?.click()"
-                                                    role="menuitem">
-                                                    <x-reicon name="restart" class="size-3.5 opacity-70" />
-                                                    Restart
-                                                </button>
-                                            @else
-                                                <button type="button" class="listbox-option justify-start! gap-2.5!" disabled>
-                                                    <x-reicon name="restart" class="size-3.5 opacity-70" />
-                                                    Restart
-                                                </button>
-                                            @endcan
+                                        @if ($application->build_pack !== 'dockercompose')
+                                            <button type="button" class="listbox-option justify-start! gap-2.5!"
+                                                @click="open = false; document.getElementById('application-mobile-restart-trigger')?.click()"
+                                                role="menuitem">
+                                                <x-reicon name="restart" class="size-3.5 opacity-70" />
+                                                Restart
+                                            </button>
                                         @endif
                                     @endif
-                                    @can('deploy', $application)
+                                    @unless ($application->destination->server->isSwarm() && $application->build_pack === 'dockercompose')
                                         <button type="button" class="listbox-option justify-start! gap-2.5!"
                                             @click="open = false; document.getElementById('application-mobile-stop-trigger')?.click()"
                                             role="menuitem">
                                             <x-reicon name="stop-circle" class="size-3.5 text-error" />
                                             Stop
                                         </button>
-                                    @else
-                                        <button type="button" class="listbox-option justify-start! gap-2.5!" disabled>
-                                            <x-reicon name="stop-circle" class="size-3.5 opacity-70" />
-                                            Stop
-                                        </button>
-                                    @endcan
+                                    @endunless
                                 @endif
-                            </div>
-                        </div>
+                            </x-split-action>
                         @endcan
                     @endif
                 </div>

--- a/resources/views/livewire/project/database/heading.blade.php
+++ b/resources/views/livewire/project/database/heading.blade.php
@@ -70,64 +70,24 @@
         <div class="w-full xl:hidden">
             @if ($database->destination->server->isFunctional())
                 @can('manage', $database)
-                <div id="database-mobile-actions" class="relative mb-3"
-                    x-data="{ open: false }" @click.outside="open = false"
-                    @keydown.escape.window="open = false">
-                    <button type="button" class="button w-full justify-between" @click="open = !open"
-                        :aria-expanded="open" aria-haspopup="menu">
-                        <span class="inline-flex items-center gap-2">
-                            Actions
-                        </span>
-                        <span class="inline-flex transition-transform" :class="open && 'rotate-180'">
-                            <x-reicon name="chevron-down" class="size-3 opacity-55" />
-                        </span>
-                    </button>
-
-                    <div x-cloak x-show="open" x-transition.origin.top.left
-                        class="listbox-panel top-full! left-0! right-0! mt-1! w-full! min-w-0!" role="menu">
+                    <x-split-action id="database-mobile-actions" class="mb-3 flex w-full">
                         @if (! $databaseStatus->startsWith('exited'))
-                            @can('manage', $database)
-                                <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                    @click="open = false; document.getElementById('database-restart-trigger')?.click()"
-                                    role="menuitem">
-                                    <x-reicon name="restart" class="size-3.5 opacity-70" />
-                                    Restart
-                                </button>
-                                <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                    @click="open = false; document.getElementById('database-stop-trigger')?.click()"
-                                    role="menuitem">
-                                    <x-reicon name="stop" class="size-3.5 text-error" />
-                                    Stop
-                                </button>
-                            @else
-                                <button type="button" class="listbox-option justify-start! gap-2.5!" disabled
-                                    role="menuitem">
-                                    <x-reicon name="restart" class="size-3.5 opacity-70" />
-                                    Restart
-                                </button>
-                                <button type="button" class="listbox-option justify-start! gap-2.5!" disabled
-                                    role="menuitem">
-                                    <x-reicon name="stop" class="size-3.5 opacity-70" />
-                                    Stop
-                                </button>
-                            @endcan
+                            <x-slot:main @click="document.getElementById('database-restart-trigger')?.click()">
+                                <x-reicon name="restart" class="size-3.5" />
+                                Restart
+                            </x-slot:main>
+                            <button type="button" class="listbox-option justify-start! gap-2.5!"
+                                @click="open = false; document.getElementById('database-stop-trigger')?.click()" role="menuitem">
+                                <x-reicon name="stop-circle" class="size-3.5 text-error" />
+                                Stop
+                            </button>
                         @else
-                            @can('manage', $database)
-                                <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                    @click="open = false; $wire.dispatch('startEvent')" role="menuitem">
-                                    <x-reicon name="play-circle" class="size-3.5 opacity-70" />
-                                    Start
-                                </button>
-                            @else
-                                <button type="button" class="listbox-option justify-start! gap-2.5!" disabled
-                                    role="menuitem">
-                                    <x-reicon name="play-circle" class="size-3.5 opacity-70" />
-                                    Start
-                                </button>
-                            @endcan
+                            <x-slot:main @click="$wire.dispatch('startEvent')">
+                                <x-reicon name="play-circle" class="size-3.5" />
+                                Start
+                            </x-slot:main>
                         @endif
-                    </div>
-                </div>
+                    </x-split-action>
                 @endcan
             @endif
 
@@ -140,25 +100,24 @@
                 <div class="resource-heading-actions flex shrink-0 items-center gap-0.5">
                     @if ($database->destination->server->isFunctional())
                         @can('manage', $database)
-                        <div id="database-desktop-actions" class="flex items-center gap-0.5">
-                            @if (! $databaseStatus->startsWith('exited'))
-                                <button type="button" class="button button-highlighted"
-                                    @disabled(!auth()->user()->can('manage', $database))
-                                    @click="document.getElementById('database-restart-trigger')?.click()">
-                                    Restart
-                                </button>
-                                <button type="button" class="button"
-                                    @disabled(!auth()->user()->can('manage', $database))
-                                    @click="document.getElementById('database-stop-trigger')?.click()">
-                                    Stop
-                                </button>
-                            @else
-                                <x-forms.button class="button-highlighted" canGate="manage" :canResource="$database"
-                                    @click="$wire.dispatch('startEvent')">
-                                    Start
-                                </x-forms.button>
-                            @endif
-                        </div>
+                            <x-split-action id="database-desktop-actions">
+                                @if (! $databaseStatus->startsWith('exited'))
+                                    <x-slot:main @click="document.getElementById('database-restart-trigger')?.click()">
+                                        <x-reicon name="restart" class="size-3.5" />
+                                        Restart
+                                    </x-slot:main>
+                                    <button type="button" class="listbox-option justify-start! gap-2.5!"
+                                        @click="open = false; document.getElementById('database-stop-trigger')?.click()" role="menuitem">
+                                        <x-reicon name="stop-circle" class="size-3.5 text-error" />
+                                        Stop
+                                    </button>
+                                @else
+                                    <x-slot:main @click="$wire.dispatch('startEvent')">
+                                        <x-reicon name="play-circle" class="size-3.5" />
+                                        Start
+                                    </x-slot:main>
+                                @endif
+                            </x-split-action>
                         @endcan
                     @else
                         <x-status-badge status="Server unavailable" type="error" />

--- a/resources/views/livewire/project/service/heading.blade.php
+++ b/resources/views/livewire/project/service/heading.blade.php
@@ -74,85 +74,40 @@
         <div class="w-full xl:hidden">
             @if ($service->isDeployable)
                 @can('deploy', $service)
-                <div id="service-mobile-actions" class="relative mb-3"
-                    x-data="{ open: false }" @click.outside="open = false"
-                    @keydown.escape.window="open = false">
-                    <button type="button" class="button w-full justify-between" x-bind:disabled="deploying"
-                        @click="open = !open"
-                        :aria-expanded="open" aria-haspopup="menu">
-                        <span class="inline-flex items-center gap-2">
-                            <x-loading-on-button x-show="deploying" x-cloak />
-                            <span x-text="deploying ? 'Deploying…' : 'Actions'">Actions</span>
-                        </span>
-                        <span class="inline-flex transition-transform" :class="open && 'rotate-180'">
-                            <x-reicon name="chevron-down" class="size-3 opacity-55" />
-                        </span>
-                    </button>
-
-                    <div x-cloak x-show="open" x-transition.origin.top.left
-                        class="listbox-panel top-full! left-0! right-0! mt-1! w-full! min-w-0!" role="menu">
+                    <x-split-action id="service-mobile-actions" class="mb-3 flex w-full">
                         @if ($serviceStatus->contains('running') || $serviceStatus->contains('degraded'))
-                            @can('deploy', $service)
-                                <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                    @click="open = false; document.getElementById('service-restart-trigger')?.click()"
-                                    role="menuitem">
-                                    <x-reicon name="restart" class="size-3.5 opacity-70" />
-                                    Restart current version
-                                </button>
-                            @else
-                                <button type="button" class="listbox-option justify-start! gap-2.5!" disabled
-                                    role="menuitem">
-                                    <x-reicon name="restart" class="size-3.5 opacity-70" />
-                                    Restart current version
-                                </button>
-                            @endcan
+                            <x-slot:main x-bind:disabled="deploying"
+                                @click="document.getElementById('service-restart-trigger')?.click()">
+                                <x-reicon name="restart" class="size-3.5" />
+                                Restart
+                            </x-slot:main>
                             @if ($serviceStatus->contains('running'))
                                 <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                    @disabled(!auth()->user()->can('deploy', $service))
-                                    @click="$wire.dispatch('pullAndRestartEvent'); open = false"
-                                    role="menuitem">
+                                    @click="$wire.dispatch('pullAndRestartEvent'); open = false" role="menuitem">
                                     <x-reicon name="refresh" class="size-3.5 opacity-70" />
-                                    Pull latest and restart
+                                    Restart (pull latest)
                                 </button>
-                            @else
+                            @endif
+                            @if ($serviceStatus->contains('degraded'))
                                 <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                    @disabled(!auth()->user()->can('deploy', $service))
-                                    @click="$wire.dispatch('forceDeployEvent'); open = false"
-                                    role="menuitem">
+                                    @click="$wire.dispatch('forceDeployEvent'); open = false" role="menuitem">
                                     <x-reicon name="refresh" class="size-3.5 opacity-70" />
                                     Force Restart
                                 </button>
                             @endif
-                            @can('stop', $service)
-                                <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                    @click="open = false; document.getElementById('service-stop-trigger')?.click()"
-                                    role="menuitem">
-                                    <x-reicon name="stop-circle" class="size-3.5 text-error" />
-                                    Stop
-                                </button>
-                            @else
-                                <button type="button" class="listbox-option justify-start! gap-2.5!" disabled
-                                    role="menuitem">
-                                    <x-reicon name="stop-circle" class="size-3.5 opacity-70" />
-                                    Stop
-                                </button>
-                            @endcan
-                        @else
-                            @can('deploy', $service)
-                                <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                    @click="open = false; deploying = true; $wire.dispatch('startEvent')" role="menuitem">
-                                    <x-reicon name="play-circle" class="size-3.5 opacity-70" />
-                                    Deploy
-                                </button>
-                            @else
-                                <button type="button" class="listbox-option justify-start! gap-2.5!" disabled
-                                    role="menuitem">
-                                    <x-reicon name="play-circle" class="size-3.5 opacity-70" />
-                                    Deploy
-                                </button>
-                            @endcan
                             <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                @disabled(!auth()->user()->can('deploy', $service))
+                                @disabled(!auth()->user()->can('stop', $service))
+                                @click="open = false; document.getElementById('service-stop-trigger')?.click()" role="menuitem">
+                                <x-reicon name="stop-circle" class="size-3.5 text-error" />
+                                Stop
+                            </button>
+                        @else
+                            <x-slot:main x-bind:disabled="deploying" @click="deploying = true; $wire.dispatch('startEvent')">
+                                <x-loading-on-button x-show="deploying" x-cloak />
+                                <x-reicon name="play-circle" class="size-3.5" x-show="!deploying" />
+                                <span x-text="deploying ? 'Deploying…' : 'Deploy'">Deploy</span>
+                            </x-slot:main>
+                            <button type="button" class="listbox-option justify-start! gap-2.5!"
                                 @click="$wire.dispatch('forceDeployEvent'); open = false" role="menuitem">
                                 <x-reicon name="refresh" class="size-3.5 opacity-70" />
                                 Force Deploy
@@ -164,8 +119,7 @@
                                 Force Cleanup Containers
                             </button>
                         @endif
-                    </div>
-                </div>
+                    </x-split-action>
                 @endcan
             @else
                 <a href="{{ $environmentVariablesUrl }}" {{ wireNavigate() }}
@@ -186,70 +140,52 @@
                             <x-services.links :service="$service" />
                         </div>
                         @can('deploy', $service)
-                        <div id="service-desktop-actions" class="relative" x-data="{ open: false }"
-                                x-effect="$dispatch('resource-actions-toggled', { open })"
-                                @click.outside="open = false" @keydown.escape.window="open = false">
-                                <button type="button" class="button button-highlighted" @click="open = !open" :aria-expanded="open">
-                                    Actions
-                                    <x-reicon name="chevron-down" class="size-3 opacity-55" />
-                                </button>
-                                <div x-cloak x-show="open" x-transition.origin.top.right
-                                    class="listbox-panel top-full! right-0! left-auto! mt-1! w-64! min-w-0!" role="menu">
-                                    @if ($serviceStatus->contains('running') || $serviceStatus->contains('degraded'))
+                            <x-split-action id="service-desktop-actions">
+                                @if ($serviceStatus->contains('running') || $serviceStatus->contains('degraded'))
+                                    <x-slot:main x-bind:disabled="deploying"
+                                        @click="document.getElementById('service-restart-trigger')?.click()">
+                                        <x-reicon name="restart" class="size-3.5" />
+                                        Restart
+                                    </x-slot:main>
+                                    @if ($serviceStatus->contains('running'))
                                         <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                            @disabled(!auth()->user()->can('deploy', $service))
-                                            @click="open = false; document.getElementById('service-restart-trigger')?.click()">
-                                            <x-reicon name="restart" class="size-3.5 opacity-70" />
-                                            Restart
+                                            @click="$wire.dispatch('pullAndRestartEvent'); open = false" role="menuitem">
+                                            <x-reicon name="refresh" class="size-3.5 opacity-70" />
+                                            Restart (pull latest)
                                         </button>
-                                        @if ($serviceStatus->contains('running'))
-                                            <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                                @disabled(!auth()->user()->can('deploy', $service))
-                                                @click="$wire.dispatch('pullAndRestartEvent'); open = false">
-                                                <x-reicon name="refresh" class="size-3.5 opacity-70" />
-                                                Restart (pull latest)
-                                            </button>
-                                        @endif
-                                        <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                            @disabled(!auth()->user()->can('stop', $service))
-                                            @click="open = false; document.getElementById('service-stop-trigger')?.click()">
-                                            <x-reicon name="stop-circle" class="size-3.5 text-error" />
-                                            Stop
-                                        </button>
-                                    @elseif (! $serviceStatus->contains('running'))
-                                        <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                            @disabled(!auth()->user()->can('deploy', $service))
-                                            @click="deploying = true; $wire.dispatch('startEvent'); open = false">
-                                            <x-reicon name="play-circle" class="size-3.5 opacity-70" />
-                                            Deploy
-                                        </button>
-                                    @endif
-                                    @if (! $serviceStatus->contains('running'))
-                                        <div class="my-1 border-t border-coolgray-200 dark:border-coolgray-300" role="separator"></div>
                                     @endif
                                     @if ($serviceStatus->contains('degraded'))
                                         <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                            @disabled(!auth()->user()->can('deploy', $service))
-                                            @click="$wire.dispatch('forceDeployEvent'); open = false">
+                                            @click="$wire.dispatch('forceDeployEvent'); open = false" role="menuitem">
                                             <x-reicon name="refresh" class="size-3.5 opacity-70" />
                                             Force Restart
                                         </button>
-                                    @elseif (! $serviceStatus->contains('running'))
-                                        <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                            @disabled(!auth()->user()->can('deploy', $service))
-                                            @click="$wire.dispatch('forceDeployEvent'); open = false">
-                                            <x-reicon name="refresh" class="size-3.5 opacity-70" />
-                                            Force Deploy
-                                        </button>
-                                        <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                            @disabled(!auth()->user()->can('stop', $service))
-                                            @click="$wire.dispatch('cleanupEvent'); open = false">
-                                            <x-reicon name="trash" class="size-3.5 opacity-70" />
-                                            Force Cleanup Containers
-                                        </button>
                                     @endif
-                                </div>
-                        </div>
+                                    <button type="button" class="listbox-option justify-start! gap-2.5!"
+                                        @disabled(!auth()->user()->can('stop', $service))
+                                        @click="open = false; document.getElementById('service-stop-trigger')?.click()" role="menuitem">
+                                        <x-reicon name="stop-circle" class="size-3.5 text-error" />
+                                        Stop
+                                    </button>
+                                @else
+                                    <x-slot:main x-bind:disabled="deploying" @click="deploying = true; $wire.dispatch('startEvent')">
+                                        <x-loading-on-button x-show="deploying" x-cloak />
+                                        <x-reicon name="play-circle" class="size-3.5" x-show="!deploying" />
+                                        <span x-text="deploying ? 'Deploying…' : 'Deploy'">Deploy</span>
+                                    </x-slot:main>
+                                    <button type="button" class="listbox-option justify-start! gap-2.5!"
+                                        @click="$wire.dispatch('forceDeployEvent'); open = false" role="menuitem">
+                                        <x-reicon name="refresh" class="size-3.5 opacity-70" />
+                                        Force Deploy
+                                    </button>
+                                    <button type="button" class="listbox-option justify-start! gap-2.5!"
+                                        @disabled(!auth()->user()->can('stop', $service))
+                                        @click="$wire.dispatch('cleanupEvent'); open = false" role="menuitem">
+                                        <x-reicon name="trash" class="size-3.5 opacity-70" />
+                                        Force Cleanup Containers
+                                    </button>
+                                @endif
+                            </x-split-action>
                         @endcan
                     @else
                         <a href="{{ $environmentVariablesUrl }}" {{ wireNavigate() }}

--- a/resources/views/livewire/server/navbar.blade.php
+++ b/resources/views/livewire/server/navbar.blade.php
@@ -156,8 +156,17 @@
                     class="min-w-0 truncate text-[24px]! leading-7! font-semibold! tracking-tight! text-black dark:text-fg">
                     {{ $server->name }}
                 </h1>
-                <x-server.status-summary :server="$server" :proxy-status="$proxyStatus"
-                    :show-sentinel-status="$showSentinelStatus" />
+                <div class="flex w-full min-w-0 items-center gap-2">
+                    <x-server.status-summary :server="$server" :proxy-status="$proxyStatus"
+                        :show-sentinel-status="$showSentinelStatus" />
+                    @if ($traefikDashboardAvailable)
+                        <a target="_blank" href="http://{{ $serverIp }}:8080" title="Open Traefik dashboard"
+                            class="inline-flex h-6 shrink-0 items-center gap-1.5 rounded-full border border-neutral-200 bg-neutral-100 px-2 text-xs font-medium leading-none text-neutral-700 dark:border-white/[0.12] dark:bg-white/[0.07] dark:text-white">
+                            <x-reicon name="external-link" class="size-3" />
+                            Traefik
+                        </a>
+                    @endif
+                </div>
             </div>
         </div>
 
@@ -191,13 +200,6 @@
                             <x-reicon name="refresh" class="size-3.5 opacity-70" />
                             Refresh Proxy Status
                         </button>
-                            @if ($traefikDashboardAvailable)
-                                <a class="listbox-option justify-start! gap-2.5!" target="_blank"
-                                    href="http://{{ $serverIp }}:8080" @click="open = false" role="menuitem">
-                                    <x-reicon name="external-link" class="size-3.5 opacity-70" />
-                                    Traefik Dashboard
-                                </a>
-                            @endif
                     </x-split-action>
 
                     {{-- Programmatic open only (clicked from the Actions menu). Keep fully
@@ -273,6 +275,15 @@
 
                 @if ($server->proxySet())
                     @can('manageProxy', $server)
+                        @if ($traefikDashboardAvailable)
+                            <div class="resource-heading-menus shrink-0">
+                                <a class="app-tab shrink-0 gap-1" target="_blank" title="Open Traefik dashboard"
+                                    href="http://{{ $serverIp }}:8080">
+                                    <x-reicon name="external-link" class="size-3.5 shrink-0 opacity-70" />
+                                    Traefik Dashboard
+                                </a>
+                            </div>
+                        @endif
                         <x-split-action id="server-desktop-actions" class="resource-heading-actions shrink-0">
                             @if ($proxyCanBeStopped)
                                 <x-slot:main wire:loading.attr="disabled" wire:loading.class="is-loading"
@@ -299,13 +310,6 @@
                                 <x-reicon name="refresh" class="size-3.5 opacity-70" />
                                 Refresh Proxy Status
                             </button>
-                                @if ($traefikDashboardAvailable)
-                                    <a class="listbox-option justify-start! gap-2.5!" target="_blank"
-                                        href="http://{{ $serverIp }}:8080" @click="open = false" role="menuitem">
-                                        <x-reicon name="external-link" class="size-3.5 opacity-70" />
-                                        Traefik Dashboard
-                                    </a>
-                                @endif
                         </x-split-action>
                     @endcan
                 @endif

--- a/resources/views/livewire/server/navbar.blade.php
+++ b/resources/views/livewire/server/navbar.blade.php
@@ -165,66 +165,40 @@
         <div class="w-full xl:hidden">
             @if ($server->proxySet())
                 @can('manageProxy', $server)
-                    <div id="server-mobile-actions" class="relative mb-3"
-                        x-data="{ open: false }" @click.outside="open = false"
-                        @keydown.escape.window="open = false">
-                        <button type="button" class="button w-full justify-between" @click="open = !open"
-                            :aria-expanded="open" aria-haspopup="menu">
-                            <span class="inline-flex items-center gap-2">
-                                Actions
-                            </span>
-                            <span class="inline-flex transition-transform" :class="open && 'rotate-180'">
-                                <x-reicon name="chevron-down" class="size-3 opacity-55" />
-                            </span>
-                        </button>
-
-                        <div x-cloak x-show="open" x-transition.origin.top.left
-                            class="listbox-panel top-full! left-0! right-0! mt-1! w-full! min-w-0!" role="menu">
-                            @if ($proxyCanBeStopped)
-                                <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                    @click="open = false; document.getElementById('server-mobile-restart-proxy-trigger')?.click()"
-                                    role="menuitem">
-                                    <span class="flex size-4 shrink-0 items-center justify-center">
-                                            <x-reicon name="restart" class="size-3.5 text-orange-500 dark:text-warning" />
-                                    </span>
-                                    Restart Proxy
-                                </button>
-                                <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                    @click="open = false; document.getElementById('server-mobile-stop-proxy-trigger')?.click()"
-                                    role="menuitem">
-                                    <span class="flex size-4 shrink-0 items-center justify-center">
-                                        <x-reicon name="stop-circle" class="size-3.5 text-error" />
-                                    </span>
-                                    Stop Proxy
-                                </button>
-                                @if ($traefikDashboardAvailable)
-                                    <a class="listbox-option justify-start! gap-2.5!" target="_blank"
-                                        href="http://{{ $serverIp }}:8080" @click="open = false" role="menuitem">
-                                        <span class="flex size-4 shrink-0 items-center justify-center">
-                                        <x-reicon name="external-link" class="size-3! opacity-70" />
-                                        </span>
-                                        Traefik Dashboard
-                                    </a>
-                                @endif
-                            @else
-                                <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                    @click="open = false; $wire.dispatch('checkProxyEvent')" role="menuitem">
-                                    <span class="flex size-4 shrink-0 items-center justify-center">
-                                            <x-reicon name="play-circle" class="size-3.5 text-warning" />
-                                    </span>
-                                    Start Proxy
-                                </button>
-                            @endif
+                    <x-split-action id="server-mobile-actions" class="mb-3 flex w-full">
+                        @if ($proxyCanBeStopped)
+                            <x-slot:main wire:loading.attr="disabled" wire:loading.class="is-loading"
+                                wire:target="checkProxy,startProxy"
+                                @click="document.getElementById('server-mobile-restart-proxy-trigger')?.click()">
+                                <x-reicon name="restart" class="size-3.5" />
+                                Restart Proxy
+                            </x-slot:main>
                             <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                wire:click="checkProxyStatus" wire:loading.attr="disabled"
-                                @click="open = false" role="menuitem">
-                                <span class="flex size-4 shrink-0 items-center justify-center">
-                                    <x-reicon name="refresh" class="size-3.5 opacity-70" />
-                                </span>
-                                Refresh Proxy Status
+                                @click="open = false; document.getElementById('server-mobile-stop-proxy-trigger')?.click()"
+                                role="menuitem">
+                                <x-reicon name="stop-circle" class="size-3.5 text-error" />
+                                Stop Proxy
                             </button>
-                        </div>
-                    </div>
+                        @else
+                            <x-slot:main wire:loading.attr="disabled" wire:loading.class="is-loading"
+                                wire:target="checkProxy,startProxy" @click="$wire.dispatch('checkProxyEvent')">
+                                <x-reicon name="play-circle" class="size-3.5" />
+                                Start Proxy
+                            </x-slot:main>
+                        @endif
+                        <button type="button" class="listbox-option justify-start! gap-2.5!" wire:click="checkProxyStatus"
+                            wire:loading.attr="disabled" @click="open = false" role="menuitem">
+                            <x-reicon name="refresh" class="size-3.5 opacity-70" />
+                            Refresh Proxy Status
+                        </button>
+                            @if ($traefikDashboardAvailable)
+                                <a class="listbox-option justify-start! gap-2.5!" target="_blank"
+                                    href="http://{{ $serverIp }}:8080" @click="open = false" role="menuitem">
+                                    <x-reicon name="external-link" class="size-3.5 opacity-70" />
+                                    Traefik Dashboard
+                                </a>
+                            @endif
+                    </x-split-action>
 
                     {{-- Programmatic open only (clicked from the Actions menu). Keep fully
                          display:none so the modal shells never reserve a layout row. --}}
@@ -299,66 +273,40 @@
 
                 @if ($server->proxySet())
                     @can('manageProxy', $server)
-                        <div id="server-desktop-actions" class="resource-heading-actions relative shrink-0"
-                            x-data="{ open: false }" x-effect="$dispatch('resource-actions-toggled', { open })"
-                            @click.outside="open = false"
-                            @keydown.escape.window="open = false">
-                            <button type="button" class="button button-highlighted" @click="open = !open" :aria-expanded="open"
-                                aria-haspopup="menu" wire:loading.attr="disabled" wire:loading.class="is-loading"
-                                wire:target="checkProxy,startProxy">
-                                Actions
-                                <x-reicon name="chevron-down" class="size-3 opacity-55" />
-                            </button>
-
-                            <div x-cloak x-show="open" x-transition.origin.top.right
-                                class="listbox-panel top-full! right-0! left-auto! mt-1! w-60! min-w-0!" role="menu">
-                                @if ($proxyCanBeStopped)
-                                    <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                        @click="open = false; document.getElementById('server-mobile-restart-proxy-trigger')?.click()"
-                                        role="menuitem">
-                                        <span class="flex size-4 shrink-0 items-center justify-center">
-                                            <x-reicon name="restart" class="size-3.5 opacity-70" />
-                                        </span>
-                                        Restart Proxy
-                                    </button>
-                                    <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                        @click="open = false; document.getElementById('server-mobile-stop-proxy-trigger')?.click()"
-                                        role="menuitem">
-                                        <span class="flex size-4 shrink-0 items-center justify-center">
-                                            <x-reicon name="stop-circle" class="size-3.5 text-error" />
-                                        </span>
-                                        Stop Proxy
-                                    </button>
-                                @else
-                                    <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                        @click="open = false; $wire.dispatch('checkProxyEvent')" role="menuitem">
-                                        <span class="flex size-4 shrink-0 items-center justify-center">
-                                            <x-reicon name="play-circle" class="size-3.5 opacity-70" />
-                                        </span>
-                                        Start Proxy
-                                    </button>
-                                @endif
-                                <div class="my-1 border-t border-coolgray-200 dark:border-coolgray-300"
-                                    role="separator"></div>
+                        <x-split-action id="server-desktop-actions" class="resource-heading-actions shrink-0">
+                            @if ($proxyCanBeStopped)
+                                <x-slot:main wire:loading.attr="disabled" wire:loading.class="is-loading"
+                                    wire:target="checkProxy,startProxy"
+                                    @click="document.getElementById('server-mobile-restart-proxy-trigger')?.click()">
+                                    <x-reicon name="restart" class="size-3.5" />
+                                    Restart Proxy
+                                </x-slot:main>
                                 <button type="button" class="listbox-option justify-start! gap-2.5!"
-                                    wire:click="checkProxyStatus" wire:loading.attr="disabled"
-                                    @click="open = false" role="menuitem">
-                                    <span class="flex size-4 shrink-0 items-center justify-center">
-                                            <x-reicon name="refresh" class="size-3.5 opacity-70" />
-                                    </span>
-                                    Refresh Proxy Status
+                                    @click="open = false; document.getElementById('server-mobile-stop-proxy-trigger')?.click()"
+                                    role="menuitem">
+                                    <x-reicon name="stop-circle" class="size-3.5 text-error" />
+                                    Stop Proxy
                                 </button>
+                            @else
+                                <x-slot:main wire:loading.attr="disabled" wire:loading.class="is-loading"
+                                    wire:target="checkProxy,startProxy" @click="$wire.dispatch('checkProxyEvent')">
+                                    <x-reicon name="play-circle" class="size-3.5" />
+                                    Start Proxy
+                                </x-slot:main>
+                            @endif
+                            <button type="button" class="listbox-option justify-start! gap-2.5!" wire:click="checkProxyStatus"
+                                wire:loading.attr="disabled" @click="open = false" role="menuitem">
+                                <x-reicon name="refresh" class="size-3.5 opacity-70" />
+                                Refresh Proxy Status
+                            </button>
                                 @if ($traefikDashboardAvailable)
                                     <a class="listbox-option justify-start! gap-2.5!" target="_blank"
                                         href="http://{{ $serverIp }}:8080" @click="open = false" role="menuitem">
-                                        <span class="flex size-4 shrink-0 items-center justify-center">
-                                            <x-reicon name="external-link" class="size-3! opacity-70" />
-                                        </span>
+                                        <x-reicon name="external-link" class="size-3.5 opacity-70" />
                                         Traefik Dashboard
                                     </a>
                                 @endif
-                            </div>
-                        </div>
+                        </x-split-action>
                     @endcan
                 @endif
             </div>

--- a/resources/views/livewire/server/navbar.blade.php
+++ b/resources/views/livewire/server/navbar.blade.php
@@ -176,8 +176,7 @@
                 @can('manageProxy', $server)
                     <x-split-action id="server-mobile-actions" class="mb-3 flex w-full">
                         @if ($proxyCanBeStopped)
-                            <x-slot:main wire:loading.attr="disabled" wire:loading.class="is-loading"
-                                wire:target="checkProxy,startProxy"
+                            <x-slot:main wire:loading.attr="disabled" wire:target="checkProxy,startProxy"
                                 @click="document.getElementById('server-mobile-restart-proxy-trigger')?.click()">
                                 <x-reicon name="restart" class="size-3.5" />
                                 Restart Proxy
@@ -189,8 +188,7 @@
                                 Stop Proxy
                             </button>
                         @else
-                            <x-slot:main wire:loading.attr="disabled" wire:loading.class="is-loading"
-                                wire:target="checkProxy,startProxy" @click="$wire.dispatch('checkProxyEvent')">
+                            <x-slot:main wire:loading.attr="disabled" wire:target="checkProxy,startProxy" @click="$wire.dispatch('checkProxyEvent')">
                                 <x-reicon name="play-circle" class="size-3.5" />
                                 Start Proxy
                             </x-slot:main>
@@ -286,8 +284,7 @@
                         @endif
                         <x-split-action id="server-desktop-actions" class="resource-heading-actions shrink-0">
                             @if ($proxyCanBeStopped)
-                                <x-slot:main wire:loading.attr="disabled" wire:loading.class="is-loading"
-                                    wire:target="checkProxy,startProxy"
+                                <x-slot:main wire:loading.attr="disabled" wire:target="checkProxy,startProxy"
                                     @click="document.getElementById('server-mobile-restart-proxy-trigger')?.click()">
                                     <x-reicon name="restart" class="size-3.5" />
                                     Restart Proxy
@@ -299,8 +296,7 @@
                                     Stop Proxy
                                 </button>
                             @else
-                                <x-slot:main wire:loading.attr="disabled" wire:loading.class="is-loading"
-                                    wire:target="checkProxy,startProxy" @click="$wire.dispatch('checkProxyEvent')">
+                                <x-slot:main wire:loading.attr="disabled" wire:target="checkProxy,startProxy" @click="$wire.dispatch('checkProxyEvent')">
                                     <x-reicon name="play-circle" class="size-3.5" />
                                     Start Proxy
                                 </x-slot:main>

--- a/tests/Feature/MutableLivewireComponentsAuthorizationTest.php
+++ b/tests/Feature/MutableLivewireComponentsAuthorizationTest.php
@@ -43,7 +43,7 @@ it('hides resource action menus when the user cannot manage the resource', funct
 
     foreach (['mobile', 'desktop'] as $viewport) {
         expect($source)->toMatch(
-            "/@can\\('{$ability}', \\$".$resource."\\)[\\s\\S]*?<div id=\"{$prefix}-{$viewport}-actions\"/"
+            "/@can\\('{$ability}', \\$".$resource."\\)[\\s\\S]*?<x-split-action id=\"{$prefix}-{$viewport}-actions\"/"
         );
     }
 })->with([

--- a/tests/Feature/ResourceHeadingUnifiedNavbarTest.php
+++ b/tests/Feature/ResourceHeadingUnifiedNavbarTest.php
@@ -163,14 +163,14 @@ it('keeps advanced operations in a dedicated Advanced dropdown', function () {
     expect(substr_count($application, 'resource-heading-navbar'))->toBe(1);
 });
 
-it('groups desktop application lifecycle controls in one Actions dropdown', function () {
+it('groups desktop application lifecycle controls in one split control', function () {
     $heading = file_get_contents(resource_path('views/livewire/project/application/heading.blade.php'));
     $desktop = str($heading)->after('resource-heading-actions flex')->toString();
 
     expect($desktop)
         ->toContain('application-desktop-actions')
-        ->toContain('Actions')
-        ->toContain('listbox-panel top-full! right-0! left-auto!')
+        ->toContain('<x-split-action')
+        ->toContain('<x-slot:main')
         ->toContain('listbox-option')
         ->toContain('Deploy')
         ->toContain('Restart')
@@ -217,8 +217,8 @@ it('groups service restart options in the Actions dropdown', function () {
     $mobile = str($heading)->before("@teleport('#resource-action-hud-slot')")->toString();
 
     expect($mobile)
-        ->toContain('Restart current version')
-        ->toContain('Pull latest and restart')
+        ->toContain('Restart')
+        ->toContain('Restart (pull latest)')
         ->not->toContain('Pull Latest Images & Restart');
 });
 
@@ -232,21 +232,17 @@ it('orders service restart actions before stop and advanced operations', functio
         ->toBeLessThan(strpos($actions, 'Stop'));
 });
 
-it('groups application lifecycle options in an Actions dropdown', function () {
+it('promotes the primary application action in the desktop split control', function () {
     $heading = file_get_contents(resource_path('views/livewire/project/application/heading.blade.php'));
     $desktop = str($heading)->after('resource-heading-actions flex')->toString();
-    $trigger = str($desktop)->after('id="application-desktop-actions"')->before('<div x-cloak')->toString();
 
     expect($desktop)
         ->toContain('id="application-desktop-actions"')
-        ->toContain('Actions')
+        ->toContain('<x-slot:main wire:click="deploy">')
         ->toContain('Deploy')
         ->toContain('Deploy (without cache)')
         ->toContain('force_deploy_without_cache')
-        ->toContain('deploy(true)')
-        ->and($trigger)
-        ->toContain('button button-highlighted')
-        ->not->toContain('play-circle');
+        ->toContain('deploy(true)');
 
     $mobile = str($heading)->before("@teleport('#resource-action-hud-slot')")->toString();
 
@@ -277,18 +273,17 @@ it('uses the shared Coollabs gradient for primary resource actions in the deskto
         ->toContain('@apply button-highlighted;');
 });
 
-it('uses iconless highlighted Actions dropdowns for service and proxy lifecycle controls', function () {
+it('promotes a primary action for service and proxy lifecycle controls', function () {
     foreach ([
         resource_path('views/livewire/project/service/heading.blade.php') => 'service-desktop-actions',
         resource_path('views/livewire/server/navbar.blade.php') => 'server-desktop-actions',
     ] as $path => $id) {
         $heading = file_get_contents($path);
-        $trigger = str($heading)->after("id=\"{$id}\"")->before('<div x-cloak')->toString();
+        $control = str($heading)->after("id=\"{$id}\"")->before('</x-split-action>')->toString();
 
-        expect($trigger)
-            ->toContain('button button-highlighted')
-            ->toContain('Actions')
-            ->not->toContain('play-circle');
+        expect($control)
+            ->toContain('<x-slot:main')
+            ->toContain('listbox-option');
     }
 });
 
@@ -305,10 +300,10 @@ it('keeps database lifecycle controls direct and highlights the primary action',
     $desktop = str($heading)->after('resource-heading-actions flex')->before('@endteleport')->toString();
 
     expect($desktop)
+        ->toContain('<x-split-action')
+        ->toContain('<x-slot:main')
         ->toContain('Restart')
         ->toContain('Stop')
-        ->toContain('button button-highlighted')
-        ->not->toContain('<x-reicon')
         ->not->toContain('<x-resource-heading-overflow');
 });
 
@@ -498,7 +493,7 @@ it('uses the same mobile heading gap on deployment pages as application settings
     $deploymentShow = file_get_contents(resource_path('views/livewire/project/application/deployment/show.blade.php'));
 
     expect($configuration)->toContain('application-settings-workspace mt-4')
-        ->and($deploymentIndex)->toContain("'mt-4 max-w-[1180px] lg:mt-0' => ! \$embedded")
+        ->and($deploymentIndex)->toContain("'mt-4 max-w-none lg:mt-0' => ! \$embedded")
         ->and($deploymentShow)->toContain('application-settings-workspace mt-4')
         ->toContain('lg:mt-0');
 });
@@ -536,9 +531,9 @@ it('fits the combined deployment history and logs within the desktop viewport', 
 
     expect($indexClass)->toContain('$this->defaultTake = 3;')
         ->and($showView)
-        ->toContain('xl:h-[calc(100dvh-7.5rem)]')
-        ->toContain('xl:overflow-hidden')
-        ->toContain('xl:flex-1');
+        ->toContain('min-h-[calc(100dvh-7.5rem)]')
+        ->toContain('xl:h-[32rem] xl:min-h-0 xl:flex-none')
+        ->toContain('overflow-hidden');
 });
 
 it('uses only the healthcheck toggle action to communicate enabled state', function () {

--- a/tests/Feature/ResourceHeadingUnifiedNavbarTest.php
+++ b/tests/Feature/ResourceHeadingUnifiedNavbarTest.php
@@ -287,12 +287,14 @@ it('promotes a primary action for service and proxy lifecycle controls', functio
     }
 });
 
-it('places the Traefik dashboard last in the server Actions menu', function () {
+it('links the Traefik dashboard beside the server actions instead of inside the dropdown', function () {
     $navbar = file_get_contents(resource_path('views/livewire/server/navbar.blade.php'));
-    $actions = str($navbar)->after('id="server-desktop-actions"')->before('@endcan')->toString();
+    $desktopActions = str($navbar)->after('id="server-desktop-actions"')->before('</x-split-action>')->toString();
+    $mobileActions = str($navbar)->after('id="server-mobile-actions"')->before('</x-split-action>')->toString();
 
-    expect(strpos($actions, 'Refresh Proxy Status'))
-        ->toBeLessThan(strpos($actions, 'Traefik Dashboard'));
+    expect($desktopActions)->not->toContain('Traefik')
+        ->and($mobileActions)->not->toContain('Traefik')
+        ->and($navbar)->toContain('Traefik Dashboard');
 });
 
 it('keeps database lifecycle controls direct and highlights the primary action', function () {


### PR DESCRIPTION
## Changes

- Add split action button component
- Show traefik dashboard link beside proxy actions

## Why?

This provides a much better user experience because the primary action is now only one click away, rather than two clicks and hidden inside a dropdown menu. It also reduces code duplication across all action buttons.

## Preview

### Before

https://github.com/user-attachments/assets/91dc9e03-db19-4951-aa26-d5ea09441297

### After

https://github.com/user-attachments/assets/0f67937f-2c20-4957-80b2-9cb260c2192b
