### PR TITLE
feat(var): allow duplicating environment variables across resources

### DIFF
--- a/app/Livewire/Project/Shared/EnvironmentVariable/Show.php
+++ b/app/Livewire/Project/Shared/EnvironmentVariable/Show.php
@@ -9,11 +9,21 @@ use App\Models\Project;
 use App\Models\Server;
 use App\Models\Service;
 use App\Models\SharedEnvironmentVariable;
+use App\Models\StandaloneClickhouse;
+use App\Models\StandaloneDragonfly;
+use App\Models\StandaloneKeydb;
+use App\Models\StandaloneMariadb;
+use App\Models\StandaloneMongodb;
+use App\Models\StandaloneMysql;
+use App\Models\StandalonePostgresql;
+use App\Models\StandaloneRedis;
 use App\Support\ValidationPatterns;
 use App\Traits\EnvironmentVariableAnalyzer;
 use App\Traits\EnvironmentVariableProtection;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Facades\Validator;
 use Livewire\Attributes\Computed;
 use Livewire\Component;
 
@@ -82,6 +92,35 @@ class Show extends Component
     public bool $editorOpen = false;
 
     public array $problematicVariables = [];
+
+    public bool $duplicateModalOpen = false;
+
+    /**
+     * Duplicate target options are loaded on demand when the duplicate modal
+     * opens so table rows stay cheap to render.
+     */
+    public bool $duplicateOptionsLoaded = false;
+
+    public string $duplicateKey = '';
+
+    /**
+     * Resource types that can receive a copied environment variable, keyed by
+     * their `type()` slug as used in the duplicate target picker.
+     *
+     * @var array<string, class-string<Model>>
+     */
+    private const DUPLICATE_TARGET_TYPES = [
+        'application' => Application::class,
+        'service' => Service::class,
+        'standalone-postgresql' => StandalonePostgresql::class,
+        'standalone-mysql' => StandaloneMysql::class,
+        'standalone-mariadb' => StandaloneMariadb::class,
+        'standalone-mongodb' => StandaloneMongodb::class,
+        'standalone-redis' => StandaloneRedis::class,
+        'standalone-keydb' => StandaloneKeydb::class,
+        'standalone-dragonfly' => StandaloneDragonfly::class,
+        'standalone-clickhouse' => StandaloneClickhouse::class,
+    ];
 
     protected $listeners = [
         'refreshEnvs' => 'refresh',
@@ -484,5 +523,227 @@ class Show extends Component
         } catch (\Exception $e) {
             return handleError($e);
         }
