### PR TITLE
fix(ui): align auth surfaces with the dashboard layer card

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -714,6 +714,17 @@ Use these as implementation references:
 | Outline icons | `resources/views/components/reicon.blade.php` |
 | Shared styling | `resources/css/app.css`, `resources/css/utilities.css` |
 | HTTP error pages | `resources/views/components/error-page.blade.php`, `resources/views/errors/*` |
+| Public auth surfaces | `resources/views/components/auth/shell.blade.php`, `resources/views/auth/*` |
+
+Public auth surfaces (login, register, password reset, two-factor, email
+verification) share `<x-auth.shell>`, which repeats the layer-card anatomy on a
+flat canvas: an 8px shell with a hairline ring, a 3rem brand strip carrying the
+Coolify mark and wordmark at the same height and treatment as the application
+top bar, and a nested base-color body with its own fill ring and 16px padding.
+The title slot is the page's own heading (`Welcome back`, `Set up your
+instance`), not the product name, and the optional footer slot holds the single
+cross-link. Do not reintroduce an accent glow behind the card or a drop shadow
+heavier than the shell ring.
 
 HTTP error pages (400, 401, 402, 403, 404, 419, 429, 500, 503) use the shared
 `<x-error-page>` component on the public auth-style canvas: theme-aware status

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1061,13 +1061,14 @@ html[data-theme="custom"] textarea:disabled {
     color: var(--color-fg-dim) !important;
 }
 
-/* Public authentication surfaces */
+/* Public authentication surfaces.
+   Anatomy mirrors the layer card (.application-settings-section): flat canvas,
+   elevated shell with a hairline ring, a compact 3rem brand strip that echoes
+   the application top bar, and a nested base-color body with its own fill ring. */
 .auth-shell {
     min-height: 100dvh;
     display: flex;
-    background:
-        radial-gradient(circle at 50% 0%, color-mix(in oklab, var(--color-coollabs) 9%, transparent), transparent 34rem),
-        var(--coollabs-canvas);
+    background: var(--coollabs-canvas);
     color: #171717;
 }
 
@@ -1085,23 +1086,53 @@ html[data-theme="custom"] textarea:disabled {
 }
 
 .auth-card {
-    width: min(100%, 27rem);
-    overflow: hidden;
-    border-radius: 10px;
+    width: min(100%, 25rem);
+    display: flex;
+    flex-direction: column;
+    border-radius: 8px;
     background: var(--coollabs-elevated);
-    box-shadow: 0 0 0 1px var(--coollabs-hairline), 0 20px 60px rgb(0 0 0 / 0.14);
+    box-shadow:
+        0 0 0 1px var(--coollabs-hairline),
+        0 1px 2px rgb(0 0 0 / 0.04);
+}
+
+/* Brand strip: same 3rem height, inset, and wordmark treatment as the app top bar. */
+.auth-card-brand {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    min-height: 3rem;
+    padding: 0.5rem 1rem;
+    border-radius: 8px 8px 0 0;
+}
+
+.auth-card-brand img {
+    width: 1.25rem;
+    height: 1.25rem;
+}
+
+.auth-card-brand span {
+    font-size: 0.9375rem;
+    line-height: 1.25rem;
+    font-weight: 600;
+    letter-spacing: -0.015em;
+    color: #171717;
+}
+
+.dark .auth-card-brand span {
+    color: var(--color-fg);
 }
 
 .auth-card-heading {
-    padding: 1.25rem 1.25rem 1rem;
+    margin-bottom: 1rem;
 }
 
 .auth-card-heading h1 {
     margin: 0;
-    font-size: 1.25rem;
-    line-height: 1.75rem;
+    font-size: 1rem;
+    line-height: 1.5rem;
     font-weight: 600;
-    letter-spacing: -0.015em;
+    letter-spacing: -0.01em;
     color: #171717;
 }
 
@@ -1110,7 +1141,7 @@ html[data-theme="custom"] textarea:disabled {
 }
 
 .auth-card-heading p {
-    margin-top: 0.25rem;
+    margin-top: 0.125rem;
     max-width: 38ch;
     font-size: 0.8125rem;
     line-height: 1.25rem;
@@ -1118,8 +1149,8 @@ html[data-theme="custom"] textarea:disabled {
 }
 
 .auth-card-body {
-    border-radius: 10px;
-    padding: 1.25rem;
+    border-radius: 8px;
+    padding: 1rem;
     background: var(--coollabs-base);
     box-shadow: 0 0 0 1px var(--coollabs-fill);
 }
@@ -1130,7 +1161,7 @@ html[data-theme="custom"] textarea:disabled {
     justify-content: center;
     gap: 0.375rem;
     min-height: 3rem;
-    padding: 0.75rem 1.25rem;
+    padding: 0.75rem 1rem;
     font-size: 0.8125rem;
     color: var(--coollabs-subtle);
 }
@@ -1180,7 +1211,7 @@ html[data-theme="custom"] textarea:disabled {
     line-height: 1rem;
 }
 
-/* Public error surfaces (401/404/500/…). Match auth shell canvas + accent. */
+/* Public error surfaces (401/404/500/…). Match the auth shell canvas. */
 .error-page-body {
     width: 100vw;
     height: 100dvh;
@@ -1194,9 +1225,7 @@ html[data-theme="custom"] textarea:disabled {
     justify-content: center;
     width: 100%;
     padding: 2rem 1rem;
-    background:
-        radial-gradient(circle at 50% 0%, color-mix(in oklab, var(--color-coollabs) 9%, transparent), transparent 34rem),
-        var(--coollabs-canvas);
+    background: var(--coollabs-canvas);
     color: #171717;
 }
 

--- a/resources/views/auth/confirm-password.blade.php
+++ b/resources/views/auth/confirm-password.blade.php
@@ -1,5 +1,5 @@
 <x-layout-simple>
-    <x-auth.shell title="Coolify" description="Confirm your password to continue to this secure area.">
+    <x-auth.shell title="Confirm your password" description="Confirm your password to continue to this secure area.">
         <div class="flex flex-col gap-4">
             @if (session('status'))
                 <x-auth.alert type="success">{{ session('status') }}</x-auth.alert>

--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -1,5 +1,5 @@
 <x-layout-simple>
-    <x-auth.shell title="Coolify"
+    <x-auth.shell title="Reset your password"
         description="Enter your account email and we’ll send you a secure reset link.">
         <div class="flex flex-col gap-4">
             @if (session('status'))

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,5 +1,5 @@
 <x-layout-simple>
-    <x-auth.shell title="Coolify" description="Sign in to manage your applications and infrastructure.">
+    <x-auth.shell title="Welcome back" description="Sign in to manage your applications and infrastructure.">
         <div class="flex flex-col gap-4">
             @if (session('status'))
                 <x-auth.alert type="success">{{ session('status') }}</x-auth.alert>
@@ -33,7 +33,7 @@
                         label="{{ __('input.password') }}" />
                 @endenv
 
-                <div class="flex justify-end">
+                <div class="-mt-1 flex justify-end">
                     @if (is_transactional_emails_enabled())
                         <a href="/forgot-password" class="auth-text-link">
                             {{ __('auth.forgot_password_link') }}

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -11,7 +11,7 @@ $email = getOldOrLocal('email', 'test3@example.com');
 ?>
 
 <x-layout-simple>
-    <x-auth.shell title="Coolify"
+    <x-auth.shell :title="$isFirstUser ? 'Set up your instance' : 'Create your account'"
         :description="$isFirstUser ? 'Create the root account for this instance.' : 'Create your account to get started.'">
         <div class="flex flex-col gap-4">
             @if ($isFirstUser)

--- a/resources/views/auth/two-factor-challenge.blade.php
+++ b/resources/views/auth/two-factor-challenge.blade.php
@@ -1,5 +1,5 @@
 <x-layout-simple>
-    <x-auth.shell title="Coolify" description="Verify your identity to finish signing in.">
+    <x-auth.shell title="Two-factor authentication" description="Verify your identity to finish signing in.">
         <div class="flex flex-col gap-4" x-data="{
             showRecovery: false,
             submitAuthenticatorCode(event) {

--- a/resources/views/auth/verify-email.blade.php
+++ b/resources/views/auth/verify-email.blade.php
@@ -1,5 +1,5 @@
 <x-layout-simple>
-    <x-auth.shell title="Coolify" description="Verify your email address to activate your account.">
+    <x-auth.shell title="Verify your email" description="Verify your email address to activate your account.">
         <div class="flex flex-col gap-4">
             <div class="auth-guidance">
                 <x-reicon name="mail" class="mt-0.5 size-4 shrink-0" />

--- a/resources/views/components/auth/shell.blade.php
+++ b/resources/views/components/auth/shell.blade.php
@@ -6,14 +6,20 @@
 <section class="auth-shell application-settings-form">
     <div class="auth-shell-content">
         <div class="auth-card">
-            <div class="auth-card-heading">
-                <h1>{{ $title }}</h1>
-                @if ($description)
-                    <p>{{ $description }}</p>
-                @endif
+            {{-- Brand strip: same height and wordmark treatment as the application top bar. --}}
+            <div class="auth-card-brand">
+                <img src="/coolify-logo.svg" alt="" aria-hidden="true" />
+                <span>Coolify</span>
             </div>
 
             <div class="auth-card-body">
+                <div class="auth-card-heading">
+                    <h1>{{ $title }}</h1>
+                    @if ($description)
+                        <p>{{ $description }}</p>
+                    @endif
+                </div>
+
                 {{ $slot }}
             </div>
 

--- a/tests/Feature/AuthShellRedesignTest.php
+++ b/tests/Feature/AuthShellRedesignTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use App\Models\InstanceSettings;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\View;
+use Illuminate\Support\ViewErrorBag;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::forceCreate([
+        'id' => 0,
+        'is_registration_enabled' => true,
+    ]);
+
+    // The auth views are rendered directly, so share the bag the error
+    // middleware would normally provide to the shared form components.
+    View::share('errors', new ViewErrorBag);
+});
+
+it('renders the auth shell with the dashboard layer-card anatomy', function () {
+    $html = Blade::render(
+        '<x-auth.shell title="Welcome back" description="Sign in.">'
+        .'<p>form</p>'
+        .'<x-slot:footer>footer</x-slot:footer>'
+        .'</x-auth.shell>'
+    );
+
+    expect($html)
+        // flat canvas shell wrapping the layer-card shape
+        ->toContain('auth-shell')
+        ->toContain('auth-card')
+        // brand strip mirrors the application top bar
+        ->toContain('auth-card-brand')
+        ->toContain('/coolify-logo.svg')
+        // nested body panel carries the heading and the form
+        ->toContain('auth-card-body')
+        ->toContain('auth-card-heading')
+        ->toContain('Welcome back')
+        ->toContain('Sign in.')
+        ->toContain('auth-card-footer')
+        ->toContain('footer');
+
+    // The brand belongs to the strip, not to the page heading.
+    expect($html)->not->toContain('<h1>Coolify</h1>');
+});
+
+it('renders the login surface with its own heading and the brand strip', function () {
+    $html = view('auth.login', [
+        'enabled_oauth_providers' => collect(),
+        'is_registration_enabled' => true,
+    ])->render();
+
+    expect($html)
+        ->toContain('auth-card-brand')
+        ->toContain('Welcome back')
+        ->toContain('Sign in to manage your applications and infrastructure.')
+        ->toContain('Login');
+});
+
+it('titles the registration surface by what the account does', function (bool $isFirstUser, string $title, string $description) {
+    $html = view('auth.register', ['isFirstUser' => $isFirstUser])->render();
+
+    expect($html)
+        ->toContain('auth-card-brand')
+        ->toContain($title)
+        ->toContain($description);
+})->with([
+    'root account' => [true, 'Set up your instance', 'Create the root account for this instance.'],
+    'invited member' => [false, 'Create your account', 'Create your account to get started.'],
+]);


### PR DESCRIPTION
## Changes

<!-- - Auth pages now have their own shell, independent of DESIGN.md
     - Purple radial glow replaced with a flat canvas background
     - Card style (10px + 20/60px drop shadow) replaced with a layered card structure (8px + hairline ring)
     - "Coolify" branding moved from <h1> to a 3rem brand strip (similar to the top bar)
     - Each auth page now has its own specific title -->

## Issues

- Fixes

## Category

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Before / after, dark and light, rendered with the compiled stylesheet:

<!-- lampirkan screenshot di sini -->

The auth shell now reuses `.application-settings-section` anatomy: flat
`--coollabs-canvas` ground, 8px shell with a hairline ring, a 3rem brand strip
matching the application top bar, and a nested base-color body with its own
fill ring.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Opus 5)
- How extensively: Used to audit the auth surfaces against `DESIGN.md`, rewrite
  the `.auth-*` block in `resources/css/app.css`, restructure
  `components/auth/shell.blade.php`, retitle the seven auth views, add
  `tests/Feature/AuthShellRedesignTest.php`, and document the pattern in
  `DESIGN.md`. Every change was reviewed by me before committing. No behavior,
  route, or form logic was touched.

## Testing

- `php artisan test --compact tests/Feature/AuthShellRedesignTest.php` - 4 passed
  (shell anatomy, login heading/brand strip, both registration titles).
- `php artisan test --compact tests/Feature/ErrorPagesRedesignTest.php` - 13 passed
  (the public error surfaces share the auth canvas, which this PR flattens).
- `vendor/bin/pint --dirty` - passed.
- `npm run build`, then the login, register and settings surfaces inspected in
  both light and dark themes against the compiled stylesheet.
- Copy asserted by `tests/v4/Browser/LoginTest.php` and `RegistrationTest.php`
  ("Sign in to manage your applications and infrastructure.", "Create the root
  account for this instance.", "Login", "Create account") is unchanged.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.