### PR TITLE
fix(server): reset unreachable_count after successful connection check

### DIFF
--- a/app/Jobs/ServerConnectionCheckJob.php
+++ b/app/Jobs/ServerConnectionCheckJob.php
@@ -100,7 +100,10 @@ class ServerConnectionCheckJob implements ShouldBeEncrypted, ShouldQueue
             ]);
 
             if ($this->server->unreachable_count > 0) {
-                $this->server->update(['unreachable_count' => 0]);
+                // Direct assignment: unreachable_count is not mass-assignable,
+                // so update() would silently drop the reset.
+                $this->server->unreachable_count = 0;
+                $this->server->save();
             }
 
             $this->dispatchReachabilityChangedIfNeeded($wasReachable, $wasNotified, true);

--- a/tests/Feature/ServerConnectionCheckIsolationTest.php
+++ b/tests/Feature/ServerConnectionCheckIsolationTest.php
@@ -78,3 +78,21 @@ it('does not call cloud provider APIs during an SSH connection check', function 
 
     Http::assertNothingSent();
 });
+
+it('resets unreachable_count after a successful connection check', function () {
+    $server = createServerForConnectionIsolationTest(['ip' => '203.0.113.10']);
+    // unreachable_count is not mass-assignable, so it must be set directly.
+    $server->unreachable_count = 5;
+    $server->save();
+
+    Process::fake([
+        '*' => Process::result(
+            output: '{"Server":{"Version":"27.0.0"}}',
+            exitCode: 0,
+        ),
+    ]);
+
+    (new ServerConnectionCheckJob($server->fresh(), disableMux: false))->handle();
+
+    expect($server->fresh()->unreachable_count)->toBe(0);
+});


### PR DESCRIPTION
## Changes

- The reset in `ServerConnectionCheckJob` used `update(['unreachable_count' => 0])`, but `unreachable_count` isn't mass-assignable on `Server`, so the guard discarded the write and the counter only ever climbed. This swaps it for direct assignment + `save()`, the same pattern `Team::finalizeServersForDeletion()` already uses on this column.
- I kept the column out of `$fillable` on purpose—opening it to mass assignment would also open it to any future request-data path, and one call site doesn't justify that.
- Added a regression test to `ServerConnectionCheckIsolationTest`.

## Issues

- Fixes #11416

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not a UI change. Before/after on a live instance: counter stuck at 62 with the server reachable → after the fix, one successful check resets it to 0 and it stays there.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code
- How extensively: helped trace the code path while I debugged unreachable emails on my live instance, and drafted the patch and test. I reviewed every line, and the reproduction and verification are from my own instance.

## Testing

1. `vendor/bin/pest tests/Feature/ServerConnectionCheckIsolationTest.php` on `main` without the fix: the new test fails (count stays 5), the 4 existing tests pass.
2. Same command with the fix: 5 passed, 14 assertions. `vendor/bin/pint --test` clean on both changed files.
3. Live instance (v4.3.9): reset the counter, re-ran `ServerConnectionCheckJob` against a reachable server—count stays 0 across checks, where before it was stuck at 62.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