+    }
+
+    /**
+     * Whether this row offers the duplicate action. Shared, magic, and
+     * structural credential variables cannot be duplicated.
+     */
+    public function canDuplicate(): bool
+    {
+        return ! $this->isSharedVariable
+            && ! $this->isMagicVariable
+            && ! $this->is_redis_credential
+            && $this->env instanceof ModelsEnvironmentVariable
+            && $this->env->exists
+            && (auth()->user()?->can('update', $this->env) ?? false);
+    }
+
+    /**
+     * Prepare the duplicate modal: suggest a collision-free name and load the
+     * target picker options. Called when the modal opens.
+     */
+    public function prepareDuplicate(): void
+    {
+        if ($this->duplicateOptionsLoaded || ! $this->canDuplicate()) {
+            return;
+        }
+
+        $this->duplicateKey = $this->suggestedDuplicateKey();
+        $this->duplicateOptionsLoaded = true;
+    }
+
+    /**
+     * Project → environment → resource tree for the duplicate target picker,
+     * scoped to the current team.
+     *
+     * @return list<array{id: int, name: string, environments: list<array{id: int, name: string, resources: list<array{value: string, label: string, current: bool}>}>}>
+     */
+    #[Computed]
+    public function duplicateTargets(): array
+    {
+        if (! $this->duplicateOptionsLoaded || ! currentTeam()) {
+            return [];
+        }
+
+        $projects = Project::ownedByCurrentTeamCached()->sortBy('name')->values();
+
+        $resourcesByEnvironment = collect(self::DUPLICATE_TARGET_TYPES)
+            ->flatMap(function (string $class, string $type) {
+                return $class::query()
+                    ->whereIn('environment_id', $this->environmentIdsForDuplicateTargets())
+                    ->get(['id', 'name', 'environment_id'])
+                    ->map(fn (Model $resource) => [
+                        'environment_id' => $resource->environment_id,
+                        'value' => "{$type}:{$resource->id}",
+                        'label' => $resource->name.' ('.$this->duplicateTargetTypeLabel($type).')',
+                        'current' => $this->env->resourceable_type === $class
+                            && (int) $this->env->resourceable_id === (int) $resource->id,
+                    ]);
+            })
+            ->groupBy('environment_id');
+
+        return $projects->map(fn (Project $project) => [
+            'id' => $project->id,
+            'name' => $project->name,
+            'environments' => $project->environments->sortBy('name')->values()->map(fn (Environment $environment) => [
+                'id' => $environment->id,
+                'name' => $environment->name,
+                'resources' => $resourcesByEnvironment->get($environment->id, collect())
+                    ->map(fn (array $resource) => collect($resource)->except('environment_id')->all())
+                    ->sortBy('label')
+                    ->values()
+                    ->all(),
+            ])->all(),
+        ])->all();
+    }
+
+    /**
+     * Duplicate this environment variable onto the given target resource,
+     * using the name entered in the duplicate modal.
+     */
+    public function duplicateVariable(string $target)
+    {
+        try {
+            if (! $this->canDuplicate()) {
+                return;
+            }
+
+            $this->authorize('update', $this->env);
+
+            // Table rows omit the encrypted value column; fetch a full model.
+            $source = ModelsEnvironmentVariable::query()->findOrFail($this->env->id);
+
+            $validator = Validator::make(
+                ['duplicateKey' => ValidationPatterns::normalizeEnvironmentVariableKey($this->duplicateKey)],
+                ['duplicateKey' => ValidationPatterns::environmentVariableKeyRules()],
+                ValidationPatterns::environmentVariableKeyMessages('duplicateKey', 'name'),
+            );
+            if ($validator->fails()) {
+                $this->dispatch('error', $validator->errors()->first('duplicateKey'));
+
+                return;
+            }
+            $newKey = $validator->validated()['duplicateKey'];
+
+            if (str($newKey)->startsWith(['SERVICE_FQDN', 'SERVICE_URL', 'SERVICE_NAME'])) {
+                $this->dispatch('error', 'Names starting with SERVICE_FQDN, SERVICE_URL or SERVICE_NAME are reserved for magic variables.');
+
+                return;
+            }
+
+            $targetResource = $this->resolveDuplicateTarget($target);
+            if (! $targetResource || $targetResource->team()?->id !== $source->resourceable?->team()?->id) {
+                $this->dispatch('error', 'Target resource not found.');
+
+                return;
+            }
+
+            $this->authorize('manageEnvironment', $targetResource);
+
+            // Preview variables only exist on applications; kept scope otherwise drops to production.
+            $isPreview = $source->is_preview && $targetResource instanceof Application;
+
+            $keyTaken = ModelsEnvironmentVariable::query()
+                ->where('resourceable_type', $targetResource->getMorphClass())
+                ->where('resourceable_id', $targetResource->id)
+                ->where('is_preview', $isPreview)
+                ->where('key', $newKey)
+                ->exists();
+            if ($keyTaken) {
+                $this->dispatch('error', "Environment variable '{$newKey}' already exists on the target resource.");
+
+                return;
+            }
+
+            $maxOrder = ModelsEnvironmentVariable::query()
+                ->where('resourceable_type', $targetResource->getMorphClass())
+                ->where('resourceable_id', $targetResource->id)
+                ->where('is_preview', $isPreview)
+                ->max('order') ?? 0;
+
+            $duplicate = $source->replicate(['id', 'uuid', 'created_at', 'updated_at', 'version']);
+            $duplicate->key = $newKey;
+            $duplicate->resourceable_type = $targetResource->getMorphClass();
+            $duplicate->resourceable_id = $targetResource->id;
+            $duplicate->is_preview = $isPreview;
+            // Required is a property of the original template variable, not of copies.
+            $duplicate->is_required = false;
+            $duplicate->order = $maxOrder + 1;
+            $duplicate->save();
+
+            $this->duplicateModalOpen = false;
+            $this->duplicateOptionsLoaded = false;
+            $this->duplicateKey = '';
+
+            $isSameResource = $targetResource->getMorphClass() === $source->resourceable_type
+                && (int) $targetResource->id === (int) $source->resourceable_id;
+            if ($isSameResource) {
+                $this->dispatch('refreshEnvs');
+                $this->dispatch('configurationChanged');
+                $this->dispatch('success', 'Environment variable duplicated.');
+            } else {
+                $this->dispatch('success', "Environment variable copied to '{$targetResource->name}'.");
+            }
+        } catch (\Exception $e) {
+            return handleError($e);
+        }
+    }
+
+    /** @return list<int> */
+    private function environmentIdsForDuplicateTargets(): array
+    {
+        return Project::ownedByCurrentTeamCached()
+            ->flatMap(fn (Project $project) => $project->environments->pluck('id'))
+            ->map(fn (int|string $id): int => (int) $id)
+            ->all();
+    }
+
+    private function duplicateTargetTypeLabel(string $type): string
+    {
+        return match ($type) {
+            'application' => 'Application',
+            'service' => 'Service',
+            default => 'Database',
+        };
+    }
+
+    private function resolveDuplicateTarget(string $target): ?Model
+    {
+        [$type, $id] = array_pad(explode(':', $target, 2), 2, null);
+
+        $class = self::DUPLICATE_TARGET_TYPES[$type] ?? null;
+        if ($class === null || ! ctype_digit((string) $id)) {
+            return null;
+        }
+
+        return $class::query()->find((int) $id);
+    }
+
+    /**
+     * First collision-free "KEY_COPY" style name on the source resource.
+     */
+    private function suggestedDuplicateKey(): string
+    {
+        $base = mb_substr($this->env->key, 0, 240);
+        $candidate = $base.'_COPY';
+        $suffix = 2;
+
+        while ($this->duplicateKeyExistsOnSource($candidate) && $suffix <= 100) {
+            $candidate = $base.'_COPY'.$suffix;
+            $suffix++;
+        }
+
+        return $candidate;
+    }
+
+    private function duplicateKeyExistsOnSource(string $key): bool
+    {
+        return ModelsEnvironmentVariable::query()
+            ->where('resourceable_type', $this->env->resourceable_type)
+            ->where('resourceable_id', $this->env->resourceable_id)
+            ->where('is_preview', (bool) $this->env->is_preview)
+            ->where('key', $key)
+            ->exists();
     }
 }

