### PR TITLE
fix(deployments): honor selected Docker image rollback tag

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -614,6 +614,10 @@ class ApplicationDeploymentJob implements ShouldBeEncrypted, ShouldQueue
             return $this->dockerImagePreviewTag;
         }
 
+        if ($this->rollback && str($this->commit)->isNotEmpty()) {
+            return $this->commit;
+        }
+
         if (str($this->application->docker_registry_image_tag)->isNotEmpty()) {
             return $this->application->docker_registry_image_tag;
         }

--- a/tests/Unit/DockerImagePreviewTagResolutionTest.php
+++ b/tests/Unit/DockerImagePreviewTagResolutionTest.php
@@ -59,6 +59,70 @@ it('prefers the selected tag for docker image rollback deployments', function ()
     expect($method->invoke($job))->toBe('e487515a098c8d4f69c74712f1d0cc86e483e890');
 });
 
+it('falls back to the application docker image tag for rollbacks without a selected tag', function () {
+    $reflection = new ReflectionClass(ApplicationDeploymentJob::class);
+    $job = $reflection->newInstanceWithoutConstructor();
+
+    $pullRequestProperty = $reflection->getProperty('pull_request_id');
+    $pullRequestProperty->setAccessible(true);
+    $pullRequestProperty->setValue($job, 0);
+
+    $rollbackProperty = $reflection->getProperty('rollback');
+    $rollbackProperty->setAccessible(true);
+    $rollbackProperty->setValue($job, true);
+
+    $commitProperty = $reflection->getProperty('commit');
+    $commitProperty->setAccessible(true);
+    $commitProperty->setValue($job, '');
+
+    $applicationProperty = $reflection->getProperty('application');
+    $applicationProperty->setAccessible(true);
+    $applicationProperty->setValue($job, new Application([
+        'docker_registry_image_tag' => 'stable',
+    ]));
+
+    $previewTagProperty = $reflection->getProperty('dockerImagePreviewTag');
+    $previewTagProperty->setAccessible(true);
+    $previewTagProperty->setValue($job, null);
+
+    $method = $reflection->getMethod('resolveDockerImageTag');
+    $method->setAccessible(true);
+
+    expect($method->invoke($job))->toBe('stable');
+});
+
+it('falls back to latest for rollbacks without selected or configured tags', function () {
+    $reflection = new ReflectionClass(ApplicationDeploymentJob::class);
+    $job = $reflection->newInstanceWithoutConstructor();
+
+    $pullRequestProperty = $reflection->getProperty('pull_request_id');
+    $pullRequestProperty->setAccessible(true);
+    $pullRequestProperty->setValue($job, 0);
+
+    $rollbackProperty = $reflection->getProperty('rollback');
+    $rollbackProperty->setAccessible(true);
+    $rollbackProperty->setValue($job, true);
+
+    $commitProperty = $reflection->getProperty('commit');
+    $commitProperty->setAccessible(true);
+    $commitProperty->setValue($job, '');
+
+    $applicationProperty = $reflection->getProperty('application');
+    $applicationProperty->setAccessible(true);
+    $applicationProperty->setValue($job, new Application([
+        'docker_registry_image_tag' => '',
+    ]));
+
+    $previewTagProperty = $reflection->getProperty('dockerImagePreviewTag');
+    $previewTagProperty->setAccessible(true);
+    $previewTagProperty->setValue($job, null);
+
+    $method = $reflection->getMethod('resolveDockerImageTag');
+    $method->setAccessible(true);
+
+    expect($method->invoke($job))->toBe('latest');
+});
+
 it('falls back to the application docker image tag for non preview deployments', function () {
     $reflection = new ReflectionClass(ApplicationDeploymentJob::class);
     $job = $reflection->newInstanceWithoutConstructor();

--- a/tests/Unit/DockerImagePreviewTagResolutionTest.php
+++ b/tests/Unit/DockerImagePreviewTagResolutionTest.php
@@ -27,6 +27,38 @@ it('prefers the preview specific docker image tag for preview deployments', func
     expect($method->invoke($job))->toBe('pr_42');
 });
 
+it('prefers the selected tag for docker image rollback deployments', function () {
+    $reflection = new ReflectionClass(ApplicationDeploymentJob::class);
+    $job = $reflection->newInstanceWithoutConstructor();
+
+    $pullRequestProperty = $reflection->getProperty('pull_request_id');
+    $pullRequestProperty->setAccessible(true);
+    $pullRequestProperty->setValue($job, 0);
+
+    $rollbackProperty = $reflection->getProperty('rollback');
+    $rollbackProperty->setAccessible(true);
+    $rollbackProperty->setValue($job, true);
+
+    $commitProperty = $reflection->getProperty('commit');
+    $commitProperty->setAccessible(true);
+    $commitProperty->setValue($job, 'e487515a098c8d4f69c74712f1d0cc86e483e890');
+
+    $applicationProperty = $reflection->getProperty('application');
+    $applicationProperty->setAccessible(true);
+    $applicationProperty->setValue($job, new Application([
+        'docker_registry_image_tag' => '6de68657a0e794e163ea2275c54c293a93fe065a',
+    ]));
+
+    $previewTagProperty = $reflection->getProperty('dockerImagePreviewTag');
+    $previewTagProperty->setAccessible(true);
+    $previewTagProperty->setValue($job, null);
+
+    $method = $reflection->getMethod('resolveDockerImageTag');
+    $method->setAccessible(true);
+
+    expect($method->invoke($job))->toBe('e487515a098c8d4f69c74712f1d0cc86e483e890');
+});
+
 it('falls back to the application docker image tag for non preview deployments', function () {
     $reflection = new ReflectionClass(ApplicationDeploymentJob::class);
     $job = $reflection->newInstanceWithoutConstructor();
@@ -34,6 +66,10 @@ it('falls back to the application docker image tag for non preview deployments',
     $pullRequestProperty = $reflection->getProperty('pull_request_id');
     $pullRequestProperty->setAccessible(true);
     $pullRequestProperty->setValue($job, 0);
+
+    $rollbackProperty = $reflection->getProperty('rollback');
+    $rollbackProperty->setAccessible(true);
+    $rollbackProperty->setValue($job, false);
 
     $applicationProperty = $reflection->getProperty('application');
     $applicationProperty->setAccessible(true);
@@ -58,6 +94,10 @@ it('falls back to latest when neither preview nor application tags are set', fun
     $pullRequestProperty = $reflection->getProperty('pull_request_id');
     $pullRequestProperty->setAccessible(true);
     $pullRequestProperty->setValue($job, 7);
+
+    $rollbackProperty = $reflection->getProperty('rollback');
+    $rollbackProperty->setAccessible(true);
+    $rollbackProperty->setValue($job, false);
 
     $applicationProperty = $reflection->getProperty('application');
     $applicationProperty->setAccessible(true);


### PR DESCRIPTION
## Summary

- Use the selected image tag when rolling back Docker Image applications instead of redeploying the configured tag.
- Keep preview and standard deployment tag resolution unchanged.
- Add unit coverage for rollback tag selection and existing fallback behavior.

Fixes #11467

---

Fixes #11467