### PR TITLE
fix(domains): allow adding domains without explicit ports

### DIFF
--- a/app/Support/DomainUrlParts.php
+++ b/app/Support/DomainUrlParts.php
@@ -4,11 +4,11 @@ namespace App\Support;
 
 class DomainUrlParts
 {
-    public static function compose(string $scheme, string $host, string $port = '', string $path = ''): string
+    public static function compose(string $scheme, string $host, ?string $port = '', string $path = ''): string
     {
         $scheme = strtolower(trim($scheme)) === 'http' ? 'http' : 'https';
         $host = trim($host);
-        $port = trim($port);
+        $port = trim((string) $port);
         $path = trim($path);
 
         if ($path !== '' && ! str_starts_with($path, '/') && ! str_starts_with($path, '?') && ! str_starts_with($path, '#')) {

--- a/tests/Unit/DomainUrlPartsTest.php
+++ b/tests/Unit/DomainUrlPartsTest.php
@@ -28,3 +28,8 @@ it('defaults empty values for an invalid URL', function () {
 it('preserves an explicitly configured default port', function () {
     expect(DomainUrlParts::split('https://app.example.com:443')['port'])->toBe('443');
 });
+
+it('composes a domain when Livewire hydrates an empty numeric port as null', function () {
+    expect(DomainUrlParts::compose('https', 'app.example.com', null))
+        ->toBe('https://app.example.com');
+});


### PR DESCRIPTION
## Summary

- Accept empty ports hydrated as `null` when composing domain URLs.
- Restore adding domains without an explicitly configured port.
- Add regression coverage for Livewire's empty numeric port handling.

Fixes #11440.

---

Fixes #11440