--- a/resources/views/livewire/project/shared/environment-variable/show.blade.php
+++ b/resources/views/livewire/project/shared/environment-variable/show.blade.php
@@ -87,6 +87,100 @@
             @if (! $isLocked && ! $isValueHidden)
                 <x-copy-button resolve="$wire.copyValue()" label="Copy value" />
             @endif
+            @if ($this->canDuplicate())
+                {{-- Open modal immediately (Alpine); load duplicate targets in a follow-up Livewire request. --}}
+                <x-modal-input title="Duplicate environment variable" :closeOutside="false" :wireIgnore="false"
+                    wireOpen="duplicateModalOpen">
+                    <x-slot:content>
+                        <button type="button" wire:click="prepareDuplicate" class="icon-button shrink-0"
+                            title="Duplicate environment variable" aria-label="Duplicate environment variable">
+                            <x-reicon name="layers" class="size-3.5" />
+                        </button>
+                    </x-slot:content>
+
+                    <div wire:key="env-duplicate-{{ $env->id }}" class="flex w-full flex-col gap-4">
+                        @if ($duplicateOptionsLoaded)
+                            @php
+                                $duplicateCurrentEnvironment = $this->env->resourceable?->environment;
+                                $duplicateCurrentProjectId = $duplicateCurrentEnvironment?->project?->id;
+                                $duplicateCurrentTarget =
+                                    ($this->env->resourceable?->type() ?? '') . ':' . $this->env->resourceable_id;
+                            @endphp
+                            <div class="flex w-full flex-col gap-4" x-data="{
+                                selectedProject: @js($duplicateCurrentProjectId),
+                                selectedEnvironment: @js($duplicateCurrentEnvironment?->id),
+                                selectedResource: @js($duplicateCurrentTarget),
+                                projects: @js($this->duplicateTargets),
+                                get selectedProjectData() {
+                                    return this.projects.find(project => project.id == this.selectedProject);
+                                },
+                                get projectOptions() {
+                                    return this.projects.map(project => ({
+                                        value: project.id,
+                                        label: project.name + (project.id == @js($duplicateCurrentProjectId) ? ' (current)' : ''),
+                                    }));
+                                },
+                                get environmentOptions() {
+                                    if (!this.selectedProjectData) return [];
+                                    return this.selectedProjectData.environments.map(environment => ({
+                                        value: environment.id,
+                                        label: environment.name + (environment.id == @js($duplicateCurrentEnvironment?->id) ? ' (current)' : ''),
+                                    }));
+                                },
+                                get resourceOptions() {
+                                    if (!this.selectedProjectData) return [];
+                                    const environment = this.selectedProjectData.environments.find(environment => environment.id == this.selectedEnvironment);
+                                    if (!environment) return [];
+                                    return environment.resources.map(resource => ({
+                                        value: resource.value,
+                                        label: resource.label + (resource.current ? ' (current)' : ''),
+                                    }));
+                                }
+                            }" x-init="
+                                $watch('selectedProject', () => { selectedEnvironment = null; selectedResource = null });
+                                $watch('selectedEnvironment', () => { selectedResource = null });
+                            ">
+                                <x-forms.input id="duplicateKey" label="Name" required
+                                    helper="The name of the duplicated variable. It must not exist on the destination resource yet." />
+                                @if ($is_shown_once)
+                                    <div class="text-xs text-neutral-500 dark:text-fg-faint">
+                                        The value of this locked variable is copied along, but stays hidden.
+                                    </div>
+                                @endif
+
+                                <div
+                                    class="grid gap-4 border-t border-neutral-200 pt-4 dark:border-white/[0.07] sm:grid-cols-3">
+                                    <x-forms.listbox id="duplicate-project-{{ $env->id }}" label="Project"
+                                        :wire="false" x-model="selectedProject" x-effect="options = projectOptions"
+                                        placeholder="Choose a project…" />
+                                    <x-forms.listbox id="duplicate-environment-{{ $env->id }}" label="Environment"
+                                        :wire="false" x-model="selectedEnvironment"
+                                        x-effect="options = environmentOptions" x-bind:disabled="!selectedProject"
+                                        placeholder="Choose an environment…"
+                                        emptyText="No environments are available in this project." />
+                                    <x-forms.listbox id="duplicate-resource-{{ $env->id }}" label="Resource"
+                                        :wire="false" x-model="selectedResource" x-effect="options = resourceOptions"
+                                        x-bind:disabled="!selectedEnvironment" placeholder="Choose a resource…"
+                                        emptyText="No resources are available in this environment." />
+                                </div>
+
+                                <div
+                                    class="flex flex-col gap-3 border-t border-neutral-200 pt-4 sm:flex-row sm:items-center sm:justify-between dark:border-white/[0.07]">
+                                    <p class="text-[13px] text-neutral-500 dark:text-fg-dim">
+                                        The value and settings are copied to the selected resource.
+                                    </p>
+                                    <x-forms.button x-bind:disabled="!selectedResource"
+                                        @click="modalOpen = false; $wire.duplicateVariable(selectedResource)">
+                                        Duplicate variable
+                                    </x-forms.button>
+                                </div>
+                            </div>
+                        @else
+                            <x-loading text="Loading..." />
+                        @endif
+                    </div>
+                </x-modal-input>
+            @endif
             {{-- Open modal immediately (Alpine); decrypt value in a follow-up Livewire request. --}}
             <x-modal-input title="Edit environment variable" :closeOutside="false" :wireIgnore="false"
                 wireOpen="editorOpen">

