### PR TITLE
fix(deployments): emit stop_grace_period into the generated compose file

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -3323,6 +3323,10 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
         if (! is_null($this->application->limits_cpuset)) {
             data_set($docker_compose, 'services.'.$this->container_name.'.cpuset', $this->application->limits_cpuset);
         }
+        $stop_grace_period = $this->application->settings->composeStopGracePeriod();
+        if (! is_null($stop_grace_period)) {
+            $docker_compose['services'][$this->container_name]['stop_grace_period'] = $stop_grace_period;
+        }
         if ($this->mainServer->isSwarm()) {
             data_forget($docker_compose, 'services.'.$this->container_name.'.container_name');
             data_forget($docker_compose, 'services.'.$this->container_name.'.expose');

--- a/app/Models/ApplicationSetting.php
+++ b/app/Models/ApplicationSetting.php
@@ -142,6 +142,15 @@ class ApplicationSetting extends Model
         return $this->stopGracePeriodSeconds();
     }
 
+    public function composeStopGracePeriod(): ?string
+    {
+        if (is_null($this->stop_grace_period)) {
+            return null;
+        }
+
+        return $this->stopGracePeriodSeconds().'s';
+    }
+
     public function isStatic(): Attribute
     {
         return Attribute::make(

--- a/tests/Unit/ApplicationSettingComposeStopGracePeriodTest.php
+++ b/tests/Unit/ApplicationSettingComposeStopGracePeriodTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Tests for ApplicationSetting::composeStopGracePeriod
+ *
+ * NOTE: These tests verify the compose duration emitted for the generated
+ * docker-compose service. When stop_grace_period is not configured, no value
+ * is emitted so the container keeps Docker's default behavior; when it is
+ * configured, the effective (validated) value is emitted as a duration string.
+ */
+
+use App\Models\ApplicationSetting;
+
+it('returns null when stop_grace_period is not configured', function () {
+    $setting = new ApplicationSetting;
+    $setting->setRawAttributes(['stop_grace_period' => null]);
+
+    expect($setting->composeStopGracePeriod())->toBeNull();
+});
+
+it('returns the configured value as a compose duration string', function () {
+    $setting = new ApplicationSetting;
+    $setting->setRawAttributes(['stop_grace_period' => 700]);
+
+    expect($setting->composeStopGracePeriod())->toBe('700s');
+});
+
+it('returns the minimum allowed value as a compose duration string', function () {
+    $setting = new ApplicationSetting;
+    $setting->setRawAttributes(['stop_grace_period' => MIN_STOP_GRACE_PERIOD_SECONDS]);
+
+    expect($setting->composeStopGracePeriod())->toBe(MIN_STOP_GRACE_PERIOD_SECONDS.'s');
+});
+
+it('returns the maximum allowed value as a compose duration string', function () {
+    $setting = new ApplicationSetting;
+    $setting->setRawAttributes(['stop_grace_period' => MAX_STOP_GRACE_PERIOD_SECONDS]);
+
+    expect($setting->composeStopGracePeriod())->toBe(MAX_STOP_GRACE_PERIOD_SECONDS.'s');
+});
+
+it('falls back to the default effective value for an out-of-range configured value', function () {
+    $setting = new ApplicationSetting;
+    $setting->setRawAttributes(['stop_grace_period' => MAX_STOP_GRACE_PERIOD_SECONDS + 1]);
+
+    expect($setting->composeStopGracePeriod())->toBe(DEFAULT_STOP_GRACE_PERIOD_SECONDS.'s');
+});


### PR DESCRIPTION
## Changes

- Emit `stop_grace_period` into the generated docker-compose service so the configured grace period also applies to daemon-initiated stops (host reboot, `systemctl restart docker`, plain `docker stop`), not only to Coolify-driven stops (which already run `docker stop --time <n>`).
- Emission is gated on the setting being explicitly configured: applications that never set it keep exactly today's behavior — no change to defaults.
- New `ApplicationSetting::composeStopGracePeriod(): ?string` returns the effective validated value as a compose duration (`"700s"`) or `null` when unset; `generate_compose_file()` adds the key before the swarm / consistent-container-name handling so both paths inherit it (swarm supports `stop_grace_period`).
- Adds 5 unit tests for the new accessor.

## Issues

- Fixes #11493

## Category

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Adding new one click service
- [ ] Fixing or updating existing one click service

## Preview

Generated service with the setting configured to 700 (key absent when the setting is unset):

```yaml
services:
    myapp:
        image: 'app:latest'
        restart: always
        stop_grace_period: 700s
```

Docker maps this to `"StopTimeout": 700` in the container's HostConfig, which daemon-initiated stops honor.

## AI Assistance

- [ ] AI was NOT used to create this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Claude Fable 5)
- How extensively: the patch, the unit tests, and this PR description were drafted with Claude Code, directed and reviewed by the account owner. Disclosing in full, including that this description text itself is AI-drafted.

## Testing

- `./vendor/bin/pest tests/Unit/ApplicationSettingComposeStopGracePeriodTest.php tests/Unit/ApplicationSettingStaticCastTest.php` — 25 passed (65 assertions), including the 5 new tests. Pint and PHPStan clean on the touched files.
- Emission verified by dumping the service array through Symfony Yaml exactly as `generate_compose_file()` does: `stop_grace_period: 700s` present when configured, key absent when unset.
- Docker-level mechanism verified (Docker 29.6.2): a compose service with `stop_grace_period: 15s` gets `HostConfig.StopTimeout` set and `time docker stop` takes ~15.3s, vs ~10.4s for an identical service without the key; `700s` → `"StopTimeout": 700`.
- The underlying gap was measured on a production v4.1.2 instance: with the grace period configured, a host reboot still killed the worker after ~10s because the generated compose carried no `stop_grace_period`.
- Not yet verified on a local development instance of Coolify — the third agreement checkbox is left unchecked for that reason. Happy to add a dev-instance verification if you want it before review.

## Contributor Agreement

> [!IMPORTANT]
>
> - [x] I have read and understood the [contributor guidelines](https://github.com/coollabsio/coolify/blob/HEAD/CONTRIBUTING.md). If I have failed to follow any guideline, I understand that this PR may be closed without review.
> - [x] I have searched [existing issues](https://github.com/coollabsio/coolify/issues) and [pull requests](https://github.com/coollabsio/coolify/pulls) (including closed ones) to ensure this isn't a duplicate.
> - [ ] I have tested all the changes thoroughly with a local development instance of Coolify and I am confident that they will work as expected when a maintainer tests them.
