### PR TITLE
Update DATABASE_URL format in vaultwarden.yaml

### DIFF
--- a/templates/compose/vaultwarden.yaml
+++ b/templates/compose/vaultwarden.yaml
@@ -11,7 +11,7 @@ services:
     environment:
       - SERVICE_URL_VAULTWARDEN
       - DOMAIN=${SERVICE_URL_VAULTWARDEN}
-      - DATABASE_URL=${VAULTWARDEN_DB_URL:-data/db.sqlite3}
+      - DATABASE_URL=${VAULTWARDEN_DB_URL:-sqlite:///data/db.sqlite3}
       - SIGNUPS_ALLOWED=${SIGNUP_ALLOWED:-true}
       - ADMIN_TOKEN=${SERVICE_PASSWORD_64_ADMIN}
       - IP_HEADER=X-Forwarded-For


### PR DESCRIPTION
## Description
Updates the default Vaultwarden database URL to use the correct SQLite connection string format.

## Changes
- Modified the default `DATABASE_URL` environment variable from `data/db.sqlite3` to `sqlite:///data/db.sqlite3`
- This ensures proper SQLite URI scheme compliance for Vaultwarden

## Why
The SQLite connection string requires the `sqlite://` scheme prefix. The original format (`data/db.sqlite3`) was missing the proper URI scheme, which could cause connection issues or unexpected behavior in Vaultwarden's database initialization.

## Testing
- Verify that Vaultwarden containers start correctly with the SQLite database
- Confirm that existing data is properly loaded from the database location

## Files Changed
- `templates/compose/vaultwarden.yaml` - Updated DATABASE_URL environment variable format