### PR TITLE
fix(api): encrypt env values with the laravel cast

### DIFF
--- a/app/Models/EnvironmentVariable.php
+++ b/app/Models/EnvironmentVariable.php
@@ -4,7 +4,6 @@ namespace App\Models;
 
 use App\Models\EnvironmentVariable as ModelsEnvironmentVariable;
 use App\Support\ValidationPatterns;
-use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use OpenApi\Attributes as OA;
@@ -125,6 +124,7 @@ class EnvironmentVariable extends BaseModel
         });
 
         static::saving(function (ModelsEnvironmentVariable $environmentVariable) {
+            $environmentVariable->encryptPlaintextValueAttribute();
             $environmentVariable->updateIsShared();
         });
     }
@@ -156,14 +156,6 @@ class EnvironmentVariable extends BaseModel
         }
 
         return false;
-    }
-
-    protected function value(): Attribute
-    {
-        return Attribute::make(
-            get: fn (?string $value = null) => $this->get_environment_variables($value),
-            set: fn (?string $value = null) => $this->set_environment_variables($value),
-        );
     }
 
     /**
@@ -356,31 +348,14 @@ class EnvironmentVariable extends BaseModel
         return str($environment_variable)->value();
     }
 
-    private function get_environment_variables(?string $environment_variable = null): ?string
+    private function encryptPlaintextValueAttribute(): void
     {
-        if (! $environment_variable) {
-            return null;
+        $raw = $this->attributes['value'] ?? null;
+        if (! is_string($raw) || $raw === '' || str_starts_with($raw, 'eyJpdiI6')) {
+            return;
         }
 
-        try {
-            return trim(decrypt($environment_variable));
-        } catch (DecryptException) {
-            return trim($environment_variable);
-        }
-    }
-
-    private function set_environment_variables(?string $environment_variable = null): ?string
-    {
-        if (is_null($environment_variable)) {
-            return null;
-        }
-        $environment_variable = trim($environment_variable);
-        $type = str($environment_variable)->after('{{')->before('.')->value;
-        if (str($environment_variable)->startsWith('{{'.$type) && str($environment_variable)->endsWith('}}')) {
-            return encrypt($environment_variable);
-        }
-
-        return encrypt($environment_variable);
+        $this->attributes['value'] = encrypt(trim($raw));
     }
 
     protected function key(): Attribute

--- a/app/Models/EnvironmentVariable.php
+++ b/app/Models/EnvironmentVariable.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Models\EnvironmentVariable as ModelsEnvironmentVariable;
 use App\Support\ValidationPatterns;
+use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use OpenApi\Attributes as OA;
@@ -361,7 +362,11 @@ class EnvironmentVariable extends BaseModel
             return null;
         }
 
-        return trim(decrypt($environment_variable));
+        try {
+            return trim(decrypt($environment_variable));
+        } catch (DecryptException) {
+            return trim($environment_variable);
+        }
     }
 
     private function set_environment_variables(?string $environment_variable = null): ?string

--- a/tests/Unit/EnvironmentVariableDecryptFallbackTest.php
+++ b/tests/Unit/EnvironmentVariableDecryptFallbackTest.php
@@ -2,29 +2,10 @@
 
 use App\Models\EnvironmentVariable;
 
-function invokeGetEnvironmentVariables(?string $value): ?string
-{
-    $method = new ReflectionMethod(EnvironmentVariable::class, 'get_environment_variables');
+it('stores assigned values with the encrypted cast', function () {
+    $environmentVariable = new EnvironmentVariable;
+    $environmentVariable->value = 'smtp';
 
-    return $method->invoke(new EnvironmentVariable, $value);
-}
-
-it('returns null when the stored value is empty', function () {
-    expect(invokeGetEnvironmentVariables(null))->toBeNull();
-    expect(invokeGetEnvironmentVariables(''))->toBeNull();
+    expect($environmentVariable->getAttributes()['value'])->toStartWith('eyJpdiI6');
+    expect($environmentVariable->value)->toBe('smtp');
 });
-
-it('decrypts a valid encrypted payload', function () {
-    $plain = 'smtp.example.test';
-
-    expect(invokeGetEnvironmentVariables(encrypt($plain)))->toBe($plain);
-});
-
-it('returns the raw value when decrypt fails', function (string $raw) {
-    expect(invokeGetEnvironmentVariables($raw))->toBe(trim($raw));
-})->with([
-    'plain mailer' => 'smtp',
-    'port' => '587',
-    'email' => 'ops@example.test',
-    'padded' => '  smtp  ',
-]);

--- a/tests/Unit/EnvironmentVariableDecryptFallbackTest.php
+++ b/tests/Unit/EnvironmentVariableDecryptFallbackTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Models\EnvironmentVariable;
+
+function invokeGetEnvironmentVariables(?string $value): ?string
+{
+    $method = new ReflectionMethod(EnvironmentVariable::class, 'get_environment_variables');
+
+    return $method->invoke(new EnvironmentVariable, $value);
+}
+
+it('returns null when the stored value is empty', function () {
+    expect(invokeGetEnvironmentVariables(null))->toBeNull();
+    expect(invokeGetEnvironmentVariables(''))->toBeNull();
+});
+
+it('decrypts a valid encrypted payload', function () {
+    $plain = 'smtp.example.test';
+
+    expect(invokeGetEnvironmentVariables(encrypt($plain)))->toBe($plain);
+});
+
+it('returns the raw value when decrypt fails', function (string $raw) {
+    expect(invokeGetEnvironmentVariables($raw))->toBe(trim($raw));
+})->with([
+    'plain mailer' => 'smtp',
+    'port' => '587',
+    'email' => 'ops@example.test',
+    'padded' => '  smtp  ',
+]);

--- a/tests/Unit/EnvironmentVariableEncryptionTest.php
+++ b/tests/Unit/EnvironmentVariableEncryptionTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Models\EnvironmentVariable;
+
+function invokeEncryptPlaintextValueAttribute(EnvironmentVariable $environmentVariable): void
+{
+    $method = new ReflectionMethod(EnvironmentVariable::class, 'encryptPlaintextValueAttribute');
+    $method->invoke($environmentVariable);
+}
+
+it('stores assigned values with the encrypted cast', function () {
+    $environmentVariable = new EnvironmentVariable;
+    $environmentVariable->value = 'smtp';
+
+    expect($environmentVariable->getAttributes()['value'])->toStartWith('eyJpdiI6');
+    expect($environmentVariable->value)->toBe('smtp');
+});
+
+it('encrypts raw plaintext attributes before save', function () {
+    $environmentVariable = new EnvironmentVariable;
+    $environmentVariable->setRawAttributes(['value' => '  smtp  ']);
+
+    invokeEncryptPlaintextValueAttribute($environmentVariable);
+
+    expect($environmentVariable->getAttributes()['value'])->toStartWith('eyJpdiI6');
+    expect($environmentVariable->value)->toBe('smtp');
+});
+
+it('does not re-encrypt an existing laravel payload', function () {
+    $payload = encrypt('keep-me');
+    $environmentVariable = new EnvironmentVariable;
+    $environmentVariable->setRawAttributes(['value' => $payload]);
+
+    invokeEncryptPlaintextValueAttribute($environmentVariable);
+
+    expect($environmentVariable->getAttributes()['value'])->toBe($payload);
+    expect($environmentVariable->value)->toBe('keep-me');
+});


### PR DESCRIPTION
## Changes

- Stop encrypting and decrypting `EnvironmentVariable.value` in a custom Attribute. That Attribute was shadowing the Laravel `encrypted` cast, so `decrypt()` ran on the raw column and one plaintext row 500ed the UI.
- Store values the same way as `SharedEnvironmentVariable`: `'value' => 'encrypted'` only.
- On save, encrypt leftover plaintext that did not go through `setAttribute`. Existing Laravel payloads (`eyJpdiI6...`) are left untouched so an APP_KEY mismatch cannot rewrite ciphertext.

## Issues

- Fixes #11411

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

N/A. Backend model change. Application configuration should keep loading after env writes, and new or raw plaintext values should be persisted as ciphertext.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Cursor Grok 4.6
- How extensively: Investigated the write path after review feedback, compared `EnvironmentVariable` with `SharedEnvironmentVariable`, reproduced mixed plaintext rows on a self-hosted instance, and drafted the cast-only storage plus saving guard. I reviewed the Eloquent get/set precedence and the Application `created` hook that mirrors preview vars.

## Testing

1. `vendor/bin/pest tests/Unit/EnvironmentVariableEncryptionTest.php`
2. Assign `$env->value = 'smtp'` and confirm the raw attribute starts with `eyJpdiI6`
3. `setRawAttributes(['value' => 'smtp'])` then save and confirm the row is ciphertext
4. Confirm an existing `eyJpdiI6` payload is not re-encrypted
5. Open Application configuration after creating or editing env vars

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