--- a/tests/Feature/EnvironmentVariableDuplicationTest.php
+++ b/tests/Feature/EnvironmentVariableDuplicationTest.php
@@ -1,0 +1,257 @@
+<?php
+
+use App\Livewire\Project\Shared\EnvironmentVariable\Show;
+use App\Models\Application;
+use App\Models\Environment;
+use App\Models\EnvironmentVariable;
+use App\Models\InstanceSettings;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\StandalonePostgresql;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    InstanceSettings::forceCreate(['id' => 0]);
+
+    $this->user = User::factory()->create();
+    $this->team = Team::factory()->create();
+    $this->team->members()->attach($this->user, ['role' => 'owner']);
+    $this->project = Project::factory()->create(['team_id' => $this->team->id]);
+    $this->environment = Environment::factory()->create(['project_id' => $this->project->id]);
+    $this->application = Application::factory()->create([
+        'environment_id' => $this->environment->id,
+        'build_pack' => 'dockerfile',
+    ]);
+
+    EnvironmentVariable::query()
+        ->where('resourceable_type', Application::class)
+        ->where('resourceable_id', $this->application->id)
+        ->delete();
+
+    $this->actingAs($this->user);
+    session(['currentTeam' => $this->team]);
+});
+
+function createVariableForDuplicationTest(Application $application, array $overrides = []): EnvironmentVariable
+{
+    $environmentVariable = EnvironmentVariable::create(array_merge([
+        'key' => 'API_KEY',
+        'value' => 'secret-value',
+        'order' => 1,
+        'is_preview' => false,
+        'resourceable_type' => Application::class,
+        'resourceable_id' => $application->id,
+    ], $overrides));
+
+    // Creating production variables on applications auto-creates preview twins;
+    // drop them so assertions stay predictable.
+    if (! $environmentVariable->is_preview) {
+        EnvironmentVariable::query()
+            ->where('resourceable_type', Application::class)
+            ->where('resourceable_id', $application->id)
+            ->where('is_preview', true)
+            ->delete();
+    }
+
+    return $environmentVariable->fresh();
+}
+
+it('duplicates a variable within the same resource with value and settings', function () {
+    $environmentVariable = createVariableForDuplicationTest($this->application, [
+        'key' => 'API_KEY',
+        'value' => 'super-secret',
+        'is_literal' => true,
+        'is_buildtime' => false,
+        'is_required' => true,
+        'comment' => 'primary credential',
+    ]);
+
+    Livewire::test(Show::class, ['env' => $environmentVariable, 'type' => 'application'])
+        ->call('prepareDuplicate')
+        ->assertSet('duplicateKey', 'API_KEY_COPY')
+        ->call('duplicateVariable', 'application:'.$this->application->id)
+        ->assertDispatched('success')
+        ->assertSet('duplicateModalOpen', false);
+
+    $duplicate = EnvironmentVariable::query()
+        ->where('resourceable_type', Application::class)
+        ->where('resourceable_id', $this->application->id)
+        ->where('is_preview', false)
+        ->where('key', 'API_KEY_COPY')
+        ->first();
+
+    expect($duplicate)->not->toBeNull()
+        ->and($duplicate->value)->toBe('super-secret')
+        ->and((bool) $duplicate->is_literal)->toBeTrue()
+        ->and($duplicate->is_buildtime)->toBeFalse()
+        ->and($duplicate->comment)->toBe('primary credential')
+        ->and((bool) $duplicate->is_required)->toBeFalse()
+        ->and($duplicate->uuid)->not->toBe($environmentVariable->uuid)
+        ->and((int) $duplicate->order)->toBe(2);
+});
+
+it('suggests a numbered name when the default copy name is taken', function () {
+    $environmentVariable = createVariableForDuplicationTest($this->application, ['key' => 'API_KEY']);
+    createVariableForDuplicationTest($this->application, ['key' => 'API_KEY_COPY', 'order' => 2]);
+
+    Livewire::test(Show::class, ['env' => $environmentVariable, 'type' => 'application'])
+        ->call('prepareDuplicate')
+        ->assertSet('duplicateKey', 'API_KEY_COPY2');
+});
+
+it('rejects a duplicate when the name already exists on the target resource', function () {
+    $environmentVariable = createVariableForDuplicationTest($this->application, ['key' => 'API_KEY']);
+    createVariableForDuplicationTest($this->application, ['key' => 'API_KEY_TAKEN', 'order' => 2]);
+
+    Livewire::test(Show::class, ['env' => $environmentVariable, 'type' => 'application'])
+        ->set('duplicateKey', 'API_KEY_TAKEN')
+        ->call('duplicateVariable', 'application:'.$this->application->id)
+        ->assertDispatched('error');
+
+    expect(EnvironmentVariable::query()
+        ->where('resourceable_type', Application::class)
+        ->where('resourceable_id', $this->application->id)
+        ->where('is_preview', false)
+        ->count())->toBe(2);
+});
+
+it('rejects invalid or reserved names', function () {
+    $environmentVariable = createVariableForDuplicationTest($this->application, ['key' => 'API_KEY']);
+
+    $component = Livewire::test(Show::class, ['env' => $environmentVariable, 'type' => 'application']);
+
+    $component->set('duplicateKey', '1INVALID KEY')
+        ->call('duplicateVariable', 'application:'.$this->application->id)
+        ->assertDispatched('error');
+
+    $component->set('duplicateKey', 'SERVICE_FQDN_APP')
+        ->call('duplicateVariable', 'application:'.$this->application->id)
+        ->assertDispatched('error');
+
+    expect(EnvironmentVariable::query()
+        ->where('resourceable_type', Application::class)
+        ->where('resourceable_id', $this->application->id)
+        ->where('is_preview', false)
+        ->count())->toBe(1);
+});
+
+it('copies a variable to a resource in another project', function () {
+    $environmentVariable = createVariableForDuplicationTest($this->application, [
+        'key' => 'SHARED_TOKEN',
+        'value' => 'copy-me',
+    ]);
+
+    $otherProject = Project::factory()->create(['team_id' => $this->team->id]);
+    $otherEnvironment = Environment::factory()->create(['project_id' => $otherProject->id]);
+    $otherApplication = Application::factory()->create([
+        'environment_id' => $otherEnvironment->id,
+        'build_pack' => 'dockerfile',
+    ]);
+    EnvironmentVariable::query()
+        ->where('resourceable_type', Application::class)
+        ->where('resourceable_id', $otherApplication->id)
+        ->delete();
+
+    Livewire::test(Show::class, ['env' => $environmentVariable, 'type' => 'application'])
+        ->set('duplicateKey', 'SHARED_TOKEN')
+        ->call('duplicateVariable', 'application:'.$otherApplication->id)
+        ->assertDispatched('success');
+
+    $copy = EnvironmentVariable::query()
+        ->where('resourceable_type', Application::class)
+        ->where('resourceable_id', $otherApplication->id)
+        ->where('is_preview', false)
+        ->where('key', 'SHARED_TOKEN')
+        ->first();
+
+    expect($copy)->not->toBeNull()
+        ->and($copy->value)->toBe('copy-me')
+        ->and((int) $copy->order)->toBe(1);
+});
+
+it('copies preview variables to non-application resources as production variables', function () {
+    $environmentVariable = createVariableForDuplicationTest($this->application, [
+        'key' => 'PREVIEW_TOKEN',
+        'value' => 'preview-secret',
+        'is_preview' => true,
+    ]);
+
+    $server = Server::factory()->create(['team_id' => $this->team->id]);
+    $destination = StandaloneDocker::where('server_id', $server->id)->firstOrFail();
+    $database = StandalonePostgresql::create([
+        'name' => 'postgres',
+        'image' => 'postgres:16-alpine',
+        'postgres_user' => 'postgres',
+        'postgres_password' => 'password',
+        'postgres_db' => 'postgres',
+        'environment_id' => $this->environment->id,
+        'destination_id' => $destination->id,
+        'destination_type' => $destination->getMorphClass(),
+    ]);
+
+    Livewire::test(Show::class, ['env' => $environmentVariable, 'type' => 'application'])
+        ->set('duplicateKey', 'PREVIEW_TOKEN')
+        ->call('duplicateVariable', 'standalone-postgresql:'.$database->id)
+        ->assertDispatched('success');
+
+    $copy = EnvironmentVariable::query()
+        ->where('resourceable_type', StandalonePostgresql::class)
+        ->where('resourceable_id', $database->id)
+        ->where('key', 'PREVIEW_TOKEN')
+        ->first();
+
+    expect($copy)->not->toBeNull()
+        ->and((bool) $copy->is_preview)->toBeFalse()
+        ->and($copy->value)->toBe('preview-secret');
+});
+
+it('rejects targets that belong to another team', function () {
+    $environmentVariable = createVariableForDuplicationTest($this->application, ['key' => 'API_KEY']);
+
+    $otherTeam = Team::factory()->create();
+    $otherProject = Project::factory()->create(['team_id' => $otherTeam->id]);
+    $otherEnvironment = Environment::factory()->create(['project_id' => $otherProject->id]);
+    $otherApplication = Application::factory()->create([
+        'environment_id' => $otherEnvironment->id,
+        'build_pack' => 'dockerfile',
+    ]);
+    EnvironmentVariable::query()
+        ->where('resourceable_type', Application::class)
+        ->where('resourceable_id', $otherApplication->id)
+        ->delete();
+
+    Livewire::test(Show::class, ['env' => $environmentVariable, 'type' => 'application'])
+        ->set('duplicateKey', 'API_KEY')
+        ->call('duplicateVariable', 'application:'.$otherApplication->id)
+        ->assertDispatched('error');
+
+    expect(EnvironmentVariable::query()
+        ->where('resourceable_type', Application::class)
+        ->where('resourceable_id', $otherApplication->id)
+        ->count())->toBe(0);
+});
+
+it('does not allow members to duplicate variables', function () {
+    $environmentVariable = createVariableForDuplicationTest($this->application, ['key' => 'API_KEY']);
+
+    $member = User::factory()->create();
+    $this->team->members()->attach($member, ['role' => 'member']);
+    $this->actingAs($member);
+    session(['currentTeam' => $this->team]);
+
+    Livewire::test(Show::class, ['env' => $environmentVariable, 'type' => 'application'])
+        ->set('duplicateKey', 'API_KEY_COPY')
+        ->call('duplicateVariable', 'application:'.$this->application->id);
+
+    expect(EnvironmentVariable::query()
+        ->where('resourceable_type', Application::class)
+        ->where('resourceable_id', $this->application->id)
+        ->where('is_preview', false)
+        ->count())->toBe(1);
+});


