### PR TITLE
fix(deployments): honor stop grace period in compose services

### DIFF
--- a/app/Jobs/ApplicationDeploymentJob.php
+++ b/app/Jobs/ApplicationDeploymentJob.php
@@ -3301,6 +3301,10 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf");
         // Always use .env file
         $docker_compose['services'][$this->container_name]['env_file'] = ['.env'];
 
+        if ($this->application->settings->stop_grace_period !== null) {
+            $docker_compose['services'][$this->container_name]['stop_grace_period'] = $this->application->settings->stopGracePeriodSeconds().'s';
+        }
+
         // Only add Coolify healthcheck if no custom HEALTHCHECK found in Dockerfile
         // If custom_healthcheck_found is true, the Dockerfile's HEALTHCHECK will be used
         // If healthcheck is disabled, no healthcheck will be added

--- a/tests/Unit/ApplicationDeploymentStopGracePeriodTest.php
+++ b/tests/Unit/ApplicationDeploymentStopGracePeriodTest.php
@@ -1,0 +1,9 @@
+<?php
+
+it('adds an explicitly configured stop grace period to generated compose services', function () {
+    $source = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
+
+    expect($source)
+        ->toContain('if ($this->application->settings->stop_grace_period !== null) {')
+        ->toContain("['stop_grace_period'] = \$this->application->settings->stopGracePeriodSeconds().'s'");
+});

--- a/tests/Unit/ApplicationDeploymentStopGracePeriodTest.php
+++ b/tests/Unit/ApplicationDeploymentStopGracePeriodTest.php
@@ -1,9 +1,85 @@
 <?php
 
-it('adds an explicitly configured stop grace period to generated compose services', function () {
-    $source = file_get_contents(__DIR__.'/../../app/Jobs/ApplicationDeploymentJob.php');
+use App\Jobs\ApplicationDeploymentJob;
+use App\Models\Application;
+use App\Models\ApplicationDeploymentQueue;
+use App\Models\Environment;
+use App\Models\Project;
+use App\Models\Server;
+use App\Models\StandaloneDocker;
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
+use Symfony\Component\Yaml\Yaml;
+use Tests\TestCase;
 
-    expect($source)
-        ->toContain('if ($this->application->settings->stop_grace_period !== null) {')
-        ->toContain("['stop_grace_period'] = \$this->application->settings->stopGracePeriodSeconds().'s'");
+uses(TestCase::class, RefreshDatabase::class);
+
+class TestableStopGracePeriodDeploymentJob extends ApplicationDeploymentJob
+{
+    public function __construct() {}
+
+    public function execute_remote_command(...$commands): void {}
+}
+
+function generateComposeServiceWithStopGracePeriod(?int $stopGracePeriod): array
+{
+    $team = Team::create([
+        'name' => 'Stop Grace Period Team',
+        'personal_team' => false,
+        'show_boarding' => false,
+    ]);
+    $project = Project::create([
+        'name' => 'Stop Grace Period Project',
+        'team_id' => $team->id,
+    ]);
+    $environment = Environment::where('project_id', $project->id)->firstOrFail();
+    $server = Server::factory()->create(['team_id' => $team->id]);
+    $destination = $server->standaloneDockers()->firstOrFail();
+    $application = Application::factory()->create([
+        'environment_id' => $environment->id,
+        'destination_id' => $destination->id,
+        'destination_type' => StandaloneDocker::class,
+        'build_pack' => 'nixpacks',
+    ]);
+    $application->settings()->update(['stop_grace_period' => $stopGracePeriod]);
+
+    $queue = Mockery::mock(ApplicationDeploymentQueue::class)->makePartial();
+    $queue->status = 'queued';
+    $queue->shouldReceive('refresh')->once()->andReturnSelf();
+
+    $job = new TestableStopGracePeriodDeploymentJob;
+    $reflection = new ReflectionClass(ApplicationDeploymentJob::class);
+
+    foreach ([
+        'application' => $application->fresh(),
+        'application_deployment_queue' => $queue,
+        'destination' => $destination,
+        'server' => $server,
+        'mainServer' => $server,
+        'pull_request_id' => 0,
+        'container_name' => 'stop-grace-period-app',
+        'production_image_name' => 'example/app:latest',
+        'deployment_uuid' => 'deployment-uuid',
+        'workdir' => '/artifacts/stop-grace-period-app',
+        'configuration_dir' => '/data/coolify/applications/test',
+        'saved_outputs' => new Collection,
+    ] as $property => $value) {
+        $reflection->getProperty($property)->setValue($job, $value);
+    }
+
+    $reflection->getMethod('generate_compose_file')->invoke($job);
+    $compose = Yaml::parse($reflection->getProperty('docker_compose')->getValue($job));
+
+    return $compose['services']['stop-grace-period-app'];
+}
+
+it('adds an explicitly configured stop grace period to generated compose services', function () {
+    expect(generateComposeServiceWithStopGracePeriod(700))
+        ->toHaveKey('stop_grace_period', '700s');
+});
+
+it('omits the stop grace period from generated compose services when it is not configured', function () {
+    expect(generateComposeServiceWithStopGracePeriod(null))
+        ->not->toHaveKey('stop_grace_period');
 });


### PR DESCRIPTION
## Summary

- Add the configured `stop_grace_period` to generated Docker Compose services.
- Preserve Docker's default behavior when no grace period is explicitly configured.
- Add unit coverage for compose generation.

## Docker inspection compatibility

Coolify emits the portable Compose setting:

```yaml
stop_grace_period: 700s
```

Docker Compose translates this into the Engine create-container request. The location shown by `docker inspect` varies by Docker/Compose version: current versions may expose it as `.Config.StopTimeout`, while other versions or references may show `.HostConfig.StopTimeout`. The daemon honors the configured timeout in either case.

Use this portable verification command:

```bash
docker inspect <container> | jq '.[0].Config.StopTimeout // .[0].HostConfig.StopTimeout'
```

For a configured value of 700 seconds, the expected output is `700`. Avoid directly formatting only `.HostConfig.StopTimeout`, because Docker's Go template can fail when that key is absent.

Fixes #11493
