### PR TITLE
fix(deployments): restore commit links in deployment logs

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -739,24 +739,20 @@ class Application extends BaseModel
 
             return "{$this->source->html_url}/{$this->git_repository}/commit/{$link}";
         }
-        if (str($this->git_repository)->contains('bitbucket')) {
-            $git_repository = str_replace('.git', '', $this->git_repository);
-            $url = Url::fromString($git_repository);
-            $url = $url->withUserInfo('');
-            $url = $url->withPath($url->getPath().'/commits/'.$link);
 
-            return $url->__toString();
-        }
+        $git_repository = $this->git_repository;
         if (strpos($this->git_repository, 'git@') === 0) {
-            $git_repository = str_replace(['git@', ':', '.git'], ['', '/', ''], $this->git_repository);
-            if (data_get($this, 'source.html_url')) {
-                return "{$this->source->html_url}/{$git_repository}/commit/{$link}";
-            }
-
-            return "{$git_repository}/commit/{$link}";
+            $git_repository = preg_replace('/^git@([^:]+):/', 'https://$1/', $git_repository);
+        } elseif (str($this->git_repository)->startsWith('ssh://')) {
+            $git_repository = 'https://'.parse_url($git_repository, PHP_URL_HOST).parse_url($git_repository, PHP_URL_PATH);
         }
 
-        return $this->git_repository;
+        $url = Url::fromString(Str::replaceEnd('.git', '', $git_repository));
+        $url = $url->withUserInfo('');
+        $commitPath = str($git_repository)->contains('bitbucket') ? 'commits' : 'commit';
+        $url = $url->withPath(Str::finish($url->getPath(), '/').$commitPath.'/'.$link);
+
+        return $url->__toString();
     }
 
     public function dockerfileLocation(): Attribute

--- a/resources/views/livewire/project/application/deployment/index.blade.php
+++ b/resources/views/livewire/project/application/deployment/index.blade.php
@@ -213,39 +213,43 @@
                             $commitMessage = $deployment->commitMessage()
                                 ? Str::before($deployment->commitMessage(), "\n")
                                 : null;
+                            $deploymentUrl = $current_url . '/' . data_get($deployment, 'deployment_uuid');
+                            $commitUrl = data_get($deployment, 'commit')
+                                ? $application->gitCommitLink(data_get($deployment, 'commit'))
+                                : null;
                         @endphp
-                        <a wire:key="deployment-{{ data_get($deployment, 'deployment_uuid') }}"
-                            href="{{ $current_url . '/' . data_get($deployment, 'deployment_uuid') }}"
-                            {{ wireNavigate() }}
+                        <div wire:key="deployment-{{ data_get($deployment, 'deployment_uuid') }}"
                             @class([
                                 'data-table-row deployment-table-grid border-b border-neutral-200 text-[13px] text-neutral-600 dark:border-white/[0.08] dark:text-fg-dim',
                                 'data-table-row-active' => $selectedDeploymentUuid === data_get($deployment, 'deployment_uuid'),
                             ])>
-                            <span><x-status-badge :status="$statusLabel" :type="$statusType" /></span>
-                            <span>{{ $sourceLabel }}</span>
+                            <a href="{{ $deploymentUrl }}" {{ wireNavigate() }}><x-status-badge :status="$statusLabel" :type="$statusType" /></a>
+                            <a href="{{ $deploymentUrl }}" {{ wireNavigate() }}>{{ $sourceLabel }}</a>
                             <span class="min-w-0">
                                 @if (data_get($deployment, 'commit'))
                                     <span class="flex min-w-0 items-center gap-2">
-                                        <span class="shrink-0 font-mono text-xs text-neutral-950 dark:text-fg">
+                                        <a href="{{ $commitUrl }}" target="_blank" rel="noopener noreferrer"
+                                            class="shrink-0 font-mono text-xs text-neutral-950 underline decoration-neutral-400 underline-offset-2 dark:text-fg dark:decoration-neutral-600">
                                             {{ substr(data_get($deployment, 'commit'), 0, 7) }}
-                                        </span>
+                                        </a>
                                         @if ($commitMessage)
-                                            <span class="truncate text-neutral-500 dark:text-fg-faint"
-                                                title="{{ $commitMessage }}">{{ $commitMessage }}</span>
+                                            <a href="{{ $deploymentUrl }}" {{ wireNavigate() }}
+                                                class="truncate text-neutral-500 dark:text-fg-faint"
+                                                title="{{ $commitMessage }}">{{ $commitMessage }}</a>
                                         @endif
                                     </span>
                                 @else
                                     <span class="text-neutral-400 dark:text-fg-faint">-</span>
                                 @endif
                             </span>
-                            <span title="{{ formatDateInServerTimezone(data_get($deployment, 'created_at'), data_get($application, 'destination.server')) }}">
+                            <a href="{{ $deploymentUrl }}" {{ wireNavigate() }} title="{{ formatDateInServerTimezone(data_get($deployment, 'created_at'), data_get($application, 'destination.server')) }}">
                                 {{ \Carbon\Carbon::parse(data_get($deployment, 'created_at'))->diffForHumans() }}
