### PR TITLE
fix(proxy): restore project networks after host reboot

### DIFF
--- a/bootstrap/helpers/proxy.php
+++ b/bootstrap/helpers/proxy.php
@@ -123,7 +123,7 @@ function connectProxyToNetworks(Server $server)
     }
 
     return collect([
-        'for network in $(docker inspect $(docker ps --filter label=coolify.managed=true --format "{{.ID}}") --format=\'{{range $network, $_ := .NetworkSettings.Networks}}{{println $network}}{{end}}\' 2>/dev/null | sort -u); do',
+        'for network in $(docker inspect $(docker ps -a --filter label=coolify.managed=true --format "{{.ID}}") --format=\'{{range $network, $_ := .NetworkSettings.Networks}}{{println $network}}{{end}}\' 2>/dev/null | sort -u); do',
         '    if [ -z "$network" ] || [ "$network" = "bridge" ] || [ "$network" = "host" ] || [ "$network" = "none" ] || [ "$network" = "default" ]; then',
         '        continue',
         '    fi',

--- a/tests/Feature/Proxy/RuntimeNetworkReconciliationTest.php
+++ b/tests/Feature/Proxy/RuntimeNetworkReconciliationTest.php
@@ -6,14 +6,14 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 
 uses(RefreshDatabase::class);
 
-it('discovers running container networks instead of relying on cached resource statuses', function () {
+it('discovers managed container networks regardless of container status', function () {
     $team = Team::factory()->create();
     $server = Server::factory()->create(['team_id' => $team->id]);
 
     $commands = connectProxyToNetworks($server)->implode("\n");
 
     expect($commands)
-        ->toContain('docker ps --filter label=coolify.managed=true')
+        ->toContain('docker ps -a --filter label=coolify.managed=true')
         ->toContain('.NetworkSettings.Networks')
         ->toContain('docker network inspect "$network"')
         ->toContain('docker network connect "$network" coolify-proxy')


### PR DESCRIPTION
## Summary

- Discover networks from all managed containers, including stopped containers, when reconnecting `coolify-proxy`.
- Restore project network access during post-reboot startup before applications are running.
- Update proxy reconciliation coverage for stopped managed containers.

fixes #11436

---

Fixes #11436