### PR TITLE
fix(api): honor is_system_wide on GitHub App lookup in private-github-app create

### DIFF
--- a/app/Http/Controllers/Api/ApplicationsController.php
+++ b/app/Http/Controllers/Api/ApplicationsController.php
@@ -1604,7 +1604,12 @@ class ApplicationsController extends Controller
             if ($return instanceof JsonResponse) {
                 return $return;
             }
-            $githubApp = GithubApp::whereTeamId($teamId)->where('uuid', $githubAppUuid)->first();
+            $githubApp = GithubApp::where('uuid', $githubAppUuid)
+                ->where(function ($q) use ($teamId) {
+                    $q->where('team_id', $teamId)
+                        ->orWhere('is_system_wide', true);
+                })
+                ->first();
             if (! $githubApp) {
                 return response()->json(['message' => 'Github App not found.'], 404);
             }


### PR DESCRIPTION
## Changes

When a Coolify team uses an API token to create an application backed by a system-wide GitHub App, the create endpoint returned `404 Github App not found` — even though the same App shows up in that team's UI Sources dropdown. This mirrors the UI's team query so the API resolves system-wide Apps the same way, and non-root teams can automate application creation without a root token.

## Issues

- Fixes #11449

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

_n/a — API-only fix, no UI changes._

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Anthropic).
- How extensively: Claude Code investigated the bug, identified the root cause by reading `ApplicationsController.php` and comparing against the UI-side `Team::githubApps()` query (fixed for the analogous UI bug in #2643), drafted the one-hunk patch, drafted the Testing section, and drafted the Changes section text used above. As the PR author I reviewed the diff, applied it to a running self-hosted Coolify v4.3.7 instance via `docker cp`, verified the fix end-to-end with a team-scoped API token against a system-wide GitHub App owned by Root Team, rolled the patch back, and confirmed the endpoint regressed to `404` on stock v4.3.7 before finalizing. The change is a single-hunk, strictly additive query modification that mirrors an already-approved pattern in the codebase.

## Testing

Applied the patched `ApplicationsController.php` to a running self-hosted Coolify v4.3.7 instance via `docker cp` and restarted the `coolify` container.

Set-up:

- GitHub App source registered in Root Team with `is_system_wide = true` (confirmed via `GET /api/v1/github-apps`).
- API token issued from a non-root team, with view + create + deploy permissions.
- Project + environment created inside that same non-root team.
- Server + destination visible to the team.

**Pre-patch:** `POST /api/v1/applications/private-github-app` with the team-scoped token returned `HTTP 404 {"message":"Github App not found."}`.

**Post-patch:** same request returned `HTTP 201` with the new application UUID:

```
{"uuid":"...","domains":"http://..."}
```

Cleaned up the test application with `DELETE /api/v1/applications/{uuid}`. Rolled the patch back and confirmed the endpoint returns to `404` on stock v4.3.7.

No changes were made to the UI code path (`Team::githubApps()`), which was already correct after #2643. No new automated tests were added — this is a one-line query change mirroring an existing pattern; happy to add coverage if the maintainers would prefer.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
