### PR TITLE
fix(api): accept cuid for private_key_uuid on GitHub App update

### DIFF
--- a/app/Http/Controllers/Api/GithubController.php
+++ b/app/Http/Controllers/Api/GithubController.php
@@ -642,7 +642,7 @@ class GithubController extends Controller
                 $rules['webhook_secret'] = 'string';
             }
             if (isset($payload['private_key_uuid'])) {
-                $rules['private_key_uuid'] = 'string|uuid';
+                $rules['private_key_uuid'] = 'string';
             }
             if (! isCloud() && isset($payload['is_system_wide'])) {
                 $rules['is_system_wide'] = 'boolean';

--- a/tests/Feature/Api/GithubAppsListApiTest.php
+++ b/tests/Feature/Api/GithubAppsListApiTest.php
@@ -494,36 +494,3 @@ describe('GitHub app API url normalization', function () {
         Http::assertSent(fn ($request) => $request->url() === 'https://api.octocorp.ghe.com/repos/octocorp/repo/branches');
     });
 });
-
-
-describe('PATCH /api/v1/github-apps/{id} private key identifier', function () {
-    test('accepts the private key public identifier', function () {
-        $githubApp = GithubApp::create([
-            'name' => 'Test GitHub App',
-            'api_url' => 'https://api.github.com',
-            'html_url' => 'https://github.com',
-            'app_id' => 12345,
-            'installation_id' => 67890,
-            'client_id' => 'test-client-id',
-            'client_secret' => 'test-client-secret',
-            'webhook_secret' => 'test-webhook-secret',
-            'private_key_id' => $this->privateKey->id,
-            'team_id' => $this->team->id,
-            'is_system_wide' => false,
-            'is_public' => false,
-        ]);
-
-        // Coolify's public identifiers are 24-character lowercase alphanumeric
-        // strings, not RFC 4122 UUIDs, so the `uuid` rule rejects them.
-        expect($this->privateKey->uuid)->not->toContain('-');
-
-        $response = $this->withHeaders([
-            'Authorization' => 'Bearer '.$this->bearerToken,
-        ])->patchJson("/api/v1/github-apps/{$githubApp->id}", [
-            'private_key_uuid' => $this->privateKey->uuid,
-        ]);
-
-        $response->assertSuccessful()
-            ->assertJsonPath('data.private_key_id', $this->privateKey->id);
-    });
-});

--- a/tests/Feature/Api/GithubAppsListApiTest.php
+++ b/tests/Feature/Api/GithubAppsListApiTest.php
@@ -494,3 +494,36 @@ describe('GitHub app API url normalization', function () {
         Http::assertSent(fn ($request) => $request->url() === 'https://api.octocorp.ghe.com/repos/octocorp/repo/branches');
     });
 });
+
+
+describe('PATCH /api/v1/github-apps/{id} private key identifier', function () {
+    test('accepts the private key public identifier', function () {
+        $githubApp = GithubApp::create([
+            'name' => 'Test GitHub App',
+            'api_url' => 'https://api.github.com',
+            'html_url' => 'https://github.com',
+            'app_id' => 12345,
+            'installation_id' => 67890,
+            'client_id' => 'test-client-id',
+            'client_secret' => 'test-client-secret',
+            'webhook_secret' => 'test-webhook-secret',
+            'private_key_id' => $this->privateKey->id,
+            'team_id' => $this->team->id,
+            'is_system_wide' => false,
+            'is_public' => false,
+        ]);
+
+        // Coolify's public identifiers are 24-character lowercase alphanumeric
+        // strings, not RFC 4122 UUIDs, so the `uuid` rule rejects them.
+        expect($this->privateKey->uuid)->not->toContain('-');
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->bearerToken,
+        ])->patchJson("/api/v1/github-apps/{$githubApp->id}", [
+            'private_key_uuid' => $this->privateKey->uuid,
+        ]);
+
+        $response->assertSuccessful()
+            ->assertJsonPath('data.private_key_id', $this->privateKey->id);
+    });
+});


### PR DESCRIPTION
## Changes

- The update endpoint validated this field with the `uuid` rule, which requires the RFC 4122 format, but Coolify generates plain 24-character lowercase text, so the value never passed validation. The create endpoint already accepted the same field as plain text, which is why creating worked and updating did not. I changed the update rule to match the create one, so both accept the format Coolify actually generates.

## Issues

- Fixes #10936

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Not a UI change. Covered by the regression test below.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude
- How extensively: It helped me find the inconsistency between the create and update validation rules, draft the regression test, and translate my description into English. I wrote the description myself in Spanish, set up the local environment, reproduced the failure, applied the fix and verified the result.

## Testing

Ran the GitHub Apps API test file against a local development instance:

- Before any change: 15 tests passing.
- After adding the regression test: 1 failing, with a 422 and the message "The private key uuid field must be a valid UUID".
- After the one-line fix: 16 passing.

## Contributor Agreement

<!-- Do not remove this section. PRs without the contributor agreement will be closed. -->

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [x] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.