### PR TITLE
fix(deployments): ignore newly tracked static configuration

### DIFF
--- a/app/Services/DeploymentConfiguration/ConfigurationDiffer.php
+++ b/app/Services/DeploymentConfiguration/ConfigurationDiffer.php
@@ -17,28 +17,8 @@ class ConfigurationDiffer
      */
     private const IGNORED_KEYS = ['build.docker_compose'];
 
-    /**
-     * Defaults for fields introduced after configuration snapshots were first
-     * stored. Older snapshots omitted these keys, which should not make an
-     * unchanged default look like a pending configuration change.
-     *
-     * @var array<string, mixed>
-     */
-    private const INTRODUCED_DEFAULTS = [
-        'build.is_static' => false,
-        'build.is_spa' => false,
-        'build.is_git_submodules_enabled' => true,
-        'build.is_git_lfs_enabled' => true,
-        'build.is_git_shallow_clone_enabled' => true,
-        'build.is_env_sorting_enabled' => [false, true],
-        'runtime.is_consistent_container_name_enabled' => false,
-        'runtime.is_container_label_escape_enabled' => true,
-        'runtime.is_container_label_readonly_enabled' => true,
-        'runtime.is_log_drain_enabled' => false,
-        'runtime.is_swarm_only_worker_nodes' => true,
-        'runtime.is_preserve_repository_enabled' => false,
-        'domains.noindex_domains' => [],
-    ];
+    /** @var array<int, string> */
+    private const DYNAMIC_SECTIONS = ['environment', 'storage'];
 
     /**
      * @param  array<string, mixed>  $previousSnapshot
@@ -59,11 +39,7 @@ class ConfigurationDiffer
             $previous = $previousItems[$key] ?? null;
             $current = $currentItems[$key] ?? null;
 
-            if (
-                $previous === null
-                && array_key_exists($key, self::INTRODUCED_DEFAULTS)
-                && $this->matchesIntroducedDefault($key, data_get($current, 'compare_value'))
-            ) {
+            if ($previous === null && ! in_array(data_get($current, 'section'), self::DYNAMIC_SECTIONS, true)) {
                 continue;
             }
 
@@ -125,17 +101,6 @@ class ConfigurationDiffer
         }
 
         return ConfigurationDiff::fromChanges($changes);
-    }
-
-    private function matchesIntroducedDefault(string $key, mixed $value): bool
-    {
-        $default = self::INTRODUCED_DEFAULTS[$key];
-
-        if (is_array($default) && $default !== [] && array_is_list($default)) {
-            return in_array($value, $default, true);
-        }
-
-        return $value === $default;
     }
 
     /**

--- a/tests/Unit/DeploymentConfiguration/ApplicationConfigurationSnapshotTest.php
+++ b/tests/Unit/DeploymentConfiguration/ApplicationConfigurationSnapshotTest.php
@@ -296,6 +296,25 @@ it('accepts the historical environment sorting default in older snapshots', func
     expect(app(ConfigurationDiffer::class)->diff($previousSnapshot, $currentSnapshot)->isChanged())->toBeFalse();
 });
 
+it('does not report newly tracked static configuration as a pending change', function () {
+    $application = snapshotTestApplication();
+    $currentSnapshot = $application->deploymentConfigurationSnapshot();
+    $previousSnapshot = $currentSnapshot;
+
+    data_set($currentSnapshot, 'sections.runtime.items', [
+        ...data_get($currentSnapshot, 'sections.runtime.items'),
+        [
+            'key' => 'newly_tracked_setting',
+            'label' => 'Newly tracked setting',
+            'impact' => 'redeploy',
+            'compare_value' => 'already configured',
+            'display_value' => 'already configured',
+        ],
+    ]);
+
+    expect(app(ConfigurationDiffer::class)->diff($previousSnapshot, $currentSnapshot)->isChanged())->toBeFalse();
+});
+
 it('detects environment variable value changes without exposing secret values', function () {
     $application = snapshotTestApplication();
     EnvironmentVariable::create([


### PR DESCRIPTION
## Summary

- Prevent newly tracked static configuration values from appearing as pending changes after upgrades.
- Continue detecting additions to dynamic environment and storage configuration.
- Add regression coverage for newly introduced static settings.

Related to #11426.

---

Fixes #11426