### PR DESCRIPTION
## Changes

<!-- Describe what changes were made and why in your own words. This "Changes" section must be human-written and not AI-generated. -->

- Adds a **Duplicate** action to environment variables, as requested in #11452 (discussion).
- Each variable row gets a Duplicate button that opens a modal with a suggested collision-free name and a Project → Environment → Resource picker (defaulting to the current resource). The value, comment, and flags are copied server-side.

### Behavior

- Duplicate within the current resource under a new name, or copy to any resource in the team (applications, services, standalone databases), including resources on other servers
- Preview variables are copied as production variables when the destination is not an application
- Copies never inherit `is_required` and always get a fresh UUID
- Requires team admin on both the source variable and the destination resource; magic (`SERVICE_*`), shared, and Redis credential variables are excluded

## Issues

<!-- Link related issues or discussions. If reopening a closed PR, explain why it should be reconsidered. -->

- Implements https://github.com/coollabsio/coolify/discussions/11452, which I had been earlier instructed to open in the discussion.

## Category

- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

<!-- Screenshot or short video showing your changes in action. Mandatory for new features. -->
[![Watch the feature preview video](https://cursorful.com/share/2yzRrqcrtES8)](https://cursorful.com/share/2yzRrqcrtES8)
<video src="https://cursorful.com/share/2yzRrqcrtES8" controls width="640" height="360"></video>

## AI Assistance

<!-- AI-assisted PRs that are human reviewed are welcome, just let us know so we can review appropriately. -->

- [x] AI was NOT used to create this PR
- [ ] AI was used (please describe below)

**If AI was used:**

- Tools used:
- How extensively:

## Testing

<!-- Describe how you tested these changes. -->
I have added a feature test with 8 cases `tests/Feature/EnvironmentVariableDuplicationTest.php` which covers duplication with value/flag copying, name suggestion, collision and reserved-name rejection, cross-project copies, preview coercion, cross-team target rejection, and member authorization. Pint clean and all passing. 
I've also used the feature in local development tests, and it works end-to-end.

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
This reverts commit 7bbd911.Add a Duplicate action to each environment variable row. It copies the
value, comment, and flags either within the current resource under a
collision-free suggested name, or to another resource picked through a
project / environment / resource selector, including resources hosted
on other servers.

Preview-scoped variables are copied as production variables when the
destination is not an application. Copies never inherit the required
flag, and duplication is limited to team admins on both the source and
the destination resource.

Implements the request in discussion #11452.