-                            </span>
-                            <span class="tabular-nums">{{ $duration }}</span>
-                            <span class="truncate">
+                            </a>
+                            <a href="{{ $deploymentUrl }}" {{ wireNavigate() }} class="tabular-nums">{{ $duration }}</a>
+                            <a href="{{ $deploymentUrl }}" {{ wireNavigate() }} class="truncate">
                                 {{ data_get($deployment, 'server_name') ?: data_get($application, 'destination.server.name', '-') }}
-                            </span>
-                        </a>
+                            </a>
+                        </div>
                         @endforeach
                     </div>
 

--- a/tests/Feature/DeploymentLogsLayoutTest.php
+++ b/tests/Feature/DeploymentLogsLayoutTest.php
@@ -4,6 +4,7 @@ use App\Enums\ApplicationDeploymentStatus;
 use App\Models\Application;
 use App\Models\ApplicationDeploymentQueue;
 use App\Models\Environment;
+use App\Models\GithubApp;
 use App\Models\InstanceSettings;
 use App\Models\Project;
 use App\Models\Server;
@@ -212,6 +213,42 @@ it('keeps deployment history fields and the log status badge accessible on mobil
         ->toContain(".deployment-table-grid {\n        min-width: 0;")
         ->not->toContain('.deployment-table-grid > :nth-child')
         ->toContain(".logs-viewer-primary .logs-viewer-actions {\n    width: auto;\n    flex: 1 1 auto;");
+});
+
+it('links deployment commit hashes to the source commit page', function () {
+    $githubApp = GithubApp::query()->create([
+        'team_id' => $this->team->id,
+        'name' => 'GitHub',
+        'api_url' => 'https://api.github.com',
+        'html_url' => 'https://github.com',
+    ]);
+    $this->application->update([
+        'source_id' => $githubApp->id,
+        'source_type' => $githubApp->getMorphClass(),
+        'git_repository' => 'coollabsio/coolify',
+        'git_branch' => 'main',
+    ]);
+    ApplicationDeploymentQueue::query()->create([
+        'application_id' => $this->application->id,
+        'deployment_uuid' => 'deploy-commit-link-test',
+        'server_id' => $this->server->id,
+        'status' => ApplicationDeploymentStatus::FINISHED->value,
+        'commit' => '1234567890abcdef1234567890abcdef12345678',
+    ]);
+
+    $response = $this->get(route('project.application.deployment.index', [
+        'project_uuid' => $this->project->uuid,
+        'environment_uuid' => $this->environment->uuid,
+        'application_uuid' => $this->application->uuid,
+    ]));
+
+    $response->assertSuccessful();
+    $response->assertSee(
+        'href="https://github.com/coollabsio/coolify/commit/1234567890abcdef1234567890abcdef12345678"',
+        false,
+    );
+    $response->assertSee('target="_blank"', false);
+    $response->assertSee('rel="noopener noreferrer"', false);
 });
 
 it('places cancel deployment controls inside the deployment logs toolbar', function () {

--- a/tests/Feature/DeploymentLogsLayoutTest.php
+++ b/tests/Feature/DeploymentLogsLayoutTest.php
@@ -244,11 +244,9 @@ it('links deployment commit hashes to the source commit page', function () {
 
     $response->assertSuccessful();
     $response->assertSee(
-        'href="https://github.com/coollabsio/coolify/commit/1234567890abcdef1234567890abcdef12345678"',
+        'href="https://github.com/coollabsio/coolify/commit/1234567890abcdef1234567890abcdef12345678" target="_blank" rel="noopener noreferrer"',
         false,
     );
-    $response->assertSee('target="_blank"', false);
-    $response->assertSee('rel="noopener noreferrer"', false);
 });
 
 it('places cancel deployment controls inside the deployment logs toolbar', function () {

--- a/tests/Unit/ApplicationGitCommitLinkTest.php
+++ b/tests/Unit/ApplicationGitCommitLinkTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Models\Application;
+
+it('generates commit links for direct repository remotes', function (string $repository, string $expected) {
+    $application = new Application;
+    $application->setRelation('source', null);
+    $application->git_repository = $repository;
+
+    expect($application->gitCommitLink('1234567890abcdef'))->toBe($expected);
+})->with([
+    'HTTPS remote' => [
+        'https://github.com/coollabsio/coolify.git',
+        'https://github.com/coollabsio/coolify/commit/1234567890abcdef',
+    ],
+    'SSH remote' => [
+        'git@github.com:coollabsio/coolify.git',
+        'https://github.com/coollabsio/coolify/commit/1234567890abcdef',
+    ],
+    'SSH URL' => [
+        'ssh://git@gitlab.com/coollabsio/coolify.git',
+        'https://gitlab.com/coollabsio/coolify/commit/1234567890abcdef',
+    ],
+    'Bitbucket HTTPS remote' => [
+        'https://bitbucket.org/coollabsio/coolify.git',
+        'https://bitbucket.org/coollabsio/coolify/commits/1234567890abcdef',
+    ],
+]);


### PR DESCRIPTION
## Summary

- Restore clickable commit hashes in the deployment logs table.
- Open commits on their source repository page in a new tab.
- Preserve navigation to deployment details from the other table fields.
- Add test coverage for GitHub commit links.

Fixes #11482

---

Fixes #11482