### PR TITLE
fix(proxy): clear stale Traefik branch upgrade warnings

### DIFF
--- a/app/Livewire/Server/Proxy.php
+++ b/app/Livewire/Server/Proxy.php
@@ -353,17 +353,24 @@ class Proxy extends Component
 
     private function clearAppliedTraefikBranchWarning(): void
     {
-        if (data_get($this->server->traefik_outdated_info, 'type') !== 'minor_upgrade') {
+        $outdatedInfo = $this->server->traefik_outdated_info;
+
+        if (data_get($outdatedInfo, 'type') !== 'minor_upgrade') {
             return;
         }
 
         $configuredBranch = $this->getConfiguredTraefikBranch();
-        $upgradeTarget = ltrim((string) data_get($this->server->traefik_outdated_info, 'upgrade_target'), 'v');
+        $upgradeTarget = ltrim((string) data_get($outdatedInfo, 'upgrade_target'), 'v');
 
         if (! $configuredBranch || ! $upgradeTarget || version_compare($configuredBranch, $upgradeTarget, '<')) {
             return;
         }
 
-        $this->server->update(['traefik_outdated_info' => null]);
+        Server::query()
+            ->whereKey($this->server->id)
+            ->where('traefik_outdated_info->type', data_get($outdatedInfo, 'type'))
+            ->where('traefik_outdated_info->current', data_get($outdatedInfo, 'current'))
+            ->where('traefik_outdated_info->upgrade_target', data_get($outdatedInfo, 'upgrade_target'))
+            ->update(['traefik_outdated_info' => null]);
     }
 }

--- a/app/Livewire/Server/Proxy.php
+++ b/app/Livewire/Server/Proxy.php
@@ -57,6 +57,7 @@ class Proxy extends Component
         $this->redirectUrl = data_get($this->server, 'proxy.redirect_url');
         $this->syncData(false);
         $this->loadProxyConfiguration();
+        $this->clearAppliedTraefikBranchWarning();
     }
 
     private function syncData(bool $toModel = false): void
@@ -276,6 +277,8 @@ class Proxy extends Component
                 return null;
             }
 
+            $configuredBranch = $this->getConfiguredTraefikBranch();
+
             // Check if we have outdated info stored for this server (faster than computing)
             $outdatedInfo = $this->server->traefik_outdated_info;
             $storedCurrentVersion = ltrim((string) data_get($outdatedInfo, 'current'), 'v');
@@ -283,9 +286,15 @@ class Proxy extends Component
             if ($storedCurrentVersion === $detectedCurrentVersion && data_get($outdatedInfo, 'type') === 'minor_upgrade') {
                 // Use the upgrade_target field if available (e.g., "v3.6")
                 if (isset($outdatedInfo['upgrade_target'])) {
-                    return str_starts_with($outdatedInfo['upgrade_target'], 'v')
+                    $upgradeTarget = str_starts_with($outdatedInfo['upgrade_target'], 'v')
                         ? $outdatedInfo['upgrade_target']
                         : "v{$outdatedInfo['upgrade_target']}";
+
+                    if ($configuredBranch && version_compare($configuredBranch, ltrim($upgradeTarget, 'v'), '>=')) {
+                        return null;
+                    }
+
+                    return $upgradeTarget;
                 }
             }
 
@@ -315,9 +324,46 @@ class Proxy extends Component
                 }
             }
 
-            return $newestBranch ? "v{$newestBranch}" : null;
+            if (! $newestBranch || ($configuredBranch && version_compare($configuredBranch, $newestBranch, '>='))) {
+                return null;
+            }
+
+            return "v{$newestBranch}";
         } catch (\Throwable $e) {
             return null;
         }
+    }
+
+    private function getConfiguredTraefikBranch(): ?string
+    {
+        if ($this->server->proxy->get('status') !== 'running' || $this->server->hasPendingProxyConfiguration()) {
+            return null;
+        }
+
+        if (! is_string($this->proxySettings)) {
+            return null;
+        }
+
+        if (! preg_match('/^\s*image:\s*[\'\"]?traefik:v?(\d+\.\d+)(?:\.\d+)?[\'\"]?\s*$/mi', $this->proxySettings, $matches)) {
+            return null;
+        }
+
+        return $matches[1];
+    }
+
+    private function clearAppliedTraefikBranchWarning(): void
+    {
+        if (data_get($this->server->traefik_outdated_info, 'type') !== 'minor_upgrade') {
+            return;
+        }
+
+        $configuredBranch = $this->getConfiguredTraefikBranch();
+        $upgradeTarget = ltrim((string) data_get($this->server->traefik_outdated_info, 'upgrade_target'), 'v');
+
+        if (! $configuredBranch || ! $upgradeTarget || version_compare($configuredBranch, $upgradeTarget, '<')) {
+            return;
+        }
+
+        $this->server->update(['traefik_outdated_info' => null]);
     }
 }

--- a/tests/Feature/TraefikVersionStateTest.php
+++ b/tests/Feature/TraefikVersionStateTest.php
@@ -35,6 +35,89 @@ it('ignores stale minor upgrade information for the detected Traefik version', f
     expect($component->getNewerTraefikBranchAvailableProperty())->toBeNull();
 });
 
+it('does not offer the Traefik branch already configured on a running proxy', function () {
+    Cache::put('coolify:versions:all', [
+        'traefik' => [
+            'v3.7' => '3.7.8',
+            'v3.6' => '3.6.23',
+        ],
+    ]);
+
+    $server = Server::factory()->make([
+        'proxy' => [
+            'type' => ProxyTypes::TRAEFIK->value,
+            'status' => 'running',
+        ],
+        'detected_traefik_version' => '3.6.23',
+        'traefik_outdated_info' => [
+            'current' => '3.6.23',
+            'latest' => '3.7.8',
+            'type' => 'minor_upgrade',
+            'upgrade_target' => 'v3.7',
+        ],
+    ]);
+
+    $component = new Proxy;
+    $component->server = $server;
+    $component->proxySettings = <<<'YAML'
+services:
+  traefik:
+    image: 'traefik:v3.7'
+YAML;
+
+    expect($component->getNewerTraefikBranchAvailableProperty())->toBeNull();
+});
+
+it('still offers a newer Traefik branch than the configured image', function () {
+    Cache::put('coolify:versions:all', [
+        'traefik' => [
+            'v3.7' => '3.7.8',
+            'v3.6' => '3.6.23',
+        ],
+    ]);
+
+    $server = Server::factory()->make([
+        'proxy' => [
+            'type' => ProxyTypes::TRAEFIK->value,
+            'status' => 'running',
+        ],
+        'detected_traefik_version' => '3.6.23',
+    ]);
+
+    $component = new Proxy;
+    $component->server = $server;
+    $component->proxySettings = 'services:'.PHP_EOL.'  traefik:'.PHP_EOL.'    image: traefik:v3.6';
+
+    expect($component->getNewerTraefikBranchAvailableProperty())->toBe('v3.7');
+});
+
+it('clears the stale minor warning after the configured branch is applied', function () {
+    $team = Team::factory()->create();
+    $server = Server::factory()->create([
+        'team_id' => $team->id,
+        'proxy' => [
+            'type' => ProxyTypes::TRAEFIK->value,
+            'status' => 'running',
+        ],
+        'detected_traefik_version' => '3.6.23',
+        'traefik_outdated_info' => [
+            'current' => '3.6.23',
+            'latest' => '3.7.8',
+            'type' => 'minor_upgrade',
+            'upgrade_target' => 'v3.7',
+        ],
+    ]);
+
+    $component = new Proxy;
+    $component->server = $server;
+    $component->proxySettings = 'services:'.PHP_EOL.'  traefik:'.PHP_EOL.'    image: traefik:v3.7';
+
+    $method = new ReflectionMethod($component, 'clearAppliedTraefikBranchWarning');
+    $method->invoke($component);
+
+    expect($server->refresh()->traefik_outdated_info)->toBeNull();
+});
+
 it('does not mark stale Traefik outdated information as a current warning', function () {
     $server = Server::factory()->make([
         'proxy' => ['type' => ProxyTypes::TRAEFIK->value],

--- a/tests/Feature/TraefikVersionStateTest.php
+++ b/tests/Feature/TraefikVersionStateTest.php
@@ -98,6 +98,35 @@ it('clears the stale minor warning after the configured branch is applied', func
         'proxy' => [
             'type' => ProxyTypes::TRAEFIK->value,
             'status' => 'running',
+            'last_saved_proxy_configuration' => <<<'YAML'
+services:
+  traefik:
+    image: traefik:v3.7
+YAML,
+        ],
+        'detected_traefik_version' => '3.6.23',
+        'traefik_outdated_info' => [
+            'current' => '3.6.23',
+            'latest' => '3.7.8',
+            'type' => 'minor_upgrade',
+            'upgrade_target' => 'v3.7',
+        ],
+    ]);
+
+    $component = new Proxy;
+    $component->server = $server;
+    $component->mount();
+
+    expect($server->refresh()->traefik_outdated_info)->toBeNull();
+});
+
+it('preserves a newer Traefik warning stored after the warning was inspected', function () {
+    $team = Team::factory()->create();
+    $server = Server::factory()->create([
+        'team_id' => $team->id,
+        'proxy' => [
+            'type' => ProxyTypes::TRAEFIK->value,
+            'status' => 'running',
         ],
         'detected_traefik_version' => '3.6.23',
         'traefik_outdated_info' => [
@@ -112,10 +141,18 @@ it('clears the stale minor warning after the configured branch is applied', func
     $component->server = $server;
     $component->proxySettings = 'services:'.PHP_EOL.'  traefik:'.PHP_EOL.'    image: traefik:v3.7';
 
+    $newerWarning = [
+        'current' => '3.7.8',
+        'latest' => '3.8.1',
+        'type' => 'minor_upgrade',
+        'upgrade_target' => 'v3.8',
+    ];
+    Server::query()->whereKey($server->id)->update(['traefik_outdated_info' => $newerWarning]);
+
     $method = new ReflectionMethod($component, 'clearAppliedTraefikBranchWarning');
     $method->invoke($component);
 
-    expect($server->refresh()->traefik_outdated_info)->toBeNull();
+    expect($server->refresh()->traefik_outdated_info)->toBe($newerWarning);
 });
 
 it('does not mark stale Traefik outdated information as a current warning', function () {


### PR DESCRIPTION
## Summary

- Stop showing an upgrade warning when the running proxy already uses the suggested Traefik branch.
- Clear stored minor-upgrade warnings after the configured branch has been applied.
- Preserve warnings when a newer branch is still available.
- Add feature tests for configured, outdated, and stale warning states.

fixes #11490

---

Fixes #11490