### PR TITLE
fix(docker): handle commas in container label values

### DIFF
--- a/bootstrap/helpers/docker.php
+++ b/bootstrap/helpers/docker.php
@@ -166,11 +166,13 @@ function format_docker_labels_to_json(string|array $rawOutput): Collection
             $outputArray = explode(',', $outputLine);
 
             return collect($outputArray)
-                ->map(function ($outputLine) {
-                    return explode('=', $outputLine);
-                })
                 ->mapWithKeys(function ($outputLine) {
-                    return [$outputLine[0] => $outputLine[1]];
+                    $label = explode('=', $outputLine, 2);
+                    if (count($label) !== 2) {
+                        return [];
+                    }
+
+                    return [$label[0] => $label[1]];
                 });
         })[0];
 }

--- a/tests/Unit/Api/LogEndpointHelpersTest.php
+++ b/tests/Unit/Api/LogEndpointHelpersTest.php
@@ -94,6 +94,18 @@ it('filters service sub containers in PHP instead of using user input in shell f
         ->toBe(['first', 'third']);
 });
 
+it('filters service containers when another Docker label contains commas', function () {
+    $containers = collect([
+        [
+            'ID' => 'app',
+            'Labels' => 'traefik.http.routers.app.rule=Host(`one.example.com`,`two.example.com`),coolify.name=app-service-uuid',
+        ],
+    ]);
+
+    expect(filterServiceSubContainersByName($containers, 'app-service-uuid')->pluck('ID')->all())
+        ->toBe(['app']);
+});
+
 it('does not interpolate the requested service name into the docker ps shell command', function () {
     $source = file_get_contents(__DIR__.'/../../../bootstrap/helpers/docker.php');
 


### PR DESCRIPTION
## Summary

- Prevent service log requests from failing when Docker label values contain commas.
- Safely skip malformed label fragments instead of accessing a missing array key.
- Add regression coverage for service container lookup with comma-containing Traefik labels.

Fixes #11454.

---

Fixes #11454