### PR TITLE
fix(teams): allow deletion with system-wide Git sources

### DIFF
--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -283,8 +283,8 @@ class Team extends Model implements SendsDiscord, SendsEmail, SendsPushover, Sen
         return array_filter([
             'projects' => $this->projects()->count(),
             'servers' => $this->servers()->count(),
-            'sources' => GithubApp::query()->where('team_id', $this->id)->count()
-                + GitlabApp::query()->where('team_id', $this->id)->count(),
+            'sources' => GithubApp::query()->where('team_id', $this->id)->where('is_system_wide', false)->count()
+                + GitlabApp::query()->where('team_id', $this->id)->where('is_system_wide', false)->count(),
         ]);
     }
 

--- a/resources/views/livewire/team/danger-zone.blade.php
+++ b/resources/views/livewire/team/danger-zone.blade.php
@@ -85,7 +85,8 @@
                                     confirmationText="{{ currentTeam()->name }}"
                                     confirmationLabel="Enter the team name to confirm permanent deletion"
                                     shortConfirmationLabel="Team name" :confirmWithPassword="false"
-                                    step2ButtonText="Permanently Delete" />
+                                    step2ButtonText="Permanently Delete" canGate="delete"
+                                    :canResource="$team" />
                             @else
                                 <x-forms.button disabled tooltip="Resolve the requirements shown before deleting this team.">
                                     Delete team

--- a/tests/Feature/Team/TeamDeletionTest.php
+++ b/tests/Feature/Team/TeamDeletionTest.php
@@ -73,6 +73,39 @@ test('unused private keys do not block team deletion', function () {
         ->and(PrivateKey::find($privateKey->id))->toBeNull();
 });
 
+test('system-wide git sources do not block team deletion', function () {
+    Team::forceCreate([
+        'id' => 0,
+        'name' => 'Root Team',
+        'personal_team' => false,
+    ]);
+
+    $githubApp = GithubApp::forceCreate([
+        'name' => 'System-wide GitHub source',
+        'team_id' => $this->teamToDelete->id,
+        'api_url' => 'https://api.github.com',
+        'html_url' => 'https://github.com',
+        'is_public' => false,
+        'is_system_wide' => true,
+    ]);
+    $gitlabApp = GitlabApp::forceCreate([
+        'name' => 'System-wide GitLab source',
+        'team_id' => $this->teamToDelete->id,
+        'api_url' => 'https://gitlab.com/api/v4',
+        'html_url' => 'https://gitlab.com',
+        'is_public' => false,
+        'is_system_wide' => true,
+    ]);
+
+    expect($this->teamToDelete->isEmpty())->toBeTrue();
+
+    app(DeleteTeam::class)->handle($this->teamToDelete, $this->owner);
+
+    expect(Team::find($this->teamToDelete->id))->toBeNull()
+        ->and($githubApp->refresh()->team_id)->toBe(0)
+        ->and($gitlabApp->refresh()->team_id)->toBe(0);
+});
+
 test('the danger zone names and links blocking resource types', function () {
     Project::factory()->count(2)->create(['team_id' => $this->teamToDelete->id]);
 


### PR DESCRIPTION
## Summary

- Exclude system-wide GitHub and GitLab sources from team deletion blockers.
- Preserve system-wide sources by moving them to the root team when their owning team is deleted.
- Apply the team deletion authorization gate to the confirmation modal.
- Add coverage for deleting teams that own system-wide Git sources.

Related to #11494.

---

Fixes #11494