### PR TITLE
fix(websockets): route connections through dashboard origin

### DIFF
--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -683,20 +683,6 @@ class Server extends BaseModel
                                 'service' => 'coolify',
                                 'rule' => "Host(`{$host}`)",
                             ],
-                            'coolify-realtime-ws' => [
-                                'entryPoints' => [
-                                    0 => 'http',
-                                ],
-                                'service' => 'coolify-realtime',
-                                'rule' => "Host(`{$host}`) && PathPrefix(`/app`)",
-                            ],
-                            'coolify-terminal-ws' => [
-                                'entryPoints' => [
-                                    0 => 'http',
-                                ],
-                                'service' => 'coolify-terminal',
-                                'rule' => "Host(`{$host}`) && PathPrefix(`/terminal/ws`)",
-                            ],
                         ],
                         'services' => [
                             'coolify' => [
@@ -704,24 +690,6 @@ class Server extends BaseModel
                                     'servers' => [
                                         0 => [
                                             'url' => 'http://coolify:8080',
-                                        ],
-                                    ],
-                                ],
-                            ],
-                            'coolify-realtime' => [
-                                'loadBalancer' => [
-                                    'servers' => [
-                                        0 => [
-                                            'url' => 'http://coolify-realtime:6001',
-                                        ],
-                                    ],
-                                ],
-                            ],
-                            'coolify-terminal' => [
-                                'loadBalancer' => [
-                                    'servers' => [
-                                        0 => [
-                                            'url' => 'http://coolify-realtime:6002',
                                         ],
                                     ],
                                 ],
@@ -742,26 +710,6 @@ class Server extends BaseModel
                         ],
                         'service' => 'coolify',
                         'rule' => "Host(`{$host}`)",
-                        'tls' => [
-                            'certresolver' => 'letsencrypt',
-                        ],
-                    ];
-                    $traefik_dynamic_conf['http']['routers']['coolify-realtime-wss'] = [
-                        'entryPoints' => [
-                            0 => 'https',
-                        ],
-                        'service' => 'coolify-realtime',
-                        'rule' => "Host(`{$host}`) && PathPrefix(`/app`)",
-                        'tls' => [
-                            'certresolver' => 'letsencrypt',
-                        ],
-                    ];
-                    $traefik_dynamic_conf['http']['routers']['coolify-terminal-wss'] = [
-                        'entryPoints' => [
-                            0 => 'https',
-                        ],
-                        'service' => 'coolify-terminal',
-                        'rule' => "Host(`{$host}`) && PathPrefix(`/terminal/ws`)",
                         'tls' => [
                             'certresolver' => 'letsencrypt',
                         ],
@@ -794,12 +742,6 @@ class Server extends BaseModel
                 $caddy_file = "
 $siteAddress {
     encode zstd gzip
-    handle /app/* {
-        reverse_proxy coolify-realtime:6001
-    }
-    handle /terminal/ws {
-        reverse_proxy coolify-realtime:6002
-    }
     reverse_proxy coolify:8080
 }";
                 $base64 = base64_encode($caddy_file);

--- a/bootstrap/helpers/shared.php
+++ b/bootstrap/helpers/shared.php
@@ -1857,12 +1857,7 @@ function getRealtime()
     $envDefined = config('constants.pusher.port');
     if (empty($envDefined)) {
         $url = Url::fromString(Request::getSchemeAndHttpHost());
-        $port = $url->getPort();
-        if ($port) {
-            return '6001';
-        } else {
-            return null;
-        }
+        return $url->getPort();
     } else {
         return $envDefined;
     }

--- a/docker/development/etc/nginx/site-opts.d/http.conf
+++ b/docker/development/etc/nginx/site-opts.d/http.conf
@@ -30,7 +30,7 @@ location /healthcheck {
 }
 
 # Proxy Coolify's websocket services through the same endpoint as the dashboard.
-location ^~ /app {
+location ^~ /app/ {
     proxy_pass http://coolify-realtime:6001;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;

--- a/docker/development/etc/nginx/site-opts.d/http.conf
+++ b/docker/development/etc/nginx/site-opts.d/http.conf
@@ -29,6 +29,29 @@ location /healthcheck {
     fastcgi_pass   127.0.0.1:9000;
 }
 
+# Proxy Coolify's websocket services through the same endpoint as the dashboard.
+location ^~ /app {
+    proxy_pass http://coolify-realtime:6001;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_read_timeout 3600s;
+    proxy_send_timeout 3600s;
+}
+
+location = /terminal/ws {
+    proxy_pass http://coolify-realtime:6002;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_read_timeout 3600s;
+    proxy_send_timeout 3600s;
+}
+
 # Have NGINX try searching for PHP files as well
 location / {
     try_files $uri $uri/ /index.php?$query_string;

--- a/docker/production/etc/nginx/site-opts.d/http.conf
+++ b/docker/production/etc/nginx/site-opts.d/http.conf
@@ -30,7 +30,7 @@ location /healthcheck {
 }
 
 # Proxy Coolify's websocket services through the same endpoint as the dashboard.
-location ^~ /app {
+location ^~ /app/ {
     proxy_pass http://coolify-realtime:6001;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;

--- a/docker/production/etc/nginx/site-opts.d/http.conf
+++ b/docker/production/etc/nginx/site-opts.d/http.conf
@@ -29,6 +29,29 @@ location /healthcheck {
     fastcgi_pass   127.0.0.1:9000;
 }
 
+# Proxy Coolify's websocket services through the same endpoint as the dashboard.
+location ^~ /app {
+    proxy_pass http://coolify-realtime:6001;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_read_timeout 3600s;
+    proxy_send_timeout 3600s;
+}
+
+location = /terminal/ws {
+    proxy_pass http://coolify-realtime:6002;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_read_timeout 3600s;
+    proxy_send_timeout 3600s;
+}
+
 # Have NGINX try searching for PHP files as well
 location / {
     try_files $uri $uri/ /index.php?$query_string;

--- a/resources/js/terminal.js
+++ b/resources/js/terminal.js
@@ -601,13 +601,10 @@ export function initializeTerminalComponent() {
                 const connectionString = {
                     protocol: window.location.protocol === 'https:' ? 'wss' : 'ws',
                     host: window.location.hostname,
-                    port: ":6002",
+                    port: window.location.port ? `:${window.location.port}` : '',
                     path: '/terminal/ws'
                 }
 
-                if (!window.location.port) {
-                    connectionString.port = ''
-                }
                 if (predefined.host) {
                     connectionString.host = predefined.host
                 }

--- a/tests/Feature/RealtimeTerminalPackagingTest.php
+++ b/tests/Feature/RealtimeTerminalPackagingTest.php
@@ -2,7 +2,7 @@
 
 it('proxies realtime websocket traffic through the bundled nginx server', function (string $environment) {
     $nginxConfiguration = file_get_contents(base_path("docker/{$environment}/etc/nginx/site-opts.d/http.conf"));
-    $locationFound = preg_match('/location \^~ \/app \{(?<body>.*?)\n\}/s', $nginxConfiguration, $location);
+    $locationFound = preg_match('/location \^~ \/app\/ \{(?<body>.*?)\n\}/s', $nginxConfiguration, $location);
 
     expect($locationFound)
         ->toBe(1)

--- a/tests/Feature/RealtimeTerminalPackagingTest.php
+++ b/tests/Feature/RealtimeTerminalPackagingTest.php
@@ -2,20 +2,28 @@
 
 it('proxies realtime websocket traffic through the bundled nginx server', function (string $environment) {
     $nginxConfiguration = file_get_contents(base_path("docker/{$environment}/etc/nginx/site-opts.d/http.conf"));
+    $locationFound = preg_match('/location \^~ \/app \{(?<body>.*?)\n\}/s', $nginxConfiguration, $location);
 
-    expect($nginxConfiguration)
-        ->toContain('location ^~ /app')
+    expect($locationFound)
+        ->toBe(1)
+        ->and($location['body'])
         ->toContain('proxy_pass http://coolify-realtime:6001;')
+        ->toContain('proxy_http_version 1.1;')
         ->toContain('proxy_set_header Upgrade $http_upgrade;')
         ->toContain('proxy_set_header Connection "upgrade";');
 })->with(['development', 'production']);
 
 it('proxies terminal websocket traffic through the bundled nginx server', function (string $environment) {
     $nginxConfiguration = file_get_contents(base_path("docker/{$environment}/etc/nginx/site-opts.d/http.conf"));
+    $locationFound = preg_match('/location = \/terminal\/ws \{(?<body>.*?)\n\}/s', $nginxConfiguration, $location);
 
-    expect($nginxConfiguration)
-        ->toContain('location = /terminal/ws')
+    expect($locationFound)
+        ->toBe(1)
+        ->and($location['body'])
         ->toContain('proxy_pass http://coolify-realtime:6002;')
+        ->toContain('proxy_http_version 1.1;')
+        ->toContain('proxy_set_header Upgrade $http_upgrade;')
+        ->toContain('proxy_set_header Connection "upgrade";')
         ->toContain('proxy_read_timeout 3600s;')
         ->toContain('proxy_send_timeout 3600s;');
 })->with(['development', 'production']);

--- a/tests/Feature/RealtimeTerminalPackagingTest.php
+++ b/tests/Feature/RealtimeTerminalPackagingTest.php
@@ -1,5 +1,47 @@
 <?php
 
+it('proxies realtime websocket traffic through the bundled nginx server', function (string $environment) {
+    $nginxConfiguration = file_get_contents(base_path("docker/{$environment}/etc/nginx/site-opts.d/http.conf"));
+
+    expect($nginxConfiguration)
+        ->toContain('location ^~ /app')
+        ->toContain('proxy_pass http://coolify-realtime:6001;')
+        ->toContain('proxy_set_header Upgrade $http_upgrade;')
+        ->toContain('proxy_set_header Connection "upgrade";');
+})->with(['development', 'production']);
+
+it('proxies terminal websocket traffic through the bundled nginx server', function (string $environment) {
+    $nginxConfiguration = file_get_contents(base_path("docker/{$environment}/etc/nginx/site-opts.d/http.conf"));
+
+    expect($nginxConfiguration)
+        ->toContain('location = /terminal/ws')
+        ->toContain('proxy_pass http://coolify-realtime:6002;')
+        ->toContain('proxy_read_timeout 3600s;')
+        ->toContain('proxy_send_timeout 3600s;');
+})->with(['development', 'production']);
+
+it('does not route realtime services directly from the generated external proxy configuration', function () {
+    $serverConfiguration = file_get_contents(app_path('Models/Server.php'));
+
+    expect($serverConfiguration)
+        ->not->toContain("'url' => 'http://coolify-realtime:6001'")
+        ->not->toContain("'url' => 'http://coolify-realtime:6002'")
+        ->not->toContain('reverse_proxy coolify-realtime:6001')
+        ->not->toContain('reverse_proxy coolify-realtime:6002');
+});
+
+it('uses the dashboard port for same-origin realtime and terminal websocket connections', function () {
+    $helpers = file_get_contents(base_path('bootstrap/helpers/shared.php'));
+    $terminalClient = file_get_contents(resource_path('js/terminal.js'));
+
+    expect($helpers)
+        ->toContain('return $url->getPort();')
+        ->not->toContain("return '6001';")
+        ->and($terminalClient)
+        ->toContain("port: window.location.port ? `:\${window.location.port}` : ''")
+        ->not->toContain('port: ":6002"');
+});
+
 it('renders the resource terminal shell while containers are discovered', function () {
     $terminalComponent = file_get_contents(app_path('Livewire/Project/Shared/ExecuteContainerCommand.php'));
     $terminalView = file_get_contents(resource_path('views/livewire/project/shared/execute-container-command.blade.php'));


### PR DESCRIPTION
## Summary

- Proxy realtime and terminal WebSocket traffic through the bundled NGINX server using the dashboard origin.
- Remove direct WebSocket routing from generated Traefik and Caddy configurations.
- Preserve the dashboard port when building same-origin WebSocket connections.
- Add coverage for development and production proxy configurations.

fixes #11366

---

Fixes